### PR TITLE
fix(solver): key conditional branch verdicts by exact optional (#14347)

### DIFF
--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -297,13 +297,11 @@ pub trait TypeCompilerOptions {
 
 /// Per-file cache hooks for evaluated generic applications.
 ///
-/// The cache is keyed by the resolver-independent `(DefId, args,
-/// no_unchecked_indexed_access)` triple. Callers are responsible for using it
-/// only from authoritative full-resolver contexts; limited/noop resolvers can
-/// otherwise skip fallback behavior that is part of recursive and inference
-/// parity. Keeping these hooks separate from [`TypeDatabase`] makes
-/// application-eval cache access a narrow cache capability instead of growing
-/// the general type storage interface.
+/// The application-eval cache is keyed by `(DefId, args,
+/// no_unchecked_indexed_access, exact_optional_property_types)`. Use it only
+/// from authoritative full-resolver contexts; limited/noop resolvers can skip
+/// fallback behavior that is part of recursive and inference parity. Keeping
+/// this separate from [`TypeDatabase`] avoids growing the storage interface.
 pub trait TypeApplicationEvalCache {
     /// Project-wide (#14345) instantiation result lookup. Default `None`.
     fn lookup_proto_instantiation_cache(
@@ -398,9 +396,9 @@ pub trait TypeApplicationEvalCache {
     /// Evaluating a closed type is resolver-independent and deterministic per
     /// interner, so the result can be memoized project-wide and reused across
     /// the many fresh `TypeEvaluator` instances created during instantiation
-    /// (`evaluate_index_access`, `evaluate_keyof`, …). The key is keyed by both
-    /// the `TypeId` and `no_unchecked_indexed_access` because the latter changes
-    /// `T[K]` results. Default returns `None` so non-cache backends opt out.
+    /// (`evaluate_index_access`, `evaluate_keyof`, …). The key is keyed by the
+    /// `TypeId` plus both option flags, which can change `T[K]` results.
+    /// Default returns `None` so non-cache backends opt out.
     fn lookup_closed_eval_cache(
         &self,
         _type_id: TypeId,
@@ -429,8 +427,8 @@ pub trait TypeApplicationEvalCache {
     /// stored into — the ordinary subtype relation cache. Only *definitive*
     /// verdicts (`Holds`/`Fails`) that consumed no unregistered `Lazy` body,
     /// took no depth bail, and tripped no recursion/iteration limit are
-    /// persisted, so a stored verdict is a stable function of
-    /// `(check, extends, no_unchecked_indexed_access)` reusable across the many
+    /// persisted, so a stored verdict is stable for `(check, extends,
+    /// no_unchecked_indexed_access, exact_optional_property_types)` across the
     /// fresh `TypeEvaluator` instances instantiation spins up. Default returns
     /// `None` so non-cache backends opt out.
     fn lookup_conditional_branch_verdict(
@@ -438,6 +436,7 @@ pub trait TypeApplicationEvalCache {
         _check: TypeId,
         _extends: TypeId,
         _no_unchecked_indexed_access: bool,
+        _exact_optional_property_types: bool,
     ) -> Option<bool> {
         None
     }
@@ -450,6 +449,7 @@ pub trait TypeApplicationEvalCache {
         _check: TypeId,
         _extends: TypeId,
         _no_unchecked_indexed_access: bool,
+        _exact_optional_property_types: bool,
         _verdict: bool,
     ) {
     }

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -49,6 +49,7 @@ mod resolver;
 // does not depend on that option and it is intentionally not part of this key.
 type ElementAccessTypeCacheKey = (TypeId, TypeId, Option<u32>, bool);
 type PropertyAccessCacheKey = (TypeId, Atom, bool, bool);
+type ConditionalBranchVerdictCacheKey = (TypeId, TypeId, bool, bool);
 
 const SUBTYPE_POLICY_TRACE_OP: &str = "is_subtype_of_with_policy";
 const ASSIGNABILITY_POLICY_TRACE_OP: &str = "is_assignable_to_with_policy";
@@ -225,14 +226,16 @@ pub struct QueryCache<'a> {
     interner: &'a TypeInterner,
     eval_cache: RefCell<FxHashMap<EvaluationCacheKey, TypeId>>,
     /// Substitution-independent evaluation cache (see the `closed_eval` module
-    /// in `evaluate`). Keyed by `(TypeId, no_unchecked_indexed_access)`.
+    /// in `evaluate`). Keyed by
+    /// `(TypeId, no_unchecked_indexed_access, exact_optional_property_types)`.
     closed_eval_cache: RefCell<FxHashMap<EvaluationCacheKey, TypeId>>,
     /// Persistent conditional-branch subtype verdicts (issues #8356 / #13097).
-    /// Keyed by `(check, extends, no_unchecked_indexed_access)`; stores only
-    /// definitive, limit-free verdicts so it survives the per-evaluator
-    /// `conditional_subtype_cache` that is dropped on every evaluator
-    /// construction. Shares this cache's `clear()`/file lifecycle envelope.
-    conditional_branch_verdict_cache: RefCell<FxHashMap<(TypeId, TypeId, bool), bool>>,
+    /// Keyed by `(check, extends, no_unchecked_indexed_access,
+    /// exact_optional_property_types)`; stores only definitive, limit-free
+    /// verdicts so it survives the per-evaluator `conditional_subtype_cache`
+    /// that is dropped on every evaluator construction. Shares this cache's
+    /// `clear()`/file lifecycle envelope.
+    conditional_branch_verdict_cache: RefCell<FxHashMap<ConditionalBranchVerdictCacheKey, bool>>,
     application_eval_cache: RefCell<FxHashMap<ApplicationEvalCacheKey, TypeId>>,
     application_eval_dependency_index: ApplicationEvalDependencyIndex,
     element_access_cache: RefCell<FxHashMap<ElementAccessTypeCacheKey, TypeId>>,

--- a/crates/tsz-solver/src/caches/query_cache_application_eval.rs
+++ b/crates/tsz-solver/src/caches/query_cache_application_eval.rs
@@ -136,10 +136,16 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
         check: TypeId,
         extends: TypeId,
         no_unchecked_indexed_access: bool,
+        exact_optional_property_types: bool,
     ) -> Option<bool> {
         self.conditional_branch_verdict_cache
             .borrow()
-            .get(&(check, extends, no_unchecked_indexed_access))
+            .get(&(
+                check,
+                extends,
+                no_unchecked_indexed_access,
+                exact_optional_property_types,
+            ))
             .copied()
     }
 
@@ -148,10 +154,17 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
         check: TypeId,
         extends: TypeId,
         no_unchecked_indexed_access: bool,
+        exact_optional_property_types: bool,
         verdict: bool,
     ) {
-        self.conditional_branch_verdict_cache
-            .borrow_mut()
-            .insert((check, extends, no_unchecked_indexed_access), verdict);
+        self.conditional_branch_verdict_cache.borrow_mut().insert(
+            (
+                check,
+                extends,
+                no_unchecked_indexed_access,
+                exact_optional_property_types,
+            ),
+            verdict,
+        );
     }
 }

--- a/crates/tsz-solver/src/caches/query_cache_size.rs
+++ b/crates/tsz-solver/src/caches/query_cache_size.rs
@@ -22,7 +22,7 @@ impl QueryCache<'_> {
 
         let mut size = std::mem::size_of::<Self>();
 
-        // eval_cache: (TypeId, bool) -> TypeId
+        // eval_cache: EvaluationCacheKey -> TypeId
         {
             let map = self.eval_cache.borrow();
             size += map.capacity()
@@ -31,7 +31,7 @@ impl QueryCache<'_> {
                     + std::mem::size_of::<TypeId>());
         }
 
-        // closed_eval_cache: (TypeId, bool) -> TypeId
+        // closed_eval_cache: EvaluationCacheKey -> TypeId
         {
             let map = self.closed_eval_cache.borrow();
             size += map.capacity()
@@ -40,12 +40,12 @@ impl QueryCache<'_> {
                     + std::mem::size_of::<TypeId>());
         }
 
-        // conditional_branch_verdict_cache: (TypeId, TypeId, bool) -> bool
+        // conditional_branch_verdict_cache: (TypeId, TypeId, bool, bool) -> bool
         {
             let map = self.conditional_branch_verdict_cache.borrow();
             size += map.capacity()
                 * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<(TypeId, TypeId, bool)>()
+                    + std::mem::size_of::<ConditionalBranchVerdictCacheKey>()
                     + std::mem::size_of::<bool>());
         }
 

--- a/crates/tsz-solver/src/caches/query_cache_statistics.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics.rs
@@ -120,9 +120,9 @@ impl QueryCacheStatistics {
 
         let eval = self.eval_cache_entries * (BUCKET_OVERHEAD + 13);
         let closed_eval = self.closed_eval_cache_entries * (BUCKET_OVERHEAD + 13);
-        // (TypeId, TypeId, bool) key + bool value ≈ 10 bytes.
+        // (TypeId, TypeId, bool, bool) key + bool value ≈ 12 bytes.
         let conditional_verdict =
-            self.conditional_branch_verdict_cache_entries * (BUCKET_OVERHEAD + 10);
+            self.conditional_branch_verdict_cache_entries * (BUCKET_OVERHEAD + 12);
         let app_eval = self.application_eval_cache_entries * (BUCKET_OVERHEAD + 37);
         let elem = self.element_access_cache_entries * (BUCKET_OVERHEAD + 21);
         let spread = self.object_spread_cache_entries * (BUCKET_OVERHEAD + 4 + 24 + 256);

--- a/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
@@ -72,10 +72,11 @@ fn closed_eval_cache_is_visible_in_statistics_and_size_estimate() {
 fn conditional_branch_verdict_cache_round_trips_and_is_key_partitioned() {
     // Structural rule (issues #8356 / #13097): the conditional-branch verdict
     // cache is a per-`QueryCache` map keyed by
-    // `(check, extends, no_unchecked_indexed_access)`. It stores `bool`
-    // verdicts (a distinct relation from plain subtyping), is partitioned by
-    // the `no_unchecked_indexed_access` flag, and is cleared with the rest of
-    // the query cache. Raw-interner backends opt out (default `None`/no-op).
+    // `(check, extends, no_unchecked_indexed_access,
+    // exact_optional_property_types)`. It stores `bool` verdicts (a distinct
+    // relation from plain subtyping), is partitioned by both option flags, and
+    // is cleared with the rest of the query cache. Raw-interner backends opt
+    // out (default `None`/no-op).
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);
     let before = db.statistics();
@@ -83,14 +84,14 @@ fn conditional_branch_verdict_cache_round_trips_and_is_key_partitioned() {
 
     // Miss on an empty cache.
     assert_eq!(
-        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false),
+        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, false),
         None
     );
 
     // Round-trip a `true` verdict.
-    db.insert_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, true);
+    db.insert_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, false, true);
     assert_eq!(
-        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false),
+        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, false),
         Some(true)
     );
 
@@ -103,19 +104,36 @@ fn conditional_branch_verdict_cache_round_trips_and_is_key_partitioned() {
     // The `no_unchecked_indexed_access` flag partitions the key: the same
     // type pair under the other flag value is a distinct, still-empty slot.
     assert_eq!(
-        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, true),
+        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, true, false),
         None
+    );
+    // `exactOptionalPropertyTypes` also partitions the key. A branch probe can
+    // depend on mapped/indexed access semantics that distinguish optional
+    // markers from explicit `| undefined`, so reusing the same pair across
+    // exact-optional modes would select the wrong branch.
+    assert_eq!(
+        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, true),
+        None
+    );
+    db.insert_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, true, false);
+    assert_eq!(
+        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, true),
+        Some(false)
+    );
+    assert_eq!(
+        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, false),
+        Some(true)
     );
     // Operand order matters — `check`/`extends` are not symmetric.
     assert_eq!(
-        db.lookup_conditional_branch_verdict(TypeId::NUMBER, TypeId::STRING, false),
+        db.lookup_conditional_branch_verdict(TypeId::NUMBER, TypeId::STRING, false, false),
         None
     );
 
     // A `false` verdict round-trips distinctly from an absent entry.
-    db.insert_conditional_branch_verdict(TypeId::NUMBER, TypeId::STRING, false, false);
+    db.insert_conditional_branch_verdict(TypeId::NUMBER, TypeId::STRING, false, false, false);
     assert_eq!(
-        db.lookup_conditional_branch_verdict(TypeId::NUMBER, TypeId::STRING, false),
+        db.lookup_conditional_branch_verdict(TypeId::NUMBER, TypeId::STRING, false, false),
         Some(false)
     );
 
@@ -123,11 +141,11 @@ fn conditional_branch_verdict_cache_round_trips_and_is_key_partitioned() {
     db.clear();
     assert_eq!(db.statistics().conditional_branch_verdict_cache_entries, 0);
     assert_eq!(
-        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false),
+        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, false),
         None
     );
     assert_eq!(
-        db.lookup_conditional_branch_verdict(TypeId::NUMBER, TypeId::STRING, false),
+        db.lookup_conditional_branch_verdict(TypeId::NUMBER, TypeId::STRING, false, false),
         None
     );
 }
@@ -137,9 +155,9 @@ fn conditional_branch_verdict_cache_defaults_off_for_raw_interner() {
     // The trait default is a no-op so raw `TypeInterner` backends and tests
     // opt out: a lookup always misses and an insert is dropped.
     let interner = TypeInterner::new();
-    interner.insert_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, true);
+    interner.insert_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, false, true);
     assert_eq!(
-        interner.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false),
+        interner.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, false),
         None
     );
 }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -149,6 +149,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     fn conditional_subtype_checker(&self) -> SubtypeChecker<'a, R> {
         let mut checker = SubtypeChecker::with_resolver(self.interner(), self.resolver());
         checker.no_unchecked_indexed_access = self.no_unchecked_indexed_access();
+        checker.exact_optional_property_types = self.exact_optional_property_types();
         if let Some(query_db) = self.query_db() {
             checker = checker.with_query_db(query_db);
         }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -675,6 +675,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 check_type,
                 extends_type,
                 self.no_unchecked_indexed_access(),
+                self.exact_optional_property_types(),
             )
         {
             tsz_common::perf_counters::record_eval_conditional_verdict_persist_hit();
@@ -774,7 +775,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             self.cache_conditional_subtype(check_type, extends_type, verdict);
 
             // Publish to the cross-evaluator verdict cache only when the answer
-            // is a stable function of `(check, extends, no_unchecked)`:
+            // is a stable function of `(check, extends, no_unchecked, exact_optional)`:
             //  - definitive (not `Undetermined`, already guaranteed here) — a
             //    `false` that consumed an unregistered `Lazy` body never reaches
             //    this arm, so no registration-window artifact is published;
@@ -795,6 +796,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     check_type,
                     extends_type,
                     self.no_unchecked_indexed_access(),
+                    self.exact_optional_property_types(),
                     verdict,
                 );
                 tsz_common::perf_counters::record_eval_conditional_verdict_persist_insert();

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/tests.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/tests.rs
@@ -3,7 +3,7 @@ use crate::caches::db::TypeApplicationEvalCache;
 use crate::caches::query_cache::QueryCache;
 use crate::evaluation::result::TerminationKind;
 use crate::intern::TypeInterner;
-use crate::types::TypeId;
+use crate::types::{PropertyInfo, TypeId};
 
 #[test]
 fn test_is_primitive_vs_function_intrinsic() {
@@ -279,7 +279,7 @@ fn incomplete_request_verdict_blocks_conditional_branch_persistent_write() {
         BranchRelation::Holds
     );
     assert_eq!(
-        cache.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::UNKNOWN, false),
+        cache.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::UNKNOWN, false, false),
         Some(true)
     );
 
@@ -290,7 +290,45 @@ fn incomplete_request_verdict_blocks_conditional_branch_persistent_write() {
         BranchRelation::Holds
     );
     assert_eq!(
-        cache.lookup_conditional_branch_verdict(TypeId::NUMBER, TypeId::UNKNOWN, false),
+        cache.lookup_conditional_branch_verdict(TypeId::NUMBER, TypeId::UNKNOWN, false, false),
         None
+    );
+}
+
+#[test]
+fn conditional_subtype_relation_tracks_exact_optional_property_types() {
+    let interner = TypeInterner::new();
+    let cache = QueryCache::new(&interner);
+    let name = interner.intern_string("x");
+    let source = interner.object(vec![PropertyInfo::new(name, TypeId::UNDEFINED)]);
+    let target = interner.object(vec![PropertyInfo::opt(name, TypeId::NUMBER)]);
+
+    let mut exact_off = TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&cache);
+    exact_off.set_exact_optional_property_types(false);
+    assert_eq!(
+        exact_off.conditional_subtype_relation(source, target),
+        BranchRelation::Holds
+    );
+    assert_eq!(
+        cache.lookup_conditional_branch_verdict(source, target, false, false),
+        Some(true)
+    );
+
+    let mut exact_on = TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&cache);
+    exact_on.set_exact_optional_property_types(true);
+    assert_eq!(
+        exact_on.conditional_subtype_relation(source, target),
+        BranchRelation::Fails
+    );
+    assert_eq!(
+        cache.lookup_conditional_branch_verdict(source, target, false, true),
+        Some(false)
+    );
+
+    let mut exact_off_again = TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&cache);
+    exact_off_again.set_exact_optional_property_types(false);
+    assert_eq!(
+        exact_off_again.conditional_subtype_relation(source, target),
+        BranchRelation::Holds
     );
 }


### PR DESCRIPTION
## Summary

The persistent conditional-branch verdict cache now treats `exactOptionalPropertyTypes` as part of the branch relation key, alongside `check`, `extends`, and `noUncheckedIndexedAccess`. The cache hook takes the full option pair explicitly so fresh evaluators do not rely on `QueryCache` side-channel state for exact-optional mode.

The conditional branch probe itself now carries `exact_optional_property_types` into `SubtypeChecker`, so exact-optional-sensitive object-shape relations are computed under the active policy before any verdict can be published. Size/stat accounting and tests were updated for the wider key.

**Structural rule:** When a conditional branch relation compares optional-property object shapes, `tsc` selects the branch under the active `exactOptionalPropertyTypes` policy; `tsz` owns that through solver `TypeEvaluator` conditional branch probing and the persistent branch verdict cache.

**Owner layer:** solver `TypeEvaluator` / `QueryCache`. Checker remains only the option/config caller.

**Adjacent matrix:**
- Same `(check, extends)` with exact-optional off vs on uses separate verdict slots.
- Existing `noUncheckedIndexedAccess` partition remains separate.
- Operand order remains non-symmetric.
- Raw `TypeInterner` backends keep default `None`/no-op cache behavior.
- Incomplete/request-tainted verdicts still do not publish.

**Fallback:** Non-cache backends still miss and drop inserts. Budget, unresolved-`Lazy`, and taint gates are unchanged; only definitive depth-agnostic verdicts publish.

Goal: hold

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(conditional_branch_verdict_cache_round_trips_and_is_key_partitioned) | test(conditional_branch_verdict_cache_defaults_off_for_raw_interner) | test(incomplete_request_verdict_blocks_conditional_branch_persistent_write) | test(conditional_subtype_relation_tracks_exact_optional_property_types)'`
- `scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `scripts/safe-run.sh cargo clippy -p tsz-solver --lib -- -D warnings`
- `python3 scripts/arch/arch_guard.py --json`

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high