### PR TITLE
fix(solver): invalidate inheritance descendants (#14351)

### DIFF
--- a/crates/tsz-solver/src/classes/inheritance.rs
+++ b/crates/tsz-solver/src/classes/inheritance.rs
@@ -32,6 +32,38 @@ pub struct InheritanceGraph {
     max_symbol_id: Cell<usize>,
 }
 
+#[derive(Debug, Default)]
+struct DescendantInvalidationState {
+    queue: VecDeque<SymbolId>,
+    visited: FxHashSet<SymbolId>,
+}
+
+impl DescendantInvalidationState {
+    fn invalidate_from(&mut self, nodes: &mut FxHashMap<SymbolId, ClassNode>, root: SymbolId) {
+        self.queue.clear();
+        self.visited.clear();
+        self.queue.push_back(root);
+
+        while let Some(current) = self.queue.pop_front() {
+            if !self.visited.insert(current) {
+                continue;
+            }
+
+            let children = if let Some(node) = nodes.get_mut(&current) {
+                node.ancestors_bitset = None;
+                node.mro = None;
+                node.children.clone()
+            } else {
+                Vec::new()
+            };
+
+            for child in children {
+                self.queue.push_back(child);
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MroVisitState {
     Entered,
@@ -72,27 +104,36 @@ impl InheritanceGraph {
         }
         self.max_symbol_id.set(max_id);
 
-        // Register child
-        let child_node = nodes.entry(child).or_default();
+        let previous_parents = {
+            // Register child
+            let child_node = nodes.entry(child).or_default();
 
-        // Check if edges actually changed to avoid invalidating cache unnecessarily
-        if child_node.parents == parents {
-            return;
+            // Check if edges actually changed to avoid invalidating cache unnecessarily
+            if child_node.parents == parents {
+                return;
+            }
+
+            std::mem::replace(&mut child_node.parents, parents.to_vec())
+        };
+
+        for old_parent in previous_parents {
+            if parents.contains(&old_parent) {
+                continue;
+            }
+            if let Some(parent_node) = nodes.get_mut(&old_parent) {
+                parent_node.children.retain(|&candidate| candidate != child);
+            }
         }
 
-        child_node.parents = parents.to_vec();
-
-        // Invalidate caches
-        child_node.ancestors_bitset = None;
-        child_node.mro = None;
-
-        // Register reverse edges (for future invalidation logic)
+        // Register reverse edges for descendant cache invalidation.
         for &parent in parents {
             let parent_node = nodes.entry(parent).or_default();
             if !parent_node.children.contains(&child) {
                 parent_node.children.push(child);
             }
         }
+
+        DescendantInvalidationState::default().invalidate_from(&mut nodes, child);
     }
 
     /// Checks if `child` is a subtype of `ancestor` nominally.

--- a/crates/tsz-solver/tests/inheritance_tests.rs
+++ b/crates/tsz-solver/tests/inheritance_tests.rs
@@ -147,3 +147,85 @@ fn test_no_common_ancestor() {
     // No common ancestor
     assert_eq!(graph.find_common_ancestor(b, d), None);
 }
+
+#[test]
+fn descendant_closure_cache_invalidates_when_intermediate_parent_changes() {
+    let graph = InheritanceGraph::new();
+    let root = SymbolId(1);
+    let mid = SymbolId(2);
+    let leaf = SymbolId(3);
+
+    graph.add_inheritance(mid, &[root]);
+    graph.add_inheritance(leaf, &[mid]);
+
+    assert!(graph.is_derived_from(leaf, root));
+    assert!(graph.is_derived_from(leaf, mid));
+
+    graph.add_inheritance(mid, &[]);
+
+    assert!(!graph.is_derived_from(leaf, root));
+    assert!(graph.is_derived_from(leaf, mid));
+}
+
+#[test]
+fn descendant_mro_cache_invalidates_when_intermediate_parent_changes() {
+    let graph = InheritanceGraph::new();
+    let root = SymbolId(1);
+    let replacement_root = SymbolId(2);
+    let mid = SymbolId(3);
+    let leaf = SymbolId(4);
+
+    graph.add_inheritance(mid, &[root]);
+    graph.add_inheritance(leaf, &[mid]);
+
+    assert_eq!(graph.get_resolution_order(leaf), vec![leaf, mid, root]);
+
+    graph.add_inheritance(mid, &[replacement_root]);
+
+    assert_eq!(
+        graph.get_resolution_order(leaf),
+        vec![leaf, mid, replacement_root]
+    );
+}
+
+#[test]
+fn parent_rewrite_updates_reverse_children_edges() {
+    let graph = InheritanceGraph::new();
+    let old_root = SymbolId(1);
+    let new_root = SymbolId(2);
+    let child = SymbolId(3);
+
+    graph.add_inheritance(child, &[old_root]);
+    graph.add_inheritance(child, &[new_root]);
+
+    let nodes = graph.nodes.borrow();
+    assert!(
+        !nodes
+            .get(&old_root)
+            .is_some_and(|node| node.children.contains(&child))
+    );
+    assert!(
+        nodes
+            .get(&new_root)
+            .is_some_and(|node| node.children.contains(&child))
+    );
+}
+
+#[test]
+fn common_ancestor_recomputes_after_descendant_cache_invalidation() {
+    let graph = InheritanceGraph::new();
+    let root = SymbolId(1);
+    let sibling = SymbolId(2);
+    let mid = SymbolId(3);
+    let leaf = SymbolId(4);
+
+    graph.add_inheritance(sibling, &[root]);
+    graph.add_inheritance(mid, &[root]);
+    graph.add_inheritance(leaf, &[mid]);
+
+    assert_eq!(graph.find_common_ancestor(leaf, sibling), Some(root));
+
+    graph.add_inheritance(mid, &[]);
+
+    assert_eq!(graph.find_common_ancestor(leaf, sibling), None);
+}


### PR DESCRIPTION
Goal: green

## Summary
- Add `DescendantInvalidationState` to own inheritance-graph descendant cache invalidation.
- Invalidate ancestor-closure and MRO caches for the changed node and all transitive children after a heritage edge rewrite.
- Keep reverse `children` edges consistent when a parent list is replaced.
- Add stale-cache regression tests for descendant closure, MRO, reverse edges, and common-ancestor lookup.

## Structural Rule
When registered heritage edges change, `tsc` answers derivation from the current heritage graph. `tsz` now invalidates cached solver `InheritanceGraph` closure/MRO data for the edited node and every transitive child through a named descendant invalidation state, so nominal subtype, resolution-order, and common-ancestor queries observe the current graph instead of stale descendant caches.

## Owner Layer
Solver: `classes::inheritance::InheritanceGraph` owns nominal heritage edges, reverse child edges, transitive closure caching, MRO caching, and descendant invalidation. Checker/query-boundary callers continue to consume the graph through existing APIs.

## Adjacent Matrix
- Rewriting an intermediate parent removes stale root membership from descendant `is_derived_from` answers.
- Rewriting an intermediate parent recomputes descendant MRO with the replacement root.
- Removed parents no longer retain stale reverse `children` edges.
- `find_common_ancestor` recomputes from invalidated descendant closures after an edge rewrite.
- Existing simple, transitive, diamond, cycle, and subtype inheritance tests remain green.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib inheritance`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --lib -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
