### PR TITLE
fix(emit): key ES5 async __awaiter callback line-break on source-line shape

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -47,6 +47,10 @@ name = "async_lowered_single_line_hoist_tests"
 path = "tests/async_lowered_single_line_hoist_tests.rs"
 
 [[test]]
+name = "async_es5_callback_source_line_tests"
+path = "tests/async_es5_callback_source_line_tests.rs"
+
+[[test]]
 name = "es5_private_in_brand_check_tests"
 path = "tests/es5_private_in_brand_check_tests.rs"
 

--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -232,7 +232,17 @@ impl<'a> AsyncES5Transformer<'a> {
     /// as multi-line), matching the emitter's `is_body_source_single_line`.
     /// Delegates to the shared [`emit_utils::source_block_is_single_line`] scan
     /// so the transform and print phases cannot drift.
-    fn body_source_is_single_line(&self, body_idx: NodeIndex) -> bool {
+    ///
+    /// Shared by every async ES5 lowering site that builds an `__awaiter`
+    /// callback (plain functions, object/class methods, class-field async
+    /// arrows, and async auto-accessor arrows), so they all key
+    /// `multiline_callback` on the same structural signal rather than
+    /// re-deriving it. This source-line shape is the *sole* callback line-break
+    /// trigger for those sites; only the plain async function/expression path
+    /// additionally ORs in an `arguments` capture (there the capture is folded
+    /// into the callback, whereas arrows hoist it onto the outer wrapper and
+    /// methods use native `arguments`).
+    pub(in crate::transforms) fn body_source_is_single_line(&self, body_idx: NodeIndex) -> bool {
         let Some(text) = self.source_text else {
             return false;
         };

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_bindings.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_bindings.rs
@@ -18,25 +18,28 @@ impl AsyncES5Transformer<'_> {
     ///
     /// Returns the statement list for the wrapper `FunctionExpr` body: an
     /// optional `var arguments_N = arguments;` declaration followed by the
-    /// `__awaiter` call. Unlike ordinary async functions, async arrows keep the
-    /// compact inline-generator callback form (`multiline_callback: false`)
-    /// even when they capture `arguments`; only the outer wrapper picks up the
-    /// extra capture statement.
+    /// `__awaiter` call. Unlike ordinary async functions, async arrows never
+    /// fold an `arguments` capture into the callback shape — the capture goes on
+    /// the outer wrapper — so the callback breaks across lines only for a
+    /// multi-line source body, keeping the compact inline form
+    /// (`multiline_callback: false`) for a single-line one, exactly like the
+    /// async function/expression path. `body_idx` is the arrow's source body
+    /// block, used for that source-line decision.
     pub(crate) fn build_async_arrow_awaiter_body(
         &self,
         this_arg: IRNode,
         generator_body: IRNode,
         hoisted_var_groups: Vec<Vec<String>>,
+        body_idx: NodeIndex,
     ) -> Vec<IRNode> {
         let mut body = Vec::new();
         self.emit_arguments_capture_decl(&mut body);
-        // Preserve the prior behavior for class-member async arrows: hoisted
-        // `var` groups keep the callback body multi-line. Known divergence from
-        // `tsc` (which keeps a single-line source body inline even with hoisted
-        // vars); this path does not receive the body block index, so applying
-        // the source-line rule here needs a signature change — a follow-up kept
-        // out of this zero-regression change.
-        let callback_multiline = !hoisted_var_groups.is_empty();
+        // Key the callback shape on the source-line rule (shared with the async
+        // function/expression path) rather than on hoisted-var presence: `tsc`
+        // keeps a single-line source body's callback inline even when it hoists
+        // `var` groups, and breaks a multi-line body's callback even when it
+        // hoists none.
+        let callback_multiline = !self.body_source_is_single_line(body_idx);
         body.push(IRNode::AwaiterCall {
             this_arg: Box::new(this_arg),
             needs_lexical_this_capture: generator_body.contains_captured_this_reference(),

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
@@ -905,6 +905,7 @@ impl<'a> AsyncES5Transformer<'a> {
                 },
                 generator_body,
                 hoisted_var_groups,
+                func.body,
             );
             let is_expression_body = !transformer.state.captures_arguments;
 

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_objects.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_objects.rs
@@ -614,13 +614,12 @@ impl AsyncES5Transformer<'_> {
             let mut generator_body = nested.transform_generator_body(method.body, has_await);
             let hoisted_var_groups =
                 AsyncES5Transformer::extract_and_remove_var_decl_groups(&mut generator_body);
-            // Preserve the prior behavior for object async methods: hoisted
-            // `var` groups keep the callback body multi-line. Known divergence
-            // from `tsc` (which keeps a single-line source body inline even with
-            // hoisted vars, like the async function/expression path); switching
-            // to the source-line rule here — `method.body` is in scope — is a
-            // follow-up kept out of this zero-regression change.
-            let callback_multiline = !hoisted_var_groups.is_empty();
+            // `tsc` keeps the `__awaiter` callback body inline for a single-line
+            // source method body — even when it hoists `var` groups — and only
+            // breaks it across lines for a multi-line source body, exactly like
+            // the async function/expression path. Key on the source-line shape
+            // (`method.body` is in scope) rather than on hoisted-var presence.
+            let callback_multiline = !nested.body_source_is_single_line(method.body);
             return IRNode::FunctionExpr {
                 name: None,
                 parameters,

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -1664,6 +1664,7 @@ impl<'a> AstToIr<'a> {
             this_arg,
             generator_body,
             hoisted_var_groups,
+            arrow.body,
         );
         let is_expression_body = !transformer.state.captures_arguments;
         IRNode::FunctionExpr {

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_auto_accessor.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_auto_accessor.rs
@@ -382,12 +382,12 @@ impl<'a> ES5ClassTransformer<'a> {
             .set(async_transformer.dynamic_import_promise_counter.get());
         let hoisted_var_groups =
             AsyncES5Transformer::extract_and_remove_var_decl_groups(&mut generator_body);
-        // Preserve the prior behavior for async auto-accessor arrows: hoisted
-        // `var` groups keep the callback body multi-line. Known divergence from
-        // `tsc` (which keeps a single-line source body inline even with hoisted
-        // vars); moving to the source-line rule is a follow-up kept out of this
-        // zero-regression change.
-        let callback_multiline = !hoisted_var_groups.is_empty();
+        // `tsc` keeps the `__awaiter` callback body inline for a single-line
+        // source arrow body — even when it hoists `var` groups — and only breaks
+        // it across lines for a multi-line source body, exactly like the async
+        // function/expression path. Key on the source-line shape (`arrow.body`)
+        // rather than on hoisted-var presence.
+        let callback_multiline = !async_transformer.body_source_is_single_line(arrow.body);
 
         Some(IRNode::FunctionExpr {
             name: None,

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
@@ -690,6 +690,11 @@ impl<'a> ES5ClassTransformer<'a> {
                 .set(async_transformer.dynamic_import_promise_counter.get());
             let hoisted_var_groups =
                 AsyncES5Transformer::extract_and_remove_var_decl_groups(&mut generator_body);
+            // `tsc` breaks the `__awaiter` callback across lines for a multi-line
+            // source method body and keeps it inline for a single-line one (even
+            // with hoisted `var` groups), exactly like the async
+            // function/expression path — key on the source-line shape.
+            let callback_multiline = !async_transformer.body_source_is_single_line(body_idx);
             vec![IRNode::AwaiterCall {
                 this_arg: Box::new(IRNode::this()),
                 needs_lexical_this_capture: generator_body.contains_captured_this_reference(),
@@ -697,7 +702,7 @@ impl<'a> ES5ClassTransformer<'a> {
                 hoisted_var_groups,
                 promise_constructor: self
                     .async_method_promise_constructor(method_data.type_annotation),
-                multiline_callback: false,
+                multiline_callback: callback_multiline,
                 directives: Vec::new(),
             }]
         } else if is_async_generator {
@@ -901,6 +906,13 @@ impl<'a> ES5ClassTransformer<'a> {
                             AsyncES5Transformer::extract_and_remove_var_decl_groups(
                                 &mut generator_body,
                             );
+                        // `tsc` breaks the `__awaiter` callback across lines for a
+                        // multi-line source method body and keeps it inline for a
+                        // single-line one (even with hoisted `var` groups), exactly
+                        // like the async function/expression path — key on the
+                        // source-line shape.
+                        let callback_multiline =
+                            !async_transformer.body_source_is_single_line(method_data.body);
                         vec![IRNode::AwaiterCall {
                             this_arg: Box::new(IRNode::this()),
                             needs_lexical_this_capture: generator_body
@@ -909,7 +921,7 @@ impl<'a> ES5ClassTransformer<'a> {
                             hoisted_var_groups,
                             promise_constructor: self
                                 .async_method_promise_constructor(method_data.type_annotation),
-                            multiline_callback: false,
+                            multiline_callback: callback_multiline,
                             directives: Vec::new(),
                         }]
                     } else if is_async_generator {
@@ -1056,6 +1068,13 @@ impl<'a> ES5ClassTransformer<'a> {
                             AsyncES5Transformer::extract_and_remove_var_decl_groups(
                                 &mut generator_body,
                             );
+                        // `tsc` breaks the `__awaiter` callback across lines for a
+                        // multi-line source method body and keeps it inline for a
+                        // single-line one (even with hoisted `var` groups), exactly
+                        // like the async function/expression path — key on the
+                        // source-line shape.
+                        let callback_multiline =
+                            !async_transformer.body_source_is_single_line(method_data.body);
                         vec![IRNode::AwaiterCall {
                             this_arg: Box::new(IRNode::this()),
                             needs_lexical_this_capture: generator_body
@@ -1064,7 +1083,7 @@ impl<'a> ES5ClassTransformer<'a> {
                             hoisted_var_groups,
                             promise_constructor: self
                                 .async_method_promise_constructor(method_data.type_annotation),
-                            multiline_callback: false,
+                            multiline_callback: callback_multiline,
                             directives: Vec::new(),
                         }]
                     } else if is_async_generator {

--- a/crates/tsz-emitter/tests/async_es5_callback_source_line_tests.rs
+++ b/crates/tsz-emitter/tests/async_es5_callback_source_line_tests.rs
@@ -1,0 +1,185 @@
+//! ES5 `__awaiter` callback multi-line shape follows the source-line rule.
+//!
+//! When an `async` method/arrow is lowered to
+//! `__awaiter(..., function () { ... return __generator(...) })` at target ES5,
+//! `tsc` keeps the generator callback body **inline** for a single-line source
+//! body — even when the body hoists `var` groups — and only breaks it across
+//! lines for a multi-line source body. The plain async function/expression path
+//! already followed this rule; the object-method, class-field async-arrow, and
+//! async auto-accessor-arrow paths instead keyed the shape on hoisted-`var`
+//! presence (`!hoisted_var_groups.is_empty()`), which diverged from `tsc` in
+//! both directions:
+//!   * single-line body **with** a hoisted `var` was wrongly broken multi-line;
+//!   * multi-line body **without** a hoisted `var` was wrongly kept inline.
+//!
+//! These tests pin the corrected source-line rule across all three sites, in
+//! both directions, with varied binder names (the decision is structural over
+//! the source body span, not over any identifier). Output verified
+//! byte-compatible with `tsc` target ES5 for each shape.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::{PrintOptions, lower_and_print};
+use tsz_parser::parser::ParserState;
+
+fn emit_es5(source: &str) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let opts = PrintOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::CommonJS,
+        remove_comments: true,
+        ..PrintOptions::default()
+    };
+    lower_and_print(&parser.arena, root, opts).code
+}
+
+// --- Object async methods ------------------------------------------------
+
+/// Single-line object async method that hoists a `var` keeps the `__awaiter`
+/// callback inline (was wrongly broken multi-line pre-fix).
+#[test]
+fn object_method_single_line_with_hoisted_var_stays_inline() {
+    let output = emit_es5("const bag_a = { async run_a() { var tmp_a = 1; return tmp_a; } };");
+
+    assert!(
+        output.contains("function () { var tmp_a; return __generator(this, function (_a) {"),
+        "single-line object async method must keep the hoisted-var callback inline.\nOutput:\n{output}"
+    );
+}
+
+/// Multi-line object async method that hoists a `var` breaks the callback
+/// across lines (unchanged: already correct, guards against over-inlining).
+#[test]
+fn object_method_multi_line_with_hoisted_var_breaks() {
+    let output = emit_es5(
+        "const bag_b = {\n  async run_b() {\n    var tmp_b = 1;\n    return tmp_b;\n  }\n};",
+    );
+
+    assert!(
+        !output.contains("function () { var tmp_b;"),
+        "multi-line object async method must break the callback across lines.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("function () {\n            var tmp_b;"),
+        "multi-line object async method must declare the hoisted var on its own line.\nOutput:\n{output}"
+    );
+}
+
+// --- Class async methods (instance / static) -----------------------------
+
+/// Single-line class async method that hoists a `var` keeps the callback
+/// inline.
+#[test]
+fn class_method_single_line_with_hoisted_var_stays_inline() {
+    let output = emit_es5("class Cls_h { async run_h() { var tmp_h = 1; return tmp_h; } }");
+
+    assert!(
+        output.contains("function () { var tmp_h; return __generator(this, function (_a) {"),
+        "single-line class async method must keep the hoisted-var callback inline.\nOutput:\n{output}"
+    );
+}
+
+/// Multi-line class async method breaks the callback across lines. Pre-fix the
+/// hardcoded `multiline_callback: false` wrongly kept this inline.
+#[test]
+fn class_method_multi_line_breaks() {
+    let output =
+        emit_es5("class Cls_i {\n  async run_i() {\n    var tmp_i = 1;\n    return tmp_i;\n  }\n}");
+
+    assert!(
+        !output.contains("function () { var tmp_i;"),
+        "multi-line class async method must break the callback across lines.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("void 0, function () {\n"),
+        "multi-line class async method callback body must start on a new line.\nOutput:\n{output}"
+    );
+}
+
+/// Multi-line `static` async method breaks the callback across lines too (the
+/// static member-emission path shares the same hardcoded-`false` bug pre-fix).
+#[test]
+fn static_class_method_multi_line_breaks() {
+    let output = emit_es5(
+        "class Cls_j {\n  static async run_j() {\n    var tmp_j = 1;\n    return tmp_j;\n  }\n}",
+    );
+
+    assert!(
+        !output.contains("function () { var tmp_j;"),
+        "multi-line static async method must break the callback across lines.\nOutput:\n{output}"
+    );
+}
+
+// --- Class-field async arrows --------------------------------------------
+
+/// Single-line class-field async arrow that hoists a `var` keeps the callback
+/// inline (was wrongly broken multi-line pre-fix).
+#[test]
+fn class_field_arrow_single_line_with_hoisted_var_stays_inline() {
+    let output =
+        emit_es5("class Cls_c { field_c = async () => { var tmp_c = 2; return tmp_c; }; }");
+
+    assert!(
+        output.contains("function () { var tmp_c; return __generator(this, function (_a) {"),
+        "single-line class-field async arrow must keep the hoisted-var callback inline.\nOutput:\n{output}"
+    );
+}
+
+/// Multi-line class-field async arrow with **no** hoisted `var` breaks the
+/// callback across lines. Pre-fix the hoisted-var predicate wrongly kept this
+/// inline (the reverse-direction witness).
+#[test]
+fn class_field_arrow_multi_line_without_hoisted_var_breaks() {
+    let output = emit_es5("class Cls_d { field_d = async () => {\n    return 1;\n  }; }");
+
+    assert!(
+        !output.contains("function () { return __generator"),
+        "multi-line class-field async arrow must break the callback across lines even with no hoisted var.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("void 0, function () {\n"),
+        "multi-line class-field async arrow callback body must start on a new line.\nOutput:\n{output}"
+    );
+}
+
+/// A single-line class-field async arrow with **no** hoisted `var` stays inline
+/// (control: the source-line rule and the old predicate agree here).
+#[test]
+fn class_field_arrow_single_line_without_hoisted_var_stays_inline() {
+    let output = emit_es5("class Cls_e { field_e = async () => { return 3; }; }");
+
+    assert!(
+        output.contains("function () { return __generator(this, function (_a) {"),
+        "single-line class-field async arrow with no hoisted var must stay inline.\nOutput:\n{output}"
+    );
+}
+
+// --- Async auto-accessor arrows ------------------------------------------
+
+/// Single-line async auto-accessor arrow that hoists a `var` keeps the callback
+/// inline (was wrongly broken multi-line pre-fix).
+#[test]
+fn auto_accessor_arrow_single_line_with_hoisted_var_stays_inline() {
+    let output = emit_es5(
+        "class Cls_f { accessor field_f = async () => { var tmp_f = 4; return tmp_f; }; }",
+    );
+
+    assert!(
+        output.contains("function () { var tmp_f; return __generator(this, function (_a) {"),
+        "single-line async auto-accessor arrow must keep the hoisted-var callback inline.\nOutput:\n{output}"
+    );
+}
+
+/// Multi-line async auto-accessor arrow that hoists a `var` breaks the callback
+/// across lines (guards against over-inlining).
+#[test]
+fn auto_accessor_arrow_multi_line_with_hoisted_var_breaks() {
+    let output = emit_es5(
+        "class Cls_g { accessor field_g = async () => {\n    var tmp_g = 5;\n    return tmp_g;\n  }; }",
+    );
+
+    assert!(
+        !output.contains("function () { var tmp_g;"),
+        "multi-line async auto-accessor arrow must break the callback across lines.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #15320.

At target ES5, an `async` method/arrow lowers to
`__awaiter(..., function () { ... return __generator(...) })`. **When the source
body is single-line, `tsc` keeps the generator callback inline** (even when it
hoists `var` groups); **when it is multi-line, `tsc` breaks the callback across
lines** (even when it hoists none). tsz does X through the emitter's ES5 async
transforms: the plain async function/expression path already keyed
`multiline_callback` on `body_source_is_single_line`, but **six** sibling
`IRNode::AwaiterCall` construction sites used the wrong signal —

- object async methods, class-field async arrows, async auto-accessor arrows →
  `!hoisted_var_groups.is_empty()`
- class async methods (instance + static; three member-emission paths) →
  hardcoded `multiline_callback: false`

so they diverged from `tsc` in **both** directions: single-line + hoisted `var`
was wrongly broken multi-line, and multi-line bodies were wrongly kept inline.

All six sites now call the shared
`AsyncES5Transformer::body_source_is_single_line` helper (widened to
`pub(in crate::transforms)` — the single structural source-of-truth every
async-lowering site already used), so the callback shape follows `tsc`'s
source-line rule. `build_async_arrow_awaiter_body` gains a `body_idx` param;
its two callers pass the arrow body they already hold. Pure output-form fix;
no semantic change — aligns with the anti-hardcoding gate (a `hoisted-var`
heuristic / hardcoded constant is not the structural signal `tsc` uses; the
decision keys on the source body span, verified with renamed binders).

Owner layer: emitter / ES5 async transforms (`crates/tsz-emitter/src/transforms/`:
`async_es5_ir.rs`, `async_es5_ir_objects.rs`, `class_es5_ir_auto_accessor.rs`,
`async_es5_ir_bindings.rs` + its two callers, `class_es5_ir_members.rs`).

Adjacent matrix (all verified **byte-identical to `tsc` target ES5**): object
async method single/multi-line + var; class-field async arrow single-line +
var, single-line no-var control, multi-line no-var (reverse-direction witness);
async auto-accessor arrow single/multi-line + var; class async method
single-line + var, multi-line, `static` multi-line; `arguments`-capturing
single-line arrow stays inline (capture on outer wrapper).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --test async_es5_callback_source_line_tests` → 10 passed, 0 failed (new: all six sites, both directions, varied binder names)
- Full `cargo test -p tsz-emitter`: no new failures; the sole failure
  (`generator_object_literal_prefix_before_yield_omits_source_trailing_comma`)
  reproduces on clean `main` and is unrelated to this change
- CLI output diffed byte-for-byte against `tsc` 6.0.2 `--target es5` for the full adjacent matrix → identical
- `cargo fmt -p tsz-emitter --check`, `git diff --check`, `cargo clippy -p tsz-emitter --tests` (0 warnings), `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean
- Branch rebased on latest `main`; ready-review CI owns the broad conformance / emit / fourslash baselines

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01LaaBe7zfxc76oo9WK78rUo)_