### PR TITLE
refactor(checker): stamp optional-chain caches by resolver generation (#14351)

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping_tests.rs
+++ b/crates/tsz-checker/src/context/def_mapping_tests.rs
@@ -5,7 +5,7 @@ use super::super::{CheckerContext, CheckerOptions};
 use std::sync::Arc;
 use tsz_binder::BinderState;
 use tsz_parser::parser::ParserState;
-use tsz_solver::computation::TypeEnvironment;
+use tsz_solver::computation::{TypeEnvironment, TypeResolver};
 use tsz_solver::construction::TypeInterner;
 use tsz_solver::def::DefinitionInfo;
 
@@ -129,6 +129,56 @@ fn ensure_both_envs_is_generation_idempotent_on_repeated_calls() {
         ctx.type_environment.borrow().generation(),
         gen_flow,
         "type_environment generation must not change on idempotent reinstall"
+    );
+}
+
+#[test]
+fn checker_context_resolver_generation_tracks_env_and_symbol_cache_state() {
+    use tsz_binder::SymbolId;
+    use tsz_solver::{SymbolRef, TypeId};
+
+    let (arena, binder, types) = minimal_checker_ctx();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    let initial = TypeResolver::resolver_generation(&ctx);
+
+    ctx.type_env
+        .borrow_mut()
+        .insert(SymbolRef(1), TypeId::STRING);
+    let after_eval_env = TypeResolver::resolver_generation(&ctx);
+    assert!(
+        after_eval_env > initial,
+        "authoritative env mutations must move the resolver generation"
+    );
+
+    ctx.type_environment
+        .borrow_mut()
+        .insert(SymbolRef(2), TypeId::NUMBER);
+    let after_flow_env = TypeResolver::resolver_generation(&ctx);
+    assert!(
+        after_flow_env > after_eval_env,
+        "flow env mutations must move the resolver generation"
+    );
+
+    ctx.symbol_types.insert(SymbolId(1), TypeId::BOOLEAN);
+    let after_symbol_type = TypeResolver::resolver_generation(&ctx);
+    assert!(
+        after_symbol_type > after_flow_env,
+        "`symbol_types` mutations must move the resolver generation"
+    );
+
+    ctx.symbol_instance_types
+        .insert(SymbolId(2), TypeId::BIGINT);
+    let after_symbol_instance = TypeResolver::resolver_generation(&ctx);
+    assert!(
+        after_symbol_instance > after_symbol_type,
+        "`symbol_instance_types` mutations must move the resolver generation"
     );
 }
 

--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -709,6 +709,26 @@ impl<'a> CheckerContext<'a> {
 /// - Cache is populated by `CheckerState::get_type_of_symbol()` before Application evaluation
 /// - This separation keeps the solver layer (`ApplicationEvaluator`) independent of checker logic
 impl<'a> TypeResolver for CheckerContext<'a> {
+    /// Monotone stamp for resolver-visible checker state.
+    ///
+    /// Optional-chain and property caches need to distinguish results computed
+    /// before and after lazy definitions or symbol-type caches materialize. The
+    /// checker owns two resolver environments plus value/type symbol caches, so
+    /// fold the same components used by assignability memo stamps into the
+    /// solver-facing generation.
+    fn resolver_generation(&self) -> u64 {
+        let env_generation = self.type_env.try_borrow().map_or(0, |env| env.generation());
+        let environment_generation = self
+            .type_environment
+            .try_borrow()
+            .map_or(0, |env| env.generation());
+
+        env_generation
+            .saturating_add(environment_generation)
+            .saturating_add(self.symbol_types.version())
+            .saturating_add(self.symbol_instance_types.version())
+    }
+
     /// Resolve a symbol reference to its cached type (deprecated).
     ///
     /// `TypeData::Ref` is removed, but we keep this for compatibility.

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -15,6 +15,8 @@ use tsz_solver::TypeId;
 
 #[path = "access/global_this_keyed.rs"]
 mod global_this_keyed;
+#[path = "access/invalid_target.rs"]
+mod invalid_target;
 #[path = "access/optional_chain.rs"]
 mod optional_chain;
 #[path = "access/symbol_constructor_index.rs"]
@@ -92,6 +94,11 @@ impl<'a> CheckerState<'a> {
         } else {
             index_type_for_access
         };
+
+        if self.optional_chain_invalid_assignment_target_context(idx) {
+            let _ = self.get_type_of_node_with_request(access.expression, &read_request);
+            return TypeId::ANY;
+        }
 
         // Get the type of the object. In write context, prefer the receiver's
         // declared type when it already has the indexed member, otherwise fall

--- a/crates/tsz-checker/src/types/computation/access/invalid_target.rs
+++ b/crates/tsz-checker/src/types/computation/access/invalid_target.rs
@@ -2,7 +2,7 @@ use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 
-impl<'a> CheckerState<'a> {
+impl CheckerState<'_> {
     pub(crate) fn optional_chain_invalid_assignment_target_context(&self, idx: NodeIndex) -> bool {
         if !super::optional_chain::is_optional_chain(self.ctx.arena, idx) {
             return false;

--- a/crates/tsz-checker/src/types/computation/access/invalid_target.rs
+++ b/crates/tsz-checker/src/types/computation/access/invalid_target.rs
@@ -1,0 +1,85 @@
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> CheckerState<'a> {
+    pub(crate) fn optional_chain_invalid_assignment_target_context(&self, idx: NodeIndex) -> bool {
+        if !super::optional_chain::is_optional_chain(self.ctx.arena, idx) {
+            return false;
+        }
+
+        let mut current = idx;
+        loop {
+            if self.property_access_is_direct_write_target(current) {
+                return true;
+            }
+
+            let Some(parent) = self.ctx.arena.parent_of(current) else {
+                return false;
+            };
+            let Some(parent_node) = self.ctx.arena.get(parent) else {
+                return false;
+            };
+
+            if (parent_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                || parent_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
+                && self
+                    .ctx
+                    .arena
+                    .get_access_expr(parent_node)
+                    .is_some_and(|access| access.expression == current)
+            {
+                current = parent;
+                continue;
+            }
+
+            if (parent_node.kind == syntax_kind_ext::FOR_IN_STATEMENT
+                || parent_node.kind == syntax_kind_ext::FOR_OF_STATEMENT)
+                && self
+                    .ctx
+                    .arena
+                    .get_for_in_of(parent_node)
+                    .is_some_and(|for_data| for_data.initializer == current)
+            {
+                return true;
+            }
+
+            if self.ctx.in_destructuring_target {
+                if parent_node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT
+                    && self
+                        .ctx
+                        .arena
+                        .get_property_assignment(parent_node)
+                        .is_some_and(|prop| prop.initializer == current)
+                {
+                    return true;
+                }
+
+                if parent_node.kind == syntax_kind_ext::SPREAD_ELEMENT
+                    || parent_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT
+                {
+                    let spread_expr = self
+                        .ctx
+                        .arena
+                        .get_spread(parent_node)
+                        .map(|spread| spread.expression)
+                        .or_else(|| {
+                            self.ctx
+                                .arena
+                                .get_unary_expr_ex(parent_node)
+                                .map(|unary| unary.expression)
+                        });
+                    if spread_expr == Some(current) {
+                        return true;
+                    }
+                }
+
+                if parent_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/crates/tsz-checker/src/types/property_access_type/optional_fast_path.rs
+++ b/crates/tsz-checker/src/types/property_access_type/optional_fast_path.rs
@@ -57,20 +57,22 @@ impl<'a> CheckerState<'a> {
         let prop_atom = self.ctx.types.intern_string(property_name);
 
         // TOP-LEVEL CACHE: check the dedicated optional_chain_cache first.
-        // This is keyed by (object_type_with_nullish, prop_atom) and stores
-        // the FINAL result including undefined union. On cache hit, we skip
+        // This is keyed by (object_type_with_nullish, prop_atom,
+        // resolver_generation) and stores the FINAL result including undefined
+        // union. On cache hit, we skip
         // split_nullish, resolve_type, contains_type_params, property lookup,
         // and union2, eliminating repeated RefCell borrows and HashMap lookups.
         // Only used when flow narrowing is skipped (skip_result_flow_for_result),
         // which guarantees the result is context-independent.
+        let cache_generation = TypeResolver::resolver_generation(&self.ctx);
         if skip_result_flow_for_result
-            && let Some(&cached) = self
+            && let Some(cached) = self
                 .ctx
                 .flow_shared
                 .narrowing_cache
                 .optional_chain_cache
                 .borrow()
-                .get(&(object_type, prop_atom))
+                .get(&(object_type, prop_atom), cache_generation)
         {
             return Some(cached);
         }
@@ -139,7 +141,7 @@ impl<'a> CheckerState<'a> {
                     .narrowing_cache
                     .optional_chain_cache
                     .borrow_mut()
-                    .insert((object_type, prop_atom), result_type);
+                    .insert((object_type, prop_atom), resolver_generation, result_type);
             }
             return Some(self.finalize_property_access_result(
                 idx,
@@ -223,7 +225,7 @@ impl<'a> CheckerState<'a> {
                         .narrowing_cache
                         .optional_chain_cache
                         .borrow_mut()
-                        .insert((object_type, prop_atom), result_type);
+                        .insert((object_type, prop_atom), resolver_generation, result_type);
                 }
                 if let Some(key) = optional_property_chain_cache_key {
                     self.ctx
@@ -231,7 +233,7 @@ impl<'a> CheckerState<'a> {
                         .narrowing_cache
                         .optional_property_chain_cache
                         .borrow_mut()
-                        .insert(key.clone(), result_type);
+                        .insert(key.clone(), resolver_generation, result_type);
                 }
                 Some(self.finalize_property_access_result(
                     idx,

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -56,19 +56,26 @@ impl<'a> CheckerState<'a> {
             let _ = self.get_type_of_node(access.expression);
             return TypeId::ERROR;
         }
+
+        if self.optional_chain_invalid_assignment_target_context(idx) {
+            let read_request = request.read().normal_origin().contextual_opt(None);
+            let _ = self.get_type_of_node_with_request(access.expression, &read_request);
+            return TypeId::ANY;
+        }
+
         let optional_property_chain_cache_key =
             self.optional_property_chain_cache_key(idx, request);
         let optional_property_chain_cache_generation = TypeResolver::resolver_generation(&self.ctx);
-        if let Some(key) = optional_property_chain_cache_key.as_ref()
-            && let Some(cached) = self
+        if let Some(key) = optional_property_chain_cache_key.as_ref() {
+            let cache = self
                 .ctx
                 .flow_shared
                 .narrowing_cache
                 .optional_property_chain_cache
-                .borrow()
-                .get(key, optional_property_chain_cache_generation)
-        {
-            return cached;
+                .borrow();
+            if let Some(cached) = cache.get(key, optional_property_chain_cache_generation) {
+                return cached;
+            }
         }
 
         if let Some(type_id) = self.partial_object_literal_initializer_property_type(

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -4,6 +4,7 @@
 //! all property access type resolution including optional chaining, enum/namespace
 //! fast paths, class member access, and diagnostic emission.
 use crate::context::TypingRequest;
+use crate::query_boundaries::common::TypeResolver;
 use crate::query_boundaries::property_access as access_query;
 use crate::state::CheckerState;
 use tsz_binder::symbol_flags;
@@ -57,14 +58,15 @@ impl<'a> CheckerState<'a> {
         }
         let optional_property_chain_cache_key =
             self.optional_property_chain_cache_key(idx, request);
+        let optional_property_chain_cache_generation = TypeResolver::resolver_generation(&self.ctx);
         if let Some(key) = optional_property_chain_cache_key.as_ref()
-            && let Some(&cached) = self
+            && let Some(cached) = self
                 .ctx
                 .flow_shared
                 .narrowing_cache
                 .optional_property_chain_cache
                 .borrow()
-                .get(key)
+                .get(key, optional_property_chain_cache_generation)
         {
             return cached;
         }

--- a/crates/tsz-solver/src/narrowing/cache.rs
+++ b/crates/tsz-solver/src/narrowing/cache.rs
@@ -12,6 +12,8 @@ type DiscriminantIndex = FxHashMap<(TypeId, Atom), Arc<DiscriminantMembers>>;
 type PropertyCacheKey = (TypeId, Atom);
 type NarrowedPropertyCache = GenerationMemo<PropertyCacheKey, Option<CachedPropertyType>>;
 type RequiredPropertyCache = GenerationMemo<PropertyCacheKey, bool>;
+type OptionalChainCache = GenerationMemo<PropertyCacheKey, TypeId>;
+type OptionalPropertyChainCache = GenerationMemo<OptionalPropertyChainKey, TypeId>;
 
 /// Cache key for a successful identifier-rooted optional property chain.
 ///
@@ -115,19 +117,21 @@ pub struct NarrowingCache {
     /// Cache for "type contains type parameters" checks.
     pub contains_type_parameters_cache: RefCell<FxHashMap<TypeId, bool>>,
     /// Cache for optional chain property access results.
-    /// Keyed by `(object_type_with_nullish, property_atom)` -> final result `TypeId`.
+    /// Keyed by `(object_type_with_nullish, property_atom, resolver_generation)`
+    /// -> final result `TypeId`.
     /// Unlike `property_cache` which is keyed by resolved (non-nullish) base type,
     /// this caches the COMPLETE result including nullish union and undefined addition.
     /// This skips `split_nullish`, `resolve_type`, `contains_type_params`, and property
     /// lookup on cache hits, eliminating 4+ `RefCell` borrows per repeated access.
-    pub optional_chain_cache: RefCell<FxHashMap<(TypeId, Atom), TypeId>>,
+    pub optional_chain_cache: RefCell<OptionalChainCache>,
     /// Cache for full optional property chains such as
     /// `options?.nested?.transport?.backoff?.base`.
     ///
-    /// This is keyed by semantic root type and atomized path rather than by AST
-    /// node, so repeated textual chains in generated code can reuse the final
-    /// successful read result without re-walking every segment.
-    pub optional_property_chain_cache: RefCell<FxHashMap<OptionalPropertyChainKey, TypeId>>,
+    /// This is keyed by semantic root type, atomized path, and resolver
+    /// generation rather than by AST node, so repeated textual chains in
+    /// generated code can reuse the final successful read result without
+    /// re-walking every segment while still observing lazy resolver changes.
+    pub optional_property_chain_cache: RefCell<OptionalPropertyChainCache>,
     /// Cache for contextual type resolution in object literal property typing.
     /// Maps raw contextual `TypeId` -> fully resolved `TypeId` after the
     /// evaluate/resolve/lazy/application chain. Avoids repeating the expensive
@@ -260,14 +264,8 @@ impl NarrowingCache {
                 1024,
                 FxBuildHasher,
             )),
-            optional_chain_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
-                512,
-                FxBuildHasher,
-            )),
-            optional_property_chain_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
-                512,
-                FxBuildHasher,
-            )),
+            optional_chain_cache: RefCell::new(GenerationMemo::default()),
+            optional_property_chain_cache: RefCell::new(GenerationMemo::default()),
             contextual_resolve_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
                 256,
                 FxBuildHasher,
@@ -294,6 +292,8 @@ impl NarrowingCache {
         let narrow_subtype_cache = self.narrow_subtype_cache.borrow();
         let generation_stamped_cache_keys = property_cache.key_count()
             + required_property_cache.key_count()
+            + self.optional_chain_cache.borrow().key_count()
+            + self.optional_property_chain_cache.borrow().key_count()
             + narrow_type_cache.key_count()
             + narrow_excluding_cache.key_count()
             + narrow_assignable_cache.key_count()
@@ -301,6 +301,10 @@ impl NarrowingCache {
         let max_generation_slots_per_cache_key = [
             property_cache.max_slots_per_key(),
             required_property_cache.max_slots_per_key(),
+            self.optional_chain_cache.borrow().max_slots_per_key(),
+            self.optional_property_chain_cache
+                .borrow()
+                .max_slots_per_key(),
             narrow_type_cache.max_slots_per_key(),
             narrow_excluding_cache.max_slots_per_key(),
             narrow_assignable_cache.max_slots_per_key(),
@@ -371,21 +375,14 @@ impl NarrowingCache {
         }
         {
             let map = self.optional_chain_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<(TypeId, Atom)>()
-                    + std::mem::size_of::<TypeId>());
+            size += map.estimated_size_bytes(BUCKET_OVERHEAD);
         }
         {
             let map = self.optional_property_chain_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<OptionalPropertyChainKey>()
-                    + std::mem::size_of::<TypeId>());
-            size += map
-                .keys()
-                .map(|key| key.properties.capacity() * std::mem::size_of::<Atom>())
-                .sum::<usize>();
+            size += map.estimated_size_bytes(BUCKET_OVERHEAD);
+            size += map.key_extra_size_bytes(|key| {
+                key.properties.capacity() * std::mem::size_of::<Atom>()
+            });
         }
         {
             let map = self.contextual_resolve_cache.borrow();

--- a/crates/tsz-solver/src/narrowing/cache/cache_visibility_tests.rs
+++ b/crates/tsz-solver/src/narrowing/cache/cache_visibility_tests.rs
@@ -48,11 +48,11 @@ fn narrowing_cache_statistics_report_entries_and_size() {
     cache
         .optional_chain_cache
         .borrow_mut()
-        .insert((TypeId::STRING, prop), TypeId::BOOLEAN);
+        .insert((TypeId::STRING, prop), 7, TypeId::BOOLEAN);
     cache
         .optional_property_chain_cache
         .borrow_mut()
-        .insert(chain_key, TypeId::BOOLEAN);
+        .insert(chain_key, 7, TypeId::BOOLEAN);
     cache
         .contextual_resolve_cache
         .borrow_mut()
@@ -92,6 +92,12 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
     let prop = db.intern_string("prop");
     let cache = NarrowingCache::new();
     let property_key = (TypeId::STRING, prop);
+    let chain_key = OptionalPropertyChainKey {
+        root_type: TypeId::STRING,
+        properties: vec![prop],
+        optional_mask: 1,
+        no_unchecked_indexed_access: false,
+    };
     let request_key =
         NarrowingRequest::new(TypeId::STRING, TypeGuard::Truthy, GuardSense::Positive)
             .stable_cache_key(NarrowingOptions::new());
@@ -110,6 +116,15 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
             .required_property_cache
             .borrow_mut()
             .insert(property_key, generation, true);
+        cache
+            .optional_chain_cache
+            .borrow_mut()
+            .insert(property_key, generation, TypeId::BOOLEAN);
+        cache.optional_property_chain_cache.borrow_mut().insert(
+            chain_key.clone(),
+            generation,
+            TypeId::NUMBER,
+        );
         cache.narrow_type_cache.borrow_mut().insert(
             request_key.clone(),
             generation,
@@ -130,7 +145,7 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
     }
 
     let stats = cache.cache_statistics();
-    assert_eq!(stats.generation_stamped_cache_keys, 6);
+    assert_eq!(stats.generation_stamped_cache_keys, 8);
     assert_eq!(
         stats.max_generation_slots_per_cache_key,
         MAX_GENERATIONS_PER_NARROWING_KEY
@@ -141,6 +156,14 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
     );
     assert_eq!(
         stats.required_property_cache_entries,
+        MAX_GENERATIONS_PER_NARROWING_KEY
+    );
+    assert_eq!(
+        stats.optional_chain_cache_entries,
+        MAX_GENERATIONS_PER_NARROWING_KEY
+    );
+    assert_eq!(
+        stats.optional_property_chain_cache_entries,
         MAX_GENERATIONS_PER_NARROWING_KEY
     );
     assert_eq!(
@@ -165,10 +188,78 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
         cache.property_cache.borrow().get(&property_key, 7),
         Some(Some(CachedPropertyType::explicit(TypeId::BOOLEAN)))
     );
+    assert_eq!(
+        cache.optional_chain_cache.borrow().get(&property_key, 1),
+        None
+    );
+    assert_eq!(
+        cache.optional_chain_cache.borrow().get(&property_key, 7),
+        Some(TypeId::BOOLEAN)
+    );
+    assert_eq!(
+        cache
+            .optional_property_chain_cache
+            .borrow()
+            .get(&chain_key, 1),
+        None
+    );
+    assert_eq!(
+        cache
+            .optional_property_chain_cache
+            .borrow()
+            .get(&chain_key, 7),
+        Some(TypeId::NUMBER)
+    );
     assert_eq!(cache.narrow_type_cache.borrow().get(&request_key, 1), None);
     assert_eq!(
         cache.narrow_type_cache.borrow().get(&request_key, 7),
         Some(TypeId::STRING)
+    );
+}
+
+#[test]
+fn optional_chain_caches_serve_only_matching_resolver_generation() {
+    let db = TypeInterner::new();
+    let prop = db.intern_string("prop");
+    let property_key = (TypeId::STRING, prop);
+    let chain_key = OptionalPropertyChainKey {
+        root_type: TypeId::STRING,
+        properties: vec![prop],
+        optional_mask: 1,
+        no_unchecked_indexed_access: false,
+    };
+    let cache = NarrowingCache::new();
+
+    cache
+        .optional_chain_cache
+        .borrow_mut()
+        .insert(property_key, 3, TypeId::BOOLEAN);
+    cache
+        .optional_property_chain_cache
+        .borrow_mut()
+        .insert(chain_key.clone(), 3, TypeId::NUMBER);
+
+    assert_eq!(
+        cache.optional_chain_cache.borrow().get(&property_key, 3),
+        Some(TypeId::BOOLEAN)
+    );
+    assert_eq!(
+        cache.optional_chain_cache.borrow().get(&property_key, 4),
+        None
+    );
+    assert_eq!(
+        cache
+            .optional_property_chain_cache
+            .borrow()
+            .get(&chain_key, 3),
+        Some(TypeId::NUMBER)
+    );
+    assert_eq!(
+        cache
+            .optional_property_chain_cache
+            .borrow()
+            .get(&chain_key, 4),
+        None
     );
 }
 

--- a/crates/tsz-solver/src/narrowing/generation_memo.rs
+++ b/crates/tsz-solver/src/narrowing/generation_memo.rs
@@ -80,6 +80,10 @@ where
         }
         size
     }
+
+    pub fn key_extra_size_bytes(&self, extra_size: impl FnMut(&K) -> usize) -> usize {
+        self.entries.keys().map(extra_size).sum()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Goal: green

## Summary
- Move single-hop and full optional property-chain result caches onto solver-owned `GenerationMemo` storage.
- Teach the checker `TypeResolver` adapter to publish a real resolver generation from both type environments and symbol-type cache versions.
- Add focused cache-visibility and checker stamp tests so optional-chain results cannot cross resolver-generation changes.
- Suppress redundant semantic member/index diagnostics after checker-owned invalid optional-chain target recovery emits the TS277x diagnostic family.

## Structural Rule
When optional property-chain lookup depends on lazy resolver-materialized declarations, `tsc` observes the current resolved graph; `tsz` serves a memoized optional-chain result only for the current checker resolver generation through solver-owned `NarrowingCache`. When an optional-chain expression is an invalid assignment/update/destructuring/for-in/of target, `tsc` reports the TS277x invalid-target diagnostic and does not cascade into redundant member/index lookup errors; `tsz` handles that through checker access recovery while keeping optional-chain caches generation-exact.

## Owner Layer
Solver owns `NarrowingCache` storage, bounded generation slots, stats, and cache-size accounting. Checker owns syntax-rooted optional-chain key construction, invalid-target access recovery, and supplies the current resolver generation through the existing `TypeResolver` adapter; property semantics stay on the existing property-access path.

## Adjacent Matrix
- Single-hop `obj?.prop` final-result cache hits only at the matching resolver generation.
- Full chained `obj?.a?.b` final-result cache hits only at the matching resolver generation.
- Generation-retention bounds now include both optional-chain caches.
- `CheckerContext` resolver generation moves when `type_env`, `type_environment`, `symbol_types`, or `symbol_instance_types` changes.
- Invalid optional-chain targets in assignment/update/destructuring/for-in/of contexts keep TS277x diagnostics but suppress redundant TS2339/TS7053 follow-ons.
- Fallback: generation mismatch misses the memo and recomputes through the existing property-access resolution path; diagnostics and property semantics are unchanged.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(narrowing_cache_statistics_report_entries_and_size) or test(generation_stamped_narrowing_caches_bound_retained_generations) or test(optional_chain_caches_serve_only_matching_resolver_generation)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(checker_context_resolver_generation_tracks_env_and_symbol_cache_state)'`
- `scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter propertyAccessChain.3 --workers 1 --verbose`
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter elementAccessChain.3 --workers 1 --verbose`

## Notes
Local checker test linking initially exhausted disk (`errno=28`) after building broad test targets. Per `tsz-disk-cache-hygiene`, I ran `scripts/setup/disk-worktree-guard.sh --auto-prune` and `scripts/setup/clean.sh --quiet`; when those preserved caches and left only ~116 MB free, I removed only this new worktree's rebuildable `.target` cache. Free space recovered to ~41 GB, and the focused tests/checks above were rerun on rebased head `f3e6f8e986`. The optional-chain invalid-target conformance repair was rerun on follow-up head `3514aa136c`.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high