### PR TITLE
refactor(checker): name class instance walk state (#14351)

### DIFF
--- a/crates/tsz-checker/src/types/class_type/core.rs
+++ b/crates/tsz-checker/src/types/class_type/core.rs
@@ -9,9 +9,9 @@
 
 use super::helpers::exceeds_class_inheritance_depth_limit;
 use super::instance::{ClassInstanceBuilder, ClassInstanceFlags, RestoreEnclosingClass};
+use super::walk_state::ClassInstanceWalkState;
 use crate::state::CheckerState;
-use rustc_hash::{FxHashMap, FxHashSet};
-use tsz_binder::SymbolId;
+use rustc_hash::FxHashMap;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
@@ -25,12 +25,11 @@ impl<'a> CheckerState<'a> {
     /// 4. Merging base class members
     /// 5. Adding private brand for nominal typing if needed
     /// 6. Inheriting Object prototype members
-    pub(crate) fn get_class_instance_type_inner(
+    pub(super) fn get_class_instance_type_inner(
         &mut self,
         class_idx: NodeIndex,
         class: &tsz_parser::parser::node::ClassData,
-        visited: &mut FxHashSet<SymbolId>,
-        visited_nodes: &mut FxHashSet<NodeIndex>,
+        walk_state: &mut ClassInstanceWalkState,
         apply_module_augmentations: bool,
     ) -> TypeId {
         let current_sym = self.class_declaration_symbol(class_idx);
@@ -50,7 +49,7 @@ impl<'a> CheckerState<'a> {
         // Check for cycles using both symbol ID (for same-file cycles)
         // and node index (for cross-file cycles with @Filename annotations)
         if let Some(sym_id) = current_sym
-            && !visited.insert(sym_id)
+            && !walk_state.enter_symbol(sym_id)
         {
             // Cleanup global set before returning (only if we inserted it)
             if did_insert_into_global_set {
@@ -58,14 +57,14 @@ impl<'a> CheckerState<'a> {
             }
             return TypeId::ERROR; // Circular reference detected via symbol
         }
-        if !visited_nodes.insert(class_idx) {
+        if !walk_state.enter_node(class_idx) {
             // Cleanup global set before returning (only if we inserted it)
             if did_insert_into_global_set && let Some(sym_id) = current_sym {
                 self.ctx.class_instance_resolution_set.remove(&sym_id);
             }
             return TypeId::ERROR; // Circular reference detected via node index
         }
-        if exceeds_class_inheritance_depth_limit(visited_nodes.len()) {
+        if exceeds_class_inheritance_depth_limit(walk_state.node_depth()) {
             if did_insert_into_global_set && let Some(sym_id) = current_sym {
                 self.ctx.class_instance_resolution_set.remove(&sym_id);
             }
@@ -140,13 +139,9 @@ impl<'a> CheckerState<'a> {
 
         // Merge base class members. A detected cycle/forward reference performs
         // the resolution-set cleanup inline and short-circuits the whole call.
-        if let Some(early) = self.class_instance_merge_base_members(
-            class,
-            class_idx,
-            visited,
-            visited_nodes,
-            &mut builder,
-        ) {
+        if let Some(early) =
+            self.class_instance_merge_base_members(class, class_idx, walk_state, &mut builder)
+        {
             return early;
         }
 
@@ -158,8 +153,7 @@ impl<'a> CheckerState<'a> {
         self.class_instance_build_final_type(
             class_idx,
             apply_module_augmentations,
-            visited,
-            visited_nodes,
+            walk_state,
             builder,
         )
     }

--- a/crates/tsz-checker/src/types/class_type/entry.rs
+++ b/crates/tsz-checker/src/types/class_type/entry.rs
@@ -1,8 +1,8 @@
 //! Public entrypoints for class instance type construction.
 
 use super::helpers::in_progress_class_instance_result;
+use super::walk_state::ClassInstanceWalkState;
 use crate::state::CheckerState;
-use rustc_hash::FxHashSet;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
@@ -120,13 +120,11 @@ impl<'a> CheckerState<'a> {
             return self.ctx.create_lazy_type_ref(sym_id);
         }
 
-        let mut visited = FxHashSet::default();
-        let mut visited_nodes = FxHashSet::default();
+        let mut walk_state = ClassInstanceWalkState::default();
         let result = self.get_class_instance_type_inner(
             class_idx,
             class,
-            &mut visited,
-            &mut visited_nodes,
+            &mut walk_state,
             apply_module_augmentations,
         );
 

--- a/crates/tsz-checker/src/types/class_type/instance_merge.rs
+++ b/crates/tsz-checker/src/types/class_type/instance_merge.rs
@@ -10,11 +10,10 @@
 
 use super::helpers::{can_skip_base_instantiation, declaration_is_module_augmentation};
 use super::instance::ClassInstanceBuilder;
+use super::walk_state::ClassInstanceWalkState;
 use crate::query_boundaries::class_type::{callable_shape_for_type, object_shape_for_type};
 use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
 use crate::state::CheckerState;
-use rustc_hash::FxHashSet;
-use tsz_binder::SymbolId;
 use tsz_lowering::TypeLowering;
 use tsz_parser::parser::NodeIndex;
 use tsz_scanner::SyntaxKind;
@@ -31,8 +30,7 @@ impl CheckerState<'_> {
         &mut self,
         class: &'b tsz_parser::parser::node::ClassData,
         class_idx: NodeIndex,
-        visited: &mut FxHashSet<SymbolId>,
-        visited_nodes: &mut FxHashSet<NodeIndex>,
+        walk_state: &mut ClassInstanceWalkState,
         b: &mut ClassInstanceBuilder<'b>,
     ) -> Option<TypeId> {
         let current_sym = b.current_sym;
@@ -111,8 +109,7 @@ impl CheckerState<'_> {
                     .contains(&base_sym_id)
                     || canonical_base_sym
                         .is_some_and(|sym| self.ctx.class_instance_resolution_set.contains(&sym));
-                let base_visited = visited.contains(&base_sym_id)
-                    || canonical_base_sym.is_some_and(|sym| visited.contains(&sym));
+                let base_visited = walk_state.contains_base_symbol(base_sym_id, canonical_base_sym);
 
                 // CRITICAL: Check for self-referential class BEFORE processing
                 // This catches class C extends C, class D<T> extends D<T>, etc.
@@ -220,7 +217,7 @@ impl CheckerState<'_> {
 
                 // Check for circular inheritance using node index tracking (for cross-file cycles)
                 // CRITICAL: Return immediately to prevent infinite recursion, not just break
-                if visited_nodes.contains(&base_class_idx) {
+                if walk_state.contains_node(base_class_idx) {
                     if did_insert_into_global_set && let Some(sym_id) = current_sym {
                         self.ctx.class_instance_resolution_set.remove(&sym_id);
                     }
@@ -253,7 +250,7 @@ impl CheckerState<'_> {
                     // If we've seen this node before in the current resolution path, it's a cycle
                     // This handles cases like: class C extends E {} where E doesn't exist yet
                     // but will be declared later with extends D, and D extends C
-                    if visited_nodes.contains(&base_class_idx) {
+                    if walk_state.contains_node(base_class_idx) {
                         if did_insert_into_global_set && let Some(sym_id) = current_sym {
                             self.ctx.class_instance_resolution_set.remove(&sym_id);
                         }
@@ -654,8 +651,7 @@ impl CheckerState<'_> {
         &mut self,
         class_idx: NodeIndex,
         apply_module_augmentations: bool,
-        visited: &mut FxHashSet<SymbolId>,
-        visited_nodes: &mut FxHashSet<NodeIndex>,
+        walk_state: &mut ClassInstanceWalkState,
         b: ClassInstanceBuilder<'_>,
     ) -> TypeId {
         let factory = self.ctx.types.factory();
@@ -720,8 +716,7 @@ impl CheckerState<'_> {
                 }
             }
 
-            visited.remove(&sym_id);
-            visited_nodes.remove(&class_idx);
+            walk_state.leave_class(sym_id, class_idx);
             // Only remove from global set if we inserted it ourselves
             if did_insert_into_global_set {
                 self.ctx.class_instance_resolution_set.remove(&sym_id);

--- a/crates/tsz-checker/src/types/class_type/mod.rs
+++ b/crates/tsz-checker/src/types/class_type/mod.rs
@@ -9,5 +9,6 @@ mod instance;
 mod instance_merge;
 mod js_class_properties;
 mod prescan;
+mod walk_state;
 
 pub(super) use helpers::can_skip_base_instantiation;

--- a/crates/tsz-checker/src/types/class_type/walk_state.rs
+++ b/crates/tsz-checker/src/types/class_type/walk_state.rs
@@ -1,0 +1,43 @@
+//! Traversal state for checker-owned class instance construction.
+
+use rustc_hash::FxHashSet;
+use tsz_binder::SymbolId;
+use tsz_parser::parser::NodeIndex;
+
+#[derive(Default)]
+pub(super) struct ClassInstanceWalkState {
+    symbols: FxHashSet<SymbolId>,
+    nodes: FxHashSet<NodeIndex>,
+}
+
+impl ClassInstanceWalkState {
+    pub(super) fn enter_symbol(&mut self, sym_id: SymbolId) -> bool {
+        self.symbols.insert(sym_id)
+    }
+
+    pub(super) fn enter_node(&mut self, class_idx: NodeIndex) -> bool {
+        self.nodes.insert(class_idx)
+    }
+
+    pub(super) fn contains_base_symbol(
+        &self,
+        base_sym_id: SymbolId,
+        canonical_base_sym: Option<SymbolId>,
+    ) -> bool {
+        self.symbols.contains(&base_sym_id)
+            || canonical_base_sym.is_some_and(|sym| self.symbols.contains(&sym))
+    }
+
+    pub(super) fn contains_node(&self, class_idx: NodeIndex) -> bool {
+        self.nodes.contains(&class_idx)
+    }
+
+    pub(super) fn node_depth(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub(super) fn leave_class(&mut self, sym_id: SymbolId, class_idx: NodeIndex) {
+        self.symbols.remove(&sym_id);
+        self.nodes.remove(&class_idx);
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -21,7 +21,11 @@
 //!   constructs signature-bearing solver types only through
 //!   `query_boundaries::construct_signatures`, never via inline shape
 //!   literals or direct interning calls.
+//! - `class_instance_walk_state_scans`: class instance base traversal uses a
+//!   named checker-owned walk state instead of paired raw visited sets.
 
+#[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
+mod class_instance_walk_state_scans;
 #[path = "arch_source_scans/common_boundary_export_ratchets.rs"]
 mod common_boundary_export_ratchets;
 #[path = "arch_source_scans/construction_boundary_signature_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans/class_instance_walk_state_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/class_instance_walk_state_scans.rs
@@ -1,0 +1,101 @@
+//! Class-instance traversal-state source scans (issue #14351).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn read_checker_source(relative: &str) -> String {
+    fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"))
+}
+
+#[test]
+fn class_instance_walk_state_owns_symbol_and_node_tracking() {
+    let source = read_checker_source("src/types/class_type/walk_state.rs");
+    for required in [
+        "struct ClassInstanceWalkState",
+        "fn enter_symbol(",
+        "fn enter_node(",
+        "fn contains_base_symbol(",
+        "fn contains_node(",
+        "fn node_depth(",
+        "fn leave_class(",
+    ] {
+        assert!(
+            source.contains(required),
+            "class instance traversal state must own `{required}`"
+        );
+    }
+}
+
+#[test]
+fn class_instance_orchestration_threads_named_walk_state() {
+    let entry = read_checker_source("src/types/class_type/entry.rs");
+    assert!(
+        entry.contains("let mut walk_state = ClassInstanceWalkState::default();"),
+        "class instance entrypoint should seed the named walk state"
+    );
+
+    for (relative, required) in [
+        (
+            "src/types/class_type/core.rs",
+            "walk_state: &mut ClassInstanceWalkState",
+        ),
+        (
+            "src/types/class_type/instance_merge.rs",
+            "walk_state: &mut ClassInstanceWalkState",
+        ),
+    ] {
+        let source = read_checker_source(relative);
+        assert!(
+            source.contains(required),
+            "{relative} should thread class instance traversal through ClassInstanceWalkState"
+        );
+    }
+}
+
+#[test]
+fn class_instance_orchestration_does_not_reintroduce_raw_walk_sets() {
+    const CLEAN_MODULES: &[&str] = &[
+        "src/types/class_type/entry.rs",
+        "src/types/class_type/core.rs",
+        "src/types/class_type/instance_merge.rs",
+    ];
+    const FORBIDDEN: &[&str] = &[
+        "visited: &mut FxHashSet",
+        "visited_nodes",
+        "let mut visited = FxHashSet",
+        "let mut visited_nodes = FxHashSet",
+        "FxHashSet<SymbolId>",
+        "FxHashSet<NodeIndex>",
+    ];
+
+    let mut violations = Vec::new();
+    for relative in CLEAN_MODULES {
+        let source = read_checker_source(relative);
+        for (line_index, line) in source.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            for pattern in FORBIDDEN {
+                if line.contains(pattern) {
+                    violations.push(format!(
+                        "{relative}:{} contains `{pattern}`",
+                        line_index + 1
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "class instance type construction should use ClassInstanceWalkState \
+         instead of paired raw visited sets:\n{}",
+        violations.join("\n")
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
- Move class instance base traversal symbol/node tracking into `ClassInstanceWalkState`.
- Thread the named state through class instance entry, core orchestration, and base-member merging instead of paired raw visited sets.
- Add an arch source scan that keeps the class-instance traversal owner from regressing to ad hoc raw walk sets.

## Structural Rule
When checker materializes class instance members through base classes, `tsc` terminates recursive heritage walks by the active class path, not by caller-local ad hoc state. `tsz` now names that through checker-owned `ClassInstanceWalkState`, preserving the existing symbol/node cycle behavior, depth limit, and final cleanup while keeping relation semantics solver-owned.

## Owner Layer
Checker: `types/class_type` owns class instance construction, heritage member materialization, and traversal termination. Solver relation behavior and class assignability policy are unchanged.

## Adjacent Matrix
- Same-file symbol cycles still return the existing `ERROR` bailout.
- Cross-file/node cycles still return the existing `ERROR`/`ANY` bailouts at the same points.
- Canonical base-symbol alias checks still compare both the resolved symbol and declaration symbol.
- Inheritance depth fuel still keys off the active node path length.
- Final class-instance registration still removes the active symbol/node from the traversal path and cleans the global resolution set only when this build inserted it.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test arch_source_scans class_instance`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts2506_cross_file_cycle_tests --test self_referencing_alias_member_inheritance_tests --test self_referential_class_ctor_window_tests --test class_shape_cache_stability_tests --test class_expression_heritage_ts2416_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib base_type_param_default_inheritance_tests cross_module_class_self_member_tests class_static_init_self_new_tests class_implements_generic_override_variance_tests generic_mixed_inheritance_chain_tests`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --lib --test arch_source_scans --test ts2506_cross_file_cycle_tests --test self_referencing_alias_member_inheritance_tests --test self_referential_class_ctor_window_tests --test class_shape_cache_stability_tests --test class_expression_heritage_ts2416_tests -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high