### PR TITLE
fix(solver): stamp intersection merge cache by resolver generation (#14347)

### DIFF
--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -29,6 +29,30 @@ use tsz_common::interner::Atom;
 
 pub use crate::caches::display_provenance::TypeDisplayProvenance;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IntersectionMergeCacheEntry {
+    Merged(TypeId),
+    NotEligible,
+}
+
+impl IntersectionMergeCacheEntry {
+    #[inline]
+    pub const fn from_result(result: Option<TypeId>) -> Self {
+        match result {
+            Some(type_id) => Self::Merged(type_id),
+            None => Self::NotEligible,
+        }
+    }
+
+    #[inline]
+    pub const fn into_result(self) -> Option<TypeId> {
+        match self {
+            Self::Merged(type_id) => Some(type_id),
+            Self::NotEligible => None,
+        }
+    }
+}
+
 /// Read-only access to interned type storage.
 ///
 /// This is the narrow capability for helpers that only inspect existing
@@ -1860,7 +1884,7 @@ pub trait QueryDatabase: TypeDatabase + TypeResolver + CollectPropertiesResultCa
         &self,
         _intersection_id: TypeId,
         _resolver_generation: u64,
-    ) -> Option<Option<TypeId>> {
+    ) -> Option<IntersectionMergeCacheEntry> {
         None
     }
 

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -1853,17 +1853,27 @@ pub trait QueryDatabase: TypeDatabase + TypeResolver + CollectPropertiesResultCa
 
     /// Look up a cached intersection-to-merged-object result.
     /// Used by `build_object_intersection_target` to avoid expensive property
-    /// collection for large intersections that are checked multiple times
-    /// (e.g., `T extends A & B & C & ...` in constraint checking).
+    /// collection for large intersections that are checked multiple times.
+    /// The stamp must come from the resolver used to resolve lazy members.
     /// Returns `None` if not cached.
-    fn lookup_intersection_merge(&self, _intersection_id: TypeId) -> Option<Option<TypeId>> {
+    fn lookup_intersection_merge(
+        &self,
+        _intersection_id: TypeId,
+        _resolver_generation: u64,
+    ) -> Option<Option<TypeId>> {
         None
     }
 
     /// Cache an intersection-to-merged-object result.
     /// `result` is `Some(merged_type_id)` on success, `None` if the intersection
     /// is not eligible for merging (contains callables, non-objects, etc.).
-    fn insert_intersection_merge(&self, _intersection_id: TypeId, _result: Option<TypeId>) {}
+    fn insert_intersection_merge(
+        &self,
+        _intersection_id: TypeId,
+        _resolver_generation: u64,
+        _result: Option<TypeId>,
+    ) {
+    }
 
     /// Look up a cached assignability result for the given key.
     /// Returns `None` if the result is not cached.

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -260,8 +260,10 @@ pub struct QueryCache<'a> {
     /// Cache for intersection-to-merged-object results.
     /// Avoids expensive `collect_properties` calls for the same intersection target
     /// across multiple `SubtypeChecker` instances (common in constraint checking).
+    /// Scoped by resolver generation because lazy member resolution can change
+    /// both successful merges and negative eligibility decisions.
     /// `Some(type_id)` = successfully merged, `None` = not eligible for merging.
-    intersection_merge_cache: RefCell<FxHashMap<TypeId, Option<TypeId>>>,
+    intersection_merge_cache: RefCell<intersection_merge_memo::IntersectionMergeMemo>,
     /// Cross-call cache for `instantiate_type` results, keyed by
     /// `(TypeId, CanonicalSubst, mode_bits, Option<this_type>)`.
     ///
@@ -342,7 +344,9 @@ impl<'a> QueryCache<'a> {
             property_cache: RefCell::new(FxHashMap::default()),
             variance_cache: RefCell::new(FxHashMap::default()),
             canonical_cache: RefCell::new(FxHashMap::default()),
-            intersection_merge_cache: RefCell::new(FxHashMap::default()),
+            intersection_merge_cache: RefCell::new(
+                intersection_merge_memo::IntersectionMergeMemo::default(),
+            ),
             instantiation_cache: InstantiationCache::new(),
             subtype_reduction_cache: SubtypeReductionCache::new(),
             application_eval_cache_stats: SharedCacheCounter::new(),
@@ -438,7 +442,10 @@ impl<'a> QueryCache<'a> {
             property_cache_entries: self.property_cache.borrow().len(),
             variance_cache_entries: self.variance_cache.borrow().len(),
             canonical_cache_entries: self.canonical_cache.borrow().len(),
-            intersection_merge_cache_entries: self.intersection_merge_cache.borrow().len(),
+            intersection_merge_cache_entries: self
+                .intersection_merge_cache
+                .borrow()
+                .total_entries(),
             intersection_merge_cache_hits: self.intersection_merge_cache_stats.hits(),
             intersection_merge_cache_misses: self.intersection_merge_cache_stats.misses(),
             instantiation_cache_entries: self.instantiation_cache.len(),
@@ -1752,12 +1759,15 @@ impl QueryDatabase for QueryCache<'_> {
         self.insert_policy_relation_cache(CachedPolicyRelation::Assignability, key, result);
     }
 
-    fn lookup_intersection_merge(&self, intersection_id: TypeId) -> Option<Option<TypeId>> {
+    fn lookup_intersection_merge(
+        &self,
+        intersection_id: TypeId,
+        resolver_generation: u64,
+    ) -> Option<Option<TypeId>> {
         let result = self
             .intersection_merge_cache
             .borrow()
-            .get(&intersection_id)
-            .copied();
+            .get(intersection_id, resolver_generation);
         if result.is_some() {
             self.intersection_merge_cache_stats.record_hit();
         } else {
@@ -1766,10 +1776,17 @@ impl QueryDatabase for QueryCache<'_> {
         result
     }
 
-    fn insert_intersection_merge(&self, intersection_id: TypeId, result: Option<TypeId>) {
-        self.intersection_merge_cache
-            .borrow_mut()
-            .insert(intersection_id, result);
+    fn insert_intersection_merge(
+        &self,
+        intersection_id: TypeId,
+        resolver_generation: u64,
+        result: Option<TypeId>,
+    ) {
+        self.intersection_merge_cache.borrow_mut().insert(
+            intersection_id,
+            resolver_generation,
+            result,
+        );
     }
 
     fn get_index_signatures(&self, type_id: TypeId) -> IndexInfo {
@@ -1935,6 +1952,8 @@ mod tests;
 
 #[path = "query_cache_collect_properties_memo.rs"]
 mod collect_properties_memo;
+#[path = "query_cache_intersection_merge_memo.rs"]
+mod intersection_merge_memo;
 
 #[path = "query_cache_application_eval.rs"]
 mod application_eval;

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -6,9 +6,9 @@
 
 use crate::caches::application_eval_index::{self, ApplicationEvalDependencyIndex};
 use crate::caches::db::{
-    QueryDatabase, TypeCompilerOptions, TypeContainsByIdCache, TypeDatabase, TypeDisplayProvenance,
-    TypeExtractParamsCache, TypePredicateCache, TypePruneUnionCache, TypeSubstitutionConstruction,
-    TypeTupleLimitSignal, TypeWidenCache,
+    IntersectionMergeCacheEntry, QueryDatabase, TypeCompilerOptions, TypeContainsByIdCache,
+    TypeDatabase, TypeDisplayProvenance, TypeExtractParamsCache, TypePredicateCache,
+    TypePruneUnionCache, TypeSubstitutionConstruction, TypeTupleLimitSignal, TypeWidenCache,
 };
 use crate::caches::instantiation_cache::{InstantiationCache, InstantiationCacheKey};
 use crate::caches::query_cache_statistics::{QueryCacheStatistics, RelationCacheStats};
@@ -1763,7 +1763,7 @@ impl QueryDatabase for QueryCache<'_> {
         &self,
         intersection_id: TypeId,
         resolver_generation: u64,
-    ) -> Option<Option<TypeId>> {
+    ) -> Option<IntersectionMergeCacheEntry> {
         let result = self
             .intersection_merge_cache
             .borrow()

--- a/crates/tsz-solver/src/caches/query_cache_intersection_merge_memo.rs
+++ b/crates/tsz-solver/src/caches/query_cache_intersection_merge_memo.rs
@@ -1,0 +1,77 @@
+//! Generation-bounded memo for intersection-to-merged-object results.
+//!
+//! Split out of `query_cache.rs` to keep that shard under the 2000-line
+//! file-size cap. This is a child module of `query_cache`.
+
+use crate::types::TypeId;
+use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
+
+const MAX_GENERATIONS_PER_INTERSECTION: usize = 4;
+
+type GenerationSlots = SmallVec<[(u64, Option<TypeId>); 1]>;
+
+#[derive(Default)]
+pub(super) struct IntersectionMergeMemo {
+    entries: FxHashMap<TypeId, GenerationSlots>,
+}
+
+impl IntersectionMergeMemo {
+    pub(super) fn get(&self, intersection_id: TypeId, generation: u64) -> Option<Option<TypeId>> {
+        self.entries
+            .get(&intersection_id)?
+            .iter()
+            .find(|(slot_generation, _)| *slot_generation == generation)
+            .map(|(_, result)| *result)
+    }
+
+    pub(super) fn insert(
+        &mut self,
+        intersection_id: TypeId,
+        generation: u64,
+        result: Option<TypeId>,
+    ) {
+        let slots = self.entries.entry(intersection_id).or_default();
+
+        if let Some(slot) = slots
+            .iter_mut()
+            .find(|(slot_generation, _)| *slot_generation == generation)
+        {
+            slot.1 = result;
+            return;
+        }
+
+        if slots.len() >= MAX_GENERATIONS_PER_INTERSECTION
+            && let Some(oldest) = slots
+                .iter()
+                .enumerate()
+                .min_by_key(|(_, (slot_generation, _))| *slot_generation)
+                .map(|(index, _)| index)
+        {
+            slots.swap_remove(oldest);
+        }
+
+        slots.push((generation, result));
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    pub(super) fn total_entries(&self) -> usize {
+        self.entries.values().map(SmallVec::len).sum()
+    }
+
+    pub(super) fn estimated_size_bytes(&self, bucket_overhead: usize) -> usize {
+        let mut size = self.entries.capacity()
+            * (bucket_overhead
+                + std::mem::size_of::<TypeId>()
+                + std::mem::size_of::<GenerationSlots>());
+        for slots in self.entries.values() {
+            if slots.spilled() {
+                size += slots.capacity() * std::mem::size_of::<(u64, Option<TypeId>)>();
+            }
+        }
+        size
+    }
+}

--- a/crates/tsz-solver/src/caches/query_cache_intersection_merge_memo.rs
+++ b/crates/tsz-solver/src/caches/query_cache_intersection_merge_memo.rs
@@ -3,13 +3,14 @@
 //! Split out of `query_cache.rs` to keep that shard under the 2000-line
 //! file-size cap. This is a child module of `query_cache`.
 
+use crate::caches::db::IntersectionMergeCacheEntry;
 use crate::types::TypeId;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 
 const MAX_GENERATIONS_PER_INTERSECTION: usize = 4;
 
-type GenerationSlots = SmallVec<[(u64, Option<TypeId>); 1]>;
+type GenerationSlots = SmallVec<[(u64, IntersectionMergeCacheEntry); 1]>;
 
 #[derive(Default)]
 pub(super) struct IntersectionMergeMemo {
@@ -17,7 +18,11 @@ pub(super) struct IntersectionMergeMemo {
 }
 
 impl IntersectionMergeMemo {
-    pub(super) fn get(&self, intersection_id: TypeId, generation: u64) -> Option<Option<TypeId>> {
+    pub(super) fn get(
+        &self,
+        intersection_id: TypeId,
+        generation: u64,
+    ) -> Option<IntersectionMergeCacheEntry> {
         self.entries
             .get(&intersection_id)?
             .iter()
@@ -31,13 +36,14 @@ impl IntersectionMergeMemo {
         generation: u64,
         result: Option<TypeId>,
     ) {
+        let entry = IntersectionMergeCacheEntry::from_result(result);
         let slots = self.entries.entry(intersection_id).or_default();
 
         if let Some(slot) = slots
             .iter_mut()
             .find(|(slot_generation, _)| *slot_generation == generation)
         {
-            slot.1 = result;
+            slot.1 = entry;
             return;
         }
 
@@ -51,7 +57,7 @@ impl IntersectionMergeMemo {
             slots.swap_remove(oldest);
         }
 
-        slots.push((generation, result));
+        slots.push((generation, entry));
     }
 
     pub(super) fn clear(&mut self) {
@@ -69,7 +75,8 @@ impl IntersectionMergeMemo {
                 + std::mem::size_of::<GenerationSlots>());
         for slots in self.entries.values() {
             if slots.spilled() {
-                size += slots.capacity() * std::mem::size_of::<(u64, Option<TypeId>)>();
+                size +=
+                    slots.capacity() * std::mem::size_of::<(u64, IntersectionMergeCacheEntry)>();
             }
         }
         size

--- a/crates/tsz-solver/src/caches/query_cache_size.rs
+++ b/crates/tsz-solver/src/caches/query_cache_size.rs
@@ -137,14 +137,10 @@ impl QueryCache<'_> {
             size += map.capacity() * (BUCKET_OVERHEAD + 2 * std::mem::size_of::<TypeId>());
         }
 
-        // intersection_merge_cache: TypeId -> Option<TypeId>
-        {
-            let map = self.intersection_merge_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<TypeId>()
-                    + std::mem::size_of::<Option<TypeId>>());
-        }
+        size += self
+            .intersection_merge_cache
+            .borrow()
+            .estimated_size_bytes(BUCKET_OVERHEAD);
 
         // instantiation_cache: (TypeId, CanonicalSubst, u8, Option<TypeId>) -> TypeId
         // CanonicalSubst's inline SmallVec buffer is included in the

--- a/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
@@ -1,6 +1,6 @@
 //! Query cache statistics and size-accounting coverage tests.
 
-use crate::caches::db::{QueryDatabase, TypeApplicationEvalCache};
+use crate::caches::db::{IntersectionMergeCacheEntry, QueryDatabase, TypeApplicationEvalCache};
 use crate::caches::instantiation_cache::{CanonicalSubst, InstantiationCacheKey};
 use crate::caches::query_cache::{QueryCache, SharedQueryCache};
 use crate::caches::query_cache_statistics::QueryCacheStatistics;
@@ -22,7 +22,7 @@ fn intersection_merge_cache_is_visible_in_statistics_and_size_estimate() {
     db.insert_intersection_merge(TypeId::STRING, 1, Some(TypeId::NUMBER));
     assert_eq!(
         db.lookup_intersection_merge(TypeId::STRING, 1),
-        Some(Some(TypeId::NUMBER))
+        Some(IntersectionMergeCacheEntry::Merged(TypeId::NUMBER))
     );
 
     let after = db.statistics();
@@ -43,14 +43,20 @@ fn intersection_merge_cache_partitions_results_by_resolver_generation() {
     let db = QueryCache::new(&interner);
 
     db.insert_intersection_merge(TypeId::STRING, 1, None);
-    assert_eq!(db.lookup_intersection_merge(TypeId::STRING, 1), Some(None));
+    assert_eq!(
+        db.lookup_intersection_merge(TypeId::STRING, 1),
+        Some(IntersectionMergeCacheEntry::NotEligible)
+    );
     assert_eq!(db.lookup_intersection_merge(TypeId::STRING, 2), None);
 
     db.insert_intersection_merge(TypeId::STRING, 2, Some(TypeId::NUMBER));
-    assert_eq!(db.lookup_intersection_merge(TypeId::STRING, 1), Some(None));
+    assert_eq!(
+        db.lookup_intersection_merge(TypeId::STRING, 1),
+        Some(IntersectionMergeCacheEntry::NotEligible)
+    );
     assert_eq!(
         db.lookup_intersection_merge(TypeId::STRING, 2),
-        Some(Some(TypeId::NUMBER))
+        Some(IntersectionMergeCacheEntry::Merged(TypeId::NUMBER))
     );
 
     let stats = db.statistics();

--- a/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
@@ -18,10 +18,10 @@ fn intersection_merge_cache_is_visible_in_statistics_and_size_estimate() {
     assert_eq!(before.intersection_merge_cache_hits, 0);
     assert_eq!(before.intersection_merge_cache_misses, 0);
 
-    assert_eq!(db.lookup_intersection_merge(TypeId::STRING), None);
-    db.insert_intersection_merge(TypeId::STRING, Some(TypeId::NUMBER));
+    assert_eq!(db.lookup_intersection_merge(TypeId::STRING, 1), None);
+    db.insert_intersection_merge(TypeId::STRING, 1, Some(TypeId::NUMBER));
     assert_eq!(
-        db.lookup_intersection_merge(TypeId::STRING),
+        db.lookup_intersection_merge(TypeId::STRING, 1),
         Some(Some(TypeId::NUMBER))
     );
 
@@ -35,6 +35,28 @@ fn intersection_merge_cache_is_visible_in_statistics_and_size_estimate() {
     let rendered = after.to_string();
     assert!(rendered.contains("intersection_merge"));
     assert!(rendered.contains("1 hits, 1 misses"));
+}
+
+#[test]
+fn intersection_merge_cache_partitions_results_by_resolver_generation() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    db.insert_intersection_merge(TypeId::STRING, 1, None);
+    assert_eq!(db.lookup_intersection_merge(TypeId::STRING, 1), Some(None));
+    assert_eq!(db.lookup_intersection_merge(TypeId::STRING, 2), None);
+
+    db.insert_intersection_merge(TypeId::STRING, 2, Some(TypeId::NUMBER));
+    assert_eq!(db.lookup_intersection_merge(TypeId::STRING, 1), Some(None));
+    assert_eq!(
+        db.lookup_intersection_merge(TypeId::STRING, 2),
+        Some(Some(TypeId::NUMBER))
+    );
+
+    let stats = db.statistics();
+    assert_eq!(stats.intersection_merge_cache_entries, 2);
+    assert_eq!(stats.intersection_merge_cache_hits, 3);
+    assert_eq!(stats.intersection_merge_cache_misses, 1);
 }
 
 #[test]

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -631,12 +631,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
         if let Some(members) = intersection_list_id(self.interner, target) {
             let member_list = self.interner.type_list(members);
+            let resolver_generation = self.resolver.resolver_generation();
 
             // Fast path: check the shared intersection merge cache first to
             // skip the O(N) eligibility scan for repeated constraint checks.
             let cached = self
                 .query_db
-                .and_then(|db| db.lookup_intersection_merge(target));
+                .and_then(|db| db.lookup_intersection_merge(target, resolver_generation));
             let merged_target = if let Some(cached_result) = cached {
                 cached_result
             } else if self.can_use_object_intersection_fast_path(&member_list) {
@@ -644,7 +645,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             } else {
                 // Not eligible; cache the negative result to avoid re-scanning.
                 if let Some(db) = self.query_db {
-                    db.insert_intersection_merge(target, None);
+                    db.insert_intersection_merge(target, resolver_generation, None);
                 }
                 None
             };

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -639,7 +639,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 .query_db
                 .and_then(|db| db.lookup_intersection_merge(target, resolver_generation));
             let merged_target = if let Some(cached_result) = cached {
-                cached_result
+                cached_result.into_result()
             } else if self.can_use_object_intersection_fast_path(&member_list) {
                 self.build_object_intersection_target(target)
             } else {

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -159,10 +159,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         &self,
         target_intersection: TypeId,
     ) -> Option<TypeId> {
+        let resolver_generation = self.resolver.resolver_generation();
         // Check the shared QueryCache first to avoid expensive property collection
         // for large intersections checked across multiple SubtypeChecker instances.
         if let Some(db) = self.query_db
-            && let Some(cached) = db.lookup_intersection_merge(target_intersection)
+            && let Some(cached) =
+                db.lookup_intersection_merge(target_intersection, resolver_generation)
         {
             return cached;
         }
@@ -205,7 +207,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
         // Cache the result for subsequent SubtypeChecker instances.
         if let Some(db) = self.query_db {
-            db.insert_intersection_merge(target_intersection, result);
+            db.insert_intersection_merge(target_intersection, resolver_generation, result);
         }
         result
     }

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -166,7 +166,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             && let Some(cached) =
                 db.lookup_intersection_merge(target_intersection, resolver_generation)
         {
-            return cached;
+            return cached.into_result();
         }
 
         use crate::objects::collect_properties_cached;

--- a/crates/tsz-solver/tests/db_tests.rs
+++ b/crates/tsz-solver/tests/db_tests.rs
@@ -34,7 +34,7 @@ impl<'a> QueryCache<'a> {
     }
 
     fn intersection_merge_cache_len(&self) -> usize {
-        self.intersection_merge_cache.borrow().len()
+        self.intersection_merge_cache.borrow().total_entries()
     }
 }
 
@@ -693,7 +693,7 @@ fn query_cache_estimated_size_resets_on_clear() {
         RelationCacheKey::for_subtype(str_type, TypeId::NUMBER, RelationCacheConfig::default()),
         true,
     );
-    cache.insert_intersection_merge(str_type, Some(TypeId::STRING));
+    cache.insert_intersection_merge(str_type, 1, Some(TypeId::STRING));
 
     let before_clear = cache.estimated_size_bytes();
     assert_eq!(cache.intersection_merge_cache_len(), 1);
@@ -702,7 +702,7 @@ fn query_cache_estimated_size_resets_on_clear() {
 
     let after_clear = cache.estimated_size_bytes();
     assert_eq!(cache.intersection_merge_cache_len(), 0);
-    assert_eq!(cache.lookup_intersection_merge(str_type), None);
+    assert_eq!(cache.lookup_intersection_merge(str_type, 1), None);
     // After clear, size should not exceed before_clear (maps may retain capacity).
     // The key invariant: statistics-based estimate resets to zero.
     let stats = cache.statistics();

--- a/crates/tsz-solver/tests/lazy_heritage_member_resolution_tests.rs
+++ b/crates/tsz-solver/tests/lazy_heritage_member_resolution_tests.rs
@@ -31,12 +31,12 @@
 //! name (per the anti-hardcoding contract).
 
 use crate::classes::inheritance::InheritanceGraph;
-use crate::construction::TypeInterner;
+use crate::construction::{QueryCache, TypeInterner};
 use crate::def::resolver::TypeEnvironment;
 use crate::def::{DefId, DefKind};
 use crate::objects::collect::{PropertyCollectionResult, collect_properties};
 use crate::operations::property::PropertyAccessEvaluator;
-use crate::relations::subtype::SubtypeChecker;
+use crate::relations::subtype::{SubtypeChecker, TypeResolver};
 use crate::types::{PropertyInfo, SymbolRef, TypeData, TypeId, TypeParamInfo};
 use tsz_binder::SymbolId;
 
@@ -388,6 +388,81 @@ fn subtype_enforces_inherited_member_on_lazy_heritage_target() {
     assert!(
         !checker.check_subtype(missing_inherited, target).is_true(),
         "source missing the inherited member must be rejected",
+    );
+}
+
+#[test]
+fn target_intersection_merge_cache_recomputes_after_lazy_resolver_generation_change() {
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+    let cache = QueryCache::new(&interner);
+    let base = DefId(31_011);
+
+    declare_interface(
+        &mut env,
+        base,
+        object(&interner, &[("old_branch_member", TypeId::STRING)]),
+    );
+
+    let stable_target_members = [
+        "stable_a", "stable_b", "stable_c", "stable_d", "stable_e", "stable_f", "stable_g",
+    ];
+    let target = stable_target_members
+        .iter()
+        .map(|&name| object(&interner, &[(name, TypeId::NUMBER)]))
+        .chain(std::iter::once(interner.lazy(base)))
+        .reduce(|left, right| interner.intersect_types_raw2(left, right))
+        .expect("target intersection has members");
+
+    let source_with_old = object(
+        &interner,
+        &[
+            ("stable_a", TypeId::NUMBER),
+            ("stable_b", TypeId::NUMBER),
+            ("stable_c", TypeId::NUMBER),
+            ("stable_d", TypeId::NUMBER),
+            ("stable_e", TypeId::NUMBER),
+            ("stable_f", TypeId::NUMBER),
+            ("stable_g", TypeId::NUMBER),
+            ("old_branch_member", TypeId::STRING),
+        ],
+    );
+    let source_with_old_again = object(
+        &interner,
+        &[
+            ("stable_a", TypeId::NUMBER),
+            ("stable_b", TypeId::NUMBER),
+            ("stable_c", TypeId::NUMBER),
+            ("stable_d", TypeId::NUMBER),
+            ("stable_e", TypeId::NUMBER),
+            ("stable_f", TypeId::NUMBER),
+            ("stable_g", TypeId::NUMBER),
+            ("old_branch_member", TypeId::STRING),
+            ("extra_marker", TypeId::BOOLEAN),
+        ],
+    );
+
+    let mut first_checker = SubtypeChecker::with_resolver(&interner, &env).with_query_db(&cache);
+    assert!(
+        first_checker
+            .check_subtype(source_with_old, target)
+            .is_true(),
+        "control: initial lazy member is satisfied and populates the merge cache",
+    );
+
+    let generation_before_mutation = env.resolver_generation();
+    env.insert_def(
+        base,
+        object(&interner, &[("fresh_branch_member", TypeId::BOOLEAN)]),
+    );
+    assert!(env.resolver_generation() > generation_before_mutation);
+
+    let mut second_checker = SubtypeChecker::with_resolver(&interner, &env).with_query_db(&cache);
+    assert!(
+        !second_checker
+            .check_subtype(source_with_old_again, target)
+            .is_true(),
+        "the cached merged target must miss after resolver generation changes",
     );
 }
 


### PR DESCRIPTION
Goal: hold

## Structural Rule
When an object-intersection target contains lazy resolver-materialized members, `tsc` observes the declarations currently visible through the resolver. `tsz` owns that in solver `SubtypeChecker` / `QueryCache`, so intersection merge cache results must be keyed by the resolver generation that resolved the target members.

## Scope
- Stamp positive and negative `intersection_merge_cache` entries with `resolver_generation`.
- Thread the stamp through `QueryDatabase::lookup_intersection_merge` and `insert_intersection_merge`.
- Use `self.resolver.resolver_generation()` at both relation call sites instead of the cache database generation.
- Add direct cache partition coverage and a lazy-heritage target regression that mutates the same `TypeEnvironment` between checks.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(intersection_merge_cache_is_visible_in_statistics_and_size_estimate) | test(intersection_merge_cache_partitions_results_by_resolver_generation) | test(target_intersection_merge_cache_recomputes_after_lazy_resolver_generation_change) | test(query_cache_estimated_size_resets_on_clear)'`
- `scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `scripts/safe-run.sh cargo clippy -p tsz-solver --lib --tests -- -D warnings`
- `python3 scripts/arch/arch_guard.py --json`

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high