### PR TITLE
fix(checker): type array-destructuring binding elements from tuple slices and iterated sources

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -464,6 +464,9 @@ path = "tests/tuple_rest_array_canonicalization_tests.rs"
 name = "tuple_rest_destructuring_slice_tests"
 path = "tests/tuple_rest_destructuring_slice_tests.rs"
 [[test]]
+name = "destructuring_binding_element_source_tests"
+path = "tests/destructuring_binding_element_source_tests.rs"
+[[test]]
 name = "nan_equality_lib_symbol_ids_tests"
 path = "tests/nan_equality_lib_symbol_ids_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -786,21 +786,11 @@ impl<'a> CheckerState<'a> {
             {
                 return (t, Vec::new());
             }
+            // Binding element (any nesting depth, object or array pattern)
+            // inside an annotated function parameter.
             if resolved_value_decl.is_some()
-                && let Some(t) = self
-                    .resolve_binding_element_from_annotated_param(resolved_value_decl, escaped_name)
-            {
-                return (t, Vec::new());
-            }
-            // Nested destructure inside an annotated parameter
-            // (e.g. `c` in `function f({ a: { b, c } }: T)`). The single-level
-            // walker above only resolves Identifier → BindingElement → Pattern →
-            // Parameter; nested patterns add another BindingElement layer.
-            if resolved_value_decl.is_some()
-                && let Some(t) = self.resolve_nested_binding_element_from_annotated_param(
-                    resolved_value_decl,
-                    escaped_name,
-                )
+                && let Some(t) =
+                    self.resolve_binding_element_from_annotated_param(resolved_value_decl)
             {
                 return (t, Vec::new());
             }

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
@@ -287,7 +287,7 @@ impl<'a> CheckerState<'a> {
         be_idx: NodeIndex,
         depth: usize,
     ) -> Option<TypeId> {
-        if depth > 24 {
+        if depth > 10 {
             return None;
         }
         let ext = self.ctx.arena.get_extended(be_idx)?;

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
@@ -1,6 +1,6 @@
 use super::computed_helpers_namespace_display::trim_namespace_display_path;
 use crate::context::TypingRequest;
-use crate::query_boundaries::common::{object_shape_for_type, union_members};
+use crate::query_boundaries::common::object_shape_for_type;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::{SymbolId, symbol_flags};
@@ -252,7 +252,6 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn resolve_binding_element_from_annotated_param(
         &mut self,
         value_decl: NodeIndex,
-        name: &str,
     ) -> Option<TypeId> {
         let node = self.ctx.arena.get(value_decl)?;
         if node.kind != SyntaxKind::Identifier as u16 {
@@ -268,223 +267,114 @@ impl<'a> CheckerState<'a> {
         if be_node.kind != syntax_kind_ext::BINDING_ELEMENT {
             return None;
         }
-        let be_data = self.ctx.arena.get_binding_element(be_node)?;
+        self.annotated_param_binding_element_type(be_idx, 0)
+    }
 
-        let ext2 = self.ctx.arena.get_extended(be_idx)?;
-        let pat_idx = ext2.parent;
+    /// Compute the type of a binding element whose pattern chain terminates at
+    /// an annotated parameter, at arbitrary nesting depth
+    /// (`BindingElement` → Pattern → (`BindingElement` | `Parameter`) → ...).
+    ///
+    /// Each level's source type is either the parameter's annotation
+    /// (outermost) or the enclosing binding element's own type (nested), and
+    /// the element type routes through
+    /// `get_binding_element_type_with_request` — the same owner the
+    /// variable-declaration destructuring pass uses — so object properties,
+    /// array positions, tuple rest slices, object rest, and iterated
+    /// (string/`Iterable`) sources all resolve identically to destructured
+    /// variable declarations.
+    fn annotated_param_binding_element_type(
+        &mut self,
+        be_idx: NodeIndex,
+        depth: usize,
+    ) -> Option<TypeId> {
+        if depth > 24 {
+            return None;
+        }
+        let ext = self.ctx.arena.get_extended(be_idx)?;
+        let pat_idx = ext.parent;
         if !pat_idx.is_some() {
             return None;
         }
         let pat_node = self.ctx.arena.get(pat_idx)?;
-        let is_obj = pat_node.kind == syntax_kind_ext::OBJECT_BINDING_PATTERN;
-        let is_arr = pat_node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN;
-        if !is_obj && !is_arr {
+        if pat_node.kind != syntax_kind_ext::OBJECT_BINDING_PATTERN
+            && pat_node.kind != syntax_kind_ext::ARRAY_BINDING_PATTERN
+        {
             return None;
         }
 
-        let ext3 = self.ctx.arena.get_extended(pat_idx)?;
-        let param_idx = ext3.parent;
-        if !param_idx.is_some() {
+        // The pattern's parent is either the annotated parameter (terminal)
+        // or the next enclosing binding element (nested).
+        let ext2 = self.ctx.arena.get_extended(pat_idx)?;
+        let pat_parent_idx = ext2.parent;
+        if !pat_parent_idx.is_some() {
             return None;
         }
-        let param_node = self.ctx.arena.get(param_idx)?;
-        let param = self.ctx.arena.get_parameter(param_node)?;
-        if !param.type_annotation.is_some() {
-            return None;
-        }
-
-        let ann_type = self.get_type_from_type_node(param.type_annotation);
-        if ann_type == TypeId::ANY || ann_type == TypeId::UNKNOWN || ann_type == TypeId::ERROR {
-            return None;
-        }
-
-        let ann_type = self.evaluate_type_for_assignability(ann_type);
-        if is_obj {
-            let prop_name_str = if be_data.property_name.is_some() {
-                self.get_identifier_text_from_idx(be_data.property_name)
-            } else {
-                Some(name.to_string())
-            }?;
-            let prop_atom = self.ctx.types.intern_string(&prop_name_str);
-
-            // Try direct object shape first
-            if let Some(shape) = object_shape_for_type(self.ctx.types, ann_type)
-                && let Some(prop) = shape.properties.iter().find(|p| p.name == prop_atom)
-            {
-                let mut t = prop.type_id;
-                if prop.optional && self.ctx.strict_null_checks() {
-                    t = self.ctx.types.factory().union2(t, TypeId::UNDEFINED);
-                }
-                if be_data.initializer.is_some() && self.ctx.strict_null_checks() {
-                    t = crate::query_boundaries::flow::narrow_destructuring_default(
-                        self.ctx.types,
-                        t,
-                        true,
-                    );
-                }
-                return Some(t);
-            }
-
-            // For union types (e.g., { kind: 'A', payload: number } | { kind: 'B', payload: string }),
-            // collect the property type from each union member and return their union.
-            // This enables correlated narrowing for dependent destructured variables.
-            if let Some(members) = union_members(self.ctx.types, ann_type) {
-                let mut prop_types = Vec::new();
-                for &member in &members {
-                    let evaluated = self.evaluate_type_for_assignability(member);
-                    if let Some(shape) = object_shape_for_type(self.ctx.types, evaluated)
-                        && let Some(prop) = shape.properties.iter().find(|p| p.name == prop_atom)
-                    {
-                        let mut t = prop.type_id;
-                        if prop.optional && self.ctx.strict_null_checks() {
-                            t = self.ctx.types.factory().union2(t, TypeId::UNDEFINED);
-                        }
-                        prop_types.push(t);
-                    }
-                }
-                if !prop_types.is_empty() {
-                    let mut t = tsz_solver::utils::union_or_single(self.ctx.types, prop_types);
-                    if be_data.initializer.is_some() && self.ctx.strict_null_checks() {
-                        t = crate::query_boundaries::flow::narrow_destructuring_default(
-                            self.ctx.types,
-                            t,
-                            true,
-                        );
-                    }
-                    return Some(t);
-                }
-            }
-        }
-
-        None
-    }
-
-    /// Resolve a binding element type when the binding is nested inside another
-    /// binding pattern in an annotated function parameter, e.g. `c` in
-    /// `function f({ a: { b, c } }: { a: { b: number; c?: number } })`.
-    ///
-    /// `resolve_binding_element_from_annotated_param` only handles one level
-    /// of destructure (Identifier → `BindingElement` → Pattern → Parameter).
-    /// Anything deeper has a `Pattern → BindingElement → Pattern → ...` chain
-    /// that the single-level walker rejects.  This helper walks the chain
-    /// of arbitrary depth, collects the property-name path from innermost
-    /// out to the parameter, then applies the path against the parameter's
-    /// annotation.  At each step it propagates `| undefined` for optional
-    /// properties and strips it for any binding-element default.
-    pub(crate) fn resolve_nested_binding_element_from_annotated_param(
-        &mut self,
-        value_decl: NodeIndex,
-        name: &str,
-    ) -> Option<TypeId> {
-        let node = self.ctx.arena.get(value_decl)?;
-        if node.kind != SyntaxKind::Identifier as u16 {
-            return None;
-        }
-
-        // Walk: Identifier → BindingElement → Pattern → (BindingElement|Parameter) → ...
-        // Collect (property_name, has_initializer) from innermost outward.
-        let mut path: Vec<(String, bool)> = Vec::new();
-        let mut current = value_decl;
-        let param_idx = loop {
-            let ext = self.ctx.arena.get_extended(current)?;
-            let parent_idx = ext.parent;
-            if !parent_idx.is_some() {
+        let pat_parent_node = self.ctx.arena.get(pat_parent_idx)?;
+        let source_type = if pat_parent_node.kind == syntax_kind_ext::PARAMETER {
+            let param = self.ctx.arena.get_parameter(pat_parent_node)?;
+            if param.name != pat_idx {
                 return None;
             }
-            let parent_node = self.ctx.arena.get(parent_idx)?;
-            if parent_node.kind != syntax_kind_ext::BINDING_ELEMENT {
-                return None;
-            }
-            let be_data = self.ctx.arena.get_binding_element(parent_node)?;
-            // Property name resolution:
-            //   - explicit property_name (`{ a: {b, c} }` outer element has property_name="a")
-            //   - else: shorthand with `name` ident (`{ b, c }` inner element has no
-            //     property_name; the property name equals the binding identifier)
-            let prop_name_str = if be_data.property_name.is_some() {
-                self.get_identifier_text_from_idx(be_data.property_name)?
-            } else if path.is_empty() {
-                // Innermost: caller provided the binding identifier text as `name`.
-                name.to_string()
+            // The pattern's source is the annotation, or the default
+            // initializer's type when the parameter is unannotated
+            // (`function k([a, ...r] = [1, 'x'] as [number, string])`).
+            // The initializer is typed under the pattern's contextual type so
+            // a fresh array literal infers as a tuple, exactly like a
+            // destructured variable declaration's initializer.
+            let src = if param.type_annotation.is_some() {
+                self.get_type_from_type_node(param.type_annotation)
+            } else if param.initializer.is_some() {
+                let init_request = self.declaration_pattern_initializer_request(
+                    pat_idx,
+                    param.initializer,
+                    &TypingRequest::NONE,
+                );
+                self.get_type_of_node_with_request(param.initializer, &init_request)
             } else {
-                // Shorthand with no explicit property_name where `name` is itself a
-                // sub-pattern. This shape can't occur in valid TS at outer levels,
-                // so bail rather than guess.
                 return None;
             };
-            path.push((prop_name_str, be_data.initializer.is_some()));
-            // Advance past BindingElement to the enclosing Pattern.
-            let ext2 = self.ctx.arena.get_extended(parent_idx)?;
-            let pat_idx = ext2.parent;
-            if !pat_idx.is_some() {
+            if src == TypeId::ANY || src == TypeId::UNKNOWN || src == TypeId::ERROR {
                 return None;
             }
-            let pat_node = self.ctx.arena.get(pat_idx)?;
-            if pat_node.kind != syntax_kind_ext::OBJECT_BINDING_PATTERN
-                && pat_node.kind != syntax_kind_ext::ARRAY_BINDING_PATTERN
-            {
-                return None;
-            }
-            // Pattern's parent is either the next BindingElement (nested) or a
-            // Parameter (terminal). Anything else means this is not a parameter
-            // binding chain (e.g. variable declaration destructuring).
-            let ext3 = self.ctx.arena.get_extended(pat_idx)?;
-            let pat_parent_idx = ext3.parent;
-            if !pat_parent_idx.is_some() {
-                return None;
-            }
-            let pat_parent_node = self.ctx.arena.get(pat_parent_idx)?;
-            if pat_parent_node.kind == syntax_kind_ext::PARAMETER {
-                break pat_parent_idx;
-            }
-            if pat_parent_node.kind != syntax_kind_ext::BINDING_ELEMENT {
-                return None;
-            }
-            // Continue walking from the pattern; next iteration's
-            // get_extended(current).parent will yield the outer BindingElement.
-            current = pat_idx;
+            self.evaluate_type_for_assignability(src)
+        } else if pat_parent_node.kind == syntax_kind_ext::BINDING_ELEMENT {
+            self.annotated_param_binding_element_type(pat_parent_idx, depth + 1)?
+        } else {
+            return None;
         };
 
-        // We need at least 2 levels of path entries to be meaningfully "nested";
-        // single-level cases are handled by the existing
-        // `resolve_binding_element_from_annotated_param`.
-        if path.len() < 2 {
-            return None;
-        }
+        let pattern_data = self.ctx.arena.get_binding_pattern(pat_node)?;
+        let element_index = pattern_data
+            .elements
+            .nodes
+            .iter()
+            .position(|&elem| elem == be_idx)?;
+        let be_node = self.ctx.arena.get(be_idx)?;
+        let be_data = self.ctx.arena.get_binding_element(be_node)?;
 
-        // Resolve the parameter annotation type.
-        let param_node = self.ctx.arena.get(param_idx)?;
-        let param = self.ctx.arena.get_parameter(param_node)?;
-        if !param.type_annotation.is_some() {
+        // Carry the source as the contextual type: the parameter binding
+        // pattern has a typed source here, so untyped-parameter gates
+        // (e.g. object rest falling back to `any`) must not fire.
+        let request = TypingRequest::with_contextual_type(source_type);
+        let mut t = self.get_binding_element_type_with_request(
+            pat_idx,
+            element_index,
+            source_type,
+            be_data,
+            &request,
+        );
+        if t == TypeId::ERROR {
             return None;
         }
-        let ann_type = self.get_type_from_type_node(param.type_annotation);
-        if ann_type == TypeId::ANY || ann_type == TypeId::UNKNOWN || ann_type == TypeId::ERROR {
-            return None;
+        // A default initializer guarantees the binding is not undefined.
+        if be_data.initializer.is_some() && self.ctx.strict_null_checks() {
+            t = crate::query_boundaries::flow::narrow_destructuring_default(
+                self.ctx.types,
+                t,
+                true,
+            );
         }
-
-        // Walk the property-name path outermost-first against the annotation,
-        // propagating optional `| undefined` for `?:` properties and stripping
-        // it for elements that have a default initializer.
-        let strict = self.ctx.strict_null_checks();
-        let mut current_type = self.evaluate_type_for_assignability(ann_type);
-        for (prop_name, has_init) in path.iter().rev() {
-            let prop_atom = self.ctx.types.intern_string(prop_name);
-            let shape = object_shape_for_type(self.ctx.types, current_type)?;
-            let prop = shape.properties.iter().find(|p| p.name == prop_atom)?;
-            let mut t = prop.type_id;
-            if prop.optional && strict {
-                t = self.ctx.types.factory().union2(t, TypeId::UNDEFINED);
-            }
-            if *has_init && strict {
-                t = crate::query_boundaries::flow::narrow_destructuring_default(
-                    self.ctx.types,
-                    t,
-                    true,
-                );
-            }
-            current_type = self.evaluate_type_for_assignability(t);
-        }
-        Some(current_type)
+        Some(t)
     }
 
     /// Compute the type of a class symbol.

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
@@ -287,7 +287,10 @@ impl<'a> CheckerState<'a> {
         be_idx: NodeIndex,
         depth: usize,
     ) -> Option<TypeId> {
-        if depth > 10 {
+        // The walk terminates at the parameter on well-formed arenas; this is
+        // a stack-safety net for malformed parent chains, not a semantic cap.
+        const MAX_BINDING_PATTERN_NESTING: usize = 10;
+        if depth > MAX_BINDING_PATTERN_NESTING {
             return None;
         }
         let ext = self.ctx.arena.get_extended(be_idx)?;

--- a/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
+++ b/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
@@ -406,25 +406,19 @@ impl<'a> CheckerState<'a> {
         parent_type: TypeId,
         rest_index: usize,
     ) -> TypeId {
-        // Resolve each member's tuple elements once. A plain array member (or a
-        // non-array-like member) makes the union not all-tuple, so we stop and
-        // fall back to the single-array form.
+        // Classify each member once: collect tuple elements, and note plain
+        // arrays and non-array-like members (string, `Iterable<T>`, `Set`, ...).
         let mut member_elements: Vec<Vec<TupleElement>> = Vec::with_capacity(members.len());
-        let mut every_tuple = true;
+        let mut saw_non_array_like = false;
         for &member in members {
             let member = query::unwrap_readonly_deep(self.ctx.types, member);
-            if query::array_element_type(self.ctx.types, member).is_some() {
-                every_tuple = false;
-                break;
-            }
             if let Some(elems) = query::tuple_elements(self.ctx.types, member) {
                 member_elements.push(elems);
-            } else {
-                every_tuple = false;
-                break;
+            } else if query::array_element_type(self.ctx.types, member).is_none() {
+                saw_non_array_like = true;
             }
         }
-        if every_tuple {
+        if member_elements.len() == members.len() {
             let slices: Vec<TypeId> = member_elements
                 .iter()
                 .map(|elems| self.tuple_rest_binding_type(elems, rest_index))
@@ -435,16 +429,12 @@ impl<'a> CheckerState<'a> {
                 self.ctx.types.factory().union(slices)
             };
         }
-        // Members that are all array-like distribute numeric indexed access;
-        // a non-array-like member (string, `Iterable<T>`, `Set`, ...) switches
-        // the whole union to its iterated element type, mirroring tsc's
-        // `checkIteratedTypeOrElementType`.
-        let every_member_array_like = members.iter().all(|&member| {
-            let member = query::unwrap_readonly_deep(self.ctx.types, member);
-            query::array_element_type(self.ctx.types, member).is_some()
-                || query::tuple_elements(self.ctx.types, member).is_some()
-        });
-        if !every_member_array_like {
+        // All-array-like members distribute numeric indexed access; a
+        // non-array-like member switches the whole union to its iterated
+        // element type, mirroring tsc's `checkIteratedTypeOrElementType`.
+        // ANY/ERROR mean the union could not be iterated, so keep the
+        // indexed-access fallback.
+        if saw_non_array_like {
             let iterated = self.for_of_element_type(parent_type, false);
             if iterated != TypeId::ANY && iterated != TypeId::ERROR {
                 return self.ctx.types.factory().array(iterated);

--- a/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
+++ b/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
@@ -409,16 +409,20 @@ impl<'a> CheckerState<'a> {
         // Classify each member once: collect tuple elements, and note plain
         // arrays and non-array-like members (string, `Iterable<T>`, `Set`, ...).
         let mut member_elements: Vec<Vec<TupleElement>> = Vec::with_capacity(members.len());
+        let mut every_tuple = true;
         let mut saw_non_array_like = false;
         for &member in members {
             let member = query::unwrap_readonly_deep(self.ctx.types, member);
             if let Some(elems) = query::tuple_elements(self.ctx.types, member) {
                 member_elements.push(elems);
-            } else if query::array_element_type(self.ctx.types, member).is_none() {
-                saw_non_array_like = true;
+            } else {
+                every_tuple = false;
+                if query::array_element_type(self.ctx.types, member).is_none() {
+                    saw_non_array_like = true;
+                }
             }
         }
-        if member_elements.len() == members.len() {
+        if every_tuple {
             let slices: Vec<TypeId> = member_elements
                 .iter()
                 .map(|elems| self.tuple_rest_binding_type(elems, rest_index))

--- a/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
+++ b/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
@@ -435,6 +435,21 @@ impl<'a> CheckerState<'a> {
                 self.ctx.types.factory().union(slices)
             };
         }
+        // Members that are all array-like distribute numeric indexed access;
+        // a non-array-like member (string, `Iterable<T>`, `Set`, ...) switches
+        // the whole union to its iterated element type, mirroring tsc's
+        // `checkIteratedTypeOrElementType`.
+        let every_member_array_like = members.iter().all(|&member| {
+            let member = query::unwrap_readonly_deep(self.ctx.types, member);
+            query::array_element_type(self.ctx.types, member).is_some()
+                || query::tuple_elements(self.ctx.types, member).is_some()
+        });
+        if !every_member_array_like {
+            let iterated = self.for_of_element_type(parent_type, false);
+            if iterated != TypeId::ANY && iterated != TypeId::ERROR {
+                return self.ctx.types.factory().array(iterated);
+            }
+        }
         let element_type = self.get_element_access_type(parent_type, TypeId::NUMBER, None);
         self.ctx.types.factory().array(element_type)
     }

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -110,7 +110,7 @@ impl<'a> CheckerState<'a> {
             })
     }
 
-    pub(super) fn declaration_pattern_initializer_request(
+    pub(crate) fn declaration_pattern_initializer_request(
         &mut self,
         pattern_idx: NodeIndex,
         initializer_idx: NodeIndex,

--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -697,22 +697,8 @@ impl<'a> CheckerState<'a> {
                 if element_data.dot_dot_dot_token {
                     return self.union_rest_binding_type(&members, parent_type, element_index);
                 }
-                // When some member is not array-like (string, `Iterable<T>`,
-                // `Set`, ...), tsc types every position from the iterated
-                // element type of the whole union rather than distributing
-                // indexed access over the members.
-                let every_member_array_like = members.iter().all(|&member| {
-                    let member = query::unwrap_readonly_deep(self.ctx.types, member);
-                    query::array_element_type(self.ctx.types, member).is_some()
-                        || query::tuple_elements(self.ctx.types, member).is_some()
-                });
-                if !every_member_array_like {
-                    let iterated = self.for_of_element_type(parent_type, false);
-                    if iterated != TypeId::ANY && iterated != TypeId::ERROR {
-                        return iterated;
-                    }
-                }
                 let mut elem_types = Vec::new();
+                let mut saw_non_array_like = false;
                 let factory = self.ctx.types.factory();
                 for &member in &members {
                     let member = query::unwrap_readonly_deep(self.ctx.types, member);
@@ -743,6 +729,19 @@ impl<'a> CheckerState<'a> {
                                 elem_types.push(elem);
                             }
                         }
+                    } else {
+                        saw_non_array_like = true;
+                    }
+                }
+                // When some member is not array-like (string, `Iterable<T>`,
+                // `Set`, ...), tsc types every position from the iterated
+                // element type of the whole union rather than distributing
+                // indexed access over the members. ANY/ERROR mean the union
+                // could not be iterated, so keep the distributed result.
+                if saw_non_array_like {
+                    let iterated = self.for_of_element_type(parent_type, false);
+                    if iterated != TypeId::ANY && iterated != TypeId::ERROR {
+                        return iterated;
                     }
                 }
                 if elem_types.is_empty() {
@@ -806,6 +805,8 @@ impl<'a> CheckerState<'a> {
                 // Non-array-like iterable sources (string, `Iterable<T>`,
                 // `Map`, generators) bind an array of the iterated element
                 // type, mirroring tsc's `checkIteratedTypeOrElementType`.
+                // Unlike the union paths there is no better fallback here, so
+                // an ANY result flows through as `any[]`.
                 let iterated = self.for_of_element_type(array_like, false);
                 if iterated == TypeId::ERROR {
                     return self.rest_binding_array_type(TypeId::ANY);
@@ -930,6 +931,8 @@ impl<'a> CheckerState<'a> {
                 // Non-array-like iterable sources (string, `Iterable<T>`,
                 // `Map`, generators) bind the iterated element type at every
                 // position, mirroring tsc's `checkIteratedTypeOrElementType`.
+                // Unlike the union paths there is no better fallback here, so
+                // an ANY result flows through unchanged.
                 let iterated = self.for_of_element_type(array_like, false);
                 if iterated == TypeId::ERROR {
                     TypeId::ANY

--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -347,19 +347,13 @@ impl<'a> CheckerState<'a> {
     /// Returns `true` when an array binding pattern's destructuring source is a
     /// fresh array-literal initializer (`var [a, ...rest] = [1, 2, 3]`).
     ///
-    /// tsc slices every tuple source for a `...rest` element
-    /// (`sliceTupleType`), but it slices the *widened* literal tuple, so the
-    /// slice of `[1, 'x', true]` is `[string, boolean]`. tsz keeps the
-    /// un-widened literal tuple as the destructuring source (for positional
-    /// `const` literal-default precision, e.g. `const [first = 0] = [10, 20]`
-    /// → `0 | 10`), so the rest path detects the fresh-literal origin and
-    /// widens the slice, while declared and `as const` tuple sources slice
-    /// as-is.
+    /// tsz keeps fresh array literals as un-widened literal tuples, so the
+    /// rest-binding path uses this to decide widening (see the call site).
     ///
     /// Walks up through nested binding patterns/elements to the enclosing
     /// `VARIABLE_DECLARATION`. A `[...] as const` initializer is an
-    /// `AS_EXPRESSION` (not an `ARRAY_LITERAL_EXPRESSION`), so it slices
-    /// as-is; parameter sources (annotated tuple types) are never fresh.
+    /// `AS_EXPRESSION` (not an `ARRAY_LITERAL_EXPRESSION`), so it is not
+    /// fresh; parameter sources (annotated tuple types) are never fresh.
     pub(crate) fn array_binding_source_is_fresh_array_literal(
         &self,
         pattern_idx: NodeIndex,
@@ -805,8 +799,6 @@ impl<'a> CheckerState<'a> {
                 // Non-array-like iterable sources (string, `Iterable<T>`,
                 // `Map`, generators) bind an array of the iterated element
                 // type, mirroring tsc's `checkIteratedTypeOrElementType`.
-                // Unlike the union paths there is no better fallback here, so
-                // an ANY result flows through as `any[]`.
                 let iterated = self.for_of_element_type(array_like, false);
                 if iterated == TypeId::ERROR {
                     return self.rest_binding_array_type(TypeId::ANY);
@@ -931,8 +923,6 @@ impl<'a> CheckerState<'a> {
                 // Non-array-like iterable sources (string, `Iterable<T>`,
                 // `Map`, generators) bind the iterated element type at every
                 // position, mirroring tsc's `checkIteratedTypeOrElementType`.
-                // Unlike the union paths there is no better fallback here, so
-                // an ANY result flows through unchanged.
                 let iterated = self.for_of_element_type(array_like, false);
                 if iterated == TypeId::ERROR {
                     TypeId::ANY

--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -347,19 +347,19 @@ impl<'a> CheckerState<'a> {
     /// Returns `true` when an array binding pattern's destructuring source is a
     /// fresh array-literal initializer (`var [a, ...rest] = [1, 2, 3]`).
     ///
-    /// tsc widens a fresh array literal to `ElementType[]` via
-    /// `getWidenedTypeForVariableLikeDeclaration`, so a `...rest` element binds
-    /// `createArrayType(elementType)` — *not* the residual tuple slice. tsz
-    /// keeps the un-widened literal tuple as the destructuring source (for
-    /// positional `const` literal-default precision, e.g. `const [first = 0] =
-    /// [10, 20]`), so the rest path detects the fresh-literal origin and widens,
-    /// while declared and `as const` tuple sources keep slicing
-    /// (`sliceTupleType`).
+    /// tsc slices every tuple source for a `...rest` element
+    /// (`sliceTupleType`), but it slices the *widened* literal tuple, so the
+    /// slice of `[1, 'x', true]` is `[string, boolean]`. tsz keeps the
+    /// un-widened literal tuple as the destructuring source (for positional
+    /// `const` literal-default precision, e.g. `const [first = 0] = [10, 20]`
+    /// → `0 | 10`), so the rest path detects the fresh-literal origin and
+    /// widens the slice, while declared and `as const` tuple sources slice
+    /// as-is.
     ///
     /// Walks up through nested binding patterns/elements to the enclosing
     /// `VARIABLE_DECLARATION`. A `[...] as const` initializer is an
-    /// `AS_EXPRESSION` (not an `ARRAY_LITERAL_EXPRESSION`), so it keeps slicing;
-    /// parameter sources (annotated tuple types) are never fresh.
+    /// `AS_EXPRESSION` (not an `ARRAY_LITERAL_EXPRESSION`), so it slices
+    /// as-is; parameter sources (annotated tuple types) are never fresh.
     pub(crate) fn array_binding_source_is_fresh_array_literal(
         &self,
         pattern_idx: NodeIndex,
@@ -697,6 +697,21 @@ impl<'a> CheckerState<'a> {
                 if element_data.dot_dot_dot_token {
                     return self.union_rest_binding_type(&members, parent_type, element_index);
                 }
+                // When some member is not array-like (string, `Iterable<T>`,
+                // `Set`, ...), tsc types every position from the iterated
+                // element type of the whole union rather than distributing
+                // indexed access over the members.
+                let every_member_array_like = members.iter().all(|&member| {
+                    let member = query::unwrap_readonly_deep(self.ctx.types, member);
+                    query::array_element_type(self.ctx.types, member).is_some()
+                        || query::tuple_elements(self.ctx.types, member).is_some()
+                });
+                if !every_member_array_like {
+                    let iterated = self.for_of_element_type(parent_type, false);
+                    if iterated != TypeId::ANY && iterated != TypeId::ERROR {
+                        return iterated;
+                    }
+                }
                 let mut elem_types = Vec::new();
                 let factory = self.ctx.types.factory();
                 for &member in &members {
@@ -769,18 +784,33 @@ impl<'a> CheckerState<'a> {
                     // Array source `E[]` → `E[]`.
                     return self.rest_binding_array_type(elem);
                 } else if let Some(elems) = query::tuple_elements(self.ctx.types, array_like) {
-                    // A fresh array-literal source is widened by tsc to
-                    // `createArrayType(elementType)` (it is `E[]`, not a tuple,
-                    // at the destructuring site), so the rest binds the element
-                    // array. Declared / `as const` tuple sources slice the
-                    // residual, matching tsc's `sliceTupleType`.
-                    if self.array_binding_source_is_fresh_array_literal(pattern_idx) {
+                    // Tuple sources slice the residual, matching tsc's
+                    // `sliceTupleType`. Two fresh array-literal adjustments:
+                    // a leading rest (`[...r] = [0, 1]`) never puts the
+                    // literal in tuple context, so it binds the widened
+                    // element array; and a trailing rest slices the
+                    // *widened* literal tuple (tsz keeps unwidened literal
+                    // elements for positional `const` literal-default
+                    // precision, e.g. `const [first = 0] = [10, 20]` → `0 | 10`).
+                    let is_fresh = self.array_binding_source_is_fresh_array_literal(pattern_idx);
+                    if is_fresh && element_index == 0 {
                         let elem = self.get_element_access_type(array_like, TypeId::NUMBER, None);
                         return self.rest_binding_array_type(elem);
                     }
-                    return self.tuple_rest_binding_type(&elems, element_index);
+                    let sliced = self.tuple_rest_binding_type(&elems, element_index);
+                    if is_fresh {
+                        return self.widen_initializer_type_for_mutable_binding(sliced);
+                    }
+                    return sliced;
                 }
-                return self.rest_binding_array_type(TypeId::ANY);
+                // Non-array-like iterable sources (string, `Iterable<T>`,
+                // `Map`, generators) bind an array of the iterated element
+                // type, mirroring tsc's `checkIteratedTypeOrElementType`.
+                let iterated = self.for_of_element_type(array_like, false);
+                if iterated == TypeId::ERROR {
+                    return self.rest_binding_array_type(TypeId::ANY);
+                }
+                return self.rest_binding_array_type(iterated);
             }
 
             return if let Some(elem) = query::array_element_type(self.ctx.types, array_like) {
@@ -897,7 +927,15 @@ impl<'a> CheckerState<'a> {
                     TypeId::ANY
                 }
             } else {
-                TypeId::ANY
+                // Non-array-like iterable sources (string, `Iterable<T>`,
+                // `Map`, generators) bind the iterated element type at every
+                // position, mirroring tsc's `checkIteratedTypeOrElementType`.
+                let iterated = self.for_of_element_type(array_like, false);
+                if iterated == TypeId::ERROR {
+                    TypeId::ANY
+                } else {
+                    iterated
+                }
             };
         }
 

--- a/crates/tsz-checker/tests/destructuring_binding_element_source_tests.rs
+++ b/crates/tsz-checker/tests/destructuring_binding_element_source_tests.rs
@@ -12,6 +12,8 @@
 //! All expectations are pinned against `tsc` 6.0.2. Binder names vary across
 //! cases so the behaviour is structural, not name-driven.
 
+use std::sync::{Arc, OnceLock};
+use tsz_binder::lib_loader::LibFile;
 use tsz_checker::CheckerOptions;
 use tsz_checker::test_utils::{
     check_source_diagnostics, check_source_with_libs_code_messages, load_default_lib_files,
@@ -35,8 +37,9 @@ fn messages_2322(source: &str) -> Vec<String> {
 /// TS2322 messages with the default lib loaded, for sources that need
 /// `Iterable` / `Set` / `Map` / generator types to resolve.
 fn lib_messages_2322(source: &str) -> Vec<String> {
-    let lib_files = load_default_lib_files();
-    check_source_with_libs_code_messages(source, "test.ts", CheckerOptions::default(), &lib_files)
+    static LIBS: OnceLock<Vec<Arc<LibFile>>> = OnceLock::new();
+    let lib_files = LIBS.get_or_init(load_default_lib_files);
+    check_source_with_libs_code_messages(source, "test.ts", CheckerOptions::default(), lib_files)
         .into_iter()
         .filter(|(code, _)| *code == 2322)
         .map(|(_, message)| message)
@@ -114,10 +117,10 @@ const fn = ([alpha, ...omega]: [number, string]) => {
   const wrong: boolean = omega[0];
 };
 "#;
+    let arrow_codes = codes(arrow);
     assert!(
-        codes(arrow).contains(&2322),
-        "arrow param rest element is string; got {:?}",
-        codes(arrow)
+        arrow_codes.contains(&2322),
+        "arrow param rest element is string; got {arrow_codes:?}"
     );
 
     let method = r#"
@@ -127,10 +130,10 @@ class Holder {
   }
 }
 "#;
+    let method_codes = codes(method);
     assert!(
-        codes(method).contains(&2322),
-        "method param rest element is string; got {:?}",
-        codes(method)
+        method_codes.contains(&2322),
+        "method param rest element is string; got {method_codes:?}"
     );
 
     let object_literal_method = r#"
@@ -140,10 +143,10 @@ const bag = {
   },
 };
 "#;
+    let method_prop_codes = codes(object_literal_method);
     assert!(
-        codes(object_literal_method).contains(&2322),
-        "object-literal method param rest element is string; got {:?}",
-        codes(object_literal_method)
+        method_prop_codes.contains(&2322),
+        "object-literal method param rest element is string; got {method_prop_codes:?}"
     );
 }
 
@@ -214,10 +217,10 @@ function withLiteral([lo, ...hi] = [1, "x"]) {
   const wrong: boolean = lo;
 }
 "#;
+    let literal_codes = codes(literal_form);
     assert!(
-        codes(literal_form).contains(&2322),
-        "fresh-literal default binds lo: number; got {:?}",
-        codes(literal_form)
+        literal_codes.contains(&2322),
+        "fresh-literal default binds lo: number; got {literal_codes:?}"
     );
 }
 
@@ -231,10 +234,10 @@ fn string_source_binds_string_elements() {
 const [ch] = "hi";
 const wrong: boolean = ch;
 "#;
+    let positional_codes = codes(positional);
     assert!(
-        codes(positional).contains(&2322),
-        "string positional element is string; got {:?}",
-        codes(positional)
+        positional_codes.contains(&2322),
+        "string positional element is string; got {positional_codes:?}"
     );
 
     let rest = r#"
@@ -255,24 +258,20 @@ declare const nums: Iterable<number>;
 const [...gathered] = nums;
 const show: "X" = gathered;
 "#;
+    let iterable_msgs = lib_messages_2322(iterable);
     assert!(
-        lib_messages_2322(iterable)
-            .iter()
-            .any(|m| m.contains("number[]")),
-        "Iterable<number> rest binds number[]; got {:?}",
-        lib_messages_2322(iterable)
+        iterable_msgs.iter().any(|m| m.contains("number[]")),
+        "Iterable<number> rest binds number[]; got {iterable_msgs:?}"
     );
 
     let set = r#"
 const [...uniques] = new Set([1, 2]);
 const show: "X" = uniques;
 "#;
+    let set_msgs = lib_messages_2322(set);
     assert!(
-        lib_messages_2322(set)
-            .iter()
-            .any(|m| m.contains("number[]")),
-        "Set<number> rest binds number[]; got {:?}",
-        lib_messages_2322(set)
+        set_msgs.iter().any(|m| m.contains("number[]")),
+        "Set<number> rest binds number[]; got {set_msgs:?}"
     );
 
     let map = r#"
@@ -280,12 +279,10 @@ declare const table: Map<string, number>;
 const [...entries] = table;
 const show: "X" = entries;
 "#;
+    let map_msgs = lib_messages_2322(map);
     assert!(
-        lib_messages_2322(map)
-            .iter()
-            .any(|m| m.contains("[string, number][]")),
-        "Map rest binds [string, number][]; got {:?}",
-        lib_messages_2322(map)
+        map_msgs.iter().any(|m| m.contains("[string, number][]")),
+        "Map rest binds [string, number][]; got {map_msgs:?}"
     );
 
     let generator = r#"
@@ -293,12 +290,10 @@ function* words() { yield "a"; }
 const [...taken] = words();
 const show: "X" = taken;
 "#;
+    let generator_msgs = lib_messages_2322(generator);
     assert!(
-        lib_messages_2322(generator)
-            .iter()
-            .any(|m| m.contains("string[]")),
-        "generator rest binds string[]; got {:?}",
-        lib_messages_2322(generator)
+        generator_msgs.iter().any(|m| m.contains("string[]")),
+        "generator rest binds string[]; got {generator_msgs:?}"
     );
 }
 
@@ -369,21 +364,21 @@ declare const trio: [number, string, boolean];
 const [x, ...xs] = trio;
 const show: "X" = xs;
 "#;
+    let declared_msgs = messages_2322(declared);
     assert!(
-        messages_2322(declared)
+        declared_msgs
             .iter()
             .any(|m| m.contains("[string, boolean]")),
-        "declared tuple rest still slices; got {:?}",
-        messages_2322(declared)
+        "declared tuple rest still slices; got {declared_msgs:?}"
     );
 
     let as_const = r#"
 const [y, ...ys] = [1, "x"] as const;
 const show: "X" = ys;
 "#;
+    let as_const_msgs = messages_2322(as_const);
     assert!(
-        messages_2322(as_const).iter().any(|m| m.contains("\"x\"")),
-        "as-const rest keeps literal slice elements; got {:?}",
-        messages_2322(as_const)
+        as_const_msgs.iter().any(|m| m.contains("\"x\"")),
+        "as-const rest keeps literal slice elements; got {as_const_msgs:?}"
     );
 }

--- a/crates/tsz-checker/tests/destructuring_binding_element_source_tests.rs
+++ b/crates/tsz-checker/tests/destructuring_binding_element_source_tests.rs
@@ -1,0 +1,389 @@
+//! Binding-element types from annotated parameters and iterated sources.
+//!
+//! tsc's `getBindingElementTypeFromParentType` types every element of an
+//! array binding pattern from the pattern's source: tuple sources index
+//! positionally and slice for rest (`sliceTupleType`); non-array-like
+//! iterable sources (string, `Iterable<T>`, `Map`, generators) use the
+//! destructuring-iterated element type; a union with a non-array-like member
+//! switches every position to the iterated element type of the whole union.
+//! The same rules apply to annotated function parameters, which previously
+//! bound `any` for array-pattern elements and object rest.
+//!
+//! All expectations are pinned against `tsc` 6.0.2. Binder names vary across
+//! cases so the behaviour is structural, not name-driven.
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{
+    check_source_diagnostics, check_source_with_libs_code_messages, load_default_lib_files,
+};
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn messages_2322(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+/// TS2322 messages with the default lib loaded, for sources that need
+/// `Iterable` / `Set` / `Map` / generator types to resolve.
+fn lib_messages_2322(source: &str) -> Vec<String> {
+    let lib_files = load_default_lib_files();
+    check_source_with_libs_code_messages(source, "test.ts", CheckerOptions::default(), &lib_files)
+        .into_iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, message)| message)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Annotated parameters: array patterns
+// ---------------------------------------------------------------------------
+
+#[test]
+fn annotated_param_array_pattern_positional_element_is_typed() {
+    // Previously `lead` bound `any`, silently accepting any assignment.
+    let source = r#"
+function pick([lead, second]: [number, string]) {
+  const wrong: boolean = lead;
+  const alsoWrong: boolean = second;
+}
+"#;
+    let cs = codes(source);
+    assert!(
+        cs.iter().filter(|&&c| c == 2322).count() == 2,
+        "annotated param array elements are number/string, not any; got {cs:?}"
+    );
+}
+
+#[test]
+fn annotated_param_array_rest_slices_the_tuple() {
+    let source = r#"
+function grab([head, ...tail]: [number, string, boolean]) {
+  const show: "X" = tail;
+}
+"#;
+    let msgs = messages_2322(source);
+    assert!(
+        msgs.iter().any(|m| m.contains("[string, boolean]")),
+        "annotated param rest slices to [string, boolean]; got {msgs:?}"
+    );
+}
+
+#[test]
+fn annotated_param_readonly_tuple_rest_slices() {
+    let source = r#"
+function fromRo([one, ...more]: readonly [number, string, boolean]) {
+  const show: "X" = more;
+}
+"#;
+    let msgs = messages_2322(source);
+    assert!(
+        msgs.iter().any(|m| m.contains("[string, boolean]")),
+        "readonly tuple param rest slices to a mutable [string, boolean]; got {msgs:?}"
+    );
+}
+
+#[test]
+fn rest_parameter_tuple_pattern_rest_binds_array_form() {
+    // `...[first, ...remaining]: [number, ...string[]]` binds `string[]`.
+    let source = r#"
+function spreadForm(...[first, ...remaining]: [number, ...string[]]) {
+  const wrong: boolean = remaining[0];
+  const alsoWrong: boolean = first;
+}
+"#;
+    let cs = codes(source);
+    assert!(
+        cs.iter().filter(|&&c| c == 2322).count() == 2,
+        "rest-parameter tuple pattern binds string[]/number; got {cs:?}"
+    );
+}
+
+#[test]
+fn annotated_arrow_and_method_param_patterns_are_typed() {
+    let arrow = r#"
+const fn = ([alpha, ...omega]: [number, string]) => {
+  const wrong: boolean = omega[0];
+};
+"#;
+    assert!(
+        codes(arrow).contains(&2322),
+        "arrow param rest element is string; got {:?}",
+        codes(arrow)
+    );
+
+    let method = r#"
+class Holder {
+  consume([x, ...ys]: [number, string]) {
+    const wrong: boolean = ys[0];
+  }
+}
+"#;
+    assert!(
+        codes(method).contains(&2322),
+        "method param rest element is string; got {:?}",
+        codes(method)
+    );
+
+    let object_literal_method = r#"
+const bag = {
+  eat([p, ...qs]: [number, string]) {
+    const wrong: boolean = qs[0];
+  },
+};
+"#;
+    assert!(
+        codes(object_literal_method).contains(&2322),
+        "object-literal method param rest element is string; got {:?}",
+        codes(object_literal_method)
+    );
+}
+
+#[test]
+fn annotated_param_object_rest_omits_named_siblings() {
+    // Previously `remainder` bound `any`.
+    let source = r#"
+function strip({ keep, ...remainder }: { keep: number; other: string }) {
+  const show: "X" = remainder;
+}
+"#;
+    let msgs = messages_2322(source);
+    assert!(
+        msgs.iter().any(|m| m.contains("{ other: string; }")),
+        "annotated param object rest is {{ other: string; }}; got {msgs:?}"
+    );
+}
+
+#[test]
+fn annotated_param_nested_array_in_object_pattern_is_typed() {
+    // Nested chains previously resolved only pure object paths.
+    let source = r#"
+function nest({ inner: [count, ...labels] }: { inner: [number, string, string] }) {
+  const wrong: boolean = count;
+  const alsoWrong: boolean = labels[0];
+}
+"#;
+    let cs = codes(source);
+    assert!(
+        cs.iter().filter(|&&c| c == 2322).count() == 2,
+        "nested array pattern under object pattern is typed; got {cs:?}"
+    );
+}
+
+#[test]
+fn unannotated_param_pattern_stays_implicit_any() {
+    // Negative control: no annotation and no contextual type still reports
+    // implicit-any (TS7031), and must not invent element types.
+    let source = r#"
+function loose([a, ...rest]) {
+  return rest;
+}
+"#;
+    let cs = codes(source);
+    assert!(
+        cs.contains(&7031),
+        "unannotated pattern elements stay implicitly any (TS7031); got {cs:?}"
+    );
+}
+
+#[test]
+fn param_default_initializer_types_the_pattern() {
+    // Unannotated parameter with a default: the pattern's source is the
+    // initializer's type, and a fresh literal infers as a tuple.
+    let cast_form = r#"
+function withCast([lo, ...hi] = [1, "x"] as [number, string]) {
+  const show: "X" = hi;
+}
+"#;
+    let msgs = messages_2322(cast_form);
+    assert!(
+        msgs.iter().any(|m| m.contains("[string]")),
+        "cast default slices to [string]; got {msgs:?}"
+    );
+
+    let literal_form = r#"
+function withLiteral([lo, ...hi] = [1, "x"]) {
+  const wrong: boolean = lo;
+}
+"#;
+    assert!(
+        codes(literal_form).contains(&2322),
+        "fresh-literal default binds lo: number; got {:?}",
+        codes(literal_form)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Iterated (non-array-like) sources
+// ---------------------------------------------------------------------------
+
+#[test]
+fn string_source_binds_string_elements() {
+    let positional = r#"
+const [ch] = "hi";
+const wrong: boolean = ch;
+"#;
+    assert!(
+        codes(positional).contains(&2322),
+        "string positional element is string; got {:?}",
+        codes(positional)
+    );
+
+    let rest = r#"
+const [...chars] = "hello";
+const show: "X" = chars;
+"#;
+    let msgs = messages_2322(rest);
+    assert!(
+        msgs.iter().any(|m| m.contains("string[]")),
+        "string rest binds string[]; got {msgs:?}"
+    );
+}
+
+#[test]
+fn iterable_map_set_and_generator_sources_bind_element_arrays() {
+    let iterable = r#"
+declare const nums: Iterable<number>;
+const [...gathered] = nums;
+const show: "X" = gathered;
+"#;
+    assert!(
+        lib_messages_2322(iterable)
+            .iter()
+            .any(|m| m.contains("number[]")),
+        "Iterable<number> rest binds number[]; got {:?}",
+        lib_messages_2322(iterable)
+    );
+
+    let set = r#"
+const [...uniques] = new Set([1, 2]);
+const show: "X" = uniques;
+"#;
+    assert!(
+        lib_messages_2322(set)
+            .iter()
+            .any(|m| m.contains("number[]")),
+        "Set<number> rest binds number[]; got {:?}",
+        lib_messages_2322(set)
+    );
+
+    let map = r#"
+declare const table: Map<string, number>;
+const [...entries] = table;
+const show: "X" = entries;
+"#;
+    assert!(
+        lib_messages_2322(map)
+            .iter()
+            .any(|m| m.contains("[string, number][]")),
+        "Map rest binds [string, number][]; got {:?}",
+        lib_messages_2322(map)
+    );
+
+    let generator = r#"
+function* words() { yield "a"; }
+const [...taken] = words();
+const show: "X" = taken;
+"#;
+    assert!(
+        lib_messages_2322(generator)
+            .iter()
+            .any(|m| m.contains("string[]")),
+        "generator rest binds string[]; got {:?}",
+        lib_messages_2322(generator)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unions with non-array-like members
+// ---------------------------------------------------------------------------
+
+#[test]
+fn union_with_string_member_uses_iterated_element_type_everywhere() {
+    // `string | [number, boolean]`: every position binds
+    // `string | number | boolean` (not per-member indexed access).
+    let source = r#"
+declare const mixed: string | [number, boolean];
+const [firstEl, secondEl] = mixed;
+const show: "X" = firstEl;
+const show2: "X" = secondEl;
+"#;
+    let msgs = messages_2322(source);
+    assert!(
+        msgs.iter()
+            .filter(|m| m.contains("string | number | boolean"))
+            .count()
+            == 2,
+        "both positions bind string | number | boolean; got {msgs:?}"
+    );
+}
+
+#[test]
+fn union_with_iterable_member_rest_binds_iterated_array() {
+    let source = r#"
+declare const source: Set<symbol> | boolean[];
+const [lead, ...others] = source;
+const show: "X" = others;
+"#;
+    let msgs = lib_messages_2322(source);
+    assert!(
+        msgs.iter()
+            .any(|m| m.contains("(boolean | symbol)[]") || m.contains("(symbol | boolean)[]")),
+        "rest over Set|array union binds the iterated element array; got {msgs:?}"
+    );
+}
+
+#[test]
+fn all_array_like_union_keeps_distributed_indexing() {
+    // Negative control: no non-array-like member, so per-member indexed
+    // access is unchanged (`number | boolean`, not the full iterated union).
+    let source = r#"
+declare const pair: [number, string] | boolean[];
+const [headOf] = pair;
+const show: "X" = headOf;
+"#;
+    let msgs = messages_2322(source);
+    assert!(
+        msgs.iter()
+            .any(|m| m.contains("number | boolean") && !m.contains("string")),
+        "all-array-like union keeps per-member indexing; got {msgs:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Declared-source negative controls
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declared_tuple_and_as_const_sources_unchanged() {
+    let declared = r#"
+declare const trio: [number, string, boolean];
+const [x, ...xs] = trio;
+const show: "X" = xs;
+"#;
+    assert!(
+        messages_2322(declared)
+            .iter()
+            .any(|m| m.contains("[string, boolean]")),
+        "declared tuple rest still slices; got {:?}",
+        messages_2322(declared)
+    );
+
+    let as_const = r#"
+const [y, ...ys] = [1, "x"] as const;
+const show: "X" = ys;
+"#;
+    assert!(
+        messages_2322(as_const).iter().any(|m| m.contains("\"x\"")),
+        "as-const rest keeps literal slice elements; got {:?}",
+        messages_2322(as_const)
+    );
+}

--- a/crates/tsz-checker/tests/tuple_rest_destructuring_slice_tests.rs
+++ b/crates/tsz-checker/tests/tuple_rest_destructuring_slice_tests.rs
@@ -193,41 +193,67 @@ const show: "X" = tail;
 }
 
 #[test]
-fn fresh_array_literal_rest_widens_to_array_not_a_slice() {
-    // A *fresh* array-literal destructuring source is widened by tsc
-    // (`getWidenedTypeForVariableLikeDeclaration`), so the `...rest` binds the
-    // element array `number[]`, NOT the residual tuple slice `[number, number]`
-    // that a declared tuple would produce.
+fn fresh_array_literal_trailing_rest_slices_to_widened_tuple() {
+    // A *fresh* array-literal source destructured with a trailing rest is in
+    // tuple context, so tsc slices the widened literal tuple: `...spread`
+    // over `[1, 2, 3]` binds `[number, number]` (pinned against tsc 6.0.2),
+    // which is also assignable to `number[]`.
     let assignable_to_array = r#"
 const [head, ...spread] = [1, 2, 3];
 const ok: number[] = spread;
 "#;
     assert!(
         !codes(assignable_to_array).contains(&2322),
-        "fresh-literal rest should be number[] (assignable to number[]); got {:?}",
+        "fresh-literal trailing rest [number, number] is assignable to number[]; got {:?}",
         codes(assignable_to_array)
     );
 
-    let not_a_tuple = r#"
+    let is_a_tuple = r#"
 const [lead, ...trailing] = [1, 2, 3];
-const wrong: [number, number] = trailing;
+const ok: [number, number] = trailing;
 "#;
     assert!(
-        codes(not_a_tuple).contains(&2322),
-        "fresh-literal rest is number[], not the tuple [number, number]; got {:?}",
-        codes(not_a_tuple)
+        !codes(is_a_tuple).contains(&2322),
+        "fresh-literal trailing rest is the slice [number, number]; got {:?}",
+        codes(is_a_tuple)
     );
 
-    // `var` fresh literal widens identically.
+    let widens_literals = r#"
+const [first, ...rem] = [1, "x", true];
+const show: "X" = rem;
+"#;
+    let msgs = messages_2322(widens_literals);
+    assert!(
+        msgs.iter().any(|m| m.contains("[string, boolean]")),
+        "fresh-literal slice widens element literals to [string, boolean]; got {msgs:?}"
+    );
+
+    // `var` fresh literal slices identically.
     let var_form = r#"
 var [v, ...vrest] = [1, 2, 3];
 const okv: number[] = vrest;
-const wrongv: [number, number] = vrest;
+const okv2: [number, number] = vrest;
 "#;
     let cs = codes(var_form);
     assert!(
-        cs.iter().filter(|&&c| c == 2322).count() == 1,
-        "var fresh-literal rest is number[]: ok for number[], TS2322 for tuple; got {cs:?}"
+        !cs.contains(&2322),
+        "var fresh-literal trailing rest slices to [number, number]; got {cs:?}"
+    );
+}
+
+#[test]
+fn fresh_array_literal_leading_rest_stays_widened_array() {
+    // A rest element at index 0 never puts the fresh literal in tuple
+    // context, so `[...r] = [0, 1]` binds the widened element array
+    // `number[]`, not a slice (pinned against tsc 6.0.2).
+    let source = r#"
+var [...whole] = [0, 1];
+const show: "X" = whole;
+"#;
+    let msgs = messages_2322(source);
+    assert!(
+        msgs.iter().any(|m| m.contains("number[]")),
+        "leading rest over a fresh literal binds number[]; got {msgs:?}"
     );
 }
 
@@ -235,9 +261,9 @@ const wrongv: [number, number] = vrest;
 fn rest_element_object_pattern_over_fresh_literal_reports_number_array() {
     // restElementWithBindingPattern2.ts conformance shape: tsc reports
     //   TS2339 Property 'b' does not exist on type 'number[]'.
-    // The rest source `[0, 1]` widens to `number[]`, so the nested object
-    // pattern resolves the missing property against `number[]`, not against a
-    // tuple `[number, number]`.
+    // The leading rest keeps the fresh source `[0, 1]` out of tuple context,
+    // so the nested object pattern resolves the missing property against
+    // `number[]`, not against a tuple `[number, number]`.
     let source = "var [...{0: a, b }] = [0, 1];\n";
     let msgs: Vec<String> = check_source_diagnostics(source)
         .into_iter()


### PR DESCRIPTION
Fixes #15373

Goal: hold

## Structural rule

When an array binding pattern destructures a source whose every constituent is a tuple, tsc types the rest element as the residual tuple slice (`sliceTupleType`) and positional elements by index; when every constituent is merely array-like, positional elements distribute numeric indexed access; when any constituent is not array-like but iterable (string, `Iterable<T>`, `Map`, generators), every position binds the iterated element type of the whole source (`checkIteratedTypeOrElementType`) and rest binds its array. tsz does this through the checker's shared binding-element owner, `get_binding_element_type_with_request`, for **all** declaration forms including annotated parameters.

Fresh array-literal sub-rules (pinned against tsc 6.0.2): a trailing rest slices the *widened* literal tuple (`const [a, ...r] = [1, 'x', true]` → `r: [string, boolean]`); a rest at index 0 never puts the literal in tuple context, so `[...r] = [0, 1]` binds `number[]` (conformance shape `restElementWithBindingPattern2.ts` preserved).

## What was wrong

- `get_binding_element_type_with_request` carried a carve-out claiming tsc widens fresh array-literal rest sources to `E[]` — empirically false for tsc 6.0.2 except at rest index 0; it produced element-union arrays like `(string | number | boolean)[]`.
- Non-array-like iterable sources fell through to `any`/`any[]` at every position (false negatives for string/`Set`/`Map`/generator sources).
- Unions with a non-array-like member dropped those members' contributions instead of switching to the iterated element type.
- Annotated-parameter binding patterns resolved through an object-shape-only walker (`resolve_binding_element_from_annotated_param` + its nested variant), so array-pattern elements, object rest, and initializer-typed patterns all silently bound `any` — e.g. `function g([a, ...r]: [number, string, boolean])` type-checked `r` as `any`. The walker is replaced with a recursive resolver that routes every level through the shared owner.

## Owner layer

Checker: `state/variable_checking/destructuring.rs` (binding-element source typing), `state/variable_checking/binding_rest.rs` (union rest), `state/type_analysis/computed_helpers_binding.rs` (annotated-param lazy symbol resolution). Iterated element types come from the existing `for_of_element_type` owner (`checkers/iterable_checker.rs`), which wraps solver iterator queries — no new type-shape recursion in the checker, no printer-output predicates, no name-driven logic.

## Adjacent-case matrix

Verified by randomized differential sweeps vs `tsc` 6.0.2 (`--noEmit --strict --pretty false`, randomized binder names): 176/176 generated + probe cases match, covering `const`/`let`/`var`, holes, nested rest, defaults (`const [a = 9, ...r]` keeps `1 | 9` positional precision), `as const`, readonly tuples, declared tuples, optional elements, all-tuple unions, tuple-or-array unions, string/literal/`Iterable`/`Set`/`Map`/generator sources, function/arrow/method/object-literal-method parameters, rest-parameter tuple patterns (`...[a, ...r]: [number, ...string[]]`), parameter default initializers (cast and fresh-literal), contextual callback parameters (unchanged), for-of patterns (unchanged), assignment destructuring (unchanged), and negative controls (unannotated patterns keep TS7031; `restElementWithBindingPattern2.ts` shape keeps `number[]`).

Known residuals (pre-existing, out of scope, strictly improved or unchanged): union member display ordering (`string | 1 | 2` vs tsc's `string | 2 | 1`; main rendered wrong membership entirely) and a `yield*` generator for-of element false negative that exists on main.

## Verification

- `cargo nextest run -p tsz-checker --test destructuring_binding_element_source_tests --test tuple_rest_destructuring_slice_tests` — 28/28 pass (new regression suite + corrected stale expectations that contradicted tsc 6.0.2).
- `cargo nextest run -p tsz-checker --lib` and 216 destructuring/binding/tuple/iterable/rest/param integration targets: failure sets identical to `main` baseline (zero new failures; 13/170 pre-existing failures on main are unrelated, see #15338).
- `cargo nextest run -p tsz-emitter` destructuring targets: 109/109 pass.
- `cargo clippy -p tsz-checker --lib` clean.
- Full conformance/emit/fourslash parity: ready-review CI (TS corpus is not fetchable from this sandbox; proxy is repo-scoped).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: max

---
_Generated by [Claude Code](https://claude.ai/code/session_012ce4pJsSzdvjA2sdskg4Xr)_