### PR TITLE
fix(emit): keep es5 async __awaiter callback body inline for hoisted vars

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -266,10 +266,11 @@ impl<'a> Printer<'a> {
                 // deeper inside the hand-written callback).
                 async_emitter.set_indent_level(self.writer.indent_level());
                 async_emitter.set_helper_import_aliases(self.helper_import_aliases.clone());
-                // tsc keeps the multi-line callback format whenever the
-                // source body spans multiple lines, even if nothing is
-                // hoisted; the IR printer owns the remaining multi-line
-                // triggers (hoists, directives, lexical-this capture).
+                // The IR printer owns the inline-vs-multi-line callback
+                // decision. `tsc` keeps the callback body multi-line when the
+                // source body spans multiple lines (`force_multiline`), for a
+                // directive prologue, or for a `var _this = this;` lexical
+                // capture — but NOT merely because a `var` group was hoisted.
                 let rendered = async_emitter.emit_awaiter_call(
                     body,
                     body_has_await,

--- a/crates/tsz-emitter/src/emitter/source_file/es5_async_awaiter_callback_inline_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_async_awaiter_callback_inline_tests.rs
@@ -1,0 +1,121 @@
+//! Down-leveled (`target: ES5`) async-function `__awaiter` callback layout
+//! parity tests.
+//!
+//! `tsc` lowers an `async` function/expression to
+//! `return __awaiter(this, void 0, void 0, function () { … })`, where the
+//! callback body is a synthesized **single-line** block: its braces hug the
+//! lone `return __generator(...)` statement (and any hoisted `var`
+//! declarations) even though the inner state machine spans multiple lines —
+//! `function () { [var a;] return __generator(this, function (_a) {` … `}); }`.
+//!
+//! The callback body is only broken onto multiple lines for the two structural
+//! triggers `tsc` uses: a directive prologue (`"use strict";`) or a
+//! `var _this = this;` lexical-this capture emitted inside the callback. A
+//! multi-line *source* body and hoisted `var` groups do NOT force the
+//! multi-line form.
+//!
+//! All differential expectations were verified against the pinned `tsc` 6.0.3
+//! (`tsc in.ts --target es5`). Binder names are varied to keep the decision
+//! structural (no identifier-string special-casing).
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+
+fn emit_es5(source: &str) -> String {
+    let mut parser = tsz_parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target: ScriptTarget::ES5,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn async_function_with_await_awaiter_callback_is_inline() {
+    let output = emit_es5("async function run(x: number) { await x; return x + 1; }\n");
+    assert!(
+        output.contains(
+            "return __awaiter(this, void 0, void 0, function () { return __generator(this, \
+             function (_a) {"
+        ),
+        "Awaiter callback body should hug `return __generator(...)` on its opening line.\n\
+         Output:\n{output}"
+    );
+    assert!(
+        !output.contains("function () {\n"),
+        "Awaiter callback body must not be broken onto its own line.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_function_hoisted_var_stays_inline_before_generator() {
+    // A body-local `let` hoists to a `var` declaration in the awaiter wrapper
+    // scope; `tsc` keeps it inline: `function () { var a; return __generator(...`.
+    let output = emit_es5("async function run(x: number) { let a = x + 1; await a; return a; }\n");
+    assert!(
+        output.contains(
+            "return __awaiter(this, void 0, void 0, function () { var a; return __generator(this, \
+             function (_a) {"
+        ),
+        "Hoisted `var` must stay inline on the awaiter callback's opening line.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("function () {\n        var a;"),
+        "Hoisted `var` must not force the multi-line callback form.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_function_for_of_hoists_group_inline() {
+    // `for..of` down-leveling hoists a comma-joined `var _i, items_1, i;` group;
+    // `tsc` emits the whole group inline before `return __generator`.
+    let output =
+        emit_es5("async function run(items: number[]) { for (const i of items) { await i; } }\n");
+    assert!(
+        output
+            .contains("function () { var _i, items_1, i; return __generator(this, function (_a) {"),
+        "A hoisted `var` group must be emitted inline (comma-joined).\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_function_directive_prologue_forces_multiline_callback() {
+    // A `"use strict";` directive prologue is the one case where `tsc` breaks
+    // the callback body across lines, emitting the directive before
+    // `return __generator`.
+    let output = emit_es5("async function run(x: number) { \"use strict\"; await x; return x; }\n");
+    assert!(
+        output.contains("function () {\n"),
+        "A directive prologue must force the multi-line callback form.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("\"use strict\";"),
+        "The directive prologue must be emitted inside the callback.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("function () { \"use strict\"; return __generator"),
+        "The directive must not be collapsed onto the callback's opening line.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_function_expression_hoisted_var_inline_is_binder_name_agnostic() {
+    // Same structural rule with different binder names and function-expression
+    // syntax — the decision is not keyed on any identifier string.
+    let output =
+        emit_es5("const zeta = async function (q: number) { let w = q; await w; return w; };\n");
+    assert!(
+        output.contains("function () { var w; return __generator(this, function (_a) {"),
+        "Function-expression hoisted `var` must stay inline regardless of binder names.\n\
+         Output:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -58,6 +58,8 @@ mod async_arrow_arguments_capture_tests;
 #[cfg(test)]
 mod empty_statement_comment_elision_tests;
 #[cfg(test)]
+mod es5_async_awaiter_callback_inline_tests;
+#[cfg(test)]
 mod es5_async_lexical_this_tests;
 #[cfg(test)]
 mod es5_emit_recovery_tail_tests;

--- a/crates/tsz-emitter/src/transforms/async_es5.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5.rs
@@ -394,8 +394,11 @@ impl<'a> AsyncES5Emitter<'a> {
     /// multi-line callback format, directive prologues, hoisted `var` groups,
     /// the `var _this = this;` lexical capture, and generator state naming.
     ///
-    /// `force_multiline` mirrors tsc's rule that a multi-line source body
-    /// keeps the multi-line callback format even when nothing is hoisted.
+    /// `force_multiline` mirrors `tsc`'s rule that a **multi-line source body**
+    /// keeps the multi-line callback format. Hoisted `var` groups do NOT force
+    /// the multi-line form on their own — with a single-line source body they
+    /// stay inline (`function () { var a; return __generator(...) })`), matching
+    /// `tsc`.
     pub fn emit_awaiter_call(
         &mut self,
         body_idx: NodeIndex,

--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -225,9 +225,23 @@ impl<'a> AsyncES5Transformer<'a> {
         }
     }
 
-    /// Record a hoisted-temp name produced by an IR-conversion lowering
-    /// (`??`, `?.`, etc.) so the surrounding `transform_*` entry point can
-    /// declare it alongside the rest of the state-machine var hoists.
+    /// Whether the async function's source `body` block fits on a single line —
+    /// the structural signal `tsc` uses to keep the `__awaiter` callback body
+    /// inline (`function () { [var a;] return __generator(...) })`) versus
+    /// breaking it across lines. Absent source text, defaults to `false` (treat
+    /// as multi-line), matching the emitter's `is_body_source_single_line`.
+    /// Delegates to the shared [`emit_utils::source_block_is_single_line`] scan
+    /// so the transform and print phases cannot drift.
+    fn body_source_is_single_line(&self, body_idx: NodeIndex) -> bool {
+        let Some(text) = self.source_text else {
+            return false;
+        };
+        let Some(node) = self.arena.get(body_idx) else {
+            return false;
+        };
+        super::emit_utils::source_block_is_single_line(text, node.pos as usize, node.end as usize)
+    }
+
     /// Transform an async function declaration to IR
     ///
     /// Returns an `IRNode::AwaiterCall` with a nested `IRNode::GeneratorBody`
@@ -399,7 +413,10 @@ impl<'a> AsyncES5Transformer<'a> {
             generator_body: Box::new(generator_body),
             hoisted_var_groups,
             promise_constructor,
-            multiline_callback: captures_arguments,
+            // `tsc` breaks the callback body across lines for a multi-line
+            // source body (or, historically here, an `arguments` capture);
+            // hoisted `var` groups alone stay inline.
+            multiline_callback: captures_arguments || !self.body_source_is_single_line(body_idx),
             directives,
         };
 

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_bindings.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_bindings.rs
@@ -30,13 +30,20 @@ impl AsyncES5Transformer<'_> {
     ) -> Vec<IRNode> {
         let mut body = Vec::new();
         self.emit_arguments_capture_decl(&mut body);
+        // Preserve the prior behavior for class-member async arrows: hoisted
+        // `var` groups keep the callback body multi-line. Known divergence from
+        // `tsc` (which keeps a single-line source body inline even with hoisted
+        // vars); this path does not receive the body block index, so applying
+        // the source-line rule here needs a signature change — a follow-up kept
+        // out of this zero-regression change.
+        let callback_multiline = !hoisted_var_groups.is_empty();
         body.push(IRNode::AwaiterCall {
             this_arg: Box::new(this_arg),
             needs_lexical_this_capture: generator_body.contains_captured_this_reference(),
             generator_body: Box::new(generator_body),
             hoisted_var_groups,
             promise_constructor: None,
-            multiline_callback: false,
+            multiline_callback: callback_multiline,
             directives: Vec::new(),
         });
         body

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_objects.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_objects.rs
@@ -614,6 +614,13 @@ impl AsyncES5Transformer<'_> {
             let mut generator_body = nested.transform_generator_body(method.body, has_await);
             let hoisted_var_groups =
                 AsyncES5Transformer::extract_and_remove_var_decl_groups(&mut generator_body);
+            // Preserve the prior behavior for object async methods: hoisted
+            // `var` groups keep the callback body multi-line. Known divergence
+            // from `tsc` (which keeps a single-line source body inline even with
+            // hoisted vars, like the async function/expression path); switching
+            // to the source-line rule here — `method.body` is in scope — is a
+            // follow-up kept out of this zero-regression change.
+            let callback_multiline = !hoisted_var_groups.is_empty();
             return IRNode::FunctionExpr {
                 name: None,
                 parameters,
@@ -623,7 +630,7 @@ impl AsyncES5Transformer<'_> {
                     generator_body: Box::new(generator_body),
                     hoisted_var_groups,
                     promise_constructor: None,
-                    multiline_callback: false,
+                    multiline_callback: callback_multiline,
                     directives: Vec::new(),
                 }],
                 is_expression_body: false,

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_auto_accessor.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_auto_accessor.rs
@@ -382,6 +382,12 @@ impl<'a> ES5ClassTransformer<'a> {
             .set(async_transformer.dynamic_import_promise_counter.get());
         let hoisted_var_groups =
             AsyncES5Transformer::extract_and_remove_var_decl_groups(&mut generator_body);
+        // Preserve the prior behavior for async auto-accessor arrows: hoisted
+        // `var` groups keep the callback body multi-line. Known divergence from
+        // `tsc` (which keeps a single-line source body inline even with hoisted
+        // vars); moving to the source-line rule is a follow-up kept out of this
+        // zero-regression change.
+        let callback_multiline = !hoisted_var_groups.is_empty();
 
         Some(IRNode::FunctionExpr {
             name: None,
@@ -396,7 +402,7 @@ impl<'a> ES5ClassTransformer<'a> {
                 generator_body: Box::new(generator_body),
                 hoisted_var_groups,
                 promise_constructor: self.async_method_promise_constructor(arrow.type_annotation),
-                multiline_callback: false,
+                multiline_callback: callback_multiline,
                 directives: Vec::new(),
             }],
             is_expression_body: true,

--- a/crates/tsz-emitter/src/transforms/emit_utils.rs
+++ b/crates/tsz-emitter/src/transforms/emit_utils.rs
@@ -187,6 +187,41 @@ pub(crate) fn identifier_text_or_empty(arena: &NodeArena, idx: NodeIndex) -> Str
     identifier_text(arena, idx).unwrap_or_default()
 }
 
+/// Whether the `{ … }` block spanning `[pos, end)` of `source` fits on a single
+/// line — the structural signal `tsc` uses to decide whether a synthesized
+/// wrapper body (e.g. the ES5 `__awaiter` callback) hugs its opening brace or
+/// breaks across lines. Scans from the first `{` to its matching `}` (brace
+/// depth) and reports whether that span contains a newline; a range with no
+/// `{ … }` block falls back to whether the whole span is newline-free. An empty
+/// or out-of-bounds range is treated as multi-line (`false`), matching the
+/// emitter's `is_body_source_single_line` default.
+///
+/// Shared by the transform-phase (`AsyncES5Transformer`) and print-phase
+/// (`IRPrinter`) so the two cannot drift.
+pub(crate) fn source_block_is_single_line(source: &str, pos: usize, end: usize) -> bool {
+    let end = end.min(source.len());
+    if pos >= end {
+        return false;
+    }
+    let slice = &source[pos..end];
+    if let Some(open) = slice.find('{') {
+        let mut depth = 1u32;
+        for (i, ch) in slice[open + 1..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return !slice[open..open + 1 + i + 1].contains('\n');
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    !slice.contains('\n')
+}
+
 /// Maximum alias-target recursion depth for decorator-metadata serialization, so
 /// a cyclic alias (`type A = B; type B = A`) cannot loop forever; past the cap a
 /// metadata type reference yields `Object`.

--- a/crates/tsz-emitter/src/transforms/ir.rs
+++ b/crates/tsz-emitter/src/transforms/ir.rs
@@ -424,9 +424,14 @@ pub enum IRNode {
         hoisted_var_groups: Vec<Vec<String>>,
         /// Custom promise constructor for the third `__awaiter` arg.
         promise_constructor: Option<String>,
-        /// Force the awaiter callback body onto multiple lines even when no
-        /// generator-local vars were hoisted. `tsc` does this when the async
-        /// function captures `arguments` in the wrapper scope.
+        /// Force the awaiter callback body onto multiple lines. This is a
+        /// generic "break the callback body" flag whose trigger is chosen by the
+        /// construction site — the printer stays construction-agnostic. The
+        /// async function/expression path sets it from the source-body line span
+        /// (`tsc` keeps a single-line source body inline, incl. hoisted `var`
+        /// groups), while some class-member paths set it to preserve their prior
+        /// hoist-forces-multiline behavior. It is orthogonal to `directives` and
+        /// `needs_lexical_this_capture`, which independently force multi-line.
         multiline_callback: bool,
         /// Directive prologues (e.g. `"use strict"`) extracted from the start of
         /// the generator body. `tsc` places these inside the `__awaiter` callback

--- a/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
@@ -463,14 +463,24 @@ impl<'a> IRPrinter<'a> {
         } else {
             self.write(", void 0, void 0, function () {");
         }
-        let needs_multiline = !hoisted_var_groups.is_empty()
-            || *multiline_callback
-            || *needs_lexical_this_capture
-            || !directives.is_empty();
+        // The printer stays policy-agnostic: it breaks the callback body across
+        // lines only for `multiline_callback` (set by the construction site), a
+        // directive prologue, or a `var _this = this;` lexical capture. It no
+        // longer forces multi-line merely because a `var` group was hoisted —
+        // `tsc` keeps `function () { var a; return __generator(...) })` inline
+        // for a single-line source body — so hoisted groups render inline unless
+        // one of the above triggers fires.
+        let needs_multiline =
+            *multiline_callback || *needs_lexical_this_capture || !directives.is_empty();
         if !needs_multiline {
-            // TSC keeps the generator call on the awaiter callback's
-            // opening line when no hoisted variables are needed.
+            // Inline: hoisted `var` groups (if any) precede `return __generator`
+            // on the callback's opening line, matching tsc.
             self.write(" ");
+            for group in hoisted_var_groups {
+                self.write("var ");
+                self.write(&group.join(", "));
+                self.write("; ");
+            }
             self.emit_node(generator_body);
             self.write(" });");
         } else {

--- a/crates/tsz-emitter/src/transforms/ir_printer_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_helpers.rs
@@ -62,36 +62,10 @@ impl<'a> IRPrinter<'a> {
     }
 
     pub(super) fn is_body_source_single_line(&self, body_source_range: Option<(u32, u32)>) -> bool {
-        body_source_range
-            .and_then(|(pos, end)| {
-                self.source_text.map(|text| {
-                    let start = pos as usize;
-                    let end = std::cmp::min(end as usize, text.len());
-                    if start < end {
-                        let slice = &text[start..end];
-                        if let Some(open) = slice.find('{') {
-                            let mut depth = 1;
-                            for (i, ch) in slice[open + 1..].char_indices() {
-                                match ch {
-                                    '{' => depth += 1,
-                                    '}' => {
-                                        depth -= 1;
-                                        if depth == 0 {
-                                            let inner = &slice[open..open + 1 + i + 1];
-                                            return !inner.contains('\n');
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
-                        !slice.contains('\n')
-                    } else {
-                        false
-                    }
-                })
-            })
-            .unwrap_or(false)
+        let (Some((pos, end)), Some(text)) = (body_source_range, self.source_text) else {
+            return false;
+        };
+        crate::transforms::emit_utils::source_block_is_single_line(text, pos as usize, end as usize)
     }
 
     /// Emit function body with default parameter checks prepended (ES5 style)

--- a/crates/tsz-emitter/tests/async_es5_ir_parts/part_00.rs
+++ b/crates/tsz-emitter/tests/async_es5_ir_parts/part_00.rs
@@ -206,7 +206,7 @@ fn array_literal_prefix_before_await_is_captured_before_yield() {
         "A prefix temp should be hoisted before the generator body.\nOutput:\n{output}"
     );
     assert!(
-        output.contains("_a = [head];\n                    return [4 /*yield*/, tail];"),
+        output.contains("_a = [head];\n                return [4 /*yield*/, tail];"),
         "Array elements before the suspending element must be evaluated before yielding.\nOutput:\n{output}"
     );
     assert!(
@@ -222,7 +222,7 @@ fn array_literal_multiple_awaits_accumulates_prefix_between_yields() {
 
     assert!(
         output
-            .contains("_a = [_b.sent(), middle];\n                    return [4 /*yield*/, last];"),
+            .contains("_a = [_b.sent(), middle];\n                return [4 /*yield*/, last];"),
         "The resumed first await and intervening elements should be captured before the second yield.\nOutput:\n{output}"
     );
     assert!(
@@ -236,7 +236,7 @@ fn spread_array_literal_with_suspending_spread_uses_spread_array_apply() {
     let output = transform_and_print("async function f() { x = [...(await values), z]; }");
 
     assert!(
-        output.contains("_a = [[]];\n                    return [4 /*yield*/, values];"),
+        output.contains("_a = [[]];\n                return [4 /*yield*/, values];"),
         "A suspending first spread still needs a captured spread-argument prefix.\nOutput:\n{output}"
     );
     assert!(
@@ -450,7 +450,7 @@ fn test_class_declaration_in_async_body_uses_structured_es5_assignment() {
         transform_and_print("async function foo() { class C extends B { static { await; } } }");
 
     assert!(
-        output.contains("var C;\n        return __generator"),
+        output.contains("var C; return __generator"),
         "Class declarations inside async bodies should hoist the class binding to the awaiter scope.\nOutput:\n{output}"
     );
     assert!(
@@ -1269,7 +1269,7 @@ fn test_await_assignment_captures_property_target_before_yield() {
         "Object temp should be hoisted with local declarations: {output}"
     );
     assert!(
-        output.contains("_a = o;\n                    return [4 /*yield*/, p];"),
+        output.contains("_a = o;\n                return [4 /*yield*/, p];"),
         "Property assignment target should be captured before yielding: {output}"
     );
     assert!(
@@ -1288,7 +1288,7 @@ fn test_await_call_argument_captures_identifier_callee_before_yield() {
         "Callee temp should be hoisted with local declarations: {output}"
     );
     assert!(
-        output.contains("_a = fn;\n                    return [4 /*yield*/, p];"),
+        output.contains("_a = fn;\n                return [4 /*yield*/, p];"),
         "Call callee should be captured before yielding: {output}"
     );
     assert!(
@@ -1303,7 +1303,7 @@ fn test_computed_object_after_await_uses_separate_temp_var_statement() {
         transform_and_print("async function foo(): Promise<void> { var v = { [await]: foo } }");
 
     assert!(
-        output.contains("var v;\n        var _a;"),
+        output.contains("var v; var _a;"),
         "Computed-object temp should be emitted in a separate hoisted var statement: {output}"
     );
 }
@@ -1317,7 +1317,7 @@ fn test_return_await_call_argument_captures_identifier_callee_before_yield() {
         "Callee temp should be hoisted for suspended return calls: {output}"
     );
     assert!(
-        output.contains("_a = fn;\n                    return [4 /*yield*/, p];"),
+        output.contains("_a = fn;\n                return [4 /*yield*/, p];"),
         "Return call callee should be captured before yielding: {output}"
     );
     assert!(
@@ -1381,7 +1381,7 @@ fn test_await_call_argument_preserves_prefix_arguments() {
     );
     assert!(
         output.contains(
-            "_a = fn;\n                    _b = [a];\n                    return [4 /*yield*/, p];"
+            "_a = fn;\n                _b = [a];\n                return [4 /*yield*/, p];"
         ),
         "Callee and prefix arguments should be captured before yielding: {output}"
     );
@@ -1401,7 +1401,7 @@ fn test_await_method_call_argument_captures_receiver_before_yield() {
         "Receiver and method temps should be hoisted: {output}"
     );
     assert!(
-        output.contains("_b = (_a = o).fn;\n                    return [4 /*yield*/, p];"),
+        output.contains("_b = (_a = o).fn;\n                return [4 /*yield*/, p];"),
         "Method receiver and function should be captured before yielding: {output}"
     );
     assert!(
@@ -1742,7 +1742,7 @@ fn labeled_for_await_continue_targets_iteration_case() {
     );
 
     assert!(
-        output.contains("x = _d;\n                    return [3 /*break*/, 3];"),
+        output.contains("x = _d;\n                return [3 /*break*/, 3];"),
         "A labeled continue targeting the for-await loop should jump to the loop iteration case.\nOutput:\n{output}"
     );
     assert!(


### PR DESCRIPTION
At `--target es5`, tsz down-levels an `async` function to
`return __awaiter(this, void 0, void 0, function () { … })` whose callback body
is the synthesized `return __generator(this, function (_a) { … })`. `tsc` keeps
that callback body **inline** — `function () { [var a;] return __generator(...) })`
— hugging the lone `return __generator(...)` (and any hoisted `var` groups) on
the opening line, and only breaks it across lines for a **multi-line source
body**, a **directive prologue** (`"use strict";`), or a `var _this = this;`
lexical-`this` capture. tsz instead forced the multi-line callback form whenever
a `var` group was hoisted, so any `async` function with a body-local `let`/
`const` or a down-leveled `for..of` (both hoist temps) emitted a callback that
`tsc` keeps inline.

## Structural rule
When lowering an `async` function to the ES5 `__awaiter`/`__generator` state
machine, `tsc` emits the `__awaiter` callback body on a single line unless the
**source body spans multiple lines**, a directive prologue is present, or the
callback declares `var _this = this;`. Hoisted `var` groups do **not**
independently force the multi-line form. tsz now keys the decision on those
structural triggers instead of on `!hoisted_var_groups.is_empty()`.

### Repro (`tsc in.ts --target es5 --module esnext`)
```ts
export async function f(x: number) { let a = x + 1; await a; return a; }
```
- tsc 6.0.3 / tsz after:
  `return __awaiter(this, void 0, void 0, function () { var a; return __generator(this, function (_a) {` …
- tsz before: the callback body was split across lines
  (`function () {` ⏎ `var a;` ⏎ `return __generator(...)`).

A multi-line source body still keeps the multi-line callback (matching tsc):
```ts
export async function f(x: number) {
    let a = x + 1;
    await a;
    return a;
}
```

## Owner layer
Emitter only. The inline-vs-multi-line decision is owned by the IR printer
(`crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs`,
`emit_awaiter_call_node`): the `!hoisted_var_groups.is_empty()` trigger is
removed and the inline branch now emits any hoisted `var` groups inline before
`return __generator`. Each `IRNode::AwaiterCall` construction site sets
`multiline_callback` from its own structural signal:
- the async **function declaration / expression** path
  (`emitter/es5/helpers_async.rs` → `transforms/async_es5.rs::emit_awaiter_call`)
  and `transforms/async_es5_ir.rs::transform_async_function` use the
  **source-line** rule (`!body_source_is_single_line`), matching the emitter's
  `is_single_line`;
- the object-method, class-member-arrow, and auto-accessor paths fold the prior
  hoist signal into `multiline_callback` (`!hoisted_var_groups.is_empty()`), so
  their output is byte-unchanged.

The source-body single-line scan is extracted into one shared
`transforms/emit_utils::source_block_is_single_line`, which the transform-phase
(`AsyncES5Transformer`) and print-phase (`IRPrinter::is_body_source_single_line`)
both delegate to, so the two phases cannot drift.

No user-name / file-name / rendered-output predicate drives the decision — it is
keyed purely on the source body's line span and the presence of a directive
prologue or lexical-`this` capture.

### Adjacent matrix (verified byte-identical vs pinned `tsc` 6.0.3, `--target es5`)
- single-line source, no hoist → inline;
- single-line source + hoisted `let` → inline (`var a;` inline);
- single-line source + `for..of` hoist group → inline (`var _i, items_1, i;` inline);
- multi-line source (± hoist) → multi-line;
- directive prologue (`"use strict";`) → multi-line;
- `var _this = this;` lexical capture → multi-line;
- promise-constructor return type + hoist → inline;
- class-field async arrow with hoisted temp (multi-line source) → multi-line (unchanged).

### Out of scope (tracked follow-ups, pre-existing, unchanged here)
- The stand-alone async-**arrow** const-initializer path
  (`emitter/es5/helpers.rs::emit_async_arrow_es5_inline`) is a separate
  hand-written emitter with source-map offset handling; its callback layout is
  not touched by this change.
- A stray `return [7 /*endfinally*/]` after a `return` inside a `finally` block
  in the async ES5 state machine (distinct control-flow bug).

## Goal
Goal: hold

## Verification
- New emit-parity suite
  `crates/tsz-emitter/src/emitter/source_file/es5_async_awaiter_callback_inline_tests.rs`
  (5 tests, binder-name-varied): inline callback, hoisted `var` inline, `for..of`
  hoist group inline, directive-prologue multi-line, function-expression variant.
- Updated 12 `async_es5_ir` layout assertions to the tsc-correct inline form.
- End-to-end `tsz` vs pinned `tsc` 6.0.3 (`--target es5`) diffed byte-for-byte on
  the adjacent matrix above — all match, including the multi-line-source and
  `_this`-capture cases and the class-field-arrow case (no regression).
- `cargo test -p tsz-emitter` — full emitter suite green.
- `cargo fmt --all -- --check`, `cargo clippy --profile ci-lint -p tsz-emitter --lib -- -D warnings` — clean.
- ready-review CI owns the broad conformance/emit baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01MGAskFpZofeJCsA84iwNCb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGAskFpZofeJCsA84iwNCb)_