### PR TITLE
fix(checker): value-position name suggestions offer value globals, not type keywords

### DIFF
--- a/crates/tsz-checker/src/error_reporter/suggestions.rs
+++ b/crates/tsz-checker/src/error_reporter/suggestions.rs
@@ -5,17 +5,28 @@ use crate::state_type_analysis::cross_file_direct::is_builtin_lib_file_name;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
 
-/// Built-in TypeScript intrinsic type names that tsc registers as symbols
-/// in the checker's globals. Used as candidates for spelling suggestions
-/// so that typos like "sting" → "string" produce TS2552.
+/// Built-in TypeScript intrinsic **type** names that tsc registers as symbols
+/// in the checker's globals. Used as candidates for spelling suggestions in
+/// *type* position so that typos like "sting" → "string" produce TS2552.
 ///
-/// NOTE: Only types that tsc registers as actual symbol entries in its
-/// global scope are included here. Keyword types like `null`, `undefined`,
-/// `unknown`, `void`, `never`, and `any` are parsed syntactically and do
-/// NOT appear in tsc's globals map, so they must NOT be offered as
-/// spelling suggestions.
+/// NOTE: Only intrinsics that tsc registers as actual *type*-meaning symbol
+/// entries in its global scope are included here. Keyword literals `null`,
+/// `void`, `never`, `any`, and `unknown` are parsed syntactically and do NOT
+/// appear in tsc's globals map, so they must NOT be offered as suggestions.
+/// `undefined` is the exception: tsc registers it as a *value* symbol (see
+/// [`BUILTIN_VALUE_KEYWORDS`]), so it is a value-position candidate, not a
+/// type-position one.
 const BUILTIN_TYPE_KEYWORDS: &[&str] =
     &["string", "number", "boolean", "symbol", "bigint", "object"];
+
+/// Built-in TypeScript intrinsic **value** names that tsc registers as symbols
+/// in the checker's globals. `undefined` is created as a global `Property`
+/// symbol (tsc's `undefinedSymbol`), so a value-position typo such as
+/// `udefined` suggests `undefined` (TS2552). It is *not* a type-meaning symbol,
+/// so type-position lookups never offer it — matching tsc, which reports plain
+/// TS2304 for `let x: undefindd`. `NaN`/`Infinity` are already real lib.es5
+/// symbols and are found through the ordinary lib-globals scan.
+const BUILTIN_VALUE_KEYWORDS: &[&str] = &["undefined"];
 
 impl<'a> CheckerState<'a> {
     // =========================================================================
@@ -585,20 +596,36 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // When searching for TYPE meanings, also include built-in type keywords.
-        // In tsc, intrinsic types (string, number, boolean, etc.) are registered
-        // in the checker's globals map. We include them here as candidates so
-        // that typos like "sting" → "string" are caught.
-        if meaning_flags == 0 || meaning_flags & tsz_binder::symbol_flags::TYPE != 0 {
-            for keyword in BUILTIN_TYPE_KEYWORDS {
-                Self::consider_identifier_suggestion(
-                    name,
-                    keyword,
-                    name_len,
-                    maximum_length_difference,
-                    best_distance,
-                    best_candidate,
-                );
+        // Also include the built-in intrinsic keywords that tsc registers as
+        // symbols in its globals map.
+        //
+        // The `VALUE` and `TYPE` flag masks OVERLAP (both include
+        // `CLASS`/`ENUM`/`ENUM_MEMBER`), so testing `meaning_flags & TYPE`
+        // (or `& VALUE`) would misclassify a pure value-position or
+        // type-position lookup — e.g. a value lookup passes `meaning == VALUE`,
+        // yet `VALUE & TYPE != 0`, which used to leak the *type* keywords
+        // (`number`, `boolean`, …) into value position so `numbr` wrongly
+        // suggested `number` instead of the value `Number`. Gate on the
+        // *exclusive* bits of each meaning so type keywords are offered only to
+        // type/unconstrained lookups and value keywords only to
+        // value/unconstrained lookups.
+        const TYPE_ONLY: u32 = tsz_binder::symbol_flags::TYPE & !tsz_binder::symbol_flags::VALUE;
+        const VALUE_ONLY: u32 = tsz_binder::symbol_flags::VALUE & !tsz_binder::symbol_flags::TYPE;
+        for (gate, keywords) in [
+            (TYPE_ONLY, BUILTIN_TYPE_KEYWORDS),
+            (VALUE_ONLY, BUILTIN_VALUE_KEYWORDS),
+        ] {
+            if meaning_flags == 0 || meaning_flags & gate != 0 {
+                for keyword in keywords {
+                    Self::consider_identifier_suggestion(
+                        name,
+                        keyword,
+                        name_len,
+                        maximum_length_difference,
+                        best_distance,
+                        best_candidate,
+                    );
+                }
             }
         }
     }

--- a/crates/tsz-checker/tests/lib_type_spelling_suggestions_tests.rs
+++ b/crates/tsz-checker/tests/lib_type_spelling_suggestions_tests.rs
@@ -67,3 +67,51 @@ fn type_position_mapp_suggests_map() {
         "expected TS2552 'Mapp' -> 'Map', got: {diags:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Value- vs type-position keyword candidates (type-position half).
+//
+// The `VALUE` and `TYPE` symbol-flag masks overlap (both include
+// `CLASS`/`ENUM`/`ENUM_MEMBER`), so gating the built-in intrinsic keywords on
+// `meaning & TYPE` used to leak the lowercase *type* keywords (`number`,
+// `boolean`, ...) into *value*-position lookups, and never offered the global
+// *value* symbol `undefined`. The value-position half is exercised end-to-end
+// in `crates/tsz-cli/tests/cannot_find_name_value_suggestion_cli_tests.rs`
+// (the in-process checker harness here does not report value-position
+// `cannot find name`). These two guards lock the *type*-position side: the
+// intrinsic type keywords stay available, and `undefined` — a value symbol,
+// not a type symbol — is never offered in type position.
+// ---------------------------------------------------------------------------
+
+/// True when the diagnostics contain a bare TS2304 for `typo` and do NOT offer
+/// any TS2552 spelling suggestion for it.
+fn is_bare_not_found(diags: &[Diagnostic], typo: &str) -> bool {
+    let mentions = |code: u32| {
+        diags
+            .iter()
+            .any(|d| d.code == code && d.message_text.contains(&format!("'{typo}'")))
+    };
+    mentions(2304) && !mentions(2552)
+}
+
+/// `undefined` is NOT a type-meaning symbol, so a type-position typo near it
+/// stays a bare TS2304 (tsc reports no suggestion for `let x: undefindd`).
+#[test]
+fn type_position_undefined_typo_has_no_suggestion() {
+    let diags = check_with_es2015("let x: undefindd;\n");
+    assert!(
+        is_bare_not_found(&diags, "undefindd"),
+        "expected bare TS2304 for 'undefindd' in type position, got: {diags:?}"
+    );
+}
+
+/// Regression guard: fixing the value-position leak must NOT remove the
+/// (correct) type-keyword suggestions in *type* position — `sting` → `string`.
+#[test]
+fn type_position_type_keyword_still_suggested() {
+    let diags = check_with_es2015("let s: sting;\n");
+    assert!(
+        finds_suggestion(&diags, "sting", "string"),
+        "expected TS2552 'sting' -> 'string', got: {diags:?}"
+    );
+}

--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -164,6 +164,10 @@ name = "lib_target_suggestion_ts2550_tests"
 path = "tests/lib_target_suggestion_ts2550_tests.rs"
 
 [[test]]
+name = "cannot_find_name_value_suggestion_cli_tests"
+path = "tests/cannot_find_name_value_suggestion_cli_tests.rs"
+
+[[test]]
 name = "cross_binder_reexport_meaning_tests"
 path = "tests/cross_binder_reexport_meaning_tests.rs"
 

--- a/crates/tsz-cli/tests/cannot_find_name_value_suggestion_cli_tests.rs
+++ b/crates/tsz-cli/tests/cannot_find_name_value_suggestion_cli_tests.rs
@@ -1,0 +1,158 @@
+//! Value-position "Cannot find name" spelling-suggestion parity (TS2552).
+//!
+//! `undefined` is a global *value* symbol in tsc (its synthetic
+//! `undefinedSymbol`), while the intrinsic *type* keywords (`number`,
+//! `boolean`, ...) are type-meaning symbols. Because tsz's `VALUE` and `TYPE`
+//! symbol-flag masks overlap (both include `CLASS`/`ENUM`/`ENUM_MEMBER`),
+//! gating the built-in keyword candidates on `meaning & TYPE` used to leak the
+//! lowercase type keywords into value position (`numbr` → `number`) and never
+//! offered `undefined`. tsc instead suggests the value *constructor*
+//! (`numbr` → `Number`) and `undefined` (`udefined` → `undefined`).
+//!
+//! These end-to-end tests drive the real `tsz` binary — the in-process checker
+//! harness does not report value-position `cannot find name`, so this is the
+//! canonical place to lock the value/type split to tsc's behavior.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_cannot_find_name_value_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+/// Run `tsz --strict --noEmit` on `source` and return combined stdout+stderr.
+fn run_tsz(name: &str, source: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let file = temp.path.join("repro.ts");
+    std::fs::write(&file, source).expect("write repro file");
+    let output = Command::new(tsz_bin)
+        .args([
+            "repro.ts", "--strict", "--noEmit", "--pretty", "false", "--target", "esnext", "--lib",
+            "esnext",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz");
+    let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    Some(text)
+}
+
+/// Assert `source` reports TS2552 for `typo` suggesting `expected`.
+fn assert_suggests(name: &str, source: &str, typo: &str, expected: &str) {
+    let Some(out) = run_tsz(name, source) else {
+        println!("tsz binary not found; skipping {name}");
+        return;
+    };
+    let needle = format!("Cannot find name '{typo}'. Did you mean '{expected}'?");
+    assert!(
+        out.contains("TS2552") && out.contains(&needle),
+        "expected TS2552 \"{needle}\" for {name}, got:\n{out}"
+    );
+}
+
+/// Assert `source` reports a bare TS2304 for `typo` and offers no TS2552
+/// suggestion for it.
+fn assert_bare_not_found(name: &str, source: &str, typo: &str) {
+    let Some(out) = run_tsz(name, source) else {
+        println!("tsz binary not found; skipping {name}");
+        return;
+    };
+    assert!(
+        out.contains(&format!("Cannot find name '{typo}'.")) && !out.contains("TS2552"),
+        "expected bare TS2304 for '{typo}' in {name}, got:\n{out}"
+    );
+}
+
+// --- Bug A: type keywords must not leak into value position; the value
+// constructor is suggested instead. ---
+
+#[test]
+fn value_numbr_suggests_number_constructor() {
+    assert_suggests("numbr", "const x = numbr;\n", "numbr", "Number");
+}
+
+#[test]
+fn value_objet_suggests_object_constructor() {
+    assert_suggests("objet", "const x = objet;\n", "objet", "Object");
+}
+
+#[test]
+fn value_booleen_suggests_boolean_constructor() {
+    assert_suggests("booleen", "const x = booleen;\n", "booleen", "Boolean");
+}
+
+#[test]
+fn value_symbl_suggests_symbol_constructor() {
+    assert_suggests("symbl", "const x = symbl;\n", "symbl", "Symbol");
+}
+
+// --- Bug B: `undefined` is a value symbol and is suggested in value position. ---
+
+#[test]
+fn value_udefined_suggests_undefined() {
+    assert_suggests("udefined", "const x = udefined;\n", "udefined", "undefined");
+}
+
+#[test]
+fn value_typeof_undefined_typo_suggests_undefined() {
+    assert_suggests(
+        "typeof_undef",
+        "const x = typeof udnefined;\n",
+        "udnefined",
+        "undefined",
+    );
+}
+
+// --- Negatives: keyword literals with no symbol entry are never suggested. ---
+
+#[test]
+fn value_viod_has_no_suggestion() {
+    assert_bare_not_found("viod", "const x = viod;\n", "viod");
+}
+
+#[test]
+fn value_nulll_has_no_suggestion() {
+    assert_bare_not_found("nulll", "const x = nulll;\n", "nulll");
+}
+
+// --- Type position is unchanged: `undefined` is not a type symbol. ---
+
+#[test]
+fn type_undefined_typo_has_no_suggestion() {
+    assert_bare_not_found("t_undef", "let x: undefindd;\n", "undefindd");
+}


### PR DESCRIPTION
Fixes #15269.

Goal: hold

## What

In **value position**, tsz's TS2552 "Cannot find name … Did you mean …?" suggestion diverged from `tsc` 6.0.2: it offered the lowercase *type* keywords (`numbr` → `number`) instead of the value constructor (`numbr` → `Number`), and never offered `undefined` (`udefined` → bare TS2304). Type position was already correct.

## Structural rule

`When resolving an unresolved value identifier, tsc suggests value-meaning globals — the primitive constructors (Number/String/…) and undefined — never the type-only keywords; when resolving a type identifier it suggests the type keywords, never undefined.`

`crates/tsz-checker/src/error_reporter/suggestions.rs::search_global_candidates` gated the built-in intrinsic keyword candidates on `meaning_flags & symbol_flags::TYPE`. But `symbol_flags::VALUE` and `symbol_flags::TYPE` **overlap** (both include `CLASS | ENUM | ENUM_MEMBER`, see `crates/tsz-binder/src/symbols.rs`), so a pure value lookup (`meaning == VALUE`, `VALUE & TYPE != 0`) leaked the type keywords into value position, and `undefined` — a global *value* symbol in tsc (`undefinedSymbol`) — was in no list at all.

## Owner layer

Checker — spelling-suggestion candidate collection. No solver/relation changes; the printer/type layers are untouched.

## Fix

Gate each keyword set on the meaning-**exclusive** bits:
- type keywords for `meaning & (TYPE & !VALUE)` (or unconstrained) — `sting` → `string` still works in type position;
- a new `BUILTIN_VALUE_KEYWORDS = ["undefined"]` for `meaning & (VALUE & !TYPE)` (or unconstrained) — `udefined` → `undefined` in value position.

The primitive value constructors (`Number`, `Object`, …) are real `lib.es5` symbols already surfaced by the ordinary lib-globals scan, so removing the type keywords from value position lets them win. `null`/`void`/`never`/`any`/`unknown` are keyword literals with no symbol entry and remain unsuggested (matching tsc).

## Adjacent matrix (all verified against tsc 6.0.2)

| case | tsc | tsz after |
|---|---|---|
| `const x = numbr` | `Number` | `Number` ✓ |
| `const x = objet` / `booleen` / `symbl` / `bigfnt` | `Object`/`Boolean`/`Symbol`/`BigInt` | matches ✓ |
| `const x = udefined` / `typeof udnefined` | `undefined` | `undefined` ✓ |
| `let x: sting` (type pos) | `string` | `string` ✓ |
| `let x: undefindd` (type pos) | bare TS2304 | bare TS2304 ✓ |
| `const x = viod` / `nulll` | bare TS2304 | bare TS2304 ✓ |

No new user-name/file-name literals, no formatted-string predicates; tests vary the typo names.

## Verification

- Differential harness vs `tsc 6.0.2` across value/type positions (all cases above match).
- `cargo test -p tsz-cli --test cannot_find_name_value_suggestion_cli_tests` — 9 end-to-end tests (value-position half; the in-process checker harness does not report value-position "cannot find name").
- `cargo test -p tsz-checker --test lib_type_spelling_suggestions_tests` — 5 tests incl. new type-position guards (keyword still suggested; `undefined` not offered in type position).
- `cargo test -p tsz-checker --test name_resolution_boundary_tests` — 49 pass (no regression).
- `cargo fmt --all --check`; `cargo clippy --profile ci-lint -p tsz-checker --lib --tests -- -D warnings`; `cargo clippy --profile ci-lint -p tsz-cli --tests -- -D warnings`.
- Broad differential sweep (~100 snippets across checker/emit/DTS) shows zero new divergences from this change.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZHmbA5SNjFGJqatfL6mQ8)_