### PR TITLE
fix(checker): preserve multi-literal generator yield unions like tsc

### DIFF
--- a/crates/tsz-checker/src/dispatch/yield_.rs
+++ b/crates/tsz-checker/src/dispatch/yield_.rs
@@ -329,9 +329,23 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
             if yield_expr.asterisk_token {
                 self.checker.ctx.skip_array_contextual_supertype_collapse = true;
             }
+            // A bare primitive-literal operand (`yield 1`, `yield "a"`, `yield true`)
+            // must reach the yield-type union *unwidened* so a multi-member literal
+            // union (`yield 1; yield 2` -> `1 | 2`) survives; the union is widened
+            // later only if it collapses to a single literal
+            // (`getWidenedType(getUnionType(...))`). Preserve the literal here — object
+            // and array operands still widen their structure (they are evaluated with
+            // preservation off), and `as const` operands keep their preserved literal.
+            let saved_preserve = self.checker.ctx.preserve_literal_types;
+            if !yield_expr.asterisk_token
+                && self.yield_operand_is_bare_literal(yield_expr.expression)
+            {
+                self.checker.ctx.preserve_literal_types = true;
+            }
             let expression_type = self
                 .checker
                 .get_type_of_node_with_request(yield_expr.expression, &yield_request);
+            self.checker.ctx.preserve_literal_types = saved_preserve;
             self.checker.ctx.skip_array_contextual_supertype_collapse = saved_skip_collapse;
             if yield_expr.asterisk_token {
                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
@@ -692,6 +706,59 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
             idx,
             crate::recovery::RecoveryReason::YieldExpressionNoGeneratorContext,
         )
+    }
+
+    /// Whether a `yield` operand is a bare primitive-literal token (`1`, `"a"`,
+    /// `true`, `-1`, `1n`), as opposed to an `as const`/type-assertion, an object
+    /// or array literal, or any other expression. Such operands are evaluated with
+    /// literal preservation so the collected yield type keeps the literal, letting a
+    /// multi-member literal union survive; the union is widened afterwards only when
+    /// it collapses to a single literal. Parentheses are transparent.
+    fn yield_operand_is_bare_literal(&self, expr_idx: NodeIndex) -> bool {
+        let mut current = expr_idx;
+        let mut guard = 0u32;
+        loop {
+            guard += 1;
+            if guard > 4096 {
+                return false;
+            }
+            let Some(node) = self.checker.ctx.arena.get(current) else {
+                return false;
+            };
+            if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION {
+                let Some(paren) = self.checker.ctx.arena.get_parenthesized(node) else {
+                    return false;
+                };
+                current = paren.expression;
+                continue;
+            }
+            if node.kind == syntax_kind_ext::PREFIX_UNARY_EXPRESSION {
+                let Some(unary) = self.checker.ctx.arena.get_unary_expr(node) else {
+                    return false;
+                };
+                if unary.operator != SyntaxKind::MinusToken as u16
+                    && unary.operator != SyntaxKind::PlusToken as u16
+                {
+                    return false;
+                }
+                return self
+                    .checker
+                    .ctx
+                    .arena
+                    .get(unary.operand)
+                    .is_some_and(|operand| {
+                        operand.kind == SyntaxKind::NumericLiteral as u16
+                            || operand.kind == SyntaxKind::BigIntLiteral as u16
+                    });
+            }
+            let kind = node.kind;
+            return kind == SyntaxKind::NumericLiteral as u16
+                || kind == SyntaxKind::StringLiteral as u16
+                || kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+                || kind == SyntaxKind::BigIntLiteral as u16
+                || kind == SyntaxKind::TrueKeyword as u16
+                || kind == SyntaxKind::FalseKeyword as u16;
+        }
     }
 
     /// Check if an expression's result value is unused (discarded).

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -303,7 +303,16 @@ impl<'a> CheckerState<'a> {
         } else {
             self.ctx.types.factory().union(yield_types)
         };
-        let widened = if ctx.early_yield_type.is_some() {
+        // tsc computes the inferred yield type as `getWidenedType(getUnionType(...))`:
+        // a single literal is widened (`yield 1` -> `number`), but a multi-member
+        // literal union is preserved (`yield 1; yield 2` -> `1 | 2`) because a union
+        // is not itself a widenable literal. Mirror that by widening only when the
+        // reduced union is a single literal type — the same gate the regular
+        // return-type inference uses in `return_type.rs`. (The yield operands reach
+        // here unwidened for bare literals, so the union keeps its members.)
+        let widened = if ctx.early_yield_type.is_some()
+            || !crate::query_boundaries::common::is_literal_type(self.ctx.types, inferred_yield)
+        {
             inferred_yield
         } else {
             self.widen_literal_type(inferred_yield)

--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -156,6 +156,10 @@ name = "generator_yield_inference_dts_emit_tests"
 path = "tests/generator_yield_inference_dts_emit_tests.rs"
 
 [[test]]
+name = "generator_yield_literal_widening_dts_emit_tests"
+path = "tests/generator_yield_literal_widening_dts_emit_tests.rs"
+
+[[test]]
 name = "declaration_type_walk_boundary_dts_emit_tests"
 path = "tests/declaration_type_walk_boundary_dts_emit_tests.rs"
 

--- a/crates/tsz-cli/tests/generator_yield_literal_widening_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/generator_yield_literal_widening_dts_emit_tests.rs
@@ -1,0 +1,214 @@
+//! DTS emit of the inferred yield type for unannotated generators, focused on
+//! literal widening.
+//!
+//! tsc computes an unannotated generator's yield type as
+//! `getWidenedType(getUnionType(<yielded operand types>))`: a *single* literal is
+//! widened to its primitive base (`yield 1` -> `number`), but a multi-member
+//! literal union is preserved (`yield 1; yield 2` -> `1 | 2`). tsz previously
+//! widened every yield operand before the union, so a directly-`export`ed
+//! generator — whose return type comes from the checker's computed signature —
+//! collapsed `1 | 2` down to `number`. The fix keeps bare literal operands
+//! unwidened until the union and widens the union only when it is a single
+//! literal, matching tsc for declarations, methods, async generators, and the
+//! directly-exported form. The rule keys on the yield operands' AST structure,
+//! not the generator's name (verified with renamed binders).
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_yield_widening_dts_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+fn emit_dts(name: &str, source: &str) -> Option<String> {
+    emit_dts_with_lib(name, source, "es2015", "es6")
+}
+
+fn emit_dts_with_lib(name: &str, source: &str, target: &str, lib: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let src_path = temp.path.join("repro.ts");
+    std::fs::write(&src_path, source).expect("write repro file");
+
+    let output = Command::new(tsz_bin)
+        .args([
+            "repro.ts",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--target",
+            target,
+            "--lib",
+            lib,
+            "--pretty",
+            "false",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz declaration emit");
+
+    let dts = std::fs::read_to_string(temp.path.join("repro.d.ts")).unwrap_or_else(|_| {
+        panic!(
+            "expected repro.d.ts to be emitted.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    Some(dts)
+}
+
+/// Primary repro: a directly-`export`ed generator that yields two distinct
+/// number literals keeps the literal union `1 | 2` instead of widening to
+/// `number`. The renamed binder proves the rule is not name-dependent.
+#[test]
+fn exported_generator_preserves_multi_literal_yield_union() {
+    let Some(dts) = emit_dts(
+        "multi_number",
+        "export function* pair() { yield 1; yield 2; }\nexport function* renamed() { yield 1; yield 2; }\n",
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("pair(): Generator<1 | 2, void, unknown>"),
+        "multi-member literal yield union must be preserved, not widened to number:\n{dts}"
+    );
+    assert!(
+        dts.contains("renamed(): Generator<1 | 2, void, unknown>"),
+        "literal-union preservation must not depend on the generator name:\n{dts}"
+    );
+}
+
+/// A mixed string/number literal union is preserved for a directly-exported
+/// generator (`1 | "s"`).
+#[test]
+fn exported_generator_preserves_mixed_literal_yield_union() {
+    let Some(dts) = emit_dts(
+        "mixed_literal",
+        "export function* mix() { yield 1; yield \"s\"; }\n",
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("mix(): Generator<1 | \"s\", void, unknown>"),
+        "mixed literal yield union must be preserved:\n{dts}"
+    );
+}
+
+/// A single literal yield is still widened to its primitive base, matching tsc
+/// (`getWidenedType` of a lone literal).
+#[test]
+fn exported_generator_widens_single_literal_yield() {
+    let Some(dts) = emit_dts(
+        "single",
+        "export function* one() { yield 1; }\nexport function* dupe() { yield 1; yield 1; }\n",
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("one(): Generator<number, void, unknown>"),
+        "a single literal yield should widen to its base:\n{dts}"
+    );
+    assert!(
+        dts.contains("dupe(): Generator<number, void, unknown>"),
+        "repeated identical literals collapse to one and widen:\n{dts}"
+    );
+}
+
+/// An async generator preserves its multi-literal yield union too.
+#[test]
+fn exported_async_generator_preserves_multi_literal_yield_union() {
+    // `AsyncGenerator` lives in the es2018 lib.
+    let Some(dts) = emit_dts_with_lib(
+        "async_multi",
+        "export async function* pair() { yield 1; yield 2; }\n",
+        "es2018",
+        "es2018",
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("pair(): AsyncGenerator<1 | 2, void, unknown>"),
+        "async generator multi-literal yield union must be preserved:\n{dts}"
+    );
+}
+
+/// A class method generator (which routes through the body-driven emitter helper)
+/// agrees with the directly-exported form.
+#[test]
+fn method_generator_preserves_multi_literal_yield_union() {
+    let Some(dts) = emit_dts(
+        "method",
+        "export class C {\n  *m() { yield 1; yield 2; }\n}\n",
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("m(): Generator<1 | 2, void, unknown>"),
+        "class method generator must preserve the literal union:\n{dts}"
+    );
+}
+
+/// Fresh object/array literal operands still widen their structure regardless of
+/// union membership (`getWidenedType` reaches those leaves) — the fix must not
+/// leak literal preservation into compound operands.
+#[test]
+fn exported_generator_widens_compound_literal_operands() {
+    let Some(dts) = emit_dts(
+        "compound",
+        "export function* arr() { yield [1, 2]; yield [3, 4]; }\nexport function* obj() { yield { a: 1 }; }\n",
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("arr(): Generator<number[], void, unknown>"),
+        "fresh array literal operands must widen to number[]:\n{dts}"
+    );
+    assert!(
+        dts.contains("a: number"),
+        "fresh object literal operands must widen their property types:\n{dts}"
+    );
+}


### PR DESCRIPTION
Fixes #15330.

An unannotated generator's inferred yield type is `getWidenedType(getUnionType(<yielded operand types>))` in tsc: a single literal widens to its base (`yield 1` -> `number`), but a multi-member literal union is preserved (`yield 1; yield 2` -> `1 | 2`), because a union is not itself a widenable literal.

tsz widened every yield operand at evaluation time (the generator body is checked with `preserve_literal_types = false`), collapsing the union before it formed. A directly-`export`ed generator — whose declared return type comes from the checker's computed signature — therefore emitted `Generator<number, void, unknown>` where tsc emits `Generator<1 | 2, void, unknown>`. Non-exported functions and methods were already correct because declaration emit reconstructs their yield type from source syntax; this change aligns the checker-computed signature, and with it hover, assignability, and the exported-emit path.

**Structural rule:** when inferring an unannotated generator's yield type, tsc keeps bare literal operands unwidened until the union and widens the union only if it collapses to a single literal. tsz now evaluates bare primitive-literal yield operands with literal preservation (object/array operands still widen their structure; `as const` operands keep their preserved literal) and gates the final widen on the reduced union being a single literal — the same `is_literal_type(union)` gate the regular return-type inference already uses in `crates/tsz-checker/src/types/utilities/return_type.rs`.

**Owner layer:** solver-backed checker generator yield inference — `crates/tsz-checker/src/dispatch/yield_.rs` (operand collection) and `crates/tsz-checker/src/types/function_type_helpers.rs` (`check_generator_body_return` widen gate). The decision keys on the yield operands' AST structure, not the generator's name (verified with renamed binders).

**Adjacent matrix (byte-identical to tsc 6.0.2):** declaration / exported / method / async-generator forms; single vs multi literal; mixed string+number literal unions (`1 | "s"`); repeated identical literals collapsing to one and widening; fresh object/array operands still widening to `number[]` / `{ a: number }`.

**Known-remaining (separate, pre-existing — unchanged from `main`, out of scope):** single `yield 1 as const` / `yield E.A` (needs fresh-literal tracking tsz does not model); `as const` literal-union member ordering (`1 | 2` vs tsc `2 | 1`, improved from `number`); generator function *expressions* in a const still emit `() => void` (a distinct function-expression return-type path).

## Goal
Goal: hold

## Verification
- New full-pipeline regression suite `crates/tsz-cli/tests/generator_yield_literal_widening_dts_emit_tests.rs` (6 tests): exported/method/async multi-literal preservation, mixed literal union, single-literal widening, renamed-binder independence, and the compound-widening guardrail — all pass.
- `cargo test -p tsz-checker --lib yield` -> 72 passed (the one failing `yield_star_generator_callback_mismatch_reports_outer_ts2345` fails identically on clean `main`; it is a harness-lib artifact, not a regression).
- `cargo test -p tsz-emitter --lib declaration_emitter::` -> 1530 passed; `cargo test -p tsz-emitter --lib generator|yield` -> 111 passed.
- Existing `generator_yield_star_dts_emit_tests` + `generator_yield_inference_dts_emit_tests` -> 17 passed (no regression).
- CLI output diffed byte-for-byte against `tsc` 6.0.2 for the adjacent matrix above.
- `cargo fmt --check`, `cargo clippy -p tsz-checker --lib` (0 warnings), `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean. Branch head rebased on latest `main`; ready-review CI owns the broad conformance / emit / fourslash baselines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_018sqb4aTvH9nMAvt4XiBjw3)_