### PR TITLE
refactor(checker): route index signatures through boundary (#14351)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -763,8 +763,6 @@ impl<'a> CheckerState<'a> {
         source: TypeId,
         target: TypeId,
     ) -> Option<Vec<tsz_common::interner::Atom>> {
-        use crate::query_boundaries::diagnostics::{IndexKind, IndexSignatureResolver};
-
         if crate::query_boundaries::diagnostics::is_type_parameter_like(self.ctx.types, source) {
             return None;
         }
@@ -788,10 +786,11 @@ impl<'a> CheckerState<'a> {
                 ],
             );
 
-        let resolver = IndexSignatureResolver::new(self.ctx.types);
         let source_has_index = source_candidates.iter().copied().any(|candidate| {
-            resolver.has_index_signature(candidate, IndexKind::String)
-                || resolver.has_index_signature(candidate, IndexKind::Number)
+            crate::query_boundaries::index_signature::has_string_or_number_index_signature(
+                self.ctx.types,
+                candidate,
+            )
         });
         if !source_has_index {
             return None;
@@ -835,8 +834,10 @@ impl<'a> CheckerState<'a> {
         let target_has_index = [target, target_env_evaluated, target_evaluated]
             .into_iter()
             .any(|candidate| {
-                resolver.has_index_signature(candidate, IndexKind::String)
-                    || resolver.has_index_signature(candidate, IndexKind::Number)
+                crate::query_boundaries::index_signature::has_string_or_number_index_signature(
+                    self.ctx.types,
+                    candidate,
+                )
             });
 
         if target_has_index

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -583,15 +583,11 @@ impl<'a> CheckerState<'a> {
         }
         let resolved = self.resolve_type_for_property_access(display_type);
         let evaluated = self.judge_evaluate(resolved);
-        let resolver =
-            tsz_solver::objects::index_signatures::IndexSignatureResolver::new(self.ctx.types);
-        let has_index_signature = resolver.has_index_signature(
-            evaluated,
-            tsz_solver::objects::index_signatures::IndexKind::String,
-        ) || resolver.has_index_signature(
-            evaluated,
-            tsz_solver::objects::index_signatures::IndexKind::Number,
-        );
+        let has_index_signature =
+            crate::query_boundaries::index_signature::has_string_or_number_index_signature(
+                self.ctx.types,
+                evaluated,
+            );
         if !formatted.starts_with('{') && !has_index_signature {
             return false;
         }

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -738,8 +738,6 @@ impl<'a> CheckerState<'a> {
             let formatted = self.format_type_for_assignability_message(display_type);
             let resolved_for_access = self.resolve_type_for_property_access(display_type);
             let resolved = self.judge_evaluate(resolved_for_access);
-            let resolver =
-                tsz_solver::objects::index_signatures::IndexSignatureResolver::new(self.ctx.types);
             if !formatted.contains('{')
                 && !formatted.contains('[')
                 && !formatted.contains('|')
@@ -749,13 +747,10 @@ impl<'a> CheckerState<'a> {
                     self.ctx.types,
                     display_type,
                 )
-                && (resolver.has_index_signature(
+                && crate::query_boundaries::index_signature::has_string_or_number_index_signature(
+                    self.ctx.types,
                     resolved,
-                    tsz_solver::objects::index_signatures::IndexKind::String,
-                ) || resolver.has_index_signature(
-                    resolved,
-                    tsz_solver::objects::index_signatures::IndexKind::Number,
-                ))
+                )
             {
                 if let Some(structural) = self.format_structural_indexed_object_type(resolved) {
                     return structural;

--- a/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
+++ b/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
@@ -443,10 +443,17 @@ impl<'a> CheckerState<'a> {
                 .is_some();
         // Check if the object has any index signature. If so, the more specific
         // TS7015/TS7053 diagnostics below should handle the error, not TS2339.
-        let idx_resolver =
-            tsz_solver::objects::index_signatures::IndexSignatureResolver::new(self.ctx.types);
-        let has_any_index_signature = idx_resolver.resolve_string_index(object_type).is_some()
-            || idx_resolver.resolve_number_index(object_type).is_some();
+        let has_any_index_signature =
+            crate::query_boundaries::index_signature::resolve_string_index(
+                self.ctx.types,
+                object_type,
+            )
+            .is_some()
+                || crate::query_boundaries::index_signature::resolve_number_index(
+                    self.ctx.types,
+                    object_type,
+                )
+                .is_some();
 
         // Helper closure to emit TS2339 for a missing property
         let emit_ts2339_for_missing_prop =
@@ -614,16 +621,19 @@ impl<'a> CheckerState<'a> {
         let is_for_in_index = self.is_for_in_variable_identifier(arg_idx);
         // For union types, ALL members must have a number index (resolve_number_index uses
         // find_map which is too permissive — it returns Some if any member matches).
-        let resolver =
-            tsz_solver::objects::index_signatures::IndexSignatureResolver::new(self.ctx.types);
         let has_number_index = if let Some(members) =
             crate::query_boundaries::common::union_members(self.ctx.types, object_type)
         {
-            members
-                .iter()
-                .all(|&m| resolver.resolve_number_index(m).is_some())
+            members.iter().all(|&m| {
+                crate::query_boundaries::index_signature::resolve_number_index(self.ctx.types, m)
+                    .is_some()
+            })
         } else {
-            resolver.resolve_number_index(object_type).is_some()
+            crate::query_boundaries::index_signature::resolve_number_index(
+                self.ctx.types,
+                object_type,
+            )
+            .is_some()
         };
         if has_number_index
             && !is_for_in_index
@@ -661,7 +671,12 @@ impl<'a> CheckerState<'a> {
                     .iter()
                     .all(|&m| self.is_element_indexable(m, true, false))
             } else {
-                resolver.resolve_string_index(object_type).is_some() || has_number_index
+                crate::query_boundaries::index_signature::resolve_string_index(
+                    self.ctx.types,
+                    object_type,
+                )
+                .is_some()
+                    || has_number_index
             };
             if has_string_index {
                 return;

--- a/crates/tsz-checker/src/error_reporter/property_receiver_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/property_receiver_formatting.rs
@@ -99,19 +99,40 @@ impl<'a> CheckerState<'a> {
 
         let argument = self.ctx.arena.skip_parenthesized_and_assertions(argument);
         let argument_node = self.ctx.arena.get(argument)?;
-        let resolver = crate::query_boundaries::common::IndexSignatureResolver::new(self.ctx.types);
         let prefers_number_index =
             self.element_access_argument_prefers_number_index(argument, argument_node.kind);
         let (raw_index_value_type, selected_number_index) = if prefers_number_index {
-            if let Some(index_value_type) = resolver.resolve_number_index(declared_type) {
+            if let Some(index_value_type) =
+                crate::query_boundaries::index_signature::resolve_number_index(
+                    self.ctx.types,
+                    declared_type,
+                )
+            {
                 (index_value_type, true)
             } else {
-                (resolver.resolve_string_index(declared_type)?, false)
+                (
+                    crate::query_boundaries::index_signature::resolve_string_index(
+                        self.ctx.types,
+                        declared_type,
+                    )?,
+                    false,
+                )
             }
-        } else if let Some(index_value_type) = resolver.resolve_string_index(declared_type) {
+        } else if let Some(index_value_type) =
+            crate::query_boundaries::index_signature::resolve_string_index(
+                self.ctx.types,
+                declared_type,
+            )
+        {
             (index_value_type, false)
         } else {
-            (resolver.resolve_number_index(declared_type)?, true)
+            (
+                crate::query_boundaries::index_signature::resolve_number_index(
+                    self.ctx.types,
+                    declared_type,
+                )?,
+                true,
+            )
         };
         if raw_index_value_type == TypeId::ANY {
             return None;

--- a/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
@@ -103,16 +103,16 @@ impl<'a> CheckerState<'a> {
         // from the Array interface and ARE named properties even though the array also has
         // a numeric index signature.
         {
-            use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
-            let resolver = IndexSignatureResolver::new(self.ctx.types);
             let target_is_array_or_tuple =
                 crate::query_boundaries::common::array_element_type(self.ctx.types, target)
                     .is_some()
                     || crate::query_boundaries::common::tuple_list_id(self.ctx.types, target)
                         .is_some();
             let target_has_index = !target_is_array_or_tuple
-                && (resolver.has_index_signature(target, IndexKind::String)
-                    || resolver.has_index_signature(target, IndexKind::Number));
+                && crate::query_boundaries::index_signature::has_string_or_number_index_signature(
+                    self.ctx.types,
+                    target,
+                );
             if target_has_index {
                 let prop_name_str = self.ctx.types.resolve_atom_ref(property_name);
                 let target_has_named_prop = crate::query_boundaries::common::find_property_by_str(
@@ -158,8 +158,6 @@ impl<'a> CheckerState<'a> {
         // is preferred over specific missing property errors.
         // Skip for array/tuple targets — their numeric index is implicit and missing named
         // properties (like `length`) should still produce TS2741.
-        use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
-        let resolver = IndexSignatureResolver::new(self.ctx.types);
         // Check both original and evaluated types (needed for generic class instances)
         let source_evaluated = self.evaluate_type_with_env(source);
         let target_evaluated = self.evaluate_type_with_env(target);
@@ -167,13 +165,17 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::array_element_type(self.ctx.types, target).is_some()
                 || crate::query_boundaries::common::tuple_list_id(self.ctx.types, target).is_some();
         let source_has_index = [source, source_evaluated].iter().any(|t| {
-            resolver.has_index_signature(*t, IndexKind::String)
-                || resolver.has_index_signature(*t, IndexKind::Number)
+            crate::query_boundaries::index_signature::has_string_or_number_index_signature(
+                self.ctx.types,
+                *t,
+            )
         });
         let target_has_index = !target_is_array_or_tuple_for_idx
             && [target, target_evaluated].iter().any(|t| {
-                resolver.has_index_signature(*t, IndexKind::String)
-                    || resolver.has_index_signature(*t, IndexKind::Number)
+                crate::query_boundaries::index_signature::has_string_or_number_index_signature(
+                    self.ctx.types,
+                    *t,
+                )
             });
         if source_has_index && target_has_index {
             let src_str = self.format_type_diagnostic(source);
@@ -1039,23 +1041,37 @@ impl<'a> CheckerState<'a> {
         // target has no explicit named properties (i.e., it's purely an index-signature
         // type like `{ [x: number]: T }`). Named interfaces that happen to have number
         // index signatures (like String, Array) should still get TS2739/TS2740.
-        use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
-        let resolver = IndexSignatureResolver::new(self.ctx.types);
         // Check both original and evaluated types (needed for generic class instances)
         let source_evaluated = self.evaluate_type_with_env(source);
         let target_evaluated = self.evaluate_type_with_env(target);
-        let source_has_string_index = [source, source_evaluated]
-            .iter()
-            .any(|t| resolver.has_index_signature(*t, IndexKind::String));
-        let target_has_string_index = [target, target_evaluated]
-            .iter()
-            .any(|t| resolver.has_index_signature(*t, IndexKind::String));
-        let source_has_number_index = [source, source_evaluated]
-            .iter()
-            .any(|t| resolver.has_index_signature(*t, IndexKind::Number));
-        let target_has_number_index = [target, target_evaluated]
-            .iter()
-            .any(|t| resolver.has_index_signature(*t, IndexKind::Number));
+        let source_has_string_index = [source, source_evaluated].iter().any(|t| {
+            crate::query_boundaries::index_signature::has_index_signature(
+                self.ctx.types,
+                *t,
+                crate::query_boundaries::index_signature::IndexKind::String,
+            )
+        });
+        let target_has_string_index = [target, target_evaluated].iter().any(|t| {
+            crate::query_boundaries::index_signature::has_index_signature(
+                self.ctx.types,
+                *t,
+                crate::query_boundaries::index_signature::IndexKind::String,
+            )
+        });
+        let source_has_number_index = [source, source_evaluated].iter().any(|t| {
+            crate::query_boundaries::index_signature::has_index_signature(
+                self.ctx.types,
+                *t,
+                crate::query_boundaries::index_signature::IndexKind::Number,
+            )
+        });
+        let target_has_number_index = [target, target_evaluated].iter().any(|t| {
+            crate::query_boundaries::index_signature::has_index_signature(
+                self.ctx.types,
+                *t,
+                crate::query_boundaries::index_signature::IndexKind::Number,
+            )
+        });
         // For number index signatures, only suppress when the missing properties are
         // NOT explicitly declared on the target (they came from index value type expansion).
         // We detect this by checking if none of the missing property names match a real

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -12,7 +12,7 @@ pub(crate) use tsz_solver::narrowing::{
     CachedPropertyType, NarrowingCache, NarrowingContext, OptionalPropertyChainKey, TypeGuard,
     TypeofKind,
 };
-pub(crate) use tsz_solver::objects::{IndexKind, IndexSignatureResolver};
+pub(crate) use tsz_solver::objects::IndexSignatureResolver;
 pub(crate) use tsz_solver::operations::property::PropertyAccessResult;
 pub(crate) use tsz_solver::operations::{AssignabilityChecker, CallResult};
 pub(crate) use tsz_solver::relations::judge::{DefaultJudge, JudgeConfig};

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -25,9 +25,8 @@ pub(crate) use super::common::{
 // (issue #12947). These remain defined in `common` for non-display callers; the
 // re-export keeps a single import surface for diagnostic render policy.
 pub(crate) use super::common::{
-    IndexKind, IndexSignatureResolver, is_conditional_type, is_generic_application,
-    is_literal_type, is_mapped_type, is_type_parameter, is_type_parameter_like, is_type_query_type,
-    is_union_type, widen_type,
+    is_conditional_type, is_generic_application, is_literal_type, is_mapped_type,
+    is_type_parameter, is_type_parameter_like, is_type_query_type, is_union_type, widen_type,
 };
 pub(crate) use tsz_solver::type_queries::AssignmentNumericDisplayChildren;
 

--- a/crates/tsz-checker/src/query_boundaries/index_signature.rs
+++ b/crates/tsz-checker/src/query_boundaries/index_signature.rs
@@ -10,6 +10,54 @@ use tsz_parser::parser::{NodeArena, NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 use tsz_solver::construction::TypeDatabase;
+use tsz_solver::objects::index_signatures::IndexSignatureResolver;
+
+pub(crate) use tsz_solver::IndexSignature;
+pub(crate) use tsz_solver::objects::index_signatures::IndexKind;
+
+/// Resolve the string index signature value type from `type_id`.
+///
+/// Checker callers ask this boundary rather than constructing the raw solver
+/// resolver directly, so resolver ownership stays in one place.
+pub(crate) fn resolve_string_index(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
+    IndexSignatureResolver::new(db).resolve_string_index(type_id)
+}
+
+/// Resolve the numeric index signature value type from `type_id`.
+pub(crate) fn resolve_number_index(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
+    IndexSignatureResolver::new(db).resolve_number_index(type_id)
+}
+
+/// Return the declared string index signature for `type_id`, if present.
+pub(crate) fn string_index_signature(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<IndexSignature> {
+    IndexSignatureResolver::new(db)
+        .get_index_info(type_id)
+        .string_index
+}
+
+/// Return the declared numeric index signature for `type_id`, if present.
+pub(crate) fn number_index_signature(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<IndexSignature> {
+    IndexSignatureResolver::new(db)
+        .get_index_info(type_id)
+        .number_index
+}
+
+/// Return whether `type_id` exposes the requested index signature kind.
+pub(crate) fn has_index_signature(db: &dyn TypeDatabase, type_id: TypeId, kind: IndexKind) -> bool {
+    IndexSignatureResolver::new(db).has_index_signature(type_id, kind)
+}
+
+/// Return whether `type_id` exposes either broad object index signature.
+pub(crate) fn has_string_or_number_index_signature(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    has_index_signature(db, type_id, IndexKind::String)
+        || has_index_signature(db, type_id, IndexKind::Number)
+}
 
 pub(crate) fn index_key_type_satisfies_index_signature(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/state/state_checking/readonly.rs
+++ b/crates/tsz-checker/src/state/state_checking/readonly.rs
@@ -802,7 +802,7 @@ impl<'a> CheckerState<'a> {
     /// Evaluates the constraint through `TypeEnvironment` first to resolve
     /// Application/Lazy wrappers (e.g., `Record<string, any>` → `{ [key: string]: any }`).
     fn constraint_has_index_signature(&mut self, type_param: TypeId, index_type: TypeId) -> bool {
-        use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
+        use crate::query_boundaries::index_signature::{IndexKind, has_index_signature};
 
         let Some(info) =
             crate::query_boundaries::common::type_param_info(self.ctx.types, type_param)
@@ -824,18 +824,16 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        let resolver = IndexSignatureResolver::new(self.ctx.types);
-
         // Check if the constraint has an index signature matching the broad index type
         if index_type == TypeId::STRING {
-            return resolver.has_index_signature(resolved, IndexKind::String);
+            return has_index_signature(self.ctx.types, resolved, IndexKind::String);
         }
         if index_type == TypeId::NUMBER {
-            return resolver.has_index_signature(resolved, IndexKind::Number);
+            return has_index_signature(self.ctx.types, resolved, IndexKind::Number);
         }
         // For symbol or unions, check for string index signature (most permissive)
-        resolver.has_index_signature(resolved, IndexKind::String)
-            || resolver.has_index_signature(resolved, IndexKind::Number)
+        has_index_signature(self.ctx.types, resolved, IndexKind::String)
+            || has_index_signature(self.ctx.types, resolved, IndexKind::Number)
     }
 
     /// Check if a type is a "broad" index type that would access through an index

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -293,13 +293,14 @@ impl<'a> CheckerState<'a> {
             // Record<string, (arg: string) => void> | Array<(arg: number) => void>
             // is treated as ambiguous, emitting TS7006 for implicit-any parameters.
             // NOTE: Resolve through Lazy(DefId) first so Record<string,T> becomes an
-            // ObjectWithIndex shape that the IndexSignatureResolver can inspect.
+            // ObjectWithIndex shape that the index-signature boundary can inspect.
             {
-                use crate::query_boundaries::common::IndexSignatureResolver;
                 let resolved = self.resolve_lazy_type(member);
                 let resolved = self.evaluate_type_with_env(resolved);
-                let resolver = IndexSignatureResolver::new(self.ctx.types);
-                let si = resolver.resolve_string_index(resolved);
+                let si = crate::query_boundaries::index_signature::resolve_string_index(
+                    self.ctx.types,
+                    resolved,
+                );
                 if let Some(value_type) = si {
                     if !applicable_shapes.contains(&value_type) {
                         applicable_shapes.push(value_type);
@@ -1475,9 +1476,11 @@ impl<'a> CheckerState<'a> {
             let resolved = self.evaluate_type_with_env(resolved);
             let resolved = self.resolve_type_for_property_access(resolved);
 
-            // Check if the resolved type has a number index signature (array-like)
-            let resolver = tsz_solver::objects::IndexSignatureResolver::new(self.ctx.types);
-            if let Some(elem) = resolver.resolve_number_index(resolved) {
+            // Check if the resolved type has a number index signature (array-like).
+            if let Some(elem) = crate::query_boundaries::index_signature::resolve_number_index(
+                self.ctx.types,
+                resolved,
+            ) {
                 element_types.push(elem);
             }
         }
@@ -1508,8 +1511,7 @@ impl<'a> CheckerState<'a> {
         let resolved = self.resolve_lazy_type(contextual);
         let resolved = self.evaluate_type_with_env(resolved);
         let resolved = self.resolve_type_for_property_access(resolved);
-        let resolver = tsz_solver::objects::IndexSignatureResolver::new(self.ctx.types);
-        resolver.resolve_number_index(resolved)
+        crate::query_boundaries::index_signature::resolve_number_index(self.ctx.types, resolved)
     }
 }
 

--- a/crates/tsz-checker/src/types/computation/identifier/resolved.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/resolved.rs
@@ -1529,12 +1529,11 @@ impl CheckerState<'_> {
                 }
             } else {
                 // No narrowing or error - check if we should preserve declared_type
-                let has_index_sig = {
-                    use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
-                    let resolver = IndexSignatureResolver::new(self.ctx.types);
-                    resolver.has_index_signature(declared_type, IndexKind::String)
-                        || resolver.has_index_signature(declared_type, IndexKind::Number)
-                };
+                let has_index_sig =
+                    crate::query_boundaries::index_signature::has_string_or_number_index_signature(
+                        self.ctx.types,
+                        declared_type,
+                    );
                 if query::is_readonly_type(self.ctx.types, declared_type) || has_index_sig {
                     declared_type
                 } else {
@@ -1614,12 +1613,11 @@ impl CheckerState<'_> {
             // type with index signatures like from a type alias), always preserve it.
             // This prevents false-positive TS2339 errors when accessing properties via
             // index signatures.
-            let has_index_sig = {
-                use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
-                let resolver = IndexSignatureResolver::new(self.ctx.types);
-                resolver.has_index_signature(declared_type, IndexKind::String)
-                    || resolver.has_index_signature(declared_type, IndexKind::Number)
-            };
+            let has_index_sig =
+                crate::query_boundaries::index_signature::has_string_or_number_index_signature(
+                    self.ctx.types,
+                    declared_type,
+                );
             if has_index_sig && (flow_type == declared_type || flow_type == TypeId::ERROR) {
                 declared_type
             } else if declared_type == TypeId::ANY {

--- a/crates/tsz-checker/src/types/computation/object_literal/spread_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/spread_element.rs
@@ -6,12 +6,13 @@ use super::computation_support::{
 };
 use crate::context::TypingRequest;
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::query_boundaries::index_signature::IndexSignature;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{IndexSignature, PropertyInfo, TypeId};
+use tsz_solver::{PropertyInfo, TypeId};
 
 pub(super) struct ObjectLiteralSpreadContext<'b> {
     pub(super) elem_idx: NodeIndex,
@@ -421,31 +422,44 @@ impl<'a> CheckerState<'a> {
                                 resolved_spread,
                             )
                         {
-                            use crate::query_boundaries::common::IndexSignatureResolver;
-                            let resolver = IndexSignatureResolver::new(self.ctx.types);
-                            let index_info = resolver.get_index_info(resolved_spread);
-                            if let Some(string_index) = index_info.string_index.or_else(|| {
-                                resolver.resolve_string_index(resolved_spread).map(|value_type| {
-                                    IndexSignature {
+                            let fallback_string_index =
+                                crate::query_boundaries::index_signature::resolve_string_index(
+                                    self.ctx.types,
+                                    resolved_spread,
+                                )
+                                .map(|value_type| IndexSignature {
                                         key_type: TypeId::STRING,
                                         value_type,
                                         readonly: false,
                                         param_name: None,
-                                    }
-                                })
-                            }) {
+                                });
+                            if let Some(string_index) =
+                                crate::query_boundaries::index_signature::string_index_signature(
+                                    self.ctx.types,
+                                    resolved_spread,
+                                )
+                                .or(fallback_string_index)
+                            {
                                 spread_string_index_signatures.push(string_index);
                             }
-                            if let Some(number_index) = index_info.number_index.or_else(|| {
-                                resolver.resolve_number_index(resolved_spread).map(|value_type| {
-                                    IndexSignature {
+                            let fallback_number_index =
+                                crate::query_boundaries::index_signature::resolve_number_index(
+                                    self.ctx.types,
+                                    resolved_spread,
+                                )
+                                .map(|value_type| IndexSignature {
                                         key_type: TypeId::NUMBER,
                                         value_type,
                                         readonly: false,
                                         param_name: None,
-                                    }
-                                })
-                            }) {
+                                });
+                            if let Some(number_index) =
+                                crate::query_boundaries::index_signature::number_index_signature(
+                                    self.ctx.types,
+                                    resolved_spread,
+                                )
+                                .or(fallback_number_index)
+                            {
                                 spread_number_index_signatures.push(number_index);
                             }
                         }

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -23,6 +23,9 @@
 //!   literals or direct interning calls.
 //! - `class_instance_walk_state_scans`: class instance base traversal uses a
 //!   named checker-owned walk state instead of paired raw visited sets.
+//! - `index_signature_boundary_scans`: production checker index-signature
+//!   queries go through `query_boundaries::index_signature` rather than
+//!   constructing the raw solver resolver at call sites.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -30,6 +33,8 @@ mod class_instance_walk_state_scans;
 mod common_boundary_export_ratchets;
 #[path = "arch_source_scans/construction_boundary_signature_scans.rs"]
 mod construction_boundary_signature_scans;
+#[path = "arch_source_scans/index_signature_boundary_scans.rs"]
+mod index_signature_boundary_scans;
 #[path = "arch_source_scans/object_flags_boundary_scans.rs"]
 mod object_flags_boundary_scans;
 #[path = "arch_source_scans/object_literal_annotation_walker_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans/index_signature_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/index_signature_boundary_scans.rs
@@ -1,0 +1,82 @@
+//! Index-signature resolver boundary scans (issue #14351).
+//!
+//! Production checker code should ask `query_boundaries::index_signature` for
+//! index-signature presence/value information. The raw solver resolver is a
+//! boundary implementation detail, not a call-site dependency.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const RAW_RESOLVER_CONSTRUCTOR: &str = "IndexSignatureResolver::new";
+
+/// Temporary overlap exceptions:
+/// - `return_context_substitution.rs` is owned by active #15167.
+/// - `types/utilities/core.rs` is owned by active #15182.
+const TEMPORARY_ALLOWLIST: &[&str] = &[
+    "src/types/computation/call_inference/return_context_substitution.rs",
+    "src/types/utilities/core.rs",
+];
+
+fn checker_src_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn rust_sources_under(dir: &Path) -> Vec<PathBuf> {
+    let mut sources = Vec::new();
+    collect_rust_sources(dir, &mut sources);
+    sources.sort();
+    sources
+}
+
+fn collect_rust_sources(dir: &Path, sources: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("failed to read source directory") {
+        let path = entry.expect("failed to read source entry").path();
+        if path.is_dir() {
+            if path.file_name().and_then(|name| name.to_str()) != Some("tests") {
+                collect_rust_sources(&path, sources);
+            }
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+            sources.push(path);
+        }
+    }
+}
+
+fn allowed_raw_resolver_constructor(relative_path: &str) -> bool {
+    relative_path == "src/query_boundaries/index_signature.rs"
+        || TEMPORARY_ALLOWLIST.contains(&relative_path)
+}
+
+#[test]
+fn production_checker_index_signature_queries_use_boundary() {
+    let mut violations = Vec::new();
+    let src_root = checker_src_root();
+
+    for path in rust_sources_under(&src_root) {
+        let relative_path = format!(
+            "src/{}",
+            path.strip_prefix(&src_root)
+                .expect("scanned path is under the src root")
+                .to_string_lossy()
+                .replace('\\', "/")
+        );
+        let source = fs::read_to_string(&path).expect("failed to read Rust source");
+        for (line_index, line) in source.lines().enumerate() {
+            if line.contains(RAW_RESOLVER_CONSTRUCTOR)
+                && !allowed_raw_resolver_constructor(&relative_path)
+            {
+                violations.push(format!(
+                    "{}:{} constructs the raw solver index-signature resolver",
+                    relative_path,
+                    line_index + 1
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "checker index-signature queries must route through \
+         query_boundaries::index_signature:\n{}",
+        violations.join("\n")
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
- Route checker index-signature presence/value lookups through `query_boundaries::index_signature` instead of constructing `IndexSignatureResolver` at diagnostic, computation, and readonly call sites.
- Remove now-unused raw resolver re-exports from diagnostics/common surfaces while leaving the two active-overlap constructor sites explicitly allowlisted.
- Add a focused `arch_source_scans` guard to keep production checker resolver construction inside the boundary.

## Structural Rule
When checker code needs index-signature semantic facts, `tsc` uses the resolved/materialized type surface; tsz should ask through a checker query boundary, with solver owning resolver/type-shape logic and checker owning spans, diagnostics, and orchestration.

Owner layer: checker query boundary over solver-owned index-signature resolver semantics.

Adjacent matrix: migrated missing-property rendering, TS7015/TS7053 display, assignability elaboration, array/object literal spread/contextual typing, identifier flow preservation, and readonly index-signature checks. Temporary exceptions remain for `return_context_substitution.rs` (#15167 overlap) and `types/utilities/core.rs` (#15182 overlap).

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test arch_source_scans production_checker_index_signature_queries_use_boundary`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- Earlier pre-rebase branch verification covered the broader migrated diagnostic/computation/index-signature regression matrix; exact-head ready-review CI owns the broad suite.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: gpt-5
Effort: high
