### PR TITLE
fix(solver): replace variadic tuple conformance rewrite (#14351)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -180,6 +180,9 @@ path = "tests/variadic_tuple_spread_arity_ts2556_tests.rs"
 name = "variadic_tuple_spread_element_type_tests"
 path = "tests/variadic_tuple_spread_element_type_tests.rs"
 [[test]]
+name = "variadic_tuple_rest_aggregate_display_tests"
+path = "tests/variadic_tuple_rest_aggregate_display_tests.rs"
+[[test]]
 name = "closure_boundary_property_narrowing_tests"
 path = "tests/closure_boundary_property_narrowing_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -544,6 +544,39 @@ impl<'a> CheckerState<'a> {
         self.emit_render_request(anchor_idx, request);
     }
 
+    fn rewrite_variadic_tuple_structural_ts2322(
+        &mut self,
+        diag: &mut Diagnostic,
+        failure_reason: &tsz_solver::SubtypeFailureReason,
+        source: TypeId,
+        target: TypeId,
+        anchor_idx: NodeIndex,
+    ) {
+        if diag.code != diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+            || !matches!(
+                failure_reason,
+                tsz_solver::SubtypeFailureReason::TupleElementTypeMismatch { .. }
+                    | tsz_solver::SubtypeFailureReason::TupleVariadicPositionMismatch { .. }
+            )
+        {
+            return;
+        }
+
+        let Some(target_str) = self.variadic_tuple_alias_structural_display(target, source) else {
+            return;
+        };
+        let source_str = self.format_type_for_diagnostic_role(
+            source,
+            DiagnosticTypeDisplayRole::AssignmentSource { target, anchor_idx },
+        );
+        let (source_str, target_str) =
+            self.finalize_pair_display_for_diagnostic(source, target, source_str, target_str);
+        diag.message_text = format_message(
+            diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[&source_str, &target_str],
+        );
+    }
+
     /// Internal helper that reports a detailed assignability failure using an
     /// already-resolved diagnostic anchor.
     pub(super) fn diagnose_assignment_failure_with_anchor(
@@ -842,30 +875,15 @@ impl<'a> CheckerState<'a> {
                 {
                     return;
                 }
-                let use_structural_variadic_tuple_display = matches!(
-                    &failure_reason,
-                    tsz_solver::SubtypeFailureReason::TupleElementTypeMismatch { .. }
-                        | tsz_solver::SubtypeFailureReason::TupleVariadicPositionMismatch { .. }
-                );
                 let mut diag =
                     self.render_failure_reason(failure_reason, source, target, anchor_idx, 0);
-                if diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
-                    && use_structural_variadic_tuple_display
-                    && let Some(target_str) =
-                        self.variadic_tuple_alias_structural_display(target, source)
-                {
-                    let source_str = self.format_type_for_diagnostic_role(
-                        source,
-                        DiagnosticTypeDisplayRole::AssignmentSource { target, anchor_idx },
-                    );
-                    let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                        source, target, source_str, target_str,
-                    );
-                    diag.message_text = format_message(
-                        diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                        &[&source_str, &target_str],
-                    );
-                }
+                self.rewrite_variadic_tuple_structural_ts2322(
+                    &mut diag,
+                    failure_reason,
+                    source,
+                    target,
+                    anchor_idx,
+                );
                 let has_static_schema_display = self
                     .static_schema_array_structural_display(source, target)
                     .is_some()

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -842,9 +842,15 @@ impl<'a> CheckerState<'a> {
                 {
                     return;
                 }
+                let use_structural_variadic_tuple_display = matches!(
+                    &failure_reason,
+                    tsz_solver::SubtypeFailureReason::TupleElementTypeMismatch { .. }
+                        | tsz_solver::SubtypeFailureReason::TupleVariadicPositionMismatch { .. }
+                );
                 let mut diag =
                     self.render_failure_reason(failure_reason, source, target, anchor_idx, 0);
                 if diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+                    && use_structural_variadic_tuple_display
                     && let Some(target_str) =
                         self.variadic_tuple_alias_structural_display(target, source)
                 {

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -844,6 +844,22 @@ impl<'a> CheckerState<'a> {
                 }
                 let mut diag =
                     self.render_failure_reason(failure_reason, source, target, anchor_idx, 0);
+                if diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+                    && let Some(target_str) =
+                        self.variadic_tuple_alias_structural_display(target, source)
+                {
+                    let source_str = self.format_type_for_diagnostic_role(
+                        source,
+                        DiagnosticTypeDisplayRole::AssignmentSource { target, anchor_idx },
+                    );
+                    let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
+                        source, target, source_str, target_str,
+                    );
+                    diag.message_text = format_message(
+                        diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                        &[&source_str, &target_str],
+                    );
+                }
                 let has_static_schema_display = self
                     .static_schema_array_structural_display(source, target)
                     .is_some()

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -70,6 +70,25 @@ impl<'a> CheckerState<'a> {
         param_type: TypeId,
         idx: NodeIndex,
     ) {
+        self.error_argument_not_assignable_at_impl(arg_type, param_type, idx, false);
+    }
+
+    pub(crate) fn error_argument_not_assignable_structural_tuple_at(
+        &mut self,
+        arg_type: TypeId,
+        param_type: TypeId,
+        idx: NodeIndex,
+    ) {
+        self.error_argument_not_assignable_at_impl(arg_type, param_type, idx, true);
+    }
+
+    fn error_argument_not_assignable_at_impl(
+        &mut self,
+        arg_type: TypeId,
+        param_type: TypeId,
+        idx: NodeIndex,
+        structural_tuple_display: bool,
+    ) {
         if self.should_suppress_argument_not_assignable_diagnostic(arg_type, param_type) {
             return;
         }
@@ -241,6 +260,21 @@ impl<'a> CheckerState<'a> {
         {
             param_str = display;
             param_display_type = None;
+        }
+        if structural_tuple_display {
+            if crate::query_boundaries::common::tuple_elements(self.ctx.types, arg_type).is_some() {
+                arg_str = self
+                    .format_type_for_assignability_message_anonymous_composite_structural(arg_type);
+                arg_display_type = None;
+            }
+            if crate::query_boundaries::common::tuple_elements(self.ctx.types, param_type).is_some()
+            {
+                param_str = self
+                    .format_type_for_assignability_message_anonymous_composite_structural(
+                        param_type,
+                    );
+                param_display_type = None;
+            }
         }
         if arg_str.starts_with('{')
             && param_str.contains("<{")

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -978,10 +978,11 @@ impl<'a> CheckerState<'a> {
     /// it with a coincidentally-shaped non-generic type-alias name.
     ///
     /// Used when the operand came from an inline / anonymous composite annotation
-    /// (`const x: { a: number } = …`, `… : { a: number } | { b: string }`): tsc
-    /// spells the alias name only when the reference carried an `aliasSymbol`, so
-    /// an anonymous annotation must render the structural shape. Nominal shapes
-    /// (interfaces / classes) and generic applications keep their names.
+    /// (`const x: { a: number } = …`, `… : { a: number } | { b: string }`,
+    /// or a synthesized rest-argument tuple): tsc spells the alias name only
+    /// when the reference carried an `aliasSymbol`, so an anonymous annotation
+    /// must render the structural shape. Nominal shapes (interfaces / classes)
+    /// and generic applications keep their names.
     pub(crate) fn format_type_for_assignability_message_anonymous_composite_structural(
         &mut self,
         ty: TypeId,
@@ -1090,6 +1091,32 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    pub(in crate::error_reporter) fn variadic_tuple_alias_structural_display(
+        &mut self,
+        ty: TypeId,
+        other: TypeId,
+    ) -> Option<String> {
+        let evaluated = self.evaluate_type_with_env(ty);
+        if evaluated == TypeId::ERROR {
+            return None;
+        }
+
+        let elements = crate::query_boundaries::common::tuple_elements(self.ctx.types, evaluated)?;
+        if !elements.iter().any(|element| element.rest) {
+            return None;
+        }
+
+        let other_evaluated = self.evaluate_type_for_assignability(other);
+        if crate::query_boundaries::common::tuple_elements(self.ctx.types, other).is_none()
+            && crate::query_boundaries::common::tuple_elements(self.ctx.types, other_evaluated)
+                .is_none()
+        {
+            return None;
+        }
+
+        Some(self.format_type_for_assignability_message_anonymous_composite_structural(evaluated))
+    }
+
     fn format_assignability_type_for_message_internal(
         &mut self,
         ty: TypeId,
@@ -1110,6 +1137,9 @@ impl<'a> CheckerState<'a> {
             return self.format_type_for_assignability_message(widened);
         }
         if let Some(display) = self.constrained_variadic_tuple_parameter_display(ty, other) {
+            return display;
+        }
+        if let Some(display) = self.variadic_tuple_alias_structural_display(ty, other) {
             return display;
         }
         if let Some(type_name) = self.format_class_constructor_name_for_assignment(ty, other) {

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -1139,9 +1139,6 @@ impl<'a> CheckerState<'a> {
         if let Some(display) = self.constrained_variadic_tuple_parameter_display(ty, other) {
             return display;
         }
-        if let Some(display) = self.variadic_tuple_alias_structural_display(ty, other) {
-            return display;
-        }
         if let Some(type_name) = self.format_class_constructor_name_for_assignment(ty, other) {
             return type_name;
         }

--- a/crates/tsz-checker/src/query_boundaries/assignability_suppression.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability_suppression.rs
@@ -426,20 +426,21 @@ impl<'a> CheckerState<'a> {
             return false; // Don't suppress - let the actual assignability check run
         }
 
-        let is_single_type_param_spread_tuple = |ty: TypeId| {
+        let is_type_param_spread_tuple = |ty: TypeId| {
             crate::query_boundaries::common::tuple_elements(self.ctx.types, ty).is_some_and(
                 |elements| {
-                    elements.len() == 1
-                        && elements[0].rest
-                        && crate::query_boundaries::common::type_param_info(
-                            self.ctx.types,
-                            elements[0].type_id,
-                        )
-                        .is_some()
+                    elements.iter().any(|element| {
+                        element.rest
+                            && crate::query_boundaries::common::type_param_info(
+                                self.ctx.types,
+                                element.type_id,
+                            )
+                            .is_some()
+                    })
                 },
             )
         };
-        if is_single_type_param_spread_tuple(source) || is_single_type_param_spread_tuple(target) {
+        if is_type_param_spread_tuple(source) || is_type_param_spread_tuple(target) {
             return false;
         }
 

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -767,7 +767,6 @@ impl CheckerState<'_> {
 
         self.rewrite_infer_generic_return_fingerprints(&sf.text);
         self.rewrite_conditional_types1_fingerprints(&sf.text);
-        self.rewrite_variadic_tuples1_fingerprints(&sf.text);
         self.align_awaited_type_instantiation_diagnostics(&sf.text);
         self.align_evolving_array_inference_diagnostics(&sf.text);
         self.align_type_inference_literal_union_diagnostics(&sf.text);
@@ -1011,98 +1010,6 @@ impl CheckerState<'_> {
         self.ctx.rebuild_emitted_diagnostics_from_current();
         for replacement in replacements {
             self.ctx.push_diagnostic(replacement);
-        }
-    }
-
-    fn rewrite_variadic_tuples1_fingerprints(&mut self, source_text: &str) {
-        use tsz_common::diagnostics::{Diagnostic, diagnostic_codes};
-
-        if !source_text.contains("type TV0<T extends unknown[]> = [string, ...T];")
-            || !source_text.contains("function curry<T extends unknown[], U extends unknown[], R>")
-            || !source_text.contains("type Unbounded = [...Numbers, boolean];")
-        {
-            return;
-        }
-
-        self.ctx.diagnostics.retain(|diag| {
-            let is_extra_assignability =
-                diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
-                    && matches!(
-                        diag.message_text.as_str(),
-                        "Type '[...T, ...T]' is not assignable to type '[unknown, unknown]'."
-                            | "Type 'number' is not assignable to type '[number, (number | undefined)?] | [number, (number | undefined)?, number]'."
-                            | "Type '[false, false]' is not assignable to type 'Unbounded'."
-                            | "Type '[boolean, false]' is not assignable to type 'Unbounded'."
-                            | "Type '[boolean, boolean]' is not assignable to type 'Unbounded'."
-                    );
-            let is_extra_argument =
-                diag.code == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
-                    && matches!(
-                        diag.message_text.as_str(),
-                        "Argument of type '(a: number, b: string, c: boolean, d: string[]) => number' is not assignable to parameter of type '(...args: [...T, ...U]) => number'."
-                            | "Argument of type '(x: number, b: boolean, ...args: string[]) => number' is not assignable to parameter of type '(...args: [...T, ...U]) => number'."
-                            | "Argument of type '(id: string, options?: { x?: string | undefined; } | undefined) => string' is not assignable to parameter of type '(...args: [...T, object]) => string'."
-                            | "Argument of type '(id: string, orgId: number, options?: { y?: number | undefined; z?: boolean | undefined; } | undefined) => void' is not assignable to parameter of type '(...args: [...T, object]) => void'."
-                    );
-            let is_extra_arity =
-                diag.code == 2555 && diag.message_text == "Expected at least 2 arguments, but got 1.";
-            !(is_extra_assignability || is_extra_argument || is_extra_arity)
-        });
-
-        let diagnostics = [
-            (
-                "foo3(1);",
-                "foo3",
-                diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,
-                "Argument of type '[]' is not assignable to parameter of type '[...unknown[], number]'.",
-            ),
-            (
-                "function f10<T extends string[], U extends T>(x: [string, ...unknown[]], y: [string, ...T], z: [string, ...U]) {\n    x = y;\n    x = z;\n    y = x;  // Error\n    y = z;\n    z = x;  // Error\n    z = y;",
-                "z = y",
-                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                "Type '[string, ...T]' is not assignable to type '[string, ...U]'.",
-            ),
-            (
-                "function ft17<T extends [] | [unknown]>(x: [unknown, unknown], y: [...T, ...T]) {\n    x = y;",
-                "x = y",
-                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                "Type '[...T, ...T]' is not assignable to type '[unknown, unknown]'.",
-            ),
-            (
-                "function ft18<T extends unknown[]>(x: [unknown, unknown], y: [...T, ...T]) {\n    x = y;",
-                "x = y",
-                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                "Type '[...T, ...T]' is not assignable to type '[unknown, unknown]'.",
-            ),
-            (
-                "let v2 = f20([\"foo\", \"bar\"]);",
-                "\"bar\"",
-                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                "Type 'string' is not assignable to type 'number'.",
-            ),
-            (
-                "const data: Unbounded = [false, false];",
-                "data",
-                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                "Type '[boolean, false]' is not assignable to type '[...number[], boolean]'.",
-            ),
-        ];
-
-        for (line_marker, anchor, code, message) in diagnostics {
-            let Some(marker_start) = source_text.find(line_marker) else {
-                continue;
-            };
-            let Some(anchor_offset) = source_text[marker_start..].find(anchor) else {
-                continue;
-            };
-            let start = marker_start + anchor_offset;
-            self.ctx.diagnostics.push(Diagnostic::error(
-                self.ctx.file_name.clone(),
-                start as u32,
-                anchor.len() as u32,
-                message,
-                code,
-            ));
         }
     }
 

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1363,11 +1363,17 @@ impl<'a> CheckerState<'a> {
                                 spread_expected,
                                 arg_idx,
                             );
-                        } else if prefer_argument_level_return_mismatch || aggregate_rest_mismatch {
-                            self.error_argument_not_assignable_at(
+                        } else if aggregate_rest_mismatch {
+                            self.error_argument_not_assignable_structural_tuple_at(
                                 reported_actual,
                                 reported_expected,
                                 aggregate_anchor_override.unwrap_or(arg_idx),
+                            );
+                        } else if prefer_argument_level_return_mismatch {
+                            self.error_argument_not_assignable_at(
+                                reported_actual,
+                                reported_expected,
+                                arg_idx,
                             );
                         } else if preserve_type_parameter_expected_display {
                             self.error_argument_not_assignable_preserving_param_display(
@@ -1413,7 +1419,7 @@ impl<'a> CheckerState<'a> {
                         && !elaborated
                     {
                         if aggregate_rest_mismatch {
-                            self.error_argument_not_assignable_at(
+                            self.error_argument_not_assignable_structural_tuple_at(
                                 reported_actual,
                                 reported_expected,
                                 aggregate_anchor_override.unwrap_or(call_idx),
@@ -1456,7 +1462,7 @@ impl<'a> CheckerState<'a> {
                         && !elaborated
                     {
                         if aggregate_rest_mismatch {
-                            self.error_argument_not_assignable_at(
+                            self.error_argument_not_assignable_structural_tuple_at(
                                 reported_actual,
                                 reported_expected,
                                 aggregate_anchor_override.unwrap_or(last_arg),
@@ -1480,7 +1486,7 @@ impl<'a> CheckerState<'a> {
                         };
                     }
                     if aggregate_rest_mismatch {
-                        self.error_argument_not_assignable_at(
+                        self.error_argument_not_assignable_structural_tuple_at(
                             reported_actual,
                             reported_expected,
                             aggregate_anchor_override.unwrap_or(call_idx),

--- a/crates/tsz-checker/src/types/computation/object_literal/spread_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/spread_element.rs
@@ -81,7 +81,6 @@ impl<'a> CheckerState<'a> {
                 // a variable or a property access.
                 // E.g. `{ ...expr + expr } = source` is invalid.
                 if !self.is_valid_rest_assignment_target(spread_expr) {
-                    use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                     self.error_at_node(
                                 spread_expr,
                                 diagnostic_messages::THE_TARGET_OF_AN_OBJECT_REST_ASSIGNMENT_MUST_BE_A_VARIABLE_OR_A_PROPERTY_ACCESS,
@@ -92,7 +91,6 @@ impl<'a> CheckerState<'a> {
                 // TS2778: The target of an object rest assignment may not be
                 // an optional property access. E.g. `{ ...obj?.a } = source`
                 else if self.is_optional_chain_access(spread_expr) {
-                    use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                     self.error_at_node(
                                 spread_expr,
                                 diagnostic_messages::THE_TARGET_OF_AN_OBJECT_REST_ASSIGNMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,

--- a/crates/tsz-checker/tests/variadic_tuple_arity_inference_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_arity_inference_tests.rs
@@ -8,7 +8,7 @@
 //! These tests verify that tsz infers the correct types and therefore accepts
 //! valid assignments and rejects only the deliberately wrong ones.
 
-use tsz_checker::test_utils::check_source_codes;
+use tsz_checker::test_utils::{check_source_code_messages, check_source_codes};
 
 fn assert_no_errors(source: &str, label: &str) {
     let codes = check_source_codes(source);
@@ -24,6 +24,60 @@ fn assert_only_one_2322(source: &str, label: &str) {
         codes,
         vec![2322],
         "{label}: expected exactly one TS2322, got {codes:?}"
+    );
+}
+
+// =============================================================================
+// Variadic tuple relation directionality
+// =============================================================================
+
+#[test]
+fn prefixed_variadic_tuple_respects_type_param_subtype_direction() {
+    let diags = check_source_code_messages(
+        r#"
+function compare<Left extends string[], Right extends Left>(
+    open: [string, ...unknown[]],
+    base: [string, ...Left],
+    narrowed: [string, ...Right],
+) {
+    base = open;
+    narrowed = open;
+    narrowed = base;
+    base = narrowed;
+}
+"#,
+    );
+
+    let ts2322: Vec<_> = diags
+        .iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, message)| message.as_str())
+        .collect();
+    assert_eq!(
+        ts2322.len(),
+        3,
+        "expected y=x, z=x, and z=y shapes to fail while base=narrowed passes; got {diags:?}"
+    );
+    assert!(
+        ts2322
+            .iter()
+            .any(|message| message.contains("Type '[string, ...Left]' is not assignable")),
+        "expected the base-to-narrowed variadic direction to fail structurally; got {diags:?}"
+    );
+}
+
+#[test]
+fn doubled_variadic_fixed_tuple_constraint_expands_to_fixed_target() {
+    assert_no_errors(
+        r#"
+function duplicate<Part extends [unknown]>(
+    target: [unknown, unknown],
+    source: [...Part, ...Part],
+) {
+    target = source;
+}
+"#,
+        "T extends [unknown] makes [...T, ...T] exactly two fixed elements",
     );
 }
 

--- a/crates/tsz-checker/tests/variadic_tuple_rest_aggregate_display_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_rest_aggregate_display_tests.rs
@@ -1,0 +1,82 @@
+use tsz_checker::context::CheckerOptions;
+
+fn messages(source: &str) -> Vec<(u32, String)> {
+    tsz_checker::test_utils::check_source(source, "test.ts", CheckerOptions::default())
+        .into_iter()
+        .filter(|diag| diag.code != 2318)
+        .map(|diag| (diag.code, diag.message_text))
+        .collect()
+}
+
+#[test]
+fn underfilled_variadic_rest_displays_empty_aggregate_not_alias() {
+    let cases = [
+        (
+            "TailAlias",
+            r#"
+type DropOne<T extends unknown[]> = T extends [unknown, ...infer Rest] ? Rest : never;
+type TailAlias = DropOne<[string]>;
+declare function foo3<T extends unknown[]>(head: number, ...tail: [...T, number]): void;
+foo3(1);
+"#,
+        ),
+        (
+            "RestAlias",
+            r#"
+type RemoveHead<Items extends unknown[]> = Items extends [unknown, ...infer Remaining] ? Remaining : never;
+type RestAlias = RemoveHead<[boolean]>;
+declare function invoke<Parts extends unknown[]>(head: number, ...tail: [...Parts, number]): void;
+invoke(1);
+"#,
+        ),
+    ];
+
+    for (alias, source) in cases {
+        let diags = messages(source);
+        let ts2345: Vec<_> = diags
+            .iter()
+            .filter(|(code, _)| *code == 2345)
+            .map(|(_, message)| message.as_str())
+            .collect();
+
+        assert_eq!(ts2345.len(), 1, "expected one TS2345, got {diags:?}");
+        assert!(
+            ts2345[0].contains(
+                "Argument of type '[]' is not assignable to parameter of type '[...unknown[], number]'."
+            ),
+            "rest aggregate diagnostic should display structural tuple; got {ts2345:?}"
+        );
+        assert!(
+            !ts2345[0].contains(alias),
+            "rest aggregate diagnostic must not leak alias {alias}; got {ts2345:?}"
+        );
+    }
+}
+
+#[test]
+fn unbounded_variadic_tuple_assignment_displays_structural_target() {
+    let source = r#"
+type Values = number[];
+type Unbounded = [...Values, boolean];
+const data: Unbounded = [false, false];
+"#;
+
+    let diags = messages(source);
+    let ts2322: Vec<_> = diags
+        .iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, message)| message.as_str())
+        .collect();
+
+    assert_eq!(ts2322.len(), 1, "expected one TS2322, got {diags:?}");
+    assert!(
+        ts2322[0].contains(
+            "Type '[boolean, false]' is not assignable to type '[...number[], boolean]'."
+        ),
+        "unbounded tuple target should display structurally; got {ts2322:?}"
+    );
+    assert!(
+        !ts2322[0].contains("Unbounded"),
+        "unbounded tuple target diagnostic must not leak alias; got {ts2322:?}"
+    );
+}

--- a/crates/tsz-checker/tests/variadic_tuple_rest_aggregate_display_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_rest_aggregate_display_tests.rs
@@ -80,3 +80,25 @@ const data: Unbounded = [false, false];
         "unbounded tuple target diagnostic must not leak alias; got {ts2322:?}"
     );
 }
+
+#[test]
+fn underfilled_variadic_tuple_assignment_preserves_alias_target() {
+    let source = r#"
+type Handler = (arg: number) => void;
+type Funcs = [...Handler[], (arg: string) => void];
+const data: Funcs = [];
+"#;
+
+    let diags = messages(source);
+    let ts2322: Vec<_> = diags
+        .iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, message)| message.as_str())
+        .collect();
+
+    assert_eq!(ts2322.len(), 1, "expected one TS2322, got {diags:?}");
+    assert!(
+        ts2322[0].contains("Type '[]' is not assignable to type 'Funcs'."),
+        "arity-only variadic tuple target should preserve alias; got {ts2322:?}"
+    );
+}

--- a/crates/tsz-checker/tests/variadic_tuple_rest_param_suffix_inference_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_rest_param_suffix_inference_tests.rs
@@ -16,7 +16,7 @@
 //! deliberately wrong target type MUST raise exactly one `TS2322`. Binder
 //! spellings are varied so the behavior is structural, not name-keyed.
 
-use tsz_checker::test_utils::check_source_codes;
+use tsz_checker::test_utils::{check_source_code_messages, check_source_codes};
 
 fn assert_no_errors(source: &str, label: &str) {
     let codes = check_source_codes(source);
@@ -224,5 +224,37 @@ const r = f("first", 1, 2, true);
 const ok: [string, [number, number], boolean] = r;
 "#,
         "fixed leading param + [...M, L] rest tuple",
+    );
+}
+
+#[test]
+fn optional_fixed_suffix_reserves_slot_for_element_check() {
+    let diags = check_source_code_messages(
+        r#"
+declare function take<Items extends unknown[] = []>(args: [...Items, number?]): Items;
+const got = take(["head", "tail"]);
+const ok: [string] = got;
+"#,
+    );
+
+    assert_eq!(
+        diags,
+        vec![(
+            2322,
+            "Type 'string' is not assignable to type 'number'.".to_string()
+        )],
+        "optional fixed suffix should report only the element mismatch"
+    );
+}
+
+#[test]
+fn optional_fixed_suffix_valid_element_keeps_variadic_middle() {
+    assert_no_errors(
+        r#"
+declare function take<Items extends unknown[] = []>(args: [...Items, number?]): Items;
+const got = take(["head", 42]);
+const ok: [string] = got;
+"#,
+        "valid optional fixed suffix reserves the trailing slot and infers Items=[string]",
     );
 }

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -1208,10 +1208,9 @@ impl<'a> TypeFormatter<'a> {
         self
     }
 
-    /// Render a composite type (`Object` / `ObjectWithIndex` / `Union` /
-    /// `Intersection`) structurally instead of repainting it with a coincidental
-    /// non-generic type-alias name reached through the reverse `find_def_for_type`
-    /// / `find_def_by_shape` lookup. See [`Self::anonymous_composite_structural`].
+    /// Render composites structurally instead of repainting them with a
+    /// coincidental non-generic type-alias name reached through reverse def/shape
+    /// lookup. See [`Self::anonymous_composite_structural`].
     pub const fn with_anonymous_composite_structural(mut self) -> Self {
         self.anonymous_composite_structural = true;
         self
@@ -1608,6 +1607,7 @@ impl<'a> TypeFormatter<'a> {
                     &key,
                     TypeData::Object(_)
                         | TypeData::ObjectWithIndex(_)
+                        | TypeData::Tuple(_)
                         | TypeData::Union(_)
                         | TypeData::Intersection(_)
                 );

--- a/crates/tsz-solver/src/operations/call_args.rs
+++ b/crates/tsz-solver/src/operations/call_args.rs
@@ -969,6 +969,78 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         }
     }
 
+    pub(crate) fn rest_tuple_mismatch_for_too_few_args(
+        &mut self,
+        params: &[ParamInfo],
+        type_params: &[TypeParamInfo],
+        arg_types: &[TypeId],
+        fallback_return: TypeId,
+    ) -> Option<CallResult> {
+        let rest_start = params.len().checked_sub(1)?;
+        let rest_param = params.last().filter(|param| param.rest)?;
+        let rest_type = self.unwrap_readonly(rest_param.type_id);
+        let expected =
+            self.substitute_sig_type_params_to_defaults_or_constraints(rest_type, type_params);
+        let expected = self.evaluate_rest_param_type(expected);
+        let should_type_check = if expected == TypeId::NEVER {
+            true
+        } else if let Some(TypeData::Tuple(elements)) = self.interner.lookup(expected) {
+            let elements = self.interner.tuple_list(elements);
+            elements.first().is_some_and(|element| element.rest)
+        } else {
+            false
+        };
+        if !should_type_check {
+            return None;
+        }
+
+        let rest_args: Vec<TypeId> = arg_types
+            .get(rest_start..)
+            .unwrap_or(&[])
+            .iter()
+            .copied()
+            .filter(|&arg| {
+                !crate::type_queries::data::is_bare_current_infer_placeholder_db(
+                    self.interner.as_type_database(),
+                    arg,
+                )
+            })
+            .collect();
+        let actual = self.aggregate_rest_actual_type(&rest_args);
+        Some(CallResult::ArgumentTypeMismatch {
+            index: rest_start,
+            expected,
+            actual,
+            fallback_return,
+        })
+    }
+
+    fn substitute_sig_type_params_to_defaults_or_constraints(
+        &self,
+        type_id: TypeId,
+        type_params: &[TypeParamInfo],
+    ) -> TypeId {
+        if type_params.is_empty() {
+            return type_id;
+        }
+        let mut subst = TypeSubstitution::new();
+        for type_param in type_params {
+            subst.insert(
+                type_param.name,
+                type_param
+                    .default
+                    .or(type_param.constraint)
+                    .unwrap_or(TypeId::UNKNOWN),
+            );
+        }
+        instantiate_type_cached(
+            self.interner.as_type_database(),
+            Some(self.interner),
+            type_id,
+            &subst,
+        )
+    }
+
     /// Look up the `ParamInfo` for a given argument index (non-rest only).
     /// Returns `None` if the index falls into a rest parameter or is out of bounds.
     fn param_info_for_arg_index<'b>(

--- a/crates/tsz-solver/src/operations/constraints/signatures.rs
+++ b/crates/tsz-solver/src/operations/constraints/signatures.rs
@@ -1146,12 +1146,6 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         if s_elem.rest {
                             break;
                         }
-                        let assignable = self
-                            .checker
-                            .is_assignable_to(s_elem.type_id, tail_elem.type_id);
-                        if tail_elem.optional && !assignable {
-                            break;
-                        }
                         trailing_count += 1;
                         source_index -= 1;
                     }

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -1463,44 +1463,17 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         let (min_args, max_args) = self.arg_count_bounds(&func.params, &func.type_params);
 
         if arg_types.len() < min_args {
-            // For variadic tuple rest params (e.g. `...args: [...T[], Required]`),
-            // TSC checks assignability of the args-as-tuple against the rest param
-            // type, producing TS2345 instead of TS2555. Detect this case and return
-            // ArgumentTypeMismatch so the checker emits TS2345.
-            if let Some(rest_param) = func.params.last().filter(|p| p.rest) {
-                let rest_type = self.unwrap_readonly(rest_param.type_id);
-                // `...args: never` means any call is invalid — TSC builds an empty
-                // tuple and checks it against `never`, producing TS2345.
-                let should_type_check = if rest_type == TypeId::NEVER {
-                    true
-                } else if let Some(TypeData::Tuple(elements)) = self.interner.lookup(rest_type) {
-                    // A leading rest element makes arity indeterminate (TS2345);
-                    // a fixed element before the first rest keeps min arity
-                    // determinate (TS2555), even for `[a, ...b[], c]`.
-                    let elems = self.interner.tuple_list(elements);
-                    elems.first().is_some_and(|e| e.rest)
-                } else {
-                    false
-                };
-                if should_type_check {
-                    // Build tuple type from actual args
-                    let args_tuple_elems: Vec<TupleElement> = arg_types
-                        .iter()
-                        .map(|&t| TupleElement {
-                            type_id: t,
-                            name: None,
-                            optional: false,
-                            rest: false,
-                        })
-                        .collect();
-                    let args_tuple = self.interner.tuple(args_tuple_elems);
-                    return CallResult::ArgumentTypeMismatch {
-                        index: 0,
-                        expected: rest_type,
-                        actual: args_tuple,
-                        fallback_return: func.return_type,
-                    };
-                }
+            // For open variadic tuple rest params (e.g.
+            // `...args: [...T, Required]`), TSC checks the supplied rest
+            // arguments as a tuple against the rest-param type, producing
+            // TS2345 instead of TS2555.
+            if let Some(result) = self.rest_tuple_mismatch_for_too_few_args(
+                &func.params,
+                &func.type_params,
+                arg_types,
+                func.return_type,
+            ) {
+                return result;
             }
             return CallResult::ArgumentCountMismatch {
                 expected_min: min_args,

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -244,6 +244,14 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         let (min_args, max_args) = self.arg_count_bounds(&func.params, &func.type_params);
 
         if arg_types.len() < min_args {
+            if let Some(result) = self.rest_tuple_mismatch_for_too_few_args(
+                &func.params,
+                &func.type_params,
+                arg_types,
+                func.return_type,
+            ) {
+                return result;
+            }
             return CallResult::ArgumentCountMismatch {
                 expected_min: min_args,
                 expected_max: max_args,

--- a/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
@@ -1111,6 +1111,14 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             // so the signature's type parameters are resolved — no erasure.
             let (min_args, max_args) = self.arg_count_bounds(&instantiated_params, &[]);
             if arg_types.len() < min_args {
+                if let Some(result) = self.rest_tuple_mismatch_for_too_few_args(
+                    &instantiated_params,
+                    &[],
+                    arg_types,
+                    func.return_type,
+                ) {
+                    return result;
+                }
                 return CallResult::ArgumentCountMismatch {
                     expected_min: min_args,
                     expected_max: max_args,

--- a/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
@@ -13,7 +13,7 @@ use crate::types::{PropertyInfo, TupleElement, TupleListId, TypeData, TypeId};
 use crate::utils::{self, TupleRestExpansion};
 use crate::visitor::{
     array_element_type, is_type_parameter, object_shape_id, object_with_index_shape_id,
-    tuple_list_id, type_param_info,
+    readonly_inner_type, tuple_list_id, type_param_info,
 };
 
 use super::super::{SubtypeChecker, SubtypeResult, TypeResolver};
@@ -56,6 +56,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             && is_type_parameter(self.interner, target[0].type_id)
         {
             return self.check_subtype(source[0].type_id, target[0].type_id);
+        }
+
+        if !target.iter().any(|elem| elem.rest)
+            && let Some(inlined_source) = self.inline_fixed_source_variadic_spreads(source)
+        {
+            return self.check_tuple_subtype(&inlined_source, target);
         }
 
         // Count required elements
@@ -166,7 +172,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                             if variadic_is_type_param
                                 && is_type_parameter(self.interner, s_elem.type_id)
                             {
-                                if !self.check_subtype(s_elem.type_id, variadic).is_true() {
+                                if !self
+                                    .check_type_parameter_variadic_spread_subtype(
+                                        s_elem.type_id,
+                                        variadic,
+                                    )
+                                    .is_true()
+                                {
                                     return SubtypeResult::False;
                                 }
                             } else if !self.check_subtype(s_elem.type_id, variadic_array).is_true()
@@ -504,6 +516,96 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// ## Examples:
     pub(crate) fn expand_tuple_rest(&self, type_id: TypeId) -> TupleRestExpansion {
         utils::expand_tuple_rest(self.interner, type_id)
+    }
+
+    fn inline_fixed_source_variadic_spreads(
+        &self,
+        source: &[TupleElement],
+    ) -> Option<Vec<TupleElement>> {
+        let mut inlined = Vec::new();
+        let mut changed = false;
+        for elem in source {
+            if !elem.rest {
+                inlined.push(*elem);
+                continue;
+            }
+
+            let fixed = self.fixed_tuple_elements_for_variadic_spread(elem.type_id)?;
+            changed = true;
+            inlined.extend(fixed);
+        }
+        changed.then_some(inlined)
+    }
+
+    fn fixed_tuple_elements_for_variadic_spread(
+        &self,
+        type_id: TypeId,
+    ) -> Option<Vec<TupleElement>> {
+        let mut current = readonly_inner_type(self.interner, type_id).unwrap_or(type_id);
+        for _ in 0..8 {
+            if let Some(list_id) = tuple_list_id(self.interner, current) {
+                let elements = self.interner.tuple_list(list_id);
+                if elements.iter().any(|elem| elem.rest) {
+                    return None;
+                }
+                return Some(elements.to_vec());
+            }
+
+            let info = type_param_info(self.interner, current)?;
+            let constraint = info.constraint?;
+            if constraint == current {
+                return None;
+            }
+            current = readonly_inner_type(self.interner, constraint).unwrap_or(constraint);
+        }
+        None
+    }
+
+    fn check_type_parameter_variadic_spread_subtype(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> SubtypeResult {
+        let Some(source_info) = type_param_info(self.interner, source) else {
+            return self.check_subtype(source, target);
+        };
+        if type_param_info(self.interner, target).is_none() {
+            return self.check_subtype(source, target);
+        }
+
+        if source == target
+            || self.type_param_constraint_chain_contains(source_info.constraint, target)
+        {
+            SubtypeResult::True
+        } else {
+            SubtypeResult::False
+        }
+    }
+
+    fn type_param_constraint_chain_contains(
+        &self,
+        constraint: Option<TypeId>,
+        target: TypeId,
+    ) -> bool {
+        let Some(mut current) = constraint else {
+            return false;
+        };
+        for _ in 0..8 {
+            if current == target {
+                return true;
+            }
+            let Some(info) = type_param_info(self.interner, current) else {
+                return false;
+            };
+            let Some(next) = info.constraint else {
+                return false;
+            };
+            if next == current {
+                return false;
+            }
+            current = next;
+        }
+        false
     }
 
     /// Check if Array<`element_type`> (the interface) is a subtype of the target.

--- a/crates/tsz-solver/tests/tuple_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/tuple_comprehensive_tests.rs
@@ -1181,3 +1181,76 @@ fn test_spread_tuple_not_assignable_to_unrelated_spread() {
         "[...T] should NOT be assignable to [...U] when T and U are unrelated"
     );
 }
+
+/// `[string, ...T]` should not be assignable to `[string, ...U]` when `U`
+/// extends `T`; the reverse direction is valid because `U` is the narrower
+/// variadic tail.
+#[test]
+fn test_prefixed_spread_tuple_preserves_type_param_direction() {
+    let interner = TypeInterner::new();
+
+    let string_array = interner.array(TypeId::STRING);
+    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: Some(string_array),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    }));
+    let u_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("U"),
+        constraint: Some(t_param),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    }));
+
+    let t_tuple = interner.tuple(vec![
+        TupleElement {
+            type_id: TypeId::STRING,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: t_param,
+            name: None,
+            optional: false,
+            rest: true,
+        },
+    ]);
+    let u_tuple = interner.tuple(vec![
+        TupleElement {
+            type_id: TypeId::STRING,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: u_param,
+            name: None,
+            optional: false,
+            rest: true,
+        },
+    ]);
+
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        !checker.is_subtype_of(t_tuple, u_tuple),
+        "[string, ...T] should not be assignable to [string, ...U] when U extends T"
+    );
+    assert!(
+        checker.is_subtype_of(u_tuple, t_tuple),
+        "[string, ...U] should be assignable to [string, ...T] when U extends T"
+    );
+
+    let mut compat = CompatChecker::new(&interner);
+    assert!(
+        !compat.is_assignable(t_tuple, u_tuple),
+        "compat should also reject [string, ...T] to [string, ...U]"
+    );
+    assert!(
+        compat.is_assignable(u_tuple, t_tuple),
+        "compat should accept [string, ...U] to [string, ...T]"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
- Remove the hardcoded `variadicTuples1` source-file fingerprint rewrite and replace it with solver/checker behavior for the underlying structural cases.
- Route underfilled tuple rest arguments through solver-owned aggregate rest mismatch reporting so synthesized rest tuples display structurally.
- Preserve variadic tuple relation direction and fixed-tuple constraint cardinality in solver tuple subtype rules.

## Structural Rule
When a variadic tuple has fixed suffix elements, `tsc` reserves those suffix slots by tuple shape before inferring the variadic middle; final assignability then reports any suffix element mismatch. When comparing variadic tuple spreads, `U extends T` proves `[...U]` is narrower than `[...T]`, but not the reverse. When a source variadic spread has a single fixed tuple constraint, that spread can be inlined for closed-target cardinality; union/open-array constraints remain variable.

## Owner Layer
Solver owns tuple inference, call rest mismatch construction, and tuple subtype/cardinality decisions. Checker owns diagnostic emission, structural tuple display, and suppressing only false-positive generic diagnostics; it no longer rewrites `variadicTuples1` fingerprints by source text.

## Adjacent Matrix
- Renamed rest/type parameter binders covered by checker tests.
- Optional fixed suffix positive and negative cases covered for `[...T, number?]`.
- Prefixed variadic relation covers `[string, ...T]` versus `[string, ...U]` in both directions.
- Fixed constraint expansion covers `T extends [unknown]`; union/open-array constraints continue to fail through existing conformance coverage.
- Fallback: non-fixed/open variadic spreads are not inlined, and aggregate rest mismatch falls back to the original too-few-args result when no structural rest tuple mismatch applies.

## Verification
- `cargo fmt --all --check`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint` (14258 warnings; below baseline)
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`
- `scripts/arch/check-checker-boundaries.sh`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver test_prefixed_spread_tuple_preserves_type_param_direction`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test variadic_tuple_rest_param_suffix_inference_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test variadic_tuple_arity_inference_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test variadic_tuple_rest_aggregate_display_tests underfilled_variadic_tuple_assignment_preserves_alias_target`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter contextualTypeTupleEnd --verbose` (1/1 passed, fingerprint-only 0)
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter variadicTuples1 --verbose` (1/1 passed, fingerprint-only 0)

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: high
