### PR TITLE
fix(emit): don't duplicate es5 cjs private-field storage var with a static field initializer

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -159,6 +159,10 @@ name = "cjs_hoisted_var_position_tests"
 path = "tests/cjs_hoisted_var_position_tests.rs"
 
 [[test]]
+name = "es5_cjs_private_storage_static_field_tests"
+path = "tests/es5_cjs_private_storage_static_field_tests.rs"
+
+[[test]]
 name = "object_literal_recovery_tests"
 path = "tests/object_literal_recovery_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
@@ -1067,13 +1067,13 @@ impl<'a> Printer<'a> {
         // additionally relocate the `var _C_x;` declaration to module scope, or
         // it would be declared twice (once at module scope, once inside the
         // IIFE). Static methods/getters/blocks and declare-only static fields do
-        // not carry a runtime initializer, so those still externalize.
-        let keeps_private_storage_inside_iife =
-            self.class_has_es5_static_field_initializer(class_data);
+        // not carry a runtime initializer, so those still externalize. The
+        // member scan is the last conjunct so it is skipped unless the cheap
+        // CommonJS-export guards already passed.
         let can_externalize_private_storage = self.ctx.outer_module_kind().is_commonjs()
             && is_commonjs_exported_class
             && !self.ctx.module_state.has_export_assignment
-            && !keeps_private_storage_inside_iife;
+            && !self.class_has_es5_static_field_initializer(class_data);
         let mut decls = if can_externalize_private_storage {
             self.es5_class_private_storage_decls(class_idx, class_name, class_data)
         } else {

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
@@ -1060,9 +1060,20 @@ impl<'a> Printer<'a> {
             return Vec::new();
         }
 
+        // A static property with a runtime initializer (e.g. `static s = 3`)
+        // forces the class's private-field WeakMap storage to stay INSIDE the
+        // generated IIFE, co-located with the `C.s = ...` static assignments,
+        // exactly as `tsc` does. In that case the CommonJS-export lift must NOT
+        // additionally relocate the `var _C_x;` declaration to module scope, or
+        // it would be declared twice (once at module scope, once inside the
+        // IIFE). Static methods/getters/blocks and declare-only static fields do
+        // not carry a runtime initializer, so those still externalize.
+        let keeps_private_storage_inside_iife =
+            self.class_has_es5_static_field_initializer(class_data);
         let can_externalize_private_storage = self.ctx.outer_module_kind().is_commonjs()
             && is_commonjs_exported_class
-            && !self.ctx.module_state.has_export_assignment;
+            && !self.ctx.module_state.has_export_assignment
+            && !keeps_private_storage_inside_iife;
         let mut decls = if can_externalize_private_storage {
             self.es5_class_private_storage_decls(class_idx, class_name, class_data)
         } else {
@@ -1196,6 +1207,36 @@ impl<'a> Printer<'a> {
         }
 
         decls
+    }
+
+    /// A class has an ES5 static field initializer when it declares at least
+    /// one non-abstract, non-ambient `static` property carrying a runtime
+    /// initializer (`static s = 3`). Such a field emits a `C.s = ...` statement
+    /// inside the class-wrapping IIFE, which keeps the class's private-field
+    /// `WeakMap` storage inside the IIFE too (matching `tsc`), rather than
+    /// lifting it to module scope. Static methods, accessors declared with a
+    /// method body, static blocks, and declare-only static fields do not
+    /// qualify.
+    fn class_has_es5_static_field_initializer(&self, class_data: &ClassData) -> bool {
+        class_data.members.nodes.iter().any(|&member_idx| {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                return false;
+            };
+            if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION {
+                return false;
+            }
+            let Some(prop) = self.arena.get_property_decl(member_node) else {
+                return false;
+            };
+            self.arena.is_static(&prop.modifiers)
+                && !self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
+                && !self
+                    .arena
+                    .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
+                && self.es5_property_initializer_has_equals(member_node, prop)
+        })
     }
 
     fn es5_class_property_has_runtime_effect(

--- a/crates/tsz-emitter/tests/es5_cjs_private_storage_static_field_tests.rs
+++ b/crates/tsz-emitter/tests/es5_cjs_private_storage_static_field_tests.rs
@@ -1,0 +1,139 @@
+//! Regression tests for ES5 CommonJS-exported class private-field storage
+//! placement when the class also declares a static field initializer.
+//!
+//! `tsc` externalizes a CommonJS-exported class's private-field `WeakMap`
+//! storage — `var _C_x;` at module scope, `_C_x = new WeakMap();` after the
+//! class IIFE — ONLY when nothing forces the storage to stay inside the IIFE.
+//! A static property with a runtime initializer (`static s = 3`) emits a
+//! `C.s = ...` assignment inside the IIFE and keeps the private `WeakMap`
+//! declaration/instantiation inside the IIFE alongside it. In that case the
+//! module-scope lift must be suppressed, or `var _C_x;` is emitted twice —
+//! once (spuriously) at module scope and once inside the IIFE.
+//!
+//! Source: `crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs`
+//! (`es5_class_externally_hoisted_decls` / `class_has_es5_static_field_initializer`).
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print as parse_lower_print;
+
+fn es5_cjs(source: &str) -> String {
+    parse_lower_print(
+        source,
+        PrintOptions {
+            target: ScriptTarget::ES5,
+            module: ModuleKind::CommonJS,
+            ..Default::default()
+        },
+    )
+}
+
+/// With a static field initializer present, the private-field `WeakMap` var
+/// must appear exactly once, inside the IIFE (never lifted to module scope).
+#[test]
+fn static_field_initializer_keeps_private_storage_inside_iife() {
+    let output = es5_cjs("export class C {\n  #y = 2;\n  static s = 3;\n}\n");
+
+    assert_eq!(
+        output.matches("var _C_y;").count(),
+        1,
+        "private-field WeakMap var must be declared exactly once (not duplicated \
+         at module scope) when a static field initializer keeps it inside the \
+         IIFE.\noutput:\n{output}"
+    );
+
+    // The single declaration must be the indented, inside-IIFE one, and the
+    // WeakMap instantiation stays inside too.
+    let var_pos = output.find("var _C_y;").expect("private WeakMap var");
+    let init_pos = output
+        .find("_C_y = new WeakMap();")
+        .expect("private WeakMap instantiation");
+    let return_pos = output.find("return C;").expect("class IIFE return");
+    assert!(
+        var_pos < init_pos && init_pos < return_pos,
+        "declaration and instantiation must both stay inside the IIFE, before \
+         `return C;`.\noutput:\n{output}"
+    );
+}
+
+/// Multiple private fields with a static initializer: none may leak to module
+/// scope.
+#[test]
+fn multiple_private_fields_with_static_field_stay_inside() {
+    let output = es5_cjs("export class C {\n  #y = 2;\n  #z = 3;\n  static s = 1;\n}\n");
+    // Both private WeakMaps are declared together on a single inside-IIFE line;
+    // before the fix that same `var _C_y, _C_z;` line was also emitted at
+    // module scope (a duplicate), so the count would be 2.
+    assert_eq!(
+        output.matches("var _C_y, _C_z;").count(),
+        1,
+        "both private WeakMap vars must be declared exactly once (not duplicated \
+         at module scope).\noutput:\n{output}"
+    );
+}
+
+/// Public instance fields alongside the private field and static initializer
+/// must not change the outcome (this is the originally-reported shape).
+#[test]
+fn public_and_private_fields_with_static_field() {
+    let output = es5_cjs("export class C {\n  x = 1;\n  #y = 2;\n  static s = 3;\n}\n");
+    assert_eq!(output.matches("var _C_y;").count(), 1, "output:\n{output}");
+}
+
+/// Control: WITHOUT a static field initializer, a CommonJS-exported private
+/// class still externalizes its storage — `var _C_y;` at module scope and no
+/// inside-IIFE declaration. Guards against over-suppression.
+#[test]
+fn no_static_field_still_externalizes_private_storage() {
+    let output = es5_cjs("export class C {\n  #y = 2;\n}\n");
+
+    assert_eq!(output.matches("var _C_y;").count(), 1, "output:\n{output}");
+
+    // Externalized: the WeakMap instantiation is emitted after the class IIFE
+    // returns (module scope), not before `return C;`.
+    let init_pos = output
+        .find("_C_y = new WeakMap();")
+        .expect("private WeakMap instantiation");
+    let return_pos = output.find("return C;").expect("class IIFE return");
+    assert!(
+        return_pos < init_pos,
+        "without a static field initializer the WeakMap instantiation must be \
+         lifted to module scope (after the IIFE).\noutput:\n{output}"
+    );
+}
+
+/// Control: a static *method* (no runtime field initializer) does not keep the
+/// storage inside — it still externalizes.
+#[test]
+fn static_method_still_externalizes_private_storage() {
+    let output = es5_cjs("export class C {\n  #y = 2;\n  static m() {}\n}\n");
+    assert_eq!(output.matches("var _C_y;").count(), 1, "output:\n{output}");
+    let init_pos = output
+        .find("_C_y = new WeakMap();")
+        .expect("private WeakMap instantiation");
+    let return_pos = output.find("return C;").expect("class IIFE return");
+    assert!(
+        return_pos < init_pos,
+        "a static method carries no runtime field initializer, so the storage \
+         must still externalize.\noutput:\n{output}"
+    );
+}
+
+/// Control: a declare-only static field (no initializer) still externalizes.
+#[test]
+fn declare_only_static_field_still_externalizes() {
+    let output = es5_cjs("export class C {\n  #y = 2;\n  static s: number;\n}\n");
+    let init_pos = output
+        .find("_C_y = new WeakMap();")
+        .expect("private WeakMap instantiation");
+    let return_pos = output.find("return C;").expect("class IIFE return");
+    assert!(
+        return_pos < init_pos,
+        "a declare-only static field has no runtime initializer, so the storage \
+         must still externalize.\noutput:\n{output}"
+    );
+}


### PR DESCRIPTION
At `--target es5 --module commonjs`, an exported class with a private instance
field emitted a **spurious module-scope `var _C_x;`** in addition to the correct
inside-IIFE declaration, whenever the class also declared a static property with
a runtime initializer (e.g. `static s = 3`). The temp was declared twice, once
at module scope and once inside the class IIFE.

### Repro (`--target es5 --module commonjs --strict`)

```ts
export class C { #y = 2; static s = 3; }
```

- **tsc 6.0.2** — the private WeakMap stays inside the class IIFE, co-located
  with the `C.s = 3` static assignment; nothing is externalized:
  ```js
  var C = /** @class */ (function () {
      function C() { _C_y.set(this, 2); }
      var _C_y;
      _C_y = new WeakMap();
      C.s = 3;
      return C;
  }());
  ```
- **tsz before this fix** — additionally emits `var _C_y;` at module scope:
  ```js
  "use strict";
  var _C_y;                 // spurious duplicate
  Object.defineProperty(exports, "__esModule", { value: true });
  ...
  ```

## Goal
Goal: hold

<!-- structural rule -->
**Structural rule:** When an ES5 CommonJS-exported class declares a `static`
property with a runtime initializer (`static s = 3`), `tsc` keeps the class's
private-field `WeakMap` storage **inside** the class-wrapping IIFE — the `var`
declaration and `= new WeakMap()` instantiation sit next to the `C.s = ...`
static assignments — and externalizes nothing. tsz's `ClassES5Emitter` already
kept the storage inside the IIFE for this shape, but
`es5_class_externally_hoisted_decls` (owner: emitter — ES5 class declaration
lowering, `crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs`)
independently decided to externalize it and pushed the name into
`hoisted_assignment_temps`, so the two decisions disagreed and the temp was
declared twice.

**Fix:** Suppress the CommonJS-export externalization of private storage when the
class has an ES5 static field initializer, so the outer decision matches the
emitter's inside-IIFE placement. A static field initializer is detected by a new
structural predicate `class_has_es5_static_field_initializer` (static,
non-abstract, non-ambient property declaration with a runtime initializer). No
identifier / file-name / rendered-output predicates — the decision is purely the
structural member shape.

**Adjacent cases (verified byte-identical to tsc 6.0.2):** static field keeps
storage inside (`static s = 3`, `static readonly s: number = 3`); multiple
private fields; public + private fields with a static field. Cases that still
externalize (no runtime static field initializer): static method, static
getter, static block, declare-only static field (`static s: number;`), private
field with no static member, private method + no static field. Non-exported and
non-es5 / non-commonjs shapes are untouched (the predicate is gated behind the
existing `target_es5` early-return and the `is_commonjs()` / exported-class
guards).

## Verification
- New regression suite `crates/tsz-emitter/tests/es5_cjs_private_storage_static_field_tests.rs`
  (6 tests: static-field-keeps-inside, multiple privates, public+private, plus
  externalization controls for no-static-field, static method, declare-only
  static field) — all pass.
- End-to-end `tsz` vs `tsc 6.0.2` (`--target es5 --module commonjs`) on the
  array/object/static matrix — byte-identical for the fixed shapes; a broad
  differential sweep across es5/es2015/es2017 × commonjs/esnext/amd shows the
  fix introduces no new divergences (the remaining pre-existing divergences are
  in non-es5 / non-commonjs paths this change does not touch).
- `cargo test -p tsz-emitter --lib` (3929 passed) plus the class / private-field
  / static-field / cjs-export / hoisting emit test targets — all green.
- `cargo fmt --all -- --check`, `cargo clippy -p tsz-emitter --lib -- -D warnings`,
  `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean.
- ready-review CI owns the broad conformance / emit / fourslash baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQqo7M8cLTQ3w2cu1y13cP)_