### PR TITLE
fix(emit): interleave static private field inits in source order

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -351,6 +351,10 @@ name = "static_field_lowering_trailing_comment_tests"
 path = "tests/static_field_lowering_trailing_comment_tests.rs"
 
 [[test]]
+name = "static_private_field_init_order_tests"
+path = "tests/static_private_field_init_order_tests.rs"
+
+[[test]]
 name = "static_super_destructure_default_target_tests"
 path = "tests/static_super_destructure_default_target_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -43,6 +43,10 @@ pub(crate) struct StaticPrivateInit {
     pub(crate) storage_name: String,
     pub(crate) initializer: NodeIndex,
     pub(crate) storage_kind: PrivateFieldStorageKind,
+    /// Source position of the declaring member, used to interleave the value
+    /// initialization with sibling public static field inits and static blocks
+    /// in source order (tsc's initialization-order semantics).
+    pub(crate) member_pos: u32,
 }
 
 /// A const enum entry scoped to a specific region of the source.

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -973,10 +973,12 @@ impl<'a> Printer<'a> {
                     } else {
                         (f.weakmap_name.clone(), PrivateFieldStorageKind::Value)
                     };
+                    let member_pos = self.arena.get(f.member_idx).map_or(u32::MAX, |n| n.pos);
                     Some(StaticPrivateInit {
                         storage_name,
                         initializer: f.initializer,
                         storage_kind,
+                        member_pos,
                     })
                 })
                 .collect();

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_after_body.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_after_body.rs
@@ -4,11 +4,21 @@ use super::StaticFieldInit;
 use super::emit_es6_private_accessors::PrivateAutoAccessorInfo;
 use super::private_comma_items::PrivateCommaItems;
 use super::replace_identifier;
-use crate::emitter::core::{PrivateAccessorDef, PrivateMethodDef};
+use crate::emitter::core::{PrivateAccessorDef, PrivateMethodDef, StaticPrivateInit};
 use std::sync::Arc;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{ClassData, Node};
 use tsz_scanner::SyntaxKind;
+
+/// Alias context needed to emit a static block IIFE in the class-declaration
+/// static-element stream (bundled so the shared emit helper stays under the
+/// argument-count lint).
+struct StaticBlockScope<'a> {
+    class_name: &'a str,
+    this_binding: Option<&'a str>,
+    super_base: Option<&'a str>,
+    class_alias: Option<&'a str>,
+}
 
 pub(super) struct ClassEs6AfterBody<'a> {
     pub(super) node: &'a Node,
@@ -242,6 +252,20 @@ impl<'a> Printer<'a> {
             && has_any_private_lowering
             && (!static_field_inits.is_empty() || !deferred_static_blocks.is_empty());
         let mut emitted_private_auto_accessors_pre_static = false;
+        // Static private field VALUE inits (`_C_x = { value: ... }`) are static
+        // *elements*: tsc interleaves them with the public static field inits and
+        // static blocks in source order. When public static field inits are
+        // present the source-ordered emission loop below runs, so divert the
+        // private value inits into this list and splice them in by source position
+        // instead of emitting the whole group up-front. With no public static
+        // field inits there is nothing to interleave against, so they keep tsc's
+        // grouped order at their existing emission site. Only the class
+        // *declaration* emission loop below is handled here; a class expression
+        // routes its static field inits through the comma-expression path and
+        // keeps its existing private-init handling.
+        let interleave_static_private_inits =
+            !static_field_inits.is_empty() && class_expr_static_temp.is_none();
+        let mut interleaved_static_private_inits: Vec<StaticPrivateInit> = Vec::new();
         if emit_private_inits_before_static_elements {
             let static_private_inits = std::mem::take(&mut self.pending_static_private_inits);
             let private_class_alias_pair = self.pending_private_class_alias.take();
@@ -264,7 +288,7 @@ impl<'a> Printer<'a> {
                 || !accessor_defs.is_empty()
                 || !private_auto_accessors.is_empty()
                 || !private_auto_instance_storage_inits.is_empty()
-                || !static_private_inits.is_empty();
+                || (!interleave_static_private_inits && !static_private_inits.is_empty());
 
             if has_pre_static_private_inits {
                 self.write_line();
@@ -362,10 +386,18 @@ impl<'a> Printer<'a> {
                     emitted_private_auto_accessors_pre_static = true;
                 }
                 self.write(";");
-                for init in &static_private_inits {
-                    self.write_line();
-                    self.emit_static_private_init(init, &class_name, true);
+                if interleave_static_private_inits {
+                    // Emitted below, interleaved with the public static field
+                    // inits and static blocks in source order.
+                    interleaved_static_private_inits = static_private_inits;
+                } else {
+                    for init in &static_private_inits {
+                        self.write_line();
+                        self.emit_static_private_init(init, &class_name, true);
+                    }
                 }
+            } else if interleave_static_private_inits {
+                interleaved_static_private_inits = static_private_inits;
             }
         }
         // No private lowering but static elements present: emit the auto-accessor
@@ -618,38 +650,28 @@ impl<'a> Printer<'a> {
                 self.write_line();
             }
             let mut next_static_block = 0usize;
+            let mut next_private_init = 0usize;
+            let static_block_scope = StaticBlockScope {
+                class_name,
+                this_binding: static_initializer_this_binding,
+                super_base: static_initializer_super_base,
+                class_alias: static_initializer_class_alias.as_deref(),
+            };
             for (name_emit, init_idx, _member_pos, leading_comments, trailing_comments) in
                 &static_field_inits
             {
-                if !self.defer_class_static_blocks {
-                    while next_static_block < deferred_static_blocks.len() {
-                        let (block_idx, comment_idx) = deferred_static_blocks[next_static_block];
-                        let block_pos = self.arena.get(block_idx).map_or(u32::MAX, |node| node.pos);
-                        if block_pos >= *_member_pos {
-                            break;
-                        }
-                        let prev_this_alias = self.scoped_static_this_alias.clone();
-                        let prev_super_alias = self.scoped_static_super_base_alias.clone();
-                        self.scoped_static_this_alias =
-                            static_initializer_this_binding.map(std::sync::Arc::from);
-                        self.scoped_static_super_base_alias =
-                            static_initializer_super_base.map(std::sync::Arc::from);
-                        let prev_self_alias = self.scoped_class_expression_self_alias.clone();
-                        if let Some(alias) = static_initializer_class_alias.as_ref() {
-                            self.scoped_class_expression_self_alias = Some((
-                                Arc::<str>::from(class_name),
-                                Arc::<str>::from(alias.as_str()),
-                            ));
-                        }
-                        self.emit_static_block_iife_expression(block_idx, comment_idx);
-                        self.scoped_class_expression_self_alias = prev_self_alias;
-                        self.scoped_static_this_alias = prev_this_alias;
-                        self.scoped_static_super_base_alias = prev_super_alias;
-                        self.write(";");
-                        self.write_line();
-                        next_static_block += 1;
-                    }
-                }
+                // Drain static blocks and static private field value inits that
+                // precede this public static field, spliced together in source
+                // order so `static #a; static { block }; static b` initializes in
+                // declaration order (tsc parity).
+                self.drain_interleaved_static_elements(
+                    *_member_pos,
+                    &deferred_static_blocks,
+                    &interleaved_static_private_inits,
+                    &mut next_static_block,
+                    &mut next_private_init,
+                    &static_block_scope,
+                );
 
                 // Emit saved leading comments from the original static property declaration
                 for (comment_text, source_pos) in leading_comments {
@@ -777,33 +799,18 @@ impl<'a> Printer<'a> {
                 }
                 self.write_line();
             }
-            if !self.defer_class_static_blocks {
-                while next_static_block < deferred_static_blocks.len() {
-                    let (block_idx, comment_idx) = deferred_static_blocks[next_static_block];
-                    let prev_this_alias = self.scoped_static_this_alias.clone();
-                    let prev_super_alias = self.scoped_static_super_base_alias.clone();
-                    self.scoped_static_this_alias =
-                        static_initializer_this_binding.map(std::sync::Arc::from);
-                    self.scoped_static_super_base_alias =
-                        static_initializer_super_base.map(std::sync::Arc::from);
-                    let prev_self_alias = self.scoped_class_expression_self_alias.clone();
-                    if let Some(alias) = static_initializer_class_alias.as_ref() {
-                        self.scoped_class_expression_self_alias = Some((
-                            Arc::<str>::from(class_name),
-                            Arc::<str>::from(alias.as_str()),
-                        ));
-                    }
-                    self.emit_static_block_iife_expression(block_idx, comment_idx);
-                    self.scoped_class_expression_self_alias = prev_self_alias;
-                    self.scoped_static_this_alias = prev_this_alias;
-                    self.scoped_static_super_base_alias = prev_super_alias;
-                    self.write(";");
-                    self.write_line();
-                    next_static_block += 1;
-                }
-                if next_static_block > 0 {
-                    deferred_static_blocks.clear();
-                }
+            // Flush any static blocks and static private field inits that come
+            // after the last public static field, still spliced in source order.
+            self.drain_interleaved_static_elements(
+                u32::MAX,
+                &deferred_static_blocks,
+                &interleaved_static_private_inits,
+                &mut next_static_block,
+                &mut next_private_init,
+                &static_block_scope,
+            );
+            if !self.defer_class_static_blocks && next_static_block > 0 {
+                deferred_static_blocks.clear();
             }
         }
 
@@ -1184,6 +1191,81 @@ impl<'a> Printer<'a> {
             );
             self.scoped_class_expression_self_alias = prev_self_alias;
         }
+    }
+
+    /// Emit the deferred static blocks and static private field value inits
+    /// whose source position precedes `threshold`, spliced together in source
+    /// order. `next_static_block` / `next_private_init` are the shared cursors
+    /// into the two position-sorted streams, advanced in place. Passing
+    /// `u32::MAX` as the threshold flushes whatever remains. This is the single
+    /// merge routine behind both the pre-field drain (stop before the next
+    /// public static field) and the trailing flush.
+    fn drain_interleaved_static_elements(
+        &mut self,
+        threshold: u32,
+        deferred_static_blocks: &[(NodeIndex, usize)],
+        interleaved_static_private_inits: &[StaticPrivateInit],
+        next_static_block: &mut usize,
+        next_private_init: &mut usize,
+        scope: &StaticBlockScope<'_>,
+    ) {
+        loop {
+            let block_pos = if !self.defer_class_static_blocks
+                && *next_static_block < deferred_static_blocks.len()
+            {
+                let (block_idx, _) = deferred_static_blocks[*next_static_block];
+                self.arena.get(block_idx).map_or(u32::MAX, |node| node.pos)
+            } else {
+                u32::MAX
+            };
+            let priv_pos = interleaved_static_private_inits
+                .get(*next_private_init)
+                .map_or(u32::MAX, |init| init.member_pos);
+            if block_pos >= threshold && priv_pos >= threshold {
+                break;
+            }
+            if priv_pos < block_pos {
+                self.emit_static_private_init(
+                    &interleaved_static_private_inits[*next_private_init],
+                    scope.class_name,
+                    true,
+                );
+                self.write_line();
+                *next_private_init += 1;
+            } else {
+                let (block_idx, comment_idx) = deferred_static_blocks[*next_static_block];
+                self.emit_scoped_static_block_stmt(block_idx, comment_idx, scope);
+                *next_static_block += 1;
+            }
+        }
+    }
+
+    /// Emit one deferred static block as a scoped IIFE statement (with the
+    /// `this`/`super`/self-class alias context installed), followed by `;` and a
+    /// newline. Shared by the source-ordered static-element drains so a static
+    /// block and a static private field init can be spliced together in position
+    /// order without duplicating the alias-context bookkeeping.
+    fn emit_scoped_static_block_stmt(
+        &mut self,
+        block_idx: NodeIndex,
+        comment_idx: usize,
+        ctx: &StaticBlockScope<'_>,
+    ) {
+        let prev_this_alias = self.scoped_static_this_alias.clone();
+        let prev_super_alias = self.scoped_static_super_base_alias.clone();
+        self.scoped_static_this_alias = ctx.this_binding.map(std::sync::Arc::from);
+        self.scoped_static_super_base_alias = ctx.super_base.map(std::sync::Arc::from);
+        let prev_self_alias = self.scoped_class_expression_self_alias.clone();
+        if let Some(alias) = ctx.class_alias {
+            self.scoped_class_expression_self_alias =
+                Some((Arc::<str>::from(ctx.class_name), Arc::<str>::from(alias)));
+        }
+        self.emit_static_block_iife_expression(block_idx, comment_idx);
+        self.scoped_class_expression_self_alias = prev_self_alias;
+        self.scoped_static_this_alias = prev_this_alias;
+        self.scoped_static_super_base_alias = prev_super_alias;
+        self.write(";");
+        self.write_line();
     }
 
     fn static_field_initializer_is_object_rest_assignment(&self, init_idx: NodeIndex) -> bool {

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -1780,7 +1780,10 @@ impl<'a> ES5ClassTransformer<'a> {
             weakmap_inits.push(format!("{instances} = new WeakSet()"));
         }
         weakmap_inits.extend(self.private_method_and_accessor_init_strings());
-        let post_weakmap_statements = self.static_private_field_init_strings();
+        // Static private field initializers are no longer emitted as a grouped
+        // block here; they are interleaved with the public static field inits and
+        // static blocks in source order via `deferred_static_prop_stmts` below,
+        // matching tsc's initialization side-effect order.
         if !private_storage_decls.is_empty() {
             body.push(IRNode::VarDeclList(
                 private_storage_decls
@@ -1796,11 +1799,6 @@ impl<'a> ES5ClassTransformer<'a> {
                     weakmap_inits.join(", ").into(),
                 )));
             }
-            body.extend(
-                post_weakmap_statements
-                    .into_iter()
-                    .map(|statement| IRNode::expr_stmt(IRNode::Raw(statement.into()))),
-            );
             weakmap_inits = Vec::new();
         } else {
             weakmap_decls.extend(private_storage_decls);

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
@@ -570,36 +570,6 @@ impl<'a> ES5ClassTransformer<'a> {
         Some(self.private_assignment_string(var, function))
     }
 
-    pub(super) fn static_private_field_init_strings(&self) -> Vec<String> {
-        self.private_fields
-            .iter()
-            .filter(|field| field.is_static)
-            .map(|field| {
-                let value = if field.has_initializer && field.initializer.is_some() {
-                    if let Some(alias) = self.current_static_class_alias.as_ref() {
-                        self.convert_expression_static_with_class_alias(field.initializer, alias)
-                    } else {
-                        self.convert_expression_static(field.initializer)
-                    }
-                } else {
-                    IRNode::Undefined
-                };
-                self.render_private_init_expression(&IRNode::assign(
-                    IRNode::id(field.weakmap_name.clone()),
-                    IRNode::ObjectLiteral {
-                        properties: vec![IRProperty {
-                            key: IRPropertyKey::Identifier("value".into()),
-                            value,
-                            kind: IRPropertyKind::Init,
-                        }],
-                        source_range: None,
-                        extra_indent: 0,
-                    },
-                ))
-            })
-            .collect()
-    }
-
     fn build_private_method_function_ir(&self, member_idx: NodeIndex) -> Option<IRNode> {
         let method = self
             .private_methods
@@ -1308,8 +1278,49 @@ impl<'a> ES5ClassTransformer<'a> {
                     if crate::transforms::emit_utils::is_runtime_omitted_member(
                         self.arena,
                         &prop_data.modifiers,
-                    ) || is_private_field
-                    {
+                    ) {
+                        continue;
+                    }
+                    if is_private_field {
+                        // Static private field initializer. tsc interleaves it
+                        // with the sibling public static field inits and static
+                        // blocks in source order (`C.a = ...; _C_b = { value: ...
+                        // }; C.c = ...`), so push it into the same source-ordered
+                        // deferred stream here rather than emitting it as a
+                        // separate grouped block before all public inits. The
+                        // storage `var _C_b` is still declared by
+                        // `private_storage_declarations_in_tsc_order`; only the
+                        // value assignment is positioned here.
+                        if let Some(field) = self
+                            .private_fields
+                            .iter()
+                            .find(|field| field.member_idx == member_idx && field.is_static)
+                        {
+                            let value = if field.has_initializer && field.initializer.is_some() {
+                                if let Some(ref alias) = class_alias {
+                                    self.convert_expression_static_with_class_alias(
+                                        field.initializer,
+                                        alias,
+                                    )
+                                } else {
+                                    self.convert_expression_static(field.initializer)
+                                }
+                            } else {
+                                IRNode::Undefined
+                            };
+                            deferred_static_prop_inits.push(IRNode::expr_stmt(IRNode::assign(
+                                IRNode::id(field.weakmap_name.clone()),
+                                IRNode::ObjectLiteral {
+                                    properties: vec![IRProperty {
+                                        key: IRPropertyKey::Identifier("value".into()),
+                                        value,
+                                        kind: IRPropertyKind::Init,
+                                    }],
+                                    source_range: None,
+                                    extra_indent: 0,
+                                },
+                            )));
+                        }
                         continue;
                     }
                     if !self.property_initializer_has_equals(member_node, prop_data) {

--- a/crates/tsz-emitter/tests/static_private_field_init_order_tests.rs
+++ b/crates/tsz-emitter/tests/static_private_field_init_order_tests.rs
@@ -1,0 +1,155 @@
+//! Tests for the source-order emission of **static** field initializers when a
+//! class mixes public static fields, private static fields, and static blocks.
+//!
+//! Structural rule: when a class declaration lowers its private fields (target
+//! `< ES2022`), `tsc` emits the static *element* initializers — public field
+//! assignments (`C.x = ...`), private field value inits
+//! (`_C_y = { value: ... }`), and static block IIFEs — in **source
+//! declaration order**, because their initializers can have observable side
+//! effects. tsz previously grouped every private static field init ahead of the
+//! public ones (`transformPropertyWorker` interleaves them; tsz emitted the
+//! private group first), so a program like
+//!
+//! ```ts
+//! class C {
+//!   static a = log("a");
+//!   static #b = log("b");
+//!   static c = log("c");
+//! }
+//! ```
+//!
+//! initialized in the order `b, a, c` instead of `a, b, c`.
+//!
+//! The private-field *storage declaration* (`var _C_y`) and the class alias
+//! (`_a = C`) still precede all static elements; only the value initialization
+//! interleaves. A class with no public static fields keeps the private inits in
+//! their existing grouped position (there is nothing to interleave against).
+//!
+//! Names are varied across cases so the ordering is driven by declaration
+//! position, not by any particular binder spelling (anti-hardcoding gate).
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print;
+use tsz_emitter::output::printer::PrintOptions;
+
+/// Assert that each needle appears in `haystack` and that they appear in the
+/// given order.
+fn assert_in_order(haystack: &str, needles: &[&str]) {
+    let mut search_from = 0usize;
+    let mut last = String::new();
+    for needle in needles {
+        match haystack[search_from..].find(needle) {
+            Some(rel) => search_from += rel + needle.len(),
+            None => panic!(
+                "expected `{needle}` after `{last}` in emit output, but it was missing or \
+                 out of order.\n--- output ---\n{haystack}"
+            ),
+        }
+        last = (*needle).to_string();
+    }
+}
+
+#[test]
+fn static_public_and_private_field_inits_interleave_in_source_order() {
+    let src = r#"
+class Ledger {
+  static first = log("first");
+  static #second = log("second");
+  static third = log("third");
+  static #fourth = log("fourth");
+  static readFourth() { return Ledger.#fourth; }
+}
+"#;
+    let out = parse_and_lower_print(src, PrintOptions::es6());
+    assert_in_order(
+        &out,
+        &[
+            "Ledger.first = log(\"first\")",
+            "_Ledger_second = { value: log(\"second\") }",
+            "Ledger.third = log(\"third\")",
+            "_Ledger_fourth = { value: log(\"fourth\") }",
+        ],
+    );
+}
+
+#[test]
+fn static_block_interleaves_with_public_and_private_static_inits() {
+    let src = r#"
+class Gauge {
+  static alpha = 1;
+  static { setup(); }
+  static #beta = 2;
+  static gamma = 3;
+  static readBeta() { return Gauge.#beta; }
+}
+"#;
+    let out = parse_and_lower_print(src, PrintOptions::es6());
+    assert_in_order(
+        &out,
+        &[
+            "Gauge.alpha = 1",
+            "setup()",
+            "_Gauge_beta = { value: 2 }",
+            "Gauge.gamma = 3",
+        ],
+    );
+}
+
+#[test]
+fn private_static_init_after_leading_public_static_field() {
+    // The private field is declared second, so its value init must follow the
+    // first public field assignment rather than being hoisted ahead of it.
+    let src = r#"
+class Meter {
+  static total = seed();
+  static #count = 0;
+  static readCount() { return Meter.#count; }
+}
+"#;
+    let out = parse_and_lower_print(src, PrintOptions::es6());
+    assert_in_order(
+        &out,
+        &["Meter.total = seed()", "_Meter_count = { value: 0 }"],
+    );
+}
+
+#[test]
+fn private_static_init_before_trailing_public_static_field() {
+    // The private field is declared first, so its value init must precede the
+    // trailing public field assignment.
+    let src = r#"
+class Widget {
+  static #tally = start();
+  static label = "w";
+  static readTally() { return Widget.#tally; }
+}
+"#;
+    let out = parse_and_lower_print(src, PrintOptions::es6());
+    assert_in_order(
+        &out,
+        &["_Widget_tally = { value: start() }", "Widget.label = \"w\""],
+    );
+}
+
+#[test]
+fn private_only_static_inits_keep_source_order() {
+    // No public static fields: the private inits stay in their existing grouped
+    // position and keep source order among themselves.
+    let src = r#"
+class Registry {
+  static #one = a();
+  static #two = b();
+  static read() { return Registry.#one + Registry.#two; }
+}
+"#;
+    let out = parse_and_lower_print(src, PrintOptions::es6());
+    assert_in_order(
+        &out,
+        &[
+            "_Registry_one = { value: a() }",
+            "_Registry_two = { value: b() }",
+        ],
+    );
+}


### PR DESCRIPTION
Static private field initializers were emitted as a single group **before** all
public static field inits, instead of interleaved with them (and with static
blocks) in source declaration order. Because static initializers can have
observable side effects, this changed program behavior.

### Repro (`--target es2015`)
```ts
class C {
  static a = console.log("a");
  static #b = console.log("b");
  static c = console.log("c");
  static getB() { return C.#b; }
}
```
- tsz before: runtime order `b, a, c` (`_C_b = { value: ... }` emitted first)
- tsc 6.0.2 / tsz after: runtime order `a, b, c`

## Structural rule
When a class declaration lowers its private fields (target `< ES2022`), `tsc`
emits every static *element* initializer — public field assignment
(`C.x = ...`), private field value init (`_C_y = { value: ... }`), and static
block IIFE — in source declaration order (`transformPropertyWorker` walks the
members once). The private-field storage declaration (`var _C_y`) and the class
alias (`_a = C`) still precede all static elements; only the value
initialization interleaves. tsz grouped every private static value init ahead of
the public ones.

## Owner layer
Emitter only. Two lowering paths carried the same grouping bug and both are
fixed:
- ES2015+ class-preserved path
  (`emitter/declarations/class/emit_es6_after_body.rs`): static private value
  inits are diverted into a position-tagged list (`StaticPrivateInit` gains a
  `member_pos`) and spliced into the class-declaration static-element emission
  loop, merged by source position with the deferred static blocks through a
  single `drain_interleaved_static_elements` helper. A shared
  `emit_scoped_static_block_stmt` helper removes the duplicated static-block
  alias-context bookkeeping.
- ES5 IIFE path (`transforms/class_es5_ir_members.rs`,
  `transforms/class_es5_ir.rs`): the static private value init is pushed into
  the existing source-ordered `deferred_static_prop_inits` stream instead of the
  separate pre-static `static_private_field_init_strings` group (now removed).

No semantic validation and no output surgery; the static private field GET form
and value expressions are unchanged.

## Scope / fallback
Only the class-**declaration** path with public static fields present is
interleaved. A class with no public static fields keeps the pre-existing grouped
order (there is nothing to interleave against and it already matched tsc). When
there are no static private fields the emission is byte-identical to before.

A class **expression** (`const C = class { … }`) with static private fields
routes through the separate comma-expression path and is intentionally left on
its existing grouped emission here — folding `StaticPrivateInit` into that
path's `CommaItem` position-sort is a larger, independent refactor and is
deferred to keep this change tightly scoped and verifiable. Declarations are the
common real-world form and the observed bug family.

## Adjacent matrix (vs tsc 6.0.2, ES2015 byte-identical)
- public + private static fields interleaved; leading-private and
  trailing-private orderings.
- static block spliced between public and private static fields
  (`static a; static { block }; static #b; static c`).
- private-only static fields (unchanged grouped order).
- class self-reference in a public static init still uses the class alias
  (`new _a()`); instance private WeakMap storage still initialized before static
  elements.
- Anti-hardcoding: regression tests vary class/field binder names
  (`Ledger`/`#second`, `Gauge`/`#beta`, `Meter`/`#count`, `Widget`/`#tally`,
  `Registry`/`#one`); ordering is driven by source position, not names.

Out of scope (pre-existing, unchanged by this PR): a static private field whose
initializer references the class by name renders `new C()` where tsc renders the
alias `new _a()`; the ES5 static-private GET form; and a computed public static
name + alias comma-grouping divergence.

## Goal
Goal: hold

## Verification
- New suite
  `crates/tsz-emitter/tests/static_private_field_init_order_tests.rs` (5 tests,
  binder-name-varied) — pass.
- Full `cargo test -p tsz-emitter` — no new failures (one pre-existing unrelated
  ES5 generator-object-literal failure reproduces identically on `main`).
- End-to-end `tsz` vs `tsc 6.0.2` on the full matrix above at ES2015 —
  byte-identical for the affected forms; broad class-shape battery (public-only,
  private-only, instance fields, blocks, inheritance, methods, accessors,
  `useDefineForClassFields`, ES2022 native) shows no regressions.
- `cargo fmt --all -- --check`, `git diff --check`,
  `python3 scripts/arch/arch_guard.py --json` (0 failures),
  `cargo clippy --profile ci-lint -p tsz-emitter --lib -- -D warnings` — clean.
- ready-review CI owns the broad conformance/emit baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01XtcnBPjFkbyke5tSKnN1jK)_