### PR TITLE
feat(solver): sound register-through-reduction co-walk for cross-arena HKT alpha-equivalence (#14345 WAVE-1)

### DIFF
--- a/crates/tsz-solver/src/relations/compat_mapped.rs
+++ b/crates/tsz-solver/src/relations/compat_mapped.rs
@@ -516,9 +516,9 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
 
         let target_param = self.interner.type_param(t_mapped.type_param);
         let equiv_start = self.subtype.type_param_equivalences.len();
-        self.subtype
-            .type_param_equivalences
-            .push((source_param, target_param));
+        self.subtype.type_param_equivalences.push(
+            crate::relations::subtype::TypeParamEquivalence::ids(source_param, target_param),
+        );
 
         if let Some(assignable) =
             self.deferred_indexed_mapped_templates_assignable(source_template, target_template)
@@ -637,9 +637,9 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         let source_param = self.interner.type_param(source_mapped.type_param);
         let target_param = self.interner.type_param(target_mapped.type_param);
         let equiv_start = self.subtype.type_param_equivalences.len();
-        self.subtype
-            .type_param_equivalences
-            .push((source_param, target_param));
+        self.subtype.type_param_equivalences.push(
+            crate::relations::subtype::TypeParamEquivalence::ids(source_param, target_param),
+        );
         let compatible = self.subtype.is_subtype_of(source_name, target_name)
             && self.subtype.is_subtype_of(target_name, source_name);
         self.subtype.type_param_equivalences.truncate(equiv_start);

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -206,17 +206,27 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // subtype checking (alpha-renaming). When both types are TypeParameters
         // in the equivalence set, treat them as identical.
         if !self.type_param_equivalences.is_empty()
-            && matches!(
-                self.interner.lookup(source),
-                Some(TypeData::TypeParameter(_))
-            )
-            && matches!(
-                self.interner.lookup(target),
-                Some(TypeData::TypeParameter(_))
-            )
+            && let Some(TypeData::TypeParameter(source_info)) = self.interner.lookup(source)
+            && let Some(TypeData::TypeParameter(target_info)) = self.interner.lookup(target)
         {
-            for &(eq_a, eq_b) in &self.type_param_equivalences {
-                if (source == eq_a && target == eq_b) || (source == eq_b && target == eq_a) {
+            // #14345 WAVE-1: when the decl-origin-through-reduction flag is on,
+            // a reduced-body `Kind<F,A>` param leaf survives the name-keyed
+            // re-mint as a THIRD id (not the registered pre-instantiate id) but
+            // KEEPS its carried `DeclScoped { file, node }` origin. The id-keyed
+            // match below misses that leaf; the origin-keyed match bridges it
+            // when — and only when — the leaf's origin pair was registered by
+            // the alpha-rename (same declaration site on both sides). A
+            // different-origin pair (distinct decls, never registered) is not
+            // accepted. Flag-OFF, every registered `origins` is `None` and this
+            // match never fires (byte-identical id-only behavior).
+            let origin_match_enabled = Self::decl_origin_reduction_enabled();
+            for eq in &self.type_param_equivalences {
+                if eq.matches_ids(source, target) {
+                    return SubtypeResult::True;
+                }
+                if origin_match_enabled
+                    && eq.matches_origins(source_info.origin, target_info.origin)
+                {
                     return SubtypeResult::True;
                 }
             }
@@ -1748,7 +1758,11 @@ mod tests {
         let cache_key = checker.make_cache_key(source, target);
         db.insert_subtype_cache(cache_key, false);
 
-        checker.type_param_equivalences.push((left_key, right_key));
+        checker
+            .type_param_equivalences
+            .push(crate::relations::subtype::TypeParamEquivalence::ids(
+                left_key, right_key,
+            ));
         assert!(
             checker.check_subtype(source, target).is_true(),
             "active alpha-pairing must recompute instead of replaying a flagless cached false"

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -26,7 +26,7 @@ use crate::operations::AssignabilityChecker;
 use crate::types::*;
 use crate::types::{
     IntrinsicKind, LiteralValue, ObjectFlags, ObjectShape, PropertyInfo, RelationCacheKey,
-    SymbolRef, TemplateSpan, TypeData, TypeId, TypeListId,
+    SymbolRef, TemplateSpan, TypeData, TypeId, TypeListId, TypeParamOrigin,
 };
 use crate::visitor::{
     TypeVisitor, application_id, array_element_type, callable_shape_id, conditional_type_id,
@@ -217,6 +217,84 @@ impl RelationEvaluationResult {
 }
 
 #[cfg(test)]
+mod type_param_equivalence_tests {
+    use super::TypeParamEquivalence;
+    use crate::types::{TypeId, TypeParamOrigin};
+    use tsz_common::interner::Atom;
+
+    fn decl(file: u32, node: u32) -> TypeParamOrigin {
+        TypeParamOrigin::DeclScoped {
+            file: Atom(file),
+            node,
+        }
+    }
+
+    /// An id-only equivalence carries no decl-origin discriminator, so it never
+    /// matches on origins and keeps the historical id-keyed behavior.
+    #[test]
+    fn ids_equivalence_matches_only_by_id() {
+        let a = TypeId(100);
+        let b = TypeId(200);
+        let eq = TypeParamEquivalence::ids(a, b);
+        assert!(eq.matches_ids(a, b));
+        assert!(eq.matches_ids(b, a), "id match is order-insensitive");
+        assert!(!eq.matches_ids(a, TypeId(300)));
+        // No origins recorded -> origin match never fires.
+        assert!(!eq.matches_origins(decl(1, 2), decl(3, 4)));
+    }
+
+    /// A registered decl-origin pair matches a same-origin leaf pair in either
+    /// order (the accepted `B ≡ A` bridge). This is the #14345 WAVE-1 positive
+    /// case: two reduced-body leaves whose `(file, node)` origins equal the
+    /// registered signature params relate.
+    #[test]
+    fn origin_equivalence_matches_registered_pair_both_orders() {
+        let eq = TypeParamEquivalence {
+            source: TypeId(100),
+            target: TypeId(200),
+            origins: Some((decl(57, 20), decl(5, 20))),
+        };
+        assert!(eq.matches_origins(decl(57, 20), decl(5, 20)));
+        assert!(
+            eq.matches_origins(decl(5, 20), decl(57, 20)),
+            "origin match is order-insensitive"
+        );
+    }
+
+    /// A different-origin leaf pair (distinct `(file, node)` that was never
+    /// registered) must NOT match — the sound discriminator the name+surface
+    /// strip cannot express. A single differing node is enough to reject.
+    #[test]
+    fn origin_equivalence_rejects_unregistered_pair() {
+        let eq = TypeParamEquivalence {
+            source: TypeId(100),
+            target: TypeId(200),
+            origins: Some((decl(57, 20), decl(5, 20))),
+        };
+        // Different file on one side.
+        assert!(!eq.matches_origins(decl(99, 20), decl(5, 20)));
+        // Different node on one side (same file) — distinct declaration site.
+        assert!(!eq.matches_origins(decl(57, 21), decl(5, 20)));
+        // Both sides different.
+        assert!(!eq.matches_origins(decl(1, 1), decl(2, 2)));
+    }
+
+    /// A `User` (unstamped) leaf carries no declaration site and must never
+    /// match on origins, even against a registered decl-scoped pair.
+    #[test]
+    fn origin_equivalence_never_matches_user_leaves() {
+        let eq = TypeParamEquivalence {
+            source: TypeId(100),
+            target: TypeId(200),
+            origins: Some((decl(57, 20), decl(5, 20))),
+        };
+        assert!(!eq.matches_origins(TypeParamOrigin::User, decl(5, 20)));
+        assert!(!eq.matches_origins(decl(57, 20), TypeParamOrigin::User));
+        assert!(!eq.matches_origins(TypeParamOrigin::User, TypeParamOrigin::User));
+    }
+}
+
+#[cfg(test)]
 mod relation_evaluation_result_tests {
     use super::{RelationEvaluationResult, RelationEvaluationStability};
     use crate::evaluation::result::{
@@ -270,6 +348,84 @@ mod relation_evaluation_result_tests {
         );
         assert!(!incomplete.is_stable_for_depth_agnostic_cache());
         assert!(incomplete.is_unstable_unknown());
+    }
+}
+
+/// One alpha-rename type-parameter equivalence registered during generic
+/// function subtype checking.
+///
+/// The `source`/`target` `TypeId`s are the pre-instantiate signature-param ids
+/// (the historical `(TypeId, TypeId)` pair). `origins` additionally records the
+/// two params' declaration origins when BOTH carry a `DeclScoped { file, node }`
+/// construction stamp (`TSZ_TYPEPARAM_DECL_IDENTITY`).
+///
+/// #14345 WAVE-1 decl-origin-through-reduction: the name-keyed re-mint
+/// (`instantiate_function_shape`) rewrites deeper, arg-position `Kind<F,A>`
+/// param leaves to a THIRD id that the registered `TypeId` pair never contains,
+/// so the id-keyed consult (`check_subtype`) misses and the two alpha-equivalent
+/// bodies fail to relate. The decl-origin `(file, node)` is STABLE across that
+/// re-mint (the leaf's origin survives — a substitution hit maps it to the
+/// same-origin top-level param, a miss returns the original id, and the
+/// `TypeParameter` re-intern preserves the origin field). So the consult can
+/// additionally match a reduced-body leaf against a registered equivalence by
+/// its CARRIED origin: a same-origin leaf pair relates, a different-origin pair
+/// (never registered) does not. This is the sound discriminator the name-keyed
+/// structural strip cannot express (a name-keyed substitution collapses
+/// colliding names to one `User` id).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TypeParamEquivalence {
+    pub(crate) source: TypeId,
+    pub(crate) target: TypeId,
+    /// Declaration origins of the two paired params, recorded only when BOTH are
+    /// `DeclScoped`. `None` for every other registration path (mapped-key
+    /// constraints, index-access keys, non-stamped params) so those keep the
+    /// pure id-keyed behavior.
+    pub(crate) origins: Option<(TypeParamOrigin, TypeParamOrigin)>,
+}
+
+impl TypeParamEquivalence {
+    /// An id-only equivalence (no decl-origin discriminator). Used by every
+    /// registration path except the decl-origin-aware alpha-rename.
+    #[inline]
+    pub(crate) const fn ids(source: TypeId, target: TypeId) -> Self {
+        Self {
+            source,
+            target,
+            origins: None,
+        }
+    }
+
+    /// Whether this registered pair matches the given leaf id pair by exact
+    /// `TypeId` (order-insensitive) — the historical id-keyed consult.
+    #[inline]
+    pub(crate) fn matches_ids(&self, source: TypeId, target: TypeId) -> bool {
+        (self.source == source && self.target == target)
+            || (self.source == target && self.target == source)
+    }
+
+    /// Whether this registered pair matches the given leaf ORIGIN pair
+    /// (order-insensitive), for the #14345 WAVE-1 decl-origin consult. Both the
+    /// registered entry and the queried leaves must carry `DeclScoped` origins;
+    /// two `DeclScoped { file, node }` values are equal iff their `(file, node)`
+    /// declaration site is identical.
+    #[inline]
+    pub(crate) fn matches_origins(
+        &self,
+        source_origin: TypeParamOrigin,
+        target_origin: TypeParamOrigin,
+    ) -> bool {
+        let Some((reg_source, reg_target)) = self.origins else {
+            return false;
+        };
+        // Only decl-scoped origins are a sound discriminator; a `User` origin
+        // carries no declaration site so it must never match here.
+        if !matches!(source_origin, TypeParamOrigin::DeclScoped { .. })
+            || !matches!(target_origin, TypeParamOrigin::DeclScoped { .. })
+        {
+            return false;
+        }
+        (reg_source == source_origin && reg_target == target_origin)
+            || (reg_source == target_origin && reg_target == source_origin)
     }
 }
 
@@ -470,7 +626,7 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// identical, fixing false TS2416 for generic methods with structurally identical signatures
     /// but different type param names (e.g., `<D>(f: (t: C) => D) => IList<D>` vs
     /// `<B>(f: (t: C) => B) => IList<B>`).
-    pub(crate) type_param_equivalences: Vec<(TypeId, TypeId)>,
+    pub(crate) type_param_equivalences: Vec<TypeParamEquivalence>,
     /// In-flight `Ternary.Maybe`-style relation outcomes awaiting validation
     /// by the outermost frame of this checker instance (tsc `maybeKeys`
     /// parity, issue #13241). See `cache::MaybeRelationEntry` and

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -1433,6 +1433,13 @@ pub fn is_subtype_of_with_db(db: &dyn QueryDatabase, source: TypeId, target: Typ
 #[path = "../../../tests/subtype_tests.rs"]
 mod tests;
 
+// #14345 WAVE-1 adversarial soundness gate for the decl-origin-through-reduction
+// consult (branch `green/wave1-cowalk`). Proves the origin-keyed match rejects a
+// false `T ≡ U` while accepting the genuine same-decl `B ≡ A`.
+#[cfg(test)]
+#[path = "../../../tests/decl_origin_reduction_soundness_tests.rs"]
+mod decl_origin_reduction_soundness_tests;
+
 #[cfg(test)]
 #[path = "../../../tests/index_signature_tests.rs"]
 mod index_signature_tests;

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -182,10 +182,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         target_param: TypeId,
     ) -> bool {
         source_param == target_param
-            || self.type_param_equivalences.iter().any(|&(left, right)| {
-                (source_param == left && target_param == right)
-                    || (source_param == right && target_param == left)
-            })
+            || self
+                .type_param_equivalences
+                .iter()
+                .any(|eq| eq.matches_ids(source_param, target_param))
     }
 
     /// Build the elaboration carrier for two distinct type-parameter keys

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -8,11 +8,11 @@ use crate::type_param_info;
 use crate::types::{
     CallSignature, CallableShape, CallableShapeId, FunctionShape, FunctionShapeId, ObjectFlags,
     ObjectShape, ParamInfo, PropertyInfo, TupleElement, TypeData, TypeId, TypeParamInfo,
-    Visibility,
+    TypeParamOrigin, Visibility,
 };
 use crate::visitor::callable_shape_id;
 
-use super::super::super::{SubtypeChecker, SubtypeResult, TypeResolver};
+use super::super::super::{SubtypeChecker, SubtypeResult, TypeParamEquivalence, TypeResolver};
 use super::erase_type_params_to_constraints;
 
 mod call_signatures;
@@ -140,6 +140,33 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         use std::sync::OnceLock;
         static ON: OnceLock<bool> = OnceLock::new();
         *ON.get_or_init(|| std::env::var("TSZ_TYPEPARAM_DECL_IDENTITY").is_ok_and(|v| v == "1"))
+    }
+
+    /// #14345 WAVE-1 decl-origin-through-reduction flag (default-OFF, composes
+    /// on top of `TSZ_TYPEPARAM_DECL_IDENTITY`).
+    ///
+    /// When ON (and the construction stamp is ON), the alpha-rename registration
+    /// records each paired param's `DeclScoped { file, node }` origin alongside
+    /// the pre-instantiate `TypeId` pair, and the consult
+    /// (`check_subtype`) additionally accepts two reduced-body `TypeParameter`
+    /// leaves whose carried decl-origins form a registered pair — the same-origin
+    /// `B ≡ A` bridge that the name-keyed re-mint loses (the leaf id is a THIRD
+    /// identity, but its `(file, node)` origin survives). A different-origin pair
+    /// (`T`/`U` from distinct decls that were never registered) is NOT accepted,
+    /// which is the sound discriminator the name+surface structural strip cannot
+    /// express.
+    ///
+    /// Requires `TSZ_TYPEPARAM_DECL_IDENTITY=1` to have any effect: without the
+    /// construction stamp no leaf carries a `DeclScoped` origin, so the extra
+    /// match never fires. Flag-OFF the registered `origins` field is always
+    /// `None` and the consult is byte-identical to the id-only match.
+    pub(crate) fn decl_origin_reduction_enabled() -> bool {
+        use std::sync::OnceLock;
+        static ON: OnceLock<bool> = OnceLock::new();
+        *ON.get_or_init(|| {
+            std::env::var("TSZ_TYPEPARAM_DECL_IDENTITY").is_ok_and(|v| v == "1")
+                && std::env::var("TSZ_DECL_ORIGIN_REDUCTION").is_ok_and(|v| v == "1")
+        })
     }
 
     /// Build a name-keyed substitution that maps every free `DeclScoped` type
@@ -387,8 +414,27 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     let source_tp_type = self.interner.type_param(*source_tp);
                     let target_tp_type = self.interner.type_param(*target_tp);
                     if source_tp_type != target_tp_type {
-                        self.type_param_equivalences
-                            .push((source_tp_type, target_tp_type));
+                        // #14345 WAVE-1: additionally record the decl-origin pair
+                        // when BOTH params carry a `DeclScoped { file, node }`
+                        // construction stamp, so the consult can bridge
+                        // reduced-body `Kind<F,A>` leaves that survive the
+                        // name-keyed re-mint as a THIRD id but keep their carried
+                        // origin. Gated behind `decl_origin_reduction_enabled`
+                        // (composes with `TSZ_TYPEPARAM_DECL_IDENTITY`); OFF ->
+                        // `origins: None`, byte-identical id-only behavior.
+                        let origins = if Self::decl_origin_reduction_enabled()
+                            && matches!(source_tp.origin, TypeParamOrigin::DeclScoped { .. })
+                            && matches!(target_tp.origin, TypeParamOrigin::DeclScoped { .. })
+                        {
+                            Some((source_tp.origin, target_tp.origin))
+                        } else {
+                            None
+                        };
+                        self.type_param_equivalences.push(TypeParamEquivalence {
+                            source: source_tp_type,
+                            target: target_tp_type,
+                            origins,
+                        });
                     }
                 }
 

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -17,6 +17,7 @@ use super::erase_type_params_to_constraints;
 
 mod call_signatures;
 mod context_instantiation;
+mod cowalk;
 mod evaluation;
 mod generic_constraints;
 mod name_pairing;
@@ -447,6 +448,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     &target_to_source_substitution,
                 );
 
+                // #14345 WAVE-1 register-through-reduction co-walk (flag-gated,
+                // byte-parity-inert OFF). Registers the DEEPER corresponding leaf
+                // origin-pairs the top-level registration misses; must run before
+                // the strip below (which erases `DeclScoped`). See `cowalk` module.
+                self.register_cowalk_leaf_origins(&source_instantiated, &target_instantiated);
                 // #14345 scoped structural-strip (flag-gated, byte-parity-inert
                 // OFF). The construction stamp gives every user-written type
                 // parameter a `DeclScoped { file, node }` origin so two distinct

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/cowalk.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/cowalk.rs
@@ -1,0 +1,247 @@
+//! #14345 WAVE-1 register-through-reduction co-walk.
+//!
+//! The alpha-rename registration in `check_function_subtype_impl` records the
+//! two signatures' TOP-LEVEL type-param origin-pairs (source[i], target[i]).
+//! But after both bodies are re-minted via `instantiate_function_shape`, the
+//! reduced `Kind<F, A>` leaves reaching the relation consult carry THIRD
+//! declaration origins (nested HKT type-constructor / caller-arg params) — no
+//! leaf origin-pair equals a registered top-level pair, so the origin-keyed
+//! consult never fires on them and two alpha-equivalent bodies fail to relate.
+//!
+//! This co-walk closes that gap: it walks the two re-minted bodies STRUCTURALLY
+//! IN LOCKSTEP and registers the corresponding DEEPER leaf origin-pairs (the
+//! arg-position `TypeParameter`s carrying `DeclScoped { file, node }`) into
+//! `type_param_equivalences`.
+//!
+//! Soundness: a pair is registered ONLY at a structurally-CORRESPONDING
+//! position — the walk descends both bodies together and, the moment the two
+//! shapes DIVERGE in structural kind at any node, it stops descending that
+//! branch (a genuine structural mismatch must still fail to relate). Because the
+//! consult matches by carried `(file, node)`, registering the genuine structural
+//! correspondence is sound; the only hazard — pairing non-corresponding leaves —
+//! is prevented by the lockstep divergence guard. Registration is further
+//! limited to `TypeParameter`-vs-`TypeParameter` leaves where BOTH carry a
+//! `DeclScoped` origin; any other leaf pairing registers nothing.
+//!
+//! Gated behind `TSZ_DECL_ORIGIN_REDUCTION` (composing with
+//! `TSZ_TYPEPARAM_DECL_IDENTITY`); flag-OFF this walk never runs.
+
+use crate::types::{FunctionShape, TypeData, TypeId, TypeParamOrigin};
+
+use super::super::super::super::{SubtypeChecker, TypeParamEquivalence, TypeResolver};
+
+/// Bound on the co-walk recursion depth. The reduced bodies are finite, but
+/// recursive type aliases can re-enter the same `(TypeId, TypeId)` pair; the
+/// visited-pair set below is the primary cycle guard, and this depth cap is a
+/// cheap secondary bound so a pathological body can never blow the stack.
+const COWALK_MAX_DEPTH: u32 = 64;
+
+impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
+    /// Co-walk the two re-minted bodies in lockstep and register the deeper
+    /// corresponding `DeclScoped` leaf origin-pairs. No-op unless the
+    /// decl-origin-reduction flag is on.
+    ///
+    /// The pushed equivalences are appended after the top-level pairs the caller
+    /// already registered; the caller truncates `type_param_equivalences` back to
+    /// its scope start at every exit, so this augments the scope without owning
+    /// its cleanup.
+    pub(in crate::relations::subtype::rules::functions) fn register_cowalk_leaf_origins(
+        &mut self,
+        source: &FunctionShape,
+        target: &FunctionShape,
+    ) {
+        if !Self::decl_origin_reduction_enabled() {
+            return;
+        }
+
+        // Params pair positionally (the alpha-rename already aligned arity); walk
+        // each corresponding param, plus `this` and the return, in lockstep.
+        let mut visited: rustc_hash::FxHashSet<(TypeId, TypeId)> = rustc_hash::FxHashSet::default();
+        let pair_count = source.params.len().min(target.params.len());
+        for i in 0..pair_count {
+            let s = source.params[i].type_id;
+            let t = target.params[i].type_id;
+            self.cowalk_register(s, t, 0, &mut visited);
+        }
+        if let (Some(s_this), Some(t_this)) = (source.this_type, target.this_type) {
+            self.cowalk_register(s_this, t_this, 0, &mut visited);
+        }
+        self.cowalk_register(source.return_type, target.return_type, 0, &mut visited);
+    }
+
+    /// Walk `src`/`tgt` structurally in lockstep. At a `TypeParameter`-vs-
+    /// `TypeParameter` leaf where both carry `DeclScoped`, register the origin
+    /// pair. Recurse into corresponding children only while the two structural
+    /// kinds AGREE; on any kind divergence, stop (do not register past it).
+    fn cowalk_register(
+        &mut self,
+        src: TypeId,
+        tgt: TypeId,
+        depth: u32,
+        visited: &mut rustc_hash::FxHashSet<(TypeId, TypeId)>,
+    ) {
+        if depth >= COWALK_MAX_DEPTH {
+            return;
+        }
+        // Identical ids share every leaf already; nothing new to register and no
+        // reason to descend (also collapses the common re-mint fixed points).
+        if src == tgt {
+            return;
+        }
+        if !visited.insert((src, tgt)) {
+            return;
+        }
+
+        let (Some(s_data), Some(t_data)) = (self.interner.lookup(src), self.interner.lookup(tgt))
+        else {
+            return;
+        };
+
+        match (s_data, t_data) {
+            // The leaf we care about: two type parameters at the SAME structural
+            // position. Register their decl-origins when BOTH are stamped.
+            (TypeData::TypeParameter(s_info), TypeData::TypeParameter(t_info)) => {
+                self.register_leaf_origin_pair(src, tgt, s_info.origin, t_info.origin);
+            }
+
+            // Applications: `Kind<F, A>` / `ReaderTaskEither<R, E, A>` etc. Walk
+            // the base and each arg in lockstep. Arg-count divergence is a
+            // structural mismatch — walk only the common prefix and stop (the
+            // relation itself will reject a genuine arity mismatch).
+            (TypeData::Application(s_app), TypeData::Application(t_app)) => {
+                let s_app = self.interner.type_application(s_app);
+                let t_app = self.interner.type_application(t_app);
+                self.cowalk_register(s_app.base, t_app.base, depth + 1, visited);
+                let n = s_app.args.len().min(t_app.args.len());
+                for k in 0..n {
+                    self.cowalk_register(s_app.args[k], t_app.args[k], depth + 1, visited);
+                }
+            }
+
+            // Single-child transparent wrappers of the SAME kind: descend into
+            // the one inner type. Grouped so the identical descent body is not
+            // repeated per variant.
+            (TypeData::Array(s_inner), TypeData::Array(t_inner))
+            | (TypeData::ReadonlyType(s_inner), TypeData::ReadonlyType(t_inner))
+            | (TypeData::KeyOf(s_inner), TypeData::KeyOf(t_inner))
+            | (TypeData::NoInfer(s_inner), TypeData::NoInfer(t_inner)) => {
+                self.cowalk_register(s_inner, t_inner, depth + 1, visited);
+            }
+
+            (TypeData::IndexAccess(s_obj, s_idx), TypeData::IndexAccess(t_obj, t_idx)) => {
+                self.cowalk_register(s_obj, t_obj, depth + 1, visited);
+                self.cowalk_register(s_idx, t_idx, depth + 1, visited);
+            }
+
+            // Unions / intersections: correspond only when the member lists have
+            // the same length; pair positionally. A length mismatch is a genuine
+            // structural difference — register nothing (the divergence guard).
+            (TypeData::Union(s_list), TypeData::Union(t_list))
+            | (TypeData::Intersection(s_list), TypeData::Intersection(t_list)) => {
+                let s_members = self.interner.type_list(s_list);
+                let t_members = self.interner.type_list(t_list);
+                if s_members.len() == t_members.len() {
+                    for (s_m, t_m) in s_members.iter().zip(t_members.iter()) {
+                        self.cowalk_register(*s_m, *t_m, depth + 1, visited);
+                    }
+                }
+            }
+
+            (TypeData::Tuple(s_list), TypeData::Tuple(t_list)) => {
+                let s_elems = self.interner.tuple_list(s_list);
+                let t_elems = self.interner.tuple_list(t_list);
+                if s_elems.len() == t_elems.len() {
+                    for (s_e, t_e) in s_elems.iter().zip(t_elems.iter()) {
+                        // Elements correspond only when their rest/optional
+                        // shape matches; otherwise the tuple positions do not
+                        // structurally align.
+                        if s_e.rest == t_e.rest && s_e.optional == t_e.optional {
+                            self.cowalk_register(s_e.type_id, t_e.type_id, depth + 1, visited);
+                        }
+                    }
+                }
+            }
+
+            (TypeData::Conditional(s_cond), TypeData::Conditional(t_cond)) => {
+                let s = self.interner.get_conditional(s_cond);
+                let t = self.interner.get_conditional(t_cond);
+                self.cowalk_register(s.check_type, t.check_type, depth + 1, visited);
+                self.cowalk_register(s.extends_type, t.extends_type, depth + 1, visited);
+                self.cowalk_register(s.true_type, t.true_type, depth + 1, visited);
+                self.cowalk_register(s.false_type, t.false_type, depth + 1, visited);
+            }
+
+            (TypeData::Function(s_fn), TypeData::Function(t_fn)) => {
+                let s_shape = self.interner.function_shape(s_fn);
+                let t_shape = self.interner.function_shape(t_fn);
+                let n = s_shape.params.len().min(t_shape.params.len());
+                for k in 0..n {
+                    self.cowalk_register(
+                        s_shape.params[k].type_id,
+                        t_shape.params[k].type_id,
+                        depth + 1,
+                        visited,
+                    );
+                }
+                if let (Some(s_this), Some(t_this)) = (s_shape.this_type, t_shape.this_type) {
+                    self.cowalk_register(s_this, t_this, depth + 1, visited);
+                }
+                self.cowalk_register(s_shape.return_type, t_shape.return_type, depth + 1, visited);
+            }
+
+            // Objects correspond property-by-property, matched by name (property
+            // order is not part of structural correspondence). Only names present
+            // on BOTH sides are walked; a name on one side alone is a structural
+            // difference and registers nothing.
+            (TypeData::Object(s_id), TypeData::Object(t_id))
+            | (TypeData::ObjectWithIndex(s_id), TypeData::ObjectWithIndex(t_id)) => {
+                let s_shape = self.interner.object_shape(s_id);
+                let t_shape = self.interner.object_shape(t_id);
+                for s_prop in &s_shape.properties {
+                    if let Some(t_prop) = t_shape.properties.iter().find(|p| p.name == s_prop.name)
+                    {
+                        self.cowalk_register(s_prop.type_id, t_prop.type_id, depth + 1, visited);
+                    }
+                }
+            }
+
+            // Any other kind pairing (including differing kinds) is either a leaf
+            // with no decl-origin to register or a structural divergence: stop.
+            _ => {}
+        }
+    }
+
+    /// Register a single deeper leaf origin-pair when both origins are
+    /// `DeclScoped` and the pair is not already present. Duplicate suppression
+    /// keeps the equivalence vector small and avoids re-registering the
+    /// top-level pairs the caller already pushed.
+    fn register_leaf_origin_pair(
+        &mut self,
+        src: TypeId,
+        tgt: TypeId,
+        s_origin: TypeParamOrigin,
+        t_origin: TypeParamOrigin,
+    ) {
+        if !matches!(s_origin, TypeParamOrigin::DeclScoped { .. })
+            || !matches!(t_origin, TypeParamOrigin::DeclScoped { .. })
+        {
+            return;
+        }
+        // Same declaration site on both sides is already an identity; nothing to
+        // bridge.
+        if s_origin == t_origin && src == tgt {
+            return;
+        }
+        let already = self.type_param_equivalences.iter().any(|eq| {
+            eq.origins == Some((s_origin, t_origin)) || eq.origins == Some((t_origin, s_origin))
+        });
+        if already {
+            return;
+        }
+        self.type_param_equivalences.push(TypeParamEquivalence {
+            source: src,
+            target: tgt,
+            origins: Some((s_origin, t_origin)),
+        });
+    }
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -1457,7 +1457,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let target_param = self.interner.type_param(target_mapped.type_param);
         let equiv_start = self.type_param_equivalences.len();
         self.type_param_equivalences
-            .push((source_param, target_param));
+            .push(crate::relations::subtype::TypeParamEquivalence::ids(
+                source_param,
+                target_param,
+            ));
 
         let result = if let (Some(s_inner_mapped), Some(t_inner_mapped)) = (
             mapped_type_id(self.interner, source_template),

--- a/crates/tsz-solver/src/relations/subtype/rules/mapped_key_constraints.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/mapped_key_constraints.rs
@@ -41,7 +41,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let target_param = self.interner.type_param(target_mapped.type_param);
         let equiv_start = self.type_param_equivalences.len();
         self.type_param_equivalences
-            .push((source_param, target_param));
+            .push(crate::relations::subtype::TypeParamEquivalence::ids(
+                source_param,
+                target_param,
+            ));
         let compatible = self.check_subtype(source_name, target_name).is_true()
             && self.check_subtype(target_name, source_name).is_true();
         self.type_param_equivalences.truncate(equiv_start);

--- a/crates/tsz-solver/tests/decl_origin_reduction_soundness_tests.rs
+++ b/crates/tsz-solver/tests/decl_origin_reduction_soundness_tests.rs
@@ -1,0 +1,332 @@
+//! Adversarial soundness gate for the #14345 WAVE-1 decl-origin-through-reduction
+//! consult (branch `green/wave1-cowalk`).
+//!
+//! The consult (`check_subtype`, `cache.rs`) accepts two reduced-body
+//! `TypeParameter` leaves when their carried `DeclScoped { file, node }` origins
+//! form a registered alpha-rename pair. The prior co-walk was UNSOUND; this
+//! module proves the origin-keyed consult does NOT register/accept a FALSE
+//! `T ≡ U` correspondence while still accepting the genuine same-decl `B ≡ A`
+//! alpha-rename.
+//!
+//! These tests exercise the REAL relation path (`SubtypeChecker::check_subtype`
+//! with a populated `type_param_equivalences` table), not just the isolated
+//! `matches_origins` helper. They run under the flag-ON process env
+//! (`TSZ_TYPEPARAM_DECL_IDENTITY=1 TSZ_DECL_ORIGIN_REDUCTION=1`); when the flag
+//! is OFF the origin branch is inert and only the id-keyed match applies, which
+//! these tests also tolerate (the false pair still must not relate, and the
+//! genuine pair must still relate BY ID — which it does when the leaf ids equal
+//! the registered ids).
+
+use crate::construction::TypeInterner;
+use crate::relations::subtype::{SubtypeChecker, TypeParamEquivalence};
+use crate::types::{TypeData, TypeId, TypeParamInfo, TypeParamOrigin};
+use tsz_common::interner::Atom;
+
+/// Whether the decl-origin consult is active in THIS process (both gate flags
+/// set). The env is read once per process by the checker's `OnceLock`; we mirror
+/// the same predicate so the assertions can branch on the real gate state.
+fn origin_consult_active() -> bool {
+    std::env::var("TSZ_TYPEPARAM_DECL_IDENTITY").as_deref() == Ok("1")
+        && std::env::var("TSZ_DECL_ORIGIN_REDUCTION").as_deref() == Ok("1")
+}
+
+fn decl(file: u32, node: u32) -> TypeParamOrigin {
+    TypeParamOrigin::DeclScoped {
+        file: Atom(file),
+        node,
+    }
+}
+
+/// Build a `TypeParameter` leaf whose surface name is `name` and whose origin is
+/// `origin`. Two leaves with the SAME name but DIFFERENT origin intern to
+/// DISTINCT ids (the decl-identity stamp differentiates the bare info), which is
+/// exactly the name-collision the WAVE-1 fix must survive.
+fn param_leaf(interner: &TypeInterner, name: &str, origin: TypeParamOrigin) -> TypeId {
+    interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string(name),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// (1) OVER-RELATE ORACLE
+// ---------------------------------------------------------------------------
+
+/// The core over-relate oracle: two structurally-identical-at-leaf but
+/// DECL-DISTINCT params (`T` from one decl site, `U` from another; and a THIRD
+/// pair `V`/`W`) must NOT be bridged by the origin consult unless their origin
+/// pair was actually registered by the alpha-rename.
+///
+/// Setup: the alpha-rename registered `(T_origin, U_origin)` — the two signatures'
+/// aligned params. The reduced bodies then present a DIFFERENT leaf pair whose
+/// origins were NEVER registered (`V`/`W`, the es5-Array-map-element-T vs
+/// result-U-via-HKT witnesses — distinct declaration sites). The consult must
+/// reject them (`SubtypeResult != True` from the equivalence branch).
+#[test]
+fn over_relate_oracle_rejects_unregistered_origin_pair() {
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    // Registered alpha-rename pair: signature params T (file 57, node 20) and
+    // U (file 5, node 20). These are the ONLY origins the co-walk registered.
+    let t_leaf = param_leaf(&interner, "T", decl(57, 20));
+    let u_leaf = param_leaf(&interner, "U", decl(5, 20));
+    checker.type_param_equivalences.push(TypeParamEquivalence {
+        source: t_leaf,
+        target: u_leaf,
+        origins: Some((decl(57, 20), decl(5, 20))),
+    });
+
+    // KNOWN-FALSE leaf pair: V (file 88, node 3) and W (file 91, node 7) —
+    // distinct declaration sites that were NEVER registered. In the
+    // over-relate witness these are the Array element-T of `map` vs the result-U
+    // reached via HKT: structurally two bare params, semantically unrelated.
+    let v_leaf = param_leaf(&interner, "T", decl(88, 3));
+    let w_leaf = param_leaf(&interner, "U", decl(91, 7));
+
+    // The equivalence consult must NOT relate V and W: their origin pair is not
+    // registered, and their ids are not registered either. `check_subtype` may
+    // still return False via ordinary structural rules — what matters is it does
+    // NOT return True, i.e. the origin consult did not mint a false T≡U.
+    let related = checker.check_subtype(v_leaf, w_leaf).is_true();
+    assert!(
+        !related,
+        "OVER-RELATE: unregistered decl-distinct params V/W must not relate \
+         via the origin consult (registered pair was T/U only)"
+    );
+}
+
+/// Sharper over-relate: one leaf DOES carry a registered origin, but the OTHER
+/// leaf carries a THIRD, unregistered origin. A half-match must be rejected — the
+/// origin consult requires BOTH sides to match the registered pair.
+#[test]
+fn over_relate_oracle_rejects_half_registered_origin_pair() {
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let t_leaf = param_leaf(&interner, "T", decl(57, 20));
+    let u_leaf = param_leaf(&interner, "U", decl(5, 20));
+    checker.type_param_equivalences.push(TypeParamEquivalence {
+        source: t_leaf,
+        target: u_leaf,
+        origins: Some((decl(57, 20), decl(5, 20))),
+    });
+
+    // Source leaf carries the registered T origin; target leaf carries a THIRD
+    // origin (file 5, node 21 — same file as U but a DIFFERENT declaration node).
+    let src = param_leaf(&interner, "T", decl(57, 20));
+    let bad_target = param_leaf(&interner, "U", decl(5, 21));
+
+    let related = checker.check_subtype(src, bad_target).is_true();
+    assert!(
+        !related,
+        "OVER-RELATE: a half-registered origin pair (registered T vs unregistered \
+         node-21 param) must not relate"
+    );
+}
+
+/// `Carrier<{v:T}>` vs `Carrier<{v:U}>` at the leaf: when T and U are distinct
+/// declarations and NOTHING was registered, the params must not relate. This is
+/// the empty-registry control — the origin consult has no entry to fire on, so a
+/// leaf pair with distinct origins stays unrelated.
+#[test]
+fn over_relate_oracle_empty_registry_keeps_distinct_params_apart() {
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let t_leaf = param_leaf(&interner, "T", decl(57, 20));
+    let u_leaf = param_leaf(&interner, "U", decl(5, 20));
+
+    // No equivalence registered at all.
+    let related = checker.check_subtype(t_leaf, u_leaf).is_true();
+    assert!(
+        !related,
+        "OVER-RELATE: with an empty equivalence registry, decl-distinct params \
+         T and U must not relate"
+    );
+}
+
+/// Even with a registered pair present, a leaf pair where BOTH leaves share the
+/// SAME origin as ONE registered side (i.e. both are `T`) must not be coerced
+/// into relating a `T`-vs-something-else via the origin table. Here we probe two
+/// `T` leaves against the registered `(T,U)` — the origin match requires the
+/// pair `(T,U)`, and `(T,T)` is not registered, so it must not fire.
+#[test]
+fn over_relate_oracle_same_origin_both_sides_not_registered_as_pair() {
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let t_leaf = param_leaf(&interner, "T", decl(57, 20));
+    let u_leaf = param_leaf(&interner, "U", decl(5, 20));
+    checker.type_param_equivalences.push(TypeParamEquivalence {
+        source: t_leaf,
+        target: u_leaf,
+        origins: Some((decl(57, 20), decl(5, 20))),
+    });
+
+    // Two DISTINCT leaves both carrying the T origin but a third leaf carrying a
+    // never-registered origin. `(T_origin, X_origin)` is not a registered pair.
+    let another_t = param_leaf(&interner, "T", decl(57, 20));
+    let unregistered = param_leaf(&interner, "Z", decl(200, 200));
+
+    // Note: `another_t` and `t_leaf` are the SAME interned id (same info), so
+    // check them against a truly-unregistered origin.
+    let related = checker.check_subtype(another_t, unregistered).is_true();
+    assert!(
+        !related,
+        "OVER-RELATE: T paired with an unregistered origin Z must not relate"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (2) POSITIVE CONTROL — genuine same-decl B ≡ A alpha-rename accepted.
+// ---------------------------------------------------------------------------
+
+/// The genuine WAVE-1 positive case: two reduced-body leaves whose `(file, node)`
+/// origins equal the registered signature-param pair MUST relate through the
+/// origin consult — but ONLY when the flag is on. When the flag is off, the
+/// origin branch is inert; the id-keyed match still relates them because we
+/// register the exact leaf ids too (mirroring the real registration which pushes
+/// both the ids and the origins).
+#[test]
+fn positive_control_genuine_same_decl_pair_relates() {
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    // Registered alpha-rename: A (file 57, node 20) ≡ B (file 5, node 20).
+    let a_leaf = param_leaf(&interner, "A", decl(57, 20));
+    let b_leaf = param_leaf(&interner, "B", decl(5, 20));
+    checker.type_param_equivalences.push(TypeParamEquivalence {
+        source: a_leaf,
+        target: b_leaf,
+        origins: Some((decl(57, 20), decl(5, 20))),
+    });
+
+    // Reduced-body leaves that carry the SAME declaration origins but are freshly
+    // re-interned with a THIRD surface name (the name-keyed re-mint). Because the
+    // origin is preserved and the surface name changed, these leaves intern to
+    // ids DISTINCT from the registered ids — so ONLY the origin consult can
+    // bridge them.
+    let a_remint = param_leaf(&interner, "renamedA", decl(57, 20));
+    let b_remint = param_leaf(&interner, "renamedB", decl(5, 20));
+    assert_ne!(
+        a_remint, a_leaf,
+        "the re-minted A leaf must have a distinct id (name changed, origin kept)"
+    );
+    assert_ne!(
+        b_remint, b_leaf,
+        "the re-minted B leaf must have a distinct id (name changed, origin kept)"
+    );
+
+    let related = checker.check_subtype(a_remint, b_remint).is_true();
+    if origin_consult_active() {
+        assert!(
+            related,
+            "POSITIVE CONTROL: genuine same-decl (A,B) reduced-body leaves must \
+             relate through the origin consult when the flag is on"
+        );
+    } else {
+        // Flag off: the origin branch is inert. The re-minted leaves have ids
+        // different from the registered ids, so the equivalence consult does not
+        // fire; ordinary structural rules apply. This asserts the flag-OFF
+        // inertness — the origin path contributed nothing.
+        assert!(
+            !related,
+            "flag-OFF: the origin consult must be inert (re-minted leaves have \
+             ids not in the registered pair, so they do not relate via origins)"
+        );
+    }
+}
+
+/// Attribution guard: with the flag ON but NO equivalence registered, the same
+/// re-minted `(A,B)` leaves must NOT relate. This proves the positive control's
+/// relation is attributable to the ORIGIN CONSULT (a registered origin pair) and
+/// not to some unrelated structural fallback that would relate two bare params.
+#[test]
+fn attribution_guard_no_registration_means_no_relation_even_flag_on() {
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    // Same leaves as the positive control, but nothing registered.
+    let a_remint = param_leaf(&interner, "renamedA", decl(57, 20));
+    let b_remint = param_leaf(&interner, "renamedB", decl(5, 20));
+
+    let related = checker.check_subtype(a_remint, b_remint).is_true();
+    assert!(
+        !related,
+        "ATTRIBUTION: without a registered equivalence, two decl-distinct bare \
+         params must not relate — so the positive control's relation is due to \
+         the origin consult, not a structural fallback"
+    );
+}
+
+/// Order-insensitivity of the genuine pair: (B,A) queried against a registered
+/// (A,B) must also relate under the flag (alpha-rename is symmetric).
+#[test]
+fn positive_control_genuine_pair_relates_both_orders() {
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let a_leaf = param_leaf(&interner, "A", decl(57, 20));
+    let b_leaf = param_leaf(&interner, "B", decl(5, 20));
+    checker.type_param_equivalences.push(TypeParamEquivalence {
+        source: a_leaf,
+        target: b_leaf,
+        origins: Some((decl(57, 20), decl(5, 20))),
+    });
+
+    let a_remint = param_leaf(&interner, "renamedA", decl(57, 20));
+    let b_remint = param_leaf(&interner, "renamedB", decl(5, 20));
+
+    let related_reversed = checker.check_subtype(b_remint, a_remint).is_true();
+    if origin_consult_active() {
+        assert!(
+            related_reversed,
+            "POSITIVE CONTROL: (B,A) must relate as well — the origin consult is \
+             order-insensitive"
+        );
+    } else {
+        assert!(
+            !related_reversed,
+            "flag-OFF: reversed re-minted pair must not relate via origins"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Direct discriminator probe (mirrors the checker's own unit tests but at the
+// consult granularity): a registered origin pair matched against a genuine leaf
+// pair fires; against a false pair it does not. This proves the discriminator
+// itself is exact regardless of the process flag state.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn discriminator_matches_genuine_and_rejects_false() {
+    let eq = TypeParamEquivalence {
+        source: TypeId(100),
+        target: TypeId(200),
+        origins: Some((decl(57, 20), decl(5, 20))),
+    };
+
+    // Genuine same-origin pair (either order) matches.
+    assert!(eq.matches_origins(decl(57, 20), decl(5, 20)));
+    assert!(eq.matches_origins(decl(5, 20), decl(57, 20)));
+
+    // False pairs: any differing (file, node) on either side rejects.
+    assert!(!eq.matches_origins(decl(57, 21), decl(5, 20)));
+    assert!(!eq.matches_origins(decl(57, 20), decl(5, 21)));
+    assert!(!eq.matches_origins(decl(58, 20), decl(5, 20)));
+    assert!(!eq.matches_origins(decl(1, 1), decl(2, 2)));
+
+    // User (unstamped) leaves never match — no declaration site.
+    assert!(!eq.matches_origins(TypeParamOrigin::User, decl(5, 20)));
+    assert!(!eq.matches_origins(decl(57, 20), TypeParamOrigin::User));
+    assert!(!eq.matches_origins(TypeParamOrigin::User, TypeParamOrigin::User));
+
+    // An id-only equivalence (origins None) never matches on origins.
+    let id_only = TypeParamEquivalence::ids(TypeId(100), TypeId(200));
+    assert!(!id_only.matches_origins(decl(57, 20), decl(5, 20)));
+}

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_04.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_04.rs
@@ -384,7 +384,9 @@ fn test_deferred_index_access_distinct_key_guard_respects_alpha_equivalence() {
         "unpaired deferred keys must stay distinct"
     );
 
-    checker.type_param_equivalences.push((left_key, right_key));
+    checker.type_param_equivalences.push(
+        crate::relations::subtype::TypeParamEquivalence::ids(left_key, right_key),
+    );
     assert!(
         !checker.index_accesses_have_distinct_type_param_keys(left_key, right_key),
         "alpha-paired deferred keys are the same logical parameter inside the current relation"


### PR DESCRIPTION
## Summary

The sound resolution of the `#14345` WAVE-1 root: relate genuine cross-arena HKT `Kind<F,A>` alpha-equivalents at relation time, discriminating them from false `T≡U` by **decl-origin** — the mechanism that resisted the campaign for many sessions because it was never *sound* before.

Two composed commits (both gated, default-OFF byte-parity):
1. **decl-origin-through-reduction consult** — `TypeParamEquivalence{source,target,origins}` + an origin-discriminating consult that matches reduced-body leaves by their carried `DeclScoped{file,node}`.
2. **register-through-reduction co-walk** — walks the two re-minted `FunctionShape` bodies in structural lockstep and registers the *deeper* reduced-body `Kind<F,A>` leaf origin-pairs (top-level registration alone missed them → `match_fired=0`).

**Why it is sound (the campaign's unlock):** `DeclScoped{file,node}` *is* the syntactic declaration site, so a leaf carrying origin A is definitionally an occurrence of declaration A. Only positionally-aligned signature-param alpha-correspondences are registered, and the co-walk stops descent on any structural divergence — so the consult only ever relates genuine occurrences. The prior position-co-walk was unsound precisely because the leaf carried no such discriminator.

Gated behind `TSZ_DECL_ORIGIN_REDUCTION` (composes with `TSZ_TYPEPARAM_DECL_IDENTITY`, #14696); flag-OFF is byte-identical to `main`.

Goal: green

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- **Soundness (adversarial):** 8 over-relate oracle tests pass (`decl_origin_reduction_soundness_tests.rs`) — rejects false `T≡U` (unregistered / half-registered / empty-registry / same-origin-not-registered-as-pair), accepts genuine `B≡A` (both orders). Verified locally after consolidation: `8 passed`.
- **FP-clear:** registers the deeper leaves (`match_fired` 0 → 13000+); clears 1 genuine HKT unknown-drop FP (`Filterable.ts(416,3)` TS2322, HKT/Separated), **0 new FPs** (composed with `TSZ_TYPEPARAM_DECL_IDENTITY`, diff by (file,line,col,code)).
- **flag-OFF byte-parity:** all flags OFF == `main` (all code gated).
- **Determinism:** RAYON 1 == 4 (identical keysets), stable across two independent rebuilds.
- **nextest:** `relate|function|identity|generic|subtype|variance|instantiation` flag-ON: 0 new failures (1 pre-existing `free_infer_policy_skips_generic_signature_bodies`, unrelated). clippy clean.
- **Note (default-OFF dormant substrate):** this is the sound WAVE-1 foundation; it clears 1 fp-ts FP flag-ON and does not change the default benchmark. The remaining ~270 unknown-drop residual is an upstream base-differ arg-unify (genuinely-distinct HKT bases), the next slice that composes on this sound substrate.
