### PR TITLE
fix(checker): nest per-candidate relation reason chain under TS2769 overload failures

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -10,6 +10,7 @@ use crate::error_reporter::fingerprint_policy::{
 };
 use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
 use crate::state::CheckerState;
+use rustc_hash::FxHashSet;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
@@ -1060,53 +1061,126 @@ impl<'a> CheckerState<'a> {
         else {
             return;
         };
-        let mut related = Vec::new();
-        let mut formatter = self.ctx.create_type_formatter();
         let span =
             tsz_solver::SourceSpan::new(self.ctx.file_name.as_str(), anchor.start, anchor.length);
 
         tracing::debug!("File name: {}", self.ctx.file_name);
 
-        for failure in failures {
-            let mut pending: PendingDiagnostic = PendingDiagnostic {
-                span: Some(span.clone()),
-                ..failure.clone()
-            };
-            // Mirror tsc's `reportRelationError` source generalization for each
-            // overload's argument failure, matching the single-signature TS2345
-            // path: a fresh literal source (`true`, `1`) is widened to its base
-            // (`boolean`, `number`) unless the parameter target could hold a
-            // top-level singleton type. The pre-built solver diagnostic carries
-            // the raw literal source, so without this the overload elaboration
-            // diverges from tsc (and from the single-overload TS2345 display).
-            if pending.code
-                == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
-                && let (
-                    Some(tsz_solver::DiagnosticArg::Type(source)),
-                    Some(tsz_solver::DiagnosticArg::Type(target)),
-                ) = (pending.args.first(), pending.args.get(1))
-            {
-                let (source, target) = (*source, *target);
-                let display_source =
-                    crate::query_boundaries::diagnostics::generalized_literal_source_for_display(
-                        self.ctx.types,
-                        source,
-                        target,
-                    );
-                if display_source != source {
-                    pending.args[0] = tsz_solver::DiagnosticArg::Type(display_source);
+        // Phase 1 — render each candidate's top-level failure line. Rendering
+        // borrows `self.ctx` immutably through the formatter, so the finished
+        // strings are collected here and the (`&mut self`) reason analysis is
+        // deferred to phase 2. Every candidate is anchored at the same shared
+        // `span`, so the header/chain span is recovered once in phase 2 rather
+        // than stored per entry. `reason_types` carries the *original*
+        // (pre-generalization) argument/parameter pair so the nested chain
+        // reflects the real relation rather than the display-widened source.
+        struct RenderedOverloadFailure {
+            message: String,
+            code: u32,
+            reason_types: Option<(TypeId, TypeId)>,
+        }
+        let mut rendered: Vec<RenderedOverloadFailure> = Vec::new();
+        {
+            let mut formatter = self.ctx.create_type_formatter();
+            for failure in failures {
+                // The original (pre-generalization) argument/parameter pair,
+                // present only for argument-not-assignable candidates. It drives
+                // both the display generalization just below and — unwidened —
+                // phase 2's reason chain, so it is extracted once from
+                // `failure.args` (the copy `pending.args` holds the same pair).
+                let arg_types: Option<(TypeId, TypeId)> = if failure.code
+                    == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+                {
+                    match (failure.args.first(), failure.args.get(1)) {
+                        (
+                            Some(tsz_solver::DiagnosticArg::Type(source)),
+                            Some(tsz_solver::DiagnosticArg::Type(target)),
+                        ) => Some((*source, *target)),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+                let mut pending: PendingDiagnostic = PendingDiagnostic {
+                    span: Some(span.clone()),
+                    ..failure.clone()
+                };
+                // Mirror tsc's `reportRelationError` source generalization for
+                // each overload's argument failure, matching the single-signature
+                // TS2345 path: a fresh literal source (`true`, `1`) is widened to
+                // its base (`boolean`, `number`) unless the parameter target could
+                // hold a top-level singleton type. The pre-built solver diagnostic
+                // carries the raw literal source, so without this the overload
+                // elaboration diverges from tsc (and from the single-overload
+                // TS2345 display).
+                if let Some((source, target)) = arg_types {
+                    let display_source =
+                        crate::query_boundaries::diagnostics::generalized_literal_source_for_display(
+                            self.ctx.types,
+                            source,
+                            target,
+                        );
+                    if display_source != source {
+                        pending.args[0] = tsz_solver::DiagnosticArg::Type(display_source);
+                    }
                 }
-            }
-            let diag = formatter.render(&pending);
-            if let Some(diag_span) = diag.span.as_ref() {
-                related.push(DiagnosticRelatedInformation {
-                    file: diag_span.file.to_string(),
-                    start: diag_span.start,
-                    length: diag_span.length,
-                    message_text: diag.message.clone(),
-                    category: DiagnosticCategory::Message,
+                // `pending.span` is always `Some` (set above) and `render`
+                // copies it through, so every candidate yields a rendered header;
+                // the entries are re-anchored to the shared `anchor` span in
+                // phase 2, so `diag.span` itself is no longer read.
+                let diag = formatter.render(&pending);
+                rendered.push(RenderedOverloadFailure {
+                    message: diag.message,
                     code: diag.code,
-                    depth: 0,
+                    reason_types: arg_types,
+                });
+            }
+        }
+
+        // Phase 2 — emit each candidate as a header line at depth 0 followed by
+        // its relation failure-reason chain nested one level deeper. The chain
+        // is built through the same `related_from_failure_reason` gateway the
+        // single-signature TS2345 path uses, so an overloaded callback mismatch
+        // carries the identical `Types of parameters 'a' and 'x' are
+        // incompatible.` sub-chain instead of a bare argument line
+        // (`getSignatureApplicabilityError` reuses the single-signature relation
+        // elaboration in tsc). Whole candidates are deduped by header so repeated
+        // identical overloads collapse to one entry exactly as before; the chain
+        // entries are re-anchored onto the header's span so they nest visually
+        // beneath it.
+        let anchor_file = span.file.to_string();
+        let mut related = Vec::new();
+        let mut seen_headers = FxHashSet::default();
+        for failure in rendered {
+            if !seen_headers.insert(failure.message.clone()) {
+                continue;
+            }
+            related.push(DiagnosticRelatedInformation {
+                file: anchor_file.clone(),
+                start: anchor.start,
+                length: anchor.length,
+                message_text: failure.message,
+                category: DiagnosticCategory::Message,
+                code: failure.code,
+                depth: 0,
+            });
+            let Some((source, target)) = failure.reason_types else {
+                continue;
+            };
+            let analysis = self.analyze_assignability_failure(source, target);
+            let Some(reason) = analysis.failure_reason else {
+                continue;
+            };
+            let Some(chain) = self.related_from_failure_reason(&reason, source, target, anchor_idx)
+            else {
+                continue;
+            };
+            for item in chain {
+                related.push(DiagnosticRelatedInformation {
+                    file: anchor_file.clone(),
+                    start: anchor.start,
+                    length: anchor.length,
+                    ..item.with_depth_shift(1)
                 });
             }
         }

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -45,6 +45,15 @@ pub(crate) struct RelatedInformationPolicy {
     include_primary: bool,
     dedupe: bool,
     limit: Option<usize>,
+    /// Whether to re-sort the related entries by `(file, start, depth, message)`
+    /// during normalization. The sort gives a deterministic outer-to-inner
+    /// order for a *single* elaboration chain anchored at one span. When several
+    /// independent chains share the same anchor span (e.g. one per failing
+    /// overload candidate, all pointing at the same argument), the global sort
+    /// interleaves them by depth and severs each chain from its header. Such
+    /// callers assemble the entries in their intended final order and set this
+    /// to `false` to keep that order.
+    sort: bool,
 }
 
 impl RelatedInformationPolicy {
@@ -52,6 +61,7 @@ impl RelatedInformationPolicy {
         include_primary: true,
         dedupe: true,
         limit: None,
+        sort: true,
     };
 
     /// Demote a diagnostic's primary message into the related chain, keeping any
@@ -61,12 +71,21 @@ impl RelatedInformationPolicy {
         include_primary: true,
         dedupe: true,
         limit: None,
+        sort: true,
     };
 
+    /// One elaboration chain per failing overload candidate, every chain
+    /// anchored at the same argument span. The caller
+    /// (`error_no_overload_matches_at`) already emits the entries grouped
+    /// header-then-chain in candidate order and dedupes whole candidates by
+    /// header, so normalization must neither re-sort (which would interleave the
+    /// chains) nor dedupe across chains (which would drop a shared inner line
+    /// such as an identical `Types of parameters …` frame and orphan its leaf).
     pub(crate) const OVERLOAD_FAILURES: Self = Self {
         include_primary: false,
-        dedupe: true,
+        dedupe: false,
         limit: None,
+        sort: false,
     };
 }
 
@@ -981,13 +1000,20 @@ impl<'a> CheckerState<'a> {
         // main message and its note. Within the same depth the message-text
         // tiebreaker still gives deterministic order when distinct code paths
         // append items in different sequences.
-        normalized.sort_by(|a, b| {
-            a.file
-                .cmp(&b.file)
-                .then(a.start.cmp(&b.start))
-                .then(a.depth.cmp(&b.depth))
-                .then(a.message_text.cmp(&b.message_text))
-        });
+        //
+        // Policies that assemble several independent chains at one shared anchor
+        // (see `OVERLOAD_FAILURES`) opt out: the caller already fixed a
+        // deterministic candidate order, and a global sort would interleave the
+        // chains by depth and detach each from its header.
+        if policy.sort {
+            normalized.sort_by(|a, b| {
+                a.file
+                    .cmp(&b.file)
+                    .then(a.start.cmp(&b.start))
+                    .then(a.depth.cmp(&b.depth))
+                    .then(a.message_text.cmp(&b.message_text))
+            });
+        }
 
         normalized
     }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1372,6 +1372,9 @@ mod overlap_relation_helper_routing_arch_tests;
 #[path = "tests/overload_anchor_at_argument_tests.rs"]
 mod overload_anchor_at_argument_tests;
 #[cfg(test)]
+#[path = "tests/overload_argument_reason_chain_tests.rs"]
+mod overload_argument_reason_chain_tests;
+#[cfg(test)]
 #[path = "tests/overload_generic_wrapper_compat_tests.rs"]
 mod overload_generic_wrapper_compat_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/overload_argument_reason_chain_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_argument_reason_chain_tests.rs
@@ -1,0 +1,200 @@
+//! Regression tests for the relation failure-reason sub-chain nested under each
+//! candidate's argument line in a TS2769 ("No overload matches this call")
+//! elaboration.
+//!
+//! When a call matches no overload and a candidate's argument mismatch has an
+//! elaborable relation failure reason (e.g. a contravariant callback-parameter
+//! incompatibility), tsc nests the full reason chain under that candidate — the
+//! same `checkTypeRelatedToAndOptionallyElaborate` chain the single-signature
+//! TS2345 path renders. Previously tsz built each candidate failure as a bare
+//! two-argument diagnostic and dropped the reason chain, so an overloaded
+//! callback mismatch printed only the flat `Argument of type … is not
+//! assignable …` line while the identical single-signature call printed the
+//! nested `Types of parameters 'a' and 'x' are incompatible.` sub-chain.
+//!
+//! The fix routes each candidate's argument failure through the shared
+//! `related_from_failure_reason` gateway (owner:
+//! `crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs`,
+//! `error_no_overload_matches_at`) and re-anchors the chain one nesting level
+//! beneath the candidate's header line.
+
+use crate::test_utils::check_source_diagnostics;
+
+/// One flattened related-information entry: `(depth, code, message)`.
+type RelatedLine = (u8, u32, String);
+
+/// Collect the flattened related-information chain of the single TS2769
+/// diagnostic, preserving the emitted order and per-line nesting depth.
+fn overload_related_chain(source: &str) -> Vec<RelatedLine> {
+    let diags = check_source_diagnostics(source);
+    let ts2769: Vec<_> = diags.iter().filter(|d| d.code == 2769).collect();
+    assert_eq!(
+        ts2769.len(),
+        1,
+        "Expected exactly one TS2769. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    ts2769[0]
+        .related_information
+        .iter()
+        .map(|r| (r.depth, r.code, r.message_text.clone()))
+        .collect()
+}
+
+/// Assert the contravariant callback-parameter sub-chain nests beneath a
+/// candidate header: the `param_frame` line (`Types of parameters '_' and '_'
+/// are incompatible.`) at depth >= 1, and the `string`/`boolean` contravariant
+/// leaf one level deeper (depth >= 2). Shared by the callback witness, the
+/// renamed-binder, and the constructor-overload cases, which differ only in the
+/// frame's parameter identifiers.
+fn assert_contravariant_nesting(chain: &[RelatedLine], param_frame: &str) {
+    assert!(
+        chain
+            .iter()
+            .any(|(depth, _, msg)| *depth >= 1 && msg == param_frame),
+        "expected the nested parameter-incompatibility frame `{param_frame}` under a candidate, got: {chain:?}"
+    );
+    assert!(
+        chain.iter().any(|(depth, _, msg)| *depth >= 2
+            && msg == "Type 'string' is not assignable to type 'boolean'."),
+        "expected the contravariant leaf under the parameter frame, got: {chain:?}"
+    );
+}
+
+/// The witness from the bug report: an overloaded callback called with a
+/// contravariantly-incompatible parameter. Each candidate's argument line must
+/// carry the nested `Types of parameters 'a' and 'x' are incompatible.` frame
+/// plus its contravariant leaf, exactly as the single-signature TS2345 path
+/// does — not a bare argument line.
+#[test]
+fn overloaded_callback_parameter_mismatch_nests_reason_chain() {
+    let chain = overload_related_chain(
+        r#"
+declare function each(cb: (x: string) => void): void;
+declare function each(cb: (x: number, i: number) => void): void;
+each((a: boolean) => {});
+"#,
+    );
+
+    // Every candidate header line is a depth-0 argument-not-assignable entry.
+    let headers: Vec<&RelatedLine> = chain.iter().filter(|(d, _, _)| *d == 0).collect();
+    assert!(
+        headers
+            .iter()
+            .all(|(_, code, msg)| *code == 2345 && msg.starts_with("Argument of type")),
+        "each candidate header must be a depth-0 TS2345 argument line, got: {chain:?}"
+    );
+    assert!(
+        headers.len() >= 2,
+        "both overloads must contribute a header line, got: {chain:?}"
+    );
+
+    // The reason sub-chain must appear nested beneath the headers: the parameter
+    // frame at depth >= 1 and the contravariant leaf one level deeper.
+    assert_contravariant_nesting(&chain, "Types of parameters 'a' and 'x' are incompatible.");
+
+    // Grouping invariant: a candidate header is immediately followed by its own
+    // deeper chain (no interleaving of the two candidates' chains).
+    let first_header = chain
+        .iter()
+        .position(|(d, _, _)| *d == 0)
+        .expect("a header must exist");
+    assert!(
+        chain
+            .get(first_header + 1)
+            .is_some_and(|(depth, _, _)| *depth >= 1),
+        "the first header must be directly followed by its nested chain, got: {chain:?}"
+    );
+}
+
+/// Anti-hardcoding: the behavior is structural, not keyed to specific binder or
+/// parameter names. Renaming the callee and the parameters produces the same
+/// nested frame (with the renamed parameter identifiers).
+#[test]
+fn nested_reason_chain_is_independent_of_binder_names() {
+    let chain = overload_related_chain(
+        r#"
+declare function apply(handler: (value: string) => void): void;
+declare function apply(handler: (value: number, index: number) => void): void;
+apply((flag: boolean) => {});
+"#,
+    );
+
+    assert_contravariant_nesting(
+        &chain,
+        "Types of parameters 'flag' and 'value' are incompatible.",
+    );
+}
+
+/// `new` overloads take the same construction path: a constructor-overload
+/// callback mismatch must nest its reason chain identically to the `call` form.
+#[test]
+fn constructor_overload_callback_mismatch_nests_reason_chain() {
+    let chain = overload_related_chain(
+        r#"
+declare class Box {
+    constructor(cb: (x: string) => void);
+    constructor(cb: (x: number, i: number) => void);
+}
+new Box((a: boolean) => {});
+"#,
+    );
+
+    assert_contravariant_nesting(&chain, "Types of parameters 'a' and 'x' are incompatible.");
+}
+
+/// A non-fresh object argument that is missing a required property nests the
+/// `Property 'id' is missing …` reason (TS2741) beneath the candidate header,
+/// confirming the gateway drills reason variants other than parameter
+/// mismatches. A declared variable source (not a fresh object literal) is used
+/// so the failure is a genuine `MissingProperty` relation reason rather than the
+/// excess-property (TS2353) path, which is elaborated elsewhere.
+#[test]
+fn overloaded_object_argument_missing_property_nests_reason_chain() {
+    let chain = overload_related_chain(
+        r#"
+interface WithId { id: number; }
+interface WithBoth { id: number; tag: string; }
+declare function save(x: WithId): void;
+declare function save(x: WithBoth): void;
+declare const partial: { tag: string };
+save(partial);
+"#,
+    );
+
+    // At least one candidate nests a missing-property reason (TS2741)
+    // beneath the header instead of leaving a bare argument line.
+    assert!(
+        chain
+            .iter()
+            .any(|(depth, _, msg)| *depth >= 1 && msg.contains("is missing in type")),
+        "expected a nested missing-property reason under a candidate, got: {chain:?}"
+    );
+}
+
+/// Control: non-elaborable primitive-vs-primitive overload mismatches keep just
+/// the flat argument headers — the fix must not synthesize an empty or spurious
+/// nested chain when the relation has no reason to elaborate.
+#[test]
+fn primitive_overload_mismatch_keeps_flat_headers() {
+    let chain = overload_related_chain(
+        r#"
+declare function f(x: number): void;
+declare function f(x: string): void;
+f(true);
+"#,
+    );
+
+    assert!(
+        chain.iter().all(|(depth, _, _)| *depth == 0),
+        "primitive overload mismatches must stay flat (no nested chain), got: {chain:?}"
+    );
+    assert!(
+        chain.iter().any(|(_, _, msg)| msg
+            == "Argument of type 'boolean' is not assignable to parameter of type 'number'."),
+        "expected the widened boolean header against the number overload, got: {chain:?}"
+    );
+}


### PR DESCRIPTION
When a call matches no overload and a candidate's argument mismatch has an
elaborable relation failure reason (e.g. a contravariant callback-parameter
incompatibility, a missing required property), tsc nests the full reason chain
under that candidate — `getSignatureApplicabilityError` reuses the same
`checkTypeRelatedToAndOptionallyElaborate` chain as the single-signature
TS2345 path. tsz previously built each candidate failure as a bare two-argument
diagnostic and dropped the reason chain, so an overloaded callback mismatch
printed only the flat `Argument of type … is not assignable …` line while the
identical single-signature call printed the nested `Types of parameters 'a' and
'x' are incompatible.` sub-chain.

Structural rule: when a candidate's argument relation fails with an elaborable
reason, tsz now routes each candidate's `(source, target)` pair through the
shared `related_from_failure_reason` reason→related gateway (owner:
`error_no_overload_matches_at` in
`crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs`) and nests
the result one level beneath the candidate's header line — the same gateway the
single-signature TS2345 path uses.

`RelatedInformationPolicy` gains an explicit `sort` flag: the global
`(file, start, depth, message)` sort orders one chain at one anchor, but several
candidate chains all anchored at the same argument span would be interleaved by
depth and severed from their headers, so `OVERLOAD_FAILURES` opts out of the
sort (and of cross-chain dedupe) and the reporter assembles the entries in
candidate order, deduping whole candidates by header. No solver construction
sites changed; the enrichment happens where the checker already has the analysis
context.

Fixes #15387.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib overload_argument_reason_chain` — 5/5 pass
  (issue witness, renamed binders, `new`/constructor overloads, missing-property
  reason, primitive-only control that stays flat).
- `cargo test -p tsz-checker --lib` full checker unit suite: identical failure
  set to pristine `origin/main` (all pre-existing, per #15338 — CI-disabled main
  drift + parallel global-counter flakiness); this change adds zero new
  failures.
- `cargo clippy -p tsz-checker --lib` — no new warnings.
- Conformance fingerprints are parsed from top-level (non-indented) diagnostic
  lines only; the entire nested chain is indented related-info and therefore
  invisible to the fingerprint diff, so codes/positions are unchanged.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1wzuwLxLSwvKGsXJe1thT)_