### PR TITLE
fix(checker): register user-declared global Array/boxed types under --noLib (#15087)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1282,6 +1282,9 @@ mod new_expression_source_display_tests;
 #[path = "../tests/new_typeof_property_tests.rs"]
 mod new_typeof_property_tests;
 #[cfg(test)]
+#[path = "tests/nolib_user_global_array_member_tests.rs"]
+mod nolib_user_global_array_member_tests;
+#[cfg(test)]
 #[path = "tests/non_generic_spread_tuple_alias_display_tests.rs"]
 mod non_generic_spread_tuple_alias_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/nolib_user_global_array_member_tests.rs
+++ b/crates/tsz-checker/src/tests/nolib_user_global_array_member_tests.rs
@@ -1,0 +1,117 @@
+//! Member access through a user-declared global `Array<T>` interface under
+//! `--noLib`.
+//!
+//! When lib files are not loaded, the program supplies its own ambient global
+//! declarations (`interface Array<T> { ... }`). tsc treats that interface as the
+//! apparent type of every array-like value, so its members resolve everywhere a
+//! built-in `Array` member would — including on each constituent of a union of
+//! array-likes (`number[] | string[]`, `[number] | [string]`).
+//!
+//! tsz registered the boxed/`Array` base types only when lib was loaded, so
+//! under `--noLib` `get_array_base_type()` stayed unset. A bare receiver still
+//! resolved methods through a checker-level apparent-type rescue, but the
+//! solver's per-union-member path (`resolve_array_property`) had no base to
+//! synthesize `Array<T>` from and reported `PropertyNotFound` — collapsing the
+//! whole union to a false `TS2339` plus a cascading `TS7006` on the (now
+//! un-contextually-typed) callback parameter.
+//!
+//! The fix registers whichever of these globals the program declares even under
+//! `--noLib`, keyed on the fixed built-in name set rather than any user-chosen
+//! identifier. Binder names below are deliberately varied (the element type and
+//! the array-like spellings differ across cases) so the assertions check the
+//! structural rule, not a specific spelling. See issue #15087.
+
+use tsz_common::options::checker::CheckerOptions;
+
+/// Minimal global environment a `--noLib` program must supply for array-like
+/// values: a generic `Array<T>` with one method and one data property, plus the
+/// other ambient globals the binder expects to exist.
+const MINIMAL_GLOBALS: &str = r#"
+interface Array<T> { every(p: (v: T) => boolean): boolean; length: number; }
+interface Boolean {} interface Number {} interface String {} interface Object {}
+interface Function {} interface IArguments {} interface RegExp {}
+interface CallableFunction {} interface NewableFunction {}
+"#;
+
+fn nolib_diagnostics(body: &str) -> Vec<crate::diagnostics::Diagnostic> {
+    let opts = CheckerOptions {
+        strict: true,
+        no_implicit_any: true,
+        strict_null_checks: true,
+        no_lib: true,
+        ..CheckerOptions::default()
+    };
+    let source = format!("{MINIMAL_GLOBALS}{body}");
+    crate::test_utils::check_source(&source, "nolib_array.ts", opts)
+}
+
+fn codes(diags: &[crate::diagnostics::Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|d| d.code).collect()
+}
+
+#[test]
+fn array_method_resolves_on_bare_receiver() {
+    // Control: a bare array receiver already resolved its method.
+    let diags = nolib_diagnostics("declare const a: number[]; a.every(c => true);\n");
+    assert!(
+        diags.is_empty(),
+        "bare array receiver must resolve the global Array method, got {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn array_method_resolves_on_union_of_distinct_element_arrays() {
+    // The reported repro: a union of two arrays with distinct element types.
+    let diags = nolib_diagnostics("declare const a: number[] | string[]; a.every(c => true);\n");
+    assert!(
+        diags.is_empty(),
+        "union of array members must resolve the global Array method (no TS2339/TS7006), got {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn array_method_resolves_on_union_of_distinct_tuples() {
+    let diags = nolib_diagnostics("declare const t: [number] | [string]; t.every(c => true);\n");
+    assert!(
+        diags.is_empty(),
+        "union of tuple members must resolve the global Array method, got {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn array_method_resolves_on_mixed_array_tuple_union() {
+    let diags = nolib_diagnostics("declare const m: number[] | [number]; m.every(c => true);\n");
+    assert!(
+        diags.is_empty(),
+        "mixed array/tuple union must resolve the global Array method, got {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn genuinely_missing_method_on_union_still_reports_ts2339() {
+    // The fix must not over-silence: a method absent from the user's `Array`
+    // declaration is still a missing property on the union.
+    let diags = nolib_diagnostics("declare const a: number[] | string[]; a.nope();\n");
+    assert!(
+        codes(&diags).contains(&2339),
+        "a method absent from the user Array interface must still report TS2339, got {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn array_data_property_resolves_on_union() {
+    // `.length` already resolved (it is answered before the Array<T> base path);
+    // pin it so the fix keeps data-property resolution working on unions too.
+    let diags =
+        nolib_diagnostics("declare const a: number[] | string[]; const n: number = a.length;\n");
+    assert!(
+        diags.is_empty(),
+        "data property `.length` must resolve on the union, got {:?}",
+        codes(&diags)
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/global.rs
+++ b/crates/tsz-checker/src/types/type_checking/global.rs
@@ -105,8 +105,18 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn register_boxed_types(&mut self) {
         use crate::query_boundaries::common::IntrinsicKind;
 
-        // Only register if lib files are loaded
-        if !self.ctx.has_lib_loaded() {
+        // Register the boxed-primitive / `Array<T>` base types so property access
+        // (e.g. `arr.every(...)`, `"s".match(...)`) resolves through the actual
+        // interface declarations rather than hardcoded fallbacks.
+        //
+        // With lib files loaded these come from lib.d.ts. Under `--noLib` the
+        // program supplies its own ambient global declarations (`interface
+        // Array<T>`, `interface String`, ...) and tsc uses *those* as the
+        // apparent/base types — so the registration must still run when the user
+        // declares them. Skip only when neither lib is loaded nor any of these
+        // globals is user-declared, since then there is nothing to register and
+        // the per-file arena scan below would be wasted work.
+        if !self.ctx.has_lib_loaded() && !self.has_user_declared_registerable_global() {
             return;
         }
 
@@ -489,6 +499,24 @@ impl<'a> CheckerState<'a> {
                 env.set_array_base_type(ty, array_type_params_for_flow);
             }
         }
+    }
+
+    /// Whether the program declares its own global `Array<T>` / boxed-primitive
+    /// interface (`String`, `Number`, ...) as an ambient global. Under `--noLib`
+    /// these are the user's responsibility, and tsc treats them as the
+    /// apparent/base types for arrays and primitives; tsz must register them so
+    /// member access resolves uniformly (including through every union member,
+    /// not just a bare receiver). Built-in name resolution here keys off the
+    /// fixed set of types `register_boxed_types` knows how to register, not on
+    /// any user-chosen identifier.
+    fn has_user_declared_registerable_global(&self) -> bool {
+        const REGISTERABLE_GLOBAL_TYPES: &[&str] = &[
+            "Array", "String", "Number", "Boolean", "Symbol", "BigInt", "Object", "Function",
+        ];
+        REGISTERABLE_GLOBAL_TYPES.iter().any(|&name| {
+            self.ctx.binder.get_global_type(name).is_some()
+                || self.ctx.binder.program_global_type(name).is_some()
+        })
     }
 
     /// Prime boxed and Array base types before checking files.


### PR DESCRIPTION
Fixes #15087.

## Summary

Under `--noLib`, a program supplies its own ambient global declarations
(`interface Array<T> { ... }`, `interface String`, ...). `tsc` treats those as
the apparent/base types for arrays and primitives, so their members resolve
everywhere a built-in member would — including on every constituent of a union
of array-likes.

tsz registered the boxed-primitive / `Array<T>` base types only when lib files
were loaded (`register_boxed_types` early-returned on `!has_lib_loaded()`), so
under `--noLib` `get_array_base_type()` stayed unset. A **bare** array receiver
still resolved its methods through a checker-level apparent-type rescue, but the
solver's **per-union-member** path (`resolve_array_property`) had no base to
synthesize `Array<element>` from. It reported `PropertyNotFound`, collapsing the
whole union to a false `TS2339` plus a cascading `TS7006` on the now
un-contextually-typed callback parameter.

```ts
// --strict --noLib --target es2015, with a minimal global `interface Array<T>`
declare const x: number[] | string[];
x.length;            // OK (answered before the Array<T> base path)
x.every(c => true);  // tsz: TS2339 'every' does not exist + TS7006 on `c`  (tsc: clean)
```

## Structural rule

When the global `Array<T>` / boxed-primitive interface is user-declared (the
`--noLib` case), `tsc` uses it as the apparent type of array-like / primitive
values, and its members resolve uniformly — on a bare receiver and on each
member of a union alike. tsz must register whichever of these globals the
program declares even when no lib files are loaded, so the solver's
array-property path (used by the per-union-member resolver) can synthesize
`Array<element>` and find the member.

Owner layer: checker global setup (`register_boxed_types` in
`crates/tsz-checker/src/types/type_checking/global.rs`), which feeds the solver's
array base via `register_array_base_type`.

## Fix

`register_boxed_types` now skips registration only when **neither** lib is loaded
**nor** the program declares any registerable global. The registration body is
already fully `Option`-guarded, so it registers exactly the globals the user
declared and nothing else. With lib loaded, behavior is unchanged
(`!has_lib_loaded()` short-circuits the new condition). The built-in detection
keys off the fixed set of type names `register_boxed_types` knows how to register
(`Array`, `String`, `Number`, `Boolean`, `Symbol`, `BigInt`, `Object`,
`Function`) — not any user-chosen identifier — per the anti-hardcoding gate. The
detection consults both `get_global_type` and `program_global_type` so it is a
superset of the sources `resolve_lib_type_by_name` uses to find these globals and
never under-triggers (which would silently skip the registration).

## Adjacent-case matrix (all now match `tsc`)

- `number[] | string[]` `.every(...)` — distinct element-type arrays — clean
- `[number] | [string]` `.every(...)` — distinct tuples — clean
- `number[] | [number]` `.every(...)` — mixed array/tuple — clean
- bare `number[]` `.every(...)` — control, still clean
- `number[] | string[]` `.nope()` — genuinely-missing method — still `TS2339`
  (the fix does not over-silence)
- `number[] | string[]` `.length` — data property on union — clean

## Goal
Goal: hold

## Verification

- New regression module
  `crates/tsz-checker/src/tests/nolib_user_global_array_member_tests.rs`
  (6 tests) — all pass.
- No regressions: the `array` / `primitive` / `boxed` / `nolib` checker-lib
  filters show an identical failing set on this branch and on clean `origin/main`
  (`ce58a85`); every failure is a pre-existing `*_relation_routing_arch_tests` /
  `architecture_contract_tests` from the in-flight #14351 campaign or an
  already-red display/spread test, not introduced here. The `array` filter goes
  376→382 passing — exactly the 6 new tests.
- Manual `tsz --noEmit --strict --noLib --target es2015` on the issue repro and
  the adjacent matrix above: matches `tsc`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01EA3hnYrtArp9B13Sg7s8Gh)_