### PR TITLE
fix(ci): aggregate unit-test rc so failed nextest batches fail the run

### DIFF
--- a/scripts/ci/full-ci.sh
+++ b/scripts/ci/full-ci.sh
@@ -408,6 +408,7 @@ run_lint() {
   python3 scripts/ci/test_ci_resources.py || return $?
   python3 scripts/ci/test_full_ci_conformance_artifacts.py || return $?
   python3 scripts/ci/test_full_ci_emit_metrics.py || return $?
+  python3 scripts/ci/test_full_ci_unit_rc.py || return $?
   python3 scripts/ci/test_refresh_readme.py || return $?
   python3 scripts/conformance/test_query_conformance.py || return $?
   python3 scripts/conformance/test_check_accepted_regression_growth.py || return $?
@@ -527,7 +528,11 @@ checker_integration_test_names() {
 
 run_unit_tests() {
   ci_section "Workspace nextest suites"
-  local package package_names checker_selected general_pkg_args
+  # Accumulate rc across every batch. `timed` disables `set -e` around this
+  # function so a failing non-final batch does not abort; without aggregation
+  # the function would return only the last command's status and a red run
+  # would report green. See issue #15404.
+  local package package_names checker_selected general_pkg_args rc=0
   # Bash 3.2 (macOS system `/bin/bash`) has no `mapfile`; use the portable shim.
   portable_read_lines package_names < <(unit_test_packages)
   if [[ -n "${_TSZ_CI_UNIT_PACKAGES_OVERRIDE:-}" ]]; then
@@ -548,21 +553,25 @@ run_unit_tests() {
     cargo nextest run --profile ci --cargo-profile ci-unit \
       --build-jobs "$CARGO_BUILD_JOBS" \
       --test-threads "$UNIT_NEXTEST_TEST_THREADS" \
-      "${general_pkg_args[@]}"
+      "${general_pkg_args[@]}" || rc="$?"
   fi
 
   if (( checker_selected )); then
     if [[ "${TSZ_CI_UNIT_SKIP_CHECKER_INTEGRATION:-0}" == "1" ]]; then
       echo "info: skipping checker integration tests in unit job"
-      return 0
+      return "$rc"
     fi
-    run_checker_integration_tests
+    run_checker_integration_tests || rc="$?"
   fi
+
+  return "$rc"
 }
 
 run_checker_integration_tests() {
   ci_section "Checker integration nextest suites"
-  local checker_batch_size checker_batch_names checker_batch_args
+  # Aggregate rc across every batch so a failing non-final batch is not masked
+  # by a green final batch. See issue #15404.
+  local checker_batch_size checker_batch_names checker_batch_args rc=0
   # The checker lib-test binary is larger than the 32 GiB CI runners can link
   # reliably. Keep checker integration tests in unit CI while avoiding that
   # monolithic `rustc --test crates/tsz-checker/src/lib.rs` artifact.
@@ -586,7 +595,7 @@ run_checker_integration_tests() {
         echo "info: checker integration batch (${#checker_batch_names[@]} targets): ${checker_batch_names[*]}"
         cargo nextest run --profile ci --cargo-profile ci-unit \
           --build-jobs "$CARGO_BUILD_JOBS" \
-          -p tsz-checker "${checker_batch_args[@]}"
+          -p tsz-checker "${checker_batch_args[@]}" || rc="$?"
         checker_batch_names=()
       fi
     done < <(checker_integration_test_names)
@@ -599,8 +608,10 @@ run_checker_integration_tests() {
       echo "info: checker integration batch (${#checker_batch_names[@]} targets): ${checker_batch_names[*]}"
       cargo nextest run --profile ci --cargo-profile ci-unit \
         --build-jobs "$CARGO_BUILD_JOBS" \
-        -p tsz-checker "${checker_batch_args[@]}"
+        -p tsz-checker "${checker_batch_args[@]}" || rc="$?"
     fi
+
+    return "$rc"
 }
 
 build_unit_test_archive() {

--- a/scripts/ci/test_full_ci_unit_rc.py
+++ b/scripts/ci/test_full_ci_unit_rc.py
@@ -1,0 +1,104 @@
+"""Contract tests for unit-test rc aggregation in full-ci.sh.
+
+Regression coverage for issue #15404: `run_unit_tests` and
+`run_checker_integration_tests` run several `nextest` batches with `set -e`
+disabled (via `timed`). Each batch must contribute to the returned status;
+otherwise a failing non-final batch is masked by a green final batch and a red
+unit run reports rc=0.
+
+These tests extract the two shell functions verbatim, stub `cargo` so a chosen
+batch fails, and assert the aggregated exit status.
+"""
+
+import pathlib
+import subprocess
+import textwrap
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+FULL_CI = ROOT / "scripts" / "ci" / "full-ci.sh"
+
+
+class UnitRcAggregationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        script = FULL_CI.read_text(encoding="utf-8")
+        cls.run_unit_tests = cls._function_body(
+            script, "run_unit_tests", "\nrun_checker_integration_tests() {"
+        )
+        cls.run_checker = cls._function_body(
+            script, "run_checker_integration_tests", "\nbuild_unit_test_archive() {"
+        )
+
+    @staticmethod
+    def _function_body(script, name, end_marker):
+        start = script.index(f"{name}() {{")
+        end = script.index(end_marker, start)
+        return script[start:end]
+
+    def _run(self, cargo_stub, env_line="", packages="tsz-core tsz-checker"):
+        # Mirror the production caller: `timed()` disables `set -e` around the
+        # invocation, so a failing batch does not abort the run — the function
+        # is responsible for returning the aggregated rc via `|| rc=...`. We
+        # reproduce that `set +e; run; rc=$?; set -e` frame here.
+        harness = textwrap.dedent(
+            f"""#!/usr/bin/env bash
+            set -Eeuo pipefail
+            {env_line}
+            ci_section() {{ :; }}
+            CARGO_BUILD_JOBS=1
+            UNIT_NEXTEST_TEST_THREADS=1
+            TSZ_CI_CHECKER_TEST_BATCH_SIZE=2
+            unit_test_packages() {{ printf '%s\\n' {packages}; }}
+            checker_integration_test_names() {{ printf '%s\\n' a b c d e; }}
+            {cargo_stub}
+            {self.run_checker}
+            {self.run_unit_tests}
+            set +e
+            run_unit_tests
+            rc=$?
+            set -e
+            echo "RC=$rc"
+            """
+        )
+        proc = subprocess.run(["bash", "-c", harness], capture_output=True, text=True)
+        # The harness itself must exit 0 (it always ends on `echo`); the tested
+        # rc is reported via the RC= line.
+        self.assertEqual(
+            proc.returncode, 0, msg=f"harness aborted:\n{proc.stdout}\n{proc.stderr}"
+        )
+        rc_lines = [ln for ln in proc.stdout.splitlines() if ln.startswith("RC=")]
+        self.assertEqual(len(rc_lines), 1, msg=f"missing RC line:\n{proc.stdout}")
+        return int(rc_lines[0][len("RC=") :])
+
+    # A cargo stub that fails whenever `token` appears in its argument list.
+    @staticmethod
+    def _fail_on(token):
+        return f'cargo() {{ for a in "$@"; do [ "$a" = "{token}" ] && return 100; done; return 0; }}'
+
+    def test_all_green_returns_zero(self):
+        self.assertEqual(self._run("cargo() { return 0; }"), 0)
+
+    def test_nonfinal_checker_batch_failure_propagates(self):
+        # Batches of 2 over (a b c d e): first batch (a b) fails, final batch
+        # (e) is green. The old code returned the final batch's 0.
+        self.assertNotEqual(self._run(self._fail_on("b")), 0)
+
+    def test_middle_checker_batch_failure_propagates(self):
+        self.assertNotEqual(self._run(self._fail_on("d")), 0)
+
+    def test_general_package_failure_propagates(self):
+        # The non-checker batch fails; every checker batch is green.
+        self.assertNotEqual(self._run(self._fail_on("tsz-core")), 0)
+
+    def test_skip_checker_integration_still_reports_general_failure(self):
+        rc = self._run(
+            self._fail_on("tsz-core"),
+            env_line="export TSZ_CI_UNIT_SKIP_CHECKER_INTEGRATION=1",
+        )
+        self.assertNotEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #15404.

`scripts/ci/full-ci.sh` `run_unit_tests` and `run_checker_integration_tests`
run several `nextest` batches while `set -e` is disabled (the wrapping `timed`
helper turns it off). Neither function accumulated the per-batch exit status,
so each returned only the status of its **last** command. A red batch followed
by a green final batch reported `rc=0` — a red unit run looked green whenever
the last checker integration batch happened to pass. This masked the 133
failing/timed-out tests observed on `origin/main` in the issue.

Structural rule: when any non-checker batch, checker integration batch, or
timeout fails, `run_unit_tests` must return nonzero. Both functions now
accumulate a nonzero rc across every sub-command (general-package batch, each
checker integration batch, and timeouts, which `nextest` surfaces as a nonzero
exit) via `|| rc="$?"` and `return "$rc"`. Batches still all run in a single
invocation, so one run captures the full failure inventory — the aggregation
only changes the returned status, not what executes.

## Goal
Goal: hold

## Verification
- `python3 scripts/ci/test_full_ci_unit_rc.py` — new regression suite
  (registered in `run_lint`). Extracts both shell functions verbatim and
  asserts the aggregated rc under non-final-batch, middle-batch,
  general-package, and skip-checker failure scenarios; all pass with the fix
  and 4/5 fail against pre-fix `origin/main` (confirming they catch the bug).
- `bash -n scripts/ci/full-ci.sh` — syntax check passes.
- `ruff check scripts/ci/test_full_ci_unit_rc.py` — clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdfYozRonwtSmdpE9XgJqE)_