### PR TITLE
fix(checker): thread the evaluation session through all relation boundaries (#14346)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -638,6 +638,7 @@ impl<'a> CheckerState<'a> {
                 flags,
                 inheritance_graph: &self.ctx.inheritance_graph,
                 sound_mode: self.ctx.sound_mode(),
+                evaluation_session: Some(self.ctx.eval_session.as_ref()),
             };
             if matches!(
                 crate::query_boundaries::assignability::check_application_variance_assignability(
@@ -1270,6 +1271,7 @@ impl<'a> CheckerState<'a> {
             flags,
             inheritance_graph: &self.ctx.inheritance_graph,
             sound_mode: self.ctx.sound_mode(),
+            evaluation_session: Some(self.ctx.eval_session.as_ref()),
         };
         // Snapshot the unresolved-`Lazy` counter before the relation so
         // `failure_memo_store` can refuse to persist an analysis that compared

--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -44,6 +44,7 @@ impl<'a> CheckerState<'a> {
                 flags,
                 inheritance_graph: &self.ctx.inheritance_graph,
                 sound_mode: self.ctx.sound_mode(),
+                evaluation_session: Some(self.ctx.eval_session.as_ref()),
             },
             &overrides,
         );
@@ -166,12 +167,15 @@ impl<'a> CheckerState<'a> {
         let lazy_failures_at_entry = crate::query_boundaries::common::lazy_resolve_failure_count();
         let (mut outcome, capture) = execute_relation(
             request,
-            self.ctx.types,
-            &self.ctx,
-            flags,
-            &self.ctx.inheritance_graph,
+            &crate::query_boundaries::assignability::RelationExecutionEnv {
+                db: self.ctx.types,
+                resolver: &self.ctx,
+                flags,
+                inheritance_graph: &self.ctx.inheritance_graph,
+                sound_mode: self.ctx.sound_mode(),
+                evaluation_session: Some(self.ctx.eval_session.as_ref()),
+            },
             &overrides,
-            self.ctx.sound_mode(),
             precomputed.as_ref(),
         );
 
@@ -279,6 +283,7 @@ impl<'a> CheckerState<'a> {
             flags,
             inheritance_graph: &self.ctx.inheritance_graph,
             sound_mode: self.ctx.sound_mode(),
+            evaluation_session: Some(self.ctx.eval_session.as_ref()),
         };
         matches!(
             check_application_variance_assignability(&inputs),
@@ -347,6 +352,7 @@ impl<'a> CheckerState<'a> {
                 flags,
                 inheritance_graph: &self.ctx.inheritance_graph,
                 sound_mode: self.ctx.sound_mode(),
+                evaluation_session: Some(self.ctx.eval_session.as_ref()),
             };
             if let Some(result) = check_application_variance_assignability(&inputs)
                 && (result || !ignore_variance_rejection)
@@ -370,12 +376,15 @@ impl<'a> CheckerState<'a> {
             let (relation_outcome, _capture) =
                 crate::query_boundaries::assignability::execute_relation(
                     &request,
-                    self.ctx.types,
-                    &*env,
-                    flags,
-                    &self.ctx.inheritance_graph,
+                    &crate::query_boundaries::assignability::RelationExecutionEnv {
+                        db: self.ctx.types,
+                        resolver: &*env,
+                        flags,
+                        inheritance_graph: &self.ctx.inheritance_graph,
+                        sound_mode: self.ctx.sound_mode(),
+                        evaluation_session: Some(self.ctx.eval_session.as_ref()),
+                    },
                     &overrides,
-                    self.ctx.sound_mode(),
                     None,
                 );
             relation_outcome
@@ -720,6 +729,7 @@ impl<'a> CheckerState<'a> {
                 flags,
                 inheritance_graph: &self.ctx.inheritance_graph,
                 sound_mode: self.ctx.sound_mode(),
+                evaluation_session: Some(self.ctx.eval_session.as_ref()),
             };
             if let Some(result) = check_application_variance_assignability(&inputs)
                 && (result
@@ -1243,6 +1253,7 @@ impl<'a> CheckerState<'a> {
                 flags,
                 inheritance_graph: &self.ctx.inheritance_graph,
                 sound_mode: self.ctx.sound_mode(),
+                evaluation_session: Some(self.ctx.eval_session.as_ref()),
             };
             if let Some(result) = check_application_variance_assignability(&inputs)
                 && (result
@@ -1701,6 +1712,7 @@ impl<'a> CheckerState<'a> {
                 flags: self.ctx.pack_relation_flags(),
                 inheritance_graph: &self.ctx.inheritance_graph,
                 sound_mode: self.ctx.sound_mode(),
+                evaluation_session: Some(self.ctx.eval_session.as_ref()),
             },
             &overrides,
         )
@@ -1798,6 +1810,7 @@ impl<'a> CheckerState<'a> {
                 flags,
                 inheritance_graph: &self.ctx.inheritance_graph,
                 sound_mode: self.ctx.sound_mode(),
+                evaluation_session: Some(self.ctx.eval_session.as_ref()),
             };
             if let Some(result) = check_application_variance_assignability(&inputs)
                 && (result || !ignore_variance_rejection)
@@ -1885,6 +1898,7 @@ impl<'a> CheckerState<'a> {
         // Preserve existing behavior: bivariant path does not use checker overrides.
         let relation_result = cached_bivariant_assignability_with_resolver(
             self.ctx.types,
+            Some(self.ctx.eval_session.as_ref()),
             &*env,
             source,
             target,

--- a/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
@@ -1737,6 +1737,7 @@ fn boundary_assignability_rejects_stricter_generic_constraints() {
             flags: checker.ctx.pack_relation_flags(),
             inheritance_graph: &checker.ctx.inheritance_graph,
             sound_mode: checker.ctx.sound_mode(),
+            evaluation_session: Some(checker.ctx.eval_session.as_ref()),
         },
         &overrides,
     );

--- a/crates/tsz-checker/src/assignability/overload_subtype_pass.rs
+++ b/crates/tsz-checker/src/assignability/overload_subtype_pass.rs
@@ -38,6 +38,7 @@ impl<'a> CheckerState<'a> {
                     flags,
                     inheritance_graph: &self.ctx.inheritance_graph,
                     sound_mode: self.ctx.sound_mode(),
+                    evaluation_session: Some(self.ctx.eval_session.as_ref()),
                 },
                 &overrides,
             );

--- a/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
+++ b/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
@@ -476,6 +476,7 @@ impl<'a> CheckerState<'a> {
             let env = self.ctx.type_env.borrow();
             is_redeclaration_identical_with_resolver(
                 self.ctx.types,
+                Some(self.ctx.eval_session.as_ref()),
                 &*env,
                 prev_type,
                 current_type,

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -29,13 +29,14 @@ fn assignability_policy_and_context<'a>(
     inheritance_graph: &'a InheritanceGraph,
     flags: u16,
     sound_mode: bool,
+    evaluation_session: Option<&'a tsz_solver::evaluation::session::EvaluationSession>,
 ) -> (RelationPolicy, RelationContext<'a>) {
     let policy = relation_policy::from_checker_flags_u16(flags)
         .with_strict_subtype_checking(sound_mode)
         .with_strict_any_propagation(sound_mode);
     let context = RelationContext {
         query_db: Some(db),
-        evaluation_session: None,
+        evaluation_session,
         inheritance_graph: Some(inheritance_graph),
         class_check: None,
     };
@@ -891,9 +892,15 @@ pub(crate) fn is_assignable_with_overrides<R: tsz_solver::relations::subtype::Ty
         flags,
         inheritance_graph,
         sound_mode,
+        evaluation_session,
     } = *inputs;
-    let (policy, context) =
-        assignability_policy_and_context(db, inheritance_graph, flags, sound_mode);
+    let (policy, context) = assignability_policy_and_context(
+        db,
+        inheritance_graph,
+        flags,
+        sound_mode,
+        evaluation_session,
+    );
     tsz_solver::relations::relation_queries::query_relation_with_overrides(RelationQueryInputs {
         interner: db.as_type_database(),
         resolver,
@@ -958,6 +965,7 @@ pub(crate) fn is_assignable_no_weak_checks<R: tsz_solver::relations::subtype::Ty
         flags,
         inheritance_graph,
         sound_mode,
+        evaluation_session,
     } = *inputs;
     let policy = relation_policy::from_checker_flags_u16(flags)
         .with_strict_subtype_checking(sound_mode)
@@ -965,7 +973,7 @@ pub(crate) fn is_assignable_no_weak_checks<R: tsz_solver::relations::subtype::Ty
         .with_skip_weak_type_checks(true);
     let context = tsz_solver::relations::relation_queries::RelationContext {
         query_db: Some(db),
-        evaluation_session: None,
+        evaluation_session,
         inheritance_graph: Some(inheritance_graph),
         class_check: None,
     };
@@ -993,6 +1001,12 @@ pub(crate) struct AssignabilityQueryInputs<'a, R: tsz_solver::relations::subtype
     pub flags: u16,
     pub inheritance_graph: &'a InheritanceGraph,
     pub sound_mode: bool,
+    /// The checker's shared `EvaluationSession`, so relation probes entered
+    /// through this boundary accrue cross-evaluator guard state (conditional
+    /// depth, cross-eval active set, query memo) on the same session as
+    /// evaluation-entered probes instead of the thread-local fallback
+    /// session (issue #14346 split-brain).
+    pub evaluation_session: Option<&'a tsz_solver::evaluation::session::EvaluationSession>,
 }
 
 pub(crate) struct AssignabilityFailureAnalysis {
@@ -1055,6 +1069,7 @@ pub(crate) fn check_assignable_gate_with_overrides<
         inputs.inheritance_graph,
         inputs.flags,
         inputs.sound_mode,
+        inputs.evaluation_session,
     );
     let outcome = query_assignability_with_failure_analysis(RelationQueryInputs {
         interner: inputs.db.as_type_database(),
@@ -1141,16 +1156,33 @@ pub(crate) struct RelationOutcome {
 /// post-processing. The second return value is the raw solver analysis of a
 /// freshly executed non-decision-only pass, for the caller to memoize; it is
 /// `None` on the decision-only path and on memo replays.
+/// The checker-environment slice of a relation execution: everything the
+/// boundary needs besides the request itself. Mirrors
+/// `AssignabilityQueryInputs` for the request-driven `execute_relation` path.
+pub(crate) struct RelationExecutionEnv<'a, R: tsz_solver::relations::subtype::TypeResolver> {
+    pub db: &'a dyn QueryDatabase,
+    pub resolver: &'a R,
+    pub flags: u16,
+    pub inheritance_graph: &'a InheritanceGraph,
+    pub sound_mode: bool,
+    /// See `AssignabilityQueryInputs::evaluation_session` (issue #14346).
+    pub evaluation_session: Option<&'a tsz_solver::evaluation::session::EvaluationSession>,
+}
+
 pub(crate) fn execute_relation<R: tsz_solver::relations::subtype::TypeResolver>(
     request: &RelationRequest,
-    db: &dyn QueryDatabase,
-    resolver: &R,
-    flags: u16,
-    inheritance_graph: &InheritanceGraph,
+    env: &RelationExecutionEnv<'_, R>,
     overrides: &dyn tsz_solver::relations::compat::AssignabilityOverrideProvider,
-    sound_mode: bool,
     precomputed: Option<&CachedAssignabilityAnalysis>,
 ) -> (RelationOutcome, Option<CachedAssignabilityAnalysis>) {
+    let RelationExecutionEnv {
+        db,
+        resolver,
+        flags,
+        inheritance_graph,
+        sound_mode,
+        evaluation_session,
+    } = *env;
     let _span = tracing::debug_span!(
         "execute_relation",
         src = request.source.0,
@@ -1194,8 +1226,13 @@ pub(crate) fn execute_relation<R: tsz_solver::relations::subtype::TypeResolver>(
             // independently configured checkers and could contradict each other
             // (or drop the reason entirely when a checker override forced the
             // failure).
-            let (policy, context) =
-                assignability_policy_and_context(db, inheritance_graph, solver_flags, sound_mode);
+            let (policy, context) = assignability_policy_and_context(
+                db,
+                inheritance_graph,
+                solver_flags,
+                sound_mode,
+                evaluation_session,
+            );
             // The overload subtype pass rides on the typed `any`-propagation mode
             // (not the packed `u16` flags, which are saturated). The mode
             // participates in `RelationPolicy::cache_config`, so pass-1 results
@@ -1777,13 +1814,14 @@ pub(crate) fn check_application_variance_assignability<
         flags,
         inheritance_graph,
         sound_mode,
+        evaluation_session,
     } = *inputs;
     let policy = relation_policy::from_checker_flags_u16(flags)
         .with_strict_subtype_checking(sound_mode)
         .with_strict_any_propagation(sound_mode);
     let context = tsz_solver::relations::relation_queries::RelationContext {
         query_db: Some(db),
-        evaluation_session: None,
+        evaluation_session,
         inheritance_graph: Some(inheritance_graph),
         class_check: None,
     };

--- a/crates/tsz-checker/src/query_boundaries/assignability/final_relation.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/final_relation.rs
@@ -82,6 +82,7 @@ pub(crate) fn cached_final_assignability(
                 flags,
                 inheritance_graph: &checker.ctx.inheritance_graph,
                 sound_mode: checker.ctx.sound_mode(),
+                evaluation_session: Some(checker.ctx.eval_session.as_ref()),
             },
             &overrides,
         )
@@ -96,6 +97,7 @@ pub(crate) fn cached_final_assignability(
                 flags,
                 inheritance_graph: &checker.ctx.inheritance_graph,
                 sound_mode: checker.ctx.sound_mode(),
+                evaluation_session: Some(checker.ctx.eval_session.as_ref()),
             },
             &overrides,
         )

--- a/crates/tsz-checker/src/query_boundaries/assignability/overload_subtype_pass.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/overload_subtype_pass.rs
@@ -44,7 +44,7 @@ pub(crate) fn cached_overload_subtype_pass_assignability<
 
     let context = tsz_solver::relations::relation_queries::RelationContext {
         query_db: Some(inputs.db),
-        evaluation_session: None,
+        evaluation_session: inputs.evaluation_session,
         inheritance_graph: Some(inputs.inheritance_graph),
         class_check: None,
     };

--- a/crates/tsz-checker/src/query_boundaries/assignability/relation_kind_variants.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/relation_kind_variants.rs
@@ -15,6 +15,7 @@ pub(crate) fn is_assignable_bivariant_with_resolver<
     R: tsz_solver::relations::subtype::TypeResolver,
 >(
     db: &dyn QueryDatabase,
+    evaluation_session: Option<&tsz_solver::evaluation::session::EvaluationSession>,
     resolver: &R,
     source: TypeId,
     target: TypeId,
@@ -27,7 +28,7 @@ pub(crate) fn is_assignable_bivariant_with_resolver<
         .with_strict_any_propagation(sound_mode);
     let context = tsz_solver::relations::relation_queries::RelationContext {
         query_db: Some(db),
-        evaluation_session: None,
+        evaluation_session,
         inheritance_graph: Some(inheritance_graph),
         class_check: None,
     };
@@ -46,6 +47,7 @@ pub(crate) fn cached_bivariant_assignability_with_resolver<
     R: tsz_solver::relations::subtype::TypeResolver,
 >(
     db: &dyn QueryDatabase,
+    evaluation_session: Option<&tsz_solver::evaluation::session::EvaluationSession>,
     resolver: &R,
     source: TypeId,
     target: TypeId,
@@ -66,6 +68,7 @@ pub(crate) fn cached_bivariant_assignability_with_resolver<
 
     let relation_result = is_assignable_bivariant_with_resolver(
         db,
+        evaluation_session,
         resolver,
         source,
         target,
@@ -114,6 +117,7 @@ pub(crate) fn is_redeclaration_identical_with_resolver<
     R: tsz_solver::relations::subtype::TypeResolver,
 >(
     db: &dyn QueryDatabase,
+    evaluation_session: Option<&tsz_solver::evaluation::session::EvaluationSession>,
     resolver: &R,
     source: TypeId,
     target: TypeId,
@@ -126,7 +130,7 @@ pub(crate) fn is_redeclaration_identical_with_resolver<
         .with_strict_any_propagation(sound_mode);
     let context = tsz_solver::relations::relation_queries::RelationContext {
         query_db: Some(db),
-        evaluation_session: None,
+        evaluation_session,
         inheritance_graph: Some(inheritance_graph),
         class_check: None,
     };

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -618,7 +618,7 @@ fn overload_return_base_matches_and_params_cover(
     let policy = relation_policy::from_checker_flags_u16(checker.ctx.pack_relation_flags());
     let context = tsz_solver::relations::relation_queries::RelationContext {
         query_db: Some(checker.ctx.types),
-        evaluation_session: None,
+        evaluation_session: Some(checker.ctx.eval_session.as_ref()),
         inheritance_graph: Some(&checker.ctx.inheritance_graph),
         class_check: None,
     };

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -45,6 +45,8 @@ mod lazy_resolution_session_scans;
 mod object_flags_boundary_scans;
 #[path = "arch_source_scans/object_literal_annotation_walker_scans.rs"]
 mod object_literal_annotation_walker_scans;
+#[path = "arch_source_scans/relation_boundary_session_scans.rs"]
+mod relation_boundary_session_scans;
 #[path = "arch_source_scans/relation_routing_residual_arch_tests.rs"]
 mod relation_routing_residual_arch_tests;
 #[path = "arch_source_scans/spelling_suggestion_gateway_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans/relation_boundary_session_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/relation_boundary_session_scans.rs
@@ -1,0 +1,66 @@
+//! Relation-boundary evaluation-session source scans (issue #14346).
+//!
+//! The solver's `EvaluationSession` owns cross-evaluator guard state
+//! (conditional-subtype depth, infer-match expansion depth, the cross-eval
+//! active set, and the per-query fresh-evaluator memo). A checker relation
+//! boundary that passes `evaluation_session: None` runs the solver against
+//! the thread-local fallback session instead of `ctx.eval_session` — so the
+//! same recursive descent accrues guard state on two different sessions
+//! depending on entry point (the #14346 split-brain). #15168 threaded the
+//! subtype-identity boundary; this ratchet keeps every relation boundary
+//! threaded.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn rust_sources_under(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources_under(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn relation_boundaries_thread_the_checker_evaluation_session() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut sources = Vec::new();
+    rust_sources_under(&src, &mut sources);
+    assert!(
+        sources.len() > 100,
+        "checker source scan walked implausibly few files ({})",
+        sources.len()
+    );
+
+    let mut offenders = Vec::new();
+    for path in sources {
+        // Test modules construct standalone inputs without a live checker
+        // session; the split-brain concern is production boundaries only.
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if name.ends_with("_tests.rs") || path.components().any(|c| c.as_os_str() == "tests") {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        for (i, line) in content.lines().enumerate() {
+            if line.contains("evaluation_session: None") {
+                offenders.push(format!("{}:{}", path.display(), i + 1));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "checker relation boundaries passing `evaluation_session: None` (the \
+         #14346 split-brain): {offenders:?}. Thread `ctx.eval_session` (see \
+         `AssignabilityQueryInputs::evaluation_session` and #15168) instead of \
+         letting the solver fall back to the thread-local session."
+    );
+}


### PR DESCRIPTION
Goal: hold

Part of #14346 (tracking: #14351). Closes the checker-relation-boundary half of the session split-brain.

## Structural rule

When a checker relation probe enters the solver, the cross-evaluator guard state it accrues (conditional-subtype depth, infer-match expansion depth, the cross-eval active set, the per-query fresh-evaluator memo — all owned by `EvaluationSession` since #15130/#15168/#15224/#15288/#15315) must accrue on the checker's `ctx.eval_session`, exactly as tsc runs one checker instance per program with one shared recursion state. tsz previously did this at only ONE relation boundary (`subtype_identity_checker.rs`, #15168); the six other boundary constructions passed `evaluation_session: None`, so the solver fell back to the thread-local `CURRENT_SESSION` — the same recursive descent accrued guard state on two different session instances depending on entry point (the #14346 cross-instance blindness).

## What changed (owner: checker query boundaries; no solver changes)

- `AssignabilityQueryInputs` gains `evaluation_session`; all 13 construction sites populate it from `ctx.eval_session`.
- `assignability_policy_and_context`, the two `relation_kind_variants` boundary fns, the overload-subtype-pass boundary, `final_relation`, and the class-overload boundary (`query_boundaries/class.rs`) thread it into `RelationContext` instead of `None`.
- `execute_relation`'s raw parameter list hit the 9-arg clippy limit; its checker-environment params are now grouped in `RelationExecutionEnv` (mirroring the existing inputs-struct idiom).
- New arch ratchet `relation_boundary_session_scans`: zero `evaluation_session: None` in production checker sources (test modules excluded). Red on pre-change src (verified by stashing), green now.

## Adjacent matrix

The threading covers all relation kinds at the boundary: default assignable (3 sites incl. failure-analysis path), bivariant-callbacks, subtype (already threaded — unchanged), redeclaration-identity, overload-subtype pass (both the checker- and boundary-side constructions), erased-overload-return (class.rs), and application-variance. Negative/fallback path unchanged: the solver's TLS fallback session remains for non-checker callers (tests, direct solver API users).

## Risk note + gauges

Merging counters that previously accumulated on two sessions can make session-owned guards fire earlier in deep recursions (the #6973 firing-order precedent). Verified locally (CI is currently disabled — full local battery):

## Verification

CI is disabled (all checks skip) — full local battery per owner instruction:

- FULL `cargo nextest run -p tsz-checker`: 17,429/17,432 — the 3 failures (ts2859 union_origin_display 60s hangs) reproduce on pristine main (#15338), zero PR-introduced
- FULL `cargo nextest run -p tsz-solver`: 7,278/7,281 — all 3 failures pre-existing on main (#15338)
- FULL `cargo nextest run -p tsz-cli`: 2,408/2,411 — all 3 failures pre-existing on main (#15338)
- FULL local conformance, pre-rebase base: **12,585/12,585, zero regressions** vs checked-in baseline
- FULL local conformance, rebased head: 12,584/12,585 — the -1 (`generatorTypeCheck63.ts`) reproduces on pristine current main and is owned by #15331 (comment filed there); verified via `--filter` run on detached origin/main with the identical toolchain/binary path
- Post-rebase: clippy ci-lint checker all-targets clean; arch_source_scans 21/26 with the 5 failures reproducing on pristine main (#15338 second batch); assignability/overload/subtype lib filters — only the pre-existing mapped_enum display failures (#15338)
- Red/green: `relation_boundary_session_scans::relation_boundaries_thread_the_checker_evaluation_session` FAILS against pre-change src (stash-verified), passes now
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` — clean
- `cargo fmt --all --check`, `git diff --check`, `python3 scripts/arch/arch_guard.py --json` (0 failures), `scripts/arch/check-checker-boundaries.sh` — clean

## Provenance

Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-fable-5
Effort: max
