### PR TITLE
ci: add known-failures baseline comparator for signoff (#15399)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -101,6 +101,27 @@ status-level = "fail"
 filter = 'test(test_ts2536_with_lib_mismatched_keyof_source) | test(compile_document_create_element_overload_augmentation_no_false_ts2430)'
 slow-timeout = { period = "90s", terminate-after = 2 }
 
+# Signoff profile (#15399) - precommit timeouts, but fail-fast disabled and junit
+# on. While main carries a known-failing set and CI is reduced, `precommit`'s
+# `fail-fast = true` bails on the first red test, so it can never produce a full
+# failure inventory to distinguish NEW regressions from the known baseline. This
+# profile runs the whole suite, writes junit, and lets
+# scripts/ci/known-failures-check.mjs adjudicate against
+# scripts/ci/known-failures.txt.
+[profile.signoff]
+slow-timeout = { period = "15s", terminate-after = 2 }
+leak-timeout = "2s"
+fail-fast = false
+test-threads = "num-cpus"
+status-level = "fail"
+
+[[profile.signoff.overrides]]
+filter = 'test(test_ts2536_with_lib_mismatched_keyof_source) | test(compile_document_create_element_overload_augmentation_no_false_ts2430)'
+slow-timeout = { period = "90s", terminate-after = 2 }
+
+[profile.signoff.junit]
+path = "target/nextest/signoff/junit.xml"
+
 # Long-running tests profile (for conformance tests)
 [profile.conformance]
 slow-timeout = { period = "120s", terminate-after = 2 }

--- a/scripts/ci/full-ci.sh
+++ b/scripts/ci/full-ci.sh
@@ -390,6 +390,7 @@ run_lint() {
   node scripts/ci/test-check-stale-ci-runs.mjs || return $?
   node scripts/ci/test-check-ci-job-timing.mjs || return $?
   node scripts/ci/test-check-main-red.mjs || return $?
+  node scripts/ci/test-known-failures-check.mjs || return $?
   node scripts/ci/test-wip-state-comments.mjs || return $?
   node scripts/ci/test-project-compatibility.mjs || return $?
   node scripts/ci/test-type-challenges-solutions-manifest.mjs || return $?

--- a/scripts/ci/known-failures-check.mjs
+++ b/scripts/ci/known-failures-check.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+// Known-failures baseline comparator (#15399).
+//
+// While main carries a known-failing test set and hosted CI is reduced, the
+// local/PR gate needs to distinguish a NEW failure (a regression this change
+// introduced) from the pre-existing known set. `cargo nextest --profile signoff`
+// runs the whole suite with fail-fast disabled and writes junit; this script
+// diffs that junit against the committed baseline in scripts/ci/known-failures.txt:
+//
+//   - any FAILING test not in the baseline  -> exit 1 (a new regression, named)
+//   - any BASELINED test that now PASSES     -> warn + list (shrink ratchet)
+//   - everything else                        -> exit 0
+//
+// `--update` rewrites the baseline to exactly the current failing set. In normal
+// PRs the baseline may only shrink (a CI guard greps the diff for additions); a
+// growth requires an explicit, reviewed baseline change.
+//
+// Bootstrap: the committed baseline ships with the header only and no reconciled
+// marker, so the script runs in advisory mode (reports the current failing set,
+// exits 0) until the first `--update` on a full-suite run stamps the marker and
+// flips it to the strict behavior above. Reconciliation is keyed on the marker,
+// not on the line count, so an empty-but-reconciled baseline (a fully green tree)
+// still blocks any failure.
+//
+// Node-less fallback: on a machine without node, run
+//   cargo nextest run --profile signoff --workspace
+// and compare the reported failures to scripts/ci/known-failures.txt by hand, or
+// pin a nextest `default-filter` that excludes the known set.
+//
+// Usage:
+//   node scripts/ci/known-failures-check.mjs [--junit <path>] [--baseline <path>] [--update]
+//
+// Exit codes:
+//   0 - no new failures (or advisory bootstrap / shrink-only)
+//   1 - one or more failing tests are absent from the baseline (regression)
+//   2 - junit or baseline unreadable/invalid (configuration error, surfaced loudly)
+import fs from "node:fs";
+import path from "node:path";
+
+const DEFAULT_JUNIT = "target/nextest/signoff/junit.xml";
+const DEFAULT_BASELINE = "scripts/ci/known-failures.txt";
+
+// Written by `--update`; its presence (not the line count) marks the baseline as
+// reconciled against a real full run. This keeps "reconciled but green" (empty
+// list + marker -> strict, blocks any failure) distinct from "never reconciled"
+// (no marker -> advisory), so the gate does not silently disable itself on a
+// clean tree.
+const RECONCILED_MARKER = "# baseline-status: reconciled";
+
+const BASELINE_HEADER = [
+  "# Known-failures baseline for scripts/ci/known-failures-check.mjs (#15399).",
+  "# One `binary-id::test-name` per line; blank lines and `#` comments ignored.",
+  "#",
+  "# Regenerate from a full signoff run (fail-fast disabled, junit on):",
+  "#   cargo nextest run --profile signoff --workspace || true",
+  "#   node scripts/ci/known-failures-check.mjs --update",
+  "#",
+  "# Until the first `--update` there is no reconciled marker and the checker",
+  "# runs in advisory mode (never blocks). `--update` stamps the marker and",
+  "# switches the checker to strict: any failing test not listed here is a new",
+  "# regression, even when the list is empty (a fully green tree). In normal PRs",
+  "# this list may only shrink.",
+];
+
+const TESTCASE_RE = /<testcase\b([^>]*?)(?:\/>|>([\s\S]*?)<\/testcase>)/g;
+const NAME_RE = /\bname="([^"]*)"/;
+const CLASSNAME_RE = /\bclassname="([^"]*)"/;
+const FAILURE_RE = /<(failure|error)\b/;
+
+// Extract a single quoted attribute value from a `<testcase ...>` attribute run.
+function attr(attrs, re) {
+  const m = re.exec(attrs);
+  return m ? m[1] : null;
+}
+
+// Parse a nextest junit document into the set of test ids that ran and the
+// subset that failed. Each `<testcase>` carries `name` (test path within its
+// binary) and `classname` (the binary-id); a failing case has a `<failure>` or
+// `<error>` child. Timeouts surface as `<failure>`, so they count as failures.
+// (A passing case may still carry `<system-out>`/`<system-err>` children, so
+// failure is keyed on the failure/error tag, never on child presence.) The
+// canonical id is `classname::name` (== nextest's `binary-id::test-name`).
+export function parseJunitFailures(xml) {
+  const all = new Set();
+  const failing = new Set();
+  TESTCASE_RE.lastIndex = 0;
+  let m;
+  while ((m = TESTCASE_RE.exec(xml)) !== null) {
+    const attrs = m[1];
+    const inner = m[2]; // undefined when the tag is self-closed
+    const name = attr(attrs, NAME_RE);
+    if (name === null) continue;
+    const classname = attr(attrs, CLASSNAME_RE);
+    const id = classname ? `${classname}::${name}` : name;
+    all.add(id);
+    if (inner !== undefined && FAILURE_RE.test(inner)) failing.add(id);
+  }
+  return { all, failing };
+}
+
+// Parse the baseline text into a set of known-failing ids.
+export function parseBaseline(text) {
+  const set = new Set();
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    set.add(line);
+  }
+  return set;
+}
+
+// A baseline is reconciled once `--update` has stamped the marker; only then
+// does the checker enforce strictly. Unreconciled baselines are advisory.
+export function baselineIsReconciled(text) {
+  return text.split(/\r?\n/).some((line) => line.trim() === RECONCILED_MARKER);
+}
+
+// Diff a junit result against the baseline set.
+//   newFailures - failing tests absent from the baseline (regressions -> block)
+//   nowPassing  - baselined tests that ran and did not fail (shrink candidates)
+export function evaluate(baseline, junit) {
+  const newFailures = [...junit.failing].filter((id) => !baseline.has(id)).sort();
+  const nowPassing = [...baseline]
+    .filter((id) => junit.all.has(id) && !junit.failing.has(id))
+    .sort();
+  return { newFailures, nowPassing };
+}
+
+// Render a baseline file body from a set/iterable of failing ids. `--update`
+// produces a reconciled file (marker stamped); the committed bootstrap file is
+// rendered unreconciled.
+export function renderBaseline(ids, { reconciled = true } = {}) {
+  const sorted = [...new Set(ids)].sort();
+  const header = reconciled ? [...BASELINE_HEADER, RECONCILED_MARKER] : BASELINE_HEADER;
+  return [...header, ...sorted].join("\n") + "\n";
+}
+
+function parseArgs(argv) {
+  const out = { junit: DEFAULT_JUNIT, baseline: DEFAULT_BASELINE, update: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--junit") out.junit = argv[++i];
+    else if (a === "--baseline") out.baseline = argv[++i];
+    else if (a === "--update") out.update = true;
+    else if (a === "--help" || a === "-h") out.help = true;
+    else {
+      out.error = `unknown argument '${a}'`;
+      return out;
+    }
+  }
+  return out;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(
+      "usage: node scripts/ci/known-failures-check.mjs [--junit <path>] [--baseline <path>] [--update]\n",
+    );
+    process.exit(0);
+  }
+  if (args.error) {
+    process.stderr.write(`known-failures-check: ${args.error}\n`);
+    process.exit(2);
+  }
+
+  let junitXml;
+  try {
+    junitXml = fs.readFileSync(args.junit, "utf8");
+  } catch (err) {
+    process.stderr.write(
+      `known-failures-check: cannot read junit ${args.junit}: ${err.message}\n` +
+        `Run the suite first: cargo nextest run --profile signoff --workspace || true\n`,
+    );
+    process.exit(2);
+  }
+  const junit = parseJunitFailures(junitXml);
+
+  // A junit with zero testcases means the run produced no results (build failed,
+  // or the runner was killed before any test recorded). Treat it as an infra
+  // error rather than "nothing failed" so a truncated run can neither pass the
+  // gate nor be written as an empty baseline. (Partial runs that record most but
+  // not all tests are not caught here; the slice-2 full CI tier owns that.)
+  if (junit.all.size === 0) {
+    process.stderr.write(
+      `known-failures-check: junit ${args.junit} recorded no testcases; ` +
+        `treating as a failed/incomplete run.\n`,
+    );
+    process.exit(2);
+  }
+
+  if (args.update) {
+    fs.mkdirSync(path.dirname(args.baseline), { recursive: true });
+    fs.writeFileSync(args.baseline, renderBaseline(junit.failing));
+    process.stdout.write(
+      `known-failures-check: wrote ${junit.failing.size} known failure(s) to ${args.baseline}.\n`,
+    );
+    process.exit(0);
+  }
+
+  let baselineText;
+  try {
+    baselineText = fs.readFileSync(args.baseline, "utf8");
+  } catch (err) {
+    process.stderr.write(
+      `known-failures-check: cannot read baseline ${args.baseline}: ${err.message}\n`,
+    );
+    process.exit(2);
+  }
+  const baseline = parseBaseline(baselineText);
+
+  // Unreconciled baseline (no `--update` yet): advisory only, never blocks.
+  if (!baselineIsReconciled(baselineText)) {
+    const failing = [...junit.failing].sort();
+    process.stdout.write(
+      `known-failures-check: baseline ${args.baseline} is unreconciled. ` +
+        `Advisory only; ${failing.length} test(s) currently failing.\n`,
+    );
+    for (const id of failing) process.stdout.write(`  would-baseline: ${id}\n`);
+    process.stdout.write(
+      `Populate with a full run once: cargo nextest run --profile signoff --workspace || true; ` +
+        `node scripts/ci/known-failures-check.mjs --update\n`,
+    );
+    process.exit(0);
+  }
+
+  const { newFailures, nowPassing } = evaluate(baseline, junit);
+  process.stdout.write(
+    `known-failures-check: ${junit.all.size} test(s) ran, ${junit.failing.size} failing, ` +
+      `baseline has ${baseline.size} known failure(s).\n`,
+  );
+  for (const id of nowPassing) {
+    process.stdout.write(`  shrink: ${id} is baselined but now passes -> drop it with --update.\n`);
+  }
+  if (newFailures.length > 0) {
+    for (const id of newFailures) process.stderr.write(`  NEW FAILURE: ${id}\n`);
+    process.stderr.write(
+      `::error title=New test failure not in baseline::${newFailures.length} failing test(s) ` +
+        `are absent from ${args.baseline}: ${newFailures.join(", ")}. ` +
+        `Fix the regression, or (if intentional and reviewed) update the baseline with ` +
+        `node scripts/ci/known-failures-check.mjs --update.\n`,
+    );
+    process.exit(1);
+  }
+  process.stdout.write("known-failures-check: no new failures.\n");
+  process.exit(0);
+}
+
+// Only run main when invoked directly, so tests can import the pure functions.
+const invokedDirectly =
+  process.argv[1] && fs.realpathSync(process.argv[1]) === fs.realpathSync(new URL(import.meta.url).pathname);
+if (invokedDirectly) main();

--- a/scripts/ci/known-failures.txt
+++ b/scripts/ci/known-failures.txt
@@ -1,0 +1,12 @@
+# Known-failures baseline for scripts/ci/known-failures-check.mjs (#15399).
+# One `binary-id::test-name` per line; blank lines and `#` comments ignored.
+#
+# Regenerate from a full signoff run (fail-fast disabled, junit on):
+#   cargo nextest run --profile signoff --workspace || true
+#   node scripts/ci/known-failures-check.mjs --update
+#
+# Until the first `--update` there is no reconciled marker and the checker
+# runs in advisory mode (never blocks). `--update` stamps the marker and
+# switches the checker to strict: any failing test not listed here is a new
+# regression, even when the list is empty (a fully green tree). In normal PRs
+# this list may only shrink.

--- a/scripts/ci/signoff.sh
+++ b/scripts/ci/signoff.sh
@@ -88,7 +88,16 @@ if [[ -n "${SIGNOFF_COMMANDS_FILE:-}" ]]; then
   done < "$SIGNOFF_COMMANDS_FILE"
 else
   commands+=("cargo fmt --all --check")
-  commands+=("scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run --profile precommit --cargo-profile ci-unit --workspace")
+  # Run the whole suite with fail-fast disabled (signoff profile) so a full
+  # failure inventory is produced, then let known-failures-check.mjs distinguish
+  # a NEW regression from the committed known-failures baseline (#15399). The
+  # nextest step is allowed to exit nonzero (known failures are expected); the
+  # baseline check is the real gate. A build failure produces no junit, which
+  # the checker reports as a hard error (exit 2). node-less machines can fall
+  # back to `--profile precommit` via SIGNOFF_COMMANDS_FILE (script header).
+  commands+=("rm -f target/nextest/signoff/junit.xml")
+  commands+=("scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run --profile signoff --cargo-profile ci-unit --workspace || true")
+  commands+=("node scripts/ci/known-failures-check.mjs --junit target/nextest/signoff/junit.xml")
 fi
 
 announce "$green" "Attempting to sign off on ${sha} as ${user}."

--- a/scripts/ci/test-known-failures-check.mjs
+++ b/scripts/ci/test-known-failures-check.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// Unit tests for the known-failures baseline comparator (#15399).
+import assert from "node:assert/strict";
+import {
+  parseJunitFailures,
+  parseBaseline,
+  baselineIsReconciled,
+  evaluate,
+  renderBaseline,
+} from "./known-failures-check.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed++;
+  console.log(`PASS ${name}`);
+}
+
+// Every test id that fails in JUNIT below. Individual tests vary a baseline off
+// this set (add a now-passing id, add an absent id, drop one) so the variation
+// is the visible part.
+const ALL_FAILING = [
+  "tsz-checker::disp::known_bad",
+  "tsz-checker::disp::hung",
+  "tsz-checker::disp::errored",
+  "tsz-solver::rel::regressed",
+];
+
+// A minimal nextest-shaped junit document. Passing cases are self-closed;
+// failing cases carry a <failure>/<error> child; a timeout is a <failure>.
+const JUNIT = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="nextest-run" tests="5" failures="3">
+  <testsuite name="tsz-solver::rel" tests="2" failures="1">
+    <testcase name="keeps_passing" classname="tsz-solver::rel" time="0.1"/>
+    <testcase name="regressed" classname="tsz-solver::rel" time="0.2">
+      <failure type="test failure">assertion failed</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="tsz-checker::disp" tests="3" failures="2">
+    <testcase name="known_bad" classname="tsz-checker::disp" time="0.3">
+      <failure type="test failure">left != right</failure>
+    </testcase>
+    <testcase name="hung" classname="tsz-checker::disp" time="60.0">
+      <failure type="slow-timeout">timed out</failure>
+    </testcase>
+    <testcase name="errored" classname="tsz-checker::disp" time="0.0">
+      <error type="test error">panicked</error>
+    </testcase>
+  </testsuite>
+</testsuites>`;
+
+check("parseJunitFailures splits passes from failures and builds binary-id::test-name ids", () => {
+  const { all, failing } = parseJunitFailures(JUNIT);
+  assert.deepEqual([...all].sort(), [
+    "tsz-checker::disp::errored",
+    "tsz-checker::disp::hung",
+    "tsz-checker::disp::known_bad",
+    "tsz-solver::rel::keeps_passing",
+    "tsz-solver::rel::regressed",
+  ]);
+  assert.deepEqual([...failing].sort(), [
+    "tsz-checker::disp::errored",
+    "tsz-checker::disp::hung",
+    "tsz-checker::disp::known_bad",
+    "tsz-solver::rel::regressed",
+  ]);
+  // a <failure> child (timeout) and an <error> child both count as failing;
+  // the self-closed passing case does not.
+  assert.ok(!failing.has("tsz-solver::rel::keeps_passing"));
+  assert.ok(failing.has("tsz-checker::disp::hung"));
+  assert.ok(failing.has("tsz-checker::disp::errored"));
+});
+
+check("testcase name with no classname falls back to the bare name", () => {
+  const { all, failing } = parseJunitFailures(
+    `<testcase name="lonely"><failure/></testcase>`,
+  );
+  assert.deepEqual([...all], ["lonely"]);
+  assert.deepEqual([...failing], ["lonely"]);
+});
+
+check("a junit with no testcases yields empty sets (drives the infra-error guard)", () => {
+  const { all, failing } = parseJunitFailures("<testsuites></testsuites>");
+  assert.equal(all.size, 0);
+  assert.equal(failing.size, 0);
+});
+
+check("parseBaseline ignores comments and blank lines", () => {
+  const set = parseBaseline(
+    "# header\n\n  tsz-checker::disp::known_bad  \n#another\ntsz-checker::disp::hung\n",
+  );
+  assert.deepEqual([...set].sort(), [
+    "tsz-checker::disp::hung",
+    "tsz-checker::disp::known_bad",
+  ]);
+});
+
+check("new failure not in baseline is reported (regression -> block)", () => {
+  // baseline omits `regressed`, so it surfaces as the one new failure.
+  const baseline = parseBaseline(ALL_FAILING.filter((id) => id !== "tsz-solver::rel::regressed").join("\n"));
+  const { newFailures, nowPassing } = evaluate(baseline, parseJunitFailures(JUNIT));
+  assert.deepEqual(newFailures, ["tsz-solver::rel::regressed"]);
+  assert.equal(nowPassing.length, 0);
+});
+
+check("all failures baselined -> no new failures, no shrink", () => {
+  const baseline = parseBaseline(ALL_FAILING.join("\n"));
+  const { newFailures, nowPassing } = evaluate(baseline, parseJunitFailures(JUNIT));
+  assert.equal(newFailures.length, 0);
+  assert.equal(nowPassing.length, 0);
+});
+
+check("baselined test that now passes is a shrink candidate (ran + not failing)", () => {
+  // `keeps_passing` ran and passed but is listed in the baseline -> shrink.
+  const baseline = parseBaseline(["tsz-solver::rel::keeps_passing", ...ALL_FAILING].join("\n"));
+  const { newFailures, nowPassing } = evaluate(baseline, parseJunitFailures(JUNIT));
+  assert.equal(newFailures.length, 0);
+  assert.deepEqual(nowPassing, ["tsz-solver::rel::keeps_passing"]);
+});
+
+check("a baselined test absent from this run is neither new nor shrink (never blocks)", () => {
+  // Partial/filtered run: `tsz-core::gone::not_run` is baselined but absent from
+  // JUNIT; every currently-failing test is baselined, so the only interesting
+  // case is the absent one -> it must not be flagged as new or as a shrink.
+  const baseline = parseBaseline([...ALL_FAILING, "tsz-core::gone::not_run"].join("\n"));
+  const { newFailures, nowPassing } = evaluate(baseline, parseJunitFailures(JUNIT));
+  assert.equal(newFailures.length, 0);
+  assert.equal(nowPassing.length, 0);
+});
+
+check("renderBaseline round-trips through parseBaseline and is sorted + deduped", () => {
+  const body = renderBaseline(["tsz-b::t::z", "tsz-a::t::a", "tsz-b::t::z"]);
+  assert.ok(body.startsWith("# Known-failures baseline"));
+  assert.deepEqual([...parseBaseline(body)].sort(), ["tsz-a::t::a", "tsz-b::t::z"]);
+  // ids appear in sorted order after the header block
+  const lines = body.split("\n").filter((l) => l && !l.startsWith("#"));
+  assert.deepEqual(lines, ["tsz-a::t::a", "tsz-b::t::z"]);
+});
+
+check("--update render (default) is reconciled -> strict even when empty (green tree blocks)", () => {
+  const body = renderBaseline([]); // what `--update` writes on a fully-green run
+  assert.equal(parseBaseline(body).size, 0);
+  assert.ok(baselineIsReconciled(body), "empty --update baseline must still be reconciled");
+});
+
+check("committed bootstrap render is unreconciled -> advisory (does not block)", () => {
+  const body = renderBaseline([], { reconciled: false });
+  assert.equal(parseBaseline(body).size, 0);
+  assert.ok(!baselineIsReconciled(body), "bootstrap baseline must be unreconciled");
+});
+
+console.log(`\nAll ${passed} known-failures-check tests passed.`);


### PR DESCRIPTION
While `main` carries a known-failing test set and hosted CI is reduced, the signoff gate runs `cargo nextest --profile precommit`, whose `fail-fast = true` bails on the first red test — so it can never produce a full failure inventory, and no merge can tell a **new** regression apart from the pre-existing known set. This lands slice 1 of #15399: the comparator mechanism.

**Structural rule:** when a full run is available, the gate must distinguish a failing test that is *not* in the committed baseline (a new regression → block) from one that is (known → allow), and warn when a baselined test starts passing (shrink). The decision is owned by one script (`known-failures-check.mjs`) reading nextest junit, not scattered across CI shell.

What this changes:
- **`[profile.signoff]`** in `.config/nextest.toml` — mirrors `precommit` timeouts/overrides but with `fail-fast = false` and junit output, so the whole suite runs and a complete failure inventory is written to `target/nextest/signoff/junit.xml`.
- **`scripts/ci/known-failures-check.mjs`** — parses that junit and diffs failures against `scripts/ci/known-failures.txt`: **exit 1** on any failing test absent from the baseline (naming it), **warn** on baselined tests that now pass (shrink ratchet), `--update` regenerates the baseline. An empty/truncated junit is treated as an infra error (**exit 2**), never as "nothing failed".
- **Explicit reconciliation marker** — `--update` stamps `# baseline-status: reconciled`; strictness is keyed on that marker, not on the line count, so a green-but-reconciled baseline (zero known failures) still blocks any regression, while the committed **bootstrap** baseline (no marker) stays advisory until a maintainer runs `--update` once. This avoids the gate silently disabling itself on a clean tree.
- **`scripts/ci/signoff.sh`** runs the signoff profile then the comparator; the nextest step tolerates expected known failures and the comparator is the real gate (stale junit is removed first so a build failure can't be masked).
- **`scripts/ci/test-known-failures-check.mjs`** — unit tests for the pure functions, registered in `run_lint`.

**Scope boundary:** the committed baseline ships unpopulated. Populating it needs one full-suite `--update` run, which the agent contract forbids running locally (no full unit/conformance sweeps) and which needs the reduced hosted suite. Slice 2 (gate-restore) owns that reconciliation and the recurring main unit tier. This PR touches only Node/shell/TOML/data — no Rust — so `clippy`/`conformance`/`emit`/`fourslash` are unaffected.

## Goal
Goal: hold

## Verification
- `node scripts/ci/test-known-failures-check.mjs` — 11 unit tests pass (junit parse incl. `<error>`/timeout as failure, baseline parse, reconciled-marker detection, new/shrink/absent diff, reconciled-vs-bootstrap render round-trip, empty-junit guard).
- End-to-end exit codes confirmed locally: unreconciled baseline → advisory exit 0; `--update` → strict, a new failing test → exit 1 naming it; reconciled-empty (green) baseline → a later failure → exit 1; a baselined test now passing → shrink warning exit 0; missing/empty junit → exit 2.
- `bash -n scripts/ci/signoff.sh scripts/ci/full-ci.sh`, `node --check` both `.mjs`, and `tomllib` parse of `.config/nextest.toml` all clean; committed `known-failures.txt` is byte-identical to `renderBaseline([], {reconciled:false})`.
- Registered in `run_lint` (`node scripts/ci/test-known-failures-check.mjs`) for the gate-restore lint tier.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1GRPS9VM7jKhoamADjsHP)_