### PR TITLE
fix(emit): route single-line-source `using` bodies through the block disposal wrapper (#15250)

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -303,6 +303,10 @@ name = "using_function_body_hoisted_temps_indent_tests"
 path = "tests/using_function_body_hoisted_temps_indent_tests.rs"
 
 [[test]]
+name = "using_single_line_function_body_wrap_tests"
+path = "tests/using_single_line_function_body_wrap_tests.rs"
+
+[[test]]
 name = "jsx_cjs_runtime_collision_tests"
 path = "tests/jsx_cjs_runtime_collision_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -181,6 +181,18 @@ impl<'a> Printer<'a> {
         // that genuinely needs hoisted line-leading declarations (`var _this =
         // this;`, captured `new.target`, hoisted assignment/for-of temps) forces
         // multi-line.
+        // A block that lowers `using`/`await using` into a block-level
+        // try/catch/finally (any target below ES2025) can never take the
+        // single-line fast path: that path emits statements inline and skips
+        // the block-level env + try wrapper set up further below, so each
+        // `using` declaration would instead be wrapped individually (with its
+        // binding hoisted to a `var`) and any statements following it in the
+        // same body would land *outside* the disposal `try`, disposing the
+        // resource before they run. tsc always expands such bodies multi-line.
+        // Computed once here and reused for the wrapper setup below.
+        let block_using_lowered = !self.ctx.options.target.supports_es2025()
+            && self.block_has_using_declarations(&block.statements);
+
         let should_emit_single_line = !block.statements.nodes.is_empty()
             && !force_multiline
             && self.is_single_line(node)
@@ -189,7 +201,8 @@ impl<'a> Printer<'a> {
             && is_function_body_block
             && self.pending_lowered_async_arrow_super_capture.is_none()
             && self.hoisted_assignment_value_temps.is_empty()
-            && self.hoisted_for_of_temps.is_empty();
+            && self.hoisted_for_of_temps.is_empty()
+            && !block_using_lowered;
 
         if should_emit_single_line {
             let private_static_shadow = self.block_shadows_private_static_class_alias(
@@ -368,12 +381,8 @@ impl<'a> Printer<'a> {
         // Block-level using-declaration lowering below ES2025.
         // When a block contains `using`/`await using` declarations, tsc wraps ALL
         // statements in the block inside a single try/catch/finally, not just the
-        // using declarations. We detect this here and set up the env + try wrapper.
-        let block_using_lowered = if !self.ctx.options.target.supports_es2025() {
-            self.block_has_using_declarations(&block.statements)
-        } else {
-            false
-        };
+        // using declarations. `block_using_lowered` (computed above, and used to
+        // suppress the single-line fast path) drives the env + try wrapper here.
         let prev_block_using_env = self.block_using_env.take();
         let block_using_names: Option<(String, String, String, bool)> = if block_using_lowered {
             let using_async = self.block_has_await_using(&block.statements);

--- a/crates/tsz-emitter/tests/using_single_line_function_body_wrap_tests.rs
+++ b/crates/tsz-emitter/tests/using_single_line_function_body_wrap_tests.rs
@@ -1,0 +1,156 @@
+//! Regression tests for `using` / `await using` lowering in a **single-line
+//! source** function body.
+//!
+//! A single-line function body (`function f() { using x = ...; more(); }`) used
+//! to take the emitter's single-line fast path, which emits each statement
+//! inline and never sets up the block-level disposal `try`. The `using`
+//! declaration was then wrapped individually — its binding hoisted to a bare
+//! `var` and only its initializer placed inside a `try`, leaving every
+//! following statement *outside* the disposal scope. That is a semantic bug:
+//! the resource is disposed before the rest of the body runs, and two `using`
+//! declarations produced two separate, non-nested `try`/`finally` regions with
+//! the wrong disposal order.
+//!
+//! tsc instead wraps the whole body in a single `try`/`catch`/`finally` with a
+//! shared disposal env and keeps the `using` binding as a `const` in place —
+//! exactly what the emitter already does for a multi-line body or a nested
+//! block. These tests pin the structural invariants (they are independent of
+//! the identifier names a user picks, so they vary the binder names rather than
+//! asserting a single fixture's exact text).
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::context::emit::EmitContext;
+use tsz_emitter::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use tsz_emitter::lowering::LoweringPass;
+use tsz_parser::parser::ParserState;
+
+fn parse_lower_emit(source: &str, opts: PrinterOptions) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let ctx = EmitContext::with_options(opts.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer = EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, opts);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+fn opts() -> PrinterOptions {
+    PrinterOptions {
+        target: ScriptTarget::ES2022,
+        module: ModuleKind::ESNext,
+        ..Default::default()
+    }
+}
+
+/// The emitted `__addDisposableResource` / `__disposeResources` helper
+/// definitions are injected ahead of the user code and themselves mention
+/// those names, so structural assertions must look only at the user code.
+/// Return the slice starting at `marker` (the user function/class/const).
+fn user_code<'a>(output: &'a str, marker: &str) -> &'a str {
+    let at = output
+        .find(marker)
+        .unwrap_or_else(|| panic!("expected `{marker}` in output.\nOutput:\n{output}"));
+    &output[at..]
+}
+
+/// A statement following a single-line-body `using` must be emitted *inside*
+/// the disposal `try` (before `__disposeResources`), never after the
+/// `finally`. The binding is kept as a `const` in place, not hoisted to a
+/// bare `var`.
+#[test]
+fn single_line_using_wraps_trailing_statement_in_try() {
+    let output = parse_lower_emit(
+        "function scope() { using handle = { [Symbol.dispose]() {} }; sideEffect(); }",
+        opts(),
+    );
+
+    let body = user_code(&output, "function scope");
+
+    let dispose_at = body
+        .find("__disposeResources")
+        .unwrap_or_else(|| panic!("expected a __disposeResources call.\nOutput:\n{output}"));
+    let side_at = body
+        .find("sideEffect()")
+        .unwrap_or_else(|| panic!("expected the trailing sideEffect() call.\nOutput:\n{output}"));
+
+    assert!(
+        side_at < dispose_at,
+        "the statement following a `using` must run inside the disposal try \
+         (before __disposeResources), not after disposal.\nOutput:\n{output}"
+    );
+    assert!(
+        body.contains("const handle = ") && body.contains("__addDisposableResource("),
+        "the `using` binding must stay a `const` initialized in place.\nOutput:\n{output}"
+    );
+    assert!(
+        !body.contains("var handle;"),
+        "the `using` binding must not be hoisted to a bare `var`.\nOutput:\n{output}"
+    );
+}
+
+/// Two `using` declarations in a single-line body share one disposal env and
+/// one `try`/`finally` (a single `__disposeResources`), so both resources are
+/// tracked together and disposed in reverse order — never two independent
+/// regions.
+#[test]
+fn single_line_two_usings_share_one_disposal_region() {
+    let output = parse_lower_emit(
+        "function region() { using first = { [Symbol.dispose]() {} }; using second = { [Symbol.dispose]() {} }; tail(); }",
+        opts(),
+    );
+
+    let body = user_code(&output, "function region");
+
+    assert_eq!(
+        body.matches("__disposeResources").count(),
+        1,
+        "two single-line-body `using` declarations must share one disposal \
+         region (one __disposeResources), not two.\nOutput:\n{output}"
+    );
+    assert_eq!(
+        body.matches("= { stack: [], error: void 0, hasError: false }")
+            .count(),
+        1,
+        "two single-line-body `using` declarations must share one disposal \
+         env, not two.\nOutput:\n{output}"
+    );
+    let dispose_at = body.find("__disposeResources").unwrap();
+    let tail_at = body
+        .find("tail()")
+        .unwrap_or_else(|| panic!("expected the trailing tail() call.\nOutput:\n{output}"));
+    assert!(
+        tail_at < dispose_at,
+        "the trailing statement must run before disposal.\nOutput:\n{output}"
+    );
+}
+
+/// The same invariant holds for an arrow-function body and a method body, and
+/// for any user-chosen identifier — it is structural, not name-keyed.
+#[test]
+fn single_line_using_wrap_holds_for_arrow_and_method_and_renamed_binders() {
+    let arrow = parse_lower_emit(
+        "const run = () => { using res = { [Symbol.dispose]() {} }; work(res); };",
+        opts(),
+    );
+    let arrow_body = user_code(&arrow, "const run");
+    let arrow_dispose = arrow_body.find("__disposeResources").unwrap();
+    assert!(
+        arrow_body.find("work(res)").unwrap() < arrow_dispose && !arrow_body.contains("var res;"),
+        "arrow single-line body must wrap the trailing statement in the \
+         disposal try.\nOutput:\n{arrow}"
+    );
+
+    let method = parse_lower_emit(
+        "class Owner { method() { using guard = { [Symbol.dispose]() {} }; finish(guard); } }",
+        opts(),
+    );
+    let method_body = user_code(&method, "class Owner");
+    let method_dispose = method_body.find("__disposeResources").unwrap();
+    assert!(
+        method_body.find("finish(guard)").unwrap() < method_dispose
+            && !method_body.contains("var guard;"),
+        "method single-line body must wrap the trailing statement in the \
+         disposal try.\nOutput:\n{method}"
+    );
+}


### PR DESCRIPTION
Fixes #15250.

Single-line-source function/method/arrow bodies that contain a `using` /
`await using` declaration were mis-lowered below ES2025: the emitter's
single-line fast path (`should_emit_single_line`) emits body statements inline
and never sets up the block-level disposal `try`, so each `using` was instead
wrapped individually — its binding hoisted to a bare `var`, only its
initializer placed in a `try`, and every following statement left **outside**
the disposal scope. The resource was therefore disposed before the rest of the
body ran, and two `using` declarations produced two separate, non-nested
`try`/`finally` regions with the wrong disposal order.

### Repro (`--target es2022`)
```ts
function f() { using x = getRes(); use(x); }
```
- Before (tsz): `function f() { var x; const env_1 = {...}; try { x = __addDisposableResource(env_1, getRes(), false); } catch ... finally { __disposeResources(env_1); } use(x); }`  ← `use(x)` runs **after** disposal
- After (tsz) / tsc semantics: `use(x)` is inside the `try`, `const x = __addDisposableResource(...)` in place, one shared `env`, disposal in `finally` after the whole body.

### Structural rule
When the emit target is below ES2025 and a function/method/arrow **body block**
contains a `using`/`await using` declaration, tsc wraps the entire body in one
`try`/`catch`/`finally` with a shared disposal env and keeps the binding as a
`const` in place — regardless of whether the source body was written on a single
line. tsz already did this for multi-line bodies and for nested blocks; the
single-line fast path was the one route that skipped the wrapper.

### Owner layer / fix
Emitter only — `crates/tsz-emitter/src/emitter/statements/core.rs`
(`Printer::emit_block`). The block-level using-lowering predicate
(`block_using_lowered`, already computed to drive the `env`+`try` wrapper) is
hoisted above the `should_emit_single_line` computation and added as a negative
guard, so a body that needs disposal lowering falls through to the normal
multi-line path — the same path multi-line source already uses, which is
byte-identical to tsc for that form. This matches the existing shape of the
guard chain (`!needs_this_capture`, `hoisted_*_temps.is_empty()`,
`pending_lowered_async_arrow_super_capture`): the single-line fast path is
disabled whenever a feature requires multi-line structure. No new
hoisted-`var`, no per-statement wrapping, no output surgery, no semantic
validation, no user-name/file-name/rendered-output predicates — the gate is a
builtin target check plus the existing `block_has_using_declarations` scan.

### Adjacent matrix (verified end-to-end vs tsc 6.0.2)
single-line `using` in a function body; `using` + following statements (now
inside the try); two `using` in one body (one shared env / one
`__disposeResources`, reverse-order disposal); single-line `await using` in an
async body (shared env, `result_N` awaited in `finally`); arrow-body and
method-body single-line `using`; renamed binders (structural, not name-keyed);
nested block unchanged; multi-line body unchanged; `esnext` native passthrough
unchanged; non-`using` single-line bodies unchanged.

### Out of scope (pre-existing, unchanged)
- For a **single-line source** body, tsc keeps the outer `{ ` inline and glues
  `const env_1 = …; try {` onto the signature line (source-newline
  preservation); this fix routes such bodies through the multi-line wrapper, so
  they now render multi-line. That is a layout-only difference with no semantic
  or conformance-baseline impact (no conformance test covers this niche — main
  produced semantically-wrong output for it and the aggregate gate is clean);
  matching tsc's inline-brace layout for the `using` transform is a separate
  emitter-formatting refinement.
- The async-ES5 `__generator` state-machine shape for `using` differs from tsc
  independently of this change (separate async-lowering path).

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New suite `crates/tsz-emitter/tests/using_single_line_function_body_wrap_tests.rs`
  (3 binder-name-varied tests: trailing-statement-in-try, two-usings-one-region,
  arrow+method+renamed) — pass.
- `cargo test -p tsz-emitter --lib` (3924 tests) — pass; existing using targets
  `using_function_body_hoisted_temps_indent_tests`, `using_force_strict_mode_3516_tests`,
  `tc39_es5_using_block_indent_tests`, `async_lowered_single_line_hoist_tests`,
  `async_try_emit` — pass.
- End-to-end `tsz` vs `tsc 6.0.2` across the adjacent matrix above — the affected
  single-line forms now carry correct disposal semantics; multi-line / nested /
  esnext / non-using forms are byte-unchanged.
- `cargo fmt --all -- --check`, `git diff --check`,
  `python3 scripts/arch/arch_guard.py --json` (0 failures),
  `cargo clippy --profile ci-lint -p tsz-emitter --lib -- -D warnings` — clean.
- ready-review CI owns the broad conformance/emit baselines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrQUpHR7u4PMQ8zJvzEBbz)_