### PR TITLE
fix(checker): elaborate TS2636 variance violations via the real relation (#14858)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -563,6 +563,9 @@ path = "tests/ts1239_parameter_decorator_tests.rs"
 name = "ts2636_method_bivariance_tests"
 path = "tests/ts2636_method_bivariance_tests.rs"
 [[test]]
+name = "ts2636_variance_elaboration_tests"
+path = "tests/ts2636_variance_elaboration_tests.rs"
+[[test]]
 name = "function_bivariance"
 path = "tests/function_bivariance.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -644,6 +644,14 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // DefId for the declaration under check, shared by the variance
+        // computation and the TS2636 elaboration body resolution below.
+        let variance_def_id = self
+            .ctx
+            .binder
+            .get_node_symbol(stmt_idx)
+            .and_then(|sid| self.ctx.get_existing_def_id(sid));
+
         // Compute all variances upfront (immutable borrow of self.ctx)
         // to avoid borrow conflicts with error_at_node (mutable borrow).
         let computed_variances: Vec<Option<tsz_solver::type_handles::Variance>> = {
@@ -652,9 +660,7 @@ impl<'a> CheckerState<'a> {
 
             // Try DefId-based resolution first (works for interfaces/classes and
             // type aliases whose bodies are already resolved)
-            let sym_id = self.ctx.binder.get_node_symbol(stmt_idx);
-            let def_id = sym_id.and_then(|sid| self.ctx.get_existing_def_id(sid));
-            let def_variances = def_id.and_then(|did| {
+            let def_variances = variance_def_id.and_then(|did| {
                 crate::query_boundaries::variance::compute_actual_type_param_variances_with_resolver(
                     db, resolver, did,
                 )
@@ -700,6 +706,17 @@ impl<'a> CheckerState<'a> {
                 Some(ident.escaped_text.clone())
             })
             .collect();
+
+        // Declaration body for the TS2636 nested elaboration, resolved lazily
+        // and at most once — only when a violation actually fires, so the
+        // common clean-annotation case pays nothing. Type aliases pass
+        // `body_type` directly (its DefId body may not be resolved yet);
+        // interfaces/classes resolve it from the DefId. A degenerate body
+        // (`unknown`/`error`/`any`, e.g. a circular alias) yields no usable
+        // relation reason, so the elaboration is left off there.
+        let body_is_usable =
+            |b: TypeId| b != TypeId::UNKNOWN && b != TypeId::ERROR && b != TypeId::ANY;
+        let mut elaboration_body: Option<Option<TypeId>> = None;
 
         for (idx, (i, info)) in annotated_params.iter().enumerate() {
             let Some(actual_variance) = computed_variances[idx] else {
@@ -761,12 +778,135 @@ impl<'a> CheckerState<'a> {
                 .replace("{0}", &sub_type)
                 .replace("{1}", &super_type);
 
-            self.error_at_node(
-                info.modifier_idx,
-                &message,
-                crate::diagnostics::diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_AS_IMPLIED_BY_VARIANCE_ANNOTATION,
-            );
+            // tsc's `checkTypeParameterDeferred` does not hand-build this
+            // message: it runs `checkTypeAssignableTo(source, target)` over the
+            // declaration body with marker substitutions for the annotated
+            // parameter, and the relation's failure reason supplies the nested
+            // elaboration tail (`The types returned by 'f()' are incompatible…`,
+            // `Types of property 'x' are incompatible…`). Reproduce that tail by
+            // running the same relation through the shared assignability gateway
+            // and grafting its reason chain under the TS2636 head. The decision
+            // is unchanged (still gated by the computed variance above); only the
+            // elaboration is added. Falls back to the flat message when the body
+            // is unavailable or the relation does not fail (e.g. the body's free
+            // parameter could not be substituted).
+            let code = crate::diagnostics::diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_AS_IMPLIED_BY_VARIANCE_ANNOTATION;
+            let body = *elaboration_body.get_or_insert_with(|| {
+                body_type.filter(|b| body_is_usable(*b)).or_else(|| {
+                    variance_def_id.and_then(|did| {
+                        let db = self.ctx.types.as_type_database();
+                        let resolver = &self.ctx as &dyn tsz_solver::def::resolver::TypeResolver;
+                        resolver
+                            .resolve_lazy(did, db)
+                            .filter(|b| body_is_usable(*b))
+                    })
+                })
+            });
+            let related = body
+                .map(|body| {
+                    self.variance_annotation_elaboration(
+                        body,
+                        info.atom,
+                        &info.name,
+                        info.declared_out,
+                        info.modifier_idx,
+                    )
+                })
+                .unwrap_or_default();
+            if related.is_empty() {
+                self.error_at_node(info.modifier_idx, &message, code);
+            } else {
+                self.error_at_node_with_related(info.modifier_idx, &message, code, related);
+            }
         }
+    }
+
+    /// Build the nested relation-reason elaboration `tsc` attaches beneath a
+    /// TS2636 variance-annotation violation.
+    ///
+    /// Mirrors tsc's `checkTypeParameterDeferred`: it substitutes a pair of
+    /// marker type parameters (`sub-T` constrained `<: super-T`) for the
+    /// annotated parameter in the declaration `body` — `sub-T` for the source
+    /// and `super-T` for the target under `out` (covariant), swapped under `in`
+    /// (contravariant) — then runs the real assignability relation. The
+    /// relation's failure reason renders the same drill-down tail tsc emits
+    /// (return-type, property, and contravariant-parameter frames). The markers
+    /// print as `super-T`/`sub-T` because a `TypeParameter` renders as its name.
+    ///
+    /// Returns the related-information chain (without the relation's own top
+    /// line, which the TS2636 head already states), or an empty vector when the
+    /// relation does not fail — in which case the caller emits the flat message.
+    fn variance_annotation_elaboration(
+        &mut self,
+        body: TypeId,
+        target_atom: tsz_common::interner::Atom,
+        name: &str,
+        declared_out: bool,
+        anchor_idx: NodeIndex,
+    ) -> Vec<crate::diagnostics::DiagnosticRelatedInformation> {
+        use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
+
+        let super_atom = self.ctx.types.intern_string(&format!("super-{name}"));
+        let sub_atom = self.ctx.types.intern_string(&format!("sub-{name}"));
+        let (super_marker, sub_marker) = {
+            let factory = self.ctx.types.factory();
+            // Two distinct unconstrained marker type parameters. They are
+            // mutually unassignable, so whichever direction the annotation
+            // implies fails exactly where the parameter occurs. They are left
+            // unconstrained on purpose: a `sub-T extends super-T` constraint
+            // would make the relation append tsc's "'super-T' is assignable to
+            // the constraint of type 'sub-T', but 'sub-T' could be instantiated
+            // with a different subtype" tail, which tsc does not emit for the
+            // variance-marker check.
+            let super_marker = factory.type_param(TypeParamInfo::simple(super_atom));
+            let sub_marker = factory.type_param(TypeParamInfo::simple(sub_atom));
+            (super_marker, sub_marker)
+        };
+        // `out T` (covariant) checks `body<sub-T> <: body<super-T>`; `in T`
+        // (contravariant) checks `body<super-T> <: body<sub-T>`. Matches the
+        // sub/super orientation of the hand-built top line above.
+        let (source_marker, target_marker) = if declared_out {
+            (sub_marker, super_marker)
+        } else {
+            (super_marker, sub_marker)
+        };
+        let source = instantiate_type(
+            self.ctx.types,
+            body,
+            &TypeSubstitution::single(target_atom, source_marker),
+        );
+        let target = instantiate_type(
+            self.ctx.types,
+            body,
+            &TypeSubstitution::single(target_atom, target_marker),
+        );
+        // No substitution happened (atom mismatch) or the relation holds: leave
+        // the decision to the caller's flat message rather than inventing a tail.
+        if source == target {
+            return Vec::new();
+        }
+        let analysis = self.analyze_assignability_failure(source, target);
+        let Some(reason) = analysis.failure_reason else {
+            return Vec::new();
+        };
+        // `render_failure_reason` builds the relation's own top line as
+        // `message_text` and the drill-down as `related_information`; the TS2636
+        // head already states the top line, so keep only the drill-down.
+        let mut diag = self.render_failure_reason(&reason, source, target, anchor_idx, 0);
+        // Drop the bare-type-parameter-target notes (TS5082 "could be
+        // instantiated with an arbitrary type" / TS5075 "could be instantiated
+        // with a different subtype of constraint"). Those explain that a *user*
+        // type parameter could still be instantiated unfavorably; the markers
+        // here are synthetic and never instantiated, so tsc omits the note in
+        // the variance-annotation check. Filter by diagnostic code, not message
+        // text, to keep this a structural decision.
+        diag.related_information.retain(|info| {
+            info.code
+                != crate::diagnostics::diagnostic_codes::COULD_BE_INSTANTIATED_WITH_AN_ARBITRARY_TYPE_WHICH_COULD_BE_UNRELATED_TO
+                && info.code
+                    != crate::diagnostics::diagnostic_codes::IS_ASSIGNABLE_TO_THE_CONSTRAINT_OF_TYPE_BUT_COULD_BE_INSTANTIATED_WITH_A_DIFFERE
+        });
+        diag.related_information
     }
 
     /// Check for duplicate property names in interface members (TS2300).

--- a/crates/tsz-checker/tests/ts2636_variance_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/ts2636_variance_elaboration_tests.rs
@@ -21,7 +21,7 @@ const TS2636: u32 = 2636;
 const TS5082_ARBITRARY_NOTE: u32 = 5082;
 const TS5075_SUBTYPE_NOTE: u32 = 5075;
 
-fn ts2636_with_related<'a>(diags: &'a [Diagnostic]) -> &'a Diagnostic {
+fn ts2636_with_related(diags: &[Diagnostic]) -> &Diagnostic {
     diags
         .iter()
         .find(|d| d.code == TS2636)
@@ -43,15 +43,11 @@ fn in_annotation_method_return_attaches_return_reason_tail() {
     let diag = ts2636_with_related(&diags);
     let texts = related_texts(diag);
     assert!(
-        texts
-            .iter()
-            .any(|t| *t == "The types returned by 'read()' are incompatible between these types."),
+        texts.contains(&"The types returned by 'read()' are incompatible between these types."),
         "expected the method-return frame in the TS2636 tail; got {texts:?}"
     );
     assert!(
-        texts
-            .iter()
-            .any(|t| *t == "Type 'super-Elem' is not assignable to type 'sub-Elem'."),
+        texts.contains(&"Type 'super-Elem' is not assignable to type 'sub-Elem'."),
         "expected the marker leaf in the TS2636 tail; got {texts:?}"
     );
 }
@@ -64,20 +60,17 @@ fn out_annotation_property_param_attaches_parameter_reason_tail() {
     let diag = ts2636_with_related(&diags);
     let texts = related_texts(diag);
     assert!(
-        texts
-            .iter()
-            .any(|t| *t == "Types of property 'write' are incompatible."),
+        texts.contains(&"Types of property 'write' are incompatible."),
         "expected the property frame in the TS2636 tail; got {texts:?}"
     );
     assert!(
-        texts.iter().any(|t| *t
-            == "Type '(x: sub-Item) => void' is not assignable to type '(x: super-Item) => void'."),
+        texts.contains(
+            &"Type '(x: sub-Item) => void' is not assignable to type '(x: super-Item) => void'.",
+        ),
         "expected the signature frame in the TS2636 tail; got {texts:?}"
     );
     assert!(
-        texts
-            .iter()
-            .any(|t| *t == "Type 'super-Item' is not assignable to type 'sub-Item'."),
+        texts.contains(&"Type 'super-Item' is not assignable to type 'sub-Item'."),
         "expected the marker leaf in the TS2636 tail; got {texts:?}"
     );
 }

--- a/crates/tsz-checker/tests/ts2636_variance_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/ts2636_variance_elaboration_tests.rs
@@ -1,0 +1,123 @@
+//! TS2636 (variance annotation) nested relation-reason elaboration.
+//!
+//! When an explicit `in`/`out` annotation contradicts the parameter's actual
+//! usage, tsc does not emit a flat message: it runs the assignability relation
+//! over the declaration body with marker substitutions for the annotated
+//! parameter and attaches the relation's failure reason as the nested tail
+//! (`The types returned by 'f()' are incompatible…`, `Types of property 'x'
+//! are incompatible…`). tsz reproduces that tail through the shared
+//! assignability gateway.
+//!
+//! The decision is unchanged (still gated by the computed variance), so these
+//! tests assert the elaboration is *attached* to the existing TS2636, not that
+//! the decision flips. Binder names are varied so no name-string drives the
+//! check, and the synthetic marker `could be instantiated` notes (TS5082 /
+//! TS5075) must be absent — tsc omits them for the variance-marker relation.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::Diagnostic;
+
+const TS2636: u32 = 2636;
+const TS5082_ARBITRARY_NOTE: u32 = 5082;
+const TS5075_SUBTYPE_NOTE: u32 = 5075;
+
+fn ts2636_with_related<'a>(diags: &'a [Diagnostic]) -> &'a Diagnostic {
+    diags
+        .iter()
+        .find(|d| d.code == TS2636)
+        .unwrap_or_else(|| panic!("expected a TS2636 diagnostic; got {diags:?}"))
+}
+
+fn related_texts(diag: &Diagnostic) -> Vec<&str> {
+    diag.related_information
+        .iter()
+        .map(|info| info.message_text.as_str())
+        .collect()
+}
+
+/// `in T` (contravariant) used in a covariant method-return position: the tail
+/// drills through the offending method return down to the marker leaf.
+#[test]
+fn in_annotation_method_return_attaches_return_reason_tail() {
+    let diags = check_source_diagnostics("interface Box<in Elem> { read(): Elem; }");
+    let diag = ts2636_with_related(&diags);
+    let texts = related_texts(diag);
+    assert!(
+        texts
+            .iter()
+            .any(|t| *t == "The types returned by 'read()' are incompatible between these types."),
+        "expected the method-return frame in the TS2636 tail; got {texts:?}"
+    );
+    assert!(
+        texts
+            .iter()
+            .any(|t| *t == "Type 'super-Elem' is not assignable to type 'sub-Elem'."),
+        "expected the marker leaf in the TS2636 tail; got {texts:?}"
+    );
+}
+
+/// `out T` (covariant) used in a contravariant function-property parameter: the
+/// tail drills through the property, signature, and parameter frames.
+#[test]
+fn out_annotation_property_param_attaches_parameter_reason_tail() {
+    let diags = check_source_diagnostics("type Sink<out Item> = { write: (x: Item) => void };");
+    let diag = ts2636_with_related(&diags);
+    let texts = related_texts(diag);
+    assert!(
+        texts
+            .iter()
+            .any(|t| *t == "Types of property 'write' are incompatible."),
+        "expected the property frame in the TS2636 tail; got {texts:?}"
+    );
+    assert!(
+        texts.iter().any(|t| *t
+            == "Type '(x: sub-Item) => void' is not assignable to type '(x: super-Item) => void'."),
+        "expected the signature frame in the TS2636 tail; got {texts:?}"
+    );
+    assert!(
+        texts
+            .iter()
+            .any(|t| *t == "Type 'super-Item' is not assignable to type 'sub-Item'."),
+        "expected the marker leaf in the TS2636 tail; got {texts:?}"
+    );
+}
+
+/// The synthetic markers are never instantiated, so the bare-type-parameter
+/// "could be instantiated…" notes (TS5082 / TS5075) must not leak into the
+/// variance elaboration — matching tsc.
+#[test]
+fn variance_tail_omits_marker_instantiation_notes() {
+    for source in [
+        "interface Box<in Elem> { read(): Elem; }",
+        "type Sink<out Item> = { write: (x: Item) => void };",
+    ] {
+        let diags = check_source_diagnostics(source);
+        let diag = ts2636_with_related(&diags);
+        assert!(
+            diag.related_information
+                .iter()
+                .all(|info| info.code != TS5082_ARBITRARY_NOTE && info.code != TS5075_SUBTYPE_NOTE),
+            "TS2636 tail must omit the synthetic-marker instantiation note for `{source}`; got {:?}",
+            related_texts(diag)
+        );
+    }
+}
+
+/// The elaboration is added without changing the decision: a sound annotation
+/// stays clean, and an unsound one still reports TS2636.
+#[test]
+fn elaboration_does_not_change_the_decision() {
+    // Sound: `out Elem` used covariantly.
+    let sound = check_source_diagnostics("interface Box<out Elem> { read(): Elem; }");
+    assert!(
+        !sound.iter().any(|d| d.code == TS2636),
+        "a sound `out` annotation must stay clean; got {sound:?}"
+    );
+
+    // Unsound: `in Elem` used covariantly still flags.
+    let unsound = check_source_diagnostics("interface Box<in Elem> { read(): Elem; }");
+    assert!(
+        unsound.iter().any(|d| d.code == TS2636),
+        "an unsound `in` annotation must still emit TS2636; got {unsound:?}"
+    );
+}


### PR DESCRIPTION
The variance-annotation check (TS2636) hand-built only the flat top line and dropped the nested relation-reason tail `tsc` attaches. e.g. `type Sink<out Item> = { write: (x: Item) => void }`:

- before: `TS2636: Type 'Sink<sub-Item>' is not assignable to type 'Sink<super-Item>' as implied by variance annotation.`
- now (matches `tsc` 6.0.2 byte-for-byte): the same head **plus** `Types of property 'write' are incompatible. / Type '(x: sub-Item) => void' is not assignable to type '(x: super-Item) => void'. / Types of parameters 'x' and 'x' are incompatible. / Type 'super-Item' is not assignable to type 'sub-Item'.`

Structural rule: when an explicit `in`/`out` annotation contradicts a type parameter's actual usage, `tsc` does not synthesize the message — its `checkTypeParameterDeferred` substitutes marker types for the annotated parameter in the declaration body and runs `checkTypeAssignableTo`, so the relation's failure reason supplies the nested elaboration; tsz now does the same through the solver-backed `analyze_assignability_failure` gateway (`check_variance_annotations_with_body` in `interface_checks.rs`). It substitutes a pair of marker type parameters (`sub-T`/`super-T`) for the annotated parameter, runs the relation in the direction the annotation implies, and grafts the rendered reason chain under the TS2636 head.

Owner layer: `tsz_checker` variance check; the relation decision and reason rendering stay owned by the shared assignability/render gateway. The synthetic markers are never user-instantiated, so the bare-type-parameter "could be instantiated…" notes (TS5082/TS5075) are filtered by diagnostic **code** (not rendered text), matching `tsc`'s variance-marker output.

The error **decision** is unchanged (still gated by the computed variance), so no row flips error/clean. The declaration body is resolved lazily — only when a violation fires — so the common clean-annotation case pays nothing. This is the **TS2636 half of #14858** (the TS2850 half is PR #15191; the method-return rendering is already merged).

Adjacent matrix (vs `tsc` 6.0.2, verified): `in T` method return, `out T`/`in T` function-typed-property param, classes, multi-parameter aliases (only the annotated param substituted), sound annotations (stay clean), no-annotation and `in out` (invariant) declarations (stay clean) — all match. Known residual (pre-existing, conformance-invisible, not variance-specific): `tsc`'s nested-chain collapse for function-typed-property returns ("The types returned by f()") and dotted paths ("The types of 'a.b' are incompatible") is a shared `render_failure` behavior outside this change; the conformance runner compares only top-line code+span+message, which is unchanged.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2636_variance_elaboration_tests` — 4/4 pass (new file; asserts the nested tail, varied binder names, absence of the TS5082/TS5075 marker notes, and decision-unchanged).
- `cargo test -p tsz-checker --test ts2636_method_bivariance_tests` — 9/9 pass (decision regression guard, unchanged).
- `cargo clippy -p tsz-checker --lib` — clean.
- Manual `tsz --noEmit --strict` vs `tsc` 6.0.2 across the adjacent matrix above (byte-for-byte on the common shapes).
- Ready-review CI owns the broad conformance suites (`varianceAnnotations*`); the TS2636 top-line code/span/message is unchanged, so the comparison set is unaffected.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErNWQxPF2reKsLvdRbJ59F)_