### PR TITLE
fix(emit): preserve ambient enum member initializer form in d.ts (#14769)

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_type_value_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_type_value_declarations.rs
@@ -96,6 +96,41 @@ impl<'a> DeclarationEmitter<'a> {
 
         self.emit_node(enum_data.name);
 
+        // The non-exported path carries leading JSDoc on each member.
+        self.emit_enum_body(enum_idx, is_const, true);
+    }
+
+    /// Emit the brace-delimited body of an enum for `.d.ts` output.
+    ///
+    /// Shared by the exported (`emit_exported_enum`) and non-exported
+    /// (`emit_enum_declaration`) paths so the ambient member-value rule lives in
+    /// a single place. In an ambient context — a `declare` enum, an enum inside a
+    /// `declare namespace`, or any enum in a `.d.ts` source — `tsc` preserves
+    /// each member's source initializer form: members written with `= ...` keep
+    /// it and bare members stay bare. Non-ambient enums always emit their
+    /// evaluated values, and `const` enums emit values regardless of ambient
+    /// context. `emit_member_jsdoc` mirrors each path's existing behavior for
+    /// leading member doc comments.
+    pub(in crate::declaration_emitter) fn emit_enum_body(
+        &mut self,
+        enum_idx: NodeIndex,
+        is_const: bool,
+        emit_member_jsdoc: bool,
+    ) {
+        let Some(enum_node) = self.arena.get(enum_idx) else {
+            return;
+        };
+        let Some(enum_data) = self.arena.get_enum(enum_node) else {
+            return;
+        };
+        // Ambient context: `declare` modifier, inside a `declare namespace`, or a
+        // `.d.ts` source. The `declare` modifier is detected for both bare
+        // (`declare enum`) and exported (`export declare enum`) forms because the
+        // parser keeps it on the enum node's own modifier list in both cases.
+        let is_ambient = self.inside_declare_namespace
+            || self.arena.is_declare(&enum_data.modifiers)
+            || self.source_is_declaration_file;
+
         self.write(" {");
         self.write_line();
         self.increase_indent();
@@ -108,8 +143,9 @@ impl<'a> DeclarationEmitter<'a> {
         let member_values = evaluator.evaluate_enum(enum_idx);
         self.all_enum_values = evaluator.take_all_enum_values();
 
+        let member_count = enum_data.members.nodes.len();
         for (i, &member_idx) in enum_data.members.nodes.iter().enumerate() {
-            if let Some(mn) = self.arena.get(member_idx) {
+            if emit_member_jsdoc && let Some(mn) = self.arena.get(member_idx) {
                 self.emit_leading_jsdoc_comments(mn.pos);
             }
             self.write_indent();
@@ -117,14 +153,8 @@ impl<'a> DeclarationEmitter<'a> {
                 && let Some(member) = self.arena.get_enum_member(member_node)
             {
                 self.emit_node(member.name);
-                // For ambient enums (inside declare context or with declare keyword), only
-                // emit values for members with explicit initializers.
-                // For implementation enums, always emit computed values.
-                let is_ambient = self.inside_declare_namespace
-                    || self
-                        .arena
-                        .has_modifier(&enum_data.modifiers, SyntaxKind::DeclareKeyword)
-                    || self.source_is_declaration_file;
+                // Ambient members keep their source initializer form; non-ambient
+                // and const members always emit the evaluated value.
                 let has_explicit_init = member.initializer.is_some();
                 let should_emit_value = !is_ambient || has_explicit_init || is_const;
                 if should_emit_value {
@@ -146,7 +176,7 @@ impl<'a> DeclarationEmitter<'a> {
                     }
                 }
             }
-            if i < enum_data.members.nodes.len() - 1 {
+            if i < member_count - 1 {
                 self.write(",");
             }
             self.write_line();

--- a/crates/tsz-emitter/src/declaration_emitter/exports/value_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/value_declarations.rs
@@ -1,7 +1,7 @@
 //! Declaration emitter - exported enum and variable declarations.
 
 use super::super::DeclarationEmitter;
-use crate::enums::evaluator::{EnumEvaluator, EnumValue};
+use crate::enums::evaluator::EnumValue;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
@@ -32,50 +32,10 @@ impl<'a> DeclarationEmitter<'a> {
         self.write("enum ");
         self.emit_node(enum_data.name);
 
-        self.write(" {");
-        self.write_line();
-        self.increase_indent();
-
-        // Evaluate enum member values to get correct auto-increment behavior.
-        // Seed with accumulated values for cross-enum reference resolution.
-        let prior = std::mem::take(&mut self.all_enum_values);
-        let mut evaluator = EnumEvaluator::with_prior_values(self.arena, prior);
-        let member_values = evaluator.evaluate_enum(enum_idx);
-        self.all_enum_values = evaluator.take_all_enum_values();
-
-        for (i, &member_idx) in enum_data.members.nodes.iter().enumerate() {
-            self.write_indent();
-            if let Some(member_node) = self.arena.get(member_idx)
-                && let Some(member) = self.arena.get_enum_member(member_node)
-            {
-                self.emit_node(member.name);
-                let member_name = self.get_enum_member_name(member.name);
-                if let Some(value) = member_values.get(&member_name) {
-                    match value {
-                        crate::enums::evaluator::EnumValue::Computed => {
-                            // Computed values: no initializer in .d.ts
-                        }
-                        _ => {
-                            self.write(" = ");
-                            self.emit_enum_value(value);
-                        }
-                    }
-                } else {
-                    // Fallback to index if evaluation failed
-                    self.write(" = ");
-                    self.write(&i.to_string());
-                }
-            }
-            if i < enum_data.members.nodes.len() - 1 {
-                self.write(",");
-            }
-            self.write_line();
-        }
-
-        self.decrease_indent();
-        self.write_indent();
-        self.write("}");
-        self.write_line();
+        // Shared body keeps the ambient member-value rule in one place so an
+        // `export declare enum` (or a `declare namespace` member enum) preserves
+        // bare members instead of synthesizing auto-increment values.
+        self.emit_enum_body(enum_idx, is_const, false);
     }
 
     /// Get the name of an enum member from its name node.

--- a/crates/tsz-emitter/src/declaration_emitter/tests/comprehensive_parity.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/comprehensive_parity.rs
@@ -641,6 +641,68 @@ export enum Mixed {
     assert_eq!(result, expected, "Mismatch with tsc");
 }
 
+// =====================================================================
+// Ambient enum member values (#14769)
+//
+// For an ambient (`declare`) non-const enum, `tsc` preserves each member's
+// source initializer form in the `.d.ts`: members with `= ...` keep it, bare
+// members stay bare. `tsz` previously synthesized auto-increment values on the
+// exported path (`export declare enum`, and enums inside a `declare namespace`),
+// which the non-exported path already handled. Const enums always emit values.
+// =====================================================================
+
+#[test]
+fn test_ambient_export_declare_enum_keeps_members_bare_vs_tsc() {
+    // `export declare enum` is the exported ambient path; bare members must stay
+    // bare (tsc 5.9.3), not get `= 0`/`= 1`.
+    let result = emit_dts("export declare enum NonConst { A, B }\n");
+    let expected = "export declare enum NonConst {\n    A,\n    B\n}\n";
+    assert_eq!(result, expected, "Mismatch with tsc");
+}
+
+#[test]
+fn test_ambient_export_declare_const_enum_keeps_values_vs_tsc() {
+    // const enums always emit values, even when ambient.
+    let result = emit_dts("export declare const enum IsConst { X, Y }\n");
+    let expected = "export declare const enum IsConst {\n    X = 0,\n    Y = 1\n}\n";
+    assert_eq!(result, expected, "Mismatch with tsc");
+}
+
+#[test]
+fn test_ambient_export_declare_enum_mixed_init_vs_tsc() {
+    // Only explicitly-initialized members keep `= ...`; the bare members between
+    // them stay bare even though their evaluated values would be 0 and 6.
+    let result = emit_dts("export declare enum E { A, B = 5, C, D = \"str\" }\n");
+    let expected = "export declare enum E {\n    A,\n    B = 5,\n    C,\n    D = \"str\"\n}\n";
+    assert_eq!(result, expected, "Mismatch with tsc");
+}
+
+#[test]
+fn test_ambient_export_declare_string_enum_keeps_explicit_init_vs_tsc() {
+    // Explicit string initializers are always preserved.
+    let result = emit_dts("export declare enum D { A = \"x\", B = \"y\" }\n");
+    let expected = "export declare enum D {\n    A = \"x\",\n    B = \"y\"\n}\n";
+    assert_eq!(result, expected, "Mismatch with tsc");
+}
+
+#[test]
+fn test_ambient_enum_inside_declare_namespace_keeps_members_bare_vs_tsc() {
+    // An enum inside a `declare namespace` is ambient via `inside_declare_namespace`
+    // even though the enum node carries no `declare` modifier of its own.
+    let result = emit_dts("export declare namespace NS { export enum D { P, Q, R } }\n");
+    let expected = "export declare namespace NS {\n    enum D {\n        P,\n        Q,\n        R\n    }\n}\n";
+    assert_eq!(result, expected, "Mismatch with tsc");
+}
+
+#[test]
+fn test_non_ambient_export_enum_still_emits_values_vs_tsc() {
+    // Control: a non-ambient `export enum` must keep emitting evaluated values so
+    // the ambient guard does not over-apply.
+    let result = emit_dts("export enum Plain { A, B }\n");
+    let expected = "export declare enum Plain {\n    A = 0,\n    B = 1\n}\n";
+    assert_eq!(result, expected, "Mismatch with tsc");
+}
+
 #[test]
 fn test_function_overloads_vs_tsc() {
     let result = emit_dts(


### PR DESCRIPTION
Closes #14769.

For an ambient (`declare`) non-const enum, `tsc` preserves each member's source initializer form in the `.d.ts`: members written with `= ...` keep it, bare members stay bare. tsz synthesized auto-increment values for the bare members of an `export declare enum` (e.g. `A = 0`, `C = 6`) and for enums inside a `declare namespace`. Const enums (even ambient) are unaffected — they always emit values.

```ts
// final.ts — flags: --declaration --emitDeclarationOnly --target es2020
export declare enum NonConst { A, B }
export declare const enum IsConst { X, Y }
export declare enum Mixed { A, B = 5, C, D = "str" }
export declare namespace NS { export enum D { P, Q, R } }
```
Before (tsz): `A = 0, B = 1` for `NonConst`; `A = 0, B = 5, C = 6, D = "str"` for `Mixed`; `P = 0, Q = 1, R = 2` for `D`.
After (tsz) / `tsc` 5.9.3 (byte-for-byte): `A,`/`B` bare; `IsConst` keeps `X = 0, Y = 1`; `Mixed` keeps only the explicitly-initialized `B = 5`/`D = "str"`; namespace `D` emits `P, Q, R` bare.

## Structural rule
When an enum is in an ambient context — it carries a `declare` modifier, is nested in a `declare namespace`, or lives in a `.d.ts` source — `tsc` does not synthesize member values: each member keeps its source initializer form. Non-ambient enums emit evaluated values; `const` enums always emit values. tsz applies this through the declaration emitter (`emit_enum_body`).

**Root cause / owner layer:** the bug was non-locality, not a wrong predicate. The non-exported enum d.ts path (`emit_enum_declaration`) already gated value emission on ambient context, but the exported path (`emit_exported_enum`) had **no ambient guard at all** and unconditionally emitted values. `export declare enum` and `declare namespace`-member enums route through the exported path, so they synthesized values while bare `declare enum` (non-exported path) was already correct. The `declare` modifier was never the problem — the parser keeps it on the enum node's own modifier list for both bare and exported forms.

**Fix:** extract a single shared `emit_enum_body(enum_idx, is_const, emit_member_jsdoc)` helper in `crates/tsz-emitter/src/declaration_emitter/core/emit_type_value_declarations.rs` that carries the ambient-aware member-value rule, and call it from both `emit_enum_declaration` and `emit_exported_enum`. The rule now lives in exactly one place, so the two paths cannot drift again. The ambient check uses the emitter's own context state (`inside_declare_namespace`, `source_is_declaration_file`) plus `arena.is_declare(modifiers)` — the parser's `is_in_ambient_context` is insufficient here because it cannot see the emit-context flags. This is a display-only change: no error decision or type is affected.

## Adjacent matrix (all verified byte-for-byte vs `tsc` 5.9.3, name-varied)
- `export declare enum NonConst { A, B }` → bare members
- `export declare const enum IsConst { X, Y }` → `X = 0, Y = 1` (const always emits)
- `export declare enum Mixed { A, B = 5, C, D = "str" }` → only `B`/`D` keep `= ...`
- ambient string enum `export declare enum D { A = "x", B = "y" }` → explicit inits preserved
- `export declare namespace NS { export enum D { P, Q, R } }` → `P, Q, R` bare
- control: non-ambient `export enum Plain { A, B }` → `A = 0, B = 1` (values still emitted)
- unchanged: bare `declare enum` (already correct), non-ambient `enum`

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib declaration_emitter::tests::comprehensive_parity` — 80 passed (6 new ambient-enum parity tests + existing non-ambient enum tests unchanged)
- `cargo test -p tsz-emitter --lib declaration_emitter::tests` — 1373 passed
- `cargo test -p tsz-emitter --lib` — 3908 passed
- Manual `tsz … --declaration --emitDeclarationOnly` vs `tsc` 5.9.3 across the matrix above — byte-for-byte
- `cargo fmt -p tsz-emitter -- --check` and `cargo clippy -p tsz-emitter --lib -- -D warnings` — clean
- Broad conformance/emit/fourslash owned by ready-review CI

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQoY5Y4CX75QuTMpzjNu2N)_