### PR TITLE
fix(checker): resolve cross-file typeof self-loop for merged value+type-alias (#15078)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/core_typeof_value.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_typeof_value.rs
@@ -102,4 +102,34 @@ impl CheckerState<'_> {
         self.ctx
             .register_typeof_value_type_in_envs(symbol_ref, value_type);
     }
+
+    /// When a resolved type is a bare deferred `typeof X` whose symbol is a
+    /// merged value+type-alias, register `X`'s value-space type so a *consuming*
+    /// file's `resolve_type_query` can break the self-loop the declaring file's
+    /// (now reset) `type_env` would otherwise leave unresolved. Calling this as a
+    /// type *reference* resolves makes the value side available before any later
+    /// relation, in every context. No-ops for everything else, since
+    /// `merged_interface_value_typeof_type` returns `None` for non-merged symbols.
+    /// See #15078.
+    pub(crate) fn register_self_referential_merged_value_typeof(&mut self, type_id: TypeId) {
+        let Some(symbol_ref) =
+            crate::query_boundaries::common::get_type_query_symbol_ref(self.ctx.types, type_id)
+        else {
+            return;
+        };
+        // Already registered (a sibling reference resolved first, or this node is
+        // re-resolved under a type-parameter scope): skip the value recompute.
+        if self
+            .ctx
+            .type_env
+            .try_borrow()
+            .is_ok_and(|env| env.get_typeof_value_type(symbol_ref).is_some())
+        {
+            return;
+        }
+        let sym_id = SymbolId(symbol_ref.0);
+        if let Some(value_type) = self.merged_interface_value_typeof_type(sym_id) {
+            self.register_typeof_value_type_in_envs(sym_id, value_type);
+        }
+    }
 }

--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -292,6 +292,13 @@ impl<'a> CheckerState<'a> {
                     }
                 }
                 let mut result = self.get_type_from_type_reference(idx);
+                // Break a cross-file `const X = ...; type X = typeof X` self-loop:
+                // register `X`'s value-space type when the reference resolves to a
+                // deferred `typeof X`, so every later relation (constraint /
+                // assignment / …) sees the value instead of the unresolvable query.
+                // No-ops unless `result` is a bare `typeof` of a merged value
+                // symbol (#15078).
+                self.register_self_referential_merged_value_typeof(result);
                 // Eagerly reduce a concrete `Awaited<…>` reference to its
                 // unwrapped form, the way tsc computes `getAwaitedType` at the
                 // reference site. The solver's lazy conditional/`infer`

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -1586,6 +1586,9 @@ mod cross_file_keyof_utility_alias_tests;
 #[path = "cross_file_lib_utility_indexed_access_tests.rs"]
 mod cross_file_lib_utility_indexed_access_tests;
 #[cfg(test)]
+#[path = "cross_file_merged_value_self_typealias_typeof_tests.rs"]
+mod cross_file_merged_value_self_typealias_typeof_tests;
+#[cfg(test)]
 #[path = "cross_file_typeof_class_constructor_tests.rs"]
 mod cross_file_typeof_class_constructor_tests;
 #[cfg(test)]

--- a/crates/tsz-cli/src/driver/cross_file_merged_value_self_typealias_typeof_tests.rs
+++ b/crates/tsz-cli/src/driver/cross_file_merged_value_self_typealias_typeof_tests.rs
@@ -1,0 +1,167 @@
+//! Project-mode coverage for a value merged with a self-referential type alias
+//! (`const X = <literal>; type X = typeof X`) used in a *consuming* file.
+//!
+//! The merged symbol stores the self-referential `TypeQuery(X)` as its
+//! type-space body. The declaring file registers `X`'s value-space type while
+//! checking the alias, but a consuming file's per-file `type_env` is reset, so
+//! the deferred `TypeQuery(X)` self-loops in `resolve_type_query` and every
+//! relation against the reference fails: a false `TS2344` when the reference is
+//! a generic argument (the original ts-pattern `anonymousSelectKey` row, arch
+//! #8225) and a false `TS2322` when it is the source of an assignment. These run
+//! the full project driver (shared `DefinitionStore`, every file checked) so the
+//! per-file reset that triggers the self-loop is exercised — the simplified
+//! single-context checker harness does not reproduce it. See #15078.
+
+use super::compile;
+use crate::args::CliArgs;
+use clap::Parser;
+use std::fs;
+use tsz_common::diagnostics::Diagnostic;
+
+const TS2344: u32 = 2344;
+const TS2322: u32 = 2322;
+
+/// Write `files` plus a strict `noEmit` tsconfig into a fresh temp dir and run
+/// the project-mode compile. Returns every emitted diagnostic.
+fn compile_project(files: &[(&str, &str)]) -> Vec<Diagnostic> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let names: Vec<String> = files
+        .iter()
+        .map(|(name, _)| format!("\"{name}\""))
+        .collect();
+    let tsconfig = format!(
+        r#"{{ "compilerOptions": {{ "strict": true, "target": "es2015", "noEmit": true }}, "files": [{}] }}"#,
+        names.join(", ")
+    );
+    fs::write(dir.path().join("tsconfig.json"), tsconfig).expect("write tsconfig");
+    for (name, source) in files {
+        fs::write(dir.path().join(name), source).expect("write source");
+    }
+
+    let project = dir.path().to_string_lossy().to_string();
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--project",
+        project.as_str(),
+        "--noEmit",
+        "--pretty",
+        "false",
+    ])
+    .expect("project args");
+    compile(&args, dir.path())
+        .expect("compile succeeds")
+        .diagnostics
+}
+
+fn count_code(diags: &[Diagnostic], code: u32) -> usize {
+    diags.iter().filter(|d| d.code == code).count()
+}
+
+const SYMBOLS: (&str, &str) = (
+    "symbols.ts",
+    "export const anonymousSelectKey = '@ts-pattern/anonymous-select-key';\n\
+     export type anonymousSelectKey = typeof anonymousSelectKey;\n",
+);
+
+/// The ts-pattern repro: a string-literal marker merged with its self-`typeof`
+/// alias satisfies a `string` constraint across files (no false TS2344).
+#[test]
+fn string_marker_satisfies_string_constraint_cross_file() {
+    let diags = compile_project(&[
+        SYMBOLS,
+        (
+            "patterns.ts",
+            "import { anonymousSelectKey } from './symbols';\n\
+             type SelectP<key extends string> = key;\n\
+             export type Bad = SelectP<anonymousSelectKey>;\n",
+        ),
+    ]);
+    assert_eq!(
+        count_code(&diags, TS2344),
+        0,
+        "string marker should satisfy the `string` constraint cross-file, got: {diags:?}"
+    );
+}
+
+/// Renamed import (`as`) keeps the value-space resolution working.
+#[test]
+fn renamed_marker_satisfies_constraint_cross_file() {
+    let diags = compile_project(&[
+        SYMBOLS,
+        (
+            "patterns.ts",
+            "import { anonymousSelectKey as Key } from './symbols';\n\
+             type SelectP<key extends string> = key;\n\
+             export type Bad = SelectP<Key>;\n",
+        ),
+    ]);
+    assert_eq!(
+        count_code(&diags, TS2344),
+        0,
+        "renamed marker should satisfy the constraint, got: {diags:?}"
+    );
+}
+
+/// Negative control: a numeric marker must NOT satisfy a `string` constraint —
+/// the value side is genuinely checked, not blindly accepted.
+#[test]
+fn number_marker_violates_string_constraint_cross_file() {
+    let diags = compile_project(&[
+        (
+            "nsym.ts",
+            "export const numKey = 42;\nexport type numKey = typeof numKey;\n",
+        ),
+        (
+            "nmain.ts",
+            "import { numKey } from './nsym';\n\
+             type NeedsString<k extends string> = k;\n\
+             export type Bad = NeedsString<numKey>;\n",
+        ),
+    ]);
+    assert_eq!(
+        count_code(&diags, TS2344),
+        1,
+        "numeric marker must violate the `string` constraint, got: {diags:?}"
+    );
+}
+
+/// The same numeric marker satisfies a `number` constraint (value side accepted).
+#[test]
+fn number_marker_satisfies_number_constraint_cross_file() {
+    let diags = compile_project(&[
+        (
+            "nsym.ts",
+            "export const numKey = 42;\nexport type numKey = typeof numKey;\n",
+        ),
+        (
+            "nmain.ts",
+            "import { numKey } from './nsym';\n\
+             type NeedsNumber<k extends number> = k;\n\
+             export type Ok = NeedsNumber<numKey>;\n",
+        ),
+    ]);
+    assert_eq!(
+        count_code(&diags, TS2344),
+        0,
+        "numeric marker should satisfy the `number` constraint, got: {diags:?}"
+    );
+}
+
+/// Assignment position: the marker's literal is assignable to `string`, so the
+/// previously-deferred self-loop no longer produces a false assignment error.
+#[test]
+fn marker_assignable_to_string_cross_file() {
+    let diags = compile_project(&[
+        SYMBOLS,
+        (
+            "use.ts",
+            "import { anonymousSelectKey } from './symbols';\n\
+             export const ok: string = null as unknown as anonymousSelectKey;\n",
+        ),
+    ]);
+    assert_eq!(
+        count_code(&diags, TS2322),
+        0,
+        "string marker should be assignable to `string`, got: {diags:?}"
+    );
+}


### PR DESCRIPTION
Fixes #15078.

When a value is merged with a self-referential type alias — `const X = "..."; type X = typeof X` (the ts-pattern `anonymousSelectKey` / fp-ts HKT-URI tag idiom) — the merged symbol stores the self-referential `TypeQuery(X)` as its type-space body. The declaring file registers `X`'s value-space type while checking that alias, but a **consuming** file's per-file `type_env` is reset, so the deferred `TypeQuery(X)` self-loops in `resolve_type_query` and stays unresolved there. Every relation against the reference then fails: a false `TS2344` when the reference is a generic argument (the reported ts-pattern row) and a false `TS2322` when it is the source of an assignment.

**Structural rule:** when a type reference resolves to a bare `typeof X` whose symbol is a value merged with a type alias, `tsc` resolves it to `X`'s value-space type in every position; tsz now does the same through the checker by registering that value side at reference-resolution time (`get_type_from_type_node` → `register_self_referential_merged_value_typeof`), so the deferred query is broken before any later relation, in every context. The helper no-ops for non-merged symbols (pure values and class merges already resolve correctly) and skips the recompute when the env already holds the value, so it is free on the common path.

Owner layer: checker type-node resolution (`crates/tsz-checker/src/state/type_environment/type_node_resolution.rs`, `state/type_analysis/core_typeof_value.rs`).

Adjacent matrix (all covered by the new witness tests): string / number markers, a renamed (`as`) import, constraint position, assignment position, plus negative controls (a number marker still violates a `string` constraint, and satisfies a `number` one) so the value side is genuinely checked rather than blindly accepted.

## Goal
Goal: hold

## Verification
- New project-driver witness suite (the simplified single-context checker harness does not exercise the per-file `type_env` reset that triggers the self-loop):
  `cargo test -p tsz-cli --lib cross_file_merged_value_self_typealias` — 5 passed. Confirmed 4 of these fail on the pre-fix tree, proving they are genuine regression guards.
- Repro from the issue (`tsz --noEmit --strict symbols.ts patterns.ts`) now exits 0; `const numKey = 42; type numKey = typeof numKey` against a `string` constraint still reports `TS2344`.
- No new failures: `cargo test -p tsz-checker --lib cross_file` reports the identical 305 passed / 9 failed before and after this change (the 9 are pre-existing, tracked by #15196).
- ready-review CI owns the broad conformance / emit / fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high