### PR TITLE
measure(solver): add deferred HKT split gauge (#14351)

### DIFF
--- a/crates/tsz-common/src/perf_counters.rs
+++ b/crates/tsz-common/src/perf_counters.rs
@@ -33,6 +33,9 @@ include!("perf_counters/residency.rs");
 include!("perf_counters/tests.rs");
 
 #[cfg(test)]
+include!("perf_counters/write_json_tests.rs");
+
+#[cfg(test)]
 include!("perf_counters/dump_tests.rs");
 
 #[cfg(test)]

--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -117,7 +117,13 @@ impl PerfCounters {
              ... cross-base (HKT)       {:>12}\n\
              Lazy-ref relation (#14351):\n  \
              heritage-reachable pairs   {:>12}\n  \
-             accessor resolved base     {:>12}\n",
+             accessor resolved base     {:>12}\n\
+             Deferred HKT split (#14345/#14351):\n  \
+             inference fallback types   {:>12}\n  \
+             inference placeholders     {:>12}\n  \
+             ... with indexed access    {:>12}\n  \
+             relation index pairs       {:>12}\n  \
+             relation index accepted    {:>12}\n",
             snap.delegate.calls,
             snap.delegate.cache_hits_lib,
             snap.delegate.cache_hits_cross_file,
@@ -210,6 +216,14 @@ impl PerfCounters {
             snap.identity.relation_app_pair_variance_fallthrough_cross_base,
             snap.identity.relation_lazy_ref_heritage_reachable,
             snap.identity.relation_lazy_ref_accessor_resolved,
+            snap.identity
+                .inference_source_placeholder_unknown_fallback_types,
+            snap.identity
+                .inference_source_placeholder_unknown_fallback_placeholders,
+            snap.identity
+                .inference_source_placeholder_unknown_fallback_index_access_types,
+            snap.identity.relation_deferred_index_access_pair_total,
+            snap.identity.relation_deferred_index_access_pair_accepted,
         ) + &Self::dump_compute_type_of_symbol_outcomes()
             + &Self::dump_shared_instantiation_cache(&snap)
             + &Self::dump_relation_limit_cache(&snap)

--- a/crates/tsz-common/src/perf_counters/recorders/solver.rs
+++ b/crates/tsz-common/src/perf_counters/recorders/solver.rs
@@ -81,6 +81,46 @@ pub fn record_relation_lazy_ref_probe(reachable: bool, resolved: bool) {
     }
 }
 
+/// #14345/#14351 inference split gauge (measure-only). Record that one
+/// normalized inferred type erased one or more higher-order source placeholders
+/// to `unknown`, partitioned by whether the pre-erasure type still contained a
+/// deferred indexed access. This never feeds back into inference.
+#[inline]
+pub fn record_inference_source_placeholder_unknown_fallback(
+    placeholder_count: u64,
+    contains_index_access: bool,
+) {
+    if !enabled_fast() {
+        return;
+    }
+    let c = counters();
+    c.inference_source_placeholder_unknown_fallback_types
+        .fetch_add(1, Ordering::Relaxed);
+    c.inference_source_placeholder_unknown_fallback_placeholders
+        .fetch_add(placeholder_count, Ordering::Relaxed);
+    if contains_index_access {
+        c.inference_source_placeholder_unknown_fallback_index_access_types
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// #14345/#14351 relation split gauge (measure-only). Record a raw deferred
+/// indexed-access pair that reached the relation visitor, partitioned by
+/// whether the existing raw/declaration-stripped relation path accepted it.
+#[inline]
+pub fn record_relation_deferred_index_access_pair(accepted: bool) {
+    if !enabled_fast() {
+        return;
+    }
+    let c = counters();
+    c.relation_deferred_index_access_pair_total
+        .fetch_add(1, Ordering::Relaxed);
+    if accepted {
+        c.relation_deferred_index_access_pair_accepted
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
 /// Record a budget-conditional `LimitTrue` relation cache hit (a limit-hit
 /// relation verdict was reused instead of re-burning the relation chain).
 #[inline]

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -107,6 +107,24 @@ pub struct PerfCounters {
     pub relation_lazy_ref_accessor_resolved: AtomicU64,
     /// #14351 denominator: cross-base pairs that are nominal-heritage reachable.
     pub relation_lazy_ref_heritage_reachable: AtomicU64,
+    /// #14345/#14351 inference split gauge: normalized inferred types whose
+    /// higher-order source placeholders survived substitution and were erased to
+    /// `unknown`. This is the "poisoned at inference fallback" seat.
+    pub inference_source_placeholder_unknown_fallback_types: AtomicU64,
+    /// Source placeholders erased across those fallback types. This gives the
+    /// fallback population size, not just the number of normalized result types.
+    pub inference_source_placeholder_unknown_fallback_placeholders: AtomicU64,
+    /// Of [`Self::inference_source_placeholder_unknown_fallback_types`], how many
+    /// still contained a deferred indexed access when the source placeholders
+    /// were erased. This is the fp-ts/HKT-specific inference poison signal.
+    pub inference_source_placeholder_unknown_fallback_index_access_types: AtomicU64,
+    /// #14345/#14351 relation split gauge: raw `IndexAccess`<->`IndexAccess`
+    /// subtype pairs that reached the relation visitor before eager evaluation.
+    /// This is the "both-deferred pairs reached relation" seat.
+    pub relation_deferred_index_access_pair_total: AtomicU64,
+    /// Of [`Self::relation_deferred_index_access_pair_total`], pairs accepted by
+    /// the existing raw/declaration-stripped deferred relation path.
+    pub relation_deferred_index_access_pair_accepted: AtomicU64,
     /// Why each `cached_cross_file_*` reader returned `None`. See
     /// [`CrossFileCacheMissCause`] for the bucket semantics. Sum of
     /// all buckets equals the flat miss count for the four reader
@@ -460,6 +478,11 @@ impl PerfCounters {
             relation_app_pair_variance_fallthrough_cross_base: AtomicU64::new(0),
             relation_lazy_ref_accessor_resolved: AtomicU64::new(0),
             relation_lazy_ref_heritage_reachable: AtomicU64::new(0),
+            inference_source_placeholder_unknown_fallback_types: AtomicU64::new(0),
+            inference_source_placeholder_unknown_fallback_placeholders: AtomicU64::new(0),
+            inference_source_placeholder_unknown_fallback_index_access_types: AtomicU64::new(0),
+            relation_deferred_index_access_pair_total: AtomicU64::new(0),
+            relation_deferred_index_access_pair_accepted: AtomicU64::new(0),
             cross_file_cache_miss_cause: [const { AtomicU64::new(0) };
                 CROSS_FILE_CACHE_MISS_CAUSE_COUNT],
             source_file_symbol_arena_cache_eligibility_outcome: [const { AtomicU64::new(0) };

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -1,6 +1,6 @@
 /// Stable schema version for `PerfCounterSnapshot`. Bump when the JSON
 /// shape changes in a way the bench harness must adapt to.
-pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 11;
+pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 12;
 
 /// Frozen value-object view of the counter state. Built by
 /// [`PerfCounters::snapshot`]; serializable to JSON via serde.
@@ -387,6 +387,17 @@ pub struct IdentityCounters {
     pub relation_lazy_ref_accessor_resolved: u64,
     /// #14351 denominator: heritage-reachable cross-base pairs (lever candidates).
     pub relation_lazy_ref_heritage_reachable: u64,
+    /// #14345/#14351 inference split gauge: inferred result types whose
+    /// higher-order source placeholders were erased to `unknown`.
+    pub inference_source_placeholder_unknown_fallback_types: u64,
+    /// Source placeholders erased across those fallback types.
+    pub inference_source_placeholder_unknown_fallback_placeholders: u64,
+    /// Fallback types that still contained a deferred indexed access at erasure.
+    pub inference_source_placeholder_unknown_fallback_index_access_types: u64,
+    /// #14345/#14351 relation split gauge: raw deferred indexed-access pairs.
+    pub relation_deferred_index_access_pair_total: u64,
+    /// Deferred indexed-access pairs accepted by the existing raw relation path.
+    pub relation_deferred_index_access_pair_accepted: u64,
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
@@ -761,6 +772,21 @@ impl PerfCounters {
                 ),
                 relation_lazy_ref_heritage_reachable: load(
                     &c.relation_lazy_ref_heritage_reachable,
+                ),
+                inference_source_placeholder_unknown_fallback_types: load(
+                    &c.inference_source_placeholder_unknown_fallback_types,
+                ),
+                inference_source_placeholder_unknown_fallback_placeholders: load(
+                    &c.inference_source_placeholder_unknown_fallback_placeholders,
+                ),
+                inference_source_placeholder_unknown_fallback_index_access_types: load(
+                    &c.inference_source_placeholder_unknown_fallback_index_access_types,
+                ),
+                relation_deferred_index_access_pair_total: load(
+                    &c.relation_deferred_index_access_pair_total,
+                ),
+                relation_deferred_index_access_pair_accepted: load(
+                    &c.relation_deferred_index_access_pair_accepted,
                 ),
             },
             lib_bootstrap: LibBootstrapCounters {

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -2,10 +2,10 @@ mod json_tests {
     use super::*;
 
     #[test]
-    fn schema_version_is_ten() {
+    fn schema_version_matches_current_snapshot_shape() {
         // Bumping schema_version is a breaking change for the bench harness;
-        // make the intent explicit. v10 added #13240 shared-cache counters.
-        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 10);
+        // make the intent explicit.
+        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 12);
     }
 
     #[test]
@@ -62,7 +62,7 @@ mod json_tests {
         ] {
             assert!(json.get(key).is_some(), "missing top-level key: {key}");
         }
-        assert_eq!(json["schema_version"], 10);
+        assert_eq!(json["schema_version"], 12);
     }
 
     #[test]
@@ -483,6 +483,11 @@ mod json_tests {
                 "relation_app_pair_variance_fallthrough_cross_base",
                 "relation_lazy_ref_accessor_resolved",
                 "relation_lazy_ref_heritage_reachable",
+                "inference_source_placeholder_unknown_fallback_types",
+                "inference_source_placeholder_unknown_fallback_placeholders",
+                "inference_source_placeholder_unknown_fallback_index_access_types",
+                "relation_deferred_index_access_pair_total",
+                "relation_deferred_index_access_pair_accepted",
             ],
         );
         assert_eq!(json["wired"]["stable_identity"], true);

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -2047,25 +2047,4 @@ mod json_tests {
             "checker.property_classification_string_fallback_target_types did not reflect the bump",
         );
     }
-
-    #[test]
-    fn write_json_to_writes_valid_json_with_atomic_rename() {
-        let dir = std::env::temp_dir();
-        let path = dir.join(format!("tsz-perf-counter-snap-{}.json", std::process::id()));
-        // Clean up beforehand if a stale file is sitting around.
-        let _ = std::fs::remove_file(&path);
-        PerfCounters::write_json_to(&path).expect("write succeeds");
-        let raw = std::fs::read_to_string(&path).expect("read back");
-        // Round-trip through serde to confirm structure.
-        let value: serde_json::Value = serde_json::from_str(&raw).expect("valid JSON");
-        assert_eq!(
-            value["schema_version"],
-            PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION
-        );
-        assert!(value["wired"].is_object());
-        // The atomic-rename `.json.tmp` should not be left behind.
-        let tmp = path.with_extension("json.tmp");
-        assert!(!tmp.exists(), "tmp file leaked: {tmp:?}");
-        let _ = std::fs::remove_file(&path);
-    }
 }

--- a/crates/tsz-common/src/perf_counters/write_json_tests.rs
+++ b/crates/tsz-common/src/perf_counters/write_json_tests.rs
@@ -1,0 +1,24 @@
+mod write_json_tests {
+    use super::*;
+
+    #[test]
+    fn write_json_to_writes_valid_json_with_atomic_rename() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("tsz-perf-counter-snap-{}.json", std::process::id()));
+        // Clean up beforehand if a stale file is sitting around.
+        let _ = std::fs::remove_file(&path);
+        PerfCounters::write_json_to(&path).expect("write succeeds");
+        let raw = std::fs::read_to_string(&path).expect("read back");
+        // Round-trip through serde to confirm structure.
+        let value: serde_json::Value = serde_json::from_str(&raw).expect("valid JSON");
+        assert_eq!(
+            value["schema_version"],
+            PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION
+        );
+        assert!(value["wired"].is_object());
+        // The atomic-rename `.json.tmp` should not be left behind.
+        let tmp = path.with_extension("json.tmp");
+        assert!(!tmp.exists(), "tmp file leaked: {tmp:?}");
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/tsz-solver/src/operations/generic_call/normalization.rs
+++ b/crates/tsz-solver/src/operations/generic_call/normalization.rs
@@ -482,7 +482,10 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             };
 
         let mut source_placeholder_subst = TypeSubstitution::new();
+        let mut contains_index_access = false;
         for ty in crate::visitor::collect_all_types(self.interner.as_type_database(), current) {
+            contains_index_access |=
+                matches!(self.interner.lookup(ty), Some(TypeData::IndexAccess(_, _)));
             if let Some(TypeData::TypeParameter(info)) = self.interner.lookup(ty)
                 && info.is_infer_source()
                 && !preserved_source_placeholders.contains(&info.name)
@@ -491,6 +494,10 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             }
         }
         if !source_placeholder_subst.is_empty() {
+            tsz_common::perf_counters::record_inference_source_placeholder_unknown_fallback(
+                source_placeholder_subst.len() as u64,
+                contains_index_access,
+            );
             current = instantiate_type(self.interner, current, &source_placeholder_subst);
         }
 

--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -989,6 +989,7 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 .check_decl_stripped_lazy_application_index_access_pair(self.source, self.target)
                 && result.is_true()
             {
+                tsz_common::perf_counters::record_relation_deferred_index_access_pair(true);
                 return result;
             }
 
@@ -996,8 +997,11 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
             if self.checker.check_subtype(object_type, t_obj).is_true()
                 && self.checker.check_subtype(key_type, t_idx).is_true()
             {
+                tsz_common::perf_counters::record_relation_deferred_index_access_pair(true);
                 return SubtypeResult::True;
             }
+
+            tsz_common::perf_counters::record_relation_deferred_index_access_pair(false);
 
             // CRITICAL FIX: Check if both keys are type parameters with different names.
             // Even if they have the same constraint, different type parameters should not

--- a/scripts/bench/deferred-hkt-split-gauge.mjs
+++ b/scripts/bench/deferred-hkt-split-gauge.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+const DEFAULT_ROWS = ["fp-ts-project", "io-ts-project", "neverthrow-project"];
+
+function usage() {
+  console.error(`usage: node scripts/bench/deferred-hkt-split-gauge.mjs [options]
+
+Options:
+  --rows <a,b,c>          Project rows to measure (default: ${DEFAULT_ROWS.join(",")})
+  --fixture-root <path>   project-compile fixture root (default: .target/project-compile-guard)
+  --summary-json <path>   Output summary JSON path
+  --from-existing         Read existing JSONL/perf artifacts instead of running the guard
+  --timeout <seconds>     Row timeout passed to project-compile-guard.sh
+`);
+}
+
+function parseArgs(argv) {
+  const out = {
+    rows: DEFAULT_ROWS,
+    fixtureRoot: path.join(ROOT, ".target", "project-compile-guard"),
+    summaryJson: null,
+    fromExisting: false,
+    timeout: null,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--rows") {
+      out.rows = argv[++i]?.split(",").map((row) => row.trim()).filter(Boolean) ?? [];
+    } else if (arg === "--fixture-root") {
+      out.fixtureRoot = path.resolve(argv[++i] ?? "");
+    } else if (arg === "--summary-json") {
+      out.summaryJson = path.resolve(argv[++i] ?? "");
+    } else if (arg === "--from-existing") {
+      out.fromExisting = true;
+    } else if (arg === "--timeout") {
+      out.timeout = argv[++i] ?? null;
+    } else if (arg === "-h" || arg === "--help") {
+      usage();
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  if (!out.rows.length) throw new Error("--rows must name at least one row");
+  out.summaryJson ??= path.join(out.fixtureRoot, "deferred-hkt-split-gauge-summary.json");
+  return out;
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function readJsonl(file) {
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, "utf8")
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line));
+}
+
+function getNumber(object, pathSegments) {
+  let current = object;
+  for (const segment of pathSegments) {
+    current = current?.[segment];
+  }
+  return Number.isFinite(Number(current)) ? Number(current) : 0;
+}
+
+function rowPerfPath(fixtureRoot, row) {
+  return path.join(fixtureRoot, "perf-counters", `${row}.perf.json`);
+}
+
+function diagnosticDeltaCount(row) {
+  if (row?.diagnostic_status === "none") return 0;
+  if (Array.isArray(row?.diagnostic_deltas)) return row.diagnostic_deltas.length;
+  return 0;
+}
+
+export function summarizeRow(row, perf) {
+  const identity = perf?.identity ?? {};
+  const inferenceFallbackTypes = getNumber(identity, [
+    "inference_source_placeholder_unknown_fallback_types",
+  ]);
+  const inferenceFallbackPlaceholders = getNumber(identity, [
+    "inference_source_placeholder_unknown_fallback_placeholders",
+  ]);
+  const inferenceFallbackIndexAccessTypes = getNumber(identity, [
+    "inference_source_placeholder_unknown_fallback_index_access_types",
+  ]);
+  const relationDeferredPairs = getNumber(identity, [
+    "relation_deferred_index_access_pair_total",
+  ]);
+  const relationDeferredAccepted = getNumber(identity, [
+    "relation_deferred_index_access_pair_accepted",
+  ]);
+
+  let split = "no-signal";
+  if (inferenceFallbackTypes > 0 && relationDeferredPairs > 0) {
+    split = "mixed";
+  } else if (inferenceFallbackTypes > 0) {
+    split = "inference-fallback";
+  } else if (relationDeferredPairs > 0) {
+    split = "relation-deferred";
+  }
+
+  return {
+    name: row.name,
+    state: row.state ?? null,
+    exit_class: row.exit_class ?? null,
+    diagnostic_status: row.diagnostic_status ?? null,
+    diagnostic_delta_count: diagnosticDeltaCount(row),
+    split,
+    counters: {
+      inference_source_placeholder_unknown_fallback_types: inferenceFallbackTypes,
+      inference_source_placeholder_unknown_fallback_placeholders: inferenceFallbackPlaceholders,
+      inference_source_placeholder_unknown_fallback_index_access_types: inferenceFallbackIndexAccessTypes,
+      relation_deferred_index_access_pair_total: relationDeferredPairs,
+      relation_deferred_index_access_pair_accepted: relationDeferredAccepted,
+    },
+  };
+}
+
+export function buildSummary({ rows, fixtureRoot, compatibilityJsonl }) {
+  const compatibilityRows = new Map(readJsonl(compatibilityJsonl).map((row) => [row.name, row]));
+  const measuredRows = rows.map((name) => {
+    const row = compatibilityRows.get(name) ?? { name, state: "missing-artifact" };
+    const perfPath = rowPerfPath(fixtureRoot, name);
+    const perf = fs.existsSync(perfPath) ? readJson(perfPath) : null;
+    return {
+      ...summarizeRow(row, perf),
+      perf_counters_json: fs.existsSync(perfPath) ? path.relative(ROOT, perfPath) : null,
+    };
+  });
+
+  const totals = measuredRows.reduce((acc, row) => {
+    acc.rows += 1;
+    acc[row.split] = (acc[row.split] ?? 0) + 1;
+    for (const [key, value] of Object.entries(row.counters)) {
+      acc.counters[key] = (acc.counters[key] ?? 0) + value;
+    }
+    return acc;
+  }, { rows: 0, counters: {} });
+
+  return {
+    schema_version: 1,
+    generated_at: new Date().toISOString(),
+    rows: measuredRows,
+    totals,
+  };
+}
+
+function renderMarkdown(summary) {
+  const lines = [
+    "### Deferred HKT split gauge",
+    "",
+    "| Row | State | Diagnostics | Split | Inference fallback | Indexed fallback | Relation pairs | Relation accepted |",
+    "| --- | --- | ---: | --- | ---: | ---: | ---: | ---: |",
+  ];
+  for (const row of summary.rows) {
+    lines.push([
+      `| ${row.name}`,
+      row.state ?? "-",
+      String(row.diagnostic_delta_count),
+      row.split,
+      String(row.counters.inference_source_placeholder_unknown_fallback_types),
+      String(row.counters.inference_source_placeholder_unknown_fallback_index_access_types),
+      String(row.counters.relation_deferred_index_access_pair_total),
+      `${row.counters.relation_deferred_index_access_pair_accepted} |`,
+    ].join(" | "));
+  }
+  return lines.join("\n");
+}
+
+function runGuard(options, compatibilityJsonl, compatibilitySummary) {
+  const filter = `^(${options.rows.map(escapeRegex).join("|")})$`;
+  const env = {
+    ...process.env,
+    TSZ_PROJECT_COMPILE_SET: "canary",
+    TSZ_PROJECT_COMPILE_FILTER: filter,
+    TSZ_PROJECT_COMPILE_ALLOW_FAILURES: "1",
+    TSZ_PROJECT_COMPILE_PERF_COUNTERS: "1",
+    TSZ_PROJECT_COMPILE_FIXTURE_ROOT: options.fixtureRoot,
+    TSZ_PROJECT_COMPILE_COMPATIBILITY_JSONL: compatibilityJsonl,
+    TSZ_PROJECT_COMPILE_COMPATIBILITY_SUMMARY: compatibilitySummary,
+    TSZ_DETERMINISTIC_STORE_ELECTION: process.env.TSZ_DETERMINISTIC_STORE_ELECTION ?? "1",
+    TSZ_PROJECT_COMPILE_RESULT_CACHE_DIR: path.join(
+      options.fixtureRoot,
+      `.result-cache-deferred-hkt-split-gauge-${process.pid}`,
+    ),
+  };
+  if (options.timeout) env.TSZ_PROJECT_COMPILE_TIMEOUT = options.timeout;
+
+  const result = spawnSync("scripts/ci/project-compile-guard.sh", {
+    cwd: ROOT,
+    stdio: "inherit",
+    env,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`project-compile-guard.sh exited ${result.status}`);
+  }
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  fs.mkdirSync(options.fixtureRoot, { recursive: true });
+  const compatibilityJsonl = path.join(options.fixtureRoot, "deferred-hkt-split-gauge.jsonl");
+  const compatibilitySummary = path.join(
+    options.fixtureRoot,
+    "deferred-hkt-split-gauge.project-summary.json",
+  );
+
+  if (!options.fromExisting) {
+    runGuard(options, compatibilityJsonl, compatibilitySummary);
+  }
+
+  const summary = buildSummary({
+    rows: options.rows,
+    fixtureRoot: options.fixtureRoot,
+    compatibilityJsonl,
+  });
+  fs.mkdirSync(path.dirname(options.summaryJson), { recursive: true });
+  fs.writeFileSync(options.summaryJson, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  console.log(renderMarkdown(summary));
+  console.log(`\nsummary: ${path.relative(ROOT, options.summaryJson)}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`error: ${error.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/bench/test-deferred-hkt-split-gauge.mjs
+++ b/scripts/bench/test-deferred-hkt-split-gauge.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+const SCRIPT = path.join(ROOT, "scripts", "bench", "deferred-hkt-split-gauge.mjs");
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-deferred-hkt-split-"));
+try {
+  fs.mkdirSync(path.join(dir, "perf-counters"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "deferred-hkt-split-gauge.jsonl"),
+    `${JSON.stringify({
+      name: "fp-ts-project",
+      state: "yellow",
+      exit_class: "nonzero exit",
+      diagnostic_status: "diagnostic mismatch or compiler error",
+      diagnostic_deltas: ["tsz: src/Alt.ts(1,1): error TS2322: mismatch"],
+    })}\n${JSON.stringify({
+      name: "neverthrow-project",
+      state: "green",
+      exit_class: "exit success",
+      diagnostic_status: "none",
+      diagnostic_deltas: [],
+    })}\n`,
+  );
+  fs.writeFileSync(
+    path.join(dir, "perf-counters", "fp-ts-project.perf.json"),
+    `${JSON.stringify({
+      identity: {
+        inference_source_placeholder_unknown_fallback_types: 7,
+        inference_source_placeholder_unknown_fallback_placeholders: 9,
+        inference_source_placeholder_unknown_fallback_index_access_types: 3,
+        relation_deferred_index_access_pair_total: 11,
+        relation_deferred_index_access_pair_accepted: 2,
+      },
+    })}\n`,
+  );
+  fs.writeFileSync(
+    path.join(dir, "perf-counters", "neverthrow-project.perf.json"),
+    `${JSON.stringify({
+      identity: {
+        inference_source_placeholder_unknown_fallback_types: 0,
+        inference_source_placeholder_unknown_fallback_placeholders: 0,
+        inference_source_placeholder_unknown_fallback_index_access_types: 0,
+        relation_deferred_index_access_pair_total: 4,
+        relation_deferred_index_access_pair_accepted: 4,
+      },
+    })}\n`,
+  );
+
+  const summaryPath = path.join(dir, "summary.json");
+  const result = spawnSync(process.execPath, [
+    SCRIPT,
+    "--from-existing",
+    "--fixture-root",
+    dir,
+    "--rows",
+    "fp-ts-project,neverthrow-project,io-ts-project",
+    "--summary-json",
+    summaryPath,
+  ], { cwd: ROOT, encoding: "utf8" });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Deferred HKT split gauge/);
+  const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+  assert.equal(summary.rows.length, 3);
+  assert.equal(summary.rows[0].split, "mixed");
+  assert.equal(summary.rows[0].diagnostic_delta_count, 1);
+  assert.equal(summary.rows[1].split, "relation-deferred");
+  assert.equal(summary.rows[2].split, "no-signal");
+  assert.equal(
+    summary.totals.counters.inference_source_placeholder_unknown_fallback_types,
+    7,
+  );
+  assert.equal(summary.totals.counters.relation_deferred_index_access_pair_total, 15);
+} finally {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+console.log("deferred-hkt-split-gauge: ok");

--- a/scripts/ci/project-compile-guard.sh
+++ b/scripts/ci/project-compile-guard.sh
@@ -21,6 +21,7 @@ ALLOW_FAILURES="${TSZ_PROJECT_COMPILE_ALLOW_FAILURES:-0}"
 PROJECT_COMPATIBILITY_JSONL="${TSZ_PROJECT_COMPILE_COMPATIBILITY_JSONL:-$FIXTURE_ROOT/project-compatibility.jsonl}"
 PROJECT_COMPATIBILITY_SUMMARY="${TSZ_PROJECT_COMPILE_COMPATIBILITY_SUMMARY:-$FIXTURE_ROOT/project-compatibility-summary.json}"
 RESULT_CACHE_DIR="${TSZ_PROJECT_COMPILE_RESULT_CACHE_DIR:-$FIXTURE_ROOT/.result-cache}"
+PROJECT_PERF_COUNTERS="${TSZ_PROJECT_COMPILE_PERF_COUNTERS:-0}"
 FAILURES=0
 LAST_PEAK_RSS_BYTES=0
 LAST_TIMEOUT_CPU_SECONDS=""
@@ -795,7 +796,7 @@ check_project() {
   # per-project; the stored fingerprint is validated on read so stale entries are
   # overwritten rather than accumulated. Disable with TSZ_PROJECT_COMPILE_RESULT_CACHE=0.
   local _fp="" _cache_file=""
-  if [[ "${TSZ_PROJECT_COMPILE_RESULT_CACHE:-1}" == "1" ]]; then
+  if [[ "${TSZ_PROJECT_COMPILE_RESULT_CACHE:-1}" == "1" && "$PROJECT_PERF_COUNTERS" != "1" ]]; then
     _fp="$(compute_compile_fingerprint "$name" "$tsconfig" "$src_dir" 2>/dev/null || true)"
     [[ -n "$_fp" ]] && _cache_file="$RESULT_CACHE_DIR/${name}"
   fi
@@ -850,13 +851,31 @@ check_project() {
   file_count="$(count_ts_files "$src_dir")"
 
   echo "::group::${name}"
-  echo "Running: $TSZ_RUN_BIN --noEmit -p $tsconfig"
+  if [[ "$PROJECT_PERF_COUNTERS" == "1" ]]; then
+    mkdir -p "$FIXTURE_ROOT/perf-counters"
+    echo "Running: $TSZ_RUN_BIN --extendedDiagnostics --perf-counters-json $FIXTURE_ROOT/perf-counters/${name}.perf.json --noEmit -p $tsconfig"
+  else
+    echo "Running: $TSZ_RUN_BIN --noEmit -p $tsconfig"
+  fi
   local rc=0 exit_class="" diagnostic_delta="" timeout_unmeasured=0
-  run_with_timeout "$PROJECT_TIMEOUT" \
-    env \
-      TSZ_USE_EMBEDDED_LIBS=1 \
-      RUST_MIN_STACK="${TSZ_RUST_MIN_STACK:-536870912}" \
-      "$TSZ_RUN_BIN" --noEmit -p "$tsconfig" >"$log" 2>&1 || rc=$?
+  if [[ "$PROJECT_PERF_COUNTERS" == "1" ]]; then
+    run_with_timeout "$PROJECT_TIMEOUT" \
+      env \
+        TSZ_USE_EMBEDDED_LIBS=1 \
+        RUST_MIN_STACK="${TSZ_RUST_MIN_STACK:-536870912}" \
+        TSZ_PERF_COUNTERS=1 \
+        "$TSZ_RUN_BIN" \
+        --extendedDiagnostics \
+        --perf-counters-json "$FIXTURE_ROOT/perf-counters/${name}.perf.json" \
+        --noEmit \
+        -p "$tsconfig" >"$log" 2>&1 || rc=$?
+  else
+    run_with_timeout "$PROJECT_TIMEOUT" \
+      env \
+        TSZ_USE_EMBEDDED_LIBS=1 \
+        RUST_MIN_STACK="${TSZ_RUST_MIN_STACK:-536870912}" \
+        "$TSZ_RUN_BIN" --noEmit -p "$tsconfig" >"$log" 2>&1 || rc=$?
+  fi
 
   if [[ "$rc" -ne 0 ]]; then
     exit_class="$(project_failure_class "$([[ "$rc" -eq 124 ]] && echo "timeout" || echo "nonzero exit")" "$rc")"


### PR DESCRIPTION
Goal: grow

## Summary
- Add measure-only perf counters for the #14345/#14351 deferred HKT split: source-placeholder fallback to `unknown` in generic-call inference, and raw deferred `IndexAccess` pairs reaching the relation visitor.
- Add `TSZ_PROJECT_COMPILE_PERF_COUNTERS=1` to `project-compile-guard.sh` so targeted project rows can emit per-row perf-counter JSON without changing default CI behavior.
- Add `scripts/bench/deferred-hkt-split-gauge.mjs` plus a Node smoke test to run/summarize the fp-ts, io-ts, and neverthrow witness rows under `TSZ_DETERMINISTIC_STORE_ELECTION=1`.

## Structural Rule
When residual HKT diagnostics involve deferred indexed-access forms, the next bulk lever must be chosen from structural evidence: either higher-order source placeholders are erased to `unknown` during generic-call inference, or both-deferred indexed-access pairs survive to the relation layer. `tsz` now measures those two seats through solver perf counters and project-row gauge tooling without changing type verdicts.

## Owner Layer
- `tsz-solver` owns the inference and relation observation sites.
- `tsz-common::perf_counters` owns the stable JSON/text counter schema.
- `scripts/ci/project-compile-guard.sh` owns per-row project execution and optional perf JSON emission.
- `scripts/bench/deferred-hkt-split-gauge.mjs` owns the Grow measurement summary.

## Adjacent Matrix
- Inference fallback: counts affected normalized result types, erased source placeholders, and the subset whose pre-erasure form still contained deferred indexed access.
- Relation survival: counts raw `IndexAccess` <-> `IndexAccess` pairs that reach the relation visitor and the subset accepted by existing raw/declaration-stripped relation paths.
- Project gauge: defaults to fp-ts, io-ts, and neverthrow canary rows, forces deterministic store election, disables result-cache replay while perf counters are requested, and keeps failures allowed because this is a classifier.
- Current exact-head local gauge result: all three witness rows are green with zero actionable residual diagnostics and zero split-signal counters on this branch.

## Overlap
- Avoids active session PRs #15315 and #15318 (`EvaluationSession`, checker lazy/type-reference state) and merged emit PR #15313 and open emit PR #15316.
- Does not change relation verdicts, inference substitution behavior, project-row metadata, fixture pins, or emitter output.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-common schema_version_matches_current_snapshot_shape identity_section_field_shape write_json_to_writes_valid_json_with_atomic_rename`
- `node scripts/bench/test-deferred-hkt-split-gauge.mjs`
- `bash -n scripts/ci/project-compile-guard.sh`
- `node scripts/ci/test-project-compile-guard-readiness-artifacts.mjs`
- `scripts/safe-run.sh cargo check -p tsz-common -p tsz-solver -p tsz-cli`
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/safe-run.sh cargo build -p tsz-cli --bin tsz`
- `TSZ_BIN=.target/debug/tsz scripts/safe-run.sh node scripts/bench/deferred-hkt-split-gauge.mjs --timeout 90` (fp-ts/io-ts/neverthrow all green, zero split-signal counters on current `origin/main`)

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high

