### PR TITLE
refactor(cli): key DateTimeFormatPart spelling baseline on span, not message text

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1223,7 +1223,8 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
             &program_context,
             &[2552],
         );
-        diagnostics.retain(is_datetimeformatpart_spelling_baseline_diagnostic);
+        diagnostics
+            .retain(|diag| is_datetimeformatpart_spelling_baseline_diagnostic(diag, checker_libs));
         diagnostics
     } else {
         Vec::new()

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -1683,6 +1683,51 @@ declare namespace Intl {
         );
     }
 
+    #[test]
+    fn datetimeformatpart_spelling_baseline_keys_on_span_not_message() {
+        // The Intl baseline predicate must identify the diagnostic by the
+        // unresolved identifier at its span, NOT by the rendered TS2552 sentence
+        // (a formatted-diagnostic-string predicate is forbidden and brittle across
+        // locales/wording). These two cases pin that contract.
+        let source = "declare namespace Intl {\n    interface DateTimeFormat {\n        formatToParts(): DateTimeFormatPart[];\n    }\n}\n";
+        let checker_libs = checker_lib_set_for_test(&[("lib.esnext.intl.d.ts", source)]);
+
+        let part_name = "DateTimeFormatPart";
+        let part_offset = source
+            .find(&format!("{part_name}["))
+            .expect("DateTimeFormatPart reference present") as u32;
+
+        // Correct span, deliberately non-canonical message: still matched.
+        let span_diag = Diagnostic::error(
+            "lib.esnext.intl.d.ts",
+            part_offset,
+            part_name.len() as u32,
+            "a completely different wording",
+            2552,
+        );
+        assert!(
+            is_datetimeformatpart_spelling_baseline_diagnostic(&span_diag, &checker_libs),
+            "must match on the span identifier regardless of the rendered message"
+        );
+
+        // Canonical-looking message, but the span covers a different identifier:
+        // not matched.
+        let other_offset = source
+            .find("DateTimeFormat {")
+            .expect("DateTimeFormat interface present") as u32;
+        let mismatched_diag = Diagnostic::error(
+            "lib.esnext.intl.d.ts",
+            other_offset,
+            "DateTimeFormat".len() as u32,
+            "Cannot find name 'DateTimeFormatPart'. Did you mean 'DateTimeFormat'?",
+            2552,
+        );
+        assert!(
+            !is_datetimeformatpart_spelling_baseline_diagnostic(&mismatched_diag, &checker_libs),
+            "must not match when the span identifier is not DateTimeFormatPart"
+        );
+    }
+
     fn collect_es2015_default_lib_diagnostics(source: &str) -> Vec<Diagnostic> {
         collect_es2015_default_lib_diagnostics_with_options(source, |_: &mut _| {})
     }

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -1692,18 +1692,16 @@ declare namespace Intl {
         let source = "declare namespace Intl {\n    interface DateTimeFormat {\n        formatToParts(): DateTimeFormatPart[];\n    }\n}\n";
         let checker_libs = checker_lib_set_for_test(&[("lib.esnext.intl.d.ts", source)]);
 
-        let part_name = "DateTimeFormatPart";
-        let part_offset = source
-            .find(&format!("{part_name}["))
-            .expect("DateTimeFormatPart reference present") as u32;
+        let intl_ts2552 = |offset: u32, length: usize, message: &str| {
+            Diagnostic::error("lib.esnext.intl.d.ts", offset, length as u32, message, 2552)
+        };
+        let name_offset = |needle: &str| source.find(needle).expect("token present") as u32;
 
         // Correct span, deliberately non-canonical message: still matched.
-        let span_diag = Diagnostic::error(
-            "lib.esnext.intl.d.ts",
-            part_offset,
-            part_name.len() as u32,
+        let span_diag = intl_ts2552(
+            name_offset("DateTimeFormatPart["),
+            "DateTimeFormatPart".len(),
             "a completely different wording",
-            2552,
         );
         assert!(
             is_datetimeformatpart_spelling_baseline_diagnostic(&span_diag, &checker_libs),
@@ -1712,15 +1710,10 @@ declare namespace Intl {
 
         // Canonical-looking message, but the span covers a different identifier:
         // not matched.
-        let other_offset = source
-            .find("DateTimeFormat {")
-            .expect("DateTimeFormat interface present") as u32;
-        let mismatched_diag = Diagnostic::error(
-            "lib.esnext.intl.d.ts",
-            other_offset,
-            "DateTimeFormat".len() as u32,
+        let mismatched_diag = intl_ts2552(
+            name_offset("DateTimeFormat {"),
+            "DateTimeFormat".len(),
             "Cannot find name 'DateTimeFormatPart'. Did you mean 'DateTimeFormat'?",
-            2552,
         );
         assert!(
             !is_datetimeformatpart_spelling_baseline_diagnostic(&mismatched_diag, &checker_libs),

--- a/crates/tsz-cli/src/driver/checker_lib_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/checker_lib_diagnostics.rs
@@ -897,15 +897,15 @@ pub(super) fn baseline_lib_datetimeformatpart_spelling_interface_names(
             continue;
         };
         let text = source_file.text.as_ref();
-        if !text.contains("DateTimeFormatPart") || !text.contains("DateTimeFormat") {
+        if !text.contains(DATE_TIME_FORMAT_PART) || !text.contains(DATE_TIME_FORMAT) {
             continue;
         }
 
         if matches!(file_name, "lib.es2021.intl.d.ts" | "es2021.intl.d.ts") {
-            interfaces.insert("DateTimeRangeFormatPart".to_string());
+            interfaces.insert(DATE_TIME_RANGE_FORMAT_PART.to_string());
         }
         if matches!(file_name, "lib.esnext.intl.d.ts" | "esnext.intl.d.ts") {
-            interfaces.insert("DateTimeFormat".to_string());
+            interfaces.insert(DATE_TIME_FORMAT.to_string());
         }
     }
 
@@ -948,6 +948,14 @@ fn is_parallel_order_sensitive_global_lib(file_name: &str) -> bool {
     )
 }
 
+/// Intl lib interface names involved in the `DateTimeFormatPart` spelling
+/// baseline. Centralized so the checker-lib recheck path has a single source of
+/// truth for these built-in identifiers instead of spreading the same string
+/// literals across call sites.
+const DATE_TIME_FORMAT: &str = "DateTimeFormat";
+const DATE_TIME_FORMAT_PART: &str = "DateTimeFormatPart";
+const DATE_TIME_RANGE_FORMAT_PART: &str = "DateTimeRangeFormatPart";
+
 fn is_datetimeformatpart_spelling_baseline_trigger_lib(file_name: &str) -> bool {
     matches!(
         file_name,
@@ -958,6 +966,31 @@ fn is_datetimeformatpart_spelling_baseline_trigger_lib(file_name: &str) -> bool 
     )
 }
 
+/// The source text covered by a diagnostic's `(file, start, length)` span, read
+/// from the checker lib whose file name matches. Diagnostic offsets are byte
+/// offsets into the source, so the range slices directly (a token span always
+/// lands on a `char` boundary, and `str::get` returns `None` rather than
+/// panicking if it somehow does not).
+fn checker_lib_diagnostic_span_text<'a>(
+    checker_libs: &'a CheckerLibSet,
+    file: &str,
+    start: u32,
+    length: u32,
+) -> Option<&'a str> {
+    let base_name = Path::new(file).file_name().and_then(|name| name.to_str())?;
+    let lib = checker_libs.files.iter().find(|lib| {
+        Path::new(&lib.file_name)
+            .file_name()
+            .and_then(|name| name.to_str())
+            == Some(base_name)
+    })?;
+    let source_file = lib.arena.get_source_file_at(lib.root_index)?;
+    let text = source_file.text.as_ref();
+    let start = start as usize;
+    let end = start.checked_add(length as usize)?;
+    text.get(start..end)
+}
+
 fn is_datetimeformatpart_spelling_baseline_lib(file_name: &str) -> bool {
     matches!(
         file_name,
@@ -965,18 +998,32 @@ fn is_datetimeformatpart_spelling_baseline_lib(file_name: &str) -> bool {
     )
 }
 
-pub(super) fn is_datetimeformatpart_spelling_baseline_diagnostic(diag: &Diagnostic) -> bool {
-    if diag.code != 2552
-        || diag.message_text
-            != "Cannot find name 'DateTimeFormatPart'. Did you mean 'DateTimeFormat'?"
-    {
+/// Whether `diag` is the `DateTimeFormatPart` cannot-find-name diagnostic the
+/// checker-lib baseline recheck must preserve.
+///
+/// The decision is structural, not textual: the diagnostic is `TS2552`, it
+/// originates in one of the Intl baseline libs, and the identifier it reports as
+/// unresolved — read from the lib source at the diagnostic's own span — is
+/// `DateTimeFormatPart`. It deliberately does *not* compare the rendered
+/// "Did you mean …?" message. Matching a formatted diagnostic string as a
+/// semantic predicate is forbidden by the anti-hardcoding gate and is brittle:
+/// it breaks under `--locale` and silently rots if the `TS2552` wording changes.
+pub(super) fn is_datetimeformatpart_spelling_baseline_diagnostic(
+    diag: &Diagnostic,
+    checker_libs: &CheckerLibSet,
+) -> bool {
+    if diag.code != 2552 {
         return false;
     }
-
-    Path::new(&diag.file)
+    let originates_in_baseline_lib = Path::new(&diag.file)
         .file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(is_datetimeformatpart_spelling_baseline_lib)
+        .is_some_and(is_datetimeformatpart_spelling_baseline_lib);
+    if !originates_in_baseline_lib {
+        return false;
+    }
+    checker_lib_diagnostic_span_text(checker_libs, &diag.file, diag.start, diag.length)
+        == Some(DATE_TIME_FORMAT_PART)
 }
 
 fn build_lib_bound_file_for_interface_checks(


### PR DESCRIPTION
Goal: hold

Closes #15240 (filed independently per the note in #14349).

## What / why

The checker-lib baseline recheck preserves one lib-internal `TS2552`
(`Cannot find name 'DateTimeFormatPart'. Did you mean 'DateTimeFormat'?`) that
`tsc` emits for certain Intl lib combinations. It selected that diagnostic by
comparing the **rendered** message against a hand-authored English literal, and
gated interface collection on scattered hardcoded interface-name literals.

Using a formatted diagnostic string as a semantic predicate is forbidden by the
Anti-Hardcoding Gate (review checklist #2). It is also brittle: it breaks under
`--locale` and rots if the `TS2552` template wording changes.

## Structural rule

When the baseline recheck decides whether a lib-internal `TS2552` is the
`DateTimeFormatPart` cannot-find-name diagnostic, it keys on the **unresolved
identifier at the diagnostic's own span** — read structurally from the lib
source — never on the rendered "Did you mean …?" sentence.

## Change

- `is_datetimeformatpart_spelling_baseline_diagnostic` now reads the identifier
  covered by the diagnostic's `(file, start, length)` **byte** span from the
  matching checker lib and compares it to `DateTimeFormatPart`; the message-text
  comparison is gone. Diagnostic offsets are byte offsets into the source, so the
  span slices directly via `str::get` (returns `None` rather than panicking on a
  non-`char`-boundary).
- The Intl interface-name literals (`DateTimeFormat`, `DateTimeFormatPart`,
  `DateTimeRangeFormatPart`) are centralized into named constants shared across
  the recheck path.

Owner layer: CLI driver diagnostics (`crates/tsz-cli/src/driver/checker_lib_diagnostics.rs`);
no checker/solver semantics change.

Behavior is unchanged — the three existing `*_spelling_baseline` tests still
pass. Fully removing the name-specificity (native lib-internal name-resolution
diagnostics à la `tsc` `skipLibCheck: false`) is a larger follow-up noted on
#15240; this PR is scoped to the gate violation.

## Adjacent cases covered

- Preserved: intl + Temporal/Date trigger lib → the `DateTimeFormatPart` 2552 is kept.
- Skipped: intl without a trigger lib → no 2552 preserved.
- Ignored: a different unresolved name (`DateTimeFormatParts`) in the same lib → not preserved.
- New: a 2552 with the correct span but non-canonical message is matched; a 2552
  with the canonical message but a span over a different identifier is rejected.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo nextest run -p tsz-cli --lib -E 'test(spelling_baseline) + test(ts2552_without) + test(keys_on_span)'` → 4 passed
- `cargo nextest run -p tsz-cli --lib -E 'test(datetimeformat) + test(checker_lib) + test(default_lib_diagnostics) + test(lib_recheck) + test(baseline)'` → 7 passed
- Conformance/emit/fourslash parity via ready-review CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dqkz6NC1F95vMuFZjJXNhB)_