### PR TITLE
fix(checker): read pre-write flow type for self-referential assignment RHS

### DIFF
--- a/crates/tsz-checker/src/flow/flow_graph_builder/expressions.rs
+++ b/crates/tsz-checker/src/flow/flow_graph_builder/expressions.rs
@@ -338,17 +338,34 @@ impl<'a> FlowGraphBuilder<'a> {
                         self.add_antecedent(merge, true_condition);
                         self.current_flow = merge;
                     }
-                } else {
-                    // Regular binary expression
-                    if Self::is_assignment_operator_token(binary.operator_token) {
-                        let flow = self.create_flow_node(
-                            flow_flags::ASSIGNMENT,
-                            self.current_flow,
-                            expr_idx,
-                        );
-                        self.current_flow = flow;
-                    }
+                } else if Self::is_assignment_operator_token(binary.operator_token) {
+                    // Assignment (`a = b`, `a += b`, destructuring `[a] = b`).
+                    //
+                    // Bind the RHS with the *pre-assignment* flow and only then
+                    // create the ASSIGNMENT flow node — matching TypeScript's
+                    // binder, which binds the operands before
+                    // `bindAssignmentTargetFlow`. A reference read on the RHS must
+                    // observe the variable's value from *before* this write.
+                    // Critically for a self-referential assignment inside a loop
+                    // (`x = x.p`), the RHS `x` must keep its pre-write, condition-
+                    // narrowed flow type; resolving it through the ASSIGNMENT node
+                    // instead treats the read as the post-write value and drops the
+                    // loop-body narrowing, producing a false TS2339.
+                    //
+                    // A reference's flow node is resolved by walking up to the
+                    // nearest recorded ancestor, so record the RHS node with the
+                    // pre-assignment flow; otherwise the RHS reads fall through to
+                    // the statement's post-assignment flow.
+                    self.handle_expression_for_assignments(binary.right);
+                    self.record_node_flow(binary.right);
 
+                    let flow =
+                        self.create_flow_node(flow_flags::ASSIGNMENT, self.current_flow, expr_idx);
+                    self.current_flow = flow;
+
+                    self.handle_expression_for_assignments(binary.left);
+                } else {
+                    // Regular (non-assignment) binary expression.
                     self.handle_expression_for_assignments(binary.left);
                     self.handle_expression_for_assignments(binary.right);
                 }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -406,6 +406,9 @@ mod local_type_alias_shadowing_tests;
 #[path = "tests/logical_assignment_member_narrowing_tests.rs"]
 mod logical_assignment_member_narrowing_tests;
 #[cfg(test)]
+#[path = "tests/loop_self_referential_property_read_tests.rs"]
+mod loop_self_referential_property_read_tests;
+#[cfg(test)]
 #[path = "tests/member_assignment_narrowing_join_tests.rs"]
 mod member_assignment_narrowing_join_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/loop_self_referential_property_read_tests.rs
+++ b/crates/tsz-checker/src/tests/loop_self_referential_property_read_tests.rs
@@ -1,0 +1,173 @@
+//! A property read on the right-hand side of a variable's own assignment must
+//! observe the variable's *pre-write*, flow-narrowed type — even inside a loop.
+//!
+//! For `x = x.p` the binder must bind the RHS with the flow that reaches the
+//! assignment (so any loop-body guard narrows `x` at the read), and only then
+//! create the ASSIGNMENT flow node. Previously tsz created the assignment node
+//! first, so the RHS `x` resolved through it and was treated as the *post-write*
+//! value; the receiver widened back to the declared union and a spurious TS2339
+//! ("Property 'p' does not exist on type 'number | { p: number }'") was reported
+//! for code `tsc` accepts.
+//!
+//! Parity anchor (`tsc` 6.0):
+//!   - `while (typeof x === "object") { x = x.p; }`   -> clean (guard re-narrows)
+//!   - `while (cond) { x = x.length; }` on `string | number` -> TS2339 (widened,
+//!     no guard) — the genuine error must still fire.
+//!
+//! Binder names are varied across cases so the behavior is driven by the
+//! structural shape (loop + self-referential property read + guard), not by any
+//! identifier spelling.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files, strict_checker_options};
+
+fn codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    let diags: Vec<Diagnostic> =
+        check_source_with_libs(source, "test.ts", strict_checker_options(), &libs);
+    diags.iter().map(|d| d.code).collect()
+}
+
+fn assert_no_2339(source: &str, label: &str) {
+    let got = codes(source);
+    assert!(
+        !got.contains(&2339),
+        "{label}: expected no TS2339 for a guarded self-referential loop read, got: {got:?}"
+    );
+}
+
+/// The reported witness: a `typeof`-object guard narrows `x` to the object
+/// constituent at the RHS read, so `x = x.p` type-checks and reassigns `number`.
+#[test]
+fn while_typeof_object_guard_self_property_read_is_clean() {
+    let source = r#"
+function walk(node: number | { p: number }) {
+    while (typeof node === "object") {
+        node = node.p;
+    }
+}
+"#;
+    assert_no_2339(source, "while typeof-object guard");
+}
+
+/// The original `.length` witness (lib-backed apparent member): a `typeof`-string
+/// guard keeps `x` a `string` at the read every iteration.
+#[test]
+fn while_typeof_string_guard_self_length_read_is_clean() {
+    let source = r#"
+function shrink(value: number | string) {
+    while (typeof value === "string") {
+        value = value.length;
+    }
+}
+"#;
+    assert_no_2339(source, "while typeof-string guard length");
+}
+
+/// A `for` loop with the guard in the condition behaves identically to `while`.
+#[test]
+fn for_loop_guard_self_property_read_is_clean() {
+    let source = r#"
+function step(cursor: number | { next: number }) {
+    for (; typeof cursor === "object"; ) {
+        cursor = cursor.next;
+    }
+}
+"#;
+    assert_no_2339(source, "for-loop guard");
+}
+
+/// A `do`/`while` whose guard is an early-`break` inside the body still narrows
+/// the read that follows it.
+#[test]
+fn do_while_break_guard_self_property_read_is_clean() {
+    let source = r#"
+function drain(item: number | { head: number }) {
+    do {
+        if (typeof item !== "object") break;
+        item = item.head;
+    } while (true);
+}
+"#;
+    assert_no_2339(source, "do-while break guard");
+}
+
+/// Anti-hardcoding: renamed binders and property spelling, same structural shape.
+#[test]
+fn renamed_binders_guard_self_property_read_is_clean() {
+    let source = r#"
+function traverse(cell: number | { forward: number }) {
+    while (typeof cell === "object") {
+        cell = cell.forward;
+    }
+}
+"#;
+    assert_no_2339(source, "renamed binders");
+}
+
+/// The reassigned value keeps flowing after the loop: a later read sees the
+/// declared union, not a leaked narrowed member (sanity that narrowing is
+/// scoped to the guarded body).
+#[test]
+fn post_loop_read_keeps_declared_union() {
+    let source = r#"
+function after(x: number | { p: number }) {
+    while (typeof x === "object") {
+        x = x.p;
+    }
+    const n: number = x;
+}
+"#;
+    // `x` is `number` after the loop (the object arm always reassigns to
+    // `number`), so the `const n: number = x` is accepted with no diagnostics.
+    let got = codes(source);
+    assert!(
+        !got.contains(&2339) && !got.contains(&2322),
+        "post-loop read parity, got: {got:?}"
+    );
+}
+
+/// Negative parity: an *unguarded* loop that widens the variable back to a union
+/// lacking the property must still report TS2339 — matching `tsc`. The fix must
+/// not blanket-suppress the diagnostic; the normal flow-typed receiver already
+/// carries the widened union at the read.
+#[test]
+fn unguarded_widening_loop_still_reports_ts2339() {
+    let source = r#"
+declare const cond: boolean;
+function widen(x: string | number) {
+    while (cond) {
+        x = x.length;
+    }
+}
+"#;
+    let got = codes(source);
+    assert!(
+        got.contains(&2339),
+        "unguarded widening must still emit TS2339 (parity with tsc), got: {got:?}"
+    );
+}
+
+/// A subexpression read (`x.p + 0`) and an element-access read (`x[k]`) already
+/// worked; keep them green so the binder reorder does not regress non-reference
+/// right-hand sides.
+#[test]
+fn subexpression_and_element_reads_stay_clean() {
+    let subexpr = r#"
+function a(x: number | { p: number }) {
+    while (typeof x === "object") {
+        x = x.p + 0;
+    }
+}
+"#;
+    assert_no_2339(subexpr, "subexpression RHS");
+
+    let element = r#"
+function b(x: number | number[]) {
+    while (typeof x === "object") {
+        x = x[0];
+    }
+}
+"#;
+    assert_no_2339(element, "element-access RHS");
+}

--- a/crates/tsz-checker/src/types/property_access_type/helpers.rs
+++ b/crates/tsz-checker/src/types/property_access_type/helpers.rs
@@ -8,7 +8,7 @@ use crate::state::{CheckerState, MAX_INSTANTIATION_DEPTH};
 use tsz_binder::symbol_flags;
 use tsz_common::common::Visibility;
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node::{AccessExprData, NodeAccess, NodeArena};
+use tsz_parser::parser::node::{NodeAccess, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
@@ -1059,103 +1059,6 @@ impl<'a> CheckerState<'a> {
                         || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
                 )
             })
-    }
-
-    pub(crate) fn report_loop_widened_receiver_property_error(
-        &mut self,
-        property_access_idx: NodeIndex,
-        access: &AccessExprData,
-        property_name: &str,
-        receiver_type: TypeId,
-        property_type: TypeId,
-        skip_flow_narrowing: bool,
-    ) -> bool {
-        if skip_flow_narrowing
-            || self.ctx.iteration_depth == 0
-            || access.question_dot_token
-            || matches!(property_type, TypeId::ANY | TypeId::ERROR | TypeId::UNKNOWN)
-        {
-            return false;
-        }
-
-        // A self-recursive loop assignment can make the next iteration's
-        // receiver wider than the first-pass receiver, e.g. `x = x.length`
-        // turns `x` from `string` into `string | number`.
-        let mut current = property_access_idx;
-        while let Some(parent_idx) = self.ctx.arena.parent_of(current) {
-            if parent_idx.is_none() {
-                break;
-            }
-            let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
-                break;
-            };
-            if parent_node.kind == syntax_kind_ext::BINARY_EXPRESSION
-                && let Some(binary) = self.ctx.arena.get_binary_expr(parent_node)
-            {
-                let assignment_is_statement = self
-                    .ctx
-                    .arena
-                    .parent_of(parent_idx)
-                    .and_then(|statement_idx| self.ctx.arena.get(statement_idx))
-                    .is_some_and(|node| node.kind == syntax_kind_ext::EXPRESSION_STATEMENT);
-                if binary.operator_token == SyntaxKind::EqualsToken as u16
-                    && binary.right == property_access_idx
-                    && assignment_is_statement
-                {
-                    let analyzer = self.flow_analyzer_for_property_reads();
-                    if analyzer.is_matching_reference(binary.left, access.expression) {
-                        // Only a *widening* self-recursive assignment drops the
-                        // property next iteration. When the narrowed first-pass
-                        // receiver is already a subtype of the assigned-back value
-                        // (`receiver_type <: property_type`), `union2` re-introduces
-                        // only the variable's own declared/flow union, which the
-                        // loop's per-iteration narrowing at this site (e.g. a
-                        // `switch (x._tag)` discriminant guarding a recursive
-                        // `x = x.child`) re-derives every pass — so the property
-                        // never actually goes missing (#14944). The genuine case
-                        // this heuristic targets escapes the receiver's domain
-                        // (`x = x.length` widening `string` with `number`, where
-                        // `string` is not a subtype of `number`) and still fires.
-                        if self.is_subtype_of(receiver_type, property_type) {
-                            return false;
-                        }
-                        let loop_receiver_type = self
-                            .ctx
-                            .types
-                            .factory()
-                            .union2(receiver_type, property_type);
-                        let loop_receiver_for_access =
-                            self.resolve_type_for_property_access(loop_receiver_type);
-                        if matches!(
-                            self.resolve_property_access_with_env(
-                                loop_receiver_for_access,
-                                property_name,
-                            ),
-                            PropertyAccessResult::PropertyNotFound { .. }
-                        ) {
-                            self.error_property_not_exist_at(
-                                property_name,
-                                loop_receiver_type,
-                                access.name_or_argument,
-                            );
-                            return true;
-                        }
-                    }
-                }
-                break;
-            }
-            if parent_node.kind == syntax_kind_ext::EXPRESSION_STATEMENT
-                || parent_node.kind == syntax_kind_ext::BLOCK
-                || parent_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                || parent_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                || parent_node.kind == syntax_kind_ext::ARROW_FUNCTION
-            {
-                break;
-            }
-            current = parent_idx;
-        }
-
-        false
     }
 
     pub(crate) fn recover_self_recursive_property_access_type(

--- a/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
+++ b/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
@@ -972,16 +972,6 @@ impl<'a> CheckerState<'a> {
                     );
                     return TypeId::ERROR;
                 }
-                if self.report_loop_widened_receiver_property_error(
-                    idx,
-                    access,
-                    property_name,
-                    object_type,
-                    prop_type,
-                    skip_flow_narrowing,
-                ) {
-                    return TypeId::ERROR;
-                }
                 // When in a write context (assignment target), use the setter
                 // type if the property has divergent getter/setter types.
                 let effective_type = effective_write_result(prop_type, write_type);


### PR DESCRIPTION
Fixes #15274.

A property read on the right-hand side of a variable's own assignment
(`x = x.p`) inside a loop under a narrowing guard emitted a false `TS2339`.
`tsc` accepts the code.

```ts
function walk(node: number | { p: number }) {
  while (typeof node === "object") {
    node = node.p; // tsz before: TS2339 on 'number | { p: number; }'; tsc: clean
  }
}
```

**Structural rule:** when the RHS of `x = …` reads `x`, that read observes `x`'s
flow type from *before* this assignment. Inside a loop the loop fixed-point at
the read site already unions the body's back-edge (widening) and the body guard
re-narrows it, so the normal flow-typed receiver is correct. `tsc` does this
because its binder binds the operands before `bindAssignmentTargetFlow`; tsz
created the `ASSIGNMENT` flow node first, so the RHS `x` resolved *through* it and
was typed as the post-write value, dropping the guard narrowing.

**Owner layer:** checker flow-graph builder
(`flow/flow_graph_builder/expressions.rs`) and property-access resolution
(`types/property_access_type`).

Two interacting defects fixed:

1. **Binder flow-node ordering.** Bind the assignment RHS with the
   pre-assignment flow and record its flow node, then create the `ASSIGNMENT`
   node — so RHS reads resolve to the pre-write, guard-narrowed flow (matching
   TypeScript's operand-before-`bindAssignmentTargetFlow` order).
2. **Removed the `report_loop_widened_receiver_property_error` heuristic.** It
   re-widened the narrowed receiver to `union(receiver, assigned)` and reported
   `TS2339` whenever the property was missing on that union — a band-aid for
   defect 1 that over-fired for guarded loops (`tsc` re-narrows the receiver
   each iteration). With defect 1 fixed the normal flow-typed receiver carries
   the correct type, and the genuine *unguarded*-widening `TS2339`
   (`x: string | number; x = x.length` with no guard) is still produced by the
   normal property-access path.

**Adjacent matrix** (new `loop_self_referential_property_read_tests`, binder
names varied for anti-hardcoding), each verified byte-for-byte against `tsc`
6.0:
- `while (typeof x === "object") { x = x.p; }` → clean;
- `while (typeof x === "string") { x = x.length; }` (lib-backed) → clean;
- `for (; typeof x === "object"; ) { x = x.next; }` → clean;
- `do { if (typeof x !== "object") break; x = x.head; } while (true)` → clean;
- renamed binders / property spelling → clean;
- post-loop read keeps the declared union;
- **negative parity:** unguarded `x: string | number; while (cond) { x = x.length; }` → still `TS2339`;
- subexpression (`x.p + 0`) and element-access (`x[0]`) RHS stay clean.

No user-name / file-name / rendered-output predicate drives the decision — it is
keyed on the structural shape (loop + self-referential property read + guard).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- loop_self_referential_property_read` — 8/8 pass.
- `cargo test -p tsz-checker --lib -- narrow property_access assignment loop widen` and `-- for_ while switch condition compound destructur increment guard flow_graph` — no new failures vs. clean `main` (identical pre-existing failure sets before/after this change).
- End-to-end `tsz` vs `tsc` 6.0 (`--noEmit --strict`) diffed on the adjacent matrix above — all match, including the unguarded-widening `TS2339` and the guarded-clean cases.
- `cargo fmt --all -- --check`, `python3 scripts/arch/arch_guard.py --json` (0 failures), `cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings` — clean.
- ready-review CI owns the broad conformance/emit/fourslash baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01HuWXRYWYsTkTo8yRSHoqaW)_