### PR TITLE
fix(checker): defer cross-arena method constraint to Lazy instead of Error (#15256)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -688,7 +688,28 @@ impl CheckerState<'_> {
                 let atom = self.ctx.types.intern_string(&name);
 
                 let constraint = if data.constraint != NodeIndex::NONE {
-                    let constraint_type = self.get_type_from_type_node(data.constraint);
+                    let mut constraint_type = self.get_type_from_type_node(data.constraint);
+                    // #15256: A method type-parameter constraint that references a
+                    // type alias imported from a THIRD module can transiently fail
+                    // to resolve inside a cross-arena class delegation: the child
+                    // checker that rebuilds the imported class attempts to resolve
+                    // the alias and yields `ERROR`, even though the alias's own
+                    // declaring file resolves it correctly. Committing that `ERROR`
+                    // as the constraint poisons generic inference — a literal
+                    // argument widens to its constraint base (e.g. kysely's
+                    // `bareC('sys.tables')` widening to `string`), cascading into
+                    // false TS2345/TS2322 diagnostics. Recover a stable deferred
+                    // reference (`Lazy(DefId)` of the alias, preserving type
+                    // arguments) so the constraint resolves through the global
+                    // `DefId -> TypeId` map at use time, order-independently,
+                    // instead of collapsing to `ERROR`.
+                    if constraint_type == TypeId::ERROR
+                        && Self::is_in_cross_arena_delegation()
+                        && let Some(deferred) =
+                            self.recover_cross_arena_deferred_constraint(data.constraint)
+                    {
+                        constraint_type = deferred;
+                    }
                     let is_typeof_constraint =
                         self.ctx.arena.get(data.constraint).is_some_and(|n| {
                             n.kind == tsz_parser::parser::syntax_kind_ext::TYPE_QUERY
@@ -791,6 +812,64 @@ impl CheckerState<'_> {
 
         self.ctx.leave_recursion();
         (params, updates)
+    }
+
+    /// #15256: Rebuild a type-parameter constraint that resolved to `ERROR`
+    /// inside a cross-arena class delegation as a stable deferred `Lazy(DefId)`
+    /// reference (preserving type arguments as an `Application`).
+    ///
+    /// The transient child checker that materializes an imported class's
+    /// instance type can fail to eagerly resolve a constraint whose alias is
+    /// declared in a different module than the class; the eager resolution
+    /// yields `ERROR` even though the alias resolves correctly through the
+    /// global `DefId -> TypeId` map. Deferring to `Lazy(DefId)` — the same way
+    /// member annotations reached through the class boundary defer — makes the
+    /// constraint resolve consistently at use time regardless of the order in
+    /// which files are checked, rather than being poisoned to `ERROR`.
+    ///
+    /// Returns `None` (leaving the caller's `ERROR` in place) when the
+    /// constraint is not a plain type reference or its symbol cannot be
+    /// resolved, so this never invents a constraint that was genuinely invalid.
+    fn recover_cross_arena_deferred_constraint(
+        &mut self,
+        constraint_node: NodeIndex,
+    ) -> Option<TypeId> {
+        let (type_name, type_arg_nodes) = {
+            let node = self.ctx.arena.get(constraint_node)?;
+            if node.kind != syntax_kind_ext::TYPE_REFERENCE {
+                return None;
+            }
+            let type_ref = self.ctx.arena.get_type_ref(node)?;
+            let type_arg_nodes = type_ref
+                .type_arguments
+                .as_ref()
+                .map(|args| args.nodes.clone())
+                .unwrap_or_default();
+            (type_ref.type_name, type_arg_nodes)
+        };
+
+        // Resolve the referenced name to a stable symbol. Bare symbol
+        // resolution succeeds in the delegated context even when full type
+        // materialization did not, and `create_lazy_type_ref` mints a
+        // `Lazy(DefId)` that the global `DefId -> TypeId` map resolves
+        // (following import aliases) at use time.
+        let TypeSymbolResolution::Type(target_sym) =
+            self.resolve_identifier_symbol_in_type_position_without_tracking(type_name)
+        else {
+            return None;
+        };
+        let lazy = self.ctx.create_lazy_type_ref(target_sym);
+        if lazy == TypeId::ERROR {
+            return None;
+        }
+        if type_arg_nodes.is_empty() {
+            return Some(lazy);
+        }
+        let args: Vec<TypeId> = type_arg_nodes
+            .iter()
+            .map(|&arg| self.get_type_from_type_node(arg))
+            .collect();
+        Some(self.ctx.types.application(lazy, args))
     }
 
     /// Allocate (or reuse) the canonical `TypeId` for one type-parameter

--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -41,6 +41,9 @@ mod cross_file_imported_const_computed_key_identity_tests;
 #[path = "../tests/cross_file_local_callee_symbol_identity_tests.rs"]
 mod cross_file_local_callee_symbol_identity_tests;
 #[cfg(test)]
+#[path = "../tests/cross_module_generic_method_constraint_cli_tests.rs"]
+mod cross_module_generic_method_constraint_cli_tests;
+#[cfg(test)]
 #[path = "../tests/driver_tests.rs"]
 mod driver_tests;
 #[cfg(test)]

--- a/crates/tsz-cli/tests/cross_module_generic_method_constraint_cli_tests.rs
+++ b/crates/tsz-cli/tests/cross_module_generic_method_constraint_cli_tests.rs
@@ -1,0 +1,187 @@
+//! Cross-module generic-method type-parameter constraint resolution (refs #15256).
+//!
+//! Structural rule: when a class exposes a generic method whose type-parameter
+//! constraint references a type alias declared in a DIFFERENT module than the
+//! class, and the class is consumed from a THIRD module, the real multi-module
+//! driver must resolve that constraint to the alias, not degrade it to `Error`.
+//!
+//! Before the fix, materializing the imported class's instance type in the
+//! consuming file rebuilt the method signature in a transient cross-arena child
+//! checker that failed to resolve the third-module alias and committed `Error`
+//! as the constraint. An `Error` constraint is trivially "satisfied", so generic
+//! inference widened a literal argument to the constraint base (`string`),
+//! producing a spurious `TS2322`/`TS2345` cascade (the kysely `bareC(...)`
+//! family) where `tsc` preserves the literal.
+//!
+//! This must be a real multi-module driver test (`crate::driver::compile`): the
+//! in-crate checker harness resolves every file through a single context and
+//! does not exercise the cross-arena class delegation that hosts the bug.
+//!
+//! The matrix varies the alias shape (bare primitive alias, generic
+//! `keyof DB & string` alias) and the binder names so the fix follows structure,
+//! not identifier text, and checks each project in both root-file orders so the
+//! result cannot depend on which file the driver happens to check first. The
+//! negative case pins that a genuinely incompatible argument still fails the
+//! restored constraint, so the recovery does not silently drop enforcement.
+
+use crate::args::CliArgs;
+use clap::Parser;
+use tsz_checker::diagnostics::Diagnostic;
+
+/// Compile `files` (written into one temp dir) with the given root-file order.
+fn compile_in_order(files: &[(&str, &str)], root_order: &[&str]) -> Vec<Diagnostic> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    for (name, contents) in files {
+        std::fs::write(dir.path().join(name), contents).expect("write repro file");
+    }
+
+    let mut argv: Vec<&str> = vec![
+        "tsz",
+        "--ignoreConfig",
+        "--noEmit",
+        "--strict",
+        "--target",
+        "es2022",
+        "--module",
+        "esnext",
+        "--moduleResolution",
+        "bundler",
+        "--lib",
+        "es2022",
+    ];
+    argv.extend_from_slice(root_order);
+
+    let args = CliArgs::try_parse_from(argv).expect("parse args");
+    crate::driver::compile(&args, dir.path())
+        .expect("compile should succeed")
+        .diagnostics
+}
+
+fn codes(diags: &[Diagnostic]) -> Vec<(u32, String)> {
+    diags
+        .iter()
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+/// Positive: the literal argument survives the cross-module constraint, so the
+/// call raises no argument error (no TS2345) and its `'lit'`-typed result assigns
+/// cleanly (no TS2322). Checked in both root-file orders.
+fn assert_literal_preserved(files: &[(&str, &str)], roots: &[&str], label: &str) {
+    for order in [roots.to_vec(), roots.iter().rev().copied().collect()] {
+        let diags = compile_in_order(files, &order);
+        let offending: Vec<_> = diags
+            .iter()
+            .filter(|d| d.code == 2322 || d.code == 2345)
+            .collect();
+        assert!(
+            offending.is_empty(),
+            "[{label}] (root order {order:?}) expected the literal argument to survive the \
+             cross-module constraint (no TS2322/TS2345), got: {:?}",
+            codes(&diags)
+        );
+    }
+}
+
+#[test]
+fn bare_primitive_alias_constraint_preserves_literal() {
+    // `type AnyTable = string` in a third module; the class method constrains
+    // `TE extends AnyTable`. `db.bareC('sys.tables')` must infer `'sys.tables'`.
+    assert_literal_preserved(
+        &[
+            ("types.ts", "export type AnyTable = string;\n"),
+            (
+                "kysely.ts",
+                "import type { AnyTable } from './types';\n\
+                 export declare class QC { bareC<TE extends AnyTable>(from: TE): TE; }\n",
+            ),
+            (
+                "use.ts",
+                "import type { QC } from './kysely';\n\
+                 declare const db: QC;\n\
+                 const a = db.bareC('sys.tables');\n\
+                 const check: 'sys.tables' = a;\n",
+            ),
+        ],
+        &["types.ts", "kysely.ts", "use.ts"],
+        "bare-primitive-alias",
+    );
+}
+
+#[test]
+fn generic_keyof_alias_constraint_preserves_literal() {
+    // The real kysely shape: `type AnyTable<DB> = keyof DB & string`.
+    assert_literal_preserved(
+        &[
+            (
+                "types.ts",
+                "export type AnyTable<DB> = keyof DB & string;\n",
+            ),
+            (
+                "kysely.ts",
+                "import type { AnyTable } from './types';\n\
+                 export declare class QC<DB> { bareC<TE extends AnyTable<DB>>(from: TE): TE; }\n",
+            ),
+            (
+                "use.ts",
+                "import type { QC } from './kysely';\n\
+                 interface DB1 { 'sys.tables': { name: string } }\n\
+                 declare const db: QC<DB1>;\n\
+                 const a = db.bareC('sys.tables');\n\
+                 const check: 'sys.tables' = a;\n",
+            ),
+        ],
+        &["types.ts", "kysely.ts", "use.ts"],
+        "generic-keyof-alias",
+    );
+}
+
+#[test]
+fn renamed_binders_preserve_literal() {
+    // Anti-hardcoding: identical structure, different identifiers everywhere.
+    assert_literal_preserved(
+        &[
+            ("names.ts", "export type Col = string;\n"),
+            (
+                "builder.ts",
+                "import type { Col } from './names';\n\
+                 export declare class Query { pick<K extends Col>(k: K): K; }\n",
+            ),
+            (
+                "app.ts",
+                "import type { Query } from './builder';\n\
+                 declare const q: Query;\n\
+                 const v = q.pick('id');\n\
+                 const keep: 'id' = v;\n",
+            ),
+        ],
+        &["names.ts", "builder.ts", "app.ts"],
+        "renamed-binders",
+    );
+}
+
+#[test]
+fn incompatible_argument_still_fails_constraint() {
+    // Negative: the recovery restores the REAL constraint, so a genuinely
+    // incompatible argument still fails the `TE extends string` check.
+    let files = &[
+        ("types.ts", "export type AnyTable = string;\n"),
+        (
+            "kysely.ts",
+            "import type { AnyTable } from './types';\n\
+             export declare class QC { bareC<TE extends AnyTable>(from: TE): TE; }\n",
+        ),
+        (
+            "use.ts",
+            "import type { QC } from './kysely';\n\
+             declare const db: QC;\n\
+             const bad = db.bareC(123);\n",
+        ),
+    ];
+    let diags = compile_in_order(files, &["types.ts", "kysely.ts", "use.ts"]);
+    assert!(
+        diags.iter().any(|d| d.code == 2345),
+        "expected TS2345 (number not assignable to the string constraint), got: {:?}",
+        codes(&diags)
+    );
+}


### PR DESCRIPTION
Fixes #15256.

A generic method's type-parameter constraint that references a type alias
declared in a **different module than the class** degraded to `Error` when the
class was consumed from a **third module**. An `Error` constraint is trivially
satisfied, so generic inference widened literal arguments to the constraint base
(`string`), cascading into false `TS2345`/`TS2322` diagnostics — the kysely
`mssql-introspector` family (14 FPs from one root, per #15256).

**Structural rule:** when a class exposes a generic method `m<T extends A>(…)`
whose constraint alias `A` is declared in a module other than the class, and the
class is consumed cross-module, `tsc` resolves the constraint to `A`. tsz
materialized the imported class's instance type in a transient cross-arena child
checker (`delegate_cross_arena_class_instance_type`) that re-resolved the method
signature via `push_type_parameters`; the third-module alias failed to resolve
eagerly in that child and was committed as `Error`, even though the alias's own
declaring file resolves it correctly and member annotations reached through the
same class boundary already defer to `Lazy(DefId)`.

**Owner layer:** checker type-parameter materialization (`push_type_parameters`,
`crates/tsz-checker/src/state/type_analysis/core.rs`). When a constraint resolves
to `Error` inside a cross-arena delegation, it is now recovered as a stable
`Lazy(DefId)` of the referenced symbol (preserving type arguments as an
`Application`), so it resolves through the global `DefId -> TypeId` map at use
time — order-independently — the same way member annotations defer. Downstream
literal-preservation (`literal_preservation_constraint_target`) already resolves
`Lazy` / `Application(Lazy, …)` constraints, so the recovered constraint both
preserves literals **and** keeps enforcing (a genuinely incompatible argument
still fails). Recovery returns `None` (leaving the caller's `Error` in place)
when the constraint is not a plain type reference or its symbol cannot be
resolved, so it never invents a constraint that was genuinely invalid. Flag/scope
is narrow: normal (non-delegation, non-`Error`) resolution is unchanged.

Adjacent matrix — new real-driver test
`cross_module_generic_method_constraint_cli_tests` (4 tests), each positive case
run in **both** root-file orders (order-independence):
- bare primitive alias (`type AnyTable = string`) — literal preserved;
- generic `keyof DB & string` alias (the kysely shape) — literal preserved;
- renamed binders (anti-hardcoding) — literal preserved;
- negative: incompatible argument still fails the restored constraint (`TS2345`).

## Goal
Goal: green

## Verification
- `cargo test -p tsz-cli --lib cross_module_generic_method_constraint` — 4/4 pass (both root orders).
- Manual `tsz --noEmit -p` on 3-file repros: cross-module literal preserved (`a: 'sys.tables'`), single-file control unchanged, `db.bareC(123)` still emits `TS2345`.
- `cargo fmt --all -- --check`, `python3 scripts/arch/arch_guard.py --json` (0 failures), `cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings` — clean.
- ready-review CI owns the broad conformance/emit/project baselines and the kysely canary.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_014GLQFvmFUjEgi6uD7ekfAm)_