### PR TITLE
fix(emitter): order for-of iteration helpers after the iterable's helpers (#15454)

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -391,6 +391,10 @@ name = "for_await_async_generator_keyword_tests"
 path = "tests/for_await_async_generator_keyword_tests.rs"
 
 [[test]]
+name = "for_of_loop_helper_order_tests"
+path = "tests/for_of_loop_helper_order_tests.rs"
+
+[[test]]
 name = "while_loop_body_capture_tests"
 path = "tests/while_loop_body_capture_tests.rs"
 

--- a/crates/tsz-emitter/src/lowering/core.rs
+++ b/crates/tsz-emitter/src/lowering/core.rs
@@ -312,15 +312,11 @@ impl<'a> LoweringPass<'a> {
         let should_lower_for_of_sync = self.ctx.target_es5 && !for_in_of.await_modifier;
         let should_lower_for_await_of =
             for_in_of.await_modifier && !self.ctx.options.target.supports_es2018();
+        let lower_for_of = should_lower_for_of_sync || should_lower_for_await_of;
 
-        if should_lower_for_of_sync || should_lower_for_await_of {
+        if lower_for_of {
             self.transforms
                 .insert(idx, TransformDirective::ES5ForOf { for_of_node: idx });
-            if for_in_of.await_modifier {
-                self.transforms.helpers_mut().mark_async_values();
-            } else if self.ctx.options.downlevel_iteration {
-                self.transforms.helpers_mut().mark_values();
-            }
         }
         if !self.ctx.options.target.supports_es2025()
             && crate::transforms::emit_utils::for_of_using_info(self.arena, for_in_of.initializer)
@@ -345,10 +341,29 @@ impl<'a> LoweringPass<'a> {
         let init_is_assignment_target =
             self.for_of_initializer_is_assignment_target(for_in_of.initializer);
 
+        // Visit the iterable expression before requesting the loop's own
+        // iteration helper. `tsc`'s `transformForOfStatement` /
+        // `transformForAwaitOfStatement` visit the iterable first and only then
+        // request `__values` / `__asyncValues`, so those no-priority helpers are
+        // ordered *after* any helper the iterable itself pulls in
+        // (`__read`/`__spreadArray` for a spread iterable, `__await`/
+        // `__asyncGenerator` for an inline async generator). Requesting the loop
+        // helper up front reversed that order in the emitted helper block.
+        self.visit(for_in_of.expression);
+        if lower_for_of {
+            if for_in_of.await_modifier {
+                self.transforms.helpers_mut().mark_async_values();
+            } else if self.ctx.options.downlevel_iteration {
+                self.transforms.helpers_mut().mark_values();
+            }
+        }
+
         if init_has_binding_pattern || init_is_assignment_target {
             // Mark __read helper when binding-pattern destructuring is used with
             // downlevelIteration. TypeScript emits __read to convert iterator
-            // results to arrays for binding-pattern destructuring. (Bare
+            // results to arrays for binding-pattern destructuring, requesting it
+            // while lowering the binding pattern — i.e. after `__values`, so it
+            // is marked here rather than before the iterable visit. (Bare
             // assignment targets keep the existing array-indexing lowering and
             // do not add __read here.)
             if init_has_binding_pattern
@@ -365,7 +380,6 @@ impl<'a> LoweringPass<'a> {
         } else {
             self.visit(for_in_of.initializer);
         }
-        self.visit(for_in_of.expression);
         self.visit(for_in_of.statement);
     }
 

--- a/crates/tsz-emitter/tests/for_of_loop_helper_order_tests.rs
+++ b/crates/tsz-emitter/tests/for_of_loop_helper_order_tests.rs
@@ -1,0 +1,109 @@
+//! Regression tests: a down-leveled `for..of` / `for await..of` must request
+//! its own iteration helper (`__values` / `__asyncValues`) *after* it has
+//! visited the iterable expression, so the helper preamble matches `tsc`.
+//!
+//! `tsc`'s `transformForOfStatement` / `transformForAwaitOfStatement` visit the
+//! iterable first and only then request the loop helper. Because those helpers
+//! have no `priority` field, `compareEmitHelpers` keeps them in request order,
+//! so any helper the iterable itself pulls in is emitted *before* the loop
+//! helper:
+//!
+//! * a spread iterable (`[...xs]`) pulls in `__read` / `__spreadArray`, which
+//!   precede the loop's `__values`;
+//! * an inline `async function*` iterable pulls in `__await` /
+//!   `__asyncGenerator`, which precede the loop's `__asyncValues`.
+//!
+//! Conversely the binding-pattern `__read` (emitted for `for (const [a, b] of
+//! …)`) is requested *while lowering the pattern*, i.e. after the loop helper,
+//! so `__values` precedes that `__read`.
+//!
+//! tsz previously marked the loop helper before visiting the iterable, which
+//! reversed all three orderings. The decision keys only on structural shape, so
+//! the fixtures vary binder names to prove no identifier spelling is involved.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::{PrintOptions, lower_and_print};
+use tsz_parser::parser::ParserState;
+
+fn emit(source: &str, target: ScriptTarget, downlevel_iteration: bool) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let opts = PrintOptions {
+        target,
+        module: ModuleKind::ESNext,
+        remove_comments: true,
+        downlevel_iteration,
+        ..PrintOptions::default()
+    };
+    lower_and_print(&parser.arena, root, opts).code
+}
+
+const VALUES_DEF: &str = "var __values = (this && this.__values)";
+const READ_DEF: &str = "var __read = (this && this.__read)";
+const SPREAD_ARRAY_DEF: &str = "var __spreadArray = (this && this.__spreadArray)";
+const AWAIT_DEF: &str = "var __await = (this && this.__await)";
+const ASYNC_GENERATOR_DEF: &str = "var __asyncGenerator = (this && this.__asyncGenerator)";
+const ASYNC_VALUES_DEF: &str = "var __asyncValues = (this && this.__asyncValues)";
+
+fn index_of(output: &str, def: &str) -> usize {
+    output
+        .find(def)
+        .unwrap_or_else(|| panic!("missing helper definition `{def}`.\nOutput:\n{output}"))
+}
+
+#[test]
+fn sync_for_of_over_spread_emits_values_after_read_and_spread_array() {
+    // `[...source]` pulls in `__read` / `__spreadArray` while the iterable is
+    // visited; the loop's `__values` is requested afterwards.
+    let output = emit(
+        "declare const source: number[];\n\
+         export function walk() { for (const item of [...source, 1]) { void item; } }",
+        ScriptTarget::ES5,
+        true,
+    );
+    let i_read = index_of(&output, READ_DEF);
+    let i_spread = index_of(&output, SPREAD_ARRAY_DEF);
+    let i_values = index_of(&output, VALUES_DEF);
+    assert!(
+        i_read < i_values && i_spread < i_values,
+        "expected `__read`/`__spreadArray` before `__values`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn sync_for_of_binding_pattern_emits_values_before_destructuring_read() {
+    // No spread in the iterable, so the only `__read` comes from lowering the
+    // binding pattern — requested after `__values`.
+    let output = emit(
+        "declare const pairs: [number, string][];\n\
+         export function walk() { for (const [head, tail] of pairs) { void head; void tail; } }",
+        ScriptTarget::ES5,
+        true,
+    );
+    let i_values = index_of(&output, VALUES_DEF);
+    let i_read = index_of(&output, READ_DEF);
+    assert!(
+        i_values < i_read,
+        "expected `__values` before the binding-pattern `__read`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn for_await_over_inline_async_generator_emits_async_values_last() {
+    // The inline `async function*` iterable pulls in `__await` /
+    // `__asyncGenerator`; the loop's `__asyncValues` is requested afterwards.
+    let output = emit(
+        "export async function drive() {\n\
+           for await (const tick of (async function*() { yield 1; })()) { void tick; }\n\
+         }",
+        ScriptTarget::ES2017,
+        false,
+    );
+    let i_await = index_of(&output, AWAIT_DEF);
+    let i_async_gen = index_of(&output, ASYNC_GENERATOR_DEF);
+    let i_async_values = index_of(&output, ASYNC_VALUES_DEF);
+    assert!(
+        i_await < i_async_values && i_async_gen < i_async_values,
+        "expected `__await`/`__asyncGenerator` before `__asyncValues`.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #15454.

A down-leveled `for..of` / `for await..of` requested its own iteration helper
(`__values` / `__asyncValues`) **before** visiting the iterable expression, so
the emitted tslib preamble put that helper ahead of any helper the iterable
itself pulls in. `tsc` visits the iterable first and only then requests the loop
helper; those helpers have no `priority` field, so `compareEmitHelpers` keeps
them in request order and the iterable's helpers come first.

Structural rule: when a down-leveled `for..of`/`for await..of` iterates a spread
or an inline `async function*`, tsc emits the iterable's no-priority helpers
before the loop's own `__values`/`__asyncValues`; tsz emitted the loop helper
first (owner layer: emitter lowering, `visit_for_of_statement`).

Before → after (helper preamble order):

| case (`tsz` flags) | tsc | tsz before | tsz after |
|---|---|---|---|
| for-await over inline `async function*` (`--target ES2017`) | `__await, __asyncGenerator, __asyncValues` | `__asyncValues, __await, __asyncGenerator` | matches tsc |
| sync for-of over `[...xs, 1]` (`--target ES5 --downlevelIteration`) | `__read, __spreadArray, __values` | `__values, __read, __spreadArray` | matches tsc |
| for-of binding pattern `[a, b]` (no spread) | `__values, __read` | `__values, __read` | unchanged |

The fix visits the iterable expression before requesting the loop helper, and
marks the binding-pattern `__read` afterwards — matching tsc, which requests
that `__read` while lowering the pattern (so `__values` still precedes it). One
traversal reorder corrects both the sync and async cases through the existing
request-order mechanism in `transforms/helpers.rs`; no per-helper special
casing, no changes to the helper-ordering table.

The remaining ES5 async-lowering formatting/temp differences for the mixed
spread cases are pre-existing and out of scope; this PR only corrects helper
ordering. The `for-await over inline async generator` and `sync for-of over
spread` cases are now byte-identical to `tsc` at ES2015/ES2017/ES5.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --test for_of_loop_helper_order_tests` (new: 3 cases, varied binder names)
- `cargo test -p tsz-emitter --lib` (3963 passed)
- Emit integration tests: `async_loop_emit`, `for_await_async_generator_keyword_tests`, `generator_downlevel_iteration_for_of_tests`, `destructuring_downlevel_iteration_read_tests`, `async_generator_yield_star_delegate_helpers_tests`, `async_try_emit` (all green)
- `cargo clippy -p tsz-emitter --lib --tests` clean
- Manual `tsz` vs `tsc` byte-diff on the repro files at ES2015/ES2017/ES5

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01W226dfh6xMyNZ2T5Fq4Vvd)_