### PR TITLE
fix(emit): preserve ambient enum member initializer form in .d.ts (#14769)

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_type_value_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_type_value_declarations.rs
@@ -96,6 +96,44 @@ impl<'a> DeclarationEmitter<'a> {
 
         self.emit_node(enum_data.name);
 
+        self.emit_enum_body(enum_idx, is_const);
+    }
+
+    /// Emit the `{ ... }` body of an enum declaration in `.d.ts` output, applying
+    /// the ambient member-value rule that `tsc` uses.
+    ///
+    /// For an **ambient** enum — one declared with `declare`, nested inside a
+    /// `declare` namespace, or sourced from a `.d.ts` file — `tsc` preserves each
+    /// member's source initializer form: members written with `= ...` keep it,
+    /// members written bare stay bare (no synthesized auto-increment value). For a
+    /// non-ambient (implementation) enum, the declaration surface carries the
+    /// computed auto-increment values. Const enums always emit their values
+    /// regardless of ambient context.
+    ///
+    /// Both the non-exported (`emit_enum_declaration`) and exported
+    /// (`emit_exported_enum`) emission paths route through this single helper so
+    /// the ambient rule is applied uniformly; emitting them separately previously
+    /// let the exported path synthesize values for ambient enums (issue #14769).
+    pub(in crate::declaration_emitter) fn emit_enum_body(
+        &mut self,
+        enum_idx: NodeIndex,
+        is_const: bool,
+    ) {
+        let Some(enum_node) = self.arena.get(enum_idx) else {
+            return;
+        };
+        let Some(enum_data) = self.arena.get_enum(enum_node) else {
+            return;
+        };
+
+        // An enum is ambient when the source carried `declare`, when it is nested
+        // inside a `declare` namespace, or when the source is a `.d.ts` file.
+        let is_ambient = self.inside_declare_namespace
+            || self
+                .arena
+                .has_modifier(&enum_data.modifiers, SyntaxKind::DeclareKeyword)
+            || self.source_is_declaration_file;
+
         self.write(" {");
         self.write_line();
         self.increase_indent();
@@ -117,14 +155,9 @@ impl<'a> DeclarationEmitter<'a> {
                 && let Some(member) = self.arena.get_enum_member(member_node)
             {
                 self.emit_node(member.name);
-                // For ambient enums (inside declare context or with declare keyword), only
-                // emit values for members with explicit initializers.
-                // For implementation enums, always emit computed values.
-                let is_ambient = self.inside_declare_namespace
-                    || self
-                        .arena
-                        .has_modifier(&enum_data.modifiers, SyntaxKind::DeclareKeyword)
-                    || self.source_is_declaration_file;
+                // For ambient enums only emit values for members with explicit
+                // initializers; const enums always emit values. For implementation
+                // enums, always emit the computed values.
                 let has_explicit_init = member.initializer.is_some();
                 let should_emit_value = !is_ambient || has_explicit_init || is_const;
                 if should_emit_value {

--- a/crates/tsz-emitter/src/declaration_emitter/exports/value_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/value_declarations.rs
@@ -1,7 +1,7 @@
 //! Declaration emitter - exported enum and variable declarations.
 
 use super::super::DeclarationEmitter;
-use crate::enums::evaluator::{EnumEvaluator, EnumValue};
+use crate::enums::evaluator::EnumValue;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
@@ -32,50 +32,10 @@ impl<'a> DeclarationEmitter<'a> {
         self.write("enum ");
         self.emit_node(enum_data.name);
 
-        self.write(" {");
-        self.write_line();
-        self.increase_indent();
-
-        // Evaluate enum member values to get correct auto-increment behavior.
-        // Seed with accumulated values for cross-enum reference resolution.
-        let prior = std::mem::take(&mut self.all_enum_values);
-        let mut evaluator = EnumEvaluator::with_prior_values(self.arena, prior);
-        let member_values = evaluator.evaluate_enum(enum_idx);
-        self.all_enum_values = evaluator.take_all_enum_values();
-
-        for (i, &member_idx) in enum_data.members.nodes.iter().enumerate() {
-            self.write_indent();
-            if let Some(member_node) = self.arena.get(member_idx)
-                && let Some(member) = self.arena.get_enum_member(member_node)
-            {
-                self.emit_node(member.name);
-                let member_name = self.get_enum_member_name(member.name);
-                if let Some(value) = member_values.get(&member_name) {
-                    match value {
-                        crate::enums::evaluator::EnumValue::Computed => {
-                            // Computed values: no initializer in .d.ts
-                        }
-                        _ => {
-                            self.write(" = ");
-                            self.emit_enum_value(value);
-                        }
-                    }
-                } else {
-                    // Fallback to index if evaluation failed
-                    self.write(" = ");
-                    self.write(&i.to_string());
-                }
-            }
-            if i < enum_data.members.nodes.len() - 1 {
-                self.write(",");
-            }
-            self.write_line();
-        }
-
-        self.decrease_indent();
-        self.write_indent();
-        self.write("}");
-        self.write_line();
+        // Route the body through the shared emitter so the ambient member-value
+        // rule (preserve source initializer form for `declare` enums) applies to
+        // exported enums too — see `emit_enum_body` and issue #14769.
+        self.emit_enum_body(enum_idx, is_const);
     }
 
     /// Get the name of an enum member from its name node.

--- a/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
@@ -1616,3 +1616,95 @@ fn test_const_enum_division_dts_is_float_value() {
         "const enum division .d.ts values must be float quotients: {result}"
     );
 }
+
+// =====================================================================
+// Ambient enum declaration-emit value preservation (issue #14769)
+//
+// For an ambient (`declare`) non-const enum, tsc preserves each member's
+// source initializer form in the `.d.ts`: members with `= ...` keep it,
+// bare members stay bare. This must hold for both exported and non-exported
+// enums (they previously took separate emit paths) and for enums nested in a
+// `declare namespace`. Const enums always emit values, ambient or not.
+// =====================================================================
+
+#[test]
+fn test_ambient_exported_enum_keeps_bare_members_14769() {
+    // `export declare enum` flows through the exported-enum emit path, which
+    // previously synthesized `A = 0, B = 1`.
+    let result = emit_dts("export declare enum NonConst { A, B }\n");
+    let expected = "export declare enum NonConst {\n    A,\n    B\n}\n";
+    assert_eq!(
+        result, expected,
+        "ambient exported enum must stay bare: {result}"
+    );
+}
+
+#[test]
+fn test_ambient_exported_const_enum_keeps_values_14769() {
+    // Const enums always emit values, even ambient — must not regress.
+    let result = emit_dts("export declare const enum IsConst { X, Y }\n");
+    let expected = "export declare const enum IsConst {\n    X = 0,\n    Y = 1\n}\n";
+    assert_eq!(
+        result, expected,
+        "ambient const enum must keep values: {result}"
+    );
+}
+
+#[test]
+fn test_ambient_nonexported_enum_keeps_bare_members_14769() {
+    // `declare enum` (no export) flows through the non-exported emit path.
+    let result = emit_dts("declare enum Bare { A, B }\n");
+    let expected = "declare enum Bare {\n    A,\n    B\n}\n";
+    assert_eq!(
+        result, expected,
+        "ambient non-exported enum must stay bare: {result}"
+    );
+}
+
+#[test]
+fn test_ambient_mixed_init_enum_preserves_form_14769() {
+    // Only explicitly-initialized members keep `= ...`; bare members stay bare.
+    let result = emit_dts("export declare enum Mixed { A, B = 5, C, D = \"str\" }\n");
+    let expected = "export declare enum Mixed {\n    A,\n    B = 5,\n    C,\n    D = \"str\"\n}\n";
+    assert_eq!(
+        result, expected,
+        "mixed-init ambient enum form must be preserved: {result}"
+    );
+}
+
+#[test]
+fn test_ambient_string_enum_preserves_explicit_values_14769() {
+    // Explicit string initializers are always preserved (already correct).
+    let result = emit_dts("export declare enum Colors { Red = \"red\", Green = \"green\" }\n");
+    let expected = "export declare enum Colors {\n    Red = \"red\",\n    Green = \"green\"\n}\n";
+    assert_eq!(
+        result, expected,
+        "ambient string enum values must be preserved: {result}"
+    );
+}
+
+#[test]
+fn test_enum_in_declare_namespace_keeps_bare_members_14769() {
+    // Inside a `declare namespace`, the member values must be dropped too.
+    let result = emit_dts("declare namespace NS { export enum D { P, Q, R } }\n");
+    assert!(
+        result.contains("enum D {\n        P,\n        Q,\n        R\n    }"),
+        "enum in declare namespace must stay bare: {result}"
+    );
+    assert!(
+        !result.contains("P = 0"),
+        "enum in declare namespace must not synthesize values: {result}"
+    );
+}
+
+#[test]
+fn test_nonambient_exported_enum_still_emits_values_14769() {
+    // Control: a real implementation enum surfaces the computed values in the
+    // `.d.ts`. The ambient guard must NOT suppress these.
+    let result = emit_dts("export enum Impl { A, B }\n");
+    let expected = "export declare enum Impl {\n    A = 0,\n    B = 1\n}\n";
+    assert_eq!(
+        result, expected,
+        "non-ambient enum must keep computed values: {result}"
+    );
+}


### PR DESCRIPTION
Fixes #14769.

For an ambient (`declare`) non-const enum, `tsc` preserves each member's source initializer form in the `.d.ts`: members written with `= ...` keep it, bare members stay bare. tsz synthesized auto-increment values (`A = 0`, `C = 6`, …) for the bare members of **exported** ambient enums and of enums nested in a `declare namespace`. This changed the public `.d.ts` surface and could break re-emit / declaration consumers.

```ts
// final.ts — flags: --target es2020 --declaration --emitDeclarationOnly
export declare enum NonConst { A, B }
export declare const enum IsConst { X, Y }
```
Before (tsz): `NonConst { A = 0, B = 1 }`. After (tsz) / `tsc` 5.9.3: `NonConst { A, B }` (const `IsConst` keeps `X = 0, Y = 1` in both).

**Structural rule:** when an enum is ambient — declared with `declare`, nested inside a `declare` namespace, or sourced from a `.d.ts` file — `tsc` emits a member's `= value` only if the source wrote one (const enums always emit values); a non-ambient implementation enum surfaces the computed auto-increment values. tsz must do the same through the declaration emitter.

**Root cause / owner layer:** the declaration emitter had **two duplicated enum-body emit paths**. `emit_enum_declaration` (`declaration_emitter/core/emit_type_value_declarations.rs`) carried the ambient member-value guard, but the separate `emit_exported_enum` (`declaration_emitter/exports/value_declarations.rs`) — reached by every *exported* enum and by enums inside a `declare namespace` — did not, and unconditionally synthesized values. The intended guard the issue cites was only ever on the non-exported path, which is why the issue author's top-level `declare enum E` (a non-exported path) looked guarded while the exported repro was not.

The fix unifies both paths through a single `emit_enum_body(enum_idx, is_const)` helper that owns the ambient rule, so the two paths can no longer diverge. This is a display-only change to declaration output; the enum value *evaluation* and JS emit are untouched.

**Adjacent matrix (new tests, name-varied so a spelling fix would not pass):**
- exported ambient enum → bare members stay bare
- non-exported ambient `declare enum` → bare members stay bare
- ambient enum inside `declare namespace` → bare members stay bare, no synthesized values
- mixed-init ambient enum (`A, B = 5, C, D = "str"`) → only explicit members keep `= ...`
- ambient string enum (explicit values) → preserved (already correct)
- ambient **const** enum → keeps computed values (must not regress)
- non-ambient exported enum → keeps computed auto-increment values (control: guard must not over-suppress)

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib enum_template_and_advanced` — 99 passed (incl. 7 new `*_14769` tests covering the matrix above).
- `cargo test -p tsz-emitter` — full crate suite green except one pre-existing, unrelated failure (`generator_object_literal_prefix_before_yield_omits_source_trailing_comma`, an ES5 `__generator` trailing-comma test) confirmed failing identically on the clean tree via `git stash`.
- `cargo fmt -p tsz-emitter -- --check` and `cargo clippy -p tsz-emitter --lib` — clean.
- Broad conformance / emit / DTS / fourslash suites owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHGu5jNt25o6vyX8DXd5cq)_