### PR TITLE
fix(emit): hoist ESM ES5 exported-destructuring source temp (#15271)

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -235,6 +235,10 @@ name = "destructuring_es5_array_nested_order_tests"
 path = "tests/destructuring_es5_array_nested_order_tests.rs"
 
 [[test]]
+name = "esm_destructuring_export_temp_hoist_tests"
+path = "tests/esm_destructuring_export_temp_hoist_tests.rs"
+
+[[test]]
 name = "destructuring_es5_nested_single_inline_tests"
 path = "tests/destructuring_es5_nested_single_inline_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/module_emission/exports_destructuring_esm.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/exports_destructuring_esm.rs
@@ -1,0 +1,265 @@
+//! ES module (`--module es2015|esnext`) downlevel export-destructuring lowering.
+//!
+//! At an ES5/ES3 target a `export const <pattern> = <init>` whose source is not
+//! a reusable identifier needs a temporary to hold the source value. `tsc`
+//! hoists that temporary as a plain, non-exported `var _a;` and folds its
+//! assignment into the first binding via a comma expression
+//! (`export var first = (_a = init, _a[0]), rest = _a.slice(1);`), so the
+//! temporary never becomes a named export.
+//!
+//! tsz's shared ES5 destructuring path instead emits the temporary inline in the
+//! `export var` list (`export var _a = init, first = _a[0], ...`), which leaks
+//! `_a` as a spurious named export of the module. This module reproduces `tsc`'s
+//! hoisted-comma form for the flat array/object patterns that trigger the leak;
+//! any shape it does not model (nested/defaulted/computed-key patterns,
+//! `downlevelIteration` array reads, object rest — handled by
+//! `emit_esm_object_rest_export_statement` — reusable identifier sources, or a
+//! single-element pattern that `tsc` already inlines) is left to the existing
+//! path unchanged.
+
+use super::super::{ModuleKind, Printer};
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::Node;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+/// How a single binding reads its value out of the hoisted source temp.
+enum EsmDestructAccess {
+    /// Array element access `temp[index]`.
+    Index(usize),
+    /// Array rest `temp.slice(index)`.
+    Slice(usize),
+    /// Object property access `temp.<key>` (identifier key only).
+    Prop(NodeIndex),
+}
+
+/// One flattened binding: the target identifier plus how it reads from the temp.
+struct EsmDestructBinding {
+    name: NodeIndex,
+    access: EsmDestructAccess,
+}
+
+impl Printer<'_> {
+    /// Emit an exported destructuring declaration through `tsc`'s hoisted-temp
+    /// comma form when it would otherwise leak the synthesized source temp as a
+    /// named export. Returns `false` (leaving the statement to the existing
+    /// path) for every shape not modeled here.
+    pub(in crate::emitter) fn emit_esm_destructuring_export_statement(
+        &mut self,
+        node: &Node,
+    ) -> bool {
+        if !matches!(
+            self.ctx.options.module,
+            ModuleKind::ES2015 | ModuleKind::ESNext
+        ) {
+            return false;
+        }
+        // Below ES2015 the binding pattern is lowered and needs the temp; at
+        // ES2015+ destructuring is emitted natively, so there is no leak.
+        if !self.ctx.target_es5 {
+            return false;
+        }
+
+        let Some(var_stmt) = self.arena.get_variable(node) else {
+            return false;
+        };
+        if !self
+            .arena
+            .has_modifier(&var_stmt.modifiers, SyntaxKind::ExportKeyword)
+            || self
+                .arena
+                .has_modifier(&var_stmt.modifiers, SyntaxKind::DefaultKeyword)
+            || self
+                .arena
+                .has_modifier(&var_stmt.modifiers, SyntaxKind::DeclareKeyword)
+        {
+            return false;
+        }
+
+        // Scope to a single declaration so temp numbering and comma joining stay
+        // trivially correct; multi-declaration lists fall through unchanged.
+        if var_stmt.declarations.nodes.len() != 1 {
+            return false;
+        }
+        let decl_list_idx = var_stmt.declarations.nodes[0];
+        let Some(decl_list_node) = self.arena.get(decl_list_idx) else {
+            return false;
+        };
+        let Some(decl_list) = self.arena.get_variable(decl_list_node) else {
+            return false;
+        };
+        if decl_list.declarations.nodes.len() != 1 {
+            return false;
+        }
+        let decl_idx = decl_list.declarations.nodes[0];
+        let Some(decl_node) = self.arena.get(decl_idx) else {
+            return false;
+        };
+        let Some(decl) = self.arena.get_variable_declaration(decl_node) else {
+            return false;
+        };
+        if decl.initializer.is_none() {
+            return false;
+        }
+        let Some(pattern_node) = self.arena.get(decl.name) else {
+            return false;
+        };
+
+        // Structural gate first: most statements reaching here are not a modeled
+        // flat multi-element pattern, and this bails without allocating the
+        // identifier text the reusable-source check below would.
+        let Some(bindings) = self.collect_esm_flat_destructuring_bindings(pattern_node) else {
+            return false;
+        };
+
+        // A reusable identifier source is repeated inline at every access by the
+        // existing path (no temp, no leak); only non-reusable sources leak.
+        if self
+            .reusable_object_rest_export_source(decl.initializer)
+            .is_some()
+        {
+            return false;
+        }
+
+        let temp = self.make_unique_name_hoisted();
+        // The `export ` keyword is already written by the enclosing transform
+        // path before this statement's body is emitted (unlike
+        // `emit_esm_object_rest_export_statement`, which is reached through the
+        // non-transform path and writes its own `export `). Emit only the `var`
+        // keyword and the bindings here.
+        self.write("var ");
+        for (index, binding) in bindings.iter().enumerate() {
+            if index > 0 {
+                self.write(", ");
+            }
+            self.write_binding_identifier_text(binding.name);
+            self.write(" = ");
+            if index == 0 {
+                // Fold the source assignment into the first binding so the
+                // hoisted temp is never part of the exported declaration list.
+                self.write("(");
+                self.write(&temp);
+                self.write(" = ");
+                self.emit(decl.initializer);
+                self.write(", ");
+                self.emit_esm_destruct_access(&temp, &binding.access);
+                self.write(")");
+            } else {
+                self.emit_esm_destruct_access(&temp, &binding.access);
+            }
+        }
+        self.write_semicolon();
+        true
+    }
+
+    /// Flatten a supported array/object binding pattern into `(target, access)`
+    /// pairs, or `None` for any shape this lowering does not model.
+    fn collect_esm_flat_destructuring_bindings(
+        &self,
+        pattern_node: &Node,
+    ) -> Option<Vec<EsmDestructBinding>> {
+        let pattern = self.arena.get_binding_pattern(pattern_node)?;
+        // A single-element pattern is inlined by `tsc` (the source is read once,
+        // so no temp is minted); the existing path already matches that. Only a
+        // pattern with more than one element mints the leaking temp.
+        if pattern.elements.nodes.len() < 2 {
+            return None;
+        }
+
+        let mut bindings = Vec::new();
+        match pattern_node.kind {
+            k if k == syntax_kind_ext::ARRAY_BINDING_PATTERN => {
+                // `downlevelIteration` reads array elements through `__read`
+                // rather than index access — a different form this lowering does
+                // not model.
+                if self.ctx.options.downlevel_iteration {
+                    return None;
+                }
+                for (element_index, &elem_idx) in pattern.elements.nodes.iter().enumerate() {
+                    if elem_idx.is_none() {
+                        // Array hole: no binding, but the position still counts.
+                        continue;
+                    }
+                    let elem_node = self.arena.get(elem_idx)?;
+                    let elem = self.arena.get_binding_element(elem_node)?;
+                    // Defaults and nested patterns are not modeled here.
+                    if elem.initializer.is_some() {
+                        return None;
+                    }
+                    let name_node = self.arena.get(elem.name)?;
+                    if !name_node.is_identifier() {
+                        return None;
+                    }
+                    let access = if elem.dot_dot_dot_token {
+                        EsmDestructAccess::Slice(element_index)
+                    } else {
+                        EsmDestructAccess::Index(element_index)
+                    };
+                    bindings.push(EsmDestructBinding {
+                        name: elem.name,
+                        access,
+                    });
+                }
+            }
+            k if k == syntax_kind_ext::OBJECT_BINDING_PATTERN => {
+                for &elem_idx in &pattern.elements.nodes {
+                    if elem_idx.is_none() {
+                        continue;
+                    }
+                    let elem_node = self.arena.get(elem_idx)?;
+                    let elem = self.arena.get_binding_element(elem_node)?;
+                    // Object rest is handled by the dedicated
+                    // `emit_esm_object_rest_export_statement`; defaults and nested
+                    // patterns are not modeled here.
+                    if elem.dot_dot_dot_token || elem.initializer.is_some() {
+                        return None;
+                    }
+                    let name_node = self.arena.get(elem.name)?;
+                    if !name_node.is_identifier() {
+                        return None;
+                    }
+                    let key_idx = if elem.property_name.is_some() {
+                        elem.property_name
+                    } else {
+                        elem.name
+                    };
+                    let key_node = self.arena.get(key_idx)?;
+                    // Only plain identifier keys map to `temp.<key>`; string /
+                    // numeric / computed keys are left to the existing path.
+                    if key_node.kind != SyntaxKind::Identifier as u16 {
+                        return None;
+                    }
+                    bindings.push(EsmDestructBinding {
+                        name: elem.name,
+                        access: EsmDestructAccess::Prop(key_idx),
+                    });
+                }
+            }
+            _ => return None,
+        }
+
+        (!bindings.is_empty()).then_some(bindings)
+    }
+
+    /// Emit `temp[index]` / `temp.slice(index)` / `temp.<key>` for one binding.
+    fn emit_esm_destruct_access(&mut self, temp: &str, access: &EsmDestructAccess) {
+        self.write(temp);
+        match *access {
+            EsmDestructAccess::Index(index) => {
+                self.write("[");
+                self.write_usize(index);
+                self.write("]");
+            }
+            EsmDestructAccess::Slice(index) => {
+                self.write(".slice(");
+                self.write_usize(index);
+                self.write(")");
+            }
+            EsmDestructAccess::Prop(key_idx) => {
+                let key = self.get_identifier_text(key_idx);
+                self.write(".");
+                self.write(&key);
+            }
+        }
+    }
+}

--- a/crates/tsz-emitter/src/emitter/module_emission/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/mod.rs
@@ -4,6 +4,7 @@ mod core;
 mod decorated_class_expression_export_tests;
 mod exports;
 mod exports_destructuring;
+mod exports_destructuring_esm;
 mod imports;
 #[cfg(test)]
 mod namespace_export_fold_tests;

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -1087,6 +1087,10 @@ impl<'a> Printer<'a> {
             return;
         }
 
+        if self.emit_esm_destructuring_export_statement(node) {
+            return;
+        }
+
         if self.is_es5_empty_binding_pattern_export_statement(node)
             && self.emit_es5_empty_binding_pattern_export(&var_stmt.declarations)
         {

--- a/crates/tsz-emitter/tests/esm_destructuring_export_temp_hoist_tests.rs
+++ b/crates/tsz-emitter/tests/esm_destructuring_export_temp_hoist_tests.rs
@@ -1,0 +1,203 @@
+//! ES module (`--module es2015|esnext`) ES5-downlevel parity with tsc for an
+//! exported destructuring declaration whose source needs a temporary.
+//!
+//! `tsc` hoists the source temp as a plain, non-exported `var _a;` and folds its
+//! assignment into the first binding via a comma expression, so the temp never
+//! becomes a named export:
+//!
+//! ```js
+//! var _a;
+//! export var first = (_a = [1, 2, 3], _a[0]), rest = _a.slice(1);
+//! ```
+//!
+//! tsz previously emitted `export var _a = [1, 2, 3], first = _a[0], ...`,
+//! leaking `_a` as a spurious named export of the module. These cases pin the
+//! hoisted-comma form and the boundaries where the existing (already-correct)
+//! path must stay in control.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print as parse_lower_emit;
+
+fn esm_es5_opts() -> PrintOptions {
+    PrintOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::ES2015,
+        ..Default::default()
+    }
+}
+
+fn esnext_es5_opts() -> PrintOptions {
+    PrintOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::ESNext,
+        ..Default::default()
+    }
+}
+
+fn es2015_opts() -> PrintOptions {
+    PrintOptions {
+        target: ScriptTarget::ES2015,
+        module: ModuleKind::ES2015,
+        ..Default::default()
+    }
+}
+
+/// The temp must never appear in the exported declaration list.
+fn assert_no_leaked_temp_export(output: &str) {
+    assert!(
+        !output.contains("export var _a"),
+        "the synthesized source temp must not be emitted as a named export.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn array_rest_export_hoists_temp_and_folds_assignment() {
+    let source = "export const [first, ...rest] = [1, 2, 3];\n";
+    let output = parse_lower_emit(source, esm_es5_opts());
+
+    assert!(
+        output.contains("var _a;"),
+        "the source temp must be hoisted as a non-exported `var _a;`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("export var first = (_a = [1, 2, 3], _a[0]), rest = _a.slice(1);"),
+        "array-with-rest export must use tsc's hoisted-comma form.\nOutput:\n{output}"
+    );
+    assert_no_leaked_temp_export(&output);
+}
+
+#[test]
+fn array_no_rest_export_hoists_temp() {
+    let source = "export const [a, b] = [4, 5];\n";
+    let output = parse_lower_emit(source, esm_es5_opts());
+
+    assert!(
+        output.contains("export var a = (_a = [4, 5], _a[0]), b = _a[1];"),
+        "array export must fold the source assignment into the first binding.\nOutput:\n{output}"
+    );
+    assert_no_leaked_temp_export(&output);
+}
+
+#[test]
+fn array_hole_preserves_element_index() {
+    let source = "export const [, second, third] = [1, 2, 3];\n";
+    let output = parse_lower_emit(source, esm_es5_opts());
+
+    assert!(
+        output.contains("export var second = (_a = [1, 2, 3], _a[1]), third = _a[2];"),
+        "array holes must keep the element index for later bindings.\nOutput:\n{output}"
+    );
+    assert_no_leaked_temp_export(&output);
+}
+
+#[test]
+fn object_export_hoists_temp() {
+    let source =
+        "declare function getObj(): { x: number; y: number };\nexport const { x, y } = getObj();\n";
+    let output = parse_lower_emit(source, esm_es5_opts());
+
+    assert!(
+        output.contains("export var x = (_a = getObj(), _a.x), y = _a.y;"),
+        "object export must fold the source assignment into the first binding.\nOutput:\n{output}"
+    );
+    assert_no_leaked_temp_export(&output);
+}
+
+#[test]
+fn object_renamed_keys_export_hoists_temp() {
+    let source = "declare function getObj(): { x: number; y: number };\nexport const { x: rx, y: ry } = getObj();\n";
+    let output = parse_lower_emit(source, esm_es5_opts());
+
+    assert!(
+        output.contains("export var rx = (_a = getObj(), _a.x), ry = _a.y;"),
+        "renamed object keys must read from the original property.\nOutput:\n{output}"
+    );
+    assert_no_leaked_temp_export(&output);
+}
+
+/// Anti-hardcoding: entirely different binder names in the same structural
+/// position must behave identically.
+#[test]
+fn renamed_binders_hoist_temp() {
+    let source = "export const [alpha, ...omega] = [7, 8, 9];\n";
+    let output = parse_lower_emit(source, esm_es5_opts());
+
+    assert!(
+        output.contains("export var alpha = (_a = [7, 8, 9], _a[0]), omega = _a.slice(1);"),
+        "the fix must be driven by structure, not specific identifiers.\nOutput:\n{output}"
+    );
+    assert_no_leaked_temp_export(&output);
+}
+
+/// `esnext` module output shares the ESM path and must hoist identically.
+#[test]
+fn esnext_module_hoists_temp() {
+    let source = "export const [first, ...rest] = [1, 2, 3];\n";
+    let output = parse_lower_emit(source, esnext_es5_opts());
+
+    assert!(
+        output.contains("export var first = (_a = [1, 2, 3], _a[0]), rest = _a.slice(1);"),
+        "esnext module must use the same hoisted-comma form as es2015.\nOutput:\n{output}"
+    );
+    assert_no_leaked_temp_export(&output);
+}
+
+// --- Boundaries: the existing (already-correct) path must stay in control. ---
+
+/// A single-element pattern reads the source once, so `tsc` inlines it with no
+/// temp; the existing path already matches and must be left unchanged.
+#[test]
+fn single_element_pattern_stays_inlined_without_temp() {
+    let source = "declare function f(): number[];\nexport const [only] = f();\nexport const [...all] = f();\n";
+    let output = parse_lower_emit(source, esm_es5_opts());
+
+    assert!(
+        output.contains("export var only = f()[0];"),
+        "a single non-rest element must inline the source (no temp).\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("export var all = f().slice(0);"),
+        "a single rest element must inline the source (no temp).\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_a"),
+        "no temp should be minted for single-element patterns.\nOutput:\n{output}"
+    );
+}
+
+/// A reusable identifier source is repeated inline at every access — no temp.
+#[test]
+fn reusable_identifier_source_stays_inlined() {
+    let source = "declare const arr: number[];\nexport const [a, b] = arr;\n";
+    let output = parse_lower_emit(source, esm_es5_opts());
+
+    assert!(
+        output.contains("export var a = arr[0], b = arr[1];"),
+        "an identifier source must be reused inline with no temp.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_a"),
+        "no temp should be minted for a reusable identifier source.\nOutput:\n{output}"
+    );
+}
+
+/// At ES2015+ destructuring is emitted natively — no lowering, no temp, no leak.
+#[test]
+fn native_destructuring_at_es2015_is_unchanged() {
+    let source = "export const [first, ...rest] = [1, 2, 3];\n";
+    let output = parse_lower_emit(source, es2015_opts());
+
+    assert!(
+        output.contains("export const [first, ...rest] = [1, 2, 3];"),
+        "ES2015 output must keep native destructuring.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_a"),
+        "no temp should be minted at ES2015.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #15271.

At `--module es2015|esnext --target es5`, an exported destructuring declaration whose source is not a reusable identifier emitted the synthesized source temporary **inside the `export var` list**, leaking it as a spurious named export of the module. `tsc` hoists the temp as a plain, non-exported `var _a;` and folds its assignment into the first binding via a comma expression.

### Repro (`--module es2015 --target es5 --strict`)

```ts
export const [first, ...rest] = [1, 2, 3];
```

- **tsc 6.0.2:**
  ```js
  var _a;
  export var first = (_a = [1, 2, 3], _a[0]), rest = _a.slice(1);
  ```
- **tsz before:** `export var _a = [1, 2, 3], first = _a[0], rest = _a.slice(1);` — `_a` becomes a named export, changing the module's export shape.

**Structural rule:** when an exported destructuring declaration is lowered below ES2015 and its source is not a reusable identifier, `tsc` allocates the source temp through hoisting (a non-exported `var _a;`) and reads it via `(temp = init, temp[0])` in the first binding so the temp never joins the exported declaration list. tsz's shared ES5 destructuring path (`emit_es5_destructuring_fallback`, `crates/tsz-emitter/src/emitter/es5/bindings.rs`) emits the temp inline via `get_temp_var_name`, so under an `export var` prefix the temp leaks.

**Owner layer:** emitter — ESM module export lowering. New `emit_esm_destructuring_export_statement` (`crates/tsz-emitter/src/emitter/module_emission/exports_destructuring_esm.rs`) mirrors the existing `emit_esm_object_rest_export_statement` sibling: it hoists the source temp (`make_unique_name_hoisted`) and folds the assignment into the first binding, producing `tsc`'s byte-exact form. It's structurally gated (flat array/object patterns only) and returns `false` for every shape it does not model — nested/defaulted/computed-key patterns, `downlevelIteration` array reads, object rest (already handled by the sibling), reusable-identifier sources, and single-element patterns — leaving them to the existing (already-correct) path unchanged. No identifier/file-name/rendered-output predicates: the decision is purely the structural pattern shape.

**Out-of-scope residual (documented):** when a *non-exported* destructuring-with-temp is interleaved between exported ones in one module scope, tsc numbers the hoisted temps before the inline temps (print-order) while tsz numbers in source order — a pre-existing divergence in the shared `make_unique_name_hoisted` numbering that also affects the shipped object-rest export path, independent of this fix.

## Goal
Goal: hold

## Verification
- New emitter regression suite `crates/tsz-emitter/tests/esm_destructuring_export_temp_hoist_tests.rs` — 10/10 pass (array / array-rest / holes / object / renamed-keys / `esnext` module, plus boundary cases: single-element inlined, reusable identifier, native ES2015).
- End-to-end `tsz` vs `tsc 6.0.2` (`--module es2015 --target es5`) on the full array/object matrix — byte-identical for all-exported files.
- `cargo test -p tsz-emitter` — full suite green (the one `generator_object_literal_...trailing_comma` failure is pre-existing dev-profile drift; reproduced identically on the base with my changes stashed).
- `cargo fmt --all -- --check`, `python3 scripts/arch/arch_guard.py --json` (0 failures), `cargo clippy -p tsz-emitter --lib -- -D warnings` — clean.
- ready-review CI owns the broad conformance/emit/fourslash baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ga62qcQfQazVQzKnGz9pVz)_