### PR TITLE
fix(emit): downlevel identifier `export * as ns` for module es2015

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -27,6 +27,10 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 
 [[test]]
+name = "esm_export_star_as_downlevel_tests"
+path = "tests/esm_export_star_as_downlevel_tests.rs"
+
+[[test]]
 name = "async_lowered_single_line_hoist_tests"
 path = "tests/async_lowered_single_line_hoist_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
@@ -940,14 +940,27 @@ impl<'a> Printer<'a> {
             && (clause_node.kind == SyntaxKind::Identifier as u16
                 || clause_node.kind == SyntaxKind::StringLiteral as u16)
         {
-            if self.ctx.options.module == ModuleKind::ES2015
-                && clause_node.kind == SyntaxKind::StringLiteral as u16
-            {
-                let temp_name = self.make_unique_name();
+            // `export * as ns from "mod"` is an ES2020 feature. When the module
+            // output target predates it (`module: es2015`), tsc rewrites the
+            // namespace re-export into a namespace import plus a re-export:
+            //   import * as ns_1 from "mod";
+            //   export { ns_1 as ns };
+            // For an identifier clause the generated import binding is named
+            // after the export name, matching tsc's `getGeneratedNameForNode`
+            // (`export * as ns` -> `ns_1`); a string-literal export name has no
+            // identifier base, so a fresh temp is used.
+            if self.ctx.options.module == ModuleKind::ES2015 {
+                let temp_name = if clause_node.kind == SyntaxKind::Identifier as u16 {
+                    let base = self.get_identifier_text_idx(export.export_clause);
+                    self.make_unique_name_from_base(&base)
+                } else {
+                    self.make_unique_name()
+                };
                 self.write("import * as ");
                 self.write(&temp_name);
                 self.write(" from ");
                 self.emit_module_specifier(export.module_specifier);
+                self.emit_import_attributes(export.attributes);
                 self.write_semicolon();
                 self.write_line();
                 self.write("export { ");

--- a/crates/tsz-emitter/tests/esm_export_star_as_downlevel_tests.rs
+++ b/crates/tsz-emitter/tests/esm_export_star_as_downlevel_tests.rs
@@ -1,0 +1,148 @@
+//! Regression tests for downleveling `export * as ns from "mod"` under
+//! `--module es2015`.
+//!
+//! `export * as ns from "mod"` (a namespace re-export) is an ES2020 feature.
+//! When the module output target predates it (`module: es2015`), tsc rewrites
+//! the statement into a namespace import plus a re-export:
+//!
+//! ```js
+//! import * as ns_1 from "mod";
+//! export { ns_1 as ns };
+//! ```
+//!
+//! The generated import binding is named after the export name (an identifier
+//! clause), matching tsc's `getGeneratedNameForNode` (`export * as ns` ->
+//! `ns_1`). tsz previously only downleveled the rare string-literal export-name
+//! form (`export * as "str" from "mod"`) and emitted the identifier form
+//! verbatim, producing output that is invalid for an ES2015 module target.
+//!
+//! For `module: es2020` and later (which support the syntax natively) the
+//! statement is preserved unchanged.
+//!
+//! Source: `crates/tsz-emitter/src/emitter/module_emission/core/mod.rs`
+//! (`emit_export_declaration_es6` — the `export * as` arm).
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print as parse_lower_emit;
+
+fn es2015_opts() -> PrintOptions {
+    PrintOptions {
+        target: ScriptTarget::ES2015,
+        module: ModuleKind::ES2015,
+        ..Default::default()
+    }
+}
+
+fn esnext_opts() -> PrintOptions {
+    PrintOptions {
+        target: ScriptTarget::ES2020,
+        module: ModuleKind::ESNext,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn es2015_downlevels_identifier_namespace_reexport() {
+    // Vary the binder names to keep the assertion structural (anti-hardcoding).
+    let output = parse_lower_emit("export * as widgets from \"./widgets\";\n", es2015_opts());
+
+    assert!(
+        output.contains("import * as widgets_1 from \"./widgets\";"),
+        "identifier namespace re-export should downlevel to a namespace import \
+         named after the export (`widgets_1`).\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("export { widgets_1 as widgets };"),
+        "downleveled re-export should bind the generated import back to the \
+         export name.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("export * as"),
+        "the ES2020 `export * as` form must not survive for an ES2015 module \
+         target.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2015_downlevel_uses_a_distinct_export_name_base() {
+    // A different export name derives a different generated binding base.
+    let output = parse_lower_emit("export * as gadgets from \"gadgets-lib\";\n", es2015_opts());
+
+    assert!(
+        output.contains("import * as gadgets_1 from \"gadgets-lib\";"),
+        "the generated binding base tracks the export name.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("export { gadgets_1 as gadgets };"),
+        "re-export binds the generated import to the export name.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2015_downlevel_avoids_colliding_with_a_local_binding() {
+    // A local `helpers_1` forces the generated name to skip to `helpers_2`,
+    // exactly as tsc's unique-name generator does.
+    let source =
+        "const helpers_1 = 0;\nexport { helpers_1 };\nexport * as helpers from \"./helpers\";\n";
+    let output = parse_lower_emit(source, es2015_opts());
+
+    assert!(
+        output.contains("import * as helpers_2 from \"./helpers\";"),
+        "the generated binding must not collide with an existing `helpers_1`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("export { helpers_2 as helpers };"),
+        "the re-export uses the collision-free generated name.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2015_still_downlevels_string_literal_namespace_reexport() {
+    // The pre-existing string-literal export-name form keeps downleveling.
+    let output = parse_lower_emit("export * as \"str name\" from \"./m\";\n", es2015_opts());
+
+    assert!(
+        output.contains("import * as ") && output.contains("from \"./m\";"),
+        "string-literal namespace re-export still downlevels to a namespace \
+         import.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("as \"str name\" }"),
+        "the string export name is preserved in the re-export.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("export * as"),
+        "no `export * as` form survives for an ES2015 module target.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2015_preserves_plain_star_reexport() {
+    // `export * from "mod"` (no `as`) is valid ES2015 and must be preserved.
+    let output = parse_lower_emit("export * from \"./barrel\";\n", es2015_opts());
+
+    assert!(
+        output.contains("export * from \"./barrel\";"),
+        "a plain star re-export is unchanged for an ES2015 module target.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn esnext_preserves_identifier_namespace_reexport() {
+    // ES2020+ module targets support `export * as ns` natively.
+    let output = parse_lower_emit("export * as tools from \"./tools\";\n", esnext_opts());
+
+    assert!(
+        output.contains("export * as tools from \"./tools\";"),
+        "an ES2020+ module target preserves the native `export * as` form.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("import * as"),
+        "no downlevel import should be synthesized for a native target.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #15245.

`export * as ns from "mod"` (an ES2020 `NamespaceExport` re-export) was emitted
verbatim under `--module es2015`, where tsc rewrites it into a namespace import
plus a re-export. tsz already downleveled the rare **string-literal**
export-name form (`export * as "str" from "mod"`) but the ES2015 downlevel
branch was gated on the clause being a `StringLiteral`, so the common
**identifier** form fell through to verbatim emit — output that is invalid for
an ES2015 module target.

### Repro (`--module es2015`)
```ts
export * as e from "mod4";
```
- tsc 6.0.2 / tsz after:
  ```js
  import * as e_1 from "mod4";
  export { e_1 as e };
  ```
- tsz before: `export * as e from "mod4";` (the ES2020 form survives at an
  ES2015 module target).

### Structural rule
When the emit module kind is `ES2015` and an `ExportDeclaration` has a
`NamespaceExport` clause (`export * as NAME from MOD`), tsc rewrites it to a
generated namespace import followed by a re-export:
`import * as GEN from MOD; export { GEN as NAME };`. The generated binding is
named after the export name via `getGeneratedNameForNode` (`export * as e` →
`e_1`). For `module: es2020` and later (native support) the statement is
preserved.

### Owner layer / fix
Emitter only —
`crates/tsz-emitter/src/emitter/module_emission/core/mod.rs`
(`emit_export_declaration_es6`, the `export * as` arm). The existing ES2015
downlevel branch is extended from string-literal-only to also handle identifier
clauses: the temp binding is derived from the export name via
`make_unique_name_from_base` (yielding `e_1`, matching tsc's generated name),
and import attributes are preserved on the synthesized import. The gate stays
`module == ES2015` (the only ESM module kind lacking native `export * as`;
`ES2020`/`ES2022`/`ESNext`/`Preserve` keep the source form). No semantic
validation, no output surgery, no user-name/file-name/rendered-output
predicates — the binding base is the true export identifier text and the gate
is a builtin `ModuleKind`.

### Adjacent matrix (all byte-match tsc 6.0.2, verified end-to-end)
identifier name (`export * as widgets` → `widgets_1`); distinct export names
derive distinct generated bases; generated-name collision with a local
`helpers_1` skips to `helpers_2`; the pre-existing string-literal name form
still downlevels; import attributes (`with { type: "json" }`) carried onto the
import; plain `export * from "mod"` preserved; `module: es2020`/`esnext`
preserve the native form; `module: commonjs` re-export path unchanged.

### Out of scope (separate, pre-existing — documented in #15245)
- A bare `--target es2020|es2022|esnext` (no explicit `--module`): tsc still
  downlevels `export * as` there, while tsz eagerly resolves `module` to the
  target's ES level and preserves it — rooted in the default-module derivation
  (`derive_default_module_kind`), which tsz also relies on for `import()`/TLA
  support, so rebasing it is a higher-risk change tracked apart from this fix.
- AMD/System binding-name parity for the namespace re-export (tsc names the
  binding after the export alias, tsz after the module path) — functionally
  correct, byte-different, in the `wrapper_entry.rs` dependency-naming
  subsystem.

## Goal
Goal: hold

## Verification
- New suite `crates/tsz-emitter/tests/esm_export_star_as_downlevel_tests.rs`
  (6 tests, binder-name-varied per the anti-hardcoding gate) — pass.
- Full `cargo test -p tsz-emitter` — no new failures. One pre-existing,
  unrelated ES5 failure
  (`generator_object_literal_emit::…prefix_before_yield_omits_source_trailing_comma`)
  reproduces identically on `main` (also noted by #15242) and is untouched by
  this change (it is on the ES5 generator-object-literal path, not the ESM
  export path).
- End-to-end `tsz` vs `tsc 6.0.2` on the full matrix above — byte-identical for
  the affected forms; the `es2020`/`esnext`/`commonjs` paths are unchanged.
- `cargo fmt --all -- --check`, `git diff --check`,
  `python3 scripts/arch/arch_guard.py --json` (0 failures),
  `cargo clippy --profile ci-lint -p tsz-emitter --lib -- -D warnings` — clean.
- ready-review CI owns the broad conformance/emit baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high