### PR TITLE
fix(checker): elaborate arrow conditional-body argument return mismatch to the conditional (#14141)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -237,6 +237,9 @@ path = "tests/tuple_call_argument_elaboration_tests.rs"
 name = "array_source_tuple_target_elaboration_tests"
 path = "tests/array_source_tuple_target_elaboration_tests.rs"
 [[test]]
+name = "arrow_conditional_body_return_elaboration_tests"
+path = "tests/arrow_conditional_body_return_elaboration_tests.rs"
+[[test]]
 name = "for_await_type_parameter_iterability_tests"
 path = "tests/for_await_type_parameter_iterability_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -946,6 +946,15 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
+        // Async callback bodies are checked through the async-return path, where
+        // the body expression is awaited before comparing against the contextual
+        // return. This call-argument elaborator only sees the callable return
+        // type; drilling into an async expression body here can turn valid
+        // `T | PromiseLike<T>` contexts into false synchronous TS2322s.
+        if func.is_async {
+            return false;
+        }
+
         // Skip elaboration when the expected return type contains unresolved
         // type parameters or inference placeholders. During generic call
         // inference, the expected callback return type may still reference

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -1020,77 +1020,56 @@ impl<'a> CheckerState<'a> {
                 || k == syntax_kind_ext::BINARY_EXPRESSION =>
             {
                 // For expression-bodied arrows with simple literal/expression bodies,
-                // check if the return expression type is assignable to the expected
-                // return type. tsc reports TS2322 on the return expression when the
-                // type violates the expected return type (e.g., returning a string
-                // where Function is expected in a property assignment context).
-                //
-                // Skip void expected return types: void-returning callbacks accept any
-                // return value, so elaborating would produce false positives.
-                if expected_return_type == TypeId::VOID {
-                    return false;
-                }
-                // Skip elaboration when the callback has explicit parameter type
-                // annotations. tsc only elaborates return types for fully contextually-
-                // typed callbacks (no explicit param annotations). When a developer
-                // explicitly annotates parameter types, the error is reported at the
-                // argument level (TS2345) rather than drilling into the return expression.
-                if self.function_value_has_explicit_param_annotation(arg_idx) {
-                    return false;
-                }
-                let body_type = self.get_type_of_node(func.body);
-                if body_type == TypeId::ERROR
-                    || body_type == TypeId::ANY
-                    || expected_return_type == TypeId::ERROR
-                    || expected_return_type == TypeId::ANY
-                    || self
-                        .return_relation_outcome(body_type, expected_return_type)
-                        .related
-                {
-                    return false;
-                }
-                // Skip elaboration when the body type is itself callable (a function type).
-                // When the return type is a function but the expected type is not (or vice
-                // versa), tsc reports TS2345 on the whole callback rather than TS2322 on
-                // the body expression.
-                if self.first_callable_return_type(body_type).is_some()
-                    && self
-                        .first_callable_return_type(expected_return_type)
-                        .is_none()
-                {
-                    return false;
-                }
-                // Report the error at the return expression with return types.
-                // tsc anchors expression-body arrow return mismatches at the body
-                // expression (col of the literal/expression), not the arrow function.
-                // E.g.: `const f: (a: number) => string = (a) => a + 1`
-                // → TS2322 at `a + 1` with "Type 'number' is not assignable to type 'string'."
-                let display_target = self.evaluate_type_with_env(expected_return_type);
-                if self.array_elaboration_widening_required_for_display(body_type, display_target) {
-                    self.error_type_not_assignable_at_with_widened_source_display(
-                        body_type,
-                        display_target,
-                        func.body,
-                    );
-                } else {
-                    self.error_type_not_assignable_at_with_anchor(
-                        body_type,
-                        display_target,
-                        func.body,
-                    );
-                }
-                true
+                // report TS2322 on the return expression when its type violates the
+                // expected return type (e.g., returning a string where Function is
+                // expected in a property assignment context).
+                self.elaborate_expression_body_return_mismatch(
+                    arg_idx,
+                    func.body,
+                    expected_return_type,
+                )
             }
             k if k == syntax_kind_ext::CONDITIONAL_EXPRESSION => {
-                // Conditionals need branch-level elaboration. Let the caller
-                // handle these at the argument/assignment level.
-                false
+                // Expression-bodied arrow whose body is a conditional
+                // (`() => cond ? a : b`). `tsc`'s `elaborateArrowFunction`
+                // elaborates the body expression; for a conditional it does not
+                // recurse per-branch but anchors the single TS2322 at the whole
+                // conditional (source = the conditional's union type). Mirror the
+                // simple-expression path so a call-argument callback drills to the
+                // conditional instead of the coarse whole-argument TS2345.
+                self.elaborate_expression_body_return_mismatch(
+                    arg_idx,
+                    func.body,
+                    expected_return_type,
+                )
             }
             k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
+                // Drill through the parenthesis and route the inner expression
+                // the same way an unparenthesized body would. An object/array
+                // literal keeps its per-property/element elaboration anchored at
+                // the inner literal (`tsc`'s `elaborateError` skips the parens for
+                // those). Any other body (conditional, simple return expression)
+                // anchors the mismatch at the whole parenthesized expression —
+                // `tsc` reports there, so pass the paren node (its type is
+                // transparent to the inner) rather than the inner expression.
                 let Some(paren) = self.ctx.arena.get_parenthesized(body_node) else {
                     return false;
                 };
-                self.try_elaborate_object_literal_arg_error(paren.expression, expected_return_type)
+                let inner = paren.expression;
+                let inner_kind = self.ctx.arena.get(inner).map(|node| node.kind);
+                match inner_kind {
+                    Some(k)
+                        if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                            || k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION =>
+                    {
+                        self.try_elaborate_object_literal_arg_error(inner, expected_return_type)
+                    }
+                    _ => self.elaborate_expression_body_return_mismatch(
+                        arg_idx,
+                        func.body,
+                        expected_return_type,
+                    ),
+                }
             }
             k if k == syntax_kind_ext::BLOCK => {
                 // Pass param_type for proper error message display
@@ -1137,6 +1116,65 @@ impl<'a> CheckerState<'a> {
             }
             _ => false,
         }
+    }
+
+    /// Anchor a return-type mismatch at an expression-bodied arrow's body
+    /// expression (`body_idx`) as `tsc`'s `elaborateArrowFunction` does, rather
+    /// than reporting the coarse whole-argument TS2345. Shared by the
+    /// simple-expression and conditional-expression body arms.
+    ///
+    /// Returns `true` (suppressing the caller's TS2345) only when a genuine
+    /// mismatch is emitted; returns `false` — deferring to the argument-level
+    /// diagnostic — for `void` expected returns, explicitly-annotated callback
+    /// parameters (the `elaborateArrowFunction` gate keys on parameters), an
+    /// `error`/`any` on either side, an already-related pair, or a
+    /// callable-vs-non-callable body/return shape (where `tsc` keeps the
+    /// whole-callback TS2345).
+    fn elaborate_expression_body_return_mismatch(
+        &mut self,
+        arg_idx: NodeIndex,
+        body_idx: NodeIndex,
+        expected_return_type: TypeId,
+    ) -> bool {
+        if expected_return_type == TypeId::VOID {
+            return false;
+        }
+        if self.function_value_has_explicit_param_annotation(arg_idx) {
+            return false;
+        }
+        let body_type = self.get_type_of_node(body_idx);
+        if body_type == TypeId::ERROR
+            || body_type == TypeId::ANY
+            || expected_return_type == TypeId::ERROR
+            || expected_return_type == TypeId::ANY
+            || self
+                .return_relation_outcome(body_type, expected_return_type)
+                .related
+        {
+            return false;
+        }
+        if self.first_callable_return_type(body_type).is_some()
+            && self
+                .first_callable_return_type(expected_return_type)
+                .is_none()
+        {
+            return false;
+        }
+        // tsc anchors expression-body arrow return mismatches at the body
+        // expression, not the arrow function. E.g.:
+        //   `const f: (a: number) => string = (a) => a + 1`
+        //   → TS2322 at `a + 1` with "Type 'number' is not assignable to type 'string'."
+        let display_target = self.evaluate_type_with_env(expected_return_type);
+        if self.array_elaboration_widening_required_for_display(body_type, display_target) {
+            self.error_type_not_assignable_at_with_widened_source_display(
+                body_type,
+                display_target,
+                body_idx,
+            );
+        } else {
+            self.error_type_not_assignable_at_with_anchor(body_type, display_target, body_idx);
+        }
+        true
     }
 
     fn try_elaborate_function_block_returns_with_param_type(

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -946,15 +946,6 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        // Async callback bodies are checked through the async-return path, where
-        // the body expression is awaited before comparing against the contextual
-        // return. This call-argument elaborator only sees the callable return
-        // type; drilling into an async expression body here can turn valid
-        // `T | PromiseLike<T>` contexts into false synchronous TS2322s.
-        if func.is_async {
-            return false;
-        }
-
         // Skip elaboration when the expected return type contains unresolved
         // type parameters or inference placeholders. During generic call
         // inference, the expected callback return type may still reference
@@ -1007,6 +998,20 @@ impl<'a> CheckerState<'a> {
         let Some(body_node) = self.ctx.arena.get(func.body) else {
             return false;
         };
+
+        // Async call-argument callbacks are checked through the async-return
+        // path, where the body expression is awaited before comparison. This
+        // generic call-argument elaborator only sees the callable return type;
+        // drilling into an async expression body there can turn valid
+        // `T | PromiseLike<T>` contexts into false synchronous TS2322s.
+        //
+        // Direct assignment/JSDoc contexts still need expression-body
+        // elaboration so `async () => 0` assigned to `function(): string`
+        // reports at the returned `0` like `tsc`. Keep block bodies out of this
+        // path because `tsc` does not drill into those async JSDoc returns.
+        if func.is_async && (!allow_unresolved_holes || body_node.kind == syntax_kind_ext::BLOCK) {
+            return false;
+        }
 
         match body_node.kind {
             // Expression-bodied arrow function: () => ({ ... })

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -850,48 +850,20 @@ impl CheckerState<'_> {
             return;
         }
 
+        // Residual divergence-A only (tracked on #14141): the contextual return
+        // type of `f1: F = () => Promise.all([...])` is not propagated into the
+        // `Promise.all` reverse-mapped-tuple argument, so `tsz` widens the tuple
+        // element and emits a spurious `() => Promise<[...]>` vs `F` TS2322. Drop
+        // it until reverse-mapped contextual argument inference lands.
+        //
+        // The former `bar(() => cond ? [A] : [B])` TS2345→TS2322 rewrite is gone:
+        // the arrow-conditional-body return mismatch now drills to the inner
+        // conditional as `tsc` does, natively (`elaborate_expression_body_return_mismatch`).
         self.ctx.diagnostics.retain(|diag| {
             !(diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
                 && diag.message_text.contains("Type '() => Promise<[")
                 && diag.message_text.contains("not assignable to type 'F'"))
         });
-
-        let Some(condition_start) =
-            source_text.find("!!true ? [{ state: State.A }] : [{ state: State.B }]")
-        else {
-            return;
-        };
-        for diag in &mut self.ctx.diagnostics {
-            if diag.code
-                != diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
-                || !diag.message_text.contains(
-                    "Argument of type '() => { state: State.A; }[] | { state: State.B; }[]'",
-                )
-                || !diag
-                    .message_text
-                    .contains("parameter of type '() => { state: State.A; }[]'")
-            {
-                continue;
-            }
-
-            diag.code = diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE;
-            diag.start = condition_start as u32;
-            diag.length = "!!true ? [{ state: State.A }] : [{ state: State.B }]".len() as u32;
-            // Preserve any trailing elaboration lines by rewriting only the
-            // TS2345 source/target phrases into TS2322 phrasing.
-            diag.message_text = diag
-                .message_text
-                .replacen(
-                    "Argument of type '() => { state: State.A; }[] | { state: State.B; }[]'",
-                    "Type '{ state: State.A; }[] | { state: State.B; }[]'",
-                    1,
-                )
-                .replacen(
-                    "parameter of type '() => { state: State.A; }[]'",
-                    "type '{ state: State.A; }[]'",
-                    1,
-                );
-        }
     }
 
     fn rewrite_conditional_types1_fingerprints(&mut self, source_text: &str) {

--- a/crates/tsz-checker/tests/arrow_conditional_body_return_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/arrow_conditional_body_return_elaboration_tests.rs
@@ -1,0 +1,154 @@
+//! An expression-bodied arrow whose body is a conditional
+//! (`() => cond ? a : b`) passed as a generic-call argument must anchor the
+//! return-type mismatch at the conditional expression with `TS2322`, mirroring
+//! `tsc`'s `elaborateArrowFunction`.
+//!
+//! Regression: `tsz` reported the coarse whole-callback `TS2345`
+//! (`Argument of type '() => …[] | …[]' is not assignable to parameter of type
+//! '() => …[]'`) at the arrow instead of drilling into the body. The
+//! elaborator's `CONDITIONAL_EXPRESSION` body arm returned `false` and deferred
+//! to the argument-level diagnostic, which never drilled a conditional. Now the
+//! conditional body routes through the same expression-body elaboration as a
+//! simple return expression, so the diagnostic lands on the conditional with
+//! the union-of-branches source type — the shape `tsc` emits.
+//!
+//! Witness (`inferFromGenericFunctionReturnTypes3`, `#14141`):
+//! ```ts
+//! declare function bar<T>(f: () => T[]): T[];
+//! let x: Foo[] = bar(() => !!true ? [{ state: State.A }] : [{ state: State.B }]);
+//! //                       ^ tsc: TS2322 here, not TS2345 on the whole arrow
+//! ```
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+const CALL_ARG_CONDITIONAL: &str = "enum State { A, B }\n\
+     type Foo = { state: State }\n\
+     declare function bar<T>(f: () => T[]): T[];\n\
+     let x: Foo[] = bar(() => !!true ? [{ state: State.A }] : [{ state: State.B }]);\n";
+
+/// The single diagnostic is a `TS2322` anchored at the conditional expression
+/// with the union-of-branches source type and the inferred single-array target
+/// — never the whole-callback `TS2345`.
+#[test]
+fn call_argument_conditional_body_anchors_ts2322_at_conditional() {
+    let diagnostics = check_source_diagnostics(CALL_ARG_CONDITIONAL);
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one diagnostic, got {diagnostics:#?}"
+    );
+    let diagnostic = &diagnostics[0];
+    assert_eq!(
+        diagnostic.code, 2322,
+        "return mismatch must drill to TS2322, not the coarse whole-callback TS2345: {diagnostic:#?}"
+    );
+    assert_eq!(
+        diagnostic.message_text,
+        "Type '{ state: State.A; }[] | { state: State.B; }[]' is not assignable to type '{ state: State.A; }[]'.",
+        "source must be the union of both branches, target the inferred single-array element"
+    );
+
+    // Anchored at the conditional expression, not the arrow function.
+    let conditional_start = CALL_ARG_CONDITIONAL
+        .find("!!true")
+        .expect("fixture contains the conditional") as u32;
+    assert_eq!(
+        diagnostic.start, conditional_start,
+        "diagnostic must anchor at the conditional expression"
+    );
+}
+
+/// The drill-in is structural, not keyed on any identifier: varying the enum,
+/// the alias, the type parameter, and the call name still yields the same
+/// TS2322-at-the-conditional shape.
+#[test]
+fn renamed_binders_still_anchor_ts2322_at_conditional() {
+    let source = "enum Mode { On, Off }\n\
+         type Cfg = { mode: Mode }\n\
+         declare function pick<U>(g: () => U[]): U[];\n\
+         let y: Cfg[] = pick(() => !!true ? [{ mode: Mode.On }] : [{ mode: Mode.Off }]);\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one diagnostic, got {diagnostics:#?}"
+    );
+    let diagnostic = &diagnostics[0];
+    assert_eq!(diagnostic.code, 2322, "{diagnostic:#?}");
+    assert_eq!(
+        diagnostic.message_text,
+        "Type '{ mode: Mode.On; }[] | { mode: Mode.Off; }[]' is not assignable to type '{ mode: Mode.On; }[]'.",
+        "{diagnostic:#?}"
+    );
+    let conditional_start = source.find("!!true").expect("conditional") as u32;
+    assert_eq!(diagnostic.start, conditional_start, "{diagnostic:#?}");
+}
+
+/// A parenthesized conditional body (`() => (cond ? a : b)`) still drills to a
+/// TS2322, anchored — as `tsc` reports it — at the whole parenthesized
+/// expression (the opening paren), not the coarse whole-callback TS2345.
+#[test]
+fn parenthesized_conditional_body_anchors_ts2322_at_parenthesized_expr() {
+    let source = "enum State { A, B }\n\
+         type Foo = { state: State }\n\
+         declare function bar<T>(f: () => T[]): T[];\n\
+         let x: Foo[] = bar(() => (!!true ? [{ state: State.A }] : [{ state: State.B }]));\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one diagnostic, got {diagnostics:#?}"
+    );
+    let diagnostic = &diagnostics[0];
+    assert_eq!(diagnostic.code, 2322, "{diagnostic:#?}");
+    assert_eq!(
+        diagnostic.message_text,
+        "Type '{ state: State.A; }[] | { state: State.B; }[]' is not assignable to type '{ state: State.A; }[]'.",
+        "{diagnostic:#?}"
+    );
+    // Anchored at the parenthesized expression (the opening paren).
+    let paren_start = source.find("(!!true").expect("parenthesized conditional") as u32;
+    assert_eq!(diagnostic.start, paren_start, "{diagnostic:#?}");
+}
+
+/// A conditional body whose union type *is* assignable to the inferred return
+/// element produces no error — the elaboration only fires on a genuine
+/// mismatch and never manufactures a false positive.
+#[test]
+fn assignable_conditional_body_produces_no_error() {
+    let source = "enum State { A, B }\n\
+         type Foo = { state: State }\n\
+         declare function bar<T>(f: () => T[]): T[];\n\
+         let x: Foo[] = bar(() => !!true ? [{ state: State.A }] : [{ state: State.A }]);\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.is_empty(),
+        "assignable conditional body must not error, got {diagnostics:#?}"
+    );
+}
+
+/// `tsc`'s `elaborateArrowFunction` gate keys on parameter annotations: when a
+/// callback parameter is explicitly annotated, the mismatch stays at the
+/// argument level (`TS2345`) rather than drilling into the body.
+#[test]
+fn explicit_param_annotation_keeps_argument_level_ts2345() {
+    let source = "enum State { A, B }\n\
+         type Foo = { state: State }\n\
+         declare function bar<T>(f: (n: number) => T[]): T[];\n\
+         let x: Foo[] = bar((n: number) => !!true ? [{ state: State.A }] : [{ state: State.B }]);\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one diagnostic, got {diagnostics:#?}"
+    );
+    let diagnostic = &diagnostics[0];
+    assert_eq!(
+        diagnostic.code, 2345,
+        "an explicitly-annotated callback parameter keeps the argument-level TS2345: {diagnostic:#?}"
+    );
+    assert!(
+        !diagnostic.message_text.is_empty(),
+        "TS2345 carries the callback source/target message"
+    );
+}

--- a/crates/tsz-checker/tests/contextual_typing_tests/part_00.rs
+++ b/crates/tsz-checker/tests/contextual_typing_tests/part_00.rs
@@ -452,13 +452,36 @@ fn test_contextual_array_literal_through_promise_like_union_return() {
     let source = r#"
 declare function f(cb: (v: boolean) => [0] | PromiseLike<[0]>): void;
 f(v => v ? [0] : Promise.reject());
+f(async v => v ? [0] : Promise.reject());
 "#;
 
     let diagnostics = check_default(source);
-    let ts2345_errors: Vec<_> = diagnostics.iter().filter(|d| d.code == 2345).collect();
+    let assignability_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2345 || d.code == 2322)
+        .collect();
     assert!(
-        ts2345_errors.is_empty(),
+        assignability_errors.is_empty(),
         "Expected PromiseLike union return context to preserve tuple typing, got diagnostics={diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_contextual_string_literal_through_promise_like_union_return() {
+    let source = r#"
+declare function g(cb: (v: boolean) => "contextuallyTypable" | PromiseLike<"contextuallyTypable">): void;
+g(v => v ? "contextuallyTypable" : Promise.reject());
+g(async v => v ? "contextuallyTypable" : Promise.reject());
+"#;
+
+    let diagnostics = check_default(source);
+    let assignability_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2345 || d.code == 2322)
+        .collect();
+    assert!(
+        assignability_errors.is_empty(),
+        "Expected PromiseLike union return context to preserve string literal typing, got diagnostics={diagnostics:?}"
     );
 }
 
@@ -468,12 +491,16 @@ fn test_contextual_function_literal_through_promise_like_union_return() {
 type MyCallback = (thing: string) => void;
 declare function h(cb: (v: boolean) => MyCallback | PromiseLike<MyCallback>): void;
 h(v => v ? (abc) => { } : Promise.reject());
+h(async v => v ? (def) => { } : Promise.reject());
 "#;
 
     let diagnostics = check_default(source);
-    let ts2345_errors: Vec<_> = diagnostics.iter().filter(|d| d.code == 2345).collect();
+    let assignability_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2345 || d.code == 2322)
+        .collect();
     assert!(
-        ts2345_errors.is_empty(),
+        assignability_errors.is_empty(),
         "Expected PromiseLike union return context to preserve function literal typing, got diagnostics={diagnostics:?}"
     );
 }

--- a/crates/tsz-checker/tests/js_jsdoc_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/js_jsdoc_diagnostics_tests.rs
@@ -3,6 +3,7 @@ use tsz_binder::BinderState;
 use tsz_checker::context::{CheckerOptions, ScriptTarget};
 use tsz_checker::module_resolution::build_module_resolution_maps;
 use tsz_checker::state::CheckerState;
+use tsz_checker::test_utils::check_source;
 use tsz_common::common::ModuleKind;
 use tsz_parser::parser::ParserState;
 use tsz_solver::construction::TypeInterner;
@@ -99,6 +100,51 @@ function f(x) {
     assert!(
         !has_error(&diagnostics, 7006),
         "Did not expect TS7006 in checked JS when noImplicitAny is disabled. Actual diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn checked_js_async_jsdoc_expression_body_ts2322_anchors_on_return_expr() {
+    // Mirrors the checked-JS shape from
+    // `asyncArrowFunction_allowJs`: expression-bodied async arrows still get
+    // the return-expression TS2322, while block-bodied async arrows keep tsc's
+    // non-drilling behavior.
+    let source = r#"
+/** @type {function(): string} */
+const expr = async () => 0;
+
+/** @type {function(): string} */
+const block = async () => {
+    return 0;
+};
+"#;
+
+    let diagnostics = check_source(
+        source,
+        "a.js",
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            strict: true,
+            target: ScriptTarget::ES2017,
+            ..CheckerOptions::default()
+        },
+    );
+    let expr_zero = source.find("=> 0").expect("expression body") + "=> ".len();
+    let block_zero = source.find("return 0").expect("block return") + "return ".len();
+
+    let ts2322_starts: Vec<u32> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.start)
+        .collect();
+    assert!(
+        ts2322_starts.contains(&(expr_zero as u32)),
+        "async expression-body JSDoc TS2322 should anchor on returned `0` at {expr_zero}, got: {diagnostics:#?}"
+    );
+    assert!(
+        !ts2322_starts.contains(&(block_zero as u32)),
+        "async block-body JSDoc return should not drill to returned `0` at {block_zero}, got: {diagnostics:#?}"
     );
 }
 


### PR DESCRIPTION
An expression-bodied arrow whose body is a conditional (`() => cond ? a : b`)
passed as a generic-call argument reported the coarse whole-callback `TS2345`
(`Argument of type '() => …[] | …[]' is not assignable to parameter of type
'() => …[]'`) at the arrow, where `tsc`'s `elaborateArrowFunction` drills into
the body and anchors a single `TS2322` at the conditional expression (source =
the union of both branch types).

### Structural rule
When an expression-bodied arrow's return expression (simple or conditional,
possibly parenthesized) genuinely mismatches the expected callback return type
and the callback is fully contextually typed, `tsc` anchors `TS2322` at the body
expression; `tsz` now does the same through the checker call-argument
elaboration layer. Display/localization only — the decision to error is
unchanged; the anchor node and diagnostic code now match `tsc`.

### Repro (`--strict --target es6 --noEmit`)
```ts
enum State { A, B }
type Foo = { state: State }
declare function bar<T>(f: () => T[]): T[];
let x: Foo[] = bar(() => !!true ? [{ state: State.A }] : [{ state: State.B }]);
```
- Before: `TS2345` at the arrow — `Argument of type '() => { state: State.A; }[] | { state: State.B; }[]' is not assignable to parameter of type '() => { state: State.A; }[]'.`
- After / `tsc`: `TS2322` at the conditional — `Type '{ state: State.A; }[] | { state: State.B; }[]' is not assignable to type '{ state: State.A; }[]'.`

### Owner layer
Checker call-argument elaboration
(`crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs`). The
`CONDITIONAL_EXPRESSION` body arm of `try_elaborate_function_arg_return_error_with_options`
previously returned `false` and deferred to the argument-level diagnostic, which
never drilled a conditional. It now routes through the same expression-body
elaboration as a simple return expression, factored into a shared
`elaborate_expression_body_return_mismatch` helper reused by both arms. The
`PARENTHESIZED_EXPRESSION` arm is generalized to route its inner expression the
same way — object/array literal keeps its per-property/element elaboration; any
other body drills — so `() => (cond ? a : b)` behaves like the unparenthesized
form. No relation, inference, or decision change.

All existing gates carry over unchanged: `void` expected returns,
explicitly-annotated callback parameters (the `elaborateArrowFunction` gate keys
on parameters), `error`/`any` on either side, an already-related pair, and a
callable-vs-non-callable body/return shape all keep the argument-level report.

### Anti-hardcoding cleanup (#14141)
Because the conditional now drills natively, the hardcoded
`bar(() => cond ? [A] : [B])` `TS2345`→`TS2322` rewrite block in
`rewrite_infer_generic_return_fingerprints` (source-text-gated, matching user
identifiers) is dead and removed. The remaining `inferFromGenericFunctionReturnTypes3`
divergence — a spurious `f1: F` `Promise.all` `TS2322` from missing
reverse-mapped-tuple contextual argument inference (`Promise.all([...])`'s
`{ [K in keyof T]: Awaited<T[K]> }` return does not propagate the contextual
element type, so the fresh tuple element is widened) — stays retained and is
documented on #14141 for a follow-up.

### Adjacent matrix (all byte-match `tsc` 6.0.3)
- call argument, conditional body, mismatch → `TS2322` at the conditional.
- parenthesized conditional body → `TS2322` at the parenthesized expression.
- renamed binders (enum/alias/type-param/call) → same structural `TS2322` (not name-keyed).
- assignable conditional body → no error (never a false positive).
- explicitly-annotated callback parameter → argument-level `TS2345` (gate preserved).
- direct assignment to a function-type target with a conditional body → contextual, `0` errors (matches `tsc`).
- simple/parenthesized-simple expression bodies → unchanged.

## Goal
Goal: hold

## Verification
- New regression suite `cargo nextest run -p tsz-checker --test arrow_conditional_body_return_elaboration_tests` — 5 pass (conditional drill, parenthesized-conditional anchor, renamed-binder invariance, assignable no-error, explicit-param gate).
- No new failures across the elaboration/`ts2322`/`ts2345` space: `cargo nextest run -p tsz-checker --lib -E 'test(elaborat) or test(call_error) or test(arrow) or test(return_expression) or test(callback) or test(ts2345) or test(ts2322)'` — failing set is byte-identical to `origin/main` (16 pre-existing failures, e.g. `index_access_type_parameter_mismatch_elaboration` per #7647; captured clean-base set and diffed → zero delta).
- End-to-end `tsz` vs `tsc` 6.0.3 on the full paren/non-paren × conditional/simple/object-literal matrix — target cases byte-identical; `inferFromGenericFunctionReturnTypes3` still emits its 2 cached fingerprints with the dead rewrite block removed.
- `cargo fmt --all -- --check`, `git diff --check`, `python3 scripts/arch/arch_guard.py --json` (0 failures), `cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings` — clean.
- ready-review CI owns the broad conformance/emit/fourslash baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01R9YUDAbfPNzbd5wToP6UG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9YUDAbfPNzbd5wToP6UG5)_