### PR TITLE
fix(emit): reconstruct mapped-type constraint and `as` clause in .d.ts instead of echoing source

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/computed_properties.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/computed_properties.rs
@@ -153,6 +153,65 @@ export function makeCompleteLookupMapping<T extends ReadonlyArray<any>, Attr ext
 }
 
 #[test]
+fn test_mapped_type_constraint_union_operator_spacing_normalized() {
+    // A mapped-type key constraint used to be echoed verbatim from source
+    // text, so union/intersection operators kept whatever spacing the author
+    // wrote (`"x"|"y"` or `"x"   |   "y"`). tsc reprints the constraint type
+    // node with normalized ` | ` / ` & ` spacing; reconstruct it from the AST
+    // instead of slicing source.
+    let output = emit_dts(
+        r#"
+export type Compact = { [K in "x"|"y"]: number };
+export type Spread = { [K in "a"   |   "b"]: number };
+export type Inter = { [K in "a"&"b"]: number };
+export type Paren = { [K in ("x"|"y")]: number };
+"#,
+    );
+
+    assert!(
+        output.contains(r#"[K in "x" | "y"]"#),
+        "Compact union constraint must normalize to ` | `: {output}"
+    );
+    assert!(
+        output.contains(r#"[K in "a" | "b"]"#),
+        "Odd-spaced union constraint must normalize to ` | `: {output}"
+    );
+    assert!(
+        output.contains(r#"[K in "a" & "b"]"#),
+        "Intersection constraint must normalize to ` & `: {output}"
+    );
+    assert!(
+        output.contains(r#"[K in ("x" | "y")]"#),
+        "Parenthesized union constraint keeps its parens and normalizes spacing: {output}"
+    );
+    // Guard against the old source-echoing behavior leaking back.
+    assert!(
+        !output.contains(r#""x"|"y""#) && !output.contains(r#""a"&"b""#),
+        "No un-normalized operator spacing should survive: {output}"
+    );
+}
+
+#[test]
+fn test_mapped_type_as_clause_union_operator_spacing_normalized() {
+    // The key-remapping `as` clause shared the same source-slicing path, so
+    // its operators kept source spacing too. It must also normalize.
+    let output = emit_dts(
+        r#"
+export type Remap = { [K in string as K|"extra"]: number };
+"#,
+    );
+
+    assert!(
+        output.contains(r#"as K | "extra""#),
+        "as-clause union must normalize operator spacing: {output}"
+    );
+    assert!(
+        !output.contains(r#"K|"extra""#),
+        "No un-normalized as-clause spacing should survive: {output}"
+    );
+}
+
+#[test]
 fn test_override_modifier_stripped_in_dts() {
     // tsc strips `override` from class members in .d.ts output —
     // it is not part of the declaration surface.

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
@@ -9,7 +9,7 @@ use super::helpers::{escape_string_for_double_quote, escape_string_for_single_qu
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_scanner::{SyntaxKind, is_ecmascript_identifier_part};
+use tsz_scanner::SyntaxKind;
 
 /// Re-escape a cooked template literal string so it can be placed back
 /// between backticks.  The parser stores the *cooked* (processed) value in
@@ -1612,80 +1612,39 @@ impl<'a> DeclarationEmitter<'a> {
         &mut self,
         constraint_idx: NodeIndex,
     ) {
-        let contains_type_literal = self.type_node_contains_type_literal(constraint_idx, 0);
-        if let Some(node) = self.arena.get(constraint_idx)
-            && let Some(text) = self.get_source_slice(node.pos, node.end)
-            && !contains_type_literal
-        {
-            let text = Self::mapped_type_constraint_source_text(&text);
-            if !text.is_empty() {
-                self.write(text);
-                return;
-            }
-        }
-
-        // tsc keeps mapped-type constraint expressions on a single line; suppress multiline tuple formatting.
-        let saved_indent = self.indent_level;
-        if !contains_type_literal {
-            self.indent_level = 0;
-        }
-        self.emit_type(constraint_idx);
-        self.indent_level = saved_indent;
+        // tsc reprints the mapped-type constraint from the type node with
+        // normalized operator spacing (`"a"|"b"` -> `"a" | "b"`) rather than
+        // echoing source text. Reconstruct it from the AST: this normalizes
+        // spacing and, because the emitter walks the node structure, it also
+        // ignores the constraint node span over-extending into a
+        // parser-recovered `as` clause.
+        let single_line = !self.type_node_contains_type_literal(constraint_idx, 0);
+        self.emit_type_single_line(constraint_idx, single_line);
     }
 
-    pub(in crate::declaration_emitter) fn emit_mapped_type_name_type(
-        &mut self,
-        name_type_idx: NodeIndex,
-    ) {
-        if let Some(node) = self.arena.get(name_type_idx)
-            && let Some(text) = self.get_source_slice(node.pos, node.end)
-            && !self.type_node_contains_mapped_type(name_type_idx, 0)
-        {
-            let text = Self::mapped_type_name_source_text(&text);
-            if !text.is_empty() {
-                self.write(text);
-                return;
-            }
-        }
-
-        // tsc keeps mapped-type name-type expressions on a single line; suppress multiline tuple
-        // formatting. When the as-clause itself contains a nested mapped type, preserve indentation.
-        if self.type_node_contains_mapped_type(name_type_idx, 0) {
-            self.emit_type(name_type_idx);
-        } else {
-            let saved_indent = self.indent_level;
+    /// Reconstruct a type node from the AST. When `single_line` is set, the
+    /// enclosing indent is forced to zero so the shared `emit_type` union path
+    /// does not switch to multiline named-tuple formatting — mapped-type
+    /// constraints and `as`-clause name types stay on one line like `tsc`.
+    fn emit_type_single_line(&mut self, type_idx: NodeIndex, single_line: bool) {
+        let saved_indent = self.indent_level;
+        if single_line {
             self.indent_level = 0;
-            self.emit_type(name_type_idx);
-            self.indent_level = saved_indent;
         }
+        self.emit_type(type_idx);
+        self.indent_level = saved_indent;
     }
 
     pub(in crate::declaration_emitter) fn emit_mapped_type_as_clause(
         &mut self,
         name_type_idx: NodeIndex,
     ) {
+        // Reconstruct the key-remapping name type from the AST (normalized
+        // operator spacing) rather than echoing source text; keep it on a
+        // single line unless it nests a mapped type, which preserves indentation.
         self.write(" as ");
-
-        if let Some(node) = self.arena.get(name_type_idx)
-            && let Some(text) = self.get_source_slice(node.pos, node.end)
-            && !self.type_node_contains_mapped_type(name_type_idx, 0)
-        {
-            let text = Self::mapped_type_name_source_text(&text);
-            if !text.is_empty() {
-                self.write(text);
-                return;
-            }
-        }
-
-        let start = self.writer.len();
-        self.emit_mapped_type_name_type(name_type_idx);
-        let emitted = self.writer.get_output()[start..].to_string();
-        let normalized = Self::mapped_type_name_source_text(&emitted);
-        if normalized != emitted.trim() {
-            let normalized = normalized.to_string();
-            self.writer.truncate(start);
-            self.write(&normalized);
-        }
+        let single_line = !self.type_node_contains_mapped_type(name_type_idx, 0);
+        self.emit_type_single_line(name_type_idx, single_line);
     }
 
     fn type_node_contains_mapped_type(&self, type_idx: NodeIndex, depth: usize) -> bool {
@@ -1718,206 +1677,5 @@ impl<'a> DeclarationEmitter<'a> {
             .get_children(type_idx)
             .into_iter()
             .any(|child_idx| self.type_node_contains_type_literal(child_idx, depth + 1))
-    }
-
-    fn mapped_type_constraint_source_text(text: &str) -> &str {
-        let text = text.trim();
-        let text = Self::split_mapped_as_clause(text)
-            .map(|(before, _)| before.trim_end())
-            .unwrap_or_else(|| Self::trim_trailing_mapped_as_keyword(text));
-        Self::trim_unbalanced_closing_bracket(text)
-    }
-
-    fn mapped_type_name_source_text(text: &str) -> &str {
-        let text = text.trim();
-        let text = Self::split_mapped_as_clause(text)
-            .map(|(_, after)| after.trim_start())
-            .unwrap_or_else(|| Self::trim_leading_mapped_as_keyword(text));
-        Self::trim_unbalanced_closing_bracket(text)
-    }
-
-    fn trim_leading_mapped_as_keyword(text: &str) -> &str {
-        let mut trimmed = text.trim_start();
-        while let Some(after_as) = trimmed.strip_prefix("as") {
-            let has_boundary = after_as
-                .chars()
-                .next()
-                .is_some_and(|ch| ch.is_whitespace() || !Self::is_identifier_part(ch));
-            if !has_boundary {
-                break;
-            }
-            trimmed = after_as.trim_start();
-        }
-        trimmed
-    }
-
-    fn split_mapped_as_clause(text: &str) -> Option<(&str, &str)> {
-        let mut string_quote: Option<char> = None;
-        let mut escaped = false;
-        let mut angle_depth = 0u32;
-        let mut brace_depth = 0u32;
-        let mut bracket_depth = 0u32;
-        let mut paren_depth = 0u32;
-
-        for (idx, ch) in text.char_indices() {
-            if let Some(quote) = string_quote {
-                if escaped {
-                    escaped = false;
-                } else if ch == '\\' {
-                    escaped = true;
-                } else if ch == quote {
-                    string_quote = None;
-                }
-                continue;
-            }
-
-            match ch {
-                '\'' | '"' | '`' => {
-                    string_quote = Some(ch);
-                    continue;
-                }
-                '<' => {
-                    angle_depth += 1;
-                    continue;
-                }
-                '>' => {
-                    angle_depth = angle_depth.saturating_sub(1);
-                    continue;
-                }
-                '{' => {
-                    brace_depth += 1;
-                    continue;
-                }
-                '}' => {
-                    brace_depth = brace_depth.saturating_sub(1);
-                    continue;
-                }
-                '[' => {
-                    bracket_depth += 1;
-                    continue;
-                }
-                ']' => {
-                    bracket_depth = bracket_depth.saturating_sub(1);
-                    continue;
-                }
-                '(' => {
-                    paren_depth += 1;
-                    continue;
-                }
-                ')' => {
-                    paren_depth = paren_depth.saturating_sub(1);
-                    continue;
-                }
-                _ => {}
-            }
-
-            if ch != 'a'
-                || !text[idx..].starts_with("as")
-                || angle_depth != 0
-                || brace_depth != 0
-                || bracket_depth != 0
-                || paren_depth != 0
-            {
-                continue;
-            }
-
-            let before = &text[..idx];
-            let after = &text[idx + 2..];
-            let before_boundary = before
-                .chars()
-                .next_back()
-                .is_some_and(|ch| ch.is_whitespace() || !Self::is_identifier_part(ch));
-            let after_boundary = after
-                .chars()
-                .next()
-                .is_some_and(|ch| ch.is_whitespace() || !Self::is_identifier_part(ch));
-            if before_boundary && after_boundary {
-                return Some((before, after));
-            }
-        }
-        None
-    }
-
-    fn trim_trailing_mapped_as_keyword(text: &str) -> &str {
-        let trimmed = text.trim_end();
-        let Some(before_as) = trimmed.strip_suffix("as") else {
-            return trimmed;
-        };
-        let had_separator = before_as
-            .chars()
-            .next_back()
-            .is_some_and(char::is_whitespace);
-        let before_as = before_as.trim_end();
-        let has_boundary = before_as
-            .chars()
-            .next_back()
-            .is_some_and(|ch| ch.is_whitespace() || !Self::is_identifier_part(ch));
-        if had_separator || has_boundary {
-            before_as
-        } else {
-            trimmed
-        }
-    }
-
-    fn trim_unbalanced_closing_bracket(text: &str) -> &str {
-        let trimmed = text.trim_end();
-        if !trimmed.ends_with(']') {
-            return trimmed;
-        }
-
-        let opens = trimmed.chars().filter(|&ch| ch == '[').count();
-        let closes = trimmed.chars().filter(|&ch| ch == ']').count();
-        if closes > opens {
-            trimmed[..trimmed.len() - 1].trim_end()
-        } else {
-            trimmed
-        }
-    }
-
-    fn is_identifier_part(ch: char) -> bool {
-        is_ecmascript_identifier_part(ch)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::DeclarationEmitter;
-
-    #[test]
-    fn mapped_type_source_text_splits_compact_as_clause_after_indexed_access() {
-        assert_eq!(
-            DeclarationEmitter::mapped_type_constraint_source_text("T[number]as Item[Attr]"),
-            "T[number]"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_constraint_source_text("T[number] as"),
-            "T[number]"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_constraint_source_text("keyof T as"),
-            "keyof T"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_name_source_text("T[number]as Item[Attr]"),
-            "Item[Attr]"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_name_source_text("as `get${Capitalize<string & K>}`"),
-            "`get${Capitalize<string & K>}`"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_name_source_text(
-                "as as `get${Capitalize<string & K>}`"
-            ),
-            "`get${Capitalize<string & K>}`"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_name_source_text("asserts T"),
-            "asserts T"
-        );
-        assert_eq!(
-            DeclarationEmitter::mapped_type_constraint_source_text("keyof T]"),
-            "keyof T"
-        );
     }
 }


### PR DESCRIPTION
Fixes #15311.

In `.d.ts` output, the type-parameter **constraint** of a mapped type
(`[K in <constraint>]`) and its key-remapping **`as`** clause were emitted by
slicing the **raw source-text span** of the node, so the author's original
operator spacing survived verbatim. `tsc` reprints the type node with
normalized ` | ` / ` & ` spacing, so tsz diverged on every mapped type whose
key/`as` operand contained a union or intersection:

| Source | tsc 6.0.2 | tsz (before) |
| --- | --- | --- |
| `[K in "x"\|"y"]` | `[K in "x" \| "y"]` | `[K in "x"\|"y"]` |
| `[K in "x"   \|   "y"]` | `[K in "x" \| "y"]` | `[K in "x"   \|   "y"]` |
| `[K in string as K\|"extra"]` | `[K in string as K \| "extra"]` | `[K in string as K\|"extra"]` |

The verbatim triple-space preservation confirmed the output was a raw source
slice, not a reconstruction.

**Structural rule:** when the `.d.ts` emitter prints a mapped type's
key-parameter constraint or `as`-clause name type, `tsc` reprints the **type
node** with normalized operator spacing; tsz now does the same through the
declaration emitter's shared `emit_type` reconstruction path
(`crates/tsz-emitter/src/declaration_emitter/type_emission.rs`), never the
node's source-text span.

Because the emitter walks node structure, reconstruction also ignores the
constraint node span over-extending into a parser-recovered `as` clause, so the
ad-hoc source-text scanners (`split_mapped_as_clause`,
`trim_*_mapped_as_keyword`, `trim_unbalanced_closing_bracket`,
`mapped_type_*_source_text`, and the now-unused `is_ecmascript_identifier_part`
import) are deleted (−244 lines). The shared single-line indent handling is
factored into one `emit_type_single_line` helper used by both the constraint
and `as`-clause positions — the same mechanism the mapped **value** type
already used.

Owner layer: emitter, `.d.ts` type-syntax emission. Pure output-form change; no
semantic validation, no output surgery.

Adjacent cases confirmed tsz == tsc (differential vs tsc 6.0.2): `keyof T`;
`keyof T & string`; template-literal `as` (`` `get${Capitalize<K>}` ``);
parenthesized union `[K in ("x" | "y")]` (parens kept); nested mapped in value;
indexed-access constraint with a real `as` (`[Item in T[number] as Item[Attr]]`);
`+readonly`/`-readonly`/`+?`/`-?` modifiers; renamed binders.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib` — 3949 pass, 0 fail (includes two new
  regression tests: `test_mapped_type_constraint_union_operator_spacing_normalized`,
  `test_mapped_type_as_clause_union_operator_spacing_normalized`).
- `cargo clippy -p tsz-emitter --lib` — clean.
- Differential vs `tsc 6.0.2` on 15 diverse mapped-type `.d.ts` fixtures
  (unions, intersections, key remapping, nested mapped, modifiers, renamed
  binders) — byte-identical.
- Ready-review CI owns the broad conformance/emit/fourslash floor.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01XeV5D6SULzWS8hTC5vm9wC)_