### PR TITLE
fix(emit): emit ESM es5 class named re-export before deferred WeakMap init

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -648,6 +648,12 @@ pub struct Printer<'a> {
     /// declaration and before post-class lowered statements (static fields/blocks).
     pub(crate) pending_commonjs_class_export_name: Option<(NodeIndex, String, Vec<String>)>,
 
+    /// For ESM class exports of an ES5-lowered class, emit `export { X };`
+    /// immediately after the class IIFE and before any deferred private/accessor
+    /// `WeakMap` storage init — the same boundary the CommonJS
+    /// `exports.X = X;` assignment uses. Keyed by the class declaration node.
+    pub(crate) pending_esm_class_export_name: Option<(NodeIndex, String)>,
+
     /// Names of namespaces already declared with `var name;` to avoid duplicates.
     pub(crate) declared_namespace_names: FxHashSet<String>,
 

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -321,6 +321,7 @@ impl<'a> Printer<'a> {
             pending_system_namespace_export_fold: None,
             suppress_default_export_merge_iife: false,
             pending_commonjs_class_export_name: None,
+            pending_esm_class_export_name: None,
             declared_namespace_names: FxHashSet::default(),
             namespace_iife_param_counter: FxHashMap::default(),
             namespace_prior_exports: FxHashMap::default(),

--- a/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
@@ -1032,7 +1032,7 @@ impl<'a> Printer<'a> {
                 // uses — so it precedes any deferred private/accessor storage init,
                 // matching tsc. Stage it and let the ES5 class IIFE emitter place it;
                 // fall back to the trailing form if it was not consumed.
-                self.pending_esm_class_export_name = Some((export.export_clause, name.clone()));
+                self.pending_esm_class_export_name = Some((export.export_clause, name));
                 self.emit(export.export_clause);
                 if let Some((_, pending_name)) = self.pending_esm_class_export_name.take() {
                     if !self.writer.is_at_line_start() {

--- a/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
@@ -1018,16 +1018,30 @@ impl<'a> Printer<'a> {
             && let Some(class) = self.arena.get_class(clause_node)
             && let Some(name) = self.get_identifier_text_opt(class.name)
         {
-            self.emit(export.export_clause);
-            self.write_line();
             if export.is_default_export {
+                // `export default C;` is emitted AFTER the deferred storage init
+                // (tsc's deliberate exception), matching the trailing placement.
+                self.emit(export.export_clause);
+                self.write_line();
                 self.write("export default ");
                 self.write(&name);
                 self.write(";");
             } else {
-                self.write("export { ");
-                self.write(&name);
-                self.write(" };");
+                // A named `export { C };` is emitted at the class IIFE / WeakMap-init
+                // boundary — the same slot the CommonJS `exports.C = C;` assignment
+                // uses — so it precedes any deferred private/accessor storage init,
+                // matching tsc. Stage it and let the ES5 class IIFE emitter place it;
+                // fall back to the trailing form if it was not consumed.
+                self.pending_esm_class_export_name = Some((export.export_clause, name.clone()));
+                self.emit(export.export_clause);
+                if let Some((_, pending_name)) = self.pending_esm_class_export_name.take() {
+                    if !self.writer.is_at_line_start() {
+                        self.write_line();
+                    }
+                    self.write("export { ");
+                    self.write(&pending_name);
+                    self.write(" };");
+                }
             }
             return;
         }

--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests/esm_class_es5_export_order_tests.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests/esm_class_es5_export_order_tests.rs
@@ -1,0 +1,149 @@
+//! ESM re-export ordering for ES5-lowered `export class` declarations.
+//!
+//! At `--target es5` with an ESM module output, a top-level `export class`
+//! that lowers a private field or auto-accessor to `WeakMap` storage must emit
+//! the `export { C };` re-export immediately after the class IIFE and *before*
+//! the deferred storage instantiation (`_C_x = new WeakMap();`) — the same slot
+//! the CommonJS `exports.C = C;` assignment uses. `export default class` is the
+//! deliberate exception: `tsc` emits `export default C;` *after* the storage
+//! init.
+
+use crate::emitter::ModuleKind;
+use tsz_common::ScriptTarget;
+
+use super::emit_with_module_and_target;
+
+/// Index of the `export { <name> };` re-export in the output.
+fn named_export_pos(output: &str, name: &str) -> usize {
+    let needle = format!("export {{ {name} }};");
+    output
+        .find(&needle)
+        .unwrap_or_else(|| panic!("expected `{needle}` in output.\nOutput:\n{output}"))
+}
+
+/// Index of the deferred `<storage> = new WeakMap();` init in the output.
+fn weakmap_init_pos(output: &str) -> usize {
+    output
+        .find("= new WeakMap();")
+        .unwrap_or_else(|| panic!("expected a deferred WeakMap init in output.\nOutput:\n{output}"))
+}
+
+const ESM_MODULES: [ModuleKind; 3] = [ModuleKind::ES2015, ModuleKind::ES2020, ModuleKind::ESNext];
+
+#[test]
+fn named_export_of_private_field_class_precedes_weakmap_init() {
+    // Binder name varied from the issue's `P` to guard against name-hardcoding.
+    let source = "export class Widget { #x = 1; getX() { return this.#x; } }\n";
+    for module in ESM_MODULES {
+        let output = emit_with_module_and_target(source, module, ScriptTarget::ES5);
+        assert!(
+            named_export_pos(&output, "Widget") < weakmap_init_pos(&output),
+            "`export {{ Widget }};` must precede the WeakMap init for module {module:?}.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn named_export_of_auto_accessor_class_precedes_weakmap_init() {
+    let source = "export class Cell { accessor value = 1; }\n";
+    for module in ESM_MODULES {
+        let output = emit_with_module_and_target(source, module, ScriptTarget::ES5);
+        assert!(
+            named_export_pos(&output, "Cell") < weakmap_init_pos(&output),
+            "`export {{ Cell }};` must precede the accessor WeakMap init for module {module:?}.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn each_class_reexport_is_colocated_with_its_own_iife() {
+    // Two exported private-field classes plus a plain named re-export. Each
+    // class's `export { C };` sits with its own IIFE, before its storage init;
+    // the non-class `export { local };` stays at the module trailer.
+    let source = "export class First { #a = 1; }\n\
+         export class Second { #b = 2; }\n\
+         const local = 3;\n\
+         export { local };\n";
+    let output = emit_with_module_and_target(source, ModuleKind::ESNext, ScriptTarget::ES5);
+
+    let first_export = named_export_pos(&output, "First");
+    let second_export = named_export_pos(&output, "Second");
+    let first_init = output
+        .find("_First_a = new WeakMap();")
+        .expect("First storage init");
+    let second_init = output
+        .find("_Second_b = new WeakMap();")
+        .expect("Second storage init");
+
+    assert!(
+        first_export < first_init,
+        "`export {{ First }};` must precede its WeakMap init.\nOutput:\n{output}"
+    );
+    assert!(
+        second_export < second_init,
+        "`export {{ Second }};` must precede its WeakMap init.\nOutput:\n{output}"
+    );
+    // The two classes stay in source order.
+    assert!(
+        first_export < second_export,
+        "class re-exports must stay in source order.\nOutput:\n{output}"
+    );
+    // The non-class local re-export is still present (at the trailer).
+    assert!(
+        output.contains("export { local };"),
+        "plain non-class re-export must remain.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn default_export_class_stays_after_weakmap_init() {
+    // `export default class` is the deliberate exception: the re-export follows
+    // the storage init (tsz already matched tsc here; guard against regression).
+    let source = "export default class Box { #x = 1; }\n";
+    for module in ESM_MODULES {
+        let output = emit_with_module_and_target(source, module, ScriptTarget::ES5);
+        let default_export = output.find("export default Box;").unwrap_or_else(|| {
+            panic!("expected `export default Box;` for module {module:?}.\nOutput:\n{output}")
+        });
+        assert!(
+            default_export > weakmap_init_pos(&output),
+            "`export default Box;` must follow the WeakMap init for module {module:?}.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn static_private_field_class_has_no_deferred_init_and_reexports_inline() {
+    // A `static #s` private field keeps its storage inside the class IIFE, so
+    // there is no deferred module-scope init and no ordering divergence — the
+    // named re-export is still emitted.
+    let source = "export class Registry { static #s = 1; }\n";
+    let output = emit_with_module_and_target(source, ModuleKind::ESNext, ScriptTarget::ES5);
+    assert!(
+        output.contains("export { Registry };"),
+        "static-private-field class must still be re-exported.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("= new WeakMap();\nexport { Registry };"),
+        "static-private storage stays inside the IIFE; no trailing init before the export.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn commonjs_named_class_export_is_unaffected() {
+    // The ESM staging must not perturb the CommonJS path, which keeps its
+    // `exports.C = C;` assignment before the storage init.
+    let source = "export class Widget { #x = 1; }\n";
+    let output = emit_with_module_and_target(source, ModuleKind::CommonJS, ScriptTarget::ES5);
+    let cjs_export = output
+        .find("exports.Widget = Widget;")
+        .expect("CommonJS export assignment");
+    assert!(
+        cjs_export < weakmap_init_pos(&output),
+        "CommonJS `exports.Widget = Widget;` must precede the WeakMap init.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("export { Widget };"),
+        "CommonJS output must not emit an ESM `export {{ }}` form.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests/mod.rs
@@ -6,6 +6,7 @@ use tsz_common::ScriptTarget;
 mod cjs_module_exports;
 mod cjs_named_import_reexport_tests;
 mod cjs_namespace_alias;
+mod esm_class_es5_export_order_tests;
 mod esm_class_namespace;
 
 fn parse_test_source(source: &str) -> (tsz_parser::ParserState, tsz_parser::parser::NodeIndex) {
@@ -18,6 +19,21 @@ fn emit_commonjs_with_target(source: &str, target: ScriptTarget) -> String {
     let (parser, root) = parse_test_source(source);
     let options = PrinterOptions {
         module: ModuleKind::CommonJS,
+        target,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer = Printer::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+fn emit_with_module_and_target(source: &str, module: ModuleKind, target: ScriptTarget) -> String {
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        module,
         target,
         ..Default::default()
     };

--- a/crates/tsz-emitter/src/emitter/transform_dispatch_es5_class.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch_es5_class.rs
@@ -57,6 +57,21 @@ impl<'a> Printer<'a> {
             );
         }
 
+        // Hand off a deferred ESM `export { X };` for a top-level `export class`
+        // lowered to an ES5 IIFE so the class emitter places it immediately after
+        // the IIFE and before the deferred private/accessor `WeakMap` storage init
+        // (matching the CommonJS `exports.X = X;` slot and tsc). Keyed by the class
+        // node; only ever set for the ESM named-export path, so it never affects
+        // CommonJS output.
+        if self
+            .pending_esm_class_export_name
+            .as_ref()
+            .is_some_and(|(pending_idx, _)| *pending_idx == class_node)
+            && let Some((_, name)) = self.pending_esm_class_export_name.take()
+        {
+            es5_emitter.set_pending_esm_class_export_name(Some(name));
+        }
+
         if self.ctx.target_es5
             && !self.ctx.options.legacy_decorators
             && let Some(class_node_ref) = self.arena.get(class_node)

--- a/crates/tsz-emitter/src/transforms/class_es5.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5.rs
@@ -95,6 +95,9 @@ pub struct ClassES5Emitter<'a> {
     /// `export class` lowered to an ES5 IIFE. Emitted right after the IIFE
     /// statement, before trailing computed-property side effects.
     pending_commonjs_class_export_name: Option<(String, Vec<String>)>,
+    /// Deferred ESM `export { <name> };` for a top-level `export class` lowered to
+    /// an ES5 IIFE. Emitted at the same IIFE boundary as the CommonJS assignment.
+    pending_esm_class_export_name: Option<String>,
 }
 
 impl<'a> ClassES5Emitter<'a> {
@@ -119,6 +122,7 @@ impl<'a> ClassES5Emitter<'a> {
             outer_reserved_for_generator_state: Vec::new(),
             tc39_wrap_output: true,
             pending_commonjs_class_export_name: None,
+            pending_esm_class_export_name: None,
         }
     }
 
@@ -148,6 +152,12 @@ impl<'a> ClassES5Emitter<'a> {
         export_names: Vec<String>,
     ) {
         self.pending_commonjs_class_export_name = Some((local_name, export_names));
+    }
+
+    /// Schedule a deferred ESM `export { <name> };` for a top-level `export class`
+    /// lowered to an ES5 IIFE.
+    pub fn set_pending_esm_class_export_name(&mut self, name: Option<String>) {
+        self.pending_esm_class_export_name = name;
     }
 
     pub fn set_block_scope_reserved_names(&mut self, names: Vec<String>) {
@@ -559,6 +569,9 @@ impl<'a> ClassES5Emitter<'a> {
         printer.set_block_scope_reserved_names(self.block_scope_reserved_names.clone());
         if let Some((local_name, export_names)) = self.pending_commonjs_class_export_name.clone() {
             printer.set_pending_commonjs_class_export_bindings(local_name, export_names);
+        }
+        if let Some(name) = self.pending_esm_class_export_name.clone() {
+            printer.set_pending_esm_class_export_name(Some(name));
         }
         if !self.outer_reserved_for_generator_state.is_empty() {
             printer.set_outer_reserved_for_generator_state(

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -100,6 +100,7 @@ pub struct IRPrinter<'a> {
     block_scope_shadowed_names: Vec<String>,
     block_scope_reserved_names: Vec<String>,
     pending_commonjs_class_export_name: Option<(String, Vec<String>)>,
+    pending_esm_class_export_name: Option<String>,
     /// Source-map mappings recorded for re-emitted `ASTRef` nodes while
     /// `capture_mappings` is set. Generated positions are relative to the start
     /// of this printer's own output, so a caller splices them with a base

--- a/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
@@ -80,6 +80,18 @@ impl<'a> IRPrinter<'a> {
             }
         }
 
+        // A top-level ESM `export class` lowered to this IIFE carries a deferred
+        // `export { X };` re-export. tsc emits it immediately after the class
+        // statement and BEFORE the deferred private/accessor `WeakMap` storage
+        // init below — the same placement as the CommonJS assignment above.
+        if let Some(export_name) = self.take_pending_esm_class_export_name() {
+            self.write_line();
+            self.write_indent();
+            self.write("export { ");
+            self.write(&export_name);
+            self.write(" };");
+        }
+
         for init in computed_prop_temp_inits {
             self.write_line();
             self.write_indent();

--- a/crates/tsz-emitter/src/transforms/ir_printer_config.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_config.rs
@@ -35,6 +35,7 @@ impl<'a> IRPrinter<'a> {
             block_scope_shadowed_names: Vec::new(),
             block_scope_reserved_names: Vec::new(),
             pending_commonjs_class_export_name: None,
+            pending_esm_class_export_name: None,
             mappings: Vec::new(),
             source_index: 0,
             capture_mappings: false,
@@ -72,6 +73,7 @@ impl<'a> IRPrinter<'a> {
             block_scope_shadowed_names: Vec::new(),
             block_scope_reserved_names: Vec::new(),
             pending_commonjs_class_export_name: None,
+            pending_esm_class_export_name: None,
             mappings: Vec::new(),
             source_index: 0,
             capture_mappings: false,
@@ -109,6 +111,7 @@ impl<'a> IRPrinter<'a> {
             block_scope_shadowed_names: Vec::new(),
             block_scope_reserved_names: Vec::new(),
             pending_commonjs_class_export_name: None,
+            pending_esm_class_export_name: None,
             mappings: Vec::new(),
             source_index: 0,
             capture_mappings: false,
@@ -133,6 +136,14 @@ impl<'a> IRPrinter<'a> {
         &mut self,
     ) -> Option<(String, Vec<String>)> {
         self.pending_commonjs_class_export_name.take()
+    }
+
+    pub fn set_pending_esm_class_export_name(&mut self, name: Option<String>) {
+        self.pending_esm_class_export_name = name;
+    }
+
+    pub(super) const fn take_pending_esm_class_export_name(&mut self) -> Option<String> {
+        self.pending_esm_class_export_name.take()
     }
 
     pub fn set_transforms(&mut self, transforms: TransformContext) {


### PR DESCRIPTION
Fixes #15283.

At `--target es5` with an ESM module output (`--module esnext|es2020|es2015`), a top-level `export class C { ... }` that lowers a private field or `accessor` auto-accessor to `WeakMap` storage emitted the re-export statement `export { C };` **after** the deferred storage instantiation (`_C_x = new WeakMap();`). `tsc` emits `export { C };` **immediately after the class IIFE and before** the storage init.

### Repro (`--module esnext`, any target, ± strict), vs `tsc` 6.0.2

```ts
export class P { #x = 1; getX() { return this.#x; } }
```

```js
    return P;
}());
// tsc / tsz (after):   // tsz (before):
export { P };           _P_x = new WeakMap();
_P_x = new WeakMap();   export { P };
```

The rest of the output is byte-identical; only the relative order of `export { P };` and `_P_x = new WeakMap();` changed.

## Structural rule

When a top-level `export class C` is lowered to an ES5 IIFE under an ESM module output, `tsc` emits the named re-export `export { C };` at the same point it emits the CommonJS `exports.C = C;` assignment — immediately after the class IIFE statement and **before** any deferred private/accessor `WeakMap` storage init. `export default class` is the deliberate exception: `tsc` emits `export default C;` **after** the storage init, and tsz already matched that.

The decision is keyed on the structural import/lowering shape (ESM module + ES5 class transform + named vs. default export), never on any identifier, file name, or rendered-output string.

## Owner layer

Emitter. tsz already had the CommonJS `pending_commonjs_class_export_name` slot — staged at the export site and consumed by the ES5 class IIFE emitter (`ir_printer_class_emit.rs`) between the IIFE and the deferred storage inits. The ESM path instead emitted `export { C };` at the module trailer (`module_emission/core/mod.rs`), which runs *after* the class statement's deferred storage init was already written.

This mirrors the CommonJS mechanism with a `pending_esm_class_export_name` slot:
- staged at the ESM named-export site (`module_emission/core/mod.rs`), with a fallback to the trailing form if it is not consumed (matching the CommonJS fallback);
- handed off to the `ClassES5Emitter` in `create_es5_class_emitter_with_decorators`, keyed by the class node so it only affects the intended class and never the CommonJS path;
- consumed in `emit_es5_class_iife_node` at the same IIFE/`WeakMap` boundary as the CommonJS assignment.

Pure output-form fix — no semantic change.

## Adjacent matrix (verified byte-identical to `tsc` 6.0.2)

`--target es5`, `--module es2015|es2020|esnext`, `--strict`, binder names varied:
- `export class P { #x }` → `export { P };` before `_P_x = new WeakMap();`
- `export class A { accessor v }` → `export { A };` before the accessor storage init
- two exported private-field classes + a plain `export { local }` → each class's `export { C };` co-located with its own IIFE (before its own init), in source order; the non-class re-export stays at the trailer
- `export default class D { #x }` → `export default D;` stays after the storage init (unchanged, matches tsc)
- `export class S { static #s }` → static private storage stays inside the IIFE; no deferred init, re-export still emitted
- heritage (`export class Sub extends Base { #x }`) and computed-member classes → `export { C };` correctly ordered

Out of scope / pre-existing (unchanged by this PR): the combined `var _C1_a, _C2_b;` WeakMap-decl hoisting across multiple classes, the es5-CJS static-field private-storage duplication (#15278 family), the computed-property-key WeakMap-init inlining, and the es2015-target default-class export separation. These live in code this change does not touch (the fix keys on `pending_esm_class_export_name`, which is only ever set on the ESM es5 named-export path).

## Goal
Goal: hold

## Verification
- New regression suite `crates/tsz-emitter/src/emitter/module_emission/core/tests/esm_class_es5_export_order_tests.rs` (6 tests: private-field/accessor ordering across es2015/es2020/esnext, per-class co-location + source order, `export default` trailing, static-`#field` no-deferred-init, CommonJS-unaffected control) — all pass.
- `cargo test -p tsz-emitter --lib` → 3938 passed, 0 failed (3932 pre-existing + 6 new; no regressions).
- End-to-end `tsz` vs `tsc` 6.0.2 across the adjacent matrix — byte-identical for the fixed shapes; the only remaining diffs are the pre-existing, out-of-scope items listed above.
- `cargo fmt --all -- --check`, `cargo clippy -p tsz-emitter --lib -- -D warnings`, `python3 scripts/arch/arch_guard.py --json` (0 failures), `git diff --check` — all clean.
- ready-review CI owns the broad conformance / emit / fourslash baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01WSBfEyafFBxVQXJx8D1W5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSBfEyafFBxVQXJx8D1W5A)_