### PR TITLE
fix(checker): defer TS2344 when a generic type-arg constraint stays an unresolved Lazy (#14337)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1319,6 +1319,9 @@ path = "tests/ts2344_typeof_merged_tests.rs"
 name = "typeof_instantiation_expression_tests"
 path = "tests/typeof_instantiation_expression_tests.rs"
 [[test]]
+name = "constraint_unresolved_lazy_defer_tests"
+path = "tests/constraint_unresolved_lazy_defer_tests.rs"
+[[test]]
 name = "ts2344_class_constructor_constraint_call"
 path = "tests/ts2344_class_constructor_constraint_call.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -1922,6 +1922,35 @@ impl CheckerState<'_> {
                     is_satisfied = false;
                 }
                 if !is_satisfied && let Some(&arg_idx) = type_args_list.nodes.get(i) {
+                    // A TS2344 satisfaction decision requires a fully-resolved
+                    // constraint. When the instantiated constraint is still an
+                    // unresolved `Lazy(DefId)` (e.g. a lib alias like `PropertyKey`
+                    // / `keyof any` whose body could not be resolved here because
+                    // the cross-file lazy-resolution budget was exhausted while a
+                    // sibling deeply-recursive type argument was evaluated), the
+                    // checker cannot know what the constraint is. Make one more
+                    // genuine resolution attempt; if it stays opaque, defer rather
+                    // than fail closed against the reference — tsc always has the
+                    // resolved constraint here, so an unresolved `Lazy` is a tsz
+                    // resolution limitation, not a real violation (#14337).
+                    if crate::query_boundaries::common::is_lazy_type(
+                        self.ctx.types,
+                        instantiated_constraint,
+                    ) {
+                        self.ensure_relation_input_ready(instantiated_constraint);
+                        let reresolved = self.resolve_lazy_type(instantiated_constraint);
+                        if crate::query_boundaries::common::is_lazy_type(self.ctx.types, reresolved)
+                        {
+                            continue;
+                        }
+                        let reresolved = self.evaluate_type_for_assignability(reresolved);
+                        if self
+                            .type_arg_constraint_no_weak_relation_outcome(type_arg, reresolved)
+                            .related
+                        {
+                            continue;
+                        }
+                    }
                     if self.type_argument_is_narrowed_by_conditional_true_branch(
                         arg_idx,
                         instantiated_constraint,

--- a/crates/tsz-checker/src/tests/constraint_validation_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/constraint_validation_relation_routing_arch_tests.rs
@@ -9,11 +9,14 @@ fn generic_constraint_validation_no_weak_checks_use_relation_outcome_boundary() 
     )
     .expect("failed to read constraint_validation.rs");
 
+    // Four routed call sites: three landed independently on main, plus the
+    // #14337 fallback that defers TS2344 when the type-argument constraint
+    // stays an unresolved `Lazy` (added by this change).
     assert_eq!(
         source
             .matches("type_arg_constraint_no_weak_relation_outcome(")
             .count(),
-        3,
+        4,
         "generic constraint validation should route no-weak relation probes through the named type-argument constraint fallback"
     );
     assert!(

--- a/crates/tsz-checker/tests/constraint_unresolved_lazy_defer_tests.rs
+++ b/crates/tsz-checker/tests/constraint_unresolved_lazy_defer_tests.rs
@@ -1,0 +1,136 @@
+//! Regression tests for #14337: the generic type-argument constraint check
+//! (`validate_type_args_against_params`, TS2344) must not fail closed against a
+//! constraint it could not fully resolve.
+//!
+//! In the ts-rest canary row, `Record<number, ContractAnyType>` (with
+//! `ContractAnyType` a deeply-recursive `zod` schema graph) produced a false
+//! `TS2344: Type 'number' does not satisfy the constraint 'string | number |
+//! symbol'`. Tracing showed the instantiated key constraint stayed an
+//! unresolved `Lazy(DefId)` for `PropertyKey` (`keyof any`) — the cross-file
+//! lazy-resolution budget was exhausted while the sibling deeply-recursive
+//! value argument was evaluated — so the reflexively-true `number <:
+//! string | number | symbol` relation came back `false` against the opaque
+//! reference. The fix makes one more genuine resolution attempt and, if the
+//! constraint stays opaque, defers rather than emitting TS2344 (matching tsc,
+//! which always has the resolved constraint here).
+//!
+//! The graph-scale trigger itself is exercised by the ts-rest canary
+//! project-compile row in CI. These unit tests lock the *acceptance* direction
+//! the bug violated (valid `PropertyKey` keys must be accepted) and guard
+//! against the fix over-deferring: genuine constraint violations, whose
+//! constraint resolves normally, must still emit TS2344.
+
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_checker::test_utils::diagnostic_code_messages;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+fn ts2344_count(source: &str) -> usize {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    checker.check_source_file(root);
+
+    diagnostic_code_messages(checker.ctx.diagnostics)
+        .iter()
+        .filter(|(code, _)| *code == 2344)
+        .count()
+}
+
+/// A valid `number` key against a `PropertyKey` (`string | number | symbol`)
+/// constraint must be accepted — the direction the #14337 false positive broke.
+#[test]
+fn number_key_satisfies_property_key_constraint() {
+    let src = r#"
+type PropertyKey = string | number | symbol;
+type Rec<K extends PropertyKey, V> = { [P in K]: V };
+type X = Rec<number, { a: number }>;
+declare const x: X;
+export { x };
+"#;
+    assert_eq!(
+        ts2344_count(src),
+        0,
+        "number satisfies string | number | symbol"
+    );
+}
+
+/// Same acceptance, name-agnostic: the rule must not key on the identifier
+/// spelling of the key parameter or the alias.
+#[test]
+fn valid_key_accepted_with_renamed_binders() {
+    let src = r#"
+type Prop = string | number | symbol;
+type Dictionary<TheKey extends Prop, TheValue> = { [Entry in TheKey]: TheValue };
+type Y = Dictionary<string, { z: boolean }>;
+declare const y: Y;
+export { y };
+"#;
+    assert_eq!(
+        ts2344_count(src),
+        0,
+        "string satisfies the renamed PropertyKey constraint"
+    );
+}
+
+/// A resolvable-constraint violation must still emit TS2344 — the fix defers
+/// only for an *unresolved* constraint, never for a genuine mismatch.
+#[test]
+fn object_key_violates_property_key_constraint_still_errors() {
+    let src = r#"
+type PropertyKey = string | number | symbol;
+type Rec<K extends PropertyKey, V> = { [P in K]: V };
+type Bad = Rec<{ a: 1 }, string>;
+declare const bad: Bad;
+export { bad };
+"#;
+    assert_eq!(
+        ts2344_count(src),
+        1,
+        "an object type does not satisfy string | number | symbol"
+    );
+}
+
+/// `boolean` is not a `PropertyKey`; a resolvable constraint must still reject
+/// it (no over-deferral).
+#[test]
+fn boolean_key_violates_property_key_constraint_still_errors() {
+    let src = r#"
+type PropertyKey = string | number | symbol;
+type Rec<K extends PropertyKey, V> = { [P in K]: V };
+type Bad = Rec<boolean, string>;
+declare const bad: Bad;
+export { bad };
+"#;
+    assert_eq!(
+        ts2344_count(src),
+        1,
+        "boolean does not satisfy string | number | symbol"
+    );
+}
+
+/// A concrete primitive constraint (`string`) with a mismatched concrete
+/// argument (`number`) must still error — guards the same modified path.
+#[test]
+fn concrete_primitive_constraint_violation_still_errors() {
+    let src = r#"
+type Wrap<K extends string> = { value: K };
+type Bad = Wrap<number>;
+declare const bad: Bad;
+export { bad };
+"#;
+    assert_eq!(ts2344_count(src), 1, "number does not satisfy string");
+}


### PR DESCRIPTION
Closes #14337 (the TS2344 constraint-degradation root; the residual `params`/`body` TS2339 is downstream of it).

Structural rule: when validating a generic type argument against its type parameter's constraint (`validate_type_args_against_params`, TS2344), the satisfaction decision requires a **fully-resolved constraint**. When the instantiated constraint is still an unresolved `Lazy(DefId)` — e.g. a lib alias such as `PropertyKey` / `keyof any` whose body could not be resolved in this context because the cross-file lazy-resolution budget was exhausted while a sibling deeply-recursive type argument was evaluated — the checker cannot know what the constraint is, so the reflexively-true `number <: string | number | symbol` relation comes back `false` against the opaque reference and a false TS2344 fires. `tsc` always has the resolved constraint here and never reports the error; tsz does through the constraint-validation owner layer.

### Root cause (trace-narrowed on a real `zod` reproduction)
`Record<number, ContractAnyType>` (with `ContractAnyType` a deeply-recursive `zod` schema graph) emitted `TS2344: Type 'number' does not satisfy the constraint 'string | number | symbol'`. A `zod`-based repro plus a `tracing` probe at the emit gate showed the check target was `Lazy(DefId(410))` (the `PropertyKey` / `keyof any` constraint), rendered by the printer as `PropertyKey<T>`, while the *displayed* constraint used a separate already-resolved form. The relation returned a genuine `related=false` (not `depth_exceeded` / `iteration_exceeded`), and the FP was deterministic (unchanged with `TSZ_DISABLE_LIMIT_RESULT_CACHE=1` and `RAYON_NUM_THREADS=1`), ruling out the limit-result-cache-poisoning and parallel-race hypotheses. The prior standing direction on the issue ("budget bail → defer") is therefore refuted; the concrete signal is that the resolved constraint stays a bare `Lazy`.

### Fix
Owner layer: `crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs`, at the final concrete-argument TS2344 emit gate. Before reporting, if the instantiated constraint is still a bare `Lazy`, make one more genuine resolution attempt (`ensure_relation_input_ready` + `resolve_lazy_type` + `evaluate_type_for_assignability`). If it stays opaque, defer instead of failing closed; if it now resolves and the argument is related, accept. This is the same "not fully resolved → defer" category as the adjacent existing `contains_type_parameters` guard, extended to unresolved lazies.

Anti-hardcoding: keys only on the structural `is_lazy_type` predicate — no identifier/file-name/rendered-text check, no single-test suppression. Tests vary binder names.

### Scope note
This is a constraint-satisfaction-boundary correctness invariant ("never decide TS2344 against an unresolved constraint"), which prevents a whole class of cross-file/registration-window false positives, not just the `zod` one. The deeper reason a lib alias like `PropertyKey` can be left unresolved under load (lazy-resolution budget exhaustion) is the eager-materialization lane tracked in #13508/#13806 and is out of scope here.

## Goal
Goal: grow

## Verification
- `cargo test -p tsz-checker --test constraint_unresolved_lazy_defer_tests` — new suite, 5/5 pass (valid `number`/`string` keys accepted incl. renamed binders; object/boolean key and `number` vs `string` violations still emit TS2344).
- `cargo test -p tsz-checker --test ts2344_generic_ref_scoped_param_concrete_constraint --test ts2344_class_constructor_constraint_expr --test ts2344_class_constructor_constraint_call --test ts2344_class_constructor_constraint_visibility` — 25/25 pass.
- Broader constraint/relation subset unchanged: `deferred_keyof_index_access_assignability_tests`, `keyless_object_record_inference_tests`, `mapped_type_errors_conformance_tests`, `conditional_true_branch_substitution_tests`, `infer_constraint_whole_candidate_tests`, `generic_method_override_constraint_ts2416_tests`, `contextual_ts2345_conformance_tests` — 72/72 pass.
- Differential vs `tsc` 5.9.3 on a real `zod` repro: `Record<number, z.ZodTypeAny>` false TS2344 cleared; genuine violations (`Record<{a:1}, string>`, `Record<boolean, string>`, `ReturnType<string>`) byte-identical to `tsc`.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --profile ci-lint --tests` clean.
- Broad conformance / emit / fourslash and the ts-rest canary project row owned by exact-head ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01QznyyGfxxW8V7cSxUHa99a)_