### PR TITLE
test(checker): cover annotated TS2559 weak-type display

### DIFF
--- a/crates/tsz-checker/tests/literal_widening_display_tests.rs
+++ b/crates/tsz-checker/tests/literal_widening_display_tests.rs
@@ -248,6 +248,25 @@ const slot: Slot = build();
     );
 }
 
+/// Control from #14829: an explicitly annotated, already widened source is
+/// unaffected and keeps its declared display.
+#[test]
+fn ts2559_annotated_widened_source_unchanged() {
+    let source = r#"
+interface Weak { a?: number; b?: number; }
+let src: { c: number } = { c: 1 };
+const w: Weak = src;
+"#;
+    let msgs = check_source_code_messages(source);
+    assert_eq!(
+        msgs,
+        vec![(
+            2559_u32,
+            "Type '{ c: number; }' has no properties in common with type 'Weak'.".to_string()
+        )],
+    );
+}
+
 /// TS2345 generic parameter display: string literal annotations inside the
 /// inferred generic application's object argument widen, while the literal
 /// key argument is preserved.


### PR DESCRIPTION
After #15197 landed the implementation for #14829, this PR preserves the remaining coverage delta: an annotated-source control proving TS2559 weak-type display does not widen a source that is already explicitly typed.

**Structural rule:** when a weak-type assignability failure displays a named/annotated source whose object member has already widened through its declared type, `tsc` preserves that declared display; tsz keeps this through the checkers shared TS2559 display helper.

Adjacent matrix:
- Fresh assignment sources still widen property literals (covered on `main`).
- Multi-property and function-return fresh sources still widen (covered on `main`).
- Annotated already-widened sources stay unchanged (covered here).

## Goal
Goal: hold

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test literal_widening_display_tests ts2559_annotated_widened_source_unchanged`

## Provenance
Machine: MacBookPro
Assistant: codex
Model: gpt-5
Effort: high