### PR TITLE
refactor(checker): own flow cache stability policy (#14351)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -81,6 +81,7 @@ pub(crate) const fn is_session_stable_flow_cache_symbol(symbol: SymbolId) -> boo
 }
 
 mod defer_classification;
+mod flow_cache_policy;
 mod flow_query;
 mod flow_traversal;
 

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_cache_policy.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_cache_policy.rs
@@ -14,22 +14,43 @@ pub(super) struct FlowCachePolicy {
     stability: FlowCacheStability,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct FlowCacheBypass {
+    explicit_unknown_switch: bool,
+    exhaustive_unknown_typeof: bool,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(super) struct FlowCacheRead {
     pub is_switch_clause: bool,
     pub is_loop_label_node: bool,
-    pub skip_cache_for_explicit_unknown_switch: bool,
-    pub skip_cache_for_exhaustive_unknown_typeof: bool,
+    pub bypass: FlowCacheBypass,
 }
 
 #[derive(Clone, Copy, Debug)]
 pub(super) struct FlowCacheWrite {
     pub is_loop_label_node: bool,
-    pub skip_cache_for_explicit_unknown_switch: bool,
-    pub skip_cache_for_exhaustive_unknown_typeof: bool,
+    pub bypass: FlowCacheBypass,
     pub final_type: TypeId,
     pub final_has_type_params: bool,
     pub unreachable_never: TypeId,
+}
+
+impl FlowCacheBypass {
+    pub const fn new(explicit_unknown_switch: bool, exhaustive_unknown_typeof: bool) -> Self {
+        Self {
+            explicit_unknown_switch,
+            exhaustive_unknown_typeof,
+        }
+    }
+
+    pub const fn none() -> Self {
+        Self::new(false, false)
+    }
+
+    const fn any(self) -> bool {
+        self.explicit_unknown_switch || self.exhaustive_unknown_typeof
+    }
 }
 
 impl FlowCachePolicy {
@@ -57,8 +78,7 @@ impl FlowCachePolicy {
     pub const fn allows_read(self, read: FlowCacheRead) -> bool {
         !read.is_switch_clause
             && (!self.skip_cache_for_control_flow_typed_any || read.is_loop_label_node)
-            && !read.skip_cache_for_explicit_unknown_switch
-            && !read.skip_cache_for_exhaustive_unknown_typeof
+            && !read.bypass.any()
             && (!self.initial_has_type_params || read.is_loop_label_node)
     }
 
@@ -66,8 +86,7 @@ impl FlowCachePolicy {
         write.final_type != write.unreachable_never
             && self.stability == FlowCacheStability::Stable
             && (!self.skip_cache_for_control_flow_typed_any || write.is_loop_label_node)
-            && !write.skip_cache_for_explicit_unknown_switch
-            && !write.skip_cache_for_exhaustive_unknown_typeof
+            && !write.bypass.any()
             && !self.initial_has_type_params
             && !write.final_has_type_params
     }
@@ -87,7 +106,9 @@ impl FlowCachePolicy {
 
 #[cfg(test)]
 mod tests {
-    use super::{FlowCachePolicy, FlowCacheRead, FlowCacheStability, FlowCacheWrite};
+    use super::{
+        FlowCacheBypass, FlowCachePolicy, FlowCacheRead, FlowCacheStability, FlowCacheWrite,
+    };
     use tsz_solver::TypeId;
 
     #[test]
@@ -97,13 +118,11 @@ mod tests {
         assert!(policy.allows_read(FlowCacheRead {
             is_switch_clause: false,
             is_loop_label_node: false,
-            skip_cache_for_explicit_unknown_switch: false,
-            skip_cache_for_exhaustive_unknown_typeof: false,
+            bypass: FlowCacheBypass::none(),
         }));
         assert!(policy.allows_write(FlowCacheWrite {
             is_loop_label_node: false,
-            skip_cache_for_explicit_unknown_switch: false,
-            skip_cache_for_exhaustive_unknown_typeof: false,
+            bypass: FlowCacheBypass::none(),
             final_type: TypeId::STRING,
             final_has_type_params: false,
             unreachable_never: TypeId::NEVER,
@@ -117,16 +136,14 @@ mod tests {
 
         assert!(!generic_initial.allows_write(FlowCacheWrite {
             is_loop_label_node: true,
-            skip_cache_for_explicit_unknown_switch: false,
-            skip_cache_for_exhaustive_unknown_typeof: false,
+            bypass: FlowCacheBypass::none(),
             final_type: TypeId::STRING,
             final_has_type_params: false,
             unreachable_never: TypeId::NEVER,
         }));
         assert!(!concrete_initial.allows_write(FlowCacheWrite {
             is_loop_label_node: false,
-            skip_cache_for_explicit_unknown_switch: false,
-            skip_cache_for_exhaustive_unknown_typeof: false,
+            bypass: FlowCacheBypass::none(),
             final_type: TypeId::STRING,
             final_has_type_params: true,
             unreachable_never: TypeId::NEVER,
@@ -143,8 +160,7 @@ mod tests {
         assert!(!policy.allows_pending_writes());
         assert!(!policy.allows_write(FlowCacheWrite {
             is_loop_label_node: false,
-            skip_cache_for_explicit_unknown_switch: false,
-            skip_cache_for_exhaustive_unknown_typeof: false,
+            bypass: FlowCacheBypass::none(),
             final_type: TypeId::STRING,
             final_has_type_params: false,
             unreachable_never: TypeId::NEVER,
@@ -159,8 +175,7 @@ mod tests {
         let loop_read = FlowCacheRead {
             is_switch_clause: false,
             is_loop_label_node: true,
-            skip_cache_for_explicit_unknown_switch: false,
-            skip_cache_for_exhaustive_unknown_typeof: false,
+            bypass: FlowCacheBypass::none(),
         };
 
         assert!(generic_policy.allows_read(loop_read));
@@ -174,13 +189,11 @@ mod tests {
         assert!(!policy.allows_read(FlowCacheRead {
             is_switch_clause: false,
             is_loop_label_node: false,
-            skip_cache_for_explicit_unknown_switch: true,
-            skip_cache_for_exhaustive_unknown_typeof: false,
+            bypass: FlowCacheBypass::new(true, false),
         }));
         assert!(!policy.allows_write(FlowCacheWrite {
             is_loop_label_node: false,
-            skip_cache_for_explicit_unknown_switch: false,
-            skip_cache_for_exhaustive_unknown_typeof: true,
+            bypass: FlowCacheBypass::new(false, true),
             final_type: TypeId::STRING,
             final_has_type_params: false,
             unreachable_never: TypeId::NEVER,

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_cache_policy.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_cache_policy.rs
@@ -1,0 +1,190 @@
+use tsz_solver::TypeId;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum FlowCacheStability {
+    Stable,
+    Provisional,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct FlowCachePolicy {
+    initial_type: TypeId,
+    initial_has_type_params: bool,
+    skip_cache_for_control_flow_typed_any: bool,
+    stability: FlowCacheStability,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct FlowCacheRead {
+    pub is_switch_clause: bool,
+    pub is_loop_label_node: bool,
+    pub skip_cache_for_explicit_unknown_switch: bool,
+    pub skip_cache_for_exhaustive_unknown_typeof: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct FlowCacheWrite {
+    pub is_loop_label_node: bool,
+    pub skip_cache_for_explicit_unknown_switch: bool,
+    pub skip_cache_for_exhaustive_unknown_typeof: bool,
+    pub final_type: TypeId,
+    pub final_has_type_params: bool,
+    pub unreachable_never: TypeId,
+}
+
+impl FlowCachePolicy {
+    pub const fn new(
+        initial_type: TypeId,
+        initial_has_type_params: bool,
+        skip_cache_for_control_flow_typed_any: bool,
+    ) -> Self {
+        Self {
+            initial_type,
+            initial_has_type_params,
+            skip_cache_for_control_flow_typed_any,
+            stability: FlowCacheStability::Stable,
+        }
+    }
+
+    pub const fn stability(self) -> FlowCacheStability {
+        self.stability
+    }
+
+    pub const fn mark_provisional(&mut self) {
+        self.stability = FlowCacheStability::Provisional;
+    }
+
+    pub const fn allows_read(self, read: FlowCacheRead) -> bool {
+        !read.is_switch_clause
+            && (!self.skip_cache_for_control_flow_typed_any || read.is_loop_label_node)
+            && !read.skip_cache_for_explicit_unknown_switch
+            && !read.skip_cache_for_exhaustive_unknown_typeof
+            && (!self.initial_has_type_params || read.is_loop_label_node)
+    }
+
+    pub fn allows_write(self, write: FlowCacheWrite) -> bool {
+        write.final_type != write.unreachable_never
+            && self.stability == FlowCacheStability::Stable
+            && (!self.skip_cache_for_control_flow_typed_any || write.is_loop_label_node)
+            && !write.skip_cache_for_explicit_unknown_switch
+            && !write.skip_cache_for_exhaustive_unknown_typeof
+            && !self.initial_has_type_params
+            && !write.final_has_type_params
+    }
+
+    pub fn allows_pending_writes(self) -> bool {
+        self.stability == FlowCacheStability::Stable
+    }
+
+    pub fn allows_passthrough_chase(self) -> bool {
+        !self.initial_has_type_params
+            && !self.skip_cache_for_control_flow_typed_any
+            && self.initial_type != TypeId::ANY
+            && self.initial_type != TypeId::ERROR
+            && self.initial_type != TypeId::UNKNOWN
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FlowCachePolicy, FlowCacheRead, FlowCacheStability, FlowCacheWrite};
+    use tsz_solver::TypeId;
+
+    #[test]
+    fn concrete_stable_flow_allows_cache_read_and_write() {
+        let policy = FlowCachePolicy::new(TypeId::NUMBER, false, false);
+
+        assert!(policy.allows_read(FlowCacheRead {
+            is_switch_clause: false,
+            is_loop_label_node: false,
+            skip_cache_for_explicit_unknown_switch: false,
+            skip_cache_for_exhaustive_unknown_typeof: false,
+        }));
+        assert!(policy.allows_write(FlowCacheWrite {
+            is_loop_label_node: false,
+            skip_cache_for_explicit_unknown_switch: false,
+            skip_cache_for_exhaustive_unknown_typeof: false,
+            final_type: TypeId::STRING,
+            final_has_type_params: false,
+            unreachable_never: TypeId::NEVER,
+        }));
+    }
+
+    #[test]
+    fn generic_initial_or_final_type_blocks_shared_writes() {
+        let generic_initial = FlowCachePolicy::new(TypeId::NUMBER, true, false);
+        let concrete_initial = FlowCachePolicy::new(TypeId::NUMBER, false, false);
+
+        assert!(!generic_initial.allows_write(FlowCacheWrite {
+            is_loop_label_node: true,
+            skip_cache_for_explicit_unknown_switch: false,
+            skip_cache_for_exhaustive_unknown_typeof: false,
+            final_type: TypeId::STRING,
+            final_has_type_params: false,
+            unreachable_never: TypeId::NEVER,
+        }));
+        assert!(!concrete_initial.allows_write(FlowCacheWrite {
+            is_loop_label_node: false,
+            skip_cache_for_explicit_unknown_switch: false,
+            skip_cache_for_exhaustive_unknown_typeof: false,
+            final_type: TypeId::STRING,
+            final_has_type_params: true,
+            unreachable_never: TypeId::NEVER,
+        }));
+    }
+
+    #[test]
+    fn provisional_walk_blocks_pending_writes() {
+        let mut policy = FlowCachePolicy::new(TypeId::NUMBER, false, false);
+
+        policy.mark_provisional();
+
+        assert_eq!(policy.stability(), FlowCacheStability::Provisional);
+        assert!(!policy.allows_pending_writes());
+        assert!(!policy.allows_write(FlowCacheWrite {
+            is_loop_label_node: false,
+            skip_cache_for_explicit_unknown_switch: false,
+            skip_cache_for_exhaustive_unknown_typeof: false,
+            final_type: TypeId::STRING,
+            final_has_type_params: false,
+            unreachable_never: TypeId::NEVER,
+        }));
+    }
+
+    #[test]
+    fn loop_label_can_read_recursion_guard_cache_for_generic_or_any_walks() {
+        let generic_policy = FlowCachePolicy::new(TypeId::NUMBER, true, false);
+        let control_flow_any_policy = FlowCachePolicy::new(TypeId::ANY, false, true);
+
+        let loop_read = FlowCacheRead {
+            is_switch_clause: false,
+            is_loop_label_node: true,
+            skip_cache_for_explicit_unknown_switch: false,
+            skip_cache_for_exhaustive_unknown_typeof: false,
+        };
+
+        assert!(generic_policy.allows_read(loop_read));
+        assert!(control_flow_any_policy.allows_read(loop_read));
+    }
+
+    #[test]
+    fn explicit_unknown_paths_skip_cache_without_marking_walk_provisional() {
+        let policy = FlowCachePolicy::new(TypeId::UNKNOWN, false, false);
+
+        assert!(!policy.allows_read(FlowCacheRead {
+            is_switch_clause: false,
+            is_loop_label_node: false,
+            skip_cache_for_explicit_unknown_switch: true,
+            skip_cache_for_exhaustive_unknown_typeof: false,
+        }));
+        assert!(!policy.allows_write(FlowCacheWrite {
+            is_loop_label_node: false,
+            skip_cache_for_explicit_unknown_switch: false,
+            skip_cache_for_exhaustive_unknown_typeof: true,
+            final_type: TypeId::STRING,
+            final_has_type_params: false,
+            unreachable_never: TypeId::NEVER,
+        }));
+        assert_eq!(policy.stability(), FlowCacheStability::Stable);
+    }
+}

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -1,4 +1,5 @@
 use super::super::flow_dp::FlowConditionDpMemos;
+use super::flow_cache_policy::{FlowCachePolicy, FlowCacheRead, FlowCacheWrite};
 use super::{
     FlowAnalyzer, FlowDeferMemos, defer_to_antecedent, flow_boundary, flow_step_budget, query,
 };
@@ -108,13 +109,17 @@ impl<'a> FlowAnalyzer<'a> {
         let cache_symbol = symbol_id
             .or_else(|| self.flow_reference_path_symbol(reference))
             .unwrap_or_else(|| super::per_node_flow_cache_symbol(reference));
+        let mut cache_policy = FlowCachePolicy::new(
+            initial_type,
+            initial_has_type_params,
+            skip_cache_for_control_flow_typed_any,
+        );
 
         // Initialize worklist with the entry point
         worklist.push_back((flow_id, initial_type));
         in_worklist.insert(flow_id);
         let step_budget = flow_step_budget(self.binder.flow_nodes.len());
         let mut steps = 0usize;
-        let mut cacheable_walk = true;
         let mut pending_cache_writes: Vec<((FlowNodeId, SymbolId, TypeId), TypeId)> = Vec::new();
         let mut condition_dp_memos = FlowConditionDpMemos::default();
         // Per-walk defer / CALL narrow-divert classification memos, shared by the
@@ -228,12 +233,12 @@ impl<'a> FlowAnalyzer<'a> {
             // Loop labels MUST always check cache because analyze_loop_fixed_point
             // injects entries as a recursion guard — skipping the check causes
             // stack overflow when types contain type parameters.
-            if !is_switch_clause
-                && (!skip_cache_for_control_flow_typed_any || is_loop_label_node)
-                && !skip_cache_for_explicit_unknown_switch
-                && !skip_cache_for_exhaustive_unknown_typeof
-                && (!initial_has_type_params || is_loop_label_node)
-                && let Some(cache) = self.flow_cache()
+            if cache_policy.allows_read(FlowCacheRead {
+                is_switch_clause,
+                is_loop_label_node,
+                skip_cache_for_explicit_unknown_switch,
+                skip_cache_for_exhaustive_unknown_typeof,
+            }) && let Some(cache) = self.flow_cache()
             {
                 let key = (current_flow, cache_symbol, initial_type);
                 if let Some(&cached_type) = cache.borrow().get(&key) {
@@ -540,7 +545,7 @@ impl<'a> FlowAnalyzer<'a> {
                             if let Some(assigned_type) =
                                 raw_assigned.filter(|&t| t != TypeId::ERROR)
                             {
-                                cacheable_walk = false;
+                                cache_policy.mark_provisional();
                                 assigned_type
                             } else if let Some(&ant) = flow.antecedent.first() {
                                 if let Some(&ant_type) = results.get(&ant) {
@@ -730,7 +735,7 @@ impl<'a> FlowAnalyzer<'a> {
                                 // This walk is provisional: assignment typing has not been computed
                                 // for the RHS yet. Do not publish the declared-type result into the
                                 // shared flow cache or later reads will reuse a stale answer.
-                                cacheable_walk = false;
+                                cache_policy.mark_provisional();
                                 // If we can't resolve the RHS type, conservatively return declared type
                                 // The value HAS changed, so we can't continue to antecedent
                                 if self.is_await_assignment_for_reference(flow.node, reference) {
@@ -965,7 +970,7 @@ impl<'a> FlowAnalyzer<'a> {
                         let (evolved_type, complete) =
                             self.array_mutation_evolved_type(antecedent_type, call, reference);
                         if !complete {
-                            cacheable_walk = false;
+                            cache_policy.mark_provisional();
                         }
                         evolved_type
                     } else {
@@ -1238,33 +1243,32 @@ impl<'a> FlowAnalyzer<'a> {
             // CRITICAL: Only cache if BOTH initial and final types are concrete (no type parameters).
             // This prevents the "Generic Result" bug where narrowing introduces type parameters.
             // Also skip caching UNREACHABLE_NEVER as it's an internal sentinel.
-            if final_type != Self::UNREACHABLE_NEVER
-                && cacheable_walk
-                && (!skip_cache_for_control_flow_typed_any
-                    || flow.has_any_flags(flow_flags::LOOP_LABEL))
-                && !(initial_type == TypeId::UNKNOWN
+            let final_has_type_params = self.contains_type_parameters_cached(final_type);
+            if cache_policy.allows_write(FlowCacheWrite {
+                is_loop_label_node: flow.has_any_flags(flow_flags::LOOP_LABEL),
+                skip_cache_for_explicit_unknown_switch: initial_type == TypeId::UNKNOWN
                     && self.flow_chain_contains_switch_clause_with_memo(
                         current_flow,
                         &mut condition_dp_memos.switch_chains,
-                    ))
-                && !(initial_type == TypeId::UNKNOWN
+                    ),
+                skip_cache_for_exhaustive_unknown_typeof: initial_type == TypeId::UNKNOWN
                     && self.flow_has_exhaustive_typeof_exclusions_with_memo(
                         current_flow,
                         reference,
                         &mut condition_dp_memos.typeof_exclusions,
-                    ))
-            {
-                let final_has_type_params = self.contains_type_parameters_cached(final_type);
-
-                // Only cache if neither initial nor final types contain type parameters
-                if !initial_has_type_params && !final_has_type_params {
-                    let key = (current_flow, cache_symbol, initial_type);
-                    pending_cache_writes.push((key, final_type));
-                }
+                    ),
+                final_type,
+                final_has_type_params,
+                unreachable_never: Self::UNREACHABLE_NEVER,
+            }) {
+                let key = (current_flow, cache_symbol, initial_type);
+                pending_cache_writes.push((key, final_type));
             }
         }
 
-        if cacheable_walk && let Some(cache) = self.flow_cache() {
+        if cache_policy.allows_pending_writes()
+            && let Some(cache) = self.flow_cache()
+        {
             let mut cache = cache.borrow_mut();
             for (key, value) in pending_cache_writes {
                 cache.insert(key, value);
@@ -1346,12 +1350,12 @@ impl<'a> FlowAnalyzer<'a> {
         // collapsing them would drop switch/typeof narrowing (e.g. `unknownType2`).
         // UNKNOWN references are catch-clause / explicit-`unknown` shaped, not the
         // concrete member-typed `const` hotspot, so this costs no perf.
-        if initial_has_type_params
-            || skip_cache_for_control_flow_typed_any
-            || initial_type == TypeId::ANY
-            || initial_type == TypeId::ERROR
-            || initial_type == TypeId::UNKNOWN
-        {
+        let cache_policy = FlowCachePolicy::new(
+            initial_type,
+            initial_has_type_params,
+            skip_cache_for_control_flow_typed_any,
+        );
+        if !cache_policy.allows_passthrough_chase() {
             return entry;
         }
         let flow_cache = self.flow_cache();

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -1,5 +1,5 @@
 use super::super::flow_dp::FlowConditionDpMemos;
-use super::flow_cache_policy::{FlowCachePolicy, FlowCacheRead, FlowCacheWrite};
+use super::flow_cache_policy::{FlowCacheBypass, FlowCachePolicy, FlowCacheRead, FlowCacheWrite};
 use super::{
     FlowAnalyzer, FlowDeferMemos, defer_to_antecedent, flow_boundary, flow_step_budget, query,
 };
@@ -227,6 +227,10 @@ impl<'a> FlowAnalyzer<'a> {
                     reference,
                     &mut condition_dp_memos.typeof_exclusions,
                 );
+            let cache_bypass = FlowCacheBypass::new(
+                skip_cache_for_explicit_unknown_switch,
+                skip_cache_for_exhaustive_unknown_typeof,
+            );
 
             // Use cache if: 1) not a switch clause, AND
             // 2) either initial type is concrete OR this is a loop label.
@@ -236,8 +240,7 @@ impl<'a> FlowAnalyzer<'a> {
             if cache_policy.allows_read(FlowCacheRead {
                 is_switch_clause,
                 is_loop_label_node,
-                skip_cache_for_explicit_unknown_switch,
-                skip_cache_for_exhaustive_unknown_typeof,
+                bypass: cache_bypass,
             }) && let Some(cache) = self.flow_cache()
             {
                 let key = (current_flow, cache_symbol, initial_type);
@@ -1246,17 +1249,19 @@ impl<'a> FlowAnalyzer<'a> {
             let final_has_type_params = self.contains_type_parameters_cached(final_type);
             if cache_policy.allows_write(FlowCacheWrite {
                 is_loop_label_node: flow.has_any_flags(flow_flags::LOOP_LABEL),
-                skip_cache_for_explicit_unknown_switch: initial_type == TypeId::UNKNOWN
-                    && self.flow_chain_contains_switch_clause_with_memo(
-                        current_flow,
-                        &mut condition_dp_memos.switch_chains,
-                    ),
-                skip_cache_for_exhaustive_unknown_typeof: initial_type == TypeId::UNKNOWN
-                    && self.flow_has_exhaustive_typeof_exclusions_with_memo(
-                        current_flow,
-                        reference,
-                        &mut condition_dp_memos.typeof_exclusions,
-                    ),
+                bypass: FlowCacheBypass::new(
+                    initial_type == TypeId::UNKNOWN
+                        && self.flow_chain_contains_switch_clause_with_memo(
+                            current_flow,
+                            &mut condition_dp_memos.switch_chains,
+                        ),
+                    initial_type == TypeId::UNKNOWN
+                        && self.flow_has_exhaustive_typeof_exclusions_with_memo(
+                            current_flow,
+                            reference,
+                            &mut condition_dp_memos.typeof_exclusions,
+                        ),
+                ),
                 final_type,
                 final_has_type_params,
                 unreachable_never: Self::UNREACHABLE_NEVER,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -955,6 +955,9 @@ mod file_session_switch_to_file_tests;
 #[path = "../tests/flow_boundary_contract_tests.rs"]
 mod flow_boundary_contract_tests;
 #[cfg(test)]
+#[path = "tests/flow_cache_policy_arch_tests.rs"]
+mod flow_cache_policy_arch_tests;
+#[cfg(test)]
 #[path = "tests/for_in_lhs_relation_routing_arch_tests.rs"]
 mod for_in_lhs_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/flow_cache_policy_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_cache_policy_arch_tests.rs
@@ -1,0 +1,34 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn checker_src_path(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join(relative)
+}
+
+#[test]
+fn flow_cache_stability_decisions_use_policy_owner() {
+    let policy_rs = fs::read_to_string(checker_src_path(
+        "flow/control_flow/core/flow_cache_policy.rs",
+    ))
+    .expect("failed to read flow_cache_policy.rs");
+    let traversal_rs =
+        fs::read_to_string(checker_src_path("flow/control_flow/core/flow_traversal.rs"))
+            .expect("failed to read flow_traversal.rs");
+
+    assert!(
+        policy_rs.contains("struct FlowCachePolicy")
+            && policy_rs.contains("enum FlowCacheStability")
+            && policy_rs.contains("mark_provisional"),
+        "flow cache read/write stability must be owned by a named policy"
+    );
+    assert!(
+        traversal_rs.contains("FlowCachePolicy::new")
+            && traversal_rs.contains(".mark_provisional(")
+            && !traversal_rs.contains("let mut cacheable_walk = true")
+            && !traversal_rs.contains("cacheable_walk = false"),
+        "flow traversal should ask FlowCachePolicy for stability instead of \
+         carrying an inline cacheable_walk boolean"
+    );
+}

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -273,6 +273,17 @@ FILE_LINE_LIMIT_CHECKS = [
         + QUERY_BOUNDARY_COMMON_LINE_GREEN_HEADROOM,
     ),
     (
+        "Solver diagnostics formatter boundary: format/mod.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-solver"
+        / "src"
+        / "diagnostics"
+        / "format"
+        / "mod.rs",
+        2012,
+    ),
+    (
         "Emitter transform boundary: class_es5_ir.rs must not grow",
         ROOT / "crates" / "tsz-emitter" / "src" / "transforms" / "class_es5_ir.rs",
         2101,


### PR DESCRIPTION
Goal: green

## Summary
- add `FlowCachePolicy` / `FlowCacheStability` as the checker-owned owner for shared flow-cache read/write eligibility
- route provisional flow walks through `mark_provisional()` instead of carrying an inline `cacheable_walk` boolean in `flow_traversal.rs`
- keep existing local flow results unchanged while preventing provisional assignment/mutation observations from being published to the shared `flow_analysis_cache`
- add focused policy unit tests plus a source-level owner guard; include the fresh-main diagnostics formatter line-count ratchet required by `test_arch_guard.py`

## Structural Rule
When a flow walk result depends on provisional, context-sensitive, or degraded traversal state, `tsc` computes the current read but does not turn that partial observation into a reusable program-level fact. `tsz` now routes flow-cache read/write eligibility through the checker control-flow `FlowCachePolicy` owner, so only stable concrete flow results are published while provisional walks still return their local result unchanged.

## Owner Layer
Checker control-flow owns flow-cache stability. This does not change solver relations, property resolution, narrowing cache semantics, application evaluation, infer-pattern handling, or heritage lookup; it only names and centralizes the checker cache publication policy already present in `FlowAnalyzer::check_flow`.

## Adjacent Matrix
- concrete stable walk: cache read/write remains allowed
- generic initial/final type: shared writes remain blocked; loop-label cache reads remain allowed for recursion guards
- control-flow-typed `any`: non-loop cache reads/writes remain skipped; loop recursion reads remain allowed
- explicit `unknown` switch/typeof paths: cache reads/writes remain skipped without marking unrelated concrete walks provisional
- provisional assignment typing and incomplete array mutation evolution: local result is returned, pending shared writes are suppressed
- internal `UNREACHABLE_NEVER` sentinel: remains uncacheable

## Verification
- red: `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib flow_cache_policy_arch_tests::flow_cache_stability_decisions_use_policy_owner` failed before implementation because `flow_cache_policy.rs` was missing
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib flow_cache_policy`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test flow_passthrough_run_narrowing_tests --test flow_dp_memoization_tests --test array_mutation_same_array_join_narrowing_tests --test array_mutation_unrelated_narrowing_tests --test equality_narrow_unknown_to_const_intrinsic_tests`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `cargo fmt --all --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/test_arch_guard.py`
- `git diff --check`
- `git diff --cached --check`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`

Disk note: a first red-check attempt exposed the machine at 0.2 GiB free (`ld: write() failed, errno=28`). I followed `tsz-disk-cache-hygiene`: auto-prune and quiet clean were insufficient, then removed only the inactive-clean 121 GiB `.target` cache at `/Users/mohsen/code/tsz/.claude/worktrees/green+14345-eval-perarena-uris/.target`; disk guard is now green with 117 GiB free.

## Provenance
Machine: m4
Assistant: codex
Model: GPT-5
Effort: high
