### PR TITLE
fix(emit): guard bigint/symbol decorator metadata globals like tsc (#14777)

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/decorators.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/decorators.rs
@@ -2,6 +2,7 @@ use super::super::super::Printer;
 use crate::context::transform::TransformDirective;
 use crate::transforms::emit_utils::{
     METADATA_ALIAS_MAX_DEPTH, MetadataEntityKind, classify_metadata_entity,
+    metadata_global_constructor_with_fallback,
 };
 use tsz_parser::parser::node::{Node, NodeAccess};
 use tsz_parser::parser::syntax_kind_ext;
@@ -508,8 +509,10 @@ impl<'a> Printer<'a> {
             k if k == sk(SyntaxKind::StringKeyword) => "String".to_string(),
             k if k == sk(SyntaxKind::NumberKeyword) => "Number".to_string(),
             k if k == sk(SyntaxKind::BooleanKeyword) => "Boolean".to_string(),
-            k if k == sk(SyntaxKind::SymbolKeyword) => "Symbol".to_string(),
-            k if k == sk(SyntaxKind::BigIntKeyword) => "BigInt".to_string(),
+            k if k == sk(SyntaxKind::SymbolKeyword) => self.metadata_symbol_constructor(),
+            k if k == sk(SyntaxKind::BigIntKeyword) => {
+                metadata_global_constructor_with_fallback("BigInt")
+            }
             k if k == sk(SyntaxKind::VoidKeyword) => "void 0".to_string(),
             k if k == sk(SyntaxKind::UndefinedKeyword) => "void 0".to_string(),
             k if k == sk(SyntaxKind::NullKeyword) => "void 0".to_string(),
@@ -632,7 +635,9 @@ impl<'a> Printer<'a> {
                     return match lit_node.kind {
                         lk if lk == sk(SyntaxKind::StringLiteral) => "String".to_string(),
                         lk if lk == sk(SyntaxKind::NumericLiteral) => "Number".to_string(),
-                        lk if lk == sk(SyntaxKind::BigIntLiteral) => "BigInt".to_string(),
+                        lk if lk == sk(SyntaxKind::BigIntLiteral) => {
+                            metadata_global_constructor_with_fallback("BigInt")
+                        }
                         lk if lk == sk(SyntaxKind::TrueKeyword)
                             || lk == sk(SyntaxKind::FalseKeyword) =>
                         {
@@ -745,8 +750,8 @@ impl<'a> Printer<'a> {
             "string" => return "String".to_string(),
             "number" => return "Number".to_string(),
             "boolean" => return "Boolean".to_string(),
-            "symbol" => return "Symbol".to_string(),
-            "bigint" => return "BigInt".to_string(),
+            "symbol" => return self.metadata_symbol_constructor(),
+            "bigint" => return metadata_global_constructor_with_fallback("BigInt"),
             "void" | "undefined" | "null" | "never" => return "void 0".to_string(),
             "any" | "unknown" | "object" => return "Object".to_string(),
             _ => {}
@@ -988,6 +993,17 @@ impl<'a> Printer<'a> {
                     value: format!("{temp}.{}", parts.last()?),
                 })
             }
+        }
+    }
+
+    /// Serialize the `symbol` metadata constructor. `tsc` guards `Symbol` only for
+    /// pre-ES2015 targets, where the global is not implied by the target; at
+    /// ES2015+ it emits a bare `Symbol`.
+    fn metadata_symbol_constructor(&self) -> String {
+        if self.ctx.options.target.supports_es2015() {
+            "Symbol".to_string()
+        } else {
+            metadata_global_constructor_with_fallback("Symbol")
         }
     }
 

--- a/crates/tsz-emitter/src/emitter/source_file/decorator_metadata_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/decorator_metadata_tests.rs
@@ -123,3 +123,118 @@ fn decorator_metadata_named_import_qualified_type_keeps_substituted_runtime_root
         "Known runtime named-import metadata should not use the unresolved fallback.\nOutput:\n{output}"
     );
 }
+
+fn metadata_options_for(target: ScriptTarget) -> PrinterOptions {
+    PrinterOptions {
+        target,
+        ..legacy_metadata_options()
+    }
+}
+
+const BIGINT_SYMBOL_SOURCE: &str = "declare function dec(...args: any[]): any;\nclass C {\n    @dec a: bigint;\n    @dec b: symbol;\n}\n";
+
+#[test]
+fn decorator_metadata_bigint_is_always_guarded_at_modern_targets() {
+    // `tsc` ALWAYS guards `bigint` because the `BigInt` global is not implied by
+    // any target; an unguarded reference throws `ReferenceError` where it is
+    // absent. This must hold even at the highest targets.
+    for target in [
+        ScriptTarget::ES2017,
+        ScriptTarget::ES2020,
+        ScriptTarget::ESNext,
+    ] {
+        let output = emit_source(BIGINT_SYMBOL_SOURCE, metadata_options_for(target));
+        assert!(
+            output.contains(
+                "__metadata(\"design:type\", typeof BigInt === \"function\" ? BigInt : Object)"
+            ),
+            "bigint metadata at {target:?} should be guarded.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn decorator_metadata_symbol_guarded_only_below_es2015() {
+    // ES5: `Symbol` is not implied by the target, so `tsc` guards it.
+    let es5 = emit_source(
+        BIGINT_SYMBOL_SOURCE,
+        metadata_options_for(ScriptTarget::ES5),
+    );
+    assert!(
+        es5.contains(
+            "__metadata(\"design:type\", typeof Symbol === \"function\" ? Symbol : Object)"
+        ),
+        "symbol metadata at ES5 should be guarded.\nOutput:\n{es5}"
+    );
+    // bigint stays guarded at ES5 too.
+    assert!(
+        es5.contains(
+            "__metadata(\"design:type\", typeof BigInt === \"function\" ? BigInt : Object)"
+        ),
+        "bigint metadata at ES5 should be guarded.\nOutput:\n{es5}"
+    );
+}
+
+#[test]
+fn decorator_metadata_symbol_is_bare_at_es2015_and_above() {
+    // ES2015 is the boundary: `Symbol` is implied, so it is emitted bare.
+    for target in [
+        ScriptTarget::ES2015,
+        ScriptTarget::ES2017,
+        ScriptTarget::ESNext,
+    ] {
+        let output = emit_source(BIGINT_SYMBOL_SOURCE, metadata_options_for(target));
+        assert!(
+            output.contains("__metadata(\"design:type\", Symbol)"),
+            "symbol metadata at {target:?} should be a bare Symbol.\nOutput:\n{output}"
+        );
+        assert!(
+            !output.contains("typeof Symbol === \"function\""),
+            "symbol metadata at {target:?} must not be guarded.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn decorator_metadata_bigint_in_paramtypes_and_returntype_is_guarded() {
+    let source = "declare function dec(...args: any[]): any;\nclass C {\n    @dec m(x: bigint): bigint { return x; }\n}\n";
+    let output = emit_source(source, metadata_options_for(ScriptTarget::ES2020));
+    assert!(
+        output.contains(
+            "__metadata(\"design:paramtypes\", [typeof BigInt === \"function\" ? BigInt : Object])"
+        ),
+        "bigint in design:paramtypes should be guarded.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "__metadata(\"design:returntype\", typeof BigInt === \"function\" ? BigInt : Object)"
+        ),
+        "bigint in design:returntype should be guarded.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn decorator_metadata_union_bigint_unwraps_to_guarded_bigint() {
+    // `bigint | undefined` unwraps to the single meaningful member, which must
+    // still carry the guard.
+    let source = "declare function dec(...args: any[]): any;\nclass C {\n    @dec a: bigint | undefined;\n}\n";
+    let output = emit_source(source, metadata_options_for(ScriptTarget::ES2020));
+    assert!(
+        output.contains(
+            "__metadata(\"design:type\", typeof BigInt === \"function\" ? BigInt : Object)"
+        ),
+        "union bigint | undefined should serialize to the guarded bigint form.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn decorator_metadata_bigint_literal_type_is_guarded() {
+    let source = "declare function dec(...args: any[]): any;\nclass C {\n    @dec a: 1n;\n}\n";
+    let output = emit_source(source, metadata_options_for(ScriptTarget::ES2020));
+    assert!(
+        output.contains(
+            "__metadata(\"design:type\", typeof BigInt === \"function\" ? BigInt : Object)"
+        ),
+        "bigint literal type should serialize to the guarded bigint form.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
@@ -2,6 +2,7 @@
 
 use crate::transforms::emit_utils::{
     METADATA_ALIAS_MAX_DEPTH, MetadataEntityKind, classify_metadata_entity, identifier_text,
+    metadata_global_constructor_with_fallback,
 };
 use rustc_hash::FxHashMap;
 use tsz_parser::parser::node::NodeArena;
@@ -34,8 +35,15 @@ fn serialize_type_for_metadata_impl(
         k if k == sk(SyntaxKind::StringKeyword) => "String".to_string(),
         k if k == sk(SyntaxKind::NumberKeyword) => "Number".to_string(),
         k if k == sk(SyntaxKind::BooleanKeyword) => "Boolean".to_string(),
-        k if k == sk(SyntaxKind::SymbolKeyword) => "Symbol".to_string(),
-        k if k == sk(SyntaxKind::BigIntKeyword) => "BigInt".to_string(),
+        // This serializer runs only for the ES5/ES3 class downlevel, where the
+        // target is always below ES2015. `tsc` guards `BigInt` for every target
+        // and `Symbol` for pre-ES2015 targets, so both are guarded here.
+        k if k == sk(SyntaxKind::SymbolKeyword) => {
+            metadata_global_constructor_with_fallback("Symbol")
+        }
+        k if k == sk(SyntaxKind::BigIntKeyword) => {
+            metadata_global_constructor_with_fallback("BigInt")
+        }
         k if k == sk(SyntaxKind::VoidKeyword)
             || k == sk(SyntaxKind::UndefinedKeyword)
             || k == sk(SyntaxKind::NullKeyword)
@@ -58,8 +66,8 @@ fn serialize_type_for_metadata_impl(
                 "string" => return "String".to_string(),
                 "number" => return "Number".to_string(),
                 "boolean" => return "Boolean".to_string(),
-                "symbol" => return "Symbol".to_string(),
-                "bigint" => return "BigInt".to_string(),
+                "symbol" => return metadata_global_constructor_with_fallback("Symbol"),
+                "bigint" => return metadata_global_constructor_with_fallback("BigInt"),
                 "void" | "undefined" | "null" | "never" => return "void 0".to_string(),
                 "any" | "unknown" | "object" => return "Object".to_string(),
                 _ => {}
@@ -174,7 +182,9 @@ fn serialize_type_for_metadata_impl(
                 return match lit_node.kind {
                     lk if lk == sk(SyntaxKind::StringLiteral) => "String".to_string(),
                     lk if lk == sk(SyntaxKind::NumericLiteral) => "Number".to_string(),
-                    lk if lk == sk(SyntaxKind::BigIntLiteral) => "BigInt".to_string(),
+                    lk if lk == sk(SyntaxKind::BigIntLiteral) => {
+                        metadata_global_constructor_with_fallback("BigInt")
+                    }
                     lk if lk == sk(SyntaxKind::TrueKeyword)
                         || lk == sk(SyntaxKind::FalseKeyword) =>
                     {

--- a/crates/tsz-emitter/src/transforms/emit_utils.rs
+++ b/crates/tsz-emitter/src/transforms/emit_utils.rs
@@ -192,6 +192,17 @@ pub(crate) fn identifier_text_or_empty(arena: &NodeArena, idx: NodeIndex) -> Str
 /// metadata type reference yields `Object`.
 pub(crate) const METADATA_ALIAS_MAX_DEPTH: u32 = 32;
 
+/// Serialize a global constructor reference for decorator metadata wrapped in the
+/// runtime-presence guard `tsc` emits for globals that may be absent under the
+/// chosen lib/target: `typeof X === "function" ? X : Object`. Mirrors `tsc`'s
+/// `getGlobalConstructorWithFallback`, which avoids a `ReferenceError` when the
+/// metadata is read on a runtime lacking the global. The operand is a single
+/// global identifier, so — unlike the entity-name fallback — no temp is hoisted;
+/// the guard is a bare conditional, exactly as `tsc` prints it.
+pub(crate) fn metadata_global_constructor_with_fallback(name: &str) -> String {
+    format!("typeof {name} === \"function\" ? {name} : Object")
+}
+
 /// How an entity-name reference in a `design:type`/`design:paramtypes`/
 /// `design:returntype` annotation resolves, for runtime metadata serialization.
 ///


### PR DESCRIPTION
Fixes #14777.

Structural rule: when a `design:type`/`design:paramtypes`/`design:returntype` reference names a global constructor not implied by the chosen lib/target, `tsc` wraps it in a runtime-presence guard (`getGlobalConstructorWithFallback`): `typeof X === "function" ? X : Object`. `BigInt` is guarded for **every** target; `Symbol` is guarded only for **pre-ES2015** targets. tsz instead hard-coded the bare global name (`BigInt`, `Symbol`), which throws `ReferenceError` (or yields wrong metadata) on runtimes lacking the global — exactly the case the guard exists for.

Owner layer: emitter decorator-metadata serializer.

### Repro
```ts
function dec(...args: any[]): any {}
class C {
  @dec a: bigint;
  @dec b: symbol;
}
```
- `--experimentalDecorators --emitDecoratorMetadata --target ES2017` → `bigint` now `typeof BigInt === "function" ? BigInt : Object`; `symbol` stays bare `Symbol`.
- `--target ES5` → both `bigint` and `symbol` guarded.

### Change
- Add `metadata_global_constructor_with_fallback` to `transforms/emit_utils.rs` as the single source of truth for the bare-global guard string. It is distinct from the existing `serialize_metadata_fallback_entity`, which hoists a temp and adds a `typeof X !== "undefined"` existence check for multi-part **entity-name** references.
- Route the `bigint` keyword/identifier/literal arms (always guarded) and the `symbol` arms (guarded below ES2015) through it in **both** metadata serializers:
  - the ES2015+ Printer path (`declarations/class/decorators.rs`), target-aware via a new `metadata_symbol_constructor` (`target.supports_es2015()`);
  - the ES5/ES3 downlevel path (`transforms/class_es5_ir_helpers.rs`), where the target is, by construction, always `< ES2015` (gated by `target_es5 = legacy_es5_or_lower`), so both are guarded.

### Adjacent cases covered
`bigint` at ES2020/ESNext (still guarded), `symbol` bare at ES2015+, `design:paramtypes`/`design:returntype` positions, `bigint | undefined` union unwrap, and bigint literal types (`1n`). No double-wrap with the no-lib/isolatedModules entity-name guard (the builtin-keyword arms return before that path).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib decorator_metadata` — 19 pass, including ES5/ES2015/ES2017/ES2020/ESNext matrix
- `cargo test -p tsz-emitter --lib` — 3914 pass, 0 fail
- `cargo clippy -p tsz-emitter` — clean
- ready-review CI owns broad conformance/emit baselines

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high