### PR TITLE
refactor(checker): route symbol refs through identity boundary (#14351)

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -1389,7 +1389,9 @@ impl CheckerContext<'_> {
         if let crate::query_boundaries::common::TypeQueryKind::TypeQuery(sym_ref) =
             crate::query_boundaries::common::classify_type_query(self.types, type_id)
         {
-            return Some(SymbolId(sym_ref.0));
+            return Some(
+                crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(sym_ref),
+            );
         }
 
         // 1. Try to get DefId from Lazy type - Phase 4.2+

--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -734,7 +734,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
     /// `TypeData::Ref` is removed, but we keep this for compatibility.
     /// Converts `SymbolRef` to `SymbolId` and looks up in cache.
     fn resolve_ref(&self, symbol: SymbolRef, _interner: &dyn TypeDatabase) -> Option<TypeId> {
-        let sym_id = tsz_binder::SymbolId(symbol.0);
+        let sym_id = crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(symbol);
         self.symbol_types.get(&sym_id)
     }
 
@@ -772,7 +772,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
         // value (kysely #10663 `typeof` family; the residual inverse of the
         // #10661 instance-resolution fix). So consult the constructor body
         // directly for a class symbol before trusting `resolve_ref`.
-        let sym_id = tsz_binder::SymbolId(symbol.0);
+        let sym_id = crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(symbol);
         if let Some(def_id) = self.get_existing_def_id(sym_id)
             && matches!(self.definition_store.get_kind(def_id), Some(DefKind::Class))
             && let Some(ctor_def_id) = self.definition_store.get_constructor_def(def_id)
@@ -1499,10 +1499,8 @@ impl<'a> TypeResolver for CheckerContext<'a> {
     ///
     /// Returns None if the `SymbolRef` doesn't have a corresponding `DefId`.
     fn symbol_to_def_id(&self, symbol: SymbolRef) -> Option<DefId> {
-        use tsz_binder::SymbolId;
-
-        // Convert SymbolRef to SymbolId
-        let sym_id = SymbolId(symbol.0);
+        // Convert through the checker-owned identity bridge.
+        let sym_id = crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(symbol);
 
         // Look up via get_existing_def_id (checks local cache + authoritative index)
         self.get_existing_def_id(sym_id)

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_source_preservation.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_source_preservation.rs
@@ -67,7 +67,8 @@ impl<'a> CheckerState<'a> {
         let evaluated = if let Some(symbol_ref) =
             crate::query_boundaries::common::type_query_symbol(self.ctx.types, display_type)
         {
-            let sym_id = tsz_binder::SymbolId(symbol_ref.0);
+            let sym_id =
+                crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(symbol_ref);
             let value_decl = self
                 .ctx
                 .binder

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
@@ -252,7 +252,7 @@ impl<'a> CheckerState<'a> {
 
     fn static_schema_type_query_value_type(&mut self, type_id: TypeId) -> Option<TypeId> {
         let sym_ref = diagnostic_query::get_type_query_symbol_ref(self.ctx.types, type_id)?;
-        let sym_id = tsz_binder::SymbolId(sym_ref.0);
+        let sym_id = crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(sym_ref);
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
         let value_decl = symbol.value_declaration.into_option().or_else(|| {
             symbol.declarations.iter().copied().find(|decl| {

--- a/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
+++ b/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
@@ -1108,7 +1108,7 @@ impl<'a> CheckerState<'a> {
     /// Returns `Some("M")` for `namespace M {}` types, enabling `typeof M` display.
     pub(super) fn get_namespace_typeof_name(&self, type_id: TypeId) -> Option<String> {
         use crate::query_boundaries::common::{NamespaceMemberKind, classify_namespace_member};
-        use tsz_binder::{SymbolId, symbol_flags};
+        use tsz_binder::symbol_flags;
 
         const fn is_pure_namespace(symbol: &tsz_binder::Symbol) -> bool {
             symbol.has_any_flags(symbol_flags::MODULE)
@@ -1119,7 +1119,9 @@ impl<'a> CheckerState<'a> {
         let kind = classify_namespace_member(self.ctx.types, type_id);
         let sym_id = match kind {
             NamespaceMemberKind::Lazy(def_id) => self.ctx.def_to_symbol_id(def_id)?,
-            NamespaceMemberKind::TypeQuery(sym_ref) => SymbolId(sym_ref.0),
+            NamespaceMemberKind::TypeQuery(sym_ref) => {
+                crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(sym_ref)
+            }
             NamespaceMemberKind::Callable(shape_id) => {
                 // Callable with namespace flags (class+namespace merges etc.)
                 let shape = self.ctx.types.callable_shape(shape_id);

--- a/crates/tsz-checker/src/error_reporter/suggestions.rs
+++ b/crates/tsz-checker/src/error_reporter/suggestions.rs
@@ -266,7 +266,9 @@ impl<'a> CheckerState<'a> {
 
         match classify_namespace_member(self.ctx.types, type_id) {
             NamespaceMemberKind::Lazy(def_id) => self.ctx.def_to_symbol_id(def_id),
-            NamespaceMemberKind::TypeQuery(sym_ref) => Some(tsz_binder::SymbolId(sym_ref.0)),
+            NamespaceMemberKind::TypeQuery(sym_ref) => {
+                Some(crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(sym_ref))
+            }
             NamespaceMemberKind::Callable(shape_id) => {
                 let shape = self.ctx.types.callable_shape(shape_id);
                 shape.symbol

--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -974,7 +974,9 @@ impl<'a> FlowAnalyzer<'a> {
         }
 
         let ctx = self.checker_context?;
-        let def_id = ctx.get_or_create_def_id(tsz_binder::SymbolId(symbol_ref.0));
+        let def_id = ctx.get_or_create_def_id(
+            crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(symbol_ref),
+        );
         if def_id.is_valid() {
             Some(self.interner.lazy(def_id))
         } else {

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
@@ -30,7 +30,8 @@ impl<'a> CheckerState<'a> {
         let type_queries = self.ctx.collect_type_queries_cached(type_id);
         let mut replacements = Vec::new();
         for symbol_ref in type_queries.iter().copied() {
-            let sym_id = tsz_binder::SymbolId(symbol_ref.0);
+            let sym_id =
+                crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(symbol_ref);
             let value_type = self.get_type_of_symbol(sym_id);
             if value_type != TypeId::ANY
                 && value_type != TypeId::ERROR

--- a/crates/tsz-checker/src/state/type_analysis/core_typeof_value.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_typeof_value.rs
@@ -127,7 +127,8 @@ impl CheckerState<'_> {
         {
             return;
         }
-        let sym_id = SymbolId(symbol_ref.0);
+        let sym_id =
+            crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(symbol_ref);
         if let Some(value_type) = self.merged_interface_value_typeof_type(sym_id) {
             self.register_typeof_value_type_in_envs(sym_id, value_type);
         }

--- a/crates/tsz-checker/src/state/type_resolution/constructors.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors.rs
@@ -734,8 +734,8 @@ impl<'a> CheckerState<'a> {
             }
             query::ConstructorTypeKind::TypeQuery(sym_ref) => {
                 // typeof X - get the type of the symbol X and collect constructors from it
-                use tsz_binder::SymbolId;
-                let sym_id = SymbolId(sym_ref.0);
+                let sym_id =
+                    crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(sym_ref);
                 let sym_type = self.get_type_of_symbol(sym_id);
                 self.collect_constructor_types_from_type_inner(sym_type, ctor_types, visited);
             }

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
@@ -232,7 +232,8 @@ impl<'a> CheckerState<'a> {
                     return;
                 };
 
-                let sym_id = SymbolId(sym_ref.0);
+                let sym_id =
+                    crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(sym_ref);
                 if self.unique_symbol_type_is_inaccessible(sym_id) {
                     result = Some(sym_id);
                 }

--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_06.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_06.rs
@@ -6,12 +6,10 @@ use super::*;
 /// Guard: solver `SymbolRef` to binder `SymbolId` reinterpretation should stay
 /// behind `query_boundaries::definition_identity::symbol_ref_to_symbol_id`.
 ///
-/// Existing legacy callsites are a migration budget, not a pattern for new
-/// code. Lower this budget whenever a PR moves another callsite behind the
-/// bridge.
+/// Raw casts are no longer allowed outside the bridge.
 #[test]
 fn test_symbol_ref_to_symbol_id_cast_budget() {
-    const RAW_SYMBOL_REF_CAST_BUDGET: usize = 21;
+    const RAW_SYMBOL_REF_CAST_BUDGET: usize = 0;
     const BRIDGE_PATH: &str = "src/query_boundaries/definition_identity.rs";
 
     fn is_raw_symbol_ref_cast(line: &str) -> bool {
@@ -46,8 +44,9 @@ fn test_symbol_ref_to_symbol_id_cast_budget() {
         }
     }
 
-    assert!(
-        hits.len() <= RAW_SYMBOL_REF_CAST_BUDGET,
+    assert_eq!(
+        hits.len(),
+        RAW_SYMBOL_REF_CAST_BUDGET,
         "raw SymbolRef -> SymbolId casts must go through \
          query_boundaries::definition_identity::symbol_ref_to_symbol_id; \
          found {} casts, budget {}:\n{}",

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1337,7 +1337,8 @@ impl<'a> CheckerState<'a> {
             // are stored as "[Symbol.xxx]" in class/interface types, not "__unique_N".
             // When the __unique_N lookup fails, try the [Symbol.xxx] format.
             if result_type.is_none() {
-                let sym_id = tsz_binder::SymbolId(sym_ref.0);
+                let sym_id =
+                    crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(sym_ref);
                 if let Some(symbol) = self.ctx.binder.get_symbol(sym_id) {
                     let sym_name = &symbol.escaped_name;
                     // Check if the parent is the Symbol global constructor

--- a/crates/tsz-checker/src/types/computation/call_inference.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference.rs
@@ -209,7 +209,7 @@ impl<'a> CheckerState<'a> {
                         self.ctx
                             .binder
                             .symbols
-                            .get(tsz_binder::SymbolId(symbol.0))
+                            .get(crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(symbol))
                             .and_then(|symbol| replacements.get(symbol.escaped_name.as_str()))
                             .copied()
                     },

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1129,8 +1129,6 @@ impl<'a> CheckerState<'a> {
                         inferred_new_type_args = Some(type_args);
                     }
                     if let Some(contextual) = contextual_type {
-                        use tsz_binder::SymbolId;
-
                         // When the contextual type is a union containing a Promise member
                         // (e.g., from async function return context), use the Promise
                         // member for application-matching against the constructor return type.
@@ -1155,7 +1153,7 @@ impl<'a> CheckerState<'a> {
                                             |sym_ref| {
                                                 self.ctx
                                                     .binder
-                                                    .get_symbol(SymbolId(sym_ref.0))
+                                                    .get_symbol(crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(sym_ref))
                                                     .map(|symbol| symbol.escaped_name.as_str())
                                             },
                                         )

--- a/crates/tsz-checker/src/types/computation/complex_constructors.rs
+++ b/crates/tsz-checker/src/types/computation/complex_constructors.rs
@@ -1462,7 +1462,6 @@ impl<'a> CheckerState<'a> {
         type_id: TypeId,
         visited: &mut rustc_hash::FxHashSet<TypeId>,
     ) -> bool {
-        use tsz_binder::SymbolId;
         use tsz_binder::symbol_flags;
 
         if !visited.insert(type_id) {
@@ -1481,8 +1480,9 @@ impl<'a> CheckerState<'a> {
 
         match query::classify_for_abstract_check(self.ctx.types, type_id) {
             query::AbstractClassCheckKind::TypeQuery(sym_ref) => {
-                if let Some(symbol) = self.ctx.binder.get_symbol(SymbolId(sym_ref.0))
-                    && symbol.has_any_flags(symbol_flags::ABSTRACT)
+                if let Some(symbol) = self.ctx.binder.get_symbol(
+                    crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(sym_ref),
+                ) && symbol.has_any_flags(symbol_flags::ABSTRACT)
                 {
                     return true;
                 }

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -1622,7 +1622,10 @@ impl<'a> CheckerState<'a> {
                 if let TypeQueryKind::TypeQuery(sym_ref) =
                     classify_type_query(self.ctx.types, object_type)
                 {
-                    let sym_id = tsz_binder::SymbolId(sym_ref.0);
+                    let sym_id =
+                        crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(
+                            sym_ref,
+                        );
                     self.get_cross_file_symbol(sym_id)
                         .filter(|s| !s.escaped_name.is_empty())
                         .map(|s| s.escaped_name.clone())

--- a/crates/tsz-checker/src/types/queries/core_names.rs
+++ b/crates/tsz-checker/src/types/queries/core_names.rs
@@ -220,7 +220,10 @@ impl<'a> CheckerState<'a> {
                 if let Some(sym_ref) =
                     crate::query_boundaries::common::unique_symbol_ref(self.ctx.types, candidate)
                 {
-                    let sym_id = tsz_binder::SymbolId(sym_ref.0);
+                    let sym_id =
+                        crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(
+                            sym_ref,
+                        );
                     if let Some(symbol) = self.ctx.binder.get_symbol(sym_id) {
                         let sym_name = symbol.escaped_name.clone();
                         if symbol.parent.is_some()

--- a/crates/tsz-checker/src/types/type_checking/declarations.rs
+++ b/crates/tsz-checker/src/types/type_checking/declarations.rs
@@ -663,7 +663,8 @@ impl<'a> CheckerState<'a> {
         if let Some(sym_ref) =
             crate::query_boundaries::common::type_query_symbol(self.ctx.types, type_id)
         {
-            let sym_id = tsz_binder::SymbolId(sym_ref.0);
+            let sym_id =
+                crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(sym_ref);
             let resolved = self.get_type_of_symbol(sym_id);
             if resolved != type_id {
                 return self.is_global_function_type(resolved);
@@ -908,8 +909,10 @@ impl<'a> CheckerState<'a> {
             //     class B extends ctor {}  // ctor: T where T extends typeof A
             //   }
             query::ConstructorCheckKind::TypeQuery(symbol_ref) => {
-                use tsz_binder::SymbolId;
-                let symbol_id = SymbolId(symbol_ref.0);
+                let symbol_id =
+                    crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(
+                        symbol_ref,
+                    );
                 if let Some(symbol) = self.ctx.binder.get_symbol(symbol_id) {
                     // Classes have constructor types
                     if (symbol.flags & tsz_binder::symbol_flags::CLASS) != 0 {


### PR DESCRIPTION
Goal: green

## Summary
- Route the remaining production checker `SymbolRef -> SymbolId` reinterpretations through `query_boundaries::definition_identity::symbol_ref_to_symbol_id`.
- Ratchet the architecture-contract budget for raw checker `SymbolRef` casts from 21 to 0.
- Preserve behavior while centralizing the one allowed solver-symbol-to-binder-symbol bridge for future identity work.

## Structural Rule
When a solver `SymbolRef` explicitly denotes a binder symbol, tsz may reinterpret the ordinal only through the checker-owned identity boundary; `DefId`-based meanings must resolve through `DefinitionStore` / `def_to_symbol_id`, not ad hoc raw casts.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(test_symbol_ref_to_symbol_id_cast_budget) or test(test_checker_raw_symbol_reference_construction_budget)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(symbol_ref_to_symbol_id_cast_budget) or test(checker_raw_symbol_reference_construction_budget) or test(unique_symbol_annotation_key_resolves_member_read) or test(well_known_symbol_in_guard_narrows_user_interfaces) or test(type_query_value_type)'`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo clippy -p tsz-checker --lib --tests -- -D warnings`
- Caveat checked: a broader `test(unique_symbol) or test(symbol_resolution) or test(lib_resolution_identity)` smoke hit `tuple_to_object_preserves_unique_symbol_keys_from_tuple_index_access` with missing `PropertyKey`/`Symbol`; the exact same failure reproduces on clean `origin/main`, so it is not caused by this branch.

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high