### PR TITLE
fix(emit): order down-leveled async-generator iteration helpers by tsc request order

### DIFF
--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -9,6 +9,36 @@ use crate::transforms::emit_utils;
 use tsz_common::ScriptTarget;
 use tsz_parser::parser::node::NodeAccess;
 
+/// The first async-iteration runtime helper a down-leveled async generator body
+/// requests, in `tsc`'s request order. Only the relative order of `__await`
+/// (`Await`) and `__asyncValues` (`AsyncValues`) varies; it decides whether the
+/// emitted helper preamble leads with `var __await` or `var __asyncValues`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AsyncGenHelperTrigger {
+    Await,
+    AsyncValues,
+}
+
+/// Async-iteration runtime helpers a down-leveled `async function*` body needs,
+/// collected in a single evaluation-order walk. `delegates` marks a delegating
+/// `yield*` (needs `__asyncValues` + `__asyncDelegator`); `for_await_of` marks a
+/// `for await…of` (needs `__asyncValues`); `first_trigger` is the first
+/// requested helper in `tsc` request order, deciding `__await`-vs-`__asyncValues`
+/// lead.
+#[derive(Default)]
+struct AsyncIterationHelperNeeds {
+    delegates: bool,
+    for_await_of: bool,
+    first_trigger: Option<AsyncGenHelperTrigger>,
+}
+
+impl AsyncIterationHelperNeeds {
+    /// Record the first-requested helper; later triggers do not displace it.
+    fn set_first(&mut self, trigger: AsyncGenHelperTrigger) {
+        self.first_trigger.get_or_insert(trigger);
+    }
+}
+
 impl<'a> LoweringPass<'a> {
     // =========================================================================
     // Helper Methods
@@ -465,28 +495,50 @@ impl<'a> LoweringPass<'a> {
     /// function*`) needs, given its `body`.
     ///
     /// A plain async generator needs `__await` + `__asyncGenerator` (plus
-    /// `__generator` at ES5). When the body additionally contains a *delegating*
-    /// `yield* x`, `tsc` lowers it to
-    /// `yield __await(yield* __asyncDelegator(__asyncValues(x)))` (ES2015+) or the
-    /// `__generator` state-machine equivalent (ES5), so it also needs
-    /// `__asyncValues` and `__asyncDelegator`. All helpers are marked here, at
-    /// the function site, in the canonical tslib emit order (`__asyncValues`,
-    /// `__await`, `__asyncDelegator`, `__asyncGenerator`) so the request-order
-    /// helper table matches `tsc` — a scan is required (rather than marking the
-    /// delegate helpers when the `yield*` node is later visited) precisely so the
-    /// order is fixed before `__await`/`__asyncGenerator` are requested.
+    /// `__generator` at ES5). A *delegating* `yield* x` additionally needs
+    /// `__asyncValues` + `__asyncDelegator` (`tsc` lowers it to
+    /// `yield __await(yield* __asyncDelegator(__asyncValues(x)))`, or the
+    /// `__generator` state-machine equivalent at ES5), and a `for await…of`
+    /// additionally needs `__asyncValues`.
     ///
-    /// The delegate decision keys on the structural presence of a delegating
-    /// `yield*` in this generator's own body, never on identifier spelling or
-    /// rendered text.
+    /// The four async-iteration helpers have no `priority` in `tsc`, so
+    /// `compareEmitHelpers` keeps them in *request order* — the order in which
+    /// the transform first lowers a construct that needs each one. The only
+    /// variable is whether `__await` or `__asyncValues` is requested first:
+    /// `__asyncValues` leads only when the first helper-triggering construct (in
+    /// evaluation order) is one that requests it — a delegating `yield*` or a
+    /// `for await…of` — rather than a plain `yield`/`await` (including an `await`
+    /// nested inside a `yield*`/`for await` operand, which evaluates first).
+    /// `__asyncDelegator` (when delegating) then `__asyncGenerator` always
+    /// follow. Marking every needed helper here at the function site — before the
+    /// body is visited — fixes that order so the request-order helper table
+    /// matches `tsc` regardless of where the later lowering marks the same
+    /// helpers (marks dedupe, and the first mark fixes the slot).
+    ///
+    /// Every decision keys on the structural shape of this generator's own body,
+    /// never on identifier spelling or rendered text.
     pub(super) fn mark_async_generator_helpers_for_body(&mut self, body: NodeIndex) {
-        let delegates = self.async_generator_body_delegates(body);
+        let mut needs = AsyncIterationHelperNeeds::default();
+        self.scan_async_iteration_helper_needs(body, true, &mut needs);
+        let async_values = needs.delegates || needs.for_await_of;
+        // `__asyncValues` leads only when it is the first trigger reached in
+        // evaluation order; otherwise `__await` (the default first trigger) leads.
+        let async_values_first = async_values
+            && matches!(
+                needs.first_trigger,
+                Some(AsyncGenHelperTrigger::AsyncValues)
+            );
         let helpers = self.transforms.helpers_mut();
-        if delegates {
+        if async_values_first {
             helpers.mark_async_values();
+            helpers.mark_await_helper();
+        } else {
+            helpers.mark_await_helper();
+            if async_values {
+                helpers.mark_async_values();
+            }
         }
-        helpers.mark_await_helper();
-        if delegates {
+        if needs.delegates {
             helpers.mark_async_delegator();
         }
         helpers.mark_async_generator();
@@ -495,32 +547,73 @@ impl<'a> LoweringPass<'a> {
         }
     }
 
-    /// Whether an async generator `body` contains a delegating `yield* x` (with a
-    /// delegate expression) that belongs to *this* generator — i.e. not nested
-    /// inside another function-like body. `yield` is only syntactically valid
-    /// inside a generator, so any `yield*` reached before a function-like
-    /// boundary delegates from this async generator.
-    fn async_generator_body_delegates(&self, body: NodeIndex) -> bool {
-        let mut stack = vec![body];
-        while let Some(idx) = stack.pop() {
-            let Some(node) = self.arena.get(idx) else {
-                continue;
-            };
-            // A `yield*` inside a nested function-like belongs to that inner
-            // generator, so stop descending at function-like boundaries.
-            if idx != body && node.is_function_like() {
-                continue;
-            }
-            if node.kind == syntax_kind_ext::YIELD_EXPRESSION
-                && let Some(unary) = self.arena.get_unary_expr_ex(node)
-                && unary.asterisk_token
-                && self.arena.get(unary.expression).is_some()
-            {
-                return true;
-            }
-            stack.extend(self.arena.get_children(idx));
+    /// Single evaluation-order walk of `node` that records, for *this*
+    /// generator's body, whether it contains a delegating `yield*`
+    /// (`delegates`), a `for await…of` (`for_await_of`), and which async-
+    /// iteration helper is requested first (`first_trigger`). Operands are
+    /// scanned before the node that owns them, so an `await` nested inside a
+    /// `yield*`/`for await` operand (which evaluates first) is the first trigger.
+    /// Nested function-like boundaries are not descended into, since their
+    /// `yield`/`await`/`for await` belong to a different generator/async scope.
+    ///
+    /// `is_root` suppresses the function-like boundary check for the top-level
+    /// body node (an arrow/function body is itself function-like but must be
+    /// scanned).
+    fn scan_async_iteration_helper_needs(
+        &self,
+        node_idx: NodeIndex,
+        is_root: bool,
+        needs: &mut AsyncIterationHelperNeeds,
+    ) {
+        let Some(node) = self.arena.get(node_idx) else {
+            return;
+        };
+        if !is_root && node.is_function_like() {
+            return;
         }
-        false
+        if node.kind == syntax_kind_ext::AWAIT_EXPRESSION {
+            if let Some(unary) = self.arena.get_unary_expr_ex(node) {
+                self.scan_async_iteration_helper_needs(unary.expression, false, needs);
+            }
+            needs.set_first(AsyncGenHelperTrigger::Await);
+            return;
+        }
+        if node.kind == syntax_kind_ext::YIELD_EXPRESSION {
+            let unary = self.arena.get_unary_expr_ex(node);
+            if let Some(unary) = unary {
+                self.scan_async_iteration_helper_needs(unary.expression, false, needs);
+            }
+            // A delegating `yield* x` requests `__asyncValues`/`__asyncDelegator`;
+            // any other `yield` requests `__await`. Its operand is scanned above,
+            // so a nested trigger there still wins the first-trigger slot.
+            let delegates = unary.is_some_and(|unary| {
+                unary.asterisk_token && self.arena.get(unary.expression).is_some()
+            });
+            if delegates {
+                needs.delegates = true;
+                needs.set_first(AsyncGenHelperTrigger::AsyncValues);
+            } else {
+                needs.set_first(AsyncGenHelperTrigger::Await);
+            }
+            return;
+        }
+        if node.kind == syntax_kind_ext::FOR_OF_STATEMENT
+            && let Some(for_of) = self.arena.get_for_in_of(node)
+            && for_of.await_modifier
+        {
+            // The iterable is evaluated before the `__asyncValues(iterable)` call,
+            // so a trigger inside it wins; otherwise `for await` requests
+            // `__asyncValues`, then its body runs.
+            self.scan_async_iteration_helper_needs(for_of.expression, false, needs);
+            needs.for_await_of = true;
+            needs.set_first(AsyncGenHelperTrigger::AsyncValues);
+            self.scan_async_iteration_helper_needs(for_of.initializer, false, needs);
+            self.scan_async_iteration_helper_needs(for_of.statement, false, needs);
+            return;
+        }
+        for child_idx in self.arena.get_children(node_idx) {
+            self.scan_async_iteration_helper_needs(child_idx, false, needs);
+        }
     }
 
     pub(super) fn has_class_member_modifier(

--- a/crates/tsz-emitter/tests/async_generator_yield_star_delegate_helpers_tests.rs
+++ b/crates/tsz-emitter/tests/async_generator_yield_star_delegate_helpers_tests.rs
@@ -144,6 +144,156 @@ fn plain_async_generator_does_not_register_delegate_helpers() {
     );
 }
 
+/// Assert the four async-iteration helper definitions emit in the order used
+/// when a plain `yield`/`await` is reached before the delegating `yield*`:
+/// `__await`, `__asyncValues`, `__asyncDelegator`, `__asyncGenerator`.
+fn assert_delegate_helpers_await_first(output: &str) {
+    for def in [
+        ASYNC_VALUES_DEF,
+        ASYNC_DELEGATOR_DEF,
+        AWAIT_DEF,
+        ASYNC_GENERATOR_DEF,
+    ] {
+        assert!(
+            output.contains(def),
+            "missing helper definition `{def}`.\nOutput:\n{output}"
+        );
+    }
+    let i_await = output.find(AWAIT_DEF).unwrap();
+    let i_values = output.find(ASYNC_VALUES_DEF).unwrap();
+    let i_delegator = output.find(ASYNC_DELEGATOR_DEF).unwrap();
+    let i_async_gen = output.find(ASYNC_GENERATOR_DEF).unwrap();
+    assert!(
+        i_await < i_values && i_values < i_delegator && i_delegator < i_async_gen,
+        "when a plain yield/await precedes the delegating yield*, async-iteration \
+         helpers must emit in tsc order (__await, __asyncValues, __asyncDelegator, \
+         __asyncGenerator).\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn plain_yield_before_delegating_yield_star_puts_await_first_es2015() {
+    // `yield 1` is lowered to `yield yield __await(1)`, which requests `__await`
+    // before the later `yield* g` requests `__asyncValues`, so `tsc` emits
+    // `__await` first. (Mirror of the `yield*`-first case, which is __asyncValues
+    // first.) The decision is source-order structural, not identifier-based.
+    let output = emit(
+        "export async function* f(g: AsyncIterable<number>) { yield 1; yield* g; }",
+        ScriptTarget::ES2015,
+    );
+    assert_delegate_helpers_await_first(&output);
+}
+
+#[test]
+fn plain_yield_before_delegating_yield_star_puts_await_first_es2017() {
+    let output = emit(
+        "export async function* f(g: AsyncIterable<number>) { yield 1; yield* g; }",
+        ScriptTarget::ES2017,
+    );
+    assert_delegate_helpers_await_first(&output);
+}
+
+#[test]
+fn plain_yield_before_delegating_yield_star_puts_await_first_es5() {
+    let output = emit(
+        "export async function* f(g: AsyncIterable<number>) { yield 1; yield* g; }",
+        ScriptTarget::ES5,
+    );
+    assert_delegate_helpers_await_first(&output);
+}
+
+#[test]
+fn await_nested_in_delegate_operand_puts_await_first() {
+    // `yield* wrap(await x)`: the `await` inside the delegate operand evaluates
+    // before the delegation, so `tsc` requests `__await` before `__asyncValues`
+    // even though the `yield*` token appears first in source.
+    let output = emit(
+        "declare function wrap(x: number): AsyncIterable<number>;\n\
+         export async function* f() { yield* wrap(await Promise.resolve(1)); }",
+        ScriptTarget::ES2015,
+    );
+    assert_delegate_helpers_await_first(&output);
+}
+
+#[test]
+fn bare_delegating_yield_star_puts_async_values_first() {
+    // No plain yield/await before the delegating `yield*`: `__asyncValues` leads.
+    let output = emit(
+        "export async function* f(g: AsyncIterable<number>) { yield* g; }",
+        ScriptTarget::ES2015,
+    );
+    assert_delegate_helpers_in_order(&output);
+}
+
+/// Assert `__asyncValues` is registered (needed for a `for await…of`) and, when
+/// present, ordered before `__asyncGenerator` — `tsc` emits its no-priority
+/// async-iteration helpers ahead of the generator wrapper in request order.
+fn assert_async_values_before_generator(output: &str) {
+    for def in [ASYNC_VALUES_DEF, AWAIT_DEF, ASYNC_GENERATOR_DEF] {
+        assert!(
+            output.contains(def),
+            "missing helper definition `{def}`.\nOutput:\n{output}"
+        );
+    }
+    let i_values = output.find(ASYNC_VALUES_DEF).unwrap();
+    let i_async_gen = output.find(ASYNC_GENERATOR_DEF).unwrap();
+    assert!(
+        i_values < i_async_gen,
+        "`for await…of` in an async generator must register __asyncValues before \
+         __asyncGenerator, not after it.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn for_await_of_in_async_generator_puts_async_values_first_es2017() {
+    // `for await` requests `__asyncValues` at loop setup, before the inner
+    // `yield` requests `__await`, so `tsc` leads with `__asyncValues`. (No
+    // `yield*`, so no `__asyncDelegator`.)
+    let output = emit(
+        "export async function* f(s: AsyncIterable<number>) { for await (const x of s) { yield x; } }",
+        ScriptTarget::ES2017,
+    );
+    assert_async_values_before_generator(&output);
+    let i_values = output.find(ASYNC_VALUES_DEF).unwrap();
+    let i_await = output.find(AWAIT_DEF).unwrap();
+    assert!(
+        i_values < i_await,
+        "for-await-of before any plain yield/await must lead with __asyncValues.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains(ASYNC_DELEGATOR_DEF),
+        "for-await-of without a delegating yield* must not emit __asyncDelegator.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn plain_yield_before_for_await_of_puts_await_first_es2017() {
+    // A plain `yield` precedes the `for await`, so `__await` leads, but
+    // `__asyncValues` must still precede `__asyncGenerator`.
+    let output = emit(
+        "export async function* f(s: AsyncIterable<number>) { yield 0; for await (const x of s) { yield x; } }",
+        ScriptTarget::ES2017,
+    );
+    assert_async_values_before_generator(&output);
+    let i_await = output.find(AWAIT_DEF).unwrap();
+    let i_values = output.find(ASYNC_VALUES_DEF).unwrap();
+    assert!(
+        i_await < i_values,
+        "a plain yield before the for-await-of must lead with __await.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn for_await_of_before_delegating_yield_star_orders_all_four_helpers_es2017() {
+    // `for await` (asyncValues) reached first, then a delegating `yield*`
+    // (asyncDelegator): __asyncValues, __await, __asyncDelegator, __asyncGenerator.
+    let output = emit(
+        "export async function* f(s: AsyncIterable<number>) { for await (const x of s) { yield x; } yield* s; }",
+        ScriptTarget::ES2017,
+    );
+    assert_delegate_helpers_in_order(&output);
+}
+
 #[test]
 fn nested_sync_generators_yield_star_does_not_pull_async_delegate_helpers() {
     // The delegating `yield*` belongs to the inner *sync* generator, which uses


### PR DESCRIPTION
When a down-leveled `async function*` (target < ES2018) needs the async-iteration
runtime helpers, tsz emitted their `var __helper = …` definitions in the wrong
order versus `tsc`, so the output was not byte-identical even though the lowered
function bodies matched. Found by differentially compiling `type-fest`'s source
against `tsc` 6.0.2.

The four helpers (`__await`, `__asyncValues`, `__asyncDelegator`,
`__asyncGenerator`) have no `priority` in `tsc`, so `compareEmitHelpers` keeps
them in **request order** — the order the ES2018 transform first lowers a
construct that needs each. tsz hard-coded a fixed order and marked `__asyncValues`
for a `for await…of` only later during body lowering, giving two divergences:

- `yield 1; yield* g;` — a plain `yield`/`await` reached before the first
  delegating `yield*`: `tsc` leads with `__await`; tsz emitted `__asyncValues`
  first.
- `for await (const x of s) { yield x; }` — the `for await…of` needs
  `__asyncValues`, but tsz emitted its definition **after** `__asyncGenerator`
  (or omitted it from the function-site ordering) instead of ahead of it.

## Goal
Goal: hold

<!-- Structural rule -->
When a construct in a down-leveled `async function*` body is lowered, `tsc`
requests `__await` for any `yield`/`await`, `__asyncValues` + `__asyncDelegator`
for a delegating `yield*`, and `__asyncValues` for a `for await…of`; the
no-priority helpers then emit in that request order, with `__asyncDelegator`
(when delegating) then `__asyncGenerator` last. `__asyncValues` leads `__await`
only when the first helper-triggering construct **in evaluation order** is one
that requests it (a delegating `yield*` or a `for await…of`, including via an
`await` nested in the operand, which evaluates first).

Owner layer: emitter lowering (`crates/tsz-emitter/src/lowering/helpers.rs`). A
single evaluation-order scan of the generator's own body (stopping at nested
function-like boundaries) records whether it delegates, whether it has a
`for await…of`, and the first-requested helper, then marks every needed helper at
the function site — before the body is visited — so the first mark fixes each
helper's slot regardless of where later lowering re-marks it (marks dedupe). The
decision keys on structural AST shape, never on identifier spelling or rendered
text. This replaces the previous fixed-order marking plus a separate delegate
scan with one pass.

Adjacent matrix (all verified byte-identical to `tsc` 6.0.2 helper order at ES5 /
ES2015 / ES2017; ES2018 emits none):
- `yield*`-first vs `yield`/`await`-first → `__asyncValues`-first vs `__await`-first
- `await` nested inside a `yield*` / `for await` operand → `__await`-first
- `for await…of` with no `yield*` (needs `__asyncValues`, not `__asyncDelegator`)
- plain `yield` before a `for await…of`; `for await…of` before a delegating `yield*`
- renamed binders (class/method/param) — decision stays structural

Out of scope (pre-existing, unchanged): the ES5 generator-body single-line vs
multi-line formatting difference (reproduces for plain sync generators too).

## Verification
- `cargo test -p tsz-emitter --test async_generator_yield_star_delegate_helpers_tests` → 15 passed (10 new/expanded, incl. `for await…of` and `yield`-first cases)
- `cargo test -p tsz-emitter --lib` → 3941 passed, 0 failed
- `cargo test -p tsz-emitter` → all pass except the pre-existing, unrelated `generator_object_literal_prefix_before_yield_omits_source_trailing_comma` (fails identically on clean `main`)
- CLI output diffed against `tsc` 6.0.2 across a 15-case × 3-target matrix (ES5/ES2015/ES2017) → helper declaration order identical in all 45; ES2015/ES2017 full output byte-identical
- `cargo fmt -p tsz-emitter -- --check`, `cargo clippy --profile ci-lint -p tsz-emitter --lib -- -D warnings`, `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01SHCF8YmXuq7RhT3QV7syJg

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHCF8YmXuq7RhT3QV7syJg)_