### PR TITLE
fix(checker): route the remaining eval-env-only writes through the env authority (#14348)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -739,10 +739,14 @@ impl<'a> CheckerState<'a> {
                 // TypeEvaluator::visit_type_query can resolve via TypeEnvironment::resolve_ref.
                 // Without this, resolve_ref returns None and the fallback resolve_lazy returns
                 // the INSTANCE type for classes, causing false TS2345 on `typeof ClassName` args.
-                if let Some(value_type) = self.ctx.symbol_types.get(&sym_id)
-                    && let Ok(mut env) = self.ctx.type_env.try_borrow_mut()
-                {
-                    env.insert(tsz_solver::SymbolRef(sym_id.0), value_type);
+                if let Some(value_type) = self.ctx.symbol_types.get(&sym_id) {
+                    // Route through the env-write authority (dual-write + defer
+                    // on borrow race instead of silently skipping; #14348).
+                    self.ctx.register_symbol_type_in_envs(
+                        tsz_solver::SymbolRef(sym_id.0),
+                        value_type,
+                        Vec::new(),
+                    );
                 }
             }
 

--- a/crates/tsz-checker/src/context/def_mapping_tests.rs
+++ b/crates/tsz-checker/src/context/def_mapping_tests.rs
@@ -1133,3 +1133,113 @@ fn resolved_def_mirror_is_deferred_under_borrow_then_envs_reconcile() {
         "envs must agree on every shared DefId -> TypeId after reconciliation"
     );
 }
+
+/// #14348: the unresolved-name resolution cache is authority-routed — it
+/// reaches BOTH environments, and a borrow race defers (never silently
+/// skips, which was the pre-#14348 behavior of the raw `try_borrow_mut`).
+#[test]
+fn unresolved_resolution_write_reaches_both_envs_and_defers_under_borrow() {
+    use tsz_common::interner::Atom;
+    use tsz_solver::TypeId;
+
+    let (arena, binder, types) = minimal_checker_ctx();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    let def_a = ctx.definition_store.register(DefinitionInfo::type_alias(
+        Atom::default(),
+        vec![],
+        TypeId::UNKNOWN,
+    ));
+    let def_b = ctx.definition_store.register(DefinitionInfo::type_alias(
+        Atom::default(),
+        vec![],
+        TypeId::UNKNOWN,
+    ));
+
+    // Uncontended: both envs receive the cache entry directly.
+    ctx.register_in_envs(
+        super::super::DeferredFlowEnvWrite::InsertUnresolvedResolution {
+            name: "AliasedName".to_string(),
+            def_id: def_a,
+        },
+    );
+    assert_eq!(
+        ctx.type_env.borrow().unresolved_resolution("AliasedName"),
+        Some(def_a),
+        "evaluator env must receive the resolution directly"
+    );
+    assert_eq!(
+        ctx.type_environment
+            .borrow()
+            .unresolved_resolution("AliasedName"),
+        Some(def_a),
+        "flow-analyzer env must receive the mirrored resolution"
+    );
+
+    // Contended: the flow-env write defers and replays instead of skipping.
+    {
+        let held = ctx.type_environment.borrow();
+        ctx.register_in_envs(
+            super::super::DeferredFlowEnvWrite::InsertUnresolvedResolution {
+                name: "RenamedBinder".to_string(),
+                def_id: def_b,
+            },
+        );
+        assert_eq!(
+            ctx.type_env.borrow().unresolved_resolution("RenamedBinder"),
+            Some(def_b),
+            "evaluator env must receive the resolution under flow-env borrow"
+        );
+        assert_eq!(
+            held.unresolved_resolution("RenamedBinder"),
+            None,
+            "flow-analyzer env must not observe the write mid-borrow"
+        );
+        assert_eq!(
+            ctx.deferred_flow_env_write_count(),
+            1,
+            "the mirror-write must queue for replay"
+        );
+    }
+    ctx.flush_deferred_flow_env_writes();
+    assert_eq!(
+        ctx.type_environment
+            .borrow()
+            .unresolved_resolution("RenamedBinder"),
+        Some(def_b),
+        "flow-analyzer env must receive the replayed resolution"
+    );
+}
+
+/// #14348: `overlay_missing_from` reports whether it had to repair anything —
+/// the deletion-readiness signal. A fully-authority-routed pair of envs must
+/// report `false`; a bypassing eval-env-only write must report `true`.
+#[test]
+fn overlay_missing_from_reports_repairs() {
+    let mut source = tsz_solver::computation::TypeEnvironment::new();
+    let mut target = tsz_solver::computation::TypeEnvironment::new();
+    assert!(
+        !target.overlay_missing_from(&source),
+        "identical empty envs need no repair"
+    );
+
+    source.insert_unresolved_resolution("OnlyInEval".to_string(), tsz_solver::def::DefId(7));
+    assert!(
+        target.overlay_missing_from(&source),
+        "an eval-only entry must be reported as a repair"
+    );
+    assert_eq!(
+        target.unresolved_resolution("OnlyInEval"),
+        Some(tsz_solver::def::DefId(7))
+    );
+    assert!(
+        !target.overlay_missing_from(&source),
+        "second overlay finds nothing left to repair"
+    );
+}

--- a/crates/tsz-checker/src/context/deferred_flow_env_write.rs
+++ b/crates/tsz-checker/src/context/deferred_flow_env_write.rs
@@ -68,6 +68,11 @@ pub enum DeferredFlowEnvWrite {
         def_id: DefId,
         kind: tsz_solver::def::DefKind,
     },
+    /// `insert_unresolved_resolution` — cache a resolved bare type-name so the
+    /// first-pass evaluator (which uses `TypeEnvironment` as its resolver) can
+    /// reduce `Application(UnresolvedTypeName(name), args)` without bouncing
+    /// back into the checker resolver.
+    InsertUnresolvedResolution { name: String, def_id: DefId },
     /// `insert_typeof_value_type` — register a merged interface+value symbol's
     /// `typeof` value-space type.
     InsertTypeofValueType {
@@ -201,6 +206,9 @@ impl DeferredFlowEnvWrite {
                 is_class,
             } => apply_augmented_def(env, *def_id, *augmented, *is_class),
             Self::InsertDefKind { def_id, kind } => env.insert_def_kind(*def_id, *kind),
+            Self::InsertUnresolvedResolution { name, def_id } => {
+                env.insert_unresolved_resolution(name.clone(), *def_id);
+            }
             Self::InsertTypeofValueType { symbol, value_type } => {
                 env.insert_typeof_value_type(*symbol, *value_type);
             }

--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -1668,16 +1668,19 @@ impl<'a> TypeResolver for CheckerContext<'a> {
 
         let canonical_name = name.rsplit('.').next().unwrap_or(name);
         let def_id = self.get_or_create_def_id_for_symbol_name(current_sym, canonical_name);
-        // Cache the resolution into `type_env` so the next solver-side
+        // Cache the resolution into BOTH environments so the next solver-side
         // evaluator pass (which uses `TypeEnvironment` as resolver) can
         // reduce `Application(UnresolvedTypeName(name), args)` without
-        // having to bounce back into the wider CheckerContext path. The
-        // first-pass evaluator runs with `&*self.type_env`, so without
-        // this cache share every nested Application keeps producing
-        // opaque results for the rest of an instantiated body.
-        if let Ok(mut env) = self.type_env.try_borrow_mut() {
-            env.insert_unresolved_resolution(name.to_string(), def_id);
-        }
+        // having to bounce back into the wider CheckerContext path. Routed
+        // through the env-write authority (deferring on borrow races instead
+        // of silently skipping, and mirroring into the flow-analyzer env so
+        // `overlay_missing_from` has nothing left to repair — #14348).
+        self.register_in_envs(
+            crate::context::DeferredFlowEnvWrite::InsertUnresolvedResolution {
+                name: name.to_string(),
+                def_id,
+            },
+        );
         Some(def_id)
     }
 

--- a/crates/tsz-checker/src/state/state_checking/source_file_env_reconcile.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file_env_reconcile.rs
@@ -4,12 +4,29 @@ use crate::state::CheckerState;
 
 impl CheckerState<'_> {
     pub(crate) fn reconcile_flow_and_evaluator_envs(&mut self) {
-        let divergences: Vec<(u32, tsz_solver::TypeId, tsz_solver::TypeId)> = {
+        let (overlay_filled, divergences): (
+            bool,
+            Vec<(u32, tsz_solver::TypeId, tsz_solver::TypeId)>,
+        ) = {
             let type_env_snapshot = self.ctx.type_env.borrow();
             let mut flow_env = self.ctx.type_environment.borrow_mut();
-            flow_env.overlay_missing_from(&type_env_snapshot);
-            flow_env.collect_def_type_divergences_from(&type_env_snapshot)
+            let overlay_filled = flow_env.overlay_missing_from(&type_env_snapshot);
+            (
+                overlay_filled,
+                flow_env.collect_def_type_divergences_from(&type_env_snapshot),
+            )
         };
+        if overlay_filled {
+            // Every env write should reach both environments through the
+            // authority helpers; the overlay is the legacy repair for writes
+            // that bypassed it. Surface survivors so the repair can eventually
+            // be deleted (#14348) — this firing means some write path still
+            // touches only the evaluator env.
+            tracing::warn!(
+                target: "tsz::env_authority",
+                "reconcile overlay filled flow-env entries the authority missed (#14348)"
+            );
+        }
 
         if !divergences.is_empty() {
             self.ctx.eval_session.reset_lazy_resolution_fuel();

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
@@ -33,11 +33,11 @@ impl<'a> CheckerState<'a> {
             let sym_id =
                 crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(symbol_ref);
             let value_type = self.get_type_of_symbol(sym_id);
-            if value_type != TypeId::ANY
-                && value_type != TypeId::ERROR
-                && let Ok(mut env) = self.ctx.type_env.try_borrow_mut()
-            {
-                env.insert(symbol_ref, value_type);
+            if value_type != TypeId::ANY && value_type != TypeId::ERROR {
+                // Route through the env-write authority (dual-write + defer on
+                // borrow race instead of silently skipping; #14348).
+                self.ctx
+                    .register_symbol_type_in_envs(symbol_ref, value_type, Vec::new());
             }
             if value_type != TypeId::ANY
                 && value_type != TypeId::ERROR

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -556,10 +556,15 @@ impl CheckerState<'_> {
             } else {
                 value_type
             };
-            if effective_type != TypeId::ERROR
-                && let Ok(mut env) = self.ctx.type_env.try_borrow_mut()
-            {
-                env.insert(tsz_solver::SymbolRef(sym_id.0), effective_type);
+            if effective_type != TypeId::ERROR {
+                // Route through the env-write authority: dual-writes the flow
+                // env and defers (instead of silently skipping) when either
+                // env is borrowed (#14348).
+                self.ctx.register_symbol_type_in_envs(
+                    tsz_solver::SymbolRef(sym_id.0),
+                    effective_type,
+                    Vec::new(),
+                );
             }
         }
     }

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -1238,7 +1238,7 @@ impl TypeEnvironment {
     /// dual-written and therefore never reach the deferred-replay queue. When a
     /// new field is added to `TypeEnvironment`, add it here too or the
     /// flow-analyzer env will silently diverge from the evaluator env.
-    pub fn overlay_missing_from(&mut self, source: &Self) {
+    pub fn overlay_missing_from(&mut self, source: &Self) -> bool {
         use std::collections::hash_map::Entry;
         let mut changed = false;
 
@@ -1311,6 +1311,7 @@ impl TypeEnvironment {
         if changed {
             self.bump_generation();
         }
+        changed
     }
 
     /// Return the first `DefId`-keyed entry on which `self` and `other` disagree.


### PR DESCRIPTION
Goal: hold

Part of #14348 (tracking: #14351). Slice A of the completion plan from the direction comment: finish the write side so the reconcile overlay can be retired.

## Structural rule

Every `TypeEnvironment` write must reach both the authoritative evaluator env (`type_env`) and the flow-analyzer env (`type_environment`) through the deferred env-write authority — deferring on borrow races, never silently skipping. tsc has one checker with one type table; tsz's dual-env design is safe only while no write path can leave the two views divergent. After the #15148/#15152/#15214/#15215/#15219/#15261 chain, four cache-seed sites still wrote only the evaluator env via raw `try_borrow_mut` (and dropped the write entirely when the env was borrowed):

- `context/resolver.rs` — unresolved-name resolution cache (new `DeferredFlowEnvWrite::InsertUnresolvedResolution`, authority-routed);
- `state/type_environment/lazy.rs` — class-expression provisional-ctor `SymbolRef` seed → `register_symbol_type_in_envs`;
- `state_checking_members/index_signature_key_helpers.rs` — TS2411 display seed → `register_symbol_type_in_envs`;
- `assignability/assignability_checker.rs` — `typeof`-value seed → `register_symbol_type_in_envs`.

`overlay_missing_from` now returns whether it repaired anything, and reconcile emits a `tsz::env_authority` warning when it fires — the measurable deletion-readiness signal for the overlay (whose "list every field" maintenance contract is the last divergence trap of the dual-env design; deletion is the follow-up slice once corpora show the warning silent).

Intentionally NOT routed: the transient `this_type` set/restore sites (flow must not observe transient `this` bindings) and the child→parent cross-file merge-back skip (deferral is structurally impossible there — snapshotting requires the borrow that failed; it keeps its warn).

## Adjacent matrix

- Uncontended write → both envs observe it immediately (new test, first half).
- Contended write (flow env borrowed) → evaluator env immediate, flow env deferred + replayed on flush (new test, second half) — previously the entire write was silently dropped.
- Overlay repair reporting: empty pair → false; eval-only entry → true then false after repair (new test).
- Existing replay/backlog/simultaneous-borrow suites (24 tests) unchanged and green.

## Verification

CI is disabled — full local gate:

- FULL `cargo nextest run -p tsz-checker` and `-p tsz-solver` on this diff vs pristine `origin/main @ 1ea86a5364`: **failure sets byte-identical** (203 unique failures on both sides — all pre-existing main breakage, catalogued in #15338; `comm` diff empty in both directions).
- FULL local conformance vs the checked-in baseline on this head: result posted in a comment below (expected: identical to main's current 12,584/12,585 — the -1 is #15331's, tracked on that PR).
- New tests: `unresolved_resolution_write_reaches_both_envs_and_defers_under_borrow`, `overlay_missing_from_reports_repairs` — the deferral half is red by construction against the old code (the old sites skipped the write under contention; the variant did not exist).
- Focused: `def_mapping`/`env_merge`/`replay`/`reconcile` filters — 24/24 + 2 new pass.
- `cargo clippy --profile ci-lint -p tsz-checker -p tsz-solver --all-targets -- -D warnings` — clean; `cargo fmt --all --check` — clean; `arch_guard.py` — 0 failures.
- Provenance note: the verified tree was recreated deterministically (exact-match scripted transformations, same base SHA) after the original working tree was lost to a worktree cleanup; the full-suite diff ran on the identical original diff, and conformance + focused suites + lint re-ran on this exact head.

## Provenance

Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-fable-5
Effort: max
