### PR TITLE
fix(emit): keep CommonJS live-export mirror on down-leveled compound assignments

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -239,6 +239,10 @@ name = "cjs_clause_export_live_binding_tests"
 path = "tests/cjs_clause_export_live_binding_tests.rs"
 
 [[test]]
+name = "cjs_live_export_downlevel_compound_assignment_tests"
+path = "tests/cjs_live_export_downlevel_compound_assignment_tests.rs"
+
+[[test]]
 name = "destructuring_es5_array_nested_order_tests"
 path = "tests/destructuring_es5_array_nested_order_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs
@@ -31,7 +31,11 @@ impl<'a> Printer<'a> {
         elements.len()
     }
 
-    fn emit_assignment_target(&mut self, target_idx: NodeIndex) {
+    /// Emit an assignment-target LHS, routing an exported local through the
+    /// CommonJS live-export mirror (`exports.x = x = ...`) and otherwise
+    /// emitting it plainly. Shared by ES5 destructuring lowering and the
+    /// down-leveled `**=` write target.
+    pub(in crate::emitter) fn emit_assignment_target(&mut self, target_idx: NodeIndex) {
         if self.emit_commonjs_live_export_assignment_target(target_idx) {
             return;
         }

--- a/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
@@ -135,7 +135,7 @@ impl<'a> Printer<'a> {
         right: NodeIndex,
     ) {
         let Some(left_node) = self.arena.get(original_left) else {
-            self.emit(original_left);
+            self.emit_assignment_target(original_left);
             self.write(" = Math.pow(");
             self.emit(unwrapped_left);
             self.write(", ");
@@ -163,7 +163,7 @@ impl<'a> Printer<'a> {
 
         if !is_element_access && !is_property_access {
             // Simple identifier: `x **= y` → `x = Math.pow(x, y)`
-            self.emit(original_left);
+            self.emit_assignment_target(original_left);
             self.write(" = Math.pow(");
             self.emit(unwrapped_left);
             self.write(", ");
@@ -173,7 +173,7 @@ impl<'a> Printer<'a> {
         }
 
         let Some(access) = self.arena.get_access_expr(left_node) else {
-            self.emit(original_left);
+            self.emit_assignment_target(original_left);
             self.write(" = Math.pow(");
             self.emit(unwrapped_left);
             self.write(", ");
@@ -365,21 +365,21 @@ impl<'a> Printer<'a> {
         if is_and {
             self.emit_expression_for_logical_assignment(binary.left);
             self.write(" && (");
-            self.emit_expression_for_logical_assignment(binary.left);
+            self.emit_logical_assignment_write_target(left, binary.left);
             self.write(" = ");
             self.emit_expression_for_logical_assignment(binary.right);
             self.write(")");
         } else if binary.operator_token == SyntaxKind::BarBarEqualsToken as u16 {
             self.emit_expression_for_logical_assignment(binary.left);
             self.write(" || (");
-            self.emit_expression_for_logical_assignment(binary.left);
+            self.emit_logical_assignment_write_target(left, binary.left);
             self.write(" = ");
             self.emit_expression_for_logical_assignment(binary.right);
             self.write(")");
         } else if self.ctx.options.target.supports_es2020() {
             self.emit_expression_for_logical_assignment(binary.left);
             self.write(" ?? (");
-            self.emit_expression_for_logical_assignment(binary.left);
+            self.emit_logical_assignment_write_target(left, binary.left);
             self.write(" = ");
             self.emit_expression_for_logical_assignment(binary.right);
             self.write(")");
@@ -390,11 +390,33 @@ impl<'a> Printer<'a> {
             self.write(" !== void 0 ? ");
             self.emit_expression_for_logical_assignment(binary.left);
             self.write(" : (");
-            self.emit_expression_for_logical_assignment(binary.left);
+            self.emit_logical_assignment_write_target(left, binary.left);
             self.write(" = ");
             self.emit_expression_for_logical_assignment(binary.right);
             self.write(")");
         }
+    }
+
+    /// Emit the inner write-target LHS of a lowered logical assignment
+    /// (`&&=` / `||=` / `??=`), threading the write through the CommonJS
+    /// live-export mirror when the target is an exported local. The non-lowered
+    /// assignment path routes the target through
+    /// [`Self::emit_commonjs_live_export_assignment_target`] (producing
+    /// `exports.x = x = ...` for a clause export or `exports.x = ...` for an
+    /// inline export); the lowered expansion must do the same or the exported
+    /// binding is never updated. `unwrapped_left` is the paren-stripped target
+    /// used for the live-export identifier check; `original_left` is the node
+    /// used for the plain fallback so parenthesized/nested forms still emit
+    /// correctly.
+    fn emit_logical_assignment_write_target(
+        &mut self,
+        unwrapped_left: NodeIndex,
+        original_left: NodeIndex,
+    ) {
+        if self.emit_commonjs_live_export_assignment_target(unwrapped_left) {
+            return;
+        }
+        self.emit_expression_for_logical_assignment(original_left);
     }
 
     /// Whether lowering a non-es2020 `??=` with target `left` consumes a hoisted

--- a/crates/tsz-emitter/tests/cjs_live_export_downlevel_compound_assignment_tests.rs
+++ b/crates/tsz-emitter/tests/cjs_live_export_downlevel_compound_assignment_tests.rs
@@ -1,0 +1,201 @@
+//! Regression tests: CommonJS live-export mirror on **down-leveled** compound
+//! assignments (`**=`, `&&=`, `||=`, `??=`).
+//!
+//! When an exported local is written with a compound-assignment operator that
+//! the target down-levels, the lowered expansion must still thread the write
+//! through the CommonJS live named export, exactly as the non-lowered path does:
+//!
+//! - clause export `export { b }` → `exports.b = b = <value>`
+//! - clause rename `export { b as foo }` → `exports.foo = b = <value>`
+//! - inline export `export let b` → `exports.b = <value>`
+//!
+//! Previously the exponentiation lowering (`emit_exponentiation_expression`) and
+//! the logical-assignment lowering (`emit_logical_assignment_expression`) emitted
+//! the write-target LHS directly, bypassing the live-export gateway, so the
+//! exported binding was never updated at runtime. `tsc` keeps the mirror:
+//!
+//! ```js
+//! // export { b }; b ??= 5;  (--target es2015 --module commonjs)
+//! b !== null && b !== void 0 ? b : (exports.b = b = 5);
+//! // b **= 2;
+//! exports.b = b = Math.pow(b, 2);
+//! ```
+//!
+//! Owner: emitter — `crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs`.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print as parse_lower_emit;
+
+fn cjs(target: ScriptTarget) -> PrintOptions {
+    PrintOptions {
+        target,
+        module: ModuleKind::CommonJS,
+        ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Clause export (`export { b }`) — down-leveled logical assignment
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clause_export_nullish_assignment_es2015_mirrors_export() {
+    let source = "let b = 1;\nb ??= 5;\nexport { b };\n";
+    let output = parse_lower_emit(source, cjs(ScriptTarget::ES2015));
+    assert!(
+        output.contains("b !== null && b !== void 0 ? b : (exports.b = b = 5);"),
+        "Down-leveled `??=` on a clause export must mirror `exports.b`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn clause_export_or_assignment_es2015_mirrors_export() {
+    let source = "let b = 1;\nb ||= 2;\nexport { b };\n";
+    let output = parse_lower_emit(source, cjs(ScriptTarget::ES2015));
+    assert!(
+        output.contains("b || (exports.b = b = 2);"),
+        "Down-leveled `||=` on a clause export must mirror `exports.b`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn clause_export_and_assignment_es2015_mirrors_export() {
+    let source = "let b = 1;\nb &&= 3;\nexport { b };\n";
+    let output = parse_lower_emit(source, cjs(ScriptTarget::ES2015));
+    assert!(
+        output.contains("b && (exports.b = b = 3);"),
+        "Down-leveled `&&=` on a clause export must mirror `exports.b`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn clause_export_exponentiation_assignment_es2015_mirrors_export() {
+    let source = "let b = 1;\nb **= 2;\nexport { b };\n";
+    let output = parse_lower_emit(source, cjs(ScriptTarget::ES2015));
+    assert!(
+        output.contains("exports.b = b = Math.pow(b, 2);"),
+        "Down-leveled `**=` on a clause export must mirror `exports.b`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn clause_export_nullish_assignment_es5_mirrors_export() {
+    let source = "let b = 1;\nb ??= 5;\nb **= 2;\nexport { b };\n";
+    let output = parse_lower_emit(source, cjs(ScriptTarget::ES5));
+    assert!(
+        output.contains("b !== null && b !== void 0 ? b : (exports.b = b = 5);"),
+        "ES5 down-leveled `??=` on a clause export must mirror `exports.b`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("exports.b = b = Math.pow(b, 2);"),
+        "ES5 down-leveled `**=` on a clause export must mirror `exports.b`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn clause_export_nullish_assignment_es2020_uses_native_nullish_and_mirrors() {
+    // ES2020 supports `??` natively but not `??=`, so the logical assignment
+    // still lowers — to the native `??` short-circuit form.
+    let source = "let b = 1;\nb ??= 5;\nexport { b };\n";
+    let output = parse_lower_emit(source, cjs(ScriptTarget::ES2020));
+    assert!(
+        output.contains("b ?? (exports.b = b = 5);"),
+        "ES2020 down-leveled `??=` on a clause export must mirror `exports.b`.\nOutput:\n{output}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Clause rename / multiple aliases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn renamed_clause_export_downlevel_compound_mirrors_alias() {
+    let source = "let b = 1;\nb ??= 5;\nb **= 2;\nexport { b as foo };\n";
+    let output = parse_lower_emit(source, cjs(ScriptTarget::ES2015));
+    assert!(
+        output.contains("b !== null && b !== void 0 ? b : (exports.foo = b = 5);"),
+        "Down-leveled `??=` must mirror the renamed export `exports.foo`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("exports.foo = b = Math.pow(b, 2);"),
+        "Down-leveled `**=` must mirror the renamed export `exports.foo`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn multi_alias_clause_export_downlevel_compound_mirrors_all() {
+    let source = "let b = 1;\nb ??= 5;\nb **= 2;\nexport { b, b as foo };\n";
+    let output = parse_lower_emit(source, cjs(ScriptTarget::ES2015));
+    assert!(
+        output.contains("b !== null && b !== void 0 ? b : (exports.foo = exports.b = b = 5);"),
+        "Down-leveled `??=` must mirror every alias in a multi-name clause.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("exports.foo = exports.b = b = Math.pow(b, 2);"),
+        "Down-leveled `**=` must mirror every alias in a multi-name clause.\nOutput:\n{output}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Inline export (`export let b`) with an extra clause alias
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inline_export_with_alias_downlevel_compound_mirrors_both() {
+    let source = "export let b = 1;\nb ??= 5;\nb **= 2;\nexport { b as foo };\n";
+    let output = parse_lower_emit(source, cjs(ScriptTarget::ES2015));
+    assert!(
+        output.contains(
+            "exports.b !== null && exports.b !== void 0 ? exports.b : (exports.foo = exports.b = 5);"
+        ),
+        "Down-leveled `??=` on an inline export must rewrite reads and mirror the alias.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("exports.foo = exports.b = Math.pow(exports.b, 2);"),
+        "Down-leveled `**=` on an inline export must rewrite reads and mirror the alias.\nOutput:\n{output}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls
+// ---------------------------------------------------------------------------
+
+#[test]
+fn non_exported_local_downlevel_compound_has_no_export_mirror() {
+    // A plain (non-exported) local must NOT gain an `exports.` mirror.
+    let source = "let local = 1;\nlocal ??= 5;\nlocal **= 2;\nexport {};\n";
+    let output = parse_lower_emit(source, cjs(ScriptTarget::ES2015));
+    assert!(
+        !output.contains("exports.local"),
+        "A non-exported local must not gain an export mirror.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("local !== null && local !== void 0 ? local : (local = 5);"),
+        "Non-exported `??=` keeps the plain lowered form.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("local = Math.pow(local, 2);"),
+        "Non-exported `**=` keeps the plain lowered form.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn native_compound_assignment_clause_export_still_mirrors() {
+    // Regression guard for the non-lowered path: at a target that supports
+    // `??=`/`**=` natively, the clause export mirror still emits (unchanged).
+    let source = "let b = 1;\nb ??= 5;\nb **= 2;\nexport { b };\n";
+    let output = parse_lower_emit(source, cjs(ScriptTarget::ESNext));
+    assert!(
+        output.contains("exports.b = b ??= 5;"),
+        "Native `??=` on a clause export must still mirror `exports.b`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("exports.b = b **= 2;"),
+        "Native `**=` on a clause export must still mirror `exports.b`.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #15289.

Under `--module commonjs`, a compound assignment to a top-level exported binding that the **target down-levels** — `**=` (target < ES2016) or `&&=`/`||=`/`??=` (target < ES2021) — dropped the CommonJS live named-export update, so the exported value observed via `require` went stale. The non-lowered forms (`=`, `+=`, `++`, and native `??=`/`**=` at ESNext) were already correct.

### Repro (`--module commonjs --target es2015`)

```ts
let b = 1;
b ??= 5; b ||= 2; b &&= 3; b **= 2;
export { b };
```

- **tsc 6.0.2**
  ```js
  b !== null && b !== void 0 ? b : (exports.b = b = 5);
  b || (exports.b = b = 2);
  b && (exports.b = b = 3);
  exports.b = b = Math.pow(b, 2);
  ```
- **tsz before** (missing `exports.b =` mirror): `(b = 5)`, `(b = 2)`, `(b = 3)`, `b = Math.pow(b, 2)`.

## Structural rule

When a top-level `let`/`var` is exported under CommonJS (inline `export let x` or clause `export { x }`), `tsc` mirrors every write through the live named export — inline `exports.x = <value>`, clause `exports.x = x = <value>`. That mirror must survive **operator down-leveling**: the lowered `**=` (`x = Math.pow(x, n)`) and the lowered `&&=`/`||=`/`??=` short-circuit/ternary expansions must wrap the innermost value-producing assignment in the `exports.x = ...` mirror, exactly as the non-lowered path does. The choice is driven by binding origin, never by inspecting rendered output.

## Owner layer

Emitter — operator down-level lowering (`crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs`). `emit_exponentiation_assignment` and `emit_logical_assignment_expression` return early (before the normal assignment dispatch in `expressions/core/private_fields.rs` that routes the target through `emit_commonjs_live_export_assignment_target`), so the lowered write target now calls the same gateway itself:

- `emit_logical_assignment_expression` routes the inner `(x = value)` write position through a new `emit_logical_assignment_write_target` (unwrapped node for the live-export identifier check, original node for the paren/nested fallback).
- `emit_exponentiation_assignment` reuses the shared `emit_assignment_target` helper — promoted from module-private in `es5/bindings_assignment.rs` and byte-identical to the removed local duplicate (a `/simplify` reuse cleanup).

Reads, non-live-export targets, and the property/element-access lowering branches are untouched. Pure output-form change; no semantic validation added. No identifier / file-name / rendered-output predicate drives the decision — it keys on the structural import/export binding origin.

## Adjacent matrix (verified byte-identical to tsc 6.0.2)

`--module commonjs`, targets es5 / es2015 / es2020, binder names varied:
- clause `export { b }` → `exports.b = b = <value>` for `**=`/`&&=`/`||=`/`??=`
- renamed clause `export { b as foo }` → `exports.foo = b = <value>`
- multi-alias `export { b, b as foo }` → `exports.foo = exports.b = b = <value>`
- inline + alias `export let b; export { b as foo }` → reads rewrite to `exports.b`, writes mirror `exports.foo = exports.b = <value>`
- chained `p **= q **= r` / `p ??= q ??= r` with `export { p, q, r }` → correctly nested mirrors
- **controls unchanged:** native `??=`/`**=` at ESNext still emit `exports.b = b ??= 5`; non-exported locals gain no mirror; property/element-access targets and their temp allocation are untouched (verified via end-to-end `tsz` vs `tsc` differential on exportless fixtures)

### Out of scope (separate, pre-existing — documented in #15289)
- Nested-scope shadowing of an exported name (`function f(){ let e = 9; e = 10; }`) keeps the mirror on the shadowing local for reads and all writes — a pervasive pre-existing defect in the name-based live-export machinery (shadow stack tracks only parameters; the clause branch is never shadow-gated) that affects the normal path identically. Not introduced or fixed here.
- System modules (`--module system`) have the parallel gap with a structurally different (`exports_1("x", ...)` call-wrap) shape.

## Goal
Goal: hold

## Verification
- New target `crates/tsz-emitter/tests/cjs_live_export_downlevel_compound_assignment_tests.rs` (11 tests: clause/renamed/multi-alias/inline+alias mirrors for `**=`/`&&=`/`||=`/`??=` at es5/es2015/es2020, plus non-exported and native-operator controls) — `cargo test -p tsz-emitter --test cjs_live_export_downlevel_compound_assignment_tests` → 11/11.
- `cargo test -p tsz-emitter --lib` → 3932 passed; related targets green (`cjs_clause_export_live_binding_tests` 33/33, `logical_assignment_temp_numbering_tests`, `cjs_destructuring_export_inline_tests`, `destructuring_es5_array_nested_order_tests`, `static_super_object_rest_assignment_target_tests`).
- End-to-end `tsz` vs `tsc 6.0.2` differential across the adjacent matrix — byte-identical; a broad logical/exponentiation-assignment sweep shows no new divergences (remaining diffs are pre-existing, in exportless property-access temp numbering and class-method `**=` lowering, which this change does not touch).
- `cargo fmt --all -- --check`, `cargo clippy -p tsz-emitter --lib -- -D warnings`, `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean.
- ready-review CI owns the broad conformance / emit / fourslash baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aca2AKA1hDWjC77VNRX6CV)_