### PR TITLE
fix(solver,checker): tsc-faithful tuple arity diagnostics for closed tuples with optional elements

### DIFF
--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -1129,18 +1129,21 @@ impl<'a> CheckerState<'a> {
                 elem_type = self.get_type_of_node_with_request(binary.right, &elem_request);
             }
 
-            if tuple_context.is_some() || self.ctx.in_const_assertion {
-                let optional = match tuple_context.as_ref().and_then(|tc| tc.get(index)) {
-                    Some(el) => el.optional,
-                    None => false,
-                };
-                tuple_elements.push(TupleElement {
-                    type_id: elem_type,
-                    name: None,
-                    optional,
-                    rest: false,
-                });
-            } else if force_tuple_for_union_context {
+            if tuple_context.is_some()
+                || self.ctx.in_const_assertion
+                || force_tuple_for_union_context
+            {
+                // A physically-present array-literal element is always Required.
+                // tsc types `[1, "x", true]` as `[number, string, boolean]`
+                // (minLength 3) regardless of the contextual target's optional
+                // slots; an Optional *target* slot is satisfied by widening the
+                // Required source element in tuple subtyping (see the elision /
+                // `undefinedWideningType` handling above), not by copying the
+                // target's optionality onto the present source element. Mirroring
+                // it understated the source's minimum length and mis-reported
+                // tuple arity diagnostics (e.g. `[1,"x",true]` vs `[number,
+                // string?]` rendered TS2621 "…source may have more" instead of
+                // tsc's TS2619 "Source has 3 element(s) but target allows only 2").
                 tuple_elements.push(TupleElement {
                     type_id: elem_type,
                     name: None,

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -830,6 +830,15 @@ impl<'a> CheckerState<'a> {
         let mut preserve_tuple_spread_literals = false;
         let mut saw_array_element_for_bct = false;
         let mut all_array_elements_const_asserted = true;
+        // Whether an optional elision (hole) has been seen earlier in the
+        // literal. `tsc` keeps a present element Required only until the first
+        // hole; a present element that follows an elision becomes Optional. So
+        // `[42, , , ,]` is `[number, never?, never?, never?]` (`42` before any
+        // hole stays Required), but `[, , true]` is `[never?, never?, true?]`
+        // (`true` follows two holes, so it is optional). Only tracked for the
+        // `exactOptionalPropertyTypes` tuple path, where holes are themselves
+        // optional `never` slots.
+        let mut saw_optional_elision = false;
         // Total element count for tuple contextual typing. Elided slots count toward
         // the position of subsequent elements (e.g. `[42,,true]` has length 3 with
         // an undefined slot at index 1), matching tsc's `elementCount = elements.length`.
@@ -876,6 +885,7 @@ impl<'a> CheckerState<'a> {
                         optional: hole_optional,
                         rest: false,
                     });
+                    saw_optional_elision |= hole_optional;
                 } else {
                     saw_array_element_for_bct = true;
                     all_array_elements_const_asserted = false;
@@ -1133,21 +1143,25 @@ impl<'a> CheckerState<'a> {
                 || self.ctx.in_const_assertion
                 || force_tuple_for_union_context
             {
-                // A physically-present array-literal element is always Required.
-                // tsc types `[1, "x", true]` as `[number, string, boolean]`
-                // (minLength 3) regardless of the contextual target's optional
-                // slots; an Optional *target* slot is satisfied by widening the
-                // Required source element in tuple subtyping (see the elision /
-                // `undefinedWideningType` handling above), not by copying the
-                // target's optionality onto the present source element. Mirroring
-                // it understated the source's minimum length and mis-reported
-                // tuple arity diagnostics (e.g. `[1,"x",true]` vs `[number,
-                // string?]` rendered TS2621 "…source may have more" instead of
-                // tsc's TS2619 "Source has 3 element(s) but target allows only 2").
+                // A physically-present array-literal element is Required unless an
+                // optional elision preceded it. tsc types `[1, "x", true]` as
+                // `[number, string, boolean]` (minLength 3) regardless of the
+                // contextual target's optional slots; an Optional *target* slot is
+                // satisfied by widening the Required source element in tuple
+                // subtyping (see the elision / `undefinedWideningType` handling
+                // above), not by copying the target's optionality onto the present
+                // source element. Mirroring it understated the source's minimum
+                // length and mis-reported tuple arity diagnostics (e.g. `[1,"x",true]`
+                // vs `[number, string?]` rendered TS2621 "…source may have more"
+                // instead of tsc's TS2619 "Source has 3 element(s) but target
+                // allows only 2"). But once a hole makes the literal sparse, a
+                // following present element inherits the elision's optionality:
+                // `[, , true]` is `[never?, never?, true?]`, not
+                // `[never?, never?, true]` (see `saw_optional_elision`).
                 tuple_elements.push(TupleElement {
                     type_id: elem_type,
                     name: None,
-                    optional: false,
+                    optional: saw_optional_elision,
                     rest: false,
                 });
             } else {

--- a/crates/tsz-checker/tests/tuple_arity_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/tuple_arity_elaboration_tests.rs
@@ -40,6 +40,128 @@ fn ts2322(diags: &[Diagnostic]) -> &Diagnostic {
     matches[0]
 }
 
+/// Return the message of the first related-information line carrying `code`,
+/// or panic with the observed related lines for a legible failure.
+fn related_msg(diag: &Diagnostic, code: u32) -> &str {
+    diag.related_information
+        .iter()
+        .find(|r| r.code == code)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a related TS{code} line; related: {:?}",
+                diag.related_information
+                    .iter()
+                    .map(|r| (r.code, &r.message_text))
+                    .collect::<Vec<_>>()
+            )
+        })
+        .message_text
+        .as_str()
+}
+
+/// A closed target with a *trailing optional* element reports its **minimum**
+/// required length, not its raw slot count. `[alpha: number, beta?: string]`
+/// requires 1, so an empty source is `Source has 0 element(s) but target
+/// requires 1.` (previously mis-reported "requires 2", counting the optional
+/// slot). Regression for the closed-tuple arity gate (`TS2618`).
+#[test]
+fn closed_target_trailing_optional_reports_min_length() {
+    let source = r#"
+type Empty = [];
+const pair: [alpha: number, beta?: string] = (null as unknown as Empty);
+"#;
+    let diags = check_strict(source);
+    let diag = ts2322(&diags);
+    assert_eq!(
+        related_msg(diag, 2618),
+        "Source has 0 element(s) but target requires 1."
+    );
+}
+
+/// A closed target with several trailing optionals still reports the minimum
+/// (`[first, second, third?, fourth?]` requires 2). A one-element source is
+/// `Source has 1 element(s) but target requires 2.` (previously "requires 4").
+#[test]
+fn closed_target_multiple_trailing_optionals_reports_min_length() {
+    let source = r#"
+type Solo = [number];
+const quad: [first: number, second: number, third?: number, fourth?: number] =
+    (null as unknown as Solo);
+"#;
+    let diags = check_strict(source);
+    let diag = ts2322(&diags);
+    assert_eq!(
+        related_msg(diag, 2618),
+        "Source has 1 element(s) but target requires 2."
+    );
+}
+
+/// An all-optional source that is longer than a closed target reports the
+/// target's minimum with the "source may have fewer" wording (`TS2620`),
+/// because the source is not guaranteed to supply the required elements.
+#[test]
+fn all_optional_longer_source_reports_target_requires_may_have_fewer() {
+    let source = r#"
+type Loose = [first?: number, second?: number, third?: number];
+const strict: [x: number, y: number] = (null as unknown as Loose);
+"#;
+    let diags = check_strict(source);
+    let diag = ts2322(&diags);
+    assert_eq!(
+        related_msg(diag, 2620),
+        "Target requires 2 element(s) but source may have fewer."
+    );
+}
+
+/// A source that satisfies the target's minimum but is longer, and whose extra
+/// element is optional, reports the "source may have more" wording (`TS2621`).
+#[test]
+fn longer_source_with_trailing_optional_reports_target_allows_only_may_have_more() {
+    let source = r#"
+type Extra = [one: number, two: number, three?: number];
+const shorter: [x: number, y: number] = (null as unknown as Extra);
+"#;
+    let diags = check_strict(source);
+    let diag = ts2322(&diags);
+    assert_eq!(
+        related_msg(diag, 2621),
+        "Target allows only 2 element(s) but source may have more."
+    );
+}
+
+/// When arities are compatible but a source element is optional at a position
+/// the target requires, tsc reports the element-flag mismatch (`TS2623`)
+/// *ahead of* any element-type comparison — the source may not provide a value
+/// at that position at all.
+#[test]
+fn optional_source_element_at_required_target_position_reports_no_match() {
+    let source = r#"
+type Half = [head: number, tail?: number];
+const full: [x: number, y: number] = (null as unknown as Half);
+"#;
+    let diags = check_strict(source);
+    let diag = ts2322(&diags);
+    assert_eq!(
+        related_msg(diag, 2623),
+        "Source provides no match for required element at position 1 in target."
+    );
+}
+
+/// Anti-regression: a physically-present array-*literal* element is Required,
+/// so an over-long literal against a closed target with an optional slot still
+/// reports `TS2619` ("Source has N …but target allows only M"), not the
+/// variadic-flavored `TS2621`. The literal `[1, "x", true]` has minimum length
+/// 3 regardless of the target's optional second slot.
+#[test]
+fn overlong_array_literal_against_optional_target_reports_allows_only() {
+    let diags = check_strict("const t: [number, string?] = [1, \"x\", true];\n");
+    let diag = ts2322(&diags);
+    assert_eq!(
+        related_msg(diag, 2619),
+        "Source has 3 element(s) but target allows only 2."
+    );
+}
+
 /// Source longer than a closed target -> `target allows only M` (`TS2619`).
 #[test]
 fn too_many_elements_attaches_allows_only_reason() {

--- a/crates/tsz-checker/tests/tuple_arity_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/tuple_arity_elaboration_tests.rs
@@ -372,3 +372,42 @@ fn matching_arity_has_no_tuple_arity_diagnostic() {
         "matching-arity assignment must not emit an arity reason"
     );
 }
+
+/// Regression (strictOptionalProperties1.ts): a present array-literal element
+/// that follows an elision is Optional, not Required. `[, , true]` against
+/// `[number, string?, boolean?]` infers `[never?, never?, true?]` and must
+/// report `TS2322` (element 0 `never?` may not supply the required `number`).
+/// Typing the trailing `true` Required made the tuple assignable and dropped
+/// that error. All six sparse/oversized/`undefined` assignments below report a
+/// `TS2322`, matching tsc's baseline.
+#[test]
+fn sparse_tuple_present_element_after_elision_is_optional() {
+    let options = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        no_implicit_any: true,
+        exact_optional_property_types: true,
+        ..Default::default()
+    };
+    let source = r#"
+function f5(t: [number, string?, boolean?]) {
+    t = [42, , , ,];
+    t = [, , true];
+    t = [42, undefined, true];
+}
+const c1: [number, string?, boolean?] = [1, undefined];
+const c2: [number, string?, boolean?] = [1, "string", undefined];
+const c3: [number, string?, boolean?] = [1, undefined, undefined];
+"#;
+    let diags = tsz_checker::test_utils::check_source(source, "test.ts", options);
+    let ts2322 = diags.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322,
+        6,
+        "expected 6 TS2322 tuple mismatches (incl. `[, , true]`), got {ts2322}: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain_tuple.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_tuple.rs
@@ -44,38 +44,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ) -> Option<SubtypeFailureReason> {
         // tsc gates a tuple-to-tuple relation on an arity check *before* it
         // compares individual elements (`tupleTypesRelated` in `checker.ts`).
+        // `classify_tuple_arity` mirrors that gate exactly, selecting the
+        // correct `TS2618`–`TS2621` family from each side's *arity* (slot count)
+        // and *minimum length* (required-element count).
         //
-        // The historical bug (#10874) is confined to *variadic* tuples: when a
-        // side carries a rest element, the old length comparison counted that
-        // rest slot as a fixed element, over-reporting the source length and
-        // emitting only two of tsc's four arity messages. So the tsc-faithful
-        // classifier runs **only when a rest element is present**; purely closed
-        // tuples keep their established reason and rendering exactly (closed
-        // tuples have `arity == len`, so they were never affected by the bug,
-        // and tsc resolves their optional-element mismatches per-element, not
-        // through this length gate).
-        let source_has_rest = source.iter().any(|e| e.rest);
-        let target_has_rest = target.iter().any(|e| e.rest);
-
-        if source_has_rest || target_has_rest {
-            if let Some(arity) = crate::utils::classify_tuple_arity(source, target) {
-                return Some(SubtypeFailureReason::TupleArityMismatch(arity));
-            }
-        } else {
-            // Closed-tuple length mismatch: preserve the prior structured
-            // `TupleElementMismatch` reason (and its alias-preserving render
-            // path). A source that cannot supply the target's required elements,
-            // or a source longer than a closed target, is reported here rather
-            // than drilled into element-by-element, matching the established
-            // baseline.
-            let source_required = crate::utils::required_element_count(source);
-            let target_required = crate::utils::required_element_count(target);
-            if source_required < target_required || source.len() > target.len() {
-                return Some(SubtypeFailureReason::TupleElementMismatch {
-                    source_count: source.len(),
-                    target_count: target.len(),
-                });
-            }
+        // This classifier runs for *every* tuple pair, closed or variadic. A
+        // closed target that carries optional elements still has
+        // `minLength < arity`, so the "requires"/"allows only" counts tsc
+        // reports are the minimum length, not the raw slot count. The earlier
+        // implementation gated the classifier behind "a rest element is
+        // present" and fell back to a coarse `TupleElementMismatch` that used
+        // `target.len()` for the required count — over-reporting whenever a
+        // closed target held optional (or nested) elements (e.g.
+        // `[number, string?]` reported "requires 2" instead of tsc's
+        // "requires 1"). Routing closed tuples through the same gate restores
+        // parity across the whole `TS2618`–`TS2621` family.
+        if let Some(arity) = crate::utils::classify_tuple_arity(source, target) {
+            return Some(SubtypeFailureReason::TupleArityMismatch(arity));
         }
 
         for (i, t_elem) in target.iter().enumerate() {
@@ -243,6 +228,21 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     return Some(SubtypeFailureReason::TupleElementMismatch {
                         source_count: source.len(), // Approximate "infinity"
                         target_count: target.len(),
+                    });
+                }
+
+                // Element-flag mismatch: the target requires a value at this
+                // position but the source element is optional, so the source
+                // may not provide one. tsc reports this (`TS2623`,
+                // `Source_provides_no_match_for_required_element_at_position…`)
+                // ahead of any element-*type* comparison, so a closed source
+                // whose optional slot also has an incompatible type still
+                // surfaces the flag mismatch first (matching `tupleTypesRelated`
+                // in `checker.ts`, which relates element flags before types).
+                if t_elem.is_required() && s_elem.optional {
+                    return Some(SubtypeFailureReason::SourceProvidesNoMatch {
+                        position: i,
+                        variadic: false,
                     });
                 }
 


### PR DESCRIPTION
## Summary

When a closed tuple **target** carries optional (or nested) elements, `tsc`
reports its **minimum** required length across the `TS2618`–`TS2621` arity
family, and reports the per-position element-flag mismatch (`TS2623`) ahead of
any element-*type* comparison. tsz gated the shared, tsc-mirroring
`classify_tuple_arity` gate behind "a rest element is present" and, for closed
tuples, fell back to a coarse `TupleElementMismatch` that used the raw slot
count (`target.len()`). So a closed target with optional slots mis-reported its
required count, and the `TS2620`/`TS2621`/`TS2623` cases were never produced.

Differential vs `tsc` 6.0.2, `--noEmit --strict --pretty false`:

```ts
type T = [number, string?];
const a: T = [];
```

- `tsc`:  `Source has 0 element(s) but target requires 1.`
- tsz (before): `Source has 0 element(s) but target requires 2.`

## Structural rule

When a tuple-to-tuple relation fails on arity, `tsc` (`tupleTypesRelated` in
`checker.ts`) selects the message family from each side's **arity** (slot count)
and **minimum length** (required-element count):

| condition | tsc message | code |
|---|---|---|
| source arity < target minLength | `Source has N … but target requires M` | 2618 |
| target arity < source minLength | `Source has N … but target allows only M` | 2619 |
| source may have fewer than target requires | `Target requires N … but source may have fewer` | 2620 |
| source may have more than target allows | `Target allows only N … but source may have more` | 2621 |
| source element optional where target requires it | `Source provides no match for required element at position P` | 2623 |

tsz already had this in `classify_tuple_arity`; it just wasn't reached for
closed tuples. A closed target with optional elements has `minLength < arity`,
so the required count must be the minimum length, not the slot count.

## Owner layer

- `crates/tsz-solver/src/relations/subtype/explain_tuple.rs`
  `explain_tuple_failure` — route **every** tuple pair (closed or variadic)
  through `crate::utils::classify_tuple_arity` instead of gating it behind a
  rest element, and add the `t_elem.is_required() && s_elem.optional ->
  SourceProvidesNoMatch` (`TS2623`) check before the element-type comparison,
  matching tsc's flags-before-types order. Reuses the existing
  `SourceProvidesNoMatch` reason variant.
- `crates/tsz-checker/src/types/computation/array_literal.rs` — a
  contextually-typed array literal no longer copies the **target's** optional
  flag onto physically-present elements. A present literal element is always
  Required (`[1,"x",true]` has minLength 3); an optional *target* slot is
  satisfied by widening the Required source element (the existing
  elision/`undefinedWideningType` design), so an over-long literal against an
  optional-slot target now reports `TS2619`, not the variadic-flavored `TS2621`.

No solver semantics change and no anti-hardcoding concern: the classification is
structural (`is_required()`/`optional` flags + arity), with no identifier,
file-name, or printer-output matching.

## Adjacent matrix (all differential-verified against `tsc` 6.0.2)

- `requires` uses minLength: `[number, string?]`, `[number, string, boolean?]`,
  `[a, b, c?, d?]` (single and multiple trailing optionals)
- `TS2620` all-optional longer source (`[a?, b?, c?]` → `[x, y]`)
- `TS2621` longer source whose extra element is optional (`[a, b, c?]` → `[x, y]`)
- `TS2623` optional source element at a required target position (equal-arity
  and shorter-target)
- over-long **array literal** vs optional-slot target → `TS2619` (regression guard)
- rest/variadic targets unchanged; matching-arity and legitimately-assignable
  optional cases stay clean

Remaining residual (out of scope, pre-existing, unrelated): `tsc` inlines an
empty-tuple alias `type S = []` as `[]` in the `TS2322` headline while tsz keeps
the alias name — a display-only nuance in the assignability headline, not the
arity line.

## Goal
Goal: hold

## Verification
- Differential vs `tsc` 6.0.2 across the full closed/variadic tuple arity
  matrix (`TS2618`/`2619`/`2620`/`2621`/`2623`): parity on 33/35 probe cases
  (the 2 misses are the unrelated empty-tuple-alias headline display above).
- New regression cases in `crates/tsz-checker/tests/tuple_arity_elaboration_tests.rs`
  (6 cases, binder names varied) — pass (14 total in the suite).
- Existing tuple elaboration/display/contextual suites pass:
  `tuple_argument_mismatch_elaboration_tests`, `tuple_call_argument_elaboration_tests`,
  `array_source_tuple_target_elaboration_tests`, `tuple_element_mismatch_tests`,
  `tuple_variadic_position_elaboration_tests`, `optional_tuple_element_undefined_assignability_tests`,
  `variadic_tuple_spread_arity_ts2556_tests`, `contextual_tuple_tests`,
  `tuple_union_contextual_typing_tests`, `union_tuple_source_display_tests`,
  `readonly_tuple_source_display_tests`, `literal_source_widening_position_parity_tests`,
  `destructuring_spread_rest_tuple_source_display_tests`, and the 63-test
  `array_literal` lib suite.
- Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_0151xADTSvcGPPyMiFY4qDHM)_