### PR TITLE
feat(solver): extend resolver rereduce to keyof instantiation (#14351)

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -838,19 +838,22 @@ pub(crate) fn instantiate_with_request_cached(
     allow_alpha_cache: bool,
     request: InstantiationRequest<'_>,
 ) -> InstantiationResult {
+    let resolver_rereduce_request = resolver_rereduce_instantiation_request(query_db);
     // Project-wide instantiation cache (#14345), consulted by ALL callers —
     // including the `query_db=None` evaluators that bypass the per-file
     // `QueryCache` instantiation cache and otherwise re-mint the same
     // `(body, subst, options, this_type)` walk. Sound because instantiation is
-    // pure structural substitution: the instantiator runs resolver-less
-    // (`with_query_db` forces `query_db=None`), `Lazy`/`TypeQuery` are leaves,
-    // and conditional/mapped bodies are not evaluated during the walk, so the
-    // result is a pure function of the key and the immutable interner —
-    // query_db-independent (proven by
-    // `instantiate_generic_cached_no_query_db_disables_cache`). The store-gate
-    // below refuses any result produced under a limit, mirroring the
-    // substitution-independent `closed_eval_cache`'s limit-gate set.
-    let proto_key = if project_instantiation_cache_enabled() {
+    // pure structural substitution in the default resolver-less mode:
+    // `Lazy`/`TypeQuery` are leaves, and conditional/mapped bodies are not
+    // evaluated during the walk, so the result is a pure function of the key and
+    // the immutable interner — query_db-independent (proven by
+    // `instantiate_generic_cached_no_query_db_disables_cache`). The staged
+    // resolver re-reduce mode deliberately breaks that purity by reading a
+    // caller-attached `DefinitionStore`, so it bypasses both project-wide and
+    // per-query instantiation caches. The store-gate below refuses any result
+    // produced under a limit, mirroring the substitution-independent
+    // `closed_eval_cache`'s limit-gate set.
+    let proto_key = if !resolver_rereduce_request && project_instantiation_cache_enabled() {
         let key = request.cache_key();
         if let Some(cached) = interner.lookup_proto_instantiation_cache(&key) {
             return InstantiationResult::ok(cached);
@@ -891,6 +894,9 @@ fn instantiate_with_request_cached_inner(
     request: InstantiationRequest<'_>,
 ) -> InstantiationResult {
     if let Some(db) = query_db {
+        if resolver_rereduce_instantiation_request(query_db) {
+            return run_instantiator(interner, query_db, request);
+        }
         let key = request.cache_key();
         if let Some(cached) = db.lookup_instantiation_cache(&key) {
             return InstantiationResult::ok(cached);
@@ -924,6 +930,11 @@ fn instantiate_with_request_cached_inner(
         return result;
     }
     run_instantiator(interner, query_db, request)
+}
+
+#[inline]
+fn resolver_rereduce_instantiation_request(query_db: Option<&dyn QueryDatabase>) -> bool {
+    query_db.is_some() && super::flags::inst_resolver_rereduce_enabled()
 }
 
 fn alpha_canonicalize_cached_result(

--- a/crates/tsz-solver/src/instantiation/instantiate/indexed.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/indexed.rs
@@ -2,6 +2,7 @@
 //! `TypeData::KeyOf`, `TypeData::TemplateLiteral`, and
 //! `TypeData::StringIntrinsic` arms of `instantiate_key`.
 
+use crate::construction::TypeDatabase;
 use crate::types::{
     IntrinsicKind, LiteralValue, StringIntrinsicKind, TemplateLiteralId, TemplateSpan, TypeData,
     TypeId,
@@ -76,35 +77,10 @@ impl<'a> TypeInstantiator<'a> {
         if self.preserve_meta_types {
             return self.interner.keyof(inst_operand);
         }
-        if matches!(
-            self.interner.lookup(inst_operand),
-            Some(
-                TypeData::TypeQuery(_)
-                    | TypeData::Lazy(_)
-                    | TypeData::Application(_)
-                    | TypeData::IndexAccess(_, _)
-            )
-        ) {
-            return self.interner.keyof(inst_operand);
-        }
-        // Union/intersection operands whose members are semantic refs
-        // (`Lazy(DefId)`), generic applications, or recursive aliases
-        // cannot be flattened to a finite key set by the resolver-less
-        // `evaluate_keyof` reached from this instantiation path: the
-        // member refs stay unresolved, so the keyof collapses to a
-        // deferred, structurally-detached form that loses the source's
-        // properties (and their optional/readonly modifiers) when the
-        // mapped type later expands. Keep the keyof deferred over the
-        // instantiated operand so the resolver-aware key extraction in
-        // `extract_mapped_keys`/`collect_properties` can resolve the
-        // member refs and recover the full key set. Fully concrete
-        // unions/intersections (e.g. `keyof ({ a: 1 } & { b: 2 })`)
-        // have no such refs and continue to evaluate eagerly below.
-        if matches!(
-            self.interner.lookup(inst_operand),
-            Some(TypeData::Union(_) | TypeData::Intersection(_))
-        ) && crate::type_queries::contains_lazy_or_recursive_db(self.interner, inst_operand)
-        {
+        if keyof_operand_needs_resolver(self.interner, inst_operand) {
+            if super::flags::inst_resolver_rereduce_enabled() && self.query_db.is_some() {
+                return self.evaluate_keyof(inst_operand);
+            }
             return self.interner.keyof(inst_operand);
         }
         // Evaluate immediately to expand keyof { a: 1 } -> "a"
@@ -198,5 +174,21 @@ impl<'a> TypeInstantiator<'a> {
         } else {
             string_intrinsic
         }
+    }
+}
+
+/// Check whether an instantiated `keyof` operand needs the outer resolver.
+fn keyof_operand_needs_resolver(interner: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    match interner.lookup(type_id) {
+        Some(
+            TypeData::Application(_)
+            | TypeData::Lazy(_)
+            | TypeData::TypeQuery(_)
+            | TypeData::IndexAccess(_, _),
+        ) => true,
+        Some(TypeData::Union(_) | TypeData::Intersection(_)) => {
+            crate::type_queries::contains_lazy_or_recursive_db(interner, type_id)
+        }
+        _ => false,
     }
 }

--- a/crates/tsz-solver/tests/instantiate_tests_parts/part_02.rs
+++ b/crates/tsz-solver/tests/instantiate_tests_parts/part_02.rs
@@ -39,3 +39,46 @@ fn cached_index_access_fast_path_uses_resolver_rereduce_when_flagged() {
         "flag-on fast path must enter the resolver-aware index re-reduce seam"
     );
 }
+
+#[test]
+fn instantiated_keyof_uses_store_backed_rereduce_when_flagged() {
+    let interner = TypeInterner::new();
+    let store = crate::def::DefinitionStore::new();
+    let def_id = DefId(143_571);
+    let property_name = interner.intern_string("ready");
+    let body = interner.object(vec![PropertyInfo::new(property_name, TypeId::STRING)]);
+    store.set_body(def_id, body);
+
+    let query_cache = crate::caches::query_cache::QueryCache::new(&interner)
+        .with_definition_store(&store);
+    let object_param_name = interner.intern_string("Obj");
+    let object_param = interner.type_param(TypeParamInfo {
+        name: object_param_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    let lazy = interner.lazy(def_id);
+    let keyed = interner.keyof(object_param);
+
+    let mut subst = TypeSubstitution::new();
+    subst.insert(object_param_name, lazy);
+
+    {
+        let _flag = super::flags::InstResolverRereduceFlagGuard::new(false);
+        let deferred = instantiate_type_cached(&interner, Some(&query_cache), keyed, &subst);
+        assert!(
+            matches!(interner.lookup(deferred), Some(TypeData::KeyOf(inner)) if inner == lazy),
+            "flag-off instantiation should preserve the historical deferred keyof"
+        );
+    }
+
+    let _flag = super::flags::InstResolverRereduceFlagGuard::new(true);
+    let reduced = instantiate_type_cached(&interner, Some(&query_cache), keyed, &subst);
+    assert_eq!(
+        reduced,
+        interner.literal_string_atom(property_name),
+        "flag-on instantiation must evaluate keyof through the store-backed resolver"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
- Extend the existing default-off `TSZ_INST_RESOLVER_REREDUCE` path from concrete indexed access to concrete `keyof` operands that still need resolver-owned semantic refs.
- Keep historical flag-off behavior: `keyof Lazy/Application/TypeQuery/IndexAccess` and lazy-bearing union/intersection operands still return deferred `KeyOf`.
- Bypass project-wide and per-query instantiation caches while the staged resolver re-reduce flag is active with a `QueryDatabase`, so resolver-dependent answers are not stored under resolver-independent keys.

## Structural Rule
When instantiation substitutes a generic so `keyof T` becomes concrete but the operand still contains resolver-only semantic refs, `tsc` reduces through the program declaration resolver. `tsz` keeps the resolver-less deferred result by default, and only under the staged resolver re-reduce gate asks the solver-owned `QueryDatabase`/store-backed evaluator to compute the key set. Resolver-dependent results must not publish into resolver-independent instantiation caches.

Owner layer: solver instantiation owns the request/cache policy and `keyof` re-reduce decision; `QueryCache`/`TypeEvaluator` remain the resolver-backed evaluation owner. No checker publication, module augmentation, diagnostics, emit, or project driver files are touched.

Adjacent matrix:
- Flag OFF: `keyof` over resolver-owned operands keeps returning deferred `KeyOf`.
- Flag ON + store-backed `QueryDatabase`: `keyof Lazy(DefId)` can resolve published body keys.
- Flag ON after a flag-OFF cache fill: resolver-dependent instantiation bypasses stale resolver-independent cache entries.
- Generic operands or `preserve_meta_types`: still defer as before.

Overlap notes:
- #15220 is a broader default-off HKT inference infra PR and currently conflict-marked; this PR is the smaller `keyof` instantiation/cache-purity slice on current `origin/main`.
- #15221 touches instantiation depth ownership in nearby files; this PR avoids depth-state and conditional-instantiation changes.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver instantiated_keyof_uses_store_backed_rereduce_when_flagged cached_index_access_fast_path_uses_resolver_rereduce_when_flagged query_database_store_backed_rereduce_resolves_published_lazy_body query_database_evaluate_entry_points_preserve_results`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver instantiated_keyof_uses_store_backed_rereduce_when_flagged cached_index_access_fast_path_uses_resolver_rereduce_when_flagged query_database_store_backed_rereduce_resolves_published_lazy_body query_database_evaluate_entry_points_preserve_results return_context_substitution_resolves_store_backed_lazy_application_bodies return_context_substitution_keeps_lazy_bodies_deferred_without_rereduce_flag`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `python3 scripts/arch/arch_guard.py --json`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `wc -l crates/tsz-solver/src/instantiation/instantiate/api.rs crates/tsz-solver/src/instantiation/instantiate/indexed.rs crates/tsz-solver/tests/instantiate_tests_parts/part_02.rs`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high