### PR TITLE
fix(checker): elaborate TS2375 exactOptionalPropertyTypes assignment failures

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -655,14 +655,25 @@ impl<'a> CheckerState<'a> {
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_WITH_EXACTOPTIONALPROPERTYTYPES_TRUE_CONSIDER_ADD,
                 &[&src_str, &tgt_str],
             );
-            if !self.emit_render_request(
-                anchor_idx,
-                DiagnosticRenderRequest::simple(
-                    DiagnosticAnchorKind::Exact,
-                    diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_WITH_EXACTOPTIONALPROPERTYTYPES_TRUE_CONSIDER_ADD,
-                    message,
-                ),
-            ) {
+            // tsc attaches the per-property relation elaboration beneath the
+            // TS2375 head (`Types of property 'X' are incompatible. / Type
+            // 'undefined' is not assignable to type '<base>'.`), exactly as the
+            // sibling call-argument TS2379 path does. Compute the same failure
+            // reason and route through the elaboration-carrying render request
+            // when one is available so the assignment and array-element paths
+            // match the argument path (and tsc).
+            let reason = self
+                .analyze_assignability_failure(source, target)
+                .failure_reason;
+            let request = DiagnosticRenderRequest::with_optional_failure_reason(
+                DiagnosticAnchorKind::Exact,
+                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_WITH_EXACTOPTIONALPROPERTYTYPES_TRUE_CONSIDER_ADD,
+                message,
+                reason,
+                source,
+                target,
+            );
+            if !self.emit_render_request(anchor_idx, request) {
                 return;
             }
             return;

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -339,18 +339,14 @@ impl<'a> CheckerState<'a> {
             self.argument_not_assignable_code_and_template(arg_type, param_type);
         let message = format_message(msg_template, &[&arg_str, &param_str]);
 
-        let request = if let Some(reason) = analysis.failure_reason {
-            DiagnosticRenderRequest::with_failure_reason(
-                DiagnosticAnchorKind::Exact,
-                code,
-                message,
-                reason,
-                arg_type,
-                param_type,
-            )
-        } else {
-            DiagnosticRenderRequest::simple(DiagnosticAnchorKind::Exact, code, message)
-        };
+        let request = DiagnosticRenderRequest::with_optional_failure_reason(
+            DiagnosticAnchorKind::Exact,
+            code,
+            message,
+            analysis.failure_reason,
+            arg_type,
+            param_type,
+        );
 
         self.emit_render_request(idx, request);
     }

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -162,6 +162,29 @@ impl DiagnosticRenderRequest {
         }
     }
 
+    /// Create a render request from an *optional* failure reason.
+    ///
+    /// Routes through [`Self::with_failure_reason`] when a reason is present so
+    /// the rendered diagnostic carries the relation elaboration, and falls back
+    /// to [`Self::simple`] (head line only) when the relation produced no
+    /// structured reason. This is the shared idiom for assignability error
+    /// paths that have already run `analyze_assignability_failure`.
+    pub(crate) fn with_optional_failure_reason(
+        anchor_kind: DiagnosticAnchorKind,
+        code: u32,
+        message: String,
+        reason: Option<tsz_solver::SubtypeFailureReason>,
+        source: TypeId,
+        target: TypeId,
+    ) -> Self {
+        match reason {
+            Some(reason) => {
+                Self::with_failure_reason(anchor_kind, code, message, reason, source, target)
+            }
+            None => Self::simple(anchor_kind, code, message),
+        }
+    }
+
     /// Create a render request with pre-built related information.
     pub(crate) const fn with_related(
         anchor_kind: DiagnosticAnchorKind,

--- a/crates/tsz-checker/tests/ts2375_exact_optional_property_display_tests.rs
+++ b/crates/tsz-checker/tests/ts2375_exact_optional_property_display_tests.rs
@@ -210,6 +210,105 @@ const b: B = a;
     );
 }
 
+// ── TS2375 nested relation-reason elaboration (#14830) ──────────────────────
+//
+// Structural rule: when an assignment-context `exactOptionalPropertyTypes`
+// mismatch emits TS2375, tsc appends the same per-property relation
+// elaboration the call-argument TS2379 path already shows — `Types of
+// property 'X' are incompatible.` (TS2326) followed by `Type 'undefined' is
+// not assignable to type '<base>'.` (TS2322). tsz previously dropped this tail
+// on the variable-assignment and array-element paths. The assertions below
+// vary the property spelling and the path (variable, nested object, array
+// element) so a hardcoded-spelling fix would not pass.
+
+fn ts2375_diag(source: &str) -> tsz_common::diagnostics::Diagnostic {
+    crate::test_utils::check_with_options(
+        source,
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            no_implicit_any: true,
+            exact_optional_property_types: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .find(|d| d.code == 2375)
+    .expect("expected a TS2375 diagnostic")
+}
+
+/// True when `diag` carries the two-line per-property elaboration tail for
+/// `prop`: `Types of property '<prop>' are incompatible.` (TS2326) and a
+/// nested `Type 'undefined' is not assignable to type '<base>'.` (TS2322).
+fn has_property_incompatible_elaboration(
+    diag: &tsz_common::diagnostics::Diagnostic,
+    prop: &str,
+    base: &str,
+) -> bool {
+    let head = format!("Types of property '{prop}' are incompatible.");
+    let leaf = format!("Type 'undefined' is not assignable to type '{base}'.");
+    let has_head = diag
+        .related_information
+        .iter()
+        .any(|info| info.code == 2326 && info.message_text == head);
+    let has_leaf = diag
+        .related_information
+        .iter()
+        .any(|info| info.code == 2322 && info.message_text == leaf);
+    has_head && has_leaf
+}
+
+#[test]
+fn ts2375_variable_assignment_carries_property_incompatible_elaboration() {
+    let diag = ts2375_diag("interface Opt { a?: number; }\nconst o1: Opt = { a: undefined };\n");
+    assert!(
+        has_property_incompatible_elaboration(&diag, "a", "number"),
+        "TS2375 on a variable assignment must carry the 'Types of property a are \
+         incompatible / Type undefined is not assignable to number' tail; got {:?}",
+        diag.related_information
+    );
+}
+
+#[test]
+fn ts2375_elaboration_is_property_name_independent() {
+    // Rename the property to prove the elaboration is structural, not keyed on
+    // the spelling 'a'.
+    let diag = ts2375_diag(
+        "interface Opt { greeting?: string; }\nconst o: Opt = { greeting: undefined };\n",
+    );
+    assert!(
+        has_property_incompatible_elaboration(&diag, "greeting", "string"),
+        "TS2375 elaboration must follow a renamed property; got {:?}",
+        diag.related_information
+    );
+}
+
+#[test]
+fn ts2375_nested_object_property_elaboration_names_base_object_type() {
+    // The nested optional object property: the leaf names the property's base
+    // object type, matching tsc.
+    let diag = ts2375_diag(
+        "interface Nested { inner?: { x: number } }\nconst n: Nested = { inner: undefined };\n",
+    );
+    assert!(
+        has_property_incompatible_elaboration(&diag, "inner", "{ x: number; }"),
+        "nested-object TS2375 must elaborate to the base object type; got {:?}",
+        diag.related_information
+    );
+}
+
+#[test]
+fn ts2375_array_element_carries_property_incompatible_elaboration() {
+    // tsc drills array-literal assignments to the offending element, reporting
+    // the element-level mismatch with the same property elaboration.
+    let diag = ts2375_diag("interface O { a?: number; }\nconst arr: O[] = [{ a: undefined }];\n");
+    assert!(
+        has_property_incompatible_elaboration(&diag, "a", "number"),
+        "array-element TS2375 must carry the property-incompatible tail; got {:?}",
+        diag.related_information
+    );
+}
+
 #[test]
 fn element_access_names_optional_property_receiver_in_ts18048() {
     let source = r#"


### PR DESCRIPTION
Fixes #14830.

Under `exactOptionalPropertyTypes`, assigning `{ a: undefined }` to an optional-property target emits TS2375. tsc appends the per-property relation elaboration; tsz dropped it on the variable-assignment and array-element paths because they emitted TS2375 via `DiagnosticRenderRequest::simple` (no related-information chain). Only the call-argument path (TS2379) elaborated.

```ts
interface Opt { a?: number; }
const o1: Opt = { a: undefined };
```
tsz before:
```
error TS2375: Type '{ a: undefined; }' is not assignable to type 'Opt' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
```
tsc 5.9.3 / tsz after:
```
error TS2375: Type '{ a: undefined; }' is not assignable to type 'Opt' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'a' are incompatible.
    Type 'undefined' is not assignable to type 'number'.
```

**Structural rule:** when an exact-optional mismatch fails on a present source property whose value type excludes the target's base, tsc attaches the property-incompatibility relation reason (TS2326 + TS2322) beneath the head diagnostic. tsz now computes that reason through the shared `analyze_assignability_failure` gateway and routes the TS2375 head through the elaboration-carrying render request — owner: `crates/tsz-checker/src/error_reporter/assignability.rs` (`diagnose_assignment_failure_with_anchor`). This matches the sibling TS2379 argument path (`error_reporter/call_errors/error_emission.rs`) and tsc. Because tsc drills array-literal assignments to the offending element, the element-anchored array-element path is fixed by the same change.

The shared "`with_failure_reason` when a reason exists, else `simple`" idiom is factored into `DiagnosticRenderRequest::with_optional_failure_reason` and reused from both the assignment and argument emission paths (behavior-preserving dedup).

**Adjacent matrix (all now match tsc, name-varied so a spelling fix would not pass):**
- variable-initializer optional property (`a: number`, `greeting: string`)
- nested optional object property (`inner?: { x: number }` → leaf names `{ x: number; }`)
- array-element optional property (`O[] = [{ a: undefined }]`)

Out of scope / not changed: TS2412 (exact-optional write-target, e.g. `obj.a = undefined`) still emits a flat line; whether tsc elaborates that code was not confirmed, so it is left untouched to avoid an unverified regression.

This is a display-only change — the error decisions (which codes fire where) are unchanged; only the related-information tail is added.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts2375_exact_optional_property_display_tests` — 12 passed (4 new elaboration tests for variable/nested/array/renamed paths)
- `cargo test -p tsz-checker --test ts2379_exact_optional_argument_tests` — 12 passed (sibling argument path unaffected by the shared-constructor dedup)
- `cargo fmt -p tsz-checker -- --check` — clean
- Full conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5SVnHW4r5MiV5jcMcpthF)_