### PR TITLE
fix(emit): register async-iteration helpers for delegating yield* in down-leveled async generators (#15301)

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_emit_tests.rs
@@ -321,6 +321,104 @@ fn async_generator_yield_uses_async_helpers() {
     );
 }
 
+/// Emit `source` at `target` with helper definitions inlined (no
+/// `import_helpers`), returning the full output including the preamble.
+fn emit_with_inline_helpers(source: &'static str, target: ScriptTarget) -> String {
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        target,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn downleveled_async_generator_delegating_yield_registers_iteration_helpers() {
+    // A delegating `yield* x` in a down-leveled `async function*` lowers to
+    // `yield __await(yield* __asyncDelegator(__asyncValues(x)))`, so both the
+    // `__asyncValues` and `__asyncDelegator` helper definitions must appear in
+    // the preamble alongside `__await`/`__asyncGenerator`.
+    for target in [
+        ScriptTarget::ES5,
+        ScriptTarget::ES2015,
+        ScriptTarget::ES2017,
+    ] {
+        let output =
+            emit_with_inline_helpers("async function* f(g) { yield* g; yield 1; }\n", target);
+        for helper in [
+            "var __await =",
+            "var __asyncGenerator =",
+            "var __asyncValues =",
+            "var __asyncDelegator =",
+        ] {
+            assert!(
+                output.contains(helper),
+                "delegating yield* at {target:?} must register `{helper}`.\nOutput:\n{output}"
+            );
+        }
+    }
+}
+
+#[test]
+fn downleveled_async_generator_method_delegating_yield_registers_iteration_helpers() {
+    let output = emit_with_inline_helpers(
+        "class C { async *m(g) { yield* g; } }\n",
+        ScriptTarget::ES2017,
+    );
+    assert!(
+        output.contains("var __asyncValues =") && output.contains("var __asyncDelegator ="),
+        "delegating yield* in an async-generator method must register the iteration helpers.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn downleveled_async_generator_without_delegation_omits_iteration_helpers() {
+    // A plain (non-delegating) async generator only needs `__await` and
+    // `__asyncGenerator`; the two async-iteration helpers must stay out.
+    let output = emit_with_inline_helpers(
+        "async function* f() { yield 1; await 2; }\n",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        output.contains("var __await =") && output.contains("var __asyncGenerator ="),
+        "async generator still needs the base helpers.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("__asyncValues") && !output.contains("__asyncDelegator"),
+        "async generator without a delegating yield* must not register iteration helpers.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn nested_sync_generator_delegation_does_not_leak_into_async_generator() {
+    // The `yield*` belongs to the nested sync generator, not the outer async
+    // generator, so the outer generator must not register the async-iteration
+    // helpers. (The nested `function*` at ES2015+ is native and needs none.)
+    let output = emit_with_inline_helpers(
+        "async function* outer() { function* inner() { yield* [1]; } yield 2; }\n",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        output.contains("var __asyncGenerator ="),
+        "outer async generator still lowers.\nOutput:\n{output}"
+    );
+    // The outer async generator owns no delegating `yield*`, so it must not
+    // register the async-iteration helper *definitions* in the preamble. (A
+    // separate, pre-existing emit-context bug — `emit_await_as_yield_await`
+    // leaking into the nested sync `function*` — can still write the delegator
+    // call in the body; that is tracked apart from helper registration.)
+    assert!(
+        !output.contains("var __asyncDelegator =") && !output.contains("var __asyncValues ="),
+        "a nested sync generator's yield* must not register async-iteration helpers for the outer generator.\nOutput:\n{output}"
+    );
+}
+
 #[test]
 fn async_generator_es2017_lowers_and_forwards_parameters() {
     let source = "async function* f1(x, y = z) {}\nasync function* f2({ [z]: x }) {}\n";

--- a/crates/tsz-emitter/src/lowering/core.rs
+++ b/crates/tsz-emitter/src/lowering/core.rs
@@ -626,7 +626,7 @@ impl<'a> LoweringPass<'a> {
             if func.is_async {
                 self.mark_function_parameter_transform_helpers(&func.parameters);
                 if func.asterisk_token {
-                    self.mark_async_generator_helpers();
+                    self.mark_async_generator_helpers(func.body);
                 } else {
                     self.mark_async_helpers();
                 }
@@ -644,7 +644,7 @@ impl<'a> LoweringPass<'a> {
                 || (!func.asterisk_token && self.ctx.needs_async_lowering))
         {
             if func.asterisk_token {
-                self.mark_async_generator_helpers();
+                self.mark_async_generator_helpers(func.body);
             } else {
                 // ES2015/ES2016: async functions need __awaiter (generators are native)
                 self.mark_async_helpers();
@@ -1008,7 +1008,7 @@ impl<'a> LoweringPass<'a> {
                 || (!func.asterisk_token && self.ctx.needs_async_lowering))
         {
             if func.asterisk_token {
-                self.mark_async_generator_helpers();
+                self.mark_async_generator_helpers(func.body);
             } else {
                 self.mark_async_helpers();
             }
@@ -1698,7 +1698,7 @@ impl<'a> LoweringPass<'a> {
             if func.is_async {
                 self.mark_function_parameter_transform_helpers(&func.parameters);
                 if func.asterisk_token {
-                    self.mark_async_generator_helpers();
+                    self.mark_async_generator_helpers(func.body);
                 } else {
                     self.mark_async_helpers();
                 }
@@ -1726,7 +1726,7 @@ impl<'a> LoweringPass<'a> {
         {
             if func.asterisk_token {
                 // ES2015+: async generators need __asyncGenerator + __await helpers
-                self.mark_async_generator_helpers();
+                self.mark_async_generator_helpers(func.body);
             } else {
                 // ES2015/ES2016: non-generator async functions need __awaiter
                 self.mark_async_helpers();

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -7,6 +7,7 @@ use super::*;
 use crate::emitter::JsxEmit;
 use crate::transforms::emit_utils;
 use tsz_common::ScriptTarget;
+use tsz_parser::parser::node::NodeAccess;
 
 impl<'a> LoweringPass<'a> {
     // =========================================================================
@@ -460,14 +461,68 @@ impl<'a> LoweringPass<'a> {
         }
     }
 
-    /// Mark helpers needed for async generator functions (async function*).
-    pub(super) fn mark_async_generator_helpers(&mut self) {
+    /// Mark helpers needed for async generator functions (`async function*`).
+    ///
+    /// Every down-leveled async generator pulls in `__await` and
+    /// `__asyncGenerator` (plus `__generator` at ES5). A **delegating** `yield*`
+    /// inside the generator body additionally lowers to
+    /// `yield __await(yield* __asyncDelegator(__asyncValues(x)))`, so it also
+    /// needs the two async-iteration helpers. The decision keys purely on the
+    /// structural presence of a delegating `yield*` that binds to this
+    /// generator, never on identifier spelling or rendered output.
+    pub(super) fn mark_async_generator_helpers(&mut self, body: NodeIndex) {
+        let delegates = self.async_generator_body_has_delegating_yield(body);
         let helpers = self.transforms.helpers_mut();
         helpers.mark_await_helper();
         helpers.mark_async_generator();
         if self.ctx.target_es5 {
             helpers.generator = true;
         }
+        if delegates {
+            helpers.mark_async_values();
+            helpers.mark_async_delegator();
+        }
+    }
+
+    /// Returns `true` when the async-generator body contains a delegating
+    /// `yield* x` that binds to *this* generator (i.e. not nested inside another
+    /// function-like or class member, which own their own `yield` scope).
+    fn async_generator_body_has_delegating_yield(&self, body: NodeIndex) -> bool {
+        if body.is_none() {
+            return false;
+        }
+        let mut stack = vec![body];
+        while let Some(current) = stack.pop() {
+            let Some(node) = self.arena.get(current) else {
+                continue;
+            };
+            if node.kind == syntax_kind_ext::YIELD_EXPRESSION
+                && let Some(unary) = self.arena.get_unary_expr_ex(node)
+                && unary.asterisk_token
+                && self.arena.get(unary.expression).is_some()
+            {
+                return true;
+            }
+            // Do not descend into nested scopes that own their own `yield`
+            // binding (or introduce none): inner functions/arrows, methods,
+            // constructors, accessors, and class bodies. The generator's own
+            // body is a block, which is never a boundary, so it is traversed.
+            if self.is_yield_scope_boundary(node) {
+                continue;
+            }
+            stack.extend(self.arena.get_children(current));
+        }
+        false
+    }
+
+    /// A node that introduces its own `yield` binding scope (or none), so a
+    /// `yield*` beneath it does not belong to an enclosing generator.
+    fn is_yield_scope_boundary(&self, node: &Node) -> bool {
+        self.arena.get_function(node).is_some()
+            || self.arena.get_method_decl(node).is_some()
+            || self.arena.get_constructor(node).is_some()
+            || self.arena.get_accessor(node).is_some()
+            || self.arena.get_class(node).is_some()
     }
 
     pub(super) fn has_class_member_modifier(

--- a/crates/tsz-emitter/src/lowering/visit_children.rs
+++ b/crates/tsz-emitter/src/lowering/visit_children.rs
@@ -241,7 +241,7 @@ impl<'a> LoweringPass<'a> {
                     {
                         if method.asterisk_token {
                             // Async generator method: needs __asyncGenerator + __await
-                            self.mark_async_generator_helpers();
+                            self.mark_async_generator_helpers(method.body);
                         } else {
                             // Non-generator async method: needs __awaiter
                             // (ES2015/ES2016 use __awaiter + generators via yield,


### PR DESCRIPTION
Fixes #15301.

When a delegating `yield* x` (a `yield*` with a delegate expression that binds to *that* generator) appears inside a down-leveled `async function*` (target `< ES2018`), `tsc` lowers it to `yield __await(yield* __asyncDelegator(__asyncValues(x)))` and emits **four** helper definitions in the preamble (`__asyncValues`, `__await`, `__asyncDelegator`, `__asyncGenerator`). tsz emitted the lowered call in the body but only registered `__await`/`__asyncGenerator` (+`__generator` at ES5), leaving `__asyncValues` and `__asyncDelegator` **undefined** — a `ReferenceError` at runtime.

**Structural rule:** when a down-leveled `async function*` body contains a delegating `yield* x` that binds to that generator, tsz must register `__asyncValues`/`__asyncDelegator` in addition to `__await`/`__asyncGenerator`, through the emitter lowering-pass helper detection. The decision keys purely on the structural presence of a delegating `yield*` in the generator's own body — never on identifier spelling or rendered output.

**Owner layer:** emitter — lowering-pass helper detection (`crates/tsz-emitter/src/lowering/`). `mark_async_generator_helpers` now takes the generator body and scans it (stack walk over `arena.get_children`) for a delegating `yield*`, stopping descent at nested function-like and class scope boundaries so a nested generator's `yield*` is not misattributed. Applied at all six async-generator marking sites (function declaration/expression, CommonJS default export, and async-generator method). Pure output-form fix; no semantic validation added, no already-emitted output patched.

**Adjacent matrix (all covered by tests):**
- Positive: delegating `yield*` at ES5, ES2015, and ES2017 registers all four helpers.
- Positive: delegating `yield*` in an async-generator method (`async *m()`) registers the iteration helpers.
- Negative: a plain async generator (no delegating `yield*`) keeps `__asyncValues`/`__asyncDelegator` out of the preamble.
- Attribution: a nested sync `function*`'s `yield*` does not register async-iteration helper definitions for the outer async generator.

Out of scope (tracked separately by the issue): `for await...of` temp hoisting, ES5 single- vs multi-line async-generator body formatting, and the `emit_await_as_yield_await` leak into a nested sync `function*` (an emit-side context bug; it can still write the delegator call in a nested sync generator's body, but no longer affects preamble registration).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib async_generator` — new regression tests (`downleveled_async_generator_delegating_yield_registers_iteration_helpers`, `..._method_...`, `..._without_delegation_omits_iteration_helpers`, `nested_sync_generator_delegation_does_not_leak_into_async_generator`) fail before the fix, pass after; 24 passed.
- `cargo test -p tsz-emitter --lib` — full emitter lib suite, 3945 passed.
- `cargo clippy -p tsz-emitter --lib` — clean under `-D warnings`.
- `cargo fmt` — clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_017sp6pQvMWb3jFdrdkBnTYX

---
_Generated by [Claude Code](https://claude.ai/code/session_017sp6pQvMWb3jFdrdkBnTYX)_