### PR TITLE
fix(emit): downlevel static private members at ES5

### DIFF
--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_private_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_private_members.rs
@@ -11,22 +11,39 @@ use tsz_parser::parser::node::BinaryExprData;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
-/// Build the read/write slot for a private accessor. An instance accessor
-/// brands against `_C_instances` and threads `func_var` (the getter/setter) as
-/// the trailing helper argument; the legacy static-accessor shape brands
-/// against `func_var` itself with no trailing reference.
-fn accessor_slot(instance_brand: Option<&str>, func_var: &str) -> PrivateMemberSlot {
-    match instance_brand {
-        Some(brand) => PrivateMemberSlot {
-            state_var: brand.to_string(),
-            kind: "a",
-            member_ref: Some(func_var.to_string()),
-        },
-        None => PrivateMemberSlot {
-            state_var: func_var.to_string(),
-            kind: "a",
-            member_ref: None,
-        },
+/// The brand a non-field private member is keyed by: the class-value alias
+/// (`_a`, the `_a = C` binding) for a static member, the `_C_instances`
+/// `WeakSet` for an instance member. `None` when the required brand var was not
+/// allocated (an instance member with no `WeakSet`, or a static member with no
+/// class alias), in which case the caller leaves the member on the existing
+/// fallthrough.
+const fn member_brand<'b>(
+    is_static: bool,
+    static_class_brand: Option<&'b str>,
+    instances_weakset: Option<&'b str>,
+) -> Option<&'b str> {
+    if is_static {
+        static_class_brand
+    } else {
+        instances_weakset
+    }
+}
+
+/// Build a read/write slot that brands against `brand` and threads `storage`
+/// (the getter/setter/method function, or a static field's `{ value }` box) as
+/// the trailing helper argument:
+/// `__classPrivateFieldGet(recv, brand, "<kind>", storage)` /
+/// `__classPrivateFieldSet(recv, brand, value, "<kind>", storage)`. `brand` is
+/// `_C_instances` for an instance accessor/method and the class-value alias
+/// (`_a`) for any static member; `kind` is `"f"` (static field), `"a"`
+/// (accessor), or `"m"` (method). Instance *fields* do not use this shape —
+/// they brand against their own `WeakMap` with no trailing reference — so they
+/// stay in `private_field_map`.
+fn member_slot(brand: &str, kind: &'static str, storage: &str) -> PrivateMemberSlot {
+    PrivateMemberSlot {
+        state_var: brand.to_string(),
+        kind,
+        member_ref: Some(storage.to_string()),
     }
 }
 
@@ -37,67 +54,81 @@ impl AstToIr<'_> {
     ///
     /// Instance accessors and methods brand against `instances_weakset`
     /// (`_C_instances`) and carry the getter/setter/method function reference,
-    /// matching tsc's 4-arg get / 5-arg set forms. Static accessors keep their
-    /// historical lowering (the function var as the brand, no trailing
-    /// reference); static methods are intentionally left to the existing
-    /// fallthrough.
+    /// matching tsc's 4-arg get / 5-arg set forms. Static fields, accessors, and
+    /// methods brand against `static_class_brand` (`_a`, the `_a = C` class-value
+    /// alias) with the storage variable threaded the same way, matching tsc's
+    /// `__classPrivateFieldGet(recv, _a, "<kind>", <storage>)` static form; a
+    /// static method read this way is invoked via `.call(recv)`, and its brand
+    /// also serves the `#name in obj` check (via `private_brand_var`).
     pub fn with_private_member_maps(
         mut self,
         fields: &[crate::transforms::private_fields_es5::PrivateFieldInfo],
         accessors: &[crate::transforms::private_fields_es5::PrivateAccessorInfo],
         methods: &[crate::transforms::private_fields_es5::PrivateMethodInfo],
         instances_weakset: Option<&str>,
+        static_class_brand: Option<&str>,
     ) -> Self {
         for field in fields {
+            // A static private field brands against the class-value alias with
+            // the `{ value }` storage box threaded as `f`
+            // (`__classPrivateFieldGet(recv, _a, "f", _C_x)`), so it needs a
+            // read/write slot rather than the instance `WeakMap` field map
+            // (`__classPrivateFieldGet(recv, _C_x, "f")`).
+            if field.is_static
+                && let Some(brand) = static_class_brand
+            {
+                self.private_read_slots.insert(
+                    field.name.clone(),
+                    member_slot(brand, "f", &field.weakmap_name),
+                );
+                self.private_write_slots.insert(
+                    field.name.clone(),
+                    member_slot(brand, "f", &field.weakmap_name),
+                );
+                continue;
+            }
             self.private_field_map
                 .insert(field.name.clone(), field.weakmap_name.clone());
         }
         for accessor in accessors {
-            // An instance accessor brands against `_C_instances` and passes the
-            // getter/setter as the trailing helper argument. A static accessor
-            // (or any accessor without an instance brand) retains the legacy
-            // form where the function var itself is the brand and there is no
-            // trailing reference.
-            let instance_brand = (!accessor.is_static).then_some(instances_weakset).flatten();
+            // Instance accessors brand against `_C_instances`; static accessors
+            // brand against the class-value alias `_a`. Either way the
+            // getter/setter is threaded as the trailing helper argument.
+            let Some(brand) =
+                member_brand(accessor.is_static, static_class_brand, instances_weakset)
+            else {
+                continue;
+            };
             if let Some(ref get_var) = accessor.get_var_name {
-                self.private_read_slots.insert(
-                    accessor.name.clone(),
-                    accessor_slot(instance_brand, get_var),
-                );
+                self.private_read_slots
+                    .insert(accessor.name.clone(), member_slot(brand, "a", get_var));
             }
             if let Some(ref set_var) = accessor.set_var_name {
-                self.private_write_slots.insert(
-                    accessor.name.clone(),
-                    accessor_slot(instance_brand, set_var),
-                );
+                self.private_write_slots
+                    .insert(accessor.name.clone(), member_slot(brand, "a", set_var));
             }
         }
         for method in methods {
-            // A private method is read as a function value branded against
-            // `_C_instances`, then invoked with `.call`. Static private methods
-            // brand against the class alias and are left to the fallthrough.
-            if method.is_static {
+            // A private method is read as a function value, then invoked with
+            // `.call`. Instance methods brand against `_C_instances`; static
+            // methods brand against the class-value alias `_a`.
+            let Some(brand) = member_brand(method.is_static, static_class_brand, instances_weakset)
+            else {
                 continue;
-            }
-            if let Some(instances) = instances_weakset {
-                self.private_read_slots.insert(
-                    method.name.clone(),
-                    PrivateMemberSlot {
-                        state_var: instances.to_string(),
-                        kind: "m",
-                        member_ref: Some(method.fn_var_name.clone()),
-                    },
-                );
-            }
+            };
+            self.private_read_slots.insert(
+                method.name.clone(),
+                member_slot(brand, "m", &method.fn_var_name),
+            );
         }
         self
     }
 
     /// Look up private-member storage info for a read of `this.#name`. Returns
     /// `(brand_var, kind, member_ref)`: `member_ref` is the trailing
-    /// getter/method function for the 4-arg `__classPrivateFieldGet` form, or
-    /// `None` for a plain field (`kind == "f"`) and the legacy static-accessor
-    /// shape where the function var is the brand.
+    /// getter/method/storage function for the 4-arg `__classPrivateFieldGet`
+    /// form, or `None` for an instance field (`kind == "f"`, brand is the
+    /// `WeakMap`).
     pub(super) fn private_read_info(
         &self,
         clean_name: &str,

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -500,6 +500,15 @@ impl<'a> ES5ClassTransformer<'a> {
         }
     }
 
+    /// The temp-sequence index that member-body hoisted temps must start from,
+    /// so they do not collide with class-IIFE-scope temp names the bodies still
+    /// reference. A static-private class reserves the class-value brand `_a`
+    /// (temp slot 0), so member bodies start at slot 1 (`_b`); otherwise there
+    /// is nothing to reserve and they start at slot 0 (`_a`), as before.
+    fn reserved_member_body_temp_start(&self) -> u32 {
+        u32::from(self.has_static_private_lowering() && self.current_static_class_alias.is_some())
+    }
+
     /// Set the base indent level for nested contexts (e.g., 1 for class inside namespace)
     pub const fn set_indent_base(&mut self, level: u32) {
         self.indent_base = level;
@@ -702,6 +711,7 @@ impl<'a> ES5ClassTransformer<'a> {
                 &self.private_accessors,
                 &self.private_methods,
                 self.private_instances_weakset_name.as_deref(),
+                self.current_static_class_alias.as_deref(),
             );
         if let Some(source_text) = self.source_text {
             converter = converter.with_source_text(source_text);
@@ -1214,7 +1224,14 @@ impl<'a> ES5ClassTransformer<'a> {
         // Snapshot hoisted temps before converting statements
         let hoisted_before = self.extra_hoisted_temps.borrow().len();
         let saved_temp_counter = self.temp_var_counter.get();
-        self.temp_var_counter.set(0);
+        // A static-private class reserves the class-value brand `_a` (temp slot
+        // 0) at IIFE scope, and member bodies reference it (e.g.
+        // `__classPrivateFieldSet(this, _a, …)`). Member-body hoisted temps must
+        // therefore start after it (`_b`, …), matching tsc; starting at `_a`
+        // would emit a `var _a;` that shadows and clobbers the brand the same
+        // body reads.
+        self.temp_var_counter
+            .set(self.reserved_member_body_temp_start());
 
         let mut stmts = if let Some(block_node) = self.arena.get(block_idx)
             && let Some(block) = self.arena.get_block(block_node)

--- a/crates/tsz-emitter/tests/class_es5.rs
+++ b/crates/tsz-emitter/tests/class_es5.rs
@@ -661,3 +661,163 @@ fn test_var_function_recovery_ignores_string_literal_text() {
         "String literal contents must not trigger the recovery tail: {output}"
     );
 }
+
+// --- ES5 static private member down-leveling (#15302) --------------------
+//
+// At sub-ES2022 targets a static private field/method/accessor brands against
+// the class-value alias (`_a`, the `_a = C` binding) with its storage variable
+// threaded as the trailing `__classPrivateFieldGet(recv, _a, "<kind>",
+// <storage>)` argument, and a static `#name in obj` brand check lowers to
+// `__classPrivateFieldIn(_a, obj)`. Before the fix these left invalid output
+// (`C.()` for a call, raw `#name in obj`, and a 3-arg get that dropped the
+// storage box). All shapes below are verified byte-identical (modulo
+// whitespace) to `tsc` 6.0.2. Receivers use `this` so the assertions do not
+// depend on the separate class self-reference aliasing of an explicit class
+// name (a pre-existing, broader gap tracked apart from static privates).
+
+#[test]
+fn test_static_private_field_read_write_es5() {
+    let output = emit_class(
+        r#"class Registry {
+            static #slot = 1;
+            static read() { return this.#slot; }
+            static write() { this.#slot = 5; }
+        }"#,
+    );
+    assert!(
+        output.contains(r#"__classPrivateFieldGet(this, _a, "f", _Registry_slot)"#),
+        "static field read must brand against `_a` with the storage box as `f`: {output}"
+    );
+    assert!(
+        output.contains(r#"__classPrivateFieldSet(this, _a, 5, "f", _Registry_slot)"#),
+        "static field write must brand against `_a` with the storage box as `f`: {output}"
+    );
+    assert!(
+        output.contains("_a = Registry"),
+        "the class-value brand must be initialized `_a = Registry`: {output}"
+    );
+}
+
+#[test]
+fn test_static_private_method_call_es5() {
+    let output = emit_class(
+        r#"class Registry {
+            static #make() { return 2; }
+            static call() { return this.#make(); }
+        }"#,
+    );
+    assert!(
+        output.contains(r#"__classPrivateFieldGet(this, _a, "m", _Registry_make).call(this)"#),
+        "static method call must read the method value branded against `_a`, then `.call(this)`: {output}"
+    );
+    assert!(
+        !output.contains(".()"),
+        "static method call must never emit the broken `C.()` form: {output}"
+    );
+}
+
+#[test]
+fn test_static_private_accessor_es5() {
+    let output = emit_class(
+        r#"class Registry {
+            static get #view() { return 3; }
+            static set #view(v: number) {}
+            static getV() { return this.#view; }
+            static setV() { this.#view = 9; }
+        }"#,
+    );
+    assert!(
+        output.contains(r#"__classPrivateFieldGet(this, _a, "a", _Registry_view_get)"#),
+        "static getter must brand against `_a` with the getter fn as the trailing ref: {output}"
+    );
+    assert!(
+        output.contains(r#"__classPrivateFieldSet(this, _a, 9, "a", _Registry_view_set)"#),
+        "static setter must brand against `_a` with the setter fn as the trailing ref: {output}"
+    );
+}
+
+#[test]
+fn test_static_private_brand_check_es5() {
+    let output = emit_class(
+        r#"class Registry {
+            static #slot = 1;
+            static #make() { return 2; }
+            static brandF(o: any) { return #slot in o; }
+            static brandM(o: any) { return #make in o; }
+        }"#,
+    );
+    assert!(
+        output.contains("__classPrivateFieldIn(_a, o)"),
+        "a static `#name in obj` brand check must lower to `__classPrivateFieldIn(_a, obj)`: {output}"
+    );
+    assert!(
+        !output.contains("#slot in") && !output.contains("#make in"),
+        "the raw `#name in obj` operator must not survive down-leveling: {output}"
+    );
+}
+
+#[test]
+fn test_static_private_increment_temp_avoids_brand_collision_es5() {
+    // The `this.#slot++` read-modify-write needs a hoisted temp; it must not
+    // reuse the class-value brand `_a` (temp slot 0), which the same expression
+    // reads. tsc allocates `_b`; a `var _a;` here would shadow and clobber the
+    // brand.
+    let output = emit_class(
+        r#"class Registry {
+            static #slot = 0;
+            static inc() { this.#slot++; return this.#slot; }
+        }"#,
+    );
+    assert!(
+        output.contains("(_b = __classPrivateFieldGet(this, _a, \"f\", _Registry_slot), _b++, _b)"),
+        "the increment temp must be `_b`, distinct from the class brand `_a`: {output}"
+    );
+    assert!(
+        !output.contains("var _a;"),
+        "must not emit a member-local `var _a;` that shadows the class brand: {output}"
+    );
+}
+
+#[test]
+fn test_static_private_anti_hardcoding_renamed_binder_es5() {
+    // The brand/storage decision keys on the binding origin, never on the
+    // spelling: different class and member names must derive different storage
+    // vars while keeping the identical `_a`-branded shape.
+    let output = emit_class(
+        r#"class Vault {
+            static #secret = 1;
+            static peek() { return this.#secret; }
+        }"#,
+    );
+    assert!(
+        output.contains(r#"__classPrivateFieldGet(this, _a, "f", _Vault_secret)"#),
+        "storage var must derive from the actual class/field names (`_Vault_secret`): {output}"
+    );
+    assert!(
+        !output.contains("_Registry_"),
+        "no hardcoded name from other fixtures may leak: {output}"
+    );
+}
+
+#[test]
+fn test_instance_private_field_unchanged_by_static_slot_change_es5() {
+    // Routing static fields through read/write slots must not perturb the
+    // instance-field form: an instance private field still brands against its
+    // own `WeakMap` with the 3-arg get (no `_a`, no trailing ref).
+    let output = emit_class(
+        r#"class Box {
+            #value = 1;
+            static #shared = 2;
+            read() { return this.#value; }
+            static readShared() { return this.#shared; }
+        }"#,
+    );
+    assert!(
+        output.contains(r#"__classPrivateFieldGet(this, _Box_value, "f")"#),
+        "instance field read must keep the WeakMap-branded 3-arg get: {output}"
+    );
+    assert!(
+        output.contains(r#"__classPrivateFieldGet(this, _a, "f", _Box_shared)"#),
+        "static field read in the same class must still brand against `_a`: {output}"
+    );
+}


### PR DESCRIPTION
Fixes #15302.

At `--target es5` the class-to-IR converter mis-lowered **every static private member**. This is the "broader unimplemented static-private-member ES5 path" that #15292 deferred as *"static private method get/call is also incomplete, tracked separately."* Static method calls were outright **invalid JavaScript**:

| Source (static private) | tsc 6.0.2 | tsz before |
| --- | --- | --- |
| `C.#m()` call | `__classPrivateFieldGet(_a, _a, "m", _C_m).call(_a)` | `C.()` ← **syntax error** |
| `C.#f` read | `__classPrivateFieldGet(_a, _a, "f", _C_f)` | `__classPrivateFieldGet(C, _C_f, "f")` ← drops storage box → runtime crash |
| `C.#f = v` write | `__classPrivateFieldSet(_a, _a, v, "f", _C_f)` | `__classPrivateFieldSet(C, _C_f, v, "f")` ← same |
| `C.#g` / `= v` accessor | `…(_a, _a, "a", _C_g_get)` | `…(C, _C_g_get, "a")` ← wrong brand, drops storage |
| `#m in o` / `#f in o` brand | `__classPrivateFieldIn(_a, o)` | `#m in o` ← raw (fixed here for statics via #15293's mechanism) |

The get/set forms used the *instance* shape (`state` = the storage var, no trailing `f`), but a static member must brand against the **class-value alias** `_a` (the `_a = C` binding) with its storage var threaded as the trailing `f` argument.

### Repro (`--target es5 --module esnext --strict`)

```ts
class C {
  static #x = 1;
  static #m() { return 2; }
  static call() { return this.#m(); }      // was C.()-broken
  static read() { return this.#x; }
  static brand(o: any) { return #x in o; }
}
```

## Structural rule

When the ES5 class-to-IR converter lowers a **static** private field, method, or accessor, `tsc` brands it against the class-value alias `_a` and threads the member's storage var (`_C_x` field box, `_C_m` method fn, `_C_g_get`/`_C_g_set` accessor fns) as the trailing `__classPrivateFieldGet(recv, _a, "<kind>", <storage>)` / `__classPrivateFieldSet(recv, _a, value, "<kind>", <storage>)` argument; a static method read is then invoked `.call(recv)`. tsz now does the same. The decision keys on the member's **static binding origin** (its storage slot), never on the identifier spelling (verified with renamed binders).

A static-private class reserves the class-value brand `_a` (temp slot 0) at IIFE scope, so member-body hoisted temps (e.g. from `this.#x++`) now start at `_b` — otherwise a `var _a;` inside a method shadows and clobbers the brand the same body reads (tsc uses `_b`).

## Owner layer

Emitter — ES5 class-to-IR conversion. Static fields/methods/accessors now route through the existing `PrivateMemberSlot` read/write-slot model (`class_es5_ast_to_ir_private_members.rs`) with brand `_a` and the storage var as the trailing ref, so the shared get/set/`.call` paths (`private_field_get_ir`/`private_field_set_ir`, `try_convert_private_member_call`) lower them correctly with **no new special-case path**. Because the brand now lives in each slot's `state_var`, the `#name in obj` brand check added in #15293 (`private_brand_var` → `private_brand_in_ir`) resolves static members to `__classPrivateFieldIn(_a, obj)` automatically — no static-specific brand-check code is added. The temp-reservation lives in `class_es5_ir.rs` (`reserved_member_body_temp_start`). Pure output-form fix; no semantic validation added.

## Adjacent matrix (verified byte-identical to tsc 6.0.2, modulo pre-existing method-body formatting)

- static field / method / accessor read, write, call — `this`, parameter, and explicit class-name receivers
- static `#name in obj` brand check (field- and method-named)
- `this.#slot++` increment: temp `_b`, no `var _a;` brand collision
- mixed static + instance in one class: instance field keeps the 3-arg WeakMap get, static keeps the `_a`-branded 4-arg get; instance brand-in (#15293) still `__classPrivateFieldIn(_C_x, o)`
- renamed binders (`Vault`/`#secret` → `_Vault_secret`) — no hardcoded names
- ES2015 / ES2022 already matched tsc and are unchanged (divergence was ES5-only)

## Out of scope (separate, pre-existing; unchanged here)

- **Class self-reference aliasing under static-private lowering**: tsc rewrites an explicit class-name reference (`C.#x`, and even public `C.pub`) to `_a` inside the IIFE. tsz keeps the class name — runtime-equivalent (`_a === C`), not byte-identical. Broader mechanism (affects public members too), tracked apart.
- **Method-body single-line vs multi-line formatting** — pre-existing general ES5 difference (reproduces for plain non-private methods).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib` → 3948 passed, 0 failed (incl. 8 new `test_static_private_*` / instance-regression tests in `crates/tsz-emitter/tests/class_es5.rs`)
- CLI output diffed byte-for-byte (whitespace-normalized) against `tsc` 6.0.2 for the full adjacent matrix above → identical
- ES2015 / ES2022 static-private output confirmed already identical to tsc (change is ES5-scoped)
- `cargo fmt --all -- --check`, `cargo clippy -p tsz-emitter --lib -- -D warnings`, `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean
- Rebased on current `main` (composes with #15293's private-in brand-check); ready-review CI owns the broad conformance / emit / fourslash baselines

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high