### PR TITLE
refactor(solver): own instantiation depth state (#14351)

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -11,6 +11,7 @@
 
 use crate::caches::db::QueryDatabase;
 use crate::construction::TypeDatabase;
+use crate::instantiation::result::InstantiationTermination;
 #[cfg(test)]
 use crate::types::*;
 use crate::types::{
@@ -28,6 +29,60 @@ use tsz_common::interner::Atom;
 /// notes at the canonical definition in [`crate::limits`].
 pub const MAX_INSTANTIATION_DEPTH: u32 = crate::limits::MAX_TYPE_SUBSTITUTION_DEPTH;
 const MAX_TUPLE_SPREAD_FLATTEN_ELEMENTS: usize = 8192;
+
+/// Named owner for one instantiation walk's recursion-depth verdict.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct InstantiationWalkState {
+    depth: u32,
+    max_depth: u32,
+    termination: InstantiationTermination,
+}
+
+/// Entry decision for an instantiation recursion frame.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InstantiationFrameState {
+    Entered,
+    DepthExceeded,
+}
+
+impl InstantiationWalkState {
+    const fn new(max_depth: u32) -> Self {
+        Self {
+            depth: 0,
+            max_depth,
+            termination: InstantiationTermination::Complete,
+        }
+    }
+
+    const fn depth(&self) -> u32 {
+        self.depth
+    }
+
+    const fn has_depth_exceeded(&self) -> bool {
+        self.termination.depth_exceeded()
+    }
+
+    const fn termination(&self) -> InstantiationTermination {
+        self.termination
+    }
+
+    const fn mark_depth_exceeded(&mut self) {
+        self.termination = InstantiationTermination::DepthExceeded;
+    }
+
+    const fn enter_frame(&mut self) -> InstantiationFrameState {
+        if self.has_depth_exceeded() || self.depth >= self.max_depth {
+            self.mark_depth_exceeded();
+            return InstantiationFrameState::DepthExceeded;
+        }
+        self.depth += 1;
+        InstantiationFrameState::Entered
+    }
+
+    const fn leave_frame(&mut self) {
+        self.depth -= 1;
+    }
+}
 
 /// Instantiator for applying type substitutions.
 pub struct TypeInstantiator<'a> {
@@ -61,9 +116,7 @@ pub struct TypeInstantiator<'a> {
     /// `instantiate_type_with_this`) where the substitution legitimately
     /// means "specialize this method body for this class".
     pub shallow_this_only: bool,
-    depth: u32,
-    max_depth: u32,
-    depth_exceeded: bool,
+    walk_state: InstantiationWalkState,
     /// Cached: `true` when every key in `substitution.map` is a solver
     /// inference variable (`__infer_*`). The substitution is immutable for the
     /// lifetime of the instantiator, so this is computed once at construction.
@@ -93,9 +146,7 @@ impl<'a> TypeInstantiator<'a> {
             preserve_unsubstituted_type_params: false,
             this_type: None,
             shallow_this_only: false,
-            depth: 0,
-            max_depth: MAX_INSTANTIATION_DEPTH,
-            depth_exceeded: false,
+            walk_state: InstantiationWalkState::new(MAX_INSTANTIATION_DEPTH),
             substitution_is_inference_only,
         }
     }
@@ -160,7 +211,19 @@ impl<'a> TypeInstantiator<'a> {
     /// deeper than `MAX_INSTANTIATION_DEPTH`.
     #[cfg(test)]
     pub(crate) const fn force_depth_exceeded_for_test(&mut self) {
-        self.depth_exceeded = true;
+        self.walk_state.termination = InstantiationTermination::DepthExceeded;
+    }
+
+    pub(crate) const fn has_depth_exceeded(&self) -> bool {
+        self.walk_state.has_depth_exceeded()
+    }
+
+    pub(crate) const fn termination(&self) -> InstantiationTermination {
+        self.walk_state.termination()
+    }
+
+    pub(crate) const fn mark_depth_exceeded(&mut self) {
+        self.walk_state.mark_depth_exceeded();
     }
 
     /// Restore the homomorphic modifier source of a self-indexed mapped type
@@ -537,20 +600,22 @@ impl<'a> TypeInstantiator<'a> {
     /// Wrapped with `stacker::maybe_grow()` to handle deeply nested generic
     /// instantiation chains that would otherwise overflow the stack.
     pub fn instantiate(&mut self, type_id: TypeId) -> TypeId {
-        let _span =
-            tracing::trace_span!("instantiate", ty = type_id.0, depth = self.depth,).entered();
+        let _span = tracing::trace_span!(
+            "instantiate",
+            ty = type_id.0,
+            depth = self.walk_state.depth(),
+        )
+        .entered();
 
         // Fast path: intrinsic types don't need instantiation
         if type_id.is_intrinsic() {
             return type_id;
         }
 
-        if self.depth_exceeded {
-            return self.bail_value(type_id);
-        }
-
-        if self.depth >= self.max_depth {
-            self.depth_exceeded = true;
+        if matches!(
+            self.walk_state.enter_frame(),
+            InstantiationFrameState::DepthExceeded
+        ) {
             return self.bail_value(type_id);
         }
 
@@ -562,13 +627,13 @@ impl<'a> TypeInstantiator<'a> {
         // `depth` is adjusted inside the body so it only counts frames we
         // actually descend into, never the exhausted-bail path.
         crate::recursion::with_solver_frame(|| {
-            self.depth += 1;
             let result = self.instantiate_inner(type_id);
-            self.depth -= 1;
+            self.walk_state.leave_frame();
             result
         })
         .unwrap_or_else(|| {
-            self.depth_exceeded = true;
+            self.walk_state.leave_frame();
+            self.mark_depth_exceeded();
             self.bail_value(type_id)
         })
     }

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -3,9 +3,7 @@ use crate::caches::db::QueryDatabase;
 use crate::caches::instantiation_cache::{CanonicalSubst, InstantiationCacheKey};
 use crate::instantiation::instantiate::cache_stability::ProjectInstantiationCacheLimitSnapshot;
 use crate::instantiation::request::{InstantiationOptions, InstantiationRequest};
-use crate::instantiation::result::{
-    InstantiationMemoResult, InstantiationResult, InstantiationTermination,
-};
+use crate::instantiation::result::{InstantiationMemoResult, InstantiationResult};
 use crate::types::{ConditionalType, FunctionShape, PropertyInfo};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
@@ -968,8 +966,7 @@ fn run_instantiator(
     instantiator.shallow_this_only = options.shallow_this_only();
     instantiator.this_type = request.this_type();
     let result = instantiator.instantiate(request.type_id());
-    let termination = InstantiationTermination::from_depth_exceeded(instantiator.depth_exceeded);
-    InstantiationResult::from_walk(result, termination)
+    InstantiationResult::from_walk(result, instantiator.termination())
 }
 
 /// Convenience function for instantiating a type with a substitution.
@@ -1365,8 +1362,7 @@ pub fn instantiate_type_with_depth_status(
     // Report the overflow verdict for callers that gate on it, but hand back
     // the relation-preserving bail value (never a substitution-bound free type
     // parameter) instead of the `TypeId::ERROR` sentinel (#13652).
-    let termination = InstantiationTermination::from_depth_exceeded(instantiator.depth_exceeded);
-    InstantiationResult::from_walk(result, termination)
+    InstantiationResult::from_walk(result, instantiator.termination())
 }
 
 /// Convenience function for instantiating a type while preserving meta-type

--- a/crates/tsz-solver/src/instantiation/instantiate/conditional.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/conditional.rs
@@ -30,7 +30,7 @@ impl<'a> TypeInstantiator<'a> {
                 let cond_type = self.interner.conditional(cond);
                 let mut results = Vec::with_capacity(2);
                 for &member in &[TypeId::BOOLEAN_TRUE, TypeId::BOOLEAN_FALSE] {
-                    if self.depth_exceeded {
+                    if self.has_depth_exceeded() {
                         return TypeId::ERROR;
                     }
                     let mut member_subst = self.substitution.clone();
@@ -51,12 +51,12 @@ impl<'a> TypeInstantiator<'a> {
                         )
                     };
                     if instantiated == TypeId::ERROR {
-                        self.depth_exceeded = true;
+                        self.mark_depth_exceeded();
                         return TypeId::ERROR;
                     }
                     let evaluated = self.evaluate_type(instantiated);
                     if evaluated == TypeId::ERROR {
-                        self.depth_exceeded = true;
+                        self.mark_depth_exceeded();
                         return TypeId::ERROR;
                     }
                     results.push(evaluated);
@@ -76,7 +76,7 @@ impl<'a> TypeInstantiator<'a> {
                 if members.len()
                     > crate::evaluation::evaluate_rules::conditional::MAX_CONDITIONAL_DISTRIBUTION_SIZE
                 {
-                    self.depth_exceeded = true;
+                    self.mark_depth_exceeded();
                     return TypeId::ERROR;
                 }
                 let cond_type = self.interner.conditional(cond);
@@ -89,7 +89,7 @@ impl<'a> TypeInstantiator<'a> {
                 let mut member_subst = self.substitution.clone();
                 for &member in members.iter() {
                     // Check depth before each distribution step
-                    if self.depth_exceeded {
+                    if self.has_depth_exceeded() {
                         return TypeId::ERROR;
                     }
                     member_subst.insert(info.name, member);
@@ -110,7 +110,7 @@ impl<'a> TypeInstantiator<'a> {
                     };
                     // Check if instantiation hit depth limit
                     if instantiated == TypeId::ERROR {
-                        self.depth_exceeded = true;
+                        self.mark_depth_exceeded();
                         return TypeId::ERROR;
                     }
                     // Don't evaluate here — the instantiator lacks a TypeResolver,

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -382,13 +382,32 @@ fn evaluation_engine_keeps_request_stage_boundary() {
             && instantiation_result_rs.contains("fn is_stable_for_project_cache(self) -> bool")
             && instantiation_api_rs.contains("ProjectInstantiationCacheLimitSnapshot::capture")
             && instantiation_api_rs.contains("InstantiationMemoResult::for_project_cache")
-            && instantiation_api_rs.contains("InstantiationTermination::from_depth_exceeded")
+            && instantiation_api_rs.contains("instantiator.termination()")
             && instantiation_api_rs.contains("is_stable_for_project_cache()")
             && !instantiation_result_rs.contains("overflowed: bool")
             && !instantiation_result_rs
                 .contains("fn from_walk(type_id: TypeId, depth_exceeded: bool)")
             && !instantiation_api_rs.contains("let limit_tripped ="),
         "project instantiation cache writes must consume InstantiationMemoResult stability instead of rebuilding a raw limit_tripped predicate"
+    );
+}
+
+#[test]
+fn instantiation_depth_state_is_named_at_the_walker_boundary() {
+    let instantiation_rs = read_solver_source("instantiation/instantiate.rs");
+    let instantiation_api_rs = read_solver_source("instantiation/instantiate/api.rs");
+
+    assert!(
+        instantiation_rs.contains("InstantiationWalkState")
+            && instantiation_rs.contains("fn has_depth_exceeded(&self) -> bool")
+            && instantiation_rs.contains("fn mark_depth_exceeded(&mut self)")
+            && instantiation_rs.contains("fn enter_frame(&mut self) -> InstantiationFrameState")
+            && instantiation_rs.contains("enum InstantiationFrameState")
+            && instantiation_api_rs.contains("instantiator.termination()")
+            && !instantiation_rs.contains("self.depth_exceeded = true")
+            && !instantiation_rs.contains("if self.depth_exceeded")
+            && !instantiation_api_rs.contains("instantiator.depth_exceeded"),
+        "instantiation overflow state must be owned by named walker-state helpers instead of direct depth_exceeded mutation"
     );
 }
 


### PR DESCRIPTION
Goal: green

## Summary
- introduce `InstantiationWalkState` and `InstantiationFrameState` as the owner for instantiation recursion-depth verdicts
- route conditional-distribution overflow and the instantiation result boundary through named helpers instead of direct `depth_exceeded` reads/writes
- add an architecture guard so the walker boundary stays typed

## Structural Rule
When type substitution hits its recursion-depth or solver-frame budget, `tsc` treats the instantiation as bounded and keeps a deferred/partial surface; tsz now records that through the solver instantiation walker state and existing `InstantiationResult` boundary while preserving the current partial `TypeId` fallback.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards instantiation_depth_state_is_named_at_the_walker_boundary` (red before implementation, green after)
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(instantiate) or test(instantiation)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: high