### PR TITLE
fix(solver): skip unstable relation eval cache writes

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -207,9 +207,12 @@ impl RelationEvaluationResult {
         self.type_id
     }
 
+    pub(crate) const fn is_stable_for_depth_agnostic_cache(self) -> bool {
+        self.cache_stability.is_stable_for_depth_agnostic_cache()
+    }
+
     pub(crate) fn is_unstable_unknown(self) -> bool {
-        self.type_id == TypeId::UNKNOWN
-            && !self.cache_stability.is_stable_for_depth_agnostic_cache()
+        self.type_id == TypeId::UNKNOWN && !self.is_stable_for_depth_agnostic_cache()
     }
 }
 
@@ -226,6 +229,7 @@ mod relation_evaluation_result_tests {
         let stable = RelationEvaluationResult::stable(TypeId::STRING);
         assert_eq!(stable.type_id(), TypeId::STRING);
         assert_eq!(stable.cache_stability, RelationEvaluationStability::Stable);
+        assert!(stable.is_stable_for_depth_agnostic_cache());
         assert!(!stable.is_unstable_unknown());
 
         let unstable_unknown = RelationEvaluationResult::unstable(TypeId::UNKNOWN);
@@ -233,6 +237,7 @@ mod relation_evaluation_result_tests {
             unstable_unknown.cache_stability,
             RelationEvaluationStability::Unstable
         );
+        assert!(!unstable_unknown.is_stable_for_depth_agnostic_cache());
         assert!(unstable_unknown.is_unstable_unknown());
 
         let unstable_string = RelationEvaluationResult::unstable(TypeId::STRING);
@@ -251,6 +256,7 @@ mod relation_evaluation_result_tests {
             complete.cache_stability,
             RelationEvaluationStability::Stable
         );
+        assert!(complete.is_stable_for_depth_agnostic_cache());
 
         let incomplete_memo = EvaluationMemoResult::for_depth_agnostic_memo(
             EvaluationResult::incomplete(TypeId::UNKNOWN, TerminationKind::DepthExceeded),
@@ -262,6 +268,7 @@ mod relation_evaluation_result_tests {
             incomplete.cache_stability,
             RelationEvaluationStability::Unstable
         );
+        assert!(!incomplete.is_stable_for_depth_agnostic_cache());
         assert!(incomplete.is_unstable_unknown());
     }
 }

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/evaluation.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/evaluation.rs
@@ -54,7 +54,9 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
             return RelationEvaluationResult::unstable(type_id);
         };
         let entry = RelationEvaluationResult::from_depth_agnostic_memo(memo_result);
-        self.eval_cache.insert(cache_key, entry);
+        if entry.is_stable_for_depth_agnostic_cache() {
+            self.eval_cache.insert(cache_key, entry);
+        }
         entry
     }
 

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -363,10 +363,11 @@ fn evaluation_engine_keeps_request_stage_boundary() {
             )
             && function_checking_eval_rs
                 .contains("RelationEvaluationResult::from_depth_agnostic_memo(memo_result)")
+            && function_checking_eval_rs.contains("if entry.is_stable_for_depth_agnostic_cache()")
             && functions_mod_rs.contains(".is_unstable_unknown()")
             && !functions_mod_rs
                 .contains("evaluate_type_with_stability(ret) == (TypeId::UNKNOWN, false)"),
-        "function-relation evaluation caches must key on EvaluationCacheKey and carry stability through RelationEvaluationResult instead of anonymous (TypeId, bool) tuples"
+        "function-relation evaluation caches must key on EvaluationCacheKey, carry stability through RelationEvaluationResult, and only publish stable relation-local eval results"
     );
     assert!(
         cross_eval_guard_rs.contains("use crate::evaluation::session::EvaluationSession;")

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_00.rs
@@ -81,6 +81,48 @@ fn subtype_checker_eval_cache_keys_on_exact_optional_property_types() {
 }
 
 #[test]
+fn subtype_checker_does_not_cache_unstable_relation_evaluations() {
+    let interner = TypeInterner::new();
+    let def = DefId(77);
+    let lazy_mapped = interner.lazy(def);
+    let mapped = interner.mapped(MappedType {
+        type_param: TypeParamInfo {
+            name: interner.intern_string("P"),
+            constraint: None,
+            default: None,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        },
+        constraint: interner.keyof(lazy_mapped),
+        name_type: None,
+        template: TypeId::NUMBER,
+        optional_modifier: None,
+        readonly_modifier: None,
+    });
+    let mut env = TypeEnvironment::new();
+    env.insert_def(def, mapped);
+    let mut checker = SubtypeChecker::with_resolver(&interner, &env);
+
+    let result = checker.evaluate_type_with_stability(mapped);
+
+    assert_eq!(result.type_id(), mapped);
+    assert!(
+        !result.is_stable_for_depth_agnostic_cache(),
+        "self-recursive mapped evaluation is a guard-truncated partial"
+    );
+    assert_eq!(
+        checker.cache_statistics().eval_entries,
+        0,
+        "relation-local eval cache must not publish guard-truncated partials"
+    );
+
+    let union = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    let stable = checker.evaluate_type_with_stability(union);
+    assert!(stable.is_stable_for_depth_agnostic_cache());
+    assert_eq!(checker.cache_statistics().eval_entries, 1);
+}
+
+#[test]
 fn test_any_top_bottom_subtyping() {
     let interner = TypeInterner::new();
     let mut checker = SubtypeChecker::new(&interner);


### PR DESCRIPTION
Goal: green

## Summary
- Gate `SubtypeChecker` relation-local eval cache writes on `RelationEvaluationResult` stability so guard-truncated partials are returned for the current comparison but not memoized under `EvaluationCacheKey`.
- Add a named relation-eval stability accessor and ratchet the architecture guard around the typed request-stage boundary.
- Add a recursive mapped-type regression proving unstable relation eval leaves the cache empty while stable evals still cache normally.

## Structural Rule
When relation-side type evaluation is guard-truncated by recursion/cycle/budget state, `tsc` does not treat the partial as a reusable normalized type; `tsz` should return that partial for the current relation step through the solver subtype owner, but only publish stable results to the relation-local eval cache.

## Verification
- `cargo fmt --all -- --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(subtype_checker_cache_statistics_account_for_eval_entries) or test(subtype_checker_eval_cache_keys_on_exact_optional_property_types) or test(subtype_checker_does_not_cache_unstable_relation_evaluations) or test(relation_evaluation_result_names_cache_stability) or test(relation_evaluation_result_imports_memo_stability)'`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards -E 'test(evaluation_engine_keeps_request_stage_boundary)'`
- `git diff --check`

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high
