### PR TITLE
fix(checker): defer lazy env authority writes (#14348)

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -1484,7 +1484,10 @@ impl CheckerState<'_> {
         }
 
         // Use try_borrow_mut to avoid panic if type_env is already borrowed.
-        // This can happen during recursive type resolution.
+        // This can happen during recursive type resolution. On contention,
+        // queue the writes through the context authority but report the
+        // traversal as incomplete so callers do not memoize a fully-resolved
+        // walk before the evaluator env has replayed the deferred write.
         if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
             if type_params.is_empty() {
                 self.ctx
@@ -1507,6 +1510,12 @@ impl CheckerState<'_> {
             self.mirror_application_def_resolution(def_id, resolved, &type_params);
             true
         } else {
+            self.ctx
+                .register_symbol_type_in_envs(symbol_ref, resolved, type_params.clone());
+            if let Some(def_id) = def_id {
+                self.ctx
+                    .register_def_auto_params_in_envs(def_id, resolved, type_params);
+            }
             false
         }
     }
@@ -1896,20 +1905,14 @@ impl CheckerState<'_> {
             // registers under the CLASS symbol's DefId, not the original DefId from
             // the Lazy type. Register under the original def_id so Lazy(DefId)
             // resolves correctly during property access.
-            if was_alias_resolved && let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
+            if was_alias_resolved {
                 if is_class {
-                    env.insert_class_instance_type(def_id, resolved);
+                    self.ctx.register_class_instance_in_envs(def_id, resolved);
                 }
-                env.insert_def(def_id, resolved);
-                // Mirror both writes into the flow-analyzer env so it does not
-                // retain a stale `def_types`/`class_instance_types` entry for this
-                // remapped def (see `mirror_def_in_type_environment`; #13086 / #13942).
-                if is_class {
-                    self.ctx
-                        .mirror_class_instance_in_type_environment(def_id, resolved);
-                }
-                self.ctx
-                    .mirror_def_in_type_environment(def_id, resolved, &[]);
+                // Register the original alias `DefId` through the same
+                // evaluator/flow authority so a recursive borrow queues the
+                // write instead of dropping it (#14348).
+                self.ctx.register_def_in_envs(def_id, resolved);
             }
 
             Some((inserted, resolved))

--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_06.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_06.rs
@@ -59,8 +59,12 @@ fn test_symbol_ref_to_symbol_id_cast_budget() {
 
 #[test]
 fn test_module_augmentation_publishes_merged_defs_through_context_authority() {
-    let source = fs::read_to_string("src/types/module_augmentation.rs")
+    let mut source = fs::read_to_string("src/types/module_augmentation.rs")
         .expect("failed to read module_augmentation.rs");
+    source.push_str(
+        &fs::read_to_string("src/types/module_augmentation_redirect.rs")
+            .expect("failed to read module_augmentation_redirect.rs"),
+    );
     let non_comment_source = source
         .lines()
         .map(|line| line.split_once("//").map_or(line, |(code, _)| code))
@@ -79,6 +83,10 @@ fn test_module_augmentation_publishes_merged_defs_through_context_authority() {
         compact_source.contains("register_augmented_def_in_envs(aug_def_id,merged_type,false)"),
         "augmentation-local self-reference bodies must publish through CheckerContext"
     );
+    assert!(
+        compact_source.contains("register_def_in_envs(home_def_id,merged_type)"),
+        "augmented base-body redirects must publish through CheckerContext"
+    );
     let raw_type_env_mut_borrows = non_comment_source.lines().filter(|line| {
         line.contains("type_env")
             && (line.contains("try_borrow_mut()") || line.contains("borrow_mut()"))
@@ -91,6 +99,28 @@ fn test_module_augmentation_publishes_merged_defs_through_context_authority() {
     assert!(
         !non_comment_source.contains("env.insert_def("),
         "module augmentation must not publish DefId bodies with raw env.insert_def"
+    );
+}
+
+#[test]
+fn test_lazy_type_env_symbol_publication_uses_context_authority_on_contention() {
+    let source =
+        fs::read_to_string("src/state/type_environment/lazy.rs").expect("failed to read lazy.rs");
+    let insert_type_env_symbol_src = source
+        .split("pub(crate) fn insert_type_env_symbol")
+        .nth(1)
+        .and_then(|tail| tail.split("/// Resolve a `DefId`").next())
+        .expect("failed to isolate insert_type_env_symbol");
+
+    assert!(
+        insert_type_env_symbol_src.contains("register_symbol_type_in_envs(")
+            && insert_type_env_symbol_src.contains("register_def_auto_params_in_envs("),
+        "insert_type_env_symbol must queue symbol/def writes through CheckerContext on evaluator-env borrow contention"
+    );
+    assert!(
+        source.contains("register_class_instance_in_envs(def_id, resolved)")
+            && source.contains("register_def_in_envs(def_id, resolved)"),
+        "lazy import-alias def remaps must publish through CheckerContext instead of raw env writes"
     );
 }
 

--- a/crates/tsz-checker/src/types/module_augmentation_redirect.rs
+++ b/crates/tsz-checker/src/types/module_augmentation_redirect.rs
@@ -43,17 +43,14 @@ impl<'a> CheckerState<'a> {
         let home_def_id = self.ctx.get_or_create_def_id(home_symbol);
 
         // Publish the merged body under the home def so `get_body(home_def_id)`
-        // surfaces the merged members for the index-reduction redirect.
-        self.ctx
-            .definition_store
-            .set_body_with_params(home_def_id, merged_type, None);
+        // surfaces the merged members for the index-reduction redirect. Route
+        // the body through the checker env authority so evaluator/flow env
+        // writes are deferred instead of dropped on recursive borrow races.
+        self.ctx.register_def_in_envs(home_def_id, merged_type);
         if let Some(shape) = type_environment::object_shape(self.ctx.types, merged_type) {
             self.ctx
                 .definition_store
                 .set_instance_shape(home_def_id, shape);
-        }
-        if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
-            env.insert_def(home_def_id, merged_type);
         }
 
         // Record the redirect edge keyed on the raw home `SymbolId` (the same


### PR DESCRIPTION
Fixes part of #14348. Contributes to the #14351 root-cause campaign.

## Summary

Two on-demand publication paths could still bypass the checker-owned dual-env authority:

- augmented base-body redirects wrote the merged `DefId` body directly into `DefinitionStore` and then opportunistically into `type_env`, dropping the evaluator-env write on a recursive borrow race;
- lazy symbol publication returned `false` on evaluator-env borrow contention without queuing the discovered symbol/def body, and import-alias remaps still wrote the original alias `DefId` through raw `type_env` mutation.

This routes those writes through `CheckerContext` publication helpers. Lazy traversal still reports the contested walk as incomplete, so callers do not memoize a fully-resolved precondition until the deferred evaluator write can replay.

## Structural Rule

When lazy, import-alias, or module-augmentation resolution discovers a declaration body while the evaluator environment is temporarily borrowed, `tsc` has one visible declaration environment; tsz must not silently drop that publication in one local env. The checker should queue evaluator/flow-env writes through the context env-publication authority, and solver/type-query consumers should observe the body after the deferred write boundary rather than depending on an opportunistic raw `type_env` insert.

## Owner Layer

Checker context env-publication boundary. The checker decides what body/shape/redirect to publish; `CheckerContext` owns how the evaluator env and flow env receive that publication, including deferred replay. Solver `TypeEnvironment` remains the storage/query substrate.

## Adjacent Matrix

- module augmentation redirect: merged home `DefId` body now uses `register_def_in_envs`; redirect edge and instance-shape metadata stay in the augmentation path;
- lazy `insert_type_env_symbol`: evaluator borrow contention queues `SymbolRef -> TypeId` and `DefId -> TypeId` writes via `register_symbol_type_in_envs` / `register_def_auto_params_in_envs`, while returning `false` so the traversal is not cached as fully resolved;
- lazy import-alias class remap: original alias `DefId` and class-instance metadata publish through `register_def_in_envs` / `register_class_instance_in_envs` instead of raw env writes;
- guards now cover both `module_augmentation.rs` and its split `module_augmentation_redirect.rs`, plus the lazy contention/remap authority calls.

Goal: hold

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(test_module_augmentation_publishes_merged_defs_through_context_authority) | test(test_lazy_type_env_symbol_publication_uses_context_authority_on_contention) | test(symbol_type_registration_deferred_mirror_preserves_params) | test(resolved_def_mirror_is_deferred_under_borrow_then_envs_reconcile) | test(augmented_def_registration_uses_store_only_params_on_replay)'`
- `python3 scripts/arch/arch_guard.py --json`

Note: an earlier broader local `nextest` invocation without `--lib` failed while linking checker integration test binaries because the local disk hit `ENOSPC`; the generated `.target` cache was removed and the focused `--lib` verification above passed.

## Provenance

Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
