### PR TITLE
fix(emit): guard BigInt/Symbol globals in decorator metadata (#14777)

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -75,6 +75,10 @@ name = "decorator_metadata_type_only_tests"
 path = "tests/decorator_metadata_type_only_tests.rs"
 
 [[test]]
+name = "decorator_metadata_global_fallback_tests"
+path = "tests/decorator_metadata_global_fallback_tests.rs"
+
+[[test]]
 name = "private_element_naming_tests"
 path = "tests/private_element_naming_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/declarations/class/decorators.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/decorators.rs
@@ -2,6 +2,7 @@ use super::super::super::Printer;
 use crate::context::transform::TransformDirective;
 use crate::transforms::emit_utils::{
     METADATA_ALIAS_MAX_DEPTH, MetadataEntityKind, classify_metadata_entity,
+    serialize_bigint_metadata_type, serialize_symbol_metadata_type,
 };
 use tsz_parser::parser::node::{Node, NodeAccess};
 use tsz_parser::parser::syntax_kind_ext;
@@ -508,8 +509,8 @@ impl<'a> Printer<'a> {
             k if k == sk(SyntaxKind::StringKeyword) => "String".to_string(),
             k if k == sk(SyntaxKind::NumberKeyword) => "Number".to_string(),
             k if k == sk(SyntaxKind::BooleanKeyword) => "Boolean".to_string(),
-            k if k == sk(SyntaxKind::SymbolKeyword) => "Symbol".to_string(),
-            k if k == sk(SyntaxKind::BigIntKeyword) => "BigInt".to_string(),
+            k if k == sk(SyntaxKind::SymbolKeyword) => self.serialize_symbol_for_metadata(),
+            k if k == sk(SyntaxKind::BigIntKeyword) => serialize_bigint_metadata_type(),
             k if k == sk(SyntaxKind::VoidKeyword) => "void 0".to_string(),
             k if k == sk(SyntaxKind::UndefinedKeyword) => "void 0".to_string(),
             k if k == sk(SyntaxKind::NullKeyword) => "void 0".to_string(),
@@ -632,16 +633,29 @@ impl<'a> Printer<'a> {
                     return match lit_node.kind {
                         lk if lk == sk(SyntaxKind::StringLiteral) => "String".to_string(),
                         lk if lk == sk(SyntaxKind::NumericLiteral) => "Number".to_string(),
-                        lk if lk == sk(SyntaxKind::BigIntLiteral) => "BigInt".to_string(),
+                        lk if lk == sk(SyntaxKind::BigIntLiteral) => {
+                            serialize_bigint_metadata_type()
+                        }
                         lk if lk == sk(SyntaxKind::TrueKeyword)
                             || lk == sk(SyntaxKind::FalseKeyword) =>
                         {
                             "Boolean".to_string()
                         }
                         lk if lk == sk(SyntaxKind::NullKeyword) => "void 0".to_string(),
-                        // Negative numeric literal: `-1` → PrefixUnaryExpression → Number
+                        // Prefix-unary literal: `-1` → Number, `-1n` → the guarded
+                        // BigInt global (like a bare bigint literal type), matching
+                        // tsc's `serializeLiteralOfLiteralTypeNode`.
                         lk if lk == syntax_kind_ext::PREFIX_UNARY_EXPRESSION => {
-                            "Number".to_string()
+                            if self
+                                .arena
+                                .get_unary_expr(lit_node)
+                                .and_then(|u| self.arena.get(u.operand))
+                                .is_some_and(|op| op.kind == sk(SyntaxKind::BigIntLiteral))
+                            {
+                                serialize_bigint_metadata_type()
+                            } else {
+                                "Number".to_string()
+                            }
                         }
                         _ => "Object".to_string(),
                     };
@@ -745,8 +759,8 @@ impl<'a> Printer<'a> {
             "string" => return "String".to_string(),
             "number" => return "Number".to_string(),
             "boolean" => return "Boolean".to_string(),
-            "symbol" => return "Symbol".to_string(),
-            "bigint" => return "BigInt".to_string(),
+            "symbol" => return self.serialize_symbol_for_metadata(),
+            "bigint" => return serialize_bigint_metadata_type(),
             "void" | "undefined" | "null" | "never" => return "void 0".to_string(),
             "any" | "unknown" | "object" => return "Object".to_string(),
             _ => {}
@@ -995,6 +1009,14 @@ impl<'a> Printer<'a> {
         self.ctx.options.no_lib
             && self.ctx.options.isolated_modules
             && !self.ctx.module_state.value_declaration_names.contains(name)
+    }
+
+    /// Serialize the `symbol` type for decorator metadata, guarded only for
+    /// pre-`ES2015` targets. Adapts the printer's `ScriptTarget` to the shared
+    /// `serialize_symbol_metadata_type` threshold (`bigint` has no target gate,
+    /// so its call sites use `serialize_bigint_metadata_type` directly).
+    fn serialize_symbol_for_metadata(&self) -> String {
+        serialize_symbol_metadata_type(!self.ctx.options.target.supports_es2015())
     }
 
     /// Emit `__metadata("design:type", ...)` for a property.

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_decorators.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_decorators.rs
@@ -1291,17 +1291,17 @@ impl<'a> ES5ClassTransformer<'a> {
                         .is_some()
                         .then_some(param.type_annotation)
                 })
-                .map(|type_idx| serialize_type_for_metadata(self.arena, type_idx))
+                .map(|type_idx| serialize_type_for_metadata(self.arena, type_idx, self.target_es5))
                 .unwrap_or_else(|| "Object".to_string())
         } else if getter_type.is_some() {
-            serialize_type_for_metadata(self.arena, getter_type)
+            serialize_type_for_metadata(self.arena, getter_type, self.target_es5)
         } else {
             "Object".to_string()
         };
 
         let param_types = setter_parameters
             .as_ref()
-            .map(|params| serialize_param_types(self.arena, params))
+            .map(|params| serialize_param_types(self.arena, params, self.target_es5))
             .unwrap_or_default();
 
         vec![
@@ -1487,7 +1487,11 @@ impl<'a> ES5ClassTransformer<'a> {
             let metadata_strs: Vec<String> = if self.emit_decorator_metadata {
                 match &meta {
                     MemberMeta::Property { type_annotation } => {
-                        let serialized = serialize_type_for_metadata(self.arena, *type_annotation);
+                        let serialized = serialize_type_for_metadata(
+                            self.arena,
+                            *type_annotation,
+                            self.target_es5,
+                        );
                         vec![format!(
                             "{}(\"design:type\", {serialized})",
                             self.helper_name("__metadata")
@@ -1498,9 +1502,10 @@ impl<'a> ES5ClassTransformer<'a> {
                         return_type,
                         async_returns_promise,
                     } => {
-                        let param_types = serialize_param_types(self.arena, parameters);
+                        let param_types =
+                            serialize_param_types(self.arena, parameters, self.target_es5);
                         let ret_type = if return_type.is_some() {
-                            serialize_type_for_metadata(self.arena, *return_type)
+                            serialize_type_for_metadata(self.arena, *return_type, self.target_es5)
                         } else if *async_returns_promise {
                             "Promise".to_string()
                         } else {
@@ -1610,7 +1615,8 @@ impl<'a> ES5ClassTransformer<'a> {
 
                     // Build constructor paramtypes metadata if emit_decorator_metadata is enabled
                     if self.emit_decorator_metadata {
-                        let param_types = serialize_param_types(self.arena, &ctor.parameters);
+                        let param_types =
+                            serialize_param_types(self.arena, &ctor.parameters, self.target_es5);
                         metadata_strs.push(format!(
                             "{}(\"design:paramtypes\", [{param_types}])",
                             self.helper_name("__metadata")
@@ -1730,7 +1736,8 @@ impl<'a> ES5ClassTransformer<'a> {
                     && member_node.kind == syntax_kind_ext::CONSTRUCTOR
                     && let Some(ctor) = self.arena.get_constructor(member_node)
                 {
-                    let param_types = serialize_param_types(self.arena, &ctor.parameters);
+                    let param_types =
+                        serialize_param_types(self.arena, &ctor.parameters, self.target_es5);
                     meta.push(format!(
                         "{}(\"design:paramtypes\", [{param_types}])",
                         self.helper_name("__metadata")

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
@@ -2,6 +2,7 @@
 
 use crate::transforms::emit_utils::{
     METADATA_ALIAS_MAX_DEPTH, MetadataEntityKind, classify_metadata_entity, identifier_text,
+    serialize_bigint_metadata_type, serialize_symbol_metadata_type,
 };
 use rustc_hash::FxHashMap;
 use tsz_parser::parser::node::NodeArena;
@@ -12,8 +13,16 @@ use tsz_scanner::SyntaxKind;
 
 /// Serialize a type annotation to a metadata runtime type string.
 /// Mirrors the `Printer::serialize_type_for_metadata` logic for ES5 context.
-pub(super) fn serialize_type_for_metadata(arena: &NodeArena, type_idx: NodeIndex) -> String {
-    serialize_type_for_metadata_impl(arena, type_idx, false, 0)
+///
+/// `target_below_es2015` is `!ScriptTarget::supports_es2015()` (equivalently the
+/// transformer's `target_es5`): `tsc` guards the `Symbol` global only for
+/// pre-ES2015 targets, while `BigInt` is guarded at every target.
+pub(super) fn serialize_type_for_metadata(
+    arena: &NodeArena,
+    type_idx: NodeIndex,
+    target_below_es2015: bool,
+) -> String {
+    serialize_type_for_metadata_impl(arena, type_idx, target_below_es2015, false, 0)
 }
 
 /// `in_alias_target` is set while serializing the resolved target of a type
@@ -23,6 +32,7 @@ pub(super) fn serialize_type_for_metadata(arena: &NodeArena, type_idx: NodeIndex
 fn serialize_type_for_metadata_impl(
     arena: &NodeArena,
     type_idx: NodeIndex,
+    target_below_es2015: bool,
     in_alias_target: bool,
     alias_depth: u32,
 ) -> String {
@@ -34,8 +44,10 @@ fn serialize_type_for_metadata_impl(
         k if k == sk(SyntaxKind::StringKeyword) => "String".to_string(),
         k if k == sk(SyntaxKind::NumberKeyword) => "Number".to_string(),
         k if k == sk(SyntaxKind::BooleanKeyword) => "Boolean".to_string(),
-        k if k == sk(SyntaxKind::SymbolKeyword) => "Symbol".to_string(),
-        k if k == sk(SyntaxKind::BigIntKeyword) => "BigInt".to_string(),
+        k if k == sk(SyntaxKind::SymbolKeyword) => {
+            serialize_symbol_metadata_type(target_below_es2015)
+        }
+        k if k == sk(SyntaxKind::BigIntKeyword) => serialize_bigint_metadata_type(),
         k if k == sk(SyntaxKind::VoidKeyword)
             || k == sk(SyntaxKind::UndefinedKeyword)
             || k == sk(SyntaxKind::NullKeyword)
@@ -58,8 +70,8 @@ fn serialize_type_for_metadata_impl(
                 "string" => return "String".to_string(),
                 "number" => return "Number".to_string(),
                 "boolean" => return "Boolean".to_string(),
-                "symbol" => return "Symbol".to_string(),
-                "bigint" => return "BigInt".to_string(),
+                "symbol" => return serialize_symbol_metadata_type(target_below_es2015),
+                "bigint" => return serialize_bigint_metadata_type(),
                 "void" | "undefined" | "null" | "never" => return "void 0".to_string(),
                 "any" | "unknown" | "object" => return "Object".to_string(),
                 _ => {}
@@ -72,7 +84,13 @@ fn serialize_type_for_metadata_impl(
                     if alias_depth >= METADATA_ALIAS_MAX_DEPTH {
                         return "Object".to_string();
                     }
-                    serialize_type_for_metadata_impl(arena, target, true, alias_depth + 1)
+                    serialize_type_for_metadata_impl(
+                        arena,
+                        target,
+                        target_below_es2015,
+                        true,
+                        alias_depth + 1,
+                    )
                 }
                 MetadataEntityKind::TypeOnly => "Object".to_string(),
                 // A local runtime value, or a name with no local type-only
@@ -130,6 +148,7 @@ fn serialize_type_for_metadata_impl(
                     return serialize_type_for_metadata_impl(
                         arena,
                         meaningful[0],
+                        target_below_es2015,
                         in_alias_target,
                         alias_depth,
                     );
@@ -138,13 +157,19 @@ fn serialize_type_for_metadata_impl(
                     let first = serialize_type_for_metadata_impl(
                         arena,
                         meaningful[0],
+                        target_below_es2015,
                         in_alias_target,
                         alias_depth,
                     );
                     if first != "Object"
                         && meaningful[1..].iter().all(|&m| {
-                            serialize_type_for_metadata_impl(arena, m, in_alias_target, alias_depth)
-                                == first
+                            serialize_type_for_metadata_impl(
+                                arena,
+                                m,
+                                target_below_es2015,
+                                in_alias_target,
+                                alias_depth,
+                            ) == first
                         })
                     {
                         return first;
@@ -161,6 +186,7 @@ fn serialize_type_for_metadata_impl(
                 return serialize_type_for_metadata_impl(
                     arena,
                     wrapped.type_node,
+                    target_below_es2015,
                     in_alias_target,
                     alias_depth,
                 );
@@ -174,14 +200,25 @@ fn serialize_type_for_metadata_impl(
                 return match lit_node.kind {
                     lk if lk == sk(SyntaxKind::StringLiteral) => "String".to_string(),
                     lk if lk == sk(SyntaxKind::NumericLiteral) => "Number".to_string(),
-                    lk if lk == sk(SyntaxKind::BigIntLiteral) => "BigInt".to_string(),
+                    lk if lk == sk(SyntaxKind::BigIntLiteral) => serialize_bigint_metadata_type(),
                     lk if lk == sk(SyntaxKind::TrueKeyword)
                         || lk == sk(SyntaxKind::FalseKeyword) =>
                     {
                         "Boolean".to_string()
                     }
                     lk if lk == sk(SyntaxKind::NullKeyword) => "void 0".to_string(),
-                    lk if lk == syntax_kind_ext::PREFIX_UNARY_EXPRESSION => "Number".to_string(),
+                    // `-1` → Number, `-1n` → the guarded BigInt global.
+                    lk if lk == syntax_kind_ext::PREFIX_UNARY_EXPRESSION => {
+                        if arena
+                            .get_unary_expr(lit_node)
+                            .and_then(|u| arena.get(u.operand))
+                            .is_some_and(|op| op.kind == sk(SyntaxKind::BigIntLiteral))
+                        {
+                            serialize_bigint_metadata_type()
+                        } else {
+                            "Number".to_string()
+                        }
+                    }
                     _ => "Object".to_string(),
                 };
             }
@@ -193,6 +230,7 @@ fn serialize_type_for_metadata_impl(
                 return serialize_type_for_metadata_impl(
                     arena,
                     type_op.type_node,
+                    target_below_es2015,
                     in_alias_target,
                     alias_depth,
                 );
@@ -204,6 +242,7 @@ fn serialize_type_for_metadata_impl(
                 return serialize_type_for_metadata_impl(
                     arena,
                     wrapped.type_node,
+                    target_below_es2015,
                     in_alias_target,
                     alias_depth,
                 );
@@ -215,12 +254,14 @@ fn serialize_type_for_metadata_impl(
                 let true_type = serialize_type_for_metadata_impl(
                     arena,
                     cond.true_type,
+                    target_below_es2015,
                     in_alias_target,
                     alias_depth,
                 );
                 let false_type = serialize_type_for_metadata_impl(
                     arena,
                     cond.false_type,
+                    target_below_es2015,
                     in_alias_target,
                     alias_depth,
                 );
@@ -237,18 +278,26 @@ fn serialize_type_for_metadata_impl(
 /// For a rest parameter, serialize the element type of the array type annotation.
 /// e.g., `...args: string[]` → "String", `...args: number[]` → "Number".
 /// If the type is not an array type or has no annotation, returns "Object".
-fn serialize_rest_param_element_type(arena: &NodeArena, type_annotation: NodeIndex) -> String {
+fn serialize_rest_param_element_type(
+    arena: &NodeArena,
+    type_annotation: NodeIndex,
+    target_below_es2015: bool,
+) -> String {
     if let Some(type_node) = arena.get(type_annotation)
         && type_node.kind == syntax_kind_ext::ARRAY_TYPE
         && let Some(arr) = arena.get_array_type(type_node)
     {
-        return serialize_type_for_metadata(arena, arr.element_type);
+        return serialize_type_for_metadata(arena, arr.element_type, target_below_es2015);
     }
     "Object".to_string()
 }
 
 /// Serialize parameter types for `design:paramtypes` metadata.
-pub(super) fn serialize_param_types(arena: &NodeArena, parameters: &NodeList) -> String {
+pub(super) fn serialize_param_types(
+    arena: &NodeArena,
+    parameters: &NodeList,
+    target_below_es2015: bool,
+) -> String {
     let mut parts = Vec::new();
     for &param_idx in &parameters.nodes {
         if let Some(param_node) = arena.get(param_idx)
@@ -269,10 +318,18 @@ pub(super) fn serialize_param_types(arena: &NodeArena, parameters: &NodeList) ->
             }
             if param.dot_dot_dot_token {
                 // Rest parameter: serialize the element type of the array type.
-                let serialized = serialize_rest_param_element_type(arena, param.type_annotation);
+                let serialized = serialize_rest_param_element_type(
+                    arena,
+                    param.type_annotation,
+                    target_below_es2015,
+                );
                 parts.push(serialized);
             } else if param.type_annotation.is_some() {
-                parts.push(serialize_type_for_metadata(arena, param.type_annotation));
+                parts.push(serialize_type_for_metadata(
+                    arena,
+                    param.type_annotation,
+                    target_below_es2015,
+                ));
             } else {
                 parts.push("Object".to_string());
             }

--- a/crates/tsz-emitter/src/transforms/emit_utils.rs
+++ b/crates/tsz-emitter/src/transforms/emit_utils.rs
@@ -260,6 +260,35 @@ pub(crate) fn classify_metadata_entity(arena: &NodeArena, name: &str) -> Metadat
     MetadataEntityKind::ValueOrUnknown
 }
 
+/// `typeof <name> === "function" ? <name> : Object` — the runtime-presence guard
+/// `tsc` wraps a possibly-absent global constructor in for decorator metadata
+/// (`getGlobalBigIntNameWithFallback` / `getGlobalSymbolNameWithFallback`).
+/// Unlike the `isolatedModules`/`noLib` fallback (which hoists a temp), this is
+/// `tsc`'s built-in-global form exactly. Shared by the `Printer` and ES5
+/// transform serializers so they cannot drift.
+pub(crate) fn metadata_global_with_fallback(name: &str) -> String {
+    format!("typeof {name} === \"function\" ? {name} : Object")
+}
+
+/// Serialize the `bigint` decorator-metadata type. `tsc` always guards the
+/// `BigInt` global — its presence is not implied by any target — so a runtime
+/// lacking `BigInt` reads `Object` instead of throwing a `ReferenceError`.
+pub(crate) fn serialize_bigint_metadata_type() -> String {
+    metadata_global_with_fallback("BigInt")
+}
+
+/// Serialize the `symbol` decorator-metadata type. `tsc` guards the `Symbol`
+/// global only for pre-ES2015 targets (`target_below_es2015`); at ES2015+
+/// `Symbol` is assumed present and emitted bare. The threshold lives here so
+/// both serializers share one definition.
+pub(crate) fn serialize_symbol_metadata_type(target_below_es2015: bool) -> String {
+    if target_below_es2015 {
+        metadata_global_with_fallback("Symbol")
+    } else {
+        "Symbol".to_string()
+    }
+}
+
 /// Collect the runtime (non-type-only) bindings of an import clause as
 /// `(name node, name)` pairs: the default name, the namespace name, and each
 /// named specifier's local name. Shared by the printer's and the lowering

--- a/crates/tsz-emitter/tests/decorator_metadata_global_fallback_tests.rs
+++ b/crates/tsz-emitter/tests/decorator_metadata_global_fallback_tests.rs
@@ -1,0 +1,213 @@
+//! Decorator `design:*` metadata must guard possibly-absent global
+//! constructors with a runtime-presence check, matching `tsc`:
+//!
+//! - `bigint` is ALWAYS serialized as
+//!   `typeof BigInt === "function" ? BigInt : Object`
+//!   (`getGlobalBigIntNameWithFallback`) — `BigInt` is not implied by any
+//!   target.
+//! - `symbol` is serialized as
+//!   `typeof Symbol === "function" ? Symbol : Object`
+//!   (`getGlobalSymbolNameWithFallback`) only for **pre-ES2015** targets; at
+//!   `ES2015`+ `Symbol` is assumed present and emitted bare.
+//!
+//! An unguarded `BigInt`/`Symbol` reference throws a `ReferenceError` (or
+//! records wrong metadata) on runtimes lacking the global, which is exactly the
+//! scenario the guard exists for.
+
+use tsz_common::ScriptTarget;
+use tsz_emitter::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use tsz_parser::ParserState;
+
+fn emit_source(source: &str, options: PrinterOptions) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut printer = EmitterPrinter::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+fn legacy_metadata_options(target: ScriptTarget) -> PrinterOptions {
+    PrinterOptions {
+        legacy_decorators: true,
+        emit_decorator_metadata: true,
+        target,
+        ..Default::default()
+    }
+}
+
+const GUARDED_BIGINT: &str = "typeof BigInt === \"function\" ? BigInt : Object";
+const GUARDED_SYMBOL: &str = "typeof Symbol === \"function\" ? Symbol : Object";
+
+fn assert_design_type(output: &str, member: &str, serialized: &str) {
+    let needle = format!("__metadata(\"design:type\", {serialized})\n], C.prototype, \"{member}\"");
+    assert!(
+        output.contains(&needle),
+        "expected `{member}` design:type to serialize to `{serialized}`.\nOutput:\n{output}"
+    );
+}
+
+/// `bigint` is guarded at every target (here ES2017), via both the `bigint`
+/// keyword and a `bigint` identifier type reference.
+#[test]
+fn bigint_keyword_is_guarded_at_es2017() {
+    let source = r#"declare const dec: any;
+class C {
+  @dec a: bigint;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options(ScriptTarget::ES2017));
+    assert_design_type(&output, "a", GUARDED_BIGINT);
+    // The bare unguarded form must NOT appear as a metadata argument.
+    assert!(
+        !output.contains("__metadata(\"design:type\", BigInt)"),
+        "bare BigInt leaked into metadata.\nOutput:\n{output}"
+    );
+}
+
+/// `bigint` stays guarded even at `ESNext` — `BigInt` presence is not implied by
+/// the target, so the guard must not be target-gated.
+#[test]
+fn bigint_is_guarded_at_esnext() {
+    let source = r#"declare const dec: any;
+class C {
+  @dec a: bigint;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options(ScriptTarget::ESNext));
+    assert_design_type(&output, "a", GUARDED_BIGINT);
+    assert!(
+        !output.contains("__metadata(\"design:type\", BigInt)"),
+        "bare BigInt leaked into ESNext metadata.\nOutput:\n{output}"
+    );
+}
+
+/// `bigint` is guarded at ES5 too (and the ES5 downlevel decorator path uses a
+/// separate serializer, so it must agree).
+#[test]
+fn bigint_is_guarded_at_es5() {
+    let source = r#"declare const dec: any;
+class C {
+  @dec a: bigint;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options(ScriptTarget::ES5));
+    assert!(
+        output.contains(&format!("__metadata(\"design:type\", {GUARDED_BIGINT})")),
+        "bigint should be guarded at ES5.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("__metadata(\"design:type\", BigInt)"),
+        "bare BigInt leaked into ES5 metadata.\nOutput:\n{output}"
+    );
+}
+
+/// `symbol` is guarded for pre-ES2015 targets (ES5 here).
+#[test]
+fn symbol_is_guarded_at_es5() {
+    let source = r#"declare const dec: any;
+class C {
+  @dec a: symbol;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options(ScriptTarget::ES5));
+    assert!(
+        output.contains(&format!("__metadata(\"design:type\", {GUARDED_SYMBOL})")),
+        "symbol should be guarded at ES5.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("__metadata(\"design:type\", Symbol)"),
+        "bare Symbol leaked into ES5 metadata.\nOutput:\n{output}"
+    );
+}
+
+/// `symbol` is emitted bare at ES2015 (the threshold) and above (ES2017) — it
+/// must NOT regress to the guarded form.
+#[test]
+fn symbol_is_bare_at_es2015_and_above() {
+    let source = r#"declare const dec: any;
+class C {
+  @dec a: symbol;
+}
+"#;
+    for target in [
+        ScriptTarget::ES2015,
+        ScriptTarget::ES2017,
+        ScriptTarget::ESNext,
+    ] {
+        let output = emit_source(source, legacy_metadata_options(target));
+        assert_design_type(&output, "a", "Symbol");
+        assert!(
+            !output.contains(GUARDED_SYMBOL),
+            "symbol must be bare at {target:?}, not guarded.\nOutput:\n{output}"
+        );
+    }
+}
+
+/// At ES2017, tsc emits guarded `BigInt` but bare `Symbol` — the two globals
+/// are gated independently.
+#[test]
+fn bigint_and_symbol_are_gated_independently_at_es2017() {
+    let source = r#"declare const dec: any;
+class C {
+  @dec a: bigint;
+  @dec b: symbol;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options(ScriptTarget::ES2017));
+    assert_design_type(&output, "a", GUARDED_BIGINT);
+    assert_design_type(&output, "b", "Symbol");
+}
+
+/// `design:paramtypes` and `design:returntype` share the serializer, so a
+/// `bigint` param/return is guarded inside the array and the return position.
+#[test]
+fn bigint_guarded_in_paramtypes_and_returntype() {
+    let source = r#"declare const dec: any;
+class C {
+  @dec method(a: bigint, b: symbol): bigint { return 0n; }
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options(ScriptTarget::ES2017));
+    // symbol is bare at ES2017; bigint is guarded in both positions.
+    assert!(
+        output.contains(&format!(
+            "__metadata(\"design:paramtypes\", [{GUARDED_BIGINT}, Symbol])"
+        )),
+        "paramtypes should guard bigint and keep Symbol bare at ES2017.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(&format!(
+            "__metadata(\"design:returntype\", {GUARDED_BIGINT})"
+        )),
+        "returntype bigint should be guarded.\nOutput:\n{output}"
+    );
+}
+
+/// `bigint | undefined` unwraps to the single meaningful member and serializes
+/// to the guarded bigint form (matching tsc).
+#[test]
+fn bigint_union_with_undefined_is_guarded() {
+    let source = r#"declare const dec: any;
+class C {
+  @dec a: bigint | undefined;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options(ScriptTarget::ES2017));
+    assert_design_type(&output, "a", GUARDED_BIGINT);
+}
+
+/// A `bigint` literal type (`1n`) and a negative bigint literal type (`-1n`)
+/// both serialize to the guarded bigint form, like the bare `bigint` keyword.
+#[test]
+fn bigint_literal_types_are_guarded() {
+    let source = r#"declare const dec: any;
+class C {
+  @dec a: 1n;
+  @dec b: -1n;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options(ScriptTarget::ES2017));
+    assert_design_type(&output, "a", GUARDED_BIGINT);
+    assert_design_type(&output, "b", GUARDED_BIGINT);
+}


### PR DESCRIPTION
Closes #14777.

With `--experimentalDecorators --emitDecoratorMetadata`, tsz serialized `bigint` to a bare `BigInt` reference (any target) and `symbol` to a bare `Symbol` reference (ES5/ES3). Those globals may not exist on the chosen lib/target, so reading the metadata throws a `ReferenceError` (or yields wrong metadata) — exactly the case the guard exists for. tsc wraps possibly-absent globals in a runtime-presence guard.

```ts
function dec(...args: any[]): any {}
class C { @dec a: bigint; @dec b: symbol; }
```

| type / target | tsz before | tsc 5.9.3 / tsz after |
|---|---|---|
| `bigint`, any target | `BigInt` | `typeof BigInt === "function" ? BigInt : Object` |
| `symbol`, ES5/ES3 | `Symbol` | `typeof Symbol === "function" ? Symbol : Object` |
| `symbol`, ES2015+ | `Symbol` | `Symbol` (bare — unchanged, correct) |

**Structural rule:** when serializing a `design:type`/`design:paramtypes`/`design:returntype` annotation, tsc guards a possibly-absent global constructor as `typeof X === "function" ? X : Object`. `BigInt` is **always** guarded (`getGlobalBigIntNameWithFallback` — presence is never implied by the target); `Symbol` is guarded **only** for pre-ES2015 targets (`getGlobalSymbolNameWithFallback`) and emitted bare at ES2015+. tsz now does the same in both metadata serializers.

**Owner layer:** emitter decorator-metadata serializer. The two parallel serializers (the `Printer` path for ES2015+ and the ES5-IR transform path) route the `bigint` (always) and `symbol` (target < ES2015) arms through shared helpers in `transforms::emit_utils` (`serialize_bigint_metadata_type` / `serialize_symbol_metadata_type` / `metadata_global_with_fallback`), joining the existing shared `classify_metadata_entity` so the two cannot drift. The ES2015 threshold for `symbol` reads the printer's `ScriptTarget::supports_es2015()` and the ES5 transform's pre-derived `target_es5` gate (`== !supports_es2015()`), both feeding one shared threshold definition. This is display-only: the error/emit *decision* of which member gets metadata is unchanged; only the serialized global text changes. No name/string is used as a semantic predicate.

**Adjacent cases (covered by tests):**
- `bigint` guarded at ES5, ES2017, and ESNext (never target-gated).
- `symbol` bare at ES2015 (threshold), ES2017, ESNext; guarded at ES5.
- `bigint`/`symbol` gated independently at ES2017 (guarded `BigInt`, bare `Symbol`).
- `bigint` inside `design:paramtypes` arrays and `design:returntype`.
- `bigint | undefined` unwraps to the guarded bigint form.
- `bigint` literal type `1n` and negative bigint literal type `-1n` → guarded BigInt (the `-1n` case also fixes the prefix-unary literal arm, matching tsc's `serializeLiteralOfLiteralTypeNode`).
- No double-wrap with the existing `noLib`/`isolatedModules` fallback (the `bigint`/`symbol` arms return before that path).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --test decorator_metadata_global_fallback_tests` — 9/9 pass (new file; bigint/symbol across ES5/ES2015/ES2017/ESNext, paramtypes/returntype, union, literal types; the ES5 path is exercised through the real downlevel serializer).
- `cargo test -p tsz-emitter --test decorator_metadata_type_only_tests` — 6/6 pass (no regression in the sibling serializer).
- `cargo test -p tsz-emitter --lib es5 / decorator / metadata` — 838 / 156 / 22 pass.
- `cargo fmt -p tsz-emitter -- --check` and `cargo clippy -p tsz-emitter --lib --tests` — clean.
- Broad conformance/emit/fourslash owned by ready-review CI (`decoratorMetadata*` baselines; the change makes tsz match tsc, so affected rows should converge, not regress).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGSJ33iaJBBSZ4jAjZLWBH)_