### PR TITLE
fix(solver): render the error-type sentinel as `any` in diagnostics

### DIFF
--- a/crates/tsz-solver/src/diagnostics/format/error_type_display_tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/error_type_display_tests.rs
@@ -1,0 +1,77 @@
+//! The error sentinel (`TypeId::ERROR`, tsc's `errorType`) must render as
+//! `any` in every structural display position, never the compiler-internal
+//! "error" token.
+//!
+//! `tsc` models a failed type resolution as `errorType` — an `Any`-flagged
+//! intrinsic whose internal name is "error" — but its printer always renders
+//! it as `any`. So a function whose body failed to type-check surfaces in a
+//! diagnostic as `(e: {...}) => any`, an errored array element as `any[]`, an
+//! errored property value as `{ r: any; }`, and so on. tsz previously leaked
+//! the raw "error" spelling into these positions.
+
+use super::*;
+use crate::construction::TypeInterner;
+use crate::types::{FunctionShape, ParamInfo, PropertyInfo, TupleElement};
+
+#[test]
+fn error_sentinel_renders_as_any() {
+    let db = TypeInterner::new();
+    let mut fmt = TypeFormatter::new(&db);
+    assert_eq!(fmt.format(TypeId::ERROR), "any");
+}
+
+#[test]
+fn none_placeholder_renders_as_any() {
+    // `TypeId::NONE` shares `TypeData::Error`; if it ever reaches the printer
+    // it must still read as `any`, exercising the key-dispatch branch that is
+    // kept in lock-step with the `TypeId::ERROR` fast path.
+    let db = TypeInterner::new();
+    let mut fmt = TypeFormatter::new(&db);
+    assert_eq!(fmt.format(TypeId::NONE), "any");
+}
+
+#[test]
+fn error_element_array_renders_as_any_array() {
+    let db = TypeInterner::new();
+    let mut fmt = TypeFormatter::new(&db);
+    let arr = db.array(TypeId::ERROR);
+    assert_eq!(fmt.format(arr), "any[]");
+}
+
+#[test]
+fn error_return_type_renders_as_arrow_to_any() {
+    let db = TypeInterner::new();
+    let mut fmt = TypeFormatter::new(&db);
+    let f = db.function(FunctionShape::new(
+        vec![ParamInfo {
+            name: Some(db.intern_string("e")),
+            type_id: TypeId::NUMBER,
+            optional: false,
+            rest: false,
+        }],
+        TypeId::ERROR,
+    ));
+    assert_eq!(fmt.format(f), "(e: number) => any");
+}
+
+#[test]
+fn error_property_value_renders_as_any() {
+    let db = TypeInterner::new();
+    let mut fmt = TypeFormatter::new(&db);
+    let obj = db.object(vec![PropertyInfo::new(
+        db.intern_string("r"),
+        TypeId::ERROR,
+    )]);
+    assert_eq!(fmt.format(obj), "{ r: any; }");
+}
+
+#[test]
+fn error_tuple_element_renders_as_any() {
+    let db = TypeInterner::new();
+    let mut fmt = TypeFormatter::new(&db);
+    let tup = db.tuple(vec![
+        TupleElement::fixed(TypeId::NUMBER),
+        TupleElement::fixed(TypeId::ERROR),
+    ]);
+    assert_eq!(fmt.format(tup), "[number, any]");
+}

--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -239,10 +239,11 @@ impl<'a> TypeFormatter<'a> {
                 // If the application's base resolved to an error type,
                 // rendering `error<args>` produces unreadable cascades in
                 // diagnostics (e.g. `error<error<error<...>>>`). Collapse to
-                // the bare "error" token — the caller's parent diagnostic
-                // already signals the underlying failure.
+                // the error sentinel's display form — tsc renders `errorType`
+                // as `any` — while the caller's parent diagnostic already
+                // signals the underlying failure.
                 if app.base == TypeId::ERROR || matches!(base_key, Some(TypeData::Error)) {
-                    return Cow::Borrowed("error");
+                    return Cow::Borrowed("any");
                 }
 
                 // A generic `Application` may lose its alias symbol and render
@@ -873,7 +874,11 @@ impl<'a> TypeFormatter<'a> {
                 let name = Self::strip_module_extension(&name);
                 format!("typeof import(\"{name}\")").into()
             }
-            TypeData::Error => Cow::Borrowed("error"),
+            // tsc renders its `errorType` sentinel (and the `NONE` placeholder,
+            // which shares `TypeData::Error`) as `any`, never the raw internal
+            // "error" token. Kept in lock-step with the `TypeId::ERROR` fast
+            // path in `format`.
+            TypeData::Error => Cow::Borrowed("any"),
             // A substitution type displays as its underlying variable (tsc
             // prints `T`, not the narrowed `T & C`).
             TypeData::Substitution { base_type, .. } => self.format(*base_type),

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -16,6 +16,8 @@ mod property_names;
 // release-mode test build doesn't try to run (or compile) tests that have
 // nothing to capture.
 #[cfg(test)]
+mod error_type_display_tests;
+#[cfg(test)]
 mod keyof_alias_display_tests;
 #[cfg(all(test, debug_assertions))]
 pub mod test_tracing;
@@ -1455,7 +1457,13 @@ impl<'a> TypeFormatter<'a> {
         match type_id {
             TypeId::NEVER => return Cow::Borrowed("never"),
             TypeId::UNKNOWN => return Cow::Borrowed("unknown"),
-            TypeId::ANY => return Cow::Borrowed("any"),
+            // The error sentinel is tsc's `errorType`: an `Any`-flagged
+            // intrinsic whose internal name is "error" but which the printer
+            // renders as `any` in every diagnostic, exactly like `ANY` itself.
+            // Surfacing the raw "error" token (e.g. `(e: {...}) => error`,
+            // `error[]`, `{ r: error; }`) leaks a compiler-internal spelling
+            // users never see from tsc.
+            TypeId::ANY | TypeId::ERROR => return Cow::Borrowed("any"),
             TypeId::VOID => return Cow::Borrowed("void"),
             TypeId::UNDEFINED => return Cow::Borrowed("undefined"),
             TypeId::NULL => return Cow::Borrowed("null"),
@@ -1466,7 +1474,6 @@ impl<'a> TypeFormatter<'a> {
             TypeId::SYMBOL => return Cow::Borrowed("symbol"),
             TypeId::OBJECT => return Cow::Borrowed("object"),
             TypeId::FUNCTION => return Cow::Borrowed("Function"),
-            TypeId::ERROR => return Cow::Borrowed("error"),
             _ => {}
         }
 

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_00.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_00.rs
@@ -322,7 +322,8 @@ fn format_all_primitive_type_ids() {
     assert_eq!(fmt.format(TypeId::SYMBOL), "symbol");
     assert_eq!(fmt.format(TypeId::OBJECT), "object");
     assert_eq!(fmt.format(TypeId::FUNCTION), "Function");
-    assert_eq!(fmt.format(TypeId::ERROR), "error");
+    // The error sentinel renders as tsc's `any`, not the internal "error".
+    assert_eq!(fmt.format(TypeId::ERROR), "any");
 }
 
 // =================================================================

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_01.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_01.rs
@@ -438,9 +438,12 @@ fn format_string_intrinsic_uncapitalize() {
 
 #[test]
 fn format_error_type() {
+    // tsc renders its `errorType` sentinel as `any` in every diagnostic; the
+    // internal "error" spelling is never surfaced to users. See
+    // `error_type_display_tests` for the structural-position coverage.
     let db = TypeInterner::new();
     let mut fmt = TypeFormatter::new(&db);
-    assert_eq!(fmt.format(TypeId::ERROR), "error");
+    assert_eq!(fmt.format(TypeId::ERROR), "any");
 }
 
 // =================================================================


### PR DESCRIPTION
Closes #15359.

Structural rule: when the error-type sentinel appears in a type printed in a diagnostic, `tsc` renders it as `any`, never the compiler-internal `error` token. `tsc` models a failed type resolution as `errorType` — an `Any`-flagged intrinsic whose internal name is `"error"` — but its printer always emits `any`. tsz mirrors that architecture with a distinct `TypeId::ERROR` sentinel (it prevents any-poisoning, per the `TypeId` docs), yet the formatter surfaced the raw `error` spelling, diverging from `tsc` in every structural position the sentinel can occupy.

Before → after (`tsz repro.ts --noEmit --strict`):

```ts
const fn = (e: { x: number }) => e.y;   // e.y fails → fn's return type is the error sentinel
const g: string = fn;
```

- before: `Type '(e: { x: number; }) => error' is not assignable to type 'string'.`
- after / `tsc`: `Type '(e: { x: number; }) => any' is not assignable to type 'string'.`

Owner layer: `crates/tsz-solver/src/diagnostics/format` (`TypeFormatter`). The fix is a display-only change at the printer, the correct altitude — it matches `tsc`'s own architecture, and the sentinel's identity and any-poisoning semantics are untouched. Three render sites spelled the sentinel `error`; all now render `any`:
- `mod.rs` — the `TypeId::ERROR` intrinsic fast path (merged with the existing `TypeId::ANY` arm, since both render `any`).
- `key.rs` — the error-based `Application` collapse guard (`error<args>` cascade).
- `key.rs` — the `TypeData::Error` key-dispatch arm (also reached by the `NONE` placeholder, which shares `TypeData::Error`).

No output surgery, no new type construction, no printer-output predicate: the sentinel's display name is simply corrected to `tsc`'s. This also moves tsz *toward* the `tsc` conformance baselines (which already say `any`), not away.

Adjacent matrix (all differential-verified against `tsc` 6.0.2): error sentinel standalone, as array element (`any[]`), function return (`=> any`), object property value (`{ r: any; }`), tuple element (`[number, any]`), and a union arm that collapses to `any`; plus the `NONE` placeholder.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-solver --lib error_type_display` — new shard `error_type_display_tests`, 6/6 pass (every structural position + the `NONE` placeholder; binder-agnostic).
- `cargo test -p tsz-solver --lib diagnostics::format` — 237/237 pass; `format_error_type` and `format_all_primitive_type_ids` updated to the correct `any` rendering.
- `cargo clippy -p tsz-solver --lib` — clean (the merged `ANY | ERROR` arm resolves the `match_same_arms` lint); `cargo fmt` — clean.
- End-to-end CLI differential vs `tsc` 6.0.2 on the full repro matrix (return / array / object / tuple / union positions) — full parity.
- Broad conformance / emit / fourslash gates owned by exact-head ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: undisclosed (harness undercover mode)
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01HF5xfSN3hwBgYCS5hv7Zmp)_