### PR TITLE
fix(emit): canonically print mapped-type constraint and `as` name-type in dts

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/probes_tsc_comparison.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/probes_tsc_comparison.rs
@@ -1546,3 +1546,48 @@ fn non_async_arrow_initializer_return_unchanged() {
         "non-async arrow return must stay unwrapped: {output}"
     );
 }
+
+// Mapped-type constraints and `as` name-types are re-printed through the shared
+// type printer, not copied from the author's source slice. `tsc`'s declaration
+// printer canonicalizes operator spacing (`"a" | "b"`, `K & string`) regardless
+// of how the source was written, so a source that omitted the spaces must still
+// emit the canonical form.
+
+#[test]
+fn mapped_type_constraint_union_canonicalizes_spacing() {
+    // Source omits spaces around `|`; tsc emits `"a" | "b" | "c"`.
+    let output = emit_dts(r#"export type T = { [K in "a"|"b"|"c"]: K };"#);
+    assert!(
+        output.contains(r#"[K in "a" | "b" | "c"]"#),
+        "mapped constraint union must be canonically spaced: {output}"
+    );
+    assert!(
+        !output.contains(r#""a"|"b""#),
+        "raw source spacing must not leak into the constraint: {output}"
+    );
+}
+
+#[test]
+fn mapped_type_as_clause_intersection_canonicalizes_spacing() {
+    // Source omits spaces around `&`; tsc emits `K & string`.
+    let output = emit_dts("export type T = { [K in keyof any as K&string]: 1 };");
+    assert!(
+        output.contains("as K & string]"),
+        "mapped as-clause intersection must be canonically spaced: {output}"
+    );
+    assert!(
+        !output.contains("K&string"),
+        "raw source spacing must not leak into the as-clause: {output}"
+    );
+}
+
+#[test]
+fn mapped_type_constraint_binder_name_agnostic() {
+    // The canonical re-print keys on type structure, not the binder spelling:
+    // a renamed key parameter emits the same canonically-spaced constraint.
+    let output = emit_dts(r#"export type T = { [Prop in "x"|"y"]?: Prop };"#);
+    assert!(
+        output.contains(r#"[Prop in "x" | "y"]?"#),
+        "renamed mapped binder must still canonicalize spacing: {output}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
@@ -9,7 +9,7 @@ use super::helpers::{escape_string_for_double_quote, escape_string_for_single_qu
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_scanner::{SyntaxKind, is_ecmascript_identifier_part};
+use tsz_scanner::SyntaxKind;
 
 /// Re-escape a cooked template literal string so it can be placed back
 /// between backticks.  The parser stores the *cooked* (processed) value in
@@ -1608,56 +1608,44 @@ impl<'a> DeclarationEmitter<'a> {
         self.expand_portable_mapped_object_text(self.arena, inner)
     }
 
+    /// Emit `type_idx` through the shared canonical type printer, forcing it
+    /// onto a single line (`indent_level` = 0) unless `keep_indent` is set.
+    /// `tsc` keeps mapped-type constraint/name-type expressions inline, so the
+    /// multi-line tuple/type-literal formatting is suppressed except where a
+    /// nested shape needs its own indentation.
+    fn emit_type_inline_unless(&mut self, type_idx: NodeIndex, keep_indent: bool) {
+        let saved_indent = self.indent_level;
+        if !keep_indent {
+            self.indent_level = 0;
+        }
+        self.emit_type(type_idx);
+        self.indent_level = saved_indent;
+    }
+
     pub(in crate::declaration_emitter) fn emit_mapped_type_constraint(
         &mut self,
         constraint_idx: NodeIndex,
     ) {
-        let contains_type_literal = self.type_node_contains_type_literal(constraint_idx, 0);
-        if let Some(node) = self.arena.get(constraint_idx)
-            && let Some(text) = self.get_source_slice(node.pos, node.end)
-            && !contains_type_literal
-        {
-            let text = Self::mapped_type_constraint_source_text(&text);
-            if !text.is_empty() {
-                self.write(text);
-                return;
-            }
-        }
-
-        // tsc keeps mapped-type constraint expressions on a single line; suppress multiline tuple formatting.
-        let saved_indent = self.indent_level;
-        if !contains_type_literal {
-            self.indent_level = 0;
-        }
-        self.emit_type(constraint_idx);
-        self.indent_level = saved_indent;
+        // Re-print the constraint through the shared type printer rather than
+        // echoing its source slice. `tsc`'s declaration printer canonicalizes
+        // type syntax (`"a" | "b"`, `K & string`, ...) and never preserves the
+        // author's operator spacing, so a raw source copy diverges whenever the
+        // source omitted the spaces. The AST already separates the constraint
+        // from the `as` name-type into distinct nodes, so the printer is also
+        // correctly bounded — no source-span splitting is required.
+        let keep_indent = self.type_node_contains_type_literal(constraint_idx, 0);
+        self.emit_type_inline_unless(constraint_idx, keep_indent);
     }
 
     pub(in crate::declaration_emitter) fn emit_mapped_type_name_type(
         &mut self,
         name_type_idx: NodeIndex,
     ) {
-        if let Some(node) = self.arena.get(name_type_idx)
-            && let Some(text) = self.get_source_slice(node.pos, node.end)
-            && !self.type_node_contains_mapped_type(name_type_idx, 0)
-        {
-            let text = Self::mapped_type_name_source_text(&text);
-            if !text.is_empty() {
-                self.write(text);
-                return;
-            }
-        }
-
-        // tsc keeps mapped-type name-type expressions on a single line; suppress multiline tuple
-        // formatting. When the as-clause itself contains a nested mapped type, preserve indentation.
-        if self.type_node_contains_mapped_type(name_type_idx, 0) {
-            self.emit_type(name_type_idx);
-        } else {
-            let saved_indent = self.indent_level;
-            self.indent_level = 0;
-            self.emit_type(name_type_idx);
-            self.indent_level = saved_indent;
-        }
+        // Canonically re-print the `as` name-type (see
+        // `emit_mapped_type_constraint`), keeping the current indentation only
+        // when the name-type nests a mapped type of its own.
+        let keep_indent = self.type_node_contains_mapped_type(name_type_idx, 0);
+        self.emit_type_inline_unless(name_type_idx, keep_indent);
     }
 
     pub(in crate::declaration_emitter) fn emit_mapped_type_as_clause(
@@ -1665,27 +1653,7 @@ impl<'a> DeclarationEmitter<'a> {
         name_type_idx: NodeIndex,
     ) {
         self.write(" as ");
-
-        if let Some(node) = self.arena.get(name_type_idx)
-            && let Some(text) = self.get_source_slice(node.pos, node.end)
-            && !self.type_node_contains_mapped_type(name_type_idx, 0)
-        {
-            let text = Self::mapped_type_name_source_text(&text);
-            if !text.is_empty() {
-                self.write(text);
-                return;
-            }
-        }
-
-        let start = self.writer.len();
         self.emit_mapped_type_name_type(name_type_idx);
-        let emitted = self.writer.get_output()[start..].to_string();
-        let normalized = Self::mapped_type_name_source_text(&emitted);
-        if normalized != emitted.trim() {
-            let normalized = normalized.to_string();
-            self.writer.truncate(start);
-            self.write(&normalized);
-        }
     }
 
     fn type_node_contains_mapped_type(&self, type_idx: NodeIndex, depth: usize) -> bool {
@@ -1718,206 +1686,5 @@ impl<'a> DeclarationEmitter<'a> {
             .get_children(type_idx)
             .into_iter()
             .any(|child_idx| self.type_node_contains_type_literal(child_idx, depth + 1))
-    }
-
-    fn mapped_type_constraint_source_text(text: &str) -> &str {
-        let text = text.trim();
-        let text = Self::split_mapped_as_clause(text)
-            .map(|(before, _)| before.trim_end())
-            .unwrap_or_else(|| Self::trim_trailing_mapped_as_keyword(text));
-        Self::trim_unbalanced_closing_bracket(text)
-    }
-
-    fn mapped_type_name_source_text(text: &str) -> &str {
-        let text = text.trim();
-        let text = Self::split_mapped_as_clause(text)
-            .map(|(_, after)| after.trim_start())
-            .unwrap_or_else(|| Self::trim_leading_mapped_as_keyword(text));
-        Self::trim_unbalanced_closing_bracket(text)
-    }
-
-    fn trim_leading_mapped_as_keyword(text: &str) -> &str {
-        let mut trimmed = text.trim_start();
-        while let Some(after_as) = trimmed.strip_prefix("as") {
-            let has_boundary = after_as
-                .chars()
-                .next()
-                .is_some_and(|ch| ch.is_whitespace() || !Self::is_identifier_part(ch));
-            if !has_boundary {
-                break;
-            }
-            trimmed = after_as.trim_start();
-        }
-        trimmed
-    }
-
-    fn split_mapped_as_clause(text: &str) -> Option<(&str, &str)> {
-        let mut string_quote: Option<char> = None;
-        let mut escaped = false;
-        let mut angle_depth = 0u32;
-        let mut brace_depth = 0u32;
-        let mut bracket_depth = 0u32;
-        let mut paren_depth = 0u32;
-
-        for (idx, ch) in text.char_indices() {
-            if let Some(quote) = string_quote {
-                if escaped {
-                    escaped = false;
-                } else if ch == '\\' {
-                    escaped = true;
-                } else if ch == quote {
-                    string_quote = None;
-                }
-                continue;
-            }
-
-            match ch {
-                '\'' | '"' | '`' => {
-                    string_quote = Some(ch);
-                    continue;
-                }
-                '<' => {
-                    angle_depth += 1;
-                    continue;
-                }
-                '>' => {
-                    angle_depth = angle_depth.saturating_sub(1);
-                    continue;
-                }
-                '{' => {
-                    brace_depth += 1;
-                    continue;
-                }
-                '}' => {
-                    brace_depth = brace_depth.saturating_sub(1);
-                    continue;
-                }
-                '[' => {
-                    bracket_depth += 1;
-                    continue;
-                }
-                ']' => {
-                    bracket_depth = bracket_depth.saturating_sub(1);
-                    continue;
-                }
-                '(' => {
-                    paren_depth += 1;
-                    continue;
-                }
-                ')' => {
-                    paren_depth = paren_depth.saturating_sub(1);
-                    continue;
-                }
-                _ => {}
-            }
-
-            if ch != 'a'
-                || !text[idx..].starts_with("as")
-                || angle_depth != 0
-                || brace_depth != 0
-                || bracket_depth != 0
-                || paren_depth != 0
-            {
-                continue;
-            }
-
-            let before = &text[..idx];
-            let after = &text[idx + 2..];
-            let before_boundary = before
-                .chars()
-                .next_back()
-                .is_some_and(|ch| ch.is_whitespace() || !Self::is_identifier_part(ch));
-            let after_boundary = after
-                .chars()
-                .next()
-                .is_some_and(|ch| ch.is_whitespace() || !Self::is_identifier_part(ch));
-            if before_boundary && after_boundary {
-                return Some((before, after));
-            }
-        }
-        None
-    }
-
-    fn trim_trailing_mapped_as_keyword(text: &str) -> &str {
-        let trimmed = text.trim_end();
-        let Some(before_as) = trimmed.strip_suffix("as") else {
-            return trimmed;
-        };
-        let had_separator = before_as
-            .chars()
-            .next_back()
-            .is_some_and(char::is_whitespace);
-        let before_as = before_as.trim_end();
-        let has_boundary = before_as
-            .chars()
-            .next_back()
-            .is_some_and(|ch| ch.is_whitespace() || !Self::is_identifier_part(ch));
-        if had_separator || has_boundary {
-            before_as
-        } else {
-            trimmed
-        }
-    }
-
-    fn trim_unbalanced_closing_bracket(text: &str) -> &str {
-        let trimmed = text.trim_end();
-        if !trimmed.ends_with(']') {
-            return trimmed;
-        }
-
-        let opens = trimmed.chars().filter(|&ch| ch == '[').count();
-        let closes = trimmed.chars().filter(|&ch| ch == ']').count();
-        if closes > opens {
-            trimmed[..trimmed.len() - 1].trim_end()
-        } else {
-            trimmed
-        }
-    }
-
-    fn is_identifier_part(ch: char) -> bool {
-        is_ecmascript_identifier_part(ch)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::DeclarationEmitter;
-
-    #[test]
-    fn mapped_type_source_text_splits_compact_as_clause_after_indexed_access() {
-        assert_eq!(
-            DeclarationEmitter::mapped_type_constraint_source_text("T[number]as Item[Attr]"),
-            "T[number]"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_constraint_source_text("T[number] as"),
-            "T[number]"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_constraint_source_text("keyof T as"),
-            "keyof T"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_name_source_text("T[number]as Item[Attr]"),
-            "Item[Attr]"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_name_source_text("as `get${Capitalize<string & K>}`"),
-            "`get${Capitalize<string & K>}`"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_name_source_text(
-                "as as `get${Capitalize<string & K>}`"
-            ),
-            "`get${Capitalize<string & K>}`"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_name_source_text("asserts T"),
-            "asserts T"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_constraint_source_text("keyof T]"),
-            "keyof T"
-        );
     }
 }


### PR DESCRIPTION
Fixes #15312.

Declaration (`.d.ts`) emit copied a mapped type's key constraint (`[K in C]`) and its `as` name-type from the raw **source slice**, so it preserved the author's operator spacing. `tsc`'s declaration printer always canonicalizes union/intersection operators to ` | ` / ` & `, so `{ [K in "a"|"b"]: K }` emitted `[K in "a"|"b"]` instead of the canonical `[K in "a" | "b"]`. Every other type position already routes through the shared `emit_type` printer and was correct; only the mapped-type `in` constraint and `as` name-type diverged.

**Structural rule:** when the declaration emitter prints a mapped type's key constraint (`type_parameter.constraint`) or its `as` name-type (`name_type`), `tsc` re-prints through its canonical type printer and never preserves the author's operator spacing; tsz now does the same through the shared `emit_type` printer (owner layer: emitter / declaration emit, `crates/tsz-emitter/src/declaration_emitter/type_emission.rs`). The decision keys on the type's AST structure, not the source characters (verified with renamed key binders).

The three helpers (`emit_mapped_type_constraint` / `emit_mapped_type_name_type` / `emit_mapped_type_as_clause`) previously took the node's source slice and munged it with a hand-rolled `as`-clause splitter (`split_mapped_as_clause` / `trim_*` / `mapped_type_*_source_text`) before writing it raw. The AST already separates `constraint` and `name_type` into distinct nodes, so that splitting only compensated for span imprecision — `emit_type` on the sub-node is both correctly bounded and canonically spaced. The dead source-text machinery (and its unit tests, which only exercised the string helpers) is removed; the shared single-line indent-suppression is factored into `emit_type_inline_unless`. Net −186 lines. Pure output-form fix; no semantic change. Aligns with the anti-hardcoding gate (source-text-scoped shortcuts over rendered output are forbidden in emit decisions).

Adjacent matrix verified **byte-identical to tsc 6.0.2** after the fix: constraint unions (2+ members), `as` intersections, nested `keyof X as \`get_${string & K}\``, conditional `as` (`K extends "a" ? "A" : "B"`), template-literal constraints (`\`a${"b"|"c"}\``), `Uppercase<K>` as-clause, `readonly`/`-readonly`/`?`/`-?` modifiers, renamed key binder; controls with no operators (`[K in keyof X]`, `[K in U]`, `[K in keyof X & string]`) unchanged.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib` → 3937 passed, 0 failed (incl. 3 new `mapped_type_*_canonicalizes_spacing` / `binder_name_agnostic` tests in `tests/probes_tsc_comparison.rs`)
- Full `cargo test -p tsz-emitter --no-fail-fast`: only pre-existing failure is `generator_object_literal_prefix_before_yield_omits_source_trailing_comma` (fails on clean `main` too; unrelated to this change)
- CLI output diffed byte-for-byte against `tsc` 6.0.2 for the full adjacent matrix above → identical
- `cargo fmt --check`, `git diff --check`, `cargo clippy -p tsz-emitter --lib` (0 warnings), `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean
- Branch head at latest `main`; ready-review CI owns the broad conformance / emit / fourslash baselines

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uv72SnXcMf8zig3DtshDRj)_