### PR TITLE
fix(emit): downlevel params following an object-rest binding param (#15249)

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -39,6 +39,10 @@ name = "es5_object_rest_param_ordering_tests"
 path = "tests/es5_object_rest_param_ordering_tests.rs"
 
 [[test]]
+name = "object_rest_preceding_param_tests"
+path = "tests/object_rest_preceding_param_tests.rs"
+
+[[test]]
 name = "es5_optional_chain_call_receiver_tests"
 path = "tests/es5_optional_chain_call_receiver_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/binding_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/binding_patterns.rs
@@ -422,10 +422,16 @@ impl<'a> Printer<'a> {
             // A following binding parameter's initializer/type is stripped from
             // the signature; its destructuring (default included) is fully
             // flattened into the body prologue, matching `tsc`'s ES2015 transform.
+            if param.initializer.is_some()
+                && let Some(initializer_node) = self.arena.get(param.initializer)
+            {
+                self.skip_comments_in_range(initializer_node.pos, initializer_node.end);
+            }
             self.pending_object_rest_param_following
                 .push(ObjectRestFollowingParam::Binding {
                     temp,
                     pattern: param.name,
+                    initializer: param.initializer,
                 });
         }
         true

--- a/crates/tsz-emitter/src/emitter/binding_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/binding_patterns.rs
@@ -3,7 +3,7 @@
 //! This module handles emission of destructuring binding patterns.
 //! Includes object binding patterns, array binding patterns, and binding elements.
 
-use super::Printer;
+use super::{ObjectRestFollowingParam, Printer};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
@@ -308,6 +308,127 @@ impl<'a> Printer<'a> {
             return false;
         };
         self.pattern_has_object_rest(param.name)
+    }
+
+    /// Allocate the next `_a`, `_b`, … temp name for an ES2018 object-rest
+    /// parameter, skipping `_i`/`_n` (reserved by `tsc`) and any name already in
+    /// the file or the local `used` set. The local counter mirrors the global
+    /// destructuring counter's first names, so downstream nested temps (minted
+    /// through the global counter after these are registered) continue past them.
+    fn next_object_rest_param_temp_name(
+        &self,
+        counter: &mut u32,
+        used: &mut Vec<String>,
+    ) -> String {
+        loop {
+            let current = *counter;
+            *counter += 1;
+
+            if current < 26 && (current == 8 || current == 13) {
+                continue;
+            }
+
+            let name = if current < 26 {
+                format!("_{}", (b'a' + current as u8) as char)
+            } else {
+                format!("_{}", current - 26)
+            };
+
+            if !self.file_identifiers.contains(&name) && !used.contains(&name) {
+                used.push(name.clone());
+                return name;
+            }
+        }
+    }
+
+    /// Apply the ES2018 "preceding object rest/spread" rule to a single function
+    /// parameter (targets es2015–es2017). Once a parameter's binding contains an
+    /// object rest, that parameter and every parameter after it are rewritten:
+    ///
+    /// - the leading object-rest parameter (and any rest parameter carrying an
+    ///   object rest) becomes a temp with a native-binding `__rest` preamble;
+    /// - every following binding parameter becomes a temp whose destructuring is
+    ///   fully flattened into the body (`c = _b[0]`, `b = _b.b`).
+    ///
+    /// Parameters before the first object-rest parameter, and plain-identifier /
+    /// `...rest` parameters, are left for the caller to emit natively. Returns
+    /// `true` when the parameter's temp name was written to the parameter list
+    /// (the caller should then `continue`).
+    pub(super) fn try_emit_object_rest_region_param(
+        &mut self,
+        param_idx: NodeIndex,
+        param_pos: usize,
+        needs_rest_lowering: bool,
+        first_object_rest_param_pos: Option<usize>,
+        counter: &mut u32,
+        used: &mut Vec<String>,
+    ) -> bool {
+        let Some(param_node) = self.arena.get(param_idx) else {
+            return false;
+        };
+        let Some(param) = self.arena.get_parameter(param_node) else {
+            return false;
+        };
+
+        // A rest (`...x`) parameter that itself carries an object rest
+        // (e.g. `...[{ a, ...r }]`) keeps the legacy preamble lowering
+        // (`...temp` + native-binding body decl) — it is never subject to the
+        // following-parameter flattening.
+        if needs_rest_lowering && param.dot_dot_dot_token && self.param_has_object_rest(param_idx) {
+            let temp = self.next_object_rest_param_temp_name(counter, used);
+            self.emit_rest_parameter_spread_prefix(param_node.pos, param.name);
+            self.write(&temp);
+            if param.type_annotation.is_some()
+                && let Some(type_node) = self.arena.get(param.type_annotation)
+            {
+                self.skip_comments_in_range(type_node.pos, type_node.end);
+            }
+            if param.initializer.is_some() {
+                self.write(" = ");
+                self.emit(param.initializer);
+            }
+            self.pending_object_rest_params.push((temp, param.name));
+            return true;
+        }
+
+        // Only non-rest parameters at or after the first object-rest parameter
+        // are rewritten by the region rule.
+        let in_region = first_object_rest_param_pos.is_some_and(|first| param_pos >= first);
+        if !in_region || param.dot_dot_dot_token {
+            return false;
+        }
+        let is_leading_object_rest = first_object_rest_param_pos == Some(param_pos);
+        if !is_leading_object_rest && !self.is_binding_pattern(param.name) {
+            return false;
+        }
+
+        let temp = self.next_object_rest_param_temp_name(counter, used);
+        self.write(&temp);
+        // Skip type annotation comments.
+        if param.type_annotation.is_some()
+            && let Some(type_node) = self.arena.get(param.type_annotation)
+        {
+            self.skip_comments_in_range(type_node.pos, type_node.end);
+        }
+        if is_leading_object_rest {
+            // The leading object-rest parameter keeps a native binding for its
+            // non-rest elements (`{ a } = _a, rest = __rest(_a, …)`).
+            if param.initializer.is_some() {
+                self.write(" = ");
+                self.emit(param.initializer);
+            }
+            self.pending_object_rest_params.push((temp, param.name));
+        } else {
+            // A following binding parameter's initializer/type is stripped from
+            // the signature; its destructuring (default included) is fully
+            // flattened into the body prologue, matching `tsc`'s ES2015 transform.
+            self.pending_object_rest_param_following
+                .push(ObjectRestFollowingParam::Binding {
+                    temp,
+                    pattern: param.name,
+                });
+        }
+        true
     }
 
     /// Emit a variable declaration that has been identified as having object rest

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -293,6 +293,27 @@ pub(crate) struct ParamTransformPlan {
     pub(crate) rest: Option<RestParamTransform>,
 }
 
+/// A parameter that follows the first object-rest binding parameter in an
+/// ES2018 "preceding object rest/spread" lowering (targets es2015–es2017).
+/// Once a parameter's binding contains an object rest, that parameter and every
+/// parameter after it are rewritten to a generated temp (or kept in the list, for
+/// a plain identifier) and their destructuring / default is hoisted into the
+/// function body prologue in parameter order.
+pub(crate) enum ObjectRestFollowingParam {
+    /// A following binding pattern (array/object, with or without its own rest):
+    /// the parameter becomes a generated temp and the pattern is fully flattened
+    /// into the body (`var c = _b[0], d = _b[2]`; `var b = _b.b`; own rest
+    /// `var b = _b.b, r2 = __rest(_b, ["b"])`), matching `tsc`'s ES2015
+    /// destructuring transform for the following parameters.
+    Binding { temp: String, pattern: NodeIndex },
+    /// A following plain-identifier parameter with a default: hoisted as an
+    /// `if (name === void 0) { name = init; }` guard.
+    Default {
+        name: String,
+        initializer: NodeIndex,
+    },
+}
+
 #[derive(Default)]
 pub(crate) struct TempScopeState {
     pub(crate) temp_var_counter: u32,
@@ -814,7 +835,11 @@ pub struct Printer<'a> {
     /// When a function parameter has `{ a, ...rest }`, the parameter is replaced with a temp
     /// and this stores `(temp_name, pattern_idx)` for body preamble emission.
     pub(crate) pending_object_rest_params: Vec<(String, NodeIndex)>,
-    pub(crate) pending_object_rest_param_defaults: Vec<(String, NodeIndex)>,
+    /// Parameters that follow the first object-rest binding parameter under the
+    /// ES2018 "preceding object rest/spread" rule (targets es2015–es2017). Their
+    /// destructuring / default is hoisted into the function body prologue, in
+    /// parameter order, after the leading object-rest preamble.
+    pub(crate) pending_object_rest_param_following: Vec<ObjectRestFollowingParam>,
 
     /// Source span of a parser-recovery expression statement already folded into
     /// the previous variable statement's emitted initializer.

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -305,7 +305,11 @@ pub(crate) enum ObjectRestFollowingParam {
     /// into the body (`var c = _b[0], d = _b[2]`; `var b = _b.b`; own rest
     /// `var b = _b.b, r2 = __rest(_b, ["b"])`), matching `tsc`'s ES2015
     /// destructuring transform for the following parameters.
-    Binding { temp: String, pattern: NodeIndex },
+    Binding {
+        temp: String,
+        pattern: NodeIndex,
+        initializer: NodeIndex,
+    },
     /// A following plain-identifier parameter with a default: hoisted as an
     /// `if (name === void 0) { name = init; }` guard.
     Default {

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -280,7 +280,7 @@ impl<'a> Printer<'a> {
             generated_temp_names: FxHashSet::default(),
             temp_scope_stack: Vec::new(),
             pending_object_rest_params: Vec::new(),
-            pending_object_rest_param_defaults: Vec::new(),
+            pending_object_rest_param_following: Vec::new(),
             consumed_recovered_expression_statement_span: None,
             suppress_next_anonymous_enum_var_after_recovered_array_binding: false,
             pending_lowered_async_arrow_super_capture: None,

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -1221,6 +1221,7 @@ impl<'a> Printer<'a> {
             && !has_prologue
             && !has_function_temps
             && !has_using_region
+            && !self.pending_object_rest_following_forces_multiline()
             && self.is_single_line(block_node)
         {
             self.map_opening_brace(block_node);
@@ -1301,8 +1302,8 @@ impl<'a> Printer<'a> {
 
         if !self.pending_object_rest_params.is_empty() {
             self.emit_pending_object_rest_param_preamble(false);
-        } else if !self.pending_object_rest_param_defaults.is_empty() {
-            self.emit_pending_object_rest_param_defaults(false);
+        } else if !self.pending_object_rest_param_following.is_empty() {
+            self.emit_pending_object_rest_param_following(false);
         }
 
         // Capture anchor for inserting hoisted temps created during statement

--- a/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
@@ -241,7 +241,7 @@ impl<'a> Printer<'a> {
         self.insert_param_binding_hoisted_temps(hoisted_start, hoist_anchor);
     }
 
-    fn insert_param_binding_hoisted_temps(
+    pub(in crate::emitter) fn insert_param_binding_hoisted_temps(
         &mut self,
         hoisted_start: usize,
         anchor: super::super::hoist_anchor::HoistAnchor,

--- a/crates/tsz-emitter/src/emitter/functions.rs
+++ b/crates/tsz-emitter/src/emitter/functions.rs
@@ -1,4 +1,4 @@
-use super::{ParamTransformPlan, Printer};
+use super::{ObjectRestFollowingParam, ParamTransformPlan, Printer};
 use tsz_parser::parser::node::{FunctionData, Node};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
@@ -637,14 +637,22 @@ impl<'a> Printer<'a> {
 
         // Clear any previous pending rest params
         self.pending_object_rest_params.clear();
-        self.pending_object_rest_param_defaults.clear();
+        self.pending_object_rest_param_following.clear();
+
+        // ES2018 "preceding object rest/spread" rule: once a parameter's binding
+        // contains an object rest, that parameter and *every parameter after it*
+        // is rewritten. Parameters before it stay native in the list. `tsc` keys
+        // the whole region on the position of the first object-rest parameter.
+        let first_object_rest_param_pos = needs_rest_lowering
+            .then(|| params.iter().position(|&p| self.param_has_object_rest(p)))
+            .flatten();
 
         let prev_namespace_exported_names = self.namespace_exported_names.clone();
         let mut first = true;
         let mut object_rest_temp_counter = 0u32;
         let mut object_rest_temp_names = Vec::<String>::new();
         let mut lowered_object_rest_param_seen = false;
-        for &param_idx in params {
+        for (param_pos, &param_idx) in params.iter().enumerate() {
             if let Some(param_node) = self.arena.get(param_idx)
                 && let Some(param) = self.arena.get_parameter(param_node)
             {
@@ -776,28 +784,19 @@ impl<'a> Printer<'a> {
                 }
                 self.emit_recovered_root_js_declaration_modifiers(&param.modifiers, true);
 
-                // ES2018 object rest lowering: replace destructuring param with a temp
-                if needs_rest_lowering && self.param_has_object_rest(param_idx) {
+                // ES2018 "preceding object rest/spread" lowering: the leading
+                // object-rest preamble plus the flattening of every binding
+                // parameter that follows it. Owned by `binding_patterns.rs`;
+                // returns true when it rewrote the parameter to a temp.
+                if self.try_emit_object_rest_region_param(
+                    param_idx,
+                    param_pos,
+                    needs_rest_lowering,
+                    first_object_rest_param_pos,
+                    &mut object_rest_temp_counter,
+                    &mut object_rest_temp_names,
+                ) {
                     lowered_object_rest_param_seen = true;
-                    let temp = self.next_object_rest_param_temp_name(
-                        &mut object_rest_temp_counter,
-                        &mut object_rest_temp_names,
-                    );
-                    if param.dot_dot_dot_token {
-                        self.emit_rest_parameter_spread_prefix(param_node.pos, param.name);
-                    }
-                    self.write(&temp);
-                    // Skip type annotation comments
-                    if param.type_annotation.is_some()
-                        && let Some(type_node) = self.arena.get(param.type_annotation)
-                    {
-                        self.skip_comments_in_range(type_node.pos, type_node.end);
-                    }
-                    if param.initializer.is_some() {
-                        self.write(" = ");
-                        self.emit(param.initializer);
-                    }
-                    self.pending_object_rest_params.push((temp, param.name));
                     continue;
                 }
 
@@ -899,8 +898,12 @@ impl<'a> Printer<'a> {
                     && param.initializer.is_some()
                     && let Some(param_name) = simple_param_name
                 {
-                    self.pending_object_rest_param_defaults
-                        .push((param_name, param.initializer));
+                    self.pending_object_rest_param_following.push(
+                        ObjectRestFollowingParam::Default {
+                            name: param_name,
+                            initializer: param.initializer,
+                        },
+                    );
                 } else if param.initializer.is_some() {
                     self.write(" = ");
                     self.emit(param.initializer);
@@ -1088,32 +1091,6 @@ impl<'a> Printer<'a> {
                 {
                     self.register_function_parameter_binding_name(elem.name);
                 }
-            }
-        }
-    }
-
-    fn next_object_rest_param_temp_name(
-        &self,
-        counter: &mut u32,
-        used: &mut Vec<String>,
-    ) -> String {
-        loop {
-            let current = *counter;
-            *counter += 1;
-
-            if current < 26 && (current == 8 || current == 13) {
-                continue;
-            }
-
-            let name = if current < 26 {
-                format!("_{}", (b'a' + current as u8) as char)
-            } else {
-                format!("_{}", current - 26)
-            };
-
-            if !self.file_identifiers.contains(&name) && !used.contains(&name) {
-                used.push(name.clone());
-                return name;
             }
         }
     }

--- a/crates/tsz-emitter/src/emitter/functions_arrow.rs
+++ b/crates/tsz-emitter/src/emitter/functions_arrow.rs
@@ -1642,13 +1642,17 @@ impl<'a> Printer<'a> {
         for (temp_name, _) in entries {
             self.generated_temp_names.insert(temp_name.clone());
         }
+        // Reserve the following-parameter temps before emitting the leading
+        // preamble so its nested destructuring temps are numbered past them.
+        self.register_pending_object_rest_following_temps();
         for (temp_name, pattern_idx) in entries {
             self.write("var ");
             self.emit_object_rest_var_decl(*pattern_idx, NodeIndex::NONE, Some(temp_name));
             self.write(";");
             self.write_line();
         }
-        self.emit_pending_object_rest_param_defaults(false);
+        let mut wrote_any = false;
+        self.emit_pending_object_rest_param_following_entries(false, &mut wrote_any);
     }
 
     /// Issue #3758: lower `async (x = init()) => body` so the default

--- a/crates/tsz-emitter/src/emitter/mod.rs
+++ b/crates/tsz-emitter/src/emitter/mod.rs
@@ -62,8 +62,8 @@ pub(crate) use self::core::get_operator_text;
 pub(crate) use self::core::is_valid_identifier_name;
 pub use self::core::{JsxEmit, Printer, PrinterOptions};
 pub(crate) use self::core::{
-    ParamTransform, ParamTransformPlan, RestParamTransform, ScopedConstEnum, TempScopeState,
-    TemplateParts,
+    ObjectRestFollowingParam, ParamTransform, ParamTransformPlan, RestParamTransform,
+    ScopedConstEnum, TempScopeState, TemplateParts,
 };
 pub use comments::{
     CommentKind, CommentRange, get_leading_comment_ranges, get_trailing_comment_ranges,

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -1,3 +1,4 @@
+use super::super::ObjectRestFollowingParam;
 use super::super::Printer;
 use super::super::get_trailing_comment_ranges;
 use super::super::hoist_anchor::HoistAnchor;
@@ -46,7 +47,7 @@ impl<'a> Printer<'a> {
             && !self.has_pending_new_target_capture()
             && is_function_body_block
             && !self.pending_object_rest_params.is_empty()
-            && self.pending_object_rest_param_defaults.is_empty()
+            && !self.pending_object_rest_following_forces_multiline()
             && self.is_single_line(node)
         {
             self.ctx.block_scope_state.enter_function_scope();
@@ -65,7 +66,7 @@ impl<'a> Printer<'a> {
             && !needs_this_capture
             && !self.has_pending_new_target_capture()
             && self.pending_object_rest_params.is_empty()
-            && self.pending_object_rest_param_defaults.is_empty()
+            && self.pending_object_rest_param_following.is_empty()
         {
             // Find the actual closing `}` position (not node.end which includes trailing trivia)
             let closing_brace_end = self.find_block_closing_brace_end(node);
@@ -202,7 +203,8 @@ impl<'a> Printer<'a> {
             && self.pending_lowered_async_arrow_super_capture.is_none()
             && self.hoisted_assignment_value_temps.is_empty()
             && self.hoisted_for_of_temps.is_empty()
-            && !block_using_lowered;
+            && !block_using_lowered
+            && !self.pending_object_rest_following_forces_multiline();
 
         if should_emit_single_line {
             let private_static_shadow = self.block_shadows_private_static_class_alias(
@@ -882,11 +884,13 @@ impl<'a> Printer<'a> {
     }
 
     /// Emit the pending ES2018 object-rest parameter prologue for a function
-    /// body block: the `var { a } = _a, rest = __rest(_a, [...])` preamble, or
-    /// — when only destructuring defaults are pending — the default guards.
-    /// `inline` selects single-line vs multi-line formatting. Returns whether
-    /// anything was emitted so a single-line caller can add the separating space
-    /// before the first body statement.
+    /// body block: the `var { a } = _a, rest = __rest(_a, [...])` leading
+    /// preamble followed by the flattened destructuring / default guards of any
+    /// parameters that follow the first object-rest parameter (the "preceding
+    /// object rest/spread" rule), in parameter order. `inline` selects
+    /// single-line vs multi-line formatting. Returns whether anything was
+    /// emitted so a single-line caller can add the separating space before the
+    /// first body statement.
     pub(in crate::emitter) fn emit_object_rest_param_prologue(
         &mut self,
         is_function_body_block: bool,
@@ -895,11 +899,33 @@ impl<'a> Printer<'a> {
         if is_function_body_block && !self.pending_object_rest_params.is_empty() {
             self.emit_pending_object_rest_param_preamble(inline);
             true
-        } else if is_function_body_block && !self.pending_object_rest_param_defaults.is_empty() {
-            self.emit_pending_object_rest_param_defaults(inline);
+        } else if is_function_body_block && !self.pending_object_rest_param_following.is_empty() {
+            self.emit_pending_object_rest_param_following(inline);
             true
         } else {
             false
+        }
+    }
+
+    /// Whether any pending following parameter is a plain-identifier default,
+    /// which lowers to an `if (name === void 0) { … }` guard. Such a guard is a
+    /// `startOnNewLine` statement in `tsc`, so its presence forces a single-line
+    /// source body multi-line. Flattened-binding `var` statements do not.
+    pub(in crate::emitter) fn pending_object_rest_following_forces_multiline(&self) -> bool {
+        self.pending_object_rest_param_following
+            .iter()
+            .any(|entry| matches!(entry, ObjectRestFollowingParam::Default { .. }))
+    }
+
+    /// Register every parameter-level temp (the leading object-rest temps and the
+    /// following-binding temps) as a generated name before any flattening runs,
+    /// so nested destructuring temps continue past the parameter temps — matching
+    /// `tsc`'s print-order name numbering (`_a`, `_b` in the list, then `_c`…).
+    pub(in crate::emitter) fn register_pending_object_rest_following_temps(&mut self) {
+        for entry in &self.pending_object_rest_param_following {
+            if let ObjectRestFollowingParam::Binding { temp, .. } = entry {
+                self.generated_temp_names.insert(temp.clone());
+            }
         }
     }
 
@@ -909,36 +935,78 @@ impl<'a> Printer<'a> {
         for (temp_name, _) in &rest_params {
             self.generated_temp_names.insert(temp_name.clone());
         }
-        for (i, (temp_name, pattern_idx)) in rest_params.iter().enumerate() {
-            if inline && i > 0 {
+        self.register_pending_object_rest_following_temps();
+        let mut wrote_any = false;
+        for (temp_name, pattern_idx) in &rest_params {
+            if inline && wrote_any {
                 self.write(" ");
             }
             self.write("var ");
             self.emit_object_rest_var_decl(*pattern_idx, NodeIndex::NONE, Some(temp_name));
             self.write(";");
-            if !inline {
+            if inline {
+                wrote_any = true;
+            } else {
                 self.write_line();
             }
         }
-        self.emit_pending_object_rest_param_defaults(inline);
+        self.emit_pending_object_rest_param_following_entries(inline, &mut wrote_any);
     }
 
-    pub(in crate::emitter) fn emit_pending_object_rest_param_defaults(&mut self, inline: bool) {
-        let defaults: Vec<(String, NodeIndex)> =
-            std::mem::take(&mut self.pending_object_rest_param_defaults);
-        for (i, (name, initializer)) in defaults.iter().enumerate() {
-            if inline && i > 0 {
-                self.write(" ");
-            }
-            self.write("if (");
-            self.write(name);
-            self.write(" === void 0) { ");
-            self.write(name);
-            self.write(" = ");
-            self.emit_expression(*initializer);
-            self.write("; }");
-            if !inline {
-                self.write_line();
+    /// Emit the following-parameter prologue on its own (no leading object-rest
+    /// preamble). Used only via the `emit_object_rest_param_prologue` fallback;
+    /// in the non-ES5 path the region always begins with a leading object-rest
+    /// preamble, so this normally runs through the preamble emitter above.
+    pub(in crate::emitter) fn emit_pending_object_rest_param_following(&mut self, inline: bool) {
+        self.register_pending_object_rest_following_temps();
+        let mut wrote_any = false;
+        self.emit_pending_object_rest_param_following_entries(inline, &mut wrote_any);
+    }
+
+    /// Emit each following-parameter prologue entry in parameter order. `wrote_any`
+    /// threads the inline-separator state through from an already-emitted leading
+    /// preamble so a single space separates every inline statement.
+    pub(in crate::emitter) fn emit_pending_object_rest_param_following_entries(
+        &mut self,
+        inline: bool,
+        wrote_any: &mut bool,
+    ) {
+        let following: Vec<ObjectRestFollowingParam> =
+            std::mem::take(&mut self.pending_object_rest_param_following);
+        for entry in &following {
+            match entry {
+                ObjectRestFollowingParam::Binding { temp, pattern } => {
+                    if inline && *wrote_any {
+                        self.write(" ");
+                    }
+                    let mut started = false;
+                    self.emit_param_binding_assignments(*pattern, temp, &mut started);
+                    if started {
+                        self.write(";");
+                        if inline {
+                            *wrote_any = true;
+                        } else {
+                            self.write_line();
+                        }
+                    }
+                }
+                ObjectRestFollowingParam::Default { name, initializer } => {
+                    if inline && *wrote_any {
+                        self.write(" ");
+                    }
+                    self.write("if (");
+                    self.write(name);
+                    self.write(" === void 0) { ");
+                    self.write(name);
+                    self.write(" = ");
+                    self.emit_expression(*initializer);
+                    self.write("; }");
+                    if inline {
+                        *wrote_any = true;
+                    } else {
+                        self.write_line();
+                    }
+                }
             }
         }
     }

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -975,12 +975,31 @@ impl<'a> Printer<'a> {
             std::mem::take(&mut self.pending_object_rest_param_following);
         for entry in &following {
             match entry {
-                ObjectRestFollowingParam::Binding { temp, pattern } => {
+                ObjectRestFollowingParam::Binding {
+                    temp,
+                    pattern,
+                    initializer,
+                } => {
                     if inline && *wrote_any {
                         self.write(" ");
                     }
+                    let hoisted_start = self.hoisted_assignment_temps.len();
+                    let hoist_anchor = self.capture_hoist_anchor();
                     let mut started = false;
-                    self.emit_param_binding_assignments(*pattern, temp, &mut started);
+                    if initializer.is_some() {
+                        let source = self.get_temp_var_name();
+                        self.emit_param_assignment_prefix(&mut started);
+                        self.write(&source);
+                        self.write(" = ");
+                        self.write(temp);
+                        self.write(" === void 0 ? ");
+                        self.emit_expression(*initializer);
+                        self.write(" : ");
+                        self.write(temp);
+                        self.emit_param_binding_assignments(*pattern, &source, &mut started);
+                    } else {
+                        self.emit_param_binding_assignments(*pattern, temp, &mut started);
+                    }
                     if started {
                         self.write(";");
                         if inline {
@@ -989,6 +1008,7 @@ impl<'a> Printer<'a> {
                             self.write_line();
                         }
                     }
+                    self.insert_param_binding_hoisted_temps(hoisted_start, hoist_anchor);
                 }
                 ObjectRestFollowingParam::Default { name, initializer } => {
                     if inline && *wrote_any {

--- a/crates/tsz-emitter/tests/object_rest_preceding_param_tests.rs
+++ b/crates/tsz-emitter/tests/object_rest_preceding_param_tests.rs
@@ -1,0 +1,159 @@
+//! ES2018 "preceding object rest/spread" rule (issue #15249).
+//!
+//! At an ES module target below ES2018 but at/above ES2015 (binding patterns
+//! native, object rest/spread not), once a parameter's binding contains an
+//! object rest, that parameter *and every parameter after it* is rewritten: the
+//! leading object-rest parameter keeps a native binding (`{ a } = _a`), and every
+//! following binding parameter is replaced by a generated temp with its
+//! destructuring fully flattened into the body, in parameter order. A following
+//! plain identifier stays in the list; its default is hoisted as an
+//! `if (name === void 0) { … }` guard, which forces a single-line body multi-line.
+//!
+//! Structural (not name-keyed): the tests vary binder names and assert on shape.
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_print_with_opts;
+use tsz_common::common::ScriptTarget;
+use tsz_emitter::output::printer::PrintOptions;
+
+fn es2017() -> PrintOptions {
+    PrintOptions {
+        target: ScriptTarget::ES2017,
+        ..Default::default()
+    }
+}
+
+/// The issue's core repro: a following array binding (with a hole) is lowered to
+/// a temp and flattened to indexed reads, in parameter order after the leading
+/// object-rest preamble.
+#[test]
+fn following_array_pattern_is_flattened_after_leading_object_rest() {
+    let source = "function f({ a, ...r }: any, [c, , d]: number[]) { return a + c + d + r; }";
+    let output = parse_and_print_with_opts(source, es2017());
+    assert!(
+        output.contains(
+            "function f(_a, _b) { var { a } = _a, r = __rest(_a, [\"a\"]); var c = _b[0], d = _b[2]; return a + c + d + r; }"
+        ),
+        "following array pattern must be flattened to indexed reads.\nOutput:\n{output}"
+    );
+}
+
+/// A following object binding is flattened to property reads (`var b = _b.b`),
+/// unlike the leading object-rest which keeps a native binding (`{ a } = _a`).
+#[test]
+fn following_object_pattern_is_flattened_to_property_reads() {
+    let source = "function g({ a, ...r }: any, { b }: any) { return a + b + r; }";
+    let output = parse_and_print_with_opts(source, es2017());
+    assert!(
+        output.contains(
+            "function g(_a, _b) { var { a } = _a, r = __rest(_a, [\"a\"]); var b = _b.b; return a + b + r; }"
+        ),
+        "following object pattern must be flattened to property reads.\nOutput:\n{output}"
+    );
+}
+
+/// A following object binding that carries its own object rest is flattened and
+/// still routes the rest through `__rest`.
+#[test]
+fn following_object_pattern_with_own_rest_uses_rest_helper() {
+    let source = "function h({ a, ...r }: any, { b, ...r2 }: any) { return r2; }";
+    let output = parse_and_print_with_opts(source, es2017());
+    assert!(
+        output.contains(
+            "function h(_a, _b) { var { a } = _a, r = __rest(_a, [\"a\"]); var b = _b.b, r2 = __rest(_b, [\"b\"]); return r2; }"
+        ),
+        "following object pattern with own rest must flatten and keep __rest.\nOutput:\n{output}"
+    );
+}
+
+/// A binding parameter *before* the first object-rest parameter stays native in
+/// the parameter list; only the object-rest parameter and everything after it is
+/// rewritten.
+#[test]
+fn binding_before_object_rest_stays_native() {
+    let source = "function j([c, d]: number[], { a, ...r }: any) { return c + d + a + r; }";
+    let output = parse_and_print_with_opts(source, es2017());
+    assert!(
+        output.contains(
+            "function j([c, d], _a) { var { a } = _a, r = __rest(_a, [\"a\"]); return c + d + a + r; }"
+        ),
+        "a binding before the first object-rest parameter must stay native.\nOutput:\n{output}"
+    );
+}
+
+/// A following plain-identifier default is hoisted to an `if (name === void 0)`
+/// guard and forces the single-line source body multi-line.
+#[test]
+fn following_plain_default_hoists_and_forces_multiline() {
+    let source = "function k({ a, ...r }: any, x = 5) { return a + x + r; }";
+    let output = parse_and_print_with_opts(source, es2017());
+    assert!(
+        output.contains("function k(_a, x) {\n"),
+        "a following plain-identifier default must force a multi-line body.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var { a } = _a, r = __rest(_a, [\"a\"]);"),
+        "leading object-rest preamble missing.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("if (x === void 0) { x = 5; }"),
+        "following plain default guard missing.\nOutput:\n{output}"
+    );
+}
+
+/// A following `...rest` parameter stays native in the parameter list.
+#[test]
+fn following_rest_identifier_stays_in_parameter_list() {
+    let source = "function m({ a, ...r }: any, ...rest: number[]) { return rest; }";
+    let output = parse_and_print_with_opts(source, es2017());
+    assert!(
+        output.contains(
+            "function m(_a, ...rest) { var { a } = _a, r = __rest(_a, [\"a\"]); return rest; }"
+        ),
+        "a following rest identifier must stay in the parameter list.\nOutput:\n{output}"
+    );
+}
+
+/// Renamed binders produce the same structural lowering — the rule is keyed on
+/// the pattern shape, not any identifier text.
+#[test]
+fn renamed_binders_produce_same_structural_lowering() {
+    let source = "function fn({ alpha, ...beta }: any, [gamma, delta]: number[]) { return alpha + gamma + delta + beta; }";
+    let output = parse_and_print_with_opts(source, es2017());
+    assert!(
+        output.contains(
+            "function fn(_a, _b) { var { alpha } = _a, beta = __rest(_a, [\"alpha\"]); var gamma = _b[0], delta = _b[1]; return alpha + gamma + delta + beta; }"
+        ),
+        "renamed binders must lower structurally.\nOutput:\n{output}"
+    );
+}
+
+/// A method with the same shape lowers identically (the parameter path is shared
+/// by function, arrow, and method builders).
+#[test]
+fn method_following_binding_is_flattened() {
+    let source = "class C { m({ a, ...r }: any, [c, d]: number[]) { return a + c + d + r; } }";
+    let output = parse_and_print_with_opts(source, es2017());
+    assert!(
+        output.contains("var { a } = _a, r = __rest(_a, [\"a\"]); var c = _b[0], d = _b[1];"),
+        "method following binding must be flattened.\nOutput:\n{output}"
+    );
+}
+
+/// Deep nested case: the leading object-rest's own nested temp is numbered
+/// before the following parameter's nested temp (`_c` then `_d`), because both
+/// parameter-level temps (`_a`, `_b`) are reserved before any flattening —
+/// matching `tsc`'s print-order temp numbering.
+#[test]
+fn nested_temps_are_numbered_after_all_parameter_temps() {
+    let source = "function n({ a: { p, ...q }, ...r }: any, [{ x, ...y }]: any[]) { return q; }";
+    let output = parse_and_print_with_opts(source, es2017());
+    assert!(
+        output.contains(
+            "function n(_a, _b) { var _c = _a.a, { p } = _c, q = __rest(_c, [\"p\"]), r = __rest(_a, [\"a\"]); var _d = _b[0], x = _d.x, y = __rest(_d, [\"x\"]); return q; }"
+        ),
+        "nested temps must be numbered after all parameter temps.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/tests/object_rest_preceding_param_tests.rs
+++ b/crates/tsz-emitter/tests/object_rest_preceding_param_tests.rs
@@ -103,6 +103,20 @@ fn following_plain_default_hoists_and_forces_multiline() {
     );
 }
 
+/// A following binding pattern with a parameter default creates a source temp
+/// using the `=== void 0` ternary, then flattens from that temp.
+#[test]
+fn following_binding_default_uses_void0_ternary_temp() {
+    let source = "function l({ key, ...rest }: any, [lo, hi] = [1, 2]) { return lo + hi + rest; }";
+    let output = parse_and_print_with_opts(source, es2017());
+    assert!(
+        output.contains(
+            "function l(_a, _b) { var { key } = _a, rest = __rest(_a, [\"key\"]); var _c = _b === void 0 ? [1, 2] : _b, lo = _c[0], hi = _c[1]; return lo + hi + rest; }"
+        ),
+        "following binding default must flatten from a void0 source temp.\nOutput:\n{output}"
+    );
+}
+
 /// A following `...rest` parameter stays native in the parameter list.
 #[test]
 fn following_rest_identifier_stays_in_parameter_list() {


### PR DESCRIPTION
Fixes #15249.

At an ES module target below ES2018 but at/above ES2015 (`--target es2015|es2016|es2017`, where binding patterns are native but object rest/spread is not), tsz downleveled an object-rest **binding parameter** itself (`{a, ...r}` -> `_a` + body destructuring) but left **every parameter that followed it** untouched. That was both a byte divergence from `tsc` and a real evaluation-order bug: the following binding pattern destructured at call-binding time before the object-rest parameter's body prologue.

## Structural rule
When the emit path lowers a leading object-rest binding parameter below ES2018, `tsc` applies the ES2018 "preceding object rest/spread" rule: once a parameter's binding contains an object rest, that parameter and every parameter after it is rewritten.

- Leading object-rest parameter: temp parameter plus native non-rest binding and `__rest` in the body.
- Following binding pattern: temp parameter plus fully flattened ES2015-style destructuring in the body, including parameter defaults via `temp === void 0 ? init : temp` source temps.
- Following plain identifier: remains in the parameter list; defaults lower to `if (name === void 0) { name = init; }`.
- Parameters before the first object-rest parameter remain native.

## Owner layer
Emitter only. The region decision lives in `try_emit_object_rest_region_param` (`crates/tsz-emitter/src/emitter/binding_patterns.rs`), driven from `emit_function_parameters_js`. The body prologue is emitted in parameter order by `pending_object_rest_params` / `pending_object_rest_param_following` in `crates/tsz-emitter/src/emitter/statements/core.rs`, reusing the existing ES2015 flatten primitive `emit_param_binding_assignments`. No semantic validation, checker/solver imports, output surgery, user-name checks, file-name checks, or rendered-output predicates.

## Adjacent matrix
Covered shapes include following array with hole, following object, following object with own rest, following binding default, binding-before-object-rest stays native, following plain default, following `...rest`, renamed binders, method form, and nested temp numbering. The transform is target-gated to ES2015-ES2017; ES2018+ remains native and ES5 stays on the existing full ES2015 lowering path.

## Out of scope
For a single-line source body, a following plain-identifier default routes through the multi-line wrapper because the `if (x === void 0)` guard is a new statement. That is a layout-only difference with no semantic or conformance-baseline impact and matches the nearby single-line using-body precedent.

## Goal
Goal: hold

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter --test object_rest_preceding_param_tests` (10/10)
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter --test arrow_parameter_prologue_tests --test es5_object_rest_param_ordering_tests --test function_parameter_native_prologue_tests` (42/42)
- `scripts/safe-run.sh cargo check -p tsz-emitter`
- `scripts/safe-run.sh python3 scripts/arch/arch_guard.py --json` (0 failures)
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --lib -- -D warnings`
- ready-review CI owns the broad conformance/emit/fourslash baselines.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
