### PR TITLE
fix(checker,solver): emit per-overload TS2772 elaboration under TS2769 (#15361)

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
@@ -1007,6 +1007,10 @@ impl<'a> CheckerState<'a> {
         // type callback/object-literal arguments correctly. The union pass above can
         // miss those, producing false negatives and downstream false TS2345/TS2322.
         let mut failures = Vec::new();
+        // Declared candidate signatures aligned 1:1 with `failures`, so the
+        // reporter can build the per-overload TS2772 elaboration in declaration
+        // order.
+        let mut failing_signatures: Vec<tsz_solver::CallSignature> = Vec::new();
         let mut all_arg_count_mismatches = true;
         let mut any_has_rest = false;
         let mut exact_expected_counts = std::collections::BTreeSet::new();
@@ -1667,6 +1671,7 @@ impl<'a> CheckerState<'a> {
                                 };
                             callback_body_failure_return.get_or_insert(recovery_return);
                             failures.clear();
+                            failing_signatures.clear();
                             failures.push(
                                 PendingDiagnosticBuilder::argument_not_assignable(
                                     return_type,
@@ -1674,6 +1679,7 @@ impl<'a> CheckerState<'a> {
                                 )
                                 .with_span(span),
                             );
+                            failing_signatures.push(original_sig.clone());
                             type_mismatch_count = type_mismatch_count.max(1);
                             best_type_mismatch = Some((
                                 OverloadResolution {
@@ -1834,6 +1840,7 @@ impl<'a> CheckerState<'a> {
                             PendingDiagnosticBuilder::argument_not_assignable(actual, expected)
                                 .with_optional_span(self.arg_source_span(args, index)),
                         );
+                        failing_signatures.push(original_sig.clone());
                     }
                 }
                 CallResult::ArgumentCountMismatch {
@@ -1854,6 +1861,7 @@ impl<'a> CheckerState<'a> {
                         max,
                         actual,
                     ));
+                    failing_signatures.push(original_sig.clone());
                 }
                 _ => {
                     all_arg_count_mismatches = false;
@@ -1976,12 +1984,17 @@ impl<'a> CheckerState<'a> {
                 tsz_solver::operations::overload_failure_return_type(self.ctx.types, signatures)
             })
         });
+        let overload_elaborations = tsz_solver::operations::build_overload_elaborations(
+            &failing_signatures,
+            signatures.len(),
+        );
         Some(OverloadResolution {
             arg_types: arg_types.clone(),
             result: CallResult::NoOverloadMatch {
                 func_type: TypeId::ANY,
                 arg_types,
                 failures,
+                overload_elaborations,
                 fallback_return,
             },
             selected_type_predicate: None,

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -757,10 +757,19 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Report "No overload matches this call" with related overload failures.
+    ///
+    /// When `elaborations` is non-empty (the 2–3 candidate case), each failure is
+    /// grouped under a `TS2772`
+    /// `Overload {n} of {m}, '{signature}', gave the following error.` header
+    /// (depth 0) with the candidate's applicability error nested one level
+    /// deeper (depth 1), in declaration order — matching `tsc`'s per-overload
+    /// elaboration. An empty `elaborations` keeps the flat rendering (the
+    /// `>3`-candidate `TS2770` shape).
     pub fn error_no_overload_matches_at(
         &mut self,
         idx: NodeIndex,
         failures: &[tsz_solver::PendingDiagnostic],
+        elaborations: &[tsz_solver::operations::OverloadElaboration],
     ) {
         tracing::debug!(
             "error_no_overload_matches_at: File name: {}",
@@ -1067,7 +1076,16 @@ impl<'a> CheckerState<'a> {
 
         tracing::debug!("File name: {}", self.ctx.file_name);
 
-        for failure in failures {
+        // tsc groups a no-overload failure per candidate when 2 or 3 candidates
+        // reached argument checking: a TS2772 header per candidate with its
+        // applicability error nested one level deeper, in declaration order. The
+        // elaboration vector is aligned 1:1 with `failures`; only wrap when it
+        // is present and aligned, otherwise keep the flat rendering (the
+        // >3-candidate TS2770 shape).
+        let use_per_overload_elaboration =
+            !elaborations.is_empty() && elaborations.len() == failures.len();
+
+        for (failure_idx, failure) in failures.iter().enumerate() {
             let mut pending: PendingDiagnostic = PendingDiagnostic {
                 span: Some(span.clone()),
                 ..failure.clone()
@@ -1099,14 +1117,45 @@ impl<'a> CheckerState<'a> {
             }
             let diag = formatter.render(&pending);
             if let Some(diag_span) = diag.span.as_ref() {
+                let (file, start, length) = (
+                    diag_span.file.to_string(),
+                    diag_span.start,
+                    diag_span.length,
+                );
+                // In the per-overload case, emit the TS2772 header first (depth 0)
+                // and nest the candidate's applicability error one level deeper
+                // (depth 1); otherwise the applicability error stays flat (depth 0).
+                let child_depth = if use_per_overload_elaboration {
+                    let elab = &elaborations[failure_idx];
+                    let signature = formatter.format_call_signature_display(&elab.signature);
+                    related.push(DiagnosticRelatedInformation {
+                        file: file.clone(),
+                        start,
+                        length,
+                        message_text: format_message(
+                            diagnostic_messages::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
+                            &[
+                                &elab.ordinal.to_string(),
+                                &elab.total.to_string(),
+                                &signature,
+                            ],
+                        ),
+                        category: DiagnosticCategory::Message,
+                        code: diagnostic_codes::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
+                        depth: 0,
+                    });
+                    1
+                } else {
+                    0
+                };
                 related.push(DiagnosticRelatedInformation {
-                    file: diag_span.file.to_string(),
-                    start: diag_span.start,
-                    length: diag_span.length,
+                    file,
+                    start,
+                    length,
                     message_text: diag.message.clone(),
                     category: DiagnosticCategory::Message,
                     code: diag.code,
-                    depth: 0,
+                    depth: child_depth,
                 });
             }
         }

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -45,6 +45,13 @@ pub(crate) struct RelatedInformationPolicy {
     include_primary: bool,
     dedupe: bool,
     limit: Option<usize>,
+    /// When set, keep the reporter's insertion order instead of applying the
+    /// deterministic `(file, start, depth, message)` sort. Required when the
+    /// reporter emits several sibling elaboration chains at one anchor (e.g. the
+    /// per-overload TS2772 headers with their nested applicability errors),
+    /// where the global sort would interleave the depth-0 headers ahead of every
+    /// depth-1 child and reorder declaration-ordered candidates alphabetically.
+    preserve_order: bool,
 }
 
 impl RelatedInformationPolicy {
@@ -52,6 +59,7 @@ impl RelatedInformationPolicy {
         include_primary: true,
         dedupe: true,
         limit: None,
+        preserve_order: false,
     };
 
     /// Demote a diagnostic's primary message into the related chain, keeping any
@@ -61,12 +69,17 @@ impl RelatedInformationPolicy {
         include_primary: true,
         dedupe: true,
         limit: None,
+        preserve_order: false,
     };
 
     pub(crate) const OVERLOAD_FAILURES: Self = Self {
         include_primary: false,
         dedupe: true,
         limit: None,
+        // The reporter already emits candidates in declaration order, and the
+        // per-overload TS2772 chains must stay interleaved (header then its
+        // nested error), so the global sort must not run here.
+        preserve_order: true,
     };
 }
 
@@ -981,13 +994,20 @@ impl<'a> CheckerState<'a> {
         // main message and its note. Within the same depth the message-text
         // tiebreaker still gives deterministic order when distinct code paths
         // append items in different sequences.
-        normalized.sort_by(|a, b| {
-            a.file
-                .cmp(&b.file)
-                .then(a.start.cmp(&b.start))
-                .then(a.depth.cmp(&b.depth))
-                .then(a.message_text.cmp(&b.message_text))
-        });
+        //
+        // Policies that emit several sibling chains at one anchor opt out: the
+        // flat sort cannot express "header A, child A, header B, child B" — it
+        // would group both headers first — so those reporters guarantee their
+        // own deterministic order and keep it (`preserve_order`).
+        if !policy.preserve_order {
+            normalized.sort_by(|a, b| {
+                a.file
+                    .cmp(&b.file)
+                    .then(a.start.cmp(&b.start))
+                    .then(a.depth.cmp(&b.depth))
+                    .then(a.message_text.cmp(&b.message_text))
+            });
+        }
 
         normalized
     }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1369,6 +1369,9 @@ mod overlap_relation_helper_routing_arch_tests;
 #[path = "tests/overload_anchor_at_argument_tests.rs"]
 mod overload_anchor_at_argument_tests;
 #[cfg(test)]
+#[path = "tests/overload_elaboration_tests.rs"]
+mod overload_elaboration_tests;
+#[cfg(test)]
 #[path = "tests/overload_generic_wrapper_compat_tests.rs"]
 mod overload_generic_wrapper_compat_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
@@ -1,0 +1,253 @@
+//! Regression tests for tsc's per-overload TS2772 elaboration under a
+//! TS2769 ("No overload matches this call") failure.
+//!
+//! When a call matches no overload and 2 or 3 candidate signatures reached
+//! argument checking, tsc groups the failure per candidate: the top-level
+//! TS2769 is followed, for each candidate, by a TS2772 chain node
+//! `Overload {n} of {m}, '{signature}', gave the following error.` (depth 0)
+//! with that candidate's applicability error nested one level deeper (depth 1),
+//! in declaration order. A single failing candidate collapses to a plain
+//! TS2345 (no TS2769); more than 3 candidates keep the flat rendering.
+//!
+//! See `crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs`
+//! (`error_no_overload_matches_at`), the solver's `OverloadElaboration`
+//! (`tsz_solver::operations`), and the `preserve_order` policy in
+//! `crates/tsz-checker/src/error_reporter/fingerprint_policy.rs`.
+//!
+//! Binder names (function, parameter, class) are varied per case so the
+//! elaboration is driven by the structural overload set, not any identifier.
+
+use crate::test_utils::check_source_diagnostics;
+
+/// The `(code, depth, message)` triples of the single TS2769 diagnostic's
+/// related information, in emitted order.
+fn overload_elaboration(source: &str) -> Vec<(u32, u8, String)> {
+    let diags = check_source_diagnostics(source);
+    let ts2769: Vec<_> = diags.iter().filter(|d| d.code == 2769).collect();
+    assert_eq!(
+        ts2769.len(),
+        1,
+        "Expected exactly one TS2769. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    ts2769[0]
+        .related_information
+        .iter()
+        .map(|r| (r.code, r.depth, r.message_text.clone()))
+        .collect()
+}
+
+/// Two failing overloads: each candidate is wrapped in a TS2772 header at
+/// depth 0 with its applicability error nested at depth 1, in declaration
+/// order.
+#[test]
+fn two_failing_overloads_wrap_each_candidate_in_declaration_order() {
+    let chain = overload_elaboration(
+        r#"
+declare function pick(value: number): number;
+declare function pick(value: string): string;
+pick(true);
+"#,
+    );
+
+    assert_eq!(
+        chain,
+        vec![
+            (
+                2772,
+                0,
+                "Overload 1 of 2, '(value: number): number', gave the following error.".to_string()
+            ),
+            (
+                2345,
+                1,
+                "Argument of type 'boolean' is not assignable to parameter of type 'number'."
+                    .to_string()
+            ),
+            (
+                2772,
+                0,
+                "Overload 2 of 2, '(value: string): string', gave the following error.".to_string()
+            ),
+            (
+                2345,
+                1,
+                "Argument of type 'boolean' is not assignable to parameter of type 'string'."
+                    .to_string()
+            ),
+        ],
+        "expected header/child pairs in declaration order"
+    );
+}
+
+/// Three failing overloads: all three are wrapped with an `of 3` total and the
+/// declared order is preserved (the old flat path re-sorted them by message).
+#[test]
+fn three_failing_overloads_preserve_declaration_order_not_alphabetical() {
+    let chain = overload_elaboration(
+        r#"
+declare function convert(input: number): number;
+declare function convert(input: string): string;
+declare function convert(input: boolean): boolean;
+convert(null);
+"#,
+    );
+
+    let headers: Vec<&String> = chain
+        .iter()
+        .filter(|(code, _, _)| *code == 2772)
+        .map(|(_, _, m)| m)
+        .collect();
+    assert_eq!(
+        headers,
+        vec![
+            "Overload 1 of 3, '(input: number): number', gave the following error.",
+            "Overload 2 of 3, '(input: string): string', gave the following error.",
+            "Overload 3 of 3, '(input: boolean): boolean', gave the following error.",
+        ],
+        "declaration order (number, string, boolean) must be preserved, not sorted"
+    );
+    // Each header is immediately followed by its own depth-1 applicability error.
+    assert_eq!(chain.len(), 6, "3 headers + 3 nested errors: {chain:?}");
+    for pair in chain.chunks(2) {
+        assert_eq!(pair[0].0, 2772, "header code: {pair:?}");
+        assert_eq!(pair[0].1, 0, "header depth: {pair:?}");
+        assert_eq!(pair[1].1, 1, "nested error depth: {pair:?}");
+    }
+}
+
+/// The wrapper header carries TS2772 at depth 0 and the applicability error is
+/// nested at depth 1 (renamed binders only change the rendered signature text).
+#[test]
+fn wrapper_uses_ts2772_at_depth_zero_with_nested_error_at_depth_one() {
+    let chain = overload_elaboration(
+        r#"
+declare function transform(arg: number): void;
+declare function transform(arg: string): void;
+transform(false);
+"#,
+    );
+
+    assert_eq!(
+        chain.first().map(|(code, depth, _)| (*code, *depth)),
+        Some((2772, 0)),
+        "first entry is the TS2772 header at depth 0: {chain:?}"
+    );
+    assert_eq!(
+        chain.get(1).map(|(code, depth, _)| (*code, *depth)),
+        Some((2345, 1)),
+        "second entry is the nested applicability error at depth 1: {chain:?}"
+    );
+}
+
+/// Constructor (`new`) overloads are wrapped identically. tsc's
+/// `signatureToString(candidate)` in this context passes no `SignatureKind`, so
+/// the construct signature renders without a leading `new` — `(x: number): C`.
+#[test]
+fn constructor_overloads_wrap_without_new_prefix() {
+    let chain = overload_elaboration(
+        r#"
+declare class Widget {
+  constructor(size: number);
+  constructor(label: string);
+}
+new Widget(true);
+"#,
+    );
+
+    let headers: Vec<&String> = chain
+        .iter()
+        .filter(|(code, _, _)| *code == 2772)
+        .map(|(_, _, m)| m)
+        .collect();
+    assert_eq!(
+        headers,
+        vec![
+            "Overload 1 of 2, '(size: number): Widget', gave the following error.",
+            "Overload 2 of 2, '(label: string): Widget', gave the following error.",
+        ],
+        "construct signatures render in colon form without `new`"
+    );
+}
+
+/// Generic overloads render their type parameters in the wrapped signature,
+/// matching tsc's `signatureToString` of the declared candidate.
+#[test]
+fn generic_overloads_render_type_parameters_in_signature() {
+    let chain = overload_elaboration(
+        r#"
+interface Container<T> { readonly item: T; }
+declare function unwrap<T>(source: Container<T>): T;
+declare function unwrap<T extends string>(source: T[]): T;
+unwrap(99);
+"#,
+    );
+
+    let headers: Vec<&String> = chain
+        .iter()
+        .filter(|(code, _, _)| *code == 2772)
+        .map(|(_, _, m)| m)
+        .collect();
+    assert_eq!(
+        headers,
+        vec![
+            "Overload 1 of 2, '<T>(source: Container<T>): T', gave the following error.",
+            "Overload 2 of 2, '<T extends string>(source: T[]): T', gave the following error.",
+        ],
+        "declared type parameters must appear in the wrapped signature"
+    );
+}
+
+/// A single overload never produces a TS2769: the mismatch collapses to a plain
+/// TS2345, with no TS2772 wrapper.
+#[test]
+fn single_overload_reports_plain_ts2345_without_wrapper() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function only(param: number): number;
+only(true);
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2345),
+        "expected a plain TS2345: {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2769),
+        "a single overload must not report TS2769: {diags:?}"
+    );
+    assert!(
+        diags
+            .iter()
+            .all(|d| d.related_information.iter().all(|r| r.code != 2772)),
+        "no TS2772 wrapper for a single overload: {diags:?}"
+    );
+}
+
+/// More than 3 candidates keep the flat rendering (the TS2770 last-overload
+/// shape is a documented follow-up): TS2769 stays, but no TS2772 header is
+/// emitted and every applicability error stays at depth 0.
+#[test]
+fn more_than_three_overloads_keep_flat_rendering() {
+    let chain = overload_elaboration(
+        r#"
+declare function route(seg: number): number;
+declare function route(seg: string): string;
+declare function route(seg: boolean): boolean;
+declare function route(seg: symbol): symbol;
+route(null);
+"#,
+    );
+
+    assert!(
+        chain.iter().all(|(code, _, _)| *code != 2772),
+        "no per-overload TS2772 wrapper beyond 3 candidates: {chain:?}"
+    );
+    assert!(
+        chain.iter().all(|(_, depth, _)| *depth == 0),
+        "flat fallback keeps every applicability error at depth 0: {chain:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1517,6 +1517,7 @@ impl<'a> CheckerState<'a> {
             }
             CallResult::NoOverloadMatch {
                 failures,
+                overload_elaborations,
                 fallback_return,
                 ..
             } => {
@@ -1543,7 +1544,7 @@ impl<'a> CheckerState<'a> {
                     && !self.should_suppress_weak_key_no_overload(callee_expr, args);
 
                 if should_emit_no_overload_error {
-                    self.error_no_overload_matches_at(call_idx, &failures);
+                    self.error_no_overload_matches_at(call_idx, &failures, &overload_elaborations);
                 }
                 // `fallback_return` is the intersection of the candidate
                 // signatures' return types (see `overload_failure_return_type`):

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1924,11 +1924,12 @@ impl<'a> CheckerState<'a> {
             }
             CallResult::NoOverloadMatch {
                 failures,
+                overload_elaborations,
                 fallback_return,
                 ..
             } => {
                 if !self.should_suppress_weak_key_no_overload(new_expr.expression, args) {
-                    self.error_no_overload_matches_at(idx, &failures);
+                    self.error_no_overload_matches_at(idx, &failures, &overload_elaborations);
                 }
                 if fallback_return != TypeId::ERROR {
                     query::instantiate_type_params_to_constraints(self.ctx.types, fallback_return)

--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -488,12 +488,16 @@ impl<'a> CheckerState<'a> {
             );
         let full_resolution_succeeded =
             matches!(result, tsz_solver::operations::CallResult::Success(_));
-        if let tsz_solver::operations::CallResult::NoOverloadMatch { failures, .. } = &result
+        if let tsz_solver::operations::CallResult::NoOverloadMatch {
+            failures,
+            overload_elaborations,
+            ..
+        } = &result
             && selected_callee_type != callee_type
             && let Some(selected_return) = self
                 .selected_tagged_template_nullish_overload_return(selected_callee_type, &arg_types)
         {
-            self.error_no_overload_matches_at(idx, failures);
+            self.error_no_overload_matches_at(idx, failures, overload_elaborations);
             return selected_return;
         }
 

--- a/crates/tsz-solver/src/diagnostics/format/compound.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound.rs
@@ -143,6 +143,29 @@ impl<'a> TypeFormatter<'a> {
         rendered
     }
 
+    /// Render a single call/construct signature the way `tsc`'s
+    /// `signatureToString` does when it appears inside a diagnostic message
+    /// chain (e.g. the TS2772 `Overload N of M, '<sig>', gave the following
+    /// error.` header). The separator is a colon, so the result is
+    /// `<T>(x: T): T` — the call-signature spelling, never the `=>` function-type
+    /// form and (matching `resolveCall`'s `signatureToString(candidate)` call,
+    /// which passes no `SignatureKind`) without a leading `new ` for construct
+    /// signatures. Type predicates are preserved in the return position.
+    pub fn format_call_signature_display(&mut self, signature: &CallSignature) -> String {
+        self.format_signature_with_predicate(
+            &signature.type_params,
+            &signature.params,
+            signature.return_type,
+            &SignatureFormatOpts {
+                this_type: signature.this_type,
+                type_predicate: signature.type_predicate.as_ref(),
+                is_construct: false,
+                is_abstract: false,
+                separator: ":",
+            },
+        )
+    }
+
     /// Format a signature with the given separator between params and return type.
     pub(super) fn format_signature(
         &mut self,

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -198,8 +198,9 @@ pub mod computation {
     pub use crate::operations::widening::widen_literal_type;
     pub use crate::operations::{
         AssignabilityChecker, BinaryOpEvaluator, BinaryOpResult, CallEvaluator, CallResult,
-        GenericCallRequest, GenericCallResult, MAX_CONSTRAINT_RECURSION_DEPTH,
-        get_async_iterable_element_type, get_contextual_signature_cached_with_compat_checker,
+        GenericCallRequest, GenericCallResult, MAX_CONSTRAINT_RECURSION_DEPTH, OverloadElaboration,
+        build_overload_elaborations, get_async_iterable_element_type,
+        get_contextual_signature_cached_with_compat_checker,
         get_contextual_signature_for_arity_cached_with_compat_checker,
         get_contextual_signature_for_arity_with_compat_checker,
         get_contextual_signature_with_compat_checker, get_iterator_info,

--- a/crates/tsz-solver/src/operations/constructors.rs
+++ b/crates/tsz-solver/src/operations/constructors.rs
@@ -5,7 +5,7 @@
 //! but with construct-specific semantics (e.g., union strictness, mixin pattern).
 
 use crate::operations::{AssignabilityChecker, CallEvaluator, CallResult};
-use crate::types::{CallableShape, FunctionShape, TypeData, TypeId, TypeListId};
+use crate::types::{CallSignature, CallableShape, FunctionShape, TypeData, TypeId, TypeListId};
 use rustc_hash::FxHashSet;
 
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
@@ -139,6 +139,9 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
 
         // Handle overloads (similar to resolve_callable_call)
         let mut failures = Vec::new();
+        // Declared construct signatures aligned 1:1 with `failures`, for the
+        // per-overload TS2772 elaboration.
+        let mut failing_signatures: Vec<CallSignature> = Vec::new();
         let mut all_arg_count_mismatches = true;
         let mut min_expected = usize::MAX;
         let mut max_expected = 0;
@@ -200,6 +203,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             actual, expected,
                         ),
                     );
+                    failing_signatures.push(sig.clone());
                 }
                 CallResult::ArgumentCountMismatch {
                     expected_min,
@@ -221,6 +225,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             actual,
                         ),
                     );
+                    failing_signatures.push(sig.clone());
                 }
                 // Track this-type mismatches for TS2345 optimization (tsc reports TS2345 not TS2769
                 // when all count-compatible overloads fail with the same this-type mismatch)
@@ -242,6 +247,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             actual_this,
                         ),
                     );
+                    failing_signatures.push(sig.clone());
                 }
                 _ => {
                     all_arg_count_mismatches = false;
@@ -319,10 +325,15 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             };
         }
 
+        let overload_elaborations = crate::operations::build_overload_elaborations(
+            &failing_signatures,
+            shape.construct_signatures.len(),
+        );
         CallResult::NoOverloadMatch {
             func_type: self.interner.callable(shape.clone()),
             arg_types: arg_types.to_vec(),
             failures,
+            overload_elaborations,
             fallback_return: shape
                 .construct_signatures
                 .first()

--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -137,6 +137,62 @@ pub trait AssignabilityChecker {
 // Function Call Resolution
 // =============================================================================
 
+/// Per-candidate elaboration for a `NoOverloadMatch` (`TS2769`) failure.
+///
+/// `tsc` groups an overload failure *per candidate*: under the top-level
+/// `No overload matches this call.` it emits, for each candidate that reached
+/// argument checking, a `TS2772` chain node
+/// `Overload {ordinal} of {total}, '{signature}', gave the following error.`
+/// with that candidate's applicability error nested one level deeper, in
+/// declaration order. This carries the data the checker's error reporter needs
+/// to build that node: the candidate's 1-based position among the failing
+/// candidates (`ordinal`), the total number of overload signatures (`total`),
+/// and the declared candidate signature to render (`signature`,
+/// `signatureToString`-style colon form). Entries are aligned 1:1 with the
+/// `failures` vector; an empty vector means the reporter keeps its flat
+/// fallback (used for the `>3`-candidate `TS2770` shape, which is out of scope
+/// for the per-overload branch).
+#[derive(Clone, Debug)]
+pub struct OverloadElaboration {
+    /// 1-based position of this candidate among the failing candidates.
+    pub ordinal: usize,
+    /// Total number of overload signatures considered (`tsc`'s `candidates.length`).
+    pub total: usize,
+    /// The declared candidate signature to render in the `TS2772` header.
+    pub signature: CallSignature,
+}
+
+/// Build the per-candidate `TS2772` elaborations for a `NoOverloadMatch`.
+///
+/// `failing_signatures` are the declared candidate signatures whose applicability
+/// errors were collected, in declaration order and aligned 1:1 with the
+/// `failures` vector. `total` is the number of overload signatures considered
+/// (`tsc`'s `candidates.length`, the `of M` count).
+///
+/// Mirrors `tsc`'s `resolveCall` branch selection: the per-overload elaboration
+/// is produced only when 2 or 3 candidates reached argument checking. A single
+/// failing candidate collapses to a plain `TS2345` (handled upstream, before a
+/// `NoOverloadMatch` is even built) and more than 3 candidates use the `TS2770`
+/// last-overload shape, for which this returns an empty vector so the reporter
+/// keeps its flat rendering.
+pub fn build_overload_elaborations(
+    failing_signatures: &[CallSignature],
+    total: usize,
+) -> Vec<OverloadElaboration> {
+    if !(2..=3).contains(&failing_signatures.len()) {
+        return Vec::new();
+    }
+    failing_signatures
+        .iter()
+        .enumerate()
+        .map(|(index, signature)| OverloadElaboration {
+            ordinal: index + 1,
+            total,
+            signature: signature.clone(),
+        })
+        .collect()
+}
+
 /// Result of attempting to call a function type.
 #[derive(Clone, Debug)]
 pub enum CallResult {
@@ -193,6 +249,11 @@ pub enum CallResult {
         func_type: TypeId,
         arg_types: Vec<TypeId>,
         failures: Vec<PendingDiagnostic>,
+        /// Per-candidate `TS2772` elaboration data, aligned 1:1 with `failures`.
+        /// Empty when the overload set falls outside `tsc`'s per-overload branch
+        /// (the `>3`-candidate `TS2770` shape), in which case the reporter keeps
+        /// its flat rendering.
+        overload_elaborations: Vec<OverloadElaboration>,
         fallback_return: TypeId,
     },
 }

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -1562,6 +1562,10 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
 
         // Try each call signature
         let mut failures = Vec::with_capacity(callable.call_signatures.len());
+        // Declared candidate signatures aligned 1:1 with `failures`, so the
+        // reporter can build the per-overload TS2772 elaboration.
+        let mut failing_signatures: Vec<CallSignature> =
+            Vec::with_capacity(callable.call_signatures.len());
         let mut all_arg_count_mismatches = true;
         let mut min_expected = usize::MAX;
         let mut max_expected = 0;
@@ -1617,6 +1621,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             actual, expected,
                         ),
                     );
+                    failing_signatures.push(sig.clone());
                 }
                 CallResult::ArgumentCountMismatch {
                     expected_min,
@@ -1638,6 +1643,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             actual,
                         ),
                     );
+                    failing_signatures.push(sig.clone());
                 }
                 // Track this-type mismatches for TS2345 optimization (tsc reports TS2345 not TS2769
                 // when all count-compatible overloads fail with the same this-type mismatch)
@@ -1659,6 +1665,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             actual_this,
                         ),
                     );
+                    failing_signatures.push(sig.clone());
                 }
                 _ => {
                     all_arg_count_mismatches = false;
@@ -1738,10 +1745,15 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // If we got here, no signature matched.
         let fallback_return =
             overload_failure_return_type(self.interner, &callable.call_signatures);
+        let overload_elaborations = crate::operations::build_overload_elaborations(
+            &failing_signatures,
+            callable.call_signatures.len(),
+        );
         CallResult::NoOverloadMatch {
             func_type: self.interner.callable(callable.clone()),
             arg_types: arg_types.to_vec(),
             failures,
+            overload_elaborations,
             fallback_return,
         }
     }

--- a/crates/tsz-solver/src/operations/mod.rs
+++ b/crates/tsz-solver/src/operations/mod.rs
@@ -59,8 +59,8 @@ pub mod widening;
 // Re-exports from core implementation
 pub use self::core::{
     AssignabilityChecker, CallEvaluator, CallResult, CallWithCheckerResult,
-    MAX_CONSTRAINT_RECURSION_DEPTH, ResolveCallOptions,
-    compute_contextual_types_with_compat_checker,
+    MAX_CONSTRAINT_RECURSION_DEPTH, OverloadElaboration, ResolveCallOptions,
+    build_overload_elaborations, compute_contextual_types_with_compat_checker,
     get_contextual_signature_cached_with_compat_checker,
     get_contextual_signature_for_arity_cached_with_compat_checker,
     get_contextual_signature_for_arity_with_compat_checker,


### PR DESCRIPTION
Closes #15361.

**Structural rule:** when a call matches no overload and **2 or 3** candidate signatures reached argument checking, `tsc` (`resolveCall`) reports the top-level `TS2769` `No overload matches this call.` and then wraps *each* candidate's applicability error in a `TS2772` chain node `Overload {n} of {m}, '{signatureToString(candidate)}', gave the following error.` — in **declaration order**, with the applicability error nested one level deeper. tsz defined the `TS2772`/`TS2770` strings but never emitted them: it flattened every candidate's argument error directly under `TS2769` and, because the related-info normalizer sorts by `(file, start, depth, message)`, rendered them out of declaration order. This emits the per-overload `TS2772` elaboration through the checker's overload error reporter (`error_no_overload_matches_at`), fed by per-candidate signature/ordinal metadata carried on the solver's `NoOverloadMatch` result. A single failing candidate collapses to a plain `TS2345` (no `TS2769`); `>3` candidates keep the flat rendering (the `TS2770` last-overload shape is a documented follow-up).

**Owner layers**
- `tsz_solver::operations` — new `OverloadElaboration` + `build_overload_elaborations`; `CallResult::NoOverloadMatch` carries `overload_elaborations` (aligned 1:1 with `failures`), populated at all three no-overload construction sites (checker `resolve_signatures`, solver `resolve_callable_call`, solver constructor overloads).
- `tsz_solver` diagnostics formatter — `TypeFormatter::format_call_signature_display` renders a candidate signature in `signatureToString` colon form (`<T>(x: T): T`; no leading `new` for construct signatures, matching `resolveCall`'s kind-less call).
- `crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs` — builds the `TS2772` header (depth 0) + nested applicability error (depth 1) per candidate.
- `crates/tsz-checker/src/error_reporter/fingerprint_policy.rs` — `RelatedInformationPolicy` gains `preserve_order`; `OVERLOAD_FAILURES` opts out of the global related-info sort so sibling chains stay interleaved and candidates keep declaration order. Every other policy is unchanged (`preserve_order: false` → identical sort).

The top-level `TS2769` code/anchor/message are unchanged in every case, so this is conformance-fingerprint-neutral (the runner fingerprints only top-level `code`/location/message, not nested related info).

**Adjacent matrix (differential-verified vs `tsc`, CLI end-to-end)**
- two failing overloads → both wrapped, declaration order
- three failing overloads → all wrapped, `of 3`, declaration order preserved (not re-sorted)
- wrapper `TS2772` at depth 0, applicability error nested at depth 1
- binder-name independence (renamed function/params only change the rendered signature)
- generic overloads render `<T>` / `<T extends string>`
- constructor (`new`) overloads wrapped as `(x: number): C` (no `new`)
- single overload → plain `TS2345`, no `TS2769`/`TS2772`
- `>3` overloads → flat fallback, top-level `TS2769` unchanged

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib overload_elaboration` — new suite, 7/7 (binder names varied per case).
- `cargo test -p tsz-solver --lib -- operations` — 587/587 (solver `NoOverloadMatch` field addition + formatter).
- `cargo test -p tsz-checker --lib -- overload call_errors overload_anchor overload_literal` — 318 pass; the only 2 fails (`union_single_plus_multi_overload_no_match_emits_ts2349`, `reduce_like_any_seed_selects_generic_candidate`) are pre-existing on clean `origin/main` (verified by stashed re-run: 0 passed there).
- `cargo clippy -p tsz-solver -p tsz-checker` clean.
- CLI differential vs `tsc` on the 8-case overload matrix above — full parity.
- Broad conformance/emit/fourslash owned by ready-review CI (full local suites hang on the pre-existing #15338 `ts2859_*` tests).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01XEaPPTebSoiVyFzPEUUFEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEaPPTebSoiVyFzPEUUFEh)_