### PR TITLE
fix(emit): mint `??=` read-cache value temps in allocation order, one var

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -204,7 +204,6 @@ pub(crate) struct TempScopeState {
     pub(crate) preallocated_temp_names: VecDeque<String>,
     pub(crate) preallocated_hoisted_temp_names: VecDeque<String>,
     pub(crate) preallocated_assignment_temps: VecDeque<String>,
-    pub(crate) preallocated_logical_assignment_value_temps: VecDeque<String>,
     pub(crate) hoisted_assignment_value_temps: Vec<String>,
     pub(crate) hoisted_assignment_temps: Vec<String>,
     pub(crate) block_scoped_private_temps: Vec<String>,
@@ -669,13 +668,11 @@ pub struct Printer<'a> {
     /// TypeScript keeps this sequence file-scoped for ES2015+ class emit.
     pub(crate) next_auto_accessor_name_index: u32,
 
-    /// Temp names for assignment target values that need to be hoisted as `var _a, _b, ...;`.
-    /// These are emitted on a separate declaration list before reference temps.
+    /// Temp names for logical-assignment (`??=`) read-cache values. Tracked as a
+    /// distinct bucket only so a value temp minted inside a nested function body
+    /// is declared in that body; at emission the bucket is merged, in allocation
+    /// order, into the single hoisted `var` alongside the reference temps.
     pub(crate) hoisted_assignment_value_temps: Vec<String>,
-
-    /// Temp names for assignment target values that must be reserved before references.
-    /// These are used by `make_unique_name_hoisted_value`.
-    pub(crate) preallocated_logical_assignment_value_temps: VecDeque<String>,
 
     /// Temp names for assignment target values that must be reserved before references.
     /// These are used by `make_unique_name_hoisted_assignment`.

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -344,7 +344,6 @@ impl<'a> Printer<'a> {
             pending_auto_accessor_inits: Vec::new(),
             next_auto_accessor_name_index: 0,
             hoisted_assignment_value_temps: Vec::new(),
-            preallocated_logical_assignment_value_temps: VecDeque::new(),
             preallocated_assignment_temps: VecDeque::new(),
             hoisted_assignment_temps: Vec::new(),
             loop_iife_body_depth: 0,

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1815,23 +1815,13 @@ impl<'a> Printer<'a> {
             // Insert any temps hoisted while emitting field initializers (e.g.
             // `_a` for a class expression lowered inside a private-field init, or
             // a `??=` read-cache temp) at the top of this synthesized constructor
-            // body, then drop the scope. Value temps are inserted last so they
-            // land on the first line.
+            // body, then drop the scope. Assignment-target and logical-assignment
+            // value temps are declared in one `var` in allocation order, matching
+            // `tsc`.
             let synth_ctor_indent = self
                 .writer
                 .indent_string_at(synth_ctor_hoist_anchor.indent_level);
-            let assignment_temps = std::mem::take(&mut self.hoisted_assignment_temps);
-            self.insert_hoisted_var_line(
-                &assignment_temps,
-                &synth_ctor_hoist_anchor,
-                &synth_ctor_indent,
-            );
-            let value_temps = std::mem::take(&mut self.hoisted_assignment_value_temps);
-            self.insert_hoisted_var_line(
-                &value_temps,
-                &synth_ctor_hoist_anchor,
-                &synth_ctor_indent,
-            );
+            self.insert_constructor_hoisted_var_line(&synth_ctor_hoist_anchor, &synth_ctor_indent);
             self.pop_temp_scope();
             self.decrease_indent();
             self.write("}");

--- a/crates/tsz-emitter/src/emitter/declarations/class/private_method_defs.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/private_method_defs.rs
@@ -84,7 +84,6 @@ impl<'a> Printer<'a> {
         self.ctx.block_scope_state.enter_scope();
         self.push_temp_scope();
         let prev_declared = std::mem::take(&mut self.declared_namespace_names);
-        self.prepare_logical_assignment_value_temps(def.body);
         let prev_in_generator = self.ctx.flags.in_generator;
         self.ctx.flags.in_generator = def.is_generator;
         self.emit(def.body);
@@ -160,7 +159,6 @@ impl<'a> Printer<'a> {
         self.push_temp_scope();
         let prev_declared = std::mem::take(&mut self.declared_namespace_names);
         if let Some(body) = def.body {
-            self.prepare_logical_assignment_value_temps(body);
             self.emit_single_line_block(body);
         } else {
             self.write("{ }");

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -446,7 +446,6 @@ impl<'a> Printer<'a> {
                     self.preallocate_assignment_temps(temp_count);
                 }
             }
-            self.prepare_logical_assignment_value_temps(method.body);
             self.ctx.flags.in_generator = has_generator_asterisk;
             self.emit(method.body);
             self.declared_namespace_names = prev_declared;
@@ -1002,7 +1001,6 @@ impl<'a> Printer<'a> {
                 self.preallocate_assignment_temps(temp_count);
             }
         }
-        self.prepare_logical_assignment_value_temps(ctor.body);
         let auto_accessor_inits = std::mem::take(&mut self.pending_auto_accessor_inits);
         self.emit_constructor_body_with_prologue(
             ctor.body,
@@ -1387,15 +1385,12 @@ impl<'a> Printer<'a> {
 
         // Insert any hoisted temps created during statement emit (e.g., `_a` from
         // `??`/`??=` lowering). Assignment-target temps and logical-assignment
-        // value temps are inserted at the same anchor (value temps end up on the
-        // first line, matching `insert_function_body_hoisted_temps_at`).
+        // value temps are declared in one `var` in allocation order, matching
+        // `insert_function_body_hoisted_temps_at` and `tsc`.
         let hoisted_indent = self
             .writer
             .indent_string_at(hoisted_var_anchor.indent_level);
-        let assignment_temps = std::mem::take(&mut self.hoisted_assignment_temps);
-        self.insert_hoisted_var_line(&assignment_temps, &hoisted_var_anchor, &hoisted_indent);
-        let value_temps = std::mem::take(&mut self.hoisted_assignment_value_temps);
-        self.insert_hoisted_var_line(&value_temps, &hoisted_var_anchor, &hoisted_indent);
+        self.insert_constructor_hoisted_var_line(&hoisted_var_anchor, &hoisted_indent);
 
         self.decrease_indent();
         self.write("}");
@@ -1873,7 +1868,6 @@ impl<'a> Printer<'a> {
             self.push_temp_scope();
             // Save/restore declared_namespace_names for accessor body isolation.
             let prev_declared = std::mem::take(&mut self.declared_namespace_names);
-            self.prepare_logical_assignment_value_temps(body);
             self.write(" ");
             self.emit(body);
             self.declared_namespace_names = prev_declared;

--- a/crates/tsz-emitter/src/emitter/declarations/core.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/core.rs
@@ -232,7 +232,6 @@ impl<'a> Printer<'a> {
         // outer scope don't suppress declarations inside this function, and names
         // declared inside don't leak to sibling functions at the outer scope.
         let prev_declared = std::mem::take(&mut self.declared_namespace_names);
-        self.prepare_logical_assignment_value_temps(func.body);
         let prev_in_generator = self.ctx.flags.in_generator;
         self.ctx.flags.in_generator = func.asterisk_token;
         // A nested ordinary function or sync generator establishes its own

--- a/crates/tsz-emitter/src/emitter/es5/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers.rs
@@ -590,7 +590,6 @@ impl<'a> Printer<'a> {
             let needs_param_prologue = param_transforms.has_transforms();
             let prev_emitting_function_body_block = self.emitting_function_body_block;
             self.emitting_function_body_block = true;
-            self.prepare_logical_assignment_value_temps(func.body);
 
             if is_block {
                 // Check if it's a simple single-return block
@@ -858,7 +857,6 @@ impl<'a> Printer<'a> {
 
         let prev_emitting_function_body_block = self.emitting_function_body_block;
         self.emitting_function_body_block = true;
-        self.prepare_logical_assignment_value_temps(func.body);
         let previous_new_target_capture = needs_new_target_capture.then(|| {
             self.push_new_target_capture_for_initializer(
                 self.ordinary_function_new_target_initializer(function_name.as_deref()),
@@ -925,7 +923,6 @@ impl<'a> Printer<'a> {
         self.write_space();
         let prev_emitting_function_body_block = self.emitting_function_body_block;
         self.emitting_function_body_block = true;
-        self.prepare_logical_assignment_value_temps(func.body);
         let previous_new_target_capture = needs_new_target_capture.then(|| {
             self.push_new_target_capture_for_initializer(
                 self.ordinary_function_new_target_initializer(function_name.as_deref()),

--- a/crates/tsz-emitter/src/emitter/es5/helpers_object_literal.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_object_literal.rs
@@ -499,7 +499,6 @@ impl<'a> Printer<'a> {
         self.write(") ");
         let prev_emitting_function_body_block = self.emitting_function_body_block;
         self.emitting_function_body_block = true;
-        self.prepare_logical_assignment_value_temps(method.body);
         let previous_new_target_capture = self
             .function_like_contains_new_target(method.body, &method.parameters.nodes)
             .then(|| self.push_new_target_capture_for_initializer("void 0".into()));

--- a/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
@@ -477,22 +477,6 @@ impl<'a> Printer<'a> {
         }
     }
 
-    /// Whether lowering a non-es2020 `??=` with target `left` consumes a hoisted
-    /// value temp. Only a property/element-access target does (its reference is
-    /// captured: `(_a = obj.p) !== null && ...`); a bare identifier/`this`/`super`
-    /// is lowered inline with no temp. Shares the `is_property_or_element_access`
-    /// dispatch with `emit_logical_assignment_expression` so the pre-count cannot
-    /// drift from emit and desync the shared temp counter from `tsc`.
-    pub(in crate::emitter) fn nullish_assignment_consumes_value_temp(
-        &self,
-        left: NodeIndex,
-    ) -> bool {
-        let left = self.unwrap_parenthesized_logical_assignment_left(left);
-        self.arena
-            .get(left)
-            .is_some_and(is_property_or_element_access)
-    }
-
     fn unwrap_parenthesized_logical_assignment_left(&self, mut left: NodeIndex) -> NodeIndex {
         while let Some(left_node) = self.arena.get(left) {
             if left_node.kind != syntax_kind_ext::PARENTHESIZED_EXPRESSION {

--- a/crates/tsz-emitter/src/emitter/functions.rs
+++ b/crates/tsz-emitter/src/emitter/functions.rs
@@ -144,7 +144,6 @@ impl<'a> Printer<'a> {
         // outer scope don't suppress declarations inside this function, and names
         // declared inside don't leak to sibling functions at the outer scope.
         let prev_declared = std::mem::take(&mut self.declared_namespace_names);
-        self.prepare_logical_assignment_value_temps(func.body);
         let prev_in_generator = self.ctx.flags.in_generator;
         self.ctx.flags.in_generator = func.asterisk_token;
         // Regular functions have their own `arguments`, so turn off the rewrite flag

--- a/crates/tsz-emitter/src/emitter/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/helpers.rs
@@ -36,6 +36,19 @@ fn previous_identifier_token(text: &str, mut end: usize) -> Option<(&str, usize)
     (end < token_end).then(|| (&text[end..token_end], end))
 }
 
+/// Allocation rank of a canonical hoisted temp name (`_a`..`_z` -> 0..25,
+/// `_0`, `_1`, ... -> 26, 27, ...), i.e. the order `generate_fresh_temp_name`
+/// mints them. Returns `None` for non-canonical names. Ordering hoisted `var`
+/// declarations by this rank reproduces `tsc`'s single-`var` creation order.
+pub(in crate::emitter) fn temp_name_rank(name: &str) -> Option<u32> {
+    let tail = name.strip_prefix('_')?;
+    let bytes = tail.as_bytes();
+    if bytes.len() == 1 && bytes[0].is_ascii_lowercase() {
+        return Some(u32::from(bytes[0] - b'a'));
+    }
+    tail.parse::<u32>().ok().map(|rank| rank + 26)
+}
+
 impl<'a> Printer<'a> {
     pub(super) const fn take_pending_source_pos(&mut self) -> Option<SourcePosition> {
         self.pending_source_pos.take()
@@ -833,8 +846,6 @@ impl<'a> Printer<'a> {
         let saved_preallocated_hoisted = std::mem::take(&mut self.preallocated_hoisted_temp_names);
         let saved_preallocated_assignment_temps =
             std::mem::take(&mut self.preallocated_assignment_temps);
-        let saved_preallocated_logical_value_temps =
-            std::mem::take(&mut self.preallocated_logical_assignment_value_temps);
         let saved_hoisted = std::mem::take(&mut self.hoisted_assignment_temps);
         let saved_block_scoped_private_temps = std::mem::take(&mut self.block_scoped_private_temps);
         let saved_value_temps = std::mem::take(&mut self.hoisted_assignment_value_temps);
@@ -847,7 +858,6 @@ impl<'a> Printer<'a> {
             preallocated_temp_names: saved_preallocated,
             preallocated_hoisted_temp_names: saved_preallocated_hoisted,
             preallocated_assignment_temps: saved_preallocated_assignment_temps,
-            preallocated_logical_assignment_value_temps: saved_preallocated_logical_value_temps,
             hoisted_assignment_value_temps: saved_value_temps,
             hoisted_assignment_temps: saved_hoisted,
             block_scoped_private_temps: saved_block_scoped_private_temps,
@@ -867,8 +877,6 @@ impl<'a> Printer<'a> {
             self.preallocated_temp_names = state.preallocated_temp_names;
             self.preallocated_hoisted_temp_names = state.preallocated_hoisted_temp_names;
             self.preallocated_assignment_temps = state.preallocated_assignment_temps;
-            self.preallocated_logical_assignment_value_temps =
-                state.preallocated_logical_assignment_value_temps;
             self.hoisted_assignment_value_temps = state.hoisted_assignment_value_temps;
             self.hoisted_assignment_temps = state.hoisted_assignment_temps;
             self.block_scoped_private_temps = state.block_scoped_private_temps;
@@ -1023,47 +1031,6 @@ impl<'a> Printer<'a> {
         name
     }
 
-    pub(super) fn preallocate_logical_assignment_value_temps(&mut self, count: usize) {
-        self.preallocated_logical_assignment_value_temps.clear();
-        for _ in 0..count {
-            let name = self.generate_fresh_temp_name();
-            self.preallocated_logical_assignment_value_temps
-                .push_back(name);
-        }
-    }
-
-    fn count_logical_assignment_value_temps(&self, node_idx: NodeIndex) -> usize {
-        if self.ctx.options.target.supports_es2020() || node_idx.is_none() {
-            return 0;
-        }
-
-        let mut count = 0usize;
-        let mut stack = vec![node_idx];
-
-        while let Some(current) = stack.pop() {
-            let Some(node) = self.arena.get(current) else {
-                continue;
-            };
-
-            if let Some(binary) = self.arena.get_binary_expr(node)
-                && binary.operator_token == SyntaxKind::QuestionQuestionEqualsToken as u16
-                && self.nullish_assignment_consumes_value_temp(binary.left)
-            {
-                count += 1;
-            }
-
-            if self.is_logical_assignment_temp_scope_boundary(node) {
-                continue;
-            }
-
-            for child in self.arena.get_children(current) {
-                stack.push(child);
-            }
-        }
-
-        count
-    }
-
     fn is_logical_assignment_temp_scope_boundary(
         &self,
         node: &tsz_parser::parser::node::Node,
@@ -1073,17 +1040,6 @@ impl<'a> Printer<'a> {
             || self.arena.get_constructor(node).is_some()
             || self.arena.get_accessor(node).is_some()
             || self.arena.get_class(node).is_some()
-    }
-
-    pub(super) fn prepare_logical_assignment_value_temps(&mut self, node_idx: NodeIndex) {
-        if self.ctx.options.target.supports_es2020() {
-            return;
-        }
-
-        let count = self.count_logical_assignment_value_temps(node_idx);
-        if count > 0 {
-            self.preallocate_logical_assignment_value_temps(count);
-        }
     }
 
     fn count_object_rest_assignment_temps(&self, node_idx: NodeIndex) -> usize {
@@ -1303,15 +1259,51 @@ impl<'a> Printer<'a> {
 
     /// Like `make_unique_name` but also records the temp for hoisting before references.
     /// Used for assignment target values in logical-assignment lowering.
+    ///
+    /// The value temp is allocated lazily, at the point the `??=` expression is
+    /// emitted, from the same per-scope counter every other hoisted temp draws
+    /// from. This mirrors `tsc`, which mints each read-cache temp in evaluation
+    /// order so its `_a`/`_b`/... number reflects source position among the
+    /// scope's other down-leveled temps (optional-chaining, assignment-target,
+    /// `for..of`), rather than reserving low numbers ahead of them.
     pub(super) fn make_unique_name_hoisted_value(&mut self) -> String {
-        let name = if let Some(name) = self.preallocated_logical_assignment_value_temps.pop_front()
-        {
-            name
-        } else {
-            self.make_unique_name()
-        };
+        let name = self.make_unique_name();
         self.hoisted_assignment_value_temps.push(name.clone());
         name
+    }
+
+    /// Splice the logical-assignment (`??=`) read-cache value temps into
+    /// `ref_vars` at their allocation-rank positions, so the enclosing lexical
+    /// environment declares every down-leveled temp in one `var _a, _b, ...;` in
+    /// creation order — matching `tsc`, which does not split value temps onto a
+    /// separate declaration. The value temps and the reference temps draw from
+    /// the same per-scope counter, so `temp_name_rank` recovers each value
+    /// temp's creation position; the reference temps keep their relative order.
+    pub(super) fn merge_hoisted_value_temps(&self, ref_vars: &mut Vec<String>) {
+        for value in &self.hoisted_assignment_value_temps {
+            let value_rank = temp_name_rank(value);
+            let insert_at = ref_vars
+                .iter()
+                .position(|existing| match (value_rank, temp_name_rank(existing)) {
+                    (Some(v), Some(existing_rank)) => existing_rank > v,
+                    _ => false,
+                })
+                .unwrap_or(ref_vars.len());
+            ref_vars.insert(insert_at, value.clone());
+        }
+    }
+
+    /// Collect every down-leveled temp of the current lexical environment —
+    /// assignment-target, `for..of`, and merged logical-assignment (`??=`) value
+    /// temps — as one list in allocation order, ready to declare as a single
+    /// `var _a, _b, ...;`. Shared source of truth for the emission sites that
+    /// flush a scope's hoisted temps.
+    pub(super) fn collect_hoisted_ref_vars(&self) -> Vec<String> {
+        let mut ref_vars = Vec::new();
+        ref_vars.extend(self.hoisted_assignment_temps.iter().cloned());
+        ref_vars.extend(self.hoisted_for_of_temps.iter().cloned());
+        self.merge_hoisted_value_temps(&mut ref_vars);
+        ref_vars
     }
 
     // =========================================================================

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -1193,14 +1193,12 @@ impl<'a> Printer<'a> {
         self.hoisted_assignment_temps.clear();
         self.hoisted_file_level_class_temps.clear();
         self.hoisted_assignment_value_temps.clear();
-        self.preallocated_logical_assignment_value_temps.clear();
         self.preallocated_assignment_temps.clear();
         self.preallocated_hoisted_temp_names.clear();
         self.hoisted_for_of_temps.clear();
         self.preallocated_temp_names.clear();
         self.reserved_iterator_return_temps.clear();
         self.iterator_for_of_depth = 0;
-        self.prepare_logical_assignment_value_temps(source_idx);
         self.prepare_object_rest_assignment_temps(source_idx);
         self.preallocate_iterator_return_temps_for_statements(&source.statements.nodes);
         self.prealloc_for_of_destructure_temps(&source.statements.nodes);
@@ -1958,9 +1956,10 @@ impl<'a> Printer<'a> {
             (hoisted_var_byte_offset, hoisted_var_line)
         };
 
-        let mut ref_vars = Vec::new();
-        ref_vars.extend(self.hoisted_assignment_temps.iter().cloned());
-        ref_vars.extend(self.hoisted_for_of_temps.iter().cloned());
+        // Logical-assignment (`??=`) read-cache value temps share the file's temp
+        // counter with the reference temps; declare them all in one `var` in
+        // allocation order (matching `tsc`) rather than on a separate line.
+        let ref_vars = self.collect_hoisted_ref_vars();
 
         // A class-lowering temp can be reachable from more than one hoist
         // bucket (e.g. a class alias reserved as a file-level class temp that
@@ -2007,12 +2006,6 @@ impl<'a> Printer<'a> {
                 self.writer
                     .insert_line_at(hoist_byte_offset, hoist_line, &var_decl);
             }
-        }
-
-        if !self.hoisted_assignment_value_temps.is_empty() {
-            let var_decl = format!("var {};", self.hoisted_assignment_value_temps.join(", "));
-            self.writer
-                .insert_line_at(hoist_byte_offset, hoist_line, &var_decl);
         }
 
         // Insert CJS destructuring export temps before the __esModule marker.

--- a/crates/tsz-emitter/src/emitter/source_file/emit_parts/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit_parts/helpers.rs
@@ -1,5 +1,6 @@
 use super::super::super::Printer;
 use super::super::super::core::JsxEmit;
+use super::super::super::helpers::temp_name_rank;
 use tsz_common::common::ModuleKind;
 use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
@@ -531,15 +532,6 @@ impl<'a> Printer<'a> {
                 .as_ref()
                 .is_some_and(|args| args.nodes.len() >= 2)
     }
-}
-
-fn temp_name_rank(name: &str) -> Option<u32> {
-    let tail = name.strip_prefix('_')?;
-    let bytes = tail.as_bytes();
-    if bytes.len() == 1 && bytes[0].is_ascii_lowercase() {
-        return Some(u32::from(bytes[0] - b'a'));
-    }
-    tail.parse::<u32>().ok().map(|rank| rank + 26)
 }
 
 pub(in crate::emitter) fn jsx_dev_file_name(file_name: &str) -> String {

--- a/crates/tsz-emitter/src/emitter/source_file/logical_assignment_value_temp_order_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/logical_assignment_value_temp_order_tests.rs
@@ -1,0 +1,121 @@
+//! Logical-assignment (`??=`) read-cache value-temp ordering tests.
+//!
+//! Structural rule: when a lexical environment down-levels a nullish-assignment
+//! (`??=`) on a member target, `tsc` mints its read-cache value temp lazily, in
+//! evaluation order, from the same per-scope temp counter every other
+//! down-leveled temp (optional-chaining, assignment-target, `for..of`) draws
+//! from, and declares them all in a *single* `var _a, _b, ...;` in creation
+//! order. `tsz` previously (a) pre-reserved the value temp at scope entry — so a
+//! preceding optional chain wrongly received the higher numbers — and (b)
+//! declared the value temp on a *separate* `var` line. Both diverged from `tsc`.
+//!
+//! Binder/member names are varied so the assertions track the structural shape,
+//! not any spelling.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit_at(source: &str, target: ScriptTarget) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+/// A hoisted temp must never be split onto a second `var` line: `tsc` declares
+/// every down-leveled temp of one lexical environment in a single statement.
+fn assert_single_var_line(output: &str) {
+    assert!(
+        !output.contains("var _a;\nvar "),
+        "value temps must share the single hoisted `var`, not a separate line.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn optional_chain_before_nullish_assign_numbers_value_temp_last() {
+    // Optional chain (statement 1) takes `_a`,`_b`; the `??=` value temp
+    // (statement 2) is minted after, so it is `_c` — matching tsc.
+    let source = "const d = e?.f?.g?.();\nobj.x ??= 1;\n";
+    let output = emit_at(source, ScriptTarget::ES2017);
+    assert_single_var_line(&output);
+    assert!(
+        output.contains("var _a, _b, _c;"),
+        "all three temps share one `var` in creation order.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("(_c = obj.x)"),
+        "the `??=` value temp must be the last-minted `_c`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn nullish_assign_before_optional_chain_numbers_value_temp_first() {
+    // Reverse order: the `??=` value temp (statement 1) is minted first (`_a`);
+    // the optional chain (statement 2) takes `_b`,`_c`.
+    let source = "obj.x ??= 1;\nconst d = e?.f?.g?.();\n";
+    let output = emit_at(source, ScriptTarget::ES2017);
+    assert_single_var_line(&output);
+    assert!(
+        output.contains("var _a, _b, _c;"),
+        "all three temps share one `var` in creation order.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("(_a = obj.x)") && output.contains("_c = (_b ="),
+        "value temp `_a` precedes the optional-chain temps `_b`/`_c`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn renamed_binders_keep_structural_value_temp_order() {
+    // Same shape, different member spellings: the decision is structural.
+    let source = "const first = alpha?.beta?.gamma?.();\nwidget.slot ??= 7;\n";
+    let output = emit_at(source, ScriptTarget::ES2017);
+    assert_single_var_line(&output);
+    assert!(
+        output.contains("var _a, _b, _c;") && output.contains("(_c = widget.slot)"),
+        "renamed binders keep the value temp minted last (`_c`).\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn function_body_merges_value_temp_into_single_var() {
+    let source = "function run() { const d = e?.f?.g?.(); obj.x ??= 1; }\n";
+    let output = emit_at(source, ScriptTarget::ES2017);
+    assert_single_var_line(&output);
+    assert!(
+        output.contains("var _a, _b, _c;") && output.contains("(_c = obj.x)"),
+        "a function body declares its down-leveled temps in one `var`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn multiple_nullish_assign_value_temps_share_one_var_in_order() {
+    // Three `??=` in one environment: the value temps are minted in statement
+    // order and declared together, `var _a, _b, _c;` — not on separate lines
+    // and not pre-reserved out of order.
+    let source = "this0.a ??= 1;\nbox.b ??= 2;\nthis0.c ??= 3;\n";
+    let output = emit_at(source, ScriptTarget::ES2017);
+    assert_single_var_line(&output);
+    assert!(
+        output.contains("var _a, _b, _c;"),
+        "the three value temps share one `var` in creation order.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("(_a = this0.a)")
+            && output.contains("(_b = box.b)")
+            && output.contains("(_c = this0.c)"),
+        "each value temp keeps its statement-order number.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -77,3 +77,5 @@ mod es5_param_nested_default_temp_tests;
 mod es5_super_recovery_tests;
 #[cfg(test)]
 mod labeled_for_await_tests;
+#[cfg(test)]
+mod logical_assignment_value_temp_order_tests;

--- a/crates/tsz-emitter/src/emitter/source_file/top_level_using_parts/class_assignment.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/top_level_using_parts/class_assignment.rs
@@ -1,3 +1,4 @@
+use super::super::super::helpers::temp_name_rank;
 use super::super::super::{Printer, is_valid_identifier_name};
 use super::super::top_level_using_decorated::{
     export_decorate_assignment, strip_decorate_export_prefix,
@@ -8,17 +9,6 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_parser::syntax::transform_utils::is_private_identifier;
 use tsz_scanner::SyntaxKind;
-
-fn top_level_using_temp_name_rank(name: &str) -> Option<u32> {
-    let rest = name.strip_prefix('_')?;
-    if rest.len() == 1 {
-        let byte = rest.as_bytes()[0];
-        if byte.is_ascii_lowercase() {
-            return Some((byte - b'a') as u32);
-        }
-    }
-    rest.parse::<u32>().ok().map(|index| index + 26)
-}
 
 impl<'a> Printer<'a> {
     fn top_level_using_export_binding_stmt(&self, export_name: &str, local_name: &str) -> String {
@@ -471,8 +461,7 @@ impl<'a> Printer<'a> {
             .filter_map(|idx| self.file_level_class_temp_reservations.get(idx))
             .filter_map(|names| names.front().cloned())
             .collect();
-        class_expr_temps
-            .sort_by_key(|name| top_level_using_temp_name_rank(name).unwrap_or(u32::MAX));
+        class_expr_temps.sort_by_key(|name| temp_name_rank(name).unwrap_or(u32::MAX));
         for (class_idx, temp) in class_exprs
             .into_iter()
             .zip(class_expr_temps.iter().cloned())

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -745,16 +745,7 @@ impl<'a> Printer<'a> {
     }
 
     pub(in crate::emitter) fn emit_function_body_hoisted_temps(&mut self) {
-        if !self.hoisted_assignment_value_temps.is_empty() {
-            self.write("var ");
-            self.write(&self.hoisted_assignment_value_temps.join(", "));
-            self.write(";");
-            self.write_line();
-        }
-
-        let mut ref_vars = Vec::new();
-        ref_vars.extend(self.hoisted_assignment_temps.iter().cloned());
-        ref_vars.extend(self.hoisted_for_of_temps.iter().cloned());
+        let ref_vars = self.collect_hoisted_ref_vars();
 
         if !ref_vars.is_empty() {
             self.write("var ");
@@ -767,37 +758,24 @@ impl<'a> Printer<'a> {
     /// Build the inline `var _a; ` prologue for a *single-line* function/method
     /// body (e.g. `m() { o.v ??= 1; }`) and clear the underlying pools.
     ///
-    /// Mirrors the multi-line [`Self::emit_function_body_hoisted_temps`] ordering
-    /// (logical-assignment value temps first, then assignment-target/for-of
-    /// temps). The single-line block emitters historically flushed only
-    /// `hoisted_assignment_temps`, which dropped the `var` declaration for
-    /// nullish-assignment (`??=`) read-cache temps and produced non-runnable
+    /// Mirrors the multi-line [`Self::emit_function_body_hoisted_temps`]: every
+    /// down-leveled temp of the body — assignment-target, `for..of`, and
+    /// logical-assignment (`??=`) read-cache value temps — is declared in a
+    /// single `var` in allocation order. The single-line block emitters
+    /// historically flushed only `hoisted_assignment_temps`, which dropped the
+    /// `var` declaration for `??=` read-cache temps and produced non-runnable
     /// strict-mode output (`ReferenceError: _a is not defined`).
     pub(in crate::emitter) fn take_single_line_hoisted_temp_prologue(&mut self) -> String {
-        let mut prologue = String::new();
+        let ref_vars = self.collect_hoisted_ref_vars();
 
-        if !self.hoisted_assignment_value_temps.is_empty() {
-            prologue.push_str("var ");
-            prologue.push_str(&self.hoisted_assignment_value_temps.join(", "));
-            prologue.push_str("; ");
-            self.hoisted_assignment_value_temps.clear();
+        self.hoisted_assignment_value_temps.clear();
+        self.hoisted_assignment_temps.clear();
+        self.hoisted_for_of_temps.clear();
+
+        if ref_vars.is_empty() {
+            return String::new();
         }
-
-        if !self.hoisted_assignment_temps.is_empty() || !self.hoisted_for_of_temps.is_empty() {
-            let ref_vars: Vec<&str> = self
-                .hoisted_assignment_temps
-                .iter()
-                .chain(self.hoisted_for_of_temps.iter())
-                .map(String::as_str)
-                .collect();
-            prologue.push_str("var ");
-            prologue.push_str(&ref_vars.join(", "));
-            prologue.push_str("; ");
-            self.hoisted_assignment_temps.clear();
-            self.hoisted_for_of_temps.clear();
-        }
-
-        prologue
+        format!("var {}; ", ref_vars.join(", "))
     }
 
     /// Splice the body's hoisted temp declarations (`var _a, _b;`) into a
@@ -827,10 +805,9 @@ impl<'a> Printer<'a> {
     }
 
     /// Insert a `var <names>;` line for a multi-line function/constructor body at
-    /// `anchor`, indented by `indent`. Inserting the assignment-target temps and
-    /// the logical-assignment value temps at the *same* anchor (assignment first,
-    /// value second) leaves the value temps on the first line, matching
-    /// [`Self::emit_function_body_hoisted_temps`]. No-op when `names` is empty.
+    /// `anchor`, indented by `indent`. Callers pass an already-merged, allocation
+    /// ordered list, so every down-leveled temp lands on the one line. No-op when
+    /// `names` is empty.
     pub(in crate::emitter) fn insert_hoisted_var_line(
         &mut self,
         names: &[String],
@@ -845,40 +822,38 @@ impl<'a> Printer<'a> {
             .insert_line_at(anchor.byte_offset, anchor.line_no, &var_decl);
     }
 
+    /// Take the pending assignment-target temps, merge the logical-assignment
+    /// (`??=`) value temps into them in allocation order, and insert them as one
+    /// `var` line at `anchor`. Used by synthesized/constructor bodies whose
+    /// hoisted temps are inserted after the body is emitted.
+    pub(in crate::emitter) fn insert_constructor_hoisted_var_line(
+        &mut self,
+        anchor: &HoistAnchor,
+        indent: &str,
+    ) {
+        let mut ref_vars = std::mem::take(&mut self.hoisted_assignment_temps);
+        self.merge_hoisted_value_temps(&mut ref_vars);
+        self.hoisted_assignment_value_temps.clear();
+        self.insert_hoisted_var_line(&ref_vars, anchor, indent);
+    }
+
     pub(in crate::emitter) fn insert_function_body_hoisted_temps_at(
         &mut self,
         anchor: HoistAnchor,
     ) {
+        let ref_vars = self.collect_hoisted_ref_vars();
+
         // Common path: most function bodies hoist no temps. Skip the indent
         // string allocation and the buffer-shifting insert when there is
         // nothing to declare.
-        if self.hoisted_assignment_temps.is_empty()
-            && self.hoisted_for_of_temps.is_empty()
-            && self.hoisted_assignment_value_temps.is_empty()
-        {
+        if ref_vars.is_empty() {
             return;
         }
 
         let indent = self.writer.indent_string_at(anchor.indent_level);
-        let mut ref_vars = Vec::new();
-        ref_vars.extend(self.hoisted_assignment_temps.iter().cloned());
-        ref_vars.extend(self.hoisted_for_of_temps.iter().cloned());
-
-        if !ref_vars.is_empty() {
-            let var_decl = format!("{}var {};", indent, ref_vars.join(", "));
-            self.writer
-                .insert_line_at(anchor.byte_offset, anchor.line_no, &var_decl);
-        }
-
-        if !self.hoisted_assignment_value_temps.is_empty() {
-            let var_decl = format!(
-                "{}var {};",
-                indent,
-                self.hoisted_assignment_value_temps.join(", ")
-            );
-            self.writer
-                .insert_line_at(anchor.byte_offset, anchor.line_no, &var_decl);
-        }
+        let var_decl = format!("{}var {};", indent, ref_vars.join(", "));
+        self.writer
+            .insert_line_at(anchor.byte_offset, anchor.line_no, &var_decl);
     }
 
     /// Emit the pending ES2018 object-rest parameter prologue for a function


### PR DESCRIPTION
Fixes #15335.

At target `< ES2020`, a nullish-assignment (`??=`) on a member target lowers to a
read-cache temp `(_a = obj.p) !== null && _a !== void 0 ? _a : (obj.p = ...)`.

**Structural rule:** when a lexical environment down-levels a `??=` on a member
target, `tsc` mints the read-cache value temp **lazily, in evaluation order**,
from the same per-scope temp counter every other down-leveled temp
(optional-chaining, assignment-target, `for..of`) draws from, and declares them
all in a **single** `var _a, _b, ...;` in creation order. tsz did X through the
emitter's down-level transforms: it (a) **pre-reserved** the value temp at scope
entry from a dedicated `preallocated_logical_assignment_value_temps` pool — so a
preceding optional chain wrongly received the higher numbers — and (b) emitted
the value temp on a **separate `var` line**. Both diverged from `tsc` in both
directions.

Repro (`--target es2017`): `const d = e?.f?.g?.(); obj.x ??= 1;`
- tsz (before): `var _a;` + `var _b, _c;`, value temp `_a`, chain `_b`/`_c`
- `tsc`: `var _a, _b, _c;`, chain `_a`/`_b`, value temp `_c`

## What changed

- `make_unique_name_hoisted_value` now allocates lazily via the shared per-scope
  counter. The scope-entry preallocation machinery
  (`prepare_`/`count_`/`preallocate_logical_assignment_value_temps`,
  `nullish_assignment_consumes_value_temp`, and the pool field) is deleted —
  this also removes a full AST tree-walk that ran at ~13 scope-entry sites.
- The value-temp bucket is kept (nested function bodies slice it to place temps
  in the right lexical environment) but at emission is merged into the single
  hoisted `var`, ordered by `temp_name_rank` (the exact inverse of
  `generate_fresh_temp_name`), through one `collect_hoisted_ref_vars` /
  `insert_constructor_hoisted_var_line` chokepoint.
- `temp_name_rank` is centralized in `emitter::helpers`, removing two duplicate
  copies.

Anti-hardcoding: the decision keys on the source body structure, never on
identifier spelling (verified with renamed binders); a `hoisted-var` heuristic /
dedicated preallocation pool is not the structural signal `tsc` uses.

Net −101 lines (removes more than it adds). Owner layer: emitter down-level
transforms only; no semantic change, no relation/inference/checker impact.

## Adjacent matrix (verified byte-identical to `tsc` 6.0.2)

Optional-chain + `??=` in both orders across top-level, function body, arrow,
class method, constructor, async, `for..of`, object-literal-method, and
class-field scopes at ES2015/ES2017/ES2020 (30/30 cases). Several pre-existing
adjacent divergences (e.g. class async method at ES2017/ES2018) now also match.
No regressions: every case that matched `tsc` before still matches.

**Out of scope (separate pre-existing divergence, tracked in #15335):**
optional-**call** / `const`-initializer chain temps are flushed per-statement,
separately from the value-temp flush, and interleave out of order with multiple
`??=`. Distinct flush-timing bug; not touched here.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter logical_assignment_value_temp_order_tests` → 5 passed (new: both orders, renamed binders, function body, multi-value; single-`var` guard)
- `cargo test -p tsz-emitter` → all pass except the pre-existing unrelated `generator_object_literal_prefix_before_yield_omits_source_trailing_comma` (fails identically on clean `main`)
- CLI output diffed byte-for-byte against `tsc` 6.0.2 across the adjacent matrix (30 scope×target cases) → identical
- `cargo fmt -p tsz-emitter --check`, `cargo clippy --profile ci-lint -p tsz-emitter --lib -- -D warnings` (0 warnings), `python3 scripts/arch/arch_guard.py --json` (0 failures) — clean
- Rebased on latest `main`; ready-review CI owns the broad conformance / emit / fourslash baselines

## Provenance
Machine: cloud
Assistant: claude-code
Model: undisclosed (harness undercover mode)
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y41VeyWcD4kuGaUvBfBcVo)_