### PR TITLE
fix(solver): contain evaluator meta recursion by identity (#14351)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -58,6 +58,7 @@ use tsz_common::interner::Atom;
 mod application;
 mod closed_eval;
 mod display_alias;
+mod meta_recursion_identity;
 mod query_budget;
 mod support;
 

--- a/crates/tsz-solver/src/evaluation/evaluate/meta_recursion_identity.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/meta_recursion_identity.rs
@@ -1,0 +1,51 @@
+//! Recursion-identity containment for evaluator meta-operations.
+
+use super::*;
+
+impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+    // tsc bounds productive meta-operation growth by recursion identity. For
+    // evaluator-side `IndexAccess`/`KeyOf`, the stable identity is the terminal
+    // definition under transparent wrappers; when evaluation grows the wrapper
+    // chain but keeps that identity, preserve the deferred form.
+    pub(in crate::evaluation) fn same_meta_recursion_identity(
+        &self,
+        before: TypeId,
+        after: TypeId,
+    ) -> bool {
+        let Some(before_def) = self.meta_recursion_identity(before) else {
+            return false;
+        };
+        let Some(after_def) = self.meta_recursion_identity(after) else {
+            return false;
+        };
+        before_def == after_def || self.resolver.defs_are_equivalent(before_def, after_def)
+    }
+
+    fn meta_recursion_identity(&self, type_id: TypeId) -> Option<DefId> {
+        let mut current = type_id;
+        for _ in 0..32 {
+            match self.interner.lookup(current)? {
+                TypeData::Lazy(def_id) => return Some(def_id),
+                TypeData::TypeQuery(symbol_ref) => {
+                    return self.resolver.symbol_to_def_id(symbol_ref);
+                }
+                TypeData::Application(app_id) => {
+                    current = self.interner.type_application(app_id).base;
+                }
+                TypeData::IndexAccess(object, _) | TypeData::KeyOf(object) => {
+                    current = object;
+                }
+                TypeData::ReadonlyType(inner) | TypeData::NoInfer(inner) => {
+                    current = inner;
+                }
+                _ => return None,
+            }
+        }
+        None
+    }
+
+    pub(in crate::evaluation) fn defer_same_identity_meta_recursion(&mut self) {
+        self.mark_silent_depth_bailed();
+        self.note_request_termination(TerminationKind::CrossEvalCycle);
+    }
+}

--- a/crates/tsz-solver/src/evaluation/evaluate/meta_recursion_identity.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/meta_recursion_identity.rs
@@ -1,8 +1,12 @@
 //! Recursion-identity containment for evaluator meta-operations.
 
-use super::*;
+use super::TypeEvaluator;
+use crate::def::DefId;
+use crate::evaluation::result::TerminationKind;
+use crate::relations::subtype::TypeResolver;
+use crate::types::{TypeData, TypeId};
 
-impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+impl<R: TypeResolver> TypeEvaluator<'_, R> {
     // tsc bounds productive meta-operation growth by recursion identity. For
     // evaluator-side `IndexAccess`/`KeyOf`, the stable identity is the terminal
     // definition under transparent wrappers; when evaluation grows the wrapper

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -1654,6 +1654,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         let evaluated_object = self.evaluate(object_type);
         let evaluated_index = self.evaluate(index_type);
+        if (evaluated_object != object_type
+            && self.same_meta_recursion_identity(object_type, evaluated_object))
+            || (evaluated_index != index_type
+                && self.same_meta_recursion_identity(index_type, evaluated_index))
+        {
+            self.defer_same_identity_meta_recursion();
+            return self.interner().index_access(object_type, index_type);
+        }
         if evaluated_object != object_type || evaluated_index != index_type {
             // Use recurse_index_access to respect depth limits
             return self.recurse_index_access(evaluated_object, evaluated_index);

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
@@ -537,6 +537,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         {
             // For non-union types, evaluate normally
             let evaluated_operand = self.evaluate(operand);
+            if evaluated_operand != operand
+                && self.same_meta_recursion_identity(operand, evaluated_operand)
+            {
+                self.defer_same_identity_meta_recursion();
+                return self.interner().keyof(operand);
+            }
 
             let key = match self.interner().lookup(evaluated_operand) {
                 Some(k) => k,

--- a/crates/tsz-solver/tests/index_access_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/index_access_comprehensive_tests.rs
@@ -720,6 +720,100 @@ fn test_indirect_cyclic_lazy_index_access_does_not_stack_overflow() {
     );
 }
 
+#[test]
+fn index_access_productive_lazy_chain_bails_to_deferred_root() {
+    use crate::def::DefId;
+    use crate::def::resolver::TypeEnvironment;
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let def_id = DefId(14351);
+    let lazy = interner.lazy(def_id);
+    let key = interner.literal_string("member");
+    let root = interner.index_access(lazy, key);
+
+    let mut env = TypeEnvironment::new();
+    env.insert_def(def_id, root);
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    let result = evaluator.evaluate(root);
+
+    assert_eq!(
+        result, root,
+        "productive Lazy(D) -> Lazy(D)[K] chains should keep the indexed access deferred"
+    );
+    assert_ne!(
+        result,
+        TypeId::ERROR,
+        "recursion-identity containment should not collapse the deferred chain to ERROR"
+    );
+}
+
+#[test]
+fn keyof_productive_lazy_chain_bails_to_deferred_root() {
+    use crate::def::DefId;
+    use crate::def::resolver::TypeEnvironment;
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let def_id = DefId(14352);
+    let lazy = interner.lazy(def_id);
+    let root = interner.keyof(lazy);
+
+    let mut env = TypeEnvironment::new();
+    env.insert_def(def_id, root);
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    let result = evaluator.evaluate(root);
+
+    assert_eq!(
+        result, root,
+        "productive Lazy(D) -> keyof Lazy(D) chains should keep keyof deferred"
+    );
+    assert_ne!(
+        result,
+        TypeId::ERROR,
+        "keyof recursion-identity containment should not collapse the deferred chain to ERROR"
+    );
+}
+
+#[test]
+fn same_identity_containment_keeps_finite_lazy_resolution() {
+    use crate::def::DefId;
+    use crate::def::resolver::TypeEnvironment;
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let def_id = DefId(14353);
+    let lazy = interner.lazy(def_id);
+    let key = interner.literal_string("renamed");
+    let object = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("renamed"),
+        TypeId::STRING,
+    )]);
+
+    let mut env = TypeEnvironment::new();
+    env.insert_def(def_id, object);
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    assert_eq!(
+        evaluator.evaluate(interner.index_access(lazy, key)),
+        TypeId::STRING,
+        "ordinary Lazy(D) -> object resolution must still reduce indexed access"
+    );
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    let keyof_result = evaluator.evaluate(interner.keyof(lazy));
+    assert!(
+        matches!(
+            interner.lookup(keyof_result),
+            Some(TypeData::Literal(crate::types::LiteralValue::String(_)))
+        ),
+        "ordinary Lazy(D) -> object resolution must still reduce keyof, got {:?}",
+        interner.lookup(keyof_result)
+    );
+}
+
 // =============================================================================
 // Mapped Type Indexing Tests
 // =============================================================================


### PR DESCRIPTION
Goal: green

## Summary
When a productive `IndexAccess` or `KeyOf` evaluator chain grows through the same terminal recursion identity, `tsc` preserves a deferred meta type instead of treating each larger wrapper as fresh work. `tsz` now does that through the solver evaluator: if evaluating the operand grows the wrapper chain but keeps the same terminal `DefId`, the evaluator records an incomplete cross-eval-style bail and returns the current deferred `IndexAccess`/`KeyOf` form instead of recursing into the larger shell.

Owner layer: solver evaluation (`crates/tsz-solver/src/evaluation/evaluate`). No checker logic, no rendered-type predicates, and no user/file-name predicates.

Adjacent matrix:
- Positive/productive: `Lazy(D) -> Lazy(D)[K]` keeps `Lazy(D)[K]` deferred.
- Positive/productive: `Lazy(D) -> keyof Lazy(D)` keeps `keyof Lazy(D)` deferred.
- Fallback/finite: `Lazy(D) -> { renamed: string }` still reduces both indexed access and `keyof` normally.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-solver index_access_comprehensive_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver keyof_comprehensive_tests`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy -p tsz-solver --lib --tests -- -D warnings`
- `python3 scripts/arch/arch_guard.py --json`
- `git diff --check HEAD~1..HEAD`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
