### PR TITLE
fix(checker): detect circular type aliases through keyof (#15252)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -653,6 +653,9 @@ path = "tests/jsx_import_source_namespace_tests.rs"
 name = "type_alias_namespace_merge_tests"
 path = "tests/type_alias_namespace_merge_tests.rs"
 [[test]]
+name = "keyof_self_circular_alias_tests"
+path = "tests/keyof_self_circular_alias_tests.rs"
+[[test]]
 name = "tuple_spread_circular_alias_tests"
 path = "tests/tuple_spread_circular_alias_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -256,6 +256,16 @@ impl<'a> CheckerState<'a> {
                 // a plain element or an array spread (`...T[]`), which defer.
                 let is_tuple_self_spread_cycle = params.is_empty()
                     && self.tuple_alias_body_forces_resolution_chain(sym_id, type_alias.type_node);
+                // `keyof` forces its operand's apparent type, so a self-reference
+                // reached through `keyof` re-enters the alias mid-resolution and is
+                // circular (`type A = keyof A`), unlike a deferred array element or
+                // object property. The `body_is_deferred` suppression below treats a
+                // top-level `keyof` (a TYPE_OPERATOR) as deferred, so exempt this
+                // eager self-cycle just like the mapped/tuple self-cycles.
+                let is_keyof_eager_self_cycle = params.is_empty()
+                    && self
+                        .keyof_operand_reaches_resolution_chain_alias(alias_type)
+                        .is_some();
                 let is_jsx_runtime_bridge_alias = self
                     .is_jsx_import_source_runtime_bridge_alias(decl_arena, type_alias.type_node);
                 let is_circular = circularity_eligible
@@ -272,7 +282,8 @@ impl<'a> CheckerState<'a> {
                         || (self.is_simple_type_reference(type_alias.type_node)
                             && self.is_cross_file_circular_alias(sym_id, alias_type))
                         || is_non_generic_mapped_cycle
-                        || is_tuple_self_spread_cycle);
+                        || is_tuple_self_spread_cycle
+                        || is_keyof_eager_self_cycle);
                 if is_circular && !self.has_parse_errors() {
                     use crate::diagnostics::{
                         diagnostic_codes, diagnostic_messages, format_message,
@@ -306,6 +317,7 @@ impl<'a> CheckerState<'a> {
                     let body_is_deferred = self.alias_ast_is_deferred(sym_id)
                         && !is_non_generic_mapped_cycle
                         && !is_tuple_self_spread_cycle
+                        && !is_keyof_eager_self_cycle
                         && !generic_self_circular;
                     if !file_has_any_parse_diag && !has_import_partner && !body_is_deferred {
                         let name = escaped_name;

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
@@ -540,87 +540,54 @@ impl<'a> CheckerState<'a> {
         in_union_or_intersection: bool,
     ) -> bool {
         // Check if resolved_type is Lazy(DefId) pointing to a type alias in the
-        // current resolution chain.
+        // current resolution chain. `resolution_chain_alias_symbol` returns an
+        // owned SymbolId (releasing the `def_to_symbol` borrow) only for an alias
+        // that is mid-resolution, so the `&mut self` marking call below is safe.
         if let Some(def_id) = lazy_def_id(self.ctx.types, resolved_type)
-            && let Some(&target_sym_id) = self.ctx.def_to_symbol.borrow().get(&def_id)
+            && let Some(target_sym_id) = self.resolution_chain_alias_symbol(def_id)
         {
-            // Check if the target is in the resolution set (detecting cycles).
-            let is_in_resolution_chain = self.ctx.symbol_resolution_set.contains(&target_sym_id);
-
-            // Only flag type alias symbols to avoid false positives for
-            // interfaces/classes which can have valid structural recursion.
-            let is_type_alias = self
-                .ctx
-                .binder
-                .get_symbol(target_sym_id)
-                .is_some_and(|s| s.flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0);
-
-            if is_in_resolution_chain && is_type_alias {
-                if target_sym_id == sym_id
-                    && self.type_node_contains_value_type_query_for_alias(type_node, sym_id)
-                {
-                    return false;
-                }
-                let is_direct = if in_union_or_intersection {
-                    if target_sym_id == sym_id {
-                        !self
-                            .ctx
-                            .symbol_resolution_stack
-                            .iter()
-                            .skip_while(|&&stack_sym| stack_sym != target_sym_id)
-                            .skip(1)
-                            .any(|&stack_sym| {
-                                self.ctx.binder.get_symbol(stack_sym).is_some_and(|symbol| {
-                                    symbol.flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0
-                                }) && self.alias_ast_is_deferred(stack_sym)
-                            })
-                    } else {
-                        let body = self
-                            .ctx
-                            .definition_store
-                            .get_body(def_id)
-                            .filter(|&b| lazy_def_id(self.ctx.types, b).is_none());
-                        if let Some(b) = body {
-                            !crate::query_boundaries::common::is_structurally_deferred_type(
-                                self.ctx.types,
-                                b,
-                            )
-                        } else {
-                            !self.alias_ast_is_deferred(target_sym_id)
-                        }
-                    }
-                } else {
-                    self.is_simple_type_reference(type_node)
-                };
-
-                if is_direct {
-                    // Mark all aliases on stack between target and current as circular.
-                    let mut found_target = false;
-                    for &stack_sym in &self.ctx.symbol_resolution_stack {
-                        if stack_sym == target_sym_id {
-                            found_target = true;
-                        }
-                        if found_target {
-                            let is_alias = self.ctx.binder.get_symbol(stack_sym).is_some_and(|s| {
-                                s.flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0
-                            });
-                            if is_alias {
-                                self.ctx.circular_type_aliases.insert(stack_sym);
-                                if let Some(did) = self.ctx.get_existing_def_id(stack_sym) {
-                                    self.ctx.definition_store.mark_circular_def(did);
-                                }
-                            }
-                        }
-                    }
-                    // Always mark the target itself as circular (handles cross-file cycles).
-                    self.ctx.circular_type_aliases.insert(target_sym_id);
-                    if let Some(did) = self.ctx.get_existing_def_id(target_sym_id) {
-                        self.ctx.definition_store.mark_circular_def(did);
-                    }
-                }
-
-                return is_direct;
+            if target_sym_id == sym_id
+                && self.type_node_contains_value_type_query_for_alias(type_node, sym_id)
+            {
+                return false;
             }
+            let is_direct = if in_union_or_intersection {
+                if target_sym_id == sym_id {
+                    !self
+                        .ctx
+                        .symbol_resolution_stack
+                        .iter()
+                        .skip_while(|&&stack_sym| stack_sym != target_sym_id)
+                        .skip(1)
+                        .any(|&stack_sym| {
+                            self.ctx.binder.get_symbol(stack_sym).is_some_and(|symbol| {
+                                symbol.flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0
+                            }) && self.alias_ast_is_deferred(stack_sym)
+                        })
+                } else {
+                    let body = self
+                        .ctx
+                        .definition_store
+                        .get_body(def_id)
+                        .filter(|&b| lazy_def_id(self.ctx.types, b).is_none());
+                    if let Some(b) = body {
+                        !crate::query_boundaries::common::is_structurally_deferred_type(
+                            self.ctx.types,
+                            b,
+                        )
+                    } else {
+                        !self.alias_ast_is_deferred(target_sym_id)
+                    }
+                }
+            } else {
+                self.is_simple_type_reference(type_node)
+            };
+
+            if is_direct {
+                self.mark_resolution_chain_circular(target_sym_id);
+            }
+
+            return is_direct;
         }
 
         // For mapped types, check if the constraint references the alias being
@@ -638,39 +605,28 @@ impl<'a> CheckerState<'a> {
             };
             for ref_type in refs_to_check {
                 if let Some(def_id) = lazy_def_id(self.ctx.types, ref_type)
-                    && let Some(&target_sym_id) = self.ctx.def_to_symbol.borrow().get(&def_id)
-                    && self.ctx.symbol_resolution_set.contains(&target_sym_id)
-                    && self
-                        .ctx
-                        .binder
-                        .get_symbol(target_sym_id)
-                        .is_some_and(|s| s.flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0)
+                    && let Some(target_sym_id) = self.resolution_chain_alias_symbol(def_id)
                 {
-                    // Mark all aliases on stack between target and current as circular.
-                    let mut found_target = false;
-                    for &stack_sym in &self.ctx.symbol_resolution_stack {
-                        if stack_sym == target_sym_id {
-                            found_target = true;
-                        }
-                        if found_target {
-                            let is_alias = self.ctx.binder.get_symbol(stack_sym).is_some_and(|s| {
-                                s.flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0
-                            });
-                            if is_alias {
-                                self.ctx.circular_type_aliases.insert(stack_sym);
-                                if let Some(did) = self.ctx.get_existing_def_id(stack_sym) {
-                                    self.ctx.definition_store.mark_circular_def(did);
-                                }
-                            }
-                        }
-                    }
-                    self.ctx.circular_type_aliases.insert(target_sym_id);
-                    if let Some(did) = self.ctx.get_existing_def_id(target_sym_id) {
-                        self.ctx.definition_store.mark_circular_def(did);
-                    }
+                    self.mark_resolution_chain_circular(target_sym_id);
                     return true;
                 }
             }
+        }
+
+        // `keyof` forces its operand's apparent type, so a self-reference reached
+        // through `keyof` re-enters the alias mid-resolution — an eager position,
+        // unlike a deferred array element (`type N = N[]`) or object property
+        // (`type A = keyof { a: A }`). tsc reports TS2456 for `type A = keyof A`,
+        // `keyof A[]`, `keyof Array<A>`, `keyof (x | A)`, and `keyof A["k"]`. The
+        // `has_deferred_resolution_chain_ref` guard below would otherwise excuse
+        // these as legitimate deferred recursion, so detect them here first, using
+        // the same precise resolution-chain condition as the mapped-constraint
+        // block above (only a `Lazy(DefId)` for an alias already on the stack).
+        if let Some(target_sym_id) =
+            self.keyof_operand_reaches_resolution_chain_alias(resolved_type)
+        {
+            self.mark_resolution_chain_circular(target_sym_id);
+            return true;
         }
 
         // Type query (typeof X): per the TS spec, "a type query directly depends
@@ -867,6 +823,125 @@ impl<'a> CheckerState<'a> {
         }
 
         false
+    }
+
+    /// Mark every type alias on the resolution stack from `target_sym_id`
+    /// through the current alias — plus `target_sym_id` itself — as circular,
+    /// so the TS2456 collapse is observed at every use site (including
+    /// cross-file cycles where the target is not otherwise on this file's
+    /// stack). Shared by every direct-circularity detection arm.
+    fn mark_resolution_chain_circular(&mut self, target_sym_id: SymbolId) {
+        // Clone the stack (a small Vec) so its immutable borrow does not conflict
+        // with the `&mut self.ctx` field writes in the loop body. Only reached
+        // when a circular alias is actually detected, so the clone is off the
+        // hot path.
+        let stack = self.ctx.symbol_resolution_stack.clone();
+        let mut found_target = false;
+        for stack_sym in stack {
+            if stack_sym == target_sym_id {
+                found_target = true;
+            }
+            if found_target
+                && self
+                    .ctx
+                    .binder
+                    .get_symbol(stack_sym)
+                    .is_some_and(|s| s.flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0)
+            {
+                self.ctx.circular_type_aliases.insert(stack_sym);
+                if let Some(did) = self.ctx.get_existing_def_id(stack_sym) {
+                    self.ctx.definition_store.mark_circular_def(did);
+                }
+            }
+        }
+        self.ctx.circular_type_aliases.insert(target_sym_id);
+        if let Some(did) = self.ctx.get_existing_def_id(target_sym_id) {
+            self.ctx.definition_store.mark_circular_def(did);
+        }
+    }
+
+    /// When `resolved_type` is a `keyof`, follow its operand through the
+    /// positions `keyof` resolves eagerly to a type alias currently on the
+    /// resolution stack. `keyof` forces its operand's apparent type, so such a
+    /// self-reference re-enters the alias mid-resolution and is circular
+    /// (TS2456) — mirroring tsc, which flags `type A = keyof A`, `keyof A[]`,
+    /// `keyof Array<A>`, `keyof (x | A)`, and `keyof A["k"]`. Returns the
+    /// offending alias symbol.
+    pub(crate) fn keyof_operand_reaches_resolution_chain_alias(
+        &self,
+        resolved_type: TypeId,
+    ) -> Option<SymbolId> {
+        let operand = keyof_inner_type(self.ctx.types, resolved_type)?;
+        let mut visited = FxHashSet::default();
+        self.keyof_eager_operand_chain_alias(operand, &mut visited)
+    }
+
+    /// Walk the eagerly-resolved positions under a `keyof` operand — nested
+    /// `keyof`, array/tuple elements, generic type arguments,
+    /// union/intersection members, and indexed-access object/index — looking
+    /// for a `Lazy(DefId)` that resolves to a type alias currently on the
+    /// resolution stack. Object-literal property, mapped, function, and
+    /// conditional positions stay deferred and are not followed, so
+    /// `type A = keyof { a: A }` is not circular.
+    fn keyof_eager_operand_chain_alias(
+        &self,
+        ty: TypeId,
+        visited: &mut FxHashSet<TypeId>,
+    ) -> Option<SymbolId> {
+        if !visited.insert(ty) {
+            return None;
+        }
+        if let Some(def_id) = lazy_def_id(self.ctx.types, ty)
+            && let Some(sym) = self.resolution_chain_alias_symbol(def_id)
+        {
+            return Some(sym);
+        }
+        if let Some(inner) = keyof_inner_type(self.ctx.types, ty) {
+            return self.keyof_eager_operand_chain_alias(inner, visited);
+        }
+        if let Some(elem) = common::array_element_type(self.ctx.types, ty) {
+            return self.keyof_eager_operand_chain_alias(elem, visited);
+        }
+        if let Some(elems) = common::tuple_elements(self.ctx.types, ty) {
+            return elems
+                .iter()
+                .find_map(|e| self.keyof_eager_operand_chain_alias(e.type_id, visited));
+        }
+        if let Some((base, args)) = common::application_info(self.ctx.types, ty) {
+            return std::iter::once(base)
+                .chain(args)
+                .find_map(|t| self.keyof_eager_operand_chain_alias(t, visited));
+        }
+        if let Some(members) = union_members(self.ctx.types, ty) {
+            return members
+                .iter()
+                .find_map(|&m| self.keyof_eager_operand_chain_alias(m, visited));
+        }
+        if let Some(members) = intersection_members(self.ctx.types, ty) {
+            return members
+                .iter()
+                .find_map(|&m| self.keyof_eager_operand_chain_alias(m, visited));
+        }
+        if let Some((obj, idx)) = index_access_types(self.ctx.types, ty) {
+            return self
+                .keyof_eager_operand_chain_alias(obj, visited)
+                .or_else(|| self.keyof_eager_operand_chain_alias(idx, visited));
+        }
+        None
+    }
+
+    /// The type-alias `SymbolId` for `def_id` when it is currently on the
+    /// resolution stack (an in-progress alias resolution). Confines
+    /// circularity detection to genuine mid-resolution re-entry.
+    fn resolution_chain_alias_symbol(&self, def_id: tsz_solver::def::DefId) -> Option<SymbolId> {
+        let target = self.ctx.def_to_symbol.borrow().get(&def_id).copied()?;
+        (self.ctx.symbol_resolution_set.contains(&target)
+            && self
+                .ctx
+                .binder
+                .get_symbol(target)
+                .is_some_and(|s| s.flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0))
+        .then_some(target)
     }
 
     /// Walk the AST node tree under `root_idx` and return the SymbolId of any

--- a/crates/tsz-checker/tests/keyof_self_circular_alias_tests.rs
+++ b/crates/tsz-checker/tests/keyof_self_circular_alias_tests.rs
@@ -1,0 +1,102 @@
+//! Tests for TS2456 circular-type-alias detection through a `keyof` operand.
+//!
+//! `keyof T` forces `T`'s apparent type, so a self-reference reached through
+//! `keyof` re-enters the alias mid-resolution and is circular — `tsc` reports
+//! TS2456 for `type A = keyof A`, `keyof A[]`, `keyof Array<A>`,
+//! `keyof (x | A)`, and `keyof A["k"]`, and for alias hops that route back
+//! through such a `keyof`. The eagerness is confined to `keyof`: a deferred
+//! array element without `keyof` (`type N = N[]`, `readonly N[]`) and an
+//! object-literal property under `keyof` (`type A = keyof { a: A }`) stay
+//! deferred and are not circular. These tests lock that behavior to match
+//! `tsc` 6.0.2, including renamed binders so no name-literal drives the logic.
+
+use tsz_checker::test_utils::check_source_codes as get_error_codes;
+
+fn assert_ts2456(src: &str) {
+    let codes = get_error_codes(src);
+    assert!(
+        codes.contains(&2456),
+        "Expected TS2456 (circularly references itself) for:\n{src}\ngot: {codes:?}"
+    );
+}
+
+fn assert_no_ts2456(src: &str) {
+    let codes = get_error_codes(src);
+    assert!(
+        !codes.contains(&2456),
+        "Expected no TS2456 for:\n{src}\ngot: {codes:?}"
+    );
+}
+
+#[test]
+fn direct_keyof_self_is_circular() {
+    assert_ts2456("type A = keyof A;");
+}
+
+#[test]
+fn renamed_binder_keyof_self_is_circular() {
+    // No dependence on a particular alias name.
+    assert_ts2456("type Whatever = keyof Whatever;");
+    assert_ts2456("type SomethingElse = keyof SomethingElse;");
+}
+
+#[test]
+fn nested_keyof_self_is_circular() {
+    assert_ts2456("type A = keyof keyof A;");
+}
+
+#[test]
+fn keyof_self_array_is_circular() {
+    // `keyof` forces the array's apparent type, resolving the element `A`.
+    assert_ts2456("type A = keyof A[];");
+}
+
+#[test]
+fn keyof_generic_ref_to_self_is_circular() {
+    assert_ts2456("type A = keyof Array<A>;");
+}
+
+#[test]
+fn keyof_union_with_self_is_circular() {
+    assert_ts2456("type A = keyof (string | A);");
+}
+
+#[test]
+fn keyof_indexed_self_is_circular() {
+    assert_ts2456("type A = keyof A[\"x\"];");
+}
+
+#[test]
+fn keyof_self_via_alias_hop_is_circular() {
+    // `E` reaches itself only through `F`'s `keyof E`.
+    assert_ts2456("type E = keyof F; type F = E;");
+    assert_ts2456("type First = keyof Second; type Second = First;");
+}
+
+#[test]
+fn keyof_over_object_property_self_is_not_circular() {
+    // `keyof { a: A }` resolves to `"a"` without resolving the property `A`,
+    // so the object-property position stays deferred.
+    assert_no_ts2456("type A = keyof { a: A };");
+    assert_no_ts2456("type Ring = keyof { next: Ring; value: number };");
+}
+
+#[test]
+fn plain_self_array_without_keyof_is_not_circular() {
+    // Bare `N[]`/`readonly N[]` keep the element deferred — no `keyof` to force it.
+    assert_no_ts2456("type N = N[];");
+    assert_no_ts2456("type O = readonly O[];");
+}
+
+#[test]
+fn keyof_over_unrelated_type_is_not_circular() {
+    assert_no_ts2456("type Keys = keyof { a: number; b: string };");
+    assert_no_ts2456("interface Shape { x: number; y: number } type K = keyof Shape;");
+}
+
+#[test]
+fn generic_keyof_mapped_recursion_is_not_circular() {
+    // A homomorphic mapped type over `keyof T` is legitimate deferred recursion.
+    assert_no_ts2456("type Deep<T> = { [K in keyof T]: Deep<T[K]> };");
+    assert_no_ts2456("type PropKeys<T> = { [K in keyof T]: K }[keyof T];");
+}


### PR DESCRIPTION
Fixes #15252.

`keyof T` forces `T`'s apparent type, so a self-reference reached through a
`keyof` operand re-enters the alias mid-resolution and is circular — `tsc`
reports **TS2456**. `tsz` classified a top-level `keyof` (a `TYPE_OPERATOR`) as a
*deferred* wrapper, so `type A = keyof A` was silently accepted (false negative)
or mis-reported as TS2589.

## Structural rule
When a type alias body reaches the alias itself through a `keyof` operand —
recursively through the positions `keyof` resolves eagerly (nested `keyof`,
array/tuple elements, generic type arguments, union/intersection members,
indexed-access object/index) — `tsc` reports TS2456. Object-literal property,
mapped, function, and conditional positions stay deferred and do **not** make the
alias circular. tsz now matches this through the checker circular-alias detector
(`is_direct_circular_reference_inner`) plus the emission gate in
`type_alias_variable_alias.rs`.

## Owner layer
Checker circular-alias detection —
`crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs`
(new additive `keyof`-operand walker in `is_direct_circular_reference_inner`,
parallel to the existing `Lazy(DefId)` and mapped-constraint blocks, guarded by
the same precise resolution-chain condition) and
`crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs`
(exempt the `keyof` self-cycle from the `body_is_deferred` TS2456 suppression,
mirroring the existing `is_non_generic_mapped_cycle` / `is_tuple_self_spread_cycle`
flags). Also extracts the duplicated resolution-stack marking loop and the
resolution-chain alias lookup into shared helpers (`mark_resolution_chain_circular`,
`resolution_chain_alias_symbol`). No user-name/file-name/printer-output predicates;
detection is keyed on true `Lazy(DefId)` identity and the resolution stack.

## Adjacent matrix (all byte-match `tsc` 6.0.2)
Circular (now TS2456): `keyof A`, `keyof keyof A`, `keyof A[]`, `keyof Array<A>`,
`keyof (string | A)`, `keyof A["x"]`, and the alias hop `type E = keyof F; type F = E`
— with renamed binders so no name literal drives the logic.
Not circular (stay clean): `keyof { a: A }` (deferred object property),
`type N = N[]` / `readonly O[]` (deferred array element, no `keyof`),
`keyof` over unrelated types, and homomorphic mapped recursion
(`type Deep<T> = { [K in keyof T]: Deep<T[K]> }`).

Out of scope (separate mechanisms, tracked in #15252): non-generic conditional-
and template-literal-position self-references, the generic
`type C<T> = T extends C<infer U> ? U : T` form (tsc TS2456+TS2315 vs tsz TS2589),
and secondary cascade diagnostics tsc also emits (TS4109 on `keyof A[]`,
TS2537/TS2538 on `keyof A["x"]`).

## Goal
Goal: hold

## Verification
- New suite `crates/tsz-checker/tests/keyof_self_circular_alias_tests.rs` — 12 pass (binder-name-varied, positive + negative cases).
- `cargo test --profile dist-fast -p tsz-checker --test generic_self_circular_alias_tests --test tuple_spread_circular_alias_tests --test type_alias_typeof_circular_tests --test recursive_alias_counter_convergence_ts2589_tests` — all pass (no regressions).
- `cargo test --profile dist-fast -p tsz-cli --lib circular` — 7 pass.
- End-to-end `tsz` vs `tsc 6.0.2` on the keyof circularity matrix (10/10 agree on TS2456 presence) and a 12-case negative battery of legitimate `keyof`/recursive types — no new false positives; a 45-file differential re-run of prior batteries shows zero regressions.
- `cargo fmt --all -- --check`, `git diff --check`, `python3 scripts/arch/arch_guard.py --json` (0 failures), `cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings` — clean.
- ready-review CI owns the broad conformance/emit baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01WfVoiWaZiGjL2m6mSh4mFo

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfVoiWaZiGjL2m6mSh4mFo)_