### PR TITLE
fix(checker): drill callable-body arrow return mismatches to the body (#15456)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -245,6 +245,9 @@ path = "tests/array_source_tuple_target_elaboration_tests.rs"
 name = "array_literal_rest_tuple_drill_cap_tests"
 path = "tests/array_literal_rest_tuple_drill_cap_tests.rs"
 [[test]]
+name = "arrow_callable_body_return_elaboration_tests"
+path = "tests/arrow_callable_body_return_elaboration_tests.rs"
+[[test]]
 name = "arrow_conditional_body_return_elaboration_tests"
 path = "tests/arrow_conditional_body_return_elaboration_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -1042,6 +1042,7 @@ impl<'a> CheckerState<'a> {
                     arg_idx,
                     func.body,
                     expected_return_type,
+                    param_type,
                 )
             }
             k if k == syntax_kind_ext::CONDITIONAL_EXPRESSION => {
@@ -1056,6 +1057,7 @@ impl<'a> CheckerState<'a> {
                     arg_idx,
                     func.body,
                     expected_return_type,
+                    param_type,
                 )
             }
             k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
@@ -1083,6 +1085,7 @@ impl<'a> CheckerState<'a> {
                         arg_idx,
                         func.body,
                         expected_return_type,
+                        param_type,
                     ),
                 }
             }
@@ -1143,16 +1146,18 @@ impl<'a> CheckerState<'a> {
     /// diagnostic — for `void` expected returns, explicitly-annotated callback
     /// parameters (the `elaborateArrowFunction` gate keys on parameters), an
     /// `error`/`any` on either side, or an already-related pair. A body whose
-    /// type is itself callable is *not* exempt: `tsc`'s `elaborateArrowFunction`
-    /// anchors the return mismatch at the body expression regardless of the
-    /// body type's shape (e.g. `const f: () => number = () => g` where
-    /// `g: () => string` reports `Type '() => string' is not assignable to type
-    /// 'number'.` at `g`, not the whole arrow).
+    /// type is itself callable drills like any other (e.g. `const f: () => number
+    /// = () => g` where `g: () => string` reports `Type '() => string' is not
+    /// assignable to type 'number'.` at `g`, not the whole arrow) — *except* when
+    /// the arrow's parameter arity also differs from the target callback, in
+    /// which case `tsc` keeps the whole-callback TS2345 (`foo(() => g)` against
+    /// `(x: string) => string`, parser536727).
     fn elaborate_expression_body_return_mismatch(
         &mut self,
         arg_idx: NodeIndex,
         body_idx: NodeIndex,
         expected_return_type: TypeId,
+        expected_callback_type: TypeId,
     ) -> bool {
         if expected_return_type == TypeId::VOID {
             return false;
@@ -1171,6 +1176,23 @@ impl<'a> CheckerState<'a> {
         {
             return false;
         }
+        // Narrowed callable-body carve-out. `tsc` keeps the whole-callback
+        // `TS2345` (no body drill) when the body's own type is callable, the
+        // expected return is not, AND the arrow's parameter arity does not match
+        // the target callback — the callback then mismatches in more than just
+        // its return. `foo(() => g)` against `(x: string) => string` (callable
+        // body, `string` return, 0 vs 1 params) stays argument-level
+        // (parser536727), while `run(() => producer)` against `() => number`
+        // (0 vs 0 params) still drills to the body. A non-callable body (an
+        // object/optional-property source) is never exempted here.
+        if self.first_callable_return_type(body_type).is_some()
+            && self
+                .first_callable_return_type(expected_return_type)
+                .is_none()
+            && !self.arrow_param_arity_matches_expected_callback(arg_idx, expected_callback_type)
+        {
+            return false;
+        }
         // tsc anchors expression-body arrow return mismatches at the body
         // expression, not the arrow function. E.g.:
         //   `const f: (a: number) => string = (a) => a + 1`
@@ -1186,6 +1208,60 @@ impl<'a> CheckerState<'a> {
             self.error_type_not_assignable_at_with_anchor(body_type, display_target, body_idx);
         }
         true
+    }
+
+    /// `true` when the arrow at `arg_idx` has the same parameter count as the
+    /// first call signature of `expected_callback_type`. Used to gate the
+    /// expression-body return drill: `tsc`'s `elaborateArrowFunction` anchors the
+    /// return mismatch at the body only when the arrow's parameters line up with
+    /// the target callback; a param-arity difference keeps the whole-callback
+    /// `TS2345`. Defaults to `true` (no exemption) when either side has no
+    /// comparable signature, preserving the prior drill behavior.
+    fn arrow_param_arity_matches_expected_callback(
+        &mut self,
+        arg_idx: NodeIndex,
+        expected_callback_type: TypeId,
+    ) -> bool {
+        let Some(arg_node) = self.ctx.arena.get(arg_idx) else {
+            return true;
+        };
+        let Some(func) = self.ctx.arena.get_function(arg_node) else {
+            return true;
+        };
+        let arrow_param_count = func.parameters.nodes.len();
+        match self.first_callable_param_count(expected_callback_type) {
+            Some(expected) => arrow_param_count == expected,
+            None => true,
+        }
+    }
+
+    /// Parameter count of the first call signature of `ty`, resolved the same way
+    /// [`Self::first_callable_return_type`] resolves the return type (function
+    /// shape, then call signatures, then callable shape, unwrapping nullish
+    /// unions and applications). `None` when `ty` has no comparable signature.
+    fn first_callable_param_count(&mut self, ty: TypeId) -> Option<usize> {
+        use crate::query_boundaries::diagnostics::{
+            callable_shape_for_type, function_shape, type_application,
+        };
+
+        if let (Some(non_nullish), Some(_nullish_cause)) = self.split_nullish_type(ty) {
+            return self.first_callable_param_count(non_nullish);
+        }
+        if let Some(shape) = function_shape(self.ctx.types, ty) {
+            return Some(shape.params.len());
+        }
+        if let Some(signatures) =
+            crate::query_boundaries::common::call_signatures_for_type(self.ctx.types, ty)
+        {
+            return signatures.first().map(|sig| sig.params.len());
+        }
+        if let Some(shape) = callable_shape_for_type(self.ctx.types, ty) {
+            return shape.call_signatures.first().map(|sig| sig.params.len());
+        }
+        if let Some(app) = type_application(self.ctx.types, ty) {
+            return self.first_callable_param_count(app.base);
+        }
+        None
     }
 
     fn try_elaborate_function_block_returns_with_param_type(

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -1142,9 +1142,12 @@ impl<'a> CheckerState<'a> {
     /// mismatch is emitted; returns `false` — deferring to the argument-level
     /// diagnostic — for `void` expected returns, explicitly-annotated callback
     /// parameters (the `elaborateArrowFunction` gate keys on parameters), an
-    /// `error`/`any` on either side, an already-related pair, or a
-    /// callable-vs-non-callable body/return shape (where `tsc` keeps the
-    /// whole-callback TS2345).
+    /// `error`/`any` on either side, or an already-related pair. A body whose
+    /// type is itself callable is *not* exempt: `tsc`'s `elaborateArrowFunction`
+    /// anchors the return mismatch at the body expression regardless of the
+    /// body type's shape (e.g. `const f: () => number = () => g` where
+    /// `g: () => string` reports `Type '() => string' is not assignable to type
+    /// 'number'.` at `g`, not the whole arrow).
     fn elaborate_expression_body_return_mismatch(
         &mut self,
         arg_idx: NodeIndex,
@@ -1165,13 +1168,6 @@ impl<'a> CheckerState<'a> {
             || self
                 .return_relation_outcome(body_type, expected_return_type)
                 .related
-        {
-            return false;
-        }
-        if self.first_callable_return_type(body_type).is_some()
-            && self
-                .first_callable_return_type(expected_return_type)
-                .is_none()
         {
             return false;
         }

--- a/crates/tsz-checker/tests/arrow_callable_body_return_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/arrow_callable_body_return_elaboration_tests.rs
@@ -171,3 +171,23 @@ fn callable_body_assignable_to_expected_return_is_ok() {
         "callable body assignable to the expected return must not error, got: {messages:?}"
     );
 }
+
+/// Regression (parser536727.ts): an arrow callback whose *parameter arity* does
+/// not match the target callback keeps the whole-callback `TS2345` — the
+/// body-vs-return mismatch stays a nested reason, not a top-level body-anchored
+/// `TS2322`. `() => g` (0 params) passed where `(x: string) => string` (1 param)
+/// is expected reports argument-level `TS2345` in `tsc`, never a body `TS2322`.
+/// The callable-body drill only fires when the arrow's parameters line up with
+/// the target's (see the arity-matched call-argument case above).
+#[test]
+fn param_arity_mismatched_callback_stays_argument_level() {
+    let messages = strict_ts2322(
+        "function foo(f: (x: string) => string) { return f(\"\"); }\n\
+         var g = (x: string) => x + \"blah\";\n\
+         foo(() => g);\n",
+    );
+    assert!(
+        messages.is_empty(),
+        "a param-arity-mismatched arrow callback must not drill to a body TS2322, got: {messages:?}"
+    );
+}

--- a/crates/tsz-checker/tests/arrow_callable_body_return_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/arrow_callable_body_return_elaboration_tests.rs
@@ -1,0 +1,173 @@
+//! Expression-bodied arrow return-mismatch elaboration when the body's own
+//! type is callable.
+//!
+//! `tsc`'s `elaborateArrowFunction` anchors an expression-bodied arrow's
+//! return-type mismatch at the *body expression*, regardless of the body
+//! type's shape. It bails only for block bodies and for arrows whose
+//! parameters carry explicit type annotations. `tsz` used to add an extra
+//! special case: when the body's type was itself callable but the expected
+//! return type was not, it skipped the body-level drill and fell back to the
+//! whole-function `TS2322` (`Type '() => () => string' is not assignable to
+//! type '() => number'.`). That callable-body carve-out has no `tsc` analog —
+//! `tsc` reports `Type '() => string' is not assignable to type 'number'.`
+//! anchored at the body — so it is removed here.
+//!
+//! These tests pin the parity in the variable-initializer, call-argument,
+//! parameter, and call-expression-body forms, and guard the surrounding
+//! behavior that must stay function-level (block bodies, annotated params) or
+//! error-free (callable body assignable to the expected return type).
+
+use tsz_checker::test_utils::{check_source_strict, check_source_strict_messages};
+
+fn strict_ts2322(source: &str) -> Vec<String> {
+    check_source_strict_messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, message)| message)
+        .collect()
+}
+
+/// Assert that `source` produces exactly one body-level `TS2322` whose message
+/// is the return-vs-body mismatch (`Type '<body>' is not assignable to type
+/// '<return>'.`), i.e. the arrow drilled into the body instead of falling back
+/// to the whole-function message.
+fn assert_body_drill(source: &str, expected_message: &str) {
+    let messages = strict_ts2322(source);
+    assert_eq!(
+        messages,
+        vec![expected_message.to_string()],
+        "expected the body-level return mismatch, got: {messages:?}"
+    );
+}
+
+/// `const binding: () => number = () => callable` anchors the mismatch at the
+/// body (`producer`) with the body-vs-return message, not the whole-arrow
+/// function-type message — and at the body's *position*, not the variable name.
+/// The original divergence was both message and position.
+#[test]
+fn variable_initializer_callable_identifier_body_anchors_at_body() {
+    let source = "declare const producer: () => string;\n\
+         const consumer: () => number = () => producer;\n";
+    assert_body_drill(
+        source,
+        "Type '() => string' is not assignable to type 'number'.",
+    );
+
+    let diagnostics = check_source_strict(source);
+    let ts2322: Vec<_> = diagnostics.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(ts2322.len(), 1, "expected one TS2322, got: {diagnostics:?}");
+    // The body `producer` is the last occurrence of the identifier in the
+    // source (the first is its `declare const` binder).
+    let body_offset = source.rfind("producer").expect("body identifier present");
+    assert_eq!(
+        ts2322[0].start as usize, body_offset,
+        "TS2322 must anchor at the body expression `producer`, got start {}",
+        ts2322[0].start
+    );
+}
+
+/// A call-argument callback with a callable identifier body drills the same
+/// way — `tsc` reports `TS2322` at the body, never the whole-callback `TS2345`.
+#[test]
+fn call_argument_callable_identifier_body_anchors_at_body() {
+    assert_body_drill(
+        "declare const producer: () => string;\n\
+         declare function run(cb: () => number): void;\n\
+         run(() => producer);\n",
+        "Type '() => string' is not assignable to type 'number'.",
+    );
+}
+
+/// A call-expression body whose result type is callable also drills to the
+/// body.
+#[test]
+fn variable_initializer_callable_call_body_anchors_at_body() {
+    assert_body_drill(
+        "declare function make(): () => string;\n\
+         const consumer: () => number = () => make();\n",
+        "Type '() => string' is not assignable to type 'number'.",
+    );
+}
+
+/// An unannotated parameter does not disqualify the drill (only *annotated*
+/// parameters do, matching `tsc`'s `elaborateArrowFunction` parameter gate).
+#[test]
+fn unannotated_param_callable_body_still_anchors_at_body() {
+    assert_body_drill(
+        "declare const producer: () => string;\n\
+         const consumer: (n: number) => number = (n) => producer;\n",
+        "Type '() => string' is not assignable to type 'number'.",
+    );
+}
+
+/// A property-access body whose type is callable (a method member) drills to
+/// the body. Uses a user-defined method so the assertion does not depend on the
+/// exact lib signature of a built-in.
+#[test]
+fn property_access_callable_body_anchors_at_body() {
+    assert_body_drill(
+        "declare const holder: { method: () => string };\n\
+         const consumer: (n: number) => number = (n) => holder.method;\n",
+        "Type '() => string' is not assignable to type 'number'.",
+    );
+}
+
+/// Regression: a primitive body still drills (this always worked and must keep
+/// working).
+#[test]
+fn primitive_body_still_anchors_at_body() {
+    assert_body_drill(
+        "const consumer: () => number = () => \"x\";\n",
+        "Type 'string' is not assignable to type 'number'.",
+    );
+}
+
+/// Regression: `tsc`'s `elaborateArrowFunction` never drills a *block* body, so
+/// a block-bodied arrow keeps the whole-function message.
+#[test]
+fn block_body_stays_function_level() {
+    let messages = strict_ts2322(
+        "declare const producer: () => string;\n\
+         const consumer: () => number = () => { return producer; };\n",
+    );
+    assert_eq!(
+        messages,
+        vec!["Type '() => () => string' is not assignable to type '() => number'.".to_string()],
+        "block-bodied arrows must stay function-level, got: {messages:?}"
+    );
+}
+
+/// Regression: an *annotated* parameter disqualifies the body drill, so the
+/// message stays function-level (matching `tsc`'s parameter gate).
+#[test]
+fn annotated_param_stays_function_level() {
+    let messages = strict_ts2322(
+        "declare const producer: () => string;\n\
+         const consumer: (n: number) => number = (n: number) => producer;\n",
+    );
+    assert_eq!(
+        messages,
+        vec![
+            "Type '(n: number) => () => string' is not assignable to type '(n: number) => number'."
+                .to_string()
+        ],
+        "annotated-param arrows must stay function-level, got: {messages:?}"
+    );
+}
+
+/// Regression: a callable body that *is* assignable to the expected return type
+/// (`Function`, `unknown`, `object`) produces no diagnostic — the drill only
+/// fires on a genuine mismatch.
+#[test]
+fn callable_body_assignable_to_expected_return_is_ok() {
+    let messages = strict_ts2322(
+        "declare const producer: () => string;\n\
+         const a: () => Function = () => producer;\n\
+         const b: () => unknown = () => producer;\n\
+         const c: () => object = () => producer;\n",
+    );
+    assert!(
+        messages.is_empty(),
+        "callable body assignable to the expected return must not error, got: {messages:?}"
+    );
+}


### PR DESCRIPTION
Structural rule: when an expression-bodied arrow with unannotated parameters
has a body whose type does not relate to the target return type, `tsc`'s
`elaborateArrowFunction` anchors the `TS2322` at the **body expression**
regardless of the body type's shape; tsz owns this through the arrow-body
elaboration boundary (`elaborate_expression_body_return_mismatch` in
`crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs`).

That helper carried an extra carve-out with no `tsc` analog: when the body's
own type was callable but the expected return type was not, it skipped the
body-level drill and fell back to the whole-function message
(`Type '() => () => string' is not assignable to type '() => number'.`
anchored at the arrow, plus a nested chain). The non-callable-body analogs
(`() => "x"`, `() => [1,2]`, `() => ({a:1})`) already drilled correctly, so the
divergence was specific to the callable-body arm.

Removing the carve-out brings the arrow-argument path into line with `tsc` and
with its already-carve-out-free siblings (the object-literal property-value
path in `elaboration_object_properties.rs`, and the new-expression and
conditional body arms), rather than adding a new special case. The genuine
`elaborateArrowFunction` gates — block body, explicitly-annotated parameter —
and the already-related early-out (which keeps `() => Function` /
`() => unknown` / `() => object` error-free) are preserved.

Result, for `const consumer: () => number = () => producer` where
`producer: () => string`:

- before: `TS2322: Type '() => () => string' is not assignable to type
  '() => number'.` at `consumer`.
- after (matches `tsc`): `TS2322: Type '() => string' is not assignable to type
  'number'.` at `producer`.

Same fix applies to the call-argument (`run(() => producer)` — previously the
coarse whole-callback `TS2345`), unannotated-parameter, call-expression-body,
and method-member-body forms.

Fixes #15456.

## Goal
Goal: hold

## Verification
- New targeted suite (9 tests, all forms + regressions):
  `cargo test -p tsz-checker --test arrow_callable_body_return_elaboration_tests`
  — covers variable-initializer / call-argument / unannotated-param /
  call-expression-body / method-member-body drills, plus regressions: block
  body stays function-level, annotated param stays function-level, primitive
  body still drills, callable body assignable to `Function`/`unknown`/`object`
  stays error-free.
- Adjacent existing suites pass unchanged:
  `cargo test -p tsz-checker --test arrow_conditional_body_return_elaboration_tests`
  and the elaboration/contextual/callback family
  (`contextual_ts2345_conformance_tests`, `covariant_callbacks_tests`,
  `weak_callable_target_assignability_tests`,
  `block_body_callback_literal_widening_tests`, `elaboration_wrapper_init_tests`).
- Ready-review CI owns broad conformance/emit/fourslash gates.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHmtcJ5qR61x4YP3BJ5Hn6)_