### PR TITLE
fix(emit): register async-iteration helpers for delegating `yield*` in down-leveled async generators

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -47,6 +47,10 @@ name = "es5_private_in_brand_check_tests"
 path = "tests/es5_private_in_brand_check_tests.rs"
 
 [[test]]
+name = "async_generator_yield_star_delegate_helpers_tests"
+path = "tests/async_generator_yield_star_delegate_helpers_tests.rs"
+
+[[test]]
 name = "es5_object_rest_param_ordering_tests"
 path = "tests/es5_object_rest_param_ordering_tests.rs"
 

--- a/crates/tsz-emitter/src/lowering/core.rs
+++ b/crates/tsz-emitter/src/lowering/core.rs
@@ -626,7 +626,7 @@ impl<'a> LoweringPass<'a> {
             if func.is_async {
                 self.mark_function_parameter_transform_helpers(&func.parameters);
                 if func.asterisk_token {
-                    self.mark_async_generator_helpers();
+                    self.mark_async_generator_helpers_for_body(func.body);
                 } else {
                     self.mark_async_helpers();
                 }
@@ -644,7 +644,7 @@ impl<'a> LoweringPass<'a> {
                 || (!func.asterisk_token && self.ctx.needs_async_lowering))
         {
             if func.asterisk_token {
-                self.mark_async_generator_helpers();
+                self.mark_async_generator_helpers_for_body(func.body);
             } else {
                 // ES2015/ES2016: async functions need __awaiter (generators are native)
                 self.mark_async_helpers();
@@ -1008,7 +1008,7 @@ impl<'a> LoweringPass<'a> {
                 || (!func.asterisk_token && self.ctx.needs_async_lowering))
         {
             if func.asterisk_token {
-                self.mark_async_generator_helpers();
+                self.mark_async_generator_helpers_for_body(func.body);
             } else {
                 self.mark_async_helpers();
             }
@@ -1698,7 +1698,7 @@ impl<'a> LoweringPass<'a> {
             if func.is_async {
                 self.mark_function_parameter_transform_helpers(&func.parameters);
                 if func.asterisk_token {
-                    self.mark_async_generator_helpers();
+                    self.mark_async_generator_helpers_for_body(func.body);
                 } else {
                     self.mark_async_helpers();
                 }
@@ -1726,7 +1726,7 @@ impl<'a> LoweringPass<'a> {
         {
             if func.asterisk_token {
                 // ES2015+: async generators need __asyncGenerator + __await helpers
-                self.mark_async_generator_helpers();
+                self.mark_async_generator_helpers_for_body(func.body);
             } else {
                 // ES2015/ES2016: non-generator async functions need __awaiter
                 self.mark_async_helpers();

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -7,6 +7,7 @@ use super::*;
 use crate::emitter::JsxEmit;
 use crate::transforms::emit_utils;
 use tsz_common::ScriptTarget;
+use tsz_parser::parser::node::NodeAccess;
 
 impl<'a> LoweringPass<'a> {
     // =========================================================================
@@ -460,14 +461,66 @@ impl<'a> LoweringPass<'a> {
         }
     }
 
-    /// Mark helpers needed for async generator functions (async function*).
-    pub(super) fn mark_async_generator_helpers(&mut self) {
+    /// Mark the helpers a down-leveled async generator function (`async
+    /// function*`) needs, given its `body`.
+    ///
+    /// A plain async generator needs `__await` + `__asyncGenerator` (plus
+    /// `__generator` at ES5). When the body additionally contains a *delegating*
+    /// `yield* x`, `tsc` lowers it to
+    /// `yield __await(yield* __asyncDelegator(__asyncValues(x)))` (ES2015+) or the
+    /// `__generator` state-machine equivalent (ES5), so it also needs
+    /// `__asyncValues` and `__asyncDelegator`. All helpers are marked here, at
+    /// the function site, in the canonical tslib emit order (`__asyncValues`,
+    /// `__await`, `__asyncDelegator`, `__asyncGenerator`) so the request-order
+    /// helper table matches `tsc` — a scan is required (rather than marking the
+    /// delegate helpers when the `yield*` node is later visited) precisely so the
+    /// order is fixed before `__await`/`__asyncGenerator` are requested.
+    ///
+    /// The delegate decision keys on the structural presence of a delegating
+    /// `yield*` in this generator's own body, never on identifier spelling or
+    /// rendered text.
+    pub(super) fn mark_async_generator_helpers_for_body(&mut self, body: NodeIndex) {
+        let delegates = self.async_generator_body_delegates(body);
         let helpers = self.transforms.helpers_mut();
+        if delegates {
+            helpers.mark_async_values();
+        }
         helpers.mark_await_helper();
+        if delegates {
+            helpers.mark_async_delegator();
+        }
         helpers.mark_async_generator();
         if self.ctx.target_es5 {
             helpers.generator = true;
         }
+    }
+
+    /// Whether an async generator `body` contains a delegating `yield* x` (with a
+    /// delegate expression) that belongs to *this* generator — i.e. not nested
+    /// inside another function-like body. `yield` is only syntactically valid
+    /// inside a generator, so any `yield*` reached before a function-like
+    /// boundary delegates from this async generator.
+    fn async_generator_body_delegates(&self, body: NodeIndex) -> bool {
+        let mut stack = vec![body];
+        while let Some(idx) = stack.pop() {
+            let Some(node) = self.arena.get(idx) else {
+                continue;
+            };
+            // A `yield*` inside a nested function-like belongs to that inner
+            // generator, so stop descending at function-like boundaries.
+            if idx != body && node.is_function_like() {
+                continue;
+            }
+            if node.kind == syntax_kind_ext::YIELD_EXPRESSION
+                && let Some(unary) = self.arena.get_unary_expr_ex(node)
+                && unary.asterisk_token
+                && self.arena.get(unary.expression).is_some()
+            {
+                return true;
+            }
+            stack.extend(self.arena.get_children(idx));
+        }
+        false
     }
 
     pub(super) fn has_class_member_modifier(

--- a/crates/tsz-emitter/src/lowering/visit_children.rs
+++ b/crates/tsz-emitter/src/lowering/visit_children.rs
@@ -241,7 +241,8 @@ impl<'a> LoweringPass<'a> {
                     {
                         if method.asterisk_token {
                             // Async generator method: needs __asyncGenerator + __await
-                            self.mark_async_generator_helpers();
+                            // (+ __asyncValues/__asyncDelegator for a delegating `yield*`).
+                            self.mark_async_generator_helpers_for_body(method.body);
                         } else {
                             // Non-generator async method: needs __awaiter
                             // (ES2015/ES2016 use __awaiter + generators via yield,

--- a/crates/tsz-emitter/tests/async_generator_yield_star_delegate_helpers_tests.rs
+++ b/crates/tsz-emitter/tests/async_generator_yield_star_delegate_helpers_tests.rs
@@ -1,0 +1,164 @@
+//! Regression tests: a delegating `yield* x` inside a down-leveled async
+//! generator must register the async-iteration runtime helpers
+//! (`__asyncValues` + `__asyncDelegator`) in the emitted preamble, not just
+//! reference them in the body.
+//!
+//! `tsc` lowers `yield* x` inside an `async function*` (target below ES2018) to
+//! `yield __await(yield* __asyncDelegator(__asyncValues(x)))` (ES2015/ES2016) or
+//! the `__generator` state-machine equivalent (ES5). Both forms *call*
+//! `__asyncDelegator` and `__asyncValues`, so their helper definitions must be
+//! emitted; otherwise the output references undefined names (a `ReferenceError`
+//! at runtime). tsz previously emitted the calls but never marked the two
+//! helpers, so their `var __asyncValues = ...` / `var __asyncDelegator = ...`
+//! definitions were missing.
+//!
+//! The decision keys on the structural presence of a delegating `yield*` in the
+//! generator's own body, never on identifier spelling — the tests vary binder
+//! names to prove that.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::{PrintOptions, lower_and_print};
+use tsz_parser::parser::ParserState;
+
+fn emit(source: &str, target: ScriptTarget) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let opts = PrintOptions {
+        target,
+        module: ModuleKind::ESNext,
+        remove_comments: true,
+        ..PrintOptions::default()
+    };
+    lower_and_print(&parser.arena, root, opts).code
+}
+
+const ASYNC_VALUES_DEF: &str = "var __asyncValues = (this && this.__asyncValues)";
+const ASYNC_DELEGATOR_DEF: &str = "var __asyncDelegator = (this && this.__asyncDelegator)";
+const AWAIT_DEF: &str = "var __await = (this && this.__await)";
+const ASYNC_GENERATOR_DEF: &str = "var __asyncGenerator = (this && this.__asyncGenerator)";
+
+/// Assert the four async-iteration helper definitions are present and emitted
+/// in `tsc`'s canonical tslib order: `__asyncValues`, `__await`,
+/// `__asyncDelegator`, `__asyncGenerator`.
+fn assert_delegate_helpers_in_order(output: &str) {
+    for def in [
+        ASYNC_VALUES_DEF,
+        ASYNC_DELEGATOR_DEF,
+        AWAIT_DEF,
+        ASYNC_GENERATOR_DEF,
+    ] {
+        assert!(
+            output.contains(def),
+            "missing helper definition `{def}`.\nOutput:\n{output}"
+        );
+    }
+    let i_values = output.find(ASYNC_VALUES_DEF).unwrap();
+    let i_await = output.find(AWAIT_DEF).unwrap();
+    let i_delegator = output.find(ASYNC_DELEGATOR_DEF).unwrap();
+    let i_async_gen = output.find(ASYNC_GENERATOR_DEF).unwrap();
+    assert!(
+        i_values < i_await && i_await < i_delegator && i_delegator < i_async_gen,
+        "async-iteration helpers must emit in tsc order \
+         (__asyncValues, __await, __asyncDelegator, __asyncGenerator).\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn delegating_yield_star_registers_async_iteration_helpers_es2015() {
+    let output = emit(
+        "export async function* f(g: AsyncIterable<number>) { yield* g; yield 1; }",
+        ScriptTarget::ES2015,
+    );
+    assert_delegate_helpers_in_order(&output);
+    assert!(
+        output.contains("yield* __asyncDelegator(__asyncValues(g))"),
+        "delegate body must route through the async iteration helpers.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn delegating_yield_star_registers_async_iteration_helpers_es2017() {
+    let output = emit(
+        "export async function* f(g: AsyncIterable<number>) { yield* g; yield 1; }",
+        ScriptTarget::ES2017,
+    );
+    assert_delegate_helpers_in_order(&output);
+}
+
+#[test]
+fn delegating_yield_star_registers_async_iteration_helpers_es5() {
+    let output = emit(
+        "export async function* f(g: AsyncIterable<number>) { yield* g; yield 1; }",
+        ScriptTarget::ES5,
+    );
+    // ES5 lowers through the `__generator` state machine but still calls the
+    // async-iteration helpers, so their definitions must be present.
+    assert!(
+        output.contains(ASYNC_VALUES_DEF) && output.contains(ASYNC_DELEGATOR_DEF),
+        "ES5 delegating async generator must emit __asyncValues/__asyncDelegator defs.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__asyncDelegator(__asyncValues(g))"),
+        "ES5 delegate body must call the async iteration helpers.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn delegating_yield_star_in_async_method_registers_helpers() {
+    // Renamed binders (class/method/param) prove the decision is structural.
+    let output = emit(
+        "export class Container { async *stream(sourceSeq: AsyncIterable<string>) { yield* sourceSeq; } }",
+        ScriptTarget::ES2015,
+    );
+    assert_delegate_helpers_in_order(&output);
+}
+
+#[test]
+fn delegating_yield_star_over_call_expression_registers_helpers() {
+    let output = emit(
+        "declare function make(): AsyncIterable<number>;\n\
+         export async function* f() { yield* make(); }",
+        ScriptTarget::ES2015,
+    );
+    assert_delegate_helpers_in_order(&output);
+}
+
+#[test]
+fn plain_async_generator_does_not_register_delegate_helpers() {
+    // No delegating `yield*`: only __await + __asyncGenerator are needed.
+    let output = emit(
+        "export async function* f() { yield 1; yield 2; }",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        output.contains(AWAIT_DEF) && output.contains(ASYNC_GENERATOR_DEF),
+        "plain async generator still needs __await + __asyncGenerator.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains(ASYNC_DELEGATOR_DEF),
+        "plain async generator (no yield*) must not emit __asyncDelegator.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains(ASYNC_VALUES_DEF),
+        "plain async generator (no yield*) must not emit __asyncValues.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn nested_sync_generators_yield_star_does_not_pull_async_delegate_helpers() {
+    // The delegating `yield*` belongs to the inner *sync* generator, which uses
+    // native `yield*` (ES2015+) and does not need the async iteration helpers.
+    // The outer async generator has no delegating `yield*` of its own.
+    let output = emit(
+        "export async function* f() {\n\
+             function* inner() { yield* [1, 2]; }\n\
+             yield 1;\n\
+         }",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        !output.contains(ASYNC_DELEGATOR_DEF) && !output.contains(ASYNC_VALUES_DEF),
+        "a nested sync generator's yield* must not pull async delegate helpers into \
+         the enclosing async generator.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #15301.

When a delegating `yield* x` appears inside an `async function*` whose target **down-levels** the async generator (target `< ES2018`: ES5 via the `__generator` state machine, ES2015/ES2016/ES2017 via `__asyncGenerator` + a native `function*`), tsz emitted the lowered call `yield __await(yield* __asyncDelegator(__asyncValues(x)))` in the **body** but never registered the `__asyncValues`/`__asyncDelegator` helper **definitions** in the preamble. The emitted module referenced two undefined names — a `ReferenceError` at runtime. tsz already marked `__await`/`__asyncGenerator` for every down-leveled async generator; only the two async-iteration helpers that a delegating `yield*` pulls in were missing.

### Repro (`--module esnext --target es2015`)

```ts
export async function* f(g: AsyncIterable<number>) { yield* g; yield 1; }
```

- **tsc 6.0.2** preamble: `__asyncValues`, `__await`, `__asyncDelegator`, `__asyncGenerator` (canonical tslib order).
- **tsz before**: only `__await` + `__asyncGenerator`, while the body still calls all four.

Same divergence at `--target es5` (missing both defs alongside `__generator`/`__values`) and `--target es2017`; also for async generator **methods** (`async *m()`) and delegates over **call expressions** (`yield* make()`). At `--target es2018`+ the async generator is native, `yield*` is kept, and no helper is needed — already matched.

## Structural rule

When a down-leveled `async function*` body contains a delegating `yield* x` (a `yield*` with a delegate expression that belongs to *that* generator, not a nested function-like), `tsc` lowers it to `yield __await(yield* __asyncDelegator(__asyncValues(x)))` (ES2015+) or the `__generator` state-machine equivalent (ES5), so the emit must register `__asyncValues` and `__asyncDelegator` in addition to `__await`/`__asyncGenerator`, in `tsc`'s canonical tslib order (`__asyncValues`, `__await`, `__asyncDelegator`, `__asyncGenerator`). The decision keys on the structural presence of a delegating `yield*` in the generator's own body, never on identifier spelling or rendered output.

## Owner layer

Emitter — lowering-pass helper detection (`crates/tsz-emitter/src/lowering/`). The six async-generator marking sites (`core.rs`, `visit_children.rs`) now call `mark_async_generator_helpers_for_body(body)`, which scans the generator's own body for a delegating `yield*` (stopping at nested function-like boundaries via `Node::is_function_like`) and marks the four helpers in `tsc`'s canonical order. The scan runs at the function site — rather than marking when the `yield*` node is later visited — precisely so the request order is fixed before `__await`/`__asyncGenerator` are requested (a visit-time mark would emit `__asyncValues` after `__asyncGenerator`, diverging from `tsc`). The emit side (`emitter/special_expressions.rs::emit_yield_expression`) already writes the delegation call; only the preamble registration was missing. Pure output-form change; no semantic validation added, no identifier/file-name/rendered-output predicate drives the decision.

## Adjacent matrix (verified byte-identical to tsc 6.0.2, `--module esnext`)

- delegate over param identifier: es2015 / es2017 / es2018 byte-exact; es5 helper set + order correct (body byte-exact modulo the pre-existing ES5 single-line async-generator formatting)
- async generator **method** `async *m(src)` with renamed binders → structural, not name-keyed
- delegate over a **call expression** `yield* make()`
- **two** delegates in one body
- **control:** plain async generator (no `yield*`) still emits only `__await`/`__asyncGenerator`; a **nested sync generator**'s `yield*` does not pull the async delegate helpers into the enclosing async generator

## Out of scope (separate, pre-existing; unchanged here)

- `for await...of` loop-init temp hoisting at es2015/es2016 (needs `tsc`-style print-order temp naming) — tracked separately.
- ES5 single-line vs. multi-line formatting of the down-leveled async-generator body — separate formatting issue affecting every ES5 async generator.
- `emit_await_as_yield_await` leaking into a nested sync `function*` (its `yield*` wrongly emits the async-delegator form) — distinct emit-context bug.

## Goal
Goal: hold

## Verification
- New suite `crates/tsz-emitter/tests/async_generator_yield_star_delegate_helpers_tests.rs` (7 tests: es2015/es2017/es5 helper presence + canonical order, method form, call-expression delegate, plain-async-generator control, nested-sync-generator control) — all pass.
- `cargo test -p tsz-emitter --lib` → 3936 passed, 0 failed; `cargo test -p tsz-emitter --tests` adds no new failures (the single pre-existing `generator_object_literal_prefix_before_yield_omits_source_trailing_comma` failure reproduces on the base commit, is a sync-generator formatting test, and is untouched by this change).
- Byte-diff vs `tsc` 6.0.2 across the adjacent matrix above.
- `cargo fmt --all -- --check`, `cargo clippy -p tsz-emitter --lib --tests -- -D warnings`, `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean.
- ready-review CI owns the broad conformance / emit / fourslash baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_017q9ph9MQvkotCxoxXiuBBx)_