### PR TITLE
fix(checker): cap array-literal element drill-in for rest-tuple targets (#15458)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -243,6 +243,9 @@ path = "tests/tuple_call_argument_elaboration_tests.rs"
 name = "array_source_tuple_target_elaboration_tests"
 path = "tests/array_source_tuple_target_elaboration_tests.rs"
 [[test]]
+name = "array_literal_rest_tuple_drill_cap_tests"
+path = "tests/array_literal_rest_tuple_drill_cap_tests.rs"
+[[test]]
 name = "arrow_conditional_body_return_elaboration_tests"
 path = "tests/arrow_conditional_body_return_elaboration_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -85,15 +85,15 @@ impl<'a> CheckerState<'a> {
                 target_element,
                 ..
             }) => {
-                // For variadic-rest tuples with trailing fixed elements, only
-                // report element-level errors for the leading fixed section.
-                // A failure at index >= leading_fixed_count means the mismatch
-                // is in the variadic or trailing section — those can't be mapped
-                // to source element positions reliably, so defer to tuple-level.
+                // For variadic-rest tuple targets, only report element-level
+                // errors for the leading fixed section. A failure at index >=
+                // leading_fixed_count means the mismatch is in the variadic or
+                // trailing section — those can't be mapped to source element
+                // positions reliably, so defer to the whole-tuple relation.
                 if let Some(target_elements) =
                     crate::query_boundaries::common::tuple_elements(self.ctx.types, target_type)
                     && let Some(n_leading) =
-                        crate::query_boundaries::common::tuple_leading_fixed_count_before_trailing(
+                        crate::query_boundaries::common::tuple_leading_fixed_drill_cap(
                             &target_elements,
                         )
                     && index >= n_leading

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -1108,15 +1108,17 @@ impl<'a> CheckerState<'a> {
         let tuple_target_elements =
             crate::query_boundaries::common::tuple_elements(self.ctx.types, effective_param_type);
 
-        // For variadic-rest tuples with trailing fixed elements (e.g., [number, ...string[], number]),
-        // element positions can only be reliably matched against the leading fixed section.
-        // Trailing fixed elements cannot be mapped without knowing the total source length, and
-        // variadic-section positions are ambiguous when trailing elements shift the mapping.
-        // Limit elaboration to the leading fixed count; tsc emits element-level only for leading
-        // fixed failures and falls back to a tuple-level error for variadic/trailing mismatches.
+        // For variadic-rest tuple targets (e.g. `[number, ...string[]]` or
+        // `[number, ...string[], number]`), element positions can only be
+        // reliably matched against the leading fixed section. Rest-covered and
+        // trailing fixed positions cannot be mapped to a fixed source index, so
+        // tsc emits element-level errors only for leading fixed failures and
+        // falls back to the whole-tuple relation (`Type at position(s) … in
+        // source …`) for the rest. Cap element drill-in to the leading fixed
+        // count to mirror that.
         let max_elaborate_index: Option<usize> =
             tuple_target_elements.as_deref().and_then(|elements| {
-                crate::query_boundaries::common::tuple_leading_fixed_count_before_trailing(elements)
+                crate::query_boundaries::common::tuple_leading_fixed_drill_cap(elements)
             });
 
         let mut elaborated = false;

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1442,23 +1442,41 @@ pub(crate) fn get_fixed_tuple_length(db: &dyn TypeDatabase, type_id: TypeId) -> 
     tsz_solver::type_queries::get_fixed_tuple_length(db, type_id)
 }
 
-/// Returns the number of leading fixed (non-rest) elements before the first rest element,
-/// when the tuple has trailing fixed elements after the rest. Returns `None` if the tuple
-/// has no rest element or no trailing fixed elements after the rest.
+/// Upper bound (exclusive) on the source element indices that array-literal /
+/// argument elaboration may report per-element against a tuple *target* that
+/// contains a rest element.
 ///
-/// For `[number, ...string[], number]`: returns `Some(1)` (1 leading fixed before rest).
-/// For `[...string[], number]`: returns `Some(0)` (0 leading fixed before rest).
-/// For `[number, ...string[]]`: returns `None` (no trailing fixed after rest).
+/// tsc's `generateLimitedTupleElements` skips any source element whose index has
+/// no *fixed* slot in the tuple-like target (`isTupleLikeType(target) &&
+/// !getPropertyOfType(target, `${i}`)`), so only the leading fixed prefix before
+/// the first rest element is ever drilled into at the element level. Positions
+/// covered by the rest element — and any trailing fixed elements, whose position
+/// depends on the source length — fall back to the whole-type tuple relation,
+/// which renders the `Type at position(s) i[ through j] in source …` chain.
+///
+/// Returns `Some(leading_fixed_count)` when the target tuple pairs a rest element
+/// with at least one other element, capping element drill-in to that prefix.
+/// Returns `None` when there is no rest element (a closed tuple — every position
+/// is a fixed slot and drills in) or when the tuple is a lone rest element
+/// (`[...T[]]`, which is array-like — tsc drills into each element).
+///
+/// For `[number, ...string[]]`: returns `Some(1)`.
+/// For `[number, ...string[], number]`: returns `Some(1)`.
+/// For `[...string[], number]`: returns `Some(0)`.
+/// For `[...string[]]`: returns `None` (array-like — drill every element).
 /// For `[number, string]`: returns `None` (no rest element).
-pub(crate) fn tuple_leading_fixed_count_before_trailing(
+pub(crate) fn tuple_leading_fixed_drill_cap(
     elements: &[tsz_solver::TupleElement],
 ) -> Option<usize> {
+    // Fixed-length tuple spreads (`[a, ...[b, c]]`) are flattened into fixed
+    // elements before interning, so a `rest` marker denotes only a genuine
+    // variable-length rest. `first_rest_pos` is therefore the flattened count of
+    // leading fixed slots, with no nested-tuple flattening left to do.
     let first_rest_pos = elements.iter().position(|e| e.rest)?;
-    let n_trailing = elements[first_rest_pos..]
-        .iter()
-        .filter(|e| !e.rest)
-        .count();
-    if n_trailing == 0 {
+    // A lone rest element `[...T[]]` is array-like: tsc reports each element
+    // individually rather than deferring to the whole-tuple relation, so it is
+    // never capped.
+    if elements.len() == 1 {
         return None;
     }
     Some(first_rest_pos)

--- a/crates/tsz-checker/tests/arch_source_scans/common_boundary_export_ratchets.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/common_boundary_export_ratchets.rs
@@ -250,7 +250,7 @@ const ALLOWED_COMMON_PUB_CRATE_FNS: &[&str] = &[
     "substitute_this_type",
     "substitute_this_type_at_return_position",
     "tuple_elements",
-    "tuple_leading_fixed_count_before_trailing",
+    "tuple_leading_fixed_drill_cap",
     "tuple_list_id",
     "type_application",
     "type_contains_string_literal",

--- a/crates/tsz-checker/tests/array_literal_rest_tuple_drill_cap_tests.rs
+++ b/crates/tsz-checker/tests/array_literal_rest_tuple_drill_cap_tests.rs
@@ -1,0 +1,169 @@
+//! A fresh **array literal** assigned to a **tuple target with a rest element**
+//! must match `tsc`'s element-drill-in cap.
+//!
+//! `tsc`'s `generateLimitedTupleElements` skips any source element whose index
+//! has no *fixed* slot in the tuple-like target (`isTupleLikeType(target) &&
+//! !getPropertyOfType(target, `${i}`)`). So only the **leading fixed prefix**
+//! before the first rest element is ever reported at the element level; any
+//! source element covered by the rest element falls back to the whole-tuple
+//! relation, which renders the `Type at position(s) i[ through j] in source is
+//! not compatible with type at position k in target.` chain anchored at the
+//! initializer.
+//!
+//! `tsz` previously capped element drill-in only when the target tuple had
+//! *trailing* fixed elements after the rest, so `[number, ...boolean[]]` wrongly
+//! drilled into the rest-covered source element (wrong anchor, no chain, and one
+//! range-frame split into N leaf errors). The cap now applies whenever the
+//! target pairs a rest element with any fixed element. The rule is structural:
+//! it depends on the tuple shape, not the binder name or element type, so the
+//! cases vary both.
+
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn ts2322(source: &str) -> Vec<Diagnostic> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .collect()
+}
+
+fn related_lines(diagnostic: &Diagnostic) -> Vec<String> {
+    diagnostic
+        .related_information
+        .iter()
+        .map(|related| related.message_text.clone())
+        .collect()
+}
+
+fn has_related(diagnostic: &Diagnostic, expected: &str) -> bool {
+    diagnostic
+        .related_information
+        .iter()
+        .any(|related| related.message_text == expected)
+}
+
+/// Assert the source produces exactly one TS2322 whose headline is `expected` —
+/// the per-element leaf drilled at the mismatching slot (no whole-tuple chain).
+fn assert_single_leaf(source: &str, expected: &str) {
+    let diagnostics = ts2322(source);
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one TS2322 element leaf, got {diagnostics:#?}"
+    );
+    assert_eq!(diagnostics[0].message_text, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Rest-covered failure only -> one whole-tuple relation chain, not a leaf.
+// ---------------------------------------------------------------------------
+
+/// A single rest-covered element mismatch reports the whole-tuple relation at
+/// the initializer with the `Type at position 1 …` frame, not a bare element
+/// leaf.
+#[test]
+fn rest_covered_single_failure_reports_whole_tuple_chain() {
+    for source in [
+        "const bad: [number, ...boolean[]] = [1, \"no\"];",
+        // Renamed binder + different element types: same structural reason.
+        "const other: [string, ...number[]] = [\"lead\", true];",
+    ] {
+        let diagnostics = ts2322(source);
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "expected exactly one TS2322 (the whole-tuple chain), got {diagnostics:#?}"
+        );
+        let diagnostic = &diagnostics[0];
+        assert!(
+            has_related(
+                diagnostic,
+                "Type at position 1 in source is not compatible with type at position 1 in target."
+            ),
+            "missing the whole-tuple position frame; related = {:#?}",
+            related_lines(diagnostic)
+        );
+    }
+}
+
+/// Several consecutive rest-covered failures collapse into a single
+/// `Type at positions i through j …` range frame, not one leaf per element.
+#[test]
+fn rest_covered_multiple_failures_report_position_range() {
+    let diagnostics = ts2322("const bad: [number, ...boolean[]] = [1, \"a\", \"b\"];");
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected one TS2322 range frame, got {diagnostics:#?}"
+    );
+    assert!(
+        has_related(
+            &diagnostics[0],
+            "Type at positions 1 through 2 in source is not compatible with type at position 1 in target."
+        ),
+        "missing the positional-range frame; related = {:#?}",
+        related_lines(&diagnostics[0])
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mixed failures: the leading fixed prefix still drills; rest-covered elements
+// are dropped (tsc reports only the fixed-prefix leaves).
+// ---------------------------------------------------------------------------
+
+/// When a leading-fixed element fails, `tsc` drills into it and drops the
+/// rest-covered failure entirely (element elaboration reported an error, so the
+/// whole-tuple fallback never fires). Exactly one leaf, at the fixed slot.
+#[test]
+fn fixed_prefix_failure_drills_and_drops_rest_covered() {
+    assert_single_leaf(
+        "const bad: [string, ...boolean[]] = [1, \"no\"];",
+        "Type 'number' is not assignable to type 'string'.",
+    );
+}
+
+/// A fixed-prefix failure that is *not* at position 0 still drills in at its
+/// true slot, and the trailing rest-covered element is dropped.
+#[test]
+fn fixed_prefix_failure_after_passing_slot_drills() {
+    assert_single_leaf(
+        "const bad: [number, boolean, ...string[]] = [1, \"no\", \"ok\"];",
+        "Type 'string' is not assignable to type 'boolean'.",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Array-like and closed targets keep drilling into each element (unchanged):
+// a lone-rest `[...T[]]` normalizes to an array, a plain array target indexes
+// at every position, and a closed tuple makes every position a fixed slot.
+// ---------------------------------------------------------------------------
+
+/// A lone-rest tuple `[...T[]]` is array-like, so `tsc` reports each element
+/// individually — the cap must not intercept it.
+#[test]
+fn lone_rest_tuple_still_drills_into_element() {
+    assert_single_leaf(
+        "const bad: [...boolean[]] = [\"no\"];",
+        "Type 'string' is not assignable to type 'boolean'.",
+    );
+}
+
+/// A plain array target keeps per-element drill-in.
+#[test]
+fn plain_array_target_still_drills_into_element() {
+    assert_single_leaf(
+        "const bad: boolean[] = [true, \"no\"];",
+        "Type 'string' is not assignable to type 'boolean'.",
+    );
+}
+
+/// A closed (rest-free) tuple keeps its per-element leaf — the cap only applies
+/// when a rest element is present.
+#[test]
+fn closed_tuple_still_drills_into_element() {
+    assert_single_leaf(
+        "const bad: [number, boolean] = [1, \"no\"];",
+        "Type 'string' is not assignable to type 'boolean'.",
+    );
+}


### PR DESCRIPTION
Closes #15458.

When a fresh **array literal** is assigned to a **tuple target that carries a
rest element**, `tsc` only drills into source elements that map to a *fixed*
slot in the target (`generateLimitedTupleElements` skips any index with no fixed
property: `isTupleLikeType(target) && !getPropertyOfType(target, \`${i}\`)`).
Rest-covered positions fall back to the whole-tuple relation — `Type at
position(s) i[ through j] in source is not compatible with type at position k in
target.` anchored at the initializer.

**Structural rule:** when a fresh array literal targets a tuple with a rest
element, tsc reports element-level errors only for the leading fixed prefix and
defers rest-covered mismatches to the whole-tuple relation; tsz now does the
same through the checker's shared elaboration drill-in cap. Previously tsz's
`tuple_leading_fixed_count_before_trailing` only capped when the tuple had
*trailing* fixed elements after the rest, so `[number, ...boolean[]]` (rest
last) drilled into the rest-covered element — wrong anchor, no chain, and one
range-frame split into N leaf errors.

The fix generalizes the shared helper to `tuple_leading_fixed_drill_cap`: cap
drill-in at the leading-fixed count whenever a rest element pairs with any fixed
element, guarding the lone-rest `[...T[]]` array-like case (which stays
per-element). Both elaboration entry points — variable initializer
(`elaboration_object_properties.rs`) and call argument
(`elaboration_array_mismatch.rs`) — share the helper, so the fix lands on both.
tsz's relation layer already renders the positional-range chain (verified on
variable sources), so this is purely an elaboration-cap fix; the assignability
relation and resolved types are unchanged.

Before → after (`tsc 6.0.2` parity, `--noEmit --strict`):

| witness | tsc | tsz before | tsz after |
|---|---|---|---|
| `[number, ...boolean[]] = [1, "no"]` | whole-tuple chain `@init`, `position 1` | leaf `@elem` | whole-tuple chain |
| `[number, ...boolean[]] = [1, "a", "b"]` | one `positions 1 through 2` | two leaves | one range frame |
| `[string, ...boolean[]] = [1, "no"]` | one fixed-slot leaf | two leaves | one fixed-slot leaf |

Negative controls unchanged: fixed-prefix failures still drill in; closed
tuples (`[number, boolean]`), lone-rest `[...boolean[]]`, and plain `boolean[]`
targets still drill per-element; fixed-tuple spreads (`[a, ...[b, c]]`,
`[a, ...[b, c], ...d[]]`) already normalize to flattened fixed slots and are
unaffected; renamed-binder variants verified (rule is structural, not
name-driven).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test array_literal_rest_tuple_drill_cap_tests` (7 new cases, green)
- Regression batch green: `array_source_tuple_target_elaboration_tests`,
  `tuple_call_argument_elaboration_tests`, `tuple_variadic_position_elaboration_tests`,
  `tuple_argument_mismatch_elaboration_tests`, `tuple_arity_elaboration_tests`,
  `tuple_element_mismatch_tests`, `variadic_tuple_rest_aggregate_display_tests`,
  `variadic_tuple_spread_element_type_tests`, `spread_rest_diagnostics_tests`,
  `readonly_tuple_source_display_tests`, `union_tuple_source_display_tests`,
  `contextual_tuple_tests`, and ~10 more tuple/spread suites.
- `cargo clippy -p tsz-checker --tests` clean.
- Differential sweep vs `tsc 6.0.2` (`--noEmit --strict`) across ~20 tuple-shape
  witnesses (leading/trailing/pure-rest/mixed/nested/readonly, initializer + call
  paths) all match after the fix.
- Pre-existing local failures unrelated to this change (5 `arch_source_scans`
  ratchets + 1 `spread_rest_tests`) confirmed identical with the change stashed
  (tracked under #15338, CI disabled).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01QC2hYKpHqhgGyeZeVLZMgF