### PR TITLE
fix(checker): attach property-incompatibility elaboration to TS2375 exact-optional assignment

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -508,6 +508,42 @@ impl<'a> CheckerState<'a> {
         true
     }
 
+    /// Emit a TS2375 exact-optional-property assignment diagnostic, attaching
+    /// the property-incompatibility elaboration that `tsc` renders beneath it.
+    ///
+    /// The top line is already formatted by the caller; this runs the shared
+    /// assignability failure analysis on the same `source`/`target` pair so the
+    /// relation reason (`PropertyTypeMismatch`) populates the nested
+    /// `Types of property 'X' are incompatible. / Type 'S' is not assignable to
+    /// type 'T'.` related-information chain — identical to the TS2379 argument
+    /// path. When no structural reason is captured the diagnostic degrades to a
+    /// flat line, matching the prior behavior.
+    fn emit_exact_optional_assignment_diagnostic(
+        &mut self,
+        anchor_idx: NodeIndex,
+        code: u32,
+        message: String,
+        source: TypeId,
+        target: TypeId,
+    ) {
+        let reason = self
+            .analyze_assignability_failure(source, target)
+            .failure_reason;
+        let request = if let Some(reason) = reason {
+            DiagnosticRenderRequest::with_failure_reason(
+                DiagnosticAnchorKind::Exact,
+                code,
+                message,
+                reason,
+                source,
+                target,
+            )
+        } else {
+            DiagnosticRenderRequest::simple(DiagnosticAnchorKind::Exact, code, message)
+        };
+        self.emit_render_request(anchor_idx, request);
+    }
+
     /// Internal helper that reports a detailed assignability failure using an
     /// already-resolved diagnostic anchor.
     pub(super) fn diagnose_assignment_failure_with_anchor(
@@ -655,16 +691,20 @@ impl<'a> CheckerState<'a> {
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_WITH_EXACTOPTIONALPROPERTYTYPES_TRUE_CONSIDER_ADD,
                 &[&src_str, &tgt_str],
             );
-            if !self.emit_render_request(
+            // tsc routes this assignment through `checkTypeAssignableTo`, whose
+            // failure reason supplies the nested `Types of property 'X' are
+            // incompatible. / Type 'S' is not assignable to type 'T'.` chain
+            // beneath the TS2375 top line. The sibling TS2379 argument path
+            // already attaches this via `with_failure_reason`; mirror it here so
+            // the assignment-context diagnostic carries the same elaboration
+            // instead of a flat single line.
+            self.emit_exact_optional_assignment_diagnostic(
                 anchor_idx,
-                DiagnosticRenderRequest::simple(
-                    DiagnosticAnchorKind::Exact,
-                    diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_WITH_EXACTOPTIONALPROPERTYTYPES_TRUE_CONSIDER_ADD,
-                    message,
-                ),
-            ) {
-                return;
-            }
+                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_WITH_EXACTOPTIONALPROPERTYTYPES_TRUE_CONSIDER_ADD,
+                message,
+                source,
+                target,
+            );
             return;
         }
 

--- a/crates/tsz-checker/tests/ts2375_exact_optional_property_display_tests.rs
+++ b/crates/tsz-checker/tests/ts2375_exact_optional_property_display_tests.rs
@@ -11,6 +11,7 @@
 //! `with_exact_optional_property_types(bool)` on `TypeFormatter`.
 
 use crate::context::CheckerOptions;
+use crate::diagnostics::Diagnostic;
 
 fn check_with_options(source: &str, options: CheckerOptions) -> Vec<(u32, String)> {
     crate::test_utils::check_with_options(source, options)
@@ -19,8 +20,11 @@ fn check_with_options(source: &str, options: CheckerOptions) -> Vec<(u32, String
         .collect()
 }
 
-fn check_strict_exact_optional(source: &str) -> Vec<(u32, String)> {
-    check_with_options(
+/// Full diagnostics (including `related_information`) under strict +
+/// `exactOptionalPropertyTypes`. The `(code, message_text)` projection used by
+/// most tests is derived from this so the option set lives in one place.
+fn full_strict_exact_optional(source: &str) -> Vec<Diagnostic> {
+    crate::test_utils::check_with_options(
         source,
         CheckerOptions {
             strict: true,
@@ -30,6 +34,13 @@ fn check_strict_exact_optional(source: &str) -> Vec<(u32, String)> {
             ..Default::default()
         },
     )
+}
+
+fn check_strict_exact_optional(source: &str) -> Vec<(u32, String)> {
+    full_strict_exact_optional(source)
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect()
 }
 
 fn check_strict_no_exact(source: &str) -> Vec<(u32, String)> {
@@ -228,5 +239,94 @@ matchResult.groups["someVariable"].length;
             *code == 2532 && message.contains("Object is possibly 'undefined'")
         }),
         "expected TS2532 for noUncheckedIndexedAccess result before `.length`, got: {diags:#?}"
+    );
+}
+
+// ── TS2375 nested elaboration on the assignment / array-element paths ─────────
+//
+// tsc attaches the `Types of property 'X' are incompatible. / Type 'S' is not
+// assignable to type 'T'.` relation-reason chain beneath the TS2375 top line,
+// exactly as it does for the sibling TS2379 argument path. The assignment and
+// array-element contexts previously dropped that elaboration (flat single line).
+//
+// These assert the chain structurally (depth, code, leaf relation) and vary the
+// binder spellings / property positions so a fix keyed to a specific name would
+// not pass.
+
+/// Collect the nested elaboration of the first TS2375 as `(depth, code, text)`.
+fn ts2375_chain(diags: &[Diagnostic]) -> Vec<(u8, u32, String)> {
+    diags
+        .iter()
+        .find(|d| d.code == 2375)
+        .map(|d| {
+            d.related_information
+                .iter()
+                .map(|r| (r.depth, r.code, r.message_text.clone()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[test]
+fn ts2375_variable_assignment_carries_property_incompatible_elaboration() {
+    // Vary the optional property's name and primitive type to prove the chain is
+    // structural, not keyed on a spelling.
+    for (prop, ty) in [("a", "number"), ("value", "string"), ("flag", "boolean")] {
+        let source = format!(
+            "interface Opt {{ {prop}?: {ty}; }}\nconst o: Opt = {{ {prop}: undefined }};\n"
+        );
+        let diags = full_strict_exact_optional(&source);
+        let chain = ts2375_chain(&diags);
+        assert!(
+            chain.iter().any(|(depth, code, msg)| *depth == 0
+                && *code == 2326
+                && msg.contains(&format!("Types of property '{prop}' are incompatible"))),
+            "expected `Types of property '{prop}' are incompatible.` header at depth 0; got {chain:?}"
+        );
+        assert!(
+            chain.iter().any(|(depth, _, msg)| *depth == 1
+                && msg.contains("Type 'undefined' is not assignable to type")
+                && msg.contains(&format!("'{ty}'"))),
+            "expected the `undefined`→`{ty}` leaf relation at depth 1; got {chain:?}"
+        );
+    }
+}
+
+#[test]
+fn ts2375_array_element_assignment_carries_elaboration() {
+    let source = r#"
+interface O { a?: number; }
+const arr: O[] = [{ a: undefined }];
+"#;
+    let chain = ts2375_chain(&full_strict_exact_optional(source));
+    assert!(
+        chain.iter().any(|(depth, code, msg)| *depth == 0
+            && *code == 2326
+            && msg.contains("Types of property 'a' are incompatible")),
+        "array-element TS2375 must carry the property-incompatibility header; got {chain:?}"
+    );
+    assert!(
+        chain.iter().any(|(depth, _, msg)| *depth == 1
+            && msg.contains("Type 'undefined' is not assignable to type 'number'")),
+        "array-element TS2375 must carry the leaf relation; got {chain:?}"
+    );
+}
+
+#[test]
+fn ts2375_nested_optional_object_property_carries_elaboration() {
+    let source = r#"
+interface Nested { inner?: { x: number } }
+const n: Nested = { inner: undefined };
+"#;
+    let chain = ts2375_chain(&full_strict_exact_optional(source));
+    assert!(
+        chain.iter().any(|(depth, _, msg)| *depth == 0
+            && msg.contains("Types of property 'inner' are incompatible")),
+        "nested-object TS2375 must name the offending property; got {chain:?}"
+    );
+    assert!(
+        chain.iter().any(|(depth, _, msg)| *depth == 1
+            && msg.contains("Type 'undefined' is not assignable to type '{ x: number; }'")),
+        "nested-object TS2375 must drill to the object leaf type; got {chain:?}"
     );
 }


### PR DESCRIPTION
Fixes #14830.

## Summary

Under `exactOptionalPropertyTypes`, assigning `{ a: undefined }` to an optional-property type emits TS2375. `tsc` appends the nested relation-reason elaboration; tsz dropped it on the **variable-assignment** and **array-element** paths, even though the sibling **argument** path (TS2379) already emits it.

```ts
interface Opt { a?: number; }
const o1: Opt = { a: undefined };
```

tsz before:
```
error TS2375: Type '{ a: undefined; }' is not assignable to type 'Opt' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
```

tsc / tsz after:
```
error TS2375: Type '{ a: undefined; }' is not assignable to type 'Opt' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'a' are incompatible.
    Type 'undefined' is not assignable to type 'number'.
```

## Structural rule

When an assignment fails under `exactOptionalPropertyTypes` because the source carries `undefined` on a property the target declares `?`-optional-without-`undefined`, `tsc` reports TS2375 **with** the relation-reason chain produced by `checkTypeAssignableTo`. tsz now does the same through the solver-backed assignability gateway (`analyze_assignability_failure` → relation reason → `DiagnosticRenderRequest::with_failure_reason`), owner layer = checker diagnostic emission (`error_reporter/assignability.rs`).

The TS2375 path previously used `DiagnosticRenderRequest::simple` (no related-information chain). It now routes through a small `emit_exact_optional_assignment_diagnostic` helper that runs the same failure analysis the TS2379 argument path uses, so whatever structural reason applies populates the nested elaboration — `PropertyTypeMismatch` for the `undefined`-vs-`number` case, or the `Property 'x' is optional in type 'A' but required in type 'B'` line for the shared-optional case. When no structural reason is captured, it degrades to the flat line (prior behavior).

## Scope / fallback

- Fix lives at the single TS2375 emit site, so it covers the variable, nested-object, and array-element contexts uniformly.
- **TS2412** (write-target, e.g. `o.a = undefined`) intentionally stays flat — `tsc` emits TS2412 with **no** elaboration; verified against the reference binary.

## Adjacent matrix (all match `tsc` byte-for-byte)

- top-level optional property (`number`/`string`/`boolean`, varied names)
- nested optional object property (`inner?: { x: number }`)
- array-element optional property (`O[] = [{ a: undefined }]`)
- shared-optional named-source assignment (different `Property '...' is optional...` elaboration) — regression guard
- TS2412 write-target stays flat

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-checker --lib ts2375` → 16 passed (13 existing + 3 new elaboration-chain tests).
- `cargo test -p tsz-checker --lib ts2379 / exact_optional` → green.
- Failure-set diff over `exact_optional`/`ts2375`/`ts2379`/`ts2412`/`assignab` lib filters with vs. without the change: **0 new failures** (10 pre-existing failures are independent of this change; `main` is currently red per #15196).
- CLI byte-diff vs. reference `tsc` (`--pretty false`) for top-level, nested-object, array-element TS2375 and the TS2412 write case: all MATCH.

https://claude.ai/code/session_01CeEHNhKipTMh6ZkueAJe2F

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeEHNhKipTMh6ZkueAJe2F)_