### PR TITLE
fix(solver): prune alias-reached disjoint enum discriminants before keyof

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -1336,6 +1336,94 @@ type Probe = Gen2<ABC.A>;
         );
     }
 
+    /// Resolve `<probe>.<prop>` on the file-local alias `probe` and assert the
+    /// result matches `expect_success`. Shared by the alias-reached
+    /// enum-discriminant `keyof` matrix so each case only supplies source text.
+    fn assert_alias_property(source: &str, probe: &str, prop: &str, expect_success: bool) {
+        let (parser, root, binder, types) = build_checker(source);
+        let mut checker = CheckerState::new(
+            parser.get_arena(),
+            &binder,
+            &types,
+            "test.ts".to_string(),
+            CheckerOptions::default(),
+        );
+        checker.ctx.set_lib_contexts(Vec::new());
+        checker.check_source_file(root);
+
+        let sym = checker
+            .ctx
+            .binder
+            .file_locals
+            .get(probe)
+            .unwrap_or_else(|| panic!("{probe} symbol"));
+        let ty = checker.type_reference_symbol_type(sym);
+        let result = checker.resolve_property_access_with_env(ty, prop);
+        let is_success = matches!(
+            result,
+            tsz_solver::operations::property::PropertyAccessResult::Success { .. }
+        );
+        assert_eq!(
+            is_success,
+            expect_success,
+            "{probe}.{prop}: expected success={expect_success}, got {result:?} for type {}",
+            checker.format_type(ty),
+        );
+    }
+
+    /// Adjacent case: renamed binders + string enum. A concrete discriminant
+    /// reached through the alias body (`Weekday.Tue`, still a `Lazy(DefId)`)
+    /// must still prune the impossible constituent so the mapped-over-`keyof`
+    /// application exposes the member-specific key.
+    #[test]
+    fn mapped_string_enum_discriminant_application_renamed_binders_exposes_member() {
+        let source = r#"
+enum Weekday { Mon = "mon", Tue = "tue" }
+type Slot<D extends Weekday> = { day: D } & (
+  { day: Weekday.Mon, open: string } |
+  { day: Weekday.Tue, close: string }
+);
+type SlotView<D extends Weekday> = { [K in keyof Slot<D>]: string };
+type Probe = SlotView<Weekday.Mon>;
+"#;
+        assert_alias_property(source, "Probe", "open", true);
+    }
+
+    /// Adjacent case: numeric enum with explicit values.
+    #[test]
+    fn mapped_numeric_enum_discriminant_application_exposes_member() {
+        let source = r#"
+enum Level { Low = 1, High = 2 }
+type Cell<L extends Level> = { lvl: L } & (
+  { lvl: Level.Low, floor: string } |
+  { lvl: Level.High, ceil: string }
+);
+type CellView<L extends Level> = { [K in keyof Cell<L>]: string };
+type Probe = CellView<Level.Low>;
+"#;
+        assert_alias_property(source, "Probe", "floor", true);
+    }
+
+    /// Negative control: when both constituents share the *same* discriminant
+    /// member, neither is impossible, so `keyof` keeps only the shared keys and
+    /// a member-specific key must stay unresolved (matching tsc).
+    #[test]
+    fn mapped_enum_same_discriminant_keeps_only_shared_keys() {
+        let source = r#"
+enum ABC { A, B }
+type Gen<T extends ABC> = { v: T } & (
+  { v: ABC.A, a: string } |
+  { v: ABC.A, b: string }
+);
+type Gen2<T extends ABC> = { [K in keyof Gen<T>]: string };
+type Probe = Gen2<ABC.A>;
+"#;
+        // `a` and `b` live on different same-discriminant constituents, so
+        // `keyof (A | B) = keyof A & keyof B` drops both; only `v` survives.
+        assert_alias_property(source, "Probe", "a", false);
+        assert_alias_property(source, "Probe", "v", true);
+    }
+
     /// Rule: when `T extends U ? A : B` is deferred (contains type parameters),
     /// property access uses `A | B` as the apparent type. Properties not on all
     /// branches must produce TS2339; properties on all branches must be accepted.

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
@@ -513,10 +513,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 return self.interner().keyof(operand);
             }
             Some(TypeData::Union(_members)) => {
-                let narrowed_operand = crate::type_queries::prune_impossible_object_union_members(
-                    self.interner(),
-                    operand,
-                );
+                let narrowed_operand = self.prune_impossible_object_union_members_resolved(operand);
                 let Some(TypeData::Union(members)) = self.interner().lookup(narrowed_operand)
                 else {
                     return self.recurse_keyof(narrowed_operand);
@@ -554,10 +551,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             match key {
                 TypeData::Union(_members) => {
                     let narrowed_operand =
-                        crate::type_queries::prune_impossible_object_union_members(
-                            self.interner(),
-                            evaluated_operand,
-                        );
+                        self.prune_impossible_object_union_members_resolved(evaluated_operand);
                     let Some(TypeData::Union(members)) = self.interner().lookup(narrowed_operand)
                     else {
                         return self.recurse_keyof(narrowed_operand);
@@ -1075,6 +1069,112 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return false;
         }
         crate::keyof_inner_type(self.interner(), mapped.constraint).is_some_and(is_source)
+    }
+
+    /// Resolver-aware wrapper around the pure
+    /// [`prune_impossible_object_union_members`](crate::type_queries::prune_impossible_object_union_members).
+    ///
+    /// The pure prune walks the interned type DAG without a resolver, so an
+    /// object-union member whose required discriminant is an intersection of
+    /// enum members reached through an alias body (`{ v: E.A } & { v: E.B }`,
+    /// where `E.B` is still an unresolved `Lazy(DefId)`) never reduces to
+    /// `never`: `is_unit_type`/`is_subtype_of` cannot see the enum member behind
+    /// the `Lazy`, so the impossible constituent survives. `keyof` of the
+    /// discriminated union then collapses to the shared key set
+    /// (`keyof (A | B) = keyof A & keyof B`), silently dropping the
+    /// member-specific keys — e.g. `keyof ({ v: E.A, a } | { v: E.A & E.B, b })`
+    /// loses `a`. This companion runs the pure prune first (fast, memoized) and
+    /// then drops any residual member whose required discriminant is an
+    /// impossible enum-member intersection, resolving the `Lazy` references via
+    /// the evaluator's resolver. It mirrors tsc, whose `getReducedType` prunes
+    /// the impossible constituent before taking `keyof`, and materializes
+    /// nothing beyond the local disjointness decision.
+    fn prune_impossible_object_union_members_resolved(&mut self, operand: TypeId) -> TypeId {
+        let pure =
+            crate::type_queries::prune_impossible_object_union_members(self.interner(), operand);
+        let Some(TypeData::Union(list_id)) = self.interner().lookup(pure) else {
+            return pure;
+        };
+        let members = self.interner().type_list(list_id).to_vec();
+        let mut retained: Vec<TypeId> = Vec::with_capacity(members.len());
+        for &member in &members {
+            if !self.object_member_has_impossible_enum_discriminant(member) {
+                retained.push(member);
+            }
+        }
+        match retained.len() {
+            n if n == members.len() => pure,
+            0 => TypeId::NEVER,
+            1 => retained[0],
+            _ => self.interner().union_preserve_members(retained),
+        }
+    }
+
+    /// `true` when `member` is an object type carrying a required property whose
+    /// type is an impossible (`never`) intersection of pairwise-disjoint enum
+    /// members / literals, resolving transparent `Lazy(DefId)` wrappers first.
+    fn object_member_has_impossible_enum_discriminant(&mut self, member: TypeId) -> bool {
+        let Some(shape) = crate::type_queries::get_object_shape(self.interner(), member) else {
+            return false;
+        };
+        for prop in &shape.properties {
+            if prop.optional {
+                continue;
+            }
+            if self.unit_intersection_disjoint_resolving_lazy(prop.type_id) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// `true` when `type_id` is an intersection of two or more unit types
+    /// (literals / enum members) that are pairwise disjoint — i.e. a `never`
+    /// intersection — after peeling transparent `Lazy(DefId)` wrappers so an
+    /// alias-reached enum member is compared as its concrete member type.
+    fn unit_intersection_disjoint_resolving_lazy(&mut self, type_id: TypeId) -> bool {
+        let Some(TypeData::Intersection(list_id)) = self.interner().lookup(type_id) else {
+            return false;
+        };
+        let members = self.interner().type_list(list_id).to_vec();
+        let mut units: SmallVec<[TypeId; 4]> = SmallVec::new();
+        for &member in &members {
+            let resolved = self.resolve_lazy_alias_chain(member);
+            if !crate::type_queries::is_unit_type(self.interner(), resolved) {
+                continue;
+            }
+            let mut checker = crate::relations::subtype::SubtypeChecker::with_resolver(
+                self.interner(),
+                self.resolver(),
+            );
+            let disjoint = units.iter().any(|&other| {
+                !checker.is_subtype_of(resolved, other) && !checker.is_subtype_of(other, resolved)
+            });
+            if disjoint {
+                return true;
+            }
+            if !units.contains(&resolved) {
+                units.push(resolved);
+            }
+        }
+        false
+    }
+
+    /// Peel transparent `Lazy(DefId)` alias wrappers to the concrete target,
+    /// bounded against pathological alias cycles. Mirrors
+    /// [`resolve_index_signature_key_alias`] for non-key positions.
+    fn resolve_lazy_alias_chain(&self, type_id: TypeId) -> TypeId {
+        let mut current = type_id;
+        for _ in 0..8 {
+            let Some(TypeData::Lazy(def_id)) = self.interner().lookup(current) else {
+                return current;
+            };
+            match self.resolver().resolve_lazy(def_id, self.interner()) {
+                Some(next) if next != current => current = next,
+                _ => return current,
+            }
+        }
+        current
     }
 
     /// Compute keyof for an intersection type: keyof (A & B) = keyof A | keyof B


### PR DESCRIPTION
Structural rule: when `keyof` is taken over a discriminated object union whose discriminant is an **enum member reached through an alias body**, `tsc` reduces the intersection-of-union (`getReducedType`) and prunes the impossible constituent before taking `keyof`; tsz did not, so member-specific keys were silently dropped — through the solver's `keyof` evaluation prune site.

### Root cause
For `Gen<T extends E> = { v: T } & ({ v: E.A, a } | { v: E.B, b })`, the application `Gen<E.A>` distributes to `{ v: E.A, a } | { v: E.A & E.B, b }`. The second constituent is impossible (`E.A & E.B` is `never`), so `tsc` prunes it and `keyof Gen<E.A>` is `"v" | "a"`. tsz kept the impossible member, so `keyof (A | B) = keyof A ∩ keyof B` collapsed to just `"v"`, and a property access through a `{ [K in keyof Gen<E.A>]: V }` mapped application reported a spurious *property-not-found*.

The reason is exactly #15396's pattern: the discriminant `E.B` in the alias body is interned as an unresolved `Lazy(DefId)`. The pure, resolver-free `prune_impossible_object_union_members` (and the `is_unit_type` / `is_subtype_of` predicates it relies on) cannot see the enum member behind the `Lazy`, so `E.A & E.B` never reduces to `never`. The resolver *can* resolve it (`resolve_lazy_type` yields `Enum(DefId, <lit>)`) — it was simply never invoked at that decision site.

### Fix (owner layer: solver `keyof` evaluation, `crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs`)
The `keyof` evaluator already carries a resolver. Route both union `keyof` arms through a resolver-aware companion that runs the fast, memoized pure prune first, then drops any residual union member whose required discriminant is a **pairwise-disjoint unit (enum member / literal) intersection**, peeling transparent `Lazy(DefId)` wrappers via `resolver.resolve_lazy` (bounded, mirroring the existing `resolve_index_signature_key_alias`) and comparing with a resolver-equipped `SubtypeChecker`. Nothing is materialized beyond the local disjointness decision; non-discriminated unions short-circuit immediately.

This is the `keyof`-site slice of the #15396 materialize-or-defer family; the complementary mapped-identity/display half of #15392 is #15432.

### Adjacent matrix (binder names varied)
- semantic witness `mapped_enum_discriminant_application_exposes_member_property` (numeric enum `ABC`) — now resolves.
- `mapped_string_enum_discriminant_application_renamed_binders_exposes_member` — string enum, renamed binders (`Weekday`/`Slot`).
- `mapped_numeric_enum_discriminant_application_exposes_member` — numeric enum with explicit values.
- Negative control `mapped_enum_same_discriminant_keeps_only_shared_keys` — a same-discriminant union has no impossible constituent, so `keyof` keeps only shared keys and the member-specific key stays unresolved (no over-pruning).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib mapped_enum_discriminant_application_exposes_member_property` → passes (was red on `main`, part of the #15338 catalog).
- New adjacent/negative-control tests (`mapped_string_enum_discriminant_application_renamed_binders_exposes_member`, `mapped_numeric_enum_discriminant_application_exposes_member`, `mapped_enum_same_discriminant_keeps_only_shared_keys`) → pass.
- Solver suites unchanged: `cargo test -p tsz-solver --lib keyof` (280), `enum` (88), `discriminant` (107), `intersection` (481) → all green.
- Checker suites: `property_access` (103), `discriminant` (57) green; the residual `mapped`/`keyof`/`narrowing`/`indexed_access` failures are the pre-existing #15338 disabled-CI breakages, confirmed identical on the clean tree (this diff adds zero new failures and fixes one).
- `cargo fmt --check` clean; `cargo clippy -p tsz-solver --lib` and `-p tsz-checker --lib --tests` clean.
- Broad conformance / emit / fourslash owned by exact-head ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYagDLAYfpKm86HpmYzPp8)_