### PR TITLE
fix(solver): invalidate eval caches by def dependencies

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -4,6 +4,8 @@
 //! references, type parameter registration, and resolved-type registration
 //! in the `TypeEnvironment`.
 
+mod body_publication;
+
 use std::sync::Arc;
 
 use crate::query_boundaries::common::TypeResolver;
@@ -905,7 +907,7 @@ impl CheckerContext<'_> {
         // it already held (a benign re-resolution oscillation). See
         // `def_published_bodies` and `register_def_with_params_in_envs`.
         let body_seen_before = body_changed && self.record_published_body(def_id, body);
-        self.definition_store.set_body(def_id, body);
+        self.publish_definition_body(def_id, body);
         if body_changed {
             // First publication (`None -> Some`) needs no env-eval/narrowing
             // sweep, for the same reason `invalidate_application_evals_on_body_rewrite`
@@ -976,8 +978,7 @@ impl CheckerContext<'_> {
         // still sweeps. The cheap, def-keyed application-eval invalidation still
         // runs on every real body change.
         let body_seen_before = body_changed && self.record_published_body(def_id, body);
-        self.definition_store
-            .set_body_with_params(def_id, body, Some(params.clone()));
+        self.publish_definition_body_with_params(def_id, body, params.clone());
         // First publication (`prev_body == None`) needs no sweep: no cached
         // entry can reference `def_id` before it had a resolvable body (see
         // `register_def_in_envs` and `invalidate_application_evals_on_body_rewrite`).
@@ -1549,7 +1550,7 @@ impl CheckerContext<'_> {
             // find type alias names via find_type_alias_by_body(). Without
             // this, type aliases show their structural expansion in diagnostics
             // (e.g., "{ r: number; g: number; b: number }" instead of "Color").
-            self.definition_store.set_body(def_id, type_id);
+            self.publish_definition_body(def_id, type_id);
         }
     }
 

--- a/crates/tsz-checker/src/context/def_mapping/body_publication.rs
+++ b/crates/tsz-checker/src/context/def_mapping/body_publication.rs
@@ -1,0 +1,49 @@
+use crate::context::CheckerContext;
+use tsz_solver::TypeId;
+use tsz_solver::def::DefId;
+
+impl CheckerContext<'_> {
+    pub(crate) fn publish_definition_body(&self, def_id: DefId, body: TypeId) -> bool {
+        self.definition_store.set_body(def_id, body);
+        self.record_definition_body_dependencies_if_published(def_id, body)
+    }
+
+    pub(crate) fn publish_definition_body_with_params(
+        &self,
+        def_id: DefId,
+        body: TypeId,
+        params: Vec<tsz_solver::TypeParamInfo>,
+    ) -> bool {
+        self.definition_store
+            .set_body_with_params(def_id, body, Some(params));
+        self.record_definition_body_dependencies_if_published(def_id, body)
+    }
+
+    pub(crate) fn publish_finalized_definition_body(
+        &self,
+        def_id: DefId,
+        body: TypeId,
+        params: Option<Vec<tsz_solver::TypeParamInfo>>,
+    ) -> TypeId {
+        self.definition_store
+            .set_body_finalized(def_id, body, params);
+        let published = self.definition_store.get_body(def_id).unwrap_or(body);
+        self.record_definition_body_dependencies_if_published(def_id, body);
+        published
+    }
+
+    fn record_definition_body_dependencies_if_published(
+        &self,
+        def_id: DefId,
+        body: TypeId,
+    ) -> bool {
+        if self.definition_store.get_body(def_id) != Some(body) {
+            return false;
+        }
+        self.definition_store.set_body_dependency_defs(
+            def_id,
+            self.collect_lazy_def_ids_cached(body).iter().copied(),
+        );
+        true
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -884,6 +884,12 @@ impl<'a> CheckerState<'a> {
                     target,
                     anchor_idx,
                 );
+                if diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE {
+                    diag.message_text = self.rewrite_static_schema_array_target_in_ts2322_message(
+                        diag.message_text,
+                        source,
+                    );
+                }
                 let has_static_schema_display = self
                     .static_schema_array_structural_display(source, target)
                     .is_some()
@@ -1157,6 +1163,11 @@ impl<'a> CheckerState<'a> {
             target_str = display;
             static_schema_display = true;
         }
+        if let Some(display) = self.static_schema_array_structural_display_text(&target_str, source)
+        {
+            target_str = display;
+            static_schema_display = true;
+        }
         if !static_schema_display
             && let Some((direct_source, direct_target)) =
                 self.direct_type_param_alias_application_pair_display(source, target)
@@ -1366,6 +1377,10 @@ impl<'a> CheckerState<'a> {
             source_str = display;
         }
         if let Some(display) = self.static_schema_array_structural_display(target, source) {
+            target_str = display;
+        }
+        if let Some(display) = self.static_schema_array_structural_display_text(&target_str, source)
+        {
             target_str = display;
         }
         if let Some(display) =

--- a/crates/tsz-checker/src/error_reporter/assignability_generic.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_generic.rs
@@ -261,6 +261,18 @@ impl<'a> CheckerState<'a> {
                 tgt_str = display;
                 static_schema_display = true;
             }
+            if let Some(display) =
+                self.static_schema_array_structural_display_text(&tgt_str, source)
+            {
+                tgt_str = display;
+                static_schema_display = true;
+            }
+            if let Some(display) =
+                self.static_schema_type_parameter_array_constraint_display(target, &tgt_str, source)
+            {
+                tgt_str = display;
+                static_schema_display = true;
+            }
             if !static_schema_display
                 && let Some((direct_source, direct_target)) =
                     self.direct_type_param_alias_application_pair_display(source, target)

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
@@ -15,9 +15,10 @@ impl<'a> CheckerState<'a> {
             diagnostic_query::type_parameter_constraint(self.ctx.types, other).unwrap_or(other);
         let element_type = diagnostic_query::array_element_type(self.ctx.types, array_type)?;
         let array_display = self.format_type_diagnostic(array_type);
-        if let Some(query_display) = self.type_query_static_array_structural_display(&array_display)
+        if let Some(display) =
+            self.static_schema_array_structural_display_text(&array_display, other)
         {
-            return Some(query_display);
+            return Some(display);
         }
         // Fast, deterministic path: reduce the already-resolved schema element
         // object in place, recursively rewriting its nested `Static<…>`
@@ -97,6 +98,41 @@ impl<'a> CheckerState<'a> {
             }
         }
         None
+    }
+
+    fn alias_static_array_structural_display(
+        &mut self,
+        array_display: &str,
+        format_peer: TypeId,
+    ) -> Option<String> {
+        let alias_name = array_display.strip_suffix("[]")?;
+        if !alias_name
+            .chars()
+            .all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+        {
+            return None;
+        }
+        let atom = self.ctx.types.intern_string(alias_name);
+        if let Some(defs) = self.ctx.definition_store.find_defs_by_name(atom) {
+            for def_id in defs {
+                if let Some(static_type) =
+                    self.static_schema_alias_def_structural_type(Some(def_id))
+                {
+                    return Some(
+                        self.format_static_schema_array_structural_type(static_type, format_peer),
+                    );
+                }
+            }
+        }
+        if let Some(display) =
+            self.static_schema_value_name_array_structural_display(alias_name, format_peer)
+        {
+            return Some(display);
+        }
+        let sym_id = self.ctx.binder.file_locals.get(alias_name)?;
+        let def_id = self.ctx.get_existing_def_id(sym_id)?;
+        let static_type = self.static_schema_alias_def_structural_type(Some(def_id))?;
+        Some(self.format_static_schema_array_structural_type(static_type, format_peer))
     }
 
     fn static_schema_alias_def_structural_type(
@@ -275,10 +311,12 @@ impl<'a> CheckerState<'a> {
             if !matches!(static_type, TypeId::ERROR | TypeId::UNKNOWN)
                 && !diagnostic_query::contains_free_type_parameters(self.ctx.types, static_type)
             {
-                return Some(
-                    self.rewrite_nested_static_projection_members(static_type, depth + 1)
-                        .unwrap_or(static_type),
-                );
+                let static_type = self
+                    .rewrite_nested_static_projection_members(static_type, depth + 1)
+                    .unwrap_or(static_type);
+                if !self.type_has_residual_static_schema(static_type, depth + 1) {
+                    return Some(static_type);
+                }
             }
         }
 
@@ -347,6 +385,21 @@ impl<'a> CheckerState<'a> {
         let schema_name = array_display
             .strip_prefix("(typeof ")?
             .strip_suffix(".static)[]")?;
+        let static_type = self.static_schema_value_name_structural_type(schema_name)?;
+        let rebuilt = self.static_schema_array_display_type(static_type);
+        Some(self.format_type_diagnostic(rebuilt))
+    }
+
+    fn static_schema_value_name_array_structural_display(
+        &mut self,
+        schema_name: &str,
+        format_peer: TypeId,
+    ) -> Option<String> {
+        let static_type = self.static_schema_value_name_structural_type(schema_name)?;
+        Some(self.format_static_schema_array_structural_type(static_type, format_peer))
+    }
+
+    fn static_schema_value_name_structural_type(&mut self, schema_name: &str) -> Option<TypeId> {
         let sym_id = self.ctx.binder.file_locals.get(schema_name)?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
         let value_decl = symbol.value_declaration.into_option().or_else(|| {
@@ -359,8 +412,67 @@ impl<'a> CheckerState<'a> {
         let schema_type = self.type_of_value_declaration_for_symbol(sym_id, value_decl);
         let schema_type = self.evaluate_type_for_assignability(schema_type);
         let static_type = self.typebox_schema_static_type(schema_type, 0)?;
-        let rebuilt = self.static_schema_array_display_type(static_type);
-        Some(self.format_type_diagnostic(rebuilt))
+        Some(
+            self.rewrite_nested_static_projection_members(static_type, 0)
+                .unwrap_or(static_type),
+        )
+    }
+
+    pub(in crate::error_reporter) fn static_schema_array_structural_display_text(
+        &mut self,
+        array_display: &str,
+        other: TypeId,
+    ) -> Option<String> {
+        if let Some(query_display) = self.type_query_static_array_structural_display(array_display)
+        {
+            return Some(query_display);
+        }
+        let format_peer =
+            diagnostic_query::type_parameter_constraint(self.ctx.types, other).unwrap_or(other);
+        self.alias_static_array_structural_display(array_display, format_peer)
+    }
+
+    pub(in crate::error_reporter) fn static_schema_type_parameter_array_constraint_display(
+        &mut self,
+        type_parameter: TypeId,
+        array_display: &str,
+        other: TypeId,
+    ) -> Option<String> {
+        if !array_display.trim().ends_with("[]") {
+            return None;
+        }
+        let constraint =
+            diagnostic_query::type_parameter_constraint(self.ctx.types, type_parameter)?;
+        if constraint == type_parameter {
+            return None;
+        }
+        self.static_schema_array_structural_display(constraint, other)
+    }
+
+    pub(in crate::error_reporter) fn rewrite_static_schema_array_target_in_ts2322_message(
+        &mut self,
+        message: String,
+        format_peer: TypeId,
+    ) -> String {
+        let Some(rest) = message.strip_prefix("Type '") else {
+            return message;
+        };
+        let Some((source_display, target_part)) = rest.split_once("' is not assignable to type '")
+        else {
+            return message;
+        };
+        let Some(target_display) = target_part.strip_suffix("'.") else {
+            return message;
+        };
+        let Some(display) =
+            self.static_schema_array_structural_display_text(target_display, format_peer)
+        else {
+            return message;
+        };
+        crate::diagnostics::format_message(
+            crate::diagnostics::diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[source_display, &display],
+        )
     }
 
     /// Evaluate, widen, and normalize a schema's reduced element type, then wrap

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -444,6 +444,12 @@ impl<'a> CheckerState<'a> {
                 source_str = display;
                 static_schema_display = true;
             }
+            if let Some(display) =
+                self.static_schema_array_structural_display_text(&target_str, source)
+            {
+                target_str = display;
+                static_schema_display = true;
+            }
             if !static_schema_display
                 && let Some((direct_source, direct_target)) =
                     self.direct_type_param_alias_application_pair_display(source, target)

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -1681,7 +1681,7 @@ impl<'a> CheckerState<'a> {
             // overwrite when the body actually resolved — never clobber a
             // previously-resolved alias body with the `ANY` placeholder.
             if let Some(body) = result {
-                self.ctx.definition_store.set_body(def_id, body);
+                self.ctx.publish_definition_body(def_id, body);
             }
         }
 

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
@@ -400,7 +400,7 @@ impl<'a> CheckerState<'a> {
         self.ctx
             .definition_store
             .register_type_to_def(TypeId::ERROR, def_id);
-        self.ctx.definition_store.set_body(def_id, TypeId::ERROR);
+        self.ctx.publish_definition_body(def_id, TypeId::ERROR);
     }
 
     /// True when a *generic* type alias's unwrapped body is a self-application

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1647,7 +1647,7 @@ impl CheckerState<'_> {
                 self.ctx
                     .definition_store
                     .register_type_to_def(result, def_id);
-                self.ctx.definition_store.set_body(def_id, result);
+                self.ctx.publish_definition_body(def_id, result);
 
                 // Record the body's display provenance (see
                 // `record_alias_body_provenance`). Only a non-generic alias is a

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
@@ -493,7 +493,7 @@ impl<'a> CheckerState<'a> {
                 return None;
             };
             self.ctx.insert_def_type_params(def_id, params);
-            self.ctx.definition_store.set_body(def_id, body);
+            self.ctx.publish_definition_body(def_id, body);
             def_id
         };
         let Some(def_info) = self.ctx.definition_store.get(def_id) else {

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/interface_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/interface_methods.rs
@@ -137,7 +137,7 @@ impl<'a> CheckerState<'a> {
         if !params.is_empty() {
             self.ctx.insert_def_type_params(def_id, params.clone());
         }
-        self.ctx.definition_store.set_body(def_id, interface_type);
+        self.ctx.publish_definition_body(def_id, interface_type);
         self.ctx
             .definition_store
             .register_type_to_def(interface_type, def_id);

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -219,9 +219,7 @@ impl<'a> CheckerState<'a> {
                     self.ctx.definition_store.get_constructor_def(class_def)
             {
                 // Reuse the pre-populated companion identity, just set its body.
-                self.ctx
-                    .definition_store
-                    .set_body(pre_populated_ctor, result);
+                self.ctx.publish_definition_body(pre_populated_ctor, result);
                 pre_populated_ctor
             } else {
                 // Fallback: create a new DefId (anonymous classes, or classes

--- a/crates/tsz-checker/src/types/queries/lib_augmentations.rs
+++ b/crates/tsz-checker/src/types/queries/lib_augmentations.rs
@@ -234,15 +234,11 @@ impl<'a> CheckerState<'a> {
         let published = if keep_existing {
             existing_body.unwrap_or(ty)
         } else {
-            self.ctx.definition_store.set_body_finalized(
+            self.ctx.publish_finalized_definition_body(
                 def_id,
                 ty,
                 (!type_params.is_empty()).then(|| type_params.clone()),
-            );
-            // The store may still suppress the write (e.g. the opt-in freeze, or
-            // the monotone-deferral guard): mirror the AUTHORITATIVE store body,
-            // not the `ty` we attempted, so the env never diverges below it.
-            self.ctx.definition_store.get_body(def_id).unwrap_or(ty)
+            )
         };
         self.ctx
             .register_def_auto_params_in_envs(def_id, published, type_params);

--- a/crates/tsz-checker/tests/deeply_nested_mapped_types_tests.rs
+++ b/crates/tsz-checker/tests/deeply_nested_mapped_types_tests.rs
@@ -12,14 +12,18 @@ fn check(source: &str) -> Vec<u32> {
 /// scope), returning only the diagnostic codes. Skips gracefully (empty) when
 /// the bundled lib asset is unavailable in the build environment.
 fn check_with_es5_lib_codes(source: &str) -> Vec<u32> {
+    check_with_es5_lib_code_messages(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+fn check_with_es5_lib_code_messages(source: &str) -> Vec<(u32, String)> {
     let libs = load_lib_files(&["es5.d.ts"]);
     if libs.is_empty() {
         return Vec::new();
     }
     check_source_with_libs_code_messages(source, "test.ts", CheckerOptions::default(), &libs)
-        .into_iter()
-        .map(|(code, _)| code)
-        .collect()
 }
 
 fn ts2322_count(codes: &[u32]) -> usize {
@@ -567,7 +571,14 @@ function f1(ors: Input[]): Output[] { return ors; }
 function f2<T extends Output[]>(ors: Input[]): T { return ors; }
 function f3(ors: (typeof Input.static)[]): Output[] { return ors; }
 "#;
-    let codes = check(source);
+    let diagnostics = check_with_es5_lib_code_messages(source);
+    if diagnostics.is_empty() {
+        return; // lib asset unavailable — covered by CLI/conformance instead
+    }
+    let codes = diagnostics
+        .iter()
+        .map(|(code, _)| *code)
+        .collect::<Vec<_>>();
     assert!(
         !codes.contains(&2344),
         "Evaluate<PropertiesReducer> must not produce TS2344: {codes:?}"
@@ -575,6 +586,21 @@ function f3(ors: (typeof Input.static)[]): Output[] { return ors; }
     assert!(
         !codes.contains(&2464),
         "Evaluate<PropertiesReducer> must not produce TS2464: {codes:?}"
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2322
+                && message.contains("foo: string")
+                && message.contains("bar: string")
+                && !message.contains("Output[]")
+        }),
+        "generic `T extends Output[]` return mismatch must render the target structurally: {diagnostics:?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|(code, message)| *code != 2322 || !message.contains("Output[]")),
+        "TypeBox static-schema TS2322 diagnostics must not fall back to the unreduced `Output[]` alias: {diagnostics:?}"
     );
 }
 

--- a/crates/tsz-solver/src/caches/application_eval_index.rs
+++ b/crates/tsz-solver/src/caches/application_eval_index.rs
@@ -1,67 +1,90 @@
 use crate::caches::shared_instantiation::collect_application_eval_entry_def_dependencies;
 use crate::caches::shared_query_cache::ApplicationEvalCacheKey;
-use crate::def::DefId;
+use crate::def::{DefId, DefinitionStore};
 use crate::intern::TypeInterner;
 use crate::types::TypeId;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
 
-pub(super) type ApplicationEvalDependencyIndex =
-    RefCell<FxHashMap<DefId, FxHashSet<ApplicationEvalCacheKey>>>;
+#[derive(Default)]
+pub(super) struct ApplicationEvalDependencyIndexState {
+    pub(super) reverse: FxHashMap<DefId, FxHashSet<ApplicationEvalCacheKey>>,
+    pub(super) key_dependencies: FxHashMap<ApplicationEvalCacheKey, FxHashSet<DefId>>,
+}
+
+impl ApplicationEvalDependencyIndexState {
+    pub(super) fn clear(&mut self) {
+        self.reverse.clear();
+        self.key_dependencies.clear();
+    }
+}
+
+pub(super) type ApplicationEvalDependencyIndex = RefCell<ApplicationEvalDependencyIndexState>;
 
 pub(super) fn record_dependencies(
     interner: &TypeInterner,
+    definition_store: Option<&DefinitionStore>,
     index: &ApplicationEvalDependencyIndex,
     key: &ApplicationEvalCacheKey,
     old_result: Option<TypeId>,
     result: TypeId,
 ) {
     let mut index = index.borrow_mut();
-    if let Some(old_result) = old_result {
-        remove_dependencies(interner, &mut index, key, old_result);
+    if old_result.is_some() {
+        remove_dependencies(&mut index, key);
     }
-    let deps = collect_application_eval_entry_def_dependencies(interner, key, result);
-    for def_id in deps {
-        index.entry(def_id).or_default().insert(key.clone());
+    let deps =
+        collect_application_eval_entry_def_dependencies(interner, definition_store, key, result);
+    if deps.is_empty() {
+        return;
     }
+    let deps: FxHashSet<_> = deps.into_iter().collect();
+    for &def_id in &deps {
+        index.reverse.entry(def_id).or_default().insert(key.clone());
+    }
+    index.key_dependencies.insert(key.clone(), deps);
 }
 
 pub(super) fn invalidate_for_def(
-    interner: &TypeInterner,
     index: &ApplicationEvalDependencyIndex,
     cache: &RefCell<FxHashMap<ApplicationEvalCacheKey, TypeId>>,
     def_id: DefId,
 ) {
-    let Some(keys) = index.borrow_mut().remove(&def_id) else {
+    let Some(keys) = index.borrow_mut().reverse.remove(&def_id) else {
         return;
     };
     let mut cache = cache.borrow_mut();
     let mut index = index.borrow_mut();
     for key in keys {
-        if let Some(old_result) = cache.remove(&key) {
-            remove_dependencies(interner, &mut index, &key, old_result);
+        if cache.remove(&key).is_some() {
+            remove_dependencies(&mut index, &key);
         }
     }
 }
 
 #[cfg(test)]
 pub(super) fn key_count(index: &ApplicationEvalDependencyIndex, def_id: DefId) -> usize {
-    index.borrow().get(&def_id).map_or(0, FxHashSet::len)
+    index
+        .borrow()
+        .reverse
+        .get(&def_id)
+        .map_or(0, FxHashSet::len)
 }
 
 fn remove_dependencies(
-    interner: &TypeInterner,
-    index: &mut FxHashMap<DefId, FxHashSet<ApplicationEvalCacheKey>>,
+    index: &mut ApplicationEvalDependencyIndexState,
     key: &ApplicationEvalCacheKey,
-    result: TypeId,
 ) {
-    for def_id in collect_application_eval_entry_def_dependencies(interner, key, result) {
-        let Some(keys) = index.get_mut(&def_id) else {
+    let Some(deps) = index.key_dependencies.remove(key) else {
+        return;
+    };
+    for def_id in deps {
+        let Some(keys) = index.reverse.get_mut(&def_id) else {
             continue;
         };
         keys.remove(key);
         if keys.is_empty() {
-            index.remove(&def_id);
+            index.reverse.remove(&def_id);
         }
     }
 }

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -122,9 +122,13 @@ pub trait TypeApplicationEvalCache {
     ) {
     }
 
-    /// Drop every cached application-eval entry that depends on `def_id` —
-    /// entries keyed by it directly, applications of it in a key's argument
-    /// list, and entries whose cached *result* still embeds `Lazy(def_id)`.
+    /// Drop every cached eval-family entry that depends on `def_id`.
+    ///
+    /// This includes application-eval entries keyed by the def directly or by
+    /// lazy refs in their args/results, ordinary eval-memo entries whose key or
+    /// result closure mentions the def, and closed-eval entries with the same
+    /// dependency. The concrete `QueryCache` implementation also invalidates
+    /// shared eval-family entries when a shared cache is attached.
     ///
     /// Called when a definition body is (re)registered with different
     /// content: results computed under the previous body (or before any body

--- a/crates/tsz-solver/src/caches/eval_dependency_index.rs
+++ b/crates/tsz-solver/src/caches/eval_dependency_index.rs
@@ -1,0 +1,77 @@
+use crate::caches::shared_instantiation::collect_eval_entry_def_dependencies;
+use crate::def::{DefId, DefinitionStore};
+use crate::evaluation::request::EvaluationCacheKey;
+use crate::intern::TypeInterner;
+use crate::types::TypeId;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::cell::RefCell;
+
+#[derive(Default)]
+pub(super) struct EvalDependencyIndexState {
+    pub(super) reverse: FxHashMap<DefId, FxHashSet<EvaluationCacheKey>>,
+    pub(super) key_dependencies: FxHashMap<EvaluationCacheKey, FxHashSet<DefId>>,
+}
+
+impl EvalDependencyIndexState {
+    pub(super) fn clear(&mut self) {
+        self.reverse.clear();
+        self.key_dependencies.clear();
+    }
+}
+
+pub(super) type EvalDependencyIndex = RefCell<EvalDependencyIndexState>;
+
+pub(super) fn record_dependencies(
+    interner: &TypeInterner,
+    definition_store: Option<&DefinitionStore>,
+    index: &EvalDependencyIndex,
+    key: EvaluationCacheKey,
+    old_result: Option<TypeId>,
+    result: TypeId,
+) {
+    let mut index = index.borrow_mut();
+    if old_result.is_some() {
+        remove_dependencies(&mut index, key);
+    }
+    let deps = collect_eval_entry_def_dependencies(interner, definition_store, key, result);
+    if deps.is_empty() {
+        return;
+    }
+    let deps: FxHashSet<_> = deps.into_iter().collect();
+    for &def_id in &deps {
+        index.reverse.entry(def_id).or_default().insert(key);
+    }
+    index.key_dependencies.insert(key, deps);
+}
+
+pub(super) fn invalidate_for_def(
+    index: &EvalDependencyIndex,
+    cache: &RefCell<FxHashMap<EvaluationCacheKey, TypeId>>,
+    def_id: DefId,
+) {
+    let Some(keys) = index.borrow_mut().reverse.remove(&def_id) else {
+        return;
+    };
+    let mut cache = cache.borrow_mut();
+    let mut index = index.borrow_mut();
+    for key in keys {
+        if cache.remove(&key).is_some() {
+            remove_dependencies(&mut index, key);
+        }
+    }
+}
+
+fn remove_dependencies(index: &mut EvalDependencyIndexState, key: EvaluationCacheKey) {
+    let Some(deps) = index.key_dependencies.remove(&key) else {
+        return;
+    };
+    for def_id in deps {
+        let Some(keys) = index.reverse.get_mut(&def_id) else {
+            continue;
+        };
+        keys.remove(&key);
+        if keys.is_empty() {
+            index.reverse.remove(&def_id);
+        }
+    }
+}

--- a/crates/tsz-solver/src/caches/mod.rs
+++ b/crates/tsz-solver/src/caches/mod.rs
@@ -2,6 +2,7 @@ mod application_eval_index;
 pub(crate) mod db;
 mod db_base_traits;
 pub(crate) mod display_provenance;
+mod eval_dependency_index;
 pub(crate) mod instantiation_cache;
 pub(crate) mod options;
 pub(crate) mod query_cache;

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -4,12 +4,15 @@
 //! relation, property, and element access queries. This is the concrete
 //! database implementation used by the checker at runtime.
 
-use crate::caches::application_eval_index::{self, ApplicationEvalDependencyIndex};
+use crate::caches::application_eval_index::{
+    self, ApplicationEvalDependencyIndex, ApplicationEvalDependencyIndexState,
+};
 use crate::caches::db::{
     IntersectionMergeCacheEntry, QueryDatabase, TypeCompilerOptions, TypeContainsByIdCache,
     TypeDatabase, TypeDisplayProvenance, TypeExtractParamsCache, TypePredicateCache,
     TypePruneUnionCache, TypeSubstitutionConstruction, TypeTupleLimitSignal, TypeWidenCache,
 };
+use crate::caches::eval_dependency_index::{self, EvalDependencyIndex, EvalDependencyIndexState};
 use crate::caches::instantiation_cache::{InstantiationCache, InstantiationCacheKey};
 use crate::caches::query_cache_statistics::{QueryCacheStatistics, RelationCacheStats};
 use crate::caches::query_trace;
@@ -225,10 +228,12 @@ impl SharedCacheCounter {
 pub struct QueryCache<'a> {
     interner: &'a TypeInterner,
     eval_cache: RefCell<FxHashMap<EvaluationCacheKey, TypeId>>,
+    eval_dependency_index: EvalDependencyIndex,
     /// Substitution-independent evaluation cache (see the `closed_eval` module
     /// in `evaluate`). Keyed by
     /// `(TypeId, no_unchecked_indexed_access, exact_optional_property_types)`.
     closed_eval_cache: RefCell<FxHashMap<EvaluationCacheKey, TypeId>>,
+    closed_eval_dependency_index: EvalDependencyIndex,
     /// Persistent conditional-branch subtype verdicts (issues #8356 / #13097).
     /// Keyed by `(check, extends, no_unchecked_indexed_access,
     /// exact_optional_property_types)`; stores only definitive, limit-free
@@ -329,10 +334,14 @@ impl<'a> QueryCache<'a> {
         QueryCache {
             interner,
             eval_cache: RefCell::new(FxHashMap::default()),
+            eval_dependency_index: RefCell::new(EvalDependencyIndexState::default()),
             closed_eval_cache: RefCell::new(FxHashMap::default()),
+            closed_eval_dependency_index: RefCell::new(EvalDependencyIndexState::default()),
             conditional_branch_verdict_cache: RefCell::new(FxHashMap::default()),
             application_eval_cache: RefCell::new(FxHashMap::default()),
-            application_eval_dependency_index: RefCell::new(FxHashMap::default()),
+            application_eval_dependency_index: RefCell::new(
+                ApplicationEvalDependencyIndexState::default(),
+            ),
             element_access_cache: RefCell::new(FxHashMap::default()),
             object_spread_properties_cache: RefCell::new(FxHashMap::default()),
             collect_properties_result_cache: RefCell::new(
@@ -387,7 +396,9 @@ impl<'a> QueryCache<'a> {
 
     pub fn clear(&self) {
         self.eval_cache.borrow_mut().clear();
+        self.eval_dependency_index.borrow_mut().clear();
         self.closed_eval_cache.borrow_mut().clear();
+        self.closed_eval_dependency_index.borrow_mut().clear();
         self.conditional_branch_verdict_cache.borrow_mut().clear();
         self.element_access_cache.borrow_mut().clear();
         self.application_eval_cache.borrow_mut().clear();
@@ -1432,7 +1443,7 @@ impl QueryDatabase for QueryCache<'_> {
             | TypeData::Error,
         ) = self.interner.lookup(type_id)
         {
-            self.eval_cache.borrow_mut().insert(key, type_id);
+            self.insert_eval_cache_entry(key, type_id);
             return type_id;
         }
 
@@ -1490,20 +1501,24 @@ impl QueryDatabase for QueryCache<'_> {
         if union_complexity_stable
             && (top_level_clean || crate::limits::limit_result_cache_enabled())
         {
-            let mut cache = self.eval_cache.borrow_mut();
             if top_level_clean {
-                cache.insert(key, result);
+                self.insert_eval_cache_entry(key, result);
                 // Also write to shared cache for cross-file benefit.
                 if let Some(shared) = self.shared {
-                    shared.eval_cache.insert(key, result);
+                    shared.insert_eval_cache(self.interner, self.definition_store(), key, result);
                 }
             }
             for (intermediate_id, intermediate_result) in evaluator.drain_stable_cache() {
                 if intermediate_id != intermediate_result && !intermediate_id.is_intrinsic() {
                     let ikey = request.with_type_id(intermediate_id).cache_key();
-                    cache.entry(ikey).or_insert(intermediate_result);
+                    self.insert_eval_cache_entry_if_absent(ikey, intermediate_result);
                     if let Some(shared) = self.shared {
-                        shared.eval_cache.entry(ikey).or_insert(intermediate_result);
+                        shared.insert_eval_cache_if_absent(
+                            self.interner,
+                            self.definition_store(),
+                            ikey,
+                            intermediate_result,
+                        );
                     }
                 }
             }

--- a/crates/tsz-solver/src/caches/query_cache_application_eval.rs
+++ b/crates/tsz-solver/src/caches/query_cache_application_eval.rs
@@ -4,7 +4,9 @@
 //! This is a child module of `query_cache`, so it keeps access to the cache's
 //! private fields.
 
-use super::{DefId, EvaluationCacheKey, QueryCache, TypeId, application_eval_index};
+use super::{
+    DefId, EvaluationCacheKey, QueryCache, TypeId, application_eval_index, eval_dependency_index,
+};
 use crate::caches::db::{TypeApplicationEvalCache, TypeCompilerOptions};
 
 impl TypeApplicationEvalCache for QueryCache<'_> {
@@ -60,15 +62,26 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
 
     fn invalidate_application_eval_cache_for_def(&self, def_id: DefId) {
         application_eval_index::invalidate_for_def(
-            self.interner,
             &self.application_eval_dependency_index,
             &self.application_eval_cache,
             def_id,
         );
-        if let Some(shared) = self.shared
-            && shared.shares_instantiation_family()
-        {
-            shared.invalidate_application_eval_cache_for_def(self.interner, def_id);
+        eval_dependency_index::invalidate_for_def(
+            &self.eval_dependency_index,
+            &self.eval_cache,
+            def_id,
+        );
+        eval_dependency_index::invalidate_for_def(
+            &self.closed_eval_dependency_index,
+            &self.closed_eval_cache,
+            def_id,
+        );
+        if let Some(shared) = self.shared {
+            shared.invalidate_application_eval_cache_for_def(
+                self.interner,
+                self.definition_store(),
+                def_id,
+            );
         }
     }
 
@@ -94,9 +107,9 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
             no_unchecked_indexed_access,
             self.exact_optional_property_types(),
         );
-        self.eval_cache.borrow_mut().entry(key).or_insert(result);
+        self.insert_eval_cache_entry_if_absent(key, result);
         if let Some(shared) = self.shared {
-            shared.eval_cache.entry(key).or_insert(result);
+            shared.insert_eval_cache_if_absent(self.interner, self.definition_store(), key, result);
         }
     }
 
@@ -121,7 +134,7 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
         no_unchecked_indexed_access: bool,
         result: TypeId,
     ) {
-        self.closed_eval_cache.borrow_mut().insert(
+        self.insert_closed_eval_cache_entry(
             EvaluationCacheKey::new(
                 type_id,
                 no_unchecked_indexed_access,

--- a/crates/tsz-solver/src/caches/query_cache_size.rs
+++ b/crates/tsz-solver/src/caches/query_cache_size.rs
@@ -30,6 +30,24 @@ impl QueryCache<'_> {
                     + std::mem::size_of::<EvaluationCacheKey>()
                     + std::mem::size_of::<TypeId>());
         }
+        {
+            let index = self.eval_dependency_index.borrow();
+            size += index.reverse.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<DefId>()
+                    + std::mem::size_of::<FxHashSet<EvaluationCacheKey>>());
+            for keys in index.reverse.values() {
+                size +=
+                    keys.capacity() * (BUCKET_OVERHEAD + std::mem::size_of::<EvaluationCacheKey>());
+            }
+            size += index.key_dependencies.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<EvaluationCacheKey>()
+                    + std::mem::size_of::<FxHashSet<DefId>>());
+            for deps in index.key_dependencies.values() {
+                size += deps.capacity() * (BUCKET_OVERHEAD + std::mem::size_of::<DefId>());
+            }
+        }
 
         // closed_eval_cache: EvaluationCacheKey -> TypeId
         {
@@ -38,6 +56,24 @@ impl QueryCache<'_> {
                 * (BUCKET_OVERHEAD
                     + std::mem::size_of::<EvaluationCacheKey>()
                     + std::mem::size_of::<TypeId>());
+        }
+        {
+            let index = self.closed_eval_dependency_index.borrow();
+            size += index.reverse.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<DefId>()
+                    + std::mem::size_of::<FxHashSet<EvaluationCacheKey>>());
+            for keys in index.reverse.values() {
+                size +=
+                    keys.capacity() * (BUCKET_OVERHEAD + std::mem::size_of::<EvaluationCacheKey>());
+            }
+            size += index.key_dependencies.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<EvaluationCacheKey>()
+                    + std::mem::size_of::<FxHashSet<DefId>>());
+            for deps in index.key_dependencies.values() {
+                size += deps.capacity() * (BUCKET_OVERHEAD + std::mem::size_of::<DefId>());
+            }
         }
 
         // conditional_branch_verdict_cache: (TypeId, TypeId, bool, bool) -> bool
@@ -58,6 +94,32 @@ impl QueryCache<'_> {
             size += map.capacity() * base_entry;
             // SmallVec spills to heap when > 4 elements; account for spilled entries.
             for key in map.keys() {
+                if key.1.spilled() {
+                    size += key.1.capacity() * std::mem::size_of::<TypeId>();
+                }
+            }
+        }
+        {
+            let index = self.application_eval_dependency_index.borrow();
+            size += index.reverse.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<DefId>()
+                    + std::mem::size_of::<FxHashSet<ApplicationEvalCacheKey>>());
+            for keys in index.reverse.values() {
+                size += keys.capacity()
+                    * (BUCKET_OVERHEAD + std::mem::size_of::<ApplicationEvalCacheKey>());
+                for key in keys {
+                    if key.1.spilled() {
+                        size += key.1.capacity() * std::mem::size_of::<TypeId>();
+                    }
+                }
+            }
+            size += index.key_dependencies.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<ApplicationEvalCacheKey>()
+                    + std::mem::size_of::<FxHashSet<DefId>>());
+            for (key, deps) in &index.key_dependencies {
+                size += deps.capacity() * (BUCKET_OVERHEAD + std::mem::size_of::<DefId>());
                 if key.1.spilled() {
                     size += key.1.capacity() * std::mem::size_of::<TypeId>();
                 }

--- a/crates/tsz-solver/src/caches/query_cache_spread.rs
+++ b/crates/tsz-solver/src/caches/query_cache_spread.rs
@@ -89,10 +89,61 @@ impl QueryCache<'_> {
         if let Some(shared) = self.shared
             && let Some(result) = shared.eval_cache.get(&key).map(|r| *r)
         {
-            self.eval_cache.borrow_mut().insert(key, result);
+            self.insert_eval_cache_entry_if_absent(key, result);
             return Some(result);
         }
         None
+    }
+
+    pub(super) fn insert_eval_cache_entry(&self, key: EvaluationCacheKey, result: TypeId) {
+        let old_result = self.eval_cache.borrow_mut().insert(key, result);
+        eval_dependency_index::record_dependencies(
+            self.interner,
+            self.definition_store(),
+            &self.eval_dependency_index,
+            key,
+            old_result,
+            result,
+        );
+    }
+
+    pub(super) fn insert_eval_cache_entry_if_absent(
+        &self,
+        key: EvaluationCacheKey,
+        result: TypeId,
+    ) {
+        let inserted = {
+            let mut cache = self.eval_cache.borrow_mut();
+            match cache.entry(key) {
+                std::collections::hash_map::Entry::Occupied(_) => false,
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(result);
+                    true
+                }
+            }
+        };
+        if inserted {
+            eval_dependency_index::record_dependencies(
+                self.interner,
+                self.definition_store(),
+                &self.eval_dependency_index,
+                key,
+                None,
+                result,
+            );
+        }
+    }
+
+    pub(super) fn insert_closed_eval_cache_entry(&self, key: EvaluationCacheKey, result: TypeId) {
+        let old_result = self.closed_eval_cache.borrow_mut().insert(key, result);
+        eval_dependency_index::record_dependencies(
+            self.interner,
+            self.definition_store(),
+            &self.closed_eval_dependency_index,
+            key,
+            old_result,
+            result,
+        );
     }
 
     pub(super) fn check_application_eval_cache(
@@ -112,6 +163,7 @@ impl QueryCache<'_> {
                     .insert(key.clone(), result);
                 application_eval_index::record_dependencies(
                     self.interner,
+                    self.definition_store(),
                     &self.application_eval_dependency_index,
                     &key,
                     None,
@@ -139,7 +191,12 @@ impl QueryCache<'_> {
         if let Some(shared) = self.shared
             && shared.shares_instantiation_family()
         {
-            shared.insert_application_eval_cache(self.interner, key.clone(), result);
+            shared.insert_application_eval_cache(
+                self.interner,
+                self.definition_store(),
+                key.clone(),
+                result,
+            );
             self.application_eval_cache_stats.record_shared_insert();
             tsz_common::perf_counters::record_shared_application_eval_cache_insert();
         }
@@ -149,6 +206,7 @@ impl QueryCache<'_> {
             .insert(key.clone(), result);
         application_eval_index::record_dependencies(
             self.interner,
+            self.definition_store(),
             &self.application_eval_dependency_index,
             &key,
             old_result,

--- a/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
@@ -4,7 +4,7 @@ use crate::caches::db::{IntersectionMergeCacheEntry, QueryDatabase, TypeApplicat
 use crate::caches::instantiation_cache::{CanonicalSubst, InstantiationCacheKey};
 use crate::caches::query_cache::{QueryCache, SharedQueryCache};
 use crate::caches::query_cache_statistics::QueryCacheStatistics;
-use crate::def::DefId;
+use crate::def::{DefId, DefinitionStore};
 use crate::intern::TypeInterner;
 use crate::types::{RelationCacheConfig, RelationCacheKey, TypeId};
 
@@ -94,6 +94,266 @@ fn closed_eval_cache_is_visible_in_statistics_and_size_estimate() {
 
     db.clear();
     assert_eq!(db.statistics().closed_eval_cache_entries, 0);
+}
+
+#[test]
+fn eval_cache_invalidation_uses_recorded_def_dependencies() {
+    // Structural rule: persisted eval-memo entries are stable only while the
+    // lazy `DefId` bodies they mention remain unchanged. A body rewrite must
+    // evict entries whose key or result mentions that `DefId`, while leaving
+    // unrelated eval entries resident.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let key_def = DefId(101);
+    let result_def = DefId(102);
+    let unrelated_key = TypeId::BOOLEAN;
+    let key_ref = interner.lazy(key_def);
+    let result_ref = interner.lazy(result_def);
+
+    db.insert_eval_memo(key_ref, false, TypeId::STRING);
+    db.insert_eval_memo(TypeId::NUMBER, false, result_ref);
+    db.insert_eval_memo(unrelated_key, false, TypeId::STRING);
+
+    assert_eq!(db.statistics().eval_cache_entries, 3);
+
+    db.invalidate_application_eval_cache_for_def(key_def);
+
+    assert_eq!(db.lookup_eval_memo(key_ref, false), None);
+    assert_eq!(db.lookup_eval_memo(TypeId::NUMBER, false), Some(result_ref));
+    assert_eq!(
+        db.lookup_eval_memo(unrelated_key, false),
+        Some(TypeId::STRING)
+    );
+
+    db.invalidate_application_eval_cache_for_def(result_def);
+
+    assert_eq!(db.lookup_eval_memo(TypeId::NUMBER, false), None);
+    assert_eq!(
+        db.lookup_eval_memo(unrelated_key, false),
+        Some(TypeId::STRING)
+    );
+}
+
+#[test]
+fn shared_eval_cache_invalidation_clears_promoted_sibling_cache() {
+    // Structural rule: shared eval-cache hits are promoted into the local
+    // per-file cache. The promotion must record the same `DefId` dependency
+    // edges as a local write so a later body rewrite clears both the promoted
+    // local copy and the shared entry for fresh sibling checkers.
+    let interner = TypeInterner::new();
+    let shared = SharedQueryCache::new();
+    let dep_def = DefId(103);
+    let key = interner.lazy(dep_def);
+
+    {
+        let db_a = QueryCache::new_with_shared(&interner, &shared);
+        db_a.insert_eval_memo(key, false, TypeId::NUMBER);
+    }
+
+    {
+        let db_b = QueryCache::new_with_shared(&interner, &shared);
+        assert_eq!(db_b.lookup_eval_memo(key, false), Some(TypeId::NUMBER));
+        db_b.invalidate_application_eval_cache_for_def(dep_def);
+        assert_eq!(db_b.lookup_eval_memo(key, false), None);
+    }
+
+    {
+        let db_c = QueryCache::new_with_shared(&interner, &shared);
+        assert_eq!(
+            db_c.lookup_eval_memo(key, false),
+            None,
+            "fresh sibling cache must not see a shared eval entry after invalidation"
+        );
+    }
+}
+
+#[test]
+fn closed_eval_cache_invalidation_uses_recorded_def_dependencies() {
+    // Structural rule: `closed_eval_cache` is local to one `QueryCache`, but
+    // its values are still invalidated by rewritten lazy bodies when the key or
+    // result closure mentions that `DefId`.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let key_def = DefId(104);
+    let result_def = DefId(105);
+    let key_ref = interner.lazy(key_def);
+    let result_ref = interner.lazy(result_def);
+
+    db.insert_closed_eval_cache(key_ref, false, TypeId::STRING);
+    db.insert_closed_eval_cache(TypeId::NUMBER, false, result_ref);
+    db.insert_closed_eval_cache(TypeId::BOOLEAN, false, TypeId::STRING);
+
+    assert_eq!(db.statistics().closed_eval_cache_entries, 3);
+
+    db.invalidate_application_eval_cache_for_def(result_def);
+
+    assert_eq!(db.lookup_closed_eval_cache(TypeId::NUMBER, false), None);
+    assert_eq!(
+        db.lookup_closed_eval_cache(key_ref, false),
+        Some(TypeId::STRING)
+    );
+    assert_eq!(
+        db.lookup_closed_eval_cache(TypeId::BOOLEAN, false),
+        Some(TypeId::STRING)
+    );
+
+    db.invalidate_application_eval_cache_for_def(key_def);
+    assert_eq!(db.lookup_closed_eval_cache(key_ref, false), None);
+}
+
+#[test]
+fn eval_family_invalidation_follows_definition_store_body_dependencies() {
+    // Structural rule: with a shared `DefinitionStore`, an eval-family cache
+    // entry keyed by `Lazy(A)` also depends on the lazy defs reachable from
+    // A's published body. Rewriting B must therefore evict an entry computed
+    // from A when A's body was `Lazy(B)`.
+    let interner = TypeInterner::new();
+    let store = DefinitionStore::new();
+    let base_def = DefId(106);
+    let body_def = DefId(107);
+    let base_ref = interner.lazy(base_def);
+    let body_ref = interner.lazy(body_def);
+    store.set_body(base_def, body_ref);
+    store.set_body_dependency_defs(base_def, [body_def]);
+
+    let db = QueryCache::new(&interner).with_definition_store(&store);
+    db.insert_eval_memo(base_ref, false, TypeId::STRING);
+    db.insert_closed_eval_cache(base_ref, false, TypeId::NUMBER);
+    db.insert_application_eval_cache(base_def, &[TypeId::STRING], false, TypeId::BOOLEAN);
+
+    db.invalidate_application_eval_cache_for_def(body_def);
+
+    assert_eq!(db.lookup_eval_memo(base_ref, false), None);
+    assert_eq!(db.lookup_closed_eval_cache(base_ref, false), None);
+    assert_eq!(
+        db.lookup_application_eval_cache(base_def, &[TypeId::STRING], false),
+        None
+    );
+}
+
+#[test]
+fn eval_family_invalidation_follows_transitive_definition_store_body_dependencies() {
+    // Structural rule: the body-dependency graph is transitive. If a cache
+    // entry mentions `Lazy(A)`, A's body mentions `Lazy(B)`, and B's body
+    // mentions `Lazy(C)`, rewriting C must evict the entry without a full
+    // cache sweep.
+    let interner = TypeInterner::new();
+    let store = DefinitionStore::new();
+    let root_def = DefId(118);
+    let mid_def = DefId(119);
+    let leaf_def = DefId(120);
+    let unrelated_def = DefId(121);
+    let root_ref = interner.lazy(root_def);
+    let mid_ref = interner.lazy(mid_def);
+    let leaf_ref = interner.lazy(leaf_def);
+    let unrelated_ref = interner.lazy(unrelated_def);
+    store.set_body(root_def, mid_ref);
+    store.set_body_dependency_defs(root_def, [mid_def]);
+    store.set_body(mid_def, leaf_ref);
+    store.set_body_dependency_defs(mid_def, [leaf_def]);
+
+    let db = QueryCache::new(&interner).with_definition_store(&store);
+    db.insert_eval_memo(root_ref, false, TypeId::STRING);
+    db.insert_closed_eval_cache(root_ref, false, TypeId::NUMBER);
+    db.insert_application_eval_cache(root_def, &[TypeId::STRING], false, TypeId::BOOLEAN);
+    db.insert_eval_memo(unrelated_ref, false, TypeId::STRING);
+
+    db.invalidate_application_eval_cache_for_def(leaf_def);
+
+    assert_eq!(db.lookup_eval_memo(root_ref, false), None);
+    assert_eq!(db.lookup_closed_eval_cache(root_ref, false), None);
+    assert_eq!(
+        db.lookup_application_eval_cache(root_def, &[TypeId::STRING], false),
+        None
+    );
+    assert_eq!(
+        db.lookup_eval_memo(unrelated_ref, false),
+        Some(TypeId::STRING),
+        "transitive invalidation must preserve unrelated entries"
+    );
+}
+
+#[test]
+fn eval_family_invalidation_chases_store_body_deps_without_decoding_body_type_ids() {
+    // Structural rule: a shared `DefinitionStore` body can be producer-arena
+    // `TypeId` data. Cache invalidation must chase the recorded `DefId` body
+    // dependency graph instead of decoding that body through the consumer
+    // interner.
+    let producer = TypeInterner::new();
+    let consumer = TypeInterner::new();
+    let store = DefinitionStore::new();
+    let alias_def = DefId(108);
+    let dep_def = DefId(109);
+    let producer_body = producer.lazy(dep_def);
+    store.set_body(alias_def, producer_body);
+    store.set_body_dependency_defs(alias_def, [dep_def]);
+
+    let alias_ref = consumer.lazy(alias_def);
+    let db = QueryCache::new(&consumer).with_definition_store(&store);
+    db.insert_eval_memo(alias_ref, false, TypeId::STRING);
+
+    db.invalidate_application_eval_cache_for_def(dep_def);
+
+    assert_eq!(db.lookup_eval_memo(alias_ref, false), None);
+}
+
+#[test]
+fn eval_family_dependency_rewrite_removes_stale_body_dependency_edges() {
+    // Structural rule: dependency indexes describe the cache entry that was
+    // actually inserted, not the DefinitionStore graph as it happens to look
+    // at removal time. If A's body-deps change from B to C, evicting the old
+    // `Lazy(A)` entry must remove its stale B reverse edge before a fresh entry
+    // records the new C edge.
+    let interner = TypeInterner::new();
+    let store = DefinitionStore::new();
+    let root_def = DefId(122);
+    let stale_dep = DefId(123);
+    let current_dep = DefId(124);
+    let root_ref = interner.lazy(root_def);
+    let stale_ref = interner.lazy(stale_dep);
+    let current_ref = interner.lazy(current_dep);
+    store.set_body(root_def, stale_ref);
+    store.set_body_dependency_defs(root_def, [stale_dep]);
+
+    let db = QueryCache::new(&interner).with_definition_store(&store);
+    db.insert_eval_memo(root_ref, false, TypeId::STRING);
+    db.insert_closed_eval_cache(root_ref, false, TypeId::NUMBER);
+    db.insert_application_eval_cache(root_def, &[TypeId::STRING], false, TypeId::BOOLEAN);
+
+    store.set_body(root_def, current_ref);
+    store.set_body_dependency_defs(root_def, [current_dep]);
+    db.invalidate_application_eval_cache_for_def(root_def);
+
+    db.insert_eval_memo(root_ref, false, TypeId::STRING);
+    db.insert_closed_eval_cache(root_ref, false, TypeId::NUMBER);
+    db.insert_application_eval_cache(root_def, &[TypeId::STRING], false, TypeId::BOOLEAN);
+
+    db.invalidate_application_eval_cache_for_def(stale_dep);
+    assert_eq!(
+        db.lookup_eval_memo(root_ref, false),
+        Some(TypeId::STRING),
+        "stale body-dep edge must not evict the fresh eval entry"
+    );
+    assert_eq!(
+        db.lookup_closed_eval_cache(root_ref, false),
+        Some(TypeId::NUMBER),
+        "stale body-dep edge must not evict the fresh closed-eval entry"
+    );
+    assert_eq!(
+        db.lookup_application_eval_cache(root_def, &[TypeId::STRING], false),
+        Some(TypeId::BOOLEAN),
+        "stale body-dep edge must not evict the fresh application-eval entry"
+    );
+
+    db.invalidate_application_eval_cache_for_def(current_dep);
+    assert_eq!(db.lookup_eval_memo(root_ref, false), None);
+    assert_eq!(db.lookup_closed_eval_cache(root_ref, false), None);
+    assert_eq!(
+        db.lookup_application_eval_cache(root_def, &[TypeId::STRING], false),
+        None
+    );
 }
 
 #[test]
@@ -407,6 +667,52 @@ fn application_eval_cache_overwrite_replaces_recorded_result_dependencies() {
 }
 
 #[test]
+fn application_eval_cache_overwrite_replaces_key_arg_and_result_dependencies() {
+    // Structural rule: overwriting an application-eval key must leave exactly
+    // the current key/result dependency set behind. Stale argument/result edges
+    // must not evict a live replacement, while current argument/result rewrites
+    // must evict it.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let base_def = DefId(110);
+    let stale_arg_def = DefId(111);
+    let current_arg_def = DefId(112);
+    let stale_result_def = DefId(113);
+    let current_result_def = DefId(114);
+    let stale_arg = interner.lazy(stale_arg_def);
+    let current_arg = interner.lazy(current_arg_def);
+    let stale_result = interner.lazy(stale_result_def);
+    let current_result = interner.lazy(current_result_def);
+
+    db.insert_application_eval_cache(base_def, &[stale_arg], false, stale_result);
+    db.insert_application_eval_cache(base_def, &[current_arg], false, current_result);
+
+    db.invalidate_application_eval_cache_for_def(stale_arg_def);
+    db.invalidate_application_eval_cache_for_def(stale_result_def);
+    assert_eq!(
+        db.lookup_application_eval_cache(base_def, &[current_arg], false),
+        Some(current_result),
+        "stale argument/result dependencies must not evict a replacement key"
+    );
+
+    db.invalidate_application_eval_cache_for_def(current_arg_def);
+    assert_eq!(
+        db.lookup_application_eval_cache(base_def, &[current_arg], false),
+        None,
+        "current argument dependency must evict the replacement"
+    );
+
+    db.insert_application_eval_cache(base_def, &[current_arg], false, current_result);
+    db.invalidate_application_eval_cache_for_def(current_result_def);
+    assert_eq!(
+        db.lookup_application_eval_cache(base_def, &[current_arg], false),
+        None,
+        "current result dependency must evict the replacement"
+    );
+}
+
+#[test]
 fn shared_application_eval_cache_overwrite_replaces_recorded_result_dependencies() {
     // Structural rule: the opt-in shared application-eval cache has the same
     // exact-dependency invariant as the file-local cache. A stale dependency
@@ -447,6 +753,46 @@ fn shared_application_eval_cache_overwrite_replaces_recorded_result_dependencies
             db_d.lookup_application_eval_cache(base_def, &[TypeId::NUMBER], false),
             None,
             "invalidating the current shared dependency must evict the entry"
+        );
+    }
+}
+
+#[test]
+fn shared_application_eval_cache_promotion_records_local_dependency_edges() {
+    // Structural rule: a shared application-eval hit promoted into a sibling
+    // local cache must record local dependency edges. Rewriting the def from
+    // that sibling then clears both its promoted local copy and the shared
+    // entry for fresh siblings.
+    let interner = TypeInterner::new();
+    let shared = SharedQueryCache::new_for_instantiation_family_test(true);
+    let base_def = DefId(115);
+    let dep_def = DefId(116);
+    let dep_ref = interner.lazy(dep_def);
+
+    {
+        let db_a = QueryCache::new_with_shared(&interner, &shared);
+        db_a.insert_application_eval_cache(base_def, &[dep_ref], false, TypeId::STRING);
+    }
+
+    {
+        let db_b = QueryCache::new_with_shared(&interner, &shared);
+        assert_eq!(
+            db_b.lookup_application_eval_cache(base_def, &[dep_ref], false),
+            Some(TypeId::STRING)
+        );
+        db_b.invalidate_application_eval_cache_for_def(dep_def);
+        assert_eq!(
+            db_b.lookup_application_eval_cache(base_def, &[dep_ref], false),
+            None
+        );
+    }
+
+    {
+        let db_c = QueryCache::new_with_shared(&interner, &shared);
+        assert_eq!(
+            db_c.lookup_application_eval_cache(base_def, &[dep_ref], false),
+            None,
+            "fresh sibling must not see the shared application-eval entry after invalidation"
         );
     }
 }

--- a/crates/tsz-solver/src/caches/shared_instantiation.rs
+++ b/crates/tsz-solver/src/caches/shared_instantiation.rs
@@ -1,5 +1,5 @@
 use crate::caches::shared_query_cache::ApplicationEvalCacheKey;
-use crate::def::DefId;
+use crate::def::{DefId, DefinitionStore};
 use crate::types::TypeId;
 use rustc_hash::FxHashSet;
 
@@ -9,30 +9,79 @@ pub(super) fn shared_instantiation_family_requested() -> bool {
 
 pub(super) fn collect_application_eval_entry_def_dependencies(
     interner: &dyn crate::construction::TypeDatabase,
+    definition_store: Option<&DefinitionStore>,
     key: &ApplicationEvalCacheKey,
     result: TypeId,
 ) -> Vec<DefId> {
     let (key_def, key_args, _, _) = key;
+    collect_def_dependencies(
+        interner,
+        definition_store,
+        [*key_def],
+        key_args.iter().copied().chain(std::iter::once(result)),
+    )
+}
+
+pub(super) fn collect_eval_entry_def_dependencies(
+    interner: &dyn crate::construction::TypeDatabase,
+    definition_store: Option<&DefinitionStore>,
+    key: crate::evaluation::request::EvaluationCacheKey,
+    result: TypeId,
+) -> Vec<DefId> {
+    collect_def_dependencies(interner, definition_store, [], [key.type_id(), result])
+}
+
+fn collect_def_dependencies(
+    interner: &dyn crate::construction::TypeDatabase,
+    definition_store: Option<&DefinitionStore>,
+    direct_defs: impl IntoIterator<Item = DefId>,
+    roots: impl IntoIterator<Item = TypeId>,
+) -> Vec<DefId> {
     let mut seen = FxHashSet::default();
     let mut deps = Vec::new();
+    let mut pending = Vec::new();
 
-    if seen.insert(*key_def) {
-        deps.push(*key_def);
+    for def_id in direct_defs {
+        push_def_dependency(def_id, &mut seen, &mut deps, &mut pending);
     }
 
-    for &arg in key_args {
-        for def_id in crate::visitors::visitor::collect_lazy_def_ids(interner, arg) {
-            if seen.insert(def_id) {
-                deps.push(def_id);
+    for root in roots {
+        for def_id in crate::visitors::visitor::collect_lazy_def_ids(interner, root) {
+            push_def_dependency(def_id, &mut seen, &mut deps, &mut pending);
+        }
+    }
+
+    let Some(store) = definition_store else {
+        return deps;
+    };
+
+    while let Some(def_id) = pending.pop() {
+        let canonical = store.canonical_def_id(def_id);
+        if canonical != def_id {
+            push_def_dependency(canonical, &mut seen, &mut deps, &mut pending);
+        }
+
+        for body_def in [def_id, canonical] {
+            let Some(body_deps) = store.body_dependency_defs(body_def) else {
+                continue;
+            };
+            for &dependency in body_deps.iter() {
+                push_def_dependency(dependency, &mut seen, &mut deps, &mut pending);
             }
         }
     }
 
-    for def_id in crate::visitors::visitor::collect_lazy_def_ids(interner, result) {
-        if seen.insert(def_id) {
-            deps.push(def_id);
-        }
-    }
-
     deps
+}
+
+fn push_def_dependency(
+    def_id: DefId,
+    seen: &mut FxHashSet<DefId>,
+    deps: &mut Vec<DefId>,
+    pending: &mut Vec<DefId>,
+) {
+    if seen.insert(def_id) {
+        deps.push(def_id);
+        pending.push(def_id);
+    }
 }

--- a/crates/tsz-solver/src/caches/shared_query_cache.rs
+++ b/crates/tsz-solver/src/caches/shared_query_cache.rs
@@ -1,13 +1,16 @@
 //! Thread-safe shared query cache for cross-file type checking.
 
 use crate::caches::instantiation_cache::InstantiationCacheKey;
-use crate::caches::shared_instantiation::collect_application_eval_entry_def_dependencies;
 use crate::caches::shared_instantiation::shared_instantiation_family_requested;
-use crate::def::DefId;
+use crate::caches::shared_instantiation::{
+    collect_application_eval_entry_def_dependencies, collect_eval_entry_def_dependencies,
+};
+use crate::def::{DefId, DefinitionStore};
 use crate::evaluation::request::EvaluationCacheKey;
 use crate::intern::TypeInterner;
 use crate::types::{RelationCacheKey, RelationCacheValue, TypeId};
 use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 
 // The trailing two `bool`s are `no_unchecked_indexed_access` and
@@ -54,11 +57,15 @@ pub(super) type ApplicationEvalCacheKey = (DefId, smallvec::SmallVec<[TypeId; 4]
 /// request state.
 pub struct SharedQueryCache {
     pub(super) eval_cache: DashMap<EvaluationCacheKey, TypeId, FxBuildHasher>,
+    pub(super) eval_dependency_index: DashMap<DefId, FxHashSet<EvaluationCacheKey>, FxBuildHasher>,
+    eval_key_dependency_index: DashMap<EvaluationCacheKey, FxHashSet<DefId>, FxBuildHasher>,
     pub(super) subtype_cache: DashMap<RelationCacheKey, RelationCacheValue, FxBuildHasher>,
     pub(super) assignability_cache: DashMap<RelationCacheKey, RelationCacheValue, FxBuildHasher>,
     pub(super) application_eval_cache: DashMap<ApplicationEvalCacheKey, TypeId, FxBuildHasher>,
     pub(super) application_eval_dependency_index:
         DashMap<DefId, FxHashSet<ApplicationEvalCacheKey>, FxBuildHasher>,
+    application_eval_key_dependency_index:
+        DashMap<ApplicationEvalCacheKey, FxHashSet<DefId>, FxBuildHasher>,
     pub(super) instantiation_cache: DashMap<InstantiationCacheKey, TypeId, FxBuildHasher>,
     share_instantiation_family: bool,
 }
@@ -67,10 +74,13 @@ impl SharedQueryCache {
     pub fn new() -> Self {
         SharedQueryCache {
             eval_cache: DashMap::with_hasher(FxBuildHasher),
+            eval_dependency_index: DashMap::with_hasher(FxBuildHasher),
+            eval_key_dependency_index: DashMap::with_hasher(FxBuildHasher),
             subtype_cache: DashMap::with_hasher(FxBuildHasher),
             assignability_cache: DashMap::with_hasher(FxBuildHasher),
             application_eval_cache: DashMap::with_hasher(FxBuildHasher),
             application_eval_dependency_index: DashMap::with_hasher(FxBuildHasher),
+            application_eval_key_dependency_index: DashMap::with_hasher(FxBuildHasher),
             instantiation_cache: DashMap::with_hasher(FxBuildHasher),
             share_instantiation_family: shared_instantiation_family_requested(),
         }
@@ -100,43 +110,135 @@ impl SharedQueryCache {
     pub(super) fn insert_application_eval_cache(
         &self,
         interner: &TypeInterner,
+        definition_store: Option<&DefinitionStore>,
         key: ApplicationEvalCacheKey,
         result: TypeId,
     ) {
         let old_result = self.application_eval_cache.insert(key.clone(), result);
         if let Some(old_result) = old_result {
-            self.remove_application_eval_dependencies(interner, &key, old_result);
+            self.remove_application_eval_dependencies(&key, old_result);
         }
-        for def_id in collect_application_eval_entry_def_dependencies(interner, &key, result) {
+        let deps = collect_application_eval_entry_def_dependencies(
+            interner,
+            definition_store,
+            &key,
+            result,
+        );
+        if deps.is_empty() {
+            return;
+        }
+        let deps: FxHashSet<_> = deps.into_iter().collect();
+        for &def_id in &deps {
             self.application_eval_dependency_index
                 .entry(def_id)
                 .or_default()
                 .insert(key.clone());
         }
+        self.application_eval_key_dependency_index.insert(key, deps);
     }
 
     pub(super) fn invalidate_application_eval_cache_for_def(
         &self,
-        interner: &TypeInterner,
+        _interner: &TypeInterner,
+        _definition_store: Option<&DefinitionStore>,
         def_id: DefId,
     ) {
-        let Some((_, keys)) = self.application_eval_dependency_index.remove(&def_id) else {
-            return;
-        };
-        for key in keys {
-            if let Some((_, old_result)) = self.application_eval_cache.remove(&key) {
-                self.remove_application_eval_dependencies(interner, &key, old_result);
+        self.invalidate_eval_cache_for_def(def_id);
+        if let Some((_, keys)) = self.application_eval_dependency_index.remove(&def_id) {
+            for key in keys {
+                if let Some((_, old_result)) = self.application_eval_cache.remove(&key) {
+                    self.remove_application_eval_dependencies(&key, old_result);
+                }
             }
         }
     }
 
-    fn remove_application_eval_dependencies(
+    pub(super) fn insert_eval_cache(
         &self,
         interner: &TypeInterner,
-        key: &ApplicationEvalCacheKey,
+        definition_store: Option<&DefinitionStore>,
+        key: EvaluationCacheKey,
         result: TypeId,
     ) {
-        for def_id in collect_application_eval_entry_def_dependencies(interner, key, result) {
+        let old_result = self.eval_cache.insert(key, result);
+        self.record_eval_dependencies(interner, definition_store, key, old_result, result);
+    }
+
+    pub(super) fn insert_eval_cache_if_absent(
+        &self,
+        interner: &TypeInterner,
+        definition_store: Option<&DefinitionStore>,
+        key: EvaluationCacheKey,
+        result: TypeId,
+    ) {
+        match self.eval_cache.entry(key) {
+            Entry::Occupied(_) => {}
+            Entry::Vacant(vacant) => {
+                vacant.insert(result);
+                self.record_eval_dependencies(interner, definition_store, key, None, result);
+            }
+        }
+    }
+
+    fn invalidate_eval_cache_for_def(&self, def_id: DefId) {
+        let Some((_, keys)) = self.eval_dependency_index.remove(&def_id) else {
+            return;
+        };
+        for key in keys {
+            if let Some((_, old_result)) = self.eval_cache.remove(&key) {
+                self.remove_eval_dependencies(key, old_result);
+            }
+        }
+    }
+
+    fn record_eval_dependencies(
+        &self,
+        interner: &TypeInterner,
+        definition_store: Option<&DefinitionStore>,
+        key: EvaluationCacheKey,
+        old_result: Option<TypeId>,
+        result: TypeId,
+    ) {
+        if let Some(old_result) = old_result {
+            self.remove_eval_dependencies(key, old_result);
+        }
+        let deps = collect_eval_entry_def_dependencies(interner, definition_store, key, result);
+        if deps.is_empty() {
+            return;
+        }
+        let deps: FxHashSet<_> = deps.into_iter().collect();
+        for &def_id in &deps {
+            self.eval_dependency_index
+                .entry(def_id)
+                .or_default()
+                .insert(key);
+        }
+        self.eval_key_dependency_index.insert(key, deps);
+    }
+
+    fn remove_eval_dependencies(&self, key: EvaluationCacheKey, _result: TypeId) {
+        let Some((_, deps)) = self.eval_key_dependency_index.remove(&key) else {
+            return;
+        };
+        for def_id in deps {
+            let Some(mut keys) = self.eval_dependency_index.get_mut(&def_id) else {
+                continue;
+            };
+            keys.remove(&key);
+            let empty = keys.is_empty();
+            drop(keys);
+            if empty {
+                self.eval_dependency_index
+                    .remove_if(&def_id, |_, keys| keys.is_empty());
+            }
+        }
+    }
+
+    fn remove_application_eval_dependencies(&self, key: &ApplicationEvalCacheKey, _result: TypeId) {
+        let Some((_, deps)) = self.application_eval_key_dependency_index.remove(key) else {
+            return;
+        };
+        for def_id in deps {
             let Some(mut keys) = self.application_eval_dependency_index.get_mut(&def_id) else {
                 continue;
             };
@@ -144,7 +246,8 @@ impl SharedQueryCache {
             let empty = keys.is_empty();
             drop(keys);
             if empty {
-                self.application_eval_dependency_index.remove(&def_id);
+                self.application_eval_dependency_index
+                    .remove_if(&def_id, |_, keys| keys.is_empty());
             }
         }
     }
@@ -163,6 +266,22 @@ impl SharedQueryCache {
             * (DASHMAP_ENTRY_OVERHEAD
                 + std::mem::size_of::<EvaluationCacheKey>()
                 + std::mem::size_of::<TypeId>());
+        size += self.eval_dependency_index.len()
+            * (DASHMAP_ENTRY_OVERHEAD
+                + std::mem::size_of::<DefId>()
+                + std::mem::size_of::<FxHashSet<EvaluationCacheKey>>());
+        size += self.eval_key_dependency_index.len()
+            * (DASHMAP_ENTRY_OVERHEAD
+                + std::mem::size_of::<EvaluationCacheKey>()
+                + std::mem::size_of::<FxHashSet<DefId>>());
+        for keys in &self.eval_dependency_index {
+            let keys = keys.value();
+            size +=
+                keys.len() * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<EvaluationCacheKey>());
+        }
+        for deps in &self.eval_key_dependency_index {
+            size += deps.value().len() * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<DefId>());
+        }
         size += (self.subtype_cache.len() + self.assignability_cache.len())
             * (DASHMAP_ENTRY_OVERHEAD
                 + std::mem::size_of::<RelationCacheKey>()
@@ -171,6 +290,22 @@ impl SharedQueryCache {
             * (DASHMAP_ENTRY_OVERHEAD
                 + std::mem::size_of::<ApplicationEvalCacheKey>()
                 + std::mem::size_of::<TypeId>());
+        size += self.application_eval_dependency_index.len()
+            * (DASHMAP_ENTRY_OVERHEAD
+                + std::mem::size_of::<DefId>()
+                + std::mem::size_of::<FxHashSet<ApplicationEvalCacheKey>>());
+        size += self.application_eval_key_dependency_index.len()
+            * (DASHMAP_ENTRY_OVERHEAD
+                + std::mem::size_of::<ApplicationEvalCacheKey>()
+                + std::mem::size_of::<FxHashSet<DefId>>());
+        for keys in &self.application_eval_dependency_index {
+            let keys = keys.value();
+            size += keys.len()
+                * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<ApplicationEvalCacheKey>());
+        }
+        for deps in &self.application_eval_key_dependency_index {
+            size += deps.value().len() * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<DefId>());
+        }
         size += self.instantiation_cache.len()
             * (DASHMAP_ENTRY_OVERHEAD
                 + std::mem::size_of::<InstantiationCacheKey>()

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -14,6 +14,7 @@
 //! | CLI  | Sequential allocation | Fresh start each compilation |
 //! | LSP  | Content-addressed hash | Stable IDs across edits |
 mod augmentation_symbols;
+mod body_dependencies;
 mod content_addressed;
 mod cross_file_cache;
 mod decl_identity;
@@ -350,6 +351,9 @@ pub struct DefinitionStore {
     /// the structural form (e.g., show "A" instead of "{ a: string }").
     type_to_def: DefDashMap<TypeId, DefId>,
 
+    /// Body dependency graph captured as `DefId` edges by the publishing interner.
+    body_dependency_defs: DefDashMap<DefId, Arc<[DefId]>>,
+
     /// #14351 lazy-reference relation: instantiated heritage edges.
     ///
     /// Maps a derived `DefId` to the list of `(parent DefId, instantiated base
@@ -611,6 +615,7 @@ impl DefinitionStore {
             generation: AtomicU64::new(1),
             alias_forwards: DefDashMap::default(),
             type_to_def: DefDashMap::default(),
+            body_dependency_defs: DefDashMap::default(),
             heritage_instantiations: DefDashMap::default(),
             type_param_for_decl_node: DefDashMap::default(),
             symbol_def_index: DefDashMap::with_capacity_and_hasher(id_capacity, Default::default()),
@@ -836,72 +841,6 @@ impl DefinitionStore {
     /// Get the kind of a definition.
     pub fn get_kind(&self, id: DefId) -> Option<DefKind> {
         self.definitions.get(&id).map(|r| r.kind)
-    }
-
-    /// Get type parameters for a definition.
-    pub fn get_type_params(&self, id: DefId) -> Option<Vec<TypeParamInfo>> {
-        self.definitions.get(&id).map(|r| r.type_params.clone())
-    }
-
-    /// Get the body `TypeId` for a definition.
-    pub fn get_body(&self, id: DefId) -> Option<TypeId> {
-        self.definitions.get(&id).and_then(|r| r.body)
-    }
-
-    /// Whether `id` already publishes exactly `body` (and, when given,
-    /// exactly `params`). Comparison runs under the entry guard without
-    /// cloning, so no-op republication checks stay cheap on hot paths.
-    pub fn body_and_params_published(
-        &self,
-        id: DefId,
-        body: TypeId,
-        params: Option<&[TypeParamInfo]>,
-    ) -> bool {
-        self.definitions.get(&id).is_some_and(|entry| {
-            entry.body == Some(body)
-                && params.is_none_or(|params| entry.type_params.as_slice() == params)
-        })
-    }
-
-    /// Get parent class `DefId` for a class.
-    pub fn get_extends(&self, id: DefId) -> Option<DefId> {
-        self.definitions.get(&id).and_then(|r| r.extends)
-    }
-
-    /// Set the heritage (extends + implements) for a definition after registration.
-    ///
-    /// Used for cross-batch heritage resolution: when a user class extends a lib
-    /// type, the heritage is resolved by name after all pre-population batches
-    /// have completed.
-    pub fn set_heritage(&self, id: DefId, extends: Option<DefId>, implements: Vec<DefId>) {
-        if let Some(mut entry) = self.definitions.get_mut(&id) {
-            entry.extends = extends;
-            entry.implements = implements;
-            self.bump_generation();
-        }
-    }
-
-    /// #14351: record one instantiated heritage edge for the lazy-reference
-    /// relation. `derived` extends `parent`, and `base_type` is the parent
-    /// reference as written in `derived`'s own scope (e.g. `Functor1<F>` from
-    /// `interface Apply1<F> extends Functor1<F>`). First writer per
-    /// `(derived, parent)` wins; later equal writes are idempotent. This is
-    /// inert data — only the flag-gated lazy-reference relation branch reads it.
-    pub fn add_heritage_instantiation(&self, derived: DefId, parent: DefId, base_type: TypeId) {
-        let mut entry = self.heritage_instantiations.entry(derived).or_default();
-        if entry.iter().any(|&(p, _)| p == parent) {
-            return;
-        }
-        entry.push((parent, base_type));
-    }
-
-    /// #14351: the instantiated base `TypeId` for a DIRECT `extends` edge
-    /// `derived extends target`, or `None` if `target` is not a direct parent
-    /// of `derived` (the first slice handles single-hop heritage only).
-    pub fn get_heritage_instantiation(&self, derived: DefId, target: DefId) -> Option<TypeId> {
-        self.heritage_instantiations
-            .get(&derived)
-            .and_then(|edges| edges.iter().find(|&&(p, _)| p == target).map(|&(_, t)| t))
     }
 
     /// Update the body `TypeId` for a definition (for lazy evaluation).

--- a/crates/tsz-solver/src/def/core/body_dependencies.rs
+++ b/crates/tsz-solver/src/def/core/body_dependencies.rs
@@ -1,0 +1,101 @@
+use super::{DefId, DefinitionStore};
+use crate::types::{TypeId, TypeParamInfo};
+use rustc_hash::FxHashSet;
+use std::sync::Arc;
+
+impl DefinitionStore {
+    /// Get type parameters for a definition.
+    pub fn get_type_params(&self, id: DefId) -> Option<Vec<TypeParamInfo>> {
+        self.definitions.get(&id).map(|r| r.type_params.clone())
+    }
+
+    /// Get the body `TypeId` for a definition.
+    pub fn get_body(&self, id: DefId) -> Option<TypeId> {
+        self.definitions.get(&id).and_then(|r| r.body)
+    }
+
+    /// Record the `DefId`s directly referenced by a definition's published
+    /// body.
+    ///
+    /// The caller must collect these dependencies with the interner that owns
+    /// `body`. The store persists only `DefId` edges so later cache invalidators
+    /// can chase the dependency graph without interpreting a foreign `TypeId`.
+    pub fn set_body_dependency_defs(&self, id: DefId, deps: impl IntoIterator<Item = DefId>) {
+        let mut seen = FxHashSet::default();
+        let mut unique = Vec::new();
+        for dep in deps {
+            if seen.insert(dep) {
+                unique.push(dep);
+            }
+        }
+        if unique.is_empty() {
+            self.body_dependency_defs.remove(&id);
+        } else {
+            self.body_dependency_defs.insert(id, Arc::from(unique));
+        }
+    }
+
+    /// `DefId`s directly referenced by a published body, if a publisher
+    /// recorded them with that body's owning interner.
+    pub fn body_dependency_defs(&self, id: DefId) -> Option<Arc<[DefId]>> {
+        self.body_dependency_defs
+            .get(&id)
+            .map(|deps| Arc::clone(&deps))
+    }
+
+    /// Whether `id` already publishes exactly `body` (and, when given,
+    /// exactly `params`). Comparison runs under the entry guard without
+    /// cloning, so no-op republication checks stay cheap on hot paths.
+    pub fn body_and_params_published(
+        &self,
+        id: DefId,
+        body: TypeId,
+        params: Option<&[TypeParamInfo]>,
+    ) -> bool {
+        self.definitions.get(&id).is_some_and(|entry| {
+            entry.body == Some(body)
+                && params.is_none_or(|params| entry.type_params.as_slice() == params)
+        })
+    }
+
+    /// Get parent class `DefId` for a class.
+    pub fn get_extends(&self, id: DefId) -> Option<DefId> {
+        self.definitions.get(&id).and_then(|r| r.extends)
+    }
+
+    /// Set the heritage (extends + implements) for a definition after registration.
+    ///
+    /// Used for cross-batch heritage resolution: when a user class extends a lib
+    /// type, the heritage is resolved by name after all pre-population batches
+    /// have completed.
+    pub fn set_heritage(&self, id: DefId, extends: Option<DefId>, implements: Vec<DefId>) {
+        if let Some(mut entry) = self.definitions.get_mut(&id) {
+            entry.extends = extends;
+            entry.implements = implements;
+            self.bump_generation();
+        }
+    }
+
+    /// #14351: record one instantiated heritage edge for the lazy-reference
+    /// relation. `derived` extends `parent`, and `base_type` is the parent
+    /// reference as written in `derived`'s own scope (e.g. `Functor1<F>` from
+    /// `interface Apply1<F> extends Functor1<F>`). First writer per
+    /// `(derived, parent)` wins; later equal writes are idempotent. This is
+    /// inert data — only the flag-gated lazy-reference relation branch reads it.
+    pub fn add_heritage_instantiation(&self, derived: DefId, parent: DefId, base_type: TypeId) {
+        let mut entry = self.heritage_instantiations.entry(derived).or_default();
+        if entry.iter().any(|&(p, _)| p == parent) {
+            return;
+        }
+        entry.push((parent, base_type));
+    }
+
+    /// #14351: the instantiated base `TypeId` for a DIRECT `extends` edge
+    /// `derived extends target`, or `None` if `target` is not a direct parent
+    /// of `derived` (the first slice handles single-hop heritage only).
+    pub fn get_heritage_instantiation(&self, derived: DefId, target: DefId) -> Option<TypeId> {
+        self.heritage_instantiations
+            .get(&derived)
+            .and_then(|edges| edges.iter().find(|&&(p, _)| p == target).map(|&(_, t)| t))
+    }
+}


### PR DESCRIPTION
Goal: green

## Summary
- Track eval, closed-eval, shared eval, application-eval, and shared application-eval cache entries by the DefIds they depend on.
- Record DefinitionStore body dependencies as DefId -> DefId edges at checker publication time, and chase only those stable edges during solver cache invalidation.
- Snapshot dependency edges per cache key so body-dependency rewrites remove stale reverse edges instead of recomputing old dependencies from the current store graph.
- Repair the exact-head conformance failure in deeplyNestedMappedTypes by rendering TypeBox Static schema alias arrays structurally when a same-name schema value can supply the reduced object shape.

## Structural Rule
When a published DefId body is rewritten, tsc observes the rewritten body on the next evaluation. tsz must evict every eval-family cache entry whose key or result depends on that DefId, including entries that depend on it through another published lazy body, through the solver cache owner. The dependency graph uses stable DefId edges recorded by the body publisher, not cross-interner TypeId decoding.

For diagnostic display, when a Static schema alias array such as Output[] is the target of a TypeBox static-shape mismatch, tsc prints the reduced structural array target. tsz now recovers the same structural display through checker diagnostic formatting by resolving the same-name schema value and recursively reducing nested Static projections. This is display only; relation semantics remain solver-owned.

## Owner Layer
Solver caches own eval-family dependency indexes and invalidation. Checker publication only records body DefId edges while it still has the body-owning interner, and only when the attempted body is the authoritative body accepted by DefinitionStore.

Checker diagnostic formatting owns the static-schema alias-array display repair. It does not add semantic validation, inspect fixture names, or use rendered text as a type relation predicate.

## Adjacent Matrix
- Local eval key/result dependency invalidation.
- Local closed-eval key/result dependency invalidation.
- Local and opt-in shared application-eval base/arg/result invalidation.
- Shared eval promotion invalidation across sibling QueryCaches.
- Transitive DefinitionStore body dependencies without decoding producer-interner TypeIds.
- Body-dependency rewrite cleanup so stale body edges cannot evict fresh replacements.
- Unrelated entries remain resident after def-targeted invalidation.
- Static schema assignment displays cover Input[] -> Output[], typeof Input.static[] -> Output[], and generic T extends Output[] without falling back to the unreduced Output[] alias in the TS2322 fingerprint.

## Verification
- cargo fmt --all -- --check
- git diff --check
- scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E test(query_cache_statistics_tests::)
- scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker
- python3 scripts/arch/arch_guard.py --json
- scripts/arch/check-checker-boundaries.sh
- CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --lib -- -D warnings
- scripts/safe-run.sh cargo nextest run -p tsz-checker --test deeply_nested_mapped_types_tests properties_reducer_with_evaluate_wrapper_no_spurious_errors
- scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter deeplyNestedMappedTypes --verbose
- Rebased on origin/main at 7cb74bef3d and reran the focused checker test plus focused conformance filter on head 1dd35ea34588b52409599499d168a8864a5a3007.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
