### PR TITLE
fix(checker): chain tsc's TS7053 index-access reason and honor annotated receiver display (#15356)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -498,45 +498,6 @@ impl<'a> CheckerState<'a> {
             })
     }
 
-    fn object_literal_initializer_display_type_for_receiver(
-        &mut self,
-        idx: NodeIndex,
-    ) -> Option<TypeId> {
-        let receiver = self.access_receiver_for_diagnostic_node(idx)?;
-        let receiver_node = self.ctx.arena.get(receiver)?;
-        if receiver_node.kind != SyntaxKind::Identifier as u16 {
-            return None;
-        }
-
-        let sym_id = self.resolve_identifier_symbol(receiver)?;
-        let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        let decl_idx = symbol.value_declaration;
-        let decl_node = self.ctx.arena.get(decl_idx)?;
-        let decl = self.ctx.arena.get_variable_declaration(decl_node)?;
-        // Only surface the initializer's anonymous object-literal shape when the
-        // declaration has no explicit type annotation. With an annotation the
-        // declared type *is* the annotation (not the widened initializer), and
-        // tsc renders that annotated/apparent type in the index diagnostic —
-        // e.g. `t` in `const t: T = { ... }` displays as `T`, not `{ ... }`.
-        if decl.type_annotation.is_some() {
-            return None;
-        }
-        let init = self
-            .ctx
-            .arena
-            .skip_parenthesized_and_assertions(decl.initializer);
-        let init_node = self.ctx.arena.get(init)?;
-        if init_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
-            return None;
-        }
-
-        let init_type = self.get_type_of_node(init);
-        let init_type = self.resolve_type_for_property_access(init_type);
-        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, init_type)
-            .filter(|shape| shape.symbol.is_none())
-            .map(|_| init_type)
-    }
-
     fn object_rest_this_omit_display_for_receiver(&mut self, idx: NodeIndex) -> Option<String> {
         let receiver = self.access_receiver_for_diagnostic_node(idx)?;
         let receiver_node = self.ctx.arena.get(receiver)?;

--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -513,6 +513,14 @@ impl<'a> CheckerState<'a> {
         let decl_idx = symbol.value_declaration;
         let decl_node = self.ctx.arena.get(decl_idx)?;
         let decl = self.ctx.arena.get_variable_declaration(decl_node)?;
+        // Only surface the initializer's anonymous object-literal shape when the
+        // declaration has no explicit type annotation. With an annotation the
+        // declared type *is* the annotation (not the widened initializer), and
+        // tsc renders that annotated/apparent type in the index diagnostic —
+        // e.g. `t` in `const t: T = { ... }` displays as `T`, not `{ ... }`.
+        if decl.type_annotation.is_some() {
+            return None;
+        }
         let init = self
             .ctx
             .arena

--- a/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
+++ b/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
@@ -5,6 +5,45 @@
 use super::*;
 
 impl<'a> CheckerState<'a> {
+    pub(super) fn object_literal_initializer_display_type_for_receiver(
+        &mut self,
+        idx: NodeIndex,
+    ) -> Option<TypeId> {
+        let receiver = self.access_receiver_for_diagnostic_node(idx)?;
+        let receiver_node = self.ctx.arena.get(receiver)?;
+        if receiver_node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+
+        let sym_id = self.resolve_identifier_symbol(receiver)?;
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        let decl_idx = symbol.value_declaration;
+        let decl_node = self.ctx.arena.get(decl_idx)?;
+        let decl = self.ctx.arena.get_variable_declaration(decl_node)?;
+        // Only surface the initializer's anonymous object-literal shape when the
+        // declaration has no explicit type annotation. With an annotation the
+        // declared type *is* the annotation (not the widened initializer), and
+        // tsc renders that annotated/apparent type in the index diagnostic —
+        // e.g. `t` in `const t: T = { ... }` displays as `T`, not `{ ... }`.
+        if decl.type_annotation.is_some() {
+            return None;
+        }
+        let init = self
+            .ctx
+            .arena
+            .skip_parenthesized_and_assertions(decl.initializer);
+        let init_node = self.ctx.arena.get(init)?;
+        if init_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return None;
+        }
+
+        let init_type = self.get_type_of_node(init);
+        let init_type = self.resolve_type_for_property_access(init_type);
+        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, init_type)
+            .filter(|shape| shape.symbol.is_none())
+            .map(|_| init_type)
+    }
+
     pub(super) fn actual_lib_namespace_merged_type_has_property(
         &mut self,
         type_id: TypeId,

--- a/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
+++ b/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
@@ -734,13 +734,90 @@ impl<'a> CheckerState<'a> {
             "Element implicitly has an 'any' type because expression of type '{index_str}' can't be used to index type '{object_str}'."
         );
 
+        // tsc renders TS7053 as a message chain: the "Element implicitly has an
+        // 'any' type" head, then a nested reason describing *why* the key does
+        // not index the type (`getPropertyTypeForIndexType`). Mirror that chain
+        // so element-access implicit-any diagnostics match tsc exactly; keys with
+        // no nested reason (symbol/any/union/template) emit the bare head.
+        //
         // TS7053 is reported at the full element access expression.
-        self.error_at_anchor(
-            expr_idx,
-            DiagnosticAnchorKind::ElementAccessExpr,
-            &message,
-            diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
-        );
+        if let Some(anchor) =
+            self.resolve_diagnostic_anchor(expr_idx, DiagnosticAnchorKind::ElementAccessExpr)
+        {
+            let mut diag = crate::diagnostics::Diagnostic::error(
+                self.ctx.file_name.clone(),
+                anchor.start,
+                anchor.length,
+                message,
+                diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
+            );
+            if let Some((reason_message, reason_code)) =
+                self.ts7053_index_reason_elaboration(index_type, &object_str)
+            {
+                diag.push_elaboration(reason_message, reason_code, 0);
+            }
+            self.ctx.push_diagnostic(diag);
+        }
+    }
+
+    /// Build the nested reason line tsc appends beneath a TS7053
+    /// ("Element implicitly has an 'any' type ... can't be used to index type")
+    /// element-access diagnostic.
+    ///
+    /// tsc's `getPropertyTypeForIndexType` chains one of two reasons under the
+    /// implicit-any head, keyed on the index type:
+    /// * a string/number **literal** key that is not a property ->
+    ///   `Property '<name>' does not exist on type '<T>'.` (TS2339 text);
+    /// * a general `string`/`number` key with no matching index signature ->
+    ///   `No index signature with a parameter of type '<kind>' was found on type
+    ///   '<T>'.` (TS7054 text).
+    ///
+    /// `symbol`, `any`, and template-literal keys carry no nested reason, so this
+    /// returns `None` and the caller emits the bare head. `object_str` is the
+    /// receiver display already computed for the head, reused verbatim so both
+    /// lines name the same type, matching tsc.
+    fn ts7053_index_reason_elaboration(
+        &mut self,
+        index_type: TypeId,
+        object_str: &str,
+    ) -> Option<(String, u32)> {
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+
+        // A string/number *literal* key names a property that does not exist.
+        let literal_key_name =
+            crate::query_boundaries::common::string_literal_value(self.ctx.types, index_type)
+                .map(|atom| self.ctx.types.resolve_atom(atom))
+                .or_else(|| {
+                    crate::query_boundaries::common::number_literal_value(
+                        self.ctx.types,
+                        index_type,
+                    )
+                    .map(|value| tsz_solver::utils::js_number_to_string(value).into_owned())
+                });
+        if let Some(name) = literal_key_name {
+            return Some((
+                format_message(
+                    diagnostic_messages::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
+                    &[name.as_str(), object_str],
+                ),
+                diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
+            ));
+        }
+
+        let index_kind = if index_type == TypeId::STRING {
+            "string"
+        } else if index_type == TypeId::NUMBER {
+            "number"
+        } else {
+            return None;
+        };
+        Some((
+            format_message(
+                diagnostic_messages::NO_INDEX_SIGNATURE_WITH_A_PARAMETER_OF_TYPE_WAS_FOUND_ON_TYPE,
+                &[index_kind, object_str],
+            ),
+            diagnostic_codes::NO_INDEX_SIGNATURE_WITH_A_PARAMETER_OF_TYPE_WAS_FOUND_ON_TYPE,
+        ))
     }
 
     pub(super) fn no_index_signature_method_suggestion(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -661,6 +661,9 @@ mod ts7041_tests;
 #[path = "tests/ts7053_apparent_receiver_display_tests.rs"]
 mod ts7053_apparent_receiver_display_tests;
 #[cfg(test)]
+#[path = "tests/ts7053_index_reason_chain_tests.rs"]
+mod ts7053_index_reason_chain_tests;
+#[cfg(test)]
 #[path = "../tests/ts7057_yield_implicit_any.rs"]
 mod ts7057_yield_implicit_any;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/ts7053_index_reason_chain_tests.rs
+++ b/crates/tsz-checker/src/tests/ts7053_index_reason_chain_tests.rs
@@ -1,0 +1,202 @@
+//! Regression tests for the nested reason `tsc` chains beneath a `TS7053`
+//! ("Element implicitly has an 'any' type ... can't be used to index type 'X'")
+//! element-access diagnostic.
+//!
+//! Structural rule (one sentence): `tsc`'s `getPropertyTypeForIndexType` renders
+//! `TS7053` as a message chain whose nested reason is
+//! `Property '<name>' does not exist on type '<T>'.` for a string/number literal
+//! key, and `No index signature with a parameter of type '<kind>' was found on
+//! type '<T>'.` for a general `string`/`number` key; `symbol`/`any`/template
+//! keys carry no nested reason.
+//!
+//! Witness family: any element access that reports implicit-any under
+//! `noImplicitAny` (e.g. the kysely `TS7053` long tail) previously emitted only
+//! the bare head, dropping the reason line `tsc` renders.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_diagnostics;
+
+const TS7053: u32 = 7053;
+const TS2339: u32 = 2339;
+const TS7054: u32 = 7054;
+
+/// The single `TS7053` diagnostic in `source`, or a panic listing what was found.
+fn ts7053_diagnostic(source: &str) -> Diagnostic {
+    let mut hits: Vec<Diagnostic> = check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == TS7053)
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "expected exactly one TS7053 diagnostic; got: {hits:?}",
+    );
+    hits.pop().unwrap()
+}
+
+/// The `(code, message)` of a diagnostic's single elaboration reason line, or
+/// `None` when it carries no `related_information` entries.
+fn only_reason(diag: &Diagnostic) -> Option<(u32, &str)> {
+    match diag.related_information.as_slice() {
+        [] => None,
+        [reason] => Some((reason.code, reason.message_text.as_str())),
+        many => panic!("expected at most one elaboration reason; got: {many:?}"),
+    }
+}
+
+#[test]
+fn string_literal_key_chains_property_does_not_exist() {
+    let diag = ts7053_diagnostic("declare const o: { a: number }; const x = o[\"missing\"];");
+    assert_eq!(
+        only_reason(&diag),
+        Some((
+            TS2339,
+            "Property 'missing' does not exist on type '{ a: number; }'.",
+        )),
+        "string-literal key must chain the TS2339 property reason",
+    );
+}
+
+#[test]
+fn number_literal_key_chains_property_does_not_exist() {
+    let diag = ts7053_diagnostic("declare const o: { a: number }; const x = o[5];");
+    assert_eq!(
+        only_reason(&diag),
+        Some((
+            TS2339,
+            "Property '5' does not exist on type '{ a: number; }'."
+        )),
+        "number-literal key must chain the TS2339 property reason with the JS number name",
+    );
+}
+
+#[test]
+fn general_string_key_chains_no_index_signature() {
+    let diag = ts7053_diagnostic(
+        "declare const o: { a: number }; declare const k: string; const x = o[k];",
+    );
+    assert_eq!(
+        only_reason(&diag),
+        Some((
+            TS7054,
+            "No index signature with a parameter of type 'string' was found on type '{ a: number; }'.",
+        )),
+        "general `string` key must chain the TS7054 no-index-signature reason",
+    );
+}
+
+#[test]
+fn general_number_key_chains_no_index_signature() {
+    let diag = ts7053_diagnostic(
+        "declare const o: { a: number }; declare const k: number; const x = o[k];",
+    );
+    assert_eq!(
+        only_reason(&diag),
+        Some((
+            TS7054,
+            "No index signature with a parameter of type 'number' was found on type '{ a: number; }'.",
+        )),
+        "general `number` key must chain the TS7054 no-index-signature reason",
+    );
+}
+
+#[test]
+fn symbol_key_carries_no_reason() {
+    let diag = ts7053_diagnostic(
+        "declare const o: { a: number }; declare const k: symbol; const x = o[k];",
+    );
+    assert_eq!(
+        only_reason(&diag),
+        None,
+        "a `symbol` key emits the bare TS7053 head with no chained reason, matching tsc",
+    );
+}
+
+/// The chained reason and the head must name the *same* receiver type. For a
+/// template-literal index signature the key does not match, so `tsc` reports
+/// `TS7053` on the whole named interface `T` (not a structural shape) in both
+/// lines.
+#[test]
+fn template_index_signature_non_matching_key_names_the_interface() {
+    let source = r#"
+interface T { [k: `data-${string}`]: string; }
+declare const t: T;
+const bad = t["other"];
+"#;
+    let diag = ts7053_diagnostic(source);
+    assert!(
+        diag.message_text
+            .contains("can't be used to index type 'T'"),
+        "head must name the nominal interface `T`; got: {:?}",
+        diag.message_text,
+    );
+    assert_eq!(
+        only_reason(&diag),
+        Some((TS2339, "Property 'other' does not exist on type 'T'.")),
+        "the chained reason must name the same nominal type as the head",
+    );
+}
+
+/// Write-context receiver-display: an annotated variable renders its declared
+/// (annotation) type in both the head and the chained reason, not the widened
+/// object-literal initializer type. Distinct receiver-display facet fixed
+/// alongside the reason chain.
+#[test]
+fn annotated_initializer_receiver_uses_the_annotation() {
+    let source = r#"
+interface T { [k: `data-${string}`]: string; }
+const t: T = { "data-x": "1" };
+t["other"] = "3";
+"#;
+    let diag = ts7053_diagnostic(source);
+    assert!(
+        diag.message_text
+            .contains("can't be used to index type 'T'")
+            && !diag.message_text.contains("data-x"),
+        "annotated receiver must display the annotation `T`, not the initializer shape; got: {:?}",
+        diag.message_text,
+    );
+    assert_eq!(
+        only_reason(&diag),
+        Some((TS2339, "Property 'other' does not exist on type 'T'.")),
+    );
+}
+
+/// Control: with *no* annotation the declared type is the widened initializer,
+/// so the receiver still renders the anonymous object shape (the display guard
+/// only suppresses the initializer shape when an annotation exists).
+#[test]
+fn unannotated_initializer_receiver_still_uses_the_literal_shape() {
+    let diag = ts7053_diagnostic("const o = { a: 1 }; o[\"b\"] = 2;");
+    assert!(
+        diag.message_text
+            .contains("can't be used to index type '{ a: number; }'"),
+        "unannotated receiver keeps the inferred object-literal shape; got: {:?}",
+        diag.message_text,
+    );
+    assert_eq!(
+        only_reason(&diag),
+        Some((
+            TS2339,
+            "Property 'b' does not exist on type '{ a: number; }'."
+        )),
+    );
+}
+
+/// Anti-hardcoding: the reason chain is derived from the type shape, not from
+/// the user's binder or property spellings. Renaming every identifier keeps the
+/// same chain shape (only the rendered names track the new spellings).
+#[test]
+fn reason_chain_is_binder_name_agnostic() {
+    let renamed = ts7053_diagnostic(
+        "declare const container: { alpha: number }; const picked = container[\"beta\"];",
+    );
+    assert_eq!(
+        only_reason(&renamed),
+        Some((
+            TS2339,
+            "Property 'beta' does not exist on type '{ alpha: number; }'.",
+        )),
+        "the reason must follow the renamed shape, proving it is structural not name-keyed",
+    );
+}


### PR DESCRIPTION
Closes #15356.

**Structural rule:** when `getPropertyTypeForIndexType` reports **TS7053**
("Element implicitly has an 'any' type ... can't be used to index type 'T'")
for an element access under `noImplicitAny`, `tsc` renders it as a *message
chain* — the implicit-any head plus one nested reason:

- `Property 'b' does not exist on type '{ a: number; }'.` (TS2339 text) for a
  string/number **literal** key that is not a property;
- `No index signature with a parameter of type 'string' was found on type
  '{ a: number; }'.` (TS7054 text) for a general `string`/`number` key with no
  matching index signature;
- no nested reason for `symbol` / `any` / template-literal keys.

tsz emitted only the bare head, dropping the reason for the whole
element-access implicit-any family. tsz now builds the same chain through the
checker error reporter (`error_no_index_signature_at`), reusing the receiver
display already computed for the head so both lines name the same type.

Second facet (same code path): the receiver display for an **annotated**
variable in write position rendered the widened object-literal initializer
shape instead of the declared type — `const t: T = { ... }; t["x"] = ...`
showed `{ ... }` where `tsc` shows `T`. The initializer-shape display is now
suppressed when the declaration carries an explicit type annotation, so the
declared/apparent type is displayed, matching `tsc`.

**Owner layer:** checker error reporter (diagnostics/display) —
`crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs`
and `properties.rs`. No solver semantics change; index-type classification uses
structural query-boundary helpers (`string_literal_value` /
`number_literal_value`) and stable `TypeId::STRING` / `TypeId::NUMBER` identity
— no printer-output matching, no user-name/file-name predicates.

**Adjacent matrix (all differential-verified against `tsc` 6.0.2):** string
literal, number literal (JS-number name), general `string`, general `number`,
`symbol` (no chain), `any` (no chain), unconstrained type parameter (receiver
`unknown`), template-literal index signature (nominal `T` in both lines),
annotated write (renders `T`), unannotated write (keeps inferred literal
shape). **Residual (no regression):** union and template-literal *index types*
still emit the bare head — `tsc` distributes those; documented for a follow-up.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts7053` — 40/40 pass (new
  `ts7053_index_reason_chain_tests`, 9 tests, plus the 31 pre-existing `ts7053`
  tests; codes and receiver display asserted).
- Differential vs `tsc` 6.0.2 across the full index-type matrix above — full
  parity on head + chained reason.
- `cargo clippy -p tsz-checker --lib --profile ci-lint` clean; `cargo fmt` clean.
- The 8 pre-existing `index`-filter unit failures (issue #15338, `TS2322`/`TS2542`
  index-access elaboration) reproduce identically on clean `origin/main` — this
  change does not touch them.
- Exact-head ready-review CI owns the broad conformance / emit / fourslash gate.

## Provenance
Machine: cloud
Assistant: claude-code
Model: undisclosed (harness undercover mode)
Effort: high

https://claude.ai/code/session_01WfKV4JVjTywfDZmiGAWkQ6