### PR TITLE
refactor(solver): own infer-match expansion session state (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -30,6 +30,7 @@ use crate::evaluation::result::EvaluationMemoResult;
 use crate::evaluation::result::EvaluationRequestStability;
 use crate::evaluation::result::EvaluationResult;
 use crate::evaluation::result::TerminationKind;
+use crate::evaluation::session::EvaluationSession;
 #[cfg(test)]
 #[allow(unused_imports)]
 use crate::instantiation::instantiate::instantiate_generic;
@@ -70,6 +71,8 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     interner: &'a dyn TypeDatabase,
     /// Optional query database for Salsa-backed memoization.
     query_db: Option<&'a dyn QueryDatabase>,
+    /// Optional owning session for cross-evaluator depth and memo state.
+    eval_session: Option<&'a EvaluationSession>,
     resolver: &'a R,
     no_unchecked_indexed_access: bool,
     cache: FxHashMap<TypeId, TypeId>,
@@ -298,6 +301,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         TypeEvaluator {
             interner,
             query_db: None,
+            eval_session: None,
             resolver,
             no_unchecked_indexed_access: false,
             cache: FxHashMap::default(),
@@ -453,6 +457,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Set the query database for Salsa-backed memoization.
     pub fn with_query_db(mut self, db: &'a dyn QueryDatabase) -> Self {
         self.query_db = Some(db);
+        self
+    }
+
+    /// Set the owning evaluation session for fresh evaluator recursion state.
+    #[must_use]
+    pub const fn with_evaluation_session(mut self, session: &'a EvaluationSession) -> Self {
+        self.eval_session = Some(session);
         self
     }
 
@@ -702,6 +713,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     #[inline]
     pub(crate) const fn query_db(&self) -> Option<&'a dyn QueryDatabase> {
         self.query_db
+    }
+
+    /// Get the owning evaluation session when one is available.
+    #[inline]
+    pub(crate) const fn evaluation_session(&self) -> Option<&'a EvaluationSession> {
+        self.eval_session
     }
 
     /// PERF: Look up a cached subtype result from conditional type evaluation.

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -152,6 +152,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         if let Some(query_db) = self.query_db() {
             checker = checker.with_query_db(query_db);
         }
+        if let Some(session) = self.evaluation_session() {
+            checker = checker.with_evaluation_session(session);
+        }
         checker
     }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -701,7 +701,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // never be published to the cross-evaluator cache (it would permanently
         // shadow the full answer a deeper-budget run derives). Carry that as a
         // typed publication verdict and consult it at the write site.
-        let probe = crate::evaluation::session::with_current_session(|session| {
+        let run_probe = |session: &crate::evaluation::session::EvaluationSession| {
             let depth_entry = session.enter_conditional_subtype_depth();
             let mut cache_stability = ConditionalBranchCacheStability::DepthAgnostic;
             // Classify against the unresolved-`Lazy` sentinel: a `false` produced
@@ -760,7 +760,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 }
             });
             ConditionalBranchProbeResult::new(relation, cache_stability)
-        });
+        };
+        let probe = if let Some(session) = self.evaluation_session() {
+            run_probe(session)
+        } else {
+            crate::evaluation::session::with_current_session(run_probe)
+        };
         // An `Undetermined` false consumed an unregistered `Lazy` body: do not
         // cache it and do not let it take the false branch — defer so a later
         // resolved pass decides the conditional (issue #14238). Definitive

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_match_expansion.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_match_expansion.rs
@@ -2,79 +2,14 @@
 
 use crate::def::DefId;
 use crate::evaluation::result::EvaluationMemoResult;
+use crate::evaluation::session::EvaluationSession;
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
 use crate::types::{TypeApplication, TypeData, TypeId};
 use rustc_hash::FxHashMap;
-use std::cell::Cell;
 use tsz_common::interner::Atom;
 
 use super::super::evaluate::TypeEvaluator;
 use super::infer_pattern::InferPatternVisited;
-
-thread_local! {
-    /// Cross-evaluator nesting depth for infer-pattern matching that expands an
-    /// `Application`/`Mapped` source or pattern in a fresh sub-evaluator.
-    ///
-    /// Infer matching cannot call `evaluate` on the current `&self` evaluator
-    /// (those methods take `&self`), so it spins up a brand-new `TypeEvaluator`
-    /// whose per-instance recursion guard, depth counter, and fuel all start at
-    /// zero. A recursive generic-wrapper application makes that expansion
-    /// re-enter conditional/infer evaluation at a deeper nesting through a new
-    /// evaluator each level, so no per-evaluator guard ever fires. This
-    /// thread-global counter bounds that cross-evaluator nesting.
-    static INFER_MATCH_EXPANSION_DEPTH: Cell<u32> = const { Cell::new(0) };
-}
-
-/// Maximum cross-evaluator nesting for infer-match sub-evaluator expansions.
-///
-/// Mirrors tsc's `instantiationDepth` cutoff (100): beyond this nesting, tsc
-/// abandons the instantiation, so tsz stops expanding too rather than recurse
-/// forever.
-pub(crate) const MAX_INFER_MATCH_EXPANSION_DEPTH: u32 = 100;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum InferMatchExpansionState {
-    Continue,
-    LimitExceeded,
-}
-
-pub(crate) const fn infer_match_expansion_state(depth: u32) -> InferMatchExpansionState {
-    if depth >= MAX_INFER_MATCH_EXPANSION_DEPTH {
-        InferMatchExpansionState::LimitExceeded
-    } else {
-        InferMatchExpansionState::Continue
-    }
-}
-
-/// RAII guard for [`INFER_MATCH_EXPANSION_DEPTH`].
-///
-/// `enter` returns `LimitExceeded` when the budget is exhausted (the caller must
-/// skip the expansion); otherwise it increments the counter and decrements it on
-/// drop, so the bound is restored even if evaluation unwinds via panic.
-struct InferMatchExpansionGuard;
-
-impl InferMatchExpansionGuard {
-    fn enter() -> Result<Self, InferMatchExpansionState> {
-        INFER_MATCH_EXPANSION_DEPTH.with(|depth| {
-            let current = depth.get();
-            match infer_match_expansion_state(current) {
-                InferMatchExpansionState::Continue => {
-                    depth.set(current + 1);
-                    Ok(Self)
-                }
-                InferMatchExpansionState::LimitExceeded => {
-                    Err(InferMatchExpansionState::LimitExceeded)
-                }
-            }
-        })
-    }
-}
-
-impl Drop for InferMatchExpansionGuard {
-    fn drop(&mut self) {
-        INFER_MATCH_EXPANSION_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
-    }
-}
 
 impl<R: TypeResolver> TypeEvaluator<'_, R> {
     /// Maximum iterations for alias-application reduction loops.
@@ -351,22 +286,35 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
     }
 
     /// Evaluate `type_id` in a fresh sub-evaluator during infer-pattern
-    /// matching, bounded by a thread-global cross-evaluator recursion budget.
+    /// matching, bounded by the owning evaluation session's cross-evaluator
+    /// expansion depth.
     pub(crate) fn evaluate_for_infer_match(&self, type_id: TypeId) -> TypeId {
-        let nuia = self.no_unchecked_indexed_access();
+        if let Some(session) = self.evaluation_session() {
+            return self.evaluate_for_infer_match_with_session(type_id, session);
+        }
         crate::evaluation::session::with_current_session(|session| {
-            crate::evaluation::cross_eval_guard::memoized_eval(session, type_id, nuia, || {
-                let Ok(_guard) = InferMatchExpansionGuard::enter() else {
-                    return EvaluationMemoResult::unstable_complete(type_id);
-                };
-                let mut evaluator = TypeEvaluator::with_resolver(self.interner(), self.resolver());
-                if let Some(query_db) = self.query_db() {
-                    evaluator = evaluator.with_query_db(query_db);
-                }
-                let request = crate::evaluation::request::EvaluationRequest::new(type_id)
-                    .with_no_unchecked_indexed_access(nuia);
-                evaluator.evaluate_request_memo_result(request)
-            })
+            self.evaluate_for_infer_match_with_session(type_id, session)
+        })
+    }
+
+    fn evaluate_for_infer_match_with_session(
+        &self,
+        type_id: TypeId,
+        session: &EvaluationSession,
+    ) -> TypeId {
+        let nuia = self.no_unchecked_indexed_access();
+        crate::evaluation::cross_eval_guard::memoized_eval(session, type_id, nuia, || {
+            let Ok(_entry) = session.enter_infer_match_expansion_depth() else {
+                return EvaluationMemoResult::unstable_complete(type_id);
+            };
+            let mut evaluator = TypeEvaluator::with_resolver(self.interner(), self.resolver())
+                .with_evaluation_session(session);
+            if let Some(query_db) = self.query_db() {
+                evaluator = evaluator.with_query_db(query_db);
+            }
+            let request = crate::evaluation::request::EvaluationRequest::new(type_id)
+                .with_no_unchecked_indexed_access(nuia);
+            evaluator.evaluate_request_memo_result(request)
         })
         .unwrap_or(type_id)
     }
@@ -374,60 +322,59 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        INFER_MATCH_EXPANSION_DEPTH, InferMatchExpansionGuard, InferMatchExpansionState,
-        MAX_INFER_MATCH_EXPANSION_DEPTH, infer_match_expansion_state,
+    use crate::evaluation::session::{
+        EvaluationSession, InferMatchExpansionDepthEntry, InferMatchExpansionDepthState,
     };
 
     #[test]
-    fn infer_match_expansion_state_allows_below_budget() {
-        assert_eq!(
-            infer_match_expansion_state(MAX_INFER_MATCH_EXPANSION_DEPTH - 1),
-            InferMatchExpansionState::Continue
-        );
-    }
-
-    #[test]
     fn infer_match_expansion_state_limits_at_budget() {
-        assert_eq!(
-            infer_match_expansion_state(MAX_INFER_MATCH_EXPANSION_DEPTH),
-            InferMatchExpansionState::LimitExceeded
-        );
-        assert_eq!(
-            infer_match_expansion_state(MAX_INFER_MATCH_EXPANSION_DEPTH + 1),
-            InferMatchExpansionState::LimitExceeded
-        );
-    }
-
-    #[test]
-    fn guard_bounds_cross_evaluator_expansion_depth() {
-        INFER_MATCH_EXPANSION_DEPTH.with(|depth| depth.set(0));
-
+        let session = EvaluationSession::new();
         let mut held = Vec::new();
-        for expected_prev in 0..MAX_INFER_MATCH_EXPANSION_DEPTH {
-            let guard =
-                InferMatchExpansionGuard::enter().expect("enter within budget must succeed");
-            held.push(guard);
-            assert_eq!(
-                INFER_MATCH_EXPANSION_DEPTH.with(std::cell::Cell::get),
-                expected_prev + 1
-            );
+        for expected_prev in 0..InferMatchExpansionDepthEntry::limit() {
+            let entry = session
+                .enter_infer_match_expansion_depth()
+                .expect("enter within budget must succeed");
+            assert_eq!(entry.prior_depth(), expected_prev);
+            held.push(entry);
+            assert_eq!(session.infer_match_expansion_depth(), expected_prev + 1);
         }
 
         assert!(
             matches!(
-                InferMatchExpansionGuard::enter(),
-                Err(InferMatchExpansionState::LimitExceeded)
+                session.enter_infer_match_expansion_depth(),
+                Err(InferMatchExpansionDepthState::LimitExceeded)
             ),
             "enter at the budget must be denied so the caller stops expanding"
         );
 
         held.clear();
-        assert_eq!(INFER_MATCH_EXPANSION_DEPTH.with(std::cell::Cell::get), 0);
+        assert_eq!(session.infer_match_expansion_depth(), 0);
         assert!(
-            InferMatchExpansionGuard::enter().is_ok(),
+            session.enter_infer_match_expansion_depth().is_ok(),
             "after unwinding, a fresh expansion must be allowed again"
         );
-        INFER_MATCH_EXPANSION_DEPTH.with(|depth| depth.set(0));
+    }
+
+    #[test]
+    fn infer_match_expansion_depth_is_session_local() {
+        let saturated = EvaluationSession::new();
+        let separate = EvaluationSession::new();
+        let mut held = Vec::new();
+        for _ in 0..InferMatchExpansionDepthEntry::limit() {
+            held.push(
+                saturated
+                    .enter_infer_match_expansion_depth()
+                    .expect("saturating session enters"),
+            );
+        }
+
+        assert!(matches!(
+            saturated.enter_infer_match_expansion_depth(),
+            Err(InferMatchExpansionDepthState::LimitExceeded)
+        ));
+        assert!(
+            separate.enter_infer_match_expansion_depth().is_ok(),
+            "a saturated infer-match depth in one session must not block another session"
+        );
     }
 }

--- a/crates/tsz-solver/src/evaluation/session.rs
+++ b/crates/tsz-solver/src/evaluation/session.rs
@@ -27,6 +27,9 @@ const MAX_GLOBAL_INSTANTIATION_FUEL: u32 = crate::limits::MAX_GLOBAL_INSTANTIATI
 /// Maximum re-entrant conditional-subtype relation depth.
 const MAX_CONDITIONAL_SUBTYPE_DEPTH: u32 = crate::limits::MAX_CONDITIONAL_SUBTYPE_DEPTH;
 
+/// Maximum infer-match fresh-evaluator expansion depth.
+const MAX_INFER_MATCH_EXPANSION_DEPTH: u32 = crate::limits::MAX_INFER_MATCH_EXPANSION_DEPTH;
+
 /// Whether the shared evaluation session can enter another instantiation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum EvaluationSessionLimitState {
@@ -39,6 +42,12 @@ impl EvaluationSessionLimitState {
     pub const fn is_exceeded(self) -> bool {
         !matches!(self, Self::WithinLimits)
     }
+}
+
+/// Whether infer-pattern matching may enter another fresh-evaluator expansion.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum InferMatchExpansionDepthState {
+    LimitExceeded,
 }
 
 /// Explicit evaluation session state.
@@ -57,6 +66,8 @@ pub struct EvaluationSession {
     /// Re-entrant conditional-subtype depth for
     /// `Evaluator -> SubtypeChecker -> Evaluator -> ...` chains.
     conditional_subtype_depth: Cell<u32>,
+    /// Cross-evaluator nesting depth for infer-pattern matching expansion.
+    infer_match_expansion_depth: Cell<u32>,
     /// `TypeId`s currently expanded by fresh evaluators in this session.
     cross_eval_active: RefCell<FxHashSet<TypeId>>,
     /// Per-top-level-query memo for stable fresh-evaluator results.
@@ -92,6 +103,38 @@ impl Drop for ConditionalSubtypeDepthEntry<'_> {
     }
 }
 
+/// RAII entry for one infer-pattern fresh-evaluator expansion in an
+/// [`EvaluationSession`].
+#[must_use]
+pub(crate) struct InferMatchExpansionDepthEntry<'a> {
+    session: &'a EvaluationSession,
+    #[cfg(test)]
+    prior_depth: u32,
+}
+
+impl InferMatchExpansionDepthEntry<'_> {
+    #[cfg(test)]
+    pub(crate) const fn prior_depth(&self) -> u32 {
+        self.prior_depth
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn limit() -> u32 {
+        MAX_INFER_MATCH_EXPANSION_DEPTH
+    }
+}
+
+impl Drop for InferMatchExpansionDepthEntry<'_> {
+    fn drop(&mut self) {
+        self.session.infer_match_expansion_depth.set(
+            self.session
+                .infer_match_expansion_depth
+                .get()
+                .saturating_sub(1),
+        );
+    }
+}
+
 impl EvaluationSession {
     /// Create a new session with all counters at zero.
     pub fn new() -> Self {
@@ -99,6 +142,7 @@ impl EvaluationSession {
             global_instantiation_depth: Cell::new(0),
             global_instantiation_fuel: Cell::new(0),
             conditional_subtype_depth: Cell::new(0),
+            infer_match_expansion_depth: Cell::new(0),
             cross_eval_active: RefCell::new(FxHashSet::default()),
             query_memo: RefCell::new(FxHashMap::default()),
         }
@@ -174,6 +218,30 @@ impl EvaluationSession {
     #[inline]
     pub(crate) const fn conditional_subtype_depth(&self) -> u32 {
         self.conditional_subtype_depth.get()
+    }
+
+    /// Enter one infer-match fresh-evaluator expansion.
+    #[inline]
+    pub(crate) fn enter_infer_match_expansion_depth(
+        &self,
+    ) -> Result<InferMatchExpansionDepthEntry<'_>, InferMatchExpansionDepthState> {
+        let prior_depth = self.infer_match_expansion_depth.get();
+        if prior_depth >= MAX_INFER_MATCH_EXPANSION_DEPTH {
+            return Err(InferMatchExpansionDepthState::LimitExceeded);
+        }
+        self.infer_match_expansion_depth.set(prior_depth + 1);
+        Ok(InferMatchExpansionDepthEntry {
+            session: self,
+            #[cfg(test)]
+            prior_depth,
+        })
+    }
+
+    /// Current infer-match fresh-evaluator expansion depth.
+    #[cfg(test)]
+    #[inline]
+    pub(crate) const fn infer_match_expansion_depth(&self) -> u32 {
+        self.infer_match_expansion_depth.get()
     }
 
     /// Enter cross-evaluator expansion of `type_id`.

--- a/crates/tsz-solver/src/limits/mod.rs
+++ b/crates/tsz-solver/src/limits/mod.rs
@@ -40,6 +40,7 @@
 //! | Conditional tail-recursion loop (`evaluation/evaluate_rules/conditional.rs`) | [`MAX_TAIL_RECURSION_DEPTH`] = 1000 | `getConditionalType` `tailCount` 1000 (exact parity) | `TS2589` + `ERROR` | tail-recursive conditional tests |
 //! | Cross-evaluator stack depth, thread-local (this module) | [`MAX_GLOBAL_EVAL_DEPTH`] = 200 live frames | none (fresh-instance artifact) | silent opaque bail (`mark_silent_depth_bailed`) | deep `implements` chains |
 //! | Conditional subtype relation depth, `EvaluationSession` (`evaluation/session.rs`) | [`MAX_CONDITIONAL_SUBTYPE_DEPTH`] = 50 re-entrant branch probes | `instantiationDepth` adjacent | conservative false, not published to branch cache | recursive conditional subtype probes |
+//! | Infer-match fresh-evaluator expansion depth, `EvaluationSession` (`evaluation/session.rs`) | [`MAX_INFER_MATCH_EXPANSION_DEPTH`] = 100 nested expansions | `instantiationDepth` | leave source/pattern opaque and skip infer expansion | recursive conditional/`infer` wrappers |
 //! | Per-query eval op budget, thread-local (this module) | [`DEFAULT_MAX_EVAL_OPS_PER_QUERY`] = 2M ops per top-level query (`TSZ_MAX_EVAL_OPS` override) | `instantiationCount` (5M) per checked element | silent opaque bail | `Unbox`/`Awaited` runaway tests (`query_budget`) |
 //! | Per-file evaluation fuel, thread-local (this module) | [`MAX_EVALUATION_FUEL`] = 2M, sampled every [`EVAL_FUEL_CHECK_INTERVAL`] = 128 guard iterations | `instantiationCount` (5M; tsz lower because eager expansion is heavier) | `TS2589`-style `ERROR` bail | ts-toolbelt corpus, #13172/#13181 |
 //! | `TypeInstantiator.depth` per-instance (`instantiation/instantiate.rs`) | [`MAX_TYPE_SUBSTITUTION_DEPTH`] = 50 | `instantiateType` recursion (tsc `instantiationDepth` = 100; see note below) | sticky `depth_exceeded`, returns input type opaque | recursive generic instantiation tests |
@@ -164,6 +165,12 @@ pub(crate) const MAX_GLOBAL_EVAL_DEPTH: u32 = 200;
 /// session. Exhaustion conservatively treats the relation as false and marks
 /// the result budget-bounded so it is not published to the branch cache.
 pub(crate) const MAX_CONDITIONAL_SUBTYPE_DEPTH: u32 = 50;
+
+/// Maximum cross-evaluator nesting for infer-match sub-evaluator expansion.
+/// Mirrors tsc's `instantiationDepth` cutoff: beyond this nesting, tsz leaves
+/// the source or pattern unchanged instead of recursing through another fresh
+/// evaluator with empty per-instance guards.
+pub(crate) const MAX_INFER_MATCH_EXPANSION_DEPTH: u32 = 100;
 
 /// Total `evaluate` operations permitted for a single top-level evaluation
 /// query (the outermost `evaluate` call on the thread, before it returns).

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/evaluation.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/evaluation.rs
@@ -71,7 +71,8 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
             type_id,
             no_unchecked_indexed_access,
             || {
-                let mut evaluator = TypeEvaluator::with_resolver(self.interner, self.resolver);
+                let mut evaluator = TypeEvaluator::with_resolver(self.interner, self.resolver)
+                    .with_evaluation_session(session);
                 if let Some(db) = self.query_db {
                     evaluator = evaluator.with_query_db(db);
                 }

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -409,6 +409,29 @@ fn subtype_function_fresh_evaluators_use_explicit_session() {
 }
 
 #[test]
+fn infer_match_fresh_evaluators_use_explicit_session_depth() {
+    let session_rs = read_solver_source("evaluation/session.rs");
+    let infer_match_expansion_rs =
+        read_solver_source("evaluation/evaluate_rules/infer_match_expansion.rs");
+    let evaluate_rs = read_solver_source("evaluation/evaluate.rs");
+    let conditional_rs = read_solver_source("evaluation/evaluate_rules/conditional.rs");
+
+    assert!(
+        session_rs.contains("infer_match_expansion_depth: Cell<u32>")
+            && session_rs.contains("enter_infer_match_expansion_depth")
+            && session_rs.contains("InferMatchExpansionDepthEntry")
+            && evaluate_rs.contains("eval_session: Option<&'a EvaluationSession>")
+            && evaluate_rs.contains("with_evaluation_session")
+            && infer_match_expansion_rs.contains("session.enter_infer_match_expansion_depth()")
+            && infer_match_expansion_rs.contains(".with_evaluation_session(session)")
+            && conditional_rs.contains("checker = checker.with_evaluation_session(session)")
+            && !infer_match_expansion_rs.contains("thread_local!")
+            && !infer_match_expansion_rs.contains("INFER_MATCH_EXPANSION_DEPTH"),
+        "infer-match fresh evaluators must route expansion depth through the owning EvaluationSession instead of a module-local thread-local counter"
+    );
+}
+
+#[test]
 fn subtype_reduction_cache_keeps_bct_request_boundary() {
     let cache_rs = read_solver_source("caches/subtype_reduction_cache.rs");
     let expression_ops_rs = read_solver_source("operations/expression_ops.rs");


### PR DESCRIPTION
Goal: green

## Summary
- Move infer-pattern fresh-evaluator expansion depth from a module-local `thread_local!` into `EvaluationSession`.
- Thread explicit evaluation sessions through relation-side fresh evaluators, conditional branch subtype checkers, and nested infer-match evaluators while preserving the current thread-default fallback for standalone evaluator entry points.
- Add session-local depth tests plus an architecture guard preventing infer-match expansion from reintroducing local TLS state.

## Structural Rule
When infer-pattern matching expands an application/source/pattern through fresh evaluators, `tsc` applies one instantiation-depth budget for the recursive evaluation chain. `tsz` now owns that cross-evaluator expansion depth in `EvaluationSession`: below the cap it expands through the existing fresh evaluator path; at the cap it preserves the existing unchanged-input fallback and skips publishing an unstable memo result.

Owner layer: solver evaluation session and fresh-evaluator boundaries. Checker/relation callers only pass the existing session through; no checker type semantics or diagnostic policy changes.

Adjacent matrix:
- Infer-match expansion below the cap increments and restores session depth through RAII.
- At the exact cap, expansion returns the existing `EvaluationMemoResult::unstable_complete(type_id)` fallback.
- Separate sessions do not block each other when one session saturates the infer-match expansion depth.
- Relation-side subtype evaluation and conditional branch subtype probes preserve their explicit session into nested evaluators.
- Standalone evaluator APIs still fall back to the thread default session for compatibility.

Overlap: avoids the active env-authority PR files, instantiation files, query-cache/HKT resolver files, generic-call/call-args files, and variadic tuple diagnostic files from #15219/#15222/#15220/#15221/#15217.

Refs #14351 and #14346.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver infer_match conditional_subtype_depth_guard_tests infer_match_fresh_evaluators_use_explicit_session_depth subtype_function_fresh_evaluators_use_explicit_session`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
