### PR TITLE
fix(ci): make safe-run.sh monitor teardown deterministic

### DIFF
--- a/docs/development/TOOLING.md
+++ b/docs/development/TOOLING.md
@@ -429,6 +429,17 @@ Use for long-running or memory-intensive commands such as a full
 not override the CI-only rule for full conformance, emit, or fourslash suites:
 keep those full suites out of normal local development and let CI run them.
 
+On macOS the guard samples physical footprint via `footprint` when available,
+falling back to RSS elsewhere. Each memory probe runs under a deadline
+(`SAFE_RUN_PROBE_TIMEOUT_SECS`, default 10s); a timed-out probe falls back to
+an RSS sample on the same tick, and after three consecutive probe failures the
+run downgrades to RSS mode permanently, so a slow or wedged `footprint` never
+disables memory enforcement or hangs the wrapper after the child exits
+(issue #15439). Teardown kills the entire monitor process tree so pipelines
+reading safe-run's output (`... | tee log`) get EOF as soon as the wrapped
+command finishes. The behavior is covered by `scripts/test/safe-run-test.sh`,
+which runs in the CI lint gate.
+
 ### `scripts/test/nextest-guard.sh`
 
 Serializes local `cargo nextest` runs and self-heals a wedged orchestrator.

--- a/scripts/ci/full-ci.sh
+++ b/scripts/ci/full-ci.sh
@@ -393,6 +393,7 @@ run_lint() {
   node scripts/ci/test-wip-state-comments.mjs || return $?
   node scripts/ci/test-project-compatibility.mjs || return $?
   node scripts/ci/test-type-challenges-solutions-manifest.mjs || return $?
+  scripts/test/safe-run-test.sh || return $?
   for test_file in scripts/agents/test_*.py scripts/setup/test_*.py; do
     [[ -f "$test_file" ]] || continue
     python3 "$test_file" || return $?

--- a/scripts/safe-run.sh
+++ b/scripts/safe-run.sh
@@ -41,7 +41,6 @@ TOTAL_RAM_MB=$(detect_system_ram_mb)
 LIMIT_MB=$((TOTAL_RAM_MB * 75 / 100))
 INTERVAL=5
 VERBOSE=0
-WARN_PRINTED=0
 
 # ─── Parse options ───────────────────────────────────────────────────
 
@@ -76,6 +75,15 @@ done
 
 if [[ $# -eq 0 ]]; then
     echo "Usage: safe-run.sh [--limit MB|%] [--interval S] [--verbose] [--] COMMAND [ARGS...]" >&2
+    exit 1
+fi
+
+if ! [[ "$LIMIT_MB" =~ ^[0-9]+$ ]]; then
+    echo "safe-run: --limit must be a number of MB or a percentage (got '$LIMIT_MB')" >&2
+    exit 1
+fi
+if ! [[ "$INTERVAL" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "safe-run: --interval must be a number of seconds (got '$INTERVAL')" >&2
     exit 1
 fi
 
@@ -190,36 +198,97 @@ get_tree_memory_kb() {
     get_tree_rss_kb "$root_pid"
 }
 
-# ─── Kill process tree (bottom-up) ──────────────────────────────────
+# ─── Bounded memory probe ────────────────────────────────────────────
+# Runs get_tree_memory_kb in the background with a deadline so a slow
+# or blocked `footprint`/`ps` invocation cannot wedge the monitor loop
+# (and with it, memory enforcement). On timeout the probe's process
+# tree is killed and the sample is reported as failed.
+# SAFE_RUN_PROBE_TIMEOUT_SECS overrides the default 10s deadline.
+
+PROBE_TIMEOUT_SECS=${SAFE_RUN_PROBE_TIMEOUT_SECS:-10}
+if ! [[ "$PROBE_TIMEOUT_SECS" =~ ^[0-9]+$ ]]; then
+    echo "safe-run: SAFE_RUN_PROBE_TIMEOUT_SECS must be a whole number of seconds (got '$PROBE_TIMEOUT_SECS')" >&2
+    exit 1
+fi
+INTERVAL_WHOLE_SECS=${INTERVAL%%.*}
+if [[ "${INTERVAL_WHOLE_SECS:-0}" -gt "$PROBE_TIMEOUT_SECS" ]]; then
+    PROBE_TIMEOUT_SECS=$INTERVAL_WHOLE_SECS
+fi
+
+sample_tree_memory_kb() {
+    local root_pid=$1
+    local out="$SAFE_RUN_TMP/probe-kb"
+    local probe_pid ticks kb
+
+    get_tree_memory_kb "$root_pid" >"$out" 2>/dev/null &
+    probe_pid=$!
+
+    ticks=$((PROBE_TIMEOUT_SECS * 5))
+    while kill -0 "$probe_pid" 2>/dev/null; do
+        if [[ "$ticks" -le 0 ]]; then
+            kill_tree "$probe_pid" KILL
+            wait "$probe_pid" 2>/dev/null
+            return 1
+        fi
+        sleep 0.2 2>/dev/null || sleep 1
+        ticks=$((ticks - 1))
+    done
+    wait "$probe_pid" 2>/dev/null || return 1
+
+    kb=$(cat "$out" 2>/dev/null)
+    [[ "$kb" =~ ^[0-9]+$ ]] || return 1
+    printf '%s\n' "$kb"
+}
+
+# ─── Kill process tree (freeze, then bottom-up) ─────────────────────
+# The root is stopped before its children are enumerated so it cannot
+# spawn new ones between the snapshot and the kill. A stopped process
+# does not act on TERM until resumed, so it is continued afterwards
+# (harmless after KILL).
 
 kill_tree() {
     local pid=$1
     local sig=${2:-TERM}
-    local children
+    kill -STOP "$pid" 2>/dev/null || true
+    local children child
     children=$(pgrep -P "$pid" 2>/dev/null) || true
     for child in $children; do
         kill_tree "$child" "$sig"
     done
     kill -"$sig" "$pid" 2>/dev/null || true
+    kill -CONT "$pid" 2>/dev/null || true
 }
 
 # ─── Cleanup on exit ────────────────────────────────────────────────
 
 MONITOR_PID=""
 CMD_PID=""
+SAFE_RUN_TMP=$(mktemp -d "${TMPDIR:-/tmp}/safe-run.XXXXXX") || exit 1
+
+# Tear down the monitor and every probe/sleep child it may have in
+# flight. SIGKILL, not SIGTERM: bash defers terminating signals while
+# blocked in a foreground child (e.g. a wedged `footprint` probe on
+# macOS), so a TERM'd monitor can linger and an unbounded `wait` on it
+# hangs the wrapper; its orphaned probe children also inherit our
+# stdout/stderr and keep downstream pipe readers (`tee`, `cat`) alive
+# after the wrapped command has exited (#15439). The monitor holds no
+# state worth a graceful shutdown.
+stop_monitor() {
+    [[ -n "$MONITOR_PID" ]] || return 0
+    kill_tree "$MONITOR_PID" KILL
+    wait "$MONITOR_PID" 2>/dev/null || true
+    MONITOR_PID=""
+}
 
 cleanup() {
-    if [[ -n "$MONITOR_PID" ]]; then
-        kill "$MONITOR_PID" 2>/dev/null || true
-        wait "$MONITOR_PID" 2>/dev/null || true
-        MONITOR_PID=""
-    fi
+    stop_monitor
     if [[ -n "$CMD_PID" ]] && kill -0 "$CMD_PID" 2>/dev/null; then
         kill_tree "$CMD_PID" TERM
         sleep 1
         kill_tree "$CMD_PID" KILL
         CMD_PID=""
     fi
+    rm -rf "$SAFE_RUN_TMP"
 }
 trap cleanup EXIT
 
@@ -242,13 +311,28 @@ echo "[safe-run] PID $CMD_PID | limit ${LIMIT_MB}MB | interval ${INTERVAL}s | mo
 
 (
     warn_printed=0
+    probe_failures=0
     while kill -0 "$CMD_PID" 2>/dev/null; do
         sleep "$INTERVAL"
 
         # Guard: process may have exited during sleep
         kill -0 "$CMD_PID" 2>/dev/null || break
 
-        MEMORY_KB=$(get_tree_memory_kb "$CMD_PID")
+        if MEMORY_KB=$(sample_tree_memory_kb "$CMD_PID"); then
+            probe_failures=0
+        else
+            # The probe timed out or produced garbage. Fall back to a
+            # plain RSS sample for this tick so memory enforcement
+            # never silently stops, and after three consecutive
+            # failures stop paying the footprint timeout every tick.
+            probe_failures=$((probe_failures + 1))
+            if [[ "$MEMORY_MODE" != "RSS" && "$probe_failures" -ge 3 ]]; then
+                echo "[safe-run] ${MEMORY_MODE} probe failed ${probe_failures}x; switching to RSS" >&2
+                MEMORY_MODE="RSS"
+            fi
+            MEMORY_KB=$(get_tree_rss_kb "$CMD_PID")
+            [[ "$MEMORY_KB" =~ ^[0-9]+$ ]] || continue
+        fi
         MEMORY_MB=$((MEMORY_KB / 1024))
 
         if [[ "$VERBOSE" -eq 1 ]]; then
@@ -273,15 +357,20 @@ echo "[safe-run] PID $CMD_PID | limit ${LIMIT_MB}MB | interval ${INTERVAL}s | mo
 MONITOR_PID=$!
 
 # ─── Wait for command ───────────────────────────────────────────────
+# `wait` returns 128+sig when interrupted by a trapped signal (the
+# INT/TERM forwarder) before the child exits; re-wait until the child
+# is actually gone so its real status is captured and forwarded.
 
-wait "$CMD_PID" 2>/dev/null
-EXIT_CODE=$?
+while :; do
+    wait "$CMD_PID" 2>/dev/null
+    EXIT_CODE=$?
+    if [[ "$EXIT_CODE" -gt 128 ]] && kill -0 "$CMD_PID" 2>/dev/null; then
+        continue
+    fi
+    break
+done
 CMD_PID=""
 
-# ─── Stop monitor ───────────────────────────────────────────────────
-
-kill "$MONITOR_PID" 2>/dev/null || true
-wait "$MONITOR_PID" 2>/dev/null || true
-MONITOR_PID=""
+stop_monitor
 
 exit "$EXIT_CODE"

--- a/scripts/safe-run.sh
+++ b/scripts/safe-run.sh
@@ -47,6 +47,10 @@ VERBOSE=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --limit)
+            if ! [[ "${2:-}" =~ ^[0-9]+%?$ ]]; then
+                echo "safe-run: --limit must be a number of MB or a percentage (got '${2:-}')" >&2
+                exit 1
+            fi
             if [[ "$2" == *% ]]; then
                 PCT=${2%\%}
                 LIMIT_MB=$((TOTAL_RAM_MB * PCT / 100))
@@ -56,6 +60,10 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --interval)
+            if ! [[ "${2:-}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+                echo "safe-run: --interval must be a number of seconds (got '${2:-}')" >&2
+                exit 1
+            fi
             INTERVAL="$2"
             shift 2
             ;;
@@ -75,15 +83,6 @@ done
 
 if [[ $# -eq 0 ]]; then
     echo "Usage: safe-run.sh [--limit MB|%] [--interval S] [--verbose] [--] COMMAND [ARGS...]" >&2
-    exit 1
-fi
-
-if ! [[ "$LIMIT_MB" =~ ^[0-9]+$ ]]; then
-    echo "safe-run: --limit must be a number of MB or a percentage (got '$LIMIT_MB')" >&2
-    exit 1
-fi
-if ! [[ "$INTERVAL" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
-    echo "safe-run: --interval must be a number of seconds (got '$INTERVAL')" >&2
     exit 1
 fi
 
@@ -235,9 +234,10 @@ sample_tree_memory_kb() {
     done
     wait "$probe_pid" 2>/dev/null || return 1
 
+    # The result stays in $PROBE_OUT; callers read it with the
+    # fork-free $(<...) instead of capturing this function's stdout.
     kb=$(<"$PROBE_OUT")
-    [[ "$kb" =~ ^[0-9]+$ ]] || return 1
-    printf '%s\n' "$kb"
+    [[ "$kb" =~ ^[0-9]+$ ]]
 }
 
 # ─── Kill process tree (freeze, then bottom-up) ─────────────────────
@@ -318,7 +318,7 @@ echo "[safe-run] PID $CMD_PID | limit ${LIMIT_MB}MB | interval ${INTERVAL}s | mo
         # Guard: process may have exited during sleep
         kill -0 "$CMD_PID" 2>/dev/null || break
 
-        if MEMORY_KB=$(sample_tree_memory_kb "$CMD_PID"); then
+        if sample_tree_memory_kb "$CMD_PID"; then
             probe_failures=0
         else
             # The probe timed out or produced garbage. Retry as a
@@ -333,8 +333,9 @@ echo "[safe-run] PID $CMD_PID | limit ${LIMIT_MB}MB | interval ${INTERVAL}s | mo
                 echo "[safe-run] ${MEMORY_MODE} probe failed ${probe_failures}x; switching to RSS" >&2
                 MEMORY_MODE="RSS"
             fi
-            MEMORY_KB=$(sample_tree_memory_kb "$CMD_PID" RSS) || continue
+            sample_tree_memory_kb "$CMD_PID" RSS || continue
         fi
+        MEMORY_KB=$(<"$PROBE_OUT")
         MEMORY_MB=$((MEMORY_KB / 1024))
 
         if [[ "$VERBOSE" -eq 1 ]]; then
@@ -373,6 +374,5 @@ while :; do
 done
 CMD_PID=""
 
-stop_monitor
-
+# The EXIT trap (cleanup -> stop_monitor) tears down the monitor tree.
 exit "$EXIT_CODE"

--- a/scripts/safe-run.sh
+++ b/scripts/safe-run.sh
@@ -211,16 +211,16 @@ if ! [[ "$PROBE_TIMEOUT_SECS" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 INTERVAL_WHOLE_SECS=${INTERVAL%%.*}
-if [[ "${INTERVAL_WHOLE_SECS:-0}" -gt "$PROBE_TIMEOUT_SECS" ]]; then
+if [[ "$INTERVAL_WHOLE_SECS" -gt "$PROBE_TIMEOUT_SECS" ]]; then
     PROBE_TIMEOUT_SECS=$INTERVAL_WHOLE_SECS
 fi
 
 sample_tree_memory_kb() {
     local root_pid=$1
-    local out="$SAFE_RUN_TMP/probe-kb"
+    local mode=${2:-$MEMORY_MODE}
     local probe_pid ticks kb
 
-    get_tree_memory_kb "$root_pid" >"$out" 2>/dev/null &
+    MEMORY_MODE="$mode" get_tree_memory_kb "$root_pid" >"$PROBE_OUT" 2>/dev/null &
     probe_pid=$!
 
     ticks=$((PROBE_TIMEOUT_SECS * 5))
@@ -235,7 +235,7 @@ sample_tree_memory_kb() {
     done
     wait "$probe_pid" 2>/dev/null || return 1
 
-    kb=$(cat "$out" 2>/dev/null)
+    kb=$(<"$PROBE_OUT")
     [[ "$kb" =~ ^[0-9]+$ ]] || return 1
     printf '%s\n' "$kb"
 }
@@ -263,7 +263,7 @@ kill_tree() {
 
 MONITOR_PID=""
 CMD_PID=""
-SAFE_RUN_TMP=$(mktemp -d "${TMPDIR:-/tmp}/safe-run.XXXXXX") || exit 1
+PROBE_OUT=$(mktemp "${TMPDIR:-/tmp}/safe-run.XXXXXX") || exit 1
 
 # Tear down the monitor and every probe/sleep child it may have in
 # flight. SIGKILL, not SIGTERM: bash defers terminating signals while
@@ -288,7 +288,7 @@ cleanup() {
         kill_tree "$CMD_PID" KILL
         CMD_PID=""
     fi
-    rm -rf "$SAFE_RUN_TMP"
+    rm -f "$PROBE_OUT"
 }
 trap cleanup EXIT
 
@@ -321,17 +321,19 @@ echo "[safe-run] PID $CMD_PID | limit ${LIMIT_MB}MB | interval ${INTERVAL}s | mo
         if MEMORY_KB=$(sample_tree_memory_kb "$CMD_PID"); then
             probe_failures=0
         else
-            # The probe timed out or produced garbage. Fall back to a
-            # plain RSS sample for this tick so memory enforcement
-            # never silently stops, and after three consecutive
-            # failures stop paying the footprint timeout every tick.
+            # The probe timed out or produced garbage. Retry as a
+            # bounded RSS sample on the same tick so memory
+            # enforcement never silently stops, and after three
+            # consecutive failures stop paying the footprint timeout
+            # every tick. When the failed sample already was RSS,
+            # skip the tick instead of probing twice.
             probe_failures=$((probe_failures + 1))
-            if [[ "$MEMORY_MODE" != "RSS" && "$probe_failures" -ge 3 ]]; then
+            [[ "$MEMORY_MODE" != "RSS" ]] || continue
+            if [[ "$probe_failures" -ge 3 ]]; then
                 echo "[safe-run] ${MEMORY_MODE} probe failed ${probe_failures}x; switching to RSS" >&2
                 MEMORY_MODE="RSS"
             fi
-            MEMORY_KB=$(get_tree_rss_kb "$CMD_PID")
-            [[ "$MEMORY_KB" =~ ^[0-9]+$ ]] || continue
+            MEMORY_KB=$(sample_tree_memory_kb "$CMD_PID" RSS) || continue
         fi
         MEMORY_MB=$((MEMORY_KB / 1024))
 

--- a/scripts/test/safe-run-test.sh
+++ b/scripts/test/safe-run-test.sh
@@ -192,6 +192,10 @@ fi
 "$SAFE_RUN" --limit bogus -- true 2>/dev/null
 [[ $? -ne 0 ]] && ok "rejects non-numeric --limit" \
     || bad "accepted non-numeric --limit"
+# A typo'd percentage must not slip through as a 0MB limit.
+"$SAFE_RUN" --limit bogus% -- true 2>/dev/null
+[[ $? -ne 0 ]] && ok "rejects non-numeric percentage --limit" \
+    || bad "accepted non-numeric percentage --limit"
 
 echo
 echo "passed: $PASS, failed: $FAIL"

--- a/scripts/test/safe-run-test.sh
+++ b/scripts/test/safe-run-test.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# safe-run-test.sh — self-test for scripts/safe-run.sh
+#
+# Exercises status/output passthrough, prompt monitor teardown (#15439),
+# hung-footprint probe recovery, memory-limit enforcement, and signal
+# forwarding with fake commands so it runs fast and hermetically on any
+# platform. The macOS-only paths (Darwin detection, `footprint`) are
+# driven through fake `uname`/`footprint` executables on PATH. Run locally:
+#
+#   scripts/test/safe-run-test.sh
+#
+# Exits non-zero if any assertion failed.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAFE_RUN="$HERE/../safe-run.sh"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/safe-run-test.XXXXXX")"
+PASS=0
+FAIL=0
+
+ok() {
+    PASS=$((PASS + 1))
+    echo "ok   - $1"
+}
+bad() {
+    FAIL=$((FAIL + 1))
+    echo "FAIL - $1" >&2
+}
+
+# Marker sleep durations make stray processes attributable to one test
+# and let anchored pgrep patterns avoid matching this script itself.
+FOOTPRINT_MARK=86399
+CHILD_MARK=86398
+
+cleanup() {
+    local p
+    for p in $(pgrep -f "^sleep ($FOOTPRINT_MARK|$CHILD_MARK)\$" 2>/dev/null); do
+        kill -9 "$p" 2>/dev/null || true
+    done
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+now() { date +%s; }
+
+kill_test_tree() {
+    local pid=$1 child
+    for child in $(pgrep -P "$pid" 2>/dev/null); do
+        kill_test_tree "$child"
+    done
+    kill -9 "$pid" 2>/dev/null || true
+}
+
+# `timeout` is not part of stock macOS; fall back to a watchdog so the
+# self-test still bounds a hang there.
+run_bounded() {
+    local secs=$1
+    shift
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$secs" "$@"
+        return $?
+    fi
+    "$@" &
+    local pid=$!
+    (
+        sleep "$secs"
+        kill_test_tree "$pid"
+    ) &
+    local watchdog=$!
+    wait "$pid"
+    local rc=$?
+    kill_test_tree "$watchdog"
+    wait "$watchdog" 2>/dev/null
+    return $rc
+}
+
+# Fake Darwin environment: `uname -s` reports Darwin and `footprint`
+# hangs forever, reproducing a wedged probe (#15439).
+FAKEBIN="$WORK/bin"
+mkdir -p "$FAKEBIN"
+printf '#!/usr/bin/env bash\necho Darwin\n' >"$FAKEBIN/uname"
+printf '#!/usr/bin/env bash\nexec sleep %s\n' "$FOOTPRINT_MARK" >"$FAKEBIN/footprint"
+chmod +x "$FAKEBIN/uname" "$FAKEBIN/footprint"
+
+# Child that holds ~20MB of RSS while sleeping. The trailing `:` stops
+# bash from exec-replacing itself with `sleep` (which would drop the
+# allocation).
+HEAVY_CHILD='x=$(head -c 20000000 /dev/zero | tr "\0" "a"); sleep 60; :'
+
+# ── 1. Exit code, argv, and stdout are forwarded ────────────────────
+out="$("$SAFE_RUN" --interval 1 -- bash -c 'echo "hi $1"; exit 7' _ world 2>/dev/null)"
+rc=$?
+[[ "$rc" -eq 7 ]] && ok "forwards exit code" || bad "exit code ($rc != 7)"
+[[ "$out" == "hi world" ]] && ok "forwards args/stdout" || bad "stdout ('$out')"
+
+# ── 2. Wrapper and pipe consumers finish promptly after child exit ──
+# Regression for #15439: the monitor (mid `sleep 60`) must be torn down
+# with its children, or the orphaned sleep holds the stdout/stderr pipe
+# open and `cat` blocks for the rest of the interval.
+start=$(now)
+run_bounded 30 bash -c "'$SAFE_RUN' --interval 60 -- sleep 1 2>&1 | cat" >/dev/null
+rc=$?
+elapsed=$(($(now) - start))
+[[ "$rc" -eq 0 && "$elapsed" -lt 20 ]] \
+    && ok "pipeline gets EOF promptly after child exit (${elapsed}s)" \
+    || bad "pipeline blocked after child exit (rc=$rc, ${elapsed}s)"
+
+# ── 3. Hung footprint probe: no wrapper hang, no orphans ────────────
+# Regression for #15439: with `footprint` wedged, the wrapper must
+# still return the child's status promptly and reap the probe tree.
+start=$(now)
+banner="$WORK/hung-footprint.stderr"
+run_bounded 40 bash -c "PATH='$FAKEBIN':\$PATH '$SAFE_RUN' --interval 1 -- sleep 2 2>'$banner' | cat" >/dev/null
+rc=$?
+elapsed=$(($(now) - start))
+[[ "$rc" -eq 0 && "$elapsed" -lt 20 ]] \
+    && ok "returns promptly despite hung footprint probe (${elapsed}s)" \
+    || bad "hung footprint probe wedged the wrapper (rc=$rc, ${elapsed}s)"
+grep -q "mode physical footprint" "$banner" \
+    && ok "fake Darwin engaged the footprint path" \
+    || bad "footprint path not engaged; test env broken"
+sleep 1
+if pgrep -f "^sleep $FOOTPRINT_MARK\$" >/dev/null 2>&1; then
+    bad "orphaned footprint probe processes remain"
+else
+    ok "no orphaned probe processes after exit"
+fi
+
+# ── 4. Probe timeout falls back to RSS and downgrades the mode ──────
+stderr="$WORK/downgrade.stderr"
+start=$(now)
+run_bounded 40 env PATH="$FAKEBIN:$PATH" SAFE_RUN_PROBE_TIMEOUT_SECS=1 \
+    "$SAFE_RUN" --interval 1 -- sleep 8 2>"$stderr"
+rc=$?
+elapsed=$(($(now) - start))
+[[ "$rc" -eq 0 ]] && ok "survives probe timeouts (rc=$rc, ${elapsed}s)" \
+    || bad "probe timeouts broke the run (rc=$rc, ${elapsed}s)"
+grep -q "switching to RSS" "$stderr" \
+    && ok "downgrades to RSS after repeated probe failures" \
+    || bad "no RSS downgrade after repeated probe failures"
+
+# ── 5. Memory limit enforcement still kills the tree (RSS mode) ─────
+start=$(now)
+stderr="$WORK/limit.stderr"
+run_bounded 40 "$SAFE_RUN" --limit 5 --interval 1 -- bash -c "$HEAVY_CHILD" 2>"$stderr"
+rc=$?
+elapsed=$(($(now) - start))
+[[ "$rc" -ne 0 && "$elapsed" -lt 30 ]] \
+    && ok "kills over-limit child (rc=$rc, ${elapsed}s)" \
+    || bad "over-limit child not killed (rc=$rc, ${elapsed}s)"
+grep -q "MEMORY LIMIT EXCEEDED" "$stderr" \
+    && ok "reports the limit breach" \
+    || bad "missing limit-breach report"
+
+# ── 6. Limit enforcement works while the footprint probe is wedged ──
+# The bounded probe must fail over to an RSS sample on the same tick so
+# a hung `footprint` never disables the memory guard.
+start=$(now)
+run_bounded 40 env PATH="$FAKEBIN:$PATH" SAFE_RUN_PROBE_TIMEOUT_SECS=1 \
+    "$SAFE_RUN" --limit 5 --interval 1 -- bash -c "$HEAVY_CHILD" 2>/dev/null
+rc=$?
+elapsed=$(($(now) - start))
+[[ "$rc" -ne 0 && "$elapsed" -lt 30 ]] \
+    && ok "enforces limit despite hung probe (rc=$rc, ${elapsed}s)" \
+    || bad "hung probe disabled enforcement (rc=$rc, ${elapsed}s)"
+
+# ── 7. TERM is forwarded to the child tree ──────────────────────────
+"$SAFE_RUN" --interval 1 -- sleep "$CHILD_MARK" 2>/dev/null &
+wrapper=$!
+sleep 1
+kill -TERM "$wrapper" 2>/dev/null
+start=$(now)
+wait "$wrapper" 2>/dev/null
+rc=$?
+elapsed=$(($(now) - start))
+[[ "$rc" -ne 0 && "$elapsed" -lt 10 ]] \
+    && ok "TERM'd wrapper exits promptly (rc=$rc, ${elapsed}s)" \
+    || bad "TERM'd wrapper lingered (rc=$rc, ${elapsed}s)"
+sleep 1
+if pgrep -f "^sleep $CHILD_MARK\$" >/dev/null 2>&1; then
+    bad "child survived forwarded TERM"
+else
+    ok "child tree gone after forwarded TERM"
+fi
+
+# ── 8. Bad option values fail fast instead of exploding later ───────
+"$SAFE_RUN" --interval bogus -- true 2>/dev/null
+[[ $? -ne 0 ]] && ok "rejects non-numeric --interval" \
+    || bad "accepted non-numeric --interval"
+"$SAFE_RUN" --limit bogus -- true 2>/dev/null
+[[ $? -ne 0 ]] && ok "rejects non-numeric --limit" \
+    || bad "accepted non-numeric --limit"
+
+echo
+echo "passed: $PASS, failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Fixes #15439

Goal: hold

## Summary

`scripts/safe-run.sh` could leave its wrapper/monitor/probe pipeline alive after the wrapped child had already exited: on macOS a wedged `footprint` probe blocked the monitor in a foreground child, bash deferred the parent's TERM, and the unbounded `wait` hung the wrapper; on every platform the monitor's orphaned `sleep`/probe children inherited safe-run's stdout/stderr and kept downstream pipe readers (`tee`, `cat`) blocked until the orphans died. Both failure modes were reproduced deterministically on Linux with a hung fake `footprint` and a long `--interval` before the fix.

## Structural rule

When the wrapped child exits (or safe-run receives INT/TERM), safe-run must tear down the entire monitor process tree — including any in-flight `sleep`, `ps`, `awk`, or `footprint` probe — within a bounded time, return the child's real exit status, and release all inherited pipe FDs. tsz does this through `scripts/safe-run.sh` (CI tooling layer): a freeze-enumerate-kill `kill_tree` (SIGSTOP closes the enumerate/spawn race; SIGCONT after delivery), a SIGKILL-based `stop_monitor` owned by the EXIT trap, and a deadline on every memory probe.

## What changed

- `kill_tree` stops the root before enumerating children and resumes it after signalling, so no process escapes the walk by spawning mid-kill.
- `stop_monitor` kills the monitor tree with SIGKILL: bash defers terminating signals while blocked in a foreground child, so TERM plus unbounded `wait` could hang forever; the monitor holds no state worth a graceful shutdown.
- Every memory sample runs under a deadline (`SAFE_RUN_PROBE_TIMEOUT_SECS`, default 10s, floored at `--interval`). A timed-out probe is killed and retried as a bounded RSS sample on the same tick, so a wedged `footprint` never silently disables memory enforcement; three consecutive failures permanently downgrade the run to RSS mode with a notice.
- The child `wait` loop re-waits after trap interruptions so the forwarded exit status is the child's real one.
- `--limit`/`--interval` are validated at the parse site (a typo'd percentage like `--limit abc%` previously collapsed to a 0MB limit and killed the child on the first tick).

## Adjacent-case matrix

Covered by the new self-test (16 assertions, hermetic — fake `uname`/`footprint` on PATH drive the Darwin paths on any platform; 5 assertions fail against the previous script):

- child exits before first monitor tick and mid-interval (long `--interval`); pipeline consumers get EOF promptly in both.
- hung probe with child exiting normally (teardown) and with an over-limit child (enforcement still fires via the bounded RSS fallback).
- probe-failure downgrade message after repeated timeouts; healthy RSS-mode runs unaffected.
- positive and negative status forwarding (exit 7 passthrough, TERM forwarding kills the child tree, no orphans in either direction).
- valid and invalid option forms (`--limit N`, `N%`, junk, junk`%`; `--interval` junk).

## Verification

- `scripts/test/safe-run-test.sh` — 16/16 pass (~20s); against the pre-fix script 5 assertions fail (pipeline hang, orphaned probes, no downgrade, disabled enforcement, accepted junk interval).
- Wired into the `full-ci.sh` lint gate so CI runs it on every PR.
- `bash -n scripts/safe-run.sh scripts/test/safe-run-test.sh scripts/ci/full-ci.sh`
- `git diff --check`
- Manual repros before/after: hung fake `footprint` + `| cat` (hang → returns in 2s, no orphans); `--interval 60 -- sleep 1 | cat` (60s stall → 1s); `--limit 5` over-limit child killed in ~1s with the breach report.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

---
https://claude.ai/code/session_01WoNsrELKGXYqMYPBx38Cxs

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoNsrELKGXYqMYPBx38Cxs)_