### PR TITLE
fix(checker): keep heritage lib fast paths checker-local (#14351)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib.rs
@@ -152,7 +152,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let name = symbol.escaped_name;
-        if self.lib_name_requires_checker_local_resolution(&name) {
+        if self.lib_name_requires_parallel_local_resolution(&name) {
             return None;
         }
 
@@ -205,7 +205,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let name = symbol.escaped_name.clone();
-        if self.lib_name_requires_checker_local_resolution(&name) {
+        if self.lib_name_requires_parallel_local_resolution(&name) {
             return None;
         }
         // DOM value/interface pairs used in type position can stay as lazy lib
@@ -233,6 +233,10 @@ impl<'a> CheckerState<'a> {
         self.ctx
             .lib_delegation_cache
             .insert_symbol_type(sym_id, (lazy_type, params.clone()));
+        // Shared publication stays gated for heritage-bearing names inside
+        // `cache_shared_actual_lib_delegation`; sequential local Lazy refs
+        // preserve type-display and member-laziness parity for safe DOM
+        // interfaces.
         self.cache_shared_actual_lib_delegation(&name, lazy_type);
         Some((lazy_type, params))
     }

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib.rs
@@ -152,7 +152,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let name = symbol.escaped_name;
-        if self.lib_name_locally_augmented(&name) {
+        if self.lib_name_requires_checker_local_resolution(&name) {
             return None;
         }
 
@@ -205,7 +205,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let name = symbol.escaped_name.clone();
-        if self.lib_name_locally_augmented(&name) {
+        if self.lib_name_requires_checker_local_resolution(&name) {
             return None;
         }
         // DOM value/interface pairs used in type position can stay as lazy lib

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
@@ -560,24 +560,27 @@ fn direct_value_merged_builtin_dom_interface_symbol_type_returns_type_position_l
         .get(&html_div_sym_id)
         .map(std::convert::AsRef::as_ref)
         .expect("HTMLDivElement should have a delegate arena");
-    let (html_div, html_div_params) = state
-        .direct_value_merged_builtin_lib_interface_symbol_type(
-            html_div_sym_id,
-            CrossArenaSymbolMissSource::SymbolArena,
-            Some(html_div_arena),
-            false,
-        )
-        .expect("value-merged DOM interfaces whose declared methods return void should stay lazy");
-    assert!(html_div_params.is_empty());
     assert!(
-        crate::query_boundaries::common::lazy_def_id(state.ctx.types, html_div).is_some(),
-        "HTMLDivElement should return a type-position Lazy ref",
+        state
+            .direct_value_merged_builtin_lib_interface_symbol_type(
+                html_div_sym_id,
+                CrossArenaSymbolMissSource::SymbolArena,
+                Some(html_div_arena),
+                false,
+            )
+            .is_none(),
+        "heritage-bearing value/interface DOM types stay on the child/interface path",
     );
     let inner_html = state
         .resolve_simple_lib_interface_own_property("HTMLDivElement", "innerHTML")
         .expect("single-member DOM resolver should walk non-generic inherited properties");
     assert_ne!(inner_html, TypeId::ERROR);
     assert_ne!(inner_html, TypeId::UNKNOWN);
+    let append_child = state
+        .resolve_simple_lib_interface_own_property("HTMLDivElement", "appendChild")
+        .expect("single-member DOM resolver should walk inherited methods");
+    assert_ne!(append_child, TypeId::ERROR);
+    assert_ne!(append_child, TypeId::UNKNOWN);
 
     let document_sym_id = state
         .ctx
@@ -601,7 +604,7 @@ fn direct_value_merged_builtin_dom_interface_symbol_type_returns_type_position_l
                 false,
             )
             .is_none(),
-        "value-merged DOM interfaces with non-void method returns should stay on the existing child/interface path",
+        "value-merged DOM interfaces with heritage stay on the existing child/interface path",
     );
     let query_selector = state
         .resolve_simple_lib_interface_own_property("Document", "querySelector")

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
@@ -560,16 +560,18 @@ fn direct_value_merged_builtin_dom_interface_symbol_type_returns_type_position_l
         .get(&html_div_sym_id)
         .map(std::convert::AsRef::as_ref)
         .expect("HTMLDivElement should have a delegate arena");
+    let (html_div, html_div_params) = state
+        .direct_value_merged_builtin_lib_interface_symbol_type(
+            html_div_sym_id,
+            CrossArenaSymbolMissSource::SymbolArena,
+            Some(html_div_arena),
+            false,
+        )
+        .expect("lazy-safe value/interface DOM types may still use local Lazy identities");
+    assert!(html_div_params.is_empty());
     assert!(
-        state
-            .direct_value_merged_builtin_lib_interface_symbol_type(
-                html_div_sym_id,
-                CrossArenaSymbolMissSource::SymbolArena,
-                Some(html_div_arena),
-                false,
-            )
-            .is_none(),
-        "heritage-bearing value/interface DOM types stay on the child/interface path",
+        crate::query_boundaries::common::lazy_def_id(state.ctx.types, html_div).is_some(),
+        "HTMLDivElement should return a local type-position Lazy ref",
     );
     let inner_html = state
         .resolve_simple_lib_interface_own_property("HTMLDivElement", "innerHTML")

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_shared_cache.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_shared_cache.rs
@@ -44,7 +44,7 @@ impl<'a> CheckerState<'a> {
                 self.get_cross_file_symbol(sym_id)
                     .filter(|s| s.has_any_flags(symbol_flags::CLASS))
                     .map(|s| s.escaped_name.clone())
-                    .filter(|n| !self.lib_name_locally_augmented(n))
+                    .filter(|n| !self.lib_name_requires_checker_local_resolution(n))
             })
             .flatten()
     }
@@ -62,7 +62,7 @@ impl<'a> CheckerState<'a> {
         }
         let symbol = self.get_cross_file_symbol(sym_id)?;
         let name = symbol.escaped_name.clone();
-        if self.lib_name_locally_augmented(&name) {
+        if self.lib_name_requires_checker_local_resolution(&name) {
             return None;
         }
         Some(name)
@@ -94,6 +94,9 @@ impl<'a> CheckerState<'a> {
     }
 
     pub(crate) fn cache_shared_actual_lib_delegation(&self, shared_name: &str, result: TypeId) {
+        if self.lib_name_requires_checker_local_resolution(shared_name) {
+            return;
+        }
         self.insert_to_shared_lib_cache(
             shared_actual_lib_delegation_cache_key(shared_name),
             result,
@@ -110,7 +113,8 @@ impl<'a> CheckerState<'a> {
         }
         let symbol = self.get_cross_file_symbol(sym_id)?;
         let name = symbol.escaped_name.clone();
-        if self.lib_name_locally_augmented(&name) || self.any_program_file_augments_lib_name(&name)
+        if self.lib_name_requires_checker_local_resolution(&name)
+            || self.any_program_file_augments_lib_name(&name)
         {
             return None;
         }
@@ -145,6 +149,9 @@ impl<'a> CheckerState<'a> {
         mode: u8,
         result: TypeId,
     ) {
+        if self.lib_name_requires_checker_local_resolution(shared_name) {
+            return;
+        }
         let Some(file_name) = decl_arena
             .source_files
             .first()
@@ -181,7 +188,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         let name = symbol.escaped_name.clone();
-        if self.lib_name_locally_augmented(&name) {
+        if self.lib_name_requires_checker_local_resolution(&name) {
             return None;
         }
         Some(name)
@@ -212,6 +219,9 @@ impl<'a> CheckerState<'a> {
         shared_name: &str,
         result: TypeId,
     ) {
+        if self.lib_name_requires_checker_local_resolution(shared_name) {
+            return;
+        }
         self.insert_to_shared_lib_cache(
             shared_actual_lib_class_delegation_cache_key(shared_name),
             result,

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -31,6 +31,21 @@ pub(super) fn lib_def_freeze_enabled() -> bool {
     *ON.get_or_init(|| std::env::var("TSZ_ENABLE_LIB_DEF_FREEZE").is_ok_and(|v| v == "1"))
 }
 
+fn lib_decl_has_heritage(decl_idx: NodeIndex, arena: &NodeArena) -> bool {
+    let Some(node) = arena.get(decl_idx) else {
+        return false;
+    };
+    arena
+        .get_interface(node)
+        .and_then(|iface| iface.heritage_clauses.as_ref())
+        .or_else(|| {
+            arena
+                .get_class(node)
+                .and_then(|class| class.heritage_clauses.as_ref())
+        })
+        .is_some_and(|heritage| !heritage.nodes.is_empty())
+}
+
 impl<'a> CheckerState<'a> {
     pub(crate) fn resolve_actual_lib_name_to_def_id_for_lowering(
         &self,
@@ -85,10 +100,12 @@ impl<'a> CheckerState<'a> {
         )
     }
 
-    /// True when callers must skip `shared_lib_type_cache` for `name`:
-    /// either this checker locally augments `name`, or `name` is multi-lib
-    /// merged where property-listing order in printed diagnostic messages
-    /// is sensitive to who resolves first (e.g. `Array<T>`).
+    /// True when callers must avoid checker-agnostic treatment for `name`.
+    ///
+    /// This includes names with local augmentations and selected multi-lib
+    /// builtins whose printed/order-sensitive shape depends on the resolving
+    /// checker. Heritage-bearing lib interfaces are handled by
+    /// [`Self::lib_name_requires_checker_local_resolution`].
     pub(crate) fn lib_name_locally_augmented(&self, name: &str) -> bool {
         // Array is merged across lib.es5/lib.es2015.iterable/etc.; cross-checker
         // shared TypeIds expose property-order races to the type printer
@@ -100,6 +117,42 @@ impl<'a> CheckerState<'a> {
             return true;
         }
         self.lib_name_has_local_augmentation(name)
+    }
+
+    /// True when a lib name must be resolved by the requesting checker rather
+    /// than through checker-agnostic direct/shared fast paths.
+    pub(crate) fn lib_name_requires_checker_local_resolution(&self, name: &str) -> bool {
+        self.lib_name_locally_augmented(name) || self.lib_name_declares_heritage(name)
+    }
+
+    fn lib_name_declares_heritage(&self, name: &str) -> bool {
+        for lib_ctx in self.ctx.lib_contexts.iter() {
+            let Some(sym_id) = lib_ctx.binder.file_locals.get(name) else {
+                continue;
+            };
+            let Some(symbol) = lib_ctx.binder.get_symbol(sym_id) else {
+                continue;
+            };
+            if !symbol.has_any_flags(symbol_flags::INTERFACE | symbol_flags::CLASS) {
+                continue;
+            }
+            let fallback_arena =
+                resolve_lib_context_fallback_arena(&lib_ctx.binder, sym_id, lib_ctx.arena.as_ref());
+            let decls_with_arenas = super::lib_resolution::collect_lib_decls_with_arenas(
+                &lib_ctx.binder,
+                sym_id,
+                &symbol.declarations,
+                fallback_arena,
+                None,
+            );
+            if decls_with_arenas
+                .iter()
+                .any(|(decl_idx, decl_arena)| lib_decl_has_heritage(*decl_idx, decl_arena))
+            {
+                return true;
+            }
+        }
+        false
     }
 
     /// Resolve a lib type by name and also return its type parameters.
@@ -124,10 +177,11 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // Short-circuit via shared cache; skip when this checker locally
-        // augments `name` (its merged TypeId would differ from peers').
-        let lib_name_locally_augmented = self.lib_name_locally_augmented(name);
-        if !lib_name_locally_augmented
+        // Short-circuit via shared cache only for names whose completed shape
+        // is independent of the checker that resolved them first.
+        let requires_checker_local_resolution =
+            self.lib_name_requires_checker_local_resolution(name);
+        if !requires_checker_local_resolution
             && let Some(ref shared) = self.ctx.shared_lib_type_cache
             && let Some(entry) = shared.get(name)
             && let Some(ty) = *entry
@@ -354,7 +408,9 @@ impl<'a> CheckerState<'a> {
         }
 
         // Mirror into shared cache when safe (no local augmentations).
-        if !lib_name_locally_augmented && let Some(ref shared) = self.ctx.shared_lib_type_cache {
+        if !requires_checker_local_resolution
+            && let Some(ref shared) = self.ctx.shared_lib_type_cache
+        {
             shared.insert(name.to_string(), lib_type_id);
         }
 

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -125,6 +125,17 @@ impl<'a> CheckerState<'a> {
         self.lib_name_locally_augmented(name) || self.lib_name_declares_heritage(name)
     }
 
+    /// True when the current checker may race sibling file checkers on a
+    /// heritage-bearing lib shape. Sequential shared-owner checkers can keep
+    /// local lazy identities for these names; the DOM/webworker forced-parallel
+    /// diagnosis lane must fall back to checker-local materialization.
+    pub(crate) fn lib_name_requires_parallel_local_resolution(&self, name: &str) -> bool {
+        self.lib_name_locally_augmented(name)
+            || (self.ctx.share_owner_symbol_type_results
+                && std::env::var_os("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK").is_some()
+                && self.lib_name_declares_heritage(name))
+    }
+
     fn lib_name_declares_heritage(&self, name: &str) -> bool {
         for lib_ctx in self.ctx.lib_contexts.iter() {
             let Some(sym_id) = lib_ctx.binder.file_locals.get(name) else {
@@ -138,6 +149,11 @@ impl<'a> CheckerState<'a> {
             }
             let fallback_arena =
                 resolve_lib_context_fallback_arena(&lib_ctx.binder, sym_id, lib_ctx.arena.as_ref());
+            if !crate::state_type_analysis::cross_file_direct::is_builtin_lib_declaration_arena(
+                fallback_arena,
+            ) {
+                continue;
+            }
             let decls_with_arenas = super::lib_resolution::collect_lib_decls_with_arenas(
                 &lib_ctx.binder,
                 sym_id,
@@ -145,10 +161,11 @@ impl<'a> CheckerState<'a> {
                 fallback_arena,
                 None,
             );
-            if decls_with_arenas
-                .iter()
-                .any(|(decl_idx, decl_arena)| lib_decl_has_heritage(*decl_idx, decl_arena))
-            {
+            if decls_with_arenas.iter().any(|(decl_idx, decl_arena)| {
+                crate::state_type_analysis::cross_file_direct::is_builtin_lib_declaration_arena(
+                    decl_arena,
+                ) && lib_decl_has_heritage(*decl_idx, decl_arena)
+            }) {
                 return true;
             }
         }
@@ -179,9 +196,9 @@ impl<'a> CheckerState<'a> {
 
         // Short-circuit via shared cache only for names whose completed shape
         // is independent of the checker that resolved them first.
-        let requires_checker_local_resolution =
-            self.lib_name_requires_checker_local_resolution(name);
-        if !requires_checker_local_resolution
+        let requires_parallel_local_resolution =
+            self.lib_name_requires_parallel_local_resolution(name);
+        if !requires_parallel_local_resolution
             && let Some(ref shared) = self.ctx.shared_lib_type_cache
             && let Some(entry) = shared.get(name)
             && let Some(ty) = *entry
@@ -408,7 +425,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Mirror into shared cache when safe (no local augmentations).
-        if !requires_checker_local_resolution
+        if !requires_parallel_local_resolution
             && let Some(ref shared) = self.ctx.shared_lib_type_cache
         {
             shared.insert(name.to_string(), lib_type_id);

--- a/crates/tsz-checker/src/types/queries/lib_namespace_direct.rs
+++ b/crates/tsz-checker/src/types/queries/lib_namespace_direct.rs
@@ -54,7 +54,7 @@ impl<'a> CheckerState<'a> {
             return *cached;
         }
 
-        if !self.lib_name_requires_checker_local_resolution(cache_name)
+        if !self.lib_name_requires_parallel_local_resolution(cache_name)
             && let Some(ref shared) = self.ctx.shared_lib_type_cache
             && let Some(entry) = shared.get(cache_name)
         {
@@ -222,7 +222,7 @@ impl<'a> CheckerState<'a> {
             .lib_type_resolution_caches
             .types
             .insert(cache_name.to_string(), Some(ty));
-        if !self.lib_name_requires_checker_local_resolution(cache_name)
+        if !self.lib_name_requires_parallel_local_resolution(cache_name)
             && let Some(ref shared) = self.ctx.shared_lib_type_cache
         {
             shared.insert(cache_name.to_string(), Some(ty));

--- a/crates/tsz-checker/src/types/queries/lib_namespace_direct.rs
+++ b/crates/tsz-checker/src/types/queries/lib_namespace_direct.rs
@@ -54,7 +54,7 @@ impl<'a> CheckerState<'a> {
             return *cached;
         }
 
-        if !self.lib_name_locally_augmented(cache_name)
+        if !self.lib_name_requires_checker_local_resolution(cache_name)
             && let Some(ref shared) = self.ctx.shared_lib_type_cache
             && let Some(entry) = shared.get(cache_name)
         {
@@ -222,7 +222,7 @@ impl<'a> CheckerState<'a> {
             .lib_type_resolution_caches
             .types
             .insert(cache_name.to_string(), Some(ty));
-        if !self.lib_name_locally_augmented(cache_name)
+        if !self.lib_name_requires_checker_local_resolution(cache_name)
             && let Some(ref shared) = self.ctx.shared_lib_type_cache
         {
             shared.insert(cache_name.to_string(), Some(ty));

--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -803,7 +803,7 @@ impl<'a> CheckerState<'a> {
             return *cached;
         }
         // Skip shared cache when this checker locally augments `name`.
-        if !self.lib_name_locally_augmented(name)
+        if !self.lib_name_requires_checker_local_resolution(name)
             && let Some(ref shared) = self.ctx.shared_lib_type_cache
             && let Some(entry) = shared.get(name)
         {
@@ -1431,7 +1431,7 @@ impl<'a> CheckerState<'a> {
             .lib_type_resolution_caches
             .types
             .insert(name.to_string(), lib_type_id);
-        if !self.lib_name_locally_augmented(name)
+        if !self.lib_name_requires_checker_local_resolution(name)
             && let Some(ref shared) = self.ctx.shared_lib_type_cache
         {
             shared.insert(name.to_string(), lib_type_id);

--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -802,8 +802,9 @@ impl<'a> CheckerState<'a> {
         {
             return *cached;
         }
-        // Skip shared cache when this checker locally augments `name`.
-        if !self.lib_name_requires_checker_local_resolution(name)
+        // Skip shared cache when this checker locally augments `name`, or when
+        // shared-owner parallel checking could observe a heritage-thin shape.
+        if !self.lib_name_requires_parallel_local_resolution(name)
             && let Some(ref shared) = self.ctx.shared_lib_type_cache
             && let Some(entry) = shared.get(name)
         {
@@ -1431,7 +1432,7 @@ impl<'a> CheckerState<'a> {
             .lib_type_resolution_caches
             .types
             .insert(name.to_string(), lib_type_id);
-        if !self.lib_name_requires_checker_local_resolution(name)
+        if !self.lib_name_requires_parallel_local_resolution(name)
             && let Some(ref shared) = self.ctx.shared_lib_type_cache
         {
             shared.insert(name.to_string(), lib_type_id);

--- a/crates/tsz-cli/tests/parallel_sequential_agreement_tests.rs
+++ b/crates/tsz-cli/tests/parallel_sequential_agreement_tests.rs
@@ -535,7 +535,7 @@ fn genuine_parallel_disposable_delegation_matches_sequential() {
     );
 }
 
-/// Forced-parallel witness for the still-open #13862 materialization campaign.
+/// Forced-parallel regression guard for the #13862 materialization campaign.
 ///
 /// `dom_element_heritage_clean_sequential` proves the *default* (DOM-gated
 /// sequential) schedule is correct. This test pins the *forced-parallel*
@@ -547,23 +547,13 @@ fn genuine_parallel_disposable_delegation_matches_sequential() {
 /// cluster of false `TS2345` ("`SVGGraphicsElement` is missing the following
 /// properties from type 'Node': ...").
 ///
-/// Confirmed contamination vectors (all on `main`, monotone publication
-/// default-on): the per-file `TypeEnvironment` rebuild, the program-shared
-/// `DefinitionStore` first-form/last-writer window before a def's first
-/// *finalized* publish, and the `shared_lib_type_cache`
-/// (`lib_resolution.rs` `resolve_lib_type_by_name`, which adopts a sibling's
-/// cached interface `TypeId` whenever `cached_lib_type_is_usable` passes —
-/// that check validates body-presence, not heritage-completeness). Priming the
-/// referenced lib-interface heritage closure in the sequential prime pass plus
-/// freeze/defer does **not** close it, because the divergence is driven by the
-/// per-worker env rebuild and the shared-cache adoption, not only the
-/// `DefinitionStore`. Lifting the gate requires the complete + deterministic
-/// materialization campaign tracked in #13862 / #13861.
-///
-/// `#[ignore]`d (repo known-bug-witness convention): un-ignoring it reproduces
-/// the open non-determinism deterministically across the attempt loop.
+/// This pins the checker-agnostic fast-path contamination vector: a worker must
+/// not use direct lazy identities or sibling-visible shared lib types for lib
+/// names whose declarations carry heritage, because the final inherited
+/// surface is still checker-relative until materialization is owned
+/// deterministically. The gate is structural over declarations, so binders and
+/// file names are irrelevant.
 #[test]
-#[ignore = "open bug #13862: forced-parallel DOM/SVG deep-heritage materialization is schedule-dependent"]
 fn forced_parallel_dom_heritage_matches_sequential_witness() {
     let Some(tsz_bin) = find_tsz_binary() else {
         println!("skipping #13862 forced-parallel DOM witness: tsz binary not found");


### PR DESCRIPTION
Goal: green

## Summary
- Add structural heritage detection for builtin lib declarations, with fallback/declaration arenas constrained to builtin lib arenas.
- Keep sibling-visible actual-lib delegation/value/class cache publication gated for heritage-bearing lib names.
- Narrow plain/direct lib fast-path gating so sequential checker-local lazy identities remain available, while the DOM/webworker forced-parallel gate-lift lane falls back before consuming heritage-thin direct/shared shapes.
- Keep the forced-parallel DOM heritage witness active so `HTMLDivElement`/`SVGGraphicsElement` inherited-member divergence stays covered.

## Structural Rule
When a builtin lib declaration carries `extends`/heritage, a sibling-visible checker-agnostic cache entry can expose an inherited surface before deterministic materialization in the forced-parallel DOM/webworker diagnosis lane. `tsz` now keeps that lane on checker-local materialization for heritage-bearing names, while preserving sequential checker-local lazy identities that `tsc` parity still needs for DOM declaration annotations and React/styled-components default-constraint behavior.

## Owner Layer
Checker lib-resolution/cache orchestration owns the gating decision. The solver remains the owner of type relation/evaluation semantics; this PR does not add solver shape inspection or diagnostic policy.

## Adjacent Matrix
- Non-heritage value/interface DOM lib names such as `ValidityState`: remain eligible for the existing lazy direct path.
- Sequential/local type-position DOM identities such as `HTMLDivElement`: remain eligible for local `Lazy(DefId)` refs so declaration annotation and diagnostic-display parity is preserved.
- Forced-parallel DOM schedule with heritage-bearing names: falls back before direct/shared fast-path adoption, matching sequential diagnostics for the #13862 witness.
- Always sibling-visible actual-lib delegation/value/class cache publication for heritage-bearing names: skipped structurally.
- Plain and namespace lib shared cache reads/writes: allowed in sequential/shared-owner mode, skipped only in the forced-parallel order-sensitive lane or for local augmentations.
- Existing local augmentation and selected multi-lib builtin exclusions: preserved.

## Overlap
- #15280 owns solver shared instantiation cache publication; no touched files overlap.
- #15282 owns checker `SymbolRef` identity-boundary raw-cast removal; no touched files overlap.
- This PR is a checker/lib-resolution safety slice in the #14351 cache/materialization lane, not the full #14344 canonical identity or #14345 SCC materialize-once implementation.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- line-count check for all touched files (all under 2000 physical lines)
- `./scripts/conformance/conformance.sh run --filter "styledComponentsInstantiaionLimitNotReached" --verbose`
- `./scripts/conformance/conformance.sh run --filter "declarationFileForHtml" --verbose`
- `./scripts/conformance/conformance.sh run --filter "intersectionsOfLargeUnions2" --verbose`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib direct_value_merged_builtin_dom_interface_symbol_type_returns_type_position_lazy_ref`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli forced_parallel_dom_heritage_matches_sequential_witness`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py --json`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
