### PR TITLE
fix(solver): filter base construct signatures by extends type-arg count (#15248)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "base_class_construct_signature_arity_filter_tests"
+path = "tests/base_class_construct_signature_arity_filter_tests.rs"
+[[test]]
 name = "class_interface_merge_member_type_tests"
 path = "tests/class_interface_merge_member_type_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/classes/constructor_checker.rs
+++ b/crates/tsz-checker/src/classes/constructor_checker.rs
@@ -745,7 +745,38 @@ impl<'a> CheckerState<'a> {
         ctor_type: TypeId,
     ) -> Option<TypeId> {
         let mut visited = FxHashSet::default();
-        self.instance_type_from_constructor_type_inner(ctor_type, &mut visited)
+        self.instance_type_from_constructor_type_inner(ctor_type, None, &mut visited)
+    }
+
+    /// Derive the instance type of a class whose base is a class-like constructor
+    /// *function* (a value typed with construct signatures, e.g. the lib `Map`
+    /// value typed `MapConstructor`, or a mixin result), rather than a class or
+    /// interface reference.
+    ///
+    /// This mirrors `tsc`'s `resolveBaseTypesOfClass` else-branch: the base type
+    /// is `getReturnTypeOfSignature(getInstantiatedConstructorsForTypeArguments(
+    /// baseConstructorType, typeArguments)[0])`. `getConstructorsForTypeArguments`
+    /// keeps only the construct signatures applicable to the extends clause's
+    /// type-argument count `N` — those where
+    /// `N in [minTypeArgumentCount, typeParameters.len()]` — and the base is the
+    /// return type of the *first* survivor. Crucially, a generic construct
+    /// signature whose minimum arity exceeds `N` (e.g. `new <K, V>(): Map<K, V>`
+    /// when `class X extends Map` supplies `N == 0`) is dropped rather than
+    /// contributing its uninstantiated return type. Without this filter tsz
+    /// unions every construct signature's return type, producing a spurious
+    /// `Map<K, V> | Map<any, any>` base whose leaked type parameters misfire the
+    /// TS2416 override-variance check (issue #15248).
+    pub(crate) fn base_class_instance_type_from_constructor_type(
+        &mut self,
+        ctor_type: TypeId,
+        base_type_arg_count: usize,
+    ) -> Option<TypeId> {
+        let mut visited = FxHashSet::default();
+        self.instance_type_from_constructor_type_inner(
+            ctor_type,
+            Some(base_type_arg_count),
+            &mut visited,
+        )
     }
 
     /// Resolve `instance_type`'s references to the construct signature's own type
@@ -833,6 +864,7 @@ impl<'a> CheckerState<'a> {
     fn instance_type_from_constructor_type_inner(
         &mut self,
         ctor_type: TypeId,
+        base_type_arg_count: Option<usize>,
         visited: &mut FxHashSet<TypeId>,
     ) -> Option<TypeId> {
         if ctor_type == TypeId::NULL {
@@ -863,11 +895,28 @@ impl<'a> CheckerState<'a> {
             }
             match classify_for_instance_type(self.ctx.types, current) {
                 InstanceTypeKind::Callable(shape_id) => {
-                    let instance_type =
-                        crate::query_boundaries::common::get_construct_return_type_union(
-                            self.ctx.types,
-                            shape_id,
-                        )?;
+                    // For a class-like constructor *function* base, tsc filters
+                    // the construct signatures to those applicable for the
+                    // extends clause's type-argument count and takes the first
+                    // survivor's return type (the solver-owned arity-aware query).
+                    // Fall back to the whole-shape union when either there is no
+                    // base-class context or no construct signature is applicable
+                    // (the latter is the separate `TS2508`-shaped gap, preserved
+                    // as-is here).
+                    let instance_type = base_type_arg_count
+                        .and_then(|count| {
+                            crate::query_boundaries::construct_signatures::get_base_construct_return_type(
+                                self.ctx.types,
+                                shape_id,
+                                count,
+                            )
+                        })
+                        .or_else(|| {
+                            crate::query_boundaries::common::get_construct_return_type_union(
+                                self.ctx.types,
+                                shape_id,
+                            )
+                        })?;
                     let resolved = self.resolve_type_for_property_access(instance_type);
                     // Register TypeId→DefId so the TypeFormatter can display the
                     // interface name (e.g., "String", "Date") instead of structural
@@ -908,7 +957,13 @@ impl<'a> CheckerState<'a> {
                 InstanceTypeKind::Intersection(members) => {
                     let instance_types: Vec<TypeId> = members
                         .into_iter()
-                        .filter_map(|m| self.instance_type_from_constructor_type_inner(m, visited))
+                        .filter_map(|m| {
+                            self.instance_type_from_constructor_type_inner(
+                                m,
+                                base_type_arg_count,
+                                visited,
+                            )
+                        })
                         .collect();
                     if instance_types.is_empty() {
                         return None;
@@ -920,7 +975,13 @@ impl<'a> CheckerState<'a> {
                 InstanceTypeKind::Union(members) => {
                     let instance_types: Vec<TypeId> = members
                         .into_iter()
-                        .filter_map(|m| self.instance_type_from_constructor_type_inner(m, visited))
+                        .filter_map(|m| {
+                            self.instance_type_from_constructor_type_inner(
+                                m,
+                                base_type_arg_count,
+                                visited,
+                            )
+                        })
                         .collect();
                     if instance_types.is_empty() {
                         return None;
@@ -930,7 +991,11 @@ impl<'a> CheckerState<'a> {
                     return Some(self.resolve_type_for_property_access(instance_type));
                 }
                 InstanceTypeKind::Readonly(inner) => {
-                    return self.instance_type_from_constructor_type_inner(inner, visited);
+                    return self.instance_type_from_constructor_type_inner(
+                        inner,
+                        base_type_arg_count,
+                        visited,
+                    );
                 }
                 InstanceTypeKind::TypeParameter { constraint } => {
                     let constraint = constraint?;

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -18,7 +18,9 @@
 //! signatures.
 
 use tsz_solver::construction::TypeDatabase;
-use tsz_solver::{CallSignature, CallableShape, FunctionShape, ParamInfo, TypeId, TypePredicate};
+use tsz_solver::{
+    CallSignature, CallableShape, CallableShapeId, FunctionShape, ParamInfo, TypeId, TypePredicate,
+};
 
 pub(crate) fn construct_signatures_for_type(
     db: &dyn TypeDatabase,
@@ -43,6 +45,19 @@ pub(crate) fn construct_signatures_for_type(
 
 pub(crate) fn has_construct_overloads(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     construct_signatures_for_type(db, type_id).is_some_and(|sigs| sigs.len() > 1)
+}
+
+/// tsc's `getInstantiatedConstructorsForTypeArguments(...)[0]` return type: the
+/// arity-aware base type of a class extending a class-like constructor function,
+/// keyed on the extends clause's type-argument count. See
+/// [`tsz_solver::type_queries::get_base_construct_return_type`]. Returns `None`
+/// when no construct signature is applicable to `type_arg_count`.
+pub(crate) fn get_base_construct_return_type(
+    db: &dyn TypeDatabase,
+    shape_id: CallableShapeId,
+    type_arg_count: usize,
+) -> Option<TypeId> {
+    tsz_solver::type_queries::get_base_construct_return_type(db, shape_id, type_arg_count)
 }
 
 /// View one call/construct signature as a standalone, non-method

--- a/crates/tsz-checker/src/state/type_resolution/constructors.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors.rs
@@ -982,7 +982,14 @@ impl<'a> CheckerState<'a> {
 
         let ctor_type = self.base_constructor_type_from_expression(expr_idx, type_arguments)?;
         let adds_implicit_any_index = self.constructor_type_explicitly_returns_any(ctor_type);
-        let mut resolved = self.instance_type_from_constructor_type(ctor_type);
+        // A class-like constructor *function* base (e.g. `class X extends Map`,
+        // where `Map`'s value is typed `MapConstructor`, or a mixin result)
+        // follows tsc's `resolveBaseTypesOfClass` else-branch: filter the
+        // construct signatures to those applicable for the extends clause's
+        // type-argument count and take the first survivor's return type, rather
+        // than unioning every construct signature's return type (issue #15248).
+        let mut resolved =
+            self.base_class_instance_type_from_constructor_type(ctor_type, type_argument_count);
         if adds_implicit_any_index && resolved.is_some_and(TypeId::is_any) {
             resolved = Some(self.implicit_any_index_base_instance_type());
         }

--- a/crates/tsz-checker/tests/base_class_construct_signature_arity_filter_tests.rs
+++ b/crates/tsz-checker/tests/base_class_construct_signature_arity_filter_tests.rs
@@ -1,0 +1,186 @@
+//! Regression tests for issue #15248.
+//!
+//! When a class extends a *value* whose type carries construct signatures (a
+//! class-like constructor function rather than a class/interface reference),
+//! `tsc` computes the base type from
+//! `getInstantiatedConstructorsForTypeArguments(baseConstructorType,
+//! typeArguments)[0]`: the construct signatures are filtered to those applicable
+//! for the extends clause's type-argument count `N`
+//! (`N in [minTypeArgumentCount, typeParameters.len()]`) and the base is the
+//! *first* survivor's return type. A generic construct signature whose minimum
+//! arity exceeds `N` — e.g. `new <K, V>(): Map<K, V>` when `class X extends Map`
+//! supplies `N == 0` — is dropped.
+//!
+//! tsz previously unioned *every* construct signature's return type, producing a
+//! spurious `Map<K, V> | Map<any, any>` base whose leaked type parameters
+//! misfired the TS2416 override-variance check (the immer `DraftMap extends Map`
+//! false positive).
+//!
+//! The tests vary binder names and signature order so no name literal or
+//! declaration order drives the behavior.
+
+use tsz_checker::test_utils::check_source_code_messages;
+
+fn diagnostics(source: &str) -> Vec<(u32, String)> {
+    check_source_code_messages(source)
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    diagnostics(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+/// The core bug: extending a two-construct-signature value with no type
+/// arguments takes only the applicable (non-generic) signature's return type,
+/// not the union with the under-applied generic signature. The under-applied
+/// generic branch would leak `tag: "b"` into the base and reject the assignment.
+#[test]
+fn zero_type_args_base_picks_non_generic_construct_return_only() {
+    let source = r#"
+interface A { tag: "a"; m(): void; }
+interface B<T> { tag: "b"; val: T; m(): void; }
+interface Ctor {
+    new (): A;
+    new <T>(x: T): B<T>;
+}
+declare const Ctor: Ctor;
+class X extends Ctor {}
+
+// Base is `A`, so `tag` is `"a"`. A union base `A | B<T>` would make `tag`
+// `"a" | "b"` and reject this assignment (the #15248 false positive).
+declare const x: X;
+const t: "a" = x.tag;
+"#;
+    assert!(
+        diagnostics(source).is_empty(),
+        "expected no diagnostics (base resolves to `A`), got {:?}",
+        diagnostics(source)
+    );
+}
+
+/// The immer `DraftMap extends Map` shape: a `set(K, V)` override that is valid
+/// against `Coll<any, any>` must not be rejected against a spurious
+/// `Coll<any, any> | Coll<K, V>` union base.
+#[test]
+fn map_like_set_override_valid_against_any_base_has_no_ts2416() {
+    let source = r#"
+interface Coll<K, V> {
+    set(key: K, value: V): this;
+    get(key: K): V | undefined;
+}
+interface CollCtor {
+    new (): Coll<any, any>;
+    new <K, V>(entries?: readonly (readonly [K, V])[]): Coll<K, V>;
+    readonly prototype: Coll<any, any>;
+}
+declare const CollCtor: CollCtor;
+class DraftColl extends CollCtor {
+    set(key: any, value: any): this {
+        return this;
+    }
+}
+"#;
+    let ts2416: Vec<_> = diagnostics(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2416)
+        .collect();
+    assert!(
+        ts2416.is_empty(),
+        "expected no TS2416 for a valid `set` override against the `Coll<any, any>` base, got {ts2416:?}"
+    );
+}
+
+/// Declaration order must not matter: the generic signature declared *first* is
+/// still filtered out for a zero-type-argument base, leaving the non-generic
+/// signature as the base.
+#[test]
+fn generic_signature_declared_first_is_still_filtered_for_zero_args() {
+    let source = r#"
+interface Base0 { kind: "zero"; ping(): void; }
+interface Base1<Elem> { kind: "one"; item: Elem; ping(): void; }
+interface Factory {
+    new <Elem>(seed: Elem): Base1<Elem>;
+    new (): Base0;
+}
+declare const Factory: Factory;
+class Gadget extends Factory {}
+
+declare const g: Gadget;
+const k: "zero" = g.kind;
+"#;
+    assert!(
+        diagnostics(source).is_empty(),
+        "expected no diagnostics (base resolves to `Base0` regardless of signature order), got {:?}",
+        diagnostics(source)
+    );
+}
+
+/// A genuinely incompatible override must still report TS2416 — and against the
+/// correct (non-union) base type. Before the fix the base displayed as the
+/// `A2 | B2<T>` union with a `number | T` target; now it is the plain `A2`.
+#[test]
+fn genuinely_incompatible_override_still_reports_ts2416_against_correct_base() {
+    let source = r#"
+interface A2 { alpha: number; }
+interface B2<T> { alpha: T; }
+interface Ctor2 {
+    new (): A2;
+    new <T>(x: T): B2<T>;
+}
+declare const Ctor2: Ctor2;
+class Bad extends Ctor2 {
+    alpha!: string;
+}
+"#;
+    let messages: Vec<String> = diagnostics(source)
+        .into_iter()
+        .filter_map(|(code, message)| (code == 2416).then_some(message))
+        .collect();
+    // The base must display as the plain `A2`, never the spurious `A2 | B2<T>`
+    // union that leaked the generic signature's return type before the fix.
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("base type 'A2'")),
+        "expected TS2416 against the plain `A2` base, got {:?}",
+        diagnostics(source)
+    );
+    assert!(
+        !messages.iter().any(|message| message.contains("B2<")),
+        "base type must not be the `A2 | B2<T>` union, got {messages:?}"
+    );
+}
+
+/// When the extends clause *does* supply the type argument, the generic
+/// signature is the applicable one and its instantiated return type is the base
+/// (`B3<string>`), so the base carries `val: string` and `tag: "b"`.
+#[test]
+fn supplied_type_argument_selects_generic_signature_base() {
+    let source = r#"
+interface A3 { tag: "a"; ping(): void; }
+interface B3<T> { tag: "b"; val: T; ping(): void; }
+interface Ctor3 {
+    new (): A3;
+    new <T>(x: T): B3<T>;
+}
+declare const Ctor3: Ctor3;
+class Z extends Ctor3<string> {}
+
+declare const z: Z;
+const v: string = z.val;
+const tg: "b" = z.tag;
+"#;
+    // `val` must exist (base is `B3<string>`, not `A3`) and both assignments
+    // must type-check; no TS2339 (missing `val`) and no TS2322 (`tag` mismatch).
+    let relevant: Vec<_> = codes(source)
+        .into_iter()
+        .filter(|code| matches!(code, 2339 | 2322))
+        .collect();
+    assert!(
+        relevant.is_empty(),
+        "expected base `B3<string>` (val: string, tag: \"b\"), got {:?}",
+        diagnostics(source)
+    );
+}

--- a/crates/tsz-solver/src/type_queries/extended_constructors.rs
+++ b/crates/tsz-solver/src/type_queries/extended_constructors.rs
@@ -438,6 +438,60 @@ pub fn classify_for_base_instance_merge(
     }
 }
 
+/// The base type of a class whose base is a class-like constructor *function*,
+/// following tsc's `resolveBaseTypesOfClass` else-branch:
+/// `getReturnTypeOfSignature(getInstantiatedConstructorsForTypeArguments(
+/// baseConstructorType, typeArguments)[0])`.
+///
+/// `getConstructorsForTypeArguments` keeps only the construct signatures whose
+/// arity window contains the extends clause's type-argument count `N` — those
+/// where `N in [minTypeArgumentCount, typeParameters.len()]` — and the base is
+/// the return type of the *first* survivor (default-instantiated when `N` is
+/// below its parameter count). A generic construct signature whose minimum arity
+/// exceeds `N` (e.g. `new <K, V>(): Map<K, V>` when `class X extends Map`
+/// supplies `N == 0`) is dropped rather than contributing its uninstantiated
+/// return type.
+///
+/// This is the arity-aware counterpart of
+/// [`get_construct_return_type_union`](super::data::get_construct_return_type_union);
+/// the union collapses every construct signature's return type together, which
+/// leaks the under-applied generic signature's free type parameters into the
+/// base (the immer `DraftMap extends Map` spurious `Map<K, V> | Map<any, any>`
+/// base, issue #15248). Returns `None` when the shape has no construct signature
+/// applicable to `type_arg_count`, so the caller can decide the fallback.
+pub fn get_base_construct_return_type(
+    db: &dyn TypeDatabase,
+    shape_id: crate::types::CallableShapeId,
+    type_arg_count: usize,
+) -> Option<TypeId> {
+    use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
+
+    let shape = db.callable_shape(shape_id);
+    // tsc `getConstructorsForTypeArguments`: the first construct signature whose
+    // `[minTypeArgumentCount, typeParameters.len()]` window contains the supplied
+    // type-argument count. `minTypeArgumentCount` is the number of leading type
+    // parameters without a default (defaults are trailing).
+    let sig = shape.construct_signatures.iter().find(|sig| {
+        let max = sig.type_params.len();
+        let min = sig
+            .type_params
+            .iter()
+            .filter(|tp| tp.default.is_none())
+            .count();
+        type_arg_count >= min && type_arg_count <= max
+    })?;
+    if sig.type_params.is_empty() {
+        return Some(sig.return_type);
+    }
+    // Under-applied within `[min, len]`: fill the unsupplied trailing type
+    // parameters from their defaults (they necessarily have defaults, since the
+    // arity filter admitted the shorter count) and read the instantiated return
+    // type — tsc's `getSignatureInstantiation`. `from_args` resolves the default
+    // chain in declaration order.
+    let substitution = TypeSubstitution::from_args(db, &sig.type_params, &[]);
+    Some(instantiate_type(db, sig.return_type, &substitution))
+}
+
 #[cfg(test)]
 #[path = "../../tests/extended_constructors_tests.rs"]
 mod tests;

--- a/crates/tsz-solver/src/type_queries/mod.rs
+++ b/crates/tsz-solver/src/type_queries/mod.rs
@@ -94,7 +94,8 @@ pub use extended_constructors::{
     ConstructorCheckKind, ConstructorReturnMergeKind, InstanceTypeKind,
     classify_for_abstract_check, classify_for_base_instance_merge, classify_for_class_decl,
     classify_for_constructor_check, classify_for_constructor_return_merge,
-    classify_for_instance_type, resolve_abstract_constructor_anchor,
+    classify_for_instance_type, get_base_construct_return_type,
+    resolve_abstract_constructor_anchor,
 };
 
 pub use data::*;

--- a/crates/tsz-solver/tests/extended_constructors_tests.rs
+++ b/crates/tsz-solver/tests/extended_constructors_tests.rs
@@ -24,11 +24,12 @@ use crate::type_queries::extended_constructors::{
     ConstructorCheckKind, ConstructorReturnMergeKind, InstanceTypeKind,
     classify_for_abstract_check, classify_for_base_instance_merge, classify_for_class_decl,
     classify_for_constructor_check, classify_for_constructor_return_merge,
-    classify_for_instance_type, resolve_abstract_constructor_anchor,
+    classify_for_instance_type, get_base_construct_return_type,
+    resolve_abstract_constructor_anchor,
 };
 use crate::types::{
-    CallableShape, ConditionalType, FunctionShape, IndexSignature, ObjectFlags, ObjectShape,
-    PropertyInfo, SymbolRef, TypeData, TypeParamInfo,
+    CallSignature, CallableShape, ConditionalType, FunctionShape, IndexSignature, ObjectFlags,
+    ObjectShape, PropertyInfo, SymbolRef, TypeData, TypeParamInfo,
 };
 
 // =============================================================================
@@ -857,4 +858,112 @@ fn anchor_application_with_non_abstract_base_is_not_abstract() {
         resolve_abstract_constructor_anchor(&interner, app),
         AbstractConstructorAnchor::NotAbstract,
     );
+}
+
+// =============================================================================
+// get_base_construct_return_type (issue #15248)
+// =============================================================================
+
+fn type_param(interner: &TypeInterner, name: &str, default: Option<TypeId>) -> TypeParamInfo {
+    TypeParamInfo {
+        name: interner.intern_string(name),
+        constraint: None,
+        default,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    }
+}
+
+/// Resolve the `CallableShapeId` for a callable type built from the given
+/// construct signatures.
+fn base_construct_return(
+    interner: &TypeInterner,
+    construct_signatures: Vec<CallSignature>,
+    type_arg_count: usize,
+) -> Option<TypeId> {
+    let callable = interner.callable(CallableShape {
+        construct_signatures,
+        ..Default::default()
+    });
+    let InstanceTypeKind::Callable(shape_id) = classify_for_instance_type(interner, callable)
+    else {
+        panic!("expected a Callable type");
+    };
+    get_base_construct_return_type(interner, shape_id, type_arg_count)
+}
+
+#[test]
+fn base_construct_zero_args_picks_non_generic_signature_not_the_generic() {
+    // `MapConstructor`-shaped: `new(): A` plus `new <K, V>(): B`. For a
+    // zero-type-argument base (`class X extends Map`), only the non-generic
+    // signature is applicable, so the base is `A` — never the union with `B`.
+    let interner = TypeInterner::new();
+    let ret_a = interner.lazy(DefId(100));
+    let ret_b = interner.lazy(DefId(200));
+    let non_generic = CallSignature::new(vec![], ret_a);
+    let generic = CallSignature {
+        type_params: vec![
+            type_param(&interner, "K", None),
+            type_param(&interner, "V", None),
+        ],
+        ..CallSignature::new(vec![], ret_b)
+    };
+    assert_eq!(
+        base_construct_return(&interner, vec![non_generic, generic], 0),
+        Some(ret_a),
+    );
+}
+
+#[test]
+fn base_construct_zero_args_is_signature_order_independent() {
+    // The generic signature declared first is still filtered out for a
+    // zero-type-argument base; the non-generic survivor is the base.
+    let interner = TypeInterner::new();
+    let ret_a = interner.lazy(DefId(100));
+    let ret_b = interner.lazy(DefId(200));
+    let generic = CallSignature {
+        type_params: vec![
+            type_param(&interner, "K", None),
+            type_param(&interner, "V", None),
+        ],
+        ..CallSignature::new(vec![], ret_b)
+    };
+    let non_generic = CallSignature::new(vec![], ret_a);
+    assert_eq!(
+        base_construct_return(&interner, vec![generic, non_generic], 0),
+        Some(ret_a),
+    );
+}
+
+#[test]
+fn base_construct_zero_args_instantiates_default_bearing_generic() {
+    // `new <T = string>(): T` is applicable for zero args (min arity 0) and its
+    // return type is instantiated with the default — the base is `string`.
+    let interner = TypeInterner::new();
+    let t = type_param(&interner, "T", Some(TypeId::STRING));
+    let ret_t = interner.type_param(t.clone());
+    let sig = CallSignature {
+        type_params: vec![t],
+        ..CallSignature::new(vec![], ret_t)
+    };
+    assert_eq!(
+        base_construct_return(&interner, vec![sig], 0),
+        Some(TypeId::STRING),
+    );
+}
+
+#[test]
+fn base_construct_zero_args_no_applicable_signature_returns_none() {
+    // Only an under-applied generic signature (min arity 2) exists, so no
+    // signature is applicable to a zero-argument base; the caller falls back.
+    let interner = TypeInterner::new();
+    let ret_b = interner.lazy(DefId(200));
+    let generic = CallSignature {
+        type_params: vec![
+            type_param(&interner, "K", None),
+            type_param(&interner, "V", None),
+        ],
+        ..CallSignature::new(vec![], ret_b)
+    };
+    assert_eq!(base_construct_return(&interner, vec![generic], 0), None);
 }

--- a/crates/tsz-solver/tests/extended_constructors_tests.rs
+++ b/crates/tsz-solver/tests/extended_constructors_tests.rs
@@ -941,7 +941,7 @@ fn base_construct_zero_args_instantiates_default_bearing_generic() {
     // return type is instantiated with the default — the base is `string`.
     let interner = TypeInterner::new();
     let t = type_param(&interner, "T", Some(TypeId::STRING));
-    let ret_t = interner.type_param(t.clone());
+    let ret_t = interner.type_param(t);
     let sig = CallSignature {
         type_params: vec![t],
         ..CallSignature::new(vec![], ret_t)


### PR DESCRIPTION
Fixes #15248.

A class that extends a *value* typed with construct signatures — a class-like
constructor function rather than a class/interface reference (e.g.
`class DraftMap extends Map`, where `Map`'s value is typed `MapConstructor`) —
computed its base instance type as a spurious **union** of every construct
signature's return type (`Map<K, V> | Map<any, any>`). The under-applied generic
signature's free type parameters leaked into the base, misfiring the TS2416
override-variance check (the immer `DraftMap.set` false positive).

## Structural rule
When a class extends a class-like constructor function supplying `N` type
arguments in its extends clause, `tsc` (`resolveBaseTypesOfClass` else-branch)
computes the base as
`getReturnTypeOfSignature(getInstantiatedConstructorsForTypeArguments(baseCtor, typeArgs)[0])`:
the construct signatures are filtered to those whose arity window
`[minTypeArgumentCount, typeParameters.len()]` contains `N`, and the base is the
return type of the *first* survivor (default-instantiated when under-applied). A
generic construct signature whose minimum arity exceeds `N` (e.g.
`new <K, V>(): Map<K, V>` when `N == 0`) is dropped rather than contributing its
uninstantiated return type. tsz now does the same instead of unioning every
construct-signature return type.

## Owner layer
Solver type-queries. The new arity-aware query `get_base_construct_return_type`
lives beside its union counterpart `get_construct_return_type_union` in
`crates/tsz-solver/src/type_queries/extended_constructors.rs`, exposed through
the `query_boundaries::construct_signatures` gateway. The checker's base-instance
derivation (`instance_type_from_constructor_type_inner`) chooses between the two
solver queries by whether it is resolving a base class (a threaded
`base_type_arg_count: Option<usize>`); every other caller keeps the whole-shape
union unchanged. No raw solver-shape recursion remains in the checker, and no
user-name/file-name/printer-output predicate drives the decision — the filter is
keyed on the structural `[min, max]` type-parameter arity window.

## Adjacent matrix (verified vs `tsc` 6.0.x)
- zero-arg base with `new(): A` + `new <T>(): B<T>` → base `A` (not `A | B<T>`).
- signature order swapped → still `A` (the filter is order-independent).
- default-bearing generic `new <T = string>(): T` at zero args → base `string`.
- supplied type argument `extends Ctor<string>` → generic signature selected
  (`B<string>`), unchanged.
- genuinely incompatible override → still TS2416, now against the plain base
  (not the leaked union).
- immer `DraftMap extends Map` `set` override → no false TS2416.
- mixins / already-instantiated construct signatures → whole-shape union path
  unchanged.

Out of scope: a base whose construct signatures are *all* under-applied for `N`
(`tsc` reports TS2508 "No base constructor has the specified number of type
arguments") — preserved as the existing whole-shape-union fallback here and
tracked separately.

## Goal
Goal: grow

## Verification
- New solver unit tests for `get_base_construct_return_type` (4 tests) in
  `crates/tsz-solver/tests/extended_constructors_tests.rs`: arity filter,
  signature-order independence, default instantiation, no-applicable-signature
  `None`.
- New checker regression suite
  `crates/tsz-checker/tests/base_class_construct_signature_arity_filter_tests.rs`
  (5 binder-name-varied tests, positive + negative).
- Targeted `cargo test --profile dist-fast -p tsz-checker` suites
  (`class_expression_heritage_ts2416`, `mixin_base_no_member_no_ts2416`,
  `array_subclass_inheritance`, `same_base_any_args_application`,
  `checker_constructor_matrix`, `abstract_method_overload_ts2416`,
  `accessor_pair_override_ts2416`) — pass.
- End-to-end `tsz` diff on the adjacent matrix above — target cases now match
  `tsc`; mixin / instantiated / supplied-arg forms byte-unchanged.
- `cargo fmt --all -- --check`, `git diff --check`,
  `python3 scripts/arch/arch_guard.py --json` (0 failures),
  `scripts/arch/check-checker-boundaries.sh` (clean),
  `cargo clippy --profile ci-lint -p tsz-solver -p tsz-checker --lib -- -D warnings`
  — clean.
- ready-review CI owns the broad conformance/emit baselines and the immer canary
  project-compile guard.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01GR32T1DUtoyrqP18YtFd4F)_