### PR TITLE
fix(solver): compare structural construct-signature params contravariantly (#14859)

### DIFF
--- a/crates/tsz-checker/tests/function_bivariance.rs
+++ b/crates/tsz-checker/tests/function_bivariance.rs
@@ -399,3 +399,91 @@ fn test_plain_function_call_callback_contravariance_errors() {
         2345,
     );
 }
+
+// ---------------------------------------------------------------------------
+// Construct-signature parameter variance (issue #14859).
+//
+// Standalone `new (...) =>` type-literal construct signatures and interface
+// `new (...): T` construct signatures compare their parameters CONTRAVARIANTLY
+// under strictFunctionTypes, exactly like call-signature literals. Only a
+// class-derived constructor (`typeof Class`) keeps constructor-parameter
+// bivariance. Binder names are varied so a spelling-level fix would not pass.
+// ---------------------------------------------------------------------------
+
+/// `new (x: number) =>` literal target must reject a `new (x: 1) =>` source
+/// (the wrong-direction strict-subtype parameter), like tsc TS2322.
+#[test]
+fn test_construct_signature_literal_param_contravariant_errors() {
+    test_function_variance(
+        r#"
+        type MakeWidget = new (size: number) => object;
+        type MakeUnit = new (size: 1) => object;
+        declare let makeWidget: MakeWidget;
+        declare let makeUnit: MakeUnit;
+        makeWidget = makeUnit;
+        "#,
+        2322,
+    );
+}
+
+/// Interface construct signatures are strict too (declaration kind
+/// `ConstructSignature`, not `Constructor`).
+#[test]
+fn test_construct_signature_interface_param_contravariant_errors() {
+    test_function_variance(
+        r#"
+        interface BuildNumeric { new (token: number): object }
+        interface BuildLiteral { new (token: 1): object }
+        declare let buildNumeric: BuildNumeric;
+        declare let buildLiteral: BuildLiteral;
+        buildNumeric = buildLiteral;
+        "#,
+        2322,
+    );
+}
+
+/// A later contravariant-bad parameter in a multi-parameter construct literal
+/// is still caught.
+#[test]
+fn test_construct_signature_multi_param_contravariant_errors() {
+    test_function_variance(
+        r#"
+        type SpawnWide = new (label: string, rank: number) => object;
+        type SpawnNarrow = new (label: string, rank: 1) => object;
+        declare let spawnWide: SpawnWide;
+        declare let spawnNarrow: SpawnNarrow;
+        spawnWide = spawnNarrow;
+        "#,
+        2322,
+    );
+}
+
+/// The contravariant-OK direction (widening the parameter) stays accepted.
+#[test]
+fn test_construct_signature_literal_contravariant_ok() {
+    test_no_errors(
+        r#"
+        type MakeWide = new (size: number) => object;
+        type MakeNarrow = new (size: 1) => object;
+        declare let makeWide: MakeWide;
+        declare let makeNarrow: MakeNarrow;
+        makeNarrow = makeWide;
+        "#,
+    );
+}
+
+/// Class-derived constructor (`typeof Class`) keeps constructor-parameter
+/// bivariance in BOTH directions — this must not regress into a TS2322.
+#[test]
+fn test_class_constructor_param_bivariance_preserved() {
+    test_no_errors(
+        r#"
+        class HostNumeric { constructor(slot: number) {} }
+        class HostLiteral { constructor(slot: 1) {} }
+        declare let hostNumeric: typeof HostNumeric;
+        declare let hostLiteral: typeof HostLiteral;
+        hostNumeric = hostLiteral;
+        hostLiteral = hostNumeric;
+        "#,
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -33,8 +33,26 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: &FunctionShape,
         target: &FunctionShape,
     ) -> SubtypeResult {
-        let allow_constructor_bivariance =
-            !Self::constructor_signatures_need_strict_params(source, target);
+        self.check_function_subtype_with_constructor_strictness(source, target, false)
+    }
+
+    /// [`Self::check_function_subtype`], but the construct-signature caller can
+    /// force strict (contravariant) parameter comparison.
+    ///
+    /// When `force_strict_construct_params` is set — a structural construct
+    /// signature, per [`Self::construct_target_requires_strict_params`] —
+    /// constructor bivariance is never granted; otherwise the prior shape-based
+    /// heuristic ([`Self::constructor_signatures_need_strict_params`]) applies,
+    /// leaving class-derived constructor bivariance and the bare-`FunctionShape`
+    /// constructor path (which always passes `false`) unchanged.
+    pub(crate) fn check_function_subtype_with_constructor_strictness(
+        &mut self,
+        source: &FunctionShape,
+        target: &FunctionShape,
+        force_strict_construct_params: bool,
+    ) -> SubtypeResult {
+        let allow_constructor_bivariance = !force_strict_construct_params
+            && !Self::constructor_signatures_need_strict_params(source, target);
         let result = self.check_function_subtype_impl(source, target, allow_constructor_bivariance);
         if result.is_true() {
             return result;
@@ -45,6 +63,39 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return retry;
         }
         result
+    }
+
+    /// Whether the construct signatures of `target` must compare their
+    /// parameters strictly (contravariantly), as `tsc` does for every construct
+    /// signature except a class-derived constructor.
+    ///
+    /// `tsc` keys constructor-parameter bivariance on the target signature's
+    /// declaration kind: only a class `constructor` (`SyntaxKind.Constructor`)
+    /// is bivariant; a `new (...) => T` type-literal (`ConstructorType`) and an
+    /// interface/object-type `new (...): T` member (`ConstructSignature`) compare
+    /// their parameters strictly under `strictFunctionTypes`, exactly like a
+    /// call-signature literal. tsz recovers that origin from the callable's
+    /// nominal `symbol`:
+    /// * no symbol — an anonymous `new (...) =>` / object-type construct
+    ///   signature literal: structural, strict.
+    /// * symbol resolves to an `Interface` — a `ConstructSignature` member:
+    ///   structural, strict.
+    /// * symbol resolves to a `Class`/`ClassConstructor` — a class constructor:
+    ///   nominal, keeps constructor bivariance.
+    /// * symbol present but unresolved in this context — preserve the prior
+    ///   bivariant behavior. A real resolver maps class symbols; defaulting an
+    ///   unresolved symbol to strict could regress a class-to-class constructor
+    ///   assignment into a false `TS2322`.
+    pub(crate) fn construct_target_requires_strict_params(&self, target: &CallableShape) -> bool {
+        match target.symbol {
+            None => true,
+            Some(symbol) => matches!(
+                self.resolver
+                    .symbol_to_def_id(crate::types::SymbolRef(symbol.0))
+                    .and_then(|def_id| self.resolver.get_def_kind(def_id)),
+                Some(crate::def::DefKind::Interface)
+            ),
+        }
     }
 
     /// True when any of `candidate_tp_ids` occurs *free* in `shape`'s parameter
@@ -1780,10 +1831,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // follow the regular property-function relation instead of method-style
         // bivariance. Standalone constructor function types still flow through
         // `check_function_subtype` with `is_constructor = true`.
+        // Only the construct-signature loop consumes this, so skip the resolver
+        // lookup entirely when the target has no construct signatures.
+        let target_construct_is_structural = !target.construct_signatures.is_empty()
+            && self.construct_target_requires_strict_params(target);
         for t_sig in &target.construct_signatures {
             let mut found_match = false;
             for s_sig in &source.construct_signatures {
-                let result = self.check_call_signature_subtype_as_constructor(s_sig, t_sig);
+                let result = self.check_call_signature_subtype_as_constructor(
+                    s_sig,
+                    t_sig,
+                    target_construct_is_structural,
+                );
                 if result.is_true() {
                     found_match = true;
                     break;
@@ -1794,7 +1853,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             {
                 for s_sig in &source.construct_signatures {
                     if self
-                        .check_erased_call_signature_subtype_as_constructor(s_sig, t_sig)
+                        .check_erased_call_signature_subtype_as_constructor(
+                            s_sig,
+                            t_sig,
+                            target_construct_is_structural,
+                        )
                         .is_true()
                     {
                         found_match = true;

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/call_signatures.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/call_signatures.rs
@@ -9,7 +9,7 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
         source: &CallSignature,
         target: &CallSignature,
     ) -> SubtypeResult {
-        self.check_call_signature_subtype_impl(source, target, false)
+        self.check_call_signature_subtype_impl(source, target, false, false)
     }
 
     pub(crate) fn callable_modality_flags_for_type(&mut self, type_id: TypeId) -> (bool, bool) {
@@ -40,12 +40,18 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
         (false, false)
     }
 
+    /// Compare two construct signatures as a constructor relation.
+    ///
+    /// `force_strict_construct_params` carries the target's construct-signature
+    /// origin (see
+    /// [`super::SubtypeChecker::construct_target_requires_strict_params`]).
     pub(crate) fn check_call_signature_subtype_as_constructor(
         &mut self,
         source: &CallSignature,
         target: &CallSignature,
+        force_strict_construct_params: bool,
     ) -> SubtypeResult {
-        self.check_call_signature_subtype_impl(source, target, true)
+        self.check_call_signature_subtype_impl(source, target, true, force_strict_construct_params)
     }
 
     fn check_call_signature_subtype_impl(
@@ -53,6 +59,7 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
         source: &CallSignature,
         target: &CallSignature,
         is_constructor: bool,
+        force_strict_construct_params: bool,
     ) -> SubtypeResult {
         let source_fn = FunctionShape {
             type_params: source.type_params.clone(),
@@ -72,7 +79,11 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
             is_constructor,
             is_method: target.is_method,
         };
-        self.check_function_subtype(&source_fn, &target_fn)
+        self.check_function_subtype_with_constructor_strictness(
+            &source_fn,
+            &target_fn,
+            force_strict_construct_params,
+        )
     }
 
     pub(crate) fn constructor_signatures_need_strict_params(

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
@@ -118,10 +118,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
     /// Compare constructor signatures after erasing type parameters to `any`.
     /// Used in N x M constructor-signature comparison to match tsc behavior.
+    ///
+    /// `force_strict_construct_params` carries the target's construct-signature
+    /// origin (see
+    /// [`super::SubtypeChecker::construct_target_requires_strict_params`]) so the
+    /// erased multi-overload fallback applies the same `strictFunctionTypes`
+    /// contravariance as the primary path; only type parameters are erased, the
+    /// declared parameter types still drive variance.
     pub(super) fn check_erased_call_signature_subtype_as_constructor(
         &mut self,
         source: &CallSignature,
         target: &CallSignature,
+        force_strict_construct_params: bool,
     ) -> SubtypeResult {
         for (s_param, t_param) in source.params.iter().zip(target.params.iter()) {
             let (s_has_call, s_has_construct) =
@@ -140,7 +148,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let mut t_erased = erase_call_sig_to_any(target, self.interner);
         s_erased.is_constructor = true;
         t_erased.is_constructor = true;
-        self.check_function_subtype(&s_erased, &t_erased)
+        self.check_function_subtype_with_constructor_strictness(
+            &s_erased,
+            &t_erased,
+            force_strict_construct_params,
+        )
     }
 
     fn check_function_subtype_either_direction(

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_09.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_09.rs
@@ -1695,8 +1695,12 @@ fn test_variance_triple_nested_contravariance() {
 }
 
 #[test]
-fn test_variance_constructor_param_bivariant() {
-    // Construct signatures use bivariant parameter checking (like methods).
+fn test_variance_constructor_param_contravariant() {
+    // Standalone `new (...) =>` construct-signature literals (no nominal
+    // `symbol`) compare their parameters CONTRAVARIANTLY under
+    // strictFunctionTypes, exactly like call-signature literals -- only a
+    // class-derived constructor (`typeof Class`) keeps constructor bivariance.
+    // tsc rejects the strict-subtype param direction here (TS2322).
     let interner = TypeInterner::new();
     let mut checker = SubtypeChecker::new(&interner);
 
@@ -1752,9 +1756,12 @@ fn test_variance_constructor_param_bivariant() {
         number_index: None,
     });
 
-    // Both directions work (bivariant for construct signatures)
+    // Contravariant: a wider parameter (`string | number`) is assignable into a
+    // target expecting a narrower one (`string`)...
     assert!(checker.is_subtype_of(ctor_wide, ctor_narrow));
-    assert!(checker.is_subtype_of(ctor_narrow, ctor_wide));
+    // ...but the reverse (narrowing the parameter) is rejected, unlike the old
+    // bivariant behavior that wrongly accepted it.
+    assert!(!checker.is_subtype_of(ctor_narrow, ctor_wide));
 }
 
 #[test]


### PR DESCRIPTION
Closes #14859.

Standalone `new (...) => T` type-literal construct signatures and interface `new (...): T` members must compare their parameters **contravariantly** under `strictFunctionTypes`, exactly like call-signature literals. tsz compared them **bivariantly**, silently accepting an assignment whose source constructor parameter is a strict *subtype* of the target's parameter — a false negative vs `tsc`'s TS2322.

```ts
// --strict --target es2022 --lib es2022
type CtorNum = new (x: number) => object;
type CtorLit = new (x: 1) => object;
declare let cn: CtorNum;
declare let cl: CtorLit;
cn = cl; // tsc: TS2322 (param 'number' not assignable to '1'); tsz before: accepted
```

## Structural rule
When the assignment target is a construct signature, `tsc` keys constructor-parameter bivariance on the target signature's **declaration kind**: only a class `constructor` (`SyntaxKind.Constructor`) is bivariant; a `new (...) => T` type-literal (`ConstructorType`) and an interface/object-type `new (...): T` member (`ConstructSignature`) compare their parameters strictly under `strictFunctionTypes`. tsz applies this through the callable subtype relation (`SubtypeChecker::construct_target_requires_strict_params`).

**Owner layer:** `tsz-solver` callable/function subtype relation. The construct-signature origin is recovered structurally from the target callable's nominal `symbol` (a binder `DefKind`, not a name/string predicate):
- no symbol — anonymous `new (...) =>` / object-type construct signature literal → structural, strict;
- symbol resolves to `Interface` (`ConstructSignature` member) → structural, strict;
- symbol resolves to `Class`/`ClassConstructor` → class constructor, keeps bivariance;
- symbol present but unresolved in this context → preserve the prior bivariant behavior (a real resolver maps class symbols; defaulting to strict could regress a class-to-class constructor assignment into a false TS2322).

The verdict threads as a single `bool` into both the primary and the erased multi-overload construct comparison. Call signatures and the bare-`FunctionShape` constructor path (class-overload checks) are unchanged, so no error flips on those paths. `symbol` already survives instantiation/canonicalization, so generic construct-literal forms (`Gen<T>`) inherit the rule with no extra plumbing.

## Adjacent matrix (verified byte-for-byte vs `tsc` 6.0.2, binder names varied)
- `new (x: number)=>` ← `new (x: 1)=>` → TS2322
- multi-param, later contravariant-bad param → TS2322
- literal/string subtype param, union-widening param → TS2322
- interface `new (x: number):` ← `new (x: 1):` → TS2322
- generic construct literal `Gen<number>` ← `Gen<1>` → TS2322
- **negative:** contravariant-OK direction (`new (x: 1)=>` ← `new (x: number)=>`) stays accepted
- **negative:** class-derived `typeof Class` constructor-param bivariance preserved in **both** directions
- return covariance already correct and unchanged

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test function_bivariance` — 22 passed (5 new construct-signature variance tests: literal/interface/multi-param strict-reject, contravariant-OK accept, class-constructor bivariance preserved both directions; varied binder names).
- `cargo test -p tsz-solver --lib relations::subtype::core::tests::test_variance_constructor_param_contravariant` — pass (updated; previously asserted the buggy bivariance for an anonymous construct literal).
- `cargo test -p tsz-solver --lib` — 7198 passed; the 7 failures are pre-existing on a clean tree (file-size-ceiling / cache-config / narrowing-arch / conditional-infer / literal-mask / free-infer), byte-identical before/after this change.
- Constructor/assignability checker suites (`checker_constructor_matrix_tests`, `abstract_constructor_argument_tests`, `weak_callable_target_assignability_tests`, `assignability_final_relation_gate_tests`) — pass.
- Manual `tsz --noEmit --strict --target es2022 --lib es2022` vs `tsc` 6.0.2 across the matrix above — error codes/spans match exactly.
- `cargo fmt -p tsz-solver -p tsz-checker -- --check` and `cargo clippy -p tsz-solver --lib` — clean.
- Broad conformance/emit/fourslash owned by ready-review CI.

Note: the construct-signature relation still emits a bare TS2322 head without the nested `Types of parameters … incompatible` elaboration on some shapes (conformance-invisible — the runner compares top-line code+span+message). That elaboration tail and an intrinsic construct-origin flag on the signature (subsuming the resolver-derived classification and the erased-fallback threading) are tracked as follow-ups; this PR fixes the variance **decision**.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxQngXLNqYEy9FnGKdvCrR)_