### PR TITLE
fix(checker): accept object-intersection for-in operands with disjoint discriminants (#15389)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -970,6 +970,9 @@ mod flow_boundary_contract_tests;
 #[path = "tests/flow_cache_policy_arch_tests.rs"]
 mod flow_cache_policy_arch_tests;
 #[cfg(test)]
+#[path = "../tests/for_in_intersection_operand_tests.rs"]
+mod for_in_intersection_operand_tests;
+#[cfg(test)]
 #[path = "tests/for_in_lhs_relation_routing_arch_tests.rs"]
 mod for_in_lhs_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/variable_checking/for_loop.rs
+++ b/crates/tsz-checker/src/state/variable_checking/for_loop.rs
@@ -356,12 +356,23 @@ impl<'a> CheckerState<'a> {
         expression: NodeIndex,
     ) {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
-        use crate::query_boundaries::dispatch as query;
 
         // Skip if type is error
         if expr_type == TypeId::ERROR {
             return;
         }
+
+        // tsc validates the *unreduced* for-in operand: `checkForInStatement` never
+        // routes the right-hand side through `getReducedType`, so an object-type
+        // intersection whose members carry a disjoint discriminant (which tsz reduces
+        // to `never` — at intern time for concrete members via
+        // `intersection_has_disjoint_object_literals`, or through property-access
+        // resolution for generic-application members) is still a valid for-in RHS:
+        // it is assignable to `object`. Judge the intersection on its raw, pre-reduction
+        // structure (resolving each member individually so a generic application like
+        // `WithKind<'a'>` exposes its object shape) BEFORE `resolve_type_for_property_access`
+        // below folds the whole operand to `never` and hides the object-like members.
+        let raw_intersection_is_valid = self.for_in_expr_type_is_valid_intersection(expr_type);
 
         // Resolve lazy/application types before checking (e.g. Record<string, any>)
         let expr_type = self.resolve_type_for_property_access(expr_type);
@@ -369,15 +380,12 @@ impl<'a> CheckerState<'a> {
         // Valid types: any, unknown, object (non-primitive), object types, type parameters
         // Invalid types: primitive types (void, null, undefined, number, string, boolean,
         // bigint, symbol) and `never` (tsc reports TS2407 for `never` as well)
-        let is_valid = expr_type == TypeId::ANY
-            || expr_type == TypeId::UNKNOWN
-            || expr_type == TypeId::OBJECT
-            || query::is_type_parameter_like(self.ctx.types, expr_type)
-            || query::is_object_like_type(self.ctx.types, expr_type)
-            || self.is_deferred_object_like_for_in(expr_type)
+        let is_valid = raw_intersection_is_valid
+            || self.for_in_leaf_type_is_valid(expr_type)
             // Also allow union types that contain valid types
             || self.for_in_expr_type_is_valid_union(expr_type)
-            // Intersection types like `object & T`: valid if ANY member is valid
+            // A deferred alias that resolves to an object intersection is valid if ANY
+            // member is object-like (the raw operand above was not itself an intersection).
             || self.for_in_expr_type_is_valid_intersection(expr_type);
 
         if !is_valid {
@@ -388,6 +396,20 @@ impl<'a> CheckerState<'a> {
             );
             self.error_at_node(expression, &message, diagnostic_codes::THE_RIGHT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MUST_BE_OF_TYPE_ANY_AN_OBJECT_TYPE_OR);
         }
+    }
+
+    /// Leaf (non-union, non-intersection) validity test for a for-in operand:
+    /// `any`, `unknown`, the `object` intrinsic, a type parameter, or any object-like
+    /// type — including deferred index-access / generic-application forms.
+    ///
+    /// `is_deferred_object_like_for_in` already returns `true` for both
+    /// `is_type_parameter_like` and `is_object_like_type`, so this is the single
+    /// predicate shared by the scalar and intersection-member checks.
+    fn for_in_leaf_type_is_valid(&mut self, ty: TypeId) -> bool {
+        ty == TypeId::ANY
+            || ty == TypeId::UNKNOWN
+            || ty == TypeId::OBJECT
+            || self.is_deferred_object_like_for_in(ty)
     }
 
     /// Helper for TS2407: Check if a union type contains at least one valid for-in expression type.
@@ -413,22 +435,32 @@ impl<'a> CheckerState<'a> {
         false
     }
 
-    /// Helper for TS2407: Check if an intersection type contains at least one valid for-in member.
-    /// `object & T` is valid because it contains `object`.
+    /// Helper for TS2407: Check if an intersection type is a valid for-in operand.
+    ///
+    /// tsc accepts an intersection RHS when it is assignable to `object` — which
+    /// holds as soon as ANY constituent is object-like / type-parameter-like, since
+    /// `A & B` is a subtype of each member. `object & T` is valid because it contains
+    /// `object`; `WithKind<'a'> & WithKind<'b'>` is valid because each member is an
+    /// object type, even though their disjoint discriminant reduces the intersection
+    /// to `never`. Each member is resolved for property access *individually* so a
+    /// deferred generic application exposes its object shape without collapsing the
+    /// whole intersection to `never`.
     fn for_in_expr_type_is_valid_intersection(&mut self, expr_type: TypeId) -> bool {
         use crate::query_boundaries::dispatch as query;
 
-        if let Some(members) = query::intersection_members(self.ctx.types, expr_type) {
-            for &member in &members {
-                if member == TypeId::ANY
-                    || member == TypeId::UNKNOWN
-                    || member == TypeId::OBJECT
-                    || query::is_type_parameter_like(self.ctx.types, member)
-                    || query::is_object_like_type(self.ctx.types, member)
-                    || self.is_deferred_object_like_for_in(member)
-                {
-                    return true;
-                }
+        let Some(members) = query::intersection_members(self.ctx.types, expr_type) else {
+            return false;
+        };
+        for &member in &members {
+            if self.for_in_leaf_type_is_valid(member) {
+                return true;
+            }
+            // Resolve deferred members (generic applications, aliases) individually.
+            // Resolving a single member does NOT trigger the whole-intersection
+            // never-collapse, so `WithKind<'a'>` becomes the object type `{ kind: 'a' }`.
+            let resolved_member = self.resolve_type_for_property_access(member);
+            if resolved_member != member && self.for_in_leaf_type_is_valid(resolved_member) {
+                return true;
             }
         }
         false

--- a/crates/tsz-checker/tests/for_in_intersection_operand_tests.rs
+++ b/crates/tsz-checker/tests/for_in_intersection_operand_tests.rs
@@ -1,0 +1,183 @@
+//! Regression tests for TS2407 on `for-in` operands that are object-type
+//! intersections carrying a disjoint discriminant (issue #15389).
+//!
+//! `tsc`'s `checkForInStatement` validates the RIGHT-HAND SIDE without ever
+//! routing it through `getReducedType`. So an object intersection whose members
+//! share a disjoint discriminant — which reduces the intersection to `never`
+//! under reduction — is still a valid for-in operand, because the unreduced
+//! intersection is assignable to `object`. tsz previously reduced the operand
+//! (via property-access resolution for generic-application members) before the
+//! validity gate and emitted a false TS2407 rendered with `never`.
+//!
+//! Binder names are varied across cases so the fix cannot rely on any
+//! user-chosen identifier.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+const TS2407: u32 = 2407;
+
+fn assert_no_2407(source: &str, label: &str) {
+    let codes = check_strict(source);
+    assert!(
+        !codes.contains(&TS2407),
+        "{label}: expected no TS2407 (tsc accepts the unreduced intersection operand), got codes: {codes:?}"
+    );
+}
+
+fn assert_has_2407(source: &str, label: &str) {
+    let codes = check_strict(source);
+    assert!(
+        codes.contains(&TS2407),
+        "{label}: expected TS2407 for a non-object for-in operand, got codes: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// MUST BE CLEAN — object-type intersections (tsc accepts)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generic_application_disjoint_discriminant_is_valid_for_in_operand() {
+    // The primary witness from #15389.
+    let source = r#"
+type WithKind<K> = { kind: K };
+declare const value: WithKind<'a'> & WithKind<'b'>;
+for (const k in value) {}
+"#;
+    assert_no_2407(source, "generic-application disjoint discriminant");
+}
+
+#[test]
+fn mixed_concrete_and_generic_disjoint_discriminant_is_valid() {
+    let source = r#"
+type Labelled<L> = { label: L };
+declare const mixed: { label: 'x' } & Labelled<'y'>;
+for (const key in mixed) {}
+"#;
+    assert_no_2407(source, "mixed concrete + generic disjoint discriminant");
+}
+
+#[test]
+fn alias_wrapped_intersection_with_renamed_binders_is_valid() {
+    let source = r#"
+type Tagged<Marker> = { tag: Marker };
+type Both = Tagged<'left'> & Tagged<'right'>;
+declare const both: Both;
+for (const entry in both) {}
+"#;
+    assert_no_2407(source, "alias-wrapped intersection, renamed binders");
+}
+
+#[test]
+fn nested_alias_intersection_is_valid() {
+    let source = r#"
+type WithMode<M> = { mode: M };
+declare const nested:
+    (WithMode<'read'> & { payload: number }) & (WithMode<'write'> & { payload: number });
+for (const field in nested) {}
+"#;
+    assert_no_2407(source, "nested alias intersection");
+}
+
+#[test]
+fn disjoint_numeric_literal_discriminant_is_valid() {
+    let source = r#"
+type Slot<N> = { slot: N };
+declare const slots: Slot<1> & Slot<2>;
+for (const s in slots) {}
+"#;
+    assert_no_2407(source, "disjoint numeric literal discriminant");
+}
+
+#[test]
+fn disjoint_boolean_literal_discriminant_is_valid() {
+    let source = r#"
+type Flagged<B> = { flag: B };
+declare const flags: Flagged<true> & Flagged<false>;
+for (const bit in flags) {}
+"#;
+    assert_no_2407(source, "disjoint boolean literal discriminant");
+}
+
+#[test]
+fn object_intrinsic_intersected_with_type_parameter_stays_valid() {
+    // `object & T` — a member (`object`) is already object-like.
+    let source = r#"
+function iterate<T extends object>(input: object & T): void {
+    for (const prop in input) {}
+}
+iterate;
+"#;
+    assert_no_2407(source, "object & T");
+}
+
+#[test]
+fn non_conflicting_application_intersection_stays_valid() {
+    let source = r#"
+type WithKind<K> = { kind: K };
+declare const merged: WithKind<'a'> & { extra: number };
+for (const k in merged) {}
+"#;
+    assert_no_2407(source, "non-conflicting application intersection");
+}
+
+#[test]
+fn bare_type_parameter_operand_stays_valid() {
+    let source = r#"
+function loop<Elem>(input: Elem): void {
+    for (const k in input) {}
+}
+loop;
+"#;
+    assert_no_2407(source, "bare type parameter operand");
+}
+
+#[test]
+fn record_alias_operand_stays_valid() {
+    let source = r#"
+declare const table: Record<string, number>;
+for (const key in table) {}
+"#;
+    assert_no_2407(source, "Record<string, number> alias operand");
+}
+
+// ---------------------------------------------------------------------------
+// MUST ERROR — genuinely invalid for-in operands (tsc rejects)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn direct_never_operand_still_errors() {
+    let source = r#"
+declare const nothing: never;
+for (const k in nothing) {}
+"#;
+    assert_has_2407(source, "direct never operand");
+}
+
+#[test]
+fn disjoint_primitive_intersection_still_errors() {
+    // `string & number` reduces to `never` and is NOT object-like — tsc errors.
+    let source = r#"
+declare const impossible: string & number;
+for (const k in impossible) {}
+"#;
+    assert_has_2407(source, "string & number operand");
+}
+
+#[test]
+fn primitive_string_operand_still_errors() {
+    let source = r#"
+declare const text: string;
+for (const k in text) {}
+"#;
+    assert_has_2407(source, "string operand");
+}
+
+#[test]
+fn primitive_number_operand_still_errors() {
+    let source = r#"
+declare const count: number;
+for (const k in count) {}
+"#;
+    assert_has_2407(source, "number operand");
+}


### PR DESCRIPTION
Closes #15389.

Structural rule: when a `for-in` right-hand side is an object-type intersection whose members carry a disjoint discriminant, `tsc` validates the **unreduced** operand — `checkForInStatement` never routes the RHS through `getReducedType`, so the intersection is a valid for-in operand because it is assignable to `object`. tsz reduced the operand first (through property-access resolution for generic-application members like `WithKind<'a'> & WithKind<'b'>`), collapsing it to `never` and emitting a false `TS2407` rendered with `never`.

Owner layer: checker — `check_for_in_expression_type` (`crates/tsz-checker/src/state/variable_checking/for_loop.rs`). The gate now judges the intersection on its **raw, pre-reduction** structure, resolving each member individually so a deferred generic application exposes its object shape without triggering the whole-intersection never-collapse. Genuine `never`, disjoint primitives (`string & number`), and other non-object operands still error. Extracted the shared leaf-validity predicate `for_in_leaf_type_is_valid` so the scalar and intersection-member checks no longer duplicate the 6-way test.

Adjacent matrix (differential intent vs `tsc` 6.0-dev):
- must be CLEAN: generic-application disjoint discriminant (the witness), mixed concrete + generic, alias-wrapped with renamed binders, nested alias intersections, disjoint numeric/boolean literals, `object & T`, non-conflicting application intersection, bare type parameter, `Record<string, number>`.
- must still ERROR: direct `never`, `string & number`, primitive `string`, primitive `number`.

Scope note: a purely-concrete inline intersection (`{ kind: 'a' } & { kind: 'b' }`) is collapsed to `never` at **intern time** — a decision that is load-bearing for assignability / `keyof` / property-access parity (those paths reduce by evaluating members and re-interning, which re-hits the same collapse). Recovering it for for-in requires deferring intersection reduction globally, which is the separate #15349 / #15350 campaign, so it is intentionally out of scope here and left unchanged (it already errored before this PR — no regression).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib for_in_intersection_operand` — 14/14 pass (10 must-be-clean, 4 must-error; binder names varied per case).
- Related suites unaffected (218 intersection tests, for-in narrowing, discriminant/narrowing families): the only failures observed are pre-existing on the base branch with this change stashed (the "disabled CI let through" main-suite breakages), not introduced here.
- End-to-end CLI differential on the full adjacent matrix: all clean cases clean, all error cases error.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --tests` clean.
- Broad conformance / emit / fourslash owned by exact-head ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_012PAu7Pf8oBpdofPoBcUsT9)_