### PR TITLE
refactor(solver): route mapped key bails through evaluation result (#14351)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -906,7 +906,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// universal `into_type_id` collapse — and the emitted type and diagnostics
     /// — are exactly as before.
     #[inline]
-    fn note_request_termination(&mut self, kind: TerminationKind) {
+    pub(in crate::evaluation) fn note_request_termination(&mut self, kind: TerminationKind) {
         // First-wins: keep the kind that first truncated the walk.
         self.request_termination_kind.get_or_insert(kind);
         use tsz_common::perf_counters::EvaluationTerminationGuard as Guard;
@@ -921,6 +921,21 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             TerminationKind::IterationExceeded => return,
         };
         tsz_common::perf_counters::record_eval_termination_guard(guard);
+    }
+
+    /// Record a limit event from an evaluation-rule-local guard and surface it
+    /// through the typed request verdict.
+    ///
+    /// Most bails flow through the evaluator's main recursion guard, whose
+    /// `mark_*` helpers bump `limit_epoch` before recording the request
+    /// verdict. Operation-local guards such as mapped-key constraint reduction
+    /// return their own opaque fallback without touching that main guard; they
+    /// must still advance `limit_epoch` so application-body cache writes do not
+    /// publish a budget-truncated result.
+    #[inline]
+    pub(in crate::evaluation) fn record_request_limit_event(&mut self, kind: TerminationKind) {
+        self.note_limit_event();
+        self.note_request_termination(kind);
     }
 
     /// Record that an application's base `DefId` had no resolvable body in

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/keyof_constraint.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/keyof_constraint.rs
@@ -2,6 +2,7 @@
 
 use crate::construction::TypeDatabase;
 use crate::evaluation::evaluate::TypeEvaluator;
+use crate::evaluation::result::TerminationKind;
 use crate::recursion::RecursionResult;
 use crate::relations::subtype::TypeResolver;
 use crate::types::{LiteralValue, TypeData, TypeId};
@@ -38,6 +39,15 @@ impl KeyofConstraintStepState {
             | Self::DepthExceeded
             | Self::IterationExceeded
             | Self::SolverFrameExhausted => Some(current),
+        }
+    }
+
+    const fn termination_kind(self) -> Option<TerminationKind> {
+        match self {
+            Self::Entered | Self::AlreadyVisited => None,
+            Self::DepthExceeded => Some(TerminationKind::DepthExceeded),
+            Self::IterationExceeded => Some(TerminationKind::IterationExceeded),
+            Self::SolverFrameExhausted => Some(TerminationKind::SolverStackFrames),
         }
     }
 }
@@ -93,7 +103,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 self.keyof_constraint_guard.enter(current),
             ) {
                 KeyofConstraintStepState::Entered => entered.push(current),
-                state => break state.fallback_type(current).unwrap_or(current),
+                state => {
+                    if let Some(kind) = state.termination_kind() {
+                        self.record_request_limit_event(kind);
+                    }
+                    break state.fallback_type(current).unwrap_or(current);
+                }
             }
 
             // Shared cross-operation stack-frame breaker (issue #7574): bound
@@ -102,9 +117,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             let Some(step) = crate::recursion::with_solver_frame(|| {
                 self.evaluate_keyof_or_constraint_inner(current)
             }) else {
-                break KeyofConstraintStepState::SolverFrameExhausted
-                    .fallback_type(current)
-                    .unwrap_or(current);
+                let state = KeyofConstraintStepState::SolverFrameExhausted;
+                if let Some(kind) = state.termination_kind() {
+                    self.record_request_limit_event(kind);
+                }
+                break state.fallback_type(current).unwrap_or(current);
             };
 
             match KeyofConstraintReductionState::from_evaluated_step(self.interner(), current, step)
@@ -186,7 +203,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::recursion::RecursionResult;
+    use crate::construction::TypeInterner;
+    use crate::evaluation::result::Termination;
+    use crate::recursion::{RecursionGuard, RecursionResult};
+
+    fn assert_request_verdict(
+        evaluator: &TypeEvaluator<'_, crate::relations::subtype::NoopResolver>,
+        partial: TypeId,
+        kind: TerminationKind,
+    ) {
+        let result = evaluator.request_result_for_test(partial);
+        assert_eq!(
+            result.termination(),
+            Termination::Incomplete { kind, partial }
+        );
+        assert_eq!(result.into_type_id(), partial);
+    }
 
     #[test]
     fn step_state_names_every_guard_fallback() {
@@ -216,6 +248,24 @@ mod tests {
             KeyofConstraintStepState::SolverFrameExhausted.fallback_type(current),
             Some(current)
         );
+        assert_eq!(
+            KeyofConstraintStepState::from_guard_entry(RecursionResult::Cycle).termination_kind(),
+            None
+        );
+        assert_eq!(
+            KeyofConstraintStepState::from_guard_entry(RecursionResult::DepthExceeded)
+                .termination_kind(),
+            Some(TerminationKind::DepthExceeded)
+        );
+        assert_eq!(
+            KeyofConstraintStepState::from_guard_entry(RecursionResult::IterationExceeded)
+                .termination_kind(),
+            Some(TerminationKind::IterationExceeded)
+        );
+        assert_eq!(
+            KeyofConstraintStepState::SolverFrameExhausted.termination_kind(),
+            Some(TerminationKind::SolverStackFrames)
+        );
     }
 
     #[test]
@@ -236,6 +286,72 @@ mod tests {
         assert_eq!(
             KeyofConstraintReductionState::from_evaluated_step(&interner, current, current),
             KeyofConstraintReductionState::Done(current)
+        );
+    }
+
+    #[test]
+    fn local_depth_bail_records_request_verdict() {
+        let interner = TypeInterner::new();
+        let mut evaluator = TypeEvaluator::new(&interner);
+        let current = interner.keyof(TypeId::STRING);
+        let mut entered = Vec::new();
+
+        for offset in 0..evaluator.keyof_constraint_guard.max_depth() {
+            let type_id = TypeId(10_000 + offset);
+            assert!(evaluator.keyof_constraint_guard.enter(type_id).is_entered());
+            entered.push(type_id);
+        }
+
+        assert_eq!(evaluator.evaluate_keyof_or_constraint(current), current);
+        assert_request_verdict(&evaluator, current, TerminationKind::DepthExceeded);
+
+        for type_id in entered.into_iter().rev() {
+            evaluator.keyof_constraint_guard.leave(type_id);
+        }
+    }
+
+    #[test]
+    fn local_iteration_bail_records_request_verdict() {
+        let interner = TypeInterner::new();
+        let mut evaluator = TypeEvaluator::new(&interner);
+        let current = interner.keyof(TypeId::STRING);
+        evaluator.keyof_constraint_guard = RecursionGuard::new(100, 0);
+
+        assert_eq!(evaluator.evaluate_keyof_or_constraint(current), current);
+        assert_request_verdict(&evaluator, current, TerminationKind::IterationExceeded);
+    }
+
+    #[test]
+    fn solver_frame_bail_records_request_verdict() {
+        let interner = TypeInterner::new();
+        let mut evaluator = TypeEvaluator::new(&interner);
+        let current = interner.keyof(TypeId::STRING);
+        crate::recursion::reset_solver_stack_frames();
+        let mut held = Vec::with_capacity(crate::recursion::MAX_SOLVER_STACK_FRAMES as usize);
+
+        for _ in 0..crate::recursion::MAX_SOLVER_STACK_FRAMES {
+            held.push(crate::recursion::try_enter_solver_frame().expect("under frame cap"));
+        }
+
+        assert_eq!(evaluator.evaluate_keyof_or_constraint(current), current);
+        drop(held);
+        crate::recursion::reset_solver_stack_frames();
+        assert_request_verdict(&evaluator, current, TerminationKind::SolverStackFrames);
+    }
+
+    #[test]
+    fn cycle_fallback_does_not_record_request_verdict() {
+        let interner = TypeInterner::new();
+        let mut evaluator = TypeEvaluator::new(&interner);
+        let current = interner.keyof(TypeId::STRING);
+
+        assert!(evaluator.keyof_constraint_guard.enter(current).is_entered());
+        assert_eq!(evaluator.evaluate_keyof_or_constraint(current), current);
+        evaluator.keyof_constraint_guard.leave(current);
+
+        assert_eq!(
+            evaluator.request_result_for_test(current).termination(),
+            Termination::Complete
         );
     }
 }

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -242,6 +242,8 @@ fn evaluation_engine_keeps_request_stage_boundary() {
     // after the engine split; the module boundary is still owned by `evaluate`.
     let evaluate_api_rs = read_solver_source("evaluation/evaluate/api.rs");
     let evaluate_application_rs = read_solver_source("evaluation/evaluate/application.rs");
+    let mapped_keyof_constraint_rs =
+        read_solver_source("evaluation/evaluate_rules/mapped/keyof_constraint.rs");
     let cross_eval_guard_rs = read_solver_source("evaluation/cross_eval_guard.rs");
     let infer_pattern_rs = read_solver_source("evaluation/evaluate_rules/infer_pattern.rs");
     let infer_match_expansion_rs =
@@ -314,6 +316,19 @@ fn evaluation_engine_keeps_request_stage_boundary() {
                 .count()
                 >= 2,
         "application evaluation depth/divergence bails must route through the typed request termination producer"
+    );
+    assert!(
+        evaluate_rs.contains("fn record_request_limit_event(&mut self, kind: TerminationKind)")
+            && mapped_keyof_constraint_rs.contains("record_request_limit_event(kind)")
+            && mapped_keyof_constraint_rs
+                .contains("Self::DepthExceeded => Some(TerminationKind::DepthExceeded)")
+            && mapped_keyof_constraint_rs
+                .contains("Self::IterationExceeded => Some(TerminationKind::IterationExceeded)")
+            && mapped_keyof_constraint_rs
+                .contains("Self::SolverFrameExhausted => Some(TerminationKind::SolverStackFrames)"),
+        "mapped keyof/constraint local guard bails must advance the evaluator-owned \
+         request termination channel instead of returning opaque fallbacks as \
+         complete results"
     );
     assert!(
         result_rs.contains("fn unstable_complete(type_id: TypeId) -> Self")


### PR DESCRIPTION
Part of #14351.

Structural rule: when mapped `keyof`/constraint reduction is cut short by its local recursion-depth guard, iteration budget, or the shared solver-stack frame budget, `tsc` treats the keyspace reduction as bounded/incomplete; tsz should record that through the solver-owned evaluation result channel while preserving the same opaque fallback `TypeId` for current consumers.

Owner layer: solver evaluation. `TypeEvaluator::record_request_limit_event` now owns operation-local limit recording, and mapped-key constraint reduction routes `DepthExceeded`, `IterationExceeded`, and `SolverStackFrames` through it before returning the same fallback type.

Adjacent matrix:
- local mapped-key depth bail: records `TerminationKind::DepthExceeded`, returns the unchanged partial
- local mapped-key iteration bail: records `TerminationKind::IterationExceeded`, returns the unchanged partial
- shared solver-frame bail: records `TerminationKind::SolverStackFrames`, returns the unchanged partial
- cycle fallback: remains a non-limit opaque fallback and reports `Complete`
- existing mapped-key reduction/name/cycle tests remain unchanged

Cache/fallback plan: the new helper also bumps the evaluator `limit_epoch`, so application-eval cache publication sees operation-local mapped-key truncation as the same kind of budget-tainted body event as the main evaluation guard. `EvaluationResult::into_type_id()` still collapses to the same `TypeId` as before, so behavior and diagnostics are intended unchanged.

## Goal
Goal: green

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver local_depth_bail_records_request_verdict local_iteration_bail_records_request_verdict solver_frame_bail_records_request_verdict cycle_fallback_does_not_record_request_verdict step_state_names_every_guard_fallback`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards evaluation_engine_keeps_request_stage_boundary`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver evaluate_keyof_or_constraint mapped_keyof_template tuple_keyof_indexed_access`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver iteration_exceeded_request_reports_incomplete_with_partial every_guard_bail_reports_incomplete_with_its_kind_and_partial depth_marker_for_request_records_depth_verdict raw_depth_marker_allows_specific_fuel_verdict`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `python3 scripts/arch/arch_guard.py --json`
- `python3 scripts/arch/test_arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- ready-review CI owns broad conformance / emit / fourslash suites.

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high
