### PR TITLE
fix(solver): count evaluator meta recursion identities (#14351)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -59,6 +59,7 @@ mod application;
 mod closed_eval;
 mod display_alias;
 mod meta_recursion_identity;
+use meta_recursion_identity::MetaRecursionIdentity;
 mod query_budget;
 mod support;
 
@@ -88,6 +89,11 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// deep and possibly infinite" behavior. Unlike a set-based cycle detector, this
     /// permits legitimate bounded recursion where each expansion converges.
     def_depth: FxHashMap<DefId, u32>,
+    /// Operation-level recursion identities for eager `keyof` / indexed-access
+    /// re-reduction. Unlike `guard`, which keys exact `TypeId` re-entry, this
+    /// mirrors tsc's `getRecursionIdentity`: productive recursion can keep
+    /// allocating fresh `TypeId`s while repeating the same origin.
+    meta_recursion_identity_stack: Vec<MetaRecursionIdentity>,
     /// #14101 SCC-discriminating probe: ordered stack of in-flight `DefId`
     /// application entries (pushed on a successful `increment_def_depth`, popped
     /// in `decrement_def_depth`). Lets the re-entry probe count the distinct
@@ -315,6 +321,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 crate::recursion::RecursionProfile::TypeEvaluation,
             ),
             def_depth: FxHashMap::default(),
+            meta_recursion_identity_stack: Vec::new(),
             def_eval_stack: Vec::new(),
             real_instantiation_depth_count: 0,
             suppress_this_binding: false,
@@ -608,6 +615,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.tainted.clear();
         self.guard.reset();
         self.def_depth.clear();
+        self.meta_recursion_identity_stack.clear();
         self.def_eval_stack.clear();
         self.real_instantiation_depth_count = 0;
         self.silent_depth_bailed = false;

--- a/crates/tsz-solver/src/evaluation/evaluate/meta_recursion_identity.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/meta_recursion_identity.rs
@@ -4,7 +4,39 @@ use super::TypeEvaluator;
 use crate::def::DefId;
 use crate::evaluation::result::TerminationKind;
 use crate::relations::subtype::TypeResolver;
-use crate::types::{TypeData, TypeId};
+use crate::types::{
+    ConditionalTypeId, ObjectShapeId, SymbolRef, TupleListId, TypeData, TypeId, TypeParamInfo,
+    TypeParamOrigin,
+};
+use tsz_common::interner::Atom;
+
+const META_REREDUCE_RECURSION_IDENTITY_MAX_DEPTH: usize = 5;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum MetaRecursionIdentity {
+    Def(DefId),
+    Symbol(tsz_binder::SymbolId),
+    Type(TypeId),
+    Object(ObjectShapeId),
+    Tuple(TupleListId),
+    Conditional(ConditionalTypeId),
+    TypeQuery(SymbolRef),
+    TypeParamDecl { file: Atom, node: u32 },
+    InferPlaceholder(u64),
+    InferSource(u64),
+    BoundParameter(u32),
+    Recursive(u32),
+}
+
+fn leftmost_index_access_object(
+    interner: &dyn crate::construction::TypeDatabase,
+    mut type_id: TypeId,
+) -> TypeId {
+    while let Some(TypeData::IndexAccess(object_type, _)) = interner.lookup(type_id) {
+        type_id = object_type;
+    }
+    type_id
+}
 
 impl<R: TypeResolver> TypeEvaluator<'_, R> {
     // tsc bounds productive meta-operation growth by recursion identity. For
@@ -22,7 +54,7 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
         let Some(after_def) = self.meta_recursion_identity(after) else {
             return false;
         };
-        before_def == after_def || self.resolver.defs_are_equivalent(before_def, after_def)
+        self.same_def_recursion_identity(before_def, after_def)
     }
 
     fn meta_recursion_identity(&self, type_id: TypeId) -> Option<DefId> {
@@ -46,6 +78,128 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
             }
         }
         None
+    }
+
+    /// Run an eager `keyof` / indexed-access re-reduction under a tsc-style
+    /// recursion identity. If this would enter the fifth nested re-reduction
+    /// with the same origin, keep the caller's deferred meta-type instead of
+    /// forcing another expansion.
+    pub(in crate::evaluation) fn with_meta_rereduce_recursion_identity(
+        &mut self,
+        type_id: TypeId,
+        deferred_fallback: TypeId,
+        body: impl FnOnce(&mut Self) -> TypeId,
+    ) -> TypeId {
+        let identity = self.meta_rereduce_recursion_identity(type_id);
+        let existing_count = self
+            .meta_recursion_identity_stack
+            .iter()
+            .filter(|&&entry| self.same_rereduce_recursion_identity(entry, identity))
+            .count();
+        if existing_count + 1 >= META_REREDUCE_RECURSION_IDENTITY_MAX_DEPTH {
+            self.record_request_limit_event(TerminationKind::IterationExceeded);
+            return deferred_fallback;
+        }
+
+        let stack_len = self.meta_recursion_identity_stack.len();
+        self.meta_recursion_identity_stack.push(identity);
+        let result = body(self);
+        debug_assert_eq!(
+            self.meta_recursion_identity_stack.get(stack_len).copied(),
+            Some(identity)
+        );
+        self.meta_recursion_identity_stack.truncate(stack_len);
+        result
+    }
+
+    fn same_def_recursion_identity(&self, left: DefId, right: DefId) -> bool {
+        let canonical_left = self.resolver.canonical_def_id(left);
+        let canonical_right = self.resolver.canonical_def_id(right);
+
+        left == right
+            || canonical_left == canonical_right
+            || self.resolver.defs_are_equivalent(left, right)
+            || self
+                .resolver
+                .defs_are_equivalent(canonical_left, canonical_right)
+    }
+
+    fn same_rereduce_recursion_identity(
+        &self,
+        left: MetaRecursionIdentity,
+        right: MetaRecursionIdentity,
+    ) -> bool {
+        match (left, right) {
+            (MetaRecursionIdentity::Def(left), MetaRecursionIdentity::Def(right)) => {
+                self.same_def_recursion_identity(left, right)
+            }
+            _ => left == right,
+        }
+    }
+
+    fn meta_rereduce_recursion_identity(&self, type_id: TypeId) -> MetaRecursionIdentity {
+        if type_id.is_intrinsic() {
+            return MetaRecursionIdentity::Type(type_id);
+        }
+
+        match self.interner.lookup(type_id) {
+            Some(TypeData::Lazy(def_id)) => {
+                MetaRecursionIdentity::Def(self.resolver.canonical_def_id(def_id))
+            }
+            Some(TypeData::TypeQuery(symbol)) => self
+                .resolver
+                .symbol_to_def_id(symbol)
+                .map_or(MetaRecursionIdentity::TypeQuery(symbol), |def_id| {
+                    MetaRecursionIdentity::Def(self.resolver.canonical_def_id(def_id))
+                }),
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+                self.interner.object_shape(shape_id).symbol.map_or(
+                    MetaRecursionIdentity::Object(shape_id),
+                    MetaRecursionIdentity::Symbol,
+                )
+            }
+            Some(TypeData::Tuple(tuple_id)) => MetaRecursionIdentity::Tuple(tuple_id),
+            Some(TypeData::Conditional(cond_id)) => MetaRecursionIdentity::Conditional(cond_id),
+            Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => {
+                Self::type_param_rereduce_recursion_identity(type_id, info)
+            }
+            Some(TypeData::BoundParameter(index)) => MetaRecursionIdentity::BoundParameter(index),
+            Some(TypeData::Recursive(index)) => MetaRecursionIdentity::Recursive(index),
+            Some(TypeData::Application(app_id)) => {
+                let app = self.interner.type_application(app_id);
+                self.meta_rereduce_recursion_identity(app.base)
+            }
+            Some(TypeData::IndexAccess(object_type, _)) => self.meta_rereduce_recursion_identity(
+                leftmost_index_access_object(self.interner, object_type),
+            ),
+            Some(TypeData::KeyOf(operand)) => self.meta_rereduce_recursion_identity(operand),
+            _ => MetaRecursionIdentity::Type(type_id),
+        }
+    }
+
+    const fn type_param_rereduce_recursion_identity(
+        type_id: TypeId,
+        info: TypeParamInfo,
+    ) -> MetaRecursionIdentity {
+        match info.origin {
+            TypeParamOrigin::DeclScoped { file, node } => {
+                MetaRecursionIdentity::TypeParamDecl { file, node }
+            }
+            TypeParamOrigin::InferPlaceholder { id } => MetaRecursionIdentity::InferPlaceholder(id),
+            TypeParamOrigin::InferSource { id, .. } => MetaRecursionIdentity::InferSource(id),
+            TypeParamOrigin::User => MetaRecursionIdentity::Type(type_id),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn seed_meta_rereduce_recursion_identity_for_test(
+        &mut self,
+        type_id: TypeId,
+        count: usize,
+    ) {
+        let identity = self.meta_rereduce_recursion_identity(type_id);
+        self.meta_recursion_identity_stack
+            .extend(std::iter::repeat_n(identity, count));
     }
 
     pub(in crate::evaluation) fn defer_same_identity_meta_recursion(&mut self) {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -1599,7 +1599,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         index_type: TypeId,
     ) -> TypeId {
         let index_access = self.interner().index_access(object_type, index_type);
-        self.evaluate(index_access)
+        self.with_meta_rereduce_recursion_identity(index_access, index_access, |evaluator| {
+            evaluator.evaluate(index_access)
+        })
     }
 
     /// Evaluate an index access type: T[K]

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
@@ -404,9 +404,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
     /// Helper to recursively evaluate keyof while respecting depth limits.
     /// Creates a `KeyOf` type and evaluates it through the main `evaluate()` method.
-    fn recurse_keyof(&mut self, operand: TypeId) -> TypeId {
+    pub(crate) fn recurse_keyof(&mut self, operand: TypeId) -> TypeId {
         let keyof = self.interner().keyof(operand);
-        self.evaluate(keyof)
+        self.with_meta_rereduce_recursion_identity(operand, keyof, |evaluator| {
+            evaluator.evaluate(keyof)
+        })
     }
 
     /// Whether a per-member `keyof` result is the *universal* key space and so is

--- a/crates/tsz-solver/tests/index_access_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/index_access_comprehensive_tests.rs
@@ -12,6 +12,7 @@ use crate::intern::TypeInterner;
 use crate::relations::subtype::SubtypeChecker;
 use crate::types::{
     ConditionalType, MappedType, PropertyInfo, TupleElement, TypeData, TypeParamInfo,
+    TypeParamOrigin,
 };
 
 // =============================================================================
@@ -811,6 +812,516 @@ fn same_identity_containment_keeps_finite_lazy_resolution() {
         ),
         "ordinary Lazy(D) -> object resolution must still reduce keyof, got {:?}",
         interner.lookup(keyof_result)
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_defers_fifth_keyof_object_identity() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let object = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(object, 4);
+    let result = evaluator.recurse_keyof(object);
+
+    assert_eq!(result, interner.keyof(object));
+    assert!(
+        matches!(interner.lookup(result), Some(TypeData::KeyOf(inner)) if inner == object),
+        "fifth same-identity keyof re-reduce should preserve the deferred operand, got {:?}",
+        interner.lookup(result)
+    );
+    assert!(
+        evaluator.has_incomplete_request_verdict(),
+        "identity-count bailout must mark the request partial for cache gates"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_allows_fourth_keyof_object_identity() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let object = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("renamed"),
+        TypeId::STRING,
+    )]);
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(object, 3);
+    let result = evaluator.recurse_keyof(object);
+
+    assert_eq!(result, interner.literal_string("renamed"));
+    assert!(
+        !evaluator.has_incomplete_request_verdict(),
+        "fourth same-identity keyof re-reduce is below the tsc-style cutoff"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_truncates_after_reducing_call() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let object = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("stable"),
+        TypeId::STRING,
+    )]);
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(object, 3);
+    assert_eq!(
+        evaluator.recurse_keyof(object),
+        interner.literal_string("stable")
+    );
+    assert_eq!(
+        evaluator.recurse_keyof(object),
+        interner.literal_string("stable")
+    );
+    assert!(
+        !evaluator.has_incomplete_request_verdict(),
+        "below-cutoff reductions must pop their temporary stack entry"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_keeps_finite_readonly_keyof_reduction() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let object = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+    let readonly = interner.intern(TypeData::ReadonlyType(object));
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    let result = evaluator.recurse_keyof(readonly);
+
+    assert_eq!(result, interner.literal_string("a"));
+    assert!(
+        !evaluator.has_incomplete_request_verdict(),
+        "finite transparent wrappers must still reduce below the identity cutoff"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_keeps_readonly_seed_distinct_from_object() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let object = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+    let readonly = interner.intern(TypeData::ReadonlyType(object));
+
+    let mut evaluator = TypeEvaluator::new(&interner);
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(readonly, 4);
+    assert_eq!(
+        evaluator.recurse_keyof(object),
+        interner.literal_string("a")
+    );
+    assert!(
+        !evaluator.has_incomplete_request_verdict(),
+        "readonly recursion entries must not make the bare object bail"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_uses_leftmost_index_access_object() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let key = interner.literal_string("a");
+    let object = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+    let first_access = interner.index_access(object, key);
+    let second_access = interner.index_access(first_access, key);
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(second_access, 4);
+    let result = evaluator.recurse_index_access(first_access, key);
+
+    assert_eq!(result, interner.index_access(first_access, key));
+    assert!(
+        matches!(interner.lookup(result), Some(TypeData::IndexAccess(obj, idx)) if obj == first_access && idx == key),
+        "fifth same-leftmost-object indexed-access re-reduce should preserve the deferred chain, got {:?}",
+        interner.lookup(result)
+    );
+    assert!(
+        evaluator.has_incomplete_request_verdict(),
+        "identity-count bailout must mark indexed-access requests partial"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_counts_object_and_indexed_leftmost_together() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let key = interner.literal_string("a");
+    let object = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+    let first_access = interner.index_access(object, key);
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(first_access, 4);
+    let result = evaluator.recurse_keyof(object);
+
+    assert_eq!(result, interner.keyof(object));
+    assert!(
+        evaluator.has_incomplete_request_verdict(),
+        "A and A[P] intentionally share the leftmost object recursion identity"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_counts_conditional_roots() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let object = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+    let conditional = interner.conditional(ConditionalType {
+        check_type: TypeId::STRING,
+        extends_type: TypeId::STRING,
+        true_type: object,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    });
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(conditional, 4);
+    let result = evaluator.recurse_keyof(conditional);
+
+    assert_eq!(result, interner.keyof(conditional));
+    assert!(
+        matches!(interner.lookup(result), Some(TypeData::KeyOf(inner)) if inner == conditional),
+        "conditional recursion identity should defer before eager branch evaluation, got {:?}",
+        interner.lookup(result)
+    );
+    assert!(
+        evaluator.has_incomplete_request_verdict(),
+        "conditional identity-count bailout must mark the request partial"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_distinct_conditional_root_still_reduces() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let object = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+    let conditional = interner.conditional(ConditionalType {
+        check_type: TypeId::STRING,
+        extends_type: TypeId::STRING,
+        true_type: object,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    });
+    let distinct_conditional = interner.conditional(ConditionalType {
+        check_type: TypeId::NUMBER,
+        extends_type: TypeId::STRING,
+        true_type: TypeId::NEVER,
+        false_type: object,
+        is_distributive: false,
+    });
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(distinct_conditional, 4);
+    let result = evaluator.recurse_keyof(conditional);
+
+    assert_eq!(result, interner.literal_string("a"));
+    assert!(
+        !evaluator.has_incomplete_request_verdict(),
+        "a different conditional root must not trip the identity-count bailout"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_counts_canonical_def_ids() {
+    use crate::construction::TypeDatabase;
+    use crate::def::DefId;
+    use crate::evaluation::evaluate::TypeEvaluator;
+    use crate::relations::subtype::TypeResolver;
+    use crate::types::SymbolRef;
+
+    struct CanonicalDefResolver {
+        body: TypeId,
+        primary: DefId,
+        alias: DefId,
+    }
+
+    impl TypeResolver for CanonicalDefResolver {
+        fn resolve_ref(&self, _symbol: SymbolRef, _interner: &dyn TypeDatabase) -> Option<TypeId> {
+            None
+        }
+
+        fn resolve_lazy(&self, def_id: DefId, _interner: &dyn TypeDatabase) -> Option<TypeId> {
+            (def_id == self.primary || def_id == self.alias).then_some(self.body)
+        }
+
+        fn canonical_def_id(&self, def_id: DefId) -> DefId {
+            if def_id == self.alias {
+                self.primary
+            } else {
+                def_id
+            }
+        }
+
+        fn defs_are_equivalent(&self, left: DefId, right: DefId) -> bool {
+            self.canonical_def_id(left) == self.canonical_def_id(right)
+        }
+    }
+
+    let interner = TypeInterner::new();
+    let primary = crate::def::DefId(14361);
+    let alias = crate::def::DefId(14362);
+    let body = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+    let resolver = CanonicalDefResolver {
+        body,
+        primary,
+        alias,
+    };
+    let primary_lazy = interner.lazy(primary);
+    let alias_lazy = interner.lazy(alias);
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &resolver);
+
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(alias_lazy, 4);
+    let result = evaluator.recurse_keyof(primary_lazy);
+
+    assert_eq!(result, interner.keyof(primary_lazy));
+    assert!(
+        evaluator.has_incomplete_request_verdict(),
+        "canonical/equivalent DefIds must count as the same recursion identity"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_keeps_distinct_def_ids_separate() {
+    use crate::def::DefId;
+    use crate::def::resolver::TypeEnvironment;
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let primary = DefId(14363);
+    let other = DefId(14364);
+    let primary_lazy = interner.lazy(primary);
+    let other_lazy = interner.lazy(other);
+    let object = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+
+    let mut env = TypeEnvironment::new();
+    env.insert_def(primary, object);
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(other_lazy, 4);
+    let result = evaluator.recurse_keyof(primary_lazy);
+
+    assert_eq!(result, interner.literal_string("a"));
+    assert!(
+        !evaluator.has_incomplete_request_verdict(),
+        "distinct DefIds without canonical/equivalent identity must not collide"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_counts_decl_scoped_type_params_without_names() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let file = interner.intern_string("types.ts");
+    let first = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::DeclScoped { file, node: 42 },
+    }));
+    let renamed = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("Renamed"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::DeclScoped { file, node: 42 },
+    }));
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(first, 4);
+    let result = evaluator.recurse_keyof(renamed);
+
+    assert_eq!(result, interner.keyof(renamed));
+    assert!(
+        evaluator.has_incomplete_request_verdict(),
+        "declaration-scoped type parameters should count by declaration site, not display name"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_keeps_distinct_decl_scoped_type_params_separate() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let file = interner.intern_string("types.ts");
+    let first = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::DeclScoped { file, node: 42 },
+    }));
+    let same_name_distinct_decl = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::DeclScoped { file, node: 43 },
+    }));
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(first, 4);
+    let _ = evaluator.recurse_keyof(same_name_distinct_decl);
+
+    assert!(
+        !evaluator.has_incomplete_request_verdict(),
+        "distinct declaration-scoped type parameters must not collide solely because names match"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_keeps_user_type_param_names_distinct() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let name = interner.intern_string("T");
+    let first = interner.fresh_type_param(TypeParamInfo {
+        name,
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::User,
+    });
+    let second = interner.fresh_type_param(TypeParamInfo {
+        name,
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::User,
+    });
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(first, 4);
+    let _ = evaluator.recurse_keyof(second);
+
+    assert!(
+        !evaluator.has_incomplete_request_verdict(),
+        "ordinary user type parameters must not collide solely because their names match"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_counts_infer_placeholders_by_id() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let first = interner.intern(TypeData::Infer(TypeParamInfo {
+        name: interner.intern_string("A"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::InferPlaceholder { id: 7 },
+    }));
+    let renamed = interner.intern(TypeData::Infer(TypeParamInfo {
+        name: interner.intern_string("Renamed"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::InferPlaceholder { id: 7 },
+    }));
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(first, 4);
+    let result = evaluator.recurse_keyof(renamed);
+
+    assert_eq!(result, interner.keyof(renamed));
+    assert!(
+        evaluator.has_incomplete_request_verdict(),
+        "infer placeholders should count by structured placeholder id, not display name"
+    );
+}
+
+#[test]
+fn meta_rereduce_identity_stack_counts_infer_sources_by_id() {
+    use crate::evaluation::evaluate::TypeEvaluator;
+
+    let interner = TypeInterner::new();
+    let origin_name = interner.intern_string("Source");
+    let first = interner.intern(TypeData::Infer(TypeParamInfo {
+        name: interner.intern_string("A"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::InferSource {
+            id: 9,
+            origin_name: Some(origin_name),
+        },
+    }));
+    let renamed = interner.intern(TypeData::Infer(TypeParamInfo {
+        name: interner.intern_string("Renamed"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::InferSource {
+            id: 9,
+            origin_name: None,
+        },
+    }));
+    let distinct = interner.intern(TypeData::Infer(TypeParamInfo {
+        name: interner.intern_string("A"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::InferSource {
+            id: 10,
+            origin_name: Some(origin_name),
+        },
+    }));
+
+    let mut evaluator = TypeEvaluator::new(&interner);
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(first, 4);
+    let _ = evaluator.recurse_keyof(distinct);
+    assert!(
+        !evaluator.has_incomplete_request_verdict(),
+        "different infer-source ids must remain distinct even with the same source name"
+    );
+
+    let mut evaluator = TypeEvaluator::new(&interner);
+    evaluator.seed_meta_rereduce_recursion_identity_for_test(first, 4);
+    let result = evaluator.recurse_keyof(renamed);
+
+    assert_eq!(result, interner.keyof(renamed));
+    assert!(
+        evaluator.has_incomplete_request_verdict(),
+        "infer-source placeholders should count by structured id, not origin display name"
     );
 }
 


### PR DESCRIPTION
Advances #14351 P2: evaluator-side recursion-identity containment for productive `keyof` / indexed-access re-reduction.

Goal: green

## Structural Rule
When eager solver evaluation re-enters `keyof T` or `T[K]` re-reduction with the same tsc-style recursion identity, tsc preserves the symbolic meta-type at a small identity count instead of forcing another expansion. tsz now owns that at the solver evaluator layer: the fifth same-identity re-reduce records `IterationExceeded` and returns the deferred `KeyOf` / `IndexAccess` fallback instead of manufacturing a deeper expansion.

The identity is structural, not string-based: canonical/equivalent `DefId`s, mapped `TypeQuery` defs, object symbols/shapes, tuple ids, conditional ids, leftmost indexed-access object identity, declaration-scoped type-parameter `(file Atom, node)` identity, and structured infer placeholder ids. Ordinary user type parameters fall back to fresh `TypeId`, so matching display names do not collide.

## Owner Layer
Solver evaluator only:
- `TypeEvaluator` carries an evaluator-local meta recursion identity stack and resets it with other recursion state.
- `recurse_keyof` and `recurse_index_access` enter the identity-count guard before re-evaluating their deferred meta-types.
- Existing same-before/after `DefId` containment now uses the same canonical/equivalent def comparison helper.

No checker, emitter, relation-cache, project metadata, or fixture-specific logic. Direct `evaluate_index_access` callers are intentionally out of scope unless they flow through the helper re-reduction path.

## Adjacent Matrix
- Fifth same object identity defers and marks the request incomplete for cache gates; fourth still reduces.
- Stack entries pop after reducing calls.
- Finite `Readonly` wrappers still reduce naturally, and seeded readonly identity does not poison bare object identity.
- `A`, `A[P]`, and `A[P][Q]` intentionally count by the leftmost object.
- Same conditional root counts; distinct conditional roots do not collide.
- Canonical/equivalent `DefId`s count together; distinct defs stay separate.
- Declaration-scoped type parameters count by declaration site, not display name; distinct declaration sites stay separate.
- Infer placeholders/source placeholders count by structured ids; ordinary same-name user params stay distinct.

## Overlap
Checked open PRs: no open PR touches this branch's five files. #15369 is adjacent #14346 relation-cache verdict-consumption work (`relations/subtype/*`, `evaluation/result.rs`) with no file overlap.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(meta_rereduce_identity_stack) or test(index_access_productive_lazy_chain_bails_to_deferred_root) or test(keyof_productive_lazy_chain_bails_to_deferred_root) or test(same_identity_containment_keeps_finite_lazy_resolution)'` — 19/19 pass
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(evaluate_keyof) or test(evaluate_index_access) or test(keyof_) or test(index_access_) or test(meta_rereduce_identity_stack)'` — 414/414 pass
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy -p tsz-solver --lib --tests -- -D warnings`
- `wc -l crates/tsz-solver/src/evaluation/evaluate/meta_recursion_identity.rs crates/tsz-solver/tests/index_access_comprehensive_tests.rs` — 209 and 1778 lines, under the 2000-line cap
- `python3 scripts/arch/arch_guard.py --json` — fails the current main baseline checker speculation metric: 5 snapshot/rollback caller files outside `speculation.rs`, cap 4; this PR touches no checker files
- `scripts/arch/check-checker-boundaries.sh` — same arch guard baseline failure

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high
