### PR TITLE
fix(emit): emit `export var X = NS;` for exported import-equals under ES module

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -207,6 +207,10 @@ name = "cjs_import_equals_export_tests"
 path = "tests/cjs_import_equals_export_tests.rs"
 
 [[test]]
+name = "esm_export_import_equals_alias_tests"
+path = "tests/esm_export_import_equals_alias_tests.rs"
+
+[[test]]
 name = "import_use_before_decl_3597_tests"
 path = "tests/import_use_before_decl_3597_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
@@ -842,11 +842,19 @@ impl<'a> Printer<'a> {
                 && self.import_equals_declaration_is_external(clause_node)
             {
                 self.emit_import_equals_declaration_inner(clause_node, true);
+                self.write_semicolon();
             } else {
-                self.write("export ");
-                self.emit_import_equals_declaration_inner(clause_node, false);
+                // The `export` keyword sits on the outer EXPORT_DECLARATION, not
+                // on the inner import-equals clause, so the clause carries no
+                // export modifier. Route it through the shared exported handler
+                // (as `emit_export_declaration_commonjs` already does) so the
+                // assignment prefix emits the right form for the module kind
+                // (`export var X = ...` for ES-module output). Pre-writing a
+                // bare `export ` here would strand an `export ;` whenever the
+                // inner emit elides (namespace-alias gate) or expands to its own
+                // `export var`.
+                self.emit_exported_import_equals_declaration(clause_node);
             }
-            self.write_semicolon();
             return;
         }
 

--- a/crates/tsz-emitter/tests/esm_export_import_equals_alias_tests.rs
+++ b/crates/tsz-emitter/tests/esm_export_import_equals_alias_tests.rs
@@ -1,0 +1,115 @@
+//! Regression tests for `export import X = NS;` under ES-module output.
+//!
+//! For an `export import` alias to a local namespace (or nested namespace
+//! member / namespaced class) under ES-module output
+//! (`--module es2015|es2020|es2022|esnext`), tsz used to emit a syntactically
+//! invalid `export ;` statement instead of `export var X = NS;`. The `export`
+//! keyword sits on the outer `EXPORT_DECLARATION`, not on the inner
+//! import-equals clause, so forcing `force_exported = false` let the
+//! namespace-alias elision gate drop the assignment while the caller had
+//! already written a bare `export `.
+//!
+//! The fix routes the ES-module path through
+//! `emit_exported_import_equals_declaration` (the same handler the CommonJS
+//! path already uses), so the clause is treated as exported and emits its own
+//! `export var X = NS;` prefix.
+//!
+//! Source: `crates/tsz-emitter/src/emitter/module_emission/core/mod.rs`
+//! (`emit_export_declaration_es6` — the `IMPORT_EQUALS_DECLARATION` arm).
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print as parse_lower_emit;
+
+fn esnext_opts() -> PrintOptions {
+    PrintOptions {
+        target: ScriptTarget::ES2020,
+        module: ModuleKind::ESNext,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn esm_export_import_alias_to_namespace_emits_export_var() {
+    let source = "namespace A { export const x = 1; }\nexport import AA = A;\n";
+    let output = parse_lower_emit(source, esnext_opts());
+
+    assert!(
+        output.contains("export var AA = A;"),
+        "exported namespace alias should emit `export var AA = A;`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("export ;"),
+        "must not strand a bare `export ;`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn esm_export_import_alias_to_nested_namespace_member_emits_export_var() {
+    let source =
+        "namespace A { export namespace B { export const x = 1; } }\nexport import AB = A.B;\n";
+    let output = parse_lower_emit(source, esnext_opts());
+
+    assert!(
+        output.contains("export var AB = A.B;"),
+        "exported nested-namespace alias should emit `export var AB = A.B;`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("export ;"),
+        "must not strand a bare `export ;`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn esm_export_import_alias_to_namespaced_class_emits_export_var() {
+    let source = "namespace A { export class K {} }\nexport import AK = A.K;\n";
+    let output = parse_lower_emit(source, esnext_opts());
+
+    assert!(
+        output.contains("export var AK = A.K;"),
+        "exported namespaced-class alias should emit `export var AK = A.K;`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("export ;"),
+        "must not strand a bare `export ;`.\nOutput:\n{output}"
+    );
+}
+
+/// Non-exported `import X = A;` under ES module is already correct and must
+/// stay a plain `var` (no `export`).
+#[test]
+fn esm_non_exported_import_alias_stays_plain_var() {
+    let source = "namespace A { export const x = 1; }\nimport AA = A;\nAA;\n";
+    let output = parse_lower_emit(source, esnext_opts());
+
+    assert!(
+        output.contains("var AA = A;"),
+        "non-exported alias should stay `var AA = A;`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("export var AA"),
+        "non-exported alias must not become an export.\nOutput:\n{output}"
+    );
+}
+
+/// An exported alias whose qualified target resolves to an *exported*
+/// interface (type-only) has no runtime value — tsc emits neither the alias
+/// nor a stray `export ;`.
+#[test]
+fn esm_export_import_alias_to_exported_interface_elides_cleanly() {
+    let source = "namespace A { export interface I {} }\nexport import AI = A.I;\n";
+    let output = parse_lower_emit(source, esnext_opts());
+
+    assert!(
+        !output.contains("export var AI"),
+        "type-only alias must not emit a runtime export.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("export ;"),
+        "type-only alias must not strand a bare `export ;`.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
When an `export import X = NS;` alias targets a local namespace (or nested
namespace member / namespaced class) and the module output is ES-module
(`--module es2015|es2020|es2022|esnext`), tsc emits `export var X = NS;`; tsz
emitted a syntactically invalid `export ;` (non-runnable JS) through the
emitter's ES6 export path.

Structural rule: when an `EXPORT_DECLARATION` wraps an `IMPORT_EQUALS_DECLARATION`
clause, the `export` keyword lives on the **outer** declaration, not the inner
clause. `emit_export_declaration_es6` pre-wrote a bare `export ` and then called
the inner emit with `force_exported = false`, so the clause looked unexported:
`is_exported_var` was false, the namespace-alias elision gate
(`imports.rs`) dropped the assignment, and only the stray `export ` + `;`
remained.

Fix (owner layer: emitter / `module_emission`): route the clause through the
existing `emit_exported_import_equals_declaration` handler — the same one the
CommonJS export path (`emit_export_declaration_commonjs`) already uses — instead
of pre-writing `export ` and forcing `force_exported = false`. The clause is now
treated as exported, so `emit_import_equals_assignment_prefix` emits the correct
per-module-kind prefix (`export var X = ...` for ES-module output), and the
handler's conditional semicolon means exported type-only aliases still elide
cleanly with no stray `export ;`.

Adjacent matrix covered by tests:
- `export import AA = A;` (namespace value) → `export var AA = A;`
- `export import AB = A.B;` (nested namespace member) → `export var AB = A.B;`
- `export import AK = A.K;` (namespaced class) → `export var AK = A.K;`
- non-exported `import AA = A;` → stays `var AA = A;` (unchanged)
- `export import AI = A.I;` where `I` is an exported interface → elides, no `export ;`
- CommonJS path unchanged (already routed through the shared handler; covered by `cjs_import_equals_export_tests`)
- node-ESM external `export import fs = require("fs")` branch unchanged (kept its own emit + semicolon)

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --test esm_export_import_equals_alias_tests` (new, 5 cases)
- `cargo test -p tsz-emitter --test cjs_import_equals_export_tests --test script_mode_import_equals_interface_alias_tests` (adjacent, unchanged)
- `cargo test -p tsz-emitter` module/namespace/cjs suites (export_equals_type_only_namespace, cjs_hoisted_var_position_tests, cjs_arbitrary_module_namespace_identifier_tests, cjs_destructuring_export_inline_tests, cjs_clause_export_live_binding_tests, namespace_iife_param_nonbinding_tests, debugger_namespace_recovery_tests, dynamic_import_amd_umd_parity_tests) — all green
- `cargo clippy -p tsz-emitter --tests` — clean
- Ready-review CI owns the broad conformance/emit suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_014uBN3g2nJQWm6DFRE7ptoG)_