### PR TITLE
fix(cli): default module to CommonJS for sub-ES2015 CLI --target (#15231)

### DIFF
--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -11,8 +11,8 @@ use std::path::{Path, PathBuf};
 use crate::args::{CliArgs, Module, ModuleDetection, ModuleResolution, NewLine, Target};
 use crate::config::{
     CompilerOptions, ModuleResolutionKind, ResolvedCompilerOptions, TsConfig,
-    checker_target_from_emitter, parse_tsconfig_with_diagnostics, resolve_default_lib_files,
-    resolve_lib_files, strict_family,
+    checker_target_from_emitter, derive_default_module_kind, parse_tsconfig_with_diagnostics,
+    resolve_default_lib_files, resolve_lib_files, strict_family,
 };
 use tsz::checker::diagnostics::{Diagnostic, diagnostic_codes};
 use tsz_common::common::NewLineKind;
@@ -52,6 +52,29 @@ pub(super) fn apply_cli_overrides_with_config_options(
     }
     if let Some(module_resolution) = args.module_resolution {
         options.module_resolution = Some(module_resolution.to_module_resolution_kind());
+    }
+    // Re-derive the default `module` from the effective target/moduleResolution
+    // when neither the tsconfig nor a CLI `--module` set it explicitly. The
+    // config-level resolution (`resolve_compiler_options`) computed the module
+    // default from the *config's* target, but a CLI `--target`/`--moduleResolution`
+    // override changes those inputs afterwards, so the default must be recomputed
+    // here to match tsc: an unspecified module resolves to CommonJS for a target
+    // below ES2015 (e.g. `--target es5`) and to the target's ES module kind
+    // otherwise, with moduleResolution `node16`/`nodenext` implying the matching
+    // module kind. Without this, `--target es5` alone wrongly kept the ambient ES
+    // module default and emitted invalid `export` syntax at an ES5 target.
+    if !options.checker.module_explicitly_set
+        && (args.target.is_some() || args.module_resolution.is_some())
+    {
+        let target_explicitly_set =
+            args.target.is_some() || config_options.is_some_and(|config| config.target.is_some());
+        let default_module = derive_default_module_kind(
+            options.printer.target,
+            target_explicitly_set,
+            options.module_resolution,
+        );
+        options.printer.module = default_module;
+        options.checker.module = default_module;
     }
     apply_module_resolution_derived_options(options, args, config_options);
     if let Some(resolve_package_json_exports) = args.resolve_package_json_exports {

--- a/crates/tsz-cli/src/driver/tests.rs
+++ b/crates/tsz-cli/src/driver/tests.rs
@@ -496,6 +496,88 @@ fn test_cli_module_resolution_preserves_config_package_json_resolution_false() {
     assert!(!options.resolve_package_json_imports);
 }
 
+/// A CLI `--target es5` with no explicit `--module` must default `module` to
+/// CommonJS, matching tsc (`getEmitModuleKind`: an unspecified module resolves
+/// to CommonJS for a target below ES2015). Regression: the CLI override path
+/// applied `--target` after the config-level module default was computed, so it
+/// kept the ambient ES module default and emitted invalid `export` syntax at an
+/// ES5 target.
+#[test]
+fn test_cli_target_es5_defaults_module_to_commonjs() {
+    let args = CliArgs::try_parse_from(["tsz", "--target", "es5"]).expect("parse args");
+    let mut options = ResolvedCompilerOptions::default();
+    super::apply_cli_overrides(&mut options, &args).expect("apply overrides");
+
+    assert_eq!(options.printer.module, ModuleKind::CommonJS);
+    assert_eq!(options.checker.module, ModuleKind::CommonJS);
+    assert!(!options.checker.module_explicitly_set);
+}
+
+/// Adjacent: a CLI `--target es2022` with no `--module` keeps the target's ES
+/// module kind (not CommonJS), so ES module emit is preserved for modern
+/// targets.
+#[test]
+fn test_cli_target_es2022_defaults_module_to_es_module() {
+    let args = CliArgs::try_parse_from(["tsz", "--target", "es2022"]).expect("parse args");
+    let mut options = ResolvedCompilerOptions::default();
+    super::apply_cli_overrides(&mut options, &args).expect("apply overrides");
+
+    assert_eq!(options.printer.module, ModuleKind::ES2022);
+    assert_eq!(options.checker.module, ModuleKind::ES2022);
+}
+
+/// An explicit CLI `--module` always wins over the target-derived default: even
+/// at `--target es5`, `--module esnext` keeps ES module emit.
+#[test]
+fn test_cli_explicit_module_wins_over_target_default() {
+    let args = CliArgs::try_parse_from(["tsz", "--target", "es5", "--module", "esnext"])
+        .expect("parse args");
+    let mut options = ResolvedCompilerOptions::default();
+    super::apply_cli_overrides(&mut options, &args).expect("apply overrides");
+
+    assert_eq!(options.printer.module, ModuleKind::ESNext);
+    assert!(options.checker.module_explicitly_set);
+}
+
+/// A `module` set explicitly in the tsconfig must survive a CLI `--target`
+/// override that changes the target-derived default: `--target es5` over a
+/// config `module: esnext` keeps ES module emit.
+#[test]
+fn test_cli_target_es5_preserves_explicit_config_module() {
+    let args = CliArgs::try_parse_from(["tsz", "--target", "es5"]).expect("parse args");
+    let mut options = ResolvedCompilerOptions::default();
+    options.printer.module = ModuleKind::ESNext;
+    options.checker.module = ModuleKind::ESNext;
+    // Mirrors the config-level resolution marking module as explicitly set.
+    options.checker.module_explicitly_set = true;
+    let config_options = CompilerOptions {
+        module: Some("esnext".to_string()),
+        ..Default::default()
+    };
+    super::apply_cli_overrides_with_config_options(&mut options, &args, Some(&config_options))
+        .expect("apply overrides");
+
+    assert_eq!(
+        options.printer.module,
+        ModuleKind::ESNext,
+        "an explicit config module must survive a CLI --target override"
+    );
+}
+
+/// A CLI `--moduleResolution node16` with no explicit `--module` implies
+/// `module: node16` (mirrors tsc and the config-level resolution), independent
+/// of target.
+#[test]
+fn test_cli_module_resolution_node16_implies_module_node16() {
+    let args =
+        CliArgs::try_parse_from(["tsz", "--moduleResolution", "node16"]).expect("parse args");
+    let mut options = ResolvedCompilerOptions::default();
+    super::apply_cli_overrides(&mut options, &args).expect("apply overrides");
+
+    assert_eq!(options.printer.module, ModuleKind::Node16);
+    assert_eq!(options.checker.module, ModuleKind::Node16);
+}
+
 /// `--strict false` on the command line must override `strict: true` from
 /// `tsconfig.json`. `preprocess_args` forwards the explicit-false intent
 /// through the hidden `--__explicitly-disabled-bool-flag` side-channel; this

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -38,7 +38,7 @@ pub use parse::{ParsedTsConfig, parse_tsconfig, parse_tsconfig_with_diagnostics}
 pub use resolved_options::{
     JsxEmit, ModuleResolutionKind, PathMapping, ResolvedCompilerOptions,
     default_module_detection_for_module, default_module_kind_for_target,
-    default_module_resolution_for_module, resolve_compiler_options,
+    default_module_resolution_for_module, derive_default_module_kind, resolve_compiler_options,
 };
 
 /// Custom deserializer for boolean options that accepts both bool and string values.

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -204,6 +204,25 @@ pub const fn default_module_kind_for_target(
     }
 }
 
+/// Resolve the default `module` kind when it is not explicitly set, matching
+/// tsc: `moduleResolution` `node16`/`nodenext` imply the matching module kind,
+/// otherwise the module is derived from the effective target
+/// (`default_module_kind_for_target`). This is the single source of truth shared
+/// by both the tsconfig resolution and the CLI-override paths so a `--target` or
+/// `--moduleResolution` override recomputes the same default.
+#[must_use]
+pub const fn derive_default_module_kind(
+    target: ScriptTarget,
+    target_explicitly_set: bool,
+    module_resolution: Option<ModuleResolutionKind>,
+) -> ModuleKind {
+    match module_resolution {
+        Some(ModuleResolutionKind::Node16) => ModuleKind::Node16,
+        Some(ModuleResolutionKind::NodeNext) => ModuleKind::NodeNext,
+        _ => default_module_kind_for_target(target, target_explicitly_set),
+    }
+}
+
 /// Default `moduleResolution` used when it is omitted for a module kind.
 #[must_use]
 pub const fn default_module_resolution_for_module(module: ModuleKind) -> ModuleResolutionKind {
@@ -389,19 +408,6 @@ pub fn resolve_compiler_options(
     }
     resolved.checker.target = checker_target_from_emitter(resolved.printer.target);
 
-    let module_explicitly_set = options.module.is_some();
-    if let Some(module) = options.module.as_deref() {
-        let kind = parse_module_kind(module)?;
-        resolved.printer.module = kind;
-        resolved.checker.module = kind;
-    } else {
-        let default_module =
-            default_module_kind_for_target(resolved.printer.target, options.target.is_some());
-        resolved.printer.module = default_module;
-        resolved.checker.module = default_module;
-    }
-    resolved.checker.module_explicitly_set = module_explicitly_set;
-
     if let Some(module_resolution) = options.module_resolution.as_deref() {
         let value = module_resolution.trim();
         if !value.is_empty() {
@@ -409,19 +415,23 @@ pub fn resolve_compiler_options(
         }
     }
 
-    // When module is not explicitly set, infer it from moduleResolution (matches tsc behavior).
-    // tsc infers module: node16 when moduleResolution: node16, etc.
-    if !module_explicitly_set && let Some(mr) = resolved.module_resolution {
-        let inferred = match mr {
-            ModuleResolutionKind::Node16 => Some(ModuleKind::Node16),
-            ModuleResolutionKind::NodeNext => Some(ModuleKind::NodeNext),
-            _ => None,
-        };
-        if let Some(kind) = inferred {
-            resolved.printer.module = kind;
-            resolved.checker.module = kind;
-        }
+    let module_explicitly_set = options.module.is_some();
+    if let Some(module) = options.module.as_deref() {
+        let kind = parse_module_kind(module)?;
+        resolved.printer.module = kind;
+        resolved.checker.module = kind;
+    } else {
+        // No explicit module: derive it from moduleResolution (node16/nodenext)
+        // or the effective target (matches tsc's `getEmitModuleKind`).
+        let default_module = derive_default_module_kind(
+            resolved.printer.target,
+            options.target.is_some(),
+            resolved.module_resolution,
+        );
+        resolved.printer.module = default_module;
+        resolved.checker.module = default_module;
     }
+    resolved.checker.module_explicitly_set = module_explicitly_set;
     let effective_resolution = resolved.effective_module_resolution();
     // TS2792 remains tied to Classic resolution sites in conformance. Keep the
     // downstream checker/resolver flag derived from the computed effective


### PR DESCRIPTION
Fixes #15231.

When `module` is set only through a CLI `--target` flag (no `--module`, no
tsconfig), tsz kept the ambient ES module default and emitted ES-module syntax
at targets tsc lowers to CommonJS. `tsz --target es5 file.ts` (a module under
`moduleDetection: force`) emitted `export var a = 1;` — invalid `export` syntax
at an ES5 target — where tsc emits CommonJS. This is a real divergence for the
common `tsc --target es5` invocation with no explicit `--module`.

Repro (`m.ts` = `export const a = 1;`), `tsz --target es5 --moduleDetection force --outDir out m.ts`:

- Before: `export var a = 1;`
- After / tsc 6.0.2:
  ```js
  "use strict";
  Object.defineProperty(exports, "__esModule", { value: true });
  exports.a = void 0;
  exports.a = 1;
  ```

## Structural rule
When `module` is not set explicitly by the tsconfig or a CLI `--module`, tsc
derives it from the effective target (`getEmitModuleKind`: target `< ES2015` →
CommonJS, otherwise the target's ES module kind) and from `moduleResolution`
(`node16`/`nodenext` imply the matching module kind). The tsconfig path
(`resolve_compiler_options`) already did this from the config's target, but the
CLI-override path (`apply_cli_overrides_with_config_options`,
`crates/tsz-cli/src/driver/plan.rs`) applied `--target` *after* the config-level
default was computed and never recomputed the module default when `--module`
was absent — so `--target es5` retained the ambient-target ES module default.

Owner layer: CLI plan / config resolution (`tsz-cli` `driver::plan` + `tsz-core`
`config::resolved_options`). Emit output is unchanged — the CommonJS lowering
path is already byte-identical to tsc under an explicit `--module commonjs`;
only the default-module selection was wrong.

The fix extracts a shared `derive_default_module_kind(target, target_explicitly_set,
module_resolution)` helper (the single source of truth: `moduleResolution`
node16/nodenext, else target-based `default_module_kind_for_target`), uses it in
the tsconfig path, and re-derives in the CLI path when a `--target` /
`--moduleResolution` override changes the inputs and no explicit module is set.

## Adjacent matrix
- `--target es5` (no module) → CommonJS; `--target es2022` (no module) → ES module (unchanged).
- `--target es5 --module esnext` → explicit module wins (ES module).
- tsconfig `module: esnext` + CLI `--target es5` → explicit config module survives.
- `--moduleResolution node16` (no module) → module `node16`.
- Config path (tsconfig `target: es5`, no module) already emitted CommonJS — unchanged.
- Emit conformance is unaffected: its harness always resolves and passes an explicit `--module`.

## Not in scope
A separate ES5/ES2017 class-emit divergence for `accessor` fields + private-field
temp-var hoisting order is noted in #15231 and tracked separately.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-cli --lib` new regression tests (all pass): `test_cli_target_es5_defaults_module_to_commonjs`, `test_cli_target_es2022_defaults_module_to_es_module`, `test_cli_explicit_module_wins_over_target_default`, `test_cli_target_es5_preserves_explicit_config_module`, `test_cli_module_resolution_node16_implies_module_node16`; existing `test_cli_module_resolution_recomputes_package_json_defaults` / `..._preserves_config_package_json_resolution_false` still pass.
- End-to-end: `tsz --target es5/es2015/es2017/es2022` with/without `--module` diffed vs tsc 6.0.2; es5 now emits CommonJS byte-identical to tsc; es2015+ unchanged.
- `cargo fmt --all -- --check`, `git diff --check`, `python3 scripts/arch/arch_guard.py --json` (0 failures).
- `cargo clippy --profile ci-lint -p tsz-core -p tsz-cli --lib -- -D warnings` and `-p tsz-cli --tests -- -D warnings` clean.
- ready-review CI owns the broad conformance/emit baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01W9gqUu14NK1BySbv7HGERk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9gqUu14NK1BySbv7HGERk)_