### PR TITLE
fix(solver): render generic reducing-operator alias applications structurally (#15391)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
@@ -407,12 +407,13 @@ impl<'a> CheckerState<'a> {
     }
 
     /// True when `ty` is a concrete (already-reduced) type whose display-alias
-    /// provenance points at a generic application of a conditional-bodied type
-    /// alias. `tsc` drops the alias name in this case (showing the resolved
-    /// structural form), but the provenance must stay in the interner because
-    /// the solver's conditional evaluator reads it (the `Equal<X, Y>`
-    /// `any`-distinction trick depends on it); so the caller suppresses only the
-    /// application-alias chase when rendering.
+    /// provenance points at a generic application of a reducing-operator-bodied
+    /// type alias — a conditional, `keyof`, indexed access, template literal, or
+    /// string-mapping intrinsic. `tsc` drops the alias name in this case
+    /// (showing the resolved structural form), but the provenance must stay in
+    /// the interner because the solver's conditional evaluator reads it (the
+    /// `Equal<X, Y>` `any`-distinction trick depends on it); so the caller
+    /// suppresses only the application-alias chase when rendering.
     ///
     /// A still-deferred `Conditional`/`IndexAccess`/`Mapped`/generic-application
     /// `ty` is excluded: `tsc` keeps `Tail<T>` for an unreduced generic
@@ -434,7 +435,7 @@ impl<'a> CheckerState<'a> {
         {
             return false;
         }
-        crate::query_boundaries::diagnostics::application_base_has_conditional_alias_body(
+        crate::query_boundaries::diagnostics::application_base_has_reducing_operator_alias_body(
             self.ctx.types.as_type_database(),
             &self.ctx.definition_store,
             alias,

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -698,7 +698,7 @@ impl<'a> CheckerState<'a> {
                     })
                 });
         if let Some(application_display) = application_display
-            && !diagnostic_query::application_base_has_conditional_alias_body(
+            && !diagnostic_query::application_base_has_reducing_operator_alias_body(
                 self.ctx.types,
                 &self.ctx.definition_store,
                 application_display,

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -602,6 +602,23 @@ pub(crate) fn application_base_has_conditional_alias_body(
     tsz_solver::type_queries::application_base_has_conditional_alias_body(db, def_store, type_id)
 }
 
+/// Display gate: true when the application base alias reduces via *any* operator
+/// body — conditional, `keyof`, indexed access, template literal, or a
+/// string-mapping intrinsic — so the reduced structural form is rendered rather
+/// than the `Name<Args>` surface. Broader than
+/// [`application_base_has_conditional_alias_body`], which the JSX
+/// deferral-comparability gates keep narrow for their semantic (non-display)
+/// use.
+pub(crate) fn application_base_has_reducing_operator_alias_body(
+    db: &dyn tsz_solver::construction::TypeDatabase,
+    def_store: &tsz_solver::def::DefinitionStore,
+    type_id: TypeId,
+) -> bool {
+    tsz_solver::type_queries::application_base_has_reducing_operator_alias_body(
+        db, def_store, type_id,
+    )
+}
+
 pub(crate) fn preserves_named_application_base(
     db: &dyn tsz_solver::construction::TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1687,7 +1687,7 @@ impl CheckerState<'_> {
                 // name-display gate stays conservative; the formatter owns the
                 // broader shape reduction where no reverse lookup intervenes.
                 let reducing_object_application = alias_is_non_generic
-                    && diagnostic_query::application_base_has_conditional_alias_body(
+                    && diagnostic_query::application_base_has_reducing_operator_alias_body(
                         self.ctx.types.as_type_database(),
                         &self.ctx.definition_store,
                         result,

--- a/crates/tsz-solver/src/diagnostics/format/alias_underlying.rs
+++ b/crates/tsz-solver/src/diagnostics/format/alias_underlying.rs
@@ -181,14 +181,56 @@ fn alias_application_underlying(
     // tsc only drops the alias symbol once the application is fully instantiated;
     // a still-generic application stays deferred as `Name<Args>` even when the
     // display-time evaluator collapses an unconstrained conditional to `never`.
-    if crate::type_queries::application_base_has_conditional_alias_body(interner, def_store, body)
-        && !crate::type_queries::contains_type_parameters_db(interner, body)
-        && application_reduces_to_displayable_shape(interner, evaluated)
+    // The per-operator render decision is shared with the solver formatter so the
+    // two display pipelines cannot drift (see `reducing_operator_render_verdict`).
+    if !crate::type_queries::contains_type_parameters_db(interner, body)
+        && let Some(operator) =
+            crate::type_queries::application_base_reducing_operator_body(interner, def_store, body)
+        && let Some(rendered) = reducing_operator_render_verdict(interner, operator, evaluated)
     {
-        return Some(evaluated);
+        return Some(rendered);
     }
     (crate::visitor::is_primitive_type(interner, evaluated) || evaluated == TypeId::NEVER)
         .then_some(evaluated)
+}
+
+/// Whether a reduced reducing-operator alias application renders its evaluated
+/// result structurally (dropping the alias name), returning the type to display
+/// or `None` to keep the `Name<Args>` / alias-name surface. Shared by the solver
+/// `TypeFormatter` and this non-generic `Lazy`-alias path so both reach the same
+/// per-kind decision:
+/// * a **conditional** keeps tsc's literal-union display-widening carve-out
+///   (`application_reduces_to_displayable_shape`), so a bare literal/union result
+///   stays on the application surface;
+/// * `keyof` / indexed access / template literal / string-mapping render their
+///   evaluated result for any concrete shape, including a bare literal union
+///   (`keyof { a: 1; b: 2 }` → `"a" | "b"`), except a non-converged recursive
+///   reduction, which would render as a truncated cycle.
+///
+/// The caller is responsible for the shared preconditions (fully instantiated,
+/// non-error, not a still-deferred conditional/indexed node).
+pub(crate) fn reducing_operator_render_verdict(
+    interner: &dyn TypeDatabase,
+    operator: crate::type_queries::ReducingAliasBody,
+    evaluated: TypeId,
+) -> Option<TypeId> {
+    let renders_structurally = match operator {
+        crate::type_queries::ReducingAliasBody::Conditional => {
+            application_reduces_to_displayable_shape(interner, evaluated)
+        }
+        crate::type_queries::ReducingAliasBody::Operator => {
+            !contains_recursive(interner, evaluated)
+        }
+    };
+    renders_structurally.then_some(evaluated)
+}
+
+/// True when `evaluated` contains a nested `Recursive` cycle marker — a
+/// non-converged recursive reduction that would render as a truncated cycle.
+fn contains_recursive(interner: &dyn TypeDatabase, evaluated: TypeId) -> bool {
+    crate::visitor::contains_type_matching(interner, evaluated, |key| {
+        matches!(key, TypeData::Recursive(_))
+    })
 }
 
 /// The set of evaluated shapes that a reduced conditional-bodied alias
@@ -213,9 +255,7 @@ pub(crate) fn application_reduces_to_displayable_shape(
 ) -> bool {
     // A non-converged recursive reduction leaves a nested `Recursive` cycle
     // marker that renders as a truncated cycle; keep the alias name instead.
-    if crate::visitor::contains_type_matching(interner, evaluated, |key| {
-        matches!(key, TypeData::Recursive(_))
-    }) {
+    if contains_recursive(interner, evaluated) {
         return false;
     }
     if evaluated == TypeId::NEVER

--- a/crates/tsz-solver/src/diagnostics/format/keyof_alias_display_tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/keyof_alias_display_tests.rs
@@ -331,3 +331,126 @@ fn lazy_index_access_alias_renders_underlying_object() {
     let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
     assert_eq!(fmt.format(lazy), "{ a: 1; }");
 }
+
+#[test]
+fn generic_keyof_alias_application_renders_underlying_literal_union() {
+    // `type Keys<T> = keyof T; type R = Keys<{ p: 1; q: 2 }>` → tsc renders
+    // `"p" | "q"`, never the `Keys<{ p: 1; q: 2; }>` application surface
+    // (issue #15391). `keyof` builds its result without stamping the enclosing
+    // alias, exactly as the non-generic `type K = keyof { … }` alias does — the
+    // generic Application path must reach the same verdict as the `Lazy` path.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let t_param = crate::types::TypeParamInfo::simple(db.intern_string("T"));
+    let body = db.keyof(db.type_param(t_param));
+    let keys_def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("Keys"),
+        vec![t_param],
+        body,
+    ));
+    let arg = db.object(vec![
+        PropertyInfo::new(db.intern_string("p"), db.literal_number(1.0)),
+        PropertyInfo::new(db.intern_string("q"), db.literal_number(2.0)),
+    ]);
+    let app = db.application(db.lazy(keys_def), vec![arg]);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(
+        fmt.format(app),
+        "\"p\" | \"q\"",
+        "A resolved generic `keyof` alias application renders the literal union"
+    );
+}
+
+#[test]
+fn generic_index_access_alias_application_renders_underlying_object() {
+    // `type Prop<T> = T["p"]; type R = Prop<{ p: { a: 1 } }>` → tsc renders
+    // `{ a: 1; }`, never `Prop<{ p: { a: 1; }; }>`: the indexed access resolves
+    // to its element type with no alias symbol. A distinct binder name keeps the
+    // assertion independent of any specific identifier (anti-hardcoding rule).
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let t_param = crate::types::TypeParamInfo::simple(db.intern_string("T"));
+    let body = db.index_access(db.type_param(t_param), db.literal_string("p"));
+    let prop_def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("Prop"),
+        vec![t_param],
+        body,
+    ));
+    let inner = db.object(vec![PropertyInfo::new(
+        db.intern_string("a"),
+        db.literal_number(1.0),
+    )]);
+    let arg = db.object(vec![PropertyInfo::new(db.intern_string("p"), inner)]);
+    let app = db.application(db.lazy(prop_def), vec![arg]);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(fmt.format(app), "{ a: 1; }");
+}
+
+#[test]
+fn forwarding_generic_keyof_alias_application_renders_underlying() {
+    // A generic alias that *forwards* to a reducing-operator alias
+    // (`type Ring<T> = Halo<T>; type Halo<T> = keyof T`) drops its alias symbol
+    // just as the forwarded target does: `Ring<{ p: 1; q: 2 }>` → `"p" | "q"`.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let t_param = crate::types::TypeParamInfo::simple(db.intern_string("T"));
+    let halo_body = db.keyof(db.type_param(t_param));
+    let halo_def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("Halo"),
+        vec![t_param],
+        halo_body,
+    ));
+    // `type Ring<T> = Halo<T>` — the body forwards through a nested application.
+    let ring_body = db.application(db.lazy(halo_def), vec![db.type_param(t_param)]);
+    let ring_def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("Ring"),
+        vec![t_param],
+        ring_body,
+    ));
+    let arg = db.object(vec![
+        PropertyInfo::new(db.intern_string("p"), db.literal_number(1.0)),
+        PropertyInfo::new(db.intern_string("q"), db.literal_number(2.0)),
+    ]);
+    let app = db.application(db.lazy(ring_def), vec![arg]);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(
+        fmt.format(app),
+        "\"p\" | \"q\"",
+        "A forwarding alias reduces exactly as its reducing-operator target"
+    );
+}
+
+#[test]
+fn generic_mapped_alias_application_keeps_its_name() {
+    // Guard the negative half of the policy: an *object*-bodied generic alias is
+    // not a reducing operator, so `tsc` keeps its alias symbol and renders
+    // `Boxed<number>`, never the structural object. This must not be swept up by
+    // the broadened reducing-operator gate.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let t_param = crate::types::TypeParamInfo::simple(db.intern_string("T"));
+    let body = db.object(vec![PropertyInfo::new(
+        db.intern_string("value"),
+        db.type_param(t_param),
+    )]);
+    let boxed_def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("Boxed"),
+        vec![t_param],
+        body,
+    ));
+    let app = db.application(db.lazy(boxed_def), vec![TypeId::NUMBER]);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(
+        fmt.format(app),
+        "Boxed<number>",
+        "An object-bodied generic alias keeps its alias name"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -406,19 +406,19 @@ impl<'a> TypeFormatter<'a> {
     /// or one whose evaluation made no progress) keeps the application form.
     /// The distributive form is handled earlier by
     /// [`Self::distributed_conditional_application_display`].
-    fn reducing_conditional_application_display(&self, type_id: TypeId) -> Option<TypeId> {
+    fn reducing_operator_application_display(&self, type_id: TypeId) -> Option<TypeId> {
         let def_store = self.def_store?;
         // Cheap structural gate (shared with the checker boundary): the base
-        // must resolve to a generic alias whose declared body is a conditional.
-        // Mapped/object-bodied applications (`Partial<T>`) fail this and keep
+        // must resolve to a generic alias whose declared body is a reducing
+        // operator — a conditional, `keyof`, indexed access, template literal,
+        // or a string-mapping intrinsic — or forwards to one. Mapped/object-
+        // bodied applications (`Partial<T>`) are not reducing operators and keep
         // their alias symbol.
-        if !crate::type_queries::application_base_has_conditional_alias_body(
+        let operator = crate::type_queries::application_base_reducing_operator_body(
             self.interner,
             def_store,
             type_id,
-        ) {
-            return None;
-        }
+        )?;
         // tsc only drops the alias symbol once the application is fully
         // instantiated. A still-generic application (`Extract<Extract<T, Foo>,
         // Bar>` with free `T`) stays deferred and is displayed as `Name<Args>`,
@@ -428,7 +428,7 @@ impl<'a> TypeFormatter<'a> {
         if crate::type_queries::contains_type_parameters_db(self.interner, type_id) {
             return None;
         }
-        // Instantiate the conditional body with the concrete arguments and
+        // Instantiate the reducing-operator body with the concrete arguments and
         // evaluate. `instantiate_generic` substitutes the def body directly,
         // which reduces a nested helper application (`DeepReadonly<{ b }>`)
         // that a bare `evaluate_type` of the wrapper would leave deferred.
@@ -453,31 +453,26 @@ impl<'a> TypeFormatter<'a> {
         }
         // A conditional/indexed access still deferred after evaluation never
         // reduced (an unresolved operand); the raw node is no more informative
-        // than the application form, so keep the application form. Otherwise tsc
-        // drops the alias symbol and renders the reduced result structurally for
-        // any concrete shape — `Reverse<[1, 2, 3]>` → `[3, 2, 1]`,
-        // `Unbox<Promise<Promise<number>>>` → `number`, `DeepReadonly<{ b }>` →
-        // `{ readonly b: number; }`. Bare literal / union results are excluded
-        // (`application_reduces_to_displayable_shape`): tsc applies literal-union
-        // display widening to those, a separate display concern, so they keep
-        // the application surface.
+        // than the application form, so keep the application form.
         if matches!(
             self.interner.lookup(evaluated),
             Some(TypeData::Conditional(_) | TypeData::IndexAccess(_, _))
-        ) || !alias_underlying::application_reduces_to_displayable_shape(
-            self.interner,
-            evaluated,
         ) {
             return None;
         }
-        Some(evaluated)
+        // The per-operator render decision is shared with the non-generic
+        // `Lazy`-alias path so the two display pipelines cannot drift: a
+        // conditional keeps tsc's literal-union widening carve-out, while
+        // `keyof` / indexed / template / string-mapping render any concrete shape
+        // (`type Keys<T> = keyof T; Keys<{ p: 1; q: 2 }>` → `"p" | "q"`, #15391).
+        alias_underlying::reducing_operator_render_verdict(self.interner, operator, evaluated)
     }
 
     /// Memoized dispatch for the four `Application` display-reduction strategies.
     ///
     /// Tries, in order, `scalar_mapped_alias_application_display`,
     /// `distributed_conditional_application_display`,
-    /// `reducing_conditional_application_display`, and
+    /// `reducing_operator_application_display`, and
     /// `variadic_tuple_alias_application_display`; the first that fires wins and
     /// its reduced `TypeId` is returned for the caller to format in place of the
     /// `Name<Args>` application surface. Each strategy runs an
@@ -500,7 +495,7 @@ impl<'a> TypeFormatter<'a> {
         let reduced = self
             .scalar_mapped_alias_application_display(type_id, app.base, &app.args)
             .or_else(|| self.distributed_conditional_application_display(app.base, &app.args))
-            .or_else(|| self.reducing_conditional_application_display(type_id))
+            .or_else(|| self.reducing_operator_application_display(type_id))
             .or_else(|| self.variadic_tuple_alias_application_display(app.base, &app.args));
         self.application_reduction_cache
             .borrow_mut()

--- a/crates/tsz-solver/src/type_queries/core.rs
+++ b/crates/tsz-solver/src/type_queries/core.rs
@@ -156,24 +156,120 @@ pub fn get_allowed_keys(db: &dyn TypeDatabase, type_id: TypeId) -> rustc_hash::F
     atoms.into_iter().map(|a| db.resolve_atom(a)).collect()
 }
 
+/// Resolve the declared body of the generic alias that `type_id`'s application
+/// base names, or `None` when `type_id` is not an application over a named
+/// alias.
+fn application_base_alias_body(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    let Some(TypeData::Application(app_id)) = db.lookup(type_id) else {
+        return None;
+    };
+    let app = db.type_application(app_id);
+    let def_id = get_lazy_def_id(db, app.base).or_else(|| def_store.find_def_for_type(app.base))?;
+    def_store.get(def_id).and_then(|def| def.body)
+}
+
+/// True when the application base alias' *direct* declared body is a
+/// conditional. Deliberately narrow — it does not follow forwarding and does not
+/// recognize the other reducing operators — because its callers are the JSX
+/// deferral-comparability gates, which need conditional-only *semantic*
+/// (non-display) behavior. It is therefore **not** expressible as
+/// `application_base_reducing_operator_body(..) == Some(Conditional)`: that
+/// classifier follows one layer of forwarding, which would silently pull
+/// forwarding-to-conditional aliases into the JSX deferral set. Display callers
+/// want [`application_base_has_reducing_operator_alias_body`] instead.
 pub fn application_base_has_conditional_alias_body(
     db: &dyn TypeDatabase,
     def_store: &DefinitionStore,
     type_id: TypeId,
 ) -> bool {
-    let Some(TypeData::Application(app_id)) = db.lookup(type_id) else {
-        return false;
-    };
-    let app = db.type_application(app_id);
-    let Some(def_id) =
-        get_lazy_def_id(db, app.base).or_else(|| def_store.find_def_for_type(app.base))
-    else {
-        return false;
-    };
-    def_store
-        .get(def_id)
-        .and_then(|def| def.body)
+    application_base_alias_body(db, def_store, type_id)
         .is_some_and(|body| matches!(db.lookup(body), Some(TypeData::Conditional(_))))
+}
+
+/// The kind of reducing operator that forms a generic alias' declared body.
+///
+/// A *reducing operator* resolves into a concrete result once the alias
+/// application is fully instantiated and never re-stamps the enclosing alias
+/// onto that result, so `tsc` renders the reduced structural form rather than
+/// the `Name<Args>` application surface. This mirrors the non-generic policy in
+/// [`crate::diagnostics::format::type_alias_displayed_as_underlying`], which
+/// already recognizes the same operator family for `Lazy` aliases.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ReducingAliasBody {
+    /// A conditional body (`T extends U ? X : Y`). `tsc` applies literal-union
+    /// display widening to a bare union/literal reduction of a conditional, so
+    /// the formatter keeps that carve-out for this kind only.
+    Conditional,
+    /// `keyof`, indexed access, template literal, or a string-mapping intrinsic
+    /// (`Uppercase`/`Lowercase`/…). These render their evaluated result for any
+    /// concrete shape — including a bare literal union such as `"a" | "b"` from
+    /// `keyof` — matching the `Lazy`-alias path.
+    Operator,
+}
+
+/// Classify a generic alias application's declared body as a reducing operator,
+/// following one layer of forwarding at a time (`type A<T> = B<T>`, or an alias
+/// that forwards through a bare `Lazy` reference) up to a bounded depth. Returns
+/// `None` when the base is not a reducing-operator alias (a mapped/object-bodied
+/// utility such as `Partial<T>` keeps its alias symbol).
+pub fn application_base_reducing_operator_body(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    type_id: TypeId,
+) -> Option<ReducingAliasBody> {
+    let body = application_base_alias_body(db, def_store, type_id)?;
+    classify_reducing_alias_body(db, def_store, body, 0)
+}
+
+/// True when the application base alias reduces via an operator body (see
+/// [`ReducingAliasBody`]). Shared cheap structural gate for the diagnostic
+/// display pipelines.
+pub fn application_base_has_reducing_operator_alias_body(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    type_id: TypeId,
+) -> bool {
+    application_base_reducing_operator_body(db, def_store, type_id).is_some()
+}
+
+fn classify_reducing_alias_body(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    body: TypeId,
+    depth: usize,
+) -> Option<ReducingAliasBody> {
+    // Bound forwarding recursion to guard against a cyclic alias chain.
+    if depth > 64 {
+        return None;
+    }
+    match db.lookup(body) {
+        Some(TypeData::Conditional(_)) => Some(ReducingAliasBody::Conditional),
+        Some(
+            TypeData::KeyOf(_)
+            | TypeData::IndexAccess(_, _)
+            | TypeData::TemplateLiteral(_)
+            | TypeData::StringIntrinsic { .. },
+        ) => Some(ReducingAliasBody::Operator),
+        // Forwarding through a nested generic application (`type A<T> = B<T>`):
+        // the surface reduces exactly as its forwarded target does.
+        Some(TypeData::Application(inner_id)) => {
+            let inner = db.type_application(inner_id);
+            let inner_def = get_lazy_def_id(db, inner.base)
+                .or_else(|| def_store.find_def_for_type(inner.base))?;
+            let inner_body = def_store.get(inner_def).and_then(|def| def.body)?;
+            classify_reducing_alias_body(db, def_store, inner_body, depth + 1)
+        }
+        // Forwarding through a bare `Lazy` alias reference (`type A<T> = R`).
+        Some(TypeData::Lazy(next_def)) => {
+            let next_body = def_store.get(next_def).and_then(|def| def.body)?;
+            classify_reducing_alias_body(db, def_store, next_body, depth + 1)
+        }
+        _ => None,
+    }
 }
 
 /// When `type_id` is a plain mutable array of a boolean literal element


### PR DESCRIPTION
When `tsc` instantiates a generic alias application `Name<Args>` whose declared
body is a **reducing operator** — a conditional, `keyof`, indexed access,
template literal, or a string-mapping intrinsic (`Uppercase`/`Lowercase`/…) — the
operator resolves into a concrete result that never re-stamps the enclosing alias
symbol, so `tsc` renders the reduced structural form. tsz's generic-application
display path recognized only `Conditional` bodies
(`application_base_has_conditional_alias_body`), so keyof/indexed/template/
string-intrinsic-bodied applications — and aliases that *forward* to one
(`type A<T> = B<T>`) — under-reduced to the `Name<Args>` surface, diverging from
`tsc` and from the non-generic `Lazy`-alias path, which already recognized the
full operator family.

Structural rule: when a fully-instantiated generic alias application's declared
body is a reducing operator (or forwards to one), `tsc` renders the reduced
structural result and drops the alias name; tsz now does the same through the
solver `TypeFormatter` (owner: solver diagnostics/formatter), with the checker's
parallel display sites routed through the same solver-owned classification.

This is the sanctioned #13082 display follow-up (issue #15391), addressing the
**under-reduction** half of the divergence matrix. The eager-evaluation
**over-reduction** half (provenance carried only in interner side-tables) remains
the tracked XL residual, as does folding the fourth checker display helper
(`alias_application_body_reduces_through_conditional_or_indexed`, still shared
with a semantic gate) into the new classification.

Implementation:
- New solver-owned classification `application_base_reducing_operator_body`
  (`ReducingAliasBody::{Conditional, Operator}`) following one layer of
  forwarding at a time, sharing an extracted `application_base_alias_body`
  helper. The narrow conditional-only query is retained for the JSX
  deferral-comparability *semantic* gates and documented as deliberately
  non-forwarding.
- Both solver display pipelines (generic `Application` + non-generic `Lazy`)
  route the per-kind render decision through one shared
  `reducing_operator_render_verdict`: conditionals keep tsc's literal-union
  widening carve-out; keyof/indexed/template/string-mapping render any concrete
  shape, including a bare literal union (`Keys<{ p: 1; q: 2 }>` → `"p" | "q"`).
- The three checker display sites use the broadened query; the two JSX semantic
  gates keep the narrow conditional-only query.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-solver --lib diagnostics::format` — 235 pass, incl. 4 new
  witnesses in `keyof_alias_display_tests` (generic keyof→union, indexed→object,
  forwarding alias, and an object-bodied negative guard that keeps its name).
- `cargo clippy -p tsz-solver --lib` — clean.
- End-to-end via the `tsz` CLI, matching `tsc` exactly:
  `Keys<{p:1;q:2}>` → `"p" | "q"`, `Prop<{p:{a:1}}>` → `{ a: 1; }`,
  `Up<"x">` → `"X"`, `Greet<"bob">` → `"hi bob"`; negatives `Boxed<number>` /
  `Partial2<{ a: number; }>` correctly keep their alias names.
- Full conformance/emit/fourslash: owned by ready-review CI (not run locally per
  the repo contract).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01QKviS6iouvMgpNmR9tvHVb

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKviS6iouvMgpNmR9tvHVb)_