### PR TITLE
perf(solver): memoize contextual signature DAG walks (#15395)

### DIFF
--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -1306,15 +1306,27 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             // types currently on the visit stack and bail with None when we
             // re-enter.
             visiting: rustc_hash::FxHashSet<TypeId>,
+            memo: FxHashMap<TypeId, Option<FunctionShape>>,
+            truncations: usize,
         }
 
         impl<'a> ContextualSignatureVisitor<'a> {
             fn visit_guarded(&mut self, type_id: TypeId) -> Option<FunctionShape> {
+                if let Some(cached) = self.memo.get(&type_id) {
+                    return cached.clone();
+                }
                 if !self.visiting.insert(type_id) {
+                    self.truncations = self.truncations.saturating_add(1);
                     return None;
                 }
+                #[cfg(test)]
+                contextual_signature_test_probe::record_visit(type_id);
+                let entry_truncations = self.truncations;
                 let result = self.visit_type(self.db, type_id);
                 self.visiting.remove(&type_id);
+                if self.truncations == entry_truncations {
+                    self.memo.insert(type_id, result.clone());
+                }
                 result
             }
         }
@@ -1532,6 +1544,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             query_db,
             arg_count,
             visiting: rustc_hash::FxHashSet::default(),
+            memo: FxHashMap::default(),
+            truncations: 0,
         };
         visitor.visit_guarded(type_id)
     }
@@ -1633,5 +1647,48 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             }
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+pub(super) mod contextual_signature_test_probe {
+    use crate::types::TypeId;
+    use std::cell::RefCell;
+
+    thread_local! {
+        static VISITS: RefCell<Option<Vec<TypeId>>> = const { RefCell::new(None) };
+    }
+
+    struct VisitRecorderGuard;
+
+    impl Drop for VisitRecorderGuard {
+        fn drop(&mut self) {
+            VISITS.with(|visits| {
+                visits.borrow_mut().take();
+            });
+        }
+    }
+
+    pub(crate) fn record_visit(type_id: TypeId) {
+        VISITS.with(|visits| {
+            if let Some(recorded) = visits.borrow_mut().as_mut() {
+                recorded.push(type_id);
+            }
+        });
+    }
+
+    pub(crate) fn with_recorded_visits<R>(f: impl FnOnce() -> R) -> (R, Vec<TypeId>) {
+        VISITS.with(|visits| {
+            assert!(
+                visits.borrow().is_none(),
+                "nested contextual visit recorder"
+            );
+            *visits.borrow_mut() = Some(Vec::new());
+        });
+        let guard = VisitRecorderGuard;
+        let result = f();
+        let recorded = VISITS.with(|visits| visits.borrow_mut().take().unwrap_or_default());
+        drop(guard);
+        (result, recorded)
     }
 }

--- a/crates/tsz-solver/src/operations/core/call_resolution_tests.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution_tests.rs
@@ -1,10 +1,12 @@
 //! Unit tests for `resolve_call`'s `Application` arm cross-file alias-of-callable
 //! recovery (refs #13947).
 
-use super::call_evaluator::{AssignabilityChecker, CallEvaluator, CallResult};
+use super::call_evaluator::{
+    AssignabilityChecker, CallEvaluator, CallResult, contextual_signature_test_probe,
+};
 use crate::TypeInterner;
 use crate::def::DefId;
-use crate::types::{FunctionShape, TypeId};
+use crate::types::{FunctionShape, ParamInfo, TypeId};
 
 /// Mock checker modelling the resolver-less cross-file case: `evaluate_type`
 /// cannot reduce the application (the trait default returns it unchanged), but
@@ -96,5 +98,95 @@ fn application_call_target_prefers_evaluation_when_available() {
     assert!(
         matches!(result, CallResult::NotCallable { .. }),
         "a non-progressing expansion must not loop or fabricate callability, got {result:?}"
+    );
+}
+
+#[test]
+fn contextual_signature_memoizes_shared_union_intersection_constituents_per_walk() {
+    let interner = TypeInterner::new();
+    let param = interner.intern_string("value");
+    let callable = |return_type| {
+        interner.function(FunctionShape::new(
+            vec![ParamInfo::required(param, TypeId::STRING)],
+            return_type,
+        ))
+    };
+    let shared = callable(TypeId::STRING);
+    let left_only = callable(TypeId::NUMBER);
+    let right_only = callable(TypeId::BOOLEAN);
+
+    let left = interner.intersect_types_raw2(shared, left_only);
+    let right = interner.intersect_types_raw2(shared, right_only);
+    let contextual = interner.union_literal_reduce(vec![left, right]);
+
+    let (signature, visits) = contextual_signature_test_probe::with_recorded_visits(|| {
+        CallEvaluator::<AliasExpandChecker>::get_contextual_signature_cached(&interner, contextual)
+    });
+
+    assert!(
+        signature.is_some(),
+        "shared callable constituents in union/intersection contextual types \
+         should still produce a contextual signature"
+    );
+    assert_eq!(
+        visits.iter().filter(|&&visited| visited == shared).count(),
+        1,
+        "a shared callable constituent should be walked once per contextual \
+         signature extraction, not once per DAG path"
+    );
+}
+
+fn contextual_signature_in_flight_cycle() -> (TypeInterner, TypeId) {
+    for raw_app in TypeId::FIRST_USER..TypeId::FIRST_USER + 512 {
+        let interner = TypeInterner::new();
+        let future_app = TypeId(raw_app);
+
+        let wrapper = interner.no_infer(future_app);
+        let base = interner.lazy(DefId(wrapper.0));
+        let app = interner.application(base, vec![TypeId::STRING]);
+
+        if app == future_app {
+            assert_eq!(
+                crate::evaluation::evaluate::evaluate_type(&interner, wrapper),
+                app
+            );
+            return (interner, app);
+        }
+    }
+
+    panic!("could not construct a stable contextual-signature cycle");
+}
+
+#[test]
+fn contextual_signature_cycle_truncation_none_is_not_memoized() {
+    let (interner, cyclic_app) = contextual_signature_in_flight_cycle();
+    let param = interner.intern_string("value");
+    let callable = |return_type| {
+        interner.function(FunctionShape::new(
+            vec![ParamInfo::required(param, TypeId::STRING)],
+            return_type,
+        ))
+    };
+
+    let left = interner.intersect_types_raw2(cyclic_app, callable(TypeId::NUMBER));
+    let right = interner.intersect_types_raw2(cyclic_app, callable(TypeId::BOOLEAN));
+    let contextual = interner.union_preserve_members(vec![left, right]);
+
+    let (signature, visits) = contextual_signature_test_probe::with_recorded_visits(|| {
+        CallEvaluator::<AliasExpandChecker>::get_contextual_signature_cached(&interner, contextual)
+    });
+
+    assert!(
+        signature.is_some(),
+        "a cycle-truncated application must not hide callable constituents"
+    );
+    assert_eq!(
+        visits
+            .iter()
+            .filter(|&&visited| visited == cyclic_app)
+            .count(),
+        2,
+        "cycle-truncated None for an in-flight contextual application must not \
+         be memoized"
     );
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Add an operation-local completed-result memo to `ContextualSignatureVisitor` so shared callable constituents in contextual union/intersection DAGs are extracted once per walk instead of once per DAG path.
- Keep the memo scoped to one visitor invocation: `arg_count`, `query_db`, and resolver/database identity are fixed by construction, and no cross-call `QueryCache` surface is added.
- Preserve cycle safety by refusing to memoize any subtree whose extraction observed an in-flight cycle truncation.

## Structural Rule
When a contextual call argument type is a union/intersection DAG with shared callable constituents, `tsc` reuses signature information for the same type object while walking that contextual type. `tsz` previously re-derived `FunctionShape` for a shared constituent once per DAG path through solver operations. `tsz` now owns this in the solver operations visitor by memoizing completed per-walk contextual signature extraction by `TypeId`, without checker, formatter, relation-cache, or fixture-name shortcuts.

## Cache Invariant
- Key: `TypeId` within one `ContextualSignatureVisitor`; `arg_count` and `query_db` are fixed for that visitor instance.
- Reset: visitor lifetime for one contextual-signature extraction; no cross-file or cross-call residency.
- Safety: the in-flight cycle guard still returns `None` on re-entry and increments a truncation counter. Any subtree that observes such a truncation is not inserted into the memo.
- Fallback: non-callable completed misses may be memoized only within the same walk.

## Adjacent Matrix
- Shared callable constituent reached through two union/intersection DAG paths is walked once and still produces a contextual signature.
- In-flight contextual application cycles still terminate, and their cycle-truncated `None` results are not memoized for sibling DAG paths.
- Existing resolver-less application call-target expansion tests remain unchanged.
- Existing contextual signature union behavior tests remain unchanged.
- The TypeBox canary remains a CPU-bound timeout after this slice, so this PR does not claim the row is green.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(contextual_signature_memoizes_shared_union_intersection_constituents_per_walk) or test(contextual_signature_cycle_truncation_none_is_not_memoized)'` (2 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(call_resolution_tests) or test(contextual_signature)'` (7 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy -p tsz-solver --lib --tests -- -D warnings`
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz`
- `TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_FILTER='^typebox-project$' TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 TSZ_PROJECT_COMPILE_TIMEOUT=120 TSZ_PROJECT_COMPILE_RESULT_CACHE=0 TSZ_PROJECT_COMPILE_TSC_ORACLE=0 scripts/safe-run.sh scripts/ci/project-compile-guard.sh` (still red: `typebox-project wall timeout after 120s with 120.35s process CPU (~100% CPU share)` on patched binary `tsz.67c17ac6a09a85e0`)

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
