### PR TITLE
fix(checker): type destructuring binding elements from the source for all declaration forms (#15373)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -288,6 +288,9 @@ path = "tests/intersection_modifier_merge_tests.rs"
 name = "array_declaration_display_summary_tests"
 path = "tests/array_declaration_display_summary_tests.rs"
 [[test]]
+name = "array_destructuring_binding_element_typing_tests"
+path = "tests/array_destructuring_binding_element_typing_tests.rs"
+[[test]]
 name = "ts2371_binding_pattern_default_tests"
 path = "tests/ts2371_binding_pattern_default_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -344,64 +344,6 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// Returns `true` when an array binding pattern's destructuring source is a
-    /// fresh array-literal initializer (`var [a, ...rest] = [1, 2, 3]`).
-    ///
-    /// tsc widens a fresh array literal to `ElementType[]` via
-    /// `getWidenedTypeForVariableLikeDeclaration`, so a `...rest` element binds
-    /// `createArrayType(elementType)` — *not* the residual tuple slice. tsz
-    /// keeps the un-widened literal tuple as the destructuring source (for
-    /// positional `const` literal-default precision, e.g. `const [first = 0] =
-    /// [10, 20]`), so the rest path detects the fresh-literal origin and widens,
-    /// while declared and `as const` tuple sources keep slicing
-    /// (`sliceTupleType`).
-    ///
-    /// Walks up through nested binding patterns/elements to the enclosing
-    /// `VARIABLE_DECLARATION`. A `[...] as const` initializer is an
-    /// `AS_EXPRESSION` (not an `ARRAY_LITERAL_EXPRESSION`), so it keeps slicing;
-    /// parameter sources (annotated tuple types) are never fresh.
-    pub(crate) fn array_binding_source_is_fresh_array_literal(
-        &self,
-        pattern_idx: NodeIndex,
-    ) -> bool {
-        let mut current = pattern_idx;
-        for _ in 0..64 {
-            let Some(ext) = self.ctx.arena.get_extended(current) else {
-                return false;
-            };
-            let parent = ext.parent;
-            if parent.is_none() {
-                return false;
-            }
-            let Some(parent_node) = self.ctx.arena.get(parent) else {
-                return false;
-            };
-            let kind = parent_node.kind;
-            if kind == syntax_kind_ext::VARIABLE_DECLARATION {
-                let Some(var_decl) = self.ctx.arena.get_variable_declaration(parent_node) else {
-                    return false;
-                };
-                if var_decl.initializer.is_none() {
-                    return false;
-                }
-                return self
-                    .ctx
-                    .arena
-                    .get(var_decl.initializer)
-                    .is_some_and(|init| init.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION);
-            }
-            if kind == syntax_kind_ext::ARRAY_BINDING_PATTERN
-                || kind == syntax_kind_ext::OBJECT_BINDING_PATTERN
-                || kind == syntax_kind_ext::BINDING_ELEMENT
-            {
-                current = parent;
-                continue;
-            }
-            return false;
-        }
-        false
-    }
-
     pub(crate) fn report_empty_array_destructuring_bounds(
         &mut self,
         pattern_idx: NodeIndex,
@@ -769,18 +711,22 @@ impl<'a> CheckerState<'a> {
                     // Array source `E[]` → `E[]`.
                     return self.rest_binding_array_type(elem);
                 } else if let Some(elems) = query::tuple_elements(self.ctx.types, array_like) {
-                    // A fresh array-literal source is widened by tsc to
-                    // `createArrayType(elementType)` (it is `E[]`, not a tuple,
-                    // at the destructuring site), so the rest binds the element
-                    // array. Declared / `as const` tuple sources slice the
-                    // residual, matching tsc's `sliceTupleType`.
-                    if self.array_binding_source_is_fresh_array_literal(pattern_idx) {
-                        let elem = self.get_element_access_type(array_like, TypeId::NUMBER, None);
-                        return self.rest_binding_array_type(elem);
-                    }
+                    // Slice the residual tuple from the rest position, matching
+                    // tsc's `sliceTupleType`. Whether a fresh array-literal source
+                    // is a tuple at all (`[a, ...r]`) or an array (`[...r]`, a
+                    // pure-rest pattern) is decided upstream by the array-literal
+                    // contextual type derived from the binding pattern; once the
+                    // source resolves to a tuple, the rest always slices it.
                     return self.tuple_rest_binding_type(&elems, element_index);
                 }
-                return self.rest_binding_array_type(TypeId::ANY);
+                // Non-tuple, non-array source: fall back to the destructuring
+                // iterated element type (`checkIteratedTypeOrElementType`), so an
+                // iterable that is neither array nor tuple — a string, `Set`,
+                // `Map`, or generator — binds `E[]`, matching tsc's
+                // `getBindingElementTypeFromParentType`. Non-iterable sources
+                // resolve to `any` here, keeping the prior `any[]` fallback.
+                let elem = self.for_of_element_type(array_like, false);
+                return self.rest_binding_array_type(elem);
             }
 
             return if let Some(elem) = query::array_element_type(self.ctx.types, array_like) {
@@ -897,7 +843,13 @@ impl<'a> CheckerState<'a> {
                     TypeId::ANY
                 }
             } else {
-                TypeId::ANY
+                // Non-tuple, non-array source: bind the destructuring iterated
+                // element type positionally (`E` from a string, `Set`, `Map`, or
+                // generator), matching tsc's `getBindingElementTypeFromParentType`
+                // via `checkIteratedTypeOrElementType`. Non-iterable sources
+                // resolve to `any` here (TS2488 is emitted separately by the
+                // iterability check), preserving the prior fallback.
+                self.for_of_element_type(array_like, false)
             };
         }
 

--- a/crates/tsz-checker/src/state/variable_checking/destructuring/tail.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring/tail.rs
@@ -497,6 +497,14 @@ impl<'a> CheckerState<'a> {
                             elem_data.initializer,
                         )
                     });
+                // A `...rest` binding element contributes a rest element to the
+                // contextual tuple (`getTypeFromArrayBindingPattern` flags it
+                // `ElementFlags.Rest`). This drives the array-vs-tuple decision
+                // for a fresh array-literal initializer: a pure-rest pattern
+                // (`[...r]`) yields an all-rest contextual type — effectively an
+                // array — so the literal widens to `E[]`, whereas `[a, ...r]`
+                // keeps a leading fixed slot and stays a tuple.
+                let is_rest = binding.is_some_and(|(_, dot_dot_dot, _)| dot_dot_dot);
                 let elem_type = match binding {
                     Some((name, _, _))
                         if matches!(
@@ -536,7 +544,7 @@ impl<'a> CheckerState<'a> {
                 tuple_elements.push(tsz_solver::TupleElement {
                     type_id: elem_type,
                     optional: false,
-                    rest: false,
+                    rest: is_rest,
                     name: None,
                 });
             }

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1374,6 +1374,19 @@ impl<'a> CheckerState<'a> {
             // This must happen before infer_return_type_from_body which evaluates body expressions.
             self.ctx.function_depth += 1;
             self.cache_parameter_types(&parameters.nodes, Some(&param_types));
+            // Seed destructured binding-element symbol types for *annotated*
+            // destructuring parameters through the shared destructuring engine,
+            // so references to array-pattern elements (positional + rest), object
+            // rest, and iterable sources resolve to their sliced / indexed /
+            // iterated element types instead of falling through the object-only
+            // lazy resolver to implicit `any`. Contextually typed (unannotated)
+            // destructuring parameters are seeded separately by
+            // `assign_contextual_types_to_destructuring_params` below. Runs for
+            // all function forms with a body (declarations, closures, methods).
+            self.assign_annotated_destructuring_parameter_binding_types(
+                &parameters.nodes,
+                &param_types,
+            );
             let refresh_body_for_contextual_param_retyping =
                 is_closure && (ctx_helper.is_some() || func_jsdoc.is_some());
             if refresh_body_for_contextual_param_retyping {

--- a/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
+++ b/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
@@ -505,6 +505,61 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Seed the destructured binding-element symbol types for *annotated*
+    /// destructuring parameters (e.g. `function f([a, ...r]: [number, string,
+    /// boolean])` or `({ p, ...rest }: T)`) through the shared destructuring
+    /// engine.
+    ///
+    /// `cache_parameter_types` only caches the parameter symbol itself; the
+    /// individual bindings inside the pattern are otherwise resolved lazily by
+    /// `resolve_binding_element_from_annotated_param`, which only understands
+    /// object property lookups. Array-pattern elements (positional and rest),
+    /// object rest, and non-array-like iterable sources therefore fell through
+    /// to implicit `any`. Routing annotated parameters through the same engine
+    /// used for variable-declaration destructuring makes every declaration form
+    /// bind identically to `tsc`'s `getBindingElementTypeFromParentType`.
+    ///
+    /// Contextually typed (unannotated) destructuring parameters are handled by
+    /// `assign_contextual_types_to_destructuring_params`, so this only processes
+    /// parameters that carry an explicit type annotation.
+    pub(crate) fn assign_annotated_destructuring_parameter_binding_types(
+        &mut self,
+        params: &[NodeIndex],
+        param_types: &[Option<TypeId>],
+    ) {
+        for (i, &param_idx) in params.iter().enumerate() {
+            let Some(param_node) = self.ctx.arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param) = self.ctx.arena.get_parameter(param_node) else {
+                continue;
+            };
+            if param.type_annotation.is_none() {
+                continue;
+            }
+            let is_binding_pattern = self.ctx.arena.kind_at(param.name).is_some_and(|kind| {
+                kind == syntax_kind_ext::OBJECT_BINDING_PATTERN
+                    || kind == syntax_kind_ext::ARRAY_BINDING_PATTERN
+            });
+            if !is_binding_pattern {
+                continue;
+            }
+            let Some(source_type) = param_types
+                .get(i)
+                .and_then(|t| *t)
+                .filter(|t| !t.is_any_unknown_or_error())
+            else {
+                continue;
+            };
+            let request = crate::context::TypingRequest::with_contextual_type(source_type);
+            self.assign_binding_pattern_symbol_types_with_request(
+                param.name,
+                source_type,
+                &request,
+            );
+        }
+    }
+
     pub(crate) fn contextual_parameter_type_from_enclosing_function(
         &mut self,
         param_idx: NodeIndex,

--- a/crates/tsz-checker/tests/array_destructuring_binding_element_typing_tests.rs
+++ b/crates/tsz-checker/tests/array_destructuring_binding_element_typing_tests.rs
@@ -1,0 +1,256 @@
+//! Array/object destructuring binds every element from the source through the
+//! same rule `tsc` uses in `getBindingElementTypeFromParentType`, for **all**
+//! declaration forms (variable declarations and annotated parameters):
+//!
+//! - tuple sources slice (`sliceTupleType`) for `...rest` and index positional
+//!   elements;
+//! - a fresh array literal is a tuple when the pattern has a leading fixed
+//!   element (`[a, ...r]`) and an array when the pattern is pure-rest (`[...r]`),
+//!   because the pattern supplies the contextual type;
+//! - non-tuple, non-array iterable sources (string, `Set`, `Map`, generator)
+//!   bind the destructuring-iterated element type (`E` positionally, `E[]` for
+//!   rest).
+//!
+//! Every expectation is pinned against `tsc` 6.0.2 with `--strict`. Binder names
+//! are varied across cases so the behaviour is structural, not name-driven.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+/// The rendered `TS2322` target-mismatch messages for `source`. Each divergence
+/// row uses `const probe: 12345 = <binding>;`, so the binding's inferred type is
+/// rendered as the assignment source in the message.
+fn messages_2322(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+fn renders_type(source: &str, rendered: &str) -> bool {
+    let needle = format!("Type '{rendered}' is not assignable to type '12345'.");
+    messages_2322(source).contains(&needle)
+}
+
+// --- Fresh array-literal sources (rows a–d) ------------------------------------
+
+#[test]
+fn fresh_literal_fixed_rest_slices_residual_tuple_const() {
+    // row a: `const [lead, ...tail] = [1, 'x', true]` → tail: [string, boolean].
+    let src = "const [lead, ...tail] = [1, 'x', true];\nconst probe: 12345 = tail;\n";
+    assert!(
+        renders_type(src, "[string, boolean]"),
+        "row a: {:?}",
+        messages_2322(src)
+    );
+}
+
+#[test]
+fn fresh_literal_fixed_rest_slices_residual_tuple_let() {
+    // row b: `let` widens the source identically to `const` at the slice site.
+    let src = "let [lead, ...remainder] = [1, 'x', true];\nconst probe: 12345 = remainder;\n";
+    assert!(
+        renders_type(src, "[string, boolean]"),
+        "row b: {:?}",
+        messages_2322(src)
+    );
+}
+
+#[test]
+fn fresh_literal_fixed_rest_with_default_slices_residual_tuple() {
+    // row c: a positional default does not change the rest slice.
+    let src = "const [first = 9, ...others] = [1, 'x', true];\nconst probe: 12345 = others;\n";
+    assert!(
+        renders_type(src, "[string, boolean]"),
+        "row c: {:?}",
+        messages_2322(src)
+    );
+}
+
+#[test]
+fn fresh_literal_nested_rest_slices_at_each_level() {
+    // row d: nested rest patterns slice the residual at each level.
+    let src =
+        "const [head, ...[neck, ...spine]] = [1, 'x', true, 'z'];\nconst probe: 12345 = spine;\n";
+    assert!(
+        renders_type(src, "[boolean, string]"),
+        "row d: {:?}",
+        messages_2322(src)
+    );
+}
+
+#[test]
+fn fresh_literal_pure_rest_widens_to_array() {
+    // A pure-rest pattern takes an array contextual type, so the literal widens.
+    let src = "const [...everything] = [1, 2, 3];\nconst probe: 12345 = everything;\n";
+    assert!(
+        renders_type(src, "number[]"),
+        "pure-rest widens: {:?}",
+        messages_2322(src)
+    );
+}
+
+// --- Annotated function parameters (rows e–i) ----------------------------------
+
+#[test]
+fn annotated_param_array_pattern_indexes_and_slices() {
+    // row e: `function fn([a, ...r]: [number, string, boolean])`.
+    let src = "function pick([alpha, ...beta]: [number, string, boolean]) {\n  const p1: 12345 = alpha;\n  const p2: 12345 = beta;\n}\n";
+    assert!(
+        renders_type(src, "number"),
+        "row e positional: {:?}",
+        messages_2322(src)
+    );
+    assert!(
+        renders_type(src, "[string, boolean]"),
+        "row e rest: {:?}",
+        messages_2322(src)
+    );
+}
+
+#[test]
+fn annotated_param_readonly_tuple_slices_to_mutable_tuple() {
+    // row f: readonly source slices to a mutable residual tuple.
+    let src = "function take([one, ...rest]: readonly [number, string, boolean]) {\n  const p: 12345 = rest;\n}\n";
+    assert!(
+        renders_type(src, "[string, boolean]"),
+        "row f: {:?}",
+        messages_2322(src)
+    );
+}
+
+#[test]
+fn annotated_rest_param_with_variadic_tuple_binds_array_slice() {
+    // row g: `function fn(...[a, ...r]: [number, ...string[]])` → r: string[].
+    let src = "function collect(...[lead, ...more]: [number, ...string[]]) {\n  const p: 12345 = more;\n}\n";
+    assert!(
+        renders_type(src, "string[]"),
+        "row g: {:?}",
+        messages_2322(src)
+    );
+}
+
+#[test]
+fn annotated_param_array_pattern_in_all_function_forms() {
+    // row h: arrow, object-literal method, and class method forms of row e all
+    // bind the rest to the sliced tuple (previously they fell to `any`).
+    let arrow =
+        "const fx = ([a1, ...b1]: [number, string, boolean]) => {\n  const p: 12345 = b1;\n};\n";
+    assert!(
+        renders_type(arrow, "[string, boolean]"),
+        "row h arrow: {:?}",
+        messages_2322(arrow)
+    );
+
+    let method = "const holder = {\n  run([a2, ...b2]: [number, string, boolean]) {\n    const p: 12345 = b2;\n  },\n};\n";
+    assert!(
+        renders_type(method, "[string, boolean]"),
+        "row h object method: {:?}",
+        messages_2322(method)
+    );
+
+    let class_method = "class Runner {\n  run([a3, ...b3]: [number, string, boolean]) {\n    const p: 12345 = b3;\n  }\n}\n";
+    assert!(
+        renders_type(class_method, "[string, boolean]"),
+        "row h class method: {:?}",
+        messages_2322(class_method)
+    );
+}
+
+#[test]
+fn annotated_param_object_rest_binds_remaining_properties() {
+    // row i: `function fn({ p, ...rest }: { p: number; q: string })`.
+    let src = "function shape({ picked, ...leftover }: { picked: number; q: string }) {\n  const p: 12345 = leftover;\n}\n";
+    assert!(
+        renders_type(src, "{ q: string; }"),
+        "row i: {:?}",
+        messages_2322(src)
+    );
+}
+
+// --- Non-array-like iterable sources (rows j–n) --------------------------------
+
+#[test]
+fn string_source_rest_binds_string_array() {
+    // row j: `const [...r] = 'hello'` → r: string[].
+    let src = "const [...letters] = 'hello';\nconst probe: 12345 = letters;\n";
+    assert!(
+        renders_type(src, "string[]"),
+        "row j: {:?}",
+        messages_2322(src)
+    );
+}
+
+#[test]
+fn string_source_positional_binds_string() {
+    // row k: `const [c] = 'hi'` → c: string.
+    let src = "const [initial] = 'hi';\nconst probe: 12345 = initial;\n";
+    assert!(
+        renders_type(src, "string"),
+        "row k: {:?}",
+        messages_2322(src)
+    );
+}
+
+// Rows l (`Set`), m (`Map`), and n (generator) exercise the same iterable
+// fallback as rows j/k but require the standard library, which this unit harness
+// does not load (`set_lib_contexts(Vec::new())`). They are verified end-to-end
+// against `tsc` 6.0.2 in the PR's differential matrix; string iteration (rows
+// j/k) covers the iterable path here because it is intrinsic.
+
+// --- Negative controls (must stay unchanged) -----------------------------------
+
+#[test]
+fn declared_tuple_source_still_slices() {
+    let src = "declare const triple: [number, string, boolean];\nconst [x, ...y] = triple;\nconst probe: 12345 = y;\n";
+    assert!(
+        renders_type(src, "[string, boolean]"),
+        "declared tuple: {:?}",
+        messages_2322(src)
+    );
+}
+
+#[test]
+fn as_const_source_still_slices_literals() {
+    let src = "const frozen = [1, 'x', true] as const;\nconst [x, ...y] = frozen;\nconst probe: 12345 = y;\n";
+    // `as const` preserves literal element types in the residual slice.
+    assert!(
+        renders_type(src, "[\"x\", true]"),
+        "as const: {:?}",
+        messages_2322(src)
+    );
+}
+
+#[test]
+fn array_source_rest_stays_an_array() {
+    let src = "declare const nums: number[];\nconst [x, ...y] = nums;\nconst probe: 12345 = y;\n";
+    assert!(
+        renders_type(src, "number[]"),
+        "array source: {:?}",
+        messages_2322(src)
+    );
+}
+
+#[test]
+fn union_of_tuples_slices_each_member() {
+    let src = "declare const u: [number, string] | [number, boolean];\nconst [x, ...y] = u;\nconst probe: 12345 = y;\n";
+    assert!(
+        renders_type(src, "[string] | [boolean]"),
+        "union of tuples: {:?}",
+        messages_2322(src)
+    );
+}
+
+#[test]
+fn assignment_destructuring_over_declared_tuple_is_unchanged() {
+    // Assignment destructuring (not a binding) keeps binding the declared targets;
+    // no spurious TS2322 from the source slice.
+    let src = "declare const triple: [number, string, boolean];\nlet head: number;\nlet tail: [string, boolean];\n[head, ...tail] = triple;\n";
+    assert!(
+        !messages_2322(src)
+            .iter()
+            .any(|m| m.contains("is not assignable")),
+        "assignment destructuring should not report TS2322: {:?}",
+        messages_2322(src)
+    );
+}

--- a/crates/tsz-checker/tests/tuple_rest_destructuring_slice_tests.rs
+++ b/crates/tsz-checker/tests/tuple_rest_destructuring_slice_tests.rs
@@ -193,41 +193,71 @@ const show: "X" = tail;
 }
 
 #[test]
-fn fresh_array_literal_rest_widens_to_array_not_a_slice() {
-    // A *fresh* array-literal destructuring source is widened by tsc
-    // (`getWidenedTypeForVariableLikeDeclaration`), so the `...rest` binds the
-    // element array `number[]`, NOT the residual tuple slice `[number, number]`
-    // that a declared tuple would produce.
-    let assignable_to_array = r#"
+fn fresh_array_literal_fixed_rest_slices_to_residual_tuple() {
+    // A fresh array-literal destructured with a *leading fixed* element takes a
+    // tuple contextual type from the binding pattern (`[any, ...any[]]`), so the
+    // literal is a tuple at the destructuring site and the `...rest` slices its
+    // residual — exactly like a declared tuple. Pinned against tsc 6.0.2:
+    // `const [head, ...spread] = [1, 2, 3]` gives `spread: [number, number]`.
+    let residual_tuple_ok = r#"
 const [head, ...spread] = [1, 2, 3];
-const ok: number[] = spread;
+const ok: [number, number] = spread;
+const okArr: number[] = spread;
 "#;
     assert!(
-        !codes(assignable_to_array).contains(&2322),
-        "fresh-literal rest should be number[] (assignable to number[]); got {:?}",
-        codes(assignable_to_array)
+        !codes(residual_tuple_ok).contains(&2322),
+        "fresh-literal fixed+rest slices to [number, number] (assignable to it and to number[]); got {:?}",
+        codes(residual_tuple_ok)
     );
 
-    let not_a_tuple = r#"
+    // The slice is precise: it is `[number, number]`, not the full-length tuple.
+    let wrong_arity = r#"
 const [lead, ...trailing] = [1, 2, 3];
-const wrong: [number, number] = trailing;
+const wrong: [number, number, number] = trailing;
 "#;
     assert!(
-        codes(not_a_tuple).contains(&2322),
-        "fresh-literal rest is number[], not the tuple [number, number]; got {:?}",
-        codes(not_a_tuple)
+        codes(wrong_arity).contains(&2322),
+        "residual slice is [number, number], not length 3; got {:?}",
+        codes(wrong_arity)
     );
 
-    // `var` fresh literal widens identically.
+    // `var` fresh literal slices identically (widening does not turn it into an array).
     let var_form = r#"
 var [v, ...vrest] = [1, 2, 3];
-const okv: number[] = vrest;
-const wrongv: [number, number] = vrest;
+const okv: [number, number] = vrest;
+const wrongv: [number, number, number] = vrest;
 "#;
     let cs = codes(var_form);
     assert!(
         cs.iter().filter(|&&c| c == 2322).count() == 1,
-        "var fresh-literal rest is number[]: ok for number[], TS2322 for tuple; got {cs:?}"
+        "var fresh-literal fixed+rest is [number, number]: ok for it, TS2322 for length 3; got {cs:?}"
+    );
+}
+
+#[test]
+fn fresh_array_literal_pure_rest_widens_to_array() {
+    // A *pure-rest* pattern (`[...rest]`) takes an array contextual type
+    // (`any[]`), so the fresh literal widens to `E[]` and the rest binds the
+    // element array — NOT a residual tuple. Pinned against tsc 6.0.2:
+    // `const [...all] = [1, 2, 3]` gives `all: number[]`.
+    let array_ok = r#"
+const [...all] = [1, 2, 3];
+const ok: number[] = all;
+"#;
+    assert!(
+        !codes(array_ok).contains(&2322),
+        "pure-rest fresh literal is number[] (assignable to number[]); got {:?}",
+        codes(array_ok)
+    );
+
+    let not_a_tuple = r#"
+const [...every] = [1, 2, 3];
+const wrong: [number, number, number] = every;
+"#;
+    assert!(
+        codes(not_a_tuple).contains(&2322),
+        "pure-rest fresh literal is number[], not a tuple; got {:?}",
+        codes(not_a_tuple)
     );
 }
 


### PR DESCRIPTION
Fixes #15373.

**Structural rule.** When an array/object binding pattern destructures a source, `tsc`'s `getBindingElementTypeFromParentType` types every element from that source: tuple sources slice (`sliceTupleType`) for `...rest` and index positional elements; a fresh array literal is a **tuple** when the pattern has a leading fixed slot (`[a, ...r]`) and an **array** when the pattern is pure-rest (`[...r]`), because the binding pattern supplies the contextual type; and a source that is neither tuple nor array but is iterable (string, `Set`, `Map`, generator) binds the destructuring-iterated element type (`E` positionally, `E[]` for rest). This holds uniformly for variable declarations and annotated function parameters. tsz now does the same through the checker's shared destructuring binding-element computation (`get_binding_element_type_with_request`) instead of three divergent paths.

Owner layers:
- `state/variable_checking/destructuring/tail.rs` — `build_contextual_type_from_pattern_with_request` now flags a `...rest` binding element as a rest element in the contextual tuple (it was hardcoded non-rest). A pure-rest pattern therefore yields an all-rest (array) contextual type so a fresh literal widens to `E[]`, while `[a, ...r]` keeps a leading fixed slot and stays a tuple.
- `state/variable_checking/destructuring.rs` — `get_binding_element_type_with_request` drops the empirically-wrong `array_binding_source_is_fresh_array_literal` carve-out (which widened fresh-literal tuple sources to `ElementType[]`); tuple sources always slice via `tuple_rest_binding_type`. The non-array/non-tuple fallbacks now consume `for_of_element_type` (the canonical iterated-element helper) instead of returning `any`/`any[]`.
- `types/function_type.rs` + `types/utilities/contextual_parameters.rs` — annotated destructuring parameters are seeded through the same `assign_binding_pattern_symbol_types_with_request` engine used by variable declarations, for every function form (declarations, closures, methods), instead of falling through the object-only lazy resolver to implicit `any`.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --test array_destructuring_binding_element_typing_tests` — new, 17 cases: issue rows a–k, annotated params in arrow/object-method/class-method forms, and negative controls (declared tuple, `as const`, array `E[]`, union of tuples, assignment destructuring); binder names varied so the behavior is structural.
- `cargo nextest run -p tsz-checker --test tuple_rest_destructuring_slice_tests` — rewrote the disproven `fresh_array_literal_rest_widens_to_array_not_a_slice` test: fresh-literal fixed+rest slices to a tuple, pure-rest widens to an array, pinned to `tsc` 6.0.2.
- Differential matrix (issue rows a–n, `--noEmit --strict --pretty false`) vs `tsc` 6.0.2 — byte-identical, including `Set`/`Map`/generator (which the no-lib unit harness cannot express) and declaration (`.d.ts`) emit for these forms.
- Full checker `--lib` destructuring/binding/param suite — no new failures vs `origin/main` (the 19 pre-existing failures are identical on both, tracked by #15338).
- `cargo clippy -p tsz-checker --tests` — clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019edNHW9iT83fUvNfdnAk6d)_