### PR TITLE
fix(checker): widen fresh object-literal source in TS2559 weak-type display (#14829)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1422,7 +1422,14 @@ impl<'a> CheckerState<'a> {
         {
             return parent.escaped_name.to_string();
         }
-        self.format_type_diagnostic(source)
+        // tsc renders the source's *widened* apparent type in the weak-type
+        // ("no properties in common") slot: a fresh object literal `{ c: 1 }`
+        // displays as `{ c: number }`, matching TS2322/TS2739/TS2741. The
+        // shared helper rewrites only a top-level *fresh* object literal, so a
+        // non-fresh annotated source (or a declared intersection rendered via a
+        // display alias) is returned untouched and keeps its existing display.
+        let display_source = self.widen_fresh_object_literal_properties_for_display(source);
+        self.format_type_diagnostic(display_source)
     }
 
     pub(crate) fn error_no_common_properties(

--- a/crates/tsz-checker/tests/literal_widening_display_tests.rs
+++ b/crates/tsz-checker/tests/literal_widening_display_tests.rs
@@ -187,6 +187,67 @@ take(fn);
     );
 }
 
+/// TS2559 assignment site: a *fresh* object-literal source widens its property
+/// literals (`{ c: 1 }` → `{ c: number }`), matching tsc and the rest of the
+/// assignability diagnostics (TS2322/TS2739/TS2741). Regression for #14829.
+#[test]
+fn ts2559_assignment_fresh_object_literal_source_widens() {
+    let source = r#"
+interface Weak { a?: number; b?: number; }
+const src = { c: 1 };
+const w: Weak = src;
+"#;
+    let msgs = check_source_code_messages(source);
+    assert_eq!(
+        msgs,
+        vec![(
+            2559_u32,
+            "Type '{ c: number; }' has no properties in common with type 'Weak'.".to_string()
+        )],
+    );
+}
+
+/// TS2559 with a multi-property fresh source widens every property literal.
+/// Binder names differ from the single-property case to prove the widening is
+/// structural, not keyed on identifier text.
+#[test]
+fn ts2559_assignment_multi_property_fresh_source_widens() {
+    let source = r#"
+interface Sink { p?: string; q?: string; }
+const payload = { first: 1, second: 2 };
+const target: Sink = payload;
+"#;
+    let msgs = check_source_code_messages(source);
+    assert_eq!(
+        msgs,
+        vec![(
+            2559_u32,
+            "Type '{ first: number; second: number; }' has no properties in common with type \
+             'Sink'."
+                .to_string()
+        )],
+    );
+}
+
+/// TS2559 with the source coming from an inferred function return widens the
+/// returned object literal's property literals.
+#[test]
+fn ts2559_assignment_function_return_fresh_source_widens() {
+    let source = r#"
+interface Slot { lo?: boolean; hi?: boolean; }
+function build() { return { count: 1 }; }
+const slot: Slot = build();
+"#;
+    let msgs = check_source_code_messages(source);
+    assert_eq!(
+        msgs,
+        vec![(
+            2559_u32,
+            "Type '{ count: number; }' has no properties in common with type 'Slot'.".to_string()
+        )],
+    );
+}
+
 /// TS2345 generic parameter display: string literal annotations inside the
 /// inferred generic application's object argument widen, while the literal
 /// key argument is preserved.


### PR DESCRIPTION
Fixes #14829.

The TS2559/TS2560 weak-type diagnostic ("Type 'X' has no properties in common with type 'Y'") rendered its source slot as the *fresh, un-widened* object-literal type (`{ c: 1 }`) instead of the widened apparent type (`{ c: number }`) that tsc shows — and that every sibling assignability diagnostic (TS2322/TS2739/TS2741) already shows for the same variable.

**Structural rule:** when the source of a weak-type failure is a *fresh* object literal, `tsc` renders its widened form (`getWidenedType`); tsz now routes the TS2559 source slot through the shared `widen_fresh_object_literal_properties_for_display` helper at the single rendering chokepoint (`ts2559_source_display` in `assignability_diagnostics.rs`) — the same widener TS2740/TS2741 already use. The helper only rewrites a top-level *fresh* object shape, so an explicitly annotated non-fresh source — or a declared `(() => …) & { a: 1 }` intersection whose call-argument display is carried by a display alias — is returned untouched and keeps its existing rendering.

**Owner layer:** checker diagnostic display; the widening itself is owned by the shared query-boundary widener. The relation/error **decision** is unchanged (still gated by the weak-union violation), so no row flips error/clean — only the rendered source string changes.

**Anti-hardcoding:** no identifier/file-name literal drives the logic; the widening is structural (gated on object freshness). New tests vary binder names to prove this.

**Adjacent matrix (new tests):** single-property fresh source, multi-property fresh source, and inferred-function-return fresh source all widen to `{ … number … }`; the existing non-fresh annotated-intersection source stays preserved (regression guard).

Known out-of-scope (separate path, pre-existing red): `ts2559_call_argument_literal_member_widens` asserts the *call-argument* display widens a non-fresh intersection member; it fails identically on `origin/main` @ `5987186` (introduced today by #15135) and lives in the call-argument display path (`error_argument_not_assignable_at`), not the assignment-site source slot this issue targets. Not touched here.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test literal_widening_display_tests` — the 3 new `ts2559_assignment_*_fresh_source_widens` cases pass, and the existing `ts2559_assignment_source_literal_member_preserved` (non-fresh) and `ts2560_*` displays stay byte-identical. The one failure, `ts2559_call_argument_literal_member_widens`, is pre-existing on `origin/main` (verified by `git stash` on the clean tree) and unrelated to this change.
- `cargo clippy -p tsz-checker --lib --profile ci-lint -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- Regression sweep (no new failures vs clean tree): `weak_object_union_member_subtype_reduction_tests`, `weak_callable_target_assignability_tests`, `assertion_freshness_elaboration_tests`, `intersection_primitive_member_assignability_tests`, `noinfer_diagnostic_display_tests`, `contextual_typing_tests` all green; the `ts2322_tests` (JSX index-access) and `namespace_qualified_diagnostic_tests` (TS2339) failures reproduce identically on the clean tree.
- Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01RiSQfHAbaDgKGrp9J4Y6UE)_