### PR TITLE
refactor(checker): stamp generic constraint proof caches (#14351)

### DIFF
--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -533,7 +533,7 @@ impl<'a> CheckerState<'a> {
 
     /// Typed checker-cache key for TS2344 constraint proof helpers that run
     /// relation/evaluation work under the current checker policy.
-    pub(crate) fn generic_constraint_proof_key(
+    pub(crate) const fn generic_constraint_proof_key(
         &self,
         source: TypeId,
         target: TypeId,

--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -1,3 +1,4 @@
+use crate::context::GenericConstraintProofKey;
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
@@ -530,6 +531,36 @@ impl<'a> CheckerState<'a> {
             && !contains_file_relative_content(db, target)
     }
 
+    /// Typed checker-cache key for TS2344 constraint proof helpers that run
+    /// relation/evaluation work under the current checker policy.
+    pub(crate) fn generic_constraint_proof_key(
+        &self,
+        source: TypeId,
+        target: TypeId,
+    ) -> GenericConstraintProofKey {
+        GenericConstraintProofKey::new(
+            source,
+            target,
+            self.ctx.pack_relation_flags(),
+            self.ctx.sound_mode(),
+        )
+    }
+
+    /// Whether a branch proof completed cleanly enough to memoize.
+    ///
+    /// Degraded proofs are valid for the current stack frame, but caching them
+    /// would make a later, cleaner attempt inherit a lazy-resolution miss,
+    /// exhausted evaluation fuel, or relation overflow fallback.
+    pub(crate) fn generic_constraint_proof_completed_clean(
+        &self,
+        lazy_failures_at_entry: u64,
+    ) -> bool {
+        crate::query_boundaries::common::lazy_resolve_failure_count() == lazy_failures_at_entry
+            && !self.ctx.types.is_evaluation_fuel_exhausted()
+            && !self.ctx.depth_exceeded.get()
+            && !self.ctx.relation_overflow.get().has_overflow()
+    }
+
     /// Probe the program-wide
     /// [`crate::context::SharedConstraintProofCache`], if installed.
     ///
@@ -567,6 +598,8 @@ impl<'a> CheckerState<'a> {
         };
         if crate::query_boundaries::common::lazy_resolve_failure_count() == lazy_failures_at_entry
             && !self.ctx.types.is_evaluation_fuel_exhausted()
+            && !self.ctx.depth_exceeded.get()
+            && !self.ctx.relation_overflow.get().has_overflow()
             && self.constraint_proof_is_program_shareable(source, target)
         {
             publish(shared);

--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -29,13 +29,13 @@ impl<'a> CheckerState<'a> {
         let lazy_failures_at_entry = crate::query_boundaries::common::lazy_resolve_failure_count();
         let result =
             self.conditional_result_branches_satisfy_constraint_uncached(type_arg, constraint);
-        if self.generic_constraint_proof_completed_clean(lazy_failures_at_entry) {
-            if let Some(stamp) = self.assignability_eval_memo_stamp() {
-                self.ctx
-                    .type_reference_validation_caches
-                    .conditional_branch_constraint
-                    .insert(stamp, cache_key, result);
-            }
+        if self.generic_constraint_proof_completed_clean(lazy_failures_at_entry)
+            && let Some(stamp) = self.assignability_eval_memo_stamp()
+        {
+            self.ctx
+                .type_reference_validation_caches
+                .conditional_branch_constraint
+                .insert(stamp, cache_key, result);
         }
         result
     }
@@ -132,13 +132,13 @@ impl<'a> CheckerState<'a> {
         let lazy_failures_at_entry = crate::query_boundaries::common::lazy_resolve_failure_count();
         let result =
             self.indexed_object_map_branch_satisfies_constraint_uncached(branch, constraint);
-        if self.generic_constraint_proof_completed_clean(lazy_failures_at_entry) {
-            if let Some(stamp) = self.assignability_eval_memo_stamp() {
-                self.ctx
-                    .type_reference_validation_caches
-                    .indexed_object_map_branch_constraint
-                    .insert(stamp, cache_key, result);
-            }
+        if self.generic_constraint_proof_completed_clean(lazy_failures_at_entry)
+            && let Some(stamp) = self.assignability_eval_memo_stamp()
+        {
+            self.ctx
+                .type_reference_validation_caches
+                .indexed_object_map_branch_constraint
+                .insert(stamp, cache_key, result);
         }
         result
     }

--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -15,47 +15,27 @@ impl<'a> CheckerState<'a> {
         {
             return false;
         }
-        let cache_key = (type_arg, constraint);
-        if let Some(&cached) = self
-            .ctx
-            .type_reference_validation_caches
-            .conditional_branch_constraint
-            .get(&cache_key)
-        {
-            return cached;
-        }
-
-        // Program-wide success tier: file checkers re-prove the same
-        // conditional-branch pairs for every file that references the same
-        // generic alias. Only successes are shared (see
-        // `SharedConstraintProofCache`).
-        if self.shared_constraint_proof_hit(|s| s.conditional_branch_successes.contains(&cache_key))
-        {
-            tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "conditional_branch", "hit");
-            self.ctx
+        let cache_key = self.generic_constraint_proof_key(type_arg, constraint);
+        if let Some(stamp) = self.assignability_eval_memo_stamp()
+            && let Some(cached) = self
+                .ctx
                 .type_reference_validation_caches
                 .conditional_branch_constraint
-                .insert(cache_key, true);
-            return true;
+                .get(stamp, cache_key)
+        {
+            return cached;
         }
 
         let lazy_failures_at_entry = crate::query_boundaries::common::lazy_resolve_failure_count();
         let result =
             self.conditional_result_branches_satisfy_constraint_uncached(type_arg, constraint);
-        self.ctx
-            .type_reference_validation_caches
-            .conditional_branch_constraint
-            .insert(cache_key, result);
-        if result {
-            self.publish_shared_constraint_proof(
-                lazy_failures_at_entry,
-                type_arg,
-                constraint,
-                |shared| {
-                    tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "conditional_branch", "publish");
-                    shared.conditional_branch_successes.insert(cache_key);
-                },
-            );
+        if self.generic_constraint_proof_completed_clean(lazy_failures_at_entry) {
+            if let Some(stamp) = self.assignability_eval_memo_stamp() {
+                self.ctx
+                    .type_reference_validation_caches
+                    .conditional_branch_constraint
+                    .insert(stamp, cache_key, result);
+            }
         }
         result
     }
@@ -138,45 +118,27 @@ impl<'a> CheckerState<'a> {
         branch: TypeId,
         constraint: TypeId,
     ) -> bool {
-        let cache_key = (branch, constraint);
-        if let Some(&cached) = self
-            .ctx
-            .type_reference_validation_caches
-            .indexed_object_map_branch_constraint
-            .get(&cache_key)
-        {
-            return cached;
-        }
-
-        // Program-wide success tier (see first probe above).
-        if self.shared_constraint_proof_hit(|s| {
-            s.indexed_object_map_branch_successes.contains(&cache_key)
-        }) {
-            tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "indexed_object_map", "hit");
-            self.ctx
+        let cache_key = self.generic_constraint_proof_key(branch, constraint);
+        if let Some(stamp) = self.assignability_eval_memo_stamp()
+            && let Some(cached) = self
+                .ctx
                 .type_reference_validation_caches
                 .indexed_object_map_branch_constraint
-                .insert(cache_key, true);
-            return true;
+                .get(stamp, cache_key)
+        {
+            return cached;
         }
 
         let lazy_failures_at_entry = crate::query_boundaries::common::lazy_resolve_failure_count();
         let result =
             self.indexed_object_map_branch_satisfies_constraint_uncached(branch, constraint);
-        self.ctx
-            .type_reference_validation_caches
-            .indexed_object_map_branch_constraint
-            .insert(cache_key, result);
-        if result {
-            self.publish_shared_constraint_proof(
-                lazy_failures_at_entry,
-                branch,
-                constraint,
-                |shared| {
-                    tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "indexed_object_map", "publish");
-                    shared.indexed_object_map_branch_successes.insert(cache_key);
-                },
-            );
+        if self.generic_constraint_proof_completed_clean(lazy_failures_at_entry) {
+            if let Some(stamp) = self.assignability_eval_memo_stamp() {
+                self.ctx
+                    .type_reference_validation_caches
+                    .indexed_object_map_branch_constraint
+                    .insert(stamp, cache_key, result);
+            }
         }
         result
     }

--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -108,6 +108,77 @@ impl TypeNodeSurfaceCaches {
     }
 }
 
+/// Typed key for checker-owned TS2344 constraint-proof memos.
+///
+/// These proofs are more than a raw `(source, target)` relation: they can
+/// observe relation policy through the packed checker flags and sound-mode bit.
+/// The local memo that stores this key is additionally guarded by
+/// [`AssignabilityEvalStamp`] so resolver/type-env generation changes never
+/// reuse a proof produced for an older program graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GenericConstraintProofKey {
+    pub source: TypeId,
+    pub target: TypeId,
+    pub relation_flags: u16,
+    pub sound_mode: bool,
+}
+
+impl GenericConstraintProofKey {
+    pub const fn new(
+        source: TypeId,
+        target: TypeId,
+        relation_flags: u16,
+        sound_mode: bool,
+    ) -> Self {
+        Self {
+            source,
+            target,
+            relation_flags,
+            sound_mode,
+        }
+    }
+}
+
+/// Stamp-guarded boolean memo for TS2344 branch proof helpers.
+#[derive(Debug, Default)]
+pub struct GenericConstraintProofMemo {
+    stamp: Option<AssignabilityEvalStamp>,
+    entries: FxHashMap<GenericConstraintProofKey, bool>,
+}
+
+impl GenericConstraintProofMemo {
+    fn roll_to(&mut self, stamp: AssignabilityEvalStamp) {
+        if self.stamp != Some(stamp) {
+            self.entries.clear();
+            self.stamp = Some(stamp);
+        }
+    }
+
+    pub fn get(
+        &mut self,
+        stamp: AssignabilityEvalStamp,
+        key: GenericConstraintProofKey,
+    ) -> Option<bool> {
+        self.roll_to(stamp);
+        self.entries.get(&key).copied()
+    }
+
+    pub fn insert(
+        &mut self,
+        stamp: AssignabilityEvalStamp,
+        key: GenericConstraintProofKey,
+        result: bool,
+    ) {
+        self.roll_to(stamp);
+        self.entries.insert(key, result);
+    }
+
+    pub fn clear(&mut self) {
+        self.stamp = None;
+        self.entries.clear();
+    }
+}
+
 /// Checker-local memos for type-reference argument validation.
 #[derive(Debug, Default)]
 pub struct TypeReferenceValidationCaches {
@@ -145,11 +216,11 @@ pub struct TypeReferenceValidationCaches {
     /// Results for conditional-branch constraint proofs. These checks can be
     /// reached repeatedly while extracting generic parameter lists from aliases
     /// imported or re-exported through several files.
-    pub conditional_branch_constraint: FxHashMap<(TypeId, TypeId), bool>,
+    pub conditional_branch_constraint: GenericConstraintProofMemo,
     /// Results for indexed-object-map branch constraint proofs. This memo sits
     /// underneath `conditional_branch_constraint` because different conditional
     /// aliases can expose the same mapped-object branch/value constraint pair.
-    pub indexed_object_map_branch_constraint: FxHashMap<(TypeId, TypeId), bool>,
+    pub indexed_object_map_branch_constraint: GenericConstraintProofMemo,
     /// Successful conditional true-branch constraint relations for prepared
     /// source/target types in the current file session.
     pub conditional_true_branch_relation_successes: FxHashSet<(TypeId, TypeId, u16, bool)>,
@@ -199,10 +270,6 @@ pub struct SharedConstraintProofCache {
     /// constraint relations keyed by prepared source/target plus the packed
     /// relation flags and sound-mode bit.
     pub type_arg_relation_successes: dashmap::DashSet<(TypeId, TypeId, u16, bool)>,
-    /// Mirror of `conditional_branch_constraint`, `true` results only.
-    pub conditional_branch_successes: dashmap::DashSet<(TypeId, TypeId)>,
-    /// Mirror of `indexed_object_map_branch_constraint`, `true` results only.
-    pub indexed_object_map_branch_successes: dashmap::DashSet<(TypeId, TypeId)>,
     /// Mirror of `conditional_true_branch_relation_successes`.
     pub conditional_true_branch_relation_successes: dashmap::DashSet<(TypeId, TypeId, u16, bool)>,
 }
@@ -899,6 +966,44 @@ impl AssignabilityFailureMemo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn generic_constraint_proof_key_partitions_relation_policy() {
+        let base = GenericConstraintProofKey::new(TypeId::STRING, TypeId::NUMBER, 0b01, false);
+        assert_ne!(
+            base,
+            GenericConstraintProofKey::new(TypeId::STRING, TypeId::NUMBER, 0b10, false),
+            "relation flags must be part of the constraint proof key"
+        );
+        assert_ne!(
+            base,
+            GenericConstraintProofKey::new(TypeId::STRING, TypeId::NUMBER, 0b01, true),
+            "sound-mode policy must be part of the constraint proof key"
+        );
+    }
+
+    #[test]
+    fn generic_constraint_proof_memo_rolls_on_stamp_change() {
+        let key = GenericConstraintProofKey::new(TypeId::STRING, TypeId::NUMBER, 0, false);
+        let stamp_a = (1, 2, 3, 4);
+        let stamp_b = (1, 2, 3, 5);
+        let mut memo = GenericConstraintProofMemo::default();
+
+        memo.insert(stamp_a, key, true);
+        assert_eq!(memo.get(stamp_a, key), Some(true));
+        assert_eq!(
+            memo.get(stamp_b, key),
+            None,
+            "a new resolver/env stamp must drop stale branch proofs"
+        );
+        memo.insert(stamp_b, key, false);
+        assert_eq!(memo.get(stamp_b, key), Some(false));
+        assert_eq!(
+            memo.get(stamp_a, key),
+            None,
+            "rolling back to an old numeric stamp starts a fresh memo epoch"
+        );
+    }
 
     #[test]
     fn cow_cache_clone_is_shared_until_first_write() {

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -14,8 +14,9 @@ pub use cache_statistics::CheckerContextCacheStatistics;
 pub use caches::{
     AssignabilityEvalMemo, AssignabilityEvalStamp, AssignabilityFailureKey,
     AssignabilityFailureMemo, AwaitedAssignabilityEvalMemo, CachedAssignabilityAnalysis, CowCache,
-    NarrowableIdentifierCache, NodeTypeCache, SharedConstraintProofCache, SymbolTypeCache,
-    TypeNodeSurfaceCaches, TypeReferenceValidationCaches,
+    GenericConstraintProofKey, GenericConstraintProofMemo, NarrowableIdentifierCache,
+    NodeTypeCache, SharedConstraintProofCache, SymbolTypeCache, TypeNodeSurfaceCaches,
+    TypeReferenceValidationCaches,
 };
 pub use canonical_app_key::CanonicalAppKey;
 pub(crate) use compiler_options::is_declaration_file_name;

--- a/crates/tsz-checker/src/tests/constraint_validation_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/constraint_validation_relation_routing_arch_tests.rs
@@ -80,6 +80,54 @@ fn successful_type_arg_constraint_relations_are_file_local_cached() {
 }
 
 #[test]
+fn conditional_branch_constraint_proofs_use_stamped_typed_cache_keys() {
+    let helper_source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/checkers/generic_checker/conditional_constraint_helpers.rs"),
+    )
+    .expect("failed to read conditional_constraint_helpers.rs");
+    let caches_source =
+        fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("src/context/caches.rs"))
+            .expect("failed to read caches.rs");
+    let reset_source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/context/file_session_reset.rs"),
+    )
+    .expect("failed to read file_session_reset.rs");
+
+    assert!(
+        caches_source.contains("GenericConstraintProofKey")
+            && caches_source.contains("GenericConstraintProofMemo")
+            && caches_source
+                .contains("pub conditional_branch_constraint: GenericConstraintProofMemo")
+            && caches_source
+                .contains("pub indexed_object_map_branch_constraint: GenericConstraintProofMemo"),
+        "conditional and indexed-object branch proof caches should use the typed, stamped TS2344 proof memo"
+    );
+    assert!(
+        helper_source.contains("generic_constraint_proof_key(")
+            && helper_source.contains("assignability_eval_memo_stamp()")
+            && helper_source.contains("generic_constraint_proof_completed_clean(")
+            && helper_source.contains(".conditional_branch_constraint")
+            && helper_source.contains(".indexed_object_map_branch_constraint"),
+        "branch proof helpers should key lookups by relation policy and stamp, then cache only clean results"
+    );
+    assert!(
+        !caches_source.contains("conditional_branch_constraint: FxHashMap<(TypeId, TypeId), bool>")
+            && !caches_source.contains(
+                "indexed_object_map_branch_constraint: FxHashMap<(TypeId, TypeId), bool>"
+            )
+            && !helper_source
+                .contains("conditional_branch_constraint\n                .get(&cache_key)")
+            && !helper_source
+                .contains("indexed_object_map_branch_constraint\n                .get(&cache_key)")
+            && reset_source.contains("conditional_branch_constraint")
+            && reset_source.contains("indexed_object_map_branch_constraint")
+            && reset_source.contains(".clear()"),
+        "branch proof caches must not regress to raw TypeId-pair maps and must keep the file-session reset boundary"
+    );
+}
+
+#[test]
 fn generic_constraint_validation_infer_result_checks_use_named_request() {
     let source = fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
Goal: green

## Summary
- Replace raw `(TypeId, TypeId)` conditional-branch and indexed-object-map TS2344 proof caches with a typed `GenericConstraintProofKey`.
- Guard those branch-proof memos by the checker assignability/evaluation stamp so resolver/type-env generation changes roll the local cache.
- Cache only clean branch proofs, rejecting attempts that observed lazy-resolution failures, exhausted evaluation fuel, depth fallback, or relation overflow.
- Keep these branch proofs file-local rather than publishing them into the program-wide shared success tier, because alias/body resolution can consult current-file context.

## Structural Rule
When a TS2344 conditional or indexed-object-map branch proof depends on relation policy, resolver-visible type state, or file-relative alias/body resolution, `tsc` evaluates it in the current checker context. `tsz` now keys the checker-owned branch proof by source, target, packed relation flags, and sound-mode bit, then stores it only for the current assignability/evaluation stamp and only after a clean proof.

## Owner Layer
Checker owns the TS2344 proof orchestration and local memo lifetime in `TypeReferenceValidationCaches`. `relation_outcome_helpers` owns construction of the typed proof key and the clean-proof predicate. Solver relation semantics remain behind the existing relation/query boundaries; these helpers do not inspect raw solver internals.

## Adjacent Matrix
- Conditional branch proof cache hit: same source/target, relation flags, sound mode, and assignability/evaluation stamp.
- Indexed-object-map branch proof cache hit: same typed key and same stamp.
- Relation flag or sound-mode changes partition the cache key.
- Type-env/resolver/symbol cache generation changes roll the memo and drop stale branch proofs.
- Lazy-resolution miss, evaluation fuel exhaustion, depth fallback, or relation overflow prevents memo insertion.
- Fallback: uncacheable or stamp-less proofs run the existing uncached branch proof path; failures remain diagnostic-path local.
- Program-wide sharing remains limited to existing relation success tiers; these branch proofs stay file-local.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(generic_constraint_proof_key_partitions_relation_policy) or test(generic_constraint_proof_memo_rolls_on_stamp_change) or test(conditional_branch_constraint_proofs_use_stamped_typed_cache_keys)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(generic_constraint_validation_regular_checks_use_relation_outcome_boundary) or test(successful_type_arg_constraint_relations_are_file_local_cached) or test(conditional_branch_constraint_proofs_use_stamped_typed_cache_keys)'`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high