### PR TITLE
fix(solver): construct-signature literal/interface params are contravariant (#14859)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -297,6 +297,9 @@ path = "tests/conditional_branch_array_literal_widening_tests.rs"
 name = "extract_alias_distributive_mapped_tests"
 path = "tests/extract_alias_distributive_mapped_tests.rs"
 [[test]]
+name = "construct_signature_param_variance_tests"
+path = "tests/construct_signature_param_variance_tests.rs"
+[[test]]
 name = "fresh_object_literal_arg_callback_param_variance_tests"
 path = "tests/fresh_object_literal_arg_callback_param_variance_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/construct_signature_param_variance_tests.rs
+++ b/crates/tsz-checker/tests/construct_signature_param_variance_tests.rs
@@ -1,0 +1,158 @@
+//! Construct-signature parameter variance (issue #14859).
+//!
+//! `tsc` reserves constructor-parameter **bivariance** for class-derived
+//! constructor functions (`typeof Class`, whose construct-signature declaration
+//! is a class `Constructor`). A standalone `new (...) => T` construct-signature
+//! **type literal** and an **interface** construct signature (declaration kind
+//! `ConstructSignature`) compare their parameters **strictly** — contravariantly
+//! under `strictFunctionTypes` — exactly like a call-signature literal.
+//!
+//! Before the fix tsz compared every construct signature's parameters
+//! bivariantly, silently accepting assignments `tsc` rejects (a false negative).
+
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+const TS2322: u32 = 2322;
+
+fn strict_options() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+/// Compile `source` under `--strict` and return the emitted diagnostic codes.
+fn diagnostic_codes(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("variance.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "variance.ts".to_string(),
+        strict_options(),
+    );
+    checker.check_source_file(root);
+    checker.ctx.diagnostics.iter().map(|d| d.code).collect()
+}
+
+fn count(source: &str, code: u32) -> usize {
+    diagnostic_codes(source)
+        .into_iter()
+        .filter(|c| *c == code)
+        .count()
+}
+
+// ---------------------------------------------------------------------------
+// `new (...) => T` construct-signature TYPE LITERALS: strict (contravariant).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn literal_construct_signature_rejects_subtype_param() {
+    // `new (x: 1) => object` is NOT assignable to `new (x: number) => object`.
+    let source = "
+        type CtorNum = new (x: number) => object;
+        type CtorLit = new (x: 1) => object;
+        declare const cl: CtorLit;
+        const bad: CtorNum = cl;
+    ";
+    assert_eq!(
+        count(source, TS2322),
+        1,
+        "expected TS2322 for a narrowed-parameter `new (...) =>` literal under strictFunctionTypes",
+    );
+}
+
+#[test]
+fn literal_construct_signature_accepts_contravariant_param() {
+    // The contravariant-OK direction stays assignable:
+    // `new (x: number) => object` IS assignable to `new (x: 1) => object`.
+    let source = "
+        type CtorNum = new (x: number) => object;
+        type CtorLit = new (x: 1) => object;
+        declare const cn: CtorNum;
+        const good: CtorLit = cn;
+    ";
+    assert_eq!(
+        count(source, TS2322),
+        0,
+        "the contravariant-OK direction must remain accepted",
+    );
+}
+
+#[test]
+fn literal_construct_signature_param_variance_is_name_independent() {
+    // Same defect with renamed binders / string-literal params, so a spelling
+    // fix would not pass.
+    let source = "
+        type MakeWide = new (token: string) => { tag: 0 };
+        type MakeNarrow = new (token: \"a\") => { tag: 0 };
+        declare const narrow: MakeNarrow;
+        const wide: MakeWide = narrow;
+    ";
+    assert_eq!(count(source, TS2322), 1);
+}
+
+// ---------------------------------------------------------------------------
+// INTERFACE construct signatures: strict (contravariant), same as literals.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interface_construct_signature_rejects_subtype_param() {
+    let source = "
+        interface ICtorNum { new (x: number): object; }
+        interface ICtorLit { new (x: 1): object; }
+        declare const icl: ICtorLit;
+        const bad: ICtorNum = icl;
+    ";
+    assert_eq!(
+        count(source, TS2322),
+        1,
+        "interface construct signatures must compare parameters strictly",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CLASS constructors (`typeof Class`): bivariant — must NOT regress.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn class_constructor_params_stay_bivariant_both_directions() {
+    let source = "
+        class CNum { constructor(x: number) {} }
+        class CLit { constructor(x: 1) {} }
+        declare const tn: typeof CNum;
+        declare const tl: typeof CLit;
+        const a: typeof CNum = tl;
+        const b: typeof CLit = tn;
+    ";
+    assert_eq!(
+        count(source, TS2322),
+        0,
+        "class-derived constructor parameters must keep tsc's bivariance",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CALL-signature literals already contravariant — guards the shared path.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn call_signature_literal_rejects_subtype_param() {
+    let source = "
+        type FnNum = (x: number) => void;
+        type FnLit = (x: 1) => void;
+        declare const fl: FnLit;
+        const bad: FnNum = fl;
+    ";
+    assert_eq!(count(source, TS2322), 1);
+}

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -402,6 +402,18 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// check via `in_property_check` (e.g. a callable property whose value is a genuine
     /// weak object still triggers TS2559).
     pub(crate) in_callable_property_check: bool,
+    /// When `true`, the immediate construct-signature comparison about to start
+    /// must compare its parameters **strictly** (contravariantly under
+    /// `strict_function_types`), suppressing constructor-parameter bivariance.
+    /// `tsc` applies constructor-parameter bivariance only to class-derived
+    /// constructor functions (`typeof Class`, declaration kind `Constructor`);
+    /// standalone `new (...) => T` type literals and interface construct
+    /// signatures (declaration kind `ConstructSignature`) compare parameters
+    /// like call-signature literals. This flag is set by `check_callable_subtype`
+    /// per construct-signature comparison when the target callable is not a
+    /// class, and is consumed (reset) on entry to `check_function_subtype` so
+    /// nested function comparisons start fresh.
+    pub(crate) force_strict_construct_params: bool,
     /// Whether recursive relation cycles and overflow should be treated as
     /// assumed-related (`true`) or definitive failure (`false`).
     pub assume_related_on_cycle: bool,
@@ -569,6 +581,7 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             in_property_check: false,
             in_intersection_member_check: false,
             in_callable_property_check: false,
+            force_strict_construct_params: false,
             assume_related_on_cycle: true,
             identity_cycle_check: false,
             bypass_evaluation: false,
@@ -625,6 +638,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             in_property_check: false,
             in_intersection_member_check: false,
             in_callable_property_check: false,
+            force_strict_construct_params: false,
             assume_related_on_cycle: true,
             identity_cycle_check: false,
             bypass_evaluation: false,

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -33,8 +33,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: &FunctionShape,
         target: &FunctionShape,
     ) -> SubtypeResult {
-        let allow_constructor_bivariance =
-            !Self::constructor_signatures_need_strict_params(source, target);
+        // Consume (and clear) the construct-parameter strictness request set by
+        // `check_callable_subtype` for the immediate construct-signature
+        // comparison. Clearing it here means nested function comparisons reached
+        // from the constructor's parameter/return types start fresh, matching
+        // `tsc`, where only the construct signature whose declaration kind is a
+        // class `Constructor` gets parameter bivariance; a `new (...) => T` type
+        // literal or interface construct signature (`ConstructSignature`) is
+        // compared strictly like a call-signature literal.
+        let force_strict_construct_params = std::mem::take(&mut self.force_strict_construct_params);
+        let allow_constructor_bivariance = !force_strict_construct_params
+            && !Self::constructor_signatures_need_strict_params(source, target);
         let result = self.check_function_subtype_impl(source, target, allow_constructor_bivariance);
         if result.is_true() {
             return result;
@@ -1780,9 +1789,22 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // follow the regular property-function relation instead of method-style
         // bivariance. Standalone constructor function types still flow through
         // `check_function_subtype` with `is_constructor = true`.
+        // Constructor-parameter bivariance is reserved for class-derived
+        // constructor functions (`typeof Class`). A `new (...) => T` type literal
+        // and an interface construct signature compare parameters strictly
+        // (contravariantly under `strict_function_types`), exactly like a
+        // call-signature literal — `tsc` keys this on whether the construct
+        // signature's declaration is a class `Constructor`. The strictness is
+        // driven by the *target* signature's kind, mirroring `tsc`'s
+        // `compareSignaturesRelated`, so it is computed from the target callable.
+        // Short-circuit on the empty case so a callable with only call
+        // signatures pays no resolver lookup.
+        let force_strict = !target.construct_signatures.is_empty()
+            && !self.callable_target_is_class_constructor(target);
         for t_sig in &target.construct_signatures {
             let mut found_match = false;
             for s_sig in &source.construct_signatures {
+                self.force_strict_construct_params = force_strict;
                 let result = self.check_call_signature_subtype_as_constructor(s_sig, t_sig);
                 if result.is_true() {
                     found_match = true;
@@ -1793,6 +1815,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 && (source.construct_signatures.len() > 1 || target.construct_signatures.len() > 1)
             {
                 for s_sig in &source.construct_signatures {
+                    self.force_strict_construct_params = force_strict;
                     if self
                         .check_erased_call_signature_subtype_as_constructor(s_sig, t_sig)
                         .is_true()
@@ -1806,6 +1829,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 return SubtypeResult::False;
             }
         }
+        // Defensive reset: ensure no leftover request leaks into the property
+        // comparison below (and any later sibling relation) if the final
+        // construct-signature comparison short-circuited before reaching
+        // `check_function_subtype`.
+        self.force_strict_construct_params = false;
 
         // Check properties (excluding private `#` fields), sorted by name to match
         // check_object_subtype's merge scan. When both callables have construct

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/call_signatures.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/call_signatures.rs
@@ -75,6 +75,52 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
         self.check_function_subtype(&source_fn, &target_fn)
     }
 
+    /// Resolve a symbol's [`DefKind`](crate::def::DefKind) through the nominal
+    /// `symbol -> def` mapping, falling back to the injected `is_class_symbol`
+    /// classifier (the binder `CLASS` flag) when no def mapping is available
+    /// (e.g. partially constructed programs). The closure can only witness
+    /// classes, so a positive fallback resolves to [`DefKind::Class`].
+    ///
+    /// Shared by the relation layer's nominal-kind checks
+    /// (`callable_target_is_class_constructor`,
+    /// `requires_explicit_declared_index_signature`).
+    pub(crate) fn symbol_def_kind(
+        &self,
+        symbol_ref: crate::SymbolRef,
+    ) -> Option<crate::def::DefKind> {
+        if let Some(def_id) = self.resolver.symbol_to_def_id(symbol_ref) {
+            return self.resolver.get_def_kind(def_id);
+        }
+        self.is_class_symbol.and_then(|is_class_symbol| {
+            is_class_symbol(symbol_ref).then_some(crate::def::DefKind::Class)
+        })
+    }
+
+    /// Whether a callable's construct signatures originate from a class
+    /// declaration (`typeof Class`), which `tsc` compares with constructor-
+    /// parameter bivariance (declaration kind `Constructor`).
+    ///
+    /// A `new (...) => T` construct-signature **type literal** carries no
+    /// nominal symbol, and an **interface** construct signature carries an
+    /// interface symbol; both compare parameters strictly (contravariantly
+    /// under `strict_function_types`), exactly like call-signature literals
+    /// (declaration kind `ConstructSignature`). Detection is the same nominal
+    /// `symbol -> DefKind` lookup the rest of the relation layer uses, narrowed
+    /// to `DefKind::Class` so interface construct signatures stay strict.
+    pub(crate) fn callable_target_is_class_constructor(
+        &self,
+        target: &crate::types::CallableShape,
+    ) -> bool {
+        // `new (...) => T` type literal: no nominal class identity.
+        let Some(sym_id) = target.symbol else {
+            return false;
+        };
+        matches!(
+            self.symbol_def_kind(crate::SymbolRef(sym_id.0)),
+            Some(crate::def::DefKind::Class)
+        )
+    }
+
     pub(crate) fn constructor_signatures_need_strict_params(
         source: &FunctionShape,
         target: &FunctionShape,

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -990,16 +990,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return false;
         };
 
-        let symbol_ref = crate::SymbolRef(sym_id.0);
-        if let Some(def_id) = self.resolver.symbol_to_def_id(symbol_ref) {
-            return matches!(
-                self.resolver.get_def_kind(def_id),
-                Some(crate::def::DefKind::Class | crate::def::DefKind::Interface)
-            );
-        }
-
-        self.is_class_symbol
-            .is_some_and(|is_class_symbol| is_class_symbol(symbol_ref))
+        matches!(
+            self.symbol_def_kind(crate::SymbolRef(sym_id.0)),
+            Some(crate::def::DefKind::Class | crate::def::DefKind::Interface)
+        )
     }
 
     /// Whether a target string index whose value type is `any` waives the

--- a/crates/tsz-solver/tests/callable_tests.rs
+++ b/crates/tsz-solver/tests/callable_tests.rs
@@ -194,6 +194,69 @@ fn test_callable_with_construct() {
     assert!(is_subtype_of(&interner, source, target));
 }
 
+// A `new (...) => T` construct-signature *type literal* (no nominal class
+// symbol) compares its parameters strictly (contravariantly), exactly like a
+// call-signature literal — not with constructor bivariance. `tsc` reserves
+// constructor-parameter bivariance for class-derived constructor functions
+// (`typeof Class`). See issue #14859.
+#[test]
+fn test_construct_sig_literal_params_are_contravariant_not_bivariant() {
+    let interner = TypeInterner::new();
+    let obj = interner.object(vec![]);
+    let one = interner.literal_number(1.0);
+
+    // source: new (x: 1) => {}
+    let narrow = interner.callable(CallableShape {
+        symbol: None,
+        is_abstract: false,
+        call_signatures: vec![],
+        construct_signatures: vec![CallSignature {
+            type_params: vec![],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("x")),
+                type_id: one,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: obj,
+            type_predicate: None,
+            is_method: false,
+        }],
+        properties: vec![],
+        ..Default::default()
+    });
+
+    // target: new (x: number) => {}
+    let wide = interner.callable(CallableShape {
+        symbol: None,
+        is_abstract: false,
+        call_signatures: vec![],
+        construct_signatures: vec![CallSignature {
+            type_params: vec![],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("x")),
+                type_id: TypeId::NUMBER,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: obj,
+            type_predicate: None,
+            is_method: false,
+        }],
+        properties: vec![],
+        ..Default::default()
+    });
+
+    // `new (x: 1) => {}` is NOT assignable to `new (x: number) => {}` under
+    // strict (contravariant) parameter comparison: the wider target supplies a
+    // `number` argument the narrow `1` parameter cannot accept.
+    assert!(!is_subtype_of(&interner, narrow, wide));
+    // The contravariant-OK direction stays assignable.
+    assert!(is_subtype_of(&interner, wide, narrow));
+}
+
 #[test]
 fn test_callable_covariant_return() {
     let interner = TypeInterner::new();

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_09.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_09.rs
@@ -1695,8 +1695,11 @@ fn test_variance_triple_nested_contravariance() {
 }
 
 #[test]
-fn test_variance_constructor_param_bivariant() {
-    // Construct signatures use bivariant parameter checking (like methods).
+fn test_variance_construct_signature_literal_param_contravariant() {
+    // A `new (...) => T` construct-signature *type literal* (no nominal class
+    // symbol) compares its parameters strictly (contravariantly), exactly like a
+    // call-signature literal. Only class-derived constructor functions
+    // (`typeof Class`) get constructor-parameter bivariance — see issue #14859.
     let interner = TypeInterner::new();
     let mut checker = SubtypeChecker::new(&interner);
 
@@ -1752,9 +1755,11 @@ fn test_variance_constructor_param_bivariant() {
         number_index: None,
     });
 
-    // Both directions work (bivariant for construct signatures)
+    // Contravariant parameters: a wider parameter is assignable to a narrower
+    // one (the target's `string` argument is accepted by the source's
+    // `string | number` parameter), but not the reverse.
     assert!(checker.is_subtype_of(ctor_wide, ctor_narrow));
-    assert!(checker.is_subtype_of(ctor_narrow, ctor_wide));
+    assert!(!checker.is_subtype_of(ctor_narrow, ctor_wide));
 }
 
 #[test]


### PR DESCRIPTION
Closes #14859.

Standalone `new (...) => T` construct-signature **type literals** and **interface** construct signatures must compare their parameters **strictly** (contravariantly under `strictFunctionTypes`), exactly like call-signature literals. tsz compared *every* construct signature's parameters bivariantly, silently accepting assignments `tsc` rejects — a TS2322 **false negative**.

```ts
// --strict
type CtorNum = new (x: number) => object;
type CtorLit = new (x: 1) => object;
declare let cn: CtorNum, cl: CtorLit;
cn = cl; // tsc: TS2322 (number not assignable to 1); tsz before: accepted
```

**Structural rule:** when relating two construct signatures, `tsc`'s `compareSignaturesRelated` keys constructor-parameter bivariance on the **target** signature's declaration kind — only a class `Constructor` (`typeof Class`) is bivariant; a `ConstructSignature` (a `new (...) => T` type literal or an interface `new (...)` member) is strict. tsz now does the same through the solver relation layer: a `new (...) => T` literal carries no nominal symbol and an interface construct signature carries an interface symbol, so both are strict; only a target whose `symbol` resolves to `DefKind::Class` keeps constructor-parameter bivariance.

This is target-driven (a class assigned to a literal-typed target is still strict, matching `tsc`), so it is **not** a name/identifier check — detection reuses the same nominal `symbol -> DefKind` lookup the relation layer already uses for index-signature class detection, factored into a shared `symbol_def_kind` helper.

**Owner layer:** `tsz-solver` relation layer. A scoped `force_strict_construct_params` flag (mirroring the existing `in_callback_param_check` / `in_callable_property_check` flags) is set by `check_callable_subtype` per construct-signature comparison when the target is not a class, and consumed (`mem::take`) on entry to `check_function_subtype` so nested function comparisons from the constructor's parameter/return types start fresh. No type-shape identity changes (no new `FunctionShape`/`CallSignature` field), so interning/caching is untouched.

**Adjacent matrix (vs tsc 5.9.3, name-varied):**
- `new (...) => T` literal: subtype-param direction rejected (TS2322), contravariant-OK direction accepted; renamed-binder/string-literal variant also rejected.
- interface `new (...)` construct signature: strict, same as literals.
- class `typeof Class`: bivariant **both directions** — unchanged.
- call-signature literal `(x) => void`: already strict — shared-path guard.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test construct_signature_param_variance_tests` — 6/6 pass (literal/interface strict, class bivariant both directions, call-sig control, name-independence).
- `cargo test -p tsz-solver --lib -- callable_tests test_variance_construct requires_explicit index_signature weak_type` — pass (new `test_construct_sig_literal_params_are_contravariant_not_bivariant`; corrected stale `test_variance_construct_signature_literal_param_contravariant`; index-signature/weak-type relation unaffected by the shared `symbol_def_kind` extraction).
- `cargo test -p tsz-checker --test construct_signature_boundary_matrix_tests --test abstract_constructor_argument_tests --test abstract_constructor_elaboration_tests --test class_protected_widening_assignability_tests --test mixin_base_no_member_no_ts2416_tests` — pass.
- `cargo fmt -p tsz-solver -p tsz-checker -- --check` and `cargo clippy -p tsz-solver --lib` — clean.
- Pre-existing unrelated failure not touched: `relation_cache_config_tests::relation_cache_config_does_not_expose_raw_constructor` (reads `src/types.rs` for an `impl RelationCacheConfig` that now lives in `src/types/relation_cache.rs`).
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKVjsMetejw3z1yTumLdAt)_