### PR TITLE
fix(emit): order es5 auto-accessor storage after private-name storage

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -1229,6 +1229,96 @@ class C2 {\n\
     );
 }
 
+// Down-leveling a class to the ES5 IIFE lifts its private-name storage out of
+// the generated function. `tsc` keeps that storage in one combined
+// declaration/initialization with a fixed order: the private-field/method
+// (`WeakMap`/`WeakSet`) storage first — in source order — and any public
+// auto-accessor storage `WeakMap`s last. The pre-fix lifter appended the
+// private storage *after* the accessor storage in the `var` declaration (while
+// prepending it in the initializer), so a class mixing `#field`/`#method` with
+// a public `accessor` emitted a reversed `var` list. These tests lock the
+// tsc-parity order at ES5; binder names are varied so the assertions track
+// structure, not a spelling. (ES2015+ parity is covered by
+// `private_field_helper_order_tests`.)
+fn emit_es5(source: &str) -> String {
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        target: ScriptTarget::ES5,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn es5_private_field_precedes_public_accessor_storage() {
+    let output = emit_es5(
+        "class Wrapper {\n    #value = 1;\n    accessor label = 2;\n    get peek() { return this.#value; }\n}\n",
+    );
+
+    assert!(
+        output.contains("var _Wrapper_value, _Wrapper_label_accessor_storage;"),
+        "es5 var declaration must list the private field before the accessor storage.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "_Wrapper_value = new WeakMap(), _Wrapper_label_accessor_storage = new WeakMap();"
+        ),
+        "es5 storage init must allocate the private field before the accessor storage.\nOutput:\n{output}"
+    );
+    // The reversed pre-fix order must not reappear.
+    assert!(
+        !output.contains("var _Wrapper_label_accessor_storage, _Wrapper_value;"),
+        "accessor storage must not precede the private field in the var declaration.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_public_accessor_storage_allocates_before_private_method_def() {
+    // Allocations (`new WeakSet()` / `new WeakMap()`) come before the private
+    // method's function definition, so the accessor storage sits between the
+    // instances `WeakSet` and the `_Kit_run = function` assignment — while the
+    // declaration lists the method helper var before the accessor storage.
+    let output = emit_es5(
+        "class Kit {\n    accessor a = 1;\n    #run() { return 2; }\n    call() { return this.#run(); }\n}\n",
+    );
+
+    assert!(
+        output.contains("var _Kit_instances, _Kit_run, _Kit_a_accessor_storage;"),
+        "es5 var declaration order must be instances, method helper, then accessor storage.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "_Kit_instances = new WeakSet(), _Kit_a_accessor_storage = new WeakMap(), _Kit_run = function"
+        ),
+        "accessor storage must be allocated after the instances WeakSet but before the private-method def.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_multiple_fields_and_accessors_preserve_grouped_source_order() {
+    let output = emit_es5(
+        "class Grid {\n    #m = 1;\n    accessor p = 2;\n    #n = 3;\n    accessor q = 4;\n    get sum() { return this.#m + this.#n; }\n}\n",
+    );
+
+    assert!(
+        output
+            .contains("var _Grid_m, _Grid_n, _Grid_p_accessor_storage, _Grid_q_accessor_storage;"),
+        "es5 var declaration must list both private fields (source order) then both accessor storages (source order).\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "_Grid_m = new WeakMap(), _Grid_n = new WeakMap(), _Grid_p_accessor_storage = new WeakMap(), _Grid_q_accessor_storage = new WeakMap();"
+        ),
+        "es5 storage init must allocate both private fields then both accessor storages, in one statement.\nOutput:\n{output}"
+    );
+}
+
 #[test]
 fn es2015_private_field_destructuring_assignment_uses_setter_target() {
     let source = "class C {\n    #value: string;\n    m(arg: { key: string }) {\n        ({ key: this.#value } = arg);\n    }\n}\n";

--- a/crates/tsz-emitter/src/transforms/class_es5.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5.rs
@@ -838,7 +838,13 @@ impl<'a> ClassES5Emitter<'a> {
             .collect();
 
         body.drain(decl_pos..return_pos);
-        weakmap_decls.extend(decl_names);
+        // The lifted names are the private-field/method/instances storage vars,
+        // which `tsc` declares BEFORE any public auto-accessor storage vars that
+        // were already seeded into `weakmap_decls`. Prepend them (mirroring the
+        // init prepend below) so the combined `var` reads
+        // `_C_field, _C_x_accessor_storage;` — private-name storage first, then
+        // accessor storage — instead of the reversed append order.
+        weakmap_decls.splice(0..0, decl_names);
 
         if let Some((first_init, trailing_statements)) = init_texts.split_first() {
             let existing_inits = std::mem::take(weakmap_inits);

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -1779,6 +1779,24 @@ impl<'a> ES5ClassTransformer<'a> {
         if let Some(instances) = self.private_instances_weakset_name.as_ref() {
             weakmap_inits.push(format!("{instances} = new WeakSet()"));
         }
+        // Auto-accessor storage WeakMaps are allocated together with the rest of
+        // the private-name storage — after the private-field WeakMaps and the
+        // private-method WeakSet, but BEFORE the private method/accessor function
+        // definitions — matching tsc's "allocations first, function defs second"
+        // initialization order (e.g.
+        // `_C_instances = new WeakSet(), _C_a_accessor_storage = new WeakMap(), _C_run = function ...`).
+        // The standalone (no private-name lowering) case is unaffected: with no
+        // fields/methods/instances ahead of it, the accessor storage still leads.
+        let auto_accessor_instance_inits_in_computed_key =
+            self.first_computed_instance_auto_accessor().is_some();
+        for accessor in &self.auto_accessors {
+            if !accessor.is_static
+                && !auto_accessor_decls_in_iife
+                && !auto_accessor_instance_inits_in_computed_key
+            {
+                weakmap_inits.push(format!("{} = new WeakMap()", accessor.weakmap_name));
+            }
+        }
         weakmap_inits.extend(self.private_method_and_accessor_init_strings());
         // Static private field initializers are no longer emitted as a grouped
         // block here; they are interleaved with the public static field inits and
@@ -1802,16 +1820,6 @@ impl<'a> ES5ClassTransformer<'a> {
             weakmap_inits = Vec::new();
         } else {
             weakmap_decls.extend(private_storage_decls);
-        }
-        let auto_accessor_instance_inits_in_computed_key =
-            self.first_computed_instance_auto_accessor().is_some();
-        for accessor in &self.auto_accessors {
-            if !accessor.is_static
-                && !auto_accessor_decls_in_iife
-                && !auto_accessor_instance_inits_in_computed_key
-            {
-                weakmap_inits.push(format!("{} = new WeakMap()", accessor.weakmap_name));
-            }
         }
         let post_weakmap_statements = Vec::new();
 


### PR DESCRIPTION
When a class is down-leveled to the ES5 IIFE, tsz lifts its private-name storage (`#field`/`#method` `WeakMap`/`WeakSet` vars) out of the generated function and folds it into the same combined `var` declaration and initializer statement that already carries any public `accessor` storage `WeakMap`s. **When a class mixes private fields/methods with a public auto-accessor, `tsc` orders the private-name storage first and the auto-accessor storage last; tsz emitted them reversed in the declaration and mis-sequenced the initializer.**

## Structural rule
When lowering a class to the ES5 IIFE, `tsc` declares the private-name environment as: private-field/method/instances storage first (source order), then public auto-accessor storage; and the initializer allocates **every** storage map (`new WeakSet()`/`new WeakMap()`) before emitting the private method/accessor **function** definitions. tsz got both backwards for the common instance case, through the emitter's ES5 class lift/assembly.

Two compounding defects, both emitter-only:
- `class_es5.rs::lift_private_storage_from_iife_body` **appended** the lifted private-storage decls after the already-seeded accessor-storage decls (while **prepending** them in the initializer — an asymmetry). So `class C { #priv; accessor a }` emitted `var _C_a_accessor_storage, _C_priv;` instead of tsc's `var _C_priv, _C_a_accessor_storage;`. The lift now prepends the private-storage decls, mirroring the init prepend.
- `class_es5_ir.rs` pushed the auto-accessor storage allocation into the initializer *after* the private method/accessor function defs. So `class C { accessor a; #run(){} }` emitted `_C_instances = new WeakSet(), _C_run = function ..., _C_a_accessor_storage = new WeakMap()` instead of tsc's allocations-first `_C_instances = new WeakSet(), _C_a_accessor_storage = new WeakMap(), _C_run = function ...`. The accessor-storage allocation now emits before the function defs.

Owner layer: emitter only. No semantic validation, no output surgery, no user-name/file-name predicate — the order is keyed purely on the private-name kind. ES2015+ parity was already correct (native class syntax, different assembly) and is untouched.

## Adjacent matrix (verified byte-identical vs `tsc` 6.0.2, `--target es5`)
- `#field; accessor a` and `accessor a; #field` → `var _C_field, _C_a_accessor_storage;` (accessor last regardless of source order);
- multiple fields + multiple accessors, interleaved (`#m; accessor p; #n; accessor q`) → fields in source order, then accessor storages in source order, one statement;
- private method (`#m(){}`) + accessor → decl `_C_instances, _C_m, _C_a_accessor_storage`; init `_C_instances = new WeakSet(), _C_a_accessor_storage = new WeakMap(), _C_m = function ...`;
- private get/set accessor + public auto-accessors; `extends` base with its own private fields.

Out of scope (separate pre-existing ES5 placement facets, confirmed **neutral-or-improved**, not regressed): the inside-vs-outside-IIFE placement when a static field is present, computed-key auto-accessor grouping, `static accessor`, static private field access, and multi-class hoist consolidation.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib es5_` — 653 pass, incl. 3 new binder-name-varied regression tests (`es5_private_field_precedes_public_accessor_storage`, `es5_public_accessor_storage_allocates_before_private_method_def`, `es5_multiple_fields_and_accessors_preserve_grouped_source_order`).
- Full `cargo test -p tsz-emitter` — no new failures (one pre-existing unrelated `generator_object_literal_*` failure present on `main` too).
- End-to-end `tsz` vs `tsc` 6.0.2 (`--target es5`) diffed byte-for-byte across the permutation matrix above — all match after the fix; the same matrix diverged before.
- `cargo fmt --all -- --check`, `cargo clippy --profile ci-lint -p tsz-emitter --lib -- -D warnings`, `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean.
- ready-review CI owns the broad conformance/emit baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeQ5ph1As64owK6hjdvej3)_