### PR TITLE
refactor(checker): route boxed global env publication through authority (#14351)

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping_env_writes.rs
+++ b/crates/tsz-checker/src/context/def_mapping_env_writes.rs
@@ -27,6 +27,41 @@ impl CheckerContext<'_> {
         self.register_in_envs(DeferredFlowEnvWrite::InsertTypeofValueType { symbol, value_type });
     }
 
+    /// Register the boxed interface type for a primitive in **both** type
+    /// environments through the race-safe deferral discipline.
+    pub(crate) fn register_boxed_type_in_envs(
+        &self,
+        kind: tsz_solver::IntrinsicKind,
+        type_id: TypeId,
+    ) {
+        self.register_in_envs(DeferredFlowEnvWrite::RegisterBoxedType { kind, type_id });
+    }
+
+    /// Register the canonical `Array<T>` base type in **both** type environments
+    /// through the race-safe deferral discipline.
+    pub(crate) fn register_array_base_type_in_envs(
+        &self,
+        type_id: TypeId,
+        params: Vec<tsz_solver::TypeParamInfo>,
+    ) {
+        self.register_in_envs(DeferredFlowEnvWrite::RegisterArrayBaseType { type_id, params });
+    }
+
+    /// Register a boxed interface's `Lazy(DefId)` body and boxed-kind marker in
+    /// **both** type environments through the race-safe deferral discipline.
+    pub(crate) fn register_boxed_def_in_envs(
+        &self,
+        kind: tsz_solver::IntrinsicKind,
+        type_id: TypeId,
+        def_id: DefId,
+    ) {
+        self.register_in_envs(DeferredFlowEnvWrite::RegisterBoxedDef {
+            kind,
+            type_id,
+            def_id,
+        });
+    }
+
     /// Register a `[Symbol.*]` computed property name's backing `SymbolRef` in
     /// **both** type environments through the race-safe deferral discipline.
     pub(crate) fn register_well_known_symbol_name_in_envs(

--- a/crates/tsz-checker/src/context/deferred_flow_env_write.rs
+++ b/crates/tsz-checker/src/context/deferred_flow_env_write.rs
@@ -74,6 +74,23 @@ pub enum DeferredFlowEnvWrite {
         symbol: tsz_solver::SymbolRef,
         value_type: TypeId,
     },
+    /// `set_boxed_type` — register the boxed interface for a primitive.
+    RegisterBoxedType {
+        kind: tsz_solver::IntrinsicKind,
+        type_id: TypeId,
+    },
+    /// `set_array_base_type` — register the canonical `Array<T>` base type.
+    RegisterArrayBaseType {
+        type_id: TypeId,
+        params: Vec<tsz_solver::TypeParamInfo>,
+    },
+    /// `insert_def` + `register_boxed_def_id` — register a boxed interface's
+    /// `Lazy(DefId)` body and intrinsic-kind marker.
+    RegisterBoxedDef {
+        kind: tsz_solver::IntrinsicKind,
+        type_id: TypeId,
+        def_id: DefId,
+    },
     /// `register_well_known_symbol_name` — register a `[Symbol.*]` computed
     /// property name's backing `SymbolRef`.
     RegisterWellKnownSymbolName {
@@ -186,6 +203,18 @@ impl DeferredFlowEnvWrite {
             Self::InsertDefKind { def_id, kind } => env.insert_def_kind(*def_id, *kind),
             Self::InsertTypeofValueType { symbol, value_type } => {
                 env.insert_typeof_value_type(*symbol, *value_type);
+            }
+            Self::RegisterBoxedType { kind, type_id } => env.set_boxed_type(*kind, *type_id),
+            Self::RegisterArrayBaseType { type_id, params } => {
+                env.set_array_base_type(*type_id, params.clone());
+            }
+            Self::RegisterBoxedDef {
+                kind,
+                type_id,
+                def_id,
+            } => {
+                env.insert_def(*def_id, *type_id);
+                env.register_boxed_def_id(*kind, *def_id);
             }
             Self::RegisterWellKnownSymbolName { name, symbol_ref } => {
                 env.register_well_known_symbol_name(name.clone(), *symbol_ref);

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -142,6 +142,9 @@ mod await_alias_union_distribution_tests;
 #[path = "tests/await_structural_thenable_tests.rs"]
 mod await_structural_thenable_tests;
 #[cfg(test)]
+#[path = "tests/boxed_global_env_authority_tests.rs"]
+mod boxed_global_env_authority_tests;
+#[cfg(test)]
 #[path = "../tests/circular_accessor_annotation_tests.rs"]
 mod circular_accessor_annotation_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
@@ -342,13 +342,20 @@ fn test_array_helpers_avoid_direct_typekey_interning() {
         "symbol_types should use dual-env helpers for interface DefId registration"
     );
 
-    // global type registration must mirror into type_environment
+    // global type registration must use the dual-env authority for boxed
+    // globals instead of raw evaluator/flow env mutation.
     let global_src = fs::read_to_string("src/types/type_checking/global.rs")
         .expect("failed to read src/types/type_checking/global.rs for architecture guard");
-    assert!(
-        global_src.contains("type_environment.try_borrow_mut()"),
-        "global type registration must mirror boxed DefId mappings into type_environment"
-    );
+    for required in [
+        "register_boxed_type_in_envs(",
+        "register_array_base_type_in_envs(",
+        "register_boxed_def_in_envs(",
+    ] {
+        assert!(
+            global_src.contains(required),
+            "global type registration must publish boxed metadata through {required}"
+        );
+    }
 
     let queries_src = fs::read_to_string("src/types/queries/core.rs")
         .expect("failed to read src/types/queries/core.rs for architecture guard");

--- a/crates/tsz-checker/src/tests/boxed_global_env_authority_tests.rs
+++ b/crates/tsz-checker/src/tests/boxed_global_env_authority_tests.rs
@@ -1,0 +1,168 @@
+use crate::context::{CheckerContext, CheckerOptions};
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+use tsz_solver::def::DefId;
+use tsz_solver::{IntrinsicKind, TypeId, TypeParamInfo};
+
+const GLOBAL_RS: &str = include_str!("../types/type_checking/global.rs");
+
+fn minimal_checker_ctx() -> (
+    Arc<tsz_parser::parser::node::NodeArena>,
+    Arc<BinderState>,
+    TypeInterner,
+) {
+    let mut parser = ParserState::new("fixture.ts".to_string(), "type T = string;".to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    (
+        Arc::new(parser.get_arena().clone()),
+        Arc::new(binder),
+        TypeInterner::new(),
+    )
+}
+
+#[test]
+fn boxed_global_metadata_flow_env_mirror_is_deferred_then_replayed() {
+    use tsz_common::interner::Atom;
+
+    let (arena, binder, types) = minimal_checker_ctx();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    let kind = IntrinsicKind::String;
+    let boxed_type = TypeId::STRING;
+    let array_base = TypeId::NUMBER;
+    let def_id = DefId(31_001);
+    let params = vec![TypeParamInfo::simple(Atom::default())];
+
+    {
+        let held_flow = ctx.type_environment.borrow();
+        ctx.register_boxed_type_in_envs(kind, boxed_type);
+        ctx.register_array_base_type_in_envs(array_base, params.clone());
+        ctx.register_boxed_def_in_envs(kind, boxed_type, def_id);
+
+        let eval = ctx.type_env.borrow();
+        assert_eq!(eval.get_boxed_type(kind), Some(boxed_type));
+        assert_eq!(eval.get_array_base_type(), Some(array_base));
+        assert_eq!(eval.get_array_base_type_params(), params.as_slice());
+        assert_eq!(eval.get_def(def_id), Some(boxed_type));
+        assert!(eval.is_boxed_def_id(def_id, kind));
+
+        assert_eq!(held_flow.get_boxed_type(kind), None);
+        assert_eq!(held_flow.get_array_base_type(), None);
+        assert_eq!(held_flow.get_def(def_id), None);
+        assert!(!held_flow.is_boxed_def_id(def_id, kind));
+        assert_eq!(
+            ctx.deferred_flow_env_write_count(),
+            3,
+            "boxed metadata mirrors must queue while the flow env is borrowed"
+        );
+    }
+
+    ctx.flush_deferred_flow_env_writes();
+    assert_eq!(ctx.deferred_flow_env_write_count(), 0);
+    let flow = ctx.type_environment.borrow();
+    assert_eq!(flow.get_boxed_type(kind), Some(boxed_type));
+    assert_eq!(flow.get_array_base_type(), Some(array_base));
+    assert_eq!(flow.get_array_base_type_params(), params.as_slice());
+    assert_eq!(flow.get_def(def_id), Some(boxed_type));
+    assert!(flow.is_boxed_def_id(def_id, kind));
+}
+
+#[test]
+fn boxed_global_metadata_eval_env_write_is_deferred_then_replayed() {
+    use tsz_common::interner::Atom;
+
+    let (arena, binder, types) = minimal_checker_ctx();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    let kind = IntrinsicKind::Function;
+    let boxed_type = TypeId::BOOLEAN;
+    let array_base = TypeId::STRING;
+    let def_id = DefId(31_002);
+    let params = vec![TypeParamInfo::simple(Atom::default())];
+
+    {
+        let held_eval = ctx.type_env.borrow();
+        ctx.register_boxed_type_in_envs(kind, boxed_type);
+        ctx.register_array_base_type_in_envs(array_base, params.clone());
+        ctx.register_boxed_def_in_envs(kind, boxed_type, def_id);
+
+        let flow = ctx.type_environment.borrow();
+        assert_eq!(flow.get_boxed_type(kind), Some(boxed_type));
+        assert_eq!(flow.get_array_base_type(), Some(array_base));
+        assert_eq!(flow.get_array_base_type_params(), params.as_slice());
+        assert_eq!(flow.get_def(def_id), Some(boxed_type));
+        assert!(flow.is_boxed_def_id(def_id, kind));
+
+        assert_eq!(held_eval.get_boxed_type(kind), None);
+        assert_eq!(held_eval.get_array_base_type(), None);
+        assert_eq!(held_eval.get_def(def_id), None);
+        assert!(!held_eval.is_boxed_def_id(def_id, kind));
+        assert_eq!(
+            ctx.deferred_eval_env_write_count(),
+            3,
+            "boxed metadata writes must queue while the evaluator env is borrowed"
+        );
+    }
+
+    ctx.flush_deferred_eval_env_writes();
+    assert_eq!(ctx.deferred_eval_env_write_count(), 0);
+    let eval = ctx.type_env.borrow();
+    assert_eq!(eval.get_boxed_type(kind), Some(boxed_type));
+    assert_eq!(eval.get_array_base_type(), Some(array_base));
+    assert_eq!(eval.get_array_base_type_params(), params.as_slice());
+    assert_eq!(eval.get_def(def_id), Some(boxed_type));
+    assert!(eval.is_boxed_def_id(def_id, kind));
+}
+
+#[test]
+fn register_boxed_types_uses_context_env_authority_for_env_publication() {
+    let start = GLOBAL_RS
+        .find("pub(crate) fn register_boxed_types")
+        .expect("register_boxed_types remains in global.rs");
+    let end = GLOBAL_RS[start..]
+        .find("fn has_user_declared_registerable_global")
+        .map(|offset| start + offset)
+        .expect("next helper remains after register_boxed_types");
+    let body = &GLOBAL_RS[start..end];
+
+    for required in [
+        "register_boxed_type_in_envs",
+        "register_array_base_type_in_envs",
+        "register_boxed_def_in_envs",
+    ] {
+        assert!(
+            body.contains(required),
+            "boxed global env publication should go through CheckerContext::{required}"
+        );
+    }
+
+    for forbidden in [
+        "self.ctx.type_env.try_borrow_mut()",
+        "self.ctx.type_environment.try_borrow_mut()",
+        "env.set_boxed_type",
+        "env.set_array_base_type",
+        "env.insert_def",
+        "env.register_boxed_def_id",
+    ] {
+        assert!(
+            !body.contains(forbidden),
+            "register_boxed_types must not publish boxed globals through raw env mutation: {forbidden}"
+        );
+    }
+}

--- a/crates/tsz-checker/src/types/type_checking/global.rs
+++ b/crates/tsz-checker/src/types/type_checking/global.rs
@@ -182,8 +182,6 @@ impl<'a> CheckerState<'a> {
         if array_type_params.is_empty() {
             array_type_params = TypeResolver::get_array_base_type_params(&self.ctx.types).to_vec();
         }
-        let array_type_params_for_flow = array_type_params.clone();
-
         // Pre-compute type parameters for commonly-used generic lib types.
         // To reduce startup overhead, only prewarm symbols referenced by this file.
         // Unreferenced symbols are still resolved lazily through normal lookup paths.
@@ -423,81 +421,35 @@ impl<'a> CheckerState<'a> {
             self.ctx.types.register_this_type_def_id(def_id);
         }
 
-        // 2. Populate the environment
-        // We use try_borrow_mut to be safe, though at this stage it should be free
-        if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
-            if let Some(ty) = string_type {
-                env.set_boxed_type(IntrinsicKind::String, ty);
-            }
-            if let Some(ty) = number_type {
-                env.set_boxed_type(IntrinsicKind::Number, ty);
-            }
-            if let Some(ty) = boolean_type {
-                env.set_boxed_type(IntrinsicKind::Boolean, ty);
-            }
-            if let Some(ty) = symbol_type {
-                env.set_boxed_type(IntrinsicKind::Symbol, ty);
-            }
-            if let Some(ty) = bigint_type {
-                env.set_boxed_type(IntrinsicKind::Bigint, ty);
-            }
-            if let Some(ty) = object_type {
-                env.set_boxed_type(IntrinsicKind::Object, ty);
-            }
-            if let Some(ty) = function_type {
-                env.set_boxed_type(IntrinsicKind::Function, ty);
-            }
-            // Register the Array<T> interface for array property resolution
-            // Use the instance type (Array<T> interface), not the constructor (Callable)
-            if let Some(ty) = array_instance_type {
-                env.set_array_base_type(ty, array_type_params);
-            }
-
-            // 3. Register DefId mappings for non-generic boxed types in the env too.
-            // When user code writes `a: Function`, the type annotation creates a
-            // Lazy(DefId) referencing the global Function symbol. The CallEvaluator
-            // uses TypeEnvironment as its resolver, which resolves Lazy types via
-            // def_types. Without this registration, Lazy(DefId) for Function can't
-            // be resolved, causing false TS2345/TS2322 errors.
-            for &(kind, ty, def_id) in &boxed_def_entries {
-                env.insert_def(def_id, ty);
-                env.register_boxed_def_id(kind, def_id);
+        for &(kind, ty) in &[
+            (IntrinsicKind::String, string_type),
+            (IntrinsicKind::Number, number_type),
+            (IntrinsicKind::Boolean, boolean_type),
+            (IntrinsicKind::Symbol, symbol_type),
+            (IntrinsicKind::Bigint, bigint_type),
+            (IntrinsicKind::Object, object_type),
+            (IntrinsicKind::Function, function_type),
+        ] {
+            if let Some(ty) = ty {
+                self.ctx.register_boxed_type_in_envs(kind, ty);
             }
         }
 
-        // Mirror boxed DefId mappings into type_environment (flow-analyzer env)
-        // so both environments stay consistent for narrowing contexts.
-        if let Ok(mut env) = self.ctx.type_environment.try_borrow_mut() {
-            for &(kind, ty, def_id) in &boxed_def_entries {
-                env.insert_def(def_id, ty);
-                env.register_boxed_def_id(kind, def_id);
-            }
+        // Register the Array<T> interface for array property resolution. Use
+        // the instance type (Array<T> interface), not the constructor (Callable).
+        if let Some(ty) = array_instance_type {
+            self.ctx
+                .register_array_base_type_in_envs(ty, array_type_params);
+        }
 
-            // Mirror boxed types and array base type into flow-analyzer env
-            if let Some(ty) = string_type {
-                env.set_boxed_type(IntrinsicKind::String, ty);
-            }
-            if let Some(ty) = number_type {
-                env.set_boxed_type(IntrinsicKind::Number, ty);
-            }
-            if let Some(ty) = boolean_type {
-                env.set_boxed_type(IntrinsicKind::Boolean, ty);
-            }
-            if let Some(ty) = symbol_type {
-                env.set_boxed_type(IntrinsicKind::Symbol, ty);
-            }
-            if let Some(ty) = bigint_type {
-                env.set_boxed_type(IntrinsicKind::Bigint, ty);
-            }
-            if let Some(ty) = object_type {
-                env.set_boxed_type(IntrinsicKind::Object, ty);
-            }
-            if let Some(ty) = function_type {
-                env.set_boxed_type(IntrinsicKind::Function, ty);
-            }
-            if let Some(ty) = array_instance_type {
-                env.set_array_base_type(ty, array_type_params_for_flow);
-            }
+        // Register DefId mappings for non-generic boxed types in both envs too.
+        // When user code writes `a: Function`, the type annotation creates a
+        // Lazy(DefId) referencing the global Function symbol. The CallEvaluator
+        // uses TypeEnvironment as its resolver, which resolves Lazy types via
+        // def_types. Without this registration, Lazy(DefId) for Function can't
+        // be resolved, causing false TS2345/TS2322 errors.
+        for &(kind, ty, def_id) in &boxed_def_entries {
+            self.ctx.register_boxed_def_in_envs(kind, ty, def_id);
         }
     }
 


### PR DESCRIPTION
Goal: green

## Summary
- Route boxed primitive, `Array<T>` base, and boxed `Lazy(DefId)` env publication through `CheckerContext` dual-env authority.
- Add deferred env write variants for boxed type metadata, Array base params, and boxed DefId markers.
- Add focused tests for evaluator-env and flow-env borrow deferral, plus source guards against raw boxed-global env mutation.

## Structural Rule
When global boxed interfaces and `Array<T>` metadata are registered, `tsc` exposes one coherent global environment; `tsz` now publishes the boxed type, Array base params, and boxed `DefId -> TypeId` mappings through checker-owned dual-env authority, replaying through the deferred write queue if either env is borrowed.

Owner layer: checker context coordinates dual-env publication; `TypeEnvironment` remains the storage/replay target; existing solver/interner global registrations stay unchanged.

Adjacent matrix:
- Eval env borrowed: boxed metadata reaches flow env immediately and evaluator replay fills it later.
- Flow env borrowed: boxed metadata reaches evaluator env immediately and flow replay fills it later.
- Source guard: `register_boxed_types` requires the context helpers and rejects raw env mutation for boxed globals.
- Fallback: no fixture-name or source-text fast paths; missing lib entries still skip through existing `Option<TypeId>` handling.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib boxed_global_env_authority_tests def_mapping`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib boxed_global_env_authority_tests def_mapping global_augmentation_computed_key_tests global_this_typeof_surface_tests window_self_globalthis_resolution_tests cross_file_interface_property_access_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib test_checker_sources_forbid_solver_internal_imports_typekey_usage_and_raw_interning boxed_global_env_authority_tests`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --tests -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high