### PR TITLE
fix(solver): key fresh eval by exact optional options (#14351)

### DIFF
--- a/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
+++ b/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
@@ -24,21 +24,21 @@
 //! treats a within-instance cycle), which lets the in-flight expansion — the one
 //! holding the real work — converge and breaks the churn.
 
+use crate::evaluation::request::{EvaluationCacheKey, EvaluationRequest};
 use crate::evaluation::result::EvaluationMemoResult;
 use crate::evaluation::session::EvaluationSession;
 use crate::types::TypeId;
 
 /// Look up a memoized fresh-evaluator result for the current top-level query.
 ///
-/// The key includes `no_unchecked_indexed_access` because evaluation results
-/// depend on it (the per-checker `eval_cache` keys on the same flag): a memo
-/// keyed on `TypeId` alone would return a result computed under the wrong mode.
+/// The key includes the index-access option pair because evaluation results
+/// depend on both flags: a memo keyed on `TypeId` alone would return a result
+/// computed under the wrong mode.
 pub(crate) fn query_memo_get(
     session: &EvaluationSession,
-    type_id: TypeId,
-    no_unchecked_indexed_access: bool,
+    key: EvaluationCacheKey,
 ) -> Option<TypeId> {
-    session.query_memo_get(type_id, no_unchecked_indexed_access)
+    session.query_memo_get(key)
 }
 
 /// Record a stable fresh-evaluator result for the current top-level query.
@@ -46,13 +46,8 @@ pub(crate) fn query_memo_get(
 /// Callers must only store results that did not hit a recursion/budget limit
 /// (`TypeEvaluator::recursion_limit_hit`), so an opaque cycle/budget bail is
 /// never cached and reused as if it were the converged answer.
-pub(crate) fn query_memo_put(
-    session: &EvaluationSession,
-    type_id: TypeId,
-    no_unchecked_indexed_access: bool,
-    result: TypeId,
-) {
-    session.query_memo_put(type_id, no_unchecked_indexed_access, result);
+pub(crate) fn query_memo_put(session: &EvaluationSession, key: EvaluationCacheKey, result: TypeId) {
+    session.query_memo_put(key, result);
 }
 
 /// Clear the per-query memo. Invoked when a fresh top-level evaluation query
@@ -76,12 +71,10 @@ pub(crate) fn reset_query_memo(session: &EvaluationSession) {
 /// whose stability decides whether the per-query memo may store it.
 pub(crate) fn memoized_eval(
     session: &EvaluationSession,
-    type_id: TypeId,
-    no_unchecked_indexed_access: bool,
+    request: EvaluationRequest,
     compute: impl FnOnce() -> EvaluationMemoResult,
 ) -> Option<TypeId> {
-    memoized_eval_with_stability(session, type_id, no_unchecked_indexed_access, compute)
-        .map(EvaluationMemoResult::into_type_id)
+    memoized_eval_with_stability(session, request, compute).map(EvaluationMemoResult::into_type_id)
 }
 
 /// Like [`memoized_eval`], but also reports whether the result is *stable*:
@@ -93,25 +86,20 @@ pub(crate) fn memoized_eval(
 /// distinguish a genuinely evaluated answer from a recursion-bail artifact.
 pub(crate) fn memoized_eval_with_stability(
     session: &EvaluationSession,
-    type_id: TypeId,
-    no_unchecked_indexed_access: bool,
+    request: EvaluationRequest,
     compute: impl FnOnce() -> EvaluationMemoResult,
 ) -> Option<EvaluationMemoResult> {
-    if let Some(cached) = query_memo_get(session, type_id, no_unchecked_indexed_access) {
+    let key = request.cache_key();
+    if let Some(cached) = query_memo_get(session, key) {
         return Some(EvaluationMemoResult::cached(cached));
     }
-    let _cross = match CrossEvalExpansionGuard::enter(session, type_id) {
+    let _cross = match CrossEvalExpansionGuard::enter(session, request.type_id()) {
         CrossEvalExpansionState::Entered(guard) => guard,
         CrossEvalExpansionState::AlreadyActive => return None,
     };
     let memo_result = compute();
     if memo_result.is_stable_for_per_query_memo() {
-        query_memo_put(
-            session,
-            type_id,
-            no_unchecked_indexed_access,
-            memo_result.type_id(),
-        );
+        query_memo_put(session, key, memo_result.type_id());
     }
     Some(memo_result)
 }
@@ -165,16 +153,26 @@ mod tests {
     use crate::evaluation::result::{EvaluationRequestStability, EvaluationResult};
 
     #[test]
-    fn memo_keys_on_no_unchecked_indexed_access() {
+    fn memo_keys_on_index_access_options() {
         let session = EvaluationSession::new();
         reset_query_memo(&session);
         let t = TypeId(7);
-        query_memo_put(&session, t, false, TypeId(70));
-        query_memo_put(&session, t, true, TypeId(71));
-        assert_eq!(query_memo_get(&session, t, false), Some(TypeId(70)));
-        assert_eq!(query_memo_get(&session, t, true), Some(TypeId(71)));
+        let default_key = EvaluationCacheKey::new(t, false, false);
+        let no_unchecked_key = EvaluationCacheKey::new(t, true, false);
+        let exact_optional_key = EvaluationCacheKey::new(t, false, true);
+        let both_key = EvaluationCacheKey::new(t, true, true);
+        query_memo_put(&session, default_key, TypeId(70));
+        query_memo_put(&session, no_unchecked_key, TypeId(71));
+        query_memo_put(&session, exact_optional_key, TypeId(72));
+        assert_eq!(query_memo_get(&session, default_key), Some(TypeId(70)));
+        assert_eq!(query_memo_get(&session, no_unchecked_key), Some(TypeId(71)));
+        assert_eq!(
+            query_memo_get(&session, exact_optional_key),
+            Some(TypeId(72))
+        );
+        assert_eq!(query_memo_get(&session, both_key), None);
         reset_query_memo(&session);
-        assert_eq!(query_memo_get(&session, t, false), None);
+        assert_eq!(query_memo_get(&session, default_key), None);
     }
 
     #[test]
@@ -183,19 +181,24 @@ mod tests {
         reset_query_memo(&session);
         let t = TypeId(8);
 
-        let first = memoized_eval(&session, t, false, || {
+        let request = EvaluationRequest::new(t);
+
+        let first = memoized_eval(&session, request, || {
             EvaluationMemoResult::unstable_complete(TypeId(80))
         });
 
         assert_eq!(first, Some(TypeId(80)));
-        assert_eq!(query_memo_get(&session, t, false), None);
+        assert_eq!(query_memo_get(&session, request.cache_key()), None);
 
-        let second = memoized_eval(&session, t, false, || {
+        let second = memoized_eval(&session, request, || {
             EvaluationMemoResult::cached(TypeId(81))
         });
 
         assert_eq!(second, Some(TypeId(81)));
-        assert_eq!(query_memo_get(&session, t, false), Some(TypeId(81)));
+        assert_eq!(
+            query_memo_get(&session, request.cache_key()),
+            Some(TypeId(81))
+        );
         reset_query_memo(&session);
     }
 
@@ -204,9 +207,10 @@ mod tests {
         let session = EvaluationSession::new();
         reset_query_memo(&session);
         let t = TypeId(9);
+        let request = EvaluationRequest::new(t);
         let mut calls = 0;
 
-        let first = memoized_eval(&session, t, false, || {
+        let first = memoized_eval(&session, request, || {
             calls += 1;
             EvaluationMemoResult::for_depth_agnostic_memo(
                 EvaluationResult::complete(TypeId(90)),
@@ -215,16 +219,22 @@ mod tests {
         });
 
         assert_eq!(first, Some(TypeId(90)));
-        assert_eq!(query_memo_get(&session, t, false), Some(TypeId(90)));
+        assert_eq!(
+            query_memo_get(&session, request.cache_key()),
+            Some(TypeId(90))
+        );
 
-        let second = memoized_eval(&session, t, false, || {
+        let second = memoized_eval(&session, request, || {
             calls += 1;
             EvaluationMemoResult::cached(TypeId(91))
         });
 
         assert_eq!(second, Some(TypeId(90)));
         assert_eq!(calls, 1);
-        assert_eq!(query_memo_get(&session, t, false), Some(TypeId(90)));
+        assert_eq!(
+            query_memo_get(&session, request.cache_key()),
+            Some(TypeId(90))
+        );
         reset_query_memo(&session);
     }
 

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -75,6 +75,7 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     eval_session: Option<&'a EvaluationSession>,
     resolver: &'a R,
     no_unchecked_indexed_access: bool,
+    exact_optional_property_types: bool,
     cache: FxHashMap<TypeId, TypeId>,
     /// Unified recursion guard for `TypeId` cycle detection, depth, and iteration limits.
     guard: crate::recursion::RecursionGuard<TypeId>,
@@ -304,6 +305,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             eval_session: None,
             resolver,
             no_unchecked_indexed_access: false,
+            exact_optional_property_types: interner.exact_optional_property_types(),
             cache: FxHashMap::default(),
             guard: crate::recursion::RecursionGuard::with_profile(
                 crate::recursion::RecursionProfile::TypeEvaluation,
@@ -580,6 +582,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.no_unchecked_indexed_access = enabled;
     }
 
+    pub fn set_exact_optional_property_types(&mut self, enabled: bool) {
+        if self.exact_optional_property_types != enabled {
+            self.cache.clear();
+            self.tainted.clear();
+        }
+        self.exact_optional_property_types = enabled;
+    }
+
     pub const fn set_max_mapped_keys(&mut self, max_mapped_keys: usize) {
         self.max_mapped_keys = max_mapped_keys;
         // A non-default expansion cap changes where evaluation bails; memo
@@ -630,6 +640,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// evaluator.
     pub fn evaluate_request_result(&mut self, request: EvaluationRequest) -> EvaluationResult {
         self.set_no_unchecked_indexed_access(request.no_unchecked_indexed_access());
+        self.set_exact_optional_property_types(request.exact_optional_property_types());
         self.request_termination_kind = None;
         self.request_unresolved_def_seen = false;
         let type_id = self.evaluate(request.type_id());
@@ -783,6 +794,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     #[inline]
     pub(crate) const fn no_unchecked_indexed_access(&self) -> bool {
         self.no_unchecked_indexed_access
+    }
+
+    /// Check if `exactOptionalPropertyTypes` is enabled.
+    #[inline]
+    pub(crate) const fn exact_optional_property_types(&self) -> bool {
+        self.exact_optional_property_types
     }
 
     /// Check if depth limit was exceeded.

--- a/crates/tsz-solver/src/evaluation/evaluate/api.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/api.rs
@@ -38,7 +38,11 @@ pub fn evaluate_index_access_with_options(
 
 /// Convenience function for full type evaluation.
 pub fn evaluate_type(interner: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    evaluate_type_with_request(interner, EvaluationRequest::new(type_id))
+    evaluate_type_with_request(
+        interner,
+        EvaluationRequest::new(type_id)
+            .with_exact_optional_property_types(interner.exact_optional_property_types()),
+    )
 }
 
 /// Convenience function for full type evaluation with an explicit resolver.

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -1469,7 +1469,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         let value_type = self.evaluate(instantiate_type(self.interner(), mapped.template, &subst));
         let value_type = if matches!(mapped.optional_modifier, Some(MappedModifier::Remove))
-            && !self.interner().exact_optional_property_types()
+            && !self.exact_optional_property_types()
             && let Some(source) = self.homomorphic_mapped_source_for_index_read(&mapped)
             && self.index_type_can_hit_optional_property(source, substitution_index)
         {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_match_expansion.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_match_expansion.rs
@@ -303,7 +303,11 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
         session: &EvaluationSession,
     ) -> TypeId {
         let nuia = self.no_unchecked_indexed_access();
-        crate::evaluation::cross_eval_guard::memoized_eval(session, type_id, nuia, || {
+        let exact_optional = self.exact_optional_property_types();
+        let request = crate::evaluation::request::EvaluationRequest::new(type_id)
+            .with_no_unchecked_indexed_access(nuia)
+            .with_exact_optional_property_types(exact_optional);
+        crate::evaluation::cross_eval_guard::memoized_eval(session, request, || {
             let Ok(_entry) = session.enter_infer_match_expansion_depth() else {
                 return EvaluationMemoResult::unstable_complete(type_id);
             };
@@ -312,8 +316,6 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
             if let Some(query_db) = self.query_db() {
                 evaluator = evaluator.with_query_db(query_db);
             }
-            let request = crate::evaluation::request::EvaluationRequest::new(type_id)
-                .with_no_unchecked_indexed_access(nuia);
             evaluator.evaluate_request_memo_result(request)
         })
         .unwrap_or(type_id)

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -175,7 +175,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// `undefined`. The sibling mapped-array shard uses the same rule for
     /// tuple element mapping.
     pub(super) fn strip_removed_optional_undefined(&self, ty: TypeId, strip: bool) -> TypeId {
-        if strip && !self.interner().exact_optional_property_types() {
+        if strip && !self.exact_optional_property_types() {
             crate::narrowing::utils::remove_undefined(self.interner(), ty)
         } else {
             ty

--- a/crates/tsz-solver/src/evaluation/request.rs
+++ b/crates/tsz-solver/src/evaluation/request.rs
@@ -156,7 +156,9 @@ mod tests {
     use super::{EvaluationCacheKey, EvaluationOptions, EvaluationRequest};
     use crate::construction::TypeInterner;
     use crate::evaluation::evaluate::evaluate_type_with_request;
-    use crate::types::TypeId;
+    use crate::types::{
+        MappedModifier, MappedType, PropertyInfo, TypeData, TypeId, TypeParamInfo, TypeParamOrigin,
+    };
 
     #[test]
     fn default_request_cache_key_disables_no_unchecked_indexed_access() {
@@ -228,5 +230,64 @@ mod tests {
         );
         let expected = interner.union(vec![TypeId::STRING, TypeId::UNDEFINED]);
         assert_eq!(no_unchecked_result, expected);
+    }
+
+    #[test]
+    fn request_routes_exact_optional_property_types_option() {
+        let interner = TypeInterner::new();
+        let prop = interner.intern_string("value");
+        let key_name = interner.intern_string("K");
+        let key_param_info = TypeParamInfo {
+            name: key_name,
+            constraint: None,
+            default: None,
+            is_const: false,
+            origin: TypeParamOrigin::User,
+        };
+        let key_param = interner.type_param(key_param_info);
+        let number_or_undefined = interner.union(vec![TypeId::NUMBER, TypeId::UNDEFINED]);
+        let source = interner.object(vec![PropertyInfo::opt(prop, number_or_undefined)]);
+        let mapped = interner.mapped(MappedType {
+            type_param: key_param_info,
+            constraint: interner.keyof(source),
+            name_type: None,
+            template: interner.index_access(source, key_param),
+            optional_modifier: Some(MappedModifier::Remove),
+            readonly_modifier: None,
+        });
+
+        let legacy_result = evaluate_type_with_request(&interner, EvaluationRequest::new(mapped));
+        let exact_result = evaluate_type_with_request(
+            &interner,
+            EvaluationRequest::new(mapped).with_exact_optional_property_types(true),
+        );
+
+        assert_eq!(
+            mapped_property_type(&interner, legacy_result, prop),
+            TypeId::NUMBER,
+            "legacy optional mode strips top-level undefined when -? removes optionality"
+        );
+        assert_eq!(
+            mapped_property_type(&interner, exact_result, prop),
+            number_or_undefined,
+            "exact optional mode preserves explicit undefined under -?"
+        );
+    }
+
+    fn mapped_property_type(
+        interner: &TypeInterner,
+        object: TypeId,
+        prop: tsz_common::Atom,
+    ) -> TypeId {
+        let Some(TypeData::Object(shape_id)) = interner.lookup(object) else {
+            panic!("expected evaluated mapped type to produce an object");
+        };
+        interner
+            .object_shape(shape_id)
+            .properties
+            .iter()
+            .find(|property| property.name == prop)
+            .map(|property| property.type_id)
+            .expect("mapped object should contain requested property")
     }
 }

--- a/crates/tsz-solver/src/evaluation/session.rs
+++ b/crates/tsz-solver/src/evaluation/session.rs
@@ -9,6 +9,7 @@
 //! via `Rc` across parent/child contexts so counters survive cross-arena
 //! delegation without implicit global state.
 
+use crate::evaluation::request::EvaluationCacheKey;
 use crate::types::TypeId;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::{Cell, RefCell};
@@ -71,7 +72,7 @@ pub struct EvaluationSession {
     /// `TypeId`s currently expanded by fresh evaluators in this session.
     cross_eval_active: RefCell<FxHashSet<TypeId>>,
     /// Per-top-level-query memo for stable fresh-evaluator results.
-    query_memo: RefCell<FxHashMap<(TypeId, bool), TypeId>>,
+    query_memo: RefCell<FxHashMap<EvaluationCacheKey, TypeId>>,
 }
 
 /// RAII entry for one conditional-subtype relation probe in an
@@ -260,28 +261,14 @@ impl EvaluationSession {
 
     /// Look up a stable fresh-evaluator result for the current top-level query.
     #[inline]
-    pub(crate) fn query_memo_get(
-        &self,
-        type_id: TypeId,
-        no_unchecked_indexed_access: bool,
-    ) -> Option<TypeId> {
-        self.query_memo
-            .borrow()
-            .get(&(type_id, no_unchecked_indexed_access))
-            .copied()
+    pub(crate) fn query_memo_get(&self, key: EvaluationCacheKey) -> Option<TypeId> {
+        self.query_memo.borrow().get(&key).copied()
     }
 
     /// Record a stable fresh-evaluator result for the current top-level query.
     #[inline]
-    pub(crate) fn query_memo_put(
-        &self,
-        type_id: TypeId,
-        no_unchecked_indexed_access: bool,
-        result: TypeId,
-    ) {
-        self.query_memo
-            .borrow_mut()
-            .insert((type_id, no_unchecked_indexed_access), result);
+    pub(crate) fn query_memo_put(&self, key: EvaluationCacheKey, result: TypeId) {
+        self.query_memo.borrow_mut().insert(key, result);
     }
 
     /// Clear the per-query fresh-evaluator memo.
@@ -404,19 +391,30 @@ mod tests {
     }
 
     #[test]
-    fn test_query_memo_keys_on_no_unchecked_indexed_access() {
+    fn test_query_memo_keys_on_index_access_options() {
         let session = EvaluationSession::new();
         let type_id = TypeId(202);
+        let default_key = EvaluationCacheKey::new(type_id, false, false);
+        let no_unchecked_key = EvaluationCacheKey::new(type_id, true, false);
+        let exact_optional_key = EvaluationCacheKey::new(type_id, false, true);
+        let both_key = EvaluationCacheKey::new(type_id, true, true);
 
-        session.query_memo_put(type_id, false, TypeId(210));
-        session.query_memo_put(type_id, true, TypeId(211));
+        session.query_memo_put(default_key, TypeId(210));
+        session.query_memo_put(no_unchecked_key, TypeId(211));
+        session.query_memo_put(exact_optional_key, TypeId(212));
 
-        assert_eq!(session.query_memo_get(type_id, false), Some(TypeId(210)));
-        assert_eq!(session.query_memo_get(type_id, true), Some(TypeId(211)));
+        assert_eq!(session.query_memo_get(default_key), Some(TypeId(210)));
+        assert_eq!(session.query_memo_get(no_unchecked_key), Some(TypeId(211)));
+        assert_eq!(
+            session.query_memo_get(exact_optional_key),
+            Some(TypeId(212))
+        );
+        assert_eq!(session.query_memo_get(both_key), None);
 
         session.reset_query_memo();
-        assert_eq!(session.query_memo_get(type_id, false), None);
-        assert_eq!(session.query_memo_get(type_id, true), None);
+        assert_eq!(session.query_memo_get(default_key), None);
+        assert_eq!(session.query_memo_get(no_unchecked_key), None);
+        assert_eq!(session.query_memo_get(exact_optional_key), None);
     }
 
     #[test]

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -17,6 +17,7 @@ use crate::construction::TypeDatabase;
 use crate::def::DefId;
 #[cfg(test)]
 use crate::diagnostics::SubtypeFailureReason;
+use crate::evaluation::request::EvaluationCacheKey;
 use crate::evaluation::result::EvaluationMemoResult;
 use crate::evaluation::session::EvaluationSession;
 use crate::objects::{PropertyCollectionResult, collect_properties_cached};
@@ -427,11 +428,11 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// Cache for `evaluate_type` results within this `SubtypeChecker`'s lifetime.
     /// This prevents O(n²) behavior when the same type (e.g., a large union) is
     /// evaluated multiple times across different subtype checks.
-    /// Key is (`TypeId`, `no_unchecked_indexed_access`) since that flag affects evaluation.
+    /// Key includes the evaluation-sensitive index-access option pair.
     /// Value records the collapsed result plus whether evaluation converged
     /// without tripping a recursion/depth/budget limit (see
     /// `evaluate_type_with_stability`).
-    pub(crate) eval_cache: FxHashMap<(TypeId, bool), RelationEvaluationResult>,
+    pub(crate) eval_cache: FxHashMap<EvaluationCacheKey, RelationEvaluationResult>,
     /// Apparent object shapes for primitive wrapper fallback.
     ///
     /// Primitive structural subtype checks can ask for the same wrapper shape
@@ -843,7 +844,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     pub fn cache_statistics(&self) -> SubtypeCheckerCacheStatistics {
         let eval_entries = self.eval_cache.len();
         let estimated_size_bytes = eval_entries
-            .saturating_mul(std::mem::size_of::<((TypeId, bool), (TypeId, bool))>())
+            .saturating_mul(std::mem::size_of::<(
+                EvaluationCacheKey,
+                RelationEvaluationResult,
+            )>())
             .saturating_add(
                 self.local_relation_cache
                     .len()

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/evaluation.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/evaluation.rs
@@ -1,3 +1,4 @@
+use crate::evaluation::request::EvaluationRequest;
 use crate::evaluation::session::{EvaluationSession, with_current_session};
 use crate::relations::subtype::{RelationEvaluationResult, SubtypeChecker, TypeResolver};
 use crate::types::TypeId;
@@ -30,7 +31,10 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
         if type_id.is_intrinsic() {
             return RelationEvaluationResult::stable(type_id);
         }
-        let cache_key = (type_id, self.no_unchecked_indexed_access);
+        let request = EvaluationRequest::new(type_id)
+            .with_no_unchecked_indexed_access(self.no_unchecked_indexed_access)
+            .with_exact_optional_property_types(self.exact_optional_property_types);
+        let cache_key = request.cache_key();
         if let Some(&cached) = self.eval_cache.get(&cache_key) {
             return cached;
         }
@@ -41,13 +45,10 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
             *fuel -= 1;
         }
 
-        let no_unchecked_indexed_access = self.no_unchecked_indexed_access;
         let memo_result = if let Some(session) = self.eval_session {
-            self.evaluate_type_with_session(type_id, no_unchecked_indexed_access, session)
+            self.evaluate_type_with_session(request, session)
         } else {
-            with_current_session(|session| {
-                self.evaluate_type_with_session(type_id, no_unchecked_indexed_access, session)
-            })
+            with_current_session(|session| self.evaluate_type_with_session(request, session))
         };
         let Some(memo_result) = memo_result else {
             return RelationEvaluationResult::unstable(type_id);
@@ -59,27 +60,19 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
 
     fn evaluate_type_with_session(
         &self,
-        type_id: TypeId,
-        no_unchecked_indexed_access: bool,
+        request: EvaluationRequest,
         session: &EvaluationSession,
     ) -> Option<crate::evaluation::result::EvaluationMemoResult> {
         use crate::evaluation::cross_eval_guard;
         use crate::evaluation::evaluate::TypeEvaluator;
 
-        cross_eval_guard::memoized_eval_with_stability(
-            session,
-            type_id,
-            no_unchecked_indexed_access,
-            || {
-                let mut evaluator = TypeEvaluator::with_resolver(self.interner, self.resolver)
-                    .with_evaluation_session(session);
-                if let Some(db) = self.query_db {
-                    evaluator = evaluator.with_query_db(db);
-                }
-                let request = crate::evaluation::request::EvaluationRequest::new(type_id)
-                    .with_no_unchecked_indexed_access(no_unchecked_indexed_access);
-                evaluator.evaluate_request_memo_result(request)
-            },
-        )
+        cross_eval_guard::memoized_eval_with_stability(session, request, || {
+            let mut evaluator = TypeEvaluator::with_resolver(self.interner, self.resolver)
+                .with_evaluation_session(session);
+            if let Some(db) = self.query_db {
+                evaluator = evaluator.with_query_db(db);
+            }
+            evaluator.evaluate_request_memo_result(request)
+        })
     }
 }

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -356,13 +356,17 @@ fn evaluation_engine_keeps_request_stage_boundary() {
             && subtype_core_rs.contains("cache_stability: RelationEvaluationStability")
             && !subtype_core_rs.contains("stable_for_depth_agnostic_cache: bool")
             && subtype_core_rs
-                .contains("eval_cache: FxHashMap<(TypeId, bool), RelationEvaluationResult>")
+                .contains("eval_cache: FxHashMap<EvaluationCacheKey, RelationEvaluationResult>")
+            && function_checking_eval_rs.contains("EvaluationRequest::new(type_id)")
+            && function_checking_eval_rs.contains(
+                ".with_exact_optional_property_types(self.exact_optional_property_types)"
+            )
             && function_checking_eval_rs
                 .contains("RelationEvaluationResult::from_depth_agnostic_memo(memo_result)")
             && functions_mod_rs.contains(".is_unstable_unknown()")
             && !functions_mod_rs
                 .contains("evaluate_type_with_stability(ret) == (TypeId::UNKNOWN, false)"),
-        "function-relation evaluation caches must carry stability through RelationEvaluationResult instead of anonymous (TypeId, bool) tuples"
+        "function-relation evaluation caches must key on EvaluationCacheKey and carry stability through RelationEvaluationResult instead of anonymous (TypeId, bool) tuples"
     );
     assert!(
         cross_eval_guard_rs.contains("use crate::evaluation::session::EvaluationSession;")

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_00.rs
@@ -54,6 +54,33 @@ fn subtype_checker_cache_statistics_account_for_eval_entries() {
 }
 
 #[test]
+fn subtype_checker_eval_cache_keys_on_exact_optional_property_types() {
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+    let union = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+
+    checker.exact_optional_property_types = false;
+    assert_eq!(checker.evaluate_type(union), union);
+    assert_eq!(checker.cache_statistics().eval_entries, 1);
+
+    checker.exact_optional_property_types = true;
+    assert_eq!(checker.evaluate_type(union), union);
+    assert_eq!(
+        checker.cache_statistics().eval_entries,
+        2,
+        "flipping exactOptionalPropertyTypes must select a distinct relation eval-cache slot"
+    );
+
+    checker.exact_optional_property_types = false;
+    assert_eq!(checker.evaluate_type(union), union);
+    assert_eq!(
+        checker.cache_statistics().eval_entries,
+        2,
+        "restoring the original option should reuse the original slot"
+    );
+}
+
+#[test]
 fn test_any_top_bottom_subtyping() {
     let interner = TypeInterner::new();
     let mut checker = SubtypeChecker::new(&interner);
@@ -1801,4 +1828,3 @@ fn test_lazy_type_params_falls_back_from_symbol_based_lazy_ref() {
     let mut checker = SubtypeChecker::with_resolver(&interner, &env);
     assert!(checker.is_subtype_of(symbol_reference, TypeId::STRING));
 }
-


### PR DESCRIPTION
Goal: green

## Summary
- Thread `exactOptionalPropertyTypes` through `EvaluationRequest` into `TypeEvaluator` so exact-sensitive mapped/indexed-access evaluation follows the request, not an implicit database fallback.
- Key relation-local fresh-evaluator caches and per-query cross-eval memo entries with `EvaluationCacheKey` instead of `(TypeId, noUncheckedIndexedAccess)`.
- Add request, session, cross-eval, relation-cache, and architecture guard coverage for the full index-access option pair.

## Structural Rule
When fresh evaluation can vary under `exactOptionalPropertyTypes` or `noUncheckedIndexedAccess`, `tsc` observes the current compiler option set; `tsz` serves fresh-evaluator memo results only for the same `EvaluationRequest` option pair through solver-owned `EvaluationCacheKey` storage.

## Owner Layer
Solver owns evaluation option requests, fresh-evaluator memo keys, and exact-sensitive mapped/indexed-access evaluation. Checker remains a policy/configuration caller and does not inspect evaluator internals.

## Adjacent Matrix
- Per-query cross-eval memo entries distinguish default, no-unchecked-only, exact-optional-only, and both-flags-on requests.
- Relation-local `SubtypeChecker::eval_cache` keys on `EvaluationCacheKey`, so flipping exact optional selects a distinct slot and restoring it reuses the original slot.
- `EvaluationRequest` now applies exact optional to `TypeEvaluator`; `Required`-style mapped evaluation preserves explicit `undefined` only in exact optional mode.
- Ambient `evaluate_type` preserves the interner's exact optional setting; explicit `evaluate_type_with_request` calls remain request-driven.
- Fallback: cache miss recomputes through the existing evaluator path; no diagnostic, relation, or checker boundary behavior is changed outside the option-keyed evaluation result.

## Verification
- `git diff --check && cargo fmt --all -- --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(request_routes_exact_optional_property_types_option) or test(request_routes_no_unchecked_indexed_access_option) or test(request_cache_key_tracks_exact_optional_property_types) or test(memo_keys_on_index_access_options) or test(test_query_memo_keys_on_index_access_options)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(subtype_checker_eval_cache_keys_on_exact_optional_property_types) or test(closed_eval_cache_keys_on_exact_optional_property_types) or test(application_eval_cache_keys_on_exact_optional_property_types) or test(remove_optional_strips_explicit_undefined_from_value) or test(remove_optional_exact_optional_preserves_explicit_undefined) or test(remove_optional_strip_is_iteration_var_name_invariant)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards -E 'test(evaluation_engine_keeps_request_stage_boundary) or test(subtype_function_fresh_evaluators_use_explicit_session)'`
- `scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
