### PR TITLE
fix(checker): preserve Mapped identity for concrete mapped aliases (#15392)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/state/type_resolution.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/type_resolution.rs
@@ -3,8 +3,9 @@ use tsz_solver::construction::TypeDatabase;
 
 pub(crate) use super::super::common::lazy_def_id as get_lazy_def_id;
 pub(crate) use super::super::common::{
-    callable_shape_for_type, intersection_members, is_tuple_like_type, is_tuple_type,
-    is_type_parameter_like, lazy_def_id, resolve_default_type_args, string_literal_value,
+    callable_shape_for_type, intersection_members, is_mapped_type, is_tuple_like_type,
+    is_tuple_type, is_type_parameter_like, lazy_def_id, resolve_default_type_args,
+    string_literal_value,
 };
 pub(crate) use super::super::generic_instantiation::instantiate_generic;
 pub(crate) use tsz_solver::type_queries::{

--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -1424,6 +1424,62 @@ type Probe = Gen2<ABC.A>;
         assert_alias_property(source, "Probe", "v", true);
     }
 
+    /// Rule: a concrete (type-parameter-free) mapped body `{ [K in E]: V }`
+    /// keeps its `Mapped` structural identity through type-alias stabilization,
+    /// rather than being eagerly materialized to a plain object (#15392, culprit
+    /// #10522). Preserving the identity is what lets diagnostics recover the enum
+    /// key origin and lets mapped-over-`keyof` property resolution see the
+    /// iteration constraint. Binder names are varied (`Weekday`/`Schedule`, not
+    /// `E`/`M`) so the check is structural, not keyed on spelling. A wrapper alias
+    /// (`type S2 = Schedule`) must preserve it too, and a plain object alias is
+    /// the negative control that stays materialized.
+    #[test]
+    fn concrete_enum_key_mapped_alias_preserves_mapped_identity() {
+        let source = r#"
+enum Weekday { Mon = "mon", Tue = "tue" }
+type Schedule = { [K in Weekday]: number };
+type ScheduleAlias = Schedule;
+type Plain = { mon: number; tue: number };
+"#;
+        let (parser, root, binder, types) = build_checker(source);
+        let mut checker = CheckerState::new(
+            parser.get_arena(),
+            &binder,
+            &types,
+            "test.ts".to_string(),
+            CheckerOptions::default(),
+        );
+        checker.ctx.set_lib_contexts(Vec::new());
+        checker.check_source_file(root);
+
+        let db = checker.ctx.types.as_type_database();
+        let resolve = |c: &mut CheckerState, name: &str| -> tsz_solver::TypeId {
+            let sym = c.ctx.binder.file_locals.get(name).expect("symbol");
+            c.type_reference_symbol_type(sym)
+        };
+
+        let schedule = resolve(&mut checker, "Schedule");
+        assert!(
+            tsz_solver::type_queries::is_mapped_type(db, schedule),
+            "concrete enum-key mapped alias must stay a Mapped type, got {}",
+            checker.format_type(schedule),
+        );
+
+        let schedule_alias = resolve(&mut checker, "ScheduleAlias");
+        assert!(
+            tsz_solver::type_queries::is_mapped_type(db, schedule_alias),
+            "wrapper alias of a concrete mapped type must preserve Mapped identity, got {}",
+            checker.format_type(schedule_alias),
+        );
+
+        let plain = resolve(&mut checker, "Plain");
+        assert!(
+            !tsz_solver::type_queries::is_mapped_type(db, plain),
+            "plain object alias must not be a Mapped type (negative control), got {}",
+            checker.format_type(plain),
+        );
+    }
+
     /// Rule: when `T extends U ? A : B` is deferred (contains type parameters),
     /// property access uses `A | B` as the apparent type. Properties not on all
     /// branches must produce TS2339; properties on all branches must be accepted.

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -441,12 +441,10 @@ impl<'a> CheckerState<'a> {
                     && structural_type != TypeId::UNKNOWN
                     && !preserve_deferred_keyof
                     && !query::is_union_or_intersection(self.ctx.types, structural_type)
-                    // Keep a concrete mapped body (`{ [K in E]: V }`) structural.
-                    // Materializing it here erases the `Mapped` identity that
-                    // diagnostics and mapped-over-`keyof` property resolution
-                    // recover the iteration constraint from (#15392). Generic
-                    // mapped bodies are already preserved via the type-parameter
-                    // guard below; this keeps their concrete forms consistent.
+                    // Keep a concrete mapped body (`{ [K in E]: V }`) structural:
+                    // materializing it erases the `Mapped` identity that diagnostics
+                    // and mapped-over-`keyof` property resolution recover the iteration
+                    // constraint from (#15392). Generic mapped bodies use the guard below.
                     && !query::is_mapped_type(self.ctx.types, structural_type)
                     && !crate::query_boundaries::common::contains_type_parameters(
                         self.ctx.types,

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -441,6 +441,13 @@ impl<'a> CheckerState<'a> {
                     && structural_type != TypeId::UNKNOWN
                     && !preserve_deferred_keyof
                     && !query::is_union_or_intersection(self.ctx.types, structural_type)
+                    // Keep a concrete mapped body (`{ [K in E]: V }`) structural.
+                    // Materializing it here erases the `Mapped` identity that
+                    // diagnostics and mapped-over-`keyof` property resolution
+                    // recover the iteration constraint from (#15392). Generic
+                    // mapped bodies are already preserved via the type-parameter
+                    // guard below; this keeps their concrete forms consistent.
+                    && !query::is_mapped_type(self.ctx.types, structural_type)
                     && !crate::query_boundaries::common::contains_type_parameters(
                         self.ctx.types,
                         structural_type,


### PR DESCRIPTION
Structural rule: when a type alias has a concrete (type-parameter-free) mapped body `{ [K in E]: V }`, tsc keeps the `Mapped`/alias identity observable to diagnostics (TS2741 renders a single missing enum key as `[E.B]`) and to property resolution on instantiations; tsz — since #10522 switched concrete-alias stabilization from `evaluate_type_with_resolution` to `evaluate_type_with_env` (`state/type_resolution/symbol_types.rs`) — materialized the mapped body to a plain object, erasing the `Mapped` node before any consumer (the enum-key display recovery in `error_reporter`, and mapped-over-`keyof` property resolution) could recover the iteration constraint.

Owner layer: checker alias stabilization (`state/type_resolution`). The eager `evaluate_type_with_env` at the stabilization gate exists to fully resolve **conditional** types for assignability; it already excludes unions/intersections, deferred `keyof`, and type-parameter-bearing bodies — which is what keeps **generic** mapped bodies structural. Concrete mapped bodies slipped through only because they carry no type parameters. This change adds `!is_mapped_type(...)` to the same gate so concrete mapped bodies stay structural too, symmetric with the generic case; nothing that needs a materialized object is starved, since property access / assignability still expand mapped types lazily on demand. Reuses the existing `query_boundaries::common::is_mapped_type` predicate (no new wrapper). Conditional-type resolution (the reason #10522 exists) is untouched.

Adjacent matrix (binder names varied — `Weekday`/`Schedule`, not `E`/`M`): direct concrete enum-key mapped alias, wrapper alias (`type S2 = Schedule`), string and numeric enums, renamed enums; negative controls: plain object alias stays materialized, string-literal-union mapped key stays bare, multi-missing TS2739 list stays bare.

Scope note: the `mapped_enum_discriminant_application_exposes_member_property` semantic witness in #15392 (property access on `Gen2<ABC.A>`, a mapped-over-`keyof`-of-intersection application) is a **distinct** root cause and stays out of scope here: `keyof` of the distributed union `{v:ABC.A,a} | {v:ABC.A&ABC.B,b}` drops `"a"` because the impossible member `{v: ABC.A & ABC.B}` is not pruned — `prune_impossible_object_union_members` returns a stale interner-memoized result computed while the enum members were still unresolved `Enum(DefId, Lazy)` (mutually-subtype). That is the intersection-reduction / materialize-or-defer campaign (#15349/#15350/#15396), not mapped-identity, and is a hot-cache change unsafe to bundle here. This test is pre-existing-red on `main` and remains red (not introduced by this PR).

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --lib assignment_checker_mapped_type_tests::mapped` — the 3 previously-red enum-key display tests (`mapped_string_enum_alias_single_missing_uses_member_display`, `mapped_numeric_enum_single_missing_uses_member_display`, `mapped_enum_key_member_display_is_not_name_specific`) now pass; string-union and multi-missing negative controls stay green.
- New `concrete_enum_key_mapped_alias_preserves_mapped_identity` (property_access tests) — asserts a concrete enum-key mapped alias and its wrapper alias stay `Mapped`, with a plain-object negative control; passes.
- Full `cargo nextest run -p tsz-checker --lib` differential vs clean `main`: baseline 85 failed → this branch 82 failed, **zero new failures**, 3 fixed. (The residual 82 are the pre-existing `#15338` disabled-CI breakages.)
- `cargo fmt -p tsz-checker` clean; `cargo clippy -p tsz-checker --lib --tests` clean (0 warnings).
- Broad conformance/emit/fourslash owned by exact-head ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Czn9hqvGf1oySEPqetTU6Y)_