### PR TITLE
fix(emit): keep System live-export call-wrap on down-leveled compound assignments

### DIFF
--- a/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
@@ -162,13 +162,17 @@ impl<'a> Printer<'a> {
         }
 
         if !is_element_access && !is_property_access {
-            // Simple identifier: `x **= y` → `x = Math.pow(x, y)`
+            // Simple identifier: `x **= y` → `x = Math.pow(x, y)`.
+            // Under `--module system`, an exported target threads the write
+            // through the live named export: `exports_1("x", x = Math.pow(x, y))`.
+            let wrap = self.system_live_export_downlevel_write_wrap_open(original_left);
             self.emit(original_left);
             self.write(" = Math.pow(");
             self.emit(unwrapped_left);
             self.write(", ");
             self.emit(right);
             self.write(")");
+            self.write_system_export_call_chain_close(wrap);
             return;
         }
 
@@ -365,23 +369,17 @@ impl<'a> Printer<'a> {
         if is_and {
             self.emit_expression_for_logical_assignment(binary.left);
             self.write(" && (");
-            self.emit_expression_for_logical_assignment(binary.left);
-            self.write(" = ");
-            self.emit_expression_for_logical_assignment(binary.right);
+            self.emit_logical_assignment_inner_write(left, binary.right);
             self.write(")");
         } else if binary.operator_token == SyntaxKind::BarBarEqualsToken as u16 {
             self.emit_expression_for_logical_assignment(binary.left);
             self.write(" || (");
-            self.emit_expression_for_logical_assignment(binary.left);
-            self.write(" = ");
-            self.emit_expression_for_logical_assignment(binary.right);
+            self.emit_logical_assignment_inner_write(left, binary.right);
             self.write(")");
         } else if self.ctx.options.target.supports_es2020() {
             self.emit_expression_for_logical_assignment(binary.left);
             self.write(" ?? (");
-            self.emit_expression_for_logical_assignment(binary.left);
-            self.write(" = ");
-            self.emit_expression_for_logical_assignment(binary.right);
+            self.emit_logical_assignment_inner_write(left, binary.right);
             self.write(")");
         } else {
             self.emit_expression_for_logical_assignment(binary.left);
@@ -390,11 +388,23 @@ impl<'a> Printer<'a> {
             self.write(" !== void 0 ? ");
             self.emit_expression_for_logical_assignment(binary.left);
             self.write(" : (");
-            self.emit_expression_for_logical_assignment(binary.left);
-            self.write(" = ");
-            self.emit_expression_for_logical_assignment(binary.right);
+            self.emit_logical_assignment_inner_write(left, binary.right);
             self.write(")");
         }
+    }
+
+    /// Emit the inner value-producing write `<target> = <right>` of a
+    /// down-leveled logical assignment (`&&=`/`||=`/`??=`), wrapping it in the
+    /// System live named-export call (`exports_1("x", target = <right>)`) when
+    /// `target` is a System-exported binding. The wrap is invisible for plain and
+    /// CommonJS output — [`Self::system_live_export_downlevel_write_wrap_open`]
+    /// returns `None` there, leaving the bare write unchanged.
+    fn emit_logical_assignment_inner_write(&mut self, target: NodeIndex, right: NodeIndex) {
+        let wrap = self.system_live_export_downlevel_write_wrap_open(target);
+        self.emit_expression_for_logical_assignment(target);
+        self.write(" = ");
+        self.emit_expression_for_logical_assignment(right);
+        self.write_system_export_call_chain_close(wrap);
     }
 
     /// Whether lowering a non-es2020 `??=` with target `left` consumes a hoisted

--- a/crates/tsz-emitter/src/emitter/module_emission/system_live_exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/system_live_exports.rs
@@ -33,6 +33,46 @@ impl<'a> Printer<'a> {
         true
     }
 
+    /// Open the System live named-export call-wrap around a down-leveled
+    /// compound-assignment write whose target is a System-exported binding.
+    ///
+    /// The operator-lowering paths (`**=` for targets `< ES2016`, and
+    /// `&&=`/`||=`/`??=` for targets `< ES2021`) expand to an inner
+    /// value-producing assignment `x = <value>` that returns before the normal
+    /// assignment dispatch and so bypasses
+    /// [`Self::emit_system_live_export_assignment_expression`]. To preserve the
+    /// live named-export update `tsc` threads through every write, the lowered
+    /// write is wrapped `exports_1("x", x = <value>)` (nested for multi-alias
+    /// re-exports), exactly as the non-lowered assignment path does.
+    ///
+    /// When `target` is a bare identifier bound to one or more System exports in
+    /// a System live-export context this writes the opening call chain
+    /// (`exports_1("alias", exports_1("x", `) and returns the chain depth so the
+    /// caller closes it with [`Self::write_system_export_call_chain_close`] after
+    /// emitting `x = <value>`. Returns `None` (writing nothing) for non-identifier
+    /// / non-exported targets or non-System output, in which case the caller emits
+    /// the bare write unchanged. The decision keys on the binding's import/export
+    /// origin, never on rendered text.
+    pub(in crate::emitter) fn system_live_export_downlevel_write_wrap_open(
+        &mut self,
+        target: NodeIndex,
+    ) -> Option<usize> {
+        if !self.is_system_live_export_context() {
+            return None;
+        }
+        let node = self.arena.get(target)?;
+        if node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let local_name = self.get_identifier_text_idx(target);
+        let export_names = self.system_export_names_for_local(&local_name);
+        if export_names.is_empty() {
+            return None;
+        }
+        self.write_system_export_call_chain_start(&export_names);
+        Some(export_names.len())
+    }
+
     pub(in crate::emitter) fn emit_system_live_export_prefix_unary(
         &mut self,
         local_name: &str,

--- a/crates/tsz-emitter/src/emitter/module_wrapper/system_live_exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/system_live_exports.rs
@@ -135,7 +135,18 @@ impl<'a> Printer<'a> {
     }
 
     pub(in crate::emitter) fn write_system_export_call_chain_end(&mut self, names: &[String]) {
-        for _ in names {
+        self.write_system_export_call_chain_close(Some(names.len()));
+    }
+
+    /// Close a System live-export call-wrap opened by
+    /// [`Self::system_live_export_downlevel_write_wrap_open`]: writes `depth`
+    /// closing parens, or nothing when the target was not a System export
+    /// (`None`). Pairs the open/close so down-leveled write sites stay one-liners.
+    pub(in crate::emitter) fn write_system_export_call_chain_close(
+        &mut self,
+        depth: Option<usize>,
+    ) {
+        for _ in 0..depth.unwrap_or(0) {
             self.write(")");
         }
     }

--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_live_exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_live_exports.rs
@@ -20,6 +20,22 @@ fn emit_system(source: &str) -> String {
     printer.get_output().to_string()
 }
 
+fn emit_system_target(source: &str, target: ScriptTarget) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        module: ModuleKind::System,
+        target,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let emit_plan = LoweringPass::new(&parser.arena, &ctx).run_plan(root);
+    let mut printer = Printer::with_emit_plan_and_options(&parser.arena, emit_plan, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
 fn assert_ordered(output: &str, snippets: &[&str]) {
     let mut start = 0;
     for snippet in snippets {
@@ -106,5 +122,159 @@ export let [b, c] = [1, 2];
             "exports_1(\"a\", a = [1][0]);",
             "_a = [1, 2], exports_1(\"b\", b = _a[0]), exports_1(\"c\", c = _a[1]);",
         ],
+    );
+}
+
+// --- Down-leveled compound assignment to a System-exported binding ---------
+//
+// `**=` (target < ES2016) and `&&=`/`||=`/`??=` (target < ES2021) lower to an
+// inner value-producing assignment `x = <value>` that returns before the normal
+// assignment dispatch. That inner write must still thread the live named export
+// `exports_1("x", x = <value>)`, exactly as the non-lowered path does. Ground
+// truth captured from `tsc` 6.0.2 `--module system`.
+
+#[test]
+fn system_downlevel_compound_assign_clause_export_wraps_es2015() {
+    let output = emit_system_target(
+        "let b = 1;\nb ??= 5;\nb ||= 2;\nb &&= 3;\nb **= 2;\nexport { b };\n",
+        ScriptTarget::ES2015,
+    );
+    assert_ordered(
+        &output,
+        &[
+            "b !== null && b !== void 0 ? b : (exports_1(\"b\", b = 5));",
+            "b || (exports_1(\"b\", b = 2));",
+            "b && (exports_1(\"b\", b = 3));",
+            "exports_1(\"b\", b = Math.pow(b, 2));",
+        ],
+    );
+    // The reads of the target stay bare — only the write threads the export.
+    assert!(
+        !output.contains("exports_1(\"b\", b) !== null"),
+        "logical-assignment read must not be wrapped.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn system_downlevel_compound_assign_clause_export_wraps_es5() {
+    let output = emit_system_target(
+        "let b = 1;\nb ??= 5;\nb ||= 2;\nb &&= 3;\nb **= 2;\nexport { b };\n",
+        ScriptTarget::ES5,
+    );
+    assert_ordered(
+        &output,
+        &[
+            "b !== null && b !== void 0 ? b : (exports_1(\"b\", b = 5));",
+            "b || (exports_1(\"b\", b = 2));",
+            "b && (exports_1(\"b\", b = 3));",
+            "exports_1(\"b\", b = Math.pow(b, 2));",
+        ],
+    );
+}
+
+#[test]
+fn system_downlevel_nullish_and_exponent_wrap_at_es2020() {
+    // At ES2020 `??=` still lowers (to native `??` short-circuit) and must wrap;
+    // native `**=` is kept and threads the export through the normal dispatch.
+    let output = emit_system_target(
+        "let b = 1;\nb ??= 5;\nb ||= 2;\nb &&= 3;\nb **= 2;\nexport { b };\n",
+        ScriptTarget::ES2020,
+    );
+    assert_ordered(
+        &output,
+        &[
+            "b ?? (exports_1(\"b\", b = 5));",
+            "b || (exports_1(\"b\", b = 2));",
+            "b && (exports_1(\"b\", b = 3));",
+            "exports_1(\"b\", b **= 2);",
+        ],
+    );
+}
+
+#[test]
+fn system_downlevel_native_logical_assignment_wraps_at_es2021() {
+    // At ES2021 the operators are native; the normal assignment dispatch already
+    // threads the export. This guards that the lowered/native paths agree.
+    let output = emit_system_target(
+        "let b = 1;\nb ??= 5;\nb ||= 2;\nb **= 2;\nexport { b };\n",
+        ScriptTarget::ES2022,
+    );
+    assert_ordered(
+        &output,
+        &[
+            "exports_1(\"b\", b ??= 5);",
+            "exports_1(\"b\", b ||= 2);",
+            "exports_1(\"b\", b **= 2);",
+        ],
+    );
+}
+
+#[test]
+fn system_downlevel_compound_assign_renamed_reexport_wraps() {
+    let output = emit_system_target(
+        "let b = 1;\nb ??= 5;\nb ||= 2;\nb **= 2;\nexport { b as foo };\n",
+        ScriptTarget::ES2015,
+    );
+    assert_ordered(
+        &output,
+        &[
+            "b !== null && b !== void 0 ? b : (exports_1(\"foo\", b = 5));",
+            "b || (exports_1(\"foo\", b = 2));",
+            "exports_1(\"foo\", b = Math.pow(b, 2));",
+        ],
+    );
+}
+
+#[test]
+fn system_downlevel_compound_assign_multi_alias_nests_call_chain() {
+    let output = emit_system_target(
+        "let c = 1;\nc &&= 3;\nc **= 2;\nexport { c, c as bar };\n",
+        ScriptTarget::ES2015,
+    );
+    assert_ordered(
+        &output,
+        &[
+            "c && (exports_1(\"bar\", exports_1(\"c\", c = 3)));",
+            "exports_1(\"bar\", exports_1(\"c\", c = Math.pow(c, 2)));",
+        ],
+    );
+}
+
+#[test]
+fn system_downlevel_chained_exponent_assign_nests_each_export() {
+    let output = emit_system_target(
+        "let p = 2, q = 3, r = 4;\np **= q **= r;\nexport { p, q, r };\n",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        output.contains("exports_1(\"p\", p = Math.pow(p, exports_1(\"q\", q = Math.pow(q, r))));"),
+        "chained `**=` must wrap each exported write.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn system_downlevel_non_exported_local_is_not_wrapped() {
+    let output = emit_system_target(
+        "let n = 0;\nlet b = 1;\nn ??= 5;\nn ||= 2;\nn &&= 3;\nn **= 2;\nb ||= 7;\nexport { b };\n",
+        ScriptTarget::ES2015,
+    );
+    // The non-exported `n` writes stay bare in every lowered form...
+    assert_ordered(
+        &output,
+        &[
+            "n !== null && n !== void 0 ? n : (n = 5);",
+            "n || (n = 2);",
+            "n && (n = 3);",
+            "n = Math.pow(n, 2);",
+        ],
+    );
+    // ...while the exported `b` still threads its export.
+    assert!(
+        output.contains("b || (exports_1(\"b\", b = 7));"),
+        "exported `b` must still wrap.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("exports_1(\"n\""),
+        "non-exported `n` must never be wrapped.\nOutput:\n{output}"
     );
 }


### PR DESCRIPTION
Fixes #15297.

Under `--module system`, a compound assignment to a top-level System-exported binding that the **target down-levels** — `**=` (target < ES2016) or `&&=`/`||=`/`??=` (target < ES2021) — dropped the System live named-export update. The lowered expansion in `binary_downlevel.rs` returns before the normal assignment dispatch that threads the target through `emit_system_live_export_assignment_expression`, so it emitted the bare LHS and a `System`/`require` observer saw a stale value. `tsc` wraps the innermost value-producing assignment `exports_1("x", x = <value>)` (nested for multi-alias) in every lowered form.

This is the System parallel of the CommonJS gap in #15289/#15290 — structurally different (call-wrap vs prefix), which #15289 explicitly deferred as "tracked separately."

### Repro (`--module system --target es2015`)

```ts
let b = 1;
b ??= 5; b ||= 2; b &&= 3; b **= 2;
export { b };
```

- **tsc 6.0.2**
  ```js
  b !== null && b !== void 0 ? b : (exports_1("b", b = 5));
  b || (exports_1("b", b = 2));
  b && (exports_1("b", b = 3));
  exports_1("b", b = Math.pow(b, 2));
  ```
- **tsz before** (missing wrap): `(b = 5)`, `(b = 2)`, `(b = 3)`, `b = Math.pow(b, 2)`.

## Structural rule

When a top-level `let`/`var` is exported under System (inline `export let x` or clause `export { x }`), `tsc` mirrors every write through the live named export `exports_1("x", x = <value>)` (nested for multi-alias). That mirror must survive **operator down-leveling**: the lowered `**=` (`x = Math.pow(x, n)`) and the lowered `&&=`/`||=`/`??=` short-circuit/ternary expansions wrap the innermost value-producing assignment in the `exports_1("x", …)` call, exactly as the non-lowered path does. The choice keys on the binding's import/export origin, never on rendered output.

## Owner layer

Emitter — operator down-level lowering (`crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs`). `emit_exponentiation_assignment` and `emit_logical_assignment_expression` return early before the normal assignment dispatch, so the lowered identifier write now calls the System call-wrap gateway itself:

- New `system_live_export_downlevel_write_wrap_open(target) -> Option<usize>` (in `module_emission/system_live_exports.rs`) writes the opening `exports_1("alias", exports_1("x", ` chain and returns its depth for System-exported identifier targets, `None` otherwise (so plain/CommonJS output is byte-for-byte unchanged).
- The paired `write_system_export_call_chain_close(Option<usize>)` (in `module_wrapper/system_live_exports.rs`) writes the closing parens; the pre-existing `write_system_export_call_chain_end(&[String])` now delegates to it.
- The four logical-assignment branches share a new `emit_logical_assignment_inner_write`.

Scope mirrors the non-lowered path: identifier targets only (property/element-access targets are not System-exported bindings and stay unwrapped, as they already were). Pure output-form change; no semantic validation added; no identifier / file-name / rendered-output predicate drives the decision.

## Adjacent matrix (verified byte-identical to tsc 6.0.2)

`--module system`, binder names varied:
- clause `export { b }` → `exports_1("b", b = …)` for `**=`/`&&=`/`||=`/`??=`, targets es5 / es2015 / es2020
- renamed `export { b as foo }` → `exports_1("foo", b = …)`
- multi-alias `export { c, c as bar }` → `exports_1("bar", exports_1("c", c = …))`
- chained `p **= q **= r` with `export { p, q, r }` → each exported write wraps, nested
- ES2020: `??=` still lowers and wraps; native `**=` threads through the normal dispatch (`exports_1("b", b **= 2)`)
- ES2021+: native `??=`/`||=`/`**=` kept, already wrapped by the normal dispatch (control)
- **controls unchanged:** non-exported locals gain no wrap in any lowered form; property/element-access targets untouched

## Goal
Goal: hold

## Verification
- New tests in `crates/tsz-emitter/src/emitter/module_wrapper/tests/system_live_exports.rs` (8 tests: clause/renamed/multi-alias/chained/native/non-exported across es5/es2015/es2020/es2022) — ground truth captured from `tsc` 6.0.2 `--module system`.
- `cargo test -p tsz-emitter --lib` → 3944 passed, 0 failed; `logical_assignment_temp_numbering_tests`, `cjs_clause_export_live_binding_tests`, `cjs_destructuring_export_inline_tests` green (no regressions on the shared lowering path).
- `cargo fmt --all -- --check`, `cargo clippy -p tsz-emitter --lib -- -D warnings`, `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean.
- ready-review CI owns the broad conformance / emit / fourslash baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZXCwBjiv8ph7tQ8rMgbnn)_