### PR TITLE
fix(checker): expand template-literal / string-intrinsic alias display to literal union (#14790)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1843,6 +1843,9 @@ path = "tests/bare_alias_display_tests.rs"
 name = "string_mapping_alias_display_tests"
 path = "tests/string_mapping_alias_display_tests.rs"
 [[test]]
+name = "template_intrinsic_literal_union_alias_display_tests"
+path = "tests/template_intrinsic_literal_union_alias_display_tests.rs"
+[[test]]
 name = "class_field_mapped_type_indexed_access_tests"
 path = "tests/class_field_mapped_type_indexed_access_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
@@ -106,6 +106,15 @@ pub(crate) fn record_source_alias_rejection_kinds(
 ///   Unions/intersections that mix in objects stay deferred to the separate
 ///   elaboration path; directly-written aliases sharing a bare object shape are
 ///   protected by the def store's "direct wins" provenance.
+/// - A **template literal** (`` `${"a" | "b"}-x` ``) and a **string-mapping
+///   intrinsic** (`Capitalize<"a" | "b">`) drop the alias name when they reduce
+///   to a finite literal union: tsc's `getTemplateLiteralType` /
+///   `getStringMappingType` build the result via `getUnionType` /
+///   `getStringLiteralType` directly, with no `aliasSymbol`, so the expanded
+///   union is shown (`"a-x" | "b-x"`, `"A" | "B"`), never the alias name. A
+///   directly-written union alias (`type Plain = "a" | "b"`) keeps its name —
+///   its body node is a `UnionType`, not a template/intrinsic, so it never
+///   reaches these arms.
 pub(crate) fn alias_declaration_body_is_computed(
     arena: &NodeArena,
     db: &dyn TypeDatabase,
@@ -121,7 +130,25 @@ pub(crate) fn alias_declaration_body_is_computed(
     let Some(body_node) = arena.get(type_alias.type_node) else {
         return false;
     };
+    // A string-mapping intrinsic body (see the doc-comment rule above) is keyed
+    // on the raw (unevaluated) `StringIntrinsic` result shape, not a body syntax
+    // kind (its body parses as a `TypeReference` to `Capitalize`/…), so it is
+    // handled before the AST-kind dispatch. A still-deferred intrinsic over a
+    // non-literal arg (`Capitalize<string>`) already renders structurally, so
+    // the mark is a harmless no-op there.
+    if crate::query_boundaries::common::is_string_intrinsic_type(db, result) {
+        return true;
+    }
     match body_node.kind {
+        // A template-literal body that reduces to a union is freshly built by
+        // tsc's `getTemplateLiteralType` (`mapType` -> `getUnionType`) with no
+        // `aliasSymbol`, so the expanded union is printed, not the alias name.
+        // A single-literal or still-deferred pattern result is not a union and
+        // is rendered structurally elsewhere (not in the composite reverse
+        // lookup), so it needs no mark.
+        syntax_kind_ext::TEMPLATE_LITERAL_TYPE => {
+            crate::query_boundaries::common::is_union_type(db, result)
+        }
         syntax_kind_ext::INTERSECTION_TYPE => result_is_primitive_literal_union(db, result),
         syntax_kind_ext::CONDITIONAL_TYPE => {
             !crate::query_boundaries::common::is_conditional_type(db, result)

--- a/crates/tsz-checker/tests/template_intrinsic_literal_union_alias_display_tests.rs
+++ b/crates/tsz-checker/tests/template_intrinsic_literal_union_alias_display_tests.rs
@@ -1,0 +1,120 @@
+//! Diagnostic-display tests for template-literal / string-intrinsic aliases that
+//! reduce to a finite literal union (issue #14790).
+//!
+//! Structural rule: a type alias whose body is a template-literal type
+//! (`` `${"a" | "b"}-x` ``) or a string-mapping intrinsic
+//! (`Capitalize<"foo" | "bar">`) and which reduces to a finite union of literals
+//! carries no `aliasSymbol` in tsc — `getTemplateLiteralType` /
+//! `getStringMappingType` build the union directly via `getUnionType`. tsc prints
+//! the expanded union (`"a-x" | "b-x"`, `"Foo" | "Bar"`); tsz previously kept the
+//! alias name because the reduced union was registered as the alias body and the
+//! reverse `find_def_for_type` lookup repainted it.
+//!
+//! The rule is keyed on the body's syntactic form (template literal) or the raw
+//! `StringIntrinsic` shape, never the alias name: the cases use distinct alias
+//! spellings (`Pair`, `Flag`, `Caps`, `Loud`) to guard against name hardcoding
+//! (§25), and each asserts the alias name is absent from the rendered message.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn ts2322(source: &str) -> String {
+    let diagnostics = check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            strict_function_types: true,
+            ..CheckerOptions::default()
+        },
+    );
+    diagnostics
+        .iter()
+        .find(|diag| diag.code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322, got: {diagnostics:#?}"))
+        .message_text
+        .clone()
+}
+
+#[test]
+fn template_literal_union_alias_target_expands() {
+    // Primary repro from #14790.
+    let msg = ts2322(
+        r#"
+type Pair = `${"a" | "b"}-x`;
+const bad: Pair = "z";
+"#,
+    );
+    assert!(
+        msg.contains(r#"Type '"z"' is not assignable to type '"a-x" | "b-x"'."#),
+        "template-literal alias target must expand to the literal union, got: {msg}"
+    );
+    assert!(
+        !msg.contains("'Pair'"),
+        "target must not keep the alias name `Pair`, got: {msg}"
+    );
+}
+
+#[test]
+fn template_literal_boolean_span_alias_expands() {
+    let msg = ts2322(
+        r#"
+type Flag = `flag-${boolean}`;
+const bad: Flag = "z";
+"#,
+    );
+    assert!(
+        msg.contains(r#"Type '"z"' is not assignable to type '"flag-false" | "flag-true"'."#),
+        "`flag-${{boolean}}` alias must expand to the literal union, got: {msg}"
+    );
+    assert!(!msg.contains("'Flag'"), "got: {msg}");
+}
+
+#[test]
+fn capitalize_literal_union_alias_expands() {
+    let msg = ts2322(
+        r#"
+type Caps = Capitalize<"foo" | "bar">;
+const bad: Caps = "z";
+"#,
+    );
+    assert!(
+        msg.contains(r#"Type '"z"' is not assignable to type '"Foo" | "Bar"'."#),
+        "Capitalize over a literal union must expand, got: {msg}"
+    );
+    assert!(!msg.contains("'Caps'"), "got: {msg}");
+}
+
+#[test]
+fn uppercase_literal_union_alias_expands() {
+    let msg = ts2322(
+        r#"
+type Loud = Uppercase<"a" | "b">;
+const bad: Loud = "z";
+"#,
+    );
+    assert!(
+        msg.contains(r#"Type '"z"' is not assignable to type '"A" | "B"'."#),
+        "Uppercase over a literal union must expand, got: {msg}"
+    );
+    assert!(!msg.contains("'Loud'"), "got: {msg}");
+}
+
+#[test]
+fn directly_written_literal_union_alias_keeps_name() {
+    // Control: a directly-written literal-union alias keeps its name in BOTH tsz
+    // and tsc — its body node is a `UnionType`, never a template/intrinsic, so it
+    // never reaches the computed-body arms. This proves the fix did not broadly
+    // disable literal-union alias names.
+    let msg = ts2322(
+        r#"
+type Plain = "a-x" | "b-x";
+const bad: Plain = "z";
+"#,
+    );
+    assert!(
+        msg.contains("is not assignable to type 'Plain'."),
+        "directly-written union alias must keep its name, got: {msg}"
+    );
+}


### PR DESCRIPTION
Fixes #14790.

A type alias whose body is a template-literal type (`` `${"a" | "b"}-x` ``) or a string-mapping intrinsic (`Capitalize<"foo" | "bar">`) that reduces to a finite union of string literals was printed by its **alias name** in tsz diagnostics, while tsc prints the **expanded union**.

```ts
type Pair = `${"a" | "b"}-x`;   // "a-x" | "b-x"
const bad: Pair = "z";
```
tsz before:
```
error TS2322: Type '"z"' is not assignable to type 'Pair'.
```
tsc 5.9.3 / tsz after:
```
error TS2322: Type '"z"' is not assignable to type '"a-x" | "b-x"'.
```

**Structural rule:** when a type alias body is a template literal that reduces to a union, or a string-mapping intrinsic (`Uppercase`/`Lowercase`/`Capitalize`/`Uncapitalize`), tsc builds the result via `getTemplateLiteralType` / `getStringMappingType` (`getUnionType` / `getStringLiteralType`) directly, with **no `aliasSymbol`**, so it renders the expanded union — never the alias name. tsz registered the reduced union as the alias body, and the def-store reverse `find_def_for_type` lookup repainted it with the alias name.

**Owner layer:** the checker's alias-body display-provenance classifier `alias_declaration_body_is_computed` (`crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs`). The fix adds two arms alongside the existing intersection / conditional / indexed-access / `keyof` arms, so the body is marked "computed" → `DefinitionStore::is_computed_body` skips the alias name → the established display path expands the union. Both predicates are solver-backed structural queries through `query_boundaries::common` (`is_string_intrinsic_type` on the raw `StringIntrinsic` shape, `is_union_type` on the reduced template body), so the rule is independent of the chosen alias name (§25) — no name/string matching.

A **directly-written** union alias (`type Plain = "a" | "b"`) keeps its name: its body node is a `UnionType`, not a template/intrinsic, so it never reaches the new arms, and the def store's "direct wins" provenance protects a shared interned shape. The error **decision** is unchanged (TS2322 still fires the same places); only the rendered target text changes.

**Adjacent matrix (new tests, name-varied):**
- template literal `` `${"a" | "b"}-x` `` (`Pair`) → `"a-x" | "b-x"`
- template literal with `boolean` span `` `flag-${boolean}` `` (`Flag`) → `"flag-false" | "flag-true"`
- `Capitalize<"foo" | "bar">` (`Caps`) → `"Foo" | "Bar"`
- `Uppercase<"a" | "b">` (`Loud`) → `"A" | "B"`
- control: directly-written `type Plain = "a-x" | "b-x"` keeps the name `Plain`

Out of scope (noted in #14790, separate owner path): **generic** template/intrinsic alias *applications* (e.g. `Loud<"a" | "b">` where `type Loud<T> = `\``${Uppercase<T>}!`\``) are rendered through the formatter's `Application` display-reduction path, not the reverse-lookup path this classifier feeds, and are left for a follow-up.

## Goal
Goal: green

## Verification
- `cargo test -p tsz-checker --test template_intrinsic_literal_union_alias_display_tests` — 5/5 pass (template, boolean-span, Capitalize, Uppercase, direct-union control)
- Regression guards (no change): `cargo test -p tsz-checker --test string_mapping_alias_display_tests --test bare_alias_display_tests --test union_origin_display_tests --test conditional_alias_source_display_tests --test keyof_source_display_tests --test mapped_identity_alias_display_pollution_tests --test template_literal_union_separator_tests` — all pass
- `cargo fmt -p tsz-checker -- --check` and `cargo clippy -p tsz-checker --lib` — clean
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKM3uJ7zb2aRGqn4ec7bzQ)_