### PR TITLE
fix(solver): filter non-applicable generic overloads from construct-return union (#15248)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -36,6 +36,9 @@ stacker = "0.1.23"
 name = "class_interface_merge_member_type_tests"
 path = "tests/class_interface_merge_member_type_tests.rs"
 [[test]]
+name = "extends_value_min_type_arg_base_union_tests"
+path = "tests/extends_value_min_type_arg_base_union_tests.rs"
+[[test]]
 name = "namespace_import_export_equals_passthrough_tests"
 path = "tests/namespace_import_export_equals_passthrough_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/extends_value_min_type_arg_base_union_tests.rs
+++ b/crates/tsz-checker/tests/extends_value_min_type_arg_base_union_tests.rs
@@ -1,0 +1,116 @@
+//! End-to-end guards for the base instance type of a class extending a *value*
+//! whose constructor type carries both a non-generic and a still-generic
+//! construct signature (the `MapConstructor` shape: `new (): T` plus
+//! `new <K, V>(): U`). The base instance type must come from the overload
+//! applicable with zero explicit type arguments, exactly as `tsc`'s
+//! `getConstructorsForTypeArguments` does — never a spurious `T | U` union that
+//! leaks the generic overload's free type parameters and misfires the
+//! override-variance check with a false TS2416 (the `class DraftMap extends Map`
+//! family from #15248, immer compat row).
+//!
+//! The underlying root cause is verified directly, red/green, at its owner
+//! layer by the solver unit tests in
+//! `crates/tsz-solver/src/type_queries/data/tests.rs`
+//! (`construct_return_union_*`), where `get_construct_return_type_union` is
+//! exercised in isolation. These checker cases are forward-looking regression
+//! guards for the class-heritage path: they pin the correct diagnostics for the
+//! extends-value shape (matching overload accepted, incompatible override still
+//! rejected, defaulted generic overload applicable) with renamed binders per the
+//! anti-hardcoding gate.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn ts2416_count(source: &str) -> usize {
+    check_source(source, "test.ts", CheckerOptions::default())
+        .iter()
+        .filter(|d| d.code == 2416)
+        .count()
+}
+
+fn assert_no_ts2416(source: &str) {
+    let diags = check_source(source, "test.ts", CheckerOptions::default());
+    let ts2416: Vec<_> = diags.iter().filter(|d| d.code == 2416).collect();
+    assert!(ts2416.is_empty(), "Expected no TS2416, got: {diags:#?}");
+}
+
+/// Override matching the applicable (non-generic) construct overload must be
+/// accepted — no false TS2416 from the dropped generic overload's free param.
+/// The base instance type is the zero-type-arg overload
+/// `{ store(entry: string): void }`, not a `string | Key` union.
+#[test]
+fn extends_value_with_generic_construct_overload_no_false_ts2416() {
+    assert_no_ts2416(
+        r#"
+declare const Base: {
+  new (): { store(entry: string): void };
+  new <Key, Value>(): { store(entry: Key): void };
+};
+
+class Draft extends Base {
+  store(entry: string): void {}
+}
+"#,
+    );
+}
+
+/// Binder-name-varied restatement of the same shape (anti-hardcoding gate): the
+/// decision must be driven by the construct signatures' type-parameter arity,
+/// never by the identifiers chosen.
+#[test]
+fn extends_value_generic_overload_renamed_binders_no_false_ts2416() {
+    assert_no_ts2416(
+        r#"
+declare const Factory: {
+  new (): { put(slot: number): void };
+  new <Alpha, Beta, Gamma>(): { put(slot: Alpha): void };
+};
+
+class Layer extends Factory {
+  put(slot: number): void {}
+}
+"#,
+    );
+}
+
+/// A fully-defaulted generic construct overload (`new <Elem = string>(): U`) has
+/// a `minTypeArgumentCount` of 0, so it stays applicable with zero type arguments
+/// and resolves to `{ read(): string }`.
+#[test]
+fn extends_value_fully_defaulted_generic_overload_is_applicable() {
+    assert_no_ts2416(
+        r#"
+declare const Base: {
+  new <Elem = string>(): { read(): Elem };
+};
+
+class View extends Base {
+  read(): string { return ""; }
+}
+"#,
+    );
+}
+
+/// Inverse control: when the override is genuinely incompatible with the
+/// applicable (non-generic) base overload, TS2416 must still fire. The filter
+/// only removes the non-applicable generic overload; it does not silence real
+/// override mismatches.
+#[test]
+fn extends_value_incompatible_override_still_emits_ts2416() {
+    let count = ts2416_count(
+        r#"
+declare const Base: {
+  new (): { store(entry: string): void };
+  new <Key, Value>(): { store(entry: Key): void };
+};
+
+class Draft extends Base {
+  store(entry: number): void {}
+}
+"#,
+    );
+    assert_eq!(
+        count, 1,
+        "Expected TS2416 when the override is incompatible with the applicable base overload"
+    );
+}

--- a/crates/tsz-solver/src/type_queries/data/construct_return_union_tests.rs
+++ b/crates/tsz-solver/src/type_queries/data/construct_return_union_tests.rs
@@ -1,0 +1,117 @@
+//! Unit tests for [`get_construct_return_type_union`] (via the public
+//! [`construct_return_type_for_type`] entry point).
+//!
+//! These pin `tsc`'s `getConstructorsForTypeArguments` rule with zero supplied
+//! type arguments: a construct signature contributes to the instance type only
+//! when it is applicable with no explicit type arguments (`minTypeArgumentCount`
+//! is 0). A `MapConstructor`-shaped value — a non-generic `new (): T` overload
+//! plus a generic `new <K, V>(): U` overload — must resolve to `T` alone, never
+//! the spurious `T | U` union that leaks the generic overload's free type
+//! parameters (the #15248 `class DraftMap extends Map` false-positive TS2416).
+
+use crate::intern::TypeInterner;
+use crate::type_queries::construct_return_type_for_type;
+use crate::types::{CallSignature, CallableShape, TypeId, TypeParamInfo};
+
+/// Build a construct signature with the given type parameters and return type
+/// (no value parameters — this suite exercises only the type-argument arity).
+fn construct_sig(type_params: Vec<TypeParamInfo>, return_type: TypeId) -> CallSignature {
+    CallSignature {
+        type_params,
+        params: vec![],
+        this_type: None,
+        return_type,
+        type_predicate: None,
+        is_method: false,
+    }
+}
+
+/// Intern a constructor value from a set of construct signatures.
+fn constructor_value(interner: &TypeInterner, construct_signatures: Vec<CallSignature>) -> TypeId {
+    interner.callable(CallableShape {
+        call_signatures: vec![],
+        construct_signatures,
+        properties: vec![],
+        string_index: None,
+        number_index: None,
+        symbol: None,
+        is_abstract: false,
+    })
+}
+
+#[test]
+fn drops_uninstantiated_generic_signature() {
+    let interner = TypeInterner::new();
+
+    // A `MapConstructor`-shaped value: a non-generic `new (): string` overload
+    // alongside a generic `new <Key, Val>(): Key` overload whose type parameters
+    // are required (no defaults). With zero explicit type arguments only the
+    // non-generic overload is applicable, so the generic overload's free type
+    // parameter must not leak into the instance type as a spurious union member.
+    let key = interner.intern_string("Key");
+    let val = interner.intern_string("Val");
+    let key_param_ty = interner.type_param(TypeParamInfo::simple(key));
+    let callable = constructor_value(
+        &interner,
+        vec![
+            construct_sig(vec![], TypeId::STRING),
+            construct_sig(
+                vec![TypeParamInfo::simple(key), TypeParamInfo::simple(val)],
+                key_param_ty,
+            ),
+        ],
+    );
+
+    assert_eq!(
+        construct_return_type_for_type(&interner, callable),
+        Some(TypeId::STRING),
+        "the uninstantiated generic construct signature must be filtered out, \
+         not unioned into the instance type"
+    );
+}
+
+#[test]
+fn keeps_fully_defaulted_generic_signature() {
+    let interner = TypeInterner::new();
+
+    // `new <Elem = number>(): number` — the sole type parameter has a default, so
+    // its `minTypeArgumentCount` is 0 and the signature is applicable with zero
+    // explicit type arguments (matching `tsc`'s `getConstructorsForTypeArguments`).
+    let elem = interner.intern_string("Elem");
+    let elem_param = TypeParamInfo {
+        default: Some(TypeId::NUMBER),
+        ..TypeParamInfo::simple(elem)
+    };
+    let callable = constructor_value(
+        &interner,
+        vec![construct_sig(vec![elem_param], TypeId::NUMBER)],
+    );
+
+    assert_eq!(
+        construct_return_type_for_type(&interner, callable),
+        Some(TypeId::NUMBER)
+    );
+}
+
+#[test]
+fn falls_back_when_every_signature_is_generic() {
+    let interner = TypeInterner::new();
+
+    // Only a required-type-parameter construct signature exists. With no
+    // applicable (zero-min-type-arg) overload, the helper still surfaces an
+    // instance type rather than collapsing to `None`.
+    let item = interner.intern_string("Item");
+    let item_param_ty = interner.type_param(TypeParamInfo::simple(item));
+    let callable = constructor_value(
+        &interner,
+        vec![construct_sig(
+            vec![TypeParamInfo::simple(item)],
+            item_param_ty,
+        )],
+    );
+
+    assert_eq!(
+        construct_return_type_for_type(&interner, callable),
+        Some(item_param_ty)
+    );
+}

--- a/crates/tsz-solver/src/type_queries/data/mod.rs
+++ b/crates/tsz-solver/src/type_queries/data/mod.rs
@@ -5,6 +5,8 @@
 //! a stable API for querying type properties without matching on `TypeData` directly.
 
 mod accessors;
+#[cfg(test)]
+mod construct_return_union_tests;
 mod content_predicate_guards;
 mod content_predicates;
 #[cfg(test)]

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -12,7 +12,7 @@ use crate::evaluation::evaluate::{TypeEvaluator, evaluate_index_access, evaluate
 use crate::evaluation::evaluate_rules::infer_pattern::InferPatternVisited;
 use crate::instantiation::instantiate::instantiate_type_params_to_constraints_uncached;
 use crate::relations::subtype::SubtypeChecker;
-use crate::types::{ConditionalType, IntrinsicKind, LiteralValue, TypeData, TypeId};
+use crate::types::{CallSignature, ConditionalType, IntrinsicKind, LiteralValue, TypeData, TypeId};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
 use tsz_common::Atom;
@@ -772,32 +772,32 @@ fn apparent_type_has_signatures_rec(
     }
 }
 
-/// Get the union of all construct signature return types from a callable shape.
-///
-/// Returns `Some(TypeId)` for the union of all construct signature return types,
-/// or `None` if the shape has no construct signatures. This encapsulates the common
-/// pattern of iterating construct signatures to collect instance types.
+/// Union of the construct signature return types applicable with zero explicit
+/// type arguments (`tsc`'s `getConstructorsForTypeArguments`): only fully
+/// defaulted signatures contribute, so still-generic overloads never leak free
+/// type parameters into the instance type (`Map<any, any> | Map<K, V>` for
+/// `class DraftMap extends Map`, #15248). Generic-only bases fall back to every
+/// signature; `None` when there are no construct signatures. See
+/// `construct_return_union_tests`.
 pub fn get_construct_return_type_union(
     db: &dyn TypeDatabase,
     shape_id: crate::types::CallableShapeId,
 ) -> Option<TypeId> {
     let shape = db.callable_shape(shape_id);
-    if shape.construct_signatures.is_empty() {
-        return None;
-    }
+    let defaulted = |sig: &CallSignature| sig.type_params.iter().all(|p| p.default.is_some());
+    let any_defaulted = shape.construct_signatures.iter().any(defaulted);
     let returns: Vec<TypeId> = shape
         .construct_signatures
         .iter()
+        .filter(|&sig| !any_defaulted || defaulted(sig))
         .map(|sig| sig.return_type)
         .collect();
-    Some(crate::utils::union_or_single(db, returns))
+    (!returns.is_empty()).then(|| crate::utils::union_or_single(db, returns))
 }
 
-/// Get the construct return type from any type (Callable or Function constructor).
-///
-/// For Callable types, returns the union of all construct signature return types.
-/// For Function types marked as constructors, returns the return type.
-/// Returns None for non-constructable types.
+/// Construct return type for any type: the applicable construct-signature union
+/// for a Callable (see `get_construct_return_type_union`), the return type for a
+/// constructor Function, `None` otherwise.
 pub fn construct_return_type_for_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
     use crate::type_queries::extended_constructors::InstanceTypeKind;
     match crate::type_queries::classify_for_instance_type(db, type_id) {


### PR DESCRIPTION
Fixes #15248.

`get_construct_return_type_union` unioned **every** construct signature's return type, including uninstantiated generic overloads. For `MapConstructor` (`new (): Map<any, any>` plus `new <K, V>(): Map<K, V>`) this produced a spurious base instance type `Map<any, any> | Map<K, V>`, leaking the generic overload's free type parameters into the instance type and misfiring the override-variance check with a false **TS2416** on `class DraftMap extends Map` (immer compat row, FP #3 from #15248; FP #2 was #15247).

## Structural rule
When a constructor value is referenced with no explicit type arguments, `tsc`'s `getConstructorsForTypeArguments` keeps only construct signatures whose `minTypeArgumentCount` is ≤ the supplied count (0 here), then derives the instance type from those. tsz now does the same through `get_construct_return_type_union` (`crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs`): a construct signature is applicable only when **every type parameter has a default** — which is exactly `minTypeArgumentCount == 0`, since an undefaulted type parameter cannot legally follow a defaulted one (TS2706). Only the applicable signatures contribute to the instance-type union, so a still-generic overload never leaks its free type parameters. When a base exposes *only* generic construct signatures the pre-filter behavior is preserved (union every signature) rather than collapsing to `None`, keeping that out-of-scope degenerate case unchanged.

### Repro (root cause, verified red/green at the owner layer)
`MapConstructor`-shaped callable → before: `string | Key` (spurious union member); after: `string` (the zero-type-arg overload alone).

## Owner layer
Solver only. `get_construct_return_type_union` is the single chokepoint every instance-from-constructor path funnels through — base-class heritage resolution, `new`-expression instance fallback, `x.constructor` narrowing, and emit declaration inference — so the one filter corrects the whole family. No user-name/file-name/rendered-output predicates: the decision is purely the construct signatures' type-parameter defaulting.

### Adjacent matrix
- non-generic + required-generic overloads → applicable overload only (the `Map` case);
- fully-defaulted generic overload (`new <T = number>(): U`) → stays applicable;
- generic-only base → fallback preserves prior behavior (no `None` regression);
- extends-value heritage end-to-end: matching override accepted, incompatible override still emits TS2416, renamed binders (anti-hardcoding gate).

### Out of scope
The full immer row also depends on the lazy-lib base-type materialization path (`actual_or_cloned_lib_instance_type_for_heritage`), which resolves `Map`'s interface instance type directly; this fix makes the constructor-return fallback agree with it (`Map<any, any>`). The end-to-end immer project row is owned by `scripts/ci/project-compile-guard.sh` / ready-review CI. `instanceof` narrowing (`narrowing/instanceof.rs`) reads `construct_signatures.first()` directly, already approximating tsc's `constructors[0]`; unchanged.

## Goal
Goal: hold

## Verification
- New solver unit suite `crates/tsz-solver/src/type_queries/data/construct_return_union_tests.rs` (3 tests) — proven **red before / green after** (before: `Some(TypeId(130))` spurious union; after: `Some(TypeId(10))` = `string`).
- New checker regression suite `crates/tsz-checker/tests/extends_value_min_type_arg_base_union_tests.rs` (4 tests, binder-name-varied) — forward-looking guards for the extends-value heritage path.
- `cargo test -p tsz-solver --lib` — no new failures (7 pre-existing failures on `main` are environment-specific and fail identically without this change).
- `cargo fmt --all -- --check`, `git diff --check`, `python3 scripts/arch/arch_guard.py --json` (passed; new tests split into a dedicated module to stay under the file-size ratchet), `cargo clippy --profile ci-lint -p tsz-solver --lib -- -D warnings` — clean.
- ready-review CI owns the broad conformance/emit/project-compile baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUdNiwEKtD3yxDdbREoNXp)_