### PR TITLE
fix(solver): keep return-position inference when contextual type contradicts evidence (#14792)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1022,6 +1022,9 @@ path = "tests/contextual_return_tuple_generic_member_tests.rs"
 name = "contextual_return_callback_param_only_inference_tests"
 path = "tests/contextual_return_callback_param_only_inference_tests.rs"
 [[test]]
+name = "contextual_return_literal_refinement_tests"
+path = "tests/contextual_return_literal_refinement_tests.rs"
+[[test]]
 name = "contextual_return_value_arg_pinned_tests"
 path = "tests/contextual_return_value_arg_pinned_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/call_context.rs
+++ b/crates/tsz-checker/src/checkers/call_context.rs
@@ -574,6 +574,17 @@ impl<'a> CheckerState<'a> {
             }
             found
         };
+
+        // A callback whose object-literal return is built entirely from
+        // concrete-pinned parameters has a fully-determined return the outer
+        // contextual type cannot refine (#14792 — see the helper's doc comment).
+        // This holds whether the call returns the bare parameter `U` or a
+        // covariant wrapper of it (`U[]`, …), so it takes precedence over the
+        // wrapped-parameter specialization path below.
+        if self.callback_object_return_pinned_by_concrete_arg(shape, args, &return_type_params) {
+            return true;
+        }
+
         if !return_is_bare_type_param
             && (has_bare_return_param_argument || has_wrapped_return_param_argument)
             && let Some(contextual_type) = contextual_type
@@ -593,27 +604,6 @@ impl<'a> CheckerState<'a> {
             {
                 return false;
             }
-        }
-
-        // Bare return type parameter `U`: when a context-sensitive callback
-        // argument returns an object literal built entirely from the callback's
-        // own parameters that are already pinned by a concrete sibling argument,
-        // the callback's argument inference for `U` is authoritative. `tsc`
-        // seeds `U` from the outer contextual type but ranks that inference
-        // below the callback's (`InferencePriority.ReturnType`), so the outer
-        // annotation can never refine the literal and the callback body is
-        // checked against the FINAL inferred `U`, not the outer annotation.
-        // Suppressing the contextual return keeps `tsz` from pushing the outer
-        // annotation onto the return-position literal and double-reporting the
-        // mismatch inside the callback body (#14792).
-        if return_is_bare_type_param
-            && self.bare_return_callback_return_pinned_by_concrete_arg(
-                shape,
-                args,
-                &return_type_params,
-            )
-        {
-            return true;
         }
 
         for (i, &arg_idx) in args.iter().enumerate() {

--- a/crates/tsz-checker/src/checkers/call_context/bare_return_overlap.rs
+++ b/crates/tsz-checker/src/checkers/call_context/bare_return_overlap.rs
@@ -7,8 +7,9 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::{FunctionShape, TypeId};
 
 impl CheckerState<'_> {
-    /// Detects the `#14792` shape: a generic call whose return type is a bare
-    /// type parameter `U`, where a context-sensitive callback argument (whose
+    /// Detects the `#14792` shape: a generic call whose return type mentions a
+    /// type parameter `U` — either bare (`(...): U`) or under a covariant wrapper
+    /// (`(...): U[]`) — where a context-sensitive callback argument (whose
     /// declared signature mentions `U` in its return position) returns an object
     /// literal built ENTIRELY from the callback's own parameters that are already
     /// pinned by a concrete (non context-sensitive) sibling argument.
@@ -25,7 +26,7 @@ impl CheckerState<'_> {
     /// fresh leaf the contextual type could refine (a free literal such as
     /// `() => 1` or `(v) => [1, 2]`) are excluded, because there the contextual
     /// return legitimately seeds inference and must not be dropped.
-    pub(super) fn bare_return_callback_return_pinned_by_concrete_arg(
+    pub(super) fn callback_object_return_pinned_by_concrete_arg(
         &mut self,
         shape: &FunctionShape,
         args: &[NodeIndex],

--- a/crates/tsz-checker/tests/contextual_return_literal_refinement_tests.rs
+++ b/crates/tsz-checker/tests/contextual_return_literal_refinement_tests.rs
@@ -1,0 +1,188 @@
+//! Regression tests for issue #14792.
+//!
+//! When a generic call `f<T, U>(x: T, fn: (x: T) => U): U` (or a covariant
+//! wrapper of `U` such as `(...): U[]`) is directly contextually typed by a
+//! MISMATCHING annotation, `tsc` seeds the return-position type parameter `U`
+//! from the outer contextual type with `InferencePriority.ReturnType` — a
+//! low-priority hint that can never override the callback's bottom-up inference.
+//! The callback body is checked against the FINAL inferred `U`, and any
+//! annotation mismatch is reported once, at the assignment site.
+//!
+//! tsz previously let the contextual return type win in two ways:
+//!   * solver — when the contextual type was a literal REFINEMENT of the
+//!     bottom-up inferred type (`{ v: 5 }` narrower than `{ v: number }`), the
+//!     `should_use_contextual_return_substitution` override replaced the
+//!     inferred `U` with the contextual type even though the real callback
+//!     evidence (`{ v: number }`) was not assignable to it. The error then
+//!     surfaced inside the callback body (or as a spurious extra diagnostic)
+//!     instead of at the assignment.
+//!   * checker — the contextual-return suppression that keeps the outer
+//!     annotation off a pinned object-literal callback return only fired for a
+//!     BARE return type parameter, so the `(...): U[]` array-wrapped form still
+//!     pushed the outer element type onto the callback body and double-reported.
+//!
+//! Anti-hardcoding: the structural rule is "the callback return is fully
+//! determined by concrete-pinned inputs, so the contextual return type cannot
+//! refine it", so the tests vary binder names and target shapes rather than
+//! matching any specific identifier or rendered message.
+
+use tsz_checker::test_utils::{
+    DiagnosticShape, assert_diagnostic_shapes_exactly, check_source_diagnostics,
+    diagnostic_code_message_refs,
+};
+
+fn assert_clean(source: &str, context: &str) {
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.is_empty(),
+        "{context}: expected no diagnostics, got {:#?}",
+        diagnostic_code_message_refs(&diagnostics),
+    );
+}
+
+#[test]
+fn inline_callback_literal_target_reports_once_at_assignment() {
+    // The callback `(x) => ({ v: x })` returns `{ v: number }`; the literal
+    // target `{ v: 5 }` cannot refine it, so the single TS2322 lands on the
+    // assignment — never inside the callback body (no second diagnostic).
+    let source = "\
+declare function call<A, B>(x: A, fn: (x: A) => B): B;
+const bad: { v: 5 } = call(1, (x) => ({ v: x }));
+";
+    let diagnostics = check_source_diagnostics(source);
+    assert_diagnostic_shapes_exactly(
+        source,
+        &diagnostics,
+        &[DiagnosticShape::code(2322)
+            .at(2, 7)
+            .with_message_fragment("is not assignable to type '{ v: 5; }'")],
+    );
+}
+
+#[test]
+fn extracted_callback_literal_target_reports_once_at_assignment() {
+    // Same shape with the callback hoisted to a variable: the bottom-up `U`
+    // is `{ v: number }`, so the result `{ v: number }` is checked against the
+    // annotation `{ v: 6 }` once, at the assignment.
+    let source = "\
+declare function pipe<S, R>(x: S, fn: (x: S) => R): R;
+const cb = (x: number) => ({ v: x });
+const bad: { v: 6 } = pipe(1, cb);
+";
+    let diagnostics = check_source_diagnostics(source);
+    assert_diagnostic_shapes_exactly(
+        source,
+        &diagnostics,
+        &[DiagnosticShape::code(2322)
+            .at(3, 7)
+            .with_message_fragment("is not assignable to type '{ v: 6; }'")],
+    );
+}
+
+#[test]
+fn block_body_callback_literal_target_reports_once_at_assignment() {
+    let source = "\
+declare function run<P, Q>(x: P, fn: (x: P) => Q): Q;
+const bad: { v: 7 } = run(1, (x) => { return { v: x }; });
+";
+    let diagnostics = check_source_diagnostics(source);
+    assert_diagnostic_shapes_exactly(
+        source,
+        &diagnostics,
+        &[DiagnosticShape::code(2322)
+            .at(2, 7)
+            .with_message_fragment("is not assignable to type '{ v: 7; }'")],
+    );
+}
+
+#[test]
+fn primitive_target_still_reports_once_at_assignment() {
+    // Control: a primitive (non-refining) mismatch already behaved correctly and
+    // must keep reporting exactly one diagnostic at the assignment.
+    let source = "\
+declare function call<A, B>(x: A, fn: (x: A) => B): B;
+const bad: { v: string } = call(1, (x) => ({ v: x }));
+";
+    let diagnostics = check_source_diagnostics(source);
+    assert_diagnostic_shapes_exactly(
+        source,
+        &diagnostics,
+        &[DiagnosticShape::code(2322)
+            .at(2, 7)
+            .with_message_fragment("is not assignable to type '{ v: string; }'")],
+    );
+}
+
+#[test]
+fn compatible_target_stays_clean() {
+    assert_clean(
+        "\
+declare function call<A, B>(x: A, fn: (x: A) => B): B;
+const ok: { v: number } = call(1, (x) => ({ v: x }));
+",
+        "compatible object target",
+    );
+}
+
+#[test]
+fn array_wrapped_callback_literal_target_reports_once_at_assignment() {
+    // `map<T, U>(arr: T[], fn: (x: T) => U): U[]`: the call return wraps the
+    // bare callback return `U`. The pinned object-literal callback return cannot
+    // be refined by the contextual element type, so the only diagnostic is the
+    // assignment-level array mismatch — no extra error inside the callback body.
+    let source = "\
+declare function map<T, U>(arr: T[], fn: (x: T) => U): U[];
+const bad: { v: string }[] = map([1], (x) => ({ v: x }));
+";
+    let diagnostics = check_source_diagnostics(source);
+    assert_diagnostic_shapes_exactly(
+        source,
+        &diagnostics,
+        &[DiagnosticShape::code(2322)
+            .at(2, 7)
+            .with_message_fragment("is not assignable to type '{ v: string; }[]'")],
+    );
+}
+
+#[test]
+fn array_wrapped_compatible_target_stays_clean() {
+    assert_clean(
+        "\
+declare function map<T, U>(arr: T[], fn: (x: T) => U): U[];
+const ok: { v: number }[] = map([1], (x) => ({ v: x }));
+",
+        "compatible array target",
+    );
+}
+
+#[test]
+fn contextual_literal_union_supertype_still_narrows() {
+    // Guard against over-suppression: when the bottom-up evidence DOES fit the
+    // contextual type (the lambda literal `1` is assignable to `0 | 1 | 2`), the
+    // contextual return substitution still applies and the call stays clean.
+    assert_clean(
+        "\
+declare function invoke<T>(f: () => T): T;
+const xx: 0 | 1 | 2 = invoke(() => 1);
+",
+        "literal fits contextual union",
+    );
+}
+
+#[test]
+fn contextual_literal_union_mismatch_reports_at_assignment() {
+    // The lambda returns `5`, which does not fit `0 | 1 | 2`; the inferred type
+    // is kept and the mismatch is reported at the assignment, matching tsc.
+    let source = "\
+declare function invoke<T>(f: () => T): T;
+const yy: 0 | 1 | 2 = invoke(() => 5);
+";
+    let diagnostics = check_source_diagnostics(source);
+    assert_diagnostic_shapes_exactly(
+        source,
+        &diagnostics,
+        &[DiagnosticShape::code(2322)
+            .at(2, 7)
+            .with_message_fragment("is not assignable to type '0 | 1 | 2'")],
+    );
+}

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -6,6 +6,19 @@ use crate::operations::{AssignabilityChecker, CallEvaluator};
 use crate::types::{FunctionShape, ObjectFlags, ParamInfo, TypeData, TypeId, TypePredicate};
 use rustc_hash::{FxHashMap, FxHashSet};
 
+/// A lower-bound inference candidate is "concrete evidence" when it carries a
+/// real type the relation can judge — not `any`/`unknown`/error, and free of
+/// unresolved type parameters or `infer` placeholders. Shared by return-position
+/// candidate selection and the contextual-return substitution evidence guard.
+pub(super) fn is_concrete_inference_bound(
+    db: &dyn crate::construction::TypeDatabase,
+    ty: TypeId,
+) -> bool {
+    !ty.is_any_unknown_or_error()
+        && !crate::visitor::contains_type_parameters(db, ty)
+        && !crate::type_queries::contains_infer_types_db(db, ty)
+}
+
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     pub(super) fn eval_type_param_default(
         &mut self,
@@ -315,17 +328,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         let mut concrete_bounds = effective_lower_bounds
             .iter()
             .copied()
-            .filter(|ty| {
-                !ty.is_any_unknown_or_error()
-                    && !crate::visitor::contains_type_parameters(
-                        self.interner.as_type_database(),
-                        *ty,
-                    )
-                    && !crate::type_queries::contains_infer_types_db(
-                        self.interner.as_type_database(),
-                        *ty,
-                    )
-            })
+            .filter(|ty| is_concrete_inference_bound(self.interner.as_type_database(), *ty))
             .collect::<Vec<_>>();
         concrete_bounds.dedup();
         // When the lone surviving "concrete" bound is `never` *and* the

--- a/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
@@ -750,7 +750,20 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     // are excluded because their inference is authoritative.
                     let indirect_narrowing_override =
                         !direct_param_vars.contains(&var) && should_use && !can_apply;
-                    if (can_apply && should_use) || indirect_narrowing_override {
+                    // The contextual return type may only REFINE the inferred type
+                    // (e.g. a widened lambda return `number` narrowed to the contextual
+                    // `0 | 1 | 2`, whose literal evidence `1` still fits). When a
+                    // concrete bottom-up candidate genuinely does not fit the contextual
+                    // type, the contextual type is a real mismatch, not a refinement, so
+                    // the inferred type must stand and the error surface at the
+                    // call/assignment site (#14792). The evidence check is the second
+                    // `&&` operand so it only runs once the cheap override gate passes.
+                    if ((can_apply && should_use) || indirect_narrowing_override)
+                        && !self.contextual_substitution_contradicts_evidence(
+                            &lower_bounds,
+                            contextual_ty,
+                        )
+                    {
                         contextual_ty
                     } else {
                         ty
@@ -1551,5 +1564,23 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         }
 
         CallResult::Success(return_type)
+    }
+
+    /// Whether substituting the contextual return type for a resolved
+    /// return-position type parameter would contradict the bottom-up inference
+    /// evidence: a concrete lower-bound candidate that is not assignable to the
+    /// contextual type marks a genuine mismatch (which tsc keeps in the inferred
+    /// type and reports at the call/assignment site), not a refinement the
+    /// contextual type may apply. See #14792.
+    fn contextual_substitution_contradicts_evidence(
+        &mut self,
+        lower_bounds: &[TypeId],
+        contextual_ty: TypeId,
+    ) -> bool {
+        let db = self.interner.as_type_database();
+        lower_bounds.iter().copied().any(|bound| {
+            super::super::inference_helpers::is_concrete_inference_bound(db, bound)
+                && !self.checker.is_assignable_to(bound, contextual_ty)
+        })
     }
 }


### PR DESCRIPTION
Fixes #14792.

A generic call `f<T, U>(x: T, fn: (x: T) => U): U` (or a covariant wrapper
`(...): U[]`) directly contextually typed by a **mismatching** annotation
emitted a false positive: tsz either reported a spurious extra `TS2322`
**inside the callback body** or shifted the single error there, instead of
reporting once at the assignment site like `tsc`.

```ts
declare function call<T, U>(x: T, fn: (x: T) => U): U;
const bad: { v: 5 } = call(1, (x) => ({ v: x }));
```
tsz before: `(2,39) TS2322: Type 'number' is not assignable to type '5'.` (inside the callback)
tsc 6.0.2 / tsz after: `(2,7) TS2322: Type '{ v: number; }' is not assignable to type '{ v: 5; }'.`

## Structural rule
When a return-position type parameter's bottom-up inference evidence is **not
assignable** to the outer contextual type, `tsc` keeps the inferred type and
reports the mismatch once, at the assignment. The contextual return type seeds
inference (`InferencePriority.ReturnType`) but never overrides contradicting
evidence; the callback body is checked against the FINAL inferred `U`, never the
raw outer annotation.

## Owner layers
Two independent root causes, each fixed at its owner:

- **solver** — `should_use_contextual_return_substitution` narrowed the resolved
  return-position type parameter to the contextual type whenever it was
  structurally narrower (`{ v: 5 }` ⊂ `{ v: number }`), even though the real
  callback evidence `{ v: number }` was not assignable to it. New guard
  `contextual_substitution_contradicts_evidence` (in `generic_call/resolve/finalize.rs`)
  blocks the override when a concrete lower-bound candidate does not fit the
  contextual type. The legitimate literal refinement (lambda literal `1` fitting
  `0 | 1 | 2`) is preserved because the evidence still fits. The concrete-bound
  predicate is shared with return-position candidate selection via the extracted
  `is_concrete_inference_bound` helper (no duplication).
- **checker** — the suppression keeping the outer annotation off a pinned
  object-literal callback return only fired for a **bare** `U`, so the
  array-wrapped `(...): U[]` form still pushed the outer element type onto the
  callback body and double-reported. `callback_object_return_pinned_by_concrete_arg`
  now fires for the wrapped form too (a pinned object-literal return cannot be
  refined regardless of the return wrapper) and takes precedence over the
  wrapped-parameter specialization path.

No new user-name/file-name literals or rendered-message predicates drive the
logic; both decisions are solver-backed structural queries (assignability +
shape predicates), and the tests vary binder names.

## Adjacent matrix (new tests, name-varied — verified vs `tsc` 6.0.2)
- inline arrow, literal target `{ v: 5 }` → single `TS2322` at the assignment
- extracted callback, literal target `{ v: 6 }` → single `TS2322` at the assignment
- block-body callback, literal target `{ v: 7 }` → single `TS2322` at the assignment
- primitive target `{ v: string }` (control) → unchanged, single error at the assignment
- compatible target `{ v: number }` → clean
- array-wrapped `map<T, U>(arr: T[], fn: (x: T) => U): U[]` → single error at the assignment, no extra in-callback error
- array-wrapped compatible target → clean
- refinement guard: `invoke(() => 1)` against `0 | 1 | 2` stays clean; `invoke(() => 5)` reports at the assignment

Out of scope (separate display path, pre-existing, not a false positive): the
array-target top-line still renders the source element as `number[]` rather than
`{ v: number; }[]` in one shape; the relation decision and elaboration are
correct and this PR does not regress it. Folding the evidence check into the
shared `should_use_contextual_return_substitution` (3 other call sites) was
deliberately avoided to keep the behavior change scoped to the validated path.

## Goal
Goal: green

## Verification
- `cargo test -p tsz-checker --test contextual_return_literal_refinement_tests` — 9/9 pass (new file)
- Regression guards (no change): `contextual_return_value_arg_pinned_tests`, `contextual_return_callback_param_only_inference_tests`, `context_sensitive_callback_inference_tests`, `generic_callback_local_literal_widening_tests`, `block_body_callback_literal_widening_tests`, `generic_inference_ordering_tests`, `covariant_callbacks_tests`, `fresh_object_literal_arg_callback_param_variance_tests`, `array_element_naked_inference_tests`, `contextual_ts2345_conformance_tests` — all pass
- `generic_call_inference_tests` — 199 pass; the 4 failures are pre-existing on the clean tree (identical before/after this change)
- Manual `tsz --strict --noEmit` vs `tsc` 6.0.2 across the adjacent matrix above
- `cargo fmt -p tsz-solver -p tsz-checker -- --check` and `cargo clippy -p tsz-solver -p tsz-checker --lib` — clean
- Broad conformance/emit/fourslash owned by ready-review CI

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01BctP37j1iAKCUwqDxcRg58)_