### PR TITLE
fix(emit): register __asyncValues/__asyncDelegator for delegating yield* in down-leveled async generators

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -371,6 +371,10 @@ name = "async_loop_emit"
 path = "tests/async_loop_emit.rs"
 
 [[test]]
+name = "async_generator_delegating_yield_helpers_tests"
+path = "tests/async_generator_delegating_yield_helpers_tests.rs"
+
+[[test]]
 name = "for_await_async_generator_keyword_tests"
 path = "tests/for_await_async_generator_keyword_tests.rs"
 

--- a/crates/tsz-emitter/src/lowering/core.rs
+++ b/crates/tsz-emitter/src/lowering/core.rs
@@ -626,7 +626,7 @@ impl<'a> LoweringPass<'a> {
             if func.is_async {
                 self.mark_function_parameter_transform_helpers(&func.parameters);
                 if func.asterisk_token {
-                    self.mark_async_generator_helpers();
+                    self.mark_async_generator_helpers(func.body);
                 } else {
                     self.mark_async_helpers();
                 }
@@ -644,7 +644,7 @@ impl<'a> LoweringPass<'a> {
                 || (!func.asterisk_token && self.ctx.needs_async_lowering))
         {
             if func.asterisk_token {
-                self.mark_async_generator_helpers();
+                self.mark_async_generator_helpers(func.body);
             } else {
                 // ES2015/ES2016: async functions need __awaiter (generators are native)
                 self.mark_async_helpers();
@@ -1008,7 +1008,7 @@ impl<'a> LoweringPass<'a> {
                 || (!func.asterisk_token && self.ctx.needs_async_lowering))
         {
             if func.asterisk_token {
-                self.mark_async_generator_helpers();
+                self.mark_async_generator_helpers(func.body);
             } else {
                 self.mark_async_helpers();
             }
@@ -1698,7 +1698,7 @@ impl<'a> LoweringPass<'a> {
             if func.is_async {
                 self.mark_function_parameter_transform_helpers(&func.parameters);
                 if func.asterisk_token {
-                    self.mark_async_generator_helpers();
+                    self.mark_async_generator_helpers(func.body);
                 } else {
                     self.mark_async_helpers();
                 }
@@ -1726,7 +1726,7 @@ impl<'a> LoweringPass<'a> {
         {
             if func.asterisk_token {
                 // ES2015+: async generators need __asyncGenerator + __await helpers
-                self.mark_async_generator_helpers();
+                self.mark_async_generator_helpers(func.body);
             } else {
                 // ES2015/ES2016: non-generator async functions need __awaiter
                 self.mark_async_helpers();

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -7,6 +7,7 @@ use super::*;
 use crate::emitter::JsxEmit;
 use crate::transforms::emit_utils;
 use tsz_common::ScriptTarget;
+use tsz_parser::parser::node::NodeAccess;
 
 impl<'a> LoweringPass<'a> {
     // =========================================================================
@@ -460,14 +461,69 @@ impl<'a> LoweringPass<'a> {
         }
     }
 
-    /// Mark helpers needed for async generator functions (async function*).
-    pub(super) fn mark_async_generator_helpers(&mut self) {
+    /// Mark helpers needed for async generator functions (`async function*`)
+    /// whose target down-levels the async generator (target `< ES2018`).
+    ///
+    /// Every down-leveled async generator needs `__await`/`__asyncGenerator`
+    /// (plus `__generator` at ES5). A *delegating* `yield* x` in the
+    /// generator's own body lowers to
+    /// `yield __await(yield* __asyncDelegator(__asyncValues(x)))`, so it
+    /// additionally needs `__asyncValues`/`__asyncDelegator`. `tsc` registers
+    /// the four helpers in canonical tslib order (`__asyncValues`, `__await`,
+    /// `__asyncDelegator`, `__asyncGenerator`); the ES2018-tier helpers emit in
+    /// request order, so the marking calls follow that sequence. `body` is the
+    /// generator's function/method body (`NodeIndex::none()` when absent, e.g.
+    /// an overload signature).
+    pub(super) fn mark_async_generator_helpers(&mut self, body: NodeIndex) {
+        let has_delegating_yield = self.async_generator_body_has_delegating_yield(body);
         let helpers = self.transforms.helpers_mut();
+        if has_delegating_yield {
+            helpers.mark_async_values();
+        }
         helpers.mark_await_helper();
+        if has_delegating_yield {
+            helpers.mark_async_delegator();
+        }
         helpers.mark_async_generator();
         if self.ctx.target_es5 {
             helpers.generator = true;
         }
+    }
+
+    /// Returns `true` if `body` (a down-leveled async generator's function or
+    /// method body) lexically contains a delegating `yield* x` — a `yield*`
+    /// with a delegate expression — that binds to *this* generator.
+    ///
+    /// A `yield` binds only to its immediately-enclosing generator, so a
+    /// delegating `yield*` inside a nested function-like belongs to that inner
+    /// function (which owns its own helper marking) and must not be attributed
+    /// here. The scan therefore stops at nested function-like boundaries. A
+    /// bare `yield*` with no delegate expression is skipped: it emits `yield* `
+    /// with no delegation call and needs neither helper.
+    fn async_generator_body_has_delegating_yield(&self, body: NodeIndex) -> bool {
+        if body.is_none() {
+            return false;
+        }
+        let mut stack = vec![body];
+        while let Some(idx) = stack.pop() {
+            let Some(node) = self.arena.get(idx) else {
+                continue;
+            };
+            if node.kind == syntax_kind_ext::YIELD_EXPRESSION
+                && let Some(unary) = self.arena.get_unary_expr_ex(node)
+                && unary.asterisk_token
+                && self.arena.get(unary.expression).is_some()
+            {
+                return true;
+            }
+            // Stop at nested function-likes: a `yield*` there binds to that
+            // inner function, not this generator (see doc comment).
+            if idx != body && emit_utils::is_function_like_boundary(node.kind) {
+                continue;
+            }
+            stack.extend(self.arena.get_children(idx));
+        }
+        false
     }
 
     pub(super) fn has_class_member_modifier(

--- a/crates/tsz-emitter/src/lowering/visit_children.rs
+++ b/crates/tsz-emitter/src/lowering/visit_children.rs
@@ -241,7 +241,7 @@ impl<'a> LoweringPass<'a> {
                     {
                         if method.asterisk_token {
                             // Async generator method: needs __asyncGenerator + __await
-                            self.mark_async_generator_helpers();
+                            self.mark_async_generator_helpers(method.body);
                         } else {
                             // Non-generator async method: needs __awaiter
                             // (ES2015/ES2016 use __awaiter + generators via yield,

--- a/crates/tsz-emitter/src/transforms/emit_utils.rs
+++ b/crates/tsz-emitter/src/transforms/emit_utils.rs
@@ -472,6 +472,21 @@ pub(crate) fn is_simple_copiable_expression(arena: &NodeArena, idx: NodeIndex) -
         || node.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
 }
 
+/// Function-like node kinds that open their own `this`/`arguments`/generator
+/// (`yield`) binding scope. A construct lexically inside one of these — a
+/// `yield*`, `await`, hoisted `var`, or `super` reference — binds to that inner
+/// function, not the enclosing body, so binding-scope-aware subtree scans stop
+/// descending at these boundaries.
+pub(crate) const fn is_function_like_boundary(kind: u16) -> bool {
+    kind == syntax_kind_ext::FUNCTION_DECLARATION
+        || kind == syntax_kind_ext::FUNCTION_EXPRESSION
+        || kind == syntax_kind_ext::ARROW_FUNCTION
+        || kind == syntax_kind_ext::METHOD_DECLARATION
+        || kind == syntax_kind_ext::CONSTRUCTOR
+        || kind == syntax_kind_ext::GET_ACCESSOR
+        || kind == syntax_kind_ext::SET_ACCESSOR
+}
+
 fn optional_chain_call_uses_simple_receiver(arena: &NodeArena, callee: NodeIndex) -> bool {
     let Some(callee_node) = arena.get(callee) else {
         return false;

--- a/crates/tsz-emitter/tests/async_generator_delegating_yield_helpers_tests.rs
+++ b/crates/tsz-emitter/tests/async_generator_delegating_yield_helpers_tests.rs
@@ -1,0 +1,196 @@
+//! Regression tests for helper registration when a down-leveled
+//! `async function*` body contains a delegating `yield* x`.
+//!
+//! Rule: when an `async function*` whose target down-levels the async generator
+//! (target `< ES2018`) contains a delegating `yield* x` that binds to *that*
+//! generator, `tsc` lowers it to
+//! `yield __await(yield* __asyncDelegator(__asyncValues(x)))` (ES2015+) or the
+//! `__generator` state-machine equivalent (ES5). The emit therefore registers
+//! `__asyncValues`/`__asyncDelegator` in addition to `__await`/`__asyncGenerator`,
+//! in `tsc`'s canonical tslib order (`__asyncValues`, `__await`,
+//! `__asyncDelegator`, `__asyncGenerator`). Without the registration the emitted
+//! module references two undefined names — a `ReferenceError` at runtime.
+//!
+//! The decision keys on the structural presence of a delegating `yield*` in the
+//! generator's own body, never on identifier spelling or rendered output; a
+//! `yield*` inside a nested function-like binds to that inner function and must
+//! not be attributed here. Binder names vary across the cases below so no logic
+//! can key on a particular spelling.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::{PrintOptions, lower_and_print};
+use tsz_parser::parser::ParserState;
+
+fn emit(source: &str, target: ScriptTarget) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let opts = PrintOptions {
+        target,
+        module: ModuleKind::ESNext,
+        remove_comments: true,
+        ..PrintOptions::default()
+    };
+    lower_and_print(&parser.arena, root, opts).code
+}
+
+/// Position of a helper *definition* (`var __name = ...`) in the preamble, or
+/// `None` when it is not registered.
+fn def_pos(output: &str, name: &str) -> Option<usize> {
+    output.find(&format!("var {name} = "))
+}
+
+fn assert_registered(output: &str, name: &str) {
+    assert!(
+        def_pos(output, name).is_some(),
+        "expected helper `{name}` to be registered in the preamble.\nOutput:\n{output}"
+    );
+}
+
+/// Asserts the four async-iteration helper definitions appear in `tsc`'s
+/// canonical tslib order: `__asyncValues`, `__await`, `__asyncDelegator`,
+/// `__asyncGenerator`.
+fn assert_canonical_async_iteration_order(output: &str) {
+    let names = [
+        "__asyncValues",
+        "__await",
+        "__asyncDelegator",
+        "__asyncGenerator",
+    ];
+    let mut last = 0usize;
+    for name in names {
+        assert_registered(output, name);
+        let pos = def_pos(output, name).unwrap();
+        assert!(
+            pos >= last,
+            "helper `{name}` is out of canonical tslib order.\nOutput:\n{output}"
+        );
+        last = pos;
+    }
+}
+
+#[test]
+fn es2015_delegating_yield_registers_iteration_helpers_in_canonical_order() {
+    let output = emit(
+        "export async function* f(g: AsyncIterable<number>) { yield* g; yield 1; }",
+        ScriptTarget::ES2015,
+    );
+    assert_canonical_async_iteration_order(&output);
+    assert!(
+        output.contains("yield __await(yield* __asyncDelegator(__asyncValues(g)))"),
+        "the delegating `yield*` body must lower through both iteration helpers.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2016_delegating_yield_registers_iteration_helpers() {
+    let output = emit(
+        "async function* stream(source: AsyncIterable<string>) { yield* source; }",
+        ScriptTarget::ES2016,
+    );
+    assert_canonical_async_iteration_order(&output);
+}
+
+#[test]
+fn es2017_delegating_yield_registers_iteration_helpers() {
+    let output = emit(
+        "async function* pipe(upstream: AsyncIterable<string>) { yield* upstream; }",
+        ScriptTarget::ES2017,
+    );
+    assert_canonical_async_iteration_order(&output);
+}
+
+#[test]
+fn es5_delegating_yield_registers_iteration_helpers_alongside_generator() {
+    let output = emit(
+        "async function* drain(src: AsyncIterable<number>) { yield* src; }",
+        ScriptTarget::ES5,
+    );
+    // ES5 down-levels via the `__generator` state machine but still pulls in the
+    // async-iteration helpers for the delegating `yield*`.
+    assert_registered(&output, "__generator");
+    assert_registered(&output, "__asyncValues");
+    assert_registered(&output, "__await");
+    assert_registered(&output, "__asyncDelegator");
+    assert_registered(&output, "__asyncGenerator");
+    // The ES2018-tier async helpers precede the ES2015 iteration tier (`__values`).
+    if let (Some(av), Some(vals)) = (
+        def_pos(&output, "__asyncValues"),
+        def_pos(&output, "__values"),
+    ) {
+        assert!(
+            av < vals,
+            "ES2018-tier `__asyncValues` must precede ES2015-tier `__values`.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn async_generator_method_delegating_yield_registers_helpers() {
+    let output = emit(
+        "class Repo { async *rows(cursor: AsyncIterable<number>) { yield* cursor; } }",
+        ScriptTarget::ES2015,
+    );
+    assert_canonical_async_iteration_order(&output);
+}
+
+#[test]
+fn call_expression_delegate_registers_helpers() {
+    let output = emit(
+        "declare function make(): AsyncIterable<number>;\
+         async function* chain() { yield* make(); }",
+        ScriptTarget::ES2015,
+    );
+    assert_canonical_async_iteration_order(&output);
+}
+
+#[test]
+fn plain_async_generator_without_delegating_yield_omits_iteration_helpers() {
+    let output = emit(
+        "async function* counter() { yield 1; yield 2; }",
+        ScriptTarget::ES2015,
+    );
+    assert_registered(&output, "__await");
+    assert_registered(&output, "__asyncGenerator");
+    assert!(
+        def_pos(&output, "__asyncValues").is_none()
+            && def_pos(&output, "__asyncDelegator").is_none(),
+        "a non-delegating async generator must not pull in the iteration helpers.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn nested_sync_generator_yield_star_not_attributed_to_outer_async_generator() {
+    // The `yield*` belongs to the nested SYNC `function*`, which binds `yield`
+    // to itself; the outer async generator has no delegating `yield*` of its own.
+    let output = emit(
+        "async function* outer() { function* inner() { yield* [1, 2]; } yield 3; }",
+        ScriptTarget::ES2015,
+    );
+    assert_registered(&output, "__await");
+    assert_registered(&output, "__asyncGenerator");
+    assert!(
+        def_pos(&output, "__asyncValues").is_none()
+            && def_pos(&output, "__asyncDelegator").is_none(),
+        "a nested sync generator's `yield*` must not register the async-iteration \
+         helpers on the outer async generator.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn native_async_generator_at_es2018_needs_no_iteration_helpers() {
+    let output = emit(
+        "async function* passthrough(g: AsyncIterable<number>) { yield* g; }",
+        ScriptTarget::ES2018,
+    );
+    assert!(
+        def_pos(&output, "__asyncValues").is_none()
+            && def_pos(&output, "__asyncDelegator").is_none()
+            && def_pos(&output, "__asyncGenerator").is_none()
+            && def_pos(&output, "__await").is_none(),
+        "at ES2018+ the async generator and `yield*` are native; no helpers needed.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("yield*"),
+        "native `yield*` must be preserved at ES2018+.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #15301.

When a down-leveled `async function*` (target `< ES2018`) body contains a delegating `yield* x` that binds to *that* generator, `tsc` lowers it to `yield __await(yield* __asyncDelegator(__asyncValues(x)))` (ES2015+) or the `__generator` state-machine equivalent (ES5), and registers the two async-iteration helper **definitions** in addition to `__await`/`__asyncGenerator`. tsz already wrote the lowered helper *calls* in the body but never registered the `__asyncValues`/`__asyncDelegator` **definitions** in the preamble, so the emitted module referenced two undefined names — a `ReferenceError` at runtime.

## Structural rule
When a down-leveled `async function*` body contains a delegating `yield* x` (a `yield*` with a delegate expression that binds to *that* generator, not a nested function-like), `tsc` registers `__asyncValues`/`__asyncDelegator` alongside `__await`/`__asyncGenerator`, emitted in the canonical tslib order (`__asyncValues`, `__await`, `__asyncDelegator`, `__asyncGenerator`). tsz now owns that in the emitter lowering pass (`crates/tsz-emitter/src/lowering`): `mark_async_generator_helpers` scans the generator's own body for a delegating `yield*` and marks the two extra helpers in request order (ES2018-tier helpers emit in request order). The decision keys on the structural presence of a delegating `yield*`, never on identifier spelling or rendered output. A `yield` binds only to its immediately-enclosing generator, so the scan stops at nested function-like boundaries.

## Owner layer
Emitter lowering-pass helper detection only. `write_helper` (emit) already writes the delegation call; only the preamble registration was missing. No semantic validation, no output surgery. The function-like boundary predicate is factored into a shared `emit_utils::is_function_like_boundary` const fn.

## Adjacent matrix
- Positive: function declaration/expression and async-generator **method** with a delegating `yield*` register all four helpers in canonical order (ES2015/ES2016/ES2017; ES5 adds them alongside `__generator`/`__values`).
- Positive: delegate over a **call expression** (`yield* make()`).
- Negative: a plain `async function*` with no delegating `yield*` marks only `__await`/`__asyncGenerator` — no over-marking.
- Negative (boundary): a nested **sync** `function*`'s `yield*` inside the outer async generator is *not* attributed to the outer generator.
- Unchanged: native ES2018+ async generator keeps `yield*` and needs no helper.

## Out of scope (tracked separately, per #15301)
`for await...of` loop-init temp hoisting at es2015/es2016; ES5 single- vs multi-line async-generator body formatting; `emit_await_as_yield_await` leaking into a nested sync `function*`.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --test async_generator_delegating_yield_helpers_tests` — 9 new cases (canonical-order registration across ES2015/2016/2017/ES5, methods, call-expr delegate, negative plain/nested-sync, native ES2018) — failed before the fix (missing defs), pass after.
- `cargo test -p tsz-emitter --lib` — 3941 passed, 0 failed.
- `cargo test -p tsz-emitter --test for_await_async_generator_keyword_tests --test generator_yield_star_es5_tests --test async_loop_emit --test async_try_emit --test generator_downlevel_iteration_for_of_tests` — no regressions.
- `cargo fmt --all --check`; `cargo clippy -p tsz-emitter --lib` — clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJr27wm4Yn2JhB8fHgaXEY)_