### PR TITLE
fix(emit): capture defaulted leaf once in inline nested es5 destructuring (#14766)

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/bindings.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings.rs
@@ -1627,18 +1627,28 @@ impl<'a> Printer<'a> {
         }
 
         self.write(", ");
-        self.write_binding_identifier_text(child_elem.name);
-        self.write(" = ");
-        self.write(source_name);
-        self.write(".");
-        self.write_identifier_text(key_idx);
         if child_elem.initializer.is_some() {
+            // Capture the leaf member access into a temp so it is evaluated once.
+            // A non-identifier source (call/object literal) or a getter with side
+            // effects must not be re-read; mirror tsc's
+            // `_c = _b.b, b = _c === void 0 ? init : _c` (matching the already-correct
+            // `_node` variant below and the multi-element path in bindings_patterns.rs).
+            let value_name = self.get_temp_var_name();
+            self.write(&value_name);
+            self.write(" = ");
+            self.emit_assignment_target_es5_with_computed(key_idx, source_name, None);
+            self.write(", ");
+            self.write_binding_identifier_text(child_elem.name);
+            self.write(" = ");
+            self.write(&value_name);
             self.write(" === void 0 ? ");
             self.emit_expression(child_elem.initializer);
             self.write(" : ");
-            self.write(source_name);
-            self.write(".");
-            self.write_identifier_text(key_idx);
+            self.write(&value_name);
+        } else {
+            self.write_binding_identifier_text(child_elem.name);
+            self.write(" = ");
+            self.emit_assignment_target_es5_with_computed(key_idx, source_name, None);
         }
         true
     }

--- a/crates/tsz-emitter/tests/destructuring_es5_nested_single_inline_tests.rs
+++ b/crates/tsz-emitter/tests/destructuring_es5_nested_single_inline_tests.rs
@@ -128,6 +128,73 @@ fn array_nested_single_binding_inlines_alongside_object_rest_sibling() {
 }
 
 #[test]
+fn object_nested_single_with_intermediate_default_captures_leaf_default_once() {
+    // Repro for #14766: a single top-level nested element with an intermediate
+    // default (`{ ... } = {}`) and a defaulted leaf, sourced from a
+    // NON-identifier expression (a call). tsc captures the leaf member access in
+    // one temp before applying the default; tsz used to re-read `.bee` twice, so
+    // a getter with side effects would fire twice.
+    let source = "declare function get(): { a?: { bee?: number } };\n\
+         const { a: { bee = 1 } = {} } = get();\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    // The leaf `.bee` member access must be read exactly once (into a temp), and
+    // the `=== void 0` default test must reference that temp, never the member
+    // access itself (the double-eval signature `X.bee === void 0 ? 1 : X.bee`).
+    assert!(
+        !output.contains(".bee === void 0"),
+        "The defaulted leaf must test a captured temp, not re-read `.bee`.\n\
+         Output:\n{output}"
+    );
+    assert_eq!(
+        output.matches(".bee").count(),
+        1,
+        "The leaf member access `.bee` must be emitted exactly once.\n\
+         Output:\n{output}"
+    );
+}
+
+#[test]
+fn object_nested_single_with_intermediate_default_object_literal_source_captures_once() {
+    // Same shape as above but sourced from an object literal (also a
+    // non-identifier expression). The leaf default must still capture once.
+    let source = "const { a: { bee = 1 } = {} } = { a: { bee: 5 } };\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        !output.contains(".bee === void 0"),
+        "Object-literal source: defaulted leaf must test a captured temp.\n\
+         Output:\n{output}"
+    );
+    assert_eq!(
+        output.matches(".bee").count(),
+        1,
+        "Object-literal source: `.bee` must be emitted exactly once.\n\
+         Output:\n{output}"
+    );
+}
+
+#[test]
+fn object_nested_single_with_intermediate_default_no_leaf_default_reads_once() {
+    // Regression guard for the no-default branch of the same inline path: the
+    // leaf without a default must still be a single inline read (no temp, no
+    // `=== void 0` test on the member access).
+    let source = "declare function get(): { a?: { bee?: number } };\n\
+         const { a: { bee } = {} } = get();\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        !output.contains(".bee === void 0"),
+        "A non-defaulted leaf must not gain a `=== void 0` test.\nOutput:\n{output}"
+    );
+    assert_eq!(
+        output.matches(".bee").count(),
+        1,
+        "A non-defaulted leaf must read `.bee` exactly once.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn multi_element_nested_pattern_keeps_intermediate_temp() {
     // Sanity: a nested pattern with more than one binding still materializes the
     // source once into a temp (`numElements !== 1`) — unchanged behaviour.


### PR DESCRIPTION
Fixes #14766.

## Summary
At `--target es5`, a single top-level nested object-destructuring element with an intermediate default and a defaulted leaf (`{ a: { b = 1 } = {} }`) that is sourced from a **non-identifier expression** (a call, an object literal, …) re-read the leaf member access twice — `_b.b === void 0 ? 1 : _b.b`. When `_b.b` is a getter with side effects tsz invoked it twice, a real behavioral divergence from `tsc`, which captures the leaf into a temp once.

### Repro
```ts
declare function get(): { a?: { b?: number } };
const { a: { b = 1 } = {} } = get();
```
`--target es5`:
- tsz (before): `var _a = get().a, _b = _a === void 0 ? {} : _a, b = _b.b === void 0 ? 1 : _b.b;`
- tsc 5.9.3:     `var _a = get().a, _b = _a === void 0 ? {} : _a, _c = _b.b, b = _c === void 0 ? 1 : _c;`

## Structural rule
When a nested object-destructuring leaf has a default and its source is a non-identifier expression, `tsc` binds the leaf member access to a fresh temp once and applies the default against that temp (`_c = _b.b, b = _c === void 0 ? init : _c`) so a side-effecting getter fires exactly once. tsz now does the same through the emitter's ES5 binding path — `emit_single_object_binding_inline_nested_object` in `crates/tsz-emitter/src/emitter/es5/bindings.rs` captures the leaf into a `get_temp_var_name()` temp before the default test, matching the already-correct sibling paths (`emit_single_object_binding_inline_nested_object_node`, the inline-simple path, and the multi-element path in `bindings_patterns.rs`).

Owner layer: emitter ES5 binding lowering. No semantic validation, no output surgery.

## Adjacent cases
- Call source (`get()`) and object-literal source (`{ a: { b: 5 } }`): both now capture the leaf once.
- No-default leaf on the same inline path: unchanged single inline read.
- Identifier source: already correct (different path), unaffected.
- Both branches now emit the member access through the shared `emit_assignment_target_es5_with_computed` helper (identifier/computed/literal keys), removing hand-rolled duplication.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --test destructuring_es5_nested_single_inline_tests` — 10 pass (3 new regression tests: call-sourced repro, object-literal-sourced, no-default branch)
- `cargo test -p tsz-emitter` destructuring targets (array-nested-order, assignment-shorthand-default, catch-clause, object-rest-param-ordering, cjs-destructuring-export-inline) — all pass
- `cargo test -p tsz-emitter --lib destructur` — 91 pass
- `cargo fmt --all --check`; `git diff --check`
- `cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings` — clean
- `python3 scripts/arch/arch_guard.py --json` — passed; `bindings.rs` = 1861 lines (< 2000)
- ready-review CI owns broad conformance/emit baselines

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01V137T94dgDu2w721uziZpS)_