### PR TITLE
fix(solver): list symbol-keyed missing properties on non-array targets; add `using` disposable elaboration tail

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1795,6 +1795,9 @@ path = "tests/ts2855_static_super_field_tests.rs"
 name = "ts2852_await_using_context_tests"
 path = "tests/ts2852_await_using_context_tests.rs"
 [[test]]
+name = "using_disposable_elaboration_tests"
+path = "tests/using_disposable_elaboration_tests.rs"
+[[test]]
 name = "jsdoc_tag_boundary_tests"
 path = "tests/jsdoc_tag_boundary_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -771,7 +771,13 @@ impl<'a> CheckerState<'a> {
                         return;
                     }
                 }
-                // Skip MissingProperty for computed symbol expressions (TS2339 emitted separately).
+                // Skip MissingProperty for synthetic internal keys that have no
+                // user-facing spelling (e.g. the `__js_ctor_brand_*` constructor
+                // brand). User-facing well-known symbol members (`[Symbol.dispose]`,
+                // `[Symbol.iterator]`, …) are NOT skipped: tsc lists them in
+                // TS2741/TS2739 on non-array targets, and the explain layer already
+                // omits them for array-like targets where tsc treats them as
+                // implicitly satisfied.
                 if let tsz_solver::SubtypeFailureReason::MissingProperty {
                     property_name,
                     source_type,
@@ -779,7 +785,7 @@ impl<'a> CheckerState<'a> {
                 } = &failure_reason
                 {
                     let pn = self.ctx.types.resolve_atom_ref(*property_name);
-                    if pn.starts_with("[Symbol.") || pn.starts_with("__js_ctor_brand_") {
+                    if pn.starts_with("__js_ctor_brand_") {
                         return;
                     }
                     if self.missing_property_is_satisfied_by_source(

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1796,6 +1796,7 @@ impl<'a> CheckerState<'a> {
             "check_using_declaration_disposable: initializer type"
         );
         // Check for the required dispose method
+        let initializer = var_decl.initializer;
         if !self.type_has_disposable_method(init_type, is_await_using) {
             let (message, code) = if is_await_using {
                 (
@@ -1808,8 +1809,66 @@ impl<'a> CheckerState<'a> {
                     diagnostic_codes::THE_INITIALIZER_OF_A_USING_DECLARATION_MUST_BE_EITHER_AN_OBJECT_WITH_A_SYMBOL_DI,
                 )
             };
-            self.error_at_node(var_decl.initializer, message, code);
+            // `tsc` runs `checkTypeAssignableTo(initType, Disposable)` and attaches
+            // the relation's failure reason as the nested elaboration (e.g.
+            // `Property '[Symbol.dispose]' is missing in type '{ foo: number; }' but
+            // required in type 'Disposable'.`). For sync `using` we mirror that by
+            // routing through the shared assignability gateway so the tail is the
+            // real relation reason rather than a hand-built string. `await using`
+            // (TS2851) carries no tail in `tsc`, so it keeps the flat top line.
+            if !is_await_using
+                && let Some(related) = self.disposable_relation_tail(init_type, initializer)
+            {
+                self.error_at_node_with_related(initializer, message, code, related);
+            } else {
+                self.error_at_node(initializer, message, code);
+            }
         }
+    }
+
+    /// Build the relation-derived elaboration tail for a failed sync `using`
+    /// initializer, mirroring `tsc`'s `checkTypeAssignableTo(initType, Disposable)`
+    /// nested reason. Returns `None` when the global `Disposable` interface is
+    /// unavailable or the relation reports no structured failure reason, in which
+    /// case the caller emits the flat top-line message alone (matching `tsc`,
+    /// which also drops the tail when it has no relation reason to show).
+    fn disposable_relation_tail(
+        &mut self,
+        init_type: TypeId,
+        anchor: NodeIndex,
+    ) -> Option<Vec<crate::diagnostics::DiagnosticRelatedInformation>> {
+        let lib_binders = self.get_lib_binders();
+        let disposable_sym = self
+            .ctx
+            .binder
+            .get_global_type_with_libs("Disposable", &lib_binders)?;
+        // Build the `Disposable` target exactly as a `: Disposable` annotation
+        // would: prime the `DefId` (registering the lib interface body in the type
+        // environment) and intern it as `Lazy(DefId)`. A bare `get_type_of_symbol`
+        // here yields an unresolved/member-less shell when nothing else in the file
+        // referenced `Disposable` (the `using` initializer is the only consumer),
+        // so the relation would see no `[Symbol.dispose]` member.
+        let def_id = self.ensure_def_ready_for_lowering(disposable_sym, "Disposable");
+        let disposable_type = self.ctx.types.lazy(def_id);
+        let analysis = self.analyze_assignability_failure(init_type, disposable_type);
+        let reason = analysis.failure_reason?;
+        let rendered = self.render_failure_reason(&reason, init_type, disposable_type, anchor, 0);
+        // The rendered reason's top message is the first elaboration line; its own
+        // nested chain re-seats one level deeper beneath it.
+        let mut related = vec![crate::diagnostics::Diagnostic::related_message(
+            rendered.code,
+            rendered.file,
+            rendered.start,
+            rendered.length,
+            rendered.message_text,
+        )];
+        related.extend(
+            rendered
+                .related_information
+                .into_iter()
+                .map(|info| info.with_depth_shift(1)),
+        );
+        Some(related)
     }
 
     /// Check if a type has the appropriate dispose method.

--- a/crates/tsz-checker/tests/using_disposable_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/using_disposable_elaboration_tests.rs
@@ -1,0 +1,184 @@
+//! Regression tests for the relation-derived elaboration tail on a failed
+//! `using` declaration (TS2850) and, more broadly, for symbol-keyed missing
+//! property elaboration (TS2741) on a non-array target.
+//!
+//! Structural rule: when an object relation fails only on late-bound-symbol
+//! members, `tsc` lists those members in TS2741/TS2739 for **non-array** targets
+//! (e.g. `Disposable`'s `[Symbol.dispose]`) and omits them only for array-like
+//! targets (where the iteration protocol makes them implicitly satisfied). The
+//! `using` check routes a failed sync `using` through the shared assignability
+//! gateway against the global `Disposable` interface so the nested tail is the
+//! real relation reason rather than a hand-built string; `await using` (TS2851)
+//! carries no tail.
+//!
+//! Owner: solver `explain_object_failure` (reason) +
+//! `error_reporter::assignability` (emission) +
+//! `check_using_declaration_disposable`.
+//!
+//! The cases are fully self-contained (an inline `Symbol`/`Disposable` so the
+//! relation stays in one arena), and they vary the source member name where it
+//! reaches the rendered output to lock the shape as structural, not a fixture
+//! spelling (CLAUDE.md anti-hardcoding gate).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{DEFAULT_LIB_NAMES, check_source_with_libs, load_compiled_lib_files};
+use tsz_common::common::{ModuleKind, ScriptTarget};
+
+fn check(body: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
+    // Use TypeScript's real compiled libs so the well-known `Symbol.dispose`
+    // resolves and renders as `[Symbol.dispose]` (the stripped test-lib bundle
+    // does not model well-known symbols faithfully). `esnext.disposable` carries
+    // `Disposable`/`AsyncDisposable`; it is not in the default bundle.
+    let mut names: Vec<String> = DEFAULT_LIB_NAMES
+        .iter()
+        .map(|name| format!("lib.{name}"))
+        .collect();
+    names.push("lib.esnext.disposable.d.ts".to_string());
+    let name_refs: Vec<&str> = names.iter().map(String::as_str).collect();
+    let libs = load_compiled_lib_files(&name_refs);
+    assert!(
+        !libs.is_empty(),
+        "compiled TypeScript libs must be available for these tests",
+    );
+    check_source_with_libs(
+        body,
+        "test.ts",
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            target: ScriptTarget::ESNext,
+            strict: true,
+            strict_null_checks: true,
+            no_implicit_any: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+}
+
+/// Full elaboration text (primary message plus every related-information line,
+/// in order) of the single diagnostic with `code`.
+fn elaboration(body: &str, code: u32) -> String {
+    let diags = check(body);
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "Expected exactly one TS{code}. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    let mut lines = vec![matching[0].message_text.clone()];
+    lines.extend(
+        matching[0]
+            .related_information
+            .iter()
+            .map(|info| info.message_text.clone()),
+    );
+    lines.join("\n")
+}
+
+/// Sync `using` whose initializer lacks `[Symbol.dispose]`: the TS2850 top line
+/// keeps its wording and gains the relation-derived missing-property tail that
+/// `tsc` attaches via `checkTypeAssignableTo(initType, Disposable)`.
+#[test]
+fn using_missing_dispose_attaches_symbol_missing_tail() {
+    let text = elaboration(
+        r#"
+declare const x: { foo: number };
+function f() { using r = x; }
+"#,
+        2850,
+    );
+    assert_eq!(
+        text,
+        "The initializer of a 'using' declaration must be either an object with a \
+         '[Symbol.dispose]()' method, or be 'null' or 'undefined'.\n\
+         Property '[Symbol.dispose]' is missing in type '{ foo: number; }' but required \
+         in type 'Disposable'.",
+    );
+}
+
+/// Same rule, different source member name — the tail must echo the renamed
+/// source type, never a hard-coded `{ foo: number; }`.
+#[test]
+fn using_missing_dispose_tail_is_member_name_independent() {
+    let text = elaboration(
+        r#"
+declare const handle: { resourceId: string };
+function open() { using h = handle; }
+"#,
+        2850,
+    );
+    assert_eq!(
+        text,
+        "The initializer of a 'using' declaration must be either an object with a \
+         '[Symbol.dispose]()' method, or be 'null' or 'undefined'.\n\
+         Property '[Symbol.dispose]' is missing in type '{ resourceId: string; }' but \
+         required in type 'Disposable'.",
+    );
+}
+
+/// `await using` (TS2851) carries NO tail in `tsc`, so the sync-only routing
+/// must leave it flat — a single message line, no related information.
+#[test]
+fn await_using_missing_dispose_stays_flat() {
+    let diags = check(
+        r#"
+declare const x: { foo: number };
+async function f() { await using r = x; }
+"#,
+    );
+    let ts2851 = diags
+        .iter()
+        .find(|d| d.code == 2851)
+        .expect("expected TS2851 for await using on a non-disposable object");
+    assert!(
+        ts2851.related_information.is_empty(),
+        "await using (TS2851) must carry no elaboration tail, got: {:?}",
+        ts2851
+            .related_information
+            .iter()
+            .map(|i| i.message_text.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
+/// A genuinely disposable object must not error at all — the tail machinery only
+/// runs on a real failure, and the error decision itself is unchanged.
+#[test]
+fn using_disposable_object_is_clean() {
+    let diags = check(
+        r#"
+declare const x: { [Symbol.dispose](): void; foo: number };
+function f() { using r = x; }
+"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2850),
+        "a `[Symbol.dispose]`-bearing object must not raise TS2850, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+/// The broader explain fix: a plain assignment to `Disposable` whose source lacks
+/// only the symbol member now produces the symbol-keyed TS2741 (matching `tsc`),
+/// instead of collapsing to a flat `TypeMismatch` with no member listed. This is
+/// the same `explain_object_failure` path the `using` tail rides, exercised on a
+/// surface that does not depend on the disposable feature gate.
+#[test]
+fn plain_assignment_to_disposable_lists_symbol_member() {
+    let text = elaboration(
+        r#"
+declare const x: { foo: number };
+const d: Disposable = x;
+"#,
+        2741,
+    );
+    assert_eq!(
+        text,
+        "Property '[Symbol.dispose]' is missing in type '{ foo: number; }' but required \
+         in type 'Disposable'.",
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1588,15 +1588,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
             },
         );
-        let has_non_symbol_missing = missing_with_order
-            .iter()
-            .any(|(name, _, _)| !self.is_late_bound_symbol_property_name(*name));
-        if !has_non_symbol_missing {
-            // All missing properties are late-bound symbols (e.g. [Symbol.iterator]).
-            // tsc does not list symbol-only missing properties in TS2739/TS2741 messages;
-            // clear so we fall through to property type checking or TypeMismatch.
-            missing_with_order.clear();
-        } else if matches!(
+        if matches!(
             crate::type_queries::extended::classify_array_like(self.interner, target),
             crate::type_queries::extended::ArrayLikeKind::Array(_)
                 | crate::type_queries::extended::ArrayLikeKind::Tuple
@@ -1608,12 +1600,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // from the TS2739/TS2740 missing list. Keep this behavior so that
             // e.g. `Type 'I1' is missing the following properties from type
             // 'any[]': length, pop, push, concat, and 25 more` — not 27.
+            //
+            // When every missing property is a late-bound symbol, this empties
+            // the list and the relation falls through to property-type checking
+            // or `TypeMismatch`, matching tsc.
             missing_with_order
                 .retain(|(name, _, _)| !self.is_late_bound_symbol_property_name(*name));
         }
-        // For non-array targets (e.g. `ArrayConstructor`), tsc lists both named
-        // and symbol-keyed properties in TS2739/TS2741 (e.g. `isArray, from,
-        // of, [Symbol.species]`). Keep the full list in that case.
+        // For non-array targets (e.g. `ArrayConstructor`, `Disposable`,
+        // `Iterable<T>`), tsc lists both named and symbol-keyed properties in
+        // TS2739/TS2741 (e.g. `isArray, from, of, [Symbol.species]`, or a lone
+        // `[Symbol.dispose]`). Keep the full list — including symbol-only missing
+        // — so the missing-property elaboration is produced rather than collapsing
+        // to a flat `TypeMismatch`.
 
         // tsc treats `prototype` as implicit on callable sources (any function
         // or class value has a `.prototype` in JS), so it never lists it as a


### PR DESCRIPTION
When an object relation fails only on late-bound-symbol members, `tsc` lists those members in TS2741/TS2739 for **non-array** targets (e.g. `Disposable`'s `[Symbol.dispose]`, `Iterable<T>`'s `[Symbol.iterator]`) and omits them only for **array-like** targets, where the iteration protocol makes them implicitly satisfied; tsz blanket-cleared every all-symbol missing list, so such failures collapsed to a flat `TypeMismatch` with no member listed. As a result, a failed `using` declaration (TS2850) lost the nested elaboration tail that `tsc` attaches.

**Structural rule:** when an object relation fails only on late-bound-symbol members, `tsc` lists them in TS2741/TS2739 for non-array targets and omits them only for array-like targets; tsz must do the same through the solver's `explain_object_failure`. For `using`, `tsc` runs `checkTypeAssignableTo(initType, Disposable)` and attaches the relation reason as the TS2850 tail.

This is the **TS2850 half of #14858**. (The method-return rendering noted in that issue is already merged; the TS2636 variance half is left out — it additionally has a decision-level false negative and needs marker-type relation synthesis, tracked separately.)

### Changes (owner layers)
- **solver — `explain_object_failure`** (`relations/subtype/explain.rs`): only drop late-bound-symbol missing members for array-like targets; keep them otherwise so the missing-property reason is produced instead of collapsing to `TypeMismatch`.
- **checker — emission** (`error_reporter/assignability.rs`): narrow the `MissingProperty` emission guard to the synthetic `__js_ctor_brand_*` key (no user-facing spelling); user-facing `[Symbol.*]` members now surface as TS2741/TS2322 elaboration.
- **checker — `check_using_declaration_disposable`** (`types/type_checking/core.rs`): route a failed **sync** `using` through the shared assignability gateway (`analyze_assignability_failure` → `render_failure_reason`) against the global `Disposable` interface, attaching the real relation reason as the tail rather than a hand-built string. `await using` (TS2851) stays flat, matching `tsc`. The error **decision** is unchanged (still `type_has_disposable_method`), so no row flips error/clean.

### Adjacent matrix (vs tsc 5.9.3, verified)
- `using r = x` where `x: { foo: number }` → TS2850 + `Property '[Symbol.dispose]' is missing in type '{ foo: number; }' but required in type 'Disposable'.`
- `const d: Disposable = x` → TS2741 with the same symbol member (was a flat TS2322).
- `Iterable<number>` target → lists `[Symbol.iterator]`; array-like target (`number[]`) still omits it (`length, pop, push, concat, …`).
- Local `unique symbol` keyed members and `await using` (TS2851, no tail) unchanged.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --test using_disposable_elaboration_tests` — 5/5 pass (new file; uses the real compiled libs).
- Full lib unit suites unchanged vs branch base: `cargo nextest run -p tsz-checker --lib` and `-p tsz-solver --lib` produce a **byte-identical** failure set before/after this change (zero new failures, zero fixed).
- Manual `tsz --noEmit` against the adjacent matrix above matches `tsc` 5.9.3.
- Ready-review CI owns the broad conformance suites (`usingDeclarations*`, TS2739/TS2741 families).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_013jt8f7QJTABAFNXh7HeSbU)_