### PR TITLE
refactor(checker): route module augmentation def publication through env authority (#14351)

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping_tests.rs
+++ b/crates/tsz-checker/src/context/def_mapping_tests.rs
@@ -740,6 +740,144 @@ fn symbol_type_registration_deferred_mirror_preserves_params() {
     );
 }
 
+/// Augmentation merges re-publish an existing `DefId` body. The replay path
+/// must preserve the def's type params; otherwise a generic interface merged by
+/// module/global augmentation becomes non-generic in whichever env lost the
+/// borrow race.
+#[test]
+fn augmented_def_registration_deferred_mirror_preserves_params() {
+    use tsz_common::interner::Atom;
+    use tsz_solver::TypeId;
+    use tsz_solver::def::DefinitionInfo;
+
+    let (arena, binder, types) = minimal_checker_ctx();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    let def_id = ctx.definition_store.register(DefinitionInfo::type_alias(
+        Atom::default(),
+        vec![],
+        TypeId::UNKNOWN,
+    ));
+    let params = vec![tsz_solver::TypeParamInfo::simple(Atom::default())];
+    ctx.register_def_with_params_in_envs(def_id, TypeId::STRING, params.clone());
+
+    {
+        let held_flow = ctx.type_environment.borrow();
+        ctx.register_augmented_def_in_envs(def_id, TypeId::NUMBER, false);
+
+        let eval = ctx.type_env.borrow();
+        assert_eq!(eval.get_def(def_id), Some(TypeId::NUMBER));
+        assert_eq!(
+            eval.get_def_params(def_id),
+            Some(params.as_slice()),
+            "evaluator env must preserve params while publishing the augmented body"
+        );
+        assert_eq!(
+            held_flow.get_def(def_id),
+            Some(TypeId::STRING),
+            "flow env write must wait while the env is borrowed"
+        );
+        assert_eq!(
+            ctx.deferred_flow_env_write_count(),
+            1,
+            "augmented def mirror must be queued rather than dropped"
+        );
+    }
+
+    ctx.flush_deferred_flow_env_writes();
+    assert_eq!(ctx.deferred_flow_env_write_count(), 0);
+    let flow = ctx.type_environment.borrow();
+    assert_eq!(flow.get_def(def_id), Some(TypeId::NUMBER));
+    assert_eq!(
+        flow.get_def_params(def_id),
+        Some(params.as_slice()),
+        "flow env replay must preserve generic params from the original def"
+    );
+}
+
+/// Companion for the shared-store path: a cross-file checker can observe a
+/// generic def whose params live only in `DefinitionStore`, not in its local
+/// `TypeEnvironment`. Replaying an augmentation merge must still re-insert the
+/// augmented body as generic by using `get_def_params_owned`.
+#[test]
+fn augmented_def_registration_uses_store_only_params_on_replay() {
+    use tsz_common::interner::Atom;
+    use tsz_solver::TypeId;
+    use tsz_solver::def::DefinitionInfo;
+
+    let (arena, binder, types) = minimal_checker_ctx();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    let def_id = ctx.definition_store.register(DefinitionInfo::type_alias(
+        Atom::default(),
+        vec![],
+        TypeId::UNKNOWN,
+    ));
+    let params = vec![tsz_solver::TypeParamInfo::simple(Atom::default())];
+    ctx.definition_store.set_type_params(def_id, params.clone());
+
+    // Attach the shared store to both envs, but leave their local param maps
+    // empty. `get_def_params_owned` can see the params; `get_def_params` cannot.
+    ctx.ensure_both_envs_have_definition_store();
+    {
+        let eval_snapshot = ctx.type_env.borrow();
+        ctx.type_environment
+            .borrow_mut()
+            .overlay_missing_from(&eval_snapshot);
+    }
+    assert_eq!(ctx.type_env.borrow().get_def_params(def_id), None);
+    assert_eq!(ctx.type_environment.borrow().get_def_params(def_id), None);
+    assert_eq!(
+        ctx.type_env.borrow().get_def_params_owned(def_id),
+        Some(params.clone())
+    );
+
+    {
+        let held_eval = ctx.type_env.borrow();
+        ctx.register_augmented_def_in_envs(def_id, TypeId::NUMBER, false);
+
+        assert_eq!(
+            held_eval.get_def_params(def_id),
+            None,
+            "evaluator env local params must not be updated while type_env is borrowed"
+        );
+        assert_eq!(
+            ctx.deferred_eval_env_write_count(),
+            1,
+            "authoritative augmented def write must be queued"
+        );
+        let flow = ctx.type_environment.borrow();
+        assert_eq!(flow.get_def(def_id), Some(TypeId::NUMBER));
+        assert_eq!(
+            flow.get_def_params(def_id),
+            Some(params.as_slice()),
+            "flow env direct write must preserve params from the store"
+        );
+    }
+
+    ctx.flush_deferred_eval_env_writes();
+    assert_eq!(ctx.deferred_eval_env_write_count(), 0);
+    let eval = ctx.type_env.borrow();
+    assert_eq!(eval.get_def(def_id), Some(TypeId::NUMBER));
+    assert_eq!(
+        eval.get_def_params(def_id),
+        Some(params.as_slice()),
+        "evaluator env replay must preserve store-only params"
+    );
+}
+
 /// Regression for #13944 / #13086: a `DefId -> TypeId` body re-published by the
 /// lazy-resolution path (`register_resolved_def_in_envs`, the gateway
 /// `try_insert_def_in_type_env` now uses) must travel the race-safe deferred

--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_06.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_06.rs
@@ -58,6 +58,43 @@ fn test_symbol_ref_to_symbol_id_cast_budget() {
 }
 
 #[test]
+fn test_module_augmentation_publishes_merged_defs_through_context_authority() {
+    let source = fs::read_to_string("src/types/module_augmentation.rs")
+        .expect("failed to read module_augmentation.rs");
+    let non_comment_source = source
+        .lines()
+        .map(|line| line.split_once("//").map_or(line, |(code, _)| code))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let compact_source = non_comment_source
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect::<String>();
+
+    assert!(
+        compact_source.contains("register_augmented_def_in_envs(def_id,result,false)"),
+        "global augmentation merged bodies must publish through CheckerContext"
+    );
+    assert!(
+        compact_source.contains("register_augmented_def_in_envs(aug_def_id,merged_type,false)"),
+        "augmentation-local self-reference bodies must publish through CheckerContext"
+    );
+    let raw_type_env_mut_borrows = non_comment_source.lines().filter(|line| {
+        line.contains("type_env")
+            && (line.contains("try_borrow_mut()") || line.contains("borrow_mut()"))
+    });
+    assert!(
+        raw_type_env_mut_borrows.count() == 0,
+        "module augmentation must not write type_env directly; route DefId bodies \
+         through the deferred dual-env authority"
+    );
+    assert!(
+        !non_comment_source.contains("env.insert_def("),
+        "module augmentation must not publish DefId bodies with raw env.insert_def"
+    );
+}
+
+#[test]
 fn test_env_eval_cache_def_invalidation_is_targeted() {
     let arena = NodeArena::new();
     let binder = BinderState::new();

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -1697,14 +1697,13 @@ impl<'a> CheckerState<'a> {
             if let Some(shape) = type_environment::object_shape(self.ctx.types, result) {
                 self.ctx.definition_store.set_instance_shape(def_id, shape);
             }
-            if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
-                env.insert_def(def_id, result);
-            }
+            self.ctx
+                .register_augmented_def_in_envs(def_id, result, false);
         }
         result
     }
 
-    /// Update `symbol_types` and `type_env` for augmentation-local interface symbols
+    /// Update `symbol_types` and both environments for augmentation-local interface symbols
     /// so self-referential type references resolve to the merged type.
     /// Searches both the current binder and `all_binders` since the augmentation
     /// may be declared in a different file than the one being checked.
@@ -1758,12 +1757,12 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // Update symbol_types, symbol_instance_types, and type_env for each matching symbol.
+        // Update symbol_types, symbol_instance_types, and env mappings for each matching symbol.
         // symbol_instance_types must be updated because resolve_lazy() checks it
         // BEFORE symbol_types for INTERFACE symbols, so an un-augmented entry there
         // would shadow the updated symbol_types value.
         // Collect def IDs first (get_or_create_def_id borrows ctx mutably),
-        // then batch-insert into type_env with a single borrow.
+        // then publish them through the context-owned dual-env authority.
         let def_ids: Vec<_> = matching_sym_ids
             .iter()
             .map(|&aug_sym_id| {
@@ -1774,10 +1773,9 @@ impl<'a> CheckerState<'a> {
                 self.ctx.get_or_create_def_id(aug_sym_id)
             })
             .collect();
-        if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
-            for aug_def_id in def_ids {
-                env.insert_def(aug_def_id, merged_type);
-            }
+        for aug_def_id in def_ids {
+            self.ctx
+                .register_augmented_def_in_envs(aug_def_id, merged_type, false);
         }
     }
 }


### PR DESCRIPTION
Goal: green

## Summary
- Route module/global augmentation merged `DefId -> TypeId` publication through `CheckerContext::register_augmented_def_in_envs` instead of raw `type_env` mutation.
- Add augmented-def env tests for deferred replay, local params, and store-only generic params.
- Add an architecture source guard preventing `module_augmentation.rs` from reintroducing direct `type_env` body publication.

## Structural Rule
When module/global augmentation produces a merged interface body, `tsc` exposes the merged declaration body to later type and flow queries. tsz now publishes that merged `DefId -> TypeId` body through the checker-owned dual-env authority, preserving generic params and deferring evaluator/flow-env writes on borrow races.

Owner layer: checker context env-publication boundary; module augmentation remains the checker orchestration caller.

Adjacent matrix: global augmentation body publication, augmentation-local self-reference body publication, generic params, store-only params, flow-env borrow replay, evaluator-env borrow replay, computed global augmentation members, cross-file property access, merged symbol computed keys, and class-instance publication controls.

Refs #14351 and #14348.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib module_augmentation def_mapping global_augmentation_computed_key_tests window_self_globalthis_resolution_tests cross_file_interface_property_access_tests cross_file_merged_symbol_value_computed_key_tests cross_file_class_instance_publication_tests`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --tests -- -D warnings`

Known baseline: `reexported_generic_interface_property_tests::member_access_through_alias_renames_parameter` fails on `origin/main` with the same TS2322, so it is not part of this PR gate.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
