### PR TITLE
test(solver): assert evaluator cache switch agreement (#14351)

### DIFF
--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -96,6 +96,10 @@ name = "parallel_sequential_agreement_tests"
 path = "tests/parallel_sequential_agreement_tests.rs"
 
 [[test]]
+name = "evaluator_cache_agreement_tests"
+path = "tests/evaluator_cache_agreement_tests.rs"
+
+[[test]]
 name = "delete_inherited_optional_heritage_tests"
 path = "tests/delete_inherited_optional_heritage_tests.rs"
 

--- a/crates/tsz-cli/tests/evaluator_cache_agreement_tests.rs
+++ b/crates/tsz-cli/tests/evaluator_cache_agreement_tests.rs
@@ -1,0 +1,194 @@
+//! Evaluator cache kill-switch agreement guards (#14351).
+//!
+//! The evaluator cache switches are process-latched with `OnceLock`, so an
+//! in-process `set_var` test can silently reuse the first configuration it
+//! observed. These tests drive the real CLI in fresh child processes and compare
+//! the default cache-on result with one disabled cache family at a time.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CLOSED_EVAL_SWITCH: &str = "TSZ_DISABLE_CLOSED_EVAL_CACHE";
+const CONDITIONAL_BRANCH_SWITCH: &str = "TSZ_DISABLE_CONDITIONAL_BRANCH_CACHE";
+const LIMIT_RESULT_SWITCH: &str = "TSZ_DISABLE_LIMIT_RESULT_CACHE";
+const ALL_CACHE_SWITCHES: &[&str] = &[
+    CLOSED_EVAL_SWITCH,
+    CONDITIONAL_BRANCH_SWITCH,
+    LIMIT_RESULT_SWITCH,
+];
+
+const VALIDATOR_KEYS_FILES: &[(&str, &str)] = &[(
+    "src/index.ts",
+    include_str!("fixtures/evaluator_cache_agreement/validator_keys/src/index.ts"),
+)];
+const VALIDATOR_KEYS_TSCONFIG: &str =
+    include_str!("fixtures/evaluator_cache_agreement/validator_keys/tsconfig.json");
+
+const BRANCH_FILTERS_FILES: &[(&str, &str)] = &[(
+    "src/index.ts",
+    include_str!("fixtures/evaluator_cache_agreement/branch_filters/src/index.ts"),
+)];
+const BRANCH_FILTERS_TSCONFIG: &str =
+    include_str!("fixtures/evaluator_cache_agreement/branch_filters/tsconfig.json");
+
+const RECURSIVE_ITERATION_FILES: &[(&str, &str)] = &[(
+    "src/index.ts",
+    include_str!("fixtures/evaluator_cache_agreement/recursive_iteration/src/index.ts"),
+)];
+const RECURSIVE_ITERATION_TSCONFIG: &str =
+    include_str!("fixtures/evaluator_cache_agreement/recursive_iteration/tsconfig.json");
+
+#[derive(Debug, PartialEq, Eq)]
+struct TszRun {
+    status_code: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_eval_cache_agreement_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+fn stage_project(name: &str, files: &[(&str, &str)], tsconfig: &str) -> TempDir {
+    let temp = TempDir::new(name).expect("temp dir");
+    for (rel, contents) in files {
+        let path = temp.path.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("fixture parent dir");
+        }
+        std::fs::write(path, contents).expect("write fixture file");
+    }
+    std::fs::write(temp.path.join("tsconfig.json"), tsconfig).expect("write tsconfig");
+    temp
+}
+
+fn run_tsz(tsz_bin: &Path, project_dir: &Path, disabled_switch: Option<&str>) -> TszRun {
+    let mut cmd = Command::new(tsz_bin);
+    cmd.args(["-p", "tsconfig.json", "--pretty", "false"])
+        .current_dir(project_dir)
+        .env_remove("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK")
+        .env_remove("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK_TINY");
+    for switch in ALL_CACHE_SWITCHES {
+        cmd.env_remove(switch);
+    }
+    if let Some(switch) = disabled_switch {
+        cmd.env(switch, "1");
+    }
+
+    let output = cmd.output().expect("run tsz on cache agreement fixture");
+    TszRun {
+        status_code: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+fn assert_clean_success(name: &str, run: &TszRun) {
+    assert_eq!(
+        run.status_code,
+        Some(0),
+        "{name} should compile cleanly; stdout:\n{}\nstderr:\n{}",
+        run.stdout,
+        run.stderr,
+    );
+    assert!(
+        !run.stdout.contains("error TS") && !run.stderr.contains("error TS"),
+        "{name} should not report TypeScript diagnostics; stdout:\n{}\nstderr:\n{}",
+        run.stdout,
+        run.stderr,
+    );
+}
+
+fn assert_cache_modes_agree(
+    name: &str,
+    files: &[(&str, &str)],
+    tsconfig: &str,
+    disabled_switches: &[&str],
+) {
+    let Some(tsz_bin) = find_tsz_binary() else {
+        println!("skipping evaluator cache agreement test: tsz binary not found");
+        return;
+    };
+    let temp = stage_project(name, files, tsconfig);
+    let baseline = run_tsz(&tsz_bin, &temp.path, None);
+    assert_clean_success(name, &baseline);
+
+    for switch in disabled_switches {
+        let disabled = run_tsz(&tsz_bin, &temp.path, Some(switch));
+        assert_clean_success(name, &disabled);
+        assert_eq!(disabled, baseline, "{name} output changed when {switch}=1");
+    }
+}
+
+#[test]
+fn validator_key_inference_agrees_with_closed_eval_and_branch_caches_disabled() {
+    // Structural rule: cache-enabled and cache-disabled runs must agree when
+    // `RequiredKeys`/`OptionalKeys` probe `Validator<infer T>` through mapped
+    // keys and indexed access; the caches may reduce repeated work, not change
+    // the inferred key set.
+    assert_cache_modes_agree(
+        "validator_keys",
+        VALIDATOR_KEYS_FILES,
+        VALIDATOR_KEYS_TSCONFIG,
+        &[CLOSED_EVAL_SWITCH, CONDITIONAL_BRANCH_SWITCH],
+    );
+}
+
+#[test]
+fn branch_filter_agrees_with_conditional_branch_cache_disabled() {
+    // Structural rule: a repeated conditional branch verdict for the same
+    // structural `(check, extends)` pair may be reused, but disabling that reuse
+    // must still select the same true/false branches.
+    assert_cache_modes_agree(
+        "branch_filters",
+        BRANCH_FILTERS_FILES,
+        BRANCH_FILTERS_TSCONFIG,
+        &[CONDITIONAL_BRANCH_SWITCH],
+    );
+}
+
+#[test]
+fn recursive_iteration_agrees_with_limit_result_cache_disabled() {
+    // Structural rule: limit-aware cache publication can keep clean
+    // intermediates from a recursive utility run, but disabling that cache
+    // family must not change the collapsed project result.
+    assert_cache_modes_agree(
+        "recursive_iteration",
+        RECURSIVE_ITERATION_FILES,
+        RECURSIVE_ITERATION_TSCONFIG,
+        &[LIMIT_RESULT_SWITCH],
+    );
+}

--- a/crates/tsz-cli/tests/fixtures/evaluator_cache_agreement/branch_filters/src/index.ts
+++ b/crates/tsz-cli/tests/fixtures/evaluator_cache_agreement/branch_filters/src/index.ts
@@ -1,0 +1,64 @@
+type Assert<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Extends<A, B> = [A] extends [never] ? false : A extends B ? true : false;
+type Contains<A, B> = Extends<A, B>;
+type Equals<A, B> = Equal<A, B>;
+type Mode = "default" | "contains" | "extends" | "equals";
+
+type Test<A, B, M extends Mode = "default"> = {
+  default: Extends<A, B>;
+  contains: Contains<A, B>;
+  extends: Extends<A, B>;
+  equals: Equals<A, B>;
+}[M];
+
+type Select<U, M, ModeName extends Mode = "default"> =
+  U extends unknown
+    ? { true: U & M; false: never }[`${Test<U, M, ModeName>}`]
+    : never;
+
+type Values<T> = T[keyof T];
+type Paths<T, P extends readonly PropertyKey[] = []> = {
+  [K in keyof T]:
+    | readonly [...P, K]
+    | (T[K] extends object ? Paths<T[K], readonly [...P, K]> : never);
+}[keyof T];
+
+type Resolve<T, P extends readonly PropertyKey[]> =
+  P extends readonly []
+    ? T
+    : P extends readonly [infer K, ...infer R]
+      ? K extends keyof T
+        ? Resolve<T[K], Extract<R, readonly PropertyKey[]>>
+        : never
+      : never;
+
+type LeafPath<T> = Select<Paths<T>, readonly ["alpha", ...PropertyKey[]], "extends">;
+
+type Model = {
+  alpha: {
+    first: string;
+    second: number;
+  };
+  beta: {
+    first: boolean;
+  };
+};
+
+type AlphaPaths = LeafPath<Model>;
+type AlphaValues = Resolve<Model, AlphaPaths>;
+type AllValues = Values<{ a: AlphaValues; b: Select<Values<Model>, { first: boolean }, "extends"> }>;
+
+type _paths = Assert<Equal<
+  AlphaPaths,
+  readonly ["alpha"] | readonly ["alpha", "first"] | readonly ["alpha", "second"]
+>>;
+type _values = Assert<Equal<
+  AllValues,
+  Model["alpha"] | string | number | { first: boolean }
+>>;
+
+export {};

--- a/crates/tsz-cli/tests/fixtures/evaluator_cache_agreement/branch_filters/tsconfig.json
+++ b/crates/tsz-cli/tests/fixtures/evaluator_cache_agreement/branch_filters/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "ES2022",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/crates/tsz-cli/tests/fixtures/evaluator_cache_agreement/recursive_iteration/src/index.ts
+++ b/crates/tsz-cli/tests/fixtures/evaluator_cache_agreement/recursive_iteration/src/index.ts
@@ -1,0 +1,62 @@
+type Assert<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Step = [
+  value: number,
+  sign: "-" | "0" | "+",
+  prev: keyof StepMap,
+  next: keyof StepMap,
+  opposite: keyof StepMap,
+];
+
+type StepMap = {
+  "__": [number, "-" | "0" | "+", "__", "__", "__"];
+  "-1": [-1, "-", "__", "0", "1"];
+  "0": [0, "0", "-1", "1", "0"];
+  "1": [1, "+", "0", "__", "-1"];
+};
+
+type StepOf<N extends number> =
+  `${N}` extends keyof StepMap ? StepMap[`${N}`] : StepMap["__"];
+type Prev<I extends Step> = StepMap[I[2]];
+type Next<I extends Step> = StepMap[I[3]];
+type Pos<I extends Step> = I[0];
+type IsNegative<I extends Step> = { "-": true; "+": false; "0": false }[I[1]];
+type IsPositive<I extends Step> = { "-": false; "+": true; "0": false }[I[1]];
+type Cast<A, B> = A extends B ? A : B;
+
+type SubPositive<A extends Step, B extends Step> = {
+  0: SubPositive<Prev<A>, Prev<B>>;
+  1: A;
+  2: StepMap["__"];
+}[Pos<B> extends 0 ? 1 : number extends Pos<B> ? 2 : 0] extends infer R
+  ? Cast<R, Step>
+  : never;
+
+type SubNegative<A extends Step, B extends Step> = {
+  0: SubNegative<Next<A>, Next<B>>;
+  1: A;
+  2: StepMap["__"];
+}[Pos<B> extends 0 ? 1 : number extends Pos<B> ? 2 : 0] extends infer R
+  ? Cast<R, Step>
+  : never;
+
+type Difference<A extends Step, B extends Step> = {
+  false: SubPositive<A, B>;
+  true: SubNegative<A, B>;
+}[`${IsNegative<B>}`];
+
+type Greater<A extends number, B extends number> =
+  A extends unknown
+    ? B extends unknown
+      ? IsPositive<Difference<StepOf<A>, StepOf<B>>>
+      : never
+    : never;
+
+type _greater = Assert<Equal<Greater<1, 0>, true>>;
+type _notGreater = Assert<Equal<Greater<0, 1>, false>>;
+type _distributed = Assert<Equal<Greater<1 | 0, 0>, boolean>>;
+
+export {};

--- a/crates/tsz-cli/tests/fixtures/evaluator_cache_agreement/recursive_iteration/tsconfig.json
+++ b/crates/tsz-cli/tests/fixtures/evaluator_cache_agreement/recursive_iteration/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "ES2022",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/crates/tsz-cli/tests/fixtures/evaluator_cache_agreement/validator_keys/src/index.ts
+++ b/crates/tsz-cli/tests/fixtures/evaluator_cache_agreement/validator_keys/src/index.ts
@@ -1,0 +1,89 @@
+export const nominalTypeHack: unique symbol = Symbol();
+
+type IsOptional<T> =
+  undefined | null extends T ? true :
+  undefined extends T ? true :
+  null extends T ? true :
+  false;
+
+type RequiredKeys<V> = {
+  [K in keyof V]-?:
+    Exclude<V[K], undefined> extends Validator<infer T>
+      ? IsOptional<T> extends true ? never : K
+      : never;
+}[keyof V];
+
+type OptionalKeys<V> = Exclude<keyof V, RequiredKeys<V>>;
+type InferPropsInner<V> = { [K in keyof V]-?: InferType<V[K]> };
+
+interface Validator<T> {
+  (props: object, propName: string): Error | null;
+  [nominalTypeHack]?: T;
+}
+
+interface Requireable<T> extends Validator<T> {
+  isRequired: Validator<NonNullable<T>>;
+}
+
+type ValidationMap<T> = { [K in keyof T]?: Validator<T[K]> };
+type InferType<V> = V extends Validator<infer T> ? T : any;
+type InferProps<V> =
+  & InferPropsInner<Pick<V, RequiredKeys<V>>>
+  & Partial<InferPropsInner<Pick<V, OptionalKeys<V>>>>;
+
+declare const PropTypes: {
+  any: Requireable<any>;
+  array: Requireable<any[]>;
+  bool: Requireable<boolean>;
+  string: Requireable<string>;
+  number: Requireable<number>;
+  shape<P extends ValidationMap<any>>(type: P): Requireable<InferProps<P>>;
+  oneOfType<T extends Validator<any>>(types: T[]): Requireable<NonNullable<InferType<T>>>;
+};
+
+interface Props {
+  any?: any;
+  array: string[];
+  bool: boolean;
+  shape: { foo: string; bar?: boolean; baz?: any };
+  oneOfType: string | boolean | { foo?: string; bar: number };
+}
+
+type PropTypesMap = ValidationMap<Props>;
+
+const innerProps = {
+  foo: PropTypes.string.isRequired,
+  bar: PropTypes.bool,
+  baz: PropTypes.any,
+};
+
+const arrayOfTypes = [
+  PropTypes.string,
+  PropTypes.bool,
+  PropTypes.shape({
+    foo: PropTypes.string,
+    bar: PropTypes.number.isRequired,
+  }),
+];
+
+const propTypes: PropTypesMap = {
+  any: PropTypes.any,
+  array: PropTypes.array.isRequired,
+  bool: PropTypes.bool.isRequired,
+  shape: PropTypes.shape(innerProps).isRequired,
+  oneOfType: PropTypes.oneOfType(arrayOfTypes).isRequired,
+};
+
+const propTypesWithoutAnnotation = {
+  any: PropTypes.any,
+  array: PropTypes.array.isRequired,
+  bool: PropTypes.bool.isRequired,
+  shape: PropTypes.shape(innerProps).isRequired,
+  oneOfType: PropTypes.oneOfType(arrayOfTypes).isRequired,
+};
+
+type ExtractedProps = InferProps<typeof propTypes>;
+type ExtractedPropsWithoutAnnotation = InferProps<typeof propTypesWithoutAnnotation>;
+type ExtractPropsMatch =
+  ExtractedProps extends ExtractedPropsWithoutAnnotation ? true : false;
+const ok: true = null as any as ExtractPropsMatch;

--- a/crates/tsz-cli/tests/fixtures/evaluator_cache_agreement/validator_keys/tsconfig.json
+++ b/crates/tsz-cli/tests/fixtures/evaluator_cache_agreement/validator_keys/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "ES2022",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/crates/tsz-solver/Cargo.toml
+++ b/crates/tsz-solver/Cargo.toml
@@ -54,3 +54,7 @@ path = "tests/conditional_deferred_return_tests.rs"
 [[test]]
 name = "conditional_infer_tuple_numeric_key_tests"
 path = "tests/conditional_infer_tuple_numeric_key_tests.rs"
+
+[[test]]
+name = "evaluation_cache_agreement_tests"
+path = "tests/evaluation_cache_agreement_tests.rs"

--- a/crates/tsz-solver/tests/evaluation_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/evaluation_cache_agreement_tests.rs
@@ -1,0 +1,153 @@
+//! Subprocess cache-toggle agreement probes (#14351).
+//!
+//! The limit-result cache switch is latched through `OnceLock`, so this test
+//! spawns the integration-test binary as a child process for each mode. The
+//! child uses only public solver APIs and prints a stable summary line.
+
+use std::process::Command;
+
+use tsz_solver::construction::{QueryCache, RelationCacheProbe, TypeInterner};
+use tsz_solver::def::DefId;
+use tsz_solver::relations::relation_queries::{
+    RelationContext, RelationKind, RelationPolicy, query_relation_with_resolver,
+};
+use tsz_solver::{PropertyInfo, RelationCacheKey, TypeId};
+
+const CHILD_ENV: &str = "TSZ_LIMIT_RESULT_CACHE_PROBE_CHILD";
+const LIMIT_RESULT_SWITCH: &str = "TSZ_DISABLE_LIMIT_RESULT_CACHE";
+const SUMMARY_PREFIX: &str = "TSZ_LIMIT_RESULT_CACHE_PROBE ";
+
+fn run_child(disable_limit_result_cache: bool) -> String {
+    let current_exe = std::env::current_exe().expect("current test binary");
+    let mut cmd = Command::new(current_exe);
+    cmd.args([
+        "--ignored",
+        "--exact",
+        "limit_result_cache_probe_child",
+        "--nocapture",
+    ])
+    .env(CHILD_ENV, "1")
+    .env_remove(LIMIT_RESULT_SWITCH);
+    if disable_limit_result_cache {
+        cmd.env(LIMIT_RESULT_SWITCH, "1");
+    }
+
+    let output = cmd.output().expect("run limit-result cache probe child");
+    assert!(
+        output.status.success(),
+        "child probe failed; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find_map(|line| line.strip_prefix(SUMMARY_PREFIX).map(str::to_owned))
+        .unwrap_or_else(|| {
+            panic!(
+                "child probe did not print summary; stdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })
+}
+
+#[test]
+fn limit_result_cache_switch_changes_cache_evidence_not_semantics() {
+    let enabled = run_child(false);
+    let disabled = run_child(true);
+
+    assert!(
+        enabled.contains("outer=true:false;direct=true:false;"),
+        "enabled run should complete the recursive relation without a relation-depth bail: {enabled}",
+    );
+    assert!(
+        disabled.contains("outer=true:false;direct=true:false;"),
+        "disabled run should keep the same recursive relation result: {disabled}",
+    );
+    assert!(
+        enabled.contains("probe=hit_true;"),
+        "cache-enabled run should promote the cycle-derived maybe key: {enabled}",
+    );
+    assert!(
+        disabled.contains("probe=miss;"),
+        "cache-disabled run should leave the cycle-derived maybe key uncached: {disabled}",
+    );
+}
+
+#[test]
+#[ignore = "spawned by limit_result_cache_switch_changes_cache_evidence_not_semantics"]
+fn limit_result_cache_probe_child() {
+    if std::env::var_os(CHILD_ENV).is_none() {
+        return;
+    }
+    println!("{SUMMARY_PREFIX}{}", compute_limit_result_cache_probe());
+}
+
+fn compute_limit_result_cache_probe() -> String {
+    let interner = TypeInterner::new();
+    let s_def = DefId(1_435_101);
+    let t_def = DefId(1_435_102);
+    let lazy_s = interner.lazy(s_def);
+    let lazy_t = interner.lazy(t_def);
+    let arr_s = interner.array(lazy_s);
+    let arr_t = interner.array(lazy_t);
+    let next = interner.intern_string("next");
+    let tag = interner.intern_string("tag");
+    let body_s = interner.object(vec![
+        PropertyInfo::new(next, arr_s),
+        PropertyInfo::new(tag, TypeId::NUMBER),
+    ]);
+    let body_t = interner.object(vec![
+        PropertyInfo::new(next, arr_t),
+        PropertyInfo::new(tag, TypeId::NUMBER),
+    ]);
+
+    let mut env = tsz_solver::computation::TypeEnvironment::new();
+    env.insert_def(s_def, body_s);
+    env.insert_def(t_def, body_t);
+
+    let db = QueryCache::new(&interner);
+    let policy = RelationPolicy::default();
+    let context = RelationContext {
+        query_db: Some(&db),
+        ..Default::default()
+    };
+    let outer = query_relation_with_resolver(
+        &interner,
+        &env,
+        lazy_s,
+        lazy_t,
+        RelationKind::Subtype,
+        policy,
+        context,
+    );
+    let arr_key = RelationCacheKey::for_subtype(arr_s, arr_t, policy.cache_config());
+    let probe = match db.probe_subtype_cache(arr_key) {
+        RelationCacheProbe::Hit(true) => "hit_true",
+        RelationCacheProbe::Hit(false) => "hit_false",
+        RelationCacheProbe::MissNotCached => "miss",
+    };
+
+    db.reset_relation_cache_stats();
+    let direct = query_relation_with_resolver(
+        &interner,
+        &env,
+        arr_s,
+        arr_t,
+        RelationKind::Subtype,
+        policy,
+        context,
+    );
+    let stats = db.statistics().relation;
+
+    format!(
+        "outer={}:{};direct={}:{};probe={probe};hits={};misses={};entries={}",
+        outer.is_related(),
+        outer.depth_exceeded(),
+        direct.is_related(),
+        direct.depth_exceeded(),
+        stats.subtype_hits,
+        stats.subtype_misses,
+        stats.subtype_entries,
+    )
+}


### PR DESCRIPTION
Goal: green

## Summary
- add a `tsz-solver` subprocess probe for `TSZ_DISABLE_LIMIT_RESULT_CACHE` that proves the recursive lazy-pair relation result stays stable while cache evidence flips from promoted hit to miss
- add `tsz-cli` child-process agreement tests for the closed-eval, conditional-branch, and limit-result cache switches against strict/noEmit fixtures
- register the new focused integration targets in `tsz-solver` and `tsz-cli`

## Structural Rule
When evaluator cache family switches disable closed-eval, conditional-branch verdict, or limit-result publication, `tsc`-parity output must stay unchanged; tsz owns those cache effects in the solver/query cache boundary, so the switches may change hits, misses, and repeated work but not the collapsed relation or project result.

Adjacent cases covered: validator-key inference through `Validator<infer T>` and mapped/indexed keys, repeated conditional branch filters, recursive iteration utilities, and a recursive lazy relation pair that confirms the limit-result switch changes cache evidence without changing semantics.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test evaluation_cache_agreement_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli --test evaluator_cache_agreement_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(limit_relation_cache_tests::cycle_maybe_keys_promoted_to_true_on_outermost_success) or test(limit_relation_cache_tests::repeat_query_of_promoted_maybe_key_is_a_counted_cache_hit) or test(limit_relation_cache_tests::promoted_maybe_keys_are_visible_through_the_shared_cache) or test(limit_relation_cache_tests::evaluate_type_with_options_persists_clean_intermediates_of_limit_hit_runs)'`
- `cargo fmt --all -- --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/perf/cache-visibility-report.py --json`

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high
