### PR TITLE
fix(checker): register user-declared globals as boxed/array base under --noLib

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -394,6 +394,9 @@ path = "tests/new_generic_construct_signature_type_arg_display_tests.rs"
 name = "new_generic_callback_contextual_infer_tests"
 path = "tests/new_generic_callback_contextual_infer_tests.rs"
 [[test]]
+name = "nolib_user_array_union_member_access_tests"
+path = "tests/nolib_user_array_union_member_access_tests.rs"
+[[test]]
 name = "noinfer_diagnostic_display_tests"
 path = "tests/noinfer_diagnostic_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/type_checking/global.rs
+++ b/crates/tsz-checker/src/types/type_checking/global.rs
@@ -540,7 +540,11 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn register_function_def_ids_early(&mut self) {
         use crate::query_boundaries::common::IntrinsicKind;
 
-        if !self.ctx.has_lib_loaded() {
+        // Mirror `register_boxed_types`: under `--noLib` a user-declared
+        // ambient `Function` interface must still be identified so `T extends
+        // Function` constraint checks resolve. The `file_locals` lookup below
+        // recovers it; lib-context loops are simply empty without lib files.
+        if !self.ctx.has_lib_loaded() && !self.has_user_declared_registerable_global() {
             return;
         }
 

--- a/crates/tsz-checker/tests/nolib_user_array_union_member_access_tests.rs
+++ b/crates/tsz-checker/tests/nolib_user_array_union_member_access_tests.rs
@@ -1,0 +1,117 @@
+//! Regression: a user-declared global `Array<T>` under `--noLib` must be
+//! registered as the array base type so array member access resolves through it
+//! — including for a *union* of array-likes, not only a single array receiver.
+//!
+//! Structural rule: when no default lib is loaded but the program declares its
+//! own ambient global `Array<T>` (and other core globals), the checker must wire
+//! that declaration up as the boxed/array base type. Array property/method
+//! lookup then routes through the `Array<T>` interface for every array-like, so
+//! `(number[] | string[]).every(...)` resolves the method (and contextually
+//! types its callback) exactly as a single `number[]` receiver does. Owner:
+//! `CheckerState::register_boxed_types` — previously it bailed under `--noLib`,
+//! leaving `get_array_base_type` unset; single-array access limped along through
+//! the checker's apparent-type recovery while unions reported a false TS2339 (and
+//! a cascading TS7006 on the callback parameter). Refs #15087.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+
+/// A minimal but method-bearing core-global preamble. `Array<T>` carries a
+/// plain data property, a non-generic method, and a generic method so the test
+/// exercises all three member shapes that route through the array base.
+const PREAMBLE: &str = r#"
+interface Array<T> {
+  length: number;
+  every(p: (v: T) => boolean): boolean;
+  map<U>(p: (v: T) => U): U[];
+}
+interface Boolean {}
+interface Number {}
+interface String { length: number; charAt(i: number): string; }
+interface Object {}
+interface Function {}
+interface IArguments {}
+interface RegExp {}
+interface CallableFunction {}
+interface NewableFunction {}
+"#;
+
+fn check_nolib(body: &str) -> Vec<Diagnostic> {
+    let mut source = String::from(PREAMBLE);
+    source.push_str(body);
+    tsz_checker::test_utils::check_with_options(
+        &source,
+        CheckerOptions {
+            no_lib: true,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn count_code(diags: &[Diagnostic], code: u32) -> usize {
+    diags.iter().filter(|d| d.code == code).count()
+}
+
+#[test]
+fn union_of_arrays_resolves_method_off_user_array_base() {
+    let diags = check_nolib("declare const x: number[] | string[];\nx.every(c => true);\n");
+    assert_eq!(
+        count_code(&diags, 2339),
+        0,
+        "method must resolve off the user-declared Array<T> for a union receiver; got {diags:#?}"
+    );
+    // The callback parameter must be contextually typed from the resolved
+    // method signature — no cascading implicit-any (TS7006).
+    assert_eq!(
+        count_code(&diags, 7006),
+        0,
+        "callback parameter must be contextually typed; got {diags:#?}"
+    );
+}
+
+#[test]
+fn union_of_tuples_resolves_method_off_user_array_base() {
+    let diags = check_nolib("declare const x: [number] | [string];\nx.every(c => true);\n");
+    assert_eq!(count_code(&diags, 2339), 0, "got {diags:#?}");
+    assert_eq!(count_code(&diags, 7006), 0, "got {diags:#?}");
+}
+
+#[test]
+fn union_resolves_generic_array_method() {
+    let diags = check_nolib("declare const x: number[] | string[];\nconst r = x.map(v => v);\n");
+    assert_eq!(count_code(&diags, 2339), 0, "got {diags:#?}");
+    assert_eq!(count_code(&diags, 7006), 0, "got {diags:#?}");
+}
+
+#[test]
+fn single_array_still_resolves_method() {
+    let diags = check_nolib("declare const x: number[];\nx.every(c => true);\n");
+    assert_eq!(count_code(&diags, 2339), 0, "got {diags:#?}");
+    assert_eq!(count_code(&diags, 7006), 0, "got {diags:#?}");
+}
+
+#[test]
+fn union_resolves_data_property() {
+    let diags = check_nolib("declare const x: number[] | string[];\nconst n: number = x.length;\n");
+    assert_eq!(count_code(&diags, 2339), 0, "got {diags:#?}");
+}
+
+#[test]
+fn user_string_interface_resolves_boxed_method() {
+    // The same registration powers boxed-primitive member access under --noLib.
+    let diags = check_nolib("declare const s: string;\nconst r: string = s.charAt(0);\n");
+    assert_eq!(count_code(&diags, 2339), 0, "got {diags:#?}");
+}
+
+#[test]
+fn genuinely_missing_method_still_errors_on_union() {
+    // The fix must not mask real missing-property errors: a method absent from
+    // the user `Array<T>` interface must still report TS2339 on a union.
+    let diags = check_nolib("declare const x: number[] | string[];\nx.nope();\n");
+    assert_eq!(
+        count_code(&diags, 2339),
+        1,
+        "absent method must still report TS2339; got {diags:#?}"
+    );
+}


### PR DESCRIPTION
Fixes #15087.

Under `--noLib`, `register_boxed_types` and `register_function_def_ids_early`
bailed early on `!has_lib_loaded()`, so a user-declared global `interface
Array<T>` (and the boxed primitives `String`/`Number`/`Function`/...) were
never wired up as the array/boxed base types. Array member access then could
not route through the `Array<T>` interface: a single `number[]` receiver limped
along via the checker's apparent-type recovery, but a **union** of array-likes
(`number[] | string[]`) reported a false `TS2339` with a cascading `TS7006` on
the method callback.

**Structural rule:** when a global `Array<T>` (or `String`/`Number`/`Function`/...)
is in scope — provided by lib, or declared by the program under `--noLib` —
every array-like must resolve its members off that one base interface, for
single **and** union receivers alike. `tsc` resolves array/primitive member
access against whatever global is in scope regardless of `--noLib`; tsz now does
the same through the checker's global-base registration.

**Owner layer:** `tsz_checker` global-type registration
(`CheckerState::register_boxed_types` / `register_function_def_ids_early`). Both
now gate on the checker-local `has_lib_loaded() ||
has_user_declared_registerable_global()` predicate instead of `has_lib_loaded()`
alone. The resolutions already fall back to the binder's `file_locals`, so under
`--noLib` they transparently pick up the user-declared form and undeclared names
register nothing; the degenerate "lib expected but none loaded and no
user-declared registerable global" case still bails, preserving prior behavior.
No solver changes were needed — once the base is registered, the existing
array/union property resolution paths work uniformly.

**Adjacent matrix (all verified):** union `number[] | string[]`, union of tuples
`[number] | [string]`, the generic method `.map`, a data property `.length`,
boxed-primitive `string.charAt`, single-array control, and a genuinely-absent
method (`.nope()`) that must still report `TS2339`.

## Goal
Goal: hold

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test nolib_user_array_union_member_access_tests --test missing_global_type_diagnostics_tests --test global_type_tests` (55 passed after rebase onto current `origin/main`)
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`
- Manual repro before the rebase: `tsz --strict --noLib --target es2015 --noEmit` on the issue's program exited 0 (was TS2339 + TS7006); with-lib array/string access unchanged.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: gpt-5
Effort: high
---
_Generated by [Claude Code](https://claude.ai/code/session_01CeuQhkgvRFtD8F8S2cjxMS)_

