### PR TITLE
perf(solver): memoize expanded app alias containment (#14351)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate/application.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/application.rs
@@ -1360,7 +1360,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 let candidate = self
                     .interner
                     .application(original_app.base, expanded_args.into_owned());
-                if crate::visitor::contains_type_by_id(self.interner, candidate, result) {
+                if self.cached_contains_type_by_id(candidate, result) {
                     original_type_id
                 } else {
                     candidate
@@ -1633,6 +1633,55 @@ mod tests {
             Some(TypeId::STRING),
             "the unresolved-def epoch is per application body, not a sticky global \
              application_eval_cache disable",
+        );
+    }
+
+    #[test]
+    fn expanded_application_display_alias_containment_uses_shared_memo() {
+        let types = TypeInterner::new();
+        let prop = types.intern_string("x");
+        let object = types.object(vec![PropertyInfo::new(prop, TypeId::NUMBER)]);
+        let key = types.literal_string("x");
+        let index_access = types.index_access(object, key);
+        let base = types.lazy(DefId(901_010));
+        let original = types.application(base, vec![index_access]);
+        let expanded_candidate = types.application(base, vec![TypeId::NUMBER]);
+
+        let mut evaluator =
+            TypeEvaluator::new(&types).with_expanded_application_display_alias_args();
+
+        assert!(crate::visitor::contains_type_by_id(
+            &types,
+            expanded_candidate,
+            TypeId::NUMBER
+        ));
+        assert_eq!(
+            types.contains_type_by_id_memo(expanded_candidate, TypeId::NUMBER),
+            None
+        );
+
+        evaluator.record_application_evaluation_display_aliases(
+            TypeId::NUMBER,
+            original,
+            &[index_access],
+            true,
+            false,
+            None,
+        );
+
+        assert_eq!(
+            types.contains_type_by_id_memo(expanded_candidate, TypeId::NUMBER),
+            Some(true)
+        );
+        assert!(
+            TypeEvaluator::new(&types)
+                .cached_contains_type_by_id(expanded_candidate, TypeId::NUMBER)
+        );
+        assert_eq!(
+            types
+                .type_predicate_cache_statistics()
+                .contains_type_by_id_cache_entries,
+            1
         );
     }
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Route expanded application display-alias containment through the existing interner-wide `contains_type_by_id` memo.
- Add a solver evaluator test that proves the declaration-style expanded alias path publishes the same raw visitor answer and a fresh evaluator reuses it.

## Structural Rule
When declaration emit asks an evaluated application alias to compare the expanded candidate `Application` against the evaluated result, the containment question is a pure immutable type-DAG predicate over `(candidate, result)`. `tsz` should answer it through the solver evaluator's shared containment memo, preserving the raw visitor verdict while avoiding repeated walks across fresh evaluators.

## Owner Layer
- `tsz-solver` evaluation owns application display-alias bookkeeping.
- `TypeEvaluator::cached_contains_type_by_id` owns the project-wide containment memo boundary.
- No checker, relation verdict, emitter output, or `EvaluationSession` policy changes.

## Adjacent Matrix
- Positive containment: `Alias<Obj["x"]>` expands to candidate `Alias<number>` and records `(Alias<number>, number) -> true` in the interner memo.
- Fresh evaluator reuse: a new evaluator reads the same memoized answer.
- Raw oracle: the test compares against `visitor::contains_type_by_id` so the behavioral answer is byte-identical.
- Fallback: identity short-circuit behavior and conditional distribution memo tests remain covered by the existing shared-memo test.

## Overlap
- Avoids active session PRs #15315 and #15318 (`EvaluationSession`, checker lazy/type-reference state).
- Avoids #15319 perf-counter/project-guard surfaces and emit helper PRs.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-solver expanded_application_display_alias_containment_uses_shared_memo contains_type_by_id_memo_is_project_wide_across_evaluators`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `cargo fmt --all -- --check`
- `git diff --check`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
