### PR TITLE
fix(checker): resolve module-augmentation new-export value types cross-arena (#14853)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -716,6 +716,9 @@ path = "tests/module_augmentation_isolation_tests.rs"
 name = "ambient_module_renamed_export_ts2460_tests"
 path = "tests/ambient_module_renamed_export_ts2460_tests.rs"
 [[test]]
+name = "ambient_module_augmentation_new_export_tests"
+path = "tests/ambient_module_augmentation_new_export_tests.rs"
+[[test]]
 name = "ambient_module_value_export_tests"
 path = "tests/ambient_module_value_export_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -791,16 +791,14 @@ impl<'a> CheckerState<'a> {
             // e.g., declare module 'express' { interface Request { user?: User; } }
             if let Some(augmentations) = self.ctx.binder.module_augmentations.get(module_name) {
                 for aug in augmentations {
-                    // Get the type of the augmentation declaration
-                    let aug_type = if aug
-                        .arena
-                        .as_ref()
-                        .is_some_and(|arena| std::ptr::eq(arena.as_ref(), self.ctx.arena))
-                    {
-                        self.get_type_of_node(aug.node)
-                    } else {
-                        tsz_solver::TypeId::ANY
-                    };
+                    // Resolve the augmentation declaration's type against its own
+                    // arena/binder (#14853). A cross-file augmentation that adds a
+                    // new export otherwise collapsed to `any` here, dropping every
+                    // assignability error against the dynamically-imported member.
+                    let aug_arena = aug.arena.as_deref().unwrap_or(self.ctx.arena);
+                    let aug_type = self
+                        .augmentation_export_declaration_type(aug.node, aug_arena)
+                        .unwrap_or(tsz_solver::TypeId::ANY);
                     let name_atom = self.ctx.types.intern_string(&aug.name);
 
                     // Check if this augments an existing export

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -1784,7 +1784,17 @@ impl<'a> CheckerState<'a> {
                 }
 
                 // Module augmentations can introduce named exports that don't appear
-                // in the base module export table. Treat those names as resolvable.
+                // in the base module export table. Resolve the augmentation export's
+                // declared value type against its own arena/binder (#14853). A new
+                // `const`/`function`/`class`/`enum` export added by an augmentation
+                // (including a cross-file one) otherwise collapsed to `any`, dropping
+                // every assignability error against it. Type-only augmentation exports
+                // (interface/type alias) keep the `any` + member-merge fallback below.
+                if let Some(aug_value_type) =
+                    self.module_augmentation_value_type(module_name, export_name)
+                {
+                    return (aug_value_type, Vec::new());
+                }
                 if self
                     .ctx
                     .binder

--- a/crates/tsz-checker/src/types/mod.rs
+++ b/crates/tsz-checker/src/types/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod function_type_helpers;
 pub(crate) mod function_type_signature_display;
 pub mod interface_type;
 pub mod module_augmentation;
+pub(crate) mod module_augmentation_value;
 pub mod object_type;
 mod property_access_augmentation;
 pub(crate) mod property_access_helpers;

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -483,28 +483,25 @@ impl<'a> CheckerState<'a> {
         use tsz_parser::parser::syntax_kind_ext;
 
         for augmentation in self.get_module_augmentation_declarations(module_spec, name) {
-            let arena = augmentation.arena.as_deref().unwrap_or(self.ctx.arena);
-            let Some(node) = arena.get(augmentation.node) else {
+            let arena_ref = augmentation.arena.as_deref().unwrap_or(self.ctx.arena);
+            let Some(node) = arena_ref.get(augmentation.node) else {
                 continue;
             };
 
             match node.kind {
-                syntax_kind_ext::VARIABLE_DECLARATION => {
-                    let Some(decl) = arena.get_variable_declaration(node) else {
-                        continue;
-                    };
-                    if decl.type_annotation.is_some() && std::ptr::eq(arena, self.ctx.arena) {
-                        let type_id = self.get_type_of_node(decl.type_annotation);
-                        if type_id != TypeId::ERROR && type_id != TypeId::UNKNOWN {
-                            return Some(type_id);
-                        }
-                    }
-                    return Some(TypeId::ANY);
-                }
-                syntax_kind_ext::FUNCTION_DECLARATION
+                syntax_kind_ext::VARIABLE_DECLARATION
+                | syntax_kind_ext::FUNCTION_DECLARATION
                 | syntax_kind_ext::CLASS_DECLARATION
                 | syntax_kind_ext::ENUM_DECLARATION => {
-                    return Some(TypeId::ANY);
+                    // Resolve the declared type against the augmentation's own
+                    // arena/binder (#14853). The declaration may live in a
+                    // foreign arena (the augmenting file) while we are checking
+                    // the consumer, so a plain `get_type_of_node` against the
+                    // current arena would misread the node — delegate instead.
+                    return Some(
+                        self.augmentation_export_declaration_type(augmentation.node, arena_ref)
+                            .unwrap_or(TypeId::ANY),
+                    );
                 }
                 _ => {}
             }

--- a/crates/tsz-checker/src/types/module_augmentation_value.rs
+++ b/crates/tsz-checker/src/types/module_augmentation_value.rs
@@ -1,0 +1,137 @@
+//! Cross-arena resolution of the value type contributed by a module
+//! augmentation's NEW exports (#14853).
+//!
+//! When `declare module "x" { export const c: T }` (or `function`/`class`/
+//! `enum`) augments an ambient module declared in another file and *adds a new
+//! export* (rather than merging into an existing one), the augmentation
+//! declaration node lives in a foreign arena relative to the file currently
+//! being checked. The merge previously typed such a new export `any`, dropping
+//! every assignability error against it. This routes the declaration through a
+//! delegate child checker over the owning arena/binder so the real declared
+//! type is recovered, mirroring
+//! `delegate_cross_arena_interface_member_simple_types`.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Resolve the declared value type of an augmentation export declaration
+    /// `node`, honoring the `arena` that owns it.
+    ///
+    /// Returns `None` when no concrete type can be recovered (the caller is
+    /// responsible for the `any` fallback). For a same-arena declaration this
+    /// resolves directly; for a foreign-arena declaration it constructs a
+    /// transient delegate child checker over the owning arena/binder so type
+    /// references in the declaration resolve against the correct symbol table.
+    pub(crate) fn augmentation_export_declaration_type(
+        &mut self,
+        node: NodeIndex,
+        arena: &tsz_parser::parser::NodeArena,
+    ) -> Option<TypeId> {
+        if std::ptr::eq(arena, self.ctx.arena) {
+            return self.augmentation_node_value_type_local(node);
+        }
+
+        // O(1) via global_arena_index; falls back to None when the arena is not
+        // part of the program overlay (e.g. lib arenas), in which case the
+        // current binder is the best available interpreter.
+        let delegate_file_idx = self.ctx.get_file_idx_for_arena(arena);
+        let delegate_binder_arc = delegate_file_idx
+            .and_then(|file_idx| self.ctx.all_binders.as_ref()?.get(file_idx).cloned());
+        let delegate_binder = delegate_binder_arc.as_deref()?;
+
+        if !Self::enter_cross_arena_delegation() {
+            return None;
+        }
+        if !self.ctx.enter_recursion() {
+            Self::leave_cross_arena_delegation();
+            return None;
+        }
+
+        let delegate_file_name = arena
+            .source_files
+            .first()
+            .map(|sf| sf.file_name.clone())
+            .unwrap_or_else(|| self.ctx.file_name.clone());
+
+        tsz_common::perf_counters::record_delegate_cross_arena_miss();
+        let _delegate_depth_guard = tsz_common::perf_counters::enter_delegate();
+
+        let mut checker = Box::new(CheckerState::with_parent_cache_attributed(
+            arena,
+            delegate_binder,
+            self.ctx.types,
+            delegate_file_name,
+            self.ctx.compiler_options.clone(),
+            self,
+            tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaOther,
+        ));
+        // Transient delegation child: diagnostics are discarded at teardown.
+        checker.ctx.diagnostics_discarded = true;
+        checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
+        checker.ctx.copy_cross_file_state_from(&self.ctx);
+        self.ctx.copy_symbol_file_targets_to_attributed(
+            &mut checker.ctx,
+            tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaOther,
+        );
+        checker.ctx.current_file_idx = delegate_file_idx.unwrap_or(self.ctx.current_file_idx);
+
+        let result = checker.augmentation_node_value_type_local(node);
+
+        self.ctx.leave_recursion();
+        Self::leave_cross_arena_delegation();
+
+        result
+    }
+
+    /// Resolve the value type of an augmentation export declaration `node`
+    /// interpreted in the *current* checker's arena/binder.
+    ///
+    /// Prefers a variable declaration's explicit type annotation (matching the
+    /// established same-file path), then falls back to the declared symbol's
+    /// type, which uniformly covers `function`/`class`/`enum` declarations as
+    /// the value they introduce.
+    fn augmentation_node_value_type_local(&mut self, node: NodeIndex) -> Option<TypeId> {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        // A type only "resolved" enough to use as the export's type when it is
+        // neither the error nor the unevaluated sentinel.
+        let concrete = |type_id: TypeId| {
+            (type_id != TypeId::ERROR && type_id != TypeId::UNKNOWN).then_some(type_id)
+        };
+
+        let arena = self.ctx.arena;
+        // For a variable declaration prefer the explicit type annotation, matching
+        // the established same-file path (`get_type_of_node` on the declaration node
+        // would resolve through its initializer / declared type indirectly).
+        let annotation = arena
+            .get(node)
+            .filter(|decl_node| decl_node.kind == syntax_kind_ext::VARIABLE_DECLARATION)
+            .and_then(|decl_node| arena.get_variable_declaration(decl_node))
+            .map(|decl| decl.type_annotation)
+            .filter(|type_annotation| type_annotation.is_some());
+
+        if let Some(type_annotation) = annotation
+            && let Some(type_id) = concrete(self.get_type_of_node(type_annotation))
+        {
+            return Some(type_id);
+        }
+
+        // Resolve through the declared symbol: this yields the value the
+        // declaration introduces — a class's constructor type (`typeof C`), an
+        // enum's enum object type, an annotation-less variable's declared type —
+        // which `get_type_of_node` on the raw declaration node does not (it would
+        // produce the class instance type or `void` for an enum).
+        if let Some(sym_id) = self.ctx.binder.get_node_symbol(node)
+            && let Some(type_id) = concrete(self.get_type_of_symbol(sym_id))
+        {
+            return Some(type_id);
+        }
+
+        // Function declarations are keyed on their name node rather than the
+        // declaration node, so `get_node_symbol` misses them; the declaration
+        // node's own type is the function type in that case.
+        concrete(self.get_type_of_node(node))
+    }
+}

--- a/crates/tsz-checker/src/types/module_augmentation_value.rs
+++ b/crates/tsz-checker/src/types/module_augmentation_value.rs
@@ -58,23 +58,19 @@ impl<'a> CheckerState<'a> {
         tsz_common::perf_counters::record_delegate_cross_arena_miss();
         let _delegate_depth_guard = tsz_common::perf_counters::enter_delegate();
 
-        let mut checker = Box::new(CheckerState::with_parent_cache_attributed(
+        let mut checker = Box::new(CheckerState::with_parent_cache(
             arena,
             delegate_binder,
             self.ctx.types,
             delegate_file_name,
             self.ctx.compiler_options.clone(),
             self,
-            tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaOther,
         ));
         // Transient delegation child: diagnostics are discarded at teardown.
         checker.ctx.diagnostics_discarded = true;
         checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
         checker.ctx.copy_cross_file_state_from(&self.ctx);
-        self.ctx.copy_symbol_file_targets_to_attributed(
-            &mut checker.ctx,
-            tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaOther,
-        );
+        self.ctx.copy_symbol_file_targets_to(&mut checker.ctx);
         checker.ctx.current_file_idx = delegate_file_idx.unwrap_or(self.ctx.current_file_idx);
 
         let result = checker.augmentation_node_value_type_local(node);

--- a/crates/tsz-checker/src/types/module_augmentation_value.rs
+++ b/crates/tsz-checker/src/types/module_augmentation_value.rs
@@ -52,8 +52,7 @@ impl<'a> CheckerState<'a> {
         let delegate_file_name = arena
             .source_files
             .first()
-            .map(|sf| sf.file_name.clone())
-            .unwrap_or_else(|| self.ctx.file_name.clone());
+            .map_or_else(|| self.ctx.file_name.clone(), |sf| sf.file_name.clone());
 
         tsz_common::perf_counters::record_delegate_cross_arena_miss();
         let _delegate_depth_guard = tsz_common::perf_counters::enter_delegate();
@@ -106,7 +105,7 @@ impl<'a> CheckerState<'a> {
             .filter(|decl_node| decl_node.kind == syntax_kind_ext::VARIABLE_DECLARATION)
             .and_then(|decl_node| arena.get_variable_declaration(decl_node))
             .map(|decl| decl.type_annotation)
-            .filter(|type_annotation| type_annotation.is_some());
+            .filter(NodeIndex::is_some);
 
         if let Some(type_annotation) = annotation
             && let Some(type_id) = concrete(self.get_type_of_node(type_annotation))

--- a/crates/tsz-checker/tests/ambient_module_augmentation_new_export_tests.rs
+++ b/crates/tsz-checker/tests/ambient_module_augmentation_new_export_tests.rs
@@ -1,0 +1,225 @@
+//! Regression coverage for #14853: a module augmentation that adds a NEW export
+//! to an ambient `declare module "x"` (declared in a .d.ts) must type that new
+//! export from its declaration, not collapse it to `any`.
+//!
+//! Structural rule: when an augmentation in file B adds an exported value symbol
+//! (`const`/`function`/`class`/`enum`) to an ambient module declared in file A,
+//! importing that symbol in file C must resolve its declared type even though the
+//! augmentation declaration lives in a foreign arena relative to the file being
+//! checked. Previously the cross-arena merge bailed to `TypeId::ANY`, silently
+//! dropping every assignability error against the new export.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file;
+
+fn diagnostics(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn has_code(diags: &[(u32, String)], expected: u32) -> bool {
+    diags.iter().any(|(code, _)| *code == expected)
+}
+
+const BASE: &str = r#"declare module "lib" { export const original: number; }"#;
+
+#[test]
+fn augmentation_added_const_keeps_declared_type() {
+    let diags = diagnostics(
+        &[
+            ("base.d.ts", BASE),
+            (
+                "aug.ts",
+                "declare module \"lib\" { export const addedConst: string; }\nexport {};\n",
+            ),
+            (
+                "main.ts",
+                "import { addedConst } from \"lib\";\nconst c: { z: 1 } = addedConst;\n",
+            ),
+        ],
+        "main.ts",
+    );
+    assert!(
+        has_code(&diags, 2322),
+        "expected TS2322 for string-typed augmentation const; got {diags:#?}"
+    );
+}
+
+#[test]
+fn augmentation_added_function_keeps_declared_type() {
+    let diags = diagnostics(
+        &[
+            ("base.d.ts", BASE),
+            (
+                "aug.ts",
+                "declare module \"lib\" { export function addedFn(): boolean; }\nexport {};\n",
+            ),
+            (
+                "main.ts",
+                "import { addedFn } from \"lib\";\nconst c: string = addedFn();\n",
+            ),
+        ],
+        "main.ts",
+    );
+    assert!(
+        has_code(&diags, 2322),
+        "expected TS2322 for boolean return of augmentation function; got {diags:#?}"
+    );
+}
+
+#[test]
+fn augmentation_added_class_resolves_constructor_type() {
+    // Same-file augmentation: the fix resolves the class through its declared
+    // symbol, yielding the constructor type so `new C()` is constructable and the
+    // instance member keeps its declared type. (The cross-file class-constructor
+    // case is verified end-to-end via the CLI; the entry-only unit harness lacks
+    // the global symbol index needed to resolve a foreign class constructor.)
+    let diags = diagnostics(
+        &[
+            ("base.d.ts", BASE),
+            (
+                "main.ts",
+                "declare module \"lib\" { export class AddedCls { x: number; } }\nimport { AddedCls } from \"lib\";\nconst inst = new AddedCls();\nconst c: string = inst.x;\n",
+            ),
+        ],
+        "main.ts",
+    );
+    // Constructable (no TS2351) and the instance member keeps its declared type.
+    assert!(
+        !has_code(&diags, 2351),
+        "augmentation class must be constructable; got {diags:#?}"
+    );
+    assert!(
+        has_code(&diags, 2322),
+        "expected TS2322 for number instance member assigned to string; got {diags:#?}"
+    );
+}
+
+#[test]
+fn augmentation_added_enum_resolves_object_type() {
+    let diags = diagnostics(
+        &[
+            ("base.d.ts", BASE),
+            (
+                "aug.ts",
+                "declare module \"lib\" { export enum AddedEnum { A, B } }\nexport {};\n",
+            ),
+            (
+                "main.ts",
+                "import { AddedEnum } from \"lib\";\nconst c: string = AddedEnum;\n",
+            ),
+        ],
+        "main.ts",
+    );
+    assert!(
+        has_code(&diags, 2322),
+        "expected TS2322 assigning enum object to string; got {diags:#?}"
+    );
+}
+
+#[test]
+fn augmentation_added_const_clean_assignment_is_not_flagged() {
+    // The declared type must be preserved precisely: a correct assignment must
+    // not spuriously error (guards against over-widening to error/never).
+    let diags = diagnostics(
+        &[
+            ("base.d.ts", BASE),
+            (
+                "aug.ts",
+                "declare module \"lib\" { export const addedConst: string; }\nexport {};\n",
+            ),
+            (
+                "main.ts",
+                "import { addedConst } from \"lib\";\nconst ok: string = addedConst;\n",
+            ),
+        ],
+        "main.ts",
+    );
+    assert!(
+        !has_code(&diags, 2322),
+        "correct string-to-string assignment should be clean; got {diags:#?}"
+    );
+}
+
+#[test]
+fn augmentation_added_export_is_not_name_specific() {
+    // Anti-hardcoding: the fix must be structural, not keyed on a fixture name.
+    let diags = diagnostics(
+        &[
+            (
+                "base.d.ts",
+                r#"declare module "widgets" { export const seed: number; }"#,
+            ),
+            (
+                "extra.ts",
+                "declare module \"widgets\" { export const quux: string; }\nexport {};\n",
+            ),
+            (
+                "use.ts",
+                "import { quux } from \"widgets\";\nconst c: { nope: 1 } = quux;\n",
+            ),
+        ],
+        "use.ts",
+    );
+    assert!(
+        has_code(&diags, 2322),
+        "expected TS2322 regardless of binder/module names; got {diags:#?}"
+    );
+}
+
+#[test]
+fn augmentation_added_const_same_file_keeps_declared_type() {
+    // Same-arena augmentation (augmentation + usage in one file) must also keep
+    // the declared type rather than collapse to `any`.
+    let diags = diagnostics(
+        &[
+            ("base.d.ts", BASE),
+            (
+                "main.ts",
+                "declare module \"lib\" { export const localAdded: string; }\nimport { localAdded } from \"lib\";\nconst c: { z: 1 } = localAdded;\n",
+            ),
+        ],
+        "main.ts",
+    );
+    assert!(
+        has_code(&diags, 2322),
+        "expected TS2322 for same-file augmentation const; got {diags:#?}"
+    );
+}
+
+#[test]
+fn augmentation_merging_existing_interface_member_still_works() {
+    // Regression guard: augmenting an EXISTING exported interface with a new
+    // member must keep working (this never went through the new-export path).
+    let diags = diagnostics(
+        &[
+            (
+                "base.d.ts",
+                r#"declare module "lib" { export interface Opts { a: number; } }"#,
+            ),
+            (
+                "aug.ts",
+                "declare module \"lib\" { interface Opts { b: string; } }\nexport {};\n",
+            ),
+            (
+                "main.ts",
+                "import { Opts } from \"lib\";\nconst o: Opts = { a: 1, b: 2 };\n",
+            ),
+        ],
+        "main.ts",
+    );
+    // `b` is `string`, assigning `2` must error; merge must not regress to clean.
+    assert!(
+        has_code(&diags, 2322) || has_code(&diags, 2353) || has_code(&diags, 2739),
+        "expected a member-type error from merged interface augmentation; got {diags:#?}"
+    );
+}


### PR DESCRIPTION
Fixes #14853.

When a file augments an ambient `declare module "x"` (declared in a `.d.ts`) and the augmentation *adds a new exported value* (`const`/`function`/`class`/`enum`) rather than merging into an existing one, tsz typed that new export `any`, dropping every assignability error against it. The augmentation declaration lives in the augmenting file, but the module's member type is resolved while checking the consumer file, so the arenas differ — and the cross-arena merge bailed to `TypeId::ANY`.

**Structural rule:** when a module augmentation introduces a new exported symbol, `tsc` types it from its declaration; tsz must resolve that declaration's type against its *owning* arena/binder instead of bailing to `any`. Owner layer: checker module-augmentation resolution (`tsz_checker::types::module_augmentation`), routed through the existing cross-arena delegate-child-checker mechanism (the same one used for cross-arena interface members).

A shared `augmentation_export_declaration_type` helper resolves the declaration's value type against its owning arena (same-arena fast path; foreign-arena via a transient delegate child checker). It prefers a variable's type annotation, then the declared symbol's type (class constructor `typeof C` / enum object), then the declaration node's own type (functions are keyed on their name node, so `get_node_symbol` misses them). Both the named-import path (`module_augmentation_value_type`) and the dynamic-import path (`get_dynamic_import_type`, the site cited in the issue) route through it.

Adjacent matrix (all verified against `tsc` 5.9.3 via the CLI):
- new `const` export → TS2322 (named + `await import()`); a *correct* assignment stays clean (no over-widening)
- new `function` export → TS2322 on the return type
- new `class` export → constructable (`new C()`), instance member keeps its declared type → TS2322
- new `enum` export → resolves to the enum object type → TS2322
- binder/module names varied to prove the fix is structural, not fixture-keyed
- existing-interface member merge unchanged (regression guard)

Known remaining facets (separate resolution subsystems, not this fix): `import * as ns` member access on an ambient module still types augmentation members `any` via the registered-export-symbol path, and an augmentation-added `interface` used as a *type* resolves through type-reference resolution. Tracked as follow-ups on #14853.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ambient_module_augmentation_new_export_tests` (new; 8 cases: const/function/class/enum/clean/name-independence/same-file/interface-merge regression)
- `cargo clippy -p tsz-checker --tests` — clean (0 warnings)
- Regression: ran the module-augmentation / ambient-module / namespace-import test targets (`ambient_module_value_export_tests`, `export_star_module_augmentation_tests`, `wildcard_ambient_module_export_tests`, `ts2451_cross_file_augmentation_tests`, `self_namespace_import_alias_leak_tests`, `module_augmentation_isolation_tests`, … 18 targets) — all green; the 3 pre-existing failures in `module_augmentation_declaration_identity_tests` reproduce identically on `main` (unrelated to this change).
- CLI parity vs `tsc` 5.9.3 on the issue repro (base.d.ts + aug.ts + main.ts): TS2322 now emitted for the new const/function/class/enum exports.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFiucEHHySMsDSRvy6KvuQ)_