### PR TITLE
refactor(solver): deterministic #14344 home-decl canonical store election (gated)

### DIFF
--- a/crates/tsz-solver/src/def/core/semantic_construction.rs
+++ b/crates/tsz-solver/src/def/core/semantic_construction.rs
@@ -12,6 +12,68 @@ use super::{Atom, DefId, DefKind, DefinitionInfo, DefinitionStore};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::atomic::Ordering;
 
+#[cfg(test)]
+thread_local! {
+    static DETERMINISTIC_ELECTION_TEST_OVERRIDE: std::cell::Cell<Option<bool>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// Test guard that forces [`deterministic_store_election_enabled`] on/off for the
+/// current thread, so the ordering invariants can be pinned without relying on a
+/// process-global env var (which an `OnceLock` would latch on first read).
+#[cfg(test)]
+pub(crate) struct DeterministicElectionGuard {
+    previous: Option<bool>,
+}
+
+#[cfg(test)]
+impl DeterministicElectionGuard {
+    pub(crate) fn new(enabled: bool) -> Self {
+        let previous = DETERMINISTIC_ELECTION_TEST_OVERRIDE.with(|slot| {
+            let previous = slot.get();
+            slot.set(Some(enabled));
+            previous
+        });
+        Self { previous }
+    }
+}
+
+#[cfg(test)]
+impl Drop for DeterministicElectionGuard {
+    fn drop(&mut self) {
+        DETERMINISTIC_ELECTION_TEST_OVERRIDE.with(|slot| slot.set(self.previous));
+    }
+}
+
+/// Whether shared-store `DefId` allocation / canonical election runs in the
+/// deterministic, `#14344`-sound home-decl order (see
+/// [`DefinitionStore::from_semantic_def_entries`]).
+///
+/// The reorder is gated so the default (all-flags-OFF) pipeline stays
+/// byte-identical to `main`: the historical construction allocates `DefId`s in
+/// `FxHashMap` iteration order, and the composed cross-arena `#14344` / `#14345`
+/// substrate channels are what make the elected canonical observable (and what
+/// the run-to-run flap manifests under). Enabled iff at least one of those
+/// shared-store channels is active, or explicitly via
+/// `TSZ_DETERMINISTIC_STORE_ELECTION=1`. When none is set, the historical
+/// construction path is preserved unchanged.
+pub(crate) fn deterministic_store_election_enabled() -> bool {
+    #[cfg(test)]
+    if let Some(enabled) = DETERMINISTIC_ELECTION_TEST_OVERRIDE.with(std::cell::Cell::get) {
+        return enabled;
+    }
+
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| {
+        std::env::var("TSZ_DETERMINISTIC_STORE_ELECTION").is_ok_and(|v| v == "1")
+            || super::typeof_uri_selfloop_enabled()
+            || super::augmented_body_symbol_redirect_enabled()
+            || super::augmentation_symbols::module_augmentation_symbol_edge_enabled()
+            || super::augmentation_symbols::module_augmentation_body_publish_enabled()
+    })
+}
+
 impl DefinitionStore {
     /// Create a pre-populated `DefinitionStore` from binder `SemanticDefEntry` data.
     ///
@@ -80,6 +142,39 @@ impl DefinitionStore {
         semantic_defs: &[(tsz_binder::SymbolId, &tsz_binder::SemanticDefEntry)],
         intern_string: impl Fn(&str) -> Atom,
     ) -> Self {
+        // `DefId`s are allocated sequentially in Pass 1 in the order of this
+        // slice, and the shared-store elections downstream — first-wins
+        // `symbol_only_index`/`symbol_to_def` (`or_insert`) and the first
+        // `name_to_defs` heritage candidate — resolve by that same order. The
+        // two public constructors build the slice by iterating `FxHashMap`s,
+        // whose iteration order is not stable across the differing insertion
+        // histories produced by parallel/overlay merges, so both the assigned
+        // `DefId` values and the elected canonical copy would otherwise vary
+        // run-to-run (issue #14344). Sort by the arena-invariant home-decl
+        // provenance — declaring `(file_id, span_start)` (both preserved across
+        // arena copies), then the raw `SymbolId` as a stable final tiebreaker —
+        // so every run allocates the same `DefId`s and elects the same canonical
+        // def. This is the sound #14344 home-decl identity, not an arbitrary
+        // stabilization: cross-arena copies of one source decl share
+        // `(file_id, span_start)` and the smaller `SymbolId` wins deterministically.
+        //
+        // Gated: the reorder changes which equivalent cross-arena copy is
+        // elected canonical, which is observable only once the composed
+        // `#14344` / `#14345` shared-store channels expose that canonical to
+        // inference. Behind `deterministic_store_election_enabled` the default
+        // (all-flags-OFF) construction keeps the historical `FxHashMap` order so
+        // it stays byte-identical to `main`.
+        let owned_sorted;
+        let semantic_defs: &[(tsz_binder::SymbolId, &tsz_binder::SemanticDefEntry)] =
+            if deterministic_store_election_enabled() {
+                let mut ordered = semantic_defs.to_vec();
+                ordered.sort_by_key(|(sym_id, entry)| (entry.file_id, entry.span_start, sym_id.0));
+                owned_sorted = ordered;
+                &owned_sorted
+            } else {
+                semantic_defs
+            };
+
         let class_count = semantic_defs
             .iter()
             .map(|(_, entry)| *entry)

--- a/crates/tsz-solver/tests/def_tests.rs
+++ b/crates/tsz-solver/tests/def_tests.rs
@@ -1979,4 +1979,5 @@ fn test_all_definition_names_qualifies_namespace_exports() {
     );
 }
 
+include!("def_tests_parts/semantic_construction_order.rs");
 include!("def_tests_parts/type_to_def.rs");

--- a/crates/tsz-solver/tests/def_tests_parts/semantic_construction_order.rs
+++ b/crates/tsz-solver/tests/def_tests_parts/semantic_construction_order.rs
@@ -1,0 +1,112 @@
+// =============================================================================
+// DefinitionStore semantic-construction ordering / election determinism (#14344)
+// =============================================================================
+//
+// `from_semantic_defs` and `from_semantic_defs_with_overlays` build their entry
+// slice by iterating `FxHashMap`s, whose iteration order is not stable across
+// the differing insertion histories produced by parallel/overlay merges. The
+// construction therefore sorts by the arena-invariant home-decl provenance —
+// declaring `(file_id, span_start)` then the raw `SymbolId` — before allocating
+// `DefId`s in Pass 1, so both the assigned `DefId` values and every first-wins
+// election (`symbol_only_index`, `name_to_defs` heritage candidate) are the same
+// on every run. These tests pin that ordering and the run-to-run stability.
+
+fn ordering_entry(
+    name: &str,
+    file_id: u32,
+    span_start: u32,
+) -> tsz_binder::SemanticDefEntry {
+    let mut entry = semantic_def_entry(name, file_id, tsz_binder::SemanticDefKind::Interface);
+    entry.span_start = span_start;
+    entry
+}
+
+/// `DefId`s are allocated by `(file_id, span_start, symbol_id)`, not by the
+/// order symbols happen to be inserted into the source `FxHashMap`.
+#[test]
+fn from_semantic_defs_allocates_by_declaration_provenance() {
+    let _guard = super::semantic_construction::DeterministicElectionGuard::new(true);
+    let interner = create_test_interner();
+    let mut defs = rustc_hash::FxHashMap::default();
+
+    // Insert out of provenance order; the store must still elect DefIds by the
+    // arena-invariant (file, span, symbol) key.
+    defs.insert(tsz_binder::SymbolId(300), ordering_entry("Late", 7, 40));
+    defs.insert(tsz_binder::SymbolId(100), ordering_entry("Early", 3, 10));
+    defs.insert(tsz_binder::SymbolId(200), ordering_entry("Middle", 3, 20));
+
+    let store = DefinitionStore::from_semantic_defs(&defs, |s| interner.intern_string(s));
+
+    let early = store.find_def_by_symbol(100).expect("Early def");
+    let middle = store.find_def_by_symbol(200).expect("Middle def");
+    let late = store.find_def_by_symbol(300).expect("Late def");
+
+    assert_eq!(
+        [early, middle, late],
+        [DefId(1), DefId(2), DefId(3)],
+        "shared-store DefId election must follow stable file/span/symbol provenance"
+    );
+}
+
+/// Same-`(file, span)` entries fall back to the raw `SymbolId` tiebreaker, so a
+/// deterministic total order still exists.
+#[test]
+fn from_semantic_defs_breaks_span_ties_by_symbol_id() {
+    let _guard = super::semantic_construction::DeterministicElectionGuard::new(true);
+    let interner = create_test_interner();
+    let mut defs = rustc_hash::FxHashMap::default();
+
+    defs.insert(tsz_binder::SymbolId(50), ordering_entry("B", 1, 5));
+    defs.insert(tsz_binder::SymbolId(40), ordering_entry("A", 1, 5));
+
+    let store = DefinitionStore::from_semantic_defs(&defs, |s| interner.intern_string(s));
+
+    assert_eq!(store.find_def_by_symbol(40), Some(DefId(1)));
+    assert_eq!(store.find_def_by_symbol(50), Some(DefId(2)));
+}
+
+/// The elected `DefId` for each symbol is identical no matter what order the
+/// entries were inserted into the base and overlay maps — the run-to-run
+/// determinism property the shared store relies on.
+#[test]
+fn from_semantic_defs_with_overlays_is_insertion_order_independent() {
+    let _guard = super::semantic_construction::DeterministicElectionGuard::new(true);
+    let interner = create_test_interner();
+
+    let build = |seed: &[(u32, &str, u32, u32)], overlay_seed: &[(u32, &str, u32, u32)]| {
+        let mut base = rustc_hash::FxHashMap::default();
+        for &(sym, name, file, span) in seed {
+            base.insert(tsz_binder::SymbolId(sym), ordering_entry(name, file, span));
+        }
+        let mut overlay = rustc_hash::FxHashMap::default();
+        for &(sym, name, file, span) in overlay_seed {
+            overlay.insert(tsz_binder::SymbolId(sym), ordering_entry(name, file, span));
+        }
+        let store = DefinitionStore::from_semantic_defs_with_overlays(&base, [&overlay], |s| {
+            interner.intern_string(s)
+        });
+        // Snapshot: (symbol -> elected DefId) for every input symbol.
+        let mut mapping: Vec<(u32, u32)> = seed
+            .iter()
+            .chain(overlay_seed.iter())
+            .map(|&(sym, _, _, _)| sym)
+            .map(|sym| (sym, store.find_def_by_symbol(sym).expect("def").0))
+            .collect();
+        mapping.sort_unstable();
+        mapping.dedup();
+        mapping
+    };
+
+    let base_a = [(5u32, "E", 4u32, 40u32), (1, "A", 1, 10), (3, "C", 2, 30)];
+    let overlay_a = [(2u32, "B", 1u32, 20u32), (4, "D", 3, 15)];
+
+    // A permuted set of the same logical entries (reverse listing order).
+    let base_b = [(3u32, "C", 2u32, 30u32), (1, "A", 1, 10), (5, "E", 4, 40)];
+    let overlay_b = [(4u32, "D", 3u32, 15u32), (2, "B", 1, 20)];
+
+    assert_eq!(
+        build(&base_a, &overlay_a),
+        build(&base_b, &overlay_b),
+        "elected DefIds must be independent of FxHashMap insertion/iteration order"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary

`DefinitionStore::from_semantic_def_entries` (crates/tsz-solver/src/def/core/semantic_construction.rs) allocates `DefId`s in Pass 1 in the order of its input slice, and the first-wins elections downstream (`symbol_only_index` / `symbol_to_def` `or_insert`, first `name_to_defs` heritage candidate) all resolve by that same order. Both public constructors (`from_semantic_defs`, `from_semantic_defs_with_overlays`) build that slice by iterating `FxHashMap`s, whose iteration order is not stable across the differing insertion histories produced by parallel/overlay merges. So the assigned `DefId`s — and the elected canonical cross-arena copy — can vary run-to-run once the composed #14344 / #14345 shared-store channels expose that canonical to inference.

## Structural rule

When multiple cross-arena copies of one source declaration are merged into the shared store, `tsc` treats them as one home declaration. `tsz` now elects the canonical copy by the arena-invariant home-decl provenance — declaring `(file_id, span_start)` (both preserved across arena copies per #14344), then the raw `SymbolId` as a stable final tiebreaker — sorting the entries before Pass 1 `DefId` allocation. This is the sound #14344 home-decl identity, not an arbitrary stabilization: cross-arena copies of one source decl share `(file_id, span_start)`, and the smaller `SymbolId` wins deterministically. Owner layer: solver (`DefinitionStore` construction).

## Gating

Behind `deterministic_store_election_enabled()` — enabled by any composed #14344 / #14345 shared-store channel (typeof-URI self-loop, augmented-body redirect/publish, module-augmentation symbol edge) or explicitly via `TSZ_DETERMINISTIC_STORE_ELECTION=1`. When none is set, the historical `FxHashMap` order is preserved unchanged, so the default (all-flags-OFF) pipeline stays byte-identical to `main`. Touches only `semantic_construction.rs` (+95) plus a new regression-test part and its include.

## Verification

Isolated single-process fp-ts fixture (`tsz-bench.tsconfig.json`, the CI guard config); diagnostics keyed by `(file, line, col, code)`.

- Default byte-parity (all-flags-OFF): this branch == a fresh `origin/main` build. Identical keyset, both 1202 keys, identical hash `717363e6`. The gate is OFF by default, so construction is unchanged from `main`.
- Standalone election delta (`TSZ_DETERMINISTIC_STORE_ELECTION=1` alone) vs baseline: 1202 -> 1141, **net -61**. 71 baseline errors cleared, 10 relocated survivors.
  - The 71 cleared are entirely the cross-arena HKT monad-transformer family (EitherT 31, OptionT 16, TheseT 9, Tree 4, StateT 3, pipeable 3, ReadonlyMap 2, Foldable 2, ReaderT 1; codes TS2345 x47 / TS2322 x18 / TS2769 x4 / TS2739 x1 / TS18046 x1). fp-ts is `tsc=0`, so every cleared key is a genuine false-positive removal (tsc-more-correct).
  - **new_fps: 0 genuine.** All 10 "new" keys (all TS2345, all in EitherT/OptionT/TheseT/Tree) are column/line relocations of the SAME underlying HKT diagnostic within statements that already carried a baseline error that cleared — 9/10 land on the exact same `(file,line)` that had a baseline error; the 10th (`Tree.ts:219`) is the same multi-line `pipe(...)` expression's error relocating from lines 217-218 (which cleared) to 219. No new false positive appears at a previously-clean statement (no over-election of a wrong canonical).
- Determinism: N=5 at `RAYON_NUM_THREADS=1` AND N=5 at `RAYON_NUM_THREADS=4`, election ON — all 10 runs produce the identical keyset hash `6f8a98a7`. The election is order-independent across thread counts.
- `cargo nextest run -p tsz-solver --lib` — the 3 new election tests pass (`from_semantic_defs_allocates_by_declaration_provenance`, `from_semantic_defs_breaks_span_ties_by_symbol_id`, `from_semantic_defs_with_overlays_is_insertion_order_independent`) plus def/identity/canonical tests (444 passed, 0 failed).
- `cargo clippy -p tsz-solver --lib --tests` — clean.

Note: the full composed #15220 substrate flag set (`TSZ_TYPEOF_URI_SELFLOOP` + `TSZ_XARENA_HERITAGE_TYPEARG` + `TSZ_TYPEPARAM_DECL_IDENTITY` + `TSZ_XARENA_BASE_DECL` + `TSZ_INST_RESOLVER_REREDUCE`) stack-overflows on both this branch AND a fresh `origin/main` build (pre-existing substrate instability, election-independent), so the composed-ON delta could not be measured here; the standalone-election delta above isolates exactly what this reorder does.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
