### PR TITLE
fix(checker,solver): emit tsc's per-overload TS2772 elaboration under TS2769 (#15361)

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/helpers.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/helpers.rs
@@ -6,13 +6,58 @@ use crate::query_boundaries::checkers::call::{
 };
 use crate::query_boundaries::common::{CallResult, ContextualTypeContext};
 use crate::state::CheckerState;
-use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
 
 use super::super::OverloadResolution;
 use super::retry_state::NoReturnContextFallback;
 
 impl<'a> CheckerState<'a> {
+    /// Collect the argument nodes that need a fresh per-overload contextual
+    /// type before the second resolution pass — those needing a contextual type
+    /// directly, needing contextual signature instantiation, or wrapping a
+    /// callback inside parentheses. Extracted from `resolve_signatures.rs` as
+    /// pure code motion to hold that file under the 2000-LOC arch limit.
+    pub(super) fn contextual_refresh_args(
+        &mut self,
+        args: &[NodeIndex],
+        union_contextual_param_types: &[Option<TypeId>],
+    ) -> Vec<NodeIndex> {
+        args.iter()
+            .copied()
+            .enumerate()
+            .filter_map(|(i, arg_idx)| {
+                if self.argument_needs_contextual_type(arg_idx) {
+                    return Some(arg_idx);
+                }
+                if self.expression_needs_contextual_signature_instantiation(
+                    arg_idx,
+                    union_contextual_param_types.get(i).copied().flatten(),
+                ) {
+                    return Some(arg_idx);
+                }
+                // Also include parenthesized expressions that might contain callbacks
+                let mut current = arg_idx;
+                for _ in 0..10 {
+                    let node = self.ctx.arena.get(current)?;
+                    if node.kind == syntax_kind_ext::ARROW_FUNCTION
+                        || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+                    {
+                        return Some(arg_idx);
+                    }
+                    if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+                        && let Some(paren) = self.ctx.arena.get_parenthesized(node)
+                    {
+                        current = paren.expression;
+                        continue;
+                    }
+                    return None;
+                }
+                None
+            })
+            .collect()
+    }
+
     /// Report whether the union-of-signatures contextual type used by the
     /// first overload pass is lossy for some callback argument.
     ///

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
@@ -11,7 +11,7 @@ use crate::query_boundaries::common::{
     CallResult, ContextualTypeContext, PendingDiagnosticBuilder,
 };
 use crate::state::CheckerState;
-use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
+use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
 use super::super::{CallableContext, OverloadResolution, SelectedTypePredicate};
@@ -108,40 +108,8 @@ impl<'a> CheckerState<'a> {
             .enumerate()
             .map(|(i, _)| ctx_helper.get_parameter_type_for_call(i, args.len()))
             .collect();
-        let contextual_refresh_args: Vec<_> = args
-            .iter()
-            .copied()
-            .enumerate()
-            .filter_map(|(i, arg_idx)| {
-                if self.argument_needs_contextual_type(arg_idx) {
-                    return Some(arg_idx);
-                }
-                if self.expression_needs_contextual_signature_instantiation(
-                    arg_idx,
-                    union_contextual_param_types.get(i).copied().flatten(),
-                ) {
-                    return Some(arg_idx);
-                }
-                // Also include parenthesized expressions that might contain callbacks
-                let mut current = arg_idx;
-                for _ in 0..10 {
-                    let node = self.ctx.arena.get(current)?;
-                    if node.kind == syntax_kind_ext::ARROW_FUNCTION
-                        || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                    {
-                        return Some(arg_idx);
-                    }
-                    if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
-                        && let Some(paren) = self.ctx.arena.get_parenthesized(node)
-                    {
-                        current = paren.expression;
-                        continue;
-                    }
-                    return None;
-                }
-                None
-            })
-            .collect();
+        let contextual_refresh_args =
+            self.contextual_refresh_args(args, &union_contextual_param_types);
         let refresh_all_args = |this: &mut Self| {
             for &arg_idx in args {
                 this.invalidate_expression_for_contextual_retry(arg_idx);

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
@@ -1062,6 +1062,23 @@ impl<'a> CheckerState<'a> {
                 contextual_type
             };
             let func_type = factory.function(sig_shape.clone());
+            // The candidate signature the reporter renders in tsc's per-overload
+            // `TS2772` wrapper. Built from the *declared* signature (not the
+            // inference-instantiated `sig`) so a generic overload elaborates with
+            // its written type parameters, exactly as tsc's `signatureToString`.
+            // Built lazily: only failing candidates push a diagnostic, so a
+            // candidate that matches or is skipped never interns this.
+            let overload_signature = || {
+                factory.function(FunctionShape {
+                    params: original_sig.params.clone(),
+                    this_type: original_sig.this_type,
+                    return_type: original_sig.return_type,
+                    type_params: original_sig.type_params.clone(),
+                    type_predicate: original_sig.type_predicate,
+                    is_constructor: false,
+                    is_method: original_sig.is_method,
+                })
+            };
             self.ctx.rollback_full(&overload_snap);
             let sig_helper = ContextualTypeContext::with_expected_and_options(
                 self.ctx.types,
@@ -1595,7 +1612,8 @@ impl<'a> CheckerState<'a> {
                         }
                         failures.push(
                             PendingDiagnosticBuilder::argument_not_assignable(actual, expected)
-                                .with_optional_span(self.arg_source_span(args, index)),
+                                .with_optional_span(self.arg_source_span(args, index))
+                                .with_overload_signature(overload_signature()),
                         );
                         self.ctx
                             .rollback_diagnostics_filtered(&candidate_snap, |diag| {
@@ -1833,7 +1851,8 @@ impl<'a> CheckerState<'a> {
                         }
                         failures.push(
                             PendingDiagnosticBuilder::argument_not_assignable(actual, expected)
-                                .with_optional_span(self.arg_source_span(args, index)),
+                                .with_optional_span(self.arg_source_span(args, index))
+                                .with_overload_signature(overload_signature()),
                         );
                     }
                 }
@@ -1850,11 +1869,14 @@ impl<'a> CheckerState<'a> {
                     let max = expected_max.unwrap_or(expected_min);
                     min_expected = min_expected.min(expected_min);
                     max_expected = max_expected.max(max);
-                    failures.push(PendingDiagnosticBuilder::argument_count_mismatch(
-                        expected_min,
-                        max,
-                        actual,
-                    ));
+                    failures.push(
+                        PendingDiagnosticBuilder::argument_count_mismatch(
+                            expected_min,
+                            max,
+                            actual,
+                        )
+                        .with_overload_signature(overload_signature()),
+                    );
                 }
                 _ => {
                     all_arg_count_mismatches = false;

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -771,8 +771,6 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        use crate::query_boundaries::common::PendingDiagnostic;
-
         let argument_failures: Vec<_> = failures
             .iter()
             .filter(|failure| {
@@ -1067,49 +1065,84 @@ impl<'a> CheckerState<'a> {
 
         tracing::debug!("File name: {}", self.ctx.file_name);
 
-        for failure in failures {
-            let mut pending: PendingDiagnostic = PendingDiagnostic {
-                span: Some(span.clone()),
-                ..failure.clone()
+        // One elaboration line at `span_of` with the given message/code/depth.
+        let related_line =
+            |span_of: &tsz_solver::SourceSpan, message_text: String, code: u32, depth: u8| {
+                DiagnosticRelatedInformation {
+                    file: span_of.file.to_string(),
+                    start: span_of.start,
+                    length: span_of.length,
+                    message_text,
+                    category: DiagnosticCategory::Message,
+                    code,
+                    depth,
+                }
             };
-            // Mirror tsc's `reportRelationError` source generalization for each
-            // overload's argument failure, matching the single-signature TS2345
-            // path: a fresh literal source (`true`, `1`) is widened to its base
-            // (`boolean`, `number`) unless the parameter target could hold a
-            // top-level singleton type. The pre-built solver diagnostic carries
-            // the raw literal source, so without this the overload elaboration
-            // diverges from tsc (and from the single-overload TS2345 display).
-            if pending.code
-                == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
-                && let (
-                    Some(tsz_solver::DiagnosticArg::Type(source)),
-                    Some(tsz_solver::DiagnosticArg::Type(target)),
-                ) = (pending.args.first(), pending.args.get(1))
-            {
-                let (source, target) = (*source, *target);
-                let display_source =
-                    crate::query_boundaries::diagnostics::generalized_literal_source_for_display(
-                        self.ctx.types,
-                        source,
-                        target,
-                    );
-                if display_source != source {
-                    pending.args[0] = tsz_solver::DiagnosticArg::Type(display_source);
+
+        // tsc reports a no-overload-match as one `Overload N of M, '<signature>',
+        // gave the following error.` (TS2772) chain per candidate — in
+        // declaration order — when 2 or 3 candidates reached argument checking
+        // (`resolveCall`). A single candidate collapses to a plain TS2345 (no
+        // TS2769 at all, handled upstream), and >3 candidates use tsc's distinct
+        // "last overload" shape, left as the historical flat rendering. Each
+        // candidate failure carries its declared signature; a 2-3 set whose
+        // failures all have one wraps, otherwise we fall back to the flat list
+        // (e.g. callback-body sets whose failures carry no signature).
+        let wrap_overloads = matches!(failures.len(), 2 | 3)
+            && failures
+                .iter()
+                .all(|failure| failure.overload_signature.is_some());
+
+        let related_policy = if wrap_overloads {
+            let total = failures.len();
+            for (ordinal, failure) in failures.iter().enumerate() {
+                let signature = failure
+                    .overload_signature
+                    .expect("wrap_overloads requires every failure to carry a signature");
+                // signatureToString colon form (`(x: number): number`); fall
+                // back to the plain render only if the type is not a signature.
+                let signature_display = formatter
+                    .format_overload_signature(signature)
+                    .unwrap_or_else(|| formatter.format(signature).into_owned());
+                related.push(related_line(
+                    &span,
+                    format_message(
+                        diagnostic_messages::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
+                        &[
+                            &(ordinal + 1).to_string(),
+                            &total.to_string(),
+                            &signature_display,
+                        ],
+                    ),
+                    diagnostic_codes::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
+                    0,
+                ));
+                let pending = self.overload_failure_generalized_pending(failure, &span);
+                let diag = formatter.render(&pending);
+                let diag_span = diag.span.as_ref().unwrap_or(&span);
+                // The candidate's applicability error nests one level under its
+                // TS2772 header; any deeper chain it carries nests below that.
+                related.push(related_line(diag_span, diag.message, diag.code, 1));
+                for nested in &diag.related {
+                    related.push(related_line(
+                        &nested.span,
+                        nested.message.clone(),
+                        0,
+                        nested.depth.saturating_add(2),
+                    ));
                 }
             }
-            let diag = formatter.render(&pending);
-            if let Some(diag_span) = diag.span.as_ref() {
-                related.push(DiagnosticRelatedInformation {
-                    file: diag_span.file.to_string(),
-                    start: diag_span.start,
-                    length: diag_span.length,
-                    message_text: diag.message.clone(),
-                    category: DiagnosticCategory::Message,
-                    code: diag.code,
-                    depth: 0,
-                });
+            RelatedInformationPolicy::OVERLOAD_CHAINS
+        } else {
+            for failure in failures {
+                let pending = self.overload_failure_generalized_pending(failure, &span);
+                let diag = formatter.render(&pending);
+                if let Some(diag_span) = diag.span.as_ref() {
+                    related.push(related_line(diag_span, diag.message, diag.code, 0));
+                }
             }
-        }
+            RelatedInformationPolicy::OVERLOAD_FAILURES
+        };
 
         self.emit_render_request_at_anchor(
             anchor,
@@ -1118,9 +1151,45 @@ impl<'a> CheckerState<'a> {
                 diagnostic_codes::NO_OVERLOAD_MATCHES_THIS_CALL,
                 diagnostic_messages::NO_OVERLOAD_MATCHES_THIS_CALL.to_string(),
                 related,
-                RelatedInformationPolicy::OVERLOAD_FAILURES,
+                related_policy,
             ),
         );
+    }
+
+    /// Build the per-overload failure diagnostic anchored at the shared
+    /// `TS2769` span, applying tsc's `reportRelationError` source
+    /// generalization: a fresh literal source (`true`, `1`) is widened to its
+    /// base (`boolean`, `number`) unless the parameter target could hold a
+    /// top-level singleton type. The pre-built solver diagnostic carries the
+    /// raw literal source, so without this the overload elaboration diverges
+    /// from tsc (and from the single-overload TS2345 display).
+    fn overload_failure_generalized_pending(
+        &self,
+        failure: &tsz_solver::PendingDiagnostic,
+        span: &tsz_solver::SourceSpan,
+    ) -> tsz_solver::PendingDiagnostic {
+        let mut pending = tsz_solver::PendingDiagnostic {
+            span: Some(span.clone()),
+            ..failure.clone()
+        };
+        if pending.code == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+            && let (
+                Some(tsz_solver::DiagnosticArg::Type(source)),
+                Some(tsz_solver::DiagnosticArg::Type(target)),
+            ) = (pending.args.first(), pending.args.get(1))
+        {
+            let (source, target) = (*source, *target);
+            let display_source =
+                crate::query_boundaries::diagnostics::generalized_literal_source_for_display(
+                    self.ctx.types,
+                    source,
+                    target,
+                );
+            if display_source != source {
+                pending.args[0] = tsz_solver::DiagnosticArg::Type(display_source);
+            }
+        }
+        pending
     }
 
     fn tagged_template_callee_has_generic_call_signature(&mut self, idx: NodeIndex) -> bool {

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -45,6 +45,12 @@ pub(crate) struct RelatedInformationPolicy {
     include_primary: bool,
     dedupe: bool,
     limit: Option<usize>,
+    /// Keep the reporter's insertion order instead of applying the
+    /// `(file, start, depth, message)` sort. Required for multi-chain
+    /// elaborations that share one anchor (e.g. the per-overload `TS2772`
+    /// chains), where the depth-keyed sort would interleave every chain's
+    /// header ahead of every chain's body and destroy the nesting.
+    preserve_order: bool,
 }
 
 impl RelatedInformationPolicy {
@@ -52,6 +58,7 @@ impl RelatedInformationPolicy {
         include_primary: true,
         dedupe: true,
         limit: None,
+        preserve_order: false,
     };
 
     /// Demote a diagnostic's primary message into the related chain, keeping any
@@ -61,12 +68,29 @@ impl RelatedInformationPolicy {
         include_primary: true,
         dedupe: true,
         limit: None,
+        preserve_order: false,
     };
 
+    /// Flat overload-failure list (1 or >3 candidates, or callback-body sets):
+    /// one related line per failure, deduped and sorted as before.
     pub(crate) const OVERLOAD_FAILURES: Self = Self {
         include_primary: false,
         dedupe: true,
         limit: None,
+        preserve_order: false,
+    };
+
+    /// Per-overload `TS2772` elaboration (the 2-3 candidate case): each
+    /// candidate contributes a depth-0 `Overload N of M, '...', gave the
+    /// following error.` header immediately followed by its applicability
+    /// error at depth 1+. Insertion order is declaration order and must be
+    /// preserved; dedupe is off so two overloads that fail identically still
+    /// each keep their own nested body under their distinct header.
+    pub(crate) const OVERLOAD_CHAINS: Self = Self {
+        include_primary: false,
+        dedupe: false,
+        limit: None,
+        preserve_order: true,
     };
 }
 
@@ -981,13 +1005,21 @@ impl<'a> CheckerState<'a> {
         // main message and its note. Within the same depth the message-text
         // tiebreaker still gives deterministic order when distinct code paths
         // append items in different sequences.
-        normalized.sort_by(|a, b| {
-            a.file
-                .cmp(&b.file)
-                .then(a.start.cmp(&b.start))
-                .then(a.depth.cmp(&b.depth))
-                .then(a.message_text.cmp(&b.message_text))
-        });
+        //
+        // `preserve_order` policies (per-overload `TS2772` chains) opt out: they
+        // build several outer-to-inner chains at one anchor, so a global
+        // depth-keyed sort would pull every chain's depth-0 header ahead of the
+        // bodies and scramble the nesting. Their insertion order is already the
+        // correct declaration order.
+        if !policy.preserve_order {
+            normalized.sort_by(|a, b| {
+                a.file
+                    .cmp(&b.file)
+                    .then(a.start.cmp(&b.start))
+                    .then(a.depth.cmp(&b.depth))
+                    .then(a.message_text.cmp(&b.message_text))
+            });
+        }
 
         normalized
     }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1375,6 +1375,9 @@ mod overlap_relation_helper_routing_arch_tests;
 #[path = "tests/overload_anchor_at_argument_tests.rs"]
 mod overload_anchor_at_argument_tests;
 #[cfg(test)]
+#[path = "tests/overload_elaboration_tests.rs"]
+mod overload_elaboration_tests;
+#[cfg(test)]
 #[path = "tests/overload_generic_wrapper_compat_tests.rs"]
 mod overload_generic_wrapper_compat_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -23,8 +23,8 @@ pub(crate) use tsz_solver::type_queries::{
     remapped_mapped_index_access_result,
 };
 pub(crate) use tsz_solver::{
-    FunctionShape, IntrinsicKind, MappedType, ParamInfo, PendingDiagnostic,
-    PendingDiagnosticBuilder, SourceLocation, SubtypeFailureReason, TypeFormatter,
+    FunctionShape, IntrinsicKind, MappedType, ParamInfo, PendingDiagnosticBuilder, SourceLocation,
+    SubtypeFailureReason, TypeFormatter,
     computation::{ContextualTypeContext, TypeSubstitution},
 };
 

--- a/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
@@ -1,0 +1,284 @@
+//! Regression tests for tsc's per-overload `TS2772` elaboration under a
+//! `TS2769` ("No overload matches this call.") diagnostic.
+//!
+//! When a call matches no overload and 2 or 3 candidate signatures reached
+//! argument checking, tsc wraps each candidate's applicability error in a
+//! `Overload {n} of {total}, '{signature}', gave the following error.` chain
+//! node (`TS2772`) — in declaration order, with the applicability error nested
+//! one level deeper. A single failing candidate collapses to a plain `TS2345`
+//! (no `TS2769`), and `>3` candidates use tsc's distinct "last overload" shape,
+//! left as the flat fallback here.
+//!
+//! Before the fix tsz defined the `TS2772` string but never emitted it: it
+//! flattened every candidate's argument error directly under `TS2769` and, due
+//! to the related-info `(file, start, depth, message)` sort, rendered them out
+//! of declaration order.
+//!
+//! See `crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs`
+//! (`error_no_overload_matches_at`) and
+//! `crates/tsz-checker/src/error_reporter/fingerprint_policy.rs`
+//! (`RelatedInformationPolicy::OVERLOAD_CHAINS`).
+
+use crate::test_utils::check_source_diagnostics;
+
+/// The `(depth, code, message)` triples of the sole `TS2769` diagnostic's
+/// related information, in emission order.
+fn overload_chain(source: &str) -> Vec<(u8, u32, String)> {
+    let diags = check_source_diagnostics(source);
+    let ts2769: Vec<_> = diags.iter().filter(|d| d.code == 2769).collect();
+    assert_eq!(
+        ts2769.len(),
+        1,
+        "Expected exactly one TS2769. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    ts2769[0]
+        .related_information
+        .iter()
+        .map(|r| (r.depth, r.code, r.message_text.clone()))
+        .collect()
+}
+
+/// Two failing overloads: both wrapped in `TS2772`, in declaration order, each
+/// header at depth 0 with its applicability error nested at depth 1. The
+/// signature is the `signatureToString` colon form, not the `=>` function-type
+/// form.
+#[test]
+fn two_failing_overloads_wrap_each_candidate_in_declaration_order() {
+    let chain = overload_chain(
+        r#"
+declare function f(x: number): number;
+declare function f(x: string): string;
+f(true);
+"#,
+    );
+
+    assert_eq!(
+        chain,
+        vec![
+            (
+                0,
+                2772,
+                "Overload 1 of 2, '(x: number): number', gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                "Argument of type 'boolean' is not assignable to parameter of type 'number'."
+                    .to_string()
+            ),
+            (
+                0,
+                2772,
+                "Overload 2 of 2, '(x: string): string', gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                "Argument of type 'boolean' is not assignable to parameter of type 'string'."
+                    .to_string()
+            ),
+        ],
+        "expected two declaration-ordered TS2772 chains with the colon signature form"
+    );
+}
+
+/// Three failing overloads: all wrapped, `of 3`, and declaration order is
+/// preserved rather than re-sorted. The bodies' alphabetical order
+/// (`boolean` < `number` < `string`) differs from declaration order
+/// (`number`, `string`, `boolean`); the fix must keep declaration order.
+#[test]
+fn three_failing_overloads_preserve_declaration_order() {
+    let chain = overload_chain(
+        r#"
+declare function g(x: number): number;
+declare function g(x: string): string;
+declare function g(x: boolean): boolean;
+g({});
+"#,
+    );
+
+    let headers: Vec<&String> = chain
+        .iter()
+        .filter(|(_, code, _)| *code == 2772)
+        .map(|(_, _, m)| m)
+        .collect();
+    assert_eq!(
+        headers,
+        vec![
+            "Overload 1 of 3, '(x: number): number', gave the following error.",
+            "Overload 2 of 3, '(x: string): string', gave the following error.",
+            "Overload 3 of 3, '(x: boolean): boolean', gave the following error.",
+        ],
+        "expected declaration-ordered `of 3` headers, got: {chain:?}"
+    );
+
+    // Bodies stay under their header in declaration order (number, string,
+    // boolean) — not the alphabetical (boolean, number, string) the old
+    // unconditional sort produced.
+    let bodies: Vec<&String> = chain
+        .iter()
+        .filter(|(_, code, _)| *code == 2345)
+        .map(|(_, _, m)| m)
+        .collect();
+    assert_eq!(
+        bodies,
+        vec![
+            "Argument of type '{}' is not assignable to parameter of type 'number'.",
+            "Argument of type '{}' is not assignable to parameter of type 'string'.",
+            "Argument of type '{}' is not assignable to parameter of type 'boolean'.",
+        ],
+        "expected declaration-ordered bodies, got: {chain:?}"
+    );
+}
+
+/// Anti-hardcoding: the wrapping is structural, independent of the callee and
+/// parameter binder names. Renaming them only changes the rendered signature.
+#[test]
+fn wrapping_is_independent_of_binder_names() {
+    let chain = overload_chain(
+        r#"
+declare function pick(value: number): number;
+declare function pick(other: string): string;
+pick(true);
+"#,
+    );
+
+    let headers: Vec<&String> = chain
+        .iter()
+        .filter(|(_, code, _)| *code == 2772)
+        .map(|(_, _, m)| m)
+        .collect();
+    assert_eq!(
+        headers,
+        vec![
+            "Overload 1 of 2, '(value: number): number', gave the following error.",
+            "Overload 2 of 2, '(other: string): string', gave the following error.",
+        ],
+        "signature renders the declared parameter names, got: {chain:?}"
+    );
+}
+
+/// Constructor (`new`) overloads are wrapped identically, and tsc's
+/// `signatureToString` renders them in the call-signature colon form
+/// (`(x: number): C`) — no `new` prefix.
+#[test]
+fn constructor_overloads_wrap_in_call_signature_form() {
+    let chain = overload_chain(
+        r#"
+declare class C {
+    constructor(x: number);
+    constructor(x: string);
+}
+new C(true);
+"#,
+    );
+
+    let headers: Vec<&String> = chain
+        .iter()
+        .filter(|(_, code, _)| *code == 2772)
+        .map(|(_, _, m)| m)
+        .collect();
+    assert_eq!(
+        headers,
+        vec![
+            "Overload 1 of 2, '(x: number): C', gave the following error.",
+            "Overload 2 of 2, '(x: string): C', gave the following error.",
+        ],
+        "constructor overloads render as call signatures returning the class, got: {chain:?}"
+    );
+    assert!(
+        headers.iter().all(|h| !h.contains("new ")),
+        "constructor overload headers must not carry a `new` prefix, got: {headers:?}"
+    );
+}
+
+/// The literal-source generalization stays applied inside each wrapped error:
+/// a fresh boolean-literal argument widens to `boolean` against non-singleton
+/// parameters, exactly as on the single-overload TS2345 path.
+#[test]
+fn literal_source_generalization_survives_wrapping() {
+    let chain = overload_chain(
+        r#"
+declare function f(x: number): number;
+declare function f(x: string): string;
+f(true);
+"#,
+    );
+
+    assert!(
+        chain
+            .iter()
+            .all(|(_, _, m)| !m.contains("Argument of type 'true'")),
+        "the raw boolean literal must not leak into the wrapped elaboration, got: {chain:?}"
+    );
+    assert!(
+        chain
+            .iter()
+            .any(|(_, code, m)| *code == 2345 && m.contains("Argument of type 'boolean'")),
+        "expected the widened `boolean` source inside a wrapped body, got: {chain:?}"
+    );
+}
+
+/// A single failing signature collapses to a plain `TS2345` with no `TS2769`
+/// wrapper at all (tsc's single-candidate branch).
+#[test]
+fn single_signature_stays_plain_ts2345() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function f(x: number): number;
+f(true);
+"#,
+    );
+
+    assert!(
+        diags.iter().any(|d| d.code == 2345),
+        "expected a plain TS2345, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2769),
+        "a single failing signature must not produce TS2769, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2772),
+        "a single failing signature must not produce TS2772, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+/// More than three failing candidates keep tsc's distinct top-level shape:
+/// tsz leaves them as the flat fallback (no `TS2772` wrappers), and the
+/// top-level `TS2769` is unchanged.
+#[test]
+fn more_than_three_overloads_stay_flat() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function f(x: number): number;
+declare function f(x: string): string;
+declare function f(x: boolean): boolean;
+declare function f(x: symbol): symbol;
+f({});
+"#,
+    );
+
+    let ts2769: Vec<_> = diags.iter().filter(|d| d.code == 2769).collect();
+    assert_eq!(
+        ts2769.len(),
+        1,
+        "expected the top-level TS2769 to be unchanged"
+    );
+    assert!(
+        !ts2769[0].related_information.iter().any(|r| r.code == 2772),
+        "the >3-candidate case must not emit TS2772 wrappers, got: {:?}",
+        ts2769[0]
+            .related_information
+            .iter()
+            .map(|r| (r.code, &r.message_text))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -567,6 +567,12 @@ pub struct PendingDiagnostic {
     pub severity: DiagnosticSeverity,
     /// Related information (additional locations)
     pub related: Vec<Self>,
+    /// The candidate signature type this diagnostic describes, when it is one
+    /// overload's applicability failure within a `NoOverloadMatch` set. The
+    /// checker reporter uses it to render tsc's per-overload `TS2772`
+    /// (`Overload N of M, '<signature>', gave the following error.`) wrapper.
+    /// `None` for every non-overload diagnostic.
+    pub overload_signature: Option<TypeId>,
 }
 
 impl PendingDiagnostic {
@@ -578,7 +584,15 @@ impl PendingDiagnostic {
             span: None,
             severity: DiagnosticSeverity::Error,
             related: Vec::new(),
+            overload_signature: None,
         }
+    }
+
+    /// Tag this diagnostic with the overload candidate signature it describes,
+    /// so the reporter can wrap it in the `TS2772` per-overload elaboration.
+    pub const fn with_overload_signature(mut self, signature: TypeId) -> Self {
+        self.overload_signature = Some(signature);
+        self
     }
 
     /// Attach a source span to this diagnostic.

--- a/crates/tsz-solver/src/diagnostics/format/compound/intersection_constructs.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/intersection_constructs.rs
@@ -435,6 +435,42 @@ impl<'a> TypeFormatter<'a> {
         )
     }
 
+    /// Render a single-signature function/callable as tsc's `signatureToString`
+    /// colon form (`(x: number): number`), used for the `TS2772`
+    /// overload-elaboration header. tsc's `signatureToString` defaults to the
+    /// call-signature spelling even for construct signatures, so `new`/`abstract`
+    /// prefixes are intentionally omitted (`new (x: number): C` renders as
+    /// `(x: number): C`). Returns `None` when the type is not a function/callable
+    /// with at least one signature.
+    pub fn format_overload_signature(&mut self, func_type: TypeId) -> Option<String> {
+        match self.interner.lookup(func_type)? {
+            TypeData::Function(shape_id) => {
+                let shape = self.interner.function_shape(shape_id);
+                Some(self.format_signature_with_predicate(
+                    &shape.type_params,
+                    &shape.params,
+                    shape.return_type,
+                    &SignatureFormatOpts {
+                        this_type: shape.this_type,
+                        type_predicate: shape.type_predicate.as_ref(),
+                        is_construct: false,
+                        is_abstract: false,
+                        separator: ":",
+                    },
+                ))
+            }
+            TypeData::Callable(shape_id) => {
+                let shape = self.interner.callable_shape(shape_id);
+                let sig = shape
+                    .call_signatures
+                    .first()
+                    .or_else(|| shape.construct_signatures.first())?;
+                Some(self.format_call_signature(sig, false, false))
+            }
+            _ => None,
+        }
+    }
+
     pub(super) fn format_conditional(&mut self, cond: &ConditionalType) -> String {
         let prev = self.preserve_optional_property_surface_syntax;
         self.preserve_optional_property_surface_syntax = true;

--- a/crates/tsz-solver/src/operations/constructors.rs
+++ b/crates/tsz-solver/src/operations/constructors.rs
@@ -198,7 +198,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     failures.push(
                         crate::diagnostics::PendingDiagnosticBuilder::argument_not_assignable(
                             actual, expected,
-                        ),
+                        )
+                        .with_overload_signature(self.interner.function(func.clone())),
                     );
                 }
                 CallResult::ArgumentCountMismatch {
@@ -219,7 +220,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             expected_min,
                             max,
                             actual,
-                        ),
+                        )
+                        .with_overload_signature(self.interner.function(func.clone())),
                     );
                 }
                 // Track this-type mismatches for TS2345 optimization (tsc reports TS2345 not TS2769
@@ -240,7 +242,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         crate::diagnostics::PendingDiagnosticBuilder::this_type_mismatch(
                             expected_this,
                             actual_this,
-                        ),
+                        )
+                        .with_overload_signature(self.interner.function(func.clone())),
                     );
                 }
                 _ => {


### PR DESCRIPTION
Closes #15361.

## Summary

When a call matches no overload, `tsc` groups the failure **per candidate**: the top-level `TS2769` (`No overload matches this call.`) is followed, for each candidate that reached argument checking, by a `TS2772` chain node `Overload {n} of {total}, '{signature}', gave the following error.` with that candidate's applicability error nested one level deeper, in **declaration order**.

tsz defined the `TS2772` string but never emitted it — it flattened every candidate's argument error directly under `TS2769` and, because the related-info normalizer sorts by `(file, start, depth, message)`, rendered them **out of declaration order** (the three-overload case reordered `boolean`/`number`/`string`).

Minimal repro (`tsz repro.ts --noEmit --strict`):

```ts
declare function f(x: number): number;
declare function f(x: string): string;
f(true);
```

Before: bare `TS2769` + two flat argument lines. After (matches `tsc` 6.0.2):

```
error TS2769: No overload matches this call.
  Overload 1 of 2, '(x: number): number', gave the following error.
    Argument of type 'boolean' is not assignable to parameter of type 'number'.
  Overload 2 of 2, '(x: string): string', gave the following error.
    Argument of type 'boolean' is not assignable to parameter of type 'string'.
```

## Structural rule

When a call resolves to no matching overload and **2 or 3** candidate signatures reached argument checking, `tsc` (`resolveCall`) reports `TS2769` and wraps each candidate's applicability error in `Overload {n} of {total}, '{signatureToString(candidate)}', gave the following error.` (`TS2772`), in declaration order. A single failing candidate collapses to a plain `TS2345` (no `TS2769`); `>3` candidates use tsc's distinct "last overload" shape. The signature is the `signatureToString` colon form (`(x: number): number`), not the `=>` function-type form — even for construct signatures (`(x: number): C`, no `new` prefix). tsz now produces this through the checker error reporter.

## Owner layers

- `tsz-solver` `diagnostics/core.rs` — `PendingDiagnostic` gains `overload_signature: Option<TypeId>` carrying the candidate signature each failure describes.
- `tsz-solver` `diagnostics/format/.../intersection_constructs.rs` — new `TypeFormatter::format_overload_signature` renders a single-signature function/callable in the colon `signatureToString` form.
- `tsz-solver` `operations/constructors.rs` and `tsz-checker` `.../overload_resolution/resolve_signatures.rs` — tag each candidate failure with its declared signature (built lazily, only on the failure path).
- `tsz-checker` `error_reporter/call_errors/error_emission.rs` (`error_no_overload_matches_at`) — when 2-3 failures each carry a signature, emit the per-overload `TS2772` header (depth 0) + nested applicability error (depth 1+); otherwise keep the historical flat list.
- `tsz-checker` `error_reporter/fingerprint_policy.rs` — new `RelatedInformationPolicy::OVERLOAD_CHAINS` with `preserve_order`, so the multi-chain-at-one-anchor elaboration keeps declaration order instead of the depth-keyed sort interleaving every header ahead of every body.

## Scope

Exact-parity fix for the **2-3 candidate** case (tsc's per-overload branch) plus constructor (`new`) overloads. The `>3`-candidate `TS2770` "last overload" shape changes the top-level code and is left as the existing flat rendering (documented follow-up). The top-level `TS2769` code/anchor/message are unchanged in every case, so this is conformance-fingerprint-neutral (the runner fingerprints only top-level `code`/location/message, not nested related info).

## Adjacent matrix

- two failing overloads → both wrapped, declaration order
- three failing overloads → all wrapped, `of 3`, declaration order preserved (not re-sorted)
- header at depth 0, applicability error nested at depth 1
- binder-name independence (renamed callee/params only change the rendered signature)
- constructor (`new`) overloads wrapped as `(x: number): C` (call-signature form, no `new`)
- literal-argument source generalization preserved inside each wrapped error
- single overload → plain `TS2345`, unchanged
- `>3` overloads → flat fallback, no `TS2772`, top-level `TS2769` unchanged

## Goal
Goal: hold

## Verification
- New checker suite `overload_elaboration_tests` (7 cases; binder names varied) — all pass.
- Existing `overload_literal_source_generalization_tests` and `overload_*` suites: only the two pre-existing failures (`union_single_plus_multi_overload_no_match_emits_ts2349`, `reduce_like_any_seed_selects_generic_candidate`) remain — verified byte-identical on pristine `origin/main`, i.e. zero new regressions.
- `cargo check`, `cargo clippy`, and `cargo fmt` clean on `tsz-solver` + `tsz-checker`.
- Broad conformance/emit/fourslash owned by exact-head ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqDbn9HLDgZF14G287w8Sa)_