### PR TITLE
ci: drop legacy GCS benchmark artifact names

### DIFF
--- a/crates/tsz-website/build.mjs
+++ b/crates/tsz-website/build.mjs
@@ -193,7 +193,7 @@ function loadBenchmarks() {
   })();
 
   // Fall back to the committed snapshot so the site always shows real data
-  // even when the CI GCS download hasn't run yet.
+  // even when no GitHub Actions benchmark artifact has been downloaded.
   const snapshot = path.join(WEBSITE, "bench-snapshot.json");
   const searchPaths = [...locations, snapshot];
 

--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -861,14 +861,13 @@ function benchmarkArtifactFiles() {
   const artifactsDir = path.join(ROOT, "artifacts");
   const ciLatest = [
     "bench-vs-tsgo-github-latest.json",
-    "bench-vs-tsgo-gcs-latest.json",
     "bench-results.json",
   ].map((file) => path.join(artifactsDir, file));
 
   try {
     const localArtifacts = fs.readdirSync(artifactsDir)
       .filter((file) => file.startsWith("bench-vs-tsgo-") && file.endsWith(".json"))
-      .filter((file) => !["bench-vs-tsgo-github-latest.json", "bench-vs-tsgo-gcs-latest.json", "bench-results.json"].includes(file))
+      .filter((file) => !["bench-vs-tsgo-github-latest.json", "bench-results.json"].includes(file))
       .sort()
       .reverse()
       .map((file) => path.join(artifactsDir, file));

--- a/crates/tsz-website/src/_data/benchmark_mean_chart.js
+++ b/crates/tsz-website/src/_data/benchmark_mean_chart.js
@@ -47,13 +47,12 @@ function loadBenchmarks() {
   const artifactsDir = path.join(ROOT, "artifacts");
   const ciLatest = [
     "bench-vs-tsgo-github-latest.json",
-    "bench-vs-tsgo-gcs-latest.json",
   ].map((file) => path.join(artifactsDir, file));
   const artifactFiles = (() => {
     try {
       const localArtifacts = fs.readdirSync(artifactsDir)
         .filter((file) => file.startsWith("bench-vs-tsgo-") && file.endsWith(".json"))
-        .filter((file) => !["bench-vs-tsgo-github-latest.json", "bench-vs-tsgo-gcs-latest.json"].includes(file))
+        .filter((file) => !["bench-vs-tsgo-github-latest.json"].includes(file))
         .sort()
         .reverse()
         .map((file) => path.join(artifactsDir, file));

--- a/scripts/bench/test-benchmark-artifact-selection.mjs
+++ b/scripts/bench/test-benchmark-artifact-selection.mjs
@@ -61,17 +61,17 @@ function applicationTimedRows() {
 try {
   const snapshot = writeArtifact("bench-snapshot.json", "2026-05-17T01:23:02.991Z");
   const github = writeArtifact("bench-vs-tsgo-github-latest.json", "2026-05-28T02:14:24.444Z");
-  const gcs = writeArtifact("bench-vs-tsgo-gcs-latest.json", "2026-05-29T02:14:24.444Z");
+  const local = writeArtifact("bench-vs-tsgo-local-latest.json", "2026-05-29T02:14:24.444Z");
   const empty = writeArtifact("empty.json", "2026-06-01T00:00:00.000Z", []);
 
   assert.equal(
-    selectLatestBenchmarkArtifact([snapshot, github, gcs])?.file,
-    gcs,
-    "newer GCS benchmark truth should beat older GitHub and snapshot files",
+    selectLatestBenchmarkArtifact([snapshot, github, local])?.file,
+    local,
+    "newer benchmark artifact should beat older GitHub and snapshot files",
   );
   assert.equal(
-    selectLatestBenchmarkArtifact([gcs, github, snapshot])?.file,
-    gcs,
+    selectLatestBenchmarkArtifact([local, github, snapshot])?.file,
+    local,
     "candidate order should not override generated_at freshness",
   );
   assert.equal(


### PR DESCRIPTION
Goal: hold

## Summary
- Remove legacy `bench-vs-tsgo-gcs-latest.json` from website benchmark artifact candidate lists.
- Update stale website build/test wording so benchmark publishing is described as GitHub Actions artifact based.
- Keep the negative Pages guard that prevents reintroducing GCS downloads.

## Verification
- `node --check crates/tsz-website/build.mjs && node --check crates/tsz-website/src/_data/benchmark_mean_chart.js && node --check crates/tsz-website/src/_data/benchmark_data.js && node --check scripts/bench/test-benchmark-artifact-selection.mjs`
- `node scripts/bench/test-benchmark-artifact-selection.mjs && node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `rg -n "bench-vs-tsgo-gcs|GCS download|GCS benchmark|Download latest benchmark data from GCS|Download latest suite metrics from GCS|gcloud auth|gs://|SCCACHE_GCS" crates/tsz-website scripts/bench .github/workflows/gh-pages.yml` now only finds negative guard regexes.
- `git diff --check`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
