### PR TITLE
fix(solver): global re-reduce depth budget for TSZ_INST_RESOLVER_REREDUCE (#14346)

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -1086,7 +1086,12 @@ pub fn instantiate_type_cached(
             && (index_access_operand_needs_resolver(interner, new_obj)
                 || index_access_operand_needs_resolver(interner, new_idx))
         {
-            return db.evaluate_index_access(new_obj, new_idx);
+            // #14346 global re-reduce depth budget: bail to the deferred
+            // index-access when the shared native-depth budget is exhausted.
+            if let Some(_g) = super::flags::rereduce_depth_try_enter() {
+                return db.evaluate_index_access(new_obj, new_idx);
+            }
+            return interner.index_access(new_obj, new_idx);
         }
         return interner.index_access(new_obj, new_idx);
     }

--- a/crates/tsz-solver/src/instantiation/instantiate/conditional.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/conditional.rs
@@ -146,7 +146,12 @@ impl<'a> TypeInstantiator<'a> {
             && !crate::visitor::contains_type_parameters(self.interner, instantiated.check_type)
             && !crate::visitor::contains_type_parameters(self.interner, instantiated.extends_type)
         {
-            return self.evaluate_type(rebuilt);
+            // #14346 global re-reduce depth budget: bail to the deferred
+            // conditional when the shared native-depth budget is exhausted.
+            if let Some(_g) = super::flags::rereduce_depth_try_enter() {
+                return self.evaluate_type(rebuilt);
+            }
+            return rebuilt;
         }
         rebuilt
     }

--- a/crates/tsz-solver/src/instantiation/instantiate/flags.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/flags.rs
@@ -1,8 +1,90 @@
 //! Env and test gates for instantiation policy.
 
+use std::cell::Cell;
 use std::sync::OnceLock;
 
 static INST_RESOLVER_REREDUCE_ENV: OnceLock<bool> = OnceLock::new();
+
+/// Global re-reduce recursion-depth budget (#14346).
+///
+/// The `TSZ_INST_RESOLVER_REREDUCE` re-reduce is a cross-arena `URItoKindN`
+/// SCC with no fixpoint: each re-reduce turn interns a strictly larger type and
+/// re-enters the deferred-leak sites (index-access, `keyof`, conditional,
+/// return-context substitution) through a chain of native frames spread across
+/// several modules. Per-def and per-`(source,target)` visited-set guards do not
+/// bound it (per-def nesting never exceeds 3; the grown pair is always fresh),
+/// so unbounded native stack growth overflows.
+///
+/// This thread-local counts the live native re-reduce depth across ALL
+/// flag-gated re-reduce entry points. Each site enters via
+/// [`rereduce_depth_try_enter`], which returns a scope guard while depth is
+/// below the cap and `None` once the budget is exhausted; the
+/// site then bails to its deferred (flag-OFF) form. The guard decrements on
+/// `Drop`, so it survives `run_instantiator` returns and panic unwinding, and
+/// the counter always reflects true live re-reduce depth.
+///
+/// The cap is BELOW the observed overflow depth (~503 native frames) and ABOVE
+/// the legitimate #15055 clears (small, few hops). The default is overridable
+/// via `TSZ_REREDUCE_DEPTH_CAP` for cap tuning; it only widens/narrows the
+/// depth budget (a counter-only knob, no name/file string checks).
+///
+/// Cap chosen from the fp-ts sweep on `TSZ_INST_RESOLVER_REREDUCE=1` (#14346):
+/// the crash is UNBOUNDED TYPE GROWTH (each cross-arena `URItoKindN` re-reduce
+/// turn interns a strictly larger type, then re-evaluates it), so evaluation
+/// cost is super-linear in the depth reached. `N=4` completes (exit 2, ~50s,
+/// the #15055 `ReaderEither`/`ReaderTaskEither` TS2322 clears preserved) while
+/// `N=8/16/32` never terminate within the run budget (the grown types become
+/// too expensive to evaluate). `N=4` sits comfortably below the native-frame
+/// overflow while still allowing the small, few-hop legitimate re-reduces.
+pub(crate) const REREDUCE_DEPTH_CAP_DEFAULT: u32 = 4;
+
+fn rereduce_depth_cap() -> u32 {
+    static CAP: OnceLock<u32> = OnceLock::new();
+    *CAP.get_or_init(|| {
+        std::env::var("TSZ_REREDUCE_DEPTH_CAP")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .filter(|&v| v > 0)
+            .unwrap_or(REREDUCE_DEPTH_CAP_DEFAULT)
+    })
+}
+
+thread_local! {
+    static REREDUCE_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+/// RAII guard for one live re-reduce recursion frame. Increments the
+/// thread-local depth on construction and decrements it on `Drop` (so it
+/// survives early returns and panic unwind).
+pub(crate) struct RereduceDepthGuard {
+    _private: (),
+}
+
+impl Drop for RereduceDepthGuard {
+    fn drop(&mut self) {
+        REREDUCE_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+    }
+}
+
+/// Try to enter one re-reduce recursion frame.
+///
+/// Returns `Some(guard)` (and increments the depth) when the live re-reduce
+/// depth is below [`REREDUCE_DEPTH_CAP_DEFAULT`] (or the
+/// `TSZ_REREDUCE_DEPTH_CAP` override). Returns `None` — WITHOUT incrementing
+/// — once the budget is exhausted, signalling the caller to bail to its
+/// deferred (flag-OFF) form. Callers must hold the returned guard for the whole
+/// recursive re-reduce call so the counter reflects true native depth.
+pub(crate) fn rereduce_depth_try_enter() -> Option<RereduceDepthGuard> {
+    let cap = rereduce_depth_cap();
+    REREDUCE_DEPTH.with(|d| {
+        let depth = d.get();
+        if depth >= cap {
+            return None;
+        }
+        d.set(depth + 1);
+        Some(RereduceDepthGuard { _private: () })
+    })
+}
 
 #[cfg(test)]
 thread_local! {

--- a/crates/tsz-solver/src/instantiation/instantiate/indexed.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/indexed.rs
@@ -39,7 +39,13 @@ impl<'a> TypeInstantiator<'a> {
             // base) instead of returning the deferred `IndexAccess`. The OFF
             // path below is the literal pre-existing deferred return.
             if super::flags::inst_resolver_rereduce_enabled() && self.query_db.is_some() {
-                return self.evaluate_index_access(inst_obj, inst_idx);
+                // #14346 global re-reduce depth budget: hold the guard for the
+                // whole recursive re-reduce; bail to the deferred index-access
+                // when the shared native-depth budget is exhausted.
+                if let Some(_g) = super::flags::rereduce_depth_try_enter() {
+                    return self.evaluate_index_access(inst_obj, inst_idx);
+                }
+                return self.interner.index_access(inst_obj, inst_idx);
             }
             return self.interner.index_access(inst_obj, inst_idx);
         }
@@ -79,7 +85,12 @@ impl<'a> TypeInstantiator<'a> {
         }
         if keyof_operand_needs_resolver(self.interner, inst_operand) {
             if super::flags::inst_resolver_rereduce_enabled() && self.query_db.is_some() {
-                return self.evaluate_keyof(inst_operand);
+                // #14346 global re-reduce depth budget: bail to the deferred
+                // `keyof` when the shared native-depth budget is exhausted.
+                if let Some(_g) = super::flags::rereduce_depth_try_enter() {
+                    return self.evaluate_keyof(inst_operand);
+                }
+                return self.interner.keyof(inst_operand);
             }
             return self.interner.keyof(inst_operand);
         }

--- a/crates/tsz-solver/src/operations/generic_call/return_context.rs
+++ b/crates/tsz-solver/src/operations/generic_call/return_context.rs
@@ -374,7 +374,13 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     }
 
     fn evaluate_return_context_match_type(&mut self, type_id: TypeId) -> TypeId {
-        if crate::instantiation::instantiate::flags::inst_resolver_rereduce_enabled() {
+        // #14346 global re-reduce depth budget: the flag-ON resolver evaluation
+        // is the per-turn growth site feeding the return-context self-recursion.
+        // Guard it on the shared native-depth budget; when exhausted, fall back
+        // to the resolver-less interner evaluation (the flag-OFF form).
+        if crate::instantiation::instantiate::flags::inst_resolver_rereduce_enabled()
+            && let Some(_g) = crate::instantiation::instantiate::flags::rereduce_depth_try_enter()
+        {
             let evaluated = self
                 .checker
                 .evaluate_type_for_return_context_substitution(type_id);
@@ -925,8 +931,16 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             }
         }
 
+        // #14346 global re-reduce depth budget: this flag-ON self-recursion on
+        // the resolver-evaluated (`source_eval`/`target_eval`) forms is the
+        // cross-arena `URItoKindN` growth site — each turn interns a strictly
+        // larger evaluated pair, so the `(source, target)` visited set never
+        // trips. Guard the recursion on the shared native-depth budget and,
+        // when exhausted, skip this re-reduce (the flag-OFF path never takes
+        // this branch at all) and fall through to the deferred fallback below.
         if crate::instantiation::instantiate::flags::inst_resolver_rereduce_enabled()
             && (source_eval != source || target_eval != target)
+            && let Some(_g) = crate::instantiation::instantiate::flags::rereduce_depth_try_enter()
         {
             self.collect_return_context_substitution(
                 source_eval,


### PR DESCRIPTION
## Summary

The `TSZ_INST_RESOLVER_REREDUCE` re-reduce is a cross-arena `URItoKindN`
SCC with no fixpoint: each re-reduce turn interns a strictly larger type
and re-enters the deferred-leak sites through native frames spread across
several modules. Per-def and per-`(source, target)` visited-set guards do
not bound it (per-def nesting never exceeds 3; the grown pair is always
fresh), and a prior 3-site depth cap failed because the recursion also
flows through `return_context.rs` unguarded, so native call-depth grew
until stack overflow (SIGABRT 134).

**Structural rule:** When `TSZ_INST_RESOLVER_REREDUCE=1` drives an
instantiation-time re-reduce through the resolver, `tsc` reduces once to a
fixpoint; `tsz` re-enters the deferred-leak sites (index-access, `keyof`,
conditional, return-context substitution) with a strictly larger interned
type each turn. This adds a **global thread-local re-reduce depth budget**
entered at every flag-gated re-reduce entry point, so the native recursion
is bounded regardless of which module the chain flows through.

**Owner layer:** solver instantiation/generic-call re-reduce sites.

## Mechanism

- `flags.rs`: thread-local `u32` depth counter + RAII `RereduceDepthGuard`
  (increments on entry, decrements on `Drop` — survives returns and panic
  unwind). `rereduce_depth_try_enter()` returns `Some(guard)` while below
  the cap, `None` once exhausted.
- Enter the counter at **every** flag-gated re-reduce entry site so the
  crash cannot move (whack-a-mole): `instantiate_index_access` +
  `instantiate_keyof` (`indexed.rs`), `instantiate_conditional`
  (`conditional.rs`), the `IndexAccess` fast-path (`api.rs`),
  `collect_return_context_substitution` self-recursion **and**
  `evaluate_return_context_match_type` (`return_context.rs`). Each site
  bails to its existing flag-OFF deferred form when the budget is exhausted.
- **Cap N=4**, chosen from the fp-ts sweep. The crash is unbounded type
  GROWTH, so evaluation cost is super-linear in the depth reached: N=4
  completes (exit 2) while N=8/16/32 never terminate (grown types too
  expensive to evaluate). Overridable via `TSZ_REREDUCE_DEPTH_CAP`
  (counter-only knob, no name/file-string checks).

Strictly gated behind `inst_resolver_rereduce_enabled()`; the guard is an
inner narrowing of pre-existing flag-ON-only branches, so **flag-OFF is
byte-identical** (edits are unreachable with the flag off).

Goal: hold

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

fp-ts `tsz-bench.tsconfig.json` (isolated copy), release binary:

- **crash_fixed:** `TSZ_INST_RESOLVER_REREDUCE=1 tsz -p ...` exits **2**
  (was 134 stack overflow), 1141 diagnostics. N=8/16/32 exit 124 (hang);
  N=4 completes.
- **flag_off_byte_parity:** flag-OFF = 1206 diagnostics == main (all edits
  are inner guards inside pre-existing `inst_resolver_rereduce_enabled()`
  branches; flag-OFF never executes them).
- **determinism:** flag-ON `RAYON_NUM_THREADS=1` and `=4` both exit 2 with
  identical 1141 diagnostic keysets (empty diff).
- **rereduce_clears_survive (#15055):** `ReaderEither.ts(893,902)` and
  `ReaderTaskEither.ts(1406,1415)` TS2322 present flag-OFF, **cleared**
  flag-ON. ReaderEither/ReaderTaskEither TS2322 count 152 -> 146.
- **nextest:** `cargo nextest run -p tsz-solver instantiation` — 181 passed,
  0 failed.
- **clippy:** `cargo clippy -p tsz-solver` — clean.

Flag-gated re-reduce sites entered at the counter:
`indexed.rs` (`instantiate_index_access`, `instantiate_keyof`),
`conditional.rs` (`instantiate_conditional`),
`api.rs` (`IndexAccess` fast-path),
`return_context.rs:~928` (`collect_return_context_substitution`) +
`return_context.rs:~377` (`evaluate_return_context_match_type`).
