### PR TITLE
refactor(checker): seed shared-store defs through env authority (#14348)

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -827,6 +827,32 @@ impl CheckerContext<'_> {
         self.mirror_to_flow_env(op);
     }
 
+    /// Seed a definition body that is already authoritative in the shared
+    /// `DefinitionStore` into the local evaluator env and flow-analyzer env.
+    ///
+    /// Shared-store warm-up may hold a long-lived mutable borrow of `type_env`
+    /// while iterating symbols. When that borrow exists, apply the evaluator
+    /// write directly through the same queued-write drain order; when it does
+    /// not, route through the ordinary race-safe evaluator queue. In both cases
+    /// the flow-analyzer env receives the exact same op through
+    /// [`Self::mirror_to_flow_env`].
+    pub(crate) fn seed_shared_store_def_in_envs(
+        &self,
+        eval_env: Option<&mut TypeEnvironment>,
+        def_id: DefId,
+        body: TypeId,
+        params: Vec<tsz_solver::TypeParamInfo>,
+    ) {
+        let op = DeferredFlowEnvWrite::insert_def_choosing_params(def_id, body, params, None);
+        if let Some(env) = eval_env {
+            drain_env_write_queue_into(&self.deferred_eval_env_writes, env);
+            op.apply(env);
+        } else {
+            self.apply_to_eval_env(op.clone());
+        }
+        self.mirror_to_flow_env(op);
+    }
+
     /// Apply (or defer) one registration to the authoritative evaluator env
     /// (`type_env`), through the shared race-safe write discipline.
     fn apply_to_eval_env(&self, op: DeferredFlowEnvWrite) {

--- a/crates/tsz-checker/src/context/def_mapping_tests.rs
+++ b/crates/tsz-checker/src/context/def_mapping_tests.rs
@@ -381,6 +381,133 @@ fn eval_env_backlog_drains_on_next_successful_write() {
     );
 }
 
+#[test]
+fn shared_store_seed_uses_borrowed_eval_env_and_deferred_flow_mirror() {
+    use tsz_common::interner::Atom;
+    use tsz_solver::TypeId;
+    use tsz_solver::def::DefinitionInfo;
+
+    let (arena, binder, types) = minimal_checker_ctx();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    let def_id = ctx.definition_store.register(DefinitionInfo::type_alias(
+        Atom::default(),
+        vec![],
+        TypeId::UNKNOWN,
+    ));
+    let params = vec![tsz_solver::TypeParamInfo::simple(types.intern_string("T"))];
+    ctx.definition_store
+        .set_body_with_params(def_id, TypeId::STRING, Some(params.clone()));
+
+    {
+        let held_flow = ctx.type_environment.borrow();
+        let mut eval_env = ctx.type_env.borrow_mut();
+        ctx.seed_shared_store_def_in_envs(
+            Some(&mut eval_env),
+            def_id,
+            TypeId::STRING,
+            params.clone(),
+        );
+
+        assert_eq!(
+            eval_env.get_def(def_id),
+            Some(TypeId::STRING),
+            "borrowed evaluator env must receive the warm-up body directly"
+        );
+        assert_eq!(
+            eval_env.get_def_params(def_id),
+            Some(params.as_slice()),
+            "borrowed evaluator env must receive warm-up type params"
+        );
+        assert_eq!(
+            ctx.deferred_eval_env_write_count(),
+            0,
+            "using the borrowed evaluator env must not queue an authoritative write"
+        );
+        assert_eq!(
+            held_flow.get_def(def_id),
+            None,
+            "held flow env must not receive the mirror until replay"
+        );
+        assert_eq!(
+            ctx.deferred_flow_env_write_count(),
+            1,
+            "flow mirror must be queued rather than dropped"
+        );
+    }
+
+    ctx.flush_deferred_flow_env_writes();
+    assert_eq!(ctx.deferred_flow_env_write_count(), 0);
+    assert_eq!(
+        ctx.type_environment.borrow().get_def(def_id),
+        Some(TypeId::STRING),
+        "flow env must receive the replayed warm-up body"
+    );
+    assert_eq!(
+        ctx.type_environment.borrow().get_def_params(def_id),
+        Some(params.as_slice()),
+        "flow env must receive replayed warm-up type params"
+    );
+}
+
+#[test]
+fn shared_store_seed_defers_authoritative_write_when_eval_env_is_borrowed() {
+    use tsz_common::interner::Atom;
+    use tsz_solver::TypeId;
+    use tsz_solver::def::DefinitionInfo;
+
+    let (arena, binder, types) = minimal_checker_ctx();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    let def_id = ctx.definition_store.register(DefinitionInfo::type_alias(
+        Atom::default(),
+        vec![],
+        TypeId::UNKNOWN,
+    ));
+    ctx.definition_store.set_body(def_id, TypeId::BOOLEAN);
+
+    {
+        let held_eval = ctx.type_env.borrow();
+        ctx.seed_shared_store_def_in_envs(None, def_id, TypeId::BOOLEAN, Vec::new());
+
+        assert_eq!(
+            held_eval.get_def(def_id),
+            None,
+            "held evaluator env must not receive the queued warm-up body yet"
+        );
+        assert_eq!(
+            ctx.deferred_eval_env_write_count(),
+            1,
+            "lost authoritative warm-up write must be queued"
+        );
+        assert_eq!(
+            ctx.type_environment.borrow().get_def(def_id),
+            Some(TypeId::BOOLEAN),
+            "flow env mirror can still apply when it is borrowable"
+        );
+    }
+
+    ctx.flush_deferred_eval_env_writes();
+    assert_eq!(ctx.deferred_eval_env_write_count(), 0);
+    assert_eq!(
+        ctx.type_env.borrow().get_def(def_id),
+        Some(TypeId::BOOLEAN),
+        "evaluator env must receive the replayed warm-up body"
+    );
+}
+
 /// Both type environments share one race-safe write discipline
 /// (`apply_or_defer_env_write`). When a single dual-env registration races
 /// *both* cells at once — the exact recursive-resolution scenario where the flow

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -1328,31 +1328,30 @@ impl CheckerState<'_> {
                 // Populate local DefId caches.
                 s2d.insert(sym_id, def_id);
                 d2s.insert(def_id, sym_id);
-                // Seed type_env with the DefId -> body mapping, and mirror the
-                // same authoritative shared-store body into the flow-analyzer
-                // env so the two envs do not diverge on it (#13944).
+                // Seed both local envs with the DefId -> body mapping through
+                // the shared dual-env write helper. This keeps warm-up on the
+                // same authoritative/mirror path as ordinary body publication
+                // while preserving the long-lived evaluator-env borrow.
                 //
                 // The global/boxed-type registration may already have seeded the
                 // flow env with a differently-interned materialization of this
                 // same def (e.g. a symbol-less object shape vs the symbol-bearing
-                // body the shared store published). Seeding only `type_env` here
-                // would leave that stale flow-env entry in place — a
-                // present-but-different `DefId -> TypeId` divergence that the
-                // vacancy-only `overlay_missing_from` cannot reconcile. The
-                // mirror defers on a borrow race and is replayed at
-                // `flush_deferred_flow_env_writes`.
+                // body the shared store published). The helper rewrites both
+                // envs with the same body (deferring flow-env writes on a borrow
+                // race), avoiding a present-but-different `DefId -> TypeId`
+                // divergence that the vacancy-only `overlay_missing_from`
+                // cannot reconcile.
                 let type_params = self
                     .ctx
                     .definition_store
                     .get_type_params(def_id)
                     .unwrap_or_default();
-                self.ctx
-                    .mirror_def_in_type_environment(def_id, body, &type_params);
-                if let Some(env) = env_opt.as_deref_mut() {
-                    // `insert_def_with_params` with empty params is equivalent to
-                    // `insert_def`, so the one call covers both arities.
-                    env.insert_def_with_params(def_id, body, type_params);
-                }
+                self.ctx.seed_shared_store_def_in_envs(
+                    env_opt.as_deref_mut(),
+                    def_id,
+                    body,
+                    type_params,
+                );
             }
             drop(s2d);
             drop(d2s);

--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
@@ -685,6 +685,34 @@ fn test_def_symbol_bridge_writes_route_through_dual_env_helper() {
 }
 
 #[test]
+fn test_shared_store_warmup_routes_env_seeds_through_context_helper() {
+    let source = fs::read_to_string("src/state/type_environment/core.rs")
+        .expect("failed to read src/state/type_environment/core.rs for architecture guard");
+    let warmup = source
+        .split("PERF: Seed symbol_types and type_env from DefinitionStore")
+        .nth(1)
+        .and_then(|tail| {
+            tail.split("// Resolve each symbol and add to the environment.")
+                .next()
+        })
+        .expect("failed to isolate shared-store warm-up block");
+
+    assert!(
+        warmup.contains("seed_shared_store_def_in_envs("),
+        "shared-store TypeEnvironment warm-up must route body seeding through CheckerContext::seed_shared_store_def_in_envs"
+    );
+    for forbidden in [
+        "mirror_def_in_type_environment(",
+        "env.insert_def_with_params(",
+    ] {
+        assert!(
+            !warmup.contains(forbidden),
+            "shared-store TypeEnvironment warm-up must not use raw env write path `{forbidden}`"
+        );
+    }
+}
+
+#[test]
 fn test_assignability_checker_routes_relation_queries_through_query_boundaries() {
     let mut assignability_source = fs::read_to_string("src/assignability/assignability_checker.rs")
         .expect("failed to read src/assignability/assignability_checker.rs for architecture guard");


### PR DESCRIPTION
Goal: green

## Summary
- Add `CheckerContext::seed_shared_store_def_in_envs` so shared `DefinitionStore` warm-up installs `DefId -> TypeId` bodies through the checker-owned dual-env authority path.
- Replace the warm-up loop's manual `mirror_def_in_type_environment` plus raw `env.insert_def_with_params` pair with the named helper while preserving the long-lived evaluator-env borrow.
- Add helper tests for borrowed-evaluator and evaluator-borrow-conflict paths, plus an architecture guard that keeps shared-store warm-up off raw env writes.

## Structural Rule
When a per-file checker seeds a body and params from the shared `DefinitionStore`, `tsc` has one published declaration body. `tsz` should install that same body/params into the evaluator env and flow-analyzer env through one checker-owned authority path, preserving deferred replay and avoiding present-but-different flow entries.

Owner layer: checker context/type-environment publication. The solver remains the `TypeEnvironment` storage/query owner; this PR only centralizes checker publication into that storage.

Adjacent matrix:
- Warm-up with a borrowed evaluator env writes the evaluator body/params directly and queues the flow mirror when the flow env is borrowed.
- Warm-up without a borrowed evaluator env uses the authoritative evaluator queue, so an evaluator borrow conflict is deferred and replayed.
- Existing dual-env replay behavior remains covered through the `def_mapping` lib filter.
- The shared-store warm-up source guard prevents reintroducing `mirror_def_in_type_environment` plus raw evaluator env insertion in that block.

Fallback/order plan: this keeps the existing symbol iteration order, shared-store lookup filters, and declaration-file early return. It changes only the env publication gateway used after the shared store has already selected an authoritative body.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib shared_store_seed`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib shared_store_warmup`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib def_mapping`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --tests -- -D warnings`

Note: an earlier broad `cargo nextest run -p tsz-checker <filter>` attempt failed before test execution with `No space left on device` because it linked every checker test target. I recovered by deleting only an inactive-clean `.target` cache identified by `scripts/setup/disk-worktree-guard.sh`, then reran the focused lib-only filters above successfully.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
