### PR TITLE
fix(checker,solver): report TS2538 for symbol element access via a string index

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/index_signature.rs
+++ b/crates/tsz-checker/src/query_boundaries/index_signature.rs
@@ -28,6 +28,19 @@ pub(crate) fn resolve_number_index(db: &dyn TypeDatabase, type_id: TypeId) -> Op
     IndexSignatureResolver::new(db).resolve_number_index(type_id)
 }
 
+/// Resolve the `symbol` index signature value type from `type_id`.
+///
+/// Returns `Some` only for a signature keyed by the bare `symbol` intrinsic; a
+/// `string` index signature (which cannot accept `symbol` keys) yields `None`.
+pub(crate) fn resolve_symbol_index(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
+    IndexSignatureResolver::new(db).resolve_symbol_index(type_id)
+}
+
+/// Return whether `type_id` exposes a `symbol` index signature.
+pub(crate) fn has_symbol_index_signature(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    resolve_symbol_index(db, type_id).is_some()
+}
+
 /// Return the declared string index signature for `type_id`, if present.
 pub(crate) fn string_index_signature(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1854,6 +1854,48 @@ impl<'a> CheckerState<'a> {
             report_no_index = true;
         }
 
+        // TS2538: an ESSymbolLike key that only resolves through a `string` index
+        // signature (no `symbol` index, no matching symbol-keyed property). tsc
+        // reports "Type 'X' cannot be used as an index type" here — distinct from
+        // the implicit-any TS7053 — because the access still yields the string
+        // signature's value type rather than `any`, so this supersedes any
+        // `report_no_index` (TS7053) verdict and keeps the resolved value type
+        // (no spurious cascade). tsc's `checkIndexedAccessIndexType` runs
+        // independently of whether a value type resolved, so this is
+        // intentionally NOT gated on `use_index_signature_check` — the precise
+        // predicate below is the gate. Scoped to concrete (non-union /
+        // non-intersection) receivers; composite receivers keep the existing
+        // per-member diagnostic paths. The predicate is the cheap discriminator
+        // (it bails in O(1) for non-symbol keys), so it leads the guard chain.
+        if self.symbol_key_resolves_via_string_index_only(
+            object_type_for_access,
+            index_type,
+            index_type_for_access,
+        ) && crate::query_boundaries::common::intersection_members(
+            self.ctx.types,
+            pre_resolution_object_type,
+        )
+        .is_none()
+            && crate::query_boundaries::common::union_members(
+                self.ctx.types,
+                object_type_for_access,
+            )
+            .is_none()
+        {
+            use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+            let index_type_str = self.format_type(index_type);
+            let message = format_message(
+                diagnostic_messages::TYPE_CANNOT_BE_USED_AS_AN_INDEX_TYPE,
+                &[&index_type_str],
+            );
+            self.error_at_node(
+                access.name_or_argument,
+                &message,
+                diagnostic_codes::TYPE_CANNOT_BE_USED_AS_AN_INDEX_TYPE,
+            );
+            report_no_index = false;
+        }
+
         if report_no_index {
             let is_write_target_or_base = self.property_access_is_write_target_or_base(idx);
             // Suppress TS7053 for expando bracket assignments on function types.

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -1271,4 +1271,80 @@ impl<'a> CheckerState<'a> {
                 .resolve_element_access_type(object_type, index_type_for_access, None);
         member == TypeId::UNDEFINED || member == TypeId::ERROR
     }
+
+    /// Whether an `ESSymbolLike` element-access key resolves *only* through a
+    /// `string` index signature.
+    ///
+    /// tsc's `checkIndexedAccessIndexType` reports TS2538 ("Type 'X' cannot be
+    /// used as an index type") — not the implicit-any TS7053 — when a `symbol`
+    /// or `unique symbol` key indexes an object that (a) has a `string` index
+    /// signature (so the access still yields that signature's value type,
+    /// exactly as tsc does — no cascade), (b) has no `symbol` index signature
+    /// that would accept any symbol key, and (c) is not matched by a declared
+    /// symbol-keyed property. Arrays/tuples are excluded — a symbol key there
+    /// takes the numeric-index diagnostic paths (TS7015/TS7053).
+    ///
+    /// The resolved value type is left to the caller: tsc keeps the `string`
+    /// signature's value type, so this only governs *which diagnostic* is
+    /// emitted, never the access result.
+    pub(crate) fn symbol_key_resolves_via_string_index_only(
+        &self,
+        object_type: TypeId,
+        index_type: TypeId,
+        index_type_for_access: TypeId,
+    ) -> bool {
+        // Cheap key discriminator first: the predicate can only ever be `true`
+        // for an ESSymbolLike key, so bail before the object-shape traversals on
+        // the common (string/number-keyed) element-access path. A bare `symbol`
+        // is a binder-converted identifier (`index_type_for_access != index_type`
+        // guards out un-converted widened well-known-symbol reads); a `unique
+        // symbol` carries its binding identity.
+        let is_wide_symbol = index_type == TypeId::SYMBOL && index_type_for_access != index_type;
+        let is_unique_symbol =
+            crate::query_boundaries::common::unique_symbol_ref(self.ctx.types, index_type)
+                .is_some();
+        if !is_wide_symbol && !is_unique_symbol {
+            return false;
+        }
+
+        // Arrays/tuples take the numeric-index diagnostic paths (TS7015/TS7053).
+        if self.is_array_like_type(object_type) {
+            return false;
+        }
+        // Without a `string` index the object reports the implicit-any TS7053
+        // family instead; TS2538 is reserved for the string-fallthrough case.
+        // (This also excludes namespace / expando receivers, which have none.)
+        if crate::query_boundaries::index_signature::resolve_string_index(
+            self.ctx.types,
+            object_type,
+        )
+        .is_none()
+        {
+            return false;
+        }
+        // A genuine `symbol` index signature accepts any symbol key — no error.
+        if crate::query_boundaries::index_signature::has_symbol_index_signature(
+            self.ctx.types,
+            object_type,
+        ) {
+            return false;
+        }
+
+        // A bare `symbol` can never name a specific declared property, so a
+        // string-index fallthrough is the only way such an access resolves.
+        if is_wide_symbol {
+            return true;
+        }
+
+        // A `unique symbol` key is legal when the object declares that exact
+        // symbol-keyed property; only an unmatched key falls through to the
+        // string index. The binding-identity key resolves through a real
+        // property or `symbol` index but NOT through the `string` signature, so
+        // an UNDEFINED/ERROR probe means "unmatched".
+        let member =
+            self.ctx
+                .types
+                .resolve_element_access_type(object_type, index_type_for_access, None);
+        member == TypeId::UNDEFINED || member == TypeId::ERROR
+    }
 }

--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -1641,3 +1641,186 @@ const x: { reveal: true } = so["foo"];
         "so[\"foo\"] must be implicit-any (not number), so no TS2322 should fire, got {codes:?}",
     );
 }
+
+// ---------------------------------------------------------------------------
+// Value-level element access `obj[sym]` where the receiver's only applicable
+// index signature is a `string` index. tsc's `checkIndexedAccessIndexType`
+// reports TS2538 ("Type 'X' cannot be used as an index type") here — the access
+// still resolves to the string signature's value type (so no cascade), but a
+// `string` index does not accept a `symbol` key. Previously tsz silently
+// resolved the wide-`symbol` case and mis-coded the `unique symbol` case as
+// TS7053.
+// ---------------------------------------------------------------------------
+
+const TS2538: u32 = diagnostic_codes::TYPE_CANNOT_BE_USED_AS_AN_INDEX_TYPE;
+const TS7015: u32 =
+    diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE;
+
+#[test]
+fn wide_symbol_value_access_on_string_index_reports_ts2538() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const sym: symbol;
+declare const strIdx: { [k: string]: number };
+strIdx[sym];
+"#,
+    );
+    assert!(
+        codes.contains(&TS2538),
+        "wide `symbol` value access on a string-index object must report TS2538, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&TS7053),
+        "a string-index fallthrough is TS2538, not the implicit-any TS7053, got {codes:?}",
+    );
+}
+
+#[test]
+fn wide_symbol_value_access_on_string_index_reports_ts2538_renamed_binders() {
+    // Anti-hardcoding: identical structural shape, different binder names.
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const banana: symbol;
+declare const WEIRD_9: { [potato: string]: number };
+WEIRD_9[banana];
+"#,
+    );
+    assert!(
+        codes.contains(&TS2538),
+        "the rule must be structural, not name-driven; expected TS2538, got {codes:?}",
+    );
+}
+
+#[test]
+fn unique_symbol_value_access_on_string_index_reports_ts2538() {
+    // Previously mis-coded as TS7053: an unmatched `unique symbol` key that only
+    // falls through to a `string` index is TS2538, exactly like the wide case.
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const us: unique symbol;
+declare const noProp: { [k: string]: number };
+noProp[us];
+"#,
+    );
+    assert!(
+        codes.contains(&TS2538),
+        "unmatched `unique symbol` on a string-index object must report TS2538, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&TS7053),
+        "the unique-symbol/string-index case is TS2538, not TS7053, got {codes:?}",
+    );
+}
+
+#[test]
+fn wide_symbol_value_access_on_class_string_index_reports_ts2538() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const sym: symbol;
+class Bag { [k: string]: number; }
+declare const bag: Bag;
+bag[sym];
+"#,
+    );
+    assert!(
+        codes.contains(&TS2538),
+        "a class instance with a string index signature must report TS2538, got {codes:?}",
+    );
+}
+
+#[test]
+fn wide_symbol_value_access_keeps_string_index_value_type_no_cascade() {
+    // tsc keeps the string signature's value type (`number`) for the access, so
+    // assigning to `number` adds no error while assigning to `string` reports a
+    // single TS2322 — proving the access did NOT collapse to `undefined`/`error`.
+    let compatible = diagnostic_codes_for_ts(
+        r#"
+declare const sym: symbol;
+declare const strIdx: { [k: string]: number };
+const ok: number = strIdx[sym];
+"#,
+    );
+    assert!(
+        compatible.contains(&TS2538),
+        "expected the index-type TS2538, got {compatible:?}",
+    );
+    assert!(
+        !compatible.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "the resolved value type is `number`, so `const ok: number` must not add TS2322, got {compatible:?}",
+    );
+
+    let incompatible = diagnostic_codes_for_ts(
+        r#"
+declare const sym: symbol;
+declare const strIdx: { [k: string]: number };
+const bad: string = strIdx[sym];
+"#,
+    );
+    assert!(
+        incompatible.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "the resolved value type `number` is not assignable to `string`; expected TS2322, got {incompatible:?}",
+    );
+}
+
+#[test]
+fn wide_symbol_value_access_with_symbol_index_is_clean() {
+    // Negative control: a genuine `symbol` index signature accepts any symbol key.
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const sym: symbol;
+declare const symIdx: { [k: symbol]: number };
+symIdx[sym];
+declare const both: { [k: string]: number; [k: symbol]: string };
+both[sym];
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2538),
+        "a symbol index signature accepts symbol keys; no TS2538 expected, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&TS7053),
+        "no implicit-any either when a symbol index resolves the access, got {codes:?}",
+    );
+}
+
+#[test]
+fn wide_symbol_value_access_without_index_still_reports_ts7053() {
+    // Negative control: with no index signature the diagnostic stays TS7053,
+    // not TS2538 (the access is genuinely implicit-any, not a string fallthrough).
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const sym: symbol;
+declare const named: { x: number };
+named[sym];
+"#,
+    );
+    assert!(
+        codes.contains(&TS7053),
+        "no-index-signature symbol access must stay TS7053, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&TS2538),
+        "TS2538 is reserved for the string-index fallthrough case, got {codes:?}",
+    );
+}
+
+#[test]
+fn wide_symbol_value_access_on_number_index_still_reports_ts7015() {
+    // Negative control: a number-only index signature yields TS7015, not TS2538.
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const sym: symbol;
+declare const numIdx: { [k: number]: string };
+numIdx[sym];
+"#,
+    );
+    assert!(
+        codes.contains(&TS7015),
+        "a number-index object indexed by symbol must report TS7015, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&TS2538),
+        "the number-index case is TS7015, not TS2538, got {codes:?}",
+    );
+}

--- a/crates/tsz-solver/src/objects/index_signatures.rs
+++ b/crates/tsz-solver/src/objects/index_signatures.rs
@@ -141,6 +141,100 @@ impl<R: TypeResolver> TypeVisitor for StringIndexResolver<'_, R> {
     }
 }
 
+/// Visitor for resolving `symbol` index signatures (`{ [key: symbol]: T }`).
+///
+/// A `symbol` index is stored either in [`ObjectShape::symbol_index`] or,
+/// historically, in `string_index` with a `key_type` of [`TypeId::SYMBOL`].
+/// This resolver is the mirror of [`StringIndexResolver`] that reads *only* the
+/// symbol-keyed signature, so callers can distinguish an object that genuinely
+/// accepts any `symbol` key from one whose `symbol` access merely falls through
+/// to a `string` index signature (which `tsc` rejects with TS2538).
+struct SymbolIndexResolver<'a, R: TypeResolver> {
+    db: &'a dyn TypeDatabase,
+    resolver: &'a R,
+}
+
+impl<R: TypeResolver> TypeVisitor for SymbolIndexResolver<'_, R> {
+    type Output = Option<TypeId>;
+
+    fn visit_intrinsic(&mut self, _kind: crate::types::IntrinsicKind) -> Self::Output {
+        None
+    }
+
+    fn visit_literal(&mut self, _value: &crate::LiteralValue) -> Self::Output {
+        None
+    }
+
+    fn visit_object_with_index(&mut self, shape_id: u32) -> Self::Output {
+        let shape = self.db.object_shape(ObjectShapeId(shape_id));
+        shape.symbol_index_signature().map(|idx| idx.value_type)
+    }
+
+    fn visit_callable(&mut self, shape_id: u32) -> Self::Output {
+        // `CallableShape` has no dedicated `symbol_index` slot, so only the
+        // historical `string_index`-with-`symbol`-key representation applies.
+        let shape = self.db.callable_shape(CallableShapeId(shape_id));
+        shape
+            .string_index
+            .as_ref()
+            .filter(|idx| idx.key_type == TypeId::SYMBOL)
+            .map(|idx| idx.value_type)
+    }
+
+    fn visit_array(&mut self, _element_type: TypeId) -> Self::Output {
+        None
+    }
+
+    fn visit_tuple(&mut self, _list_id: u32) -> Self::Output {
+        None
+    }
+
+    fn visit_union(&mut self, list_id: u32) -> Self::Output {
+        let types = self.db.type_list(crate::types::TypeListId(list_id));
+        types.iter().find_map(|&t| self.visit_type(self.db, t))
+    }
+
+    fn visit_intersection(&mut self, list_id: u32) -> Self::Output {
+        let types = self.db.type_list(crate::types::TypeListId(list_id));
+        types.iter().find_map(|&t| self.visit_type(self.db, t))
+    }
+
+    fn visit_readonly_type(&mut self, inner_type: TypeId) -> Self::Output {
+        self.visit_type(self.db, inner_type)
+    }
+
+    fn visit_application_type(&mut self, type_id: TypeId, _app_id: u32) -> Self::Output {
+        let evaluated = crate::evaluation::evaluate::evaluate_type_with_resolver(
+            self.db,
+            self.resolver,
+            type_id,
+        );
+        (evaluated != type_id)
+            .then(|| self.visit_type(self.db, evaluated))
+            .flatten()
+    }
+
+    fn visit_type(&mut self, types: &dyn TypeDatabase, type_id: TypeId) -> Self::Output {
+        match types.lookup(type_id) {
+            Some(TypeData::Application(app_id)) => self.visit_application_type(type_id, app_id.0),
+            Some(ref type_key) => self.visit_type_key(types, type_key),
+            None => Self::default_output(),
+        }
+    }
+
+    fn visit_mapped(&mut self, mapped_id: u32) -> Self::Output {
+        let type_id = self.db.mapped(self.db.get_mapped(MappedTypeId(mapped_id)));
+        let evaluated = crate::evaluation::evaluate::evaluate_type(self.db, type_id);
+        (evaluated != type_id)
+            .then(|| self.visit_type(self.db, evaluated))
+            .flatten()
+    }
+
+    fn default_output() -> Self::Output {
+        None
+    }
+}
+
 /// Visitor for resolving number index signatures.
 struct NumberIndexResolver<'a, R: TypeResolver> {
     db: &'a dyn TypeDatabase,
@@ -471,6 +565,28 @@ impl<'a, R: TypeResolver> IndexSignatureResolver<'a, R> {
     /// - `{ a: number }` → `None`
     pub fn resolve_string_index(&self, obj: TypeId) -> Option<TypeId> {
         let mut visitor = StringIndexResolver {
+            db: self.db,
+            resolver: self.resolver,
+        };
+        visitor.visit_type(self.db, obj)
+    }
+
+    /// Resolve the `symbol` index signature type from an object type.
+    ///
+    /// Returns `Some(value_type)` when the object exposes a signature keyed by
+    /// the bare `symbol` intrinsic (`{ [key: symbol]: T }`), `None` otherwise.
+    /// A `string` (or numeric-string) index signature is *not* reported here —
+    /// a `symbol` key cannot be satisfied by a `string` index, so callers can
+    /// use this to tell a genuine symbol-indexable object apart from one where a
+    /// `symbol` access only falls through to the `string` signature.
+    ///
+    /// ## Examples
+    ///
+    /// - `{ [key: symbol]: number }` → `Some(TypeId::NUMBER)`
+    /// - `Record<PropertyKey, string>` → `Some(TypeId::STRING)`
+    /// - `{ [key: string]: number }` → `None`
+    pub fn resolve_symbol_index(&self, obj: TypeId) -> Option<TypeId> {
+        let mut visitor = SymbolIndexResolver {
             db: self.db,
             resolver: self.resolver,
         };


### PR DESCRIPTION
Closes #15411

Symbol-keyed element access `obj[sym]` was silently accepted (or mis-coded as
TS7053) when the receiver's only applicable index signature is a `string`
index. A `string` index signature does not accept `symbol` keys.

Structural rule: when an element-access key is `symbol`/`unique symbol` and the
receiver has a `string` index signature but no `symbol` index signature and no
matching symbol-keyed property, tsc's `checkIndexedAccessIndexType` reports
**TS2538** ("Type 'X' cannot be used as an index type") — distinct from the
implicit-any **TS7053** — because the access still resolves to the string
signature's value type (no cascade). tsz now does the same through the checker's
element-access diagnostic path (`access.rs`), gated by the object-aware
`symbol_key_resolves_via_string_index_only` predicate and a new solver
`IndexSignatureResolver::resolve_symbol_index` query (reusing
`ObjectShape::symbol_index_signature`).

Before → after (tsc 6.0.2 parity, `--noEmit --strict`):

| witness | tsc | tsz before | tsz after |
|---|---|---|---|
| `strIdx[sym]` (`{[k:string]:number}`, wide `symbol`) | TS2538 | *(none)* | TS2538 |
| `noProp[us]` (`{[k:string]:number}`, `unique symbol`) | TS2538 | TS7053 | TS2538 |
| class `{ [k:string]:number }` + `sym` | TS2538 | *(none)* | TS2538 |
| callable `{ (): void; [k:string]:any }` + `sym` | TS2538 | *(none)* | TS2538 |

Negative controls unchanged: `{[k:symbol]:number}` / `Record<PropertyKey,V>`
(symbol index) stay clean; `{x:number}` / `{}` stay TS7053; `{[k:number]:string}`
stays TS7015; well-known-symbol reads on `Array`/`Map` stay clean; the resolved
value type stays the string-index value (assigning to `number` adds no error,
to `string` reports a single TS2322 — no cascade). Renamed-binder variants
verified (rule is structural, not name-driven). Scoped to concrete (non-union /
non-intersection) receivers; composite receivers keep the existing per-member
diagnostic paths.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test symbol_index_signature_tests` (83 passed;
  8 new value-level element-access cases + 75 existing)
- Regression batch (all green): `object_element_access_diagnostics_tests`,
  `element_access_structural_codes_tests`, `callable_interface_index_tests`,
  `ts2538_tparam_resolved_to_any_tests`, `ts7053_*_index_tests`,
  `keyof_well_known_symbol_key_tests`, `homomorphic_*`, `ts2536_*`,
  `index_signature_argument_assignability_tests`, and ~20 more index/symbol
  suites.
- `cargo clippy -p tsz-solver -p tsz-checker` clean.
- Differential sweep vs `tsc` 6.0.2 confirms the symbol divergence is closed
  with no new divergences introduced.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01XPCGNNWm9aWpxzVQhJc888

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPCGNNWm9aWpxzVQhJc888)_