### PR TITLE
fix(ci): tear down safe-run monitor subtree so wrapper never hangs after child exits

### DIFF
--- a/scripts/safe-run.sh
+++ b/scripts/safe-run.sh
@@ -203,17 +203,31 @@ kill_tree() {
     kill -"$sig" "$pid" 2>/dev/null || true
 }
 
+# ─── Stop the monitor and its whole subtree ─────────────────────────
+# A bare `kill "$MONITOR_PID"` is not enough: the monitor shell is
+# usually blocked in a foreground child (sleep/ps/footprint). On macOS a
+# slow or wedged `footprint` invocation defers a plain TERM to the
+# monitor shell indefinitely, leaving the wrapper hung after the wrapped
+# command has already exited (issue #15439). Tearing down the monitor's
+# entire subtree — children first so the in-flight child dies and the
+# shell unblocks, then escalating to KILL which cannot be deferred —
+# makes teardown bounded regardless of what the monitor is blocked on.
+
+stop_monitor() {
+    [[ -n "$MONITOR_PID" ]] || return 0
+    kill_tree "$MONITOR_PID" TERM
+    kill_tree "$MONITOR_PID" KILL
+    wait "$MONITOR_PID" 2>/dev/null || true
+    MONITOR_PID=""
+}
+
 # ─── Cleanup on exit ────────────────────────────────────────────────
 
 MONITOR_PID=""
 CMD_PID=""
 
 cleanup() {
-    if [[ -n "$MONITOR_PID" ]]; then
-        kill "$MONITOR_PID" 2>/dev/null || true
-        wait "$MONITOR_PID" 2>/dev/null || true
-        MONITOR_PID=""
-    fi
+    stop_monitor
     if [[ -n "$CMD_PID" ]] && kill -0 "$CMD_PID" 2>/dev/null; then
         kill_tree "$CMD_PID" TERM
         sleep 1
@@ -280,8 +294,6 @@ CMD_PID=""
 
 # ─── Stop monitor ───────────────────────────────────────────────────
 
-kill "$MONITOR_PID" 2>/dev/null || true
-wait "$MONITOR_PID" 2>/dev/null || true
-MONITOR_PID=""
+stop_monitor
 
 exit "$EXIT_CODE"


### PR DESCRIPTION
`scripts/safe-run.sh` stopped its background memory monitor with a bare
`kill "$MONITOR_PID"`. The monitor shell is almost always blocked in a
foreground child (`sleep`/`ps`/`footprint`), and on macOS a slow or wedged
`footprint` invocation defers a plain `TERM` to the monitor shell
indefinitely — so `wait "$MONITOR_PID"` never returns and the wrapper (plus
any downstream `tee` pipeline) hangs *after the wrapped command has already
exited*, requiring Ctrl-C and leaving orphaned `safe-run` processes (#15439).

Structural rule: when the monitor shell is blocked in an uninterruptible or
slow foreground probe, signalling only the shell's PID cannot unblock it —
the in-flight child must die first. Both teardown sites (the `EXIT`-trap
`cleanup` and the normal stop path) now route through one `stop_monitor`
helper that tears down the monitor's **whole subtree** via the existing
`kill_tree`: children first so the probe dies and the shell unblocks, then
escalating to `KILL`, which cannot be deferred. Teardown is bounded
regardless of what the monitor is blocked on, and the two previously
duplicated inline `kill`/`wait` blocks collapse into one helper.

Fixes #15439

## Goal
Goal: hold

## Verification
- `bash -n scripts/safe-run.sh` — syntax check passes.
- Reproduced the wedged-monitor class on Linux by shadowing `ps` with a
  wrapper that blocks 30s (stands in for a slow/wedged `footprint`); a
  command that exits after ~1.5s now returns the wrapper in ~2s instead of
  hanging ~30s, with no lingering `safe-run`/probe processes.
- Regression: normal short/long commands still return promptly and
  propagate the child's exit code (verified rc=7 and rc=0 cases).
- ready-review CI (`hold` lint/unit gates) owns the broad suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: medium

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyEDqri4aVBz3K3Jmsu51F)_