### PR TITLE
fix(emit): confine discarded-value context to the statement expression

### DIFF
--- a/crates/tsz-emitter/src/context/emit.rs
+++ b/crates/tsz-emitter/src/context/emit.rs
@@ -57,10 +57,25 @@ pub struct EmitFlags {
     /// `(function(){})()` instead of `(function(){}())`.
     pub paren_leftmost_function_or_object: bool,
 
-    /// Whether the current expression's result value is discarded (statement context).
-    /// Set by expression-statement and for-loop incrementor emitters so that
-    /// postfix unary lowering can use the simpler (non-value-preserving) form.
+    /// Discarded-value *propagation* flag: set by expression-statement and
+    /// for-loop incrementor emitters to mark that the expression they are about
+    /// to emit is in value-discarded position. It propagates to a node's
+    /// children only through a parenthesized expression (matching tsc, whose
+    /// `discardedValueVisitor` is transparent through parentheses only); every
+    /// other node places its children in value-used positions, so `emit_node`
+    /// clears this flag for the subtree. Readers must consult `value_discarded`
+    /// (the resolved per-node status), not this propagation flag.
     pub in_statement_expression: bool,
+
+    /// Whether the node currently being emitted is itself in value-discarded
+    /// position. Resolved by `emit_node` from `in_statement_expression` for
+    /// every node, then read by the read-modify-write lowerings (private-field
+    /// and live-export `++`/`--`, scoped-static-`super` updates, destructuring
+    /// rest assignment) to choose between the value-preserving form (result is
+    /// used) and the simpler statement form (result is discarded). Kept
+    /// separate from `in_statement_expression` so a node's own discard status
+    /// does not leak into its value-used children.
+    pub value_discarded: bool,
 
     /// A recovered JSX conditional with a missing false branch just emitted its
     /// synthetic `:`. The enclosing JSX expression owns the recovered close-tail

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -1106,6 +1106,20 @@ impl<'a> Printer<'a> {
             return;
         }
 
+        // Resolve the discarded-value context for this node. A statement's
+        // discarded expression propagates to children only through a
+        // parenthesized expression (tsc's `discardedValueVisitor` is
+        // transparent through parentheses only); every other node places its
+        // children in value-used positions, so clear the propagation flag for
+        // the subtree. `value_discarded` records THIS node's own status for the
+        // read-modify-write lowerings, without leaking into its children.
+        let prev_in_statement_expression = self.ctx.flags.in_statement_expression;
+        let prev_value_discarded = self.ctx.flags.value_discarded;
+        self.ctx.flags.value_discarded = prev_in_statement_expression;
+        if prev_in_statement_expression && node.kind != syntax_kind_ext::PARENTHESIZED_EXPRESSION {
+            self.ctx.flags.in_statement_expression = false;
+        }
+
         // Check transform directives first
         let has_transform = !self.transforms.is_empty()
             && Self::kind_may_have_transform(node.kind)
@@ -1121,6 +1135,8 @@ impl<'a> Printer<'a> {
         }
 
         self.pending_source_pos = previous_pending;
+        self.ctx.flags.in_statement_expression = prev_in_statement_expression;
+        self.ctx.flags.value_discarded = prev_value_discarded;
         self.emit_recursion_depth -= 1;
     }
 

--- a/crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs
@@ -652,7 +652,7 @@ impl<'a> Printer<'a> {
             return;
         };
 
-        if !self.ctx.flags.in_statement_expression {
+        if !self.ctx.flags.value_discarded {
             let temp = self.make_unique_name_hoisted_assignment();
             self.write("(");
             self.write(&temp);

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -1803,7 +1803,7 @@ impl<'a> Printer<'a> {
             || unary.operator == SyntaxKind::MinusMinusToken as u16)
             && let Some(pfa) = self.try_extract_private_field_access(unary.operand)
         {
-            let is_statement = self.ctx.flags.in_statement_expression;
+            let is_statement = self.ctx.flags.value_discarded;
             self.emit_private_field_unary_mutation(pfa, unary.operator, false, is_statement);
             return;
         }
@@ -1835,7 +1835,7 @@ impl<'a> Printer<'a> {
             && operand_node.kind == SyntaxKind::Identifier as u16
         {
             let local_name = self.get_identifier_text_idx(unary.operand);
-            let is_statement = self.ctx.flags.in_statement_expression;
+            let is_statement = self.ctx.flags.value_discarded;
             if self.emit_system_live_export_postfix_unary(&local_name, unary.operator, is_statement)
                 || self.emit_cjs_live_export_postfix_unary(
                     &local_name,

--- a/crates/tsz-emitter/src/emitter/expressions/static_super.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/static_super.rs
@@ -51,7 +51,7 @@ impl<'a> Printer<'a> {
             return false;
         };
 
-        if !self.ctx.flags.in_statement_expression {
+        if !self.ctx.flags.value_discarded {
             return self.emit_scoped_static_super_value_assignment(&member, operator, right);
         }
 
@@ -95,7 +95,7 @@ impl<'a> Printer<'a> {
             return false;
         }
 
-        if !self.ctx.flags.in_statement_expression {
+        if !self.ctx.flags.value_discarded {
             return self.emit_scoped_static_super_value_update(&member, operator, is_prefix);
         }
 

--- a/crates/tsz-emitter/src/emitter/module_emission/commonjs_live_exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/commonjs_live_exports.rs
@@ -167,7 +167,7 @@ impl<'a> Printer<'a> {
         local_name: &str,
         operator: u16,
     ) -> bool {
-        let needs_parens = !self.ctx.flags.in_statement_expression;
+        let needs_parens = !self.ctx.flags.value_discarded;
         match self.cjs_live_export_kind(local_name) {
             CjsLiveExportKind::NotExported => false,
             CjsLiveExportKind::Inline(aliases) => {

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -49,6 +49,8 @@ mod namespace_class_use_define_es5_tests;
 #[cfg(test)]
 mod private_field_helper_order_tests;
 #[cfg(test)]
+mod private_field_increment_value_position_tests;
+#[cfg(test)]
 mod private_tagged_template_tests;
 
 #[cfg(test)]

--- a/crates/tsz-emitter/src/emitter/source_file/private_field_increment_value_position_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_field_increment_value_position_tests.rs
@@ -1,0 +1,185 @@
+//! Regression tests for the discarded-value context of private-field
+//! `++`/`--` lowering.
+//!
+//! When a private field is down-leveled to a `WeakMap` helper, a postfix
+//! `#x++` whose result is *used* must be lowered to the value-preserving form
+//! `(__classPrivateFieldSet(...), _old)` so the pre-increment value is what the
+//! surrounding expression observes. The simpler statement form
+//! `__classPrivateFieldSet(...)` (which evaluates to the *new* value) is only
+//! valid when the result is discarded.
+//!
+//! `tsc`'s `discardedValueVisitor` treats a value as discarded only for the
+//! immediate expression of an expression statement (and the for-loop
+//! incrementor), transparent through parentheses only. A call argument, binary
+//! operand, `void` operand, comma operand, etc. are value-used positions even
+//! when the enclosing statement's own result is discarded. tsz previously
+//! propagated the statement's discarded-value flag into those children, so
+//! `sink(this.#x++);` miscompiled to the new-value form.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit(source: &str, target: ScriptTarget) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target,
+        use_define_for_class_fields: false,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+/// The value-preserving form must recover the pre-increment value, which needs
+/// a *second* temp (`(_b = get, _a = _b++, _b)` plus a trailing `, _a`), so its
+/// method declares `var _a, _b`. The discarded statement form reuses a single
+/// working temp (`(_a = get, _a++, _a)`), declaring only `var _a`. Each test
+/// isolates one `this`-received increment, so the second temp is present iff
+/// the old value is preserved. The temp names are compiler-generated, not user
+/// identifiers, so keying on them does not hard-code binder names.
+fn uses_value_form(method_body: &str) -> bool {
+    method_body.contains("var _a, _b")
+}
+
+fn method_line<'a>(output: &'a str, needle: &str) -> &'a str {
+    output
+        .lines()
+        .find(|l| l.contains(needle))
+        .unwrap_or_else(|| panic!("expected a line containing `{needle}`.\nOutput:\n{output}"))
+}
+
+#[test]
+fn private_postfix_as_call_argument_in_discarded_statement_uses_value_form() {
+    // `sink(widget.#tally++)` — the enclosing call statement's result is
+    // discarded, but the argument's value is used, so the increment must
+    // preserve the old value.
+    let source = r#"
+declare function sink(n: number): void;
+class Widget {
+    #tally = 0;
+    bump() { sink(this.#tally++); }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+    let line = method_line(&output, "bump()");
+    assert!(
+        uses_value_form(line),
+        "a private-field postfix used as a call argument must preserve the old value even when the call statement is discarded.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn private_postfix_as_bare_statement_uses_statement_form() {
+    // Binder names deliberately differ from the call-argument test so the rule
+    // is structural, not keyed on identifiers.
+    let source = r#"
+class Gauge {
+    #level = 0;
+    step() { this.#level++; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+    let line = method_line(&output, "step()");
+    assert!(
+        !uses_value_form(line),
+        "a private-field postfix that is the whole statement expression should use the discarded (statement) form.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn private_postfix_through_parentheses_stays_discarded() {
+    // Parentheses are transparent to the discarded-value context in tsc, so
+    // `(this.#count++);` keeps the statement form.
+    let source = r#"
+class Meter {
+    #count = 0;
+    tick() { (this.#count++); }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+    let line = method_line(&output, "tick()");
+    assert!(
+        !uses_value_form(line),
+        "parentheses are transparent to discarded-value context; the statement form should be kept.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn private_postfix_as_comma_operand_uses_value_form() {
+    // tsc treats a comma operand as value-used even when the comma expression
+    // is the discarded statement expression.
+    let source = r#"
+declare function other(): void;
+class Ledger {
+    #entries = 0;
+    record() { other(), this.#entries++; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+    let line = method_line(&output, "record()");
+    assert!(
+        uses_value_form(line),
+        "a private-field postfix that is a comma operand is value-used and must preserve the old value.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn private_postfix_as_void_operand_uses_value_form() {
+    let source = r#"
+class Counter {
+    #hits = 0;
+    ping() { void this.#hits++; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+    let line = method_line(&output, "ping()");
+    assert!(
+        uses_value_form(line),
+        "the operand of `void` is value-used in tsc; the increment must preserve the old value.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn private_postfix_returned_call_argument_uses_value_form() {
+    // Regression guard for the already-correct case: `return sink(this.#x++)`.
+    let source = r#"
+declare function sink(n: number): number;
+class Tracker {
+    #seen = 0;
+    read() { return sink(this.#seen++); }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+    let line = method_line(&output, "read()");
+    assert!(
+        uses_value_form(line),
+        "a call argument whose enclosing call result is used must preserve the old value.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn private_postfix_nested_call_argument_uses_value_form() {
+    // `sink(sink(this.#x++));` — outer call discarded, inner argument used.
+    let source = r#"
+declare function sink(n: number): number;
+class Relay {
+    #depth = 0;
+    forward() { sink(sink(this.#depth++)); }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+    let line = method_line(&output, "forward()");
+    assert!(
+        uses_value_form(line),
+        "a private-field postfix nested in a discarded outer call is still value-used.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes a JS emit miscompilation: a private-field postfix `#x++`/`#x--` used as a
**call/`new` argument inside a discarded expression statement** was lowered to
the new-value form, so the callee observed the post-increment value instead of
the pre-increment value.

### Repro (`--target es2015 --module commonjs`)
```ts
class A { #x = 10; run() { const out: number[] = []; out.push(this.#x++); return out[0]; } }
```
- Before: `run()` returns `11` (wrong — `out.push` got the new value)
- After / tsc 6.0.2: returns `10`

The bug fired for any value-used position **when the enclosing statement's own
result is discarded**: `f(this.#x++);`, `obj.m(this.#x++);`, `arr.push(this.#x++)`,
`f(f(this.#x++));`, and the CommonJS/System live-export and scoped-static-`super`
update forms. `return f(this.#x++)` and `const y = f(this.#x++)` were already
correct, which localized the root cause.

## Structural rule
When a read-modify-write expression (`#x++`/`#x--`, live-export `++`/`--`,
scoped-static-`super` update, destructuring rest assignment) is emitted, `tsc`
chooses the value-preserving form unless the **result is discarded**. The
discarded-value context comes only from the immediate expression of an
expression statement (and the `for` incrementor) and is transparent **through
parentheses only** — `discardedValueVisitor`. Comma operands, the `void`
operand, call/`new` arguments, binary operands, array elements, template
substitutions, object-literal property values, etc. are all value-used
positions. tsz instead propagated its `in_statement_expression` flag into every
child, so a value-used child inside a discarded statement wrongly used the
statement (new-value) form.

## Owner layer
Emitter only. The propagation is now resolved centrally in `emit_node`
(`crates/tsz-emitter/src/emitter/core.rs`): the discarded-value context
propagates to a node's children only when the node is a
`ParenthesizedExpression`; every other node clears it for the subtree. A node's
own resolved status is exposed via a new `EmitFlags::value_discarded`, which the
read-modify-write lowerings consult instead of the raw propagation flag, so a
node's discard status can no longer leak into its value-used children. No
semantic validation and no output surgery.

## Adjacent matrix (vs tsc 6.0.2, verified byte-for-byte at ES2015)
- `f(this.#x++);` / `obj.m(this.#x++);` / `arr.push(this.#x++)` → value form (old value).
- `f(f(this.#x++));` (outer discarded, inner used) → inner uses value form.
- `this.#x++;` and `(this.#x++);` (bare / parenthesized statement) → statement form.
- `other(), this.#x++;`, `this.#x++, other();`, `void this.#x++;` → value form (comma/`void` operands are value-used).
- `return f(this.#x++)`, `const y = f(this.#x++)` → unchanged (already value form).
- CommonJS live-export `sink(count++);` and scoped-static-`super` `f(super.v++);` in discarded statements → value form; runtime verified.
- Prefix `++this.#x` unchanged (always new value).
- Anti-hardcoding: regression tests vary class/field binder names (`Widget`/`#tally`, `Gauge`/`#level`, `Meter`/`#count`, `Ledger`/`#entries`, …); the value-vs-statement discriminator keys on the compiler-generated temp count, not user names.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib private_field_increment_value_position_tests` — 7 pass (new file).
- `cargo test -p tsz-emitter --lib` — 3924 pass, 0 fail (full emitter lib suite, incl. the 7 new; no regressions after rebase onto `main`).
- End-to-end `tsz` vs `tsc 6.0.2` diffed on the full matrix above at ES2015/ES2021 — byte-identical for the affected forms; runtime outputs match.
- `cargo clippy --profile ci-lint -p tsz-emitter --lib -- -D warnings` — clean.
- `cargo fmt --all -- --check`, `git diff --check`, `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean.
- ready-review CI owns the broad conformance/emit baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_0175pjVp1hC9YdnwZ1Hn8tbb