### PR TITLE
test(arch): repo-wide TSZ_ flag-registry ratchet + deterministic-election env-gate witness (#15317)

### DIFF
--- a/crates/tsz-solver/Cargo.toml
+++ b/crates/tsz-solver/Cargo.toml
@@ -58,3 +58,11 @@ path = "tests/conditional_infer_tuple_numeric_key_tests.rs"
 [[test]]
 name = "evaluation_cache_agreement_tests"
 path = "tests/evaluation_cache_agreement_tests.rs"
+
+[[test]]
+name = "flag_ledger_guard"
+path = "tests/flag_ledger_guard.rs"
+
+[[test]]
+name = "deterministic_election_env_gate"
+path = "tests/deterministic_election_env_gate.rs"

--- a/crates/tsz-solver/tests/deterministic_election_env_gate.rs
+++ b/crates/tsz-solver/tests/deterministic_election_env_gate.rs
@@ -1,0 +1,87 @@
+//! Behavioral witness for the `#15317` deterministic-election derivation:
+//! setting a `#14344` campaign channel that is *not* one of the four
+//! shared-store publication flags must still switch `DefinitionStore`
+//! construction onto the deterministic home-decl election.
+//!
+//! The derivation latches a process-global `OnceLock` on first read, so the
+//! env var must be set before the process's first store construction. The
+//! test therefore re-executes itself: the parent spawns the same test binary
+//! with `TSZ_TYPEPARAM_DECL_IDENTITY=1` in the child's environment (no
+//! `unsafe` `set_var`, and the latch order is guaranteed in the fresh
+//! process); the child performs the actual store-construction assertion.
+
+use tsz_solver::construction::TypeInterner;
+use tsz_solver::def::{DefId, DefinitionStore};
+
+const CHILD_MARKER: &str = "TSZ_ELECTION_ENV_GATE_CHILD";
+
+fn entry(name: &str, file_id: u32, span_start: u32) -> tsz_binder::SemanticDefEntry {
+    tsz_binder::SemanticDefEntry {
+        kind: tsz_binder::SemanticDefKind::Interface,
+        name: name.to_string(),
+        file_id,
+        span_start,
+        type_param_count: 0,
+        type_param_names: Vec::new(),
+        is_exported: false,
+        enum_member_names: Vec::new(),
+        is_const: false,
+        is_abstract: false,
+        extends_names: Vec::new(),
+        implements_names: Vec::new(),
+        parent_namespace: None,
+        is_global_augmentation: false,
+        is_declare: false,
+    }
+}
+
+fn assert_provenance_ordered_election() {
+    let interner = TypeInterner::new();
+    let mut defs = rustc_hash::FxHashMap::default();
+    defs.insert(tsz_binder::SymbolId(300), entry("Late", 7, 40));
+    defs.insert(tsz_binder::SymbolId(100), entry("Early", 3, 10));
+    defs.insert(tsz_binder::SymbolId(200), entry("Middle", 3, 20));
+
+    let store = DefinitionStore::from_semantic_defs(&defs, |s| interner.intern_string(s));
+
+    assert_eq!(
+        [
+            store.find_def_by_symbol(100),
+            store.find_def_by_symbol(200),
+            store.find_def_by_symbol(300),
+        ],
+        [Some(DefId(1)), Some(DefId(2)), Some(DefId(3))],
+        "a campaign channel outside the four publication flags must still \
+         elect DefIds by stable (file, span, symbol) provenance (#15317)"
+    );
+}
+
+/// `TSZ_TYPEPARAM_DECL_IDENTITY` (the decl-identity keystone, gated outside
+/// `def::core`) must enable the deterministic store election: `DefId`s follow
+/// `(file_id, span_start, symbol_id)` provenance, not `FxHashMap` iteration
+/// order.
+#[test]
+fn typeparam_decl_identity_channel_enables_deterministic_election() {
+    if std::env::var(CHILD_MARKER).is_ok() {
+        assert_provenance_ordered_election();
+        return;
+    }
+
+    let exe = std::env::current_exe().expect("test binary path");
+    let output = std::process::Command::new(exe)
+        .args([
+            "--exact",
+            "typeparam_decl_identity_channel_enables_deterministic_election",
+            "--nocapture",
+        ])
+        .env(CHILD_MARKER, "1")
+        .env("TSZ_TYPEPARAM_DECL_IDENTITY", "1")
+        .output()
+        .expect("spawn child test process");
+    assert!(
+        output.status.success(),
+        "child assertion failed under TSZ_TYPEPARAM_DECL_IDENTITY=1:\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/crates/tsz-solver/tests/flag_ledger_guard.rs
+++ b/crates/tsz-solver/tests/flag_ledger_guard.rs
@@ -1,0 +1,103 @@
+//! `#15317` repo-wide flag-registry ratchet, as a pure source-text scan (no
+//! crate internals), following the `arch_source_scans` pattern.
+//!
+//! `every_tsz_env_flag_is_documented_in_the_ledger`: every `TSZ_*` env var
+//! read anywhere in `crates/*/src` must appear in
+//! `docs/plan/campaign-flag-ledger.md` (either in the campaign tables or the
+//! full-registry appendix). Landing a new flag without documenting its owner /
+//! default / flip gate is the exact debt #15317 ratchets away. The
+//! campaign-list ↔ gauge ↔ derivation sync is separately machine-checked by
+//! the unit tests in `def/core/campaign_channels.rs`.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("crates/tsz-solver has a workspace root two levels up")
+        .to_path_buf()
+}
+
+fn rust_sources_under(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources_under(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Extract `TSZ_[A-Z0-9_]+` tokens from lines that read the environment.
+fn env_flag_reads(source: &str) -> BTreeSet<String> {
+    let mut flags = BTreeSet::new();
+    for line in source.lines() {
+        if !line.contains("env::var") {
+            continue;
+        }
+        let mut rest = line;
+        while let Some(pos) = rest.find("TSZ_") {
+            let tail = &rest[pos..];
+            let end = tail
+                .char_indices()
+                .find(|&(_, c)| !(c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_'))
+                .map_or(tail.len(), |(i, _)| i);
+            // A bare "TSZ_" prefix (e.g. from formatting) is not a flag name.
+            if end > "TSZ_".len() {
+                flags.insert(tail[..end].to_string());
+            }
+            rest = &tail[end..];
+        }
+    }
+    flags
+}
+
+fn all_env_flags_in_crates() -> BTreeSet<String> {
+    let crates_dir = workspace_root().join("crates");
+    let mut sources = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&crates_dir) else {
+        panic!("workspace crates/ directory not found at {crates_dir:?}");
+    };
+    for entry in entries.flatten() {
+        let src = entry.path().join("src");
+        if src.is_dir() {
+            rust_sources_under(&src, &mut sources);
+        }
+    }
+    assert!(
+        sources.len() > 100,
+        "flag scan walked implausibly few sources ({}); scan roots moved?",
+        sources.len()
+    );
+    let mut flags = BTreeSet::new();
+    for path in sources {
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            flags.extend(env_flag_reads(&content));
+        }
+    }
+    flags
+}
+
+#[test]
+fn every_tsz_env_flag_is_documented_in_the_ledger() {
+    let ledger_path = workspace_root().join("docs/plan/campaign-flag-ledger.md");
+    let ledger = std::fs::read_to_string(&ledger_path)
+        .unwrap_or_else(|e| panic!("flag ledger missing at {ledger_path:?}: {e}"));
+    let undocumented: Vec<String> = all_env_flags_in_crates()
+        .into_iter()
+        .filter(|flag| !ledger.contains(flag.as_str()))
+        .collect();
+    assert!(
+        undocumented.is_empty(),
+        "TSZ_* env flags read in crates/*/src but missing from \
+         docs/plan/campaign-flag-ledger.md: {undocumented:?}. \
+         Add a campaign-table row or a full-registry appendix entry — \
+         see #15317; do not land env flags without ledger coverage."
+    );
+}

--- a/docs/plan/campaign-flag-ledger.md
+++ b/docs/plan/campaign-flag-ledger.md
@@ -94,3 +94,68 @@ derivation guards against.
 4. **Record the flip verdict and blocker in this ledger** when one is
    established, with links to the deciding #14344 / #14345 comments — do not leave
    it only in thread archaeology.
+
+
+## Full `TSZ_` env-flag registry (non-campaign)
+
+The campaign tables above cover the `#14344`/`#14345` substrate. Every OTHER
+`TSZ_*` env flag read anywhere in `crates/*/src` is registered here so the
+`flag_ledger_guard` scan (tsz-solver test target) can enforce the #15317
+policy repo-wide: a new env flag does not land without a registry entry. One
+line per flag is enough; promote a flag into the campaign tables above when it
+joins the substrate.
+
+### Adjacent opt-in experiments (default OFF)
+
+`TSZ_DECL_ORIGIN_REDUCTION` (#15334 WAVE-1 sound register-through-reduction
+co-walk for cross-arena HKT alpha-equivalence; relation-layer, composes with
+`TSZ_ALPHA_NAME_PAIR` — candidate for promotion into the campaign table if it
+proves to perturb store election),
+
+`TSZ_SHARE_INSTANTIATION_CACHES` (#13284/#9507 cross-file instantiation-cache
+sharing, safety unproven), `TSZ_EAGER_WARM_LOCAL_CACHES` (rollback hatch for
+lazy local-cache warming), `TSZ_ENABLE_LIB_DEF_FREEZE` /
+`TSZ_ENABLE_LIB_DEF_DEFER_PUBLISH` (lib-def freeze/defer-publish experiments),
+`TSZ_LAZY_OWN_MEMBERS` / `TSZ_LAZY_OWN_MEMBERS_VARPOS` (#14957 lazy lib-member
+family; VARPOS is the known opt-in regression), `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK`
+/ `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK_TINY` / `TSZ_EXPERIMENT_NO_SHARED_QC`
+(parallel-check experiments), `TSZ_FILE_SESSION_REUSE` (paired with its kill
+switch below), `TSZ_CROSS_FILE_TYPE_PARAMS_CACHE` (cross-file type-param cache
+experiment), `TSZ_PROMOTE_FIRST` (interner promotion-order probe),
+`TSZ_EVAL_MEMO_PURITY_PANIC` (debug: panic on eval-memo purity violation,
+#14347 tooling), `TSZ_RECORD_FILE_SESSION_RESET_CACHE_STATS` (stats channel).
+
+### Kill switches (default ON semantics; `TSZ_DISABLE_*` turns the mechanism off)
+
+`TSZ_DISABLE_APP_CANON_ARG_IDENTITY`, `TSZ_DISABLE_CALLBACK_MISMATCH_MEMO`,
+`TSZ_DISABLE_CHECKER_POOL`, `TSZ_DISABLE_CLOSED_EVAL_CACHE`,
+`TSZ_DISABLE_CONDITIONAL_BRANCH_CACHE`,
+`TSZ_DISABLE_CONTEXTUAL_RETRY_CYCLE_GUARD`, `TSZ_DISABLE_DECL_LAZY_LIB`,
+`TSZ_DISABLE_DEFER_LAZY_DEFAULT_CONDITIONAL`,
+`TSZ_DISABLE_ENCLOSING_SCOPE_CACHE`, `TSZ_DISABLE_ENV_EVAL_SEED_CAP`,
+`TSZ_DISABLE_EXPORT_EQUALS_FAST_PATH`, `TSZ_DISABLE_FILE_SESSION_REUSE`,
+`TSZ_DISABLE_GENUINE_UNKNOWN_ALIAS_REDUCTION`,
+`TSZ_DISABLE_GLOBAL_LAZY_RECV_PRESERVE`,
+`TSZ_DISABLE_HERITAGE_BASE_MEMBER_INCORP`, `TSZ_DISABLE_INSTANTIATION_CACHE`,
+`TSZ_DISABLE_LAZY_MEMBER_ACCESS`, `TSZ_DISABLE_LAZY_OWN_MEMBERS`,
+`TSZ_DISABLE_LIB_DEF_FREEZE`, `TSZ_DISABLE_LIB_DEF_MONOTONE`,
+`TSZ_DISABLE_LIB_GENERIC_PREWARM_DEFER`, `TSZ_DISABLE_LIMIT_RESULT_CACHE`,
+`TSZ_DISABLE_NATIVE_TS`,
+`TSZ_DISABLE_NESTED_INDEXED_ACCESS_CONSTRAINT_REDUCTION`,
+`TSZ_DISABLE_ON_DEMAND_FORCING`, `TSZ_DISABLE_ORDER_INDEP_RESOLUTION`,
+`TSZ_DISABLE_REEXPORT_TYPE_ONLY_CACHE`,
+`TSZ_DISABLE_RELATION_CONDITIONAL_REDUCTION`,
+`TSZ_DISABLE_SOURCE_POSITION_CYCLE_GUARD`,
+`TSZ_DISABLE_TYPE_POSITION_RESOLUTION_CACHE`,
+`TSZ_DISABLE_UNRESOLVED_DEF_CACHE_BACKSTOP`, `TSZ_DISABLE_VARIANCE_CACHE`.
+
+### Infra / config / tracing / debug (not graduation candidates)
+
+Config: `TSZ_CHECKER_POOL`, `TSZ_LIB_DIR`, `TSZ_TESTS_LIB_DIR`,
+`TSZ_USE_EMBEDDED_LIBS`, `TSZ_MAX_EVAL_OPS`, `TSZ_LSP_MEMORY_BUDGET_BYTES`,
+`TSZ_QUERY_RUN_ID`, `TSZ_FILE_SIZE_RATCHET_UPDATE`, `TSZ_TIMEOUT_SECS`,
+`TSZ_TYPESCRIPT_PACKAGE_JSON`, `TSZ_WORKER_CONFIG_DEPRECATION` (+ its
+`TSZ_WORKER_CONFIG_DEPRECATION_ENV_KEY` constant).
+Perf/tracing: `TSZ_PERF`, `TSZ_PERF_COUNTERS`, `TSZ_LOG`, `TSZ_LOG_FORMAT`.
+Debug dumps: `TSZ_DAA_DEBUG`, `TSZ_DEBUG_CONFORMANCE_OUTPUT`,
+`TSZ_DEBUG_EMIT`, `TSZ_DEBUG_PREPARE_DIR`, `TSZ_DEBUG_RESOLVE`.


### PR DESCRIPTION
Goal: hold

Part of #15317 (child of #14351). **Rescoped after #15333 landed in parallel** — that PR independently built the campaign channel registry (`campaign_channels.rs`), the committed gauge, the scheduled lane, the campaign ledger, the widened deterministic-election derivation, and the dead-harness removal, superseding most of this PR's original content. What remains here is exactly what main still lacks:

## What this lands

1. **Full `TSZ_` env-flag registry** appended to `docs/plan/campaign-flag-ledger.md`: the campaign tables cover the 12 substrate channels; the other ~70 flags read in `crates/*/src` (adjacent opt-in experiments, `TSZ_DISABLE_*` kill switches, infra/config/tracing/debug) now have registry entries too.
2. **`flag_ledger_guard` test target** (arch source-scan pattern): every `TSZ_*` env var read anywhere in `crates/*/src` must appear in the ledger — the "no new flag lands undocumented" policy from #15317, machine-enforced repo-wide. The campaign-list ↔ gauge ↔ derivation sync stays owned by the in-code tests #15333 added; this ratchet covers the repo-wide registry dimension those don't.
3. **`deterministic_election_env_gate` test target**: an end-to-end behavioral witness (child-process re-exec, no `unsafe` `set_var`, latch-safe under nextest per-process execution) that setting a *non-publication* campaign channel (`TSZ_TYPEPARAM_DECL_IDENTITY=1`) switches `DefinitionStore` construction onto provenance-ordered election through the #15333 derivation. #15333 landed without a behavioral test of the derivation.

## Flipped tests / immediate value

- The scan **caught a real offender on its first run**: `TSZ_DECL_ORIGIN_REDUCTION` (#15334) landed hours ago with no ledger entry; this PR documents it (flagged as a promotion candidate for the campaign table).
- `every_tsz_env_flag_is_documented_in_the_ledger`: red on main+appendix-without-that-flag, green now; permanently red for any future undocumented flag.
- `typeparam_decl_identity_channel_enables_deterministic_election`: red on the pre-#15333 four-channel derivation (verified during the original round of this PR), green against #15333's derivation — it now pins that #15333's contract holds end-to-end.

## Verification

- `cargo nextest run -p tsz-solver --test flag_ledger_guard --test deterministic_election_env_gate` — 2/2 pass on rebased head
- `cargo clippy --profile ci-lint -p tsz-solver --test flag_ledger_guard --test deterministic_election_env_gate -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- Full local suites were run for the original head (solver 7278/7281 with the 3 pre-existing main failures — see #15338; checker/cli likewise only the #15338 pre-existing failures). The rebased head touches only docs + two new test targets.
- Note: CI is currently disabled (all checks skip) — verification above is the local gate per owner instruction.

## Provenance

Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-fable-5
Effort: max
