### PR TITLE
fix(emit): order hoisted CommonJS function exports own-first, then aliases in source order

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -159,6 +159,10 @@ name = "cjs_hoisted_var_position_tests"
 path = "tests/cjs_hoisted_var_position_tests.rs"
 
 [[test]]
+name = "cjs_hoisted_func_export_order_tests"
+path = "tests/cjs_hoisted_func_export_order_tests.rs"
+
+[[test]]
 name = "object_literal_recovery_tests"
 path = "tests/object_literal_recovery_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -926,8 +926,59 @@ impl<'a> Printer<'a> {
             // Merge default and named function exports, preserving source order.
             // tsc emits function exports in declaration order, not default-first.
             {
-                // Build a merged list of (source_position, export_name, local_name)
-                let mut all_func_exports: Vec<(u32, String, String)> = Vec::new();
+                // Merged list of (group_pos, within_group_rank, export_name,
+                // local_name). `group_pos` is the function declaration's source
+                // position, grouping every export of one hoisted function
+                // together; `within_group_rank` orders exports inside that group
+                // (see the sort below).
+                let mut all_func_exports: Vec<(u32, u32, String, String)> = Vec::new();
+                // Map each `export {}` clause alias's exported name to its
+                // specifier's source position, used as `within_group_rank` so
+                // aliases emit in specifier source order. An exported name that
+                // is absent (the declaration's own `export`/`export default`
+                // modifier never appears in a clause) ranks 0 and sorts first.
+                // INVARIANT: each exported name is unique across the module
+                // (TypeScript rejects duplicate exports; `func_exports` is also
+                // deduped by exported name), so one name maps to one rank.
+                let mut alias_specifier_pos: rustc_hash::FxHashMap<String, u32> =
+                    rustc_hash::FxHashMap::default();
+                for &idx in &source.statements.nodes {
+                    let Some(node) = self.arena.get(idx) else {
+                        continue;
+                    };
+                    if node.kind != syntax_kind_ext::EXPORT_DECLARATION {
+                        continue;
+                    }
+                    let Some(export) = self.arena.get_export_decl(node) else {
+                        continue;
+                    };
+                    if export.is_type_only
+                        || export.is_default_export
+                        || export.module_specifier.is_some()
+                    {
+                        continue;
+                    }
+                    let Some(clause_node) = self.arena.get(export.export_clause) else {
+                        continue;
+                    };
+                    let Some(named_exports) = self.arena.get_named_imports(clause_node) else {
+                        continue;
+                    };
+                    for &spec_idx in &named_exports.elements.nodes {
+                        let Some(spec_node) = self.arena.get(spec_idx) else {
+                            continue;
+                        };
+                        let Some(spec) = self.arena.get_specifier_at(spec_idx) else {
+                            continue;
+                        };
+                        if spec.is_type_only {
+                            continue;
+                        }
+                        if let Some(exported) = self.get_specifier_name_text(spec.name) {
+                            alias_specifier_pos.entry(exported).or_insert(spec_node.pos);
+                        }
+                    }
+                }
                 // Walk anonymous-default functions in source order so the Nth
                 // synthesized name (`default_1`, `default_2`, ...) matches the
                 // Nth occurrence. Without this, the position lookup below
@@ -1002,7 +1053,9 @@ impl<'a> Printer<'a> {
                             })
                             .unwrap_or(0)
                     };
-                    all_func_exports.push((pos, "default".to_string(), name.clone()));
+                    // A `export default function` is the declaration's own
+                    // export, so it ranks first within its group.
+                    all_func_exports.push((pos, 0, "default".to_string(), name.clone()));
                 }
                 for (exported_name, local_name) in &func_exports {
                     let pos = source
@@ -1040,17 +1093,32 @@ impl<'a> Printer<'a> {
                             }
                         })
                         .unwrap_or(0);
-                    all_func_exports.push((pos, exported_name.clone(), local_name.clone()));
+                    // Own named export (`export function foo`) is absent from
+                    // the specifier map and ranks 0; a clause alias takes its
+                    // specifier's source position.
+                    let rank = alias_specifier_pos.get(exported_name).copied().unwrap_or(0);
+                    all_func_exports.push((pos, rank, exported_name.clone(), local_name.clone()));
                 }
-                // Sort by source position, with alphabetical tiebreaker for
-                // exports referencing the same function (same position).
-                // This matches tsc: `exports.j = j;` before `exports.jj = j;`
-                // and `exports.default = f;` before `exports.f = f;`.
-                all_func_exports.sort_by(|(pos_a, name_a, _), (pos_b, name_b, _)| {
-                    pos_a.cmp(pos_b).then_with(|| name_a.cmp(name_b))
-                });
-                // Emit in source order
-                for (_, exported_name, local_name) in &all_func_exports {
+                // Emit each hoisted function's exports grouped by declaration
+                // position, and within a group the declaration's own export
+                // first (rank 0) followed by each `export {}` clause alias in
+                // specifier source order. This matches tsc's
+                // `appendExportsOfHoistedDeclaration`: `exports.default = f;`
+                // before `exports.f = f;`, `exports.j = j;` before
+                // `exports.jj = j;`, and `export { f as z, f as m }` staying in
+                // written order (`z` before `m`) rather than alphabetical. The
+                // exported-name comparison is only a final deterministic
+                // tiebreaker; distinct exports never collide on the first two
+                // keys.
+                all_func_exports.sort_by(
+                    |(pos_a, rank_a, name_a, _), (pos_b, rank_b, name_b, _)| {
+                        pos_a
+                            .cmp(pos_b)
+                            .then_with(|| rank_a.cmp(rank_b))
+                            .then_with(|| name_a.cmp(name_b))
+                    },
+                );
+                for (_, _, exported_name, local_name) in &all_func_exports {
                     self.write("exports.");
                     self.write(exported_name);
                     self.write(" = ");

--- a/crates/tsz-emitter/tests/cjs_hoisted_func_export_order_tests.rs
+++ b/crates/tsz-emitter/tests/cjs_hoisted_func_export_order_tests.rs
@@ -1,0 +1,118 @@
+//! Regression tests for the emission order of hoisted CommonJS function
+//! exports.
+//!
+//! A hoisted function declaration can be exported under several names at once:
+//! its own `export` / `export default` modifier plus any number of separate
+//! `export { fn as alias }` clauses. `tsc` emits all of these assignments in a
+//! single preamble group (before the function body, because JS function
+//! declarations hoist) and, crucially, in a fixed order dictated by
+//! `appendExportsOfHoistedDeclaration`: the declaration's **own** export first,
+//! then each clause alias in **specifier source order**.
+//!
+//! tsz previously sorted the group with an alphabetical tiebreaker, which put
+//! `exports.bar = foo;` ahead of `exports.default = foo;` and reordered
+//! `export { f as z, f as m }` to `m` before `z`. The fix keys the within-group
+//! order on (own-first, then specifier source position) instead.
+//!
+//! Source: `crates/tsz-emitter/src/emitter/source_file/emit.rs`
+//! (hoisted function export preamble).
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print as parse_lower_emit;
+
+fn cjs(target: ScriptTarget) -> PrintOptions {
+    PrintOptions {
+        target,
+        module: ModuleKind::CommonJS,
+        ..Default::default()
+    }
+}
+
+/// Extract the ordered sequence of exported names from `exports.<name> = ...;`
+/// assignment lines, ignoring `void 0` initializers and re-export bookkeeping.
+fn export_assignment_names(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            let rest = line.strip_prefix("exports.")?;
+            let (name, value) = rest.split_once(" = ")?;
+            // Skip the `exports.x = void 0;` initialization preamble.
+            if value.trim_start().starts_with("void 0") {
+                return None;
+            }
+            Some(name.to_string())
+        })
+        .collect()
+}
+
+fn assert_order(source: &str, expected: &[&str]) {
+    for target in [
+        ScriptTarget::ES5,
+        ScriptTarget::ES2015,
+        ScriptTarget::ES2020,
+    ] {
+        let output = parse_lower_emit(source, cjs(target));
+        let names = export_assignment_names(&output);
+        assert_eq!(
+            names, expected,
+            "hoisted function export order mismatch at {target:?}.\nSource:\n{source}\nOutput:\n{output}"
+        );
+    }
+}
+
+/// `export default function` followed by aliases: `default` (the declaration's
+/// own export) must come first, then the clause aliases in written order.
+#[test]
+fn default_function_then_named_reexports() {
+    assert_order(
+        "export default function foo() { return 1; }\nexport { foo as bar, foo as baz };\n",
+        &["default", "bar", "baz"],
+    );
+}
+
+/// An `export function` (own named export) precedes its `export { as }` alias,
+/// even though `bar` sorts before `foo` alphabetically.
+#[test]
+fn named_function_then_alias() {
+    assert_order(
+        "export function foo() { return 1; }\nexport { foo as bar };\n",
+        &["foo", "bar"],
+    );
+}
+
+/// Clause aliases keep specifier source order (`zeta` before `alpha`), not
+/// alphabetical order.
+#[test]
+fn alias_specifier_source_order_is_preserved() {
+    assert_order(
+        "export default function foo() {}\nexport { foo as zeta, foo as alpha };\n",
+        &["default", "zeta", "alpha"],
+    );
+}
+
+/// Two exported functions each carry their own group; aliases stay attached to
+/// the function they reference, in declaration order.
+#[test]
+fn multiple_functions_group_with_their_aliases() {
+    assert_order(
+        "export function a() {}\nexport { a as z, a as m };\nexport function b() {}\nexport { b as y };\n",
+        &["a", "z", "m", "b", "y"],
+    );
+}
+
+/// `exports.j = j;` before `exports.jj = j;` — own export first, alias after
+/// (this case is consistent under both alphabetical and source order, and must
+/// keep working).
+#[test]
+fn own_export_before_alias_alphabetical_consistent() {
+    assert_order(
+        "export function j() {}\nexport { j as jj };\n",
+        &["j", "jj"],
+    );
+}


### PR DESCRIPTION
Fixes #15276.

An exported hoisted function declaration can bind several export names at once: its own `export` / `export default` modifier plus any number of separate `export { fn as alias }` clauses. `tsc` emits every CommonJS assignment in one hoisted preamble group and, per `appendExportsOfHoistedDeclaration`, in a fixed order — the declaration's **own** export first, then each clause alias in **specifier source order**.

tsz grouped the exports by the function declaration's source position (correct) but broke ties **alphabetically**, so:

```ts
export default function foo() { return 1; }
export { foo as bar };
```

emitted `exports.bar = foo;` **before** `exports.default = foo;` (tsc emits `default` then `bar`). The same reversal hit `export function foo` + `export { foo as bar }` (tsz `bar, foo` vs tsc `foo, bar`) and reordered multi-alias clauses (`export { foo as zeta, foo as alpha }` → tsz `alpha, zeta` vs tsc `zeta, alpha`). The alphabetical tiebreaker only ever matched tsc for the narrow cases it was derived from (`default` < `f`, `j` < `jj`).

**Structural rule:** when a hoisted function declaration carries several export names, `tsc` emits the declaration's own export first (`exports.default` / `exports.<fnname>`), then each `export { fn as alias }` clause alias in specifier source order; tsz now does the same through the CommonJS hoisted-export preamble in `crates/tsz-emitter/src/emitter/source_file/emit.rs`.

**Owner layer:** emitter — CommonJS hoisted-function export preamble. Pure output-ordering fix, no semantic change. Each export entry now carries an intrinsic `(group_pos, within_group_rank)` sort key: `group_pos` is the function declaration's source position (grouping), `within_group_rank` is `0` for the declaration's own export (absent from the `export {}` clause) or the alias specifier's source position otherwise. The exported-name comparison remains only as a final deterministic tiebreaker. No identifier/file-name/rendered-output predicate — the decision is purely structural position. The CommonJS path is shared by AMD, so both are covered; System/UMD wrappers are a separate mechanism and unaffected.

## Goal
Goal: hold

## Verification
- New regression suite `crates/tsz-emitter/tests/cjs_hoisted_func_export_order_tests.rs` (5 tests across es5/es2015/es2020: default+aliases, named+alias, specifier source order vs alphabetical, multi-function grouping, own-before-alias) — 5/5 pass.
- Differential `tsz` vs `tsc 6.0.2` (`--module commonjs` and `--module amd`, targets es5..es2022) on the full default/named/alias/multi-function matrix — byte-identical.
- `cargo test -p tsz-emitter --lib` (3929 passed) and full `-p tsz-emitter` integration tests green (the one pre-existing `generator_object_literal_..._trailing_comma` dev-profile failure reproduces identically on the base with my change stashed).
- `cargo fmt --all -- --check`, `cargo clippy -p tsz-emitter --lib -- -D warnings`, `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean.
- ready-review CI owns the broad conformance/emit/fourslash baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeusrnkVr4XhtKS8BAVJan)_