### PR TITLE
refactor(solver): own BCT subtype cache requests (#14351)

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache_size.rs
+++ b/crates/tsz-solver/src/caches/query_cache_size.rs
@@ -154,9 +154,10 @@ impl QueryCache<'_> {
                 + std::mem::size_of::<InstantiationCacheKey>()
                 + std::mem::size_of::<TypeId>());
 
-        // subtype_reduction_cache: (SortedTypeIds, u8) -> Arc<[TypeId]>
-        // Inline buffer is part of `SubtypeReductionKey`; the cached value
-        // is `Arc<[TypeId]>` (16 bytes) plus the heap slice it points at.
+        // subtype_reduction_cache: request-owned (SortedTypeIds, u8) -> Arc<[TypeId]>
+        // Inline buffer is part of `SubtypeReductionKey`; request options
+        // own the mode byte. The cached value is `Arc<[TypeId]>` plus the
+        // heap slice it points at.
         size += self.subtype_reduction_cache.capacity()
             * (BUCKET_OVERHEAD
                 + std::mem::size_of::<SubtypeReductionKey>()

--- a/crates/tsz-solver/src/caches/subtype_reduction_cache.rs
+++ b/crates/tsz-solver/src/caches/subtype_reduction_cache.rs
@@ -1,10 +1,10 @@
 //! Cross-call cache for `remove_subtypes_for_bct`.
 //!
-//! Mirrors the `instantiation_cache` shape. The key is the sorted list of
-//! input `TypeId`s plus a small `mode_bits` byte that
-//! captures any inputs other than the type list which can affect the
-//! reduction result (currently: whether a `TypeResolver` was provided,
-//! which enables nominal class-hierarchy subtype resolution).
+//! Mirrors the `instantiation_cache` shape. Callers build a
+//! `SubtypeReductionRequest` from the input `TypeId`s and explicit
+//! `SubtypeReductionOptions`; the cache key stores the sorted type list plus
+//! a small `mode_bits` byte that captures request inputs other than the type
+//! list which can affect the reduction result.
 //!
 //! ### Why a memo cache here
 //!
@@ -20,12 +20,11 @@
 //! Subtype reduction is correctness-critical: the value cached here flows
 //! into `interner.union(reduced)`, so the cache key must capture every
 //! input that affects the result. `remove_subtypes_for_bct` reads only
-//! `types` and (optionally) `resolver`; the resolver's identity is stable
-//! for the lifetime of a per-file `QueryCache`, so encoding "resolver
-//! present / absent" in `mode_bits` is sufficient. The cache lives on
-//! `QueryCache` (not `TypeInterner`) for the same reason as the
-//! instantiation cache: `QueryCache::clear()` is the authoritative
-//! invalidation boundary.
+//! `types` and whether nominal hierarchy resolution is enabled; registered
+//! base-type facts are stable for the lifetime of a per-file `QueryCache`,
+//! so encoding that option in `mode_bits` is sufficient. The cache lives on
+//! `QueryCache` (not `TypeInterner`) for the same reason as the instantiation
+//! cache: `QueryCache::clear()` is the authoritative invalidation boundary.
 
 use crate::types::TypeId;
 use rustc_hash::FxHashMap;
@@ -33,13 +32,89 @@ use smallvec::SmallVec;
 use std::cell::RefCell;
 use std::sync::Arc;
 
-/// Mode bit: a `TypeResolver` was provided to `remove_subtypes_for_bct`.
+/// Mode bit: nominal hierarchy resolution is enabled for `remove_subtypes_for_bct`.
 ///
-/// The presence of a resolver enables nominal class-hierarchy lookups in
-/// the underlying `SubtypeChecker`, which can change the reduction result
-/// (e.g., `Derived` is reduced away from `[Base, Derived]` only when the
-/// checker can resolve the inheritance edge).
-pub const MODE_HAS_RESOLVER: u8 = 0b001;
+/// Nominal class-hierarchy lookups in the underlying `SubtypeChecker` can
+/// change the reduction result (e.g., `Derived` is reduced away from
+/// `[Base, Derived]` only when the checker can resolve the inheritance edge).
+pub const MODE_NOMINAL_HIERARCHY_RESOLUTION: u8 = 0b001;
+
+/// Option-sensitive inputs for `remove_subtypes_for_bct` cache identity.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct SubtypeReductionOptions {
+    nominal_hierarchy_resolution: bool,
+}
+
+impl SubtypeReductionOptions {
+    /// Build default options for a subtype-reduction request.
+    #[must_use]
+    pub(crate) const fn new() -> Self {
+        Self {
+            nominal_hierarchy_resolution: false,
+        }
+    }
+
+    /// Enable or disable nominal hierarchy resolution for this request.
+    #[must_use]
+    pub(crate) const fn with_nominal_hierarchy_resolution(mut self, enabled: bool) -> Self {
+        self.nominal_hierarchy_resolution = enabled;
+        self
+    }
+
+    /// Pack option-sensitive inputs into the cache-key mode byte.
+    #[must_use]
+    const fn mode_bits(self) -> u8 {
+        if self.nominal_hierarchy_resolution {
+            MODE_NOMINAL_HIERARCHY_RESOLUTION
+        } else {
+            0
+        }
+    }
+}
+
+/// Typed request for `remove_subtypes_for_bct` cache probes.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SubtypeReductionRequest<'a> {
+    types: &'a [TypeId],
+    options: SubtypeReductionOptions,
+}
+
+impl<'a> SubtypeReductionRequest<'a> {
+    /// Build a request from the input candidate list.
+    #[must_use]
+    pub(crate) const fn new(types: &'a [TypeId]) -> Self {
+        Self {
+            types,
+            options: SubtypeReductionOptions::new(),
+        }
+    }
+
+    /// Override option-sensitive request inputs.
+    #[must_use]
+    pub(crate) const fn with_options(mut self, options: SubtypeReductionOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    /// Enable or disable nominal hierarchy resolution for this request.
+    #[must_use]
+    pub(crate) const fn with_nominal_hierarchy_resolution(self, enabled: bool) -> Self {
+        self.with_options(self.options.with_nominal_hierarchy_resolution(enabled))
+    }
+
+    /// Borrow the original input candidate list.
+    #[cfg(test)]
+    #[must_use]
+    const fn types(self) -> &'a [TypeId] {
+        self.types
+    }
+
+    /// Derive the option-sensitive cache key for this request.
+    #[must_use]
+    pub(crate) fn cache_key(self) -> SubtypeReductionKey {
+        SubtypeReductionKey::from_request(self)
+    }
+}
 
 /// Canonical, content-hashable form of a sorted `&[TypeId]` input.
 ///
@@ -89,7 +164,8 @@ pub struct SubtypeReductionKey {
     /// Sorted input `TypeId`s — equivalent to tsc's `getTypeListId(types)`.
     pub sorted_type_ids: SortedTypeIds,
     /// Bitfield of inputs other than `types` that can affect the result.
-    /// Bit 0 (`MODE_HAS_RESOLVER`): a `TypeResolver` was provided.
+    /// Bit 0 (`MODE_NOMINAL_HIERARCHY_RESOLUTION`): nominal hierarchy
+    /// resolution is enabled.
     pub mode_bits: u8,
 }
 
@@ -103,12 +179,13 @@ impl SubtypeReductionKey {
         }
     }
 
-    /// Convenience constructor that sorts the input slice on the caller's
-    /// behalf and packs the resolver-present flag.
+    /// Construct a cache key from a typed subtype-reduction request.
     #[must_use]
-    pub fn build(types: &[TypeId], has_resolver: bool) -> Self {
-        let mode_bits = if has_resolver { MODE_HAS_RESOLVER } else { 0 };
-        Self::new(SortedTypeIds::from_slice(types), mode_bits)
+    fn from_request(request: SubtypeReductionRequest<'_>) -> Self {
+        Self::new(
+            SortedTypeIds::from_slice(request.types),
+            request.options.mode_bits(),
+        )
     }
 }
 
@@ -183,10 +260,24 @@ mod tests {
         Arc::from(v)
     }
 
+    fn cache_key(values: &[u32], options: SubtypeReductionOptions) -> SubtypeReductionKey {
+        let types: Vec<TypeId> = values.iter().copied().map(type_id).collect();
+        SubtypeReductionRequest::new(&types)
+            .with_options(options)
+            .cache_key()
+    }
+
+    fn cache_key_for_nominal_hierarchy(values: &[u32], enabled: bool) -> SubtypeReductionKey {
+        cache_key(
+            values,
+            SubtypeReductionOptions::new().with_nominal_hierarchy_resolution(enabled),
+        )
+    }
+
     #[test]
     fn empty_cache_misses() {
         let cache = SubtypeReductionCache::new();
-        let key = SubtypeReductionKey::build(&[type_id(1), type_id(2)], false);
+        let key = cache_key_for_nominal_hierarchy(&[1, 2], false);
         assert!(cache.lookup(&key).is_none());
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
@@ -195,7 +286,7 @@ mod tests {
     #[test]
     fn insert_then_lookup_roundtrip() {
         let cache = SubtypeReductionCache::new();
-        let key = SubtypeReductionKey::build(&[type_id(1), type_id(2)], false);
+        let key = cache_key_for_nominal_hierarchy(&[1, 2], false);
         let value = arc_slice(&[1, 2]);
         cache.insert(key.clone(), value.clone());
         let got = cache.lookup(&key).expect("hit");
@@ -209,8 +300,8 @@ mod tests {
         // hash to the same cache slot — that's the whole point of the
         // sorted-key form (mirrors tsc's getTypeListId).
         let cache = SubtypeReductionCache::new();
-        let k_ab = SubtypeReductionKey::build(&[type_id(3), type_id(1), type_id(2)], false);
-        let k_ba = SubtypeReductionKey::build(&[type_id(1), type_id(2), type_id(3)], false);
+        let k_ab = cache_key_for_nominal_hierarchy(&[3, 1, 2], false);
+        let k_ba = cache_key_for_nominal_hierarchy(&[1, 2, 3], false);
         assert_eq!(k_ab, k_ba);
         cache.insert(k_ab, arc_slice(&[1, 2, 3]));
         assert!(cache.lookup(&k_ba).is_some());
@@ -222,8 +313,8 @@ mod tests {
         // {1, 2} and {1, 3} must produce distinct cache entries even
         // though they share an element.
         let cache = SubtypeReductionCache::new();
-        let k_12 = SubtypeReductionKey::build(&[type_id(1), type_id(2)], false);
-        let k_13 = SubtypeReductionKey::build(&[type_id(1), type_id(3)], false);
+        let k_12 = cache_key_for_nominal_hierarchy(&[1, 2], false);
+        let k_13 = cache_key_for_nominal_hierarchy(&[1, 3], false);
         assert_ne!(k_12, k_13);
         cache.insert(k_12.clone(), arc_slice(&[1, 2]));
         cache.insert(k_13.clone(), arc_slice(&[1, 3]));
@@ -235,25 +326,25 @@ mod tests {
     }
 
     #[test]
-    fn mode_bits_isolate_resolver_present_from_absent() {
-        // Same TypeIds, different `has_resolver` flag → distinct entries.
-        // This guards against caching a no-resolver result and serving it
-        // when class-hierarchy resolution is enabled (which can change the
-        // outcome).
+    fn mode_bits_isolate_nominal_hierarchy_resolution_from_default() {
+        // Same TypeIds, different nominal-hierarchy-resolution flag →
+        // distinct entries. This guards against caching a structural-only
+        // result and serving it when class-hierarchy resolution is enabled
+        // (which can change the outcome).
         let cache = SubtypeReductionCache::new();
-        let no_res = SubtypeReductionKey::build(&[type_id(1), type_id(2)], false);
-        let with_res = SubtypeReductionKey::build(&[type_id(1), type_id(2)], true);
-        assert_ne!(no_res, with_res);
-        cache.insert(no_res.clone(), arc_slice(&[1, 2]));
-        cache.insert(with_res.clone(), arc_slice(&[1]));
+        let default = cache_key_for_nominal_hierarchy(&[1, 2], false);
+        let nominal = cache_key_for_nominal_hierarchy(&[1, 2], true);
+        assert_ne!(default, nominal);
+        assert_eq!(default.mode_bits, 0);
+        assert_eq!(nominal.mode_bits, MODE_NOMINAL_HIERARCHY_RESOLUTION);
+        cache.insert(default.clone(), arc_slice(&[1, 2]));
+        cache.insert(nominal.clone(), arc_slice(&[1]));
         assert_eq!(
-            &cache.lookup(&no_res).expect("no_res entry was inserted")[..],
+            &cache.lookup(&default).expect("default entry was inserted")[..],
             &[type_id(1), type_id(2)]
         );
         assert_eq!(
-            &cache
-                .lookup(&with_res)
-                .expect("with_res entry was inserted")[..],
+            &cache.lookup(&nominal).expect("nominal entry was inserted")[..],
             &[type_id(1)]
         );
         assert_eq!(cache.len(), 2);
@@ -262,7 +353,7 @@ mod tests {
     #[test]
     fn clear_empties_cache() {
         let cache = SubtypeReductionCache::new();
-        let key = SubtypeReductionKey::build(&[type_id(7)], false);
+        let key = cache_key_for_nominal_hierarchy(&[7], false);
         cache.insert(key.clone(), arc_slice(&[7]));
         assert_eq!(cache.len(), 1);
         cache.clear();
@@ -276,5 +367,30 @@ mod tests {
         assert_eq!(s.len(), 3);
         assert!(!s.is_empty());
         assert_eq!(s.as_slice(), &[type_id(1), type_id(2), type_id(3)]);
+    }
+
+    #[test]
+    fn request_cache_key_owns_option_packing() {
+        let types = [type_id(9), type_id(4), type_id(7)];
+        let request = SubtypeReductionRequest::new(&types).with_nominal_hierarchy_resolution(true);
+        let key = request.cache_key();
+
+        assert_eq!(request.types(), &types);
+        assert_eq!(
+            key.sorted_type_ids.as_slice(),
+            &[type_id(4), type_id(7), type_id(9)]
+        );
+        assert_eq!(key.mode_bits, MODE_NOMINAL_HIERARCHY_RESOLUTION);
+    }
+
+    #[test]
+    fn default_options_use_zero_mode_bits() {
+        assert_eq!(SubtypeReductionOptions::new().mode_bits(), 0);
+        assert_eq!(
+            SubtypeReductionOptions::new()
+                .with_nominal_hierarchy_resolution(true)
+                .mode_bits(),
+            MODE_NOMINAL_HIERARCHY_RESOLUTION
+        );
     }
 }

--- a/crates/tsz-solver/src/operations/expression_ops.rs
+++ b/crates/tsz-solver/src/operations/expression_ops.rs
@@ -6,7 +6,7 @@
 //! These functions operate purely on `TypeIds` and maintain no AST dependencies.
 
 use crate::caches::db::QueryDatabase;
-use crate::caches::subtype_reduction_cache::SubtypeReductionKey;
+use crate::caches::subtype_reduction_cache::SubtypeReductionRequest;
 use crate::construction::TypeDatabase;
 use crate::relations::subtype::SubtypeChecker;
 use crate::relations::subtype::TypeResolver;
@@ -1200,12 +1200,13 @@ fn remove_subtypes_for_bct<R: TypeResolver>(
     }
 
     // Cross-call cache probe (mirrors tsc's `subtypeReductionCache`). The
-    // key is the sorted input list plus a single `mode_bits` byte that
-    // distinguishes "resolver provided" (nominal class hierarchy enabled)
-    // from "no resolver". Class hierarchies and registered base-types are
-    // stable for the lifetime of a per-file `QueryCache`, so a hit means
-    // the recomputed answer would be identical.
-    let cache_key = query_db.map(|_| SubtypeReductionKey::build(types, resolver.is_some()));
+    // typed request owns option-sensitive key construction, including the
+    // nominal hierarchy option enabled when a resolver is available.
+    let cache_key = query_db.map(|_| {
+        SubtypeReductionRequest::new(types)
+            .with_nominal_hierarchy_resolution(resolver.is_some())
+            .cache_key()
+    });
     if let (Some(db), Some(key)) = (query_db, cache_key.as_ref())
         && let Some(hit) = db.lookup_subtype_reduction_cache(key)
     {

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -409,6 +409,29 @@ fn subtype_function_fresh_evaluators_use_explicit_session() {
 }
 
 #[test]
+fn subtype_reduction_cache_keeps_bct_request_boundary() {
+    let cache_rs = read_solver_source("caches/subtype_reduction_cache.rs");
+    let expression_ops_rs = read_solver_source("operations/expression_ops.rs");
+
+    assert!(
+        cache_rs.contains("pub(crate) struct SubtypeReductionOptions")
+            && cache_rs.contains("pub(crate) struct SubtypeReductionRequest")
+            && cache_rs.contains("fn from_request(request: SubtypeReductionRequest<'_>)")
+            && cache_rs.contains("request.options.mode_bits()")
+            && cache_rs.contains("MODE_NOMINAL_HIERARCHY_RESOLUTION")
+            && !cache_rs.contains("pub fn build("),
+        "subtype-reduction cache identity must be derived from a typed request/options boundary"
+    );
+    assert!(
+        expression_ops_rs.contains("SubtypeReductionRequest::new")
+            && expression_ops_rs.contains(".with_nominal_hierarchy_resolution(resolver.is_some())")
+            && expression_ops_rs.contains(".cache_key()")
+            && !expression_ops_rs.contains("SubtypeReductionKey::build("),
+        "BCT subtype reduction must consume the request-owned cache key instead of packing caller-local mode bits"
+    );
+}
+
+#[test]
 fn narrowing_engine_keeps_request_stage_boundary() {
     let mod_rs = read_solver_source("narrowing/mod.rs");
     let request_rs = read_solver_source("narrowing/request.rs");

--- a/crates/tsz-solver/tests/expression_ops_tests.rs
+++ b/crates/tsz-solver/tests/expression_ops_tests.rs
@@ -965,11 +965,30 @@ fn test_bct_cache_resolver_present_distinct_from_absent() {
         &[a, b],
         Some(&resolver),
     );
-    let entries_with_res = db.statistics().subtype_reduction_cache_entries;
+    let stats_with_res = db.statistics();
+    let entries_with_res = stats_with_res.subtype_reduction_cache_entries;
 
     assert!(
         entries_with_res > entries_no_res,
         "resolver-present must be a distinct cache slot ({entries_no_res} -> {entries_with_res})"
+    );
+
+    let _ = crate::operations::expression_ops::compute_best_common_type_cached::<NoopResolver>(
+        &interner,
+        Some(&db),
+        &[a, b],
+        Some(&resolver),
+    );
+    let stats_after_repeat = db.statistics();
+
+    assert_eq!(
+        stats_after_repeat.subtype_reduction_cache_entries, entries_with_res,
+        "repeating the resolver-present request should reuse its cache slot"
+    );
+    assert!(
+        stats_after_repeat.subtype_reduction_cache_hits
+            > stats_with_res.subtype_reduction_cache_hits,
+        "resolver-present repeat should hit the request-owned cache key"
     );
 }
 


### PR DESCRIPTION
Goal: green

## Summary
- Add `SubtypeReductionOptions` and `SubtypeReductionRequest` so BCT subtype-reduction cache identity is derived by the solver cache API instead of a caller-local boolean.
- Rename the option bit to `MODE_NOMINAL_HIERARCHY_RESOLUTION`, keeping the existing `(SortedTypeIds, mode_bits)` storage shape while making the semantic input explicit.
- Route `remove_subtypes_for_bct` through the request boundary and add cache/unit/architecture coverage for default vs nominal hierarchy resolution.

## Structural Rule
When BCT subtype reduction sees the same candidate `TypeId` list but nominal hierarchy resolution differs, `tsc` treats the resolver-enabled class hierarchy reduction as option-sensitive. `tsz` now does the same through the solver-owned `SubtypeReductionRequest`/`SubtypeReductionOptions` boundary before deriving `SubtypeReductionKey`.

Owner layer: solver cache/operation boundary. The checker remains only a caller of the existing type-computation entrypoints.

Adjacent matrix:
- Default structural reduction uses zero `mode_bits`.
- Nominal hierarchy resolution uses `MODE_NOMINAL_HIERARCHY_RESOLUTION`.
- Same `TypeId`s with resolver absent vs present occupy distinct cache slots.
- Repeating the resolver-present BCT request hits the same request-owned cache key.
- Sorted-key order independence and distinct input-list separation remain covered.

Fallback/order plan: leaf fast paths, unique-required-field bypass, `query_db = None`, and the existing 1,000,000 pairwise cap remain before or outside cache publication.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver subtype_reduction_cache`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver bct_cache`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --lib -- -D warnings`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --tests -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
