### PR TITLE
fix(emit): keep System live-export mirror on down-leveled compound assignments

### DIFF
--- a/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
@@ -162,13 +162,19 @@ impl<'a> Printer<'a> {
         }
 
         if !is_element_access && !is_property_access {
-            // Simple identifier: `x **= y` → `x = Math.pow(x, y)`
-            self.emit_assignment_target(original_left);
-            self.write(" = Math.pow(");
-            self.emit(unwrapped_left);
-            self.write(", ");
-            self.emit(right);
-            self.write(")");
+            // Simple identifier: `x **= y` -> `x = Math.pow(x, y)`.
+            // CommonJS live exports are emitted by `emit_assignment_target`;
+            // System live exports wrap the value-producing write in
+            // `exports_1("x", ...)`, matching the non-lowered path.
+            let system_exports = self.system_live_export_names(unwrapped_left);
+            self.emit_wrapped_in_system_export(system_exports.as_deref(), |this| {
+                this.emit_assignment_target(original_left);
+                this.write(" = Math.pow(");
+                this.emit(unwrapped_left);
+                this.write(", ");
+                this.emit(right);
+                this.write(")");
+            });
             return;
         }
 
@@ -362,26 +368,40 @@ impl<'a> Printer<'a> {
             None => return,
         }
 
+        // A System-exported identifier target keeps its live named export in
+        // sync by wrapping the inner `x = <value>` write in `exports_1("x", ...)`
+        // (nested per alias), matching the non-lowered assignment path. The
+        // short-circuit read positions stay unwrapped, exactly as `tsc` emits.
+        let system_exports = self.system_live_export_names(left);
         if is_and {
             self.emit_expression_for_logical_assignment(binary.left);
             self.write(" && (");
-            self.emit_logical_assignment_write_target(left, binary.left);
-            self.write(" = ");
-            self.emit_expression_for_logical_assignment(binary.right);
+            self.emit_logical_assignment_write(
+                left,
+                binary.left,
+                binary.right,
+                system_exports.as_deref(),
+            );
             self.write(")");
         } else if binary.operator_token == SyntaxKind::BarBarEqualsToken as u16 {
             self.emit_expression_for_logical_assignment(binary.left);
             self.write(" || (");
-            self.emit_logical_assignment_write_target(left, binary.left);
-            self.write(" = ");
-            self.emit_expression_for_logical_assignment(binary.right);
+            self.emit_logical_assignment_write(
+                left,
+                binary.left,
+                binary.right,
+                system_exports.as_deref(),
+            );
             self.write(")");
         } else if self.ctx.options.target.supports_es2020() {
             self.emit_expression_for_logical_assignment(binary.left);
             self.write(" ?? (");
-            self.emit_logical_assignment_write_target(left, binary.left);
-            self.write(" = ");
-            self.emit_expression_for_logical_assignment(binary.right);
+            self.emit_logical_assignment_write(
+                left,
+                binary.left,
+                binary.right,
+                system_exports.as_deref(),
+            );
             self.write(")");
         } else {
             self.emit_expression_for_logical_assignment(binary.left);
@@ -390,9 +410,12 @@ impl<'a> Printer<'a> {
             self.write(" !== void 0 ? ");
             self.emit_expression_for_logical_assignment(binary.left);
             self.write(" : (");
-            self.emit_logical_assignment_write_target(left, binary.left);
-            self.write(" = ");
-            self.emit_expression_for_logical_assignment(binary.right);
+            self.emit_logical_assignment_write(
+                left,
+                binary.left,
+                binary.right,
+                system_exports.as_deref(),
+            );
             self.write(")");
         }
     }
@@ -417,6 +440,41 @@ impl<'a> Printer<'a> {
             return;
         }
         self.emit_expression_for_logical_assignment(original_left);
+    }
+
+    /// Emit the inner value-producing write `<target> = <value>` of a lowered
+    /// logical assignment. CommonJS live exports rewrite the assignment target;
+    /// System live exports wrap the whole write in `exports_1("x", ...)`.
+    fn emit_logical_assignment_write(
+        &mut self,
+        unwrapped_left: NodeIndex,
+        original_left: NodeIndex,
+        value: NodeIndex,
+        system_exports: Option<&[String]>,
+    ) {
+        self.emit_wrapped_in_system_export(system_exports, |this| {
+            this.emit_logical_assignment_write_target(unwrapped_left, original_left);
+            this.write(" = ");
+            this.emit_expression_for_logical_assignment(value);
+        });
+    }
+
+    /// Run `emit_body`, wrapping its output in the System live-export call chain
+    /// `exports_1("x", ...)` when `system_exports` is `Some` (nested per alias).
+    /// `None` runs the body unwrapped, so non-System output is byte-identical.
+    /// Shared by the down-leveled `**=` and `&&=`/`||=`/`??=` write paths.
+    fn emit_wrapped_in_system_export<F: FnOnce(&mut Self)>(
+        &mut self,
+        system_exports: Option<&[String]>,
+        emit_body: F,
+    ) {
+        if let Some(names) = system_exports {
+            self.write_system_export_call_chain_start(names);
+        }
+        emit_body(self);
+        if let Some(names) = system_exports {
+            self.write_system_export_call_chain_end(names);
+        }
     }
 
     /// Whether lowering a non-es2020 `??=` with target `left` consumes a hoisted

--- a/crates/tsz-emitter/src/emitter/module_emission/system_live_exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/system_live_exports.rs
@@ -9,28 +9,54 @@ impl<'a> Printer<'a> {
         operator: u16,
         right: NodeIndex,
     ) -> bool {
-        if !self.is_system_live_export_context() || !self.is_assignment_operator(operator) {
+        if !self.is_assignment_operator(operator) {
             return false;
         }
-        let Some(left_node) = self.arena.get(left) else {
+        let Some(export_names) = self.system_live_export_names(left) else {
             return false;
         };
-        if left_node.kind != SyntaxKind::Identifier as u16 {
-            return false;
-        }
-        let local_name = self.get_identifier_text_idx(left);
-        let export_names = self.system_export_names_for_local(&local_name);
-        if export_names.is_empty() {
-            return false;
-        }
         self.write_system_export_call_chain_start(&export_names);
-        self.write_identifier(&local_name);
+        self.write_identifier_text(left);
         self.write(" ");
         self.write(get_operator_text(operator));
         self.write_space();
         self.emit(right);
         self.write_system_export_call_chain_end(&export_names);
         true
+    }
+
+    /// System live-export names for a bare-identifier assignment target, or
+    /// `None` when the target is not a live System export (not a System module
+    /// body, not an exported binding, or not a plain identifier). The decision
+    /// keys on the exported binding origin, never on rendered output.
+    ///
+    /// Shared by [`emit_system_live_export_assignment_expression`] (the
+    /// non-lowered path) and the operator-lowering emitters. Down-leveled
+    /// compound assignments (`**=` / `&&=` / `||=` / `??=`) reach the lowering
+    /// emitters directly, bypassing the normal binary dispatch, so they use this
+    /// to wrap their innermost value-producing write `x = <value>` in the
+    /// `exports_1("x", ...)` call chain; otherwise the live named export goes
+    /// stale.
+    ///
+    /// [`emit_system_live_export_assignment_expression`]: Self::emit_system_live_export_assignment_expression
+    pub(in crate::emitter) fn system_live_export_names(
+        &self,
+        target: NodeIndex,
+    ) -> Option<Vec<String>> {
+        if !self.is_system_live_export_context() {
+            return None;
+        }
+        let target_node = self.arena.get(target)?;
+        if target_node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let local_name = self.get_identifier_text_idx(target);
+        let export_names = self.system_export_names_for_local(&local_name);
+        if export_names.is_empty() {
+            None
+        } else {
+            Some(export_names)
+        }
     }
 
     pub(in crate::emitter) fn emit_system_live_export_prefix_unary(

--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests.rs
@@ -4,6 +4,7 @@ mod system_emit;
 mod system_emit_var_hoisting;
 mod system_export_star_order;
 mod system_import_export_order;
+mod system_live_export_downlevel_compound_assignment;
 mod system_live_exports;
 mod system_top_level_await;
 mod wrapped_helpers;

--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_live_export_downlevel_compound_assignment.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_live_export_downlevel_compound_assignment.rs
@@ -1,0 +1,148 @@
+//! Down-leveled compound assignments (`**=` / `&&=` / `||=` / `??=`) to a
+//! System-exported binding must keep the live named export in sync by wrapping
+//! their innermost `x = <value>` write in the `exports_1("x", ...)` call chain,
+//! exactly as the non-lowered assignment path does. See issue #15291.
+//!
+//! Expectations are byte-checked against `tsc` 6.0.2 output.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{ModuleKind, Printer, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit_system_target(source: &str, target: ScriptTarget) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        module: ModuleKind::System,
+        target,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let emit_plan = LoweringPass::new(&parser.arena, &ctx).run_plan(root);
+    let mut printer = Printer::with_emit_plan_and_options(&parser.arena, emit_plan, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+fn assert_ordered(output: &str, snippets: &[&str]) {
+    let mut start = 0;
+    for snippet in snippets {
+        let Some(pos) = output[start..].find(snippet) else {
+            panic!("Missing snippet `{snippet}` after byte {start}.\nOutput:\n{output}");
+        };
+        start += pos + snippet.len();
+    }
+}
+
+const COMPOUND_SOURCE: &str = r#"let b = 1;
+b ??= 5;
+b ||= 2;
+b &&= 3;
+b **= 2;
+export { b };
+"#;
+
+#[test]
+fn es2015_lowered_compound_assignments_wrap_the_write_in_exports_call() {
+    let output = emit_system_target(COMPOUND_SOURCE, ScriptTarget::ES2015);
+    assert_ordered(
+        &output,
+        &[
+            "b !== null && b !== void 0 ? b : (exports_1(\"b\", b = 5));",
+            "b || (exports_1(\"b\", b = 2));",
+            "b && (exports_1(\"b\", b = 3));",
+            "exports_1(\"b\", b = Math.pow(b, 2));",
+        ],
+    );
+    // The short-circuit read positions stay unwrapped, and no bare `(b = N)`
+    // write escapes the live-export mirror.
+    assert!(
+        !output.contains("(b = 5)") && !output.contains("(b = 2)") && !output.contains("(b = 3)"),
+        "Lowered writes must be wrapped in exports_1.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("exports.b"),
+        "System live exports must not use CommonJS export property writes.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2020_still_lowers_logical_assignments_and_wraps_them() {
+    // At ES2020 the logical-assignment operators still lower (native `&&=`/`||=`/`??=`
+    // are ES2021), so the wrap must be preserved; native `**=` is kept and handled
+    // by the non-lowered System gateway.
+    let output = emit_system_target(COMPOUND_SOURCE, ScriptTarget::ES2020);
+    assert_ordered(
+        &output,
+        &[
+            "b ?? (exports_1(\"b\", b = 5));",
+            "b || (exports_1(\"b\", b = 2));",
+            "b && (exports_1(\"b\", b = 3));",
+            "exports_1(\"b\", b **= 2);",
+        ],
+    );
+}
+
+#[test]
+fn renamed_reexport_wraps_the_write_under_the_export_alias() {
+    let source = r#"let b = 1;
+b ??= 5;
+b **= 2;
+export { b as foo };
+"#;
+    let output = emit_system_target(source, ScriptTarget::ES2015);
+    assert_ordered(
+        &output,
+        &[
+            "b !== null && b !== void 0 ? b : (exports_1(\"foo\", b = 5));",
+            "exports_1(\"foo\", b = Math.pow(b, 2));",
+        ],
+    );
+}
+
+#[test]
+fn multi_alias_clause_nests_the_export_calls_around_the_write() {
+    let source = r#"let b = 1;
+b ??= 5;
+b **= 2;
+export { b, b as foo };
+"#;
+    let output = emit_system_target(source, ScriptTarget::ES2015);
+    assert_ordered(
+        &output,
+        &[
+            "b !== null && b !== void 0 ? b : (exports_1(\"foo\", exports_1(\"b\", b = 5)));",
+            "exports_1(\"foo\", exports_1(\"b\", b = Math.pow(b, 2)));",
+        ],
+    );
+}
+
+#[test]
+fn non_exported_local_gets_no_export_wrap() {
+    // A non-exported binding must lower with no `exports_1` wrap, proving the
+    // decision keys on the exported-binding origin, not on the operator.
+    let source = r#"export let e = 0;
+let b = 1;
+b ??= 5;
+b ||= 2;
+b &&= 3;
+b **= 2;
+"#;
+    let output = emit_system_target(source, ScriptTarget::ES2015);
+    assert_ordered(
+        &output,
+        &[
+            "b !== null && b !== void 0 ? b : (b = 5);",
+            "b || (b = 2);",
+            "b && (b = 3);",
+            "b = Math.pow(b, 2);",
+        ],
+    );
+    assert!(
+        !output.contains("exports_1(\"b\""),
+        "Non-exported local must not be threaded through exports_1.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #15291.

Under `--module system`, a compound assignment to a top-level exported binding that the **target down-levels** — `**=` (target < ES2016) or `&&=`/`||=`/`??=` (target < ES2021) — dropped the System live named-export update, so the `exports_1("x", ...)` mirror was missing and importers observed a stale value. The non-lowered forms (`=`, `+=`, `++`, native `??=`/`**=` at ESNext/ES2020) were already correct.

This is the `--module system` parallel of the CommonJS gap in #15289 / #15290, explicitly scoped out of that issue as "tracked separately" (call-wrap `exports_1("x", x = v)` vs prefix `exports.x = x = v`).

### Repro (`--module system --target es2015`)

```ts
let b = 1;
b ??= 5; b ||= 2; b &&= 3; b **= 2;
export { b };
```

- **tsc 6.0.2** (inside the `execute` body):
  ```js
  b !== null && b !== void 0 ? b : (exports_1("b", b = 5));
  b || (exports_1("b", b = 2));
  b && (exports_1("b", b = 3));
  exports_1("b", b = Math.pow(b, 2));
  ```
- **tsz before** (missing `exports_1("b", ...)` mirror): `(b = 5)`, `(b = 2)`, `(b = 3)`, `b = Math.pow(b, 2)`.

At `--target es2020` the logical operators still lower (they are ES2021), so `b ?? (exports_1("b", b = 5))` etc. diverge, while native `**=` is already correct (`exports_1("b", b **= 2)` via the non-lowered gateway).

## Structural rule

When a top-level `let`/`var` is exported under a System module (inline `export let x` or clause `export { x }`), `tsc` mirrors every write through the live named export by wrapping the value-producing assignment in `exports_1("x", x = <value>)` (nested per alias). This wrap must survive **operator down-leveling**: the lowered `**=` (`x = Math.pow(x, n)`) and the lowered `&&=`/`||=`/`??=` short-circuit/ternary expansions wrap their innermost `x = <value>` write in the same `exports_1("x", ...)` call chain, exactly as the non-lowered path does. The decision keys on the exported-binding origin (a System-exported bare identifier), never on rendered output.

## Owner layer

Emitter — operator down-level lowering (`crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs`: `emit_exponentiation_assignment` simple-identifier arm and `emit_logical_assignment_expression` identifier arm). These emit the write target directly, returning before the normal binary dispatch reaches `emit_system_live_export_assignment_expression`, so the lowered write target now routes through the shared `system_live_export_names` gateway (`module_emission/system_live_exports.rs`) itself. System live exports only apply to bare-identifier targets, so the property/element-access lowering branches are untouched. Pure output-form change; no semantic validation added. No identifier/file-name/rendered-output predicate drives the decision.

## Adjacent matrix (verified byte-identical to tsc 6.0.2)

`--module system`, targets es2015 / es2020, binder names varied:
- clause `export { b }` → `exports_1("b", b = v)` for `**=`/`&&=`/`||=`/`??=`
- renamed clause `export { b as foo }` → `exports_1("foo", b = v)`
- multi-alias `export { b, b as foo }` → nested `exports_1("foo", exports_1("b", b = v))`
- **controls unchanged:** native `**=` at es2020 stays `exports_1("b", b **= 2)` (non-lowered gateway); non-exported locals gain no wrap (short-circuit read positions stay unwrapped)

### Out of scope (separate, pre-existing)
- **CommonJS** parallel is #15289 / #15290 (prefix `exports.x = x =` form). Mutually-exclusive context; independent path.
- **Nested-scope shadowing** of an exported name: pre-existing name-based live-export defect affecting the normal path identically; not introduced or fixed here.

## Overlap
- #15290 (CommonJS, #15289) landed first. This head is rebased on that merge and composes the two live-export paths in `binary_downlevel.rs`: CommonJS rewrites the assignment target, while System wraps the value-producing write. The module contexts remain mutually exclusive, and the combined helper uses `Option<&[String]>` so the clippy `ref_option` warn ratchet stays below baseline.

## Goal
Goal: hold

## Verification
- New suite `crates/tsz-emitter/src/emitter/module_wrapper/tests/system_live_export_downlevel_compound_assignment.rs` (5 tests: clause/renamed/multi-alias mirrors for `**=`/`&&=`/`||=`/`??=` at es2015 and es2020, plus a non-exported control) - asserts byte-exact `tsc 6.0.2` output.
- Rebased follow-up head `d6f31218843427edb063803843ea2fad97a68590` on merged #15290 and resolved the shared lowering wrapper so CommonJS and System live-export paths both hold.
- Touched-file line counts: `binary_downlevel.rs` 1031, `system_live_exports.rs` 121, `module_wrapper/tests.rs` 10, `system_live_export_downlevel_compound_assignment.rs` 148.
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter --lib system_live_export_downlevel_compound_assignment` (5/5 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter --test cjs_live_export_downlevel_compound_assignment_tests` (11/11 passed)
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint` (passed; 100 warnings below baseline)
- ready-review CI owns the broad conformance / emit / fourslash baselines.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high

