### PR TITLE
fix(checker): elaborate symbol-keyed missing members in using-disposable + relation reasons (#14858)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -811,7 +811,6 @@ impl<'a> CheckerState<'a> {
                         return;
                     }
                 }
-                // Skip MissingProperty for computed symbol expressions (TS2339 emitted separately).
                 if let tsz_solver::SubtypeFailureReason::MissingProperty {
                     property_name,
                     source_type,
@@ -819,7 +818,24 @@ impl<'a> CheckerState<'a> {
                 } = &failure_reason
                 {
                     let pn = self.ctx.types.resolve_atom_ref(*property_name);
-                    if pn.starts_with("[Symbol.") || pn.starts_with("__js_ctor_brand_") {
+                    if pn.starts_with("__js_ctor_brand_") {
+                        // Synthetic brand from JS constructor functions — not a real
+                        // property; tsc never reports it as missing.
+                        return;
+                    }
+                    if pn.starts_with("[Symbol.") {
+                        // A symbol-keyed missing member is not surfaced as a top-level
+                        // TS2741 on this ordinary-assignment path: tsc reports a
+                        // computed-symbol member *access* through a separate TS2339, and
+                        // for a plain object/interface assignment it keeps the generic
+                        // TS2322 here. The solver still produces the symbol-keyed
+                        // `MissingProperty` reason so callers that wrap it under their
+                        // own head line (e.g. the `using` disposability check, TS2850)
+                        // can elaborate it; preserve the prior generic TS2322 instead of
+                        // dropping the diagnostic entirely.
+                        self.error_type_not_assignable_generic_with_anchor(
+                            source, target, anchor_idx,
+                        );
                         return;
                     }
                     if self.missing_property_is_satisfied_by_source(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -676,6 +676,9 @@ mod typeof_unknown_logical_narrowing_tests;
 #[path = "../tests/using_binding_pattern_diagnostics_tests.rs"]
 mod using_binding_pattern_diagnostics_tests;
 #[cfg(test)]
+#[path = "../tests/using_initializer_disposable_elaboration_tests.rs"]
+mod using_initializer_disposable_elaboration_tests;
+#[cfg(test)]
 #[path = "../tests/value_usage_tests.rs"]
 mod value_usage_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1808,8 +1808,77 @@ impl<'a> CheckerState<'a> {
                     diagnostic_codes::THE_INITIALIZER_OF_A_USING_DECLARATION_MUST_BE_EITHER_AN_OBJECT_WITH_A_SYMBOL_DI,
                 )
             };
-            self.error_at_node(var_decl.initializer, message, code);
+            self.report_using_initializer_not_disposable(
+                init_type,
+                var_decl.initializer,
+                is_await_using,
+                message,
+                code,
+            );
         }
+    }
+
+    /// Emit the TS2850 / TS2854 "initializer of a `using` declaration must be a
+    /// disposable object" diagnostic with tsc's nested relation-reason tail.
+    ///
+    /// tsc reports the disposability failure through the assignability relation
+    /// against the global `Disposable` (`using`) / `AsyncDisposable`
+    /// (`await using`) interface, so the failure reason supplies the indented
+    /// elaboration (e.g. `Property '[Symbol.dispose]' is missing in type
+    /// '{ foo: number; }' but required in type 'Disposable'.`) beneath the
+    /// grammar-level top line. Routing through the same `relation -> reason ->
+    /// diagnostic` gateway the assignment paths use keeps that tail byte-for-byte
+    /// identical to TS2322/TS2741 instead of emitting a flat single-line message.
+    ///
+    /// The disposability *decision* still belongs to `type_has_disposable_method`
+    /// (which already matches tsc, including `await using` accepting a sync
+    /// `[Symbol.dispose]`); this only enriches the failure *display*. When the
+    /// global interface is unavailable or the relation surfaces no actionable
+    /// reason, it falls back to the original flat message unchanged.
+    fn report_using_initializer_not_disposable(
+        &mut self,
+        init_type: TypeId,
+        initializer_idx: NodeIndex,
+        is_await_using: bool,
+        message: &str,
+        code: u32,
+    ) {
+        use crate::error_reporter::{DiagnosticAnchorKind, DiagnosticRenderRequest};
+
+        let target_name = if is_await_using {
+            "AsyncDisposable"
+        } else {
+            "Disposable"
+        };
+
+        // Relate the initializer to the global `Disposable`/`AsyncDisposable`
+        // interface so its failure reason becomes the nested elaboration. Falls
+        // back to the flat top line when the global is absent or the relation
+        // surfaces no actionable reason. `resolve_lib_type_by_name` returns an
+        // owned `Option`, releasing the borrow before `analyze_assignability_failure`.
+        let target = self.resolve_lib_type_by_name(target_name);
+        let reason = target.and_then(|target| {
+            self.analyze_assignability_failure(init_type, target)
+                .failure_reason
+        });
+
+        let request = match (target, reason) {
+            (Some(target), Some(reason)) => DiagnosticRenderRequest::with_failure_reason(
+                DiagnosticAnchorKind::Exact,
+                code,
+                message.to_string(),
+                reason,
+                init_type,
+                target,
+            ),
+            _ => DiagnosticRenderRequest::simple(
+                DiagnosticAnchorKind::Exact,
+                code,
+                message.to_string(),
+            ),
+        };
+
+        self.emit_render_request(initializer_idx, request);
     }
 
     /// Check if a type has the appropriate dispose method.

--- a/crates/tsz-checker/tests/using_initializer_disposable_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/using_initializer_disposable_elaboration_tests.rs
@@ -1,0 +1,146 @@
+//! Regression tests for TS2850 / TS2854 (`using` / `await using` initializer
+//! must be disposable) *elaboration*.
+//!
+//! Structural rule: when the initializer of a `using` (resp. `await using`)
+//! declaration is not disposable, tsc reports the grammar-level top line
+//! (`The initializer of a 'using' declaration must be either an object with a
+//! '[Symbol.dispose]()' method, or be 'null' or 'undefined'.`) followed by the
+//! *same* relation-reason elaboration it produces for the equivalent
+//! assignment to the global `Disposable` (resp. `AsyncDisposable`) interface —
+//! the missing-`[Symbol.dispose]` frame, or, for a union source, the offending
+//! member's `Type 'X' is not assignable to type 'Disposable'.` frame.
+//!
+//! Previously tsz emitted only the flat top line and dropped the tail. The fix
+//! routes the disposability failure through the shared `relation -> reason ->
+//! diagnostic` gateway (`analyze_assignability_failure` against the global
+//! `Disposable`/`AsyncDisposable`), so the chain matches tsc. The disposability
+//! *decision* is unchanged (`type_has_disposable_method`); only the display is
+//! enriched.
+//!
+//! The rule is structural (independent of identifier spelling), so the cases
+//! below vary the binder name of the initializer.
+
+use std::sync::Arc;
+
+use tsz_binder::lib_loader::LibFile;
+
+use crate::test_utils::{
+    DEFAULT_LIB_NAMES, check_source_with_libs, load_lib_files, strict_checker_options,
+};
+
+/// Lib bundle that includes the explicit-resource-management typings
+/// (`Disposable`, `AsyncDisposable`, `Symbol.dispose`, `Symbol.asyncDispose`).
+fn disposable_libs() -> Vec<Arc<LibFile>> {
+    let mut names: Vec<&str> = DEFAULT_LIB_NAMES.to_vec();
+    names.push("esnext.disposable.d.ts");
+    load_lib_files(&names)
+}
+
+/// Full elaboration text (primary message plus every related-information line)
+/// of the single diagnostic with `code` in `source`, checked strict with the
+/// disposable lib bundle.
+fn elaboration(source: &str, code: u32) -> String {
+    let libs = disposable_libs();
+    assert!(
+        !libs.is_empty(),
+        "disposable lib bundle must load for this test to be meaningful"
+    );
+    let diags = check_source_with_libs(source, "test.ts", strict_checker_options(), &libs);
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "Expected exactly one TS{code}. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    let mut lines = vec![matching[0].message_text.clone()];
+    lines.extend(
+        matching[0]
+            .related_information
+            .iter()
+            .map(|info| info.message_text.clone()),
+    );
+    lines.join("\n")
+}
+
+/// A `using` initializer whose object type lacks `[Symbol.dispose]` must carry
+/// the missing-property relation reason against `Disposable` beneath TS2850.
+#[test]
+fn using_non_disposable_object_elaborates_missing_dispose_against_disposable() {
+    let text = elaboration(
+        r#"
+declare const widget: { foo: number };
+function f() { using handle = widget; }
+"#,
+        2850,
+    );
+    assert_eq!(
+        text,
+        "The initializer of a 'using' declaration must be either an object with a '[Symbol.dispose]()' method, or be 'null' or 'undefined'.\n\
+         Property '[Symbol.dispose]' is missing in type '{ foo: number; }' but required in type 'Disposable'.",
+    );
+}
+
+/// A `using` initializer that is a union with a non-disposable member must
+/// elaborate the offending member against `Disposable`.
+#[test]
+fn using_union_with_non_disposable_member_elaborates_member_against_disposable() {
+    let text = elaboration(
+        r#"
+declare const resource: Disposable | number;
+function f() { using held = resource; }
+"#,
+        2850,
+    );
+    assert_eq!(
+        text,
+        "The initializer of a 'using' declaration must be either an object with a '[Symbol.dispose]()' method, or be 'null' or 'undefined'.\n\
+         Type 'number' is not assignable to type 'Disposable'.",
+    );
+}
+
+/// An `await using` initializer that lacks both dispose methods must carry the
+/// missing-property relation reason against `AsyncDisposable` beneath TS2851.
+#[test]
+fn await_using_non_disposable_object_elaborates_against_async_disposable() {
+    let text = elaboration(
+        r#"
+declare const widget: { foo: number };
+async function f() { await using handle = widget; }
+"#,
+        2851,
+    );
+    assert_eq!(
+        text,
+        "The initializer of an 'await using' declaration must be either an object with a '[Symbol.asyncDispose]()' or '[Symbol.dispose]()' method, or be 'null' or 'undefined'.\n\
+         Property '[Symbol.asyncDispose]' is missing in type '{ foo: number; }' but required in type 'AsyncDisposable'.",
+    );
+}
+
+/// A genuinely disposable object must not trigger TS2850 at all (the decision
+/// path is unchanged); this guards against the elaboration routing flipping the
+/// accept/reject verdict.
+#[test]
+fn disposable_object_does_not_report_ts2850() {
+    let libs = disposable_libs();
+    let diags = check_source_with_libs(
+        r#"
+declare const widget: Disposable;
+function f() { using handle = widget; }
+"#,
+        "test.ts",
+        strict_checker_options(),
+        &libs,
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2850),
+        "a Disposable initializer must not report TS2850, got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1581,15 +1581,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
             },
         );
-        let has_non_symbol_missing = missing_with_order
-            .iter()
-            .any(|(name, _, _)| !self.is_late_bound_symbol_property_name(*name));
-        if !has_non_symbol_missing {
-            // All missing properties are late-bound symbols (e.g. [Symbol.iterator]).
-            // tsc does not list symbol-only missing properties in TS2739/TS2741 messages;
-            // clear so we fall through to property type checking or TypeMismatch.
-            missing_with_order.clear();
-        } else if matches!(
+        if matches!(
             crate::type_queries::extended::classify_array_like(self.interner, target),
             crate::type_queries::extended::ArrayLikeKind::Array(_)
                 | crate::type_queries::extended::ArrayLikeKind::Tuple
@@ -1601,12 +1593,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // from the TS2739/TS2740 missing list. Keep this behavior so that
             // e.g. `Type 'I1' is missing the following properties from type
             // 'any[]': length, pop, push, concat, and 25 more` — not 27.
+            //
+            // When the array-like target's only missing members are these
+            // protocol symbols, the list empties here and the relation falls
+            // through to property-type checking / `TypeMismatch`.
             missing_with_order
                 .retain(|(name, _, _)| !self.is_late_bound_symbol_property_name(*name));
         }
-        // For non-array targets (e.g. `ArrayConstructor`), tsc lists both named
-        // and symbol-keyed properties in TS2739/TS2741 (e.g. `isArray, from,
-        // of, [Symbol.species]`). Keep the full list in that case.
+        // For non-array targets, tsc lists symbol-keyed missing members just like
+        // named ones — `[Symbol.dispose]` for `Disposable`, `[Symbol.asyncDispose]`
+        // for `AsyncDisposable`, `[Symbol.iterator]` for `Iterable`,
+        // `[Symbol.species]` for `ArrayConstructor`, etc. So the full list
+        // (named + symbol-keyed) is kept and a `MissingProperty`/`MissingProperties`
+        // reason is produced even when every missing member is a late-bound symbol.
 
         // tsc treats `prototype` as implicit on callable sources (any function
         // or class value has a `.prototype` in JS), so it never lists it as a


### PR DESCRIPTION
Fixes the TS2850 facet of #14858 and the broader root cause behind it.

**Structural rule:** when an object/interface target requires a **late-bound symbol** member (`[Symbol.dispose]`, `[Symbol.asyncDispose]`, `[Symbol.iterator]`, …) and the source lacks it, tsc lists that member in its missing-property elaboration (TS2741, or nested under a wrapping head line such as TS2850). tsz dropped the elaboration whenever *every* missing required member was symbol-keyed, because the solver's missing-property explainer blanket-cleared the reason in that case. The omission is correct only for **array-like** targets, where the iteration-protocol symbols are implicitly satisfied — for ordinary targets (`Disposable`, `AsyncDisposable`, `Iterable`, …) the member must be listed.

This surfaced as #14858: a `using` / `await using` initializer that is not disposable produced only the flat top line, dropping the nested `Property '[Symbol.dispose]' is missing in type '{ foo: number; }' but required in type 'Disposable'.` tail that tsc attaches.

### Changes (owner layer)
- **solver** (`relations/subtype/explain.rs`, missing-property pass): remove the symbol-only blanket clear; apply the symbol filter **only for array-like targets** (iteration-protocol fallback) and keep symbol-keyed members for all other targets. A `MissingProperty`/`MissingProperties` reason is now produced even when every missing member is a late-bound symbol.
- **checker** (`types/type_checking/core.rs`): the `using`/`await using` disposability check routes the failure through the shared `relation -> reason -> diagnostic` gateway against the global `Disposable` / `AsyncDisposable` interface, so the relation reason becomes the nested elaboration under the grammar-level top line. The disposability *decision* is unchanged (`type_has_disposable_method`, which still lets `await using` accept a sync `[Symbol.dispose]`).
- **checker** (`error_reporter/assignability.rs`): the ordinary-assignment failure path keeps its prior generic TS2322 for symbol-keyed misses (tsc reports computed-symbol member *access* via a separate TS2339) instead of dropping the diagnostic now that the solver produces the reason. The synthetic-`__js_ctor_brand_` suppression is preserved unchanged.

### Adjacent matrix (new tests, `using_initializer_disposable_elaboration_tests.rs`)
- `using` non-disposable object → TS2850 + `Property '[Symbol.dispose]' is missing … required in type 'Disposable'.`
- `using` union (`Disposable | number`) → TS2850 + `Type 'number' is not assignable to type 'Disposable'.`
- `await using` non-disposable object → TS2851 + `Property '[Symbol.asyncDispose]' is missing … required in type 'AsyncDisposable'.`
- disposable object → no TS2850 (decision path unchanged).

> Note: the TS2636 (variance-annotation) facet of #14858 is **not** in this PR — its elaboration requires synthesizing tsc's `markerSub`/`markerSuper` type-parameter instances, which has no equivalent in the solver yet. #14858 stays open for that facet.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib using_initializer_disposable` → 4 passed (new adjacent-case matrix).
- `cargo test -p tsz-solver --lib` → only pre-existing sandbox failures (file-size-ceiling / cache-config / narrowing arch tests fail identically on the clean tree); no new failures.
- Targeted checker suites (`missing_propert`, `ts2741`, `ts2739`, `iterator`, `iterable`, `elaboration`, `error_reporter`, `assignability`): every failure reproduced on the clean tree (pre-existing arch-routing tests + known #13806 index-access tests + the nextest-process-isolated `passing_program_does_zero_reason_collection` counter test, which passes in isolation). No regressions introduced.
- Conformance/emit/fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019rGCPLkZ8AYSUiopAJdRri)_