### PR TITLE
ci: add emergency GCP cost scale-down

### DIFF
--- a/.github/workflows/bench-image.yml
+++ b/.github/workflows/bench-image.yml
@@ -2,10 +2,10 @@
 # Cloud Builds.
 #
 # This workflow is intentionally SEPARATE from ci.yml / bench.yml and is NOT a
-# required check. It cannot affect PR CI status. Building and pushing an image is
-# safe (it only produces SHA-tagged + :latest image tags in a registry); nothing
-# is switched over to the image until a maintainer points the bench configs at
-# it via the vars.BENCH_IMAGE_REF repo variable (see
+# required check. It cannot affect PR CI status. During emergency GCP cost
+# scale-down, this build is manual-only; nothing is switched over to the image
+# until a maintainer points the bench configs at it via the vars.BENCH_IMAGE_REF
+# repo variable (see
 # scripts/infra/bench-base/README.md). Until then the bench configs default to
 # the stock `rust:1.95` image and the inline bootstrap, so this workflow is a
 # no-op on bench behavior.
@@ -24,14 +24,6 @@ on:
         description: "Provenance note: why are you rebuilding the bench base image?"
         type: string
         default: "manual rebuild"
-  push:
-    paths:
-      - 'scripts/infra/bench-base/Dockerfile'
-      - 'scripts/cloudbuild/cloudbuild-bench-image.yaml'
-      - '.github/workflows/bench-image.yml'
-  schedule:
-    # Weekly rebuild to pick up base-image / OS security updates.
-    - cron: '0 7 * * 2'
 
 permissions:
   contents: read

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,16 +1,9 @@
 name: Bench
 
 on:
-  # Perf is measured per-tip on a cadence (not per-commit): each tick benches the
-  # current main HEAD (github.sha). Dropping the per-CI-completion workflow_run
-  # trigger removes the batch-supersession + defer/catch-up machinery — the
-  # schedule itself is the catch-up (the next tick measures the newest tip).
-  schedule:
-    - cron: '30 */3 * * *'   # perf cadence: bench current main tip every 3h
-    # Daily latest PGO release: submit the Cloud Build prep first, then publish
-    # the finished artifact without fanning out benchmark shards.
-    - cron: '0 3 * * *'
-    - cron: '0 5 * * *'
+  # Emergency GCP cost scale-down: benchmark Cloud Build fanout is manual-only.
+  # Re-enable a measured cadence only after the runner fleet and Cloud Build
+  # spend are intentionally budgeted.
   workflow_dispatch:
     inputs:
       publish_latest_pgo:
@@ -19,12 +12,11 @@ on:
         default: false
         type: boolean
 
-# Single-flight per channel. cancel-in-progress:false lets an in-flight bench
-# finish (a ~2h run is never thrown away); at most one newer run queues behind it
-# and benches the then-current tip. Perf and the daily PGO release use separate
-# groups so a long perf run never delays the release (and vice versa).
+# Single-flight per manual channel. cancel-in-progress:false lets an in-flight
+# bench finish (a ~2h run is never thrown away). Perf and the PGO release use
+# separate groups so a long perf run never delays the release (and vice versa).
 concurrency:
-  group: bench-${{ (github.event.schedule == '0 3 * * *' || github.event.schedule == '0 5 * * *' || (github.event_name == 'workflow_dispatch' && inputs.publish_latest_pgo)) && 'release' || 'perf' }}
+  group: bench-${{ inputs.publish_latest_pgo && 'release' || 'perf' }}
   cancel-in-progress: false
 
 permissions:
@@ -39,10 +31,8 @@ env:
   BENCH_PGO: "1"
   BENCH_REQUIRE_PGO: "1"
   HYPERFINE_VER: "1.18.0"
-  # Per-tip cadence: github.sha is main's HEAD at trigger time for schedule /
-  # workflow_dispatch on the default branch, so the whole pipeline measures and
-  # publishes the current tip. The cadence + the latest.json source-monotonic
-  # guard replace the old age/stale/catch-up knobs (all removed).
+  # Manual runs target github.sha for the selected ref. The latest.json
+  # source-monotonic guard still prevents publishing stale benchmark data.
   GITHUB_SHA: ${{ github.sha }}
   BENCH_TARGET_SHA: ${{ github.sha }}
   # Build image for the prepare/shard Cloud Builds. Empty (default) falls back to
@@ -81,9 +71,7 @@ jobs:
     if: >-
       needs.bench-gate.outputs.should_run == 'true' &&
       vars.TSZ_BENCH_SELF_HOSTED_PREP == '1' &&
-      !((github.event_name == 'schedule' && github.event.schedule == '0 3 * * *') ||
-        (github.event_name == 'schedule' && github.event.schedule == '0 5 * * *') ||
-        (github.event_name == 'workflow_dispatch' && inputs.publish_latest_pgo))
+      !inputs.publish_latest_pgo
     runs-on: [self-hosted, tsz-cloud-run]
     timeout-minutes: 30
     outputs:
@@ -158,10 +146,8 @@ jobs:
     needs: bench-gate
     if: >-
       needs.bench-gate.outputs.should_run == 'true' &&
-      !(github.event_name == 'schedule' && github.event.schedule == '0 5 * * *') &&
       (vars.TSZ_BENCH_SELF_HOSTED_PREP != '1' ||
-       (github.event_name == 'schedule' && github.event.schedule == '0 3 * * *') ||
-       (github.event_name == 'workflow_dispatch' && inputs.publish_latest_pgo))
+       inputs.publish_latest_pgo)
     runs-on: [self-hosted, tsz-cloud-run]
     timeout-minutes: 120
     outputs:
@@ -247,8 +233,7 @@ jobs:
     if: >-
       always() &&
       needs.bench-gate.outputs.should_run == 'true' &&
-      ((github.event_name == 'schedule' && github.event.schedule == '0 5 * * *') ||
-       (github.event_name == 'workflow_dispatch' && inputs.publish_latest_pgo))
+      inputs.publish_latest_pgo
     runs-on: [self-hosted, tsz-cloud-run]
     timeout-minutes: 25
     env:
@@ -299,12 +284,8 @@ jobs:
                 exit 1
               fi
 
-              if [[ "${{ github.event_name }}" == "workflow_dispatch" &&
-                    "${latest_target_sha}" != "${target_sha}" ]]; then
+              if [[ "${latest_target_sha}" != "${target_sha}" ]]; then
                 echo "Cloud Build artifact is for ${latest_target_sha}; waiting for ${target_sha}."
-              elif [[ "${{ github.event_name }}" == "schedule" &&
-                      "${latest_build_date}" != "$(date -u +%F)" ]]; then
-                echo "Cloud Build artifact is from ${latest_build_date:-unknown}; waiting for today's build."
               elif storage_cp \
                 "gs://tsz-ci_cloudbuild/bench-prep/${latest_target_sha}/bench-prep.env" \
                 bench-prep.env && \
@@ -338,9 +319,6 @@ jobs:
 
             if (( SECONDS >= deadline )); then
               echo "No finished Cloud Build PGO artifact is available yet."
-              if [[ "${{ github.event_name }}" == "schedule" ]]; then
-                exit 1
-              fi
               echo "ready=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
@@ -526,8 +504,7 @@ jobs:
     if: >-
       always() &&
       (needs.bench-prepare.outputs.should_run == 'true' ||
-       (!(github.event_name == 'workflow_dispatch' && inputs.publish_latest_pgo) &&
-        !(github.event_name == 'schedule' && github.event.schedule == '0 5 * * *') &&
+       (!inputs.publish_latest_pgo &&
         needs.bench-prepare-cloudbuild.outputs.should_run == 'true')) &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      full_ci:
+        description: "Run the expensive Cloud Run / Cloud Build suites despite emergency cost scale-down."
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -27,6 +33,11 @@ env:
   TSZ_CI_CACHE_BUCKET: gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache
   _TSZ_CI_CACHE_BUCKET: gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache
   TSZ_CI_RUNNER_LABEL: tsz-cloud-run
+  # Emergency GCP bill guard: automatic PR/push/merge_queue events publish the
+  # required light summary but do not fan out Cloud Run runners or Cloud Build
+  # jobs. Use workflow_dispatch with full_ci=true after re-enabling the runner
+  # fleet when a full validation pass is worth the spend.
+  TSZ_CI_EMERGENCY_SCALE_DOWN: "1"
 
 jobs:
   gate:
@@ -88,6 +99,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CI_EVENT_NAME: ${{ github.event_name }}
           METADATA_ACTIVE_SUITE_FOUND: ${{ steps.metadata-active-suite.outputs.active_suite_found }}
+          TSZ_CI_MANUAL_FULL_CI: ${{ github.event_name == 'workflow_dispatch' && inputs.full_ci || false }}
         shell: bash
         run: |
           set -euo pipefail
@@ -379,6 +391,20 @@ jobs:
                 fi
               fi
             fi
+          fi
+          if [[ "${TSZ_CI_EMERGENCY_SCALE_DOWN:-0}" == "1" &&
+                "${TSZ_CI_MANUAL_FULL_CI:-false}" != "true" ]]; then
+            echo "Emergency GCP cost scale-down is active — skipping Cloud Run / Cloud Build CI fanout."
+            echo "Dispatch this workflow manually with full_ci=true after intentionally re-enabling the runner fleet."
+            should_run=false
+            full_run=false
+            rust_cache_refresh=false
+            required_summary=true
+            bench_shell_only=false
+            perf_tool_only=false
+            arch_tool_only=false
+            metadata_only_skip=false
+            compiler_checks_required=false
           fi
           if [[ "$should_run" != "true" ]]; then
             full_run=false

--- a/.github/workflows/refresh-green-prs.yml
+++ b/.github/workflows/refresh-green-prs.yml
@@ -1,11 +1,8 @@
 name: Refresh Green PRs
 
 on:
-  push:
-    branches: [main]
-  schedule:
-    # Drain at most one stale green PR per run, away from the top of the hour.
-    - cron: '7,27,47 * * * *'
+  # Emergency GCP cost scale-down: do not auto-refresh stale PRs because each
+  # branch update can trigger a fresh expensive CI suite.
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -2,8 +2,8 @@
 # runner image for the Cloud Run fleet.
 #
 # This workflow is intentionally SEPARATE from ci.yml / bench.yml and is NOT a
-# required check. It cannot affect PR CI status. The build step is safe to run
-# automatically (it only produces a SHA-tagged image); the deploy step touches
+# required check. It cannot affect PR CI status. During emergency GCP cost
+# scale-down, build and deploy are both manual-only. The deploy step touches
 # live infrastructure and is therefore gated behind a manual workflow_dispatch
 # input AND the `runner-image-deploy` environment (configure it with required
 # reviewers for manual approval).
@@ -16,7 +16,7 @@
 #   vars.RUNNER_IMAGE_GCP_REGION           (optional; defaults to us-central1)
 #   vars.RUNNER_IMAGE_CLOUD_RUN_SERVICE    (required to deploy)
 #   vars.RUNNER_IMAGE_MIN_INSTANCES        (optional; defaults to 0)
-#   vars.RUNNER_IMAGE_MAX_INSTANCES        (optional; defaults to 50)
+#   vars.RUNNER_IMAGE_MAX_INSTANCES        (optional; defaults to 1)
 name: runner-image
 
 on:
@@ -30,16 +30,6 @@ on:
         description: "Provenance note: why are you rebuilding / deploying?"
         type: string
         default: "manual rebuild"
-  push:
-    paths:
-      - 'scripts/infra/cloud-run-gh-runner/Dockerfile'
-      - 'scripts/infra/cloud-run-gh-runner/start.sh'
-      - 'scripts/cloudbuild/cloudbuild-runner-image.yaml'
-      - '.github/workflows/runner-image.yml'
-  schedule:
-    # Weekly rebuild to pick up base-image / OS security updates. Build only;
-    # the scheduled run can never deploy (deploy requires workflow_dispatch).
-    - cron: '0 7 * * 1'
 
 permissions:
   contents: read
@@ -133,7 +123,7 @@ jobs:
           SERVICE: ${{ vars.RUNNER_IMAGE_CLOUD_RUN_SERVICE }}
           IMAGE_SHA_TAG: ${{ needs.build.outputs.image_sha_tag }}
           MIN_INSTANCES: ${{ vars.RUNNER_IMAGE_MIN_INSTANCES || '0' }}
-          MAX_INSTANCES: ${{ vars.RUNNER_IMAGE_MAX_INSTANCES || '50' }}
+          MAX_INSTANCES: ${{ vars.RUNNER_IMAGE_MAX_INSTANCES || '1' }}
         run: |
           set -euo pipefail
           echo "Deploying ${IMAGE_SHA_TAG} to Cloud Run service ${SERVICE}"

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -187,14 +187,19 @@ assert.match(
   "bench-prep-ready artifact should include both the prep manifest and tarball consumed by shard jobs",
 );
 
-// Phase 7: perf is measured per-tip on a schedule cadence. The per-commit
+// Emergency cost mode: perf fanout is manual-only. The per-commit
 // workflow_run trigger + defer-to-oldest gate + age/stale/catch-up machinery
-// were removed and replaced by a single per-channel concurrency group
-// (the authoritative single-flight) and a trivial should_run=true gate.
+// stay removed, but the scheduled cadence is disabled until Cloud Build spend
+// is intentionally budgeted again.
+assert.doesNotMatch(
+  workflow,
+  /schedule:\s*\n\s*- cron:/,
+  "bench should not run scheduled Cloud Build fanout during emergency cost scale-down",
+);
 assert.match(
   workflow,
-  /schedule:\s*\n\s*- cron: '30 \*\/3 \* \* \*'/,
-  "bench should measure perf on a 3h schedule cadence",
+  /workflow_dispatch:\s*\n\s*inputs:\s*\n\s*publish_latest_pgo:/,
+  "bench should remain manually dispatchable",
 );
 assert.doesNotMatch(
   workflow,
@@ -209,7 +214,7 @@ assert.match(
 assert.match(
   workflow,
   /BENCH_TARGET_SHA: \$\{\{ github\.sha \}\}/,
-  "bench should target the current main tip (github.sha) under the cadence model",
+  "bench should target the selected dispatch ref (github.sha) under manual mode",
 );
 assert.doesNotMatch(
   workflow,

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -172,6 +172,12 @@ assert.match(
 );
 
 assert.match(
+  ciWorkflow,
+  /full_ci:[\s\S]+?TSZ_CI_EMERGENCY_SCALE_DOWN: "1"[\s\S]+?TSZ_CI_MANUAL_FULL_CI:[\s\S]+?inputs\.full_ci[\s\S]+?Emergency GCP cost scale-down is active[\s\S]+?should_run=false[\s\S]+?full_run=false[\s\S]+?compiler_checks_required=false/,
+  "CI should default to emergency light-only mode and require explicit manual full_ci dispatch for Cloud Run / Cloud Build fanout",
+);
+
+assert.match(
   gateClassifier,
   /ci-resources\|gcp-full-ci\|github-suite\|gcp-cache\|suite-metadata\|build-dist\|dist\|wasm/,
   "ci-resources.sh changes must require compiler CI because they size dist/unit/wasm jobs",

--- a/scripts/ci/test-refresh-green-prs.mjs
+++ b/scripts/ci/test-refresh-green-prs.mjs
@@ -59,8 +59,13 @@ assert.deepEqual(
 
 assert.match(
   REFRESH_WORKFLOW,
-  /on:\s*\n\s+push:\s*\n\s+branches: \[main\]\s*\n\s+schedule:\s*\n\s+# Drain at most one stale green PR per run, away from the top of the hour\.\s*\n\s+- cron: '7,27,47 \* \* \* \*'/,
-  "refresh-green-prs should run automatically on main pushes and a staggered schedule",
+  /on:\s*\n\s+# Emergency GCP cost scale-down:[\s\S]+?workflow_dispatch:/,
+  "refresh-green-prs should be manual-only during emergency cost scale-down",
+);
+assert.doesNotMatch(
+  REFRESH_WORKFLOW,
+  /schedule:\s*\n\s*- cron:|push:\s*\n\s*branches: \[main\]/,
+  "refresh-green-prs must not auto-update branches while expensive CI is scaled down",
 );
 
 assert.equal(checkRollupState([check()]).kind, "passed");

--- a/scripts/infra/bench-base/README.md
+++ b/scripts/infra/bench-base/README.md
@@ -43,9 +43,10 @@ no-ops until a maintainer sets these repo variables:
 | `BENCH_IMAGE_REPO`          | yes      | Image repo path, e.g. `us-central1-docker.pkg.dev/<project>/<repo>/tsz-bench-base`. |
 | `BENCH_IMAGE_GCP_REGION`    | no       | Cloud Build region (defaults to `us-central1`).        |
 
-Triggers: push to the `Dockerfile` / cloudbuild config / workflow paths, a
-weekly cron, and manual `workflow_dispatch`. Every build is tagged with the
-commit SHA (provenance) and `:latest`.
+Trigger: manual `workflow_dispatch` only while emergency GCP cost scale-down is
+active. Re-enable push or scheduled rebuilds only after benchmark Cloud Build
+spend is intentionally budgeted again. Every build is tagged with the commit SHA
+(provenance) and `:latest`.
 
 ## Switch the bench builds over
 

--- a/scripts/infra/cloud-run-gh-runner/README.md
+++ b/scripts/infra/cloud-run-gh-runner/README.md
@@ -35,11 +35,11 @@ issue #13750.
 
 ## Build / deploy pipeline
 
-`.github/workflows/runner-image.yml` builds (and optionally deploys) the image:
+`.github/workflows/runner-image.yml` builds (and optionally deploys) the image.
+During emergency GCP cost scale-down it is manual-only:
 
-- **Triggers:** `workflow_dispatch`, `push` touching the `Dockerfile`,
-  `start.sh`, the cloudbuild config, or the workflow itself, and a weekly cron
-  (build-only, for base-image security updates).
+- **Triggers:** `workflow_dispatch` only. Re-enable push or scheduled rebuilds
+  only after the Cloud Run runner fleet is intentionally budgeted again.
 - **Build** (`build` job): submits
   `scripts/cloudbuild/cloudbuild-runner-image.yaml` via `gcloud builds submit`,
   producing an image tagged with the commit SHA (provenance) **and** `latest`.
@@ -66,7 +66,7 @@ variables → Actions → Variables) before the workflow does anything:
 | `RUNNER_IMAGE_GCP_REGION` | build/deploy | defaults to `us-central1` |
 | `RUNNER_IMAGE_CLOUD_RUN_SERVICE` | deploy | the Cloud Run service name |
 | `RUNNER_IMAGE_MIN_INSTANCES` | deploy | defaults to `0` (scale-to-zero) |
-| `RUNNER_IMAGE_MAX_INSTANCES` | deploy | defaults to `50` |
+| `RUNNER_IMAGE_MAX_INSTANCES` | deploy | defaults to `1` |
 
 Authentication uses the **ambient gcloud credentials** already present on the
 self-hosted runners (the same mechanism `ci.yml` / `bench.yml` rely on for
@@ -85,13 +85,14 @@ gh workflow run runner-image.yml -f deploy=true -f reason="bump runner to <ver>"
 ## Scaling policy (IaC)
 
 `cloud-run-service.yaml` captures the intended scaling policy
-(`concurrency=1`, `minScale=0`, `maxScale=50`, `timeoutSeconds=3600`) as a
+(`concurrency=1`, `minScale=0`, `maxScale=1`, `timeoutSeconds=3600`) as a
 reviewable skeleton. It is **not** applied automatically. Before adopting it as
 the source of truth, reconcile it with the live service
 (`gcloud run services describe <service> --format export`) and wire the
 `GITHUB_TOKEN` secret reference. Treat any `minScale>0` warm pool as a measured
 cost decision (per-job queue-wait data, #13715), since `minScale>0` defeats
-scale-to-zero.
+scale-to-zero. Raising `maxScale` above `1` is also a measured cost decision:
+it can multiply active 8-vCPU / 32 GiB runner spend during CI bursts.
 
 ## Health automation (issue #13750)
 

--- a/scripts/infra/cloud-run-gh-runner/cloud-run-service.yaml
+++ b/scripts/infra/cloud-run-gh-runner/cloud-run-service.yaml
@@ -13,8 +13,8 @@
 #   * minScale=0     - scale-to-zero by default. Treat any minScale>0 warm pool
 #                      as a measured cost decision using per-job queue_wait data
 #                      (#13715); minScale>0 defeats scale-to-zero.
-#   * maxScale=50    - upper bound on concurrent runners; tune to the fleet's
-#                      observed peak (health probe warns at online<20/online<5).
+#   * maxScale=1     - emergency cost ceiling: at most one runner instance may
+#                      start until the fleet is intentionally scaled back up.
 #   * timeoutSeconds=3600 - a runner job may run up to 60 minutes before the
 #                      platform reclaims the instance.
 #
@@ -33,7 +33,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/minScale: "0"
-        autoscaling.knative.dev/maxScale: "50"
+        autoscaling.knative.dev/maxScale: "1"
     spec:
       containerConcurrency: 1
       timeoutSeconds: 3600


### PR DESCRIPTION
Goal: hold

## Summary
- Add an emergency CI guard so automatic PR, push, and merge-queue events publish the required lightweight summary without starting Cloud Run runners or Cloud Build jobs.
- Keep full CI available only through manual `workflow_dispatch` with `full_ci=true` after the runner fleet is intentionally re-enabled.
- Make benchmark fanout, runner image builds, bench image builds, and stale-green-PR refreshes manual-only.
- Cap the version-controlled Cloud Run runner policy at `minScale=0` and `maxScale=1`, and update the infra docs/tests to keep that cost posture reviewable.

## Live GCP Remediation
- Set remaining Cloud Run runner services in project `tsz-ci` to no configured min instances where Cloud Run accepted the update.
- Deleted `tsz-gh-runner-crema` after Cloud Run rejected both min-instance and traffic-only scale-down attempts while it still served an old `minScale=1` revision.
- Verified the remaining Cloud Run services are `tsz-gh-runner-east`, `tsz-gh-runner-service-canary`, and `tsz-gh-runner-service-canary2`; each reports an empty `autoscaling.knative.dev/minScale` and `autoscaling.knative.dev/maxScale=1`.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/ci/test-refresh-green-prs.mjs`
- `node scripts/ci/test-pr-ready-state.mjs`
- `node scripts/ci/test-gate-path-classifier.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`
- `gcloud run services list --platform=managed --project=tsz-ci --format='value(metadata.name,region)'`
- `gcloud run services describe <remaining-service> --format=json | jq ...` confirmed no minScale and maxScale 1 for all remaining services.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
