### PR TITLE
fix(solver): make object spread traversal path-local (#14351)

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1824,9 +1824,11 @@ impl QueryDatabase for QueryCache<'_> {
             return cached;
         }
 
-        let mut visited: FxHashSet<TypeId> = FxHashSet::default();
-        let result = self.collect_object_spread_properties_inner(spread_type, &mut visited);
-        self.insert_object_spread_properties_cache(spread_type, result.clone());
+        let mut traversal = spread::ObjectSpreadTraversalState::default();
+        let result = self.collect_object_spread_properties_inner(spread_type, &mut traversal);
+        if traversal.is_cacheable() {
+            self.insert_object_spread_properties_cache(spread_type, result.clone());
+        }
         result
     }
 

--- a/crates/tsz-solver/src/caches/query_cache_spread.rs
+++ b/crates/tsz-solver/src/caches/query_cache_spread.rs
@@ -14,14 +14,28 @@ enum ObjectSpreadVisitState {
     AlreadyVisited,
 }
 
-fn object_spread_visit_state(
-    visited: &mut FxHashSet<TypeId>,
-    normalized: TypeId,
-) -> ObjectSpreadVisitState {
-    if visited.insert(normalized) {
-        ObjectSpreadVisitState::Entered
-    } else {
-        ObjectSpreadVisitState::AlreadyVisited
+#[derive(Debug, Default)]
+pub(super) struct ObjectSpreadTraversalState {
+    active: FxHashSet<TypeId>,
+    saw_cycle: bool,
+}
+
+impl ObjectSpreadTraversalState {
+    fn enter(&mut self, normalized: TypeId) -> ObjectSpreadVisitState {
+        if self.active.insert(normalized) {
+            ObjectSpreadVisitState::Entered
+        } else {
+            self.saw_cycle = true;
+            ObjectSpreadVisitState::AlreadyVisited
+        }
+    }
+
+    fn leave(&mut self, normalized: TypeId) {
+        self.active.remove(&normalized);
+    }
+
+    pub(super) const fn is_cacheable(&self) -> bool {
+        !self.saw_cycle
     }
 }
 
@@ -162,21 +176,22 @@ impl QueryCache<'_> {
     pub(super) fn collect_object_spread_properties_inner(
         &self,
         spread_type: TypeId,
-        visited: &mut FxHashSet<TypeId>,
+        traversal: &mut ObjectSpreadTraversalState,
     ) -> Vec<PropertyInfo> {
         let normalized =
             self.evaluate_type_with_options(spread_type, self.no_unchecked_indexed_access());
 
-        match object_spread_visit_state(visited, normalized) {
+        if normalized != spread_type {
+            return self.collect_object_spread_properties_inner(normalized, traversal);
+        }
+
+        match traversal.enter(normalized) {
             ObjectSpreadVisitState::Entered => {}
             ObjectSpreadVisitState::AlreadyVisited => return Vec::new(),
         }
 
-        if normalized != spread_type {
-            return self.collect_object_spread_properties_inner(normalized, visited);
-        }
-
         let Some(key) = self.interner.lookup(normalized) else {
+            traversal.leave(normalized);
             return Vec::new();
         };
 
@@ -192,7 +207,7 @@ impl QueryCache<'_> {
                 let mut merged: FxHashMap<Atom, PropertyInfo> = FxHashMap::default();
 
                 for &member in members.iter() {
-                    for prop in self.collect_object_spread_properties_inner(member, visited) {
+                    for prop in self.collect_object_spread_properties_inner(member, traversal) {
                         merged.insert(prop.name, prop);
                     }
                 }
@@ -209,66 +224,69 @@ impl QueryCache<'_> {
                 let non_nullish_count = members.iter().filter(|m| !m.is_nullable()).count();
 
                 if non_nullish_count == 0 {
-                    return Vec::new();
-                }
-
-                // Collect properties per member
-                let mut all_props: Vec<Vec<PropertyInfo>> = Vec::with_capacity(non_nullish_count);
-                for &member in members.iter().filter(|m| !m.is_nullable()) {
-                    all_props.push(self.collect_object_spread_properties_inner(member, visited));
-                }
-
-                // Merge: a property appears in the result if it exists in at
-                // least one member. Its type is the union of types across
-                // members where it appears. It is optional if it doesn't
-                // appear in all non-nullish members or if any nullish member
-                // exists (since the spread could be null/undefined → {}).
-                let mut merged: FxHashMap<Atom, (TypeId, bool, usize)> = FxHashMap::default();
-                for member_props in &all_props {
-                    for prop in member_props {
-                        let entry =
-                            merged
-                                .entry(prop.name)
-                                .or_insert((prop.type_id, prop.optional, 0));
-                        if entry.0 != prop.type_id {
-                            entry.0 = self.interner.union2(entry.0, prop.type_id);
-                        }
-                        entry.1 = entry.1 && prop.optional;
-                        entry.2 += 1;
+                    Vec::new()
+                } else {
+                    // Collect properties per member
+                    let mut all_props: Vec<Vec<PropertyInfo>> =
+                        Vec::with_capacity(non_nullish_count);
+                    for &member in members.iter().filter(|m| !m.is_nullable()) {
+                        all_props
+                            .push(self.collect_object_spread_properties_inner(member, traversal));
                     }
-                }
 
-                merged
-                    .into_iter()
-                    .map(|(name, (type_id, was_optional, count))| {
-                        let optional = was_optional || has_nullish || count < non_nullish_count;
-                        PropertyInfo {
-                            name,
-                            type_id,
-                            optional,
-                            readonly: false,
-                            write_type: type_id,
-                            is_class_prototype: false,
-                            is_method: false,
-                            visibility: Visibility::Public,
-                            parent_id: None,
-                            declaration_order: 0,
-                            is_string_named: false,
-                            is_symbol_named: false,
-                            single_quoted_name: false,
-                            non_widening: false,
+                    // Merge: a property appears in the result if it exists in at
+                    // least one member. Its type is the union of types across
+                    // members where it appears. It is optional if it doesn't
+                    // appear in all non-nullish members or if any nullish member
+                    // exists (since the spread could be null/undefined → {}).
+                    let mut merged: FxHashMap<Atom, (TypeId, bool, usize)> = FxHashMap::default();
+                    for member_props in &all_props {
+                        for prop in member_props {
+                            let entry =
+                                merged
+                                    .entry(prop.name)
+                                    .or_insert((prop.type_id, prop.optional, 0));
+                            if entry.0 != prop.type_id {
+                                entry.0 = self.interner.union2(entry.0, prop.type_id);
+                            }
+                            entry.1 = entry.1 && prop.optional;
+                            entry.2 += 1;
                         }
-                    })
-                    .collect()
+                    }
+
+                    merged
+                        .into_iter()
+                        .map(|(name, (type_id, was_optional, count))| {
+                            let optional = was_optional || has_nullish || count < non_nullish_count;
+                            PropertyInfo {
+                                name,
+                                type_id,
+                                optional,
+                                readonly: false,
+                                write_type: type_id,
+                                is_class_prototype: false,
+                                is_method: false,
+                                visibility: Visibility::Public,
+                                parent_id: None,
+                                declaration_order: 0,
+                                is_string_named: false,
+                                is_symbol_named: false,
+                                single_quoted_name: false,
+                                non_widening: false,
+                            }
+                        })
+                        .collect()
+                }
             }
             TypeData::TypeParameter(info) => {
                 // For type parameters with constraints (e.g. `T extends { x: number }`),
                 // collect properties from the constraint. Required properties in the
                 // constraint are guaranteed to exist on any value of type T.
                 if let Some(constraint) = info.constraint {
-                    return self.collect_object_spread_properties_inner(constraint, visited);
+                    self.collect_object_spread_properties_inner(constraint, traversal)
+                } else {
+                    Vec::new()
                 }
-                Vec::new()
             }
             _ => Vec::new(),
         };
@@ -279,7 +297,7 @@ impl QueryCache<'_> {
         // Class prototype members (methods/accessors) are excluded from spread results
         // because they live on the prototype, not as own enumerable properties.
         // This matches tsc's isSpreadPrototypeProperty() behavior.
-        props
+        let result = props
             .into_iter()
             .filter(|p| {
                 !p.is_class_prototype
@@ -293,7 +311,9 @@ impl QueryCache<'_> {
                 p.write_type = p.type_id;
                 p
             })
-            .collect()
+            .collect();
+        traversal.leave(normalized);
+        result
     }
 }
 
@@ -303,26 +323,44 @@ mod tests {
 
     #[test]
     fn object_spread_visit_state_records_first_entry() {
-        let mut visited = FxHashSet::default();
+        let mut traversal = ObjectSpreadTraversalState::default();
 
-        let state = object_spread_visit_state(&mut visited, TypeId::STRING);
+        let state = traversal.enter(TypeId::STRING);
 
         assert_eq!(state, ObjectSpreadVisitState::Entered);
-        assert!(visited.contains(&TypeId::STRING));
+        assert!(traversal.active.contains(&TypeId::STRING));
+        assert!(traversal.is_cacheable());
     }
 
     #[test]
     fn object_spread_visit_state_records_reentry() {
-        let mut visited = FxHashSet::default();
+        let mut traversal = ObjectSpreadTraversalState::default();
 
         assert_eq!(
-            object_spread_visit_state(&mut visited, TypeId::STRING),
+            traversal.enter(TypeId::STRING),
             ObjectSpreadVisitState::Entered
         );
         assert_eq!(
-            object_spread_visit_state(&mut visited, TypeId::STRING),
+            traversal.enter(TypeId::STRING),
             ObjectSpreadVisitState::AlreadyVisited
         );
-        assert_eq!(visited.len(), 1);
+        assert_eq!(traversal.active.len(), 1);
+        assert!(!traversal.is_cacheable());
+    }
+
+    #[test]
+    fn object_spread_traversal_leave_allows_sibling_reentry() {
+        let mut traversal = ObjectSpreadTraversalState::default();
+
+        assert_eq!(
+            traversal.enter(TypeId::STRING),
+            ObjectSpreadVisitState::Entered
+        );
+        traversal.leave(TypeId::STRING);
+        assert_eq!(
+            traversal.enter(TypeId::STRING),
+            ObjectSpreadVisitState::Entered
+        );
+        assert!(traversal.is_cacheable());
     }
 }

--- a/crates/tsz-solver/tests/db_tests.rs
+++ b/crates/tsz-solver/tests/db_tests.rs
@@ -2,6 +2,7 @@ use crate::caches::db::TypeApplicationEvalCache;
 use crate::construction::{QueryCache, QueryCacheStatistics, RelationCacheProbe};
 use crate::operations::property::PropertyAccessResult;
 use crate::relations::relation_queries::RelationPolicy;
+use crate::types::{TypeParamInfo, TypeParamOrigin};
 use crate::{
     LiteralValue, ObjectFlags, PropertyInfo, QueryDatabase, RelationCacheConfig, RelationCacheKey,
     TupleElement, TypeData, TypeDatabase, TypeId, TypeInterner, Visibility,
@@ -347,6 +348,45 @@ fn query_cache_caches_object_spread_properties() {
 
     let props_again = db.collect_object_spread_properties(spread_type);
     assert_eq!(props_again.len(), 2);
+    assert_eq!(db.object_spread_properties_cache_len(), 1);
+}
+
+#[test]
+fn object_spread_union_sibling_constraints_reenter_shared_constraint() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let shared = db.object(vec![PropertyInfo::new(
+        interner.intern_string("shared"),
+        TypeId::STRING,
+    )]);
+    let left = db.type_param(TypeParamInfo {
+        name: interner.intern_string("Left"),
+        constraint: Some(shared),
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::User,
+    });
+    let right = db.type_param(TypeParamInfo {
+        name: interner.intern_string("Right"),
+        constraint: Some(shared),
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::User,
+    });
+    let spread_type = db.union(vec![left, right]);
+
+    let props = db.collect_object_spread_properties(spread_type);
+
+    assert_eq!(props.len(), 1);
+    let shared_prop = props
+        .iter()
+        .find(|prop| interner.resolve_atom_ref(prop.name).as_ref() == "shared")
+        .expect("spread should retain the shared constrained property");
+    assert_eq!(shared_prop.type_id, TypeId::STRING);
+    assert!(
+        !shared_prop.optional,
+        "both non-nullish sibling constraints provide the property"
+    );
     assert_eq!(db.object_spread_properties_cache_len(), 1);
 }
 


### PR DESCRIPTION
Goal: green

## Summary
- Replace object-spread's sticky raw visited set with `ObjectSpreadTraversalState` that owns active-path entry/leave and cycle cacheability.
- Let sibling union/intersection branches revisit the same normalized constraint after the previous branch leaves it.
- Avoid publishing object-spread cache entries when a true active-path cycle was observed.
- Add a regression where two distinct type parameters share the same object constraint and both must contribute the required spread property.

## Structural Rule
When collecting object-spread properties from non-nullish union or intersection branches, `tsc` treats each sibling branch independently and only suppresses active recursive re-entry. `tsz` now models that through solver-owned `ObjectSpreadTraversalState`: the active path blocks cycles, branch exit clears the normalized type for siblings, and only cycle-free collections are cached.

## Owner Layer
Solver: `QueryCache` owns object-spread property collection, traversal state, and cache publication. Checker spread-source normalization and emit behavior are unchanged.

## Adjacent Matrix
- Plain object/intersection spread caching still reuses completed cycle-free results.
- Active re-entry still returns an empty property list to terminate recursive collection.
- Sibling branches can revisit a shared object constraint without making required properties optional.
- Nullish-only union spread still produces an empty property list while cleaning traversal state.
- Class prototype/private-brand filtering and readonly stripping remain in the same solver collector.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib object_spread`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --lib -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
