### PR TITLE
fix(checker): gate object-literal drill-in via findBestTypeForObjectLiteral (#15403)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -1359,6 +1359,33 @@ impl<'a> CheckerState<'a> {
         prop_name_idx: NodeIndex,
         prop_name: &str,
     ) -> Option<(TypeId, TypeId)> {
+        // Mirror tsc `getBestMatchIndexedAccessTypeOrUndefined` /
+        // `findBestTypeForObjectLiteral`: object-literal elaboration only drills
+        // into a property when the whole union — or the best-matching union
+        // member — exposes it. For a fresh object-literal source against a union
+        // target that contains an array-like member (e.g. the recursive JSON
+        // alias `string | number | ... | Json[] | { [k: string]: Json }`), the
+        // best match is the FIRST non-array-like member in union order. When a
+        // primitive member (or any member that lacks the key) is the best match,
+        // `tsc` skips the property drill-in and reports the outer relation error
+        // with its per-member chain instead of an inner property TS2322. Without
+        // this gate, tsz resolves the key through an arbitrary index-signature
+        // member and elaborates into the property, losing the outer frame.
+        let prefer_number_index = self
+            .ctx
+            .arena
+            .get(prop_name_idx)
+            .is_some_and(|node| node.kind == SyntaxKind::NumericLiteral as u16);
+        let prefer_symbol_index = self.is_symbol_property_name(prop_name_idx);
+        if self.object_literal_union_skips_property_drill_in(
+            target_type,
+            prop_name,
+            prefer_number_index,
+            prefer_symbol_index,
+        ) {
+            return None;
+        }
+
         let resolved_target = self.resolve_type_for_property_access(target_type);
         let evaluated_target = self.judge_evaluate(resolved_target);
         let contextual_target = self.evaluate_contextual_type(target_type);
@@ -1529,6 +1556,137 @@ impl<'a> CheckerState<'a> {
             })?;
 
         Some((index_value_type, index_value_type))
+    }
+
+    /// tsc `findBestTypeForObjectLiteral` gate for object-literal elaboration,
+    /// shared by the property drill-in resolver and the union index-signature
+    /// per-property check.
+    ///
+    /// `tsc` resolves a drilled-in property type through
+    /// `getBestMatchIndexedAccessTypeOrUndefined`: indexed access over the whole
+    /// union, and — when that fails — indexed access into the best-matching
+    /// union member. For a fresh object-literal source,
+    /// `findBestTypeForObjectLiteral` picks the FIRST non-array-like member
+    /// whenever the union contains an array-like member (so a recursive alias
+    /// like `Json = string | number | ... | Json[] | { [k: string]: Json }`
+    /// resolves the key against a leading primitive, not the trailing index
+    /// signature).
+    ///
+    /// Returns `true` when object-literal elaboration must SKIP drilling into
+    /// `prop_name` — i.e. the union has an array-like member and its best-match
+    /// member (the first non-array-like member) does not expose the key — so the
+    /// outer relation error is reported instead of an inner property TS2322.
+    /// Returns `false` when the gate does not apply (no array-like member, or
+    /// every member already exposes the key) or the best-match member exposes
+    /// the key, leaving the existing drill-in behavior intact.
+    pub(crate) fn object_literal_union_skips_property_drill_in(
+        &mut self,
+        target_type: TypeId,
+        prop_name: &str,
+        prefer_number_index: bool,
+        prefer_symbol_index: bool,
+    ) -> bool {
+        use crate::query_boundaries::common::union_members;
+        // Reveal a union hidden behind a type-alias/application (e.g. `Json`)
+        // before testing for the array-like member pattern. Resolve/evaluate
+        // lazily so a target that is already a union avoids the extra work.
+        let members = if let Some(members) = union_members(self.ctx.types, target_type) {
+            members
+        } else {
+            let resolved = self.resolve_type_for_property_access(target_type);
+            if let Some(members) = union_members(self.ctx.types, resolved) {
+                members
+            } else if let Some(members) =
+                union_members(self.ctx.types, self.judge_evaluate(resolved))
+            {
+                members
+            } else {
+                return false;
+            }
+        };
+        // `members` is an owned `TypeIdList` (`Arc<[TypeId]>`) that derefs to a
+        // slice and does not borrow `self`, so no copy is needed here.
+        if !members
+            .iter()
+            .any(|&member| self.is_array_like_type(member))
+        {
+            return false;
+        }
+        // `tsc` first tries indexed access over the whole union, which succeeds
+        // only when every member exposes the key; then the drill-in is valid.
+        if members.iter().all(|&member| {
+            self.union_member_exposes_object_literal_key(
+                member,
+                prop_name,
+                prefer_number_index,
+                prefer_symbol_index,
+            )
+        }) {
+            return false;
+        }
+        // findBestTypeForObjectLiteral: the first non-array-like member. Skip the
+        // drill-in unless that member genuinely exposes the key; otherwise the
+        // best match is a primitive (or a lacking object) and the outer relation
+        // error stands.
+        match members
+            .iter()
+            .copied()
+            .find(|&member| !self.is_array_like_type(member))
+        {
+            Some(best_member) => !self.union_member_exposes_object_literal_key(
+                best_member,
+                prop_name,
+                prefer_number_index,
+                prefer_symbol_index,
+            ),
+            None => true,
+        }
+    }
+
+    /// Whether a union member exposes `prop_name` the way tsc's
+    /// `getIndexedAccessTypeOrUndefined` would resolve it for a fresh
+    /// object-literal source: a named property, or an index signature applicable
+    /// to the key's kind. Primitive members (`string`, `number`, `boolean`,
+    /// `null`, `undefined`, literals) never expose a key here — tsc returns
+    /// `undefined` for `primitive["a"]` even though the apparent `String`/
+    /// `Number` interfaces carry numeric index signatures.
+    fn union_member_exposes_object_literal_key(
+        &mut self,
+        member: TypeId,
+        prop_name: &str,
+        prefer_number_index: bool,
+        prefer_symbol_index: bool,
+    ) -> bool {
+        if member == TypeId::NULL
+            || member == TypeId::UNDEFINED
+            || crate::query_boundaries::common::is_primitive_type(self.ctx.types, member)
+        {
+            return false;
+        }
+        let prop_atom = self.ctx.types.intern_string(prop_name);
+        let resolved = self.resolve_type_for_property_access(member);
+        let evaluated = self.judge_evaluate(resolved);
+        for candidate in [member, resolved, evaluated] {
+            let Some(shape) =
+                crate::query_boundaries::common::object_shape_for_type(self.ctx.types, candidate)
+            else {
+                continue;
+            };
+            if shape.properties.iter().any(|p| p.name == prop_atom) {
+                return true;
+            }
+            let has_applicable_index = if prefer_symbol_index {
+                shape.symbol_index_signature().is_some()
+            } else if prefer_number_index {
+                shape.number_index.is_some() || shape.string_index_signature().is_some()
+            } else {
+                shape.string_index_signature().is_some()
+            };
+            if has_applicable_index {
+                return true;
+            }
+        }
+        false
     }
 
     /// Check whether a target type has a named property matching ANY property

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -985,6 +985,9 @@ mod for_in_narrowing_tests;
 #[path = "tests/fresh_const_array_mutable_assignment_tests.rs"]
 mod fresh_const_array_mutable_assignment_tests;
 #[cfg(test)]
+#[path = "../tests/fresh_object_literal_union_array_member_drill_in_tests.rs"]
+mod fresh_object_literal_union_array_member_drill_in_tests;
+#[cfg(test)]
 #[path = "tests/fresh_object_literal_union_literal_kind_display_tests.rs"]
 mod fresh_object_literal_union_literal_kind_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -1017,12 +1017,10 @@ impl<'a> CheckerState<'a> {
                         || self.target_is_or_displays_type_application(candidate)
                 });
 
-            // When the target has a string index signature, outer property names are
-            // valid only when they are accepted by the index key type. Broad
-            // `[k: string]` accepts every string key, while template-literal
-            // index keys such as `` `data-${string}` `` only accept matching
-            // property names. We still check nested object literals against the
-            // applicable index signature VALUE type for excess properties.
+            // With a string index signature, outer property names are valid only when
+            // accepted by the index key type: broad `[k: string]` accepts every string
+            // key; template-literal keys like `` `data-${string}` `` only matching names.
+            // Nested object literals are still checked against the index VALUE type.
             if let Some(ref idx_sig) = target_shape.string_index {
                 if self.try_union_index_signature_value_check(
                     source_props,

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -567,6 +567,7 @@ impl<'a> CheckerState<'a> {
                 idx,
                 &target_shapes,
                 explicit_property_names.as_ref(),
+                target,
             ) {
                 return;
             }
@@ -1028,6 +1029,7 @@ impl<'a> CheckerState<'a> {
                     idx,
                     std::slice::from_ref(&target_shape),
                     explicit_property_names.as_ref(),
+                    target,
                 ) {
                     return;
                 }

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     pub(super) fn try_union_index_signature_value_check(
@@ -11,6 +12,7 @@ impl<'a> CheckerState<'a> {
         obj_literal_idx: NodeIndex,
         union_shapes: &[std::sync::Arc<tsz_solver::ObjectShape>],
         explicit_property_names: Option<&HashSet<Atom>>,
+        union_target: TypeId,
     ) -> bool {
         let diag_count_before = self.ctx.diagnostics.len();
 
@@ -37,6 +39,22 @@ impl<'a> CheckerState<'a> {
 
             let prop_name = self.ctx.types.resolve_atom(source_prop.name);
             let is_numeric_name = tsz_solver::utils::is_numeric_literal_name(&prop_name);
+
+            // tsc `findBestTypeForObjectLiteral`: when the union target has an
+            // array-like member, elaboration resolves the key against the first
+            // non-array-like member. If that best match does not expose the key
+            // (e.g. a leading primitive in a `Json`-style union), tsc reports the
+            // outer relation error rather than checking the value against a
+            // trailing index-signature member. Skip the index-signature drill-in
+            // for those keys so the outer TS2322 with its member chain stands.
+            if self.object_literal_union_skips_property_drill_in(
+                union_target,
+                prop_name.as_ref(),
+                is_numeric_name,
+                source_prop.is_symbol_named,
+            ) {
+                continue;
+            }
             let mut applicable_index_value_types = Vec::new();
             let mut accepted_by_index = false;
             let mut has_deferred_index_value_type = false;

--- a/crates/tsz-checker/tests/fresh_object_literal_union_array_member_drill_in_tests.rs
+++ b/crates/tsz-checker/tests/fresh_object_literal_union_array_member_drill_in_tests.rs
@@ -1,0 +1,193 @@
+//! Regression coverage for the object-literal elaboration drill-in gate
+//! (issue #15403).
+//!
+//! `tsc`'s `elaborateElementwise` resolves a drilled-in property type through
+//! `getBestMatchIndexedAccessTypeOrUndefined`: indexed access over the whole
+//! union, and — when that fails — indexed access into the best-matching union
+//! member. For a fresh object-literal source, `findBestTypeForObjectLiteral`
+//! picks the FIRST non-array-like member whenever the union contains an
+//! array-like member (so a recursive `Json`-style alias resolves the key
+//! against a leading primitive, not a trailing index signature). When that best
+//! match does not expose the key, `tsc` reports the OUTER whole-object
+//! assignment error instead of an inner per-property TS2322.
+//!
+//! Before this fix tsz drilled into the property (via either the elaboration
+//! property resolver or the union index-signature per-property check) and
+//! emitted an inner TS2322 at the property value, losing the outer frame.
+//!
+//! These tests assert the drill-in DECISION (outer whole-object frame vs inner
+//! per-property frame) by inspecting the TS2322 source display; the exact outer
+//! union chain / recursive-alias headline display is tracked separately.
+
+use crate::test_utils::check_source_strict_messages as check_strict;
+
+/// The single TS2322 message emitted for `source`, or a panic listing what was
+/// actually produced.
+fn only_ts2322(source: &str) -> String {
+    let diags = check_strict(source);
+    let ts2322: Vec<&(u32, String)> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322; got: {diags:?}"
+    );
+    ts2322[0].1.clone()
+}
+
+// ---------------------------------------------------------------------------
+// Best match is a leading primitive: report the OUTER whole-object frame.
+// ---------------------------------------------------------------------------
+
+/// Recursive JSON-style alias: `string | ... | Json[] | { [k: string]: Json }`.
+/// The union has an array-like member (`Json[]`), so the best match is the
+/// leading `string` primitive, which has no property `a`. tsc reports the outer
+/// assignment, not an inner `() => number` vs `Json` drill-in.
+#[test]
+fn fresh_object_vs_recursive_json_union_reports_outer_frame() {
+    let msg = only_ts2322(
+        r#"
+type Json = string | number | boolean | null | Json[] | { [k: string]: Json };
+const bad: Json = { a: () => 1 };
+"#,
+    );
+    assert!(
+        msg.starts_with("Type '{ a: () => number; }' is not assignable"),
+        "expected the OUTER whole-object frame (source `{{ a: () => number; }}`), \
+         not an inner property drill-in. Got: {msg:?}"
+    );
+}
+
+/// Same structural rule with different alias/property identifiers — the gate is
+/// structural, not keyed on `Json`/`a` (anti-hardcoding).
+#[test]
+fn fresh_object_vs_recursive_json_union_reports_outer_frame_alt_names() {
+    let msg = only_ts2322(
+        r#"
+type Payload = string | number | boolean | null | Payload[] | { [key: string]: Payload };
+const value: Payload = { handler: () => 1 };
+"#,
+    );
+    assert!(
+        msg.starts_with("Type '{ handler: () => number; }' is not assignable"),
+        "renamed alias/property must still report the OUTER frame. Got: {msg:?}"
+    );
+}
+
+/// Non-recursive union with a primitive member AND an array-like member AND an
+/// index-signature member: the index-signature per-property check must not fire
+/// because the best match is the leading primitive.
+#[test]
+fn fresh_object_vs_primitive_array_index_union_reports_outer_frame() {
+    let msg = only_ts2322(
+        r#"
+type Cell = string | number | boolean | number[] | { [k: string]: number };
+const c: Cell = { a: () => 1 };
+"#,
+    );
+    assert!(
+        msg.starts_with("Type '{ a: () => number; }' is not assignable"),
+        "a primitive best-match must suppress the index-signature drill-in and \
+         report the OUTER frame. Got: {msg:?}"
+    );
+}
+
+/// Named-property object member (no index signature) with a primitive and an
+/// array-like member: best match is still the leading primitive `string`, which
+/// lacks `z`, so the outer frame is reported.
+#[test]
+fn fresh_object_vs_named_member_union_with_array_reports_outer_frame() {
+    let msg = only_ts2322(
+        r#"
+type Elem = { p: number };
+type U = string | Elem[] | { z: number };
+const u: U = { z: () => 1 };
+"#,
+    );
+    assert!(
+        msg.starts_with("Type '{ z: () => number; }' is not assignable"),
+        "a leading primitive best-match must report the OUTER frame even when a \
+         later named-property member owns the key. Got: {msg:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Controls: best match exposes the key, OR no array-like member is present —
+// the existing inner drill-in must be preserved.
+// ---------------------------------------------------------------------------
+
+/// No primitive member: the array member `number[]` doesn't expose `a`, so the
+/// best match is `{ a: number }`, which does. tsc drills in — inner TS2322.
+#[test]
+fn array_plus_object_union_without_primitive_still_drills_in() {
+    let msg = only_ts2322(
+        r#"
+const control: number[] | { a: number } = { a: "x" };
+"#,
+    );
+    assert_eq!(
+        msg, "Type 'string' is not assignable to type 'number'.",
+        "an array + object union with no primitive member must keep the inner \
+         drill-in. Got: {msg:?}"
+    );
+}
+
+/// Tuple member is array-like; the best match is still `{ a: number }`.
+#[test]
+fn tuple_plus_object_union_still_drills_in() {
+    let msg = only_ts2322(
+        r#"
+const control: [number] | { a: number } = { a: "x" };
+"#,
+    );
+    assert_eq!(
+        msg, "Type 'string' is not assignable to type 'number'.",
+        "a tuple + object union must keep the inner drill-in. Got: {msg:?}"
+    );
+}
+
+/// `readonly` array member is array-like; the best match is `{ a: number }`.
+#[test]
+fn readonly_array_plus_object_union_still_drills_in() {
+    let msg = only_ts2322(
+        r#"
+const control: readonly string[] | { a: number } = { a: "x" };
+"#,
+    );
+    assert_eq!(
+        msg, "Type 'string' is not assignable to type 'number'.",
+        "a readonly-array + object union must keep the inner drill-in. Got: {msg:?}"
+    );
+}
+
+/// No array-like member: the gate does not apply, so the index-signature
+/// per-property drill-in is preserved (tsc reports the inner value mismatch).
+#[test]
+fn union_without_array_member_still_drills_into_index_signature() {
+    let msg = only_ts2322(
+        r#"
+type B = { z: number };
+const control: number | { [k: string]: B } = { z: null };
+"#,
+    );
+    assert_eq!(
+        msg, "Type 'null' is not assignable to type 'B'.",
+        "a union with no array-like member must keep the index-signature \
+         drill-in. Got: {msg:?}"
+    );
+}
+
+/// A single (non-union) index-signature target keeps its per-property drill-in;
+/// the array-like-union gate must not disturb the non-union path.
+#[test]
+fn single_index_signature_target_still_drills_in() {
+    let msg = only_ts2322(
+        r#"
+const control: { [k: string]: number } = { a: () => 1 };
+"#,
+    );
+    assert_eq!(
+        msg, "Type '() => number' is not assignable to type 'number'.",
+        "a non-union index-signature target must keep the inner drill-in. \
+         Got: {msg:?}"
+    );
+}


### PR DESCRIPTION
Fixes the drill-in/anchor half of #15403.

**Structural rule:** when a fresh object literal is assigned to a union target that contains an array-like member and the union's best-matching member (tsc's `findBestTypeForObjectLiteral` = the first non-array-like member) does not own the failing key, `tsc` reports the **outer** whole-object assignment error; tsz was drilling into the property and emitting an **inner** per-property `TS2322`, losing the outer frame. Now routed through a shared, tsc-faithful gate in the checker object-literal elaboration layer.

### What was wrong
`tsc`'s `elaborateElementwise` resolves a drilled-in property type via `getBestMatchIndexedAccessTypeOrUndefined`: indexed access over the whole union, then — when that fails — indexed access into the best-matching member. For a fresh object-literal source, `findBestTypeForObjectLiteral` picks the first non-array-like member whenever the union has an array-like member. For a recursive alias like `type Json = string | number | boolean | null | Json[] | { [k: string]: Json }`, that best match is the leading `string` primitive, which has no property `a`, so `tsc` reports the outer assignment.

tsz instead resolved the key through an arbitrary index-signature member and drilled in. Two independent paths produced the inner diagnostic:
- the elaboration property resolver `object_literal_target_property_type` (named-member unions), and
- the union index-signature per-property check `try_union_index_signature_value_check` (index-signature-member unions).

### The fix
- Add `object_literal_union_skips_property_drill_in` (checker `error_reporter`), a shared gate consulted by **both** paths. It reveals a union behind a type alias/application, requires an array-like member, honors the whole-union "every member exposes the key" case, and otherwise skips the drill-in when the best-match member does not expose the key.
- Add `union_member_exposes_object_literal_key`, which excludes primitive members: their apparent `String`/`Number` interfaces carry a numeric index signature that the general resolver would treat as exposing a string key, but `tsc` returns `undefined` for `primitive["a"]`. This is load-bearing for numeric keys.
- Owner layer stays in the checker; only solver/query-boundary structural helpers (`union_members`, `object_shape_for_type`, `is_primitive_type`, `is_array_like_type`) are composed — no raw `TypeKey`, no printer-output matching, no name/file-string checks.

The gate lives at the top of the one shared resolver, so the other object-literal-vs-union callers (`all_object_literal_properties_assignable_with_literals`, `object_literal_numeric_members_assign_to_mapped_target`, `object_literal_call_argument_display_with_target_literals`) inherit it uniformly; only the genuinely separate index-signature path needs the second explicit call.

### Adjacent-case matrix (varied binder names, controls)
- Recursive `Json`-style union + primitive best match → **outer** frame ✓ (plus renamed alias/property).
- Non-recursive `string | number | boolean | number[] | { [k: string]: number }` → outer ✓.
- Named-member union `string | Elem[] | { z: number }` → outer ✓.
- Controls that must keep drilling in: `number[] | { a: number }`, `[number] | { a: number }`, `readonly string[] | { a: number }` (no primitive → best match owns the key); `number | { [k: string]: B }` (no array-like member); single `{ [k: string]: number }` target (non-union).

### Known follow-ups (out of scope; some pre-existing)
- The outer diagnostic's message text still diverges: the recursive-alias headline expands the union and drops `null` (a pre-existing recursive-alias display issue the issue lists as follow-up), and the nested reason chain picks the `Json[]` member's missing-properties instead of `Types of property 'a' are incompatible → 'Json | undefined'`. That chain lives in the generic union relation reason walk / recursive-alias display, a separate surface.
- The gate is a pre-filter in front of the resolver's own index scan (which still uses an any-member index fallback); the deeper form would resolve the property type through best-match indexed access directly. Reasonable tsc-faithful interim.
- Possible latent divergence: whether the general property resolver shares the primitive numeric-index conflation for object-literal string keys — worth a separate issue, not an expansion of this gate.

## Goal
Goal: hold

## Verification
- New regression suite `crates/tsz-checker/tests/fresh_object_literal_union_array_member_drill_in_tests.rs` (9 tests, varied binder names + positive/negative controls) — passes.
- `cargo test -p tsz-checker --lib` filters `object_literal`, `index_signature`, `excess`, `union` show **no new failures vs pristine `origin/main`** (the union-filter failures are pre-existing recursive-alias-display drift, identical on clean main; see #15338).
- `cargo clippy -p tsz-checker --lib` clean (0 warnings).
- Manual repro (`tsz repro.ts --noEmit --strict`): before `(2,21) TS2322 … to type 'Json'` (inner); after `(2,7) TS2322` outer whole-object frame.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2kNrwt3bQxCuBs5MEcxHW)_