### PR TITLE
fix(ci): paginate the dedup tracking-issue sentinel lookup

### DIFF
--- a/scripts/bench/check-latest-freshness.mjs
+++ b/scripts/bench/check-latest-freshness.mjs
@@ -227,15 +227,35 @@ function runGh(args) {
 
 const TRACKED_GENERATED_RE = /generated_at:\s*`([^`]+)`/;
 
+const SENTINEL_PER_PAGE = 100;
+// The `/issues` endpoint returns open issues *and* open PRs, so on an active
+// repo the combined list routinely exceeds one 100-item page. A persistent
+// tracking issue (a standing freeze can live for hours/days) is sorted
+// created-desc and steadily sinks past page 1 as new PRs/issues land, so a
+// single-page scan silently stops finding it — then reconcileIssue re-creates a
+// duplicate every firing and can never close the real one on recovery. Page
+// through open issues until the marker is found or the list is exhausted so the
+// dedup sentinel is always located. The bound caps the walk on a pathological
+// backlog without ever masking a reachable sentinel.
+const SENTINEL_MAX_PAGES = 20;
+
 function findSentinelIssue(repository, fetchJson) {
-  const issues = fetchJson([
-    "api",
-    "-H",
-    "Accept: application/vnd.github+json",
-    `repos/${repository}/issues?state=open&per_page=100`,
-  ]);
-  if (!Array.isArray(issues)) return null;
-  return issues.find((it) => typeof it.body === "string" && it.body.includes(ISSUE_MARKER)) || null;
+  for (let page = 1; page <= SENTINEL_MAX_PAGES; page += 1) {
+    const issues = fetchJson([
+      "api",
+      "-H",
+      "Accept: application/vnd.github+json",
+      `repos/${repository}/issues?state=open&per_page=${SENTINEL_PER_PAGE}&page=${page}`,
+    ]);
+    if (!Array.isArray(issues)) return null;
+    const match = issues.find(
+      (it) => typeof it.body === "string" && it.body.includes(ISSUE_MARKER),
+    );
+    if (match) return match;
+    // A short (or empty) page is the last one — the sentinel is not open.
+    if (issues.length < SENTINEL_PER_PAGE) return null;
+  }
+  return null;
 }
 
 /**

--- a/scripts/bench/test-check-latest-freshness.mjs
+++ b/scripts/bench/test-check-latest-freshness.mjs
@@ -187,6 +187,38 @@ function NOW_ISO() {
   assert.equal(outcome.action, "closed");
   assert.ok(calls.some((c) => c[1] === "close"), "closes the tracking issue on recovery");
 }
+{
+  // Sentinel past page 1: the `/issues` list mixes open PRs, so a persistent
+  // tracking issue sinks onto a later page as new PRs/issues land. reconcileIssue
+  // must page through and find it instead of re-creating a duplicate every firing.
+  const MARKER = "<!-- bench-latest-freshness-sentinel -->";
+  const page1 = Array.from({ length: 100 }, (_, i) => ({ number: 2000 + i, body: "unrelated PR body" }));
+  const page2 = [{ number: 42, body: `${MARKER}\nstale` }];
+  const seenPages = [];
+  const calls = [];
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: at(9) }), { now: NOW, maxAgeHours: 6 });
+  const outcome = reconcileIssue(
+    verdict,
+    { url: DEFAULT_LATEST_URL, repository: "tsz-org/tsz" },
+    NOW_ISO(),
+    {
+      fetchJson: (args) => {
+        const url = String(args[args.length - 1]);
+        const page = Number((url.match(/[?&]page=(\d+)/) || [])[1] || 1);
+        seenPages.push(page);
+        return page === 1 ? page1 : page === 2 ? page2 : [];
+      },
+      runCommand: (args) => {
+        calls.push(args);
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    },
+  );
+  assert.equal(outcome.action, "updated", "finds the sentinel on page 2 and edits it");
+  assert.equal(outcome.number, 42, "locates the correct tracking issue past page 1");
+  assert.deepEqual(seenPages, [1, 2], "pages through until the marker is found");
+  assert.ok(!calls.some((c) => c[1] === "create"), "never creates a duplicate tracking issue");
+}
 
 // ---- end-to-end CLI via --fixture (offline, no network) ---------------------
 function runCli(args, fixtureValue) {

--- a/scripts/ci/check-main-red.mjs
+++ b/scripts/ci/check-main-red.mjs
@@ -410,15 +410,35 @@ function lastTrackedSha(issue) {
   return match ? match[1] : "";
 }
 
+const SENTINEL_PER_PAGE = 100;
+// The `/issues` endpoint returns open issues *and* open PRs, so on an active
+// repo the combined list routinely exceeds one 100-item page. A persistent
+// tracking issue (a standing main-red can live for hours) is sorted created-desc
+// and steadily sinks past page 1 as new PRs/issues land, so a single-page scan
+// silently stops finding it — then reconcileIssue re-creates a duplicate every
+// firing and can never close the real one on recovery. Page through open issues
+// until the marker is found or the list is exhausted so the dedup sentinel is
+// always located. The bound caps the walk on a pathological backlog without ever
+// masking a reachable sentinel.
+const SENTINEL_MAX_PAGES = 20;
+
 function findSentinelIssue(repository, fetchJson) {
-  const issues = fetchJson([
-    "api",
-    "-H",
-    "Accept: application/vnd.github+json",
-    `repos/${repository}/issues?state=open&per_page=100`,
-  ]);
-  if (!Array.isArray(issues)) return null;
-  return issues.find((it) => typeof it.body === "string" && it.body.includes(ISSUE_MARKER)) || null;
+  for (let page = 1; page <= SENTINEL_MAX_PAGES; page += 1) {
+    const issues = fetchJson([
+      "api",
+      "-H",
+      "Accept: application/vnd.github+json",
+      `repos/${repository}/issues?state=open&per_page=${SENTINEL_PER_PAGE}&page=${page}`,
+    ]);
+    if (!Array.isArray(issues)) return null;
+    const match = issues.find(
+      (it) => typeof it.body === "string" && it.body.includes(ISSUE_MARKER),
+    );
+    if (match) return match;
+    // A short (or empty) page is the last one — the sentinel is not open.
+    if (issues.length < SENTINEL_PER_PAGE) return null;
+  }
+  return null;
 }
 
 export function reconcileIssue(verdict, regressedTests, nowIso, ctx) {

--- a/scripts/ci/test-check-main-red.mjs
+++ b/scripts/ci/test-check-main-red.mjs
@@ -294,6 +294,31 @@ test("reconcileIssue closes existing issue when green", () => {
   assert.ok(calls.some((a) => a[0] === "issue" && a[1] === "close"));
 });
 
+test("reconcileIssue finds a sentinel that sank past page 1", () => {
+  // The `/issues` list mixes open PRs, so a standing main-red tracking issue
+  // sinks onto a later page as new PRs/issues land. reconcileIssue must page
+  // through and find it instead of re-creating a duplicate every firing.
+  const calls = [];
+  const seenPages = [];
+  const page1 = Array.from({ length: 100 }, (_, i) => ({ number: 3000 + i, body: "unrelated PR body" }));
+  const page2 = [{ number: 77, body: "x <!-- main-red-sentinel --> y" }];
+  const v = mainCiHealth([run({ id: 5, conclusion: "failure", created_at: "2026-06-12T21:00:00Z" })]);
+  const result = reconcileIssue(v, [], NOW, {
+    repository: "o/r",
+    fetchJson: (args) => {
+      const url = String(args[args.length - 1]);
+      const page = Number((url.match(/[?&]page=(\d+)/) || [])[1] || 1);
+      seenPages.push(page);
+      return page === 1 ? page1 : page === 2 ? page2 : [];
+    },
+    runCommand: (args) => { calls.push(args); return { status: 0, stdout: "", stderr: "" }; },
+  });
+  assert.equal(result.action, "updated");
+  assert.equal(result.number, 77);
+  assert.deepEqual(seenPages, [1, 2]);
+  assert.ok(!calls.some((a) => a[0] === "issue" && a[1] === "create"), "never creates a duplicate");
+});
+
 test("reconcileIssue noop when green and no issue", () => {
   const v = mainCiHealth([run({ id: 6, conclusion: "success", created_at: "2026-06-12T21:00:00Z" })]);
   const result = reconcileIssue(v, [], NOW, {


### PR DESCRIPTION
## What / why

`findSentinelIssue` in the two ci-health monitors — `scripts/bench/check-latest-freshness.mjs` (bench-data freeze tracker, the tooling behind #15401) and `scripts/ci/check-main-red.mjs` (main-CI red tracker) — fetched only the **first 100 open issues** (`issues?state=open&per_page=100`) and scanned that single page for the dedup marker.

The `/issues` endpoint returns open issues **and** open PRs, so on an active repo the combined list routinely exceeds one 100-item page (this repo currently has ~65 open issues + ~65 open PRs). A persistent tracking issue is sorted `created`-desc and steadily sinks past page 1 as new PRs/issues land. Once it does, the single-page scan silently stops finding it, and `reconcileIssue`:
- re-creates a **duplicate** tracking issue on every 15-minute firing (breaking the documented "ONE deduplicated tracking issue" contract), and
- can never `issue close` the real one on recovery, so the stale-data alert **never clears**.

That is a latent freeze-class defect in the monitoring itself: the freeze-tracking tooling stops being trustworthy exactly as the backlog grows.

**Fix:** page through open issues until the marker is found or the list is exhausted, matching the bounded page-loop convention already used by the sibling probes (`check-stale-ci-runs`, `check-flaky-rate`, `check-ci-job-timing`, `check-wip-state-comments`). The 20-page bound caps the walk on a pathological backlog without masking a reachable sentinel; the loop early-exits the moment the marker is found (page 1 in the steady state), so it makes **no** extra API calls in the common case. `--paginate` was deliberately not used: it would defeat the injected `fetchJson` test seam and always drain every page (no early exit).

Both monitors carry standalone copies of this helper — the whole sentinel/reconcile machinery is already duplicated per-file across these scripts and no shared gh-I/O module exists — so the fix is applied identically to both, consistent with the established structure. A regression test is added to each: it seeds a full page-1 of unrelated PRs plus the marker on page 2 and asserts the sentinel is located (never re-created).

Note: this hardens the recurring-freeze **class** in #15401's tooling. The current freeze is also operationally driven (scheduled bench runs stopped completing on 2026-07-01, so `latest.json` has not advanced); reviving the runner / republishing is a separate operational step and is not something a code change can do.

## Goal
Goal: hold

## Verification
- `node scripts/bench/test-check-latest-freshness.mjs` → pass (adds "sentinel past page 1" case)
- `node scripts/ci/test-check-main-red.mjs` → 26 tests passed (adds "reconcileIssue finds a sentinel that sank past page 1")
- Confirmed the only other failing `scripts/bench/test-*.mjs` (`test-bench-workflow-micro-coverage`, `test-project-winner-regression-report`, `test-tsgo-winner-report`) fail identically on clean `origin/main` and are unrelated to this diff (already tracked as #15405/#15407); they touch `bench.yml`, which this PR does not.
- CI node/lint gates for the `scripts/**` suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01VzrasoedsGHetuzjgVGpWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzrasoedsGHetuzjgVGpWS)_