### PR TITLE
fix(solver): default uninferable curried-callback type params to unknown

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -776,6 +776,9 @@ path = "tests/hkt_self_augmentation_keyof_repro.rs"
 name = "hkt_cross_file_augmentation_13653_repro"
 path = "tests/hkt_cross_file_augmentation_13653_repro.rs"
 [[test]]
+name = "higher_order_uninferred_param_defaults_to_unknown_tests"
+path = "tests/higher_order_uninferred_param_defaults_to_unknown_tests.rs"
+[[test]]
 name = "declare_global_interface_keyof_merge_tests"
 path = "tests/declare_global_interface_keyof_merge_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/higher_order_uninferred_param_defaults_to_unknown_tests.rs
+++ b/crates/tsz-checker/tests/higher_order_uninferred_param_defaults_to_unknown_tests.rs
@@ -1,0 +1,92 @@
+//! Regression tests: an uninferable type parameter reached only through a
+//! nested/curried callback position must default to its constraint (or
+//! `unknown`), never leak an internal `__infer_*` inference placeholder into the
+//! call-result type.
+//!
+//! Repro family (`inferentialTypingWithFunctionTypeZip`): a generic `zipWith`
+//! whose callback parameter is itself a curried generic function
+//! (`f: (x: T) => (y: S) => U`) is called with a generic `pair`. `T` infers from
+//! the array argument, `U` infers to the object the inner callback returns, but
+//! `S` occupies only a contravariant inner-parameter slot and receives no
+//! inference candidate. tsc resolves such a parameter with `getInferredType`
+//! (constraint, else `unknown`), so `U` renders as `{ x: number; y: unknown }`.
+//! tsz previously let `S` settle on a bare self-referential placeholder that
+//! rode into `U`, rendering `{ x: number; y: __infer_3 }`.
+//!
+//! Owner layer: solver generic-call finalization
+//! (`default_leaked_return_type_placeholders`).
+
+use tsz_checker::test_utils::check_source_code_messages as compile_and_get_diagnostics;
+
+/// The TS2322 message text for the single assignment error in `source`.
+fn ts2322_message(source: &str) -> String {
+    let diags = compile_and_get_diagnostics(source);
+    let msgs: Vec<&String> = diags
+        .iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, msg)| msg)
+        .collect();
+    assert_eq!(msgs.len(), 1, "expected exactly one TS2322, got {diags:?}");
+    msgs[0].clone()
+}
+
+#[test]
+fn uninferred_curried_callback_param_defaults_to_unknown() {
+    let source = r#"
+declare var zipWith: <T, S, U>(a: T[], f: (x: T) => (y: S) => U) => U[];
+declare var pair: <T, S>(x: T) => (y: S) => { x: T; y: S; };
+const r = zipWith([1], pair);
+const bad: null = r;
+"#;
+    let msg = ts2322_message(source);
+    assert!(
+        msg.contains("{ x: number; y: unknown; }[]"),
+        "uninferred S must default to `unknown`, got: {msg}"
+    );
+    assert!(
+        !msg.contains("__infer"),
+        "internal inference placeholder must not leak into the result, got: {msg}"
+    );
+}
+
+#[test]
+fn uninferred_curried_callback_param_leak_survives_renamed_binders() {
+    // Same structural shape, different type-parameter and value names. The fix
+    // must be structural, not keyed on the `T`/`S`/`U`/`zipWith`/`pair` spelling.
+    let source = r#"
+declare var combine: <Elem, Ignored, Out>(xs: Elem[], make: (e: Elem) => (i: Ignored) => Out) => Out[];
+declare var build: <A, B>(a: A) => (b: B) => { first: A; second: B; };
+const out = combine(["s"], build);
+const bad: null = out;
+"#;
+    let msg = ts2322_message(source);
+    assert!(
+        msg.contains("{ first: string; second: unknown; }[]"),
+        "renamed binders must still default the uninferred parameter to `unknown`, got: {msg}"
+    );
+    assert!(
+        !msg.contains("__infer"),
+        "internal inference placeholder must not leak under renamed binders, got: {msg}"
+    );
+}
+
+#[test]
+fn constrained_uninferred_param_defaults_to_its_constraint() {
+    // When the uninferable parameter carries a constraint, tsc uses the
+    // constraint (not `unknown`); this already worked and must keep working.
+    let source = r#"
+declare var zipWith: <T, S extends string, U>(a: T[], f: (x: T) => (y: S) => U) => U[];
+declare var pair: <T, S extends string>(x: T) => (y: S) => { x: T; y: S; };
+const r = zipWith([1], pair);
+const bad: null = r;
+"#;
+    let msg = ts2322_message(source);
+    assert!(
+        msg.contains("{ x: number; y: string; }[]"),
+        "constrained uninferred S must default to its constraint `string`, got: {msg}"
+    );
+    assert!(
+        !msg.contains("__infer"),
+        "internal inference placeholder must not leak for a constrained parameter, got: {msg}"
+    );
+}

--- a/crates/tsz-solver/src/operations/generic_call/normalization.rs
+++ b/crates/tsz-solver/src/operations/generic_call/normalization.rs
@@ -504,6 +504,52 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         self.prune_placeholder_union_members(current)
     }
 
+    /// Default any *free* inference placeholder that leaked into the finalized
+    /// call **return type** to its constraint, or to `unknown` when it has none.
+    ///
+    /// When a type parameter appears only in a nested/curried position that
+    /// never receives an inference candidate — e.g. `S` in
+    /// `zipWith<T, S, U>(a: T[], f: (x: T) => (y: S) => U): U[]` called with a
+    /// generic `pair: <T, S>(x: T) => (y: S) => { x: T; y: S }` — its resolution
+    /// can settle on a bare, self-referential inference placeholder (`__infer_N`)
+    /// that then rides into another inferred type parameter (here
+    /// `U = { x: number; y: __infer_N }`). `tsc` resolves an uninferable type
+    /// parameter to its constraint, or to `unknown` when it is unconstrained
+    /// (`getInferredType`), so the internal placeholder must never survive into
+    /// the result type. Constrained parameters already resolve to their
+    /// constraint before this point and so never leak, but honoring
+    /// `info.constraint` here keeps the fallback faithful regardless.
+    ///
+    /// Placeholders that
+    /// [`Self::hoist_source_placeholders_into_return_type`] /
+    /// [`Self::hoist_resolved_type_params_into_return_type`] re-generalized into
+    /// the return function's own type-parameter list are genuine bound
+    /// parameters (TypeScript 3.4 higher-order inference results), so they are
+    /// preserved rather than defaulted.
+    pub(super) fn default_leaked_return_type_placeholders(&self, return_type: TypeId) -> TypeId {
+        // `free_type_parameter_ids_in` is binder-aware and memoized: it reports
+        // only *free* type parameters and skips a nested generic signature's own
+        // type-parameter list, so placeholders the `hoist_*` steps re-generalized
+        // into the return function's own parameters are excluded automatically.
+        // A fully-resolved return type contributes no ids, keeping the common
+        // (leak-free) path a single cached lookup.
+        let mut subst = TypeSubstitution::new();
+        for ty in crate::visitors::visitor_predicates::free_type_parameter_ids_in(
+            self.interner.as_type_database(),
+            [return_type],
+        ) {
+            if let Some(TypeData::TypeParameter(info)) = self.interner.lookup(ty)
+                && info.is_infer_placeholder()
+            {
+                subst.insert(info.name, info.constraint.unwrap_or(TypeId::UNKNOWN));
+            }
+        }
+        if subst.is_empty() {
+            return return_type;
+        }
+        instantiate_type(self.interner, return_type, &subst)
+    }
+
     pub(super) fn normalize_inferred_placeholder_type_preserving_source_placeholders(
         &self,
         ty: TypeId,

--- a/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
@@ -1182,6 +1182,12 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             self.normalize_inferred_placeholder_type(raw_return_type, &final_arg_subst);
         let return_type =
             self.hoist_resolved_type_params_into_return_type(func, &final_subst, return_type);
+        // A type parameter reachable only through a nested/curried position that
+        // never receives an inference candidate can resolve to a bare
+        // self-referential placeholder and ride into another inferred parameter
+        // (`U = { x: number; y: __infer_N }`). Default any such leaked placeholder
+        // to its constraint-or-`unknown`, matching tsc's `getInferredType`.
+        let return_type = self.default_leaked_return_type_placeholders(return_type);
         if self.interner.get_display_alias(return_type).is_none()
             && let Some(app_id) =
                 crate::visitor::application_id(self.interner.as_type_database(), raw_return_type)


### PR DESCRIPTION
When a generic call has a type parameter reachable only through a nested/curried
callback position (e.g. `S` in `zipWith<T, S, U>(a: T[], f: (x: T) => (y: S) => U): U[]`)
and that parameter receives no inference candidate, `tsz` let it resolve to its own
self-referential `InferPlaceholder`. That placeholder had already been captured into
another inferred parameter's value (`U = { x: number; y: __infer_N }`) and leaked an
internal `__infer_N` token into the finalized call-result type.

Structural rule: when a call resolves a type parameter for which inference produced no
usable candidate, `tsc` (`getInferredType`) resolves it to its constraint, or to
`unknown` when unconstrained; no internal inference placeholder may survive into the
finalized result type — including when the placeholder was captured inside another
type parameter's inferred value. `tsz` now defaults any leaked main `InferPlaceholder`
that survives into the finalized return type the same way (owner layer: solver
generic-call finalization, `default_leaked_return_type_placeholders`), mirroring the
existing higher-order **source** placeholder (`__infer_src_*`) normalization. Uses the
binder-aware, memoized `free_type_parameter_ids_in` so placeholders re-generalized into
a returned generic function's own type-parameter list are preserved, and the leak-free
common path stays a cached lookup.

Scope is return-only by design: leaked main placeholders in *parameter* types are
load-bearing for the circular-inference tautology guard, so defaulting them there would
be incorrect.

This is the root cause behind the `inferentialTypingWithFunctionTypeZip.ts`
accepted-regression row.

Closes #15461

```ts
declare var zipWith: <T, S, U>(a: T[], f: (x: T) => (y: S) => U) => U[];
declare var pair: <T, S>(x: T) => (y: S) => { x: T; y: S; };
const r = zipWith([1], pair);
//    tsc: { x: number; y: unknown; }[]
// tsz was: { x: number; y: __infer_3; }[]   (now: { x: number; y: unknown; }[])
```

## Goal
Goal: hold

## Verification
- New checker regression suite (adjacent matrix: unconstrained → `unknown`, constrained
  `S extends string` → `string`, renamed binders): `cargo test -p tsz-checker --test
  higher_order_uninferred_param_defaults_to_unknown_tests` (3 passed).
- Differential against `tsc` 6.0.2 on the repro + constrained/default/renamed variants:
  all match.
- No new unit-test regressions vs. `main` in `generic_call_inference_tests`,
  `indexed_access_unconstrained_param_tests` (pre-existing failures unchanged, #15338),
  `array_element_naked_inference_tests`, `binding_pattern_inference_tests`,
  `variadic_tuple_recursive_zip_tests`, and solver `higher_order` lib tests.
- `cargo clippy -p tsz-solver`: no new warnings on the changed files.
- Ready-review CI owns full conformance/emit/fourslash.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7CYcnqnZXzzqgwzAx2BUi)_