### PR TITLE
fix(solver): relate decl-scoped deferred HKT indexes (#14351)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -5,23 +5,122 @@
 //! (Object contract, generic index access).
 
 use crate::def::resolver::TypeResolver;
+use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::objects::PropertyCollectionResult;
 use crate::relations::relation_queries::RelationPolicy;
 use crate::relations::subtype::{
     AnyPropagationMode, INTERSECTION_OBJECT_FAST_PATH_THRESHOLD, SubtypeChecker, SubtypeResult,
 };
 use crate::types::{
-    CachedAnyMode, ObjectFlags, ObjectShape, RelationCacheKey, RelationFlags, TypeId, Visibility,
+    CachedAnyMode, ObjectFlags, ObjectShape, RelationCacheKey, RelationFlags, TypeData, TypeId,
+    TypeParamInfo, TypeParamOrigin, Visibility,
 };
 use crate::visitor::{
     callable_shape_id, function_shape_id, index_access_parts, keyof_inner_type, literal_string,
     mapped_type_id, object_shape_id, object_with_index_shape_id, type_param_info, union_list_id,
 };
+use rustc_hash::FxHashMap;
 
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     pub(crate) const fn allows_bivariant_param_count(&self, is_method_like: bool) -> bool {
         self.allow_bivariant_param_count
             && (!self.strict_function_types || (is_method_like && !self.disable_method_bivariance))
+    }
+
+    /// Build a name-keyed substitution that erases `DeclScoped` construction
+    /// stamps for genuinely alpha-equivalent free type parameters in `roots`.
+    ///
+    /// Only same-name, same-surface (`constraint`/`default`/`is_const`) params
+    /// collapse to the same `User`-canonical id. If the same name appears with
+    /// conflicting surfaces, that name is poisoned and left unstripped.
+    pub(crate) fn build_decl_param_structural_strip_for_roots(
+        &self,
+        roots: impl IntoIterator<Item = TypeId>,
+    ) -> TypeSubstitution {
+        let free_ids =
+            crate::visitors::visitor_predicates::free_type_parameter_ids_in(self.interner, roots);
+
+        let mut by_name: FxHashMap<tsz_common::interner::Atom, Option<TypeId>> =
+            FxHashMap::default();
+        for id in free_ids {
+            let Some(info) = type_param_info(self.interner, id) else {
+                continue;
+            };
+            if !matches!(info.origin, TypeParamOrigin::DeclScoped { .. }) {
+                continue;
+            }
+
+            let canonical = self.interner.type_param(TypeParamInfo {
+                origin: TypeParamOrigin::User,
+                ..info
+            });
+            match by_name.get_mut(&info.name) {
+                None => {
+                    by_name.insert(info.name, Some(canonical));
+                }
+                Some(slot @ Some(_)) if *slot == Some(canonical) => {}
+                Some(slot) => {
+                    *slot = None;
+                }
+            }
+        }
+
+        let mut strip = TypeSubstitution::new();
+        for (name, canonical) in by_name {
+            if let Some(canonical) = canonical {
+                strip.insert(name, canonical);
+            }
+        }
+        strip
+    }
+
+    pub(crate) fn check_decl_stripped_lazy_application_index_access_pair(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> Option<SubtypeResult> {
+        let (source_object, _source_key) = index_access_parts(self.interner, source)?;
+        let (target_object, _target_key) = index_access_parts(self.interner, target)?;
+        if !self.same_lazy_application_base(source_object, target_object) {
+            return None;
+        }
+
+        let strip = self.build_decl_param_structural_strip_for_roots([source, target]);
+        if strip.is_empty() {
+            return None;
+        }
+
+        let stripped_source = instantiate_type(self.interner, source, &strip);
+        let stripped_target = instantiate_type(self.interner, target, &strip);
+        if stripped_source == source && stripped_target == target {
+            return None;
+        }
+
+        Some(self.check_subtype(stripped_source, stripped_target))
+    }
+
+    fn same_lazy_application_base(&self, source_object: TypeId, target_object: TypeId) -> bool {
+        let Some(TypeData::Application(source_app_id)) = self.interner.lookup(source_object) else {
+            return false;
+        };
+        let Some(TypeData::Application(target_app_id)) = self.interner.lookup(target_object) else {
+            return false;
+        };
+
+        let source_app = self.interner.type_application(source_app_id);
+        let target_app = self.interner.type_application(target_app_id);
+        if source_app.args.len() != target_app.args.len() {
+            return false;
+        }
+
+        matches!(
+            (
+                self.interner.lookup(source_app.base),
+                self.interner.lookup(target_app.base),
+            ),
+            (Some(TypeData::Lazy(source_def)), Some(TypeData::Lazy(target_def)))
+                if source_def == target_def
+        )
     }
 
     pub(crate) fn resolved_type_param_info(

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -166,9 +166,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: &FunctionShape,
         target: &FunctionShape,
     ) -> TypeSubstitution {
-        use crate::types::TypeParamOrigin;
-        use rustc_hash::FxHashMap;
-
         let roots = source
             .params
             .iter()
@@ -178,50 +175,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             .chain(target.params.iter().map(|p| p.type_id))
             .chain(target.this_type)
             .chain(std::iter::once(target.return_type));
-        let free_ids =
-            crate::visitors::visitor_predicates::free_type_parameter_ids_in(self.interner, roots);
-
-        // Per name: the single canonical (`User`-stripped) target id, or a
-        // poison marker once a conflicting surface is seen for the same name.
-        let mut by_name: FxHashMap<tsz_common::interner::Atom, Option<TypeId>> =
-            FxHashMap::default();
-        for id in free_ids {
-            let Some(info) = type_param_info(self.interner, id) else {
-                continue;
-            };
-            // Only DeclScoped params carry the construction stamp that splits
-            // alpha-equivalent decls. Leave User/inference placeholders alone.
-            if !matches!(info.origin, TypeParamOrigin::DeclScoped { .. }) {
-                continue;
-            }
-            // The User-canonical structural intern: same surface, origin erased.
-            // Alpha-equivalent DeclScoped params (same name+surface, distinct
-            // origins) all map to this single id.
-            let canonical = self.interner.type_param(TypeParamInfo {
-                origin: TypeParamOrigin::User,
-                ..info
-            });
-            match by_name.get_mut(&info.name) {
-                None => {
-                    by_name.insert(info.name, Some(canonical));
-                }
-                Some(slot @ Some(_)) if *slot == Some(canonical) => {}
-                // Two DeclScoped params share a name but strip to DISTINCT
-                // canonical ids = different surfaces. A name-keyed strip would
-                // unsoundly merge them; poison this name so it is excluded.
-                Some(slot) => {
-                    *slot = None;
-                }
-            }
-        }
-
-        let mut strip = TypeSubstitution::new();
-        for (name, canonical) in by_name {
-            if let Some(canonical) = canonical {
-                strip.insert(name, canonical);
-            }
-        }
-        strip
+        self.build_decl_param_structural_strip_for_roots(roots)
     }
 
     fn check_function_subtype_impl(

--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -984,6 +984,14 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
         // S[I] <: T[J]  <=>  S <: T  AND  I <: J
         // This handles deferred index access types (usually involving type parameters).
         if let Some((t_obj, t_idx)) = index_access_parts(self.checker.interner, self.target) {
+            if let Some(result) = self
+                .checker
+                .check_decl_stripped_lazy_application_index_access_pair(self.source, self.target)
+                && result.is_true()
+            {
+                return result;
+            }
+
             // Coinductive check: delegate back to check_subtype for both parts
             if self.checker.check_subtype(object_type, t_obj).is_true()
                 && self.checker.check_subtype(key_type, t_idx).is_true()

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_04.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_04.rs
@@ -411,6 +411,64 @@ fn test_deferred_index_access_distinct_key_guard_respects_alpha_equivalence() {
 }
 
 #[test]
+fn test_deferred_hkt_index_access_relates_decl_scoped_alpha_equivalent_binders() {
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let registry_def = DefId(4700);
+
+    let scoped = |name: &str, file: &str, node: u32, constraint: Option<TypeId>| {
+        interner.type_param(TypeParamInfo {
+            name: interner.intern_string(name),
+            constraint,
+            default: None,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::DeclScoped {
+                file: interner.intern_string(file),
+                node,
+            },
+        })
+    };
+
+    let left_f = scoped("F", "left.ts", 10, None);
+    let left_a = scoped("A", "left.ts", 20, None);
+    let right_f = scoped("F", "right.ts", 10, None);
+    let right_a = scoped("A", "right.ts", 20, None);
+    let right_b = scoped("B", "right.ts", 30, None);
+    let constrained_right_a = scoped("A", "right.ts", 40, Some(TypeId::STRING));
+
+    let left_kind = interner.index_access(
+        interner.application(interner.lazy(registry_def), vec![left_a]),
+        left_f,
+    );
+    let right_kind = interner.index_access(
+        interner.application(interner.lazy(registry_def), vec![right_a]),
+        right_f,
+    );
+    let different_name_kind = interner.index_access(
+        interner.application(interner.lazy(registry_def), vec![right_b]),
+        right_f,
+    );
+    let different_surface_kind = interner.index_access(
+        interner.application(interner.lazy(registry_def), vec![constrained_right_a]),
+        right_f,
+    );
+
+    assert!(
+        checker.is_subtype_of(left_kind, right_kind),
+        "same-name same-surface DeclScoped HKT binders should relate structurally"
+    );
+    assert!(
+        !checker.is_subtype_of(left_kind, different_name_kind),
+        "differently named object-side binders must not be collapsed"
+    );
+    assert!(
+        !checker.is_subtype_of(left_kind, different_surface_kind),
+        "same-name binders with different constraints must not be collapsed"
+    );
+}
+
+#[test]
 fn test_generic_covariant_return_position() {
     // Producer<T> = { get(): T } - T is in covariant position
     // Producer<string> <: Producer<string | number> (covariant)


### PR DESCRIPTION
Goal: green

## Summary
- Move the `DeclScoped` structural-strip helper into shared subtype relation helpers.
- Apply that strip narrowly when both sides are deferred indexed-access forms whose object is an `Application` over the same unresolved `Lazy(DefId)` base.
- Add a solver relation test that accepts same-name/same-surface `DeclScoped` HKT binders while rejecting different names and conflicting constraints.

## Structural Rule
When both relation endpoints are deferred HKT/indexed-access forms like `Registry<A>[F]` over the same unresolved lazy registry, and their free binders are same-name/same-surface `DeclScoped` type parameters, `tsc` relates the deferred structures modulo alpha-equivalence. tsz now owns that in the solver subtype relation by stripping only those declaration stamps before an ordinary relation check.

Differently named binders and same-name binders with different constraints remain distinct. Ordinary object indexed accesses do not take this path because the hook requires the indexed object to be a lazy-base generic application.

## Owner Layer
Solver relation (`crates/tsz-solver/src/relations/subtype`). No checker, evaluator, cache publication, or emit policy changes.

## Adjacent Matrix
- Positive: same-name/same-surface `DeclScoped` `Registry<A>[F]` relates across distinct declaration stamps.
- Negative: object-side `A` vs `B` stays unrelated.
- Negative: same-name `A` with a different constraint stays unrelated.
- Regression: existing deferred index-access distinct-key alpha-equivalence guard still passes.
- Regression: existing structural-strip soundness oracles still pass after moving the helper.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-solver test_deferred_hkt_index_access_relates_decl_scoped_alpha_equivalent_binders` (failed before the fix; passed after)
- `scripts/safe-run.sh cargo nextest run -p tsz-solver test_deferred_index_access_distinct_key_guard_respects_alpha_equivalence`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver strip_keeps_distinct_named_decl_params_distinct`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver strip_collapses_same_named_alpha_equivalent_decl_params`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver strip_excludes_name_with_conflicting_surface`
- `cargo fmt --all --check`
- `git diff --check`

Not run locally: `cargo check` / clippy. The fresh test build drove this machine to ~654 MB free; after Levels 1-2 cleanup did not recover space, I deleted only this branch's generated `.target` cache to restore ~3.7 GB. Exact-head CI should own the broader Rust checks.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high