### PR TITLE
refactor(checker): route symbol refs through identity bridge (#14351)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -5,6 +5,7 @@ use crate::query_boundaries::assignability::{
     AssignabilityEvalKind, classify_for_assignability_eval, get_keyof_type,
     get_string_literal_value, get_union_members, keyof_object_properties, map_compound_members,
 };
+use crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id;
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
 use tsz_common::interner::Atom;
@@ -736,7 +737,7 @@ impl<'a> CheckerState<'a> {
                 .iter()
                 .copied()
             {
-                let sym_id = tsz_binder::SymbolId(symbol_ref.0);
+                let sym_id = symbol_ref_to_symbol_id(symbol_ref);
                 let _ = self.get_type_of_symbol(sym_id);
                 // Populate type_env with the VALUE type (constructor for classes) so that
                 // TypeEvaluator::visit_type_query can resolve via TypeEnvironment::resolve_ref.
@@ -941,7 +942,7 @@ impl<'a> CheckerState<'a> {
                     self.ctx.types.as_type_database(),
                     type_id,
                 ) {
-                    let sym_id = tsz_binder::SymbolId(symbol_ref.0);
+                    let sym_id = symbol_ref_to_symbol_id(symbol_ref);
                     // For merged TYPE_ALIAS + VARIABLE symbols (e.g.,
                     // `type Input = Static<typeof Input>` + `const Input = ...`),
                     // get_type_of_symbol may return the type alias's circular

--- a/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
+++ b/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
@@ -10,6 +10,7 @@ use crate::query_boundaries::assignability::{
     is_relation_cacheable, is_subtype_with_resolver, mutable_array_element_for_redeclaration,
     subtype_cache_key,
 };
+use crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id;
 use crate::state::CheckerState;
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_solver::TypeId;
@@ -56,7 +57,7 @@ impl<'a> CheckerState<'a> {
 
         // Helper to check if a symbol is a class (for nominal subtyping)
         let is_class_fn = |sym_ref: tsz_solver::SymbolRef| -> bool {
-            let sym_id = tsz_binder::SymbolId(sym_ref.0);
+            let sym_id = symbol_ref_to_symbol_id(sym_ref);
             if let Some(sym) = binder.get_symbol(sym_id) {
                 sym.has_any_flags(symbol_flags::CLASS)
             } else {

--- a/crates/tsz-checker/src/classes/constructor_checker.rs
+++ b/crates/tsz-checker/src/classes/constructor_checker.rs
@@ -14,6 +14,7 @@ use crate::query_boundaries::{
         resolve_abstract_constructor_anchor,
     },
     common,
+    definition_identity::symbol_ref_to_symbol_id,
 };
 use crate::state::{CheckerState, MAX_TREE_WALK_ITERATIONS, MemberAccessLevel};
 use rustc_hash::FxHashSet;
@@ -938,8 +939,7 @@ impl<'a> CheckerState<'a> {
                 InstanceTypeKind::SymbolRef(sym_ref) => {
                     // Symbol reference (class name or typeof expression)
                     // Resolve to the class instance type
-                    use tsz_binder::SymbolId;
-                    let sym_id = SymbolId(sym_ref.0);
+                    let sym_id = symbol_ref_to_symbol_id(sym_ref);
                     if let Some(instance_type) = self.class_instance_type_from_symbol(sym_id) {
                         return Some(self.resolve_type_for_property_access(instance_type));
                     }
@@ -1107,7 +1107,7 @@ impl<'a> CheckerState<'a> {
             match resolve_abstract_constructor_anchor(self.ctx.types, type_id) {
                 AbstractConstructorAnchor::TypeQuery(sym_ref) => {
                     if let Some(symbol) =
-                        self.ctx.binder.get_symbol(tsz_binder::SymbolId(sym_ref.0))
+                        self.ctx.binder.get_symbol(symbol_ref_to_symbol_id(sym_ref))
                     {
                         symbol.has_any_flags(symbol_flags::ABSTRACT)
                     } else {
@@ -1176,7 +1176,7 @@ impl<'a> CheckerState<'a> {
 
         match classify_for_constructor_access(self.ctx.types, type_id) {
             ConstructorAccessKind::SymbolRef(symbol) => {
-                let sym_id = SymbolId(symbol.0);
+                let sym_id = symbol_ref_to_symbol_id(symbol);
                 if let Some(access) = self.class_constructor_access_level(sym_id) {
                     return Some(access);
                 }

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -3,6 +3,7 @@
 use crate::query_boundaries::common::{
     TypeResolver, contains_lazy_or_recursive, enum_def_id, get_type_query_symbol_ref, lazy_def_id,
 };
+use crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id;
 use crate::query_boundaries::state::type_environment as query;
 use crate::query_boundaries::type_defaults::fill_application_defaults;
 use crate::query_boundaries::type_predicates::contains_conditional_with_application_extends;
@@ -605,7 +606,7 @@ impl CheckerState<'_> {
     fn resolve_type_queries_for_eval(&mut self, type_id: TypeId) {
         let type_queries = self.ctx.collect_type_queries_cached(type_id);
         for symbol_ref in type_queries.iter().copied() {
-            let sym_id = tsz_binder::SymbolId(symbol_ref.0);
+            let sym_id = symbol_ref_to_symbol_id(symbol_ref);
             let _ = self.get_type_of_symbol(sym_id);
             let value_type = self.ctx.symbol_types.get(&sym_id).unwrap_or(TypeId::ERROR);
             // When circular resolution causes ERROR (e.g. `let Anon = class<T> {}` and
@@ -944,7 +945,6 @@ impl CheckerState<'_> {
         type_id: TypeId,
         visited: &mut PropertyAccessVisited,
     ) -> TypeId {
-        use tsz_binder::SymbolId;
         let factory = self.ctx.types.factory();
 
         if !visited.insert(type_id) {
@@ -1105,7 +1105,7 @@ impl CheckerState<'_> {
                 }
             }
             query::PropertyAccessResolutionKind::TypeQuery(sym_ref) => {
-                let resolved = self.get_type_of_symbol(SymbolId(sym_ref.0));
+                let resolved = self.get_type_of_symbol(symbol_ref_to_symbol_id(sym_ref));
                 if resolved == type_id {
                     type_id
                 } else {
@@ -1749,7 +1749,7 @@ impl CheckerState<'_> {
                     continue;
                 }
 
-                let sym_id = SymbolId(symbol_ref.0);
+                let sym_id = symbol_ref_to_symbol_id(symbol_ref);
                 let symbol = self.ctx.binder.get_symbol(sym_id);
                 if symbol.is_none() {
                     continue;

--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_06.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_06.rs
@@ -11,7 +11,7 @@ use super::*;
 /// bridge.
 #[test]
 fn test_symbol_ref_to_symbol_id_cast_budget() {
-    const RAW_SYMBOL_REF_CAST_BUDGET: usize = 35;
+    const RAW_SYMBOL_REF_CAST_BUDGET: usize = 21;
     const BRIDGE_PATH: &str = "src/query_boundaries/definition_identity.rs";
 
     fn is_raw_symbol_ref_cast(line: &str) -> bool {

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -9,6 +9,7 @@ use super::lib_resolution::{
     resolve_lib_node_in_lib_contexts,
 };
 use crate::query_boundaries::common::TypeResolver;
+use crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use crate::symbols_domain::name_text::{
@@ -799,7 +800,7 @@ impl<'a> CheckerState<'a> {
         // This fixes property access on variables typed as `typeof Namespace`:
         //   var m: typeof M; m.Point  → should resolve namespace export "Point"
         if let NamespaceMemberKind::TypeQuery(sym_ref) = classification {
-            let sym_id = SymbolId(sym_ref.0);
+            let sym_id = symbol_ref_to_symbol_id(sym_ref);
             if self
                 .get_cross_file_symbol(sym_id)
                 .is_some_and(|symbol| symbol.is_umd_export)
@@ -1006,7 +1007,7 @@ impl<'a> CheckerState<'a> {
 
             // Handle ModuleNamespace types (import * as ns / namespace value bindings)
             NamespaceMemberKind::ModuleNamespace(sym_ref) => {
-                let sym_id = SymbolId(sym_ref.0);
+                let sym_id = symbol_ref_to_symbol_id(sym_ref);
                 let (
                     symbol_flags_value,
                     module_name,

--- a/crates/tsz-checker/src/types/queries/type_only.rs
+++ b/crates/tsz-checker/src/types/queries/type_only.rs
@@ -4,6 +4,7 @@
 //! (exist only at the type level with no runtime value). Used by the checker
 //! to decide when to emit TS2708 and related diagnostics.
 
+use crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::{SymbolId, symbol_flags};
@@ -662,7 +663,7 @@ impl<'a> CheckerState<'a> {
 
             // TypeQuery (typeof M): resolve to the underlying symbol type and re-check
             NamespaceMemberKind::TypeQuery(sym_ref) => {
-                let sym_id = SymbolId(sym_ref.0);
+                let sym_id = symbol_ref_to_symbol_id(sym_ref);
                 let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
                     return false;
                 };
@@ -1091,7 +1092,7 @@ impl<'a> CheckerState<'a> {
                 is_pure_namespace_or_enum(symbol)
             }
             NamespaceMemberKind::ModuleNamespace(sym_ref) => {
-                let sym_id = SymbolId(sym_ref.0);
+                let sym_id = symbol_ref_to_symbol_id(sym_ref);
                 let Some(symbol) = self.get_cross_file_symbol(sym_id) else {
                     return false;
                 };
@@ -1100,7 +1101,7 @@ impl<'a> CheckerState<'a> {
             NamespaceMemberKind::Enum(_) => true,
             NamespaceMemberKind::TypeQuery(sym_ref) => {
                 // TypeQuery (typeof M): check if the underlying symbol is a namespace
-                let sym_id = SymbolId(sym_ref.0);
+                let sym_id = symbol_ref_to_symbol_id(sym_ref);
                 let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
                     return false;
                 };
@@ -1126,7 +1127,7 @@ impl<'a> CheckerState<'a> {
         use crate::query_boundaries::common::{NamespaceMemberKind, classify_namespace_member};
 
         let sym_id = match classify_namespace_member(self.ctx.types, object_type) {
-            NamespaceMemberKind::TypeQuery(sym_ref) => SymbolId(sym_ref.0),
+            NamespaceMemberKind::TypeQuery(sym_ref) => symbol_ref_to_symbol_id(sym_ref),
             NamespaceMemberKind::Lazy(def_id) => self.ctx.def_to_symbol_id(def_id)?,
             _ => return None,
         };


### PR DESCRIPTION
Part of #14351.

Structural rule: when a solver `SymbolRef` is known to represent a binder symbol from `typeof X`, namespace/type-query classification, constructor classification, or relation preconditioning, tsz should cross back to `SymbolId` through `query_boundaries::definition_identity::symbol_ref_to_symbol_id`. This preserves the current ordinal bridge while keeping raw reinterpretation centralized behind the checker identity boundary.

Owner layer: checker query-boundary identity. Solver continues to own `SymbolRef` and type-shape classification; checker orchestration now uses the existing identity bridge at TypeQuery, namespace, constructor-access, abstract-constructor, and assignability class-symbol callsites.

Adjacent matrix:
- TypeQuery environment preparation still resolves value-space symbols before evaluation
- property-access TypeQuery receivers still resolve through the same binder symbol
- abstract constructor and constructor-access classification still ask the same class/variable helpers
- namespace TypeQuery and ModuleNamespace helpers still find the same namespace/export symbols
- subtype/assignability class-symbol callbacks still classify class flags from the same binder symbol
- architecture budget drops raw `SymbolRef` -> `SymbolId` casts from the old budget of 35 to the measured post-main count of 21

Fallback/performance plan: behavior is intended unchanged; the bridge is a `const fn` wrapper around the existing conversion. No new semantic traversal or cache key is added, and no user-chosen names, source text, file paths, or rendered diagnostics are used as semantic predicates.

## Goal
Goal: green

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib test_symbol_ref_to_symbol_id_cast_budget`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib test_env_eval_cache_def_invalidation_is_targeted`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts2511_abstract_type_param_tests --test abstract_constructor_argument_tests --test interface_call_signature_typeof_param_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib namespace_typeof`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/test_arch_guard.py`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings`
- Baseline-red on clean `origin/main` `673ed6aa75`: `hkt_instance_assignable_through_typeof_uri_tag`, `hkt_instance_assignability_is_binder_name_independent`, and `return_type_of_array_map_instantiation_does_not_resolve_numbers_as_namespace`; these also fail on this branch and are not regressions from this bridge-only slice.
- ready-review CI owns broad conformance / emit / fourslash suites.

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high
