### PR TITLE
fix(emit): reserve ES5 private accessor helpers per present accessor in source order (#15235)

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
@@ -287,6 +287,93 @@ class A {
 }
 
 #[test]
+fn es5_getter_only_private_accessor_omits_setter_helper() {
+    // A getter-only private accessor lowered for ES5 must reserve only the
+    // getter helper var. `tsc` never mints a `_set` helper for an accessor that
+    // has no setter; a spurious `var ..., _X_size_set` is a dead binding.
+    let source = r#"
+class Widget {
+    #v = 1;
+    get #size() { return this.#v; }
+    probe() { return this.#size; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        output.contains("_Widget_size_get"),
+        "getter-only private accessor should reserve its getter helper.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_Widget_size_set"),
+        "getter-only private accessor must not reserve a dead setter helper.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_setter_only_private_accessor_omits_getter_helper() {
+    // Symmetric to the getter-only case: a setter-only private accessor reserves
+    // only the setter helper var, never a dead `_get`.
+    let source = r#"
+class Gauge {
+    #v = 0;
+    set #level(n: number) { this.#v = n; }
+    probe(n: number) { this.#level = n; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES5);
+
+    assert!(
+        output.contains("_Gauge_level_set"),
+        "setter-only private accessor should reserve its setter helper.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_Gauge_level_get"),
+        "setter-only private accessor must not reserve a dead getter helper.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_set_before_get_private_accessor_reserves_and_inits_setter_first() {
+    // When the setter is written before the getter in source, `tsc` reserves and
+    // initializes the `_set` helper before `_get` (source order), not a fixed
+    // get-before-set order.
+    let source = r#"
+class Meter {
+    #v = 0;
+    set #value(n: number) { this.#v = n; }
+    get #value() { return this.#v; }
+    probe() { this.#value = 2; return this.#value; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES5);
+
+    let decl_set = output
+        .find("_Meter_value_set,")
+        .or_else(|| output.find("_Meter_value_set;"))
+        .unwrap_or_else(|| panic!("expected setter helper declaration\n{output}"));
+    let decl_get = output
+        .find("_Meter_value_get,")
+        .or_else(|| output.find("_Meter_value_get;"))
+        .unwrap_or_else(|| panic!("expected getter helper declaration\n{output}"));
+    assert!(
+        decl_set < decl_get,
+        "set-before-get accessor should declare the setter helper first.\nOutput:\n{output}"
+    );
+
+    let init_set = output
+        .find("_Meter_value_set = function")
+        .unwrap_or_else(|| panic!("expected setter helper init\n{output}"));
+    let init_get = output
+        .find("_Meter_value_get = function")
+        .unwrap_or_else(|| panic!("expected getter helper init\n{output}"));
+    assert!(
+        init_set < init_get,
+        "set-before-get accessor should initialize the setter helper first.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn private_async_helpers_downlevel_for_es2015_but_preserve_native_for_es2019() {
     let source = r#"
 class A {

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
@@ -459,7 +459,6 @@ impl<'a> ES5ClassTransformer<'a> {
             decls.push(alias.clone());
         }
 
-        let mut emitted_accessor_entries: FxHashSet<usize> = FxHashSet::default();
         for &member_idx in &class_data.members.nodes {
             let Some(member_node) = self.arena.get(member_idx) else {
                 continue;
@@ -484,20 +483,22 @@ impl<'a> ES5ClassTransformer<'a> {
                     }
                 }
                 k if k == syntax_kind_ext::GET_ACCESSOR || k == syntax_kind_ext::SET_ACCESSOR => {
-                    if let Some((entry_idx, accessor)) = self
+                    // Declare each accessor's helper var at its own source
+                    // position, so a `set`-before-`get` pair declares `_set`
+                    // first and a getter-only/setter-only accessor declares only
+                    // the var it owns — matching `tsc`.
+                    if let Some(accessor) = self
                         .private_accessors
                         .iter()
-                        .enumerate()
-                        .find(|(_, accessor)| accessor.member_indices.contains(&member_idx))
+                        .find(|accessor| accessor.member_indices.contains(&member_idx))
                     {
-                        if !emitted_accessor_entries.insert(entry_idx) {
-                            continue;
-                        }
-                        if let Some(get_var) = accessor.get_var_name.as_ref() {
-                            decls.push(get_var.clone());
-                        }
-                        if let Some(set_var) = accessor.set_var_name.as_ref() {
-                            decls.push(set_var.clone());
+                        let var = if k == syntax_kind_ext::GET_ACCESSOR {
+                            accessor.get_var_name.as_ref()
+                        } else {
+                            accessor.set_var_name.as_ref()
+                        };
+                        if let Some(var) = var {
+                            decls.push(var.clone());
                         }
                     }
                 }
@@ -515,46 +516,58 @@ impl<'a> ES5ClassTransformer<'a> {
             }
         }
         for accessor in &self.private_accessors {
-            if let Some(get_var) = accessor.get_var_name.as_ref()
-                && let Some(getter_idx) = accessor.getter_body.and_then(|_| {
-                    accessor.member_indices.iter().copied().find(|&idx| {
-                        self.arena
-                            .get(idx)
-                            .is_some_and(|node| node.kind == syntax_kind_ext::GET_ACCESSOR)
-                    })
-                })
-                && let Some(mut function) = if accessor.is_static {
-                    self.build_getter_function_ir_static(getter_idx)
+            // Initialize each accessor's helper at its own source position by
+            // walking the members in source order, so a `set`-before-`get` pair
+            // assigns `_set` first, matching `tsc`.
+            for &member_idx in &accessor.member_indices {
+                let Some(node) = self.arena.get(member_idx) else {
+                    continue;
+                };
+                let init = if node.kind == syntax_kind_ext::GET_ACCESSOR {
+                    self.private_accessor_init_string(accessor, member_idx, true)
+                } else if node.kind == syntax_kind_ext::SET_ACCESSOR {
+                    self.private_accessor_init_string(accessor, member_idx, false)
                 } else {
-                    self.build_getter_function_ir(getter_idx)
-                }
-            {
-                if let IRNode::FunctionExpr { name, .. } = &mut function {
-                    *name = Some(get_var.clone().into());
-                }
-                inits.push(self.private_assignment_string(get_var, function));
-            }
-            if let Some(set_var) = accessor.set_var_name.as_ref()
-                && let Some(setter_idx) = accessor.setter_body.and_then(|_| {
-                    accessor.member_indices.iter().copied().find(|&idx| {
-                        self.arena
-                            .get(idx)
-                            .is_some_and(|node| node.kind == syntax_kind_ext::SET_ACCESSOR)
-                    })
-                })
-                && let Some(mut function) = if accessor.is_static {
-                    self.build_setter_function_ir_static(setter_idx)
-                } else {
-                    self.build_setter_function_ir(setter_idx)
-                }
-            {
-                if let IRNode::FunctionExpr { name, .. } = &mut function {
-                    *name = Some(set_var.clone().into());
-                }
-                inits.push(self.private_assignment_string(set_var, function));
+                    None
+                };
+                inits.extend(init);
             }
         }
         inits
+    }
+
+    /// Build the `_C_x_get = function ...` / `_C_x_set = function ...` helper
+    /// initializer for a single private accessor member, or `None` when the
+    /// accessor has no body to lower or its helper var was not reserved.
+    fn private_accessor_init_string(
+        &self,
+        accessor: &crate::transforms::private_fields_es5::PrivateAccessorInfo,
+        member_idx: NodeIndex,
+        is_getter: bool,
+    ) -> Option<String> {
+        // A helper is emitted only when its var was reserved and the accessor
+        // has a body to lower.
+        let var = if is_getter {
+            accessor
+                .get_var_name
+                .as_ref()
+                .filter(|_| accessor.getter_body.is_some())?
+        } else {
+            accessor
+                .set_var_name
+                .as_ref()
+                .filter(|_| accessor.setter_body.is_some())?
+        };
+        let mut function = match (is_getter, accessor.is_static) {
+            (true, true) => self.build_getter_function_ir_static(member_idx),
+            (true, false) => self.build_getter_function_ir(member_idx),
+            (false, true) => self.build_setter_function_ir_static(member_idx),
+            (false, false) => self.build_setter_function_ir(member_idx),
+        }?;
+        if let IRNode::FunctionExpr { name, .. } = &mut function {
+            *name = Some(var.clone().into());
+        }
+        Some(self.private_assignment_string(var, function))
     }
 
     pub(super) fn static_private_field_init_strings(&self) -> Vec<String> {

--- a/crates/tsz-emitter/src/transforms/private_fields_es5.rs
+++ b/crates/tsz-emitter/src/transforms/private_fields_es5.rs
@@ -732,17 +732,18 @@ pub fn collect_private_accessors_with_reserved(
             }) {
                 idx
             } else {
+                // Helper var names are reserved lazily, only when the matching
+                // getter/setter is actually seen (see below). A getter-only or
+                // setter-only private accessor reserves a single helper var, and
+                // `tsc` reserves in source order — so a `set`-before-`get` pair
+                // reserves `_set` first. Eagerly minting both here would emit a
+                // dead `_C_x_set`/`_C_x_get` and force a fixed get-before-set
+                // reservation order that diverges from `tsc`.
                 accessors.push(PrivateAccessorInfo {
                     member_indices: Vec::new(),
                     name: clean_name.to_string(),
-                    get_var_name: Some(make_unique_private_name(
-                        &format!("{}_get", private_helper_base(class_name, clean_name)),
-                        used_names,
-                    )),
-                    set_var_name: Some(make_unique_private_name(
-                        &format!("{}_set", private_helper_base(class_name, clean_name)),
-                        used_names,
-                    )),
+                    get_var_name: None,
+                    set_var_name: None,
                     has_getter: false,
                     has_setter: false,
                     getter_body: None,
@@ -758,16 +759,31 @@ pub fn collect_private_accessors_with_reserved(
             entry.member_indices.push(member_idx);
             let is_async = arena.has_modifier(&accessor_data.modifiers, SyntaxKind::AsyncKeyword);
 
-            // Update based on accessor type
+            // Update based on accessor type. The helper var name is reserved
+            // here, at the accessor's source position, so declaration and
+            // reservation order match `tsc` and only present accessors reserve a
+            // name.
             if is_getter {
                 entry.has_getter = true;
                 entry.getter_is_async = is_async;
+                if entry.get_var_name.is_none() {
+                    entry.get_var_name = Some(make_unique_private_name(
+                        &format!("{}_get", private_helper_base(class_name, clean_name)),
+                        used_names,
+                    ));
+                }
                 if accessor_data.body.is_some() {
                     entry.getter_body = Some(accessor_data.body);
                 }
             } else if member_node.kind == syntax_kind_ext::SET_ACCESSOR {
                 entry.has_setter = true;
                 entry.setter_is_async = is_async;
+                if entry.set_var_name.is_none() {
+                    entry.set_var_name = Some(make_unique_private_name(
+                        &format!("{}_set", private_helper_base(class_name, clean_name)),
+                        used_names,
+                    ));
+                }
                 if accessor_data.body.is_some() {
                     entry.setter_body = Some(accessor_data.body);
                 }


### PR DESCRIPTION
Fixes #15235.

When a class with a **private accessor** (`get #x()` / `set #x()`) is lowered to
an ES5 target, tsz's hoisted helper-var bundle diverged from tsc in two ways:

1. A **getter-only** private accessor declared a dead setter helper (`_C_x_set`),
   and a **setter-only** accessor declared a dead getter helper (`_C_x_get`).
2. A `set`-before-`get` pair declared and initialized the helpers get-before-set
   regardless of source order.

Both are ES5-only. At ES2015–ES2021 tsz already matched tsc, because that path
uses a different collector that already allocates lazily.

### Repro (`--target es5 --module esnext --moduleDetection force --ignoreDeprecations 6.0 --noCheck`)

```ts
export class C { #v = 1; get #g() { return this.#v; } m() { return this.#g; } }
```
- Before: `var _C_instances, _C_v, _C_g_get, _C_g_set;`  (dead `_C_g_set`)
- After / tsc 6.0.2: `var _C_instances, _C_v, _C_g_get;`

Matrix (var-decl line), all four now byte-match tsc:

| source | tsc / after | before |
|---|---|---|
| `get #g` only | `_C_g_get` | `_C_g_get, _C_g_set` |
| `set #g` only | `_C_g_set` | `_C_g_get, _C_g_set` |
| `get` then `set` | `_C_g_get, _C_g_set` | `_C_g_get, _C_g_set` |
| `set` then `get` | `_C_g_set, _C_g_get` | `_C_g_get, _C_g_set` |

## Structural rule
When a private accessor is lowered to a WeakMap / `__classPrivateFieldGet`
helper, tsc reserves a helper var **only for an accessor that exists** (getter
and setter independently) and reserves/initializes them in **source order**. tsz
does this through the ES5 collector `collect_private_accessors_with_reserved`
and the ES5 declaration/init builders in `class_es5_ir_members.rs`.

## Owner layer
Emitter only (`crates/tsz-emitter/src/transforms/`). No semantic validation and
no output surgery: the collector now allocates `get_var_name`/`set_var_name`
lazily at the accessor's source position (matching the already-correct ES6
collector `collect_private_members_with_reserved`), and the var-decl / init
builders emit each accessor's helper at its own member position. Present
accessors and their bodies are unchanged; only the dead helper and the
get-before-set ordering are removed.

## Adjacent matrix
- getter-only → only `_get` reserved; setter-only → only `_set`.
- `get`-then-`set` unchanged; `set`-then-`get` now reserves and inits `_set` first.
- Static private accessors, name collision with an enclosing local binding, and
  multiple accessor pairs verified against tsc 6.0.2.
- Anti-hardcoding: new tests vary class/accessor binder names (`Widget`/`#size`,
  `Gauge`/`#level`, `Meter`/`#value`).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib private_field_helper_order_tests` — 28 pass, incl. 3 new regressions (`es5_getter_only_private_accessor_omits_setter_helper`, `es5_setter_only_private_accessor_omits_getter_helper`, `es5_set_before_get_private_accessor_reserves_and_inits_setter_first`).
- `cargo test -p tsz-emitter --lib` — 3917 pass, 0 fail.
- End-to-end `tsz` vs `tsc 6.0.2` diffed on the full accessor matrix at ES5 — byte-identical for the helper-var bundle.
- `cargo clippy --profile ci-lint -p tsz-emitter --lib -- -D warnings` — clean.
- `cargo fmt --all -- --check`, `git diff --check`, `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean.
- ready-review CI owns the broad conformance/emit baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hp2CxnKBCzaLtfus5o69Tj)_