### PR TITLE
fix(emit): stop async-generator await/yield lowering leaking into nested functions

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -27,6 +27,10 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 
 [[test]]
+name = "async_generator_nested_function_context_tests"
+path = "tests/async_generator_nested_function_context_tests.rs"
+
+[[test]]
 name = "esm_export_star_as_downlevel_tests"
 path = "tests/esm_export_star_as_downlevel_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/declarations/core.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/core.rs
@@ -235,6 +235,18 @@ impl<'a> Printer<'a> {
         self.prepare_logical_assignment_value_temps(func.body);
         let prev_in_generator = self.ctx.flags.in_generator;
         self.ctx.flags.in_generator = func.asterisk_token;
+        // A nested ordinary function or sync generator establishes its own
+        // async context: `await`/`yield` inside it never inherit the enclosing
+        // async-function (`emit_await_as_yield`) or async-generator
+        // (`emit_await_as_yield_await`) lowering mode. Without this reset, a
+        // sync `function*`'s `yield* x` nested in a down-leveled async generator
+        // would wrongly lower to the `__await(yield* __asyncDelegator(...))`
+        // form. The async-lowering emit paths take earlier early-returns and
+        // set these flags for their own bodies, so they are unaffected.
+        let prev_emit_await_as_yield = self.ctx.emit_await_as_yield;
+        let prev_emit_await_as_yield_await = self.ctx.emit_await_as_yield_await;
+        self.ctx.emit_await_as_yield = false;
+        self.ctx.emit_await_as_yield_await = false;
         let prev_arguments_capture_name = self.ctx.arguments_capture_name.take();
         let prev_async_generator_shadowed_parameter_names =
             std::mem::take(&mut self.ctx.async_generator_shadowed_parameter_names);
@@ -259,6 +271,8 @@ impl<'a> Printer<'a> {
         self.ctx.arguments_capture_name = prev_arguments_capture_name;
         self.ctx.async_generator_shadowed_parameter_names =
             prev_async_generator_shadowed_parameter_names;
+        self.ctx.emit_await_as_yield = prev_emit_await_as_yield;
+        self.ctx.emit_await_as_yield_await = prev_emit_await_as_yield_await;
         self.ctx.flags.in_generator = prev_in_generator;
         if let Some(previous) = previous_new_target_capture {
             self.restore_new_target_capture(previous);

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -494,9 +494,14 @@ impl<'a> Printer<'a> {
             // `for await...of` downleveling) land inline, matching tsc.
             let var_insert_pos = self.writer.len();
             let saved_yield = self.ctx.emit_await_as_yield;
+            let saved_emit_await_as_yield_await = self.ctx.emit_await_as_yield_await;
             let saved_args = self.ctx.rewrite_arguments_to_arguments_1;
             let saved_arguments_capture_name = self.ctx.arguments_capture_name.clone();
             self.ctx.emit_await_as_yield = true;
+            // A non-generator async function lowers `await x` to `yield x`, never
+            // the async-generator `yield __await(x)` form — clear any enclosing
+            // async-generator context so it does not leak into this body.
+            self.ctx.emit_await_as_yield_await = false;
             if body_captures_arguments {
                 self.ctx.rewrite_arguments_to_arguments_1 = true;
                 self.ctx.arguments_capture_name = arguments_capture_name;
@@ -513,6 +518,7 @@ impl<'a> Printer<'a> {
             self.function_scope_depth -= 1;
             self.splice_single_line_async_generator_hoists(var_insert_pos);
             self.ctx.emit_await_as_yield = saved_yield;
+            self.ctx.emit_await_as_yield_await = saved_emit_await_as_yield_await;
             self.ctx.rewrite_arguments_to_arguments_1 = saved_args;
             self.ctx.arguments_capture_name = saved_arguments_capture_name;
             self.write(" });");
@@ -541,11 +547,16 @@ impl<'a> Printer<'a> {
 
         // Emit function body with await→yield substitution
         let saved_yield = self.ctx.emit_await_as_yield;
+        let saved_emit_await_as_yield_await = self.ctx.emit_await_as_yield_await;
         let saved_args = self.ctx.rewrite_arguments_to_arguments_1;
         let saved_arguments_capture_name = self.ctx.arguments_capture_name.clone();
         let saved_shadowed_parameter_names =
             std::mem::take(&mut self.ctx.async_generator_shadowed_parameter_names);
         self.ctx.emit_await_as_yield = true;
+        // A non-generator async function lowers `await x` to `yield x`, never
+        // the async-generator `yield __await(x)` form — clear any enclosing
+        // async-generator context so it does not leak into this body.
+        self.ctx.emit_await_as_yield_await = false;
         self.ctx.async_generator_shadowed_parameter_names = if async_shadowed_var_names.is_empty() {
             Vec::new()
         } else {
@@ -606,6 +617,7 @@ impl<'a> Printer<'a> {
         }
         self.function_scope_depth -= 1;
         self.ctx.emit_await_as_yield = saved_yield;
+        self.ctx.emit_await_as_yield_await = saved_emit_await_as_yield_await;
         self.ctx.rewrite_arguments_to_arguments_1 = saved_args;
         self.ctx.arguments_capture_name = saved_arguments_capture_name;
         self.ctx.async_generator_shadowed_parameter_names = saved_shadowed_parameter_names;

--- a/crates/tsz-emitter/src/emitter/functions_arrow.rs
+++ b/crates/tsz-emitter/src/emitter/functions_arrow.rs
@@ -1311,9 +1311,11 @@ impl<'a> Printer<'a> {
             let var_insert_pos = self.writer.len();
 
             let saved_yield = self.ctx.emit_await_as_yield;
+            let saved_emit_await_as_yield_await = self.ctx.emit_await_as_yield_await;
             let saved_args = self.ctx.rewrite_arguments_to_arguments_1;
             let saved_arguments_capture_name = self.ctx.arguments_capture_name.clone();
             self.ctx.emit_await_as_yield = true;
+            self.ctx.emit_await_as_yield_await = false;
             if let Some(capture_name) = enclosing_arguments_capture_name.clone() {
                 self.ctx.rewrite_arguments_to_arguments_1 = true;
                 self.ctx.arguments_capture_name = Some(capture_name);
@@ -1357,6 +1359,7 @@ impl<'a> Printer<'a> {
                 self.splice_single_line_async_generator_hoists(var_insert_pos);
             }
             self.ctx.emit_await_as_yield = saved_yield;
+            self.ctx.emit_await_as_yield_await = saved_emit_await_as_yield_await;
             self.ctx.rewrite_arguments_to_arguments_1 = saved_args;
             self.ctx.arguments_capture_name = saved_arguments_capture_name;
             self.write(" })");
@@ -1390,9 +1393,11 @@ impl<'a> Printer<'a> {
             let var_insert_pos = self.writer.len();
 
             let saved_yield = self.ctx.emit_await_as_yield;
+            let saved_emit_await_as_yield_await = self.ctx.emit_await_as_yield_await;
             let saved_args = self.ctx.rewrite_arguments_to_arguments_1;
             let saved_arguments_capture_name = self.ctx.arguments_capture_name.clone();
             self.ctx.emit_await_as_yield = true;
+            self.ctx.emit_await_as_yield_await = false;
             self.ctx.rewrite_arguments_to_arguments_1 = true;
             self.ctx.arguments_capture_name = Some(arguments_capture_name);
 
@@ -1440,6 +1445,7 @@ impl<'a> Printer<'a> {
             }
 
             self.ctx.emit_await_as_yield = saved_yield;
+            self.ctx.emit_await_as_yield_await = saved_emit_await_as_yield_await;
             self.ctx.rewrite_arguments_to_arguments_1 = saved_args;
             self.ctx.arguments_capture_name = saved_arguments_capture_name;
 
@@ -1463,9 +1469,11 @@ impl<'a> Printer<'a> {
             let var_insert_pos = self.writer.len();
 
             let saved_yield = self.ctx.emit_await_as_yield;
+            let saved_emit_await_as_yield_await = self.ctx.emit_await_as_yield_await;
             let saved_args = self.ctx.rewrite_arguments_to_arguments_1;
             let saved_arguments_capture_name = self.ctx.arguments_capture_name.clone();
             self.ctx.emit_await_as_yield = true;
+            self.ctx.emit_await_as_yield_await = false;
             if let Some(capture_name) = enclosing_arguments_capture_name.clone() {
                 self.ctx.rewrite_arguments_to_arguments_1 = true;
                 self.ctx.arguments_capture_name = Some(capture_name);
@@ -1480,6 +1488,7 @@ impl<'a> Printer<'a> {
             }
             self.splice_single_line_async_generator_hoists(var_insert_pos);
             self.ctx.emit_await_as_yield = saved_yield;
+            self.ctx.emit_await_as_yield_await = saved_emit_await_as_yield_await;
             self.ctx.rewrite_arguments_to_arguments_1 = saved_args;
             self.ctx.arguments_capture_name = saved_arguments_capture_name;
             self.write(" })");
@@ -1496,9 +1505,11 @@ impl<'a> Printer<'a> {
             self.write(", void 0, void 0, function* () {");
             let var_insert_pos = self.writer.len();
             let saved_yield = self.ctx.emit_await_as_yield;
+            let saved_emit_await_as_yield_await = self.ctx.emit_await_as_yield_await;
             let saved_args = self.ctx.rewrite_arguments_to_arguments_1;
             let saved_arguments_capture_name = self.ctx.arguments_capture_name.clone();
             self.ctx.emit_await_as_yield = true;
+            self.ctx.emit_await_as_yield_await = false;
             if let Some(capture_name) = enclosing_arguments_capture_name.clone() {
                 self.ctx.rewrite_arguments_to_arguments_1 = true;
                 self.ctx.arguments_capture_name = Some(capture_name);
@@ -1519,6 +1530,7 @@ impl<'a> Printer<'a> {
                 self.splice_single_line_async_generator_hoists(var_insert_pos);
             }
             self.ctx.emit_await_as_yield = saved_yield;
+            self.ctx.emit_await_as_yield_await = saved_emit_await_as_yield_await;
             self.ctx.rewrite_arguments_to_arguments_1 = saved_args;
             self.ctx.arguments_capture_name = saved_arguments_capture_name;
             self.write(" })");
@@ -1536,9 +1548,11 @@ impl<'a> Printer<'a> {
 
         // Emit body with await→yield substitution
         let saved_yield = self.ctx.emit_await_as_yield;
+        let saved_emit_await_as_yield_await = self.ctx.emit_await_as_yield_await;
         let saved_args = self.ctx.rewrite_arguments_to_arguments_1;
         let saved_arguments_capture_name = self.ctx.arguments_capture_name.clone();
         self.ctx.emit_await_as_yield = true;
+        self.ctx.emit_await_as_yield_await = false;
         if let Some(capture_name) = enclosing_arguments_capture_name {
             self.ctx.rewrite_arguments_to_arguments_1 = true;
             self.ctx.arguments_capture_name = Some(capture_name);
@@ -1559,6 +1573,7 @@ impl<'a> Printer<'a> {
         }
 
         self.ctx.emit_await_as_yield = saved_yield;
+        self.ctx.emit_await_as_yield_await = saved_emit_await_as_yield_await;
         self.ctx.rewrite_arguments_to_arguments_1 = saved_args;
         self.ctx.arguments_capture_name = saved_arguments_capture_name;
 
@@ -1755,9 +1770,11 @@ impl<'a> Printer<'a> {
         let body_has_for_await = is_block && self.body_contains_for_await(func.body);
 
         let saved_yield = self.ctx.emit_await_as_yield;
+        let saved_emit_await_as_yield_await = self.ctx.emit_await_as_yield_await;
         let saved_args = self.ctx.rewrite_arguments_to_arguments_1;
         let saved_arguments_capture_name = self.ctx.arguments_capture_name.clone();
         self.ctx.emit_await_as_yield = true;
+        self.ctx.emit_await_as_yield_await = false;
         if let Some(capture_name) = arguments_capture_name.clone() {
             self.ctx.rewrite_arguments_to_arguments_1 = true;
             self.ctx.arguments_capture_name = Some(capture_name);
@@ -1791,6 +1808,7 @@ impl<'a> Printer<'a> {
             self.splice_single_line_async_generator_hoists(var_insert_pos);
         }
         self.ctx.emit_await_as_yield = saved_yield;
+        self.ctx.emit_await_as_yield_await = saved_emit_await_as_yield_await;
         self.ctx.rewrite_arguments_to_arguments_1 = saved_args;
         if emits_arguments_capture {
             self.ctx.arguments_capture_name = arguments_capture_name.clone();

--- a/crates/tsz-emitter/tests/async_generator_nested_function_context_tests.rs
+++ b/crates/tsz-emitter/tests/async_generator_nested_function_context_tests.rs
@@ -1,0 +1,140 @@
+//! Regression tests for the `emit_await_as_yield_await` async-generator emit
+//! context leaking into nested function scopes.
+//!
+//! A down-leveled `async function*` sets an emit context in which `await`
+//! lowers to `yield __await(x)` and a delegating `yield*` lowers to
+//! `yield __await(yield* __asyncDelegator(__asyncValues(x)))`. That context
+//! belongs only to the async generator's own body — a nested function
+//! establishes its own async context. Without resetting the flag on descent,
+//! a nested sync `function*`'s `yield* x` and a nested async function/arrow's
+//! `await x` were wrongly emitted in the async-generator form.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::{PrintOptions, lower_and_print};
+use tsz_parser::parser::ParserState;
+
+fn emit(source: &str, target: ScriptTarget) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let opts = PrintOptions {
+        target,
+        module: ModuleKind::ESNext,
+        remove_comments: true,
+        ..PrintOptions::default()
+    };
+    lower_and_print(&parser.arena, root, opts).code
+}
+
+#[test]
+fn nested_sync_generator_yield_star_stays_native_at_es2015() {
+    // The inner sync generator's `yield* [1, 2]` is native at ES2015; it must
+    // not inherit the enclosing async generator's `__asyncDelegator` lowering.
+    let output = emit(
+        "export async function* outer() {
+            function* inner() { yield* [1, 2]; }
+            yield inner();
+        }",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        output.contains("function* inner() { yield* [1, 2]; }"),
+        "nested sync generator yield* must stay native:\n{output}"
+    );
+    assert!(
+        !output.contains("__asyncDelegator") && !output.contains("__asyncValues"),
+        "nested sync generator must not pull async-iteration lowering:\n{output}"
+    );
+}
+
+#[test]
+fn nested_async_function_await_uses_plain_yield_at_es2015() {
+    // The inner async (non-generator) function lowers `await x` to `yield x`
+    // via __awaiter, never the async-generator `yield __await(x)` form.
+    let output = emit(
+        "export async function* stream() {
+            async function pull() { return await Promise.resolve(7); }
+            yield pull();
+        }",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        output.contains("return yield Promise.resolve(7)"),
+        "nested async function await must lower to plain `yield`:\n{output}"
+    );
+    assert!(
+        !output.contains("yield __await(Promise.resolve(7))"),
+        "nested async function await must not use the async-generator __await form:\n{output}"
+    );
+}
+
+#[test]
+fn nested_async_arrow_await_uses_plain_yield_at_es2015() {
+    let output = emit(
+        "export async function* feed() {
+            const grab = async () => await Promise.resolve(9);
+            yield grab();
+        }",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        output.contains("return yield Promise.resolve(9)"),
+        "nested async arrow await must lower to plain `yield`:\n{output}"
+    );
+    assert!(
+        !output.contains("yield __await(Promise.resolve(9))"),
+        "nested async arrow await must not use the async-generator __await form:\n{output}"
+    );
+}
+
+#[test]
+fn nested_async_generator_reestablishes_await_context_at_es2015() {
+    // Positive control: a nested async generator is itself down-leveled, so its
+    // own delegating `yield*` MUST use the `__asyncDelegator`/`__asyncValues`
+    // form — proving the reset is scoped (save/restore) rather than permanent.
+    let output = emit(
+        "export async function* outer() {
+            async function* inner(src: AsyncIterable<number>) { yield* src; }
+            yield inner(null as any);
+        }",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        output.contains("yield* __asyncDelegator(__asyncValues(src))"),
+        "a nested async generator's own yield* must keep the delegator form:\n{output}"
+    );
+}
+
+#[test]
+fn outer_async_generator_body_still_uses_await_form_at_es2015() {
+    // Regression guard: the async generator's own `await` still lowers to the
+    // `yield __await(x)` form; only nested functions reset the context.
+    let output = emit(
+        "export async function* ticker(p: Promise<number>) { yield await p; }",
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        output.contains("yield __await(p)"),
+        "the async generator's own await must keep the __await form:\n{output}"
+    );
+}
+
+#[test]
+fn nested_sync_generator_yield_star_stays_native_at_es5() {
+    // At ES5 a sync generator delegates via the `__generator` state machine and
+    // `__values`, never the async-iteration helpers.
+    let output = emit(
+        "export async function* outer() {
+            function* inner() { yield* [3, 4]; }
+            yield inner();
+        }",
+        ScriptTarget::ES5,
+    );
+    assert!(
+        output.contains("__values([3, 4])"),
+        "ES5 nested sync generator yield* must delegate via __values:\n{output}"
+    );
+    assert!(
+        !output.contains("__asyncDelegator") && !output.contains("__asyncValues"),
+        "ES5 nested sync generator must not pull async-iteration helpers:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #15309.

A down-leveled `async function*` (target `< ES2018`) sets an emit context in which `await x` lowers to `yield __await(x)` and a delegating `yield* x` lowers to `yield __await(yield* __asyncDelegator(__asyncValues(x)))`. That context belongs **only** to the async generator's own body, but the emit flags `emit_await_as_yield` / `emit_await_as_yield_await` were never reset when emission descended into a nested function scope — so the async-generator lowering **leaked** into nested functions, producing wrong (and, for the sync-generator form, invalid) JavaScript that `tsc` does not.

This is the distinct emit-side context bug that #15301 and its PRs (#15306/#15307/#15308) each list as **out of scope** ("`emit_await_as_yield_await` leaking into a nested sync `function*`"). It touches only JS function-body emission and does not overlap that helper-registration work.

### Before / after (`--module esnext --target es2015`)

```ts
export async function* outer() {
  function* inner() { yield* [1, 2]; }
  async function pull() { return await Promise.resolve(7); }
  const grab = async () => await Promise.resolve(9);
  yield inner(); yield pull(); yield grab();
}
```

| Nested form | `tsc` 6.0.2 | tsz before |
| --- | --- | --- |
| sync `function*` `yield* [1, 2]` | `yield* [1, 2]` | `yield __await(yield* __asyncDelegator(__asyncValues([1, 2])))` |
| async fn `await p` | `return yield p` | `return yield __await(p)` |
| async arrow `await p` | `return yield p` | `return yield __await(p)` |

The outer async generator's own `await`/`yield*` correctly stay in the `__await` form.

## Structural rule
When emission descends from a down-leveled async-generator body into a **nested function-like scope**, `tsc` does not carry the async-lowering mode: an async non-generator function lowers `await x` to `yield x` (`__awaiter`), a sync generator keeps `yield* x` native (or `__values`-delegated at ES5), and only an *async generator* uses the `__await`/`__asyncDelegator` form for its own body. tsz now resets both `emit_await_as_yield` and `emit_await_as_yield_await` (save/restore) at each nested function-body emission site, so each nested function re-establishes the mode it needs. The decision keys on emission descending into a function scope — never on identifier spelling or rendered output.

Owner layer: emitter JS function-body emission — `declarations/core.rs` (generic function body), `es5/helpers_async.rs` (`__awaiter` bodies), `functions_arrow.rs` (async arrow / function-expression `__awaiter` bodies). Pure output-form fix; no semantic validation added, no already-emitted output patched.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --test async_generator_nested_function_context_tests` — 6 new cases (nested sync generator native `yield*` at ES2015/ES5, nested async fn/arrow plain-`yield` await, nested async generator re-establishes the `__await` form, outer generator regression guard) — fail before, pass after.
- `cargo test -p tsz-emitter --lib` — 3941 passed, 0 failed.
- `cargo test -p tsz-emitter` narrow async/generator targets (`async_loop_emit`, `for_await_async_generator_keyword_tests`, `generator_yield_star_es5_tests`, `generator_downlevel_iteration_for_of_tests`, `async_try_emit`, `async_lowered_single_line_hoist_tests`, `async_awaiter_body_trailing_comment_tests`, `async_arrow_default_param_3758_tests`) — no regressions.
- `cargo fmt --all -- --check`; `cargo clippy -p tsz-emitter --lib --tests -- -D warnings` — clean.
- ready-review CI owns the broad conformance / emit / fourslash baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_013BKVSfzuaryHgtpWRQ2ixv)_