### PR TITLE
fix(checker,solver): emit per-overload TS2772 elaboration for TS2769 no-overload-match

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/helpers.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/helpers.rs
@@ -6,13 +6,58 @@ use crate::query_boundaries::checkers::call::{
 };
 use crate::query_boundaries::common::{CallResult, ContextualTypeContext};
 use crate::state::CheckerState;
-use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
 
 use super::super::OverloadResolution;
 use super::retry_state::NoReturnContextFallback;
 
 impl<'a> CheckerState<'a> {
+    /// Collect the argument nodes that need a fresh per-overload contextual
+    /// type before the second resolution pass — those needing a contextual type
+    /// directly, needing contextual signature instantiation, or wrapping a
+    /// callback inside parentheses. Extracted from `resolve_signatures.rs` as
+    /// pure code motion to hold that file under the 2000-LOC arch limit.
+    pub(super) fn contextual_refresh_args(
+        &self,
+        args: &[NodeIndex],
+        union_contextual_param_types: &[Option<TypeId>],
+    ) -> Vec<NodeIndex> {
+        args.iter()
+            .copied()
+            .enumerate()
+            .filter_map(|(i, arg_idx)| {
+                if self.argument_needs_contextual_type(arg_idx) {
+                    return Some(arg_idx);
+                }
+                if self.expression_needs_contextual_signature_instantiation(
+                    arg_idx,
+                    union_contextual_param_types.get(i).copied().flatten(),
+                ) {
+                    return Some(arg_idx);
+                }
+                // Also include parenthesized expressions that might contain callbacks
+                let mut current = arg_idx;
+                for _ in 0..10 {
+                    let node = self.ctx.arena.get(current)?;
+                    if node.kind == syntax_kind_ext::ARROW_FUNCTION
+                        || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+                    {
+                        return Some(arg_idx);
+                    }
+                    if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+                        && let Some(paren) = self.ctx.arena.get_parenthesized(node)
+                    {
+                        current = paren.expression;
+                        continue;
+                    }
+                    return None;
+                }
+                None
+            })
+            .collect()
+    }
+
     /// Report whether the union-of-signatures contextual type used by the
     /// first overload pass is lossy for some callback argument.
     ///

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
@@ -10,7 +10,7 @@ use crate::query_boundaries::common::{
     CallResult, ContextualTypeContext, PendingDiagnosticBuilder,
 };
 use crate::state::CheckerState;
-use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
+use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
 use super::super::{CallableContext, OverloadResolution, SelectedTypePredicate};
@@ -107,40 +107,8 @@ impl<'a> CheckerState<'a> {
             .enumerate()
             .map(|(i, _)| ctx_helper.get_parameter_type_for_call(i, args.len()))
             .collect();
-        let contextual_refresh_args: Vec<_> = args
-            .iter()
-            .copied()
-            .enumerate()
-            .filter_map(|(i, arg_idx)| {
-                if self.argument_needs_contextual_type(arg_idx) {
-                    return Some(arg_idx);
-                }
-                if self.expression_needs_contextual_signature_instantiation(
-                    arg_idx,
-                    union_contextual_param_types.get(i).copied().flatten(),
-                ) {
-                    return Some(arg_idx);
-                }
-                // Also include parenthesized expressions that might contain callbacks
-                let mut current = arg_idx;
-                for _ in 0..10 {
-                    let node = self.ctx.arena.get(current)?;
-                    if node.kind == syntax_kind_ext::ARROW_FUNCTION
-                        || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                    {
-                        return Some(arg_idx);
-                    }
-                    if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
-                        && let Some(paren) = self.ctx.arena.get_parenthesized(node)
-                    {
-                        current = paren.expression;
-                        continue;
-                    }
-                    return None;
-                }
-                None
-            })
-            .collect();
+        let contextual_refresh_args =
+            self.contextual_refresh_args(args, &union_contextual_param_types);
         let refresh_all_args = |this: &mut Self| {
             for &arg_idx in args {
                 this.invalidate_expression_for_contextual_retry(arg_idx);

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
@@ -1007,6 +1007,14 @@ impl<'a> CheckerState<'a> {
         // type callback/object-literal arguments correctly. The union pass above can
         // miss those, producing false negatives and downstream false TS2345/TS2322.
         let mut failures = Vec::new();
+        // Index (into `signatures`) of the owning overload for each entry in
+        // `failures`, kept parallel to it so the error reporter can build tsc's
+        // TS2772 `Overload {n} of {total}, ..., gave the following error.`
+        // elaboration. Recording bare indices keeps the loop allocation-free;
+        // the owning signatures are cloned once, only when the `NoOverloadMatch`
+        // result is actually built. Every `failures.push`/`clear` below has a
+        // mirroring push/clear here.
+        let mut failing_overload_indices: Vec<usize> = Vec::new();
         let mut all_arg_count_mismatches = true;
         let mut any_has_rest = false;
         let mut exact_expected_counts = std::collections::BTreeSet::new();
@@ -1596,6 +1604,7 @@ impl<'a> CheckerState<'a> {
                             PendingDiagnosticBuilder::argument_not_assignable(actual, expected)
                                 .with_optional_span(self.arg_source_span(args, index)),
                         );
+                        failing_overload_indices.push(idx);
                         self.ctx
                             .rollback_diagnostics_filtered(&candidate_snap, |diag| {
                                 Self::should_preserve_speculative_call_diagnostic(diag)
@@ -1667,6 +1676,7 @@ impl<'a> CheckerState<'a> {
                                 };
                             callback_body_failure_return.get_or_insert(recovery_return);
                             failures.clear();
+                            failing_overload_indices.clear();
                             failures.push(
                                 PendingDiagnosticBuilder::argument_not_assignable(
                                     return_type,
@@ -1674,6 +1684,7 @@ impl<'a> CheckerState<'a> {
                                 )
                                 .with_span(span),
                             );
+                            failing_overload_indices.push(idx);
                             type_mismatch_count = type_mismatch_count.max(1);
                             best_type_mismatch = Some((
                                 OverloadResolution {
@@ -1834,6 +1845,7 @@ impl<'a> CheckerState<'a> {
                             PendingDiagnosticBuilder::argument_not_assignable(actual, expected)
                                 .with_optional_span(self.arg_source_span(args, index)),
                         );
+                        failing_overload_indices.push(idx);
                     }
                 }
                 CallResult::ArgumentCountMismatch {
@@ -1854,6 +1866,7 @@ impl<'a> CheckerState<'a> {
                         max,
                         actual,
                     ));
+                    failing_overload_indices.push(idx);
                 }
                 _ => {
                     all_arg_count_mismatches = false;
@@ -1982,6 +1995,11 @@ impl<'a> CheckerState<'a> {
                 func_type: TypeId::ANY,
                 arg_types,
                 failures,
+                overload_signatures: failing_overload_indices
+                    .iter()
+                    .map(|&i| signatures[i].clone())
+                    .collect(),
+                overload_total: signatures.len(),
                 fallback_return,
             },
             selected_type_predicate: None,

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -757,10 +757,20 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Report "No overload matches this call" with related overload failures.
+    ///
+    /// When `overload_signatures` aligns 1:1 with `failures` and there are 2 or 3
+    /// failing candidates, the related information reproduces tsc's per-overload
+    /// elaboration — each failure is wrapped in an `Overload {n} of {total},
+    /// '{signature}', gave the following error.` (TS2772) header (see
+    /// `resolveCall` in the TypeScript checker), where `overload_signatures[i]`
+    /// is the signature `failures[i]` failed against and `overload_total` is the
+    /// `{total}`. Otherwise the failures are rendered as the flat related list.
     pub fn error_no_overload_matches_at(
         &mut self,
         idx: NodeIndex,
         failures: &[tsz_solver::PendingDiagnostic],
+        overload_signatures: &[tsz_solver::CallSignature],
+        overload_total: usize,
     ) {
         tracing::debug!(
             "error_no_overload_matches_at: File name: {}",
@@ -1067,7 +1077,19 @@ impl<'a> CheckerState<'a> {
 
         tracing::debug!("File name: {}", self.ctx.file_name);
 
-        for failure in failures {
+        // tsc's `resolveCall` groups a no-overload-match by candidate when 2 or 3
+        // candidates reached argument checking: each failure is wrapped in an
+        // `Overload {n} of {total}, '{signature}', gave the following error.`
+        // (TS2772) header, with the applicability error nested one level deeper.
+        // Outside that count (a single or >3 candidates) tsc uses a different
+        // top-level shape, so we keep the existing flat related list there to
+        // avoid changing the top-level diagnostic. The metadata must align 1:1
+        // with the failures (a defensive guard for producers that do not record
+        // it — the flat fallback then applies).
+        let use_overload_elaboration = overload_signatures.len() == failures.len()
+            && matches!(overload_signatures.len(), 2 | 3);
+
+        for (position, failure) in failures.iter().enumerate() {
             let mut pending: PendingDiagnostic = PendingDiagnostic {
                 span: Some(span.clone()),
                 ..failure.clone()
@@ -1098,18 +1120,53 @@ impl<'a> CheckerState<'a> {
                 }
             }
             let diag = formatter.render(&pending);
-            if let Some(diag_span) = diag.span.as_ref() {
+            let Some(diag_span) = diag.span.as_ref() else {
+                continue;
+            };
+            // In the per-overload elaboration, each failure gets an
+            // `Overload {n} of {total}, '{signature}', gave the following error.`
+            // (TS2772) header at depth 0, and the applicability error nests one
+            // level deeper (depth 1) so it renders indented beneath its header.
+            // In the flat fallback there is no header and the error stays at
+            // depth 0. The ordinal is the 1-based position among the failing
+            // candidates.
+            if use_overload_elaboration {
+                let signature =
+                    formatter.format_call_signature(&overload_signatures[position], false, false);
+                let header = format_message(
+                    diagnostic_messages::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
+                    &[
+                        &(position + 1).to_string(),
+                        &overload_total.to_string(),
+                        &signature,
+                    ],
+                );
                 related.push(DiagnosticRelatedInformation {
                     file: diag_span.file.to_string(),
                     start: diag_span.start,
                     length: diag_span.length,
-                    message_text: diag.message.clone(),
+                    message_text: header,
                     category: DiagnosticCategory::Message,
-                    code: diag.code,
+                    code: diagnostic_codes::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
                     depth: 0,
                 });
             }
+            related.push(DiagnosticRelatedInformation {
+                file: diag_span.file.to_string(),
+                start: diag_span.start,
+                length: diag_span.length,
+                message_text: diag.message.clone(),
+                category: DiagnosticCategory::Message,
+                code: diag.code,
+                depth: u8::from(use_overload_elaboration),
+            });
         }
+
+        let related_policy = if use_overload_elaboration {
+            RelatedInformationPolicy::OVERLOAD_ELABORATION
+        } else {
+            RelatedInformationPolicy::OVERLOAD_FAILURES
+        };
 
         self.emit_render_request_at_anchor(
             anchor,
@@ -1118,7 +1175,7 @@ impl<'a> CheckerState<'a> {
                 diagnostic_codes::NO_OVERLOAD_MATCHES_THIS_CALL,
                 diagnostic_messages::NO_OVERLOAD_MATCHES_THIS_CALL.to_string(),
                 related,
-                RelatedInformationPolicy::OVERLOAD_FAILURES,
+                related_policy,
             ),
         );
     }

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -45,6 +45,14 @@ pub(crate) struct RelatedInformationPolicy {
     include_primary: bool,
     dedupe: bool,
     limit: Option<usize>,
+    /// When `true`, keep the related items in the order the reporter appended
+    /// them instead of applying the deterministic `(file, start, depth,
+    /// message)` sort. The sort is correct for chains anchored at distinct
+    /// positions, but it interleaves incorrectly when several outer-to-inner
+    /// chains share a single anchor (e.g. the per-overload TS2772 headers and
+    /// their nested applicability errors, which must stay grouped
+    /// header-then-child in declaration order).
+    preserve_order: bool,
 }
 
 impl RelatedInformationPolicy {
@@ -52,6 +60,7 @@ impl RelatedInformationPolicy {
         include_primary: true,
         dedupe: true,
         limit: None,
+        preserve_order: false,
     };
 
     /// Demote a diagnostic's primary message into the related chain, keeping any
@@ -61,12 +70,27 @@ impl RelatedInformationPolicy {
         include_primary: true,
         dedupe: true,
         limit: None,
+        preserve_order: false,
     };
 
     pub(crate) const OVERLOAD_FAILURES: Self = Self {
         include_primary: false,
         dedupe: true,
         limit: None,
+        preserve_order: false,
+    };
+
+    /// Per-overload TS2769 elaboration: each failing candidate contributes an
+    /// outer `Overload {n} of {total}, '{signature}', gave the following error.`
+    /// (TS2772) header followed by its nested applicability error. Ordering is
+    /// significant (declaration order, header before child) and the headers are
+    /// intentionally distinct, so ordering and de-duplication are both
+    /// disabled — the reporter already appends exactly the wanted sequence.
+    pub(crate) const OVERLOAD_ELABORATION: Self = Self {
+        include_primary: false,
+        dedupe: false,
+        limit: None,
+        preserve_order: true,
     };
 }
 
@@ -981,13 +1005,15 @@ impl<'a> CheckerState<'a> {
         // main message and its note. Within the same depth the message-text
         // tiebreaker still gives deterministic order when distinct code paths
         // append items in different sequences.
-        normalized.sort_by(|a, b| {
-            a.file
-                .cmp(&b.file)
-                .then(a.start.cmp(&b.start))
-                .then(a.depth.cmp(&b.depth))
-                .then(a.message_text.cmp(&b.message_text))
-        });
+        if !policy.preserve_order {
+            normalized.sort_by(|a, b| {
+                a.file
+                    .cmp(&b.file)
+                    .then(a.start.cmp(&b.start))
+                    .then(a.depth.cmp(&b.depth))
+                    .then(a.message_text.cmp(&b.message_text))
+            });
+        }
 
         normalized
     }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1372,6 +1372,9 @@ mod overlap_relation_helper_routing_arch_tests;
 #[path = "tests/overload_anchor_at_argument_tests.rs"]
 mod overload_anchor_at_argument_tests;
 #[cfg(test)]
+#[path = "tests/overload_elaboration_tests.rs"]
+mod overload_elaboration_tests;
+#[cfg(test)]
 #[path = "tests/overload_generic_wrapper_compat_tests.rs"]
 mod overload_generic_wrapper_compat_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
@@ -1,0 +1,257 @@
+//! Regression tests for tsc's per-overload TS2769 elaboration.
+//!
+//! When a call matches no overload and 2 or 3 candidate signatures reached
+//! argument checking, tsc (`resolveCall`) wraps each candidate's applicability
+//! error in an `Overload {n} of {total}, '{signature}', gave the following
+//! error.` (TS2772) header, rendered in declaration order with the specific
+//! error nested one level deeper. tsz previously flattened the per-overload
+//! errors directly under the TS2769 header (dropping the wrapper and sorting
+//! them out of declaration order).
+//!
+//! Owner: `error_no_overload_matches_at`
+//! (`crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs`),
+//! fed by the parallel `overload_candidates` metadata recorded in
+//! `resolve_overloaded_call_with_signatures`
+//! (`crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs`).
+
+use crate::test_utils::check_source_diagnostics;
+
+/// The flat list of every related-information message on the single TS2769.
+fn ts2769_related(source: &str) -> Vec<String> {
+    let diags = check_source_diagnostics(source);
+    let ts2769: Vec<_> = diags.iter().filter(|d| d.code == 2769).collect();
+    assert_eq!(
+        ts2769.len(),
+        1,
+        "Expected exactly one TS2769. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    ts2769[0]
+        .related_information
+        .iter()
+        .map(|r| r.message_text.clone())
+        .collect()
+}
+
+/// The ordered `(depth, code, message)` related chain of the single TS2769.
+fn ts2769_related_chain(source: &str) -> Vec<(u8, u32, String)> {
+    let diags = check_source_diagnostics(source);
+    let ts2769: Vec<_> = diags.iter().filter(|d| d.code == 2769).collect();
+    assert_eq!(ts2769.len(), 1, "Expected exactly one TS2769");
+    ts2769[0]
+        .related_information
+        .iter()
+        .map(|r| (r.depth, r.code, r.message_text.clone()))
+        .collect()
+}
+
+/// Two failing overloads: each argument error is wrapped in its own TS2772
+/// header, in declaration order.
+#[test]
+fn two_overloads_wrap_each_failure_in_order() {
+    let related = ts2769_related(
+        r#"
+declare function f(x: number): number;
+declare function f(x: string): string;
+f(true);
+"#,
+    );
+
+    assert_eq!(
+        related,
+        vec![
+            "Overload 1 of 2, '(x: number): number', gave the following error.".to_string(),
+            "Argument of type 'boolean' is not assignable to parameter of type 'number'."
+                .to_string(),
+            "Overload 2 of 2, '(x: string): string', gave the following error.".to_string(),
+            "Argument of type 'boolean' is not assignable to parameter of type 'string'."
+                .to_string(),
+        ],
+        "expected per-overload TS2772 wrappers in declaration order, got: {related:#?}"
+    );
+}
+
+/// The wrapper (TS2772, depth 0) precedes its applicability error (depth 1) so
+/// the CLI renders the error indented one level under its header.
+#[test]
+fn wrapper_header_is_depth_zero_and_error_is_depth_one() {
+    let chain = ts2769_related_chain(
+        r#"
+declare function f(x: number): number;
+declare function f(x: string): string;
+f(true);
+"#,
+    );
+
+    assert_eq!(
+        chain,
+        vec![
+            (
+                0,
+                2772,
+                "Overload 1 of 2, '(x: number): number', gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                "Argument of type 'boolean' is not assignable to parameter of type 'number'."
+                    .to_string()
+            ),
+            (
+                0,
+                2772,
+                "Overload 2 of 2, '(x: string): string', gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                "Argument of type 'boolean' is not assignable to parameter of type 'string'."
+                    .to_string()
+            ),
+        ],
+        "expected outer TS2772 (depth 0) then nested TS2345 (depth 1) per overload"
+    );
+}
+
+/// Three failing overloads: all three are wrapped, and the `of {total}` count
+/// and declaration order are preserved (tsc's flat-branch order, not the sorted
+/// order the flat fallback would produce).
+#[test]
+fn three_overloads_wrap_all_in_declaration_order() {
+    let related = ts2769_related(
+        r#"
+declare function f(x: number): 1;
+declare function f(x: string): 2;
+declare function f(x: boolean): 3;
+f({});
+"#,
+    );
+
+    assert_eq!(
+        related,
+        vec![
+            "Overload 1 of 3, '(x: number): 1', gave the following error.".to_string(),
+            "Argument of type '{}' is not assignable to parameter of type 'number'.".to_string(),
+            "Overload 2 of 3, '(x: string): 2', gave the following error.".to_string(),
+            "Argument of type '{}' is not assignable to parameter of type 'string'.".to_string(),
+            "Overload 3 of 3, '(x: boolean): 3', gave the following error.".to_string(),
+            "Argument of type '{}' is not assignable to parameter of type 'boolean'.".to_string(),
+        ],
+        "expected three per-overload wrappers in declaration order, got: {related:#?}"
+    );
+}
+
+/// The elaboration keys on structure, not identifier spelling: renaming the
+/// function and its parameters leaves the wrapper text unchanged apart from the
+/// rendered signature.
+#[test]
+fn wrapper_is_independent_of_binder_names() {
+    let related = ts2769_related(
+        r#"
+declare function combine(value: number): number;
+declare function combine(value: string): string;
+combine(true);
+"#,
+    );
+
+    assert_eq!(
+        related,
+        vec![
+            "Overload 1 of 2, '(value: number): number', gave the following error.".to_string(),
+            "Argument of type 'boolean' is not assignable to parameter of type 'number'."
+                .to_string(),
+            "Overload 2 of 2, '(value: string): string', gave the following error.".to_string(),
+            "Argument of type 'boolean' is not assignable to parameter of type 'string'."
+                .to_string(),
+        ],
+        "wrapper must follow the renamed signature verbatim, got: {related:#?}"
+    );
+}
+
+/// The wrapped signature is rendered via the shared signature formatter, so a
+/// type-guard overload keeps its `x is T` predicate in the header (rather than
+/// collapsing to the bare return type).
+#[test]
+fn wrapper_preserves_type_predicate_signature() {
+    let related = ts2769_related(
+        r#"
+declare function f(x: string): x is "a";
+declare function f(x: number): x is 1;
+f(true);
+"#,
+    );
+
+    assert_eq!(
+        related,
+        vec![
+            "Overload 1 of 2, '(x: string): x is \"a\"', gave the following error.".to_string(),
+            "Argument of type 'boolean' is not assignable to parameter of type 'string'."
+                .to_string(),
+            "Overload 2 of 2, '(x: number): x is 1', gave the following error.".to_string(),
+            "Argument of type 'boolean' is not assignable to parameter of type 'number'."
+                .to_string(),
+        ],
+        "type-guard overload headers must keep the `x is T` predicate, got: {related:#?}"
+    );
+}
+
+/// `new` with two failing constructor overloads is wrapped identically to a
+/// call.
+#[test]
+fn constructor_overloads_are_wrapped() {
+    let related = ts2769_related(
+        r#"
+declare class C {
+    constructor(x: number);
+    constructor(x: string);
+}
+new C(true);
+"#,
+    );
+
+    assert!(
+        related
+            .iter()
+            .any(|m| m.starts_with("Overload 1 of 2,") && m.ends_with("gave the following error.")),
+        "expected a wrapped first constructor overload, got: {related:#?}"
+    );
+    assert!(
+        related
+            .iter()
+            .any(|m| m
+                == "Argument of type 'boolean' is not assignable to parameter of type 'number'."),
+        "expected the nested applicability error, got: {related:#?}"
+    );
+}
+
+/// More than three failing overloads fall back to the flat related list (tsc
+/// uses a different top-level shape there, which tsz does not yet reproduce);
+/// no TS2772 wrapper is emitted, keeping the top-level TS2769 unchanged.
+#[test]
+fn more_than_three_overloads_stay_flat() {
+    let related = ts2769_related(
+        r#"
+declare function f(x: number): 1;
+declare function f(x: string): 2;
+declare function f(x: boolean): 3;
+declare function f(x: bigint): 4;
+f({});
+"#,
+    );
+
+    assert!(
+        !related
+            .iter()
+            .any(|m| m.contains("gave the following error.")),
+        "with >3 overloads the flat fallback must not emit TS2772 wrappers, got: {related:#?}"
+    );
+    assert!(
+        related
+            .iter()
+            .any(|m| m == "Argument of type '{}' is not assignable to parameter of type 'number'."),
+        "the flat argument errors must still be present, got: {related:#?}"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1517,6 +1517,8 @@ impl<'a> CheckerState<'a> {
             }
             CallResult::NoOverloadMatch {
                 failures,
+                overload_signatures,
+                overload_total,
                 fallback_return,
                 ..
             } => {
@@ -1543,7 +1545,12 @@ impl<'a> CheckerState<'a> {
                     && !self.should_suppress_weak_key_no_overload(callee_expr, args);
 
                 if should_emit_no_overload_error {
-                    self.error_no_overload_matches_at(call_idx, &failures);
+                    self.error_no_overload_matches_at(
+                        call_idx,
+                        &failures,
+                        &overload_signatures,
+                        overload_total,
+                    );
                 }
                 // `fallback_return` is the intersection of the candidate
                 // signatures' return types (see `overload_failure_return_type`):

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1924,11 +1924,18 @@ impl<'a> CheckerState<'a> {
             }
             CallResult::NoOverloadMatch {
                 failures,
+                overload_signatures,
+                overload_total,
                 fallback_return,
                 ..
             } => {
                 if !self.should_suppress_weak_key_no_overload(new_expr.expression, args) {
-                    self.error_no_overload_matches_at(idx, &failures);
+                    self.error_no_overload_matches_at(
+                        idx,
+                        &failures,
+                        &overload_signatures,
+                        overload_total,
+                    );
                 }
                 if fallback_return != TypeId::ERROR {
                     query::instantiate_type_params_to_constraints(self.ctx.types, fallback_return)

--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -488,12 +488,17 @@ impl<'a> CheckerState<'a> {
             );
         let full_resolution_succeeded =
             matches!(result, tsz_solver::operations::CallResult::Success(_));
-        if let tsz_solver::operations::CallResult::NoOverloadMatch { failures, .. } = &result
+        if let tsz_solver::operations::CallResult::NoOverloadMatch {
+            failures,
+            overload_signatures,
+            overload_total,
+            ..
+        } = &result
             && selected_callee_type != callee_type
             && let Some(selected_return) = self
                 .selected_tagged_template_nullish_overload_return(selected_callee_type, &arg_types)
         {
-            self.error_no_overload_matches_at(idx, failures);
+            self.error_no_overload_matches_at(idx, failures, overload_signatures, *overload_total);
             return selected_return;
         }
 

--- a/crates/tsz-solver/src/diagnostics/format/compound/intersection_constructs.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/intersection_constructs.rs
@@ -415,7 +415,14 @@ impl<'a> TypeFormatter<'a> {
         format!("{{ {}; }}", parts.join("; "))
     }
 
-    fn format_call_signature(
+    /// Render a call/construct signature in tsc's `signatureToString` colon form
+    /// (e.g. `(x: number): number`, or `new (x: number): C` when `is_construct`).
+    ///
+    /// This is the form tsc uses in the `Overload {n} of {total}, '{signature}',
+    /// gave the following error.` (TS2772) elaboration, and it forwards the
+    /// signature's type predicate (`v is T` / `asserts v is T`) — unlike the
+    /// `=>` function-type form produced by [`TypeFormatter::format`].
+    pub fn format_call_signature(
         &mut self,
         sig: &CallSignature,
         is_construct: bool,

--- a/crates/tsz-solver/src/operations/constructors.rs
+++ b/crates/tsz-solver/src/operations/constructors.rs
@@ -139,6 +139,12 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
 
         // Handle overloads (similar to resolve_callable_call)
         let mut failures = Vec::new();
+        // Index (into `construct_signatures`) of the owning overload for each
+        // entry in `failures`, so the checker's error reporter can build tsc's
+        // per-overload TS2772 elaboration for `new` calls just as it does for
+        // ordinary calls. Owning signatures are cloned once, only when the
+        // `NoOverloadMatch` result is built.
+        let mut failing_overload_indices: Vec<usize> = Vec::new();
         let mut all_arg_count_mismatches = true;
         let mut min_expected = usize::MAX;
         let mut max_expected = 0;
@@ -157,7 +163,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         let mut first_this_mismatch: Option<(TypeId, TypeId)> = None; // (expected, actual)
         let mut all_this_mismatches_identical = true;
 
-        for sig in &shape.construct_signatures {
+        for (sig_index, sig) in shape.construct_signatures.iter().enumerate() {
             let func = FunctionShape {
                 params: sig.params.clone(),
                 this_type: sig.this_type,
@@ -200,6 +206,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             actual, expected,
                         ),
                     );
+                    failing_overload_indices.push(sig_index);
                 }
                 CallResult::ArgumentCountMismatch {
                     expected_min,
@@ -221,6 +228,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             actual,
                         ),
                     );
+                    failing_overload_indices.push(sig_index);
                 }
                 // Track this-type mismatches for TS2345 optimization (tsc reports TS2345 not TS2769
                 // when all count-compatible overloads fail with the same this-type mismatch)
@@ -242,6 +250,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             actual_this,
                         ),
                     );
+                    failing_overload_indices.push(sig_index);
                 }
                 _ => {
                     all_arg_count_mismatches = false;
@@ -323,6 +332,11 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             func_type: self.interner.callable(shape.clone()),
             arg_types: arg_types.to_vec(),
             failures,
+            overload_signatures: failing_overload_indices
+                .iter()
+                .map(|&i| shape.construct_signatures[i].clone())
+                .collect(),
+            overload_total: shape.construct_signatures.len(),
             fallback_return: shape
                 .construct_signatures
                 .first()

--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -193,6 +193,18 @@ pub enum CallResult {
         func_type: TypeId,
         arg_types: Vec<TypeId>,
         failures: Vec<PendingDiagnostic>,
+        /// Owning overload signature for each entry in `failures`, in the same
+        /// order (so `overload_signatures[i]` is the signature `failures[i]`
+        /// failed against). Same length as `failures` when populated; empty when
+        /// the producer did not record grouping, in which case the error
+        /// reporter renders the flat fallback. Used to build tsc's TS2772
+        /// `Overload {n} of {total}, '{signature}', gave the following error.`
+        /// elaboration; see `error_no_overload_matches_at`.
+        overload_signatures: Vec<CallSignature>,
+        /// Total number of overload signatures — the `{total}` in the TS2772
+        /// header. (The `{n}` ordinal is the 1-based position within
+        /// `overload_signatures`.)
+        overload_total: usize,
         fallback_return: TypeId,
     },
 }

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -1562,6 +1562,12 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
 
         // Try each call signature
         let mut failures = Vec::with_capacity(callable.call_signatures.len());
+        // Index (into `call_signatures`) of the owning overload for each entry
+        // in `failures`, so the checker's error reporter can build tsc's
+        // per-overload TS2772 elaboration for calls routed through this solver
+        // path too. Owning signatures are cloned once, only when the
+        // `NoOverloadMatch` result is built.
+        let mut failing_overload_indices: Vec<usize> = Vec::new();
         let mut all_arg_count_mismatches = true;
         let mut min_expected = usize::MAX;
         let mut max_expected = 0;
@@ -1583,7 +1589,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // Snapshot incoming generic-instantiation params so a *failed* overload attempt's `cache_generic_result` `unknown[]` params can't leak into the winner/caller; a generic winner re-populates them (#14963).
         let saved_instantiated_params = self.last_instantiated_params.clone();
 
-        for sig in &callable.call_signatures {
+        for (sig_index, sig) in callable.call_signatures.iter().enumerate() {
             self.last_instantiated_params
                 .clone_from(&saved_instantiated_params);
             // Convert CallSignature to FunctionShape
@@ -1617,6 +1623,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             actual, expected,
                         ),
                     );
+                    failing_overload_indices.push(sig_index);
                 }
                 CallResult::ArgumentCountMismatch {
                     expected_min,
@@ -1638,6 +1645,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             actual,
                         ),
                     );
+                    failing_overload_indices.push(sig_index);
                 }
                 // Track this-type mismatches for TS2345 optimization (tsc reports TS2345 not TS2769
                 // when all count-compatible overloads fail with the same this-type mismatch)
@@ -1659,6 +1667,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             actual_this,
                         ),
                     );
+                    failing_overload_indices.push(sig_index);
                 }
                 _ => {
                     all_arg_count_mismatches = false;
@@ -1742,6 +1751,11 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             func_type: self.interner.callable(callable.clone()),
             arg_types: arg_types.to_vec(),
             failures,
+            overload_signatures: failing_overload_indices
+                .iter()
+                .map(|&i| callable.call_signatures[i].clone())
+                .collect(),
+            overload_total: callable.call_signatures.len(),
             fallback_return,
         }
     }


### PR DESCRIPTION
Closes #15361.

When a call matches no overload and **2 or 3** candidate signatures reached argument checking, `tsc` (`resolveCall`) wraps each candidate's applicability error in an `Overload {n} of {total}, '{signature}', gave the following error.` (TS2772) chain, in declaration order. tsz defined the TS2772/TS2770 message strings but **never emitted them**: it flattened every candidate's argument error directly under TS2769 and — because the related-info normalizer sorts by `(file, start, depth, message)` — rendered them out of declaration order.

Structural rule: when a call resolves to no matching overload and 2–3 candidates reached argument checking, `tsc` reports TS2769 and wraps each failure in TS2772 with the candidate's `signatureToString` colon form (`(x: number): number`), in declaration order; tsz now does the same through `error_no_overload_matches_at`. A single failing candidate collapses to a plain TS2345 and `>3` candidates use a different last-overload shape — both intentionally left as-is (they would change the top-level diagnostic code and are unverifiable without the full conformance corpus). The top-level TS2769 code/anchor/message are unchanged in every case, so this is conformance-fingerprint-neutral (the runner fingerprints only top-level `code`/location/message, not nested related info).

Before → after (`tsz repro.ts --noEmit --strict` on `declare function f(x: number): number; declare function f(x: string): string; f(true);`):

```
- error TS2769: No overload matches this call.
-   Argument of type 'boolean' is not assignable to parameter of type 'number'.
-   Argument of type 'boolean' is not assignable to parameter of type 'string'.
+ error TS2769: No overload matches this call.
+   Overload 1 of 2, '(x: number): number', gave the following error.
+     Argument of type 'boolean' is not assignable to parameter of type 'number'.
+   Overload 2 of 2, '(x: string): string', gave the following error.
+     Argument of type 'boolean' is not assignable to parameter of type 'string'.
```

Owner layers:
- `crates/tsz-solver/src/operations/core/call_evaluator.rs` — `CallResult::NoOverloadMatch` carries `overload_signatures` (the owning signature per `failures` entry) + `overload_total`. Producers record cheap candidate **indices** during resolution and clone the signatures once, only when the `NoOverloadMatch` result is built (off the success hot path). All three producers — checker `resolve_signatures.rs`, solver `constructors.rs`, solver `call_resolution.rs` — populate it, so `new` overloads and solver-routed calls elaborate identically (no silent divergence).
- `crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs` — `error_no_overload_matches_at` builds the TS2772 header (depth 0) and nests the applicability error (depth 1), reusing the existing colon-form `format_call_signature` (which also preserves type-guard `x is T` predicates).
- `crates/tsz-checker/src/error_reporter/fingerprint_policy.rs` — a new `preserve_order` `RelatedInformationPolicy` keeps the outer-to-inner chain in declaration order past the determinism sort (which otherwise interleaves multiple chains sharing one anchor).

Adjacent matrix (all differential-verified vs `tsc` 6.0.2):
- two / three failing overloads → all wrapped, `of {total}`, declaration order preserved (not re-sorted)
- wrapper header at depth 0, applicability error nested at depth 1
- binder-name independence (renaming the function/params only changes the rendered signature)
- constructor (`new`) overloads wrapped (`(x: number): C`)
- type-guard overloads keep their predicate (`(x: string): x is "a"`)
- literal-argument source generalization preserved inside each wrapped error
- single overload → plain TS2345, unchanged; `>3` overloads → flat fallback, top-level TS2769 unchanged

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib overload_elaboration_tests` — new suite, 7/7 pass (two/three overloads, depth chain, binder-name independence, type predicate, constructor, >3 flat fallback).
- `cargo test -p tsz-checker --lib -- overload_literal_source_generalization call_errors error_reporter` — unchanged (185 pass; the 2 pre-existing arch failures are unrelated).
- Full `cargo test -p tsz-checker --lib` failure set is a strict subset of pristine `origin/main` (84 vs 86 failures; the "in-branch-only" set is empty — zero new regressions, and 2 pre-existing failures now pass). The 84 remaining are the environment-induced failures tracked in #15338.
- `cargo clippy -p tsz-solver -p tsz-checker --lib --tests --profile ci-lint` clean; `cargo fmt` clean.
- CLI differential vs `tsc` 6.0.2 across the matrix above.
- Broad conformance / emit / fourslash owned by exact-head ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABPzCLpJnDxrYP8cpZ1yMs)_