### PR TITLE
fix(emit): lower ES5 instance private auto-accessors

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -51,6 +51,10 @@ name = "es5_optional_chain_call_receiver_tests"
 path = "tests/es5_optional_chain_call_receiver_tests.rs"
 
 [[test]]
+name = "es5_private_auto_accessor_tests"
+path = "tests/es5_private_auto_accessor_tests.rs"
+
+[[test]]
 name = "es5_super_object_literal_accessor_tests"
 path = "tests/es5_super_object_literal_accessor_tests.rs"
 

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -1496,6 +1496,20 @@ impl<'a> ES5ClassTransformer<'a> {
             &self.class_name,
             &mut used_private_names,
         );
+        // A private auto-accessor (`accessor #y`) lowers to a backing-storage
+        // `WeakMap` (collected into `auto_accessors`) plus a branded get/set pair
+        // that reads/writes that storage. Collect the storage and synthesize the
+        // accessor pair BEFORE the instance-brand decision below so the brand and
+        // the read/write routing (`with_private_member_maps`) both account for the
+        // synthesized private accessors.
+        self.auto_accessors = collect_auto_accessor_fields(self.arena, class_idx, &self.class_name);
+        self.private_accessors
+            .extend(collect_private_auto_accessor_accessors(
+                self.arena,
+                class_idx,
+                &self.class_name,
+                &mut used_private_names,
+            ));
         let has_instance_private_brand =
             self.private_methods.iter().any(|method| !method.is_static)
                 || self
@@ -1508,7 +1522,6 @@ impl<'a> ES5ClassTransformer<'a> {
                 &mut used_private_names,
             )
         });
-        self.auto_accessors = collect_auto_accessor_fields(self.arena, class_idx, &self.class_name);
 
         // Check for extends clause
         let base_class = self.get_extends_class(&class_data.heritage_clauses);
@@ -1797,7 +1810,7 @@ impl<'a> ES5ClassTransformer<'a> {
                 weakmap_inits.push(format!("{} = new WeakMap()", accessor.weakmap_name));
             }
         }
-        weakmap_inits.extend(self.private_method_and_accessor_init_strings());
+        weakmap_inits.extend(self.private_method_and_accessor_init_strings(class_data));
         // Static private field initializers are no longer emitted as a grouped
         // block here; they are interleaved with the public static field inits and
         // static blocks in source order via `deferred_static_prop_stmts` below,

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
@@ -592,8 +592,11 @@ pub(super) fn collect_private_auto_accessor_accessors(
             set_var_name: Some(set_var),
             has_getter: true,
             has_setter: true,
-            getter_body: Some(member_idx),
-            setter_body: Some(member_idx),
+            // A synthetic auto-accessor has no source getter/setter body to lower
+            // — its get/set are generated from `synthetic_storage`, so these stay
+            // `None`. Emission is driven by `synthetic_storage`, never by these.
+            getter_body: None,
+            setter_body: None,
             setter_param: None,
             getter_is_async: false,
             setter_is_async: false,

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
@@ -4,7 +4,11 @@ use crate::transforms::emit_utils::{
     METADATA_ALIAS_MAX_DEPTH, MetadataEntityKind, classify_metadata_entity, identifier_text,
     metadata_global_constructor_with_fallback,
 };
+use crate::transforms::private_fields_es5::{
+    PrivateAccessorInfo, get_private_field_name, make_unique_private_name, private_helper_base,
+};
 use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
@@ -478,28 +482,41 @@ pub(super) fn collect_auto_accessor_fields(
         if arena.has_modifier(&prop_data.modifiers, SyntaxKind::DeclareKeyword) {
             continue;
         }
-        if is_private_identifier(arena, prop_data.name) {
-            continue;
-        }
         let has_accessor = arena.has_modifier(&prop_data.modifiers, SyntaxKind::AccessorKeyword);
         if !has_accessor {
             continue;
         }
-        let Some(name_node) = arena.get(prop_data.name) else {
+        let is_static = arena.is_static(&prop_data.modifiers);
+        let is_private = is_private_identifier(arena, prop_data.name);
+        // Static private auto-accessors follow the broader (still-incomplete)
+        // static-private-member ES5 lowering and are left on the existing path;
+        // only instance private auto-accessors are lowered here alongside the
+        // public ones.
+        if is_private && is_static {
             continue;
-        };
-        let name = if name_node.kind == SyntaxKind::Identifier as u16 {
-            let Some(name) = arena
-                .get_identifier(name_node)
-                .map(|id| id.escaped_text.clone())
-            else {
+        }
+        let name = if is_private {
+            let Some(raw) = get_private_field_name(arena, prop_data.name) else {
                 continue;
             };
-            name
+            raw.strip_prefix('#').unwrap_or(&raw).to_string()
         } else {
-            let name = generated_auto_accessor_name(generated_name_index);
-            generated_name_index += 1;
-            name
+            let Some(name_node) = arena.get(prop_data.name) else {
+                continue;
+            };
+            if name_node.kind == SyntaxKind::Identifier as u16 {
+                let Some(name) = arena
+                    .get_identifier(name_node)
+                    .map(|id| id.escaped_text.clone())
+                else {
+                    continue;
+                };
+                name
+            } else {
+                let name = generated_auto_accessor_name(generated_name_index);
+                generated_name_index += 1;
+                name
+            }
         };
 
         accessors.push(AutoAccessorFieldInfo {
@@ -509,7 +526,79 @@ pub(super) fn collect_auto_accessor_fields(
                 .initializer
                 .is_some()
                 .then_some(prop_data.initializer),
-            is_static: arena.is_static(&prop_data.modifiers),
+            is_static,
+        });
+    }
+
+    accessors
+}
+
+/// Synthesize the branded get/set accessor pair for every instance private
+/// auto-accessor (`accessor #y = ...`). tsc lowers a private auto-accessor to a
+/// backing-storage `WeakMap` (collected by `collect_auto_accessor_fields`) plus a
+/// private accessor pair whose bodies read/write that storage; access to `this.#y`
+/// routes through the instance brand exactly like an ordinary private accessor.
+/// The returned entries carry `synthetic_storage`, marking their get/set bodies as
+/// generated rather than lowered from source. Names are reserved in `used_names`
+/// in source order so they compose with the other private helper names.
+pub(super) fn collect_private_auto_accessor_accessors(
+    arena: &NodeArena,
+    class_idx: NodeIndex,
+    class_name: &str,
+    used_names: &mut FxHashSet<String>,
+) -> Vec<PrivateAccessorInfo> {
+    let mut accessors = Vec::new();
+    let Some(class_node) = arena.get(class_idx) else {
+        return accessors;
+    };
+    let Some(class_data) = arena.get_class(class_node) else {
+        return accessors;
+    };
+
+    for &member_idx in &class_data.members.nodes {
+        let Some(member_node) = arena.get(member_idx) else {
+            continue;
+        };
+        if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION {
+            continue;
+        }
+        let Some(prop_data) = arena.get_property_decl(member_node) else {
+            continue;
+        };
+        if !arena.has_modifier(&prop_data.modifiers, SyntaxKind::AccessorKeyword)
+            || !is_private_identifier(arena, prop_data.name)
+            || arena.is_static(&prop_data.modifiers)
+            || arena.has_modifier(&prop_data.modifiers, SyntaxKind::AbstractKeyword)
+            || arena.has_modifier(&prop_data.modifiers, SyntaxKind::DeclareKeyword)
+        {
+            continue;
+        }
+        let Some(raw) = get_private_field_name(arena, prop_data.name) else {
+            continue;
+        };
+        let clean_name = raw.strip_prefix('#').unwrap_or(&raw).to_string();
+        let base = private_helper_base(class_name, &clean_name);
+        // Reserve get/set/storage in source order. The storage name must equal the
+        // one `collect_auto_accessor_fields` derives (`<base>_accessor_storage`);
+        // both use the same formula, so absent a collision they agree.
+        let get_var = make_unique_private_name(&format!("{base}_get"), used_names);
+        let set_var = make_unique_private_name(&format!("{base}_set"), used_names);
+        let storage = make_unique_private_name(&format!("{base}_accessor_storage"), used_names);
+
+        accessors.push(PrivateAccessorInfo {
+            member_indices: vec![member_idx],
+            name: clean_name,
+            get_var_name: Some(get_var),
+            set_var_name: Some(set_var),
+            has_getter: true,
+            has_setter: true,
+            getter_body: Some(member_idx),
+            setter_body: Some(member_idx),
+            setter_param: None,
+            getter_is_async: false,
+            setter_is_async: false,
+            is_static: false,
+            synthetic_storage: Some(storage),
         });
     }
 

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
@@ -471,6 +471,17 @@ impl<'a> ES5ClassTransformer<'a> {
                         .find(|field| field.member_idx == member_idx)
                     {
                         decls.push(field.weakmap_name.clone());
+                    } else if let Some(accessor) = self.synthetic_auto_accessor_for(member_idx) {
+                        // A private auto-accessor declares its branded get/set
+                        // helpers at its source position; the backing storage
+                        // `WeakMap` is declared later with the other auto-accessor
+                        // storages (via `weakmap_decls`), matching tsc.
+                        if let Some(get_var) = accessor.get_var_name.as_ref() {
+                            decls.push(get_var.clone());
+                        }
+                        if let Some(set_var) = accessor.set_var_name.as_ref() {
+                            decls.push(set_var.clone());
+                        }
                     }
                 }
                 k if k == syntax_kind_ext::METHOD_DECLARATION => {
@@ -508,30 +519,93 @@ impl<'a> ES5ClassTransformer<'a> {
         decls
     }
 
-    pub(super) fn private_method_and_accessor_init_strings(&self) -> Vec<String> {
+    /// Build the trailing `_C_m = function ..., _C_g_get = function ...` helper
+    /// assignment chain for the class's private methods and accessors.
+    ///
+    /// The chain is emitted in **source member order** by walking the class body
+    /// once — a private accessor declared before a private method assigns its
+    /// helper first, matching tsc (which walks the members once). A private
+    /// auto-accessor contributes a synthesized branded get/set pair that reads and
+    /// writes its backing-storage `WeakMap`.
+    pub(super) fn private_method_and_accessor_init_strings(
+        &self,
+        class_data: &tsz_parser::parser::node::ClassData,
+    ) -> Vec<String> {
         let mut inits = Vec::new();
-        for method in &self.private_methods {
-            if let Some(function) = self.build_private_method_function_ir(method.member_idx) {
-                inits.push(self.private_assignment_string(&method.fn_var_name, function));
+        for &member_idx in &class_data.members.nodes {
+            let Some(node) = self.arena.get(member_idx) else {
+                continue;
+            };
+            match node.kind {
+                k if k == syntax_kind_ext::METHOD_DECLARATION => {
+                    if let Some(method) = self
+                        .private_methods
+                        .iter()
+                        .find(|method| method.member_idx == member_idx)
+                        && let Some(function) =
+                            self.build_private_method_function_ir(method.member_idx)
+                    {
+                        inits.push(self.private_assignment_string(&method.fn_var_name, function));
+                    }
+                }
+                k if k == syntax_kind_ext::GET_ACCESSOR || k == syntax_kind_ext::SET_ACCESSOR => {
+                    if let Some(accessor) = self.private_accessors.iter().find(|accessor| {
+                        accessor.synthetic_storage.is_none()
+                            && accessor.member_indices.contains(&member_idx)
+                    }) {
+                        let is_getter = k == syntax_kind_ext::GET_ACCESSOR;
+                        inits.extend(
+                            self.private_accessor_init_string(accessor, member_idx, is_getter),
+                        );
+                    }
+                }
+                k if k == syntax_kind_ext::PROPERTY_DECLARATION => {
+                    if let Some(accessor) = self.synthetic_auto_accessor_for(member_idx) {
+                        inits.extend(self.synthetic_auto_accessor_init_strings(accessor));
+                    }
+                }
+                _ => {}
             }
         }
-        for accessor in &self.private_accessors {
-            // Initialize each accessor's helper at its own source position by
-            // walking the members in source order, so a `set`-before-`get` pair
-            // assigns `_set` first, matching `tsc`.
-            for &member_idx in &accessor.member_indices {
-                let Some(node) = self.arena.get(member_idx) else {
-                    continue;
-                };
-                let init = if node.kind == syntax_kind_ext::GET_ACCESSOR {
-                    self.private_accessor_init_string(accessor, member_idx, true)
-                } else if node.kind == syntax_kind_ext::SET_ACCESSOR {
-                    self.private_accessor_init_string(accessor, member_idx, false)
-                } else {
-                    None
-                };
-                inits.extend(init);
+        inits
+    }
+
+    /// Find the synthesized private-accessor entry (get/set pair) that a private
+    /// auto-accessor property declaration owns, if any.
+    pub(super) fn synthetic_auto_accessor_for(
+        &self,
+        member_idx: NodeIndex,
+    ) -> Option<&crate::transforms::private_fields_es5::PrivateAccessorInfo> {
+        self.private_accessors.iter().find(|accessor| {
+            accessor.synthetic_storage.is_some() && accessor.member_indices.contains(&member_idx)
+        })
+    }
+
+    /// Build the `_C_y_get = function _C_y_get() { ... }, _C_y_set = function ...`
+    /// helper assignments for a private auto-accessor. The bodies read and write
+    /// the backing-storage `WeakMap` (`synthetic_storage`) through the private
+    /// field helpers, exactly as tsc emits them.
+    fn synthetic_auto_accessor_init_strings(
+        &self,
+        accessor: &crate::transforms::private_fields_es5::PrivateAccessorInfo,
+    ) -> Vec<String> {
+        let Some(storage) = accessor.synthetic_storage.as_ref() else {
+            return Vec::new();
+        };
+        let mut inits = Vec::new();
+        if let Some(get_var) = accessor.get_var_name.as_ref() {
+            let mut function = self.build_auto_accessor_getter_function(storage);
+            if let IRNode::FunctionExpr { name, .. } = &mut function {
+                *name = Some(get_var.clone().into());
             }
+            inits.push(self.private_assignment_string(get_var, function));
+        }
+        if let Some(set_var) = accessor.set_var_name.as_ref() {
+            let mut function = self.build_auto_accessor_setter_function(storage);
+            if let IRNode::FunctionExpr { name, .. } = &mut function {
+                *name = Some(set_var.clone().into());
+            }
+            inits.push(self.private_assignment_string(set_var, function));
         }
         inits
     }

--- a/crates/tsz-emitter/src/transforms/private_fields_es5.rs
+++ b/crates/tsz-emitter/src/transforms/private_fields_es5.rs
@@ -87,6 +87,12 @@ pub struct PrivateAccessorInfo {
     pub setter_is_async: bool,
     /// Whether this is a static private accessor
     pub is_static: bool,
+    /// For a private auto-accessor (`accessor #y`), the backing-storage `WeakMap`
+    /// name (e.g. `_C_y_accessor_storage`). When set, this entry is a synthesized
+    /// accessor pair whose get/set bodies are generated (they read/write that
+    /// storage) rather than lowered from source getter/setter bodies. `None` for
+    /// ordinary source-declared private accessors.
+    pub synthetic_storage: Option<String>,
 }
 
 /// State for tracking private fields during class transformation
@@ -613,6 +619,7 @@ pub fn collect_private_members_with_reserved(
                         getter_is_async: false,
                         setter_is_async: false,
                         is_static,
+                        synthetic_storage: None,
                     });
                     accessors.len() - 1
                 };
@@ -752,6 +759,7 @@ pub fn collect_private_accessors_with_reserved(
                     getter_is_async: false,
                     setter_is_async: false,
                     is_static,
+                    synthetic_storage: None,
                 });
                 accessors.len() - 1
             };

--- a/crates/tsz-emitter/tests/es5_private_auto_accessor_tests.rs
+++ b/crates/tsz-emitter/tests/es5_private_auto_accessor_tests.rs
@@ -1,0 +1,239 @@
+//! ES5 lowering of **instance private auto-accessors** (`accessor #name`).
+//!
+//! Structural rule: a private auto-accessor lowers, at every sub-ES2022 target,
+//! to a backing-storage `WeakMap` (`_C_y_accessor_storage`) plus a branded
+//! get/set helper pair (`_C_y_get` / `_C_y_set`) that read and write that
+//! storage; access to `this.#y` routes through the instance brand exactly like
+//! an ordinary private accessor
+//! (`__classPrivateFieldGet(this, _C_instances, "a", _C_y_get)`). The prototype
+//! never gains an `Object.defineProperty` for a private auto-accessor. Before
+//! this fix the ES5 class transformer dropped the member entirely and emitted
+//! syntactically invalid `this.` for the read.
+//!
+//! The trailing helper-assignment chain and the hoisted `var` list follow
+//! **source member order** — a private accessor declared before a private method
+//! assigns its helper first — matching tsc, which walks the class body once.
+//!
+//! Ground truth captured from `tsc` 6.0.2 `--target es5 --module esnext`. Binder
+//! names vary across tests so the behaviour keys on the structural
+//! private-auto-accessor shape, not on any identifier spelling.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print;
+
+fn emit_es5(source: &str) -> String {
+    let opts = PrintOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::ESNext,
+        ..Default::default()
+    };
+    parse_and_lower_print(source, opts)
+}
+
+/// A basic instance private auto-accessor lowers to storage + branded get/set,
+/// and reads/writes route through the instance brand.
+#[test]
+fn basic_private_auto_accessor_read_and_write() {
+    let source = r#"export class Cell {
+  accessor #v = 2;
+  read() { return this.#v; }
+  write(next: number) { this.#v = next; }
+}"#;
+    let out = emit_es5(source);
+
+    // The dropped-member regression: no invalid `this.` and no raw `#v`.
+    assert!(
+        !out.contains("this.;") && !out.contains("this. ="),
+        "private auto-accessor must not emit an invalid empty property access.\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains("#v"),
+        "the private name must be fully lowered.\nOutput:\n{out}"
+    );
+
+    assert!(
+        out.contains("var _Cell_instances, _Cell_v_get, _Cell_v_set, _Cell_v_accessor_storage;"),
+        "hoisted var list: brand, get, set, then storage.\nOutput:\n{out}"
+    );
+    assert!(
+        out.contains("_Cell_instances.add(this);")
+            && out.contains("_Cell_v_accessor_storage.set(this, 2);"),
+        "constructor brands the instance and seeds the storage.\nOutput:\n{out}"
+    );
+    assert!(
+        out.contains("return __classPrivateFieldGet(this, _Cell_instances, \"a\", _Cell_v_get);"),
+        "read routes through the accessor brand.\nOutput:\n{out}"
+    );
+    assert!(
+        out.contains("__classPrivateFieldSet(this, _Cell_instances, next, \"a\", _Cell_v_set);"),
+        "write routes through the accessor brand.\nOutput:\n{out}"
+    );
+    assert!(
+        out.contains(
+            "_Cell_instances = new WeakSet(), _Cell_v_accessor_storage = new WeakMap(), _Cell_v_get = function _Cell_v_get() { return __classPrivateFieldGet(this, _Cell_v_accessor_storage, \"f\"); }, _Cell_v_set = function _Cell_v_set(value) { __classPrivateFieldSet(this, _Cell_v_accessor_storage, value, \"f\"); };"
+        ),
+        "trailing chain: brand, storage, then get/set helpers.\nOutput:\n{out}"
+    );
+}
+
+/// A private auto-accessor without an initializer seeds the storage with
+/// `void 0`.
+#[test]
+fn private_auto_accessor_without_initializer() {
+    let source = r#"export class Slot {
+  accessor #payload;
+  peek() { return this.#payload; }
+}"#;
+    let out = emit_es5(source);
+    assert!(
+        out.contains("_Slot_payload_accessor_storage.set(this, void 0);"),
+        "uninitialized storage is seeded with void 0.\nOutput:\n{out}"
+    );
+    assert!(
+        out.contains(
+            "return __classPrivateFieldGet(this, _Slot_instances, \"a\", _Slot_payload_get);"
+        ),
+        "read routes through the accessor brand.\nOutput:\n{out}"
+    );
+}
+
+/// Two private auto-accessors keep their storages and helpers in source order.
+#[test]
+fn multiple_private_auto_accessors_keep_source_order() {
+    let source = r#"export class Pair {
+  accessor #left = 1;
+  accessor #right = 2;
+}"#;
+    let out = emit_es5(source);
+    assert!(
+        out.contains(
+            "var _Pair_instances, _Pair_left_get, _Pair_left_set, _Pair_right_get, _Pair_right_set, _Pair_left_accessor_storage, _Pair_right_accessor_storage;"
+        ),
+        "helpers in source order, storages grouped after them.\nOutput:\n{out}"
+    );
+}
+
+/// A public and a private auto-accessor coexist: the public one keeps its
+/// prototype `Object.defineProperty`; the private one is branded, with the two
+/// storages in source order.
+#[test]
+fn mixed_public_and_private_auto_accessors() {
+    let source = r#"export class Mixed {
+  accessor open = 1;
+  accessor #closed = 2;
+  m() { return this.open + this.#closed; }
+}"#;
+    let out = emit_es5(source);
+    assert!(
+        out.contains("Object.defineProperty(Mixed.prototype, \"open\""),
+        "the public auto-accessor keeps its prototype descriptor.\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains("Mixed.prototype, \"closed\"")
+            && !out.contains("Mixed.prototype, \"#closed\""),
+        "the private auto-accessor must NOT define a prototype property.\nOutput:\n{out}"
+    );
+    assert!(
+        out.contains(
+            "this.open + __classPrivateFieldGet(this, _Mixed_instances, \"a\", _Mixed_closed_get)"
+        ),
+        "public access stays a plain member; private access is branded.\nOutput:\n{out}"
+    );
+    assert!(
+        out.contains(
+            "_Mixed_instances = new WeakSet(), _Mixed_open_accessor_storage = new WeakMap(), _Mixed_closed_accessor_storage = new WeakMap(), _Mixed_closed_get = function"
+        ),
+        "both accessor storages are allocated in source order.\nOutput:\n{out}"
+    );
+}
+
+/// A private field, a private auto-accessor, and a private method interleave in
+/// source order in the trailing helper chain — the private auto-accessor's
+/// get/set land at its own position, before the later method.
+#[test]
+fn private_auto_accessor_interleaves_with_field_and_method_in_source_order() {
+    let source = r#"export class Svc {
+  #flag = 0;
+  accessor #count = 1;
+  #tick() { return this.#flag; }
+  run() { return this.#tick() + this.#count; }
+}"#;
+    let out = emit_es5(source);
+    assert!(
+        out.contains(
+            "_Svc_flag = new WeakMap(), _Svc_instances = new WeakSet(), _Svc_count_accessor_storage = new WeakMap(), _Svc_count_get = function _Svc_count_get() { return __classPrivateFieldGet(this, _Svc_count_accessor_storage, \"f\"); }, _Svc_count_set = function _Svc_count_set(value) { __classPrivateFieldSet(this, _Svc_count_accessor_storage, value, \"f\"); }, _Svc_tick = function _Svc_tick() { return __classPrivateFieldGet(this, _Svc_flag, \"f\"); };"
+        ),
+        "source order: field storage, brand, accessor storage, accessor get/set, then the later method.\nOutput:\n{out}"
+    );
+}
+
+/// A compound assignment to a private auto-accessor expands to a branded
+/// get + set, both keyed on the instance brand.
+#[test]
+fn compound_assignment_to_private_auto_accessor() {
+    let source = r#"export class Counter {
+  accessor #n = 0;
+  bump() { this.#n += 1; return this.#n; }
+}"#;
+    let out = emit_es5(source);
+    assert!(
+        out.contains(
+            "__classPrivateFieldSet(this, _Counter_instances, __classPrivateFieldGet(this, _Counter_instances, \"a\", _Counter_n_get) + 1, \"a\", _Counter_n_set);"
+        ),
+        "compound assignment reads then writes through the accessor brand.\nOutput:\n{out}"
+    );
+}
+
+/// A private auto-accessor in a derived class still lowers correctly.
+#[test]
+fn private_auto_accessor_in_derived_class() {
+    let source = r#"declare class Base {}
+export class Derived extends Base {
+  accessor #tag = 9;
+  val() { return this.#tag; }
+}"#;
+    let out = emit_es5(source);
+    // A derived-class constructor captures `this` into `_this` after the super
+    // chain, so the brand/storage stores key on `_this`.
+    assert!(
+        out.contains("_Derived_instances.add(_this);")
+            && out.contains("_Derived_tag_accessor_storage.set(_this, 9);"),
+        "derived-class constructor brands and seeds after the super chain.\nOutput:\n{out}"
+    );
+    assert!(
+        out.contains(
+            "return __classPrivateFieldGet(this, _Derived_instances, \"a\", _Derived_tag_get);"
+        ),
+        "read routes through the accessor brand.\nOutput:\n{out}"
+    );
+}
+
+/// A private get/set accessor declared *before* a private method assigns its
+/// helper first — the trailing chain follows source order, not a
+/// methods-before-accessors grouping.
+#[test]
+fn private_accessor_before_method_keeps_source_order() {
+    let source = r#"export class Ordered {
+  #store = 1;
+  get #view() { return this.#store; }
+  set #view(x: number) { this.#store = x; }
+  #compute() { return this.#store; }
+  use() { return this.#view + this.#compute(); }
+}"#;
+    let out = emit_es5(source);
+    let view_get = out
+        .find("_Ordered_view_get = function")
+        .expect("view get helper");
+    let compute = out
+        .find("_Ordered_compute = function")
+        .expect("compute helper");
+    assert!(
+        view_get < compute,
+        "the accessor helper (declared first) must be assigned before the method helper.\nOutput:\n{out}"
+    );
+}


### PR DESCRIPTION
Fixes #15303.

At `--target es5` the ES5 class transformer dropped an instance private auto-accessor (`accessor #x`) **entirely** — no backing-storage `WeakMap`, no branded get/set pair, no instance brand — and a read of `this.#x` lowered to the syntactically invalid `this.` (`this. = v` on write). The class was silently broken at runtime. The ES2015–ESNext path already lowered private auto-accessors byte-identically to `tsc`; only the ES5 class-to-IR transformer (`ES5ClassTransformer`) was affected, because its auto-accessor collector skipped every private-named member and its read/write routing therefore never learned the name.

### Repro (`--target es5 --module esnext --strict`)

```ts
export class Cell {
  accessor #v = 2;
  read() { return this.#v; }
  write(next: number) { this.#v = next; }
}
```

- **tsc 6.0.2:** brands the instance, seeds `_Cell_v_accessor_storage`, and routes `this.#v` through `__classPrivateFieldGet(this, _Cell_instances, "a", _Cell_v_get)` / `__classPrivateFieldSet(...)`.
- **tsz before:** `function Cell() {}` with `return this.;` / `this. = next;` — invalid JS.

## Structural rule

When the ES5 class transformer sees an **instance** private auto-accessor (`accessor #x`), `tsc` lowers it to a backing-storage `WeakMap` (`_C_x_accessor_storage`, seeded in the constructor) **plus** a branded private-accessor get/set pair (`_C_x_get`/`_C_x_set`) whose bodies read/write that storage, and routes every `this.#x` read/write through the instance brand (`__classPrivateFieldGet(this, _C_instances, "a", _C_x_get)`). tsz now does the same through the ES5 class-to-IR owner. The decision keys on the binding origin (a private auto-accessor storage slot), never on the identifier spelling — this is the ES5 analogue of the already-correct ES2015+ path.

Reproducing this also exposed an **adjacent pre-existing** ordering divergence in the same owner: the ES5 trailing helper-assignment chain (`_C_g_get = function …, _C_m = function …`) was emitted grouped by category (methods before accessors) rather than in source member order, so a private accessor declared before a private method diverged from `tsc`. The chain now walks the class body once in source order — matching `tsc` and the already-fixed ES2015+ path (`emit_es6.rs`) — so the synthesized auto-accessor helpers interleave correctly with private fields/methods/accessors.

## Owner layer

Emitter — ES5 class-to-IR lowering.
- `class_es5_ir_helpers.rs`: `collect_auto_accessor_fields` now includes instance private auto-accessors (backing storage), and a new `collect_private_auto_accessor_accessors` synthesizes their branded get/set `PrivateAccessorInfo` (carrying `synthetic_storage`).
- `class_es5_ir.rs`: collects the storage and synthesizes the accessor pair **before** the instance-brand decision, so the brand and the read/write routing (`with_private_member_maps`) both account for it.
- `class_es5_ir_members.rs`: declares the branded helpers at the member's source position and builds their synthetic get/set bodies; `private_method_and_accessor_init_strings` now walks members in source order.
- `private_fields_es5.rs`: adds `synthetic_storage: Option<String>` to `PrivateAccessorInfo`.

Pure output-form fix; no semantic validation added; no identifier / file-name / rendered-output predicate drives the decision. The public auto-accessor path (prototype `Object.defineProperty`) is unchanged — the class-member emit already skipped private-named auto-accessors for the descriptor.

## Adjacent matrix (verified byte-identical to tsc 6.0.2, `--target es5`, binder names varied)

- basic instance private auto-accessor read + write
- no initializer (`accessor #x;` → `.set(this, void 0)`)
- multiple private auto-accessors (helpers + storages in source order)
- mixed public + private auto-accessor (public keeps its prototype descriptor; private is branded)
- private field + private auto-accessor + private method interleaved (source-order helper chain)
- compound assignment (`this.#n += 1`)
- derived class (`_this` capture)
- ordering control: private accessor declared before a private method assigns its helper first
- **controls unchanged:** ES2015/ES2017/ES2020 private auto-accessors stay byte-identical to tsc (no regression from the reorder)

## Out of scope (separate, pre-existing)

- **Static** private auto-accessors (`static accessor #s`, class-alias `{ value }` storage) stay on the broader static-private-member ES5 path.
- **ES2015+ mixed public+private auto-accessor storage ordering**: a distinct cosmetic divergence in `emit_es6.rs`, not the ES5 transformer.
- **Single-line method-body formatting**: `tsc` keeps a one-statement method body inline where tsz forces multi-line once an assignment expands to `__classPrivateFieldGet/Set`; reproduces with an ordinary private field (no auto-accessor) — a separate body-line-wrapping heuristic.

## Goal
Goal: hold

## Verification
- New suite `crates/tsz-emitter/tests/es5_private_auto_accessor_tests.rs` (8 tests, byte-exact fragments captured from `tsc` 6.0.2 `--target es5`) — all pass.
- `cargo test -p tsz-emitter` — full emitter suite green except one pre-existing, unrelated failure (`generator_object_literal_prefix_before_yield_omits_source_trailing_comma`, confirmed failing on a clean tree with this change stashed).
- `cargo test -p tsz-emitter --test {class_es5_ir,private_fields_es5,es5_super_object_literal_accessor_tests,esm_export_class_es5_weakmap_order_tests,private_element_naming_tests,static_private_field_init_order_tests,es5_cjs_private_storage_static_field_tests}` — green (no regressions on adjacent private-member paths).
- `cargo fmt --all -- --check`, `git diff --check`, `cargo clippy -p tsz-emitter --lib --tests` — clean.
- Byte-exact CLI diff vs `tsc` 6.0.2 across the adjacent matrix above at `--target es5`; ES2015/2017/2020 controls unchanged.
- ready-review CI owns the broad conformance / emit / fourslash baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj8975F1PqKmwYVL6M2LcV)_