### PR TITLE
fix(solver): default leaked call-local infer placeholders in generic-call finalization

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -408,6 +408,9 @@ path = "tests/new_generic_construct_signature_type_arg_display_tests.rs"
 name = "new_generic_callback_contextual_infer_tests"
 path = "tests/new_generic_callback_contextual_infer_tests.rs"
 [[test]]
+name = "curried_callback_uninferable_type_param_tests"
+path = "tests/curried_callback_uninferable_type_param_tests.rs"
+[[test]]
 name = "nolib_user_array_union_member_access_tests"
 path = "tests/nolib_user_array_union_member_access_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/curried_callback_uninferable_type_param_tests.rs
+++ b/crates/tsz-checker/tests/curried_callback_uninferable_type_param_tests.rs
@@ -1,0 +1,131 @@
+//! Regression tests for issue #15461: an uninferable type parameter reachable
+//! only through a nested / curried callback parameter must resolve to its
+//! constraint (or `unknown`) and must never leak an internal `__infer_N`
+//! inference placeholder into the finalized call-result type.
+//!
+//! `zipWith<T, S, U>(a: T[], f: (x: T) => (y: S) => U): U[]` called with a
+//! curried `pair` whose inner parameter `y: S` occupies only a contravariant
+//! slot: `S` receives no inference candidate. `tsc`'s `getInferredType`
+//! resolves it to `unknown` (or its constraint), so the result is
+//! `{ x: number; y: unknown; }[]` — not `{ x: number; y: __infer_3; }[]`.
+
+use tsz_checker::diagnostics::diagnostic_codes;
+use tsz_checker::test_utils::{check_source_diagnostics, diagnostic_codes as codes_of};
+
+/// The finalized result type of a curried-callback generic call must never
+/// carry an internal inference placeholder, regardless of which diagnostic
+/// (if any) fires.
+fn assert_no_leaked_placeholder(source: &str) {
+    for diag in check_source_diagnostics(source) {
+        assert!(
+            !diag.message_text.contains("__infer"),
+            "diagnostic leaked an inference placeholder: {diag:?}"
+        );
+    }
+}
+
+/// The original witness: an unconstrained uninferable inner parameter `S`
+/// defaults to `unknown`, so `r` is `{ x: number; y: unknown; }[]`.
+#[test]
+fn curried_uninferable_param_defaults_to_unknown() {
+    let source = r#"
+declare var zipWith: <T, S, U>(a: T[], f: (x: T) => (y: S) => U) => U[];
+declare var pair: <T, S>(x: T) => (y: S) => { x: T; y: S; };
+const r = zipWith([1], pair);
+const bad: null = r;
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let codes = codes_of(&diagnostics);
+    assert!(
+        codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "expected TS2322 for the `null` mismatch: {codes:?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message_text.contains("y: unknown")),
+        "result must default the uninferable inner param to `unknown`: {diagnostics:?}"
+    );
+    assert_no_leaked_placeholder(source);
+}
+
+/// A constrained uninferable inner parameter (`S extends string`) resolves to
+/// its constraint (`string`), not `unknown` and not a placeholder.
+#[test]
+fn curried_uninferable_constrained_param_defaults_to_constraint() {
+    let source = r#"
+declare var zipWith: <T, S extends string, U>(a: T[], f: (x: T) => (y: S) => U) => U[];
+declare var pair: <T, S extends string>(x: T) => (y: S) => { x: T; y: S; };
+const r = zipWith([1], pair);
+const bad: null = r;
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message_text.contains("y: string")),
+        "constrained uninferable inner param must resolve to its constraint `string`: {diagnostics:?}"
+    );
+    assert_no_leaked_placeholder(source);
+}
+
+/// The fix is structural, not keyed on the `T`/`S`/`U`/`zipWith`/`pair`
+/// spelling: renamed binders behave identically.
+#[test]
+fn curried_uninferable_param_is_structural_across_renamed_binders() {
+    let source = r#"
+declare var combine: <Elem, Ignored, Out>(a: Elem[], build: (x: Elem) => (y: Ignored) => Out) => Out[];
+declare var make: <Elem, Ignored>(x: Elem) => (y: Ignored) => { x: Elem; y: Ignored; };
+const r = combine([1], make);
+const bad: null = r;
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message_text.contains("y: unknown")),
+        "renamed binders must default the uninferable inner param to `unknown`: {diagnostics:?}"
+    );
+    assert_no_leaked_placeholder(source);
+}
+
+/// A simple single-level uninferable type parameter already defaults to
+/// `unknown`; the fix must not disturb it.
+#[test]
+fn simple_single_level_uninferred_param_stays_unknown() {
+    let source = r#"
+declare function make<T>(x: number): T;
+const r = make(1);
+const bad: null = r;
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message_text.contains("Type 'unknown'")),
+        "single-level uninferred type parameter must stay `unknown`: {diagnostics:?}"
+    );
+    assert_no_leaked_placeholder(source);
+}
+
+/// When the inner parameter IS inferable (a sibling `b: S[]` argument fixes
+/// `S`), the curried result must use the inferred type — the leak fix must not
+/// widen an inferable parameter to `unknown`. Mirrors the upstream
+/// `inferentialTypingWithFunctionTypeZip` fixture shape.
+#[test]
+fn curried_inferable_param_keeps_inferred_type() {
+    let source = r#"
+declare var zipWith: <T, S, U>(a: T[], b: S[], f: (x: T) => (y: S) => U) => U[];
+declare var pair: <T, S>(x: T) => (y: S) => { x: T; y: S; };
+const r = zipWith([1], ["a"], pair);
+const bad: null = r;
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message_text.contains("y: string")),
+        "an inferable inner param must keep its inferred type (`string`): {diagnostics:?}"
+    );
+    assert_no_leaked_placeholder(source);
+}

--- a/crates/tsz-solver/src/operations/generic_call/normalization.rs
+++ b/crates/tsz-solver/src/operations/generic_call/normalization.rs
@@ -550,6 +550,68 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         instantiate_type(self.interner, return_type, &subst)
     }
 
+    /// Default any *leaked* call-local inference placeholder (`InferPlaceholder`
+    /// origin, historically `__infer_N`) that is NOT one of the current call's
+    /// own tracked placeholders to its constraint (when concrete) or `unknown`.
+    ///
+    /// Such a placeholder is a call-local inference variable minted for a
+    /// *nested* generic call — for example a curried callback's uninferable type
+    /// parameter reachable only through an inner (contravariant) parameter slot —
+    /// that never received an inference candidate. `tsc`'s `getInferredType`
+    /// resolves an uninferable type parameter to its constraint or `unknown` and
+    /// never lets an internal placeholder ride into the finalized result type,
+    /// including when the placeholder was captured inside another type
+    /// parameter's inferred value (issue #15461).
+    ///
+    /// The higher-order *source* placeholder (`__infer_src_*`) equivalent is
+    /// already handled by [`Self::normalize_inferred_placeholder_type`]; this
+    /// covers the call-local `InferPlaceholder` family. The current call's own
+    /// placeholders are preserved (they are substituted to their resolved values
+    /// through the normal placeholder substitution, and the tautology-breaking
+    /// revert in `finish_generic_call_resolution` relies on them surviving).
+    pub(super) fn default_leaked_inference_placeholders(
+        &self,
+        ty: TypeId,
+        own_placeholder_atoms: &FxHashSet<tsz_common::Atom>,
+    ) -> TypeId {
+        // Cheap short-circuiting gate: the common (no-leak) resolved type carries
+        // no call-local placeholder at all, so avoid materializing every subtype
+        // via `collect_all_types` unless one is actually present.
+        if !crate::type_queries::data::contains_current_infer_placeholder_db(
+            self.interner.as_type_database(),
+            ty,
+        ) {
+            return ty;
+        }
+        let mut subst = TypeSubstitution::new();
+        for member in crate::visitor::collect_all_types(self.interner.as_type_database(), ty) {
+            let Some(TypeData::TypeParameter(info)) = self.interner.lookup(member) else {
+                continue;
+            };
+            if !info.is_current_infer_placeholder() || own_placeholder_atoms.contains(&info.name) {
+                continue;
+            }
+            // An uninferable parameter defaults to its constraint when that
+            // constraint is already concrete, otherwise to `unknown` (matches
+            // `tsc`'s `getInferredType` / `getConstraintOfTypeParameter` fallback).
+            let fallback = match info.constraint {
+                Some(constraint)
+                    if !crate::visitor::contains_type_parameters(
+                        self.interner.as_type_database(),
+                        constraint,
+                    ) =>
+                {
+                    constraint
+                }
+                _ => TypeId::UNKNOWN,
+            };
+            subst.insert(info.name, fallback);
+        }
+        // `instantiate_type` no-ops on an empty substitution (all leaked
+        // placeholders belonged to this call), so no explicit guard is needed.
+        instantiate_type(self.interner, ty, &subst)
+    }
+
     pub(super) fn normalize_inferred_placeholder_type_preserving_source_placeholders(
         &self,
         ty: TypeId,

--- a/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
@@ -787,6 +787,12 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // If an inferred type contains transient placeholders from source functions (e.g. __infer_src_U),
         // we must resolve them using the full inference context substitution.
         // Example: B -> Array(__infer_src_U) where __infer_src_U -> T. We want B -> Array(T).
+        // The current call's own placeholders (`__infer_N` for this call's type
+        // parameters) are legitimate and preserved; only placeholders leaked from
+        // a *nested* generic call must be defaulted. Shared by the `final_subst`
+        // cleanup below and the argument-display normalization further down.
+        let own_placeholder_atoms: FxHashSet<tsz_common::Atom> =
+            type_param_placeholder_atoms.iter().copied().collect();
         {
             let mut full_subst = infer_ctx.get_current_substitution();
             self.remove_unresolved_source_placeholders_from_substitution(&mut full_subst);
@@ -810,9 +816,15 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 }
                 resolved_subst.insert(*name, current);
             }
-            // Update final_subst with fully resolved types
+            // Update final_subst with fully resolved types, defaulting any
+            // inference placeholder that leaked in from a nested generic call
+            // (uninferable curried-callback parameter) to its constraint or
+            // `unknown` so no internal `__infer_N` survives into the finalized
+            // result type (issue #15461).
             for (name, ty) in resolved_subst.map().iter() {
-                final_subst.insert(*name, *ty);
+                let cleaned =
+                    self.default_leaked_inference_placeholders(*ty, &own_placeholder_atoms);
+                final_subst.insert(*name, cleaned);
             }
         }
 
@@ -1312,6 +1324,12 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 } else {
                     self.normalize_inferred_placeholder_type(arg, &final_arg_subst)
                 };
+                // Symmetric with the source-placeholder (`__infer_src_*`) defaulting
+                // that `normalize_inferred_placeholder_type` already performs: a
+                // call-local placeholder leaked from a nested generic call must not
+                // ride into a displayed argument type either (issue #15461).
+                let normalized =
+                    self.default_leaked_inference_placeholders(normalized, &own_placeholder_atoms);
                 let Some(param_type) =
                     self.param_type_for_arg_index(&instantiated_params, i, arg_types.len())
                 else {

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -202,5 +202,4 @@
 # and found these exact current-main rows still failing. Keep them listed as
 # path-based runway so the aggregate rejects any new unlisted conformance drift.
 TypeScript/tests/cases/compiler/recursiveConditionalTypes.ts
-TypeScript/tests/cases/compiler/inferentialTypingWithFunctionTypeZip.ts
 TypeScript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts


### PR DESCRIPTION
When a generic call resolves a type parameter reachable only through a nested / curried callback parameter (a contravariant inner-parameter slot) and inference produces no usable candidate, `tsc`'s `getInferredType` resolves it to its constraint (when present) or `unknown`, and never lets an internal inference placeholder ride into the finalized result type. `tsz` instead let such a parameter settle on a bare call-local `InferPlaceholder` (historically `__infer_N`) that leaked into the call result — both as the bare parameter value and captured inside another type parameter's inferred value.

Structural rule: when a generic call resolves a type parameter for which inference produced no usable candidate, tsz must resolve it to its constraint (when concrete) or `unknown` through the **solver generic-call finalization** layer, and no internal inference placeholder may survive into the finalized result type — including when the placeholder was captured inside another type parameter's inferred value.

Witness (`tsc` 6.0.2 vs `tsz` on `main`):

```ts
declare var zipWith: <T, S, U>(a: T[], f: (x: T) => (y: S) => U) => U[];
declare var pair: <T, S>(x: T) => (y: S) => { x: T; y: S; };
const r = zipWith([1], pair);
const bad: null = r;
```

- `tsc`: `Type '{ x: number; y: unknown; }[]' is not assignable to type 'null'.`
- `tsz` before: `Type '{ x: number; y: __infer_3; }[]' ...`
- `tsz` after: matches `tsc`.

## Owner layer & mechanism
`crates/tsz-solver/src/operations/generic_call`. The existing return-type normalization already defaults leaked higher-order **source** placeholders (`__infer_src_*`) to `unknown`; this adds the symmetric treatment for the call-local **`InferPlaceholder`** family. `default_leaked_inference_placeholders` rewrites any `InferPlaceholder`-origin type parameter that is NOT one of the current call's own tracked placeholders to its constraint-or-`unknown`. It is applied to `final_subst` (the resolved-type-param source of truth that feeds the return type, deferred constraint checks, and constructor display aliases) and — symmetric with the source-placeholder family — to the argument-display normalization. The current call's own placeholders are preserved so the tautology-breaking revert in `finish_generic_call_resolution` still fires. A cheap `contains_current_infer_placeholder_db` gate short-circuits the common no-leak case before any `collect_all_types` allocation.

## Adjacent matrix (all differential-verified against `tsc` 6.0.2)
- unconstrained uninferable parameter → `unknown`
- constrained uninferable parameter (`S extends string`) → its constraint (`string`)
- renamed binders (`Elem`/`Ignored`/`Out`, `combine`/`build`) → structural, not keyed on the `T`/`S`/`U`/`zipWith`/`pair` spelling
- genuinely-inferable sibling (`b: S[]`) → keeps its inferred type (`string`); the leak fix does not over-widen an inferable parameter
- simple single-level uninferred parameters (`make(x: number): T`) already default to `unknown` and are unaffected

## Goal
Goal: hold

## Verification
- New: `cargo test -p tsz-checker --test curried_callback_uninferable_type_param_tests` (5 cases: unconstrained, constrained, renamed binders, single-level, inferable-sibling; each asserts the result type and that no `__infer` placeholder leaks into any diagnostic).
- Regression sweep (green): `new_generic_callback_contextual_infer_tests`, `context_sensitive_callback_inference_tests`, `noinfer_diagnostic_display_tests`, `generic_conflicting_argument_type_display_tests`, `failed_generic_call_default_type_args_tests`, `fresh_object_literal_arg_callback_param_variance_tests`, `nested_generic_union_callback_return_tests`, `curried_annotated_return_object_member_implicit_any_tests`, `reverse_mapped_inference_tests`, `array_element_naked_inference_tests`, `return_only_defaulted_intersection_contextual_inference_tests`.
- Resolves the `inferentialTypingWithFunctionTypeZip.ts` accepted-regression row (removed from the ledger; ledger integrity check passes). Broad conformance/emit owned by ready-review CI.
- `cargo clippy -p tsz-solver` / `-p tsz-checker --tests` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Fixes #15461

https://claude.ai/code/session_01BgG6gLPzxyCzcA5gps2bVA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgG6gLPzxyCzcA5gps2bVA)_