### PR TITLE
fix(checker): copy cross-file resolution state for ambient class delegation (#15256)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -1346,11 +1346,23 @@ impl CheckerState<'_> {
             .get_symbol(sym_id)
             .and_then(tsz_binder::Symbol::primary_declaration)
             .is_some_and(|decl_idx| checker.is_ambient_class_declaration(decl_idx));
+        // The cross-file resolution state (all arenas/binders, resolved modules,
+        // and the global name indices) is what lets the delegated child follow
+        // import references that appear in the class's members — e.g. a generic
+        // method whose type-parameter constraint references a type alias imported
+        // into the declaring module (`bareC<TE extends AnyTable>` where `AnyTable`
+        // is `import`ed). Ambient (`declare class`) user classes need this just as
+        // much as concrete ones: without it the constraint alias resolves to
+        // `Error`, which downstream widens inferred literal arguments (a spurious
+        // `TS2322`/`TS2345` cascade) and drops the constraint's own enforcement
+        // (#15256). Declaration/lib files bail out earlier (see the
+        // `query_file_is_declaration_file` guard above), so this only broadens
+        // resolution for ambient classes in real modules. `current_file_idx` is
+        // already set above and `copy_cross_file_state_from` does not touch it;
+        // the symbol-cache invalidation stays gated on the concrete path to
+        // preserve ambient classes' cached-type reuse.
+        checker.ctx.copy_cross_file_state_from(&self.ctx);
         if !delegated_class_is_ambient {
-            checker.ctx.copy_cross_file_state_from(&self.ctx);
-            checker.ctx.current_file_idx = query_file_idx
-                .or(delegate_file_idx)
-                .unwrap_or(self.ctx.current_file_idx);
             checker.ctx.symbol_types.remove(&sym_id);
             checker.ctx.symbol_instance_types.remove(&sym_id);
             checker.ctx.symbol_to_def.borrow_mut().remove(&sym_id);

--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -176,6 +176,9 @@ name = "imported_infer_readonly_alias_cli_tests"
 path = "tests/imported_infer_readonly_alias_cli_tests.rs"
 
 [[test]]
+name = "cross_module_ambient_class_method_constraint_cli_tests"
+path = "tests/cross_module_ambient_class_method_constraint_cli_tests.rs"
+[[test]]
 name = "cross_module_conditional_constraint_union_param_cli_tests"
 path = "tests/cross_module_conditional_constraint_union_param_cli_tests.rs"
 

--- a/crates/tsz-cli/tests/cross_module_ambient_class_method_constraint_cli_tests.rs
+++ b/crates/tsz-cli/tests/cross_module_ambient_class_method_constraint_cli_tests.rs
@@ -1,0 +1,161 @@
+//! Regression: a generic method on a cross-module **ambient** (`declare class`)
+//! class whose type-parameter constraint references a type alias *imported into
+//! the declaring module* must resolve that constraint through the declaring
+//! module's own imports — not degrade it to the error type.
+//!
+//! Issue #15256. The cross-arena class-instance delegation skipped
+//! `copy_cross_file_state_from` for ambient classes, so the delegated child
+//! checker never received the all-arenas/all-binders/resolved-modules state it
+//! needs to follow the declaring module's imports. The method's constraint
+//! alias (`TE extends AnyTable`, `AnyTable` imported from a third module) then
+//! resolved to `Error`, which downstream (a) widened the inferred literal
+//! argument — a false-positive `TS2322` cascade — and (b) silently accepted
+//! arguments the constraint should have rejected (a false negative). `tsc`
+//! resolves the constraint and accepts.
+//!
+//! Requires the real project-mode driver (`-p tsconfig.json`): the bug only
+//! manifests through the `ProgramContext` shared-store cross-arena delegation
+//! path, so a command-line file list or the entry-only checker harness never
+//! reproduces it. Binder names below are varied from the kysely repro so the
+//! fix cannot be a name-scoped path.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+const TSCONFIG: &str = r#"{
+  "compilerOptions": {
+    "strict": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "lib": ["es2022"],
+    "types": [],
+    "noEmit": true
+  }
+}
+"#;
+
+/// Run `tsz -p tsconfig.json` over an in-memory project, returning
+/// `(exit_success, combined_stdout+stderr)`. Returns `None` (after printing a
+/// skip notice) when the `tsz` binary is unavailable, so each test can bail with
+/// a single `let else` instead of repeating the guard.
+fn run_project(files: &[(&str, &str)]) -> Option<(bool, String)> {
+    let tsz_bin = find_tsz_binary()?;
+    let dir = tempfile::tempdir().expect("temp dir");
+    for (name, source) in files {
+        std::fs::write(dir.path().join(name), source).expect("write file");
+    }
+    std::fs::write(dir.path().join("tsconfig.json"), TSCONFIG).expect("write tsconfig");
+    let output = Command::new(tsz_bin)
+        .args(["-p", "tsconfig.json", "--pretty", "false"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run tsz");
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    Some((output.status.success(), combined))
+}
+
+/// The #15256 gate: `declare class QC { bareC<TE extends AnyTable>(from: TE): TE }`
+/// with `AnyTable` imported into the declaring module. `db.bareC('sys.tables')`
+/// must infer `TE = "sys.tables"` (literal preserved), so the assignment to a
+/// `"sys.tables"`-typed slot type-checks with no `TS2322`.
+#[test]
+fn ambient_class_method_imported_alias_constraint_preserves_literal() {
+    let Some((ok, out)) = run_project(&[
+        ("schema.ts", "export type AnyTable = string;\n"),
+        (
+            "orm.ts",
+            "import type { AnyTable } from './schema';\n\
+             export declare class QC {\n\
+             \x20 bareC<TE extends AnyTable>(from: TE): TE;\n\
+             }\n",
+        ),
+        (
+            "app.ts",
+            "import type { QC } from './orm';\n\
+             declare const db: QC;\n\
+             const a = db.bareC('sys.tables');\n\
+             const _c: 'sys.tables' = a;\n",
+        ),
+    ]) else {
+        return;
+    };
+    assert!(
+        ok && !out.contains("TS2322"),
+        "imported-alias constraint on an ambient class method must preserve the inferred \
+         literal (no widening TS2322).\noutput:\n{out}"
+    );
+}
+
+/// Renamed binders (anti-hardcoding gate): the same structural position with
+/// entirely different identifiers must behave identically.
+#[test]
+fn ambient_class_method_imported_alias_constraint_preserves_literal_renamed() {
+    let Some((ok, out)) = run_project(&[
+        ("names.ts", "export type RowName = string;\n"),
+        (
+            "builder.ts",
+            "import type { RowName } from './names';\n\
+             export declare class Builder {\n\
+             \x20 pick<K extends RowName>(name: K): K;\n\
+             }\n",
+        ),
+        (
+            "entry.ts",
+            "import type { Builder } from './builder';\n\
+             declare const b: Builder;\n\
+             const picked = b.pick('users');\n\
+             const _w: 'users' = picked;\n",
+        ),
+    ]) else {
+        return;
+    };
+    assert!(
+        ok && !out.contains("TS2322"),
+        "renamed imported-alias constraint must preserve the inferred literal.\noutput:\n{out}"
+    );
+}
+
+/// The constraint must be genuinely resolved and *enforced*, not merely
+/// dropped: when the imported alias is `number`, a `string` argument must still
+/// be rejected with `TS2345`. Before the fix, the `Error` constraint made the
+/// assignability check vacuously true, so this error was silently missed.
+#[test]
+fn ambient_class_method_imported_alias_constraint_is_enforced() {
+    let Some((_ok, out)) = run_project(&[
+        ("keys.ts", "export type NumKey = number;\n"),
+        (
+            "svc.ts",
+            "import type { NumKey } from './keys';\n\
+             export declare class QC {\n\
+             \x20 take<T extends NumKey>(x: T): T;\n\
+             }\n",
+        ),
+        (
+            "main.ts",
+            "import type { QC } from './svc';\n\
+             declare const q: QC;\n\
+             const r = q.take('bad');\n",
+        ),
+    ]) else {
+        return;
+    };
+    assert!(
+        out.contains("TS2345"),
+        "imported-alias constraint (number) must reject a string argument with TS2345.\noutput:\n{out}"
+    );
+}


### PR DESCRIPTION
Fixes #15256.

A cross-module generic method on an **ambient** (`declare class`) class whose type-parameter constraint references a type alias *imported into the declaring module* resolved that constraint to the error type instead of the alias, producing a false-positive `TS2322`/`TS2345` cascade (`tsc` accepts).

## Structural rule
When a delegated class instance type is materialized cross-arena, `tsc` resolves the import references in its members (including a generic method's type-parameter constraint) against the declaring module. tsz materializes it through `delegate_cross_arena_class_instance_type`, which installs the requester's cross-file resolution overlay (`copy_cross_file_state_from`: all arenas/binders, resolved modules, global name indices) — **but skipped that install for ambient classes**. The delegated child then had no way to follow the declaring module's own imports, so `bareC<TE extends AnyTable>` with `AnyTable` imported (`import type { AnyTable } from './schema'`) resolved `AnyTable` to `Error`. Owner layer: checker cross-arena delegation (`crates/tsz-checker/src/state/type_analysis/cross_file.rs`).

Downstream, the `Error` constraint (a) is not literal-preserving and `is_assignable_to(x, Error)` is vacuously true, so a fresh literal argument was widened to its base (`db.bareC('sys.tables')` inferred `string`, not `"sys.tables"` → spurious `TS2322`), and (b) dropped the constraint's own enforcement (a `number` constraint no longer rejected a `string` argument). The kysely compat row's 14-error cascade in `mssql-introspector.ts` roots here.

### Repro (`--module esnext --moduleResolution bundler -p tsconfig.json`)
```ts
// schema.ts
export type AnyTable = string;
// orm.ts
import type { AnyTable } from './schema';
export declare class QC { bareC<TE extends AnyTable>(from: TE): TE; }
// app.ts
import type { QC } from './orm';
declare const db: QC;
const a = db.bareC('sys.tables');
const _c: 'sys.tables' = a;   // tsz before: TS2322 'string' not assignable to '"sys.tables"'; tsc + tsz after: clean
```

## Fix
Install the cross-file resolution overlay unconditionally. The ability to resolve import references in a delegated class's members is a property of *where the class is declared* (a real module — declaration/lib files bail out earlier via the `query_file_is_declaration_file` guard), not of whether the class is ambient. The old `if !delegated_class_is_ambient` gate coupled "install resolution scaffolding" with "is a concrete class"; the fix decouples them so ambient and concrete classes resolve imports uniformly. The now-redundant `current_file_idx` re-set (already assigned just above; `copy_cross_file_state_from` does not touch it) is dropped. The symbol-cache invalidation (`symbol_types`/`symbol_instance_types`/`symbol_to_def` removal) stays gated on the concrete path — an orthogonal caching concern that the overlay copy never touches, so ambient classes keep their cached-type reuse.

The added copy is `Arc`-refcount bumps on an already-cache-gated, child-checker-constructing path (negligible). Not a name/file-name/rendered-output predicate: the decision is purely the structural ambient/declaration-file position.

### Adjacent matrix (all match `tsc`)
imported alias constraint (`string`) preserves the literal; imported **interface** constraint; **re-exported** alias (`export type … from`); imported **generic** alias (`Id<string>`); imported `number` constraint **enforces** and rejects a `string` arg (`TS2345`, restored); renamed binders; concrete (non-ambient) class unchanged; local same-file form unchanged.

## Goal
Goal: hold

## Verification
- New CLI-driver regression suite `crates/tsz-cli/tests/cross_module_ambient_class_method_constraint_cli_tests.rs` (3 tests: preserve-literal, renamed binders, constraint-enforced). Reproduces only through the real project-mode `ProgramContext` shared-store delegation path; verified red before / green after.
- Full `cargo test -p tsz-checker --lib` diffed with vs. without the change: **identical failure set** (zero regressions; the pre-existing dev-profile failures are unchanged).
- End-to-end `tsz` vs `tsc 6.0.x` on the adjacent matrix above (project mode, `bundler`/`nodenext`/`node16` module resolution) — byte/diagnostic parity.
- `cargo fmt --all -- --check`, `git diff --check`, `python3 scripts/arch/arch_guard.py --json` (0 failures), `cargo clippy --profile ci-lint -p tsz-checker --lib` and `-p tsz-cli --test …` (`-D warnings`) — clean.
- ready-review CI owns the broad conformance/emit/fourslash baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_011ZvdaB5dDTLdSQcsQvLw5U

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZvdaB5dDTLdSQcsQvLw5U)_