### PR TITLE
fix(checker,solver): TS2538 for symbol key on a string-index-only receiver (#15411)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1430,6 +1430,9 @@ path = "tests/missing_global_type_diagnostics_tests.rs"
 name = "ts2538_tparam_resolved_to_any_tests"
 path = "tests/ts2538_tparam_resolved_to_any_tests.rs"
 [[test]]
+name = "ts2538_symbol_key_string_index_tests"
+path = "tests/ts2538_symbol_key_string_index_tests.rs"
+[[test]]
 name = "import_attributes_resolution_mode_tests"
 path = "tests/import_attributes_resolution_mode_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1302,6 +1302,14 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // TS2538 recovery value for a `symbol`-like key that only reaches this
+        // receiver's plain `string` index (see `symbol_key_string_index_fallthrough`).
+        // `Some(value)` marks the plain-`string`-fallthrough case shared by the
+        // three symbol arms below; `object_type_for_access` / `index_type` are
+        // fixed from here on, so it is computed once.
+        let symbol_string_index_fallthrough =
+            self.symbol_key_string_index_fallthrough(object_type_for_access, index_type);
+
         // Handle unique symbol index access on concrete (non-type-parameter) objects.
         // Unique symbols resolve to internal property names like "__unique_N" and need
         // write_type propagation for getter/setter divergence (e.g., `foo[k] = value`
@@ -1391,11 +1399,19 @@ impl<'a> CheckerState<'a> {
             if let PropertyAccessResult::Success {
                 type_id,
                 write_type,
-                ..
+                from_index_signature,
             } = result
             {
-                use_index_signature_check = false;
-                result_type = Some(effective_write_result(type_id, write_type));
+                // A real symbol-keyed member (`from_index_signature == false`)
+                // resolves the access. A resolution that only reached a `string`
+                // index signature must NOT swallow the key: if that string index
+                // rejects symbol keys, the fallthrough gate below reports TS2538
+                // (a `PropertyKey` / symbol-accepting index leaves the gate at
+                // `None`, so the fallthrough value is kept here).
+                if !from_index_signature || symbol_string_index_fallthrough.is_none() {
+                    use_index_signature_check = false;
+                    result_type = Some(effective_write_result(type_id, write_type));
+                }
             }
         }
 
@@ -1403,9 +1419,17 @@ impl<'a> CheckerState<'a> {
         // a binding-identity key for exact computed-member lookup. Once that
         // exact lookup misses, a receiver with a broad symbol index signature
         // should resolve through `receiver[symbol]`, not through the binding key.
+        //
+        // This applies only when the receiver genuinely accepts a `symbol` key
+        // (a `{ [k: symbol]: V }` / `Record<PropertyKey, V>` signature). A bare
+        // `string` index does NOT accept symbol keys — resolving through it here
+        // would silently swallow the TS2538 that the fallthrough gate below
+        // emits. `symbol_key_string_index_fallthrough` returns `Some` in exactly
+        // that plain-`string`-index case, so gate on its absence.
         if result_type.is_none()
             && index_type == TypeId::SYMBOL
             && index_type_for_access != index_type
+            && symbol_string_index_fallthrough.is_none()
         {
             let symbol_index_result =
                 self.get_element_access_type(object_type_for_access, TypeId::SYMBOL, None);
@@ -1425,6 +1449,35 @@ impl<'a> CheckerState<'a> {
         {
             result_type = Some(TypeId::ANY);
             use_index_signature_check = false;
+        }
+
+        // TS2538: a `symbol` / unique-symbol key indexing a concrete receiver
+        // whose only applicable index signature is `string`. A `string` index
+        // does not accept symbol keys, so tsc reports TS2538 while still
+        // resolving the access to that signature's value type (no cascade).
+        // Mirrors `getPropertyTypeForIndexType`'s `indexInfo.keyType ===
+        // stringType && !isTypeAssignableToKind(indexType, String | Number)`
+        // branch. Runs only after the concrete-member / symbol-index / late-bound
+        // resolutions above have missed (`result_type` is still `None`), so a
+        // real `[sym]: T` member or a genuine `symbol` / `PropertyKey` index is
+        // never overridden.
+        if result_type.is_none()
+            && use_index_signature_check
+            && let Some(string_index_value) = symbol_string_index_fallthrough
+        {
+            use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+            let index_type_str = self.format_type(index_type);
+            let message = format_message(
+                diagnostic_messages::TYPE_CANNOT_BE_USED_AS_AN_INDEX_TYPE,
+                &[&index_type_str],
+            );
+            self.error_at_node(
+                access.name_or_argument,
+                &message,
+                diagnostic_codes::TYPE_CANNOT_BE_USED_AS_AN_INDEX_TYPE,
+            );
+            use_index_signature_check = false;
+            result_type = Some(string_index_value);
         }
 
         // Under NUIA, value-level `any` indexes use the receiver index signature.

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -1271,4 +1271,65 @@ impl<'a> CheckerState<'a> {
                 .resolve_element_access_type(object_type, index_type_for_access, None);
         member == TypeId::UNDEFINED || member == TypeId::ERROR
     }
+
+    /// TS2538 for a symbol-like key indexing a receiver whose only applicable
+    /// index signature is `string`.
+    ///
+    /// A `string` index signature does not accept `symbol` keys, so `tsc`'s
+    /// `getPropertyTypeForIndexType` (`indexInfo.keyType === stringType &&
+    /// !isTypeAssignableToKind(indexType, String | Number)`) reports **TS2538**
+    /// while still resolving the access to that string signature's value type —
+    /// no cascade. This mirrors that branch: it returns `Some(value_type)` when
+    /// the receiver has a `string` index but no `symbol`-accepting index and no
+    /// matching symbol-keyed member, so the caller can emit TS2538 and recover
+    /// the value type; otherwise `None` (a genuine `symbol` / `PropertyKey`
+    /// index, a real member, an array/number-only receiver, or no string index
+    /// — each handled by its own diagnostic path).
+    ///
+    /// Scoped to concrete receivers; union / intersection / type-parameter
+    /// receivers keep their existing per-member paths.
+    pub(crate) fn symbol_key_string_index_fallthrough(
+        &self,
+        object_type: TypeId,
+        index_type: TypeId,
+    ) -> Option<TypeId> {
+        // The key must be `symbol` or a unique symbol.
+        let is_symbol_like = index_type == TypeId::SYMBOL
+            || crate::query_boundaries::common::unique_symbol_ref(self.ctx.types, index_type)
+                .is_some();
+        if !is_symbol_like {
+            return None;
+        }
+
+        // Composite receivers combine per-member signatures; keep them on their
+        // existing paths (documented follow-up).
+        if crate::query_boundaries::common::union_members(self.ctx.types, object_type).is_some()
+            || crate::query_boundaries::common::intersection_members(self.ctx.types, object_type)
+                .is_some()
+            || crate::query_boundaries::common::is_type_parameter(self.ctx.types, object_type)
+        {
+            return None;
+        }
+
+        let resolver = crate::query_boundaries::common::IndexSignatureResolver::new(self.ctx.types);
+        // A genuine `symbol`-accepting index (a dedicated `{ [k: symbol]: V }`
+        // slot, or the `symbol` component of `Record<PropertyKey, V>`) accepts
+        // the key: `tsc`'s `getApplicableIndexInfo` returns it (`keyType` is
+        // `symbol`, not `string`) so no TS2538.
+        if resolver.resolve_symbol_index(object_type).is_some() {
+            return None;
+        }
+        // The fallback signature must be a *plain* `string` index (`indexInfo
+        // .keyType === stringType`). A `PropertyKey` / `string | symbol` union
+        // key (`key_type != string`) accepts the symbol key and resolves
+        // cleanly; a template/pattern key or a `number`-only receiver (TS7015)
+        // / an array (TS7015) / a receiver with no string index (TS7053) are
+        // each handled by their own paths — none of which reach here because
+        // their `string_index` is absent or non-`string`-keyed.
+        let string_sig = resolver.get_index_info(object_type).string_index?;
+        if string_sig.key_type != TypeId::STRING {
+            return None;
+        }
+        Some(string_sig.value_type)
+    }
 }

--- a/crates/tsz-checker/tests/ts2538_symbol_key_string_index_tests.rs
+++ b/crates/tsz-checker/tests/ts2538_symbol_key_string_index_tests.rs
@@ -1,0 +1,248 @@
+//! TS2538 for a `symbol` / unique-symbol key indexing a receiver whose only
+//! applicable index signature is `string`.
+//!
+//! Structural rule (issue #15411): a `string` index signature does not accept
+//! `symbol` keys, so `tsc`'s `getPropertyTypeForIndexType`
+//! (`indexInfo.keyType === stringType && !isTypeAssignableToKind(indexType,
+//! String | Number)`) reports **TS2538** while resolving the access to the
+//! string signature's value type — no cascade. tsz previously emitted nothing
+//! for a wide `symbol` key (false negative) and TS7053 for a `unique symbol`
+//! key (wrong code); both now report TS2538.
+//!
+//! The predicate is structural (`symbol`-like key + a plain `string` index +
+//! no `symbol`-accepting index + no matching symbol member), not keyed on any
+//! binder name — the renamed-binder cases below vary every identifier and must
+//! behave identically. Cases that mention `Record` / `PropertyKey` / `Symbol()`
+//! load the default libs so those names resolve exactly as the CLI resolves
+//! them against `tsc`'s lib.
+
+use std::sync::Arc;
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::test_utils::{
+    diagnostic_code_messages, diagnostic_codes, load_default_lib_files, strict_checker_options,
+};
+
+fn code_messages(source: &str, libs: &[Arc<LibFile>]) -> Vec<(u32, String)> {
+    diagnostic_code_messages(tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        strict_checker_options(),
+        libs,
+    ))
+}
+
+fn codes(source: &str, libs: &[Arc<LibFile>]) -> Vec<u32> {
+    diagnostic_codes(&tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        strict_checker_options(),
+        libs,
+    ))
+}
+
+fn has_2538(source: &str, libs: &[Arc<LibFile>], expected_type: &str) -> bool {
+    code_messages(source, libs).iter().any(|(code, msg)| {
+        *code == 2538 && msg == &format!("Type '{expected_type}' cannot be used as an index type.")
+    })
+}
+
+#[test]
+fn wide_symbol_on_string_index_reports_2538() {
+    let libs = load_default_lib_files();
+    let source = r#"
+declare const s: symbol;
+declare const o: { [k: string]: number };
+o[s];
+"#;
+    assert!(
+        has_2538(source, &libs, "symbol"),
+        "wide symbol key on a string-indexed object should report TS2538 'symbol'; got {:?}",
+        code_messages(source, &libs),
+    );
+}
+
+#[test]
+fn unique_symbol_on_string_index_reports_2538() {
+    let libs = load_default_lib_files();
+    let source = r#"
+declare const u: unique symbol;
+declare const o: { [k: string]: number };
+o[u];
+"#;
+    assert!(
+        has_2538(source, &libs, "unique symbol"),
+        "unique symbol key on a string-indexed object should report TS2538 'unique symbol'; got {:?}",
+        code_messages(source, &libs),
+    );
+    // The wrong-code TS7053 must not co-occur.
+    assert!(
+        !codes(source, &libs).contains(&7053),
+        "unique symbol key on a string index must not report TS7053",
+    );
+}
+
+#[test]
+fn class_with_string_index_reports_2538() {
+    let libs = load_default_lib_files();
+    let source = r#"
+declare const s: symbol;
+class C { [k: string]: number }
+declare const c: C;
+c[s];
+"#;
+    assert!(
+        has_2538(source, &libs, "symbol"),
+        "class string index → TS2538",
+    );
+}
+
+#[test]
+fn callable_interface_with_string_index_reports_2538() {
+    let libs = load_default_lib_files();
+    let source = r#"
+declare const s: symbol;
+interface F { (): void; [k: string]: any }
+declare const f: F;
+f[s];
+"#;
+    assert!(
+        has_2538(source, &libs, "symbol"),
+        "callable interface string index → TS2538",
+    );
+}
+
+#[test]
+fn renamed_binders_still_report_2538() {
+    let libs = load_default_lib_files();
+    // Every identifier is renamed; the rule is structural, not name-keyed.
+    let wide = r#"
+declare const zeta: symbol;
+declare const bag: { [entry: string]: boolean };
+bag[zeta];
+"#;
+    assert!(
+        has_2538(wide, &libs, "symbol"),
+        "renamed wide-symbol case → TS2538",
+    );
+
+    let uniq = r#"
+declare const Rho: unique symbol;
+declare const bag: { [entry: string]: boolean };
+bag[Rho];
+"#;
+    assert!(
+        has_2538(uniq, &libs, "unique symbol"),
+        "renamed unique-symbol case → TS2538",
+    );
+}
+
+#[test]
+fn symbol_index_signature_stays_clean() {
+    let libs = load_default_lib_files();
+    // A genuine `symbol`-accepting index accepts the key: no diagnostic.
+    for source in [
+        r#"
+declare const s: symbol;
+declare const os: { [k: symbol]: number };
+os[s];
+"#,
+        r#"
+declare const s: symbol;
+declare const rec: Record<symbol, number>;
+rec[s];
+"#,
+        r#"
+declare const s: symbol;
+declare const pk: { [k: PropertyKey]: number };
+pk[s];
+"#,
+        r#"
+declare const s: symbol;
+declare const both: { [k: string]: number; [k: symbol]: string };
+both[s];
+"#,
+    ] {
+        let got = codes(source, &libs);
+        assert!(
+            !got.contains(&2538) && !got.contains(&7053),
+            "symbol-accepting index should stay clean; got {got:?} for {source}",
+        );
+    }
+}
+
+#[test]
+fn real_symbol_member_alongside_string_index_stays_clean() {
+    let libs = load_default_lib_files();
+    // A concrete `unique symbol` member coexisting with a string index is a
+    // valid access; tsc resolves it to the member type with no TS2538.
+    let source = r#"
+declare const kk: unique symbol;
+declare const withMember: { [k: string]: number; [kk]: string };
+withMember[kk];
+"#;
+    let got = codes(source, &libs);
+    assert!(
+        !got.contains(&2538),
+        "real symbol member must resolve without TS2538; got {got:?}",
+    );
+}
+
+#[test]
+fn non_string_index_receivers_keep_their_own_codes() {
+    let libs = load_default_lib_files();
+    // No index signature → TS7053 (implicit any).
+    let plain = r#"
+declare const s: symbol;
+declare const plain: { x: number };
+plain[s];
+"#;
+    let got = codes(plain, &libs);
+    assert!(
+        got.contains(&7053) && !got.contains(&2538),
+        "no-index receiver → TS7053, not TS2538; got {got:?}",
+    );
+
+    // Number-only index → TS7015 (index expression not of type number).
+    let numi = r#"
+declare const s: symbol;
+declare const numi: { [k: number]: number };
+numi[s];
+"#;
+    let got = codes(numi, &libs);
+    assert!(
+        got.contains(&7015) && !got.contains(&2538),
+        "number-index receiver → TS7015, not TS2538; got {got:?}",
+    );
+
+    // Array → TS7015.
+    let arr = r#"
+declare const s: symbol;
+declare const arr: number[];
+arr[s];
+"#;
+    let got = codes(arr, &libs);
+    assert!(
+        got.contains(&7015) && !got.contains(&2538),
+        "array receiver → TS7015, not TS2538; got {got:?}",
+    );
+}
+
+#[test]
+fn string_index_symbol_access_recovers_value_type_no_cascade() {
+    let libs = load_default_lib_files();
+    // tsc resolves the access to the string signature's value type (`number`),
+    // so a downstream `: null` assignment cascades exactly one TS2322 (number
+    // not assignable to null) — the access itself is not `error`/`any`.
+    let source = r#"
+declare const s: symbol;
+declare const o: { [k: string]: number };
+const r = o[s];
+const bad: null = r;
+"#;
+    let got = codes(source, &libs);
+    assert!(got.contains(&2538), "expected TS2538; got {got:?}");
+    assert!(
+        got.contains(&2322),
+        "access should recover to `number` (string index value), yielding TS2322 on `: null`; got {got:?}",
+    );
+}

--- a/crates/tsz-solver/src/objects/index_signatures.rs
+++ b/crates/tsz-solver/src/objects/index_signatures.rs
@@ -141,6 +141,104 @@ impl<R: TypeResolver> TypeVisitor for StringIndexResolver<'_, R> {
     }
 }
 
+/// Visitor for resolving symbol index signatures.
+///
+/// A `symbol` index signature (`{ [k: symbol]: V }`) — including the symbol
+/// component of a `PropertyKey` / `string | number | symbol` index (e.g.
+/// `Record<PropertyKey, V>`) — lives in its own [`ObjectShape::symbol_index`]
+/// slot, distinct from the `string` index. Only such a signature accepts a
+/// `symbol` key; a bare `string` index does not. This resolver reports the
+/// value type of that genuine symbol-accepting signature so callers can tell a
+/// real symbol index apart from a `string`-index fallthrough.
+struct SymbolIndexResolver<'a, R: TypeResolver> {
+    db: &'a dyn TypeDatabase,
+    resolver: &'a R,
+}
+
+impl<R: TypeResolver> TypeVisitor for SymbolIndexResolver<'_, R> {
+    type Output = Option<TypeId>;
+
+    fn visit_intrinsic(&mut self, _kind: crate::types::IntrinsicKind) -> Self::Output {
+        None
+    }
+
+    fn visit_literal(&mut self, _value: &crate::LiteralValue) -> Self::Output {
+        None
+    }
+
+    fn visit_object_with_index(&mut self, shape_id: u32) -> Self::Output {
+        let shape = self.db.object_shape(ObjectShapeId(shape_id));
+        shape.symbol_index_signature().map(|idx| idx.value_type)
+    }
+
+    fn visit_callable(&mut self, shape_id: u32) -> Self::Output {
+        // `CallableShape` carries no dedicated `symbol_index` slot; a symbol
+        // index (rare on a callable) is merged into `string_index` with
+        // `key_type == SYMBOL`.
+        let shape = self.db.callable_shape(CallableShapeId(shape_id));
+        shape
+            .string_index
+            .as_ref()
+            .filter(|idx| idx.key_type == TypeId::SYMBOL)
+            .map(|idx| idx.value_type)
+    }
+
+    // `visit_array` / `visit_tuple` intentionally use the trait default
+    // (`None`): arrays and tuples never carry a `symbol` index signature.
+
+    fn visit_union(&mut self, list_id: u32) -> Self::Output {
+        let types = self.db.type_list(crate::types::TypeListId(list_id));
+        types.iter().find_map(|&t| self.visit_type(self.db, t))
+    }
+
+    fn visit_intersection(&mut self, list_id: u32) -> Self::Output {
+        let types = self.db.type_list(crate::types::TypeListId(list_id));
+        types.first().and_then(|&t| self.visit_type(self.db, t))
+    }
+
+    fn visit_readonly_type(&mut self, inner_type: TypeId) -> Self::Output {
+        self.visit_type(self.db, inner_type)
+    }
+
+    fn visit_lazy(&mut self, def_id: u32) -> Self::Output {
+        let resolved = crate::evaluation::evaluate::evaluate_type(self.db, TypeId(def_id));
+        (resolved != TypeId(def_id))
+            .then(|| self.visit_type(self.db, resolved))
+            .flatten()
+    }
+
+    fn visit_application_type(&mut self, type_id: TypeId, _app_id: u32) -> Self::Output {
+        let evaluated = crate::evaluation::evaluate::evaluate_type_with_resolver(
+            self.db,
+            self.resolver,
+            type_id,
+        );
+        (evaluated != type_id)
+            .then(|| self.visit_type(self.db, evaluated))
+            .flatten()
+    }
+
+    fn visit_type(&mut self, types: &dyn TypeDatabase, type_id: TypeId) -> Self::Output {
+        match types.lookup(type_id) {
+            Some(TypeData::Application(app_id)) => self.visit_application_type(type_id, app_id.0),
+            Some(ref type_key) => self.visit_type_key(types, type_key),
+            None => Self::default_output(),
+        }
+    }
+
+    fn visit_mapped(&mut self, mapped_id: u32) -> Self::Output {
+        let type_id = self.db.mapped(self.db.get_mapped(MappedTypeId(mapped_id)));
+        let evaluated = crate::evaluation::evaluate::evaluate_type(self.db, type_id);
+        (evaluated != type_id)
+            .then(|| self.visit_type(self.db, evaluated))
+            .flatten()
+    }
+
+    fn default_output() -> Self::Output {
+        None
+    }
+}
+
 /// Visitor for resolving number index signatures.
 struct NumberIndexResolver<'a, R: TypeResolver> {
     db: &'a dyn TypeDatabase,
@@ -471,6 +569,32 @@ impl<'a, R: TypeResolver> IndexSignatureResolver<'a, R> {
     /// - `{ a: number }` → `None`
     pub fn resolve_string_index(&self, obj: TypeId) -> Option<TypeId> {
         let mut visitor = StringIndexResolver {
+            db: self.db,
+            resolver: self.resolver,
+        };
+        visitor.visit_type(self.db, obj)
+    }
+
+    /// Resolve the symbol index signature type from an object type.
+    ///
+    /// Returns `Some(value_type)` when the object has a genuine `symbol`-keyed
+    /// index signature that accepts a `symbol` key — a dedicated
+    /// `{ [k: symbol]: V }` signature or the `symbol` component of a
+    /// `PropertyKey` / `Record<PropertyKey, V>` index. Returns `None` for a
+    /// bare `string` index, which does not accept symbol keys.
+    ///
+    /// Callers use this to distinguish a real symbol index from a `string`-index
+    /// fallthrough: `tsc` reports TS2538 when a symbol key indexes a receiver
+    /// whose only applicable signature is `string`.
+    ///
+    /// ## Examples
+    ///
+    /// - `{ [key: symbol]: number }` → `Some(TypeId::NUMBER)`
+    /// - `{ [key: PropertyKey]: string }` → `Some(TypeId::STRING)`
+    /// - `{ [key: string]: number }` → `None`
+    /// - `{ a: number }` → `None`
+    pub fn resolve_symbol_index(&self, obj: TypeId) -> Option<TypeId> {
+        let mut visitor = SymbolIndexResolver {
             db: self.db,
             resolver: self.resolver,
         };

--- a/crates/tsz-solver/tests/index_signatures_tests.rs
+++ b/crates/tsz-solver/tests/index_signatures_tests.rs
@@ -32,6 +32,112 @@ fn test_resolve_string_index() {
 }
 
 #[test]
+fn test_resolve_symbol_index_dedicated_slot() {
+    let db = TypeInterner::new();
+
+    // `{ [k: symbol]: number }` — a dedicated symbol index slot.
+    let obj = db.object_with_index(ObjectShape {
+        symbol_index: Some(IndexSignature {
+            key_type: TypeId::SYMBOL,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: None,
+        number_index: None,
+    });
+
+    let resolver = IndexSignatureResolver::new(&db);
+    assert_eq!(resolver.resolve_symbol_index(obj), Some(TypeId::NUMBER));
+    // A dedicated symbol index is NOT reported as a string index.
+    assert_eq!(resolver.resolve_string_index(obj), None);
+}
+
+#[test]
+fn test_resolve_symbol_index_alongside_string() {
+    let db = TypeInterner::new();
+
+    // `{ [k: string]: number; [k: symbol]: boolean }` — symbol index coexists
+    // with a string index; each resolves to its own value type.
+    let obj = db.object_with_index(ObjectShape {
+        symbol_index: Some(IndexSignature {
+            key_type: TypeId::SYMBOL,
+            value_type: TypeId::BOOLEAN,
+            readonly: false,
+            param_name: None,
+        }),
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let resolver = IndexSignatureResolver::new(&db);
+    assert_eq!(resolver.resolve_symbol_index(obj), Some(TypeId::BOOLEAN));
+    assert_eq!(resolver.resolve_string_index(obj), Some(TypeId::NUMBER));
+}
+
+#[test]
+fn test_resolve_symbol_index_legacy_string_slot_encoding() {
+    let db = TypeInterner::new();
+
+    // Legacy encoding: a symbol index stored in the `string_index` slot with
+    // `key_type == SYMBOL`. `symbol_index_signature()` recovers it, and it must
+    // not be mistaken for a `string` index.
+    let obj = db.object_with_index(ObjectShape {
+        symbol_index: None,
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::SYMBOL,
+            value_type: TypeId::STRING,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let resolver = IndexSignatureResolver::new(&db);
+    assert_eq!(resolver.resolve_symbol_index(obj), Some(TypeId::STRING));
+    assert_eq!(resolver.resolve_string_index(obj), None);
+}
+
+#[test]
+fn test_resolve_symbol_index_none_for_plain_string() {
+    let db = TypeInterner::new();
+
+    // `{ [k: string]: number }` — a plain string index does NOT accept symbol
+    // keys, so there is no symbol index.
+    let obj = db.object_with_index(ObjectShape {
+        symbol_index: None,
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let resolver = IndexSignatureResolver::new(&db);
+    assert_eq!(resolver.resolve_symbol_index(obj), None);
+    assert_eq!(resolver.resolve_string_index(obj), Some(TypeId::NUMBER));
+}
+
+#[test]
 fn test_resolve_number_index() {
     let db = TypeInterner::new();
 


### PR DESCRIPTION
Fixes #15411.

When an element-access key is `symbol` / `unique symbol` and the concrete
receiver has a plain `string` index signature but **no** `symbol`-accepting
index and **no** matching symbol-keyed member, `tsc` reports **TS2538**
("Type 'X' cannot be used as an index type") while resolving the access to the
string signature's value type (no cascade); tsz did this through the checker
element-access diagnostic path plus a new solver structural query.

Before: a wide `symbol` key emitted nothing (false negative); a `unique symbol`
key emitted TS7053 (wrong code + wrong anchor).

## Structural rule

A `string` index signature does not accept `symbol` keys. This mirrors tsc's
`getPropertyTypeForIndexType`:
`indexInfo.keyType === stringType && !isTypeAssignableToKind(indexType, String | Number)`
→ TS2538, returning `indexInfo.type`.

- **Solver** (`crates/tsz-solver/src/objects/index_signatures.rs`): new
  `IndexSignatureResolver::resolve_symbol_index` distinguishes a genuine
  `symbol` / `PropertyKey` index (dedicated `symbol_index` slot, or the legacy
  `string_index`-with-`key_type == SYMBOL` encoding) from a plain-`string`
  fallthrough. The wide-`symbol` element-access probe resolves through the
  string signature, so it cannot make that distinction on its own.
- **Checker** (`crates/tsz-checker/src/types/computation/access.rs`,
  `access_helpers.rs`): `symbol_key_string_index_fallthrough` is the single
  decision. The pre-existing blocks that resolved `__symbol_<file>_<id>` binding
  names and `receiver[symbol]` through a plain string index are gated so a real
  member (`from_index_signature == false`) or a symbol-accepting index still
  resolves, but a plain-`string` fallthrough falls to the TS2538 gate, which
  emits the diagnostic and recovers the string index value type.

## Adjacent matrix (differential vs tsc 6.0.2, `--noEmit --strict`)

- wide `symbol` / `unique symbol` on `{ [k: string]: V }` → TS2538 (recovers `V`)
- class / callable-interface with a `string` index → TS2538
- `{ [k: string]: V }` + `[Symbol.iterator]` prop, wide symbol → TS2538
- renamed binders (structural, not name-keyed) → identical
- `{ [k: symbol]: V }` / `Record<symbol, V>` / `{ [k: PropertyKey]: V }` /
  string+symbol index → clean
- a real `[uniqueSym]: T` member coexisting with a string index → clean (member type)
- no index → TS7053; number index / array → TS7015; `Map` → TS7052 (unchanged)

## Scope / residual

- Scoped to concrete receivers; union / intersection keep their per-member
  paths (documented follow-up).
- The `unique symbol` widening of `typeof Symbol.iterator` in diagnostic display
  is a pre-existing, orthogonal divergence (affects any context, not just index
  access) and is unchanged here.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-solver --lib resolve_symbol_index` — 4 new pass
- `cargo test -p tsz-checker --test ts2538_symbol_key_string_index_tests` — 9 new pass
- Adjacent suites green: `symbol_index_signature_tests`,
  `object_element_access_diagnostics_tests`, `element_access_structural_codes_tests`,
  `ts7053_*`, `keyof_*symbol*`, `unique_symbol_*`, `tuple_index_access_tests`,
  `enum_indexed_access_tests`, `ts2536_keyof_string_index_signature_tests`
- CLI differential vs `tsc` 6.0.2 across the issue matrix + renamed binders +
  negative controls — byte-identical

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLdfvcf985eUv5Ed8gMmSn)_