### PR TITLE
fix(checker): elaborate fresh object-literal source per-property against plain generic targets

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -35,14 +35,21 @@ impl<'a> CheckerState<'a> {
         )
     }
 
-    fn target_prefers_outer_assignment_diagnostic(&mut self, target: TypeId) -> bool {
-        let candidates = vec![
+    /// The normalized target surfaces (self, contextual, property-access, and
+    /// assignability evaluations) that the assignment-diagnostic query boundary
+    /// inspects. Shared by `target_prefers_outer_assignment_diagnostic` and
+    /// `target_has_deferred_evaluation_surface` so both look at the same set.
+    fn target_evaluation_candidates(&mut self, target: TypeId) -> Vec<TypeId> {
+        vec![
             target,
             self.evaluate_contextual_type(target),
             self.resolve_type_for_property_access(target),
             self.evaluate_type_for_assignability(target),
-        ];
+        ]
+    }
 
+    fn target_prefers_outer_assignment_diagnostic(&mut self, target: TypeId) -> bool {
+        let candidates = self.target_evaluation_candidates(target);
         crate::query_boundaries::assignability::target_prefers_outer_assignment_diagnostic(
             self.ctx.types,
             &self.ctx,
@@ -73,6 +80,35 @@ impl<'a> CheckerState<'a> {
             Some(RelationFailure::MissingProperty { .. })
                 | Some(RelationFailure::MissingProperties { .. })
                 | Some(RelationFailure::IncompatiblePropertyValue { .. })
+        )
+    }
+
+    /// Whether the assignment/return source expression is (after stripping
+    /// parentheses and type assertions) a bare object- or array-literal — the
+    /// only source shape `tsc`'s `elaborateObjectLiteral`/`elaborateArrayLiteral`
+    /// drills into. Used to keep per-property source elaboration scoped to fresh
+    /// literals so non-literal sources (identifiers, call results) keep the outer
+    /// diagnostic and its relation-reason chain intact.
+    fn assignment_source_is_object_or_array_literal(&self, source_idx: NodeIndex) -> bool {
+        let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(source_idx);
+        self.ctx.arena.get(expr_idx).is_some_and(|node| {
+            node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                || node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+        })
+    }
+
+    /// Whether the target carries a deferred evaluation surface (generic indexed
+    /// access / mapped / conditional-with-type-params). See
+    /// `query_boundaries::assignability::target_has_deferred_evaluation_surface`.
+    /// Fresh-literal per-property elaboration is skipped on such targets because
+    /// `tsc` cannot resolve their members concretely and keeps the outer
+    /// whole-object diagnostic.
+    fn target_has_deferred_evaluation_surface(&mut self, target: TypeId) -> bool {
+        let candidates = self.target_evaluation_candidates(target);
+        crate::query_boundaries::assignability::target_has_deferred_evaluation_surface(
+            self.ctx.types,
+            &self.ctx,
+            &candidates,
         )
     }
 
@@ -1024,12 +1060,34 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        if !self.target_prefers_outer_assignment_diagnostic(target)
+        // `tsc`'s `elaborateObjectLiteral` drills a **fresh object/array-literal**
+        // source into per-property errors whenever the failure is a genuine
+        // member mismatch against a target whose members resolve concretely —
+        // including a *plain* generic interface/object application like `A<T>`.
+        // The coarse `target_prefers_outer_assignment_diagnostic` gate lumps such
+        // plain applications in with the genuinely-deferred surfaces
+        // (generic indexed access, generic mapped, conditional-with-type-params),
+        // where `tsc` cannot resolve a member type and so keeps the outer
+        // whole-object diagnostic and its nested relation-reason chain. Re-enable
+        // the literal-source elaboration only for the plain-application case: the
+        // source is a fresh object/array literal, the relation failed at a
+        // concrete member (`should_preserve_structural_property_diagnostic`), and
+        // the target has no deferred evaluation surface. A non-literal source
+        // (e.g. `X[K1]` vs `X[K2]` type-parameter drift) and any deferred target
+        // (e.g. `Pick<C<T>, 'k'> & …`) keep the outer diagnostic + chain
+        // unchanged, and `try_elaborate_assignment_source_error` still no-ops when
+        // no per-property mismatch is present.
+        let source_is_fresh_literal_with_member_failure = self
+            .assignment_source_is_object_or_array_literal(source_idx)
+            && self.should_preserve_structural_property_diagnostic(&outcome)
+            && !self.target_has_deferred_evaluation_surface(target);
+        let target_prefers_outer = self.target_prefers_outer_assignment_diagnostic(target);
+        if (!target_prefers_outer || source_is_fresh_literal_with_member_failure)
             && self.try_elaborate_assignment_source_error(source_idx, target)
         {
             return false;
         }
-        if self.target_prefers_outer_assignment_diagnostic(target)
+        if target_prefers_outer
             && !self.should_preserve_structural_property_diagnostic(&outcome)
             && self
                 .missing_required_properties_from_index_signature_source(source, target)

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -160,13 +160,45 @@ pub(crate) fn target_prefers_outer_assignment_diagnostic<R: TypeResolver>(
     expanded.into_iter().any(|candidate| {
         candidate != TypeId::ERROR
             && candidate != TypeId::ANY
-            && (super::common::contains_generic_indexed_access_surface(type_db, candidate)
-                || super::common::is_generic_mapped_type(type_db, candidate)
-                || super::common::is_generic_mapped_application(db, resolver, candidate)
-                || (super::common::contains_conditional_type(type_db, candidate)
-                    && super::common::contains_type_parameters(type_db, candidate))
+            && (candidate_has_deferred_evaluation_surface(db, resolver, candidate)
                 || super::common::is_generic_application_with_type_params(type_db, candidate))
     })
+}
+
+/// Whether a target carries a **deferred** evaluation surface — a generic
+/// indexed access, a generic mapped type/application, or a conditional that
+/// still mentions type parameters. These are the surfaces where a property type
+/// cannot be resolved to a concrete member, so `tsc` keeps the outer
+/// whole-object diagnostic (with its nested relation-reason chain) instead of
+/// drilling a fresh object literal per-property. Distinguished from a *plain*
+/// generic application like `A<T>` (a simple interface/object instantiation),
+/// whose members resolve concretely and which `tsc`'s `elaborateObjectLiteral`
+/// does drill.
+pub(crate) fn target_has_deferred_evaluation_surface<R: TypeResolver>(
+    db: &dyn QueryDatabase,
+    resolver: &R,
+    candidates: &[TypeId],
+) -> bool {
+    let expanded = alias_application_surface_candidates(db, resolver, candidates);
+    expanded
+        .into_iter()
+        .any(|candidate| candidate_has_deferred_evaluation_surface(db, resolver, candidate))
+}
+
+fn candidate_has_deferred_evaluation_surface<R: TypeResolver>(
+    db: &dyn QueryDatabase,
+    resolver: &R,
+    candidate: TypeId,
+) -> bool {
+    if candidate == TypeId::ERROR || candidate == TypeId::ANY {
+        return false;
+    }
+    let type_db = db.as_type_database();
+    super::common::contains_generic_indexed_access_surface(type_db, candidate)
+        || super::common::is_generic_mapped_type(type_db, candidate)
+        || super::common::is_generic_mapped_application(db, resolver, candidate)
+        || (super::common::contains_conditional_type(type_db, candidate)
+            && super::common::contains_type_parameters(type_db, candidate))
 }
 
 /// Expand checker-facing type surfaces through display aliases and instantiated

--- a/crates/tsz-checker/tests/generic_interface_target_property_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/generic_interface_target_property_elaboration_tests.rs
@@ -86,6 +86,138 @@ fn generic_interface_member_mismatch_drill_in_is_name_independent() {
     }
 }
 
+fn ts2322_all(source: &str) -> Vec<Diagnostic> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .collect()
+}
+
+/// A **fresh object literal** returned to a generic-interface target elaborates
+/// per-property, mirroring `tsc`'s `elaborateObjectLiteral`: each incompatible
+/// property gets its own TS2322 anchored at the property value with a direct
+/// `Type 'X' is not assignable to type 'Y'.` message — not a single whole-object
+/// `Type '{ ... }' is not assignable to type 'A<T>'.` wrapper (which would carry
+/// a nested `Types of property ...` chain and surface only once).
+///
+/// Regression: because the generic target routed to the coarse
+/// `target_prefers_outer_assignment_diagnostic` surface, the fresh-literal
+/// source elaboration was skipped and the return collapsed to the single outer
+/// wrapper, dropping the second property's error entirely. The variable-init
+/// path already drilled; only the return/assignment path diverged.
+#[test]
+fn fresh_object_literal_return_to_generic_target_elaborates_per_property() {
+    let diagnostics = ts2322_all(
+        "interface A<T> { x: number; y: string; }\n\
+         function make<T>(): A<T> { return { x: \"bad\", y: 5 }; }\n",
+    );
+    assert_eq!(
+        diagnostics.len(),
+        2,
+        "expected one TS2322 per incompatible property, got {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message_text == "Type 'string' is not assignable to type 'number'."),
+        "expected the direct per-property message for 'x', got {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message_text == "Type 'number' is not assignable to type 'string'."),
+        "expected the direct per-property message for 'y', got {diagnostics:#?}"
+    );
+    // No whole-object wrapper: a per-property elaboration never nests a
+    // `Types of property ...` frame.
+    assert!(
+        diagnostics
+            .iter()
+            .all(|d| !has_related(d, "Types of property")),
+        "expected flat per-property diagnostics, not a nested wrapper, got {diagnostics:#?}"
+    );
+}
+
+/// The per-property drill for a fresh literal is keyed on the structural
+/// relation, not on any identifier: vary the interface name, the type-parameter
+/// spelling, and the property names. Every variant elaborates both mismatches.
+#[test]
+fn fresh_object_literal_return_per_property_is_name_independent() {
+    for (iface, type_param, num_prop, str_prop) in [
+        ("Container", "Element", "head", "tail"),
+        ("Wrapper", "K", "slot", "label"),
+        ("Holder", "Payload", "count", "name"),
+    ] {
+        let source = format!(
+            "interface {iface}<{type_param}> {{ {num_prop}: number; {str_prop}: string; }}\n\
+             function build<{type_param}>(): {iface}<{type_param}> {{ \
+                return {{ {num_prop}: \"bad\", {str_prop}: 5 }}; }}\n",
+        );
+        let diagnostics = ts2322_all(&source);
+        assert_eq!(
+            diagnostics.len(),
+            2,
+            "[{iface}/{type_param}] expected two per-property TS2322, got {diagnostics:#?}"
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message_text == "Type 'string' is not assignable to type 'number'."),
+            "[{iface}/{type_param}] expected '{num_prop}' message, got {diagnostics:#?}"
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message_text == "Type 'number' is not assignable to type 'string'."),
+            "[{iface}/{type_param}] expected '{str_prop}' message, got {diagnostics:#?}"
+        );
+    }
+}
+
+/// A property whose target type is the bare free type parameter and whose source
+/// value already satisfies it is NOT flagged; only the genuinely incompatible
+/// sibling property elaborates. This proves the drill uses the real per-property
+/// relation rather than blanket-erroring every member of a generic target.
+#[test]
+fn fresh_object_literal_return_skips_satisfied_free_param_property() {
+    let diagnostics = ts2322_all(
+        "interface A<T> { x: T; y: string; }\n\
+         function make<T>(t: T): A<T> { return { x: t, y: 5 }; }\n",
+    );
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected only the incompatible 'y' property to error, got {diagnostics:#?}"
+    );
+    assert_eq!(
+        diagnostics[0].message_text, "Type 'number' is not assignable to type 'string'.",
+        "expected the direct 'y' message, got {diagnostics:#?}"
+    );
+}
+
+/// Guard against over-drilling: when the generic target is an unresolved
+/// conditional application (`C<T>` with `T` still free), `tsc` keeps the single
+/// whole-object `Type '{ ... }' is not assignable to type 'C<T>'.` wrapper
+/// because there is no concrete member surface to elaborate into. The fix must
+/// not manufacture per-property errors here.
+#[test]
+fn fresh_object_literal_return_to_unresolved_conditional_target_stays_outer() {
+    let diagnostics = ts2322_all(
+        "type C<T> = T extends string ? { a: number } : { b: string };\n\
+         function make<T extends string>(): C<T> { return { a: \"bad\" }; }\n",
+    );
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected a single whole-object wrapper for the unresolved conditional target, \
+         got {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics[0].message_text.contains("C<T>"),
+        "expected the outer wrapper naming the conditional target, got {diagnostics:#?}"
+    );
+}
+
 /// A missing required member against a generic-interface target keeps its
 /// dedicated TS2741 elaboration rather than collapsing to the outer line.
 #[test]


### PR DESCRIPTION
A fresh object/array literal assigned or returned to a **plain generic target**
(`A<T>`) collapsed to a single whole-object `TS2322` wrapper and dropped the
extra per-property errors, where `tsc`'s `elaborateObjectLiteral` drills each
incompatible property at its own span.

Structural rule: when a fresh object/array-literal source fails
assignment/return against a target whose members resolve concretely — including
a *plain* generic interface/object application `A<T>` — `tsc` reports each
incompatible member at its own value span. tsz suppressed that per-property
source elaboration for every generic-application target because the
return/assignment path routed through the coarse
`target_prefers_outer_assignment_diagnostic` gate, which lumps plain
applications in with the genuinely *deferred* surfaces (generic indexed access,
generic mapped, conditional-with-type-params) where `tsc` keeps the outer
diagnostic. Owner layer: checker diagnostics
(`crates/tsz-checker/src/assignability/assignability_diagnostics.rs` +
`query_boundaries::assignability`).

### Repro (`--strict --noEmit`)

```ts
interface A<T> { x: number; y: string; }
function make<T>(): A<T> { return { x: "bad", y: 5 }; }
```

- tsc 6.0.2 / tsz after:
  ```
  (2,37): error TS2322: Type 'string' is not assignable to type 'number'.
  (2,47): error TS2322: Type 'number' is not assignable to type 'string'.
  ```
- tsz before: one whole-object wrapper `Type '{ x: string; y: number; }' is
  not assignable to type 'A<T>'.` (the `y` error was never surfaced).

### Fix

Re-enable per-property source elaboration only for the plain-application case:
the source is a fresh object/array literal, the relation failed at a concrete
member (`should_preserve_structural_property_diagnostic`), and the target has no
deferred evaluation surface (new `target_has_deferred_evaluation_surface`,
factored out of `target_prefers_outer_assignment_diagnostic`). A non-literal
source (`X[K1]` vs `X[K2]` type-parameter drift) and any deferred target
(`Pick<C<T>, 'k'> & …`) keep the outer diagnostic and its nested relation-reason
chain unchanged. This aligns the return/assignment path with the
variable-initializer path, which already drilled plain generic targets.

Decision-neutral: the TS2322 **decision** is unchanged; only diagnostic
localization/count now match `tsc`. No user-name/file-name/rendered-message
predicates — driven by the structural relation-failure kind and the source
syntax being a fresh literal.

Contributes to the `#13212` (valibot F1 whole-object message-shape) and `#10663`
(kysely `TS2322`) row families.

## Goal
Goal: hold

## Verification
- Rebuilt `tsz` and diffed against `tsc` 6.0.2 on a matrix (all match): fresh
  object literal → `A<T>` (two per-property errors, was one wrapper); free-param
  property satisfied (only the sibling errors); fresh array literal → generic
  array; generic **mapped** target; **unresolved conditional** target `C<T>`
  (outer wrapper preserved — not over-drilled); excess property `TS2353`;
  nested object; same-generic non-literal source (unchanged); concrete `A<string>`.
- New regression suite
  `crates/tsz-checker/tests/generic_interface_target_property_elaboration_tests.rs`
  (fresh-literal per-property, binder-name invariance, satisfied-free-param
  skip, unresolved-conditional-stays-outer) — 7/7 pass.
- No new failures vs base across the `ts2322`, `assignab`, and `object_literal`
  `tsz-checker` lib filters (captured clean-base failure sets and diffed —
  zero delta); the previously-lumped
  `test_ts2322_keeps_outer_object_error_for_direct_index_access_target` passes.
- `cargo fmt --all -- --check`, `git diff --check`,
  `python3 scripts/arch/arch_guard.py --json` (0 failures),
  `scripts/arch/check-checker-boundaries.sh`,
  `cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings` — clean.
- ready-review CI owns the broad conformance/emit baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01QQGxDfrJHb4X8Yb7YvDogG

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQGxDfrJHb4X8Yb7YvDogG)_