### PR TITLE
fix(checker,solver): accept symbol keys on PropertyKey indexes

### DIFF
--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -1288,7 +1288,7 @@ impl<'a> CheckerState<'a> {
     /// signature's value type, so this only governs *which diagnostic* is
     /// emitted, never the access result.
     pub(crate) fn symbol_key_resolves_via_string_index_only(
-        &self,
+        &mut self,
         object_type: TypeId,
         index_type: TypeId,
         index_type_for_access: TypeId,
@@ -1311,6 +1311,7 @@ impl<'a> CheckerState<'a> {
         if self.is_array_like_type(object_type) {
             return false;
         }
+        let object_type = self.resolve_receiver_index_signature_keys(object_type);
         // Without a `string` index the object reports the implicit-any TS7053
         // family instead; TS2538 is reserved for the string-fallthrough case.
         // (This also excludes namespace / expando receivers, which have none.)

--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -1656,6 +1656,13 @@ const TS2538: u32 = diagnostic_codes::TYPE_CANNOT_BE_USED_AS_AN_INDEX_TYPE;
 const TS7015: u32 =
     diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE;
 
+fn ts2538_messages_for_ts(source: &str) -> Vec<String> {
+    check_source_code_messages(source)
+        .into_iter()
+        .filter_map(|(code, message)| (code == TS2538).then_some(message))
+        .collect()
+}
+
 #[test]
 fn wide_symbol_value_access_on_string_index_reports_ts2538() {
     let codes = diagnostic_codes_for_ts(
@@ -1676,6 +1683,24 @@ strIdx[sym];
 }
 
 #[test]
+fn wide_symbol_value_access_on_string_index_reports_exact_ts2538_message() {
+    let messages = ts2538_messages_for_ts(
+        r#"
+declare const token: symbol;
+declare const store: { [entry: string]: number };
+store[token];
+"#,
+    );
+
+    assert!(
+        messages
+            .iter()
+            .any(|message| message == "Type 'symbol' cannot be used as an index type."),
+        "expected exact TS2538 message for wide symbol key, got {messages:?}",
+    );
+}
+
+#[test]
 fn wide_symbol_value_access_on_string_index_reports_ts2538_renamed_binders() {
     // Anti-hardcoding: identical structural shape, different binder names.
     let codes = diagnostic_codes_for_ts(
@@ -1688,6 +1713,30 @@ WEIRD_9[banana];
     assert!(
         codes.contains(&TS2538),
         "the rule must be structural, not name-driven; expected TS2538, got {codes:?}",
+    );
+}
+
+#[test]
+fn callable_interface_string_index_indexed_by_symbol_reports_ts2538() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const channel: symbol;
+interface Dispatcher {
+    (): void;
+    [slot: string]: unknown;
+}
+declare const dispatch: Dispatcher;
+dispatch[channel];
+"#,
+    );
+
+    assert!(
+        codes.contains(&TS2538),
+        "callable interface with only a string index must reject symbol access as TS2538, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&TS7053),
+        "callable string-index fallthrough is TS2538, not TS7053, got {codes:?}",
     );
 }
 
@@ -1713,6 +1762,40 @@ noProp[us];
 }
 
 #[test]
+fn unique_symbol_value_access_on_string_index_reports_exact_ts2538_message() {
+    let messages = ts2538_messages_for_ts(
+        r#"
+declare const privateKey: unique symbol;
+declare const slots: { [entry: string]: number };
+slots[privateKey];
+"#,
+    );
+
+    assert!(
+        messages
+            .iter()
+            .any(|message| message == "Type 'unique symbol' cannot be used as an index type."),
+        "expected exact TS2538 message for unique symbol key, got {messages:?}",
+    );
+}
+
+#[test]
+fn unique_symbol_value_access_on_string_index_reports_ts2538_renamed_binders() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const Lexeme: unique symbol;
+declare const registry: { [slotName: string]: boolean };
+registry[Lexeme];
+"#,
+    );
+
+    assert!(
+        codes.contains(&TS2538),
+        "renamed unique-symbol/string-index case should still report TS2538, got {codes:?}",
+    );
+}
+
+#[test]
 fn wide_symbol_value_access_on_class_string_index_reports_ts2538() {
     let codes = diagnostic_codes_for_ts(
         r#"
@@ -1725,6 +1808,26 @@ bag[sym];
     assert!(
         codes.contains(&TS2538),
         "a class instance with a string index signature must report TS2538, got {codes:?}",
+    );
+}
+
+#[test]
+fn real_unique_symbol_member_with_string_index_stays_clean() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const precise: unique symbol;
+declare const holder: { [slot: string]: number; [precise]: string };
+const value: string = holder[precise];
+"#,
+    );
+
+    assert!(
+        !codes.contains(&TS2538),
+        "a real unique-symbol member must win over the string index, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&TS7053),
+        "a real unique-symbol member is not an implicit-any access, got {codes:?}",
     );
 }
 
@@ -1759,6 +1862,67 @@ const bad: string = strIdx[sym];
     assert!(
         incompatible.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
         "the resolved value type `number` is not assignable to `string`; expected TS2322, got {incompatible:?}",
+    );
+}
+
+#[test]
+fn record_symbol_and_property_key_accept_symbol_values() {
+    let libs = load_lib_files(&["es5.d.ts"]);
+    if libs.is_empty() {
+        return;
+    }
+    let record_diags = check_source_with_libs(
+        r#"
+declare const mark: symbol;
+declare const symbolRecord: Record<symbol, number>;
+const a: number = symbolRecord[mark];
+"#,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    );
+    let record_codes: Vec<u32> = record_diags
+        .iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect();
+
+    assert!(
+        !record_codes.contains(&TS2538),
+        "Record<symbol, V> accepts symbol keys, got {record_codes:?}",
+    );
+    assert!(
+        !record_codes.contains(&TS7053),
+        "Record<symbol, V> must not degrade to implicit any, got {record_codes:?}",
+    );
+
+    let property_key_diags = check_source_with_libs(
+        r#"
+declare const mark: symbol;
+declare const allKeys: { [key: PropertyKey]: string };
+const b: string = allKeys[mark];
+"#,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    );
+    let property_key_codes: Vec<u32> = property_key_diags
+        .iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect();
+
+    assert!(
+        !property_key_codes.contains(&TS2538),
+        "PropertyKey index accepts symbol keys, got {property_key_codes:?}",
+    );
+    assert!(
+        !property_key_codes.contains(&TS7053),
+        "PropertyKey index must not degrade to implicit any, got {property_key_codes:?}",
     );
 }
 

--- a/crates/tsz-solver/src/objects/index_signatures.rs
+++ b/crates/tsz-solver/src/objects/index_signatures.rs
@@ -129,7 +129,11 @@ impl<R: TypeResolver> TypeVisitor for StringIndexResolver<'_, R> {
     }
 
     fn visit_mapped(&mut self, mapped_id: u32) -> Self::Output {
-        let type_id = self.db.mapped(self.db.get_mapped(MappedTypeId(mapped_id)));
+        let mapped = self.db.get_mapped(MappedTypeId(mapped_id));
+        if mapped.name_type.is_none() && key_space_includes_symbol(self.db, mapped.constraint) {
+            return Some(mapped.template);
+        }
+        let type_id = self.db.mapped(mapped);
         let evaluated = crate::evaluation::evaluate::evaluate_type(self.db, type_id);
         (evaluated != type_id)
             .then(|| self.visit_type(self.db, evaluated))
@@ -167,17 +171,27 @@ impl<R: TypeResolver> TypeVisitor for SymbolIndexResolver<'_, R> {
 
     fn visit_object_with_index(&mut self, shape_id: u32) -> Self::Output {
         let shape = self.db.object_shape(ObjectShapeId(shape_id));
-        shape.symbol_index_signature().map(|idx| idx.value_type)
+        shape
+            .symbol_index_signature()
+            .or_else(|| {
+                shape
+                    .string_index
+                    .as_ref()
+                    .filter(|idx| key_space_includes_symbol(self.db, idx.key_type))
+            })
+            .map(|idx| idx.value_type)
     }
 
     fn visit_callable(&mut self, shape_id: u32) -> Self::Output {
         // `CallableShape` has no dedicated `symbol_index` slot, so only the
-        // historical `string_index`-with-`symbol`-key representation applies.
+        // historical `string_index` representation applies. The key can be the
+        // bare `symbol` intrinsic or a composite key space that includes it
+        // (for example `PropertyKey` after alias normalization).
         let shape = self.db.callable_shape(CallableShapeId(shape_id));
         shape
             .string_index
             .as_ref()
-            .filter(|idx| idx.key_type == TypeId::SYMBOL)
+            .filter(|idx| key_space_includes_symbol(self.db, idx.key_type))
             .map(|idx| idx.value_type)
     }
 
@@ -232,6 +246,19 @@ impl<R: TypeResolver> TypeVisitor for SymbolIndexResolver<'_, R> {
 
     fn default_output() -> Self::Output {
         None
+    }
+}
+
+fn key_space_includes_symbol(db: &dyn TypeDatabase, key_type: TypeId) -> bool {
+    if key_type == TypeId::SYMBOL {
+        return true;
+    }
+    match db.lookup(key_type) {
+        Some(TypeData::Union(list_id)) => db
+            .type_list(list_id)
+            .iter()
+            .any(|&member| key_space_includes_symbol(db, member)),
+        _ => false,
     }
 }
 

--- a/crates/tsz-solver/tests/index_signatures_tests.rs
+++ b/crates/tsz-solver/tests/index_signatures_tests.rs
@@ -32,6 +32,127 @@ fn test_resolve_string_index() {
 }
 
 #[test]
+fn test_resolve_symbol_index_dedicated_slot() {
+    let db = TypeInterner::new();
+
+    let obj = db.object_with_index(ObjectShape {
+        symbol_index: Some(IndexSignature {
+            key_type: TypeId::SYMBOL,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: None,
+        number_index: None,
+    });
+
+    let resolver = IndexSignatureResolver::new(&db);
+    assert_eq!(resolver.resolve_symbol_index(obj), Some(TypeId::NUMBER));
+    assert_eq!(resolver.resolve_string_index(obj), None);
+}
+
+#[test]
+fn test_resolve_symbol_index_alongside_string() {
+    let db = TypeInterner::new();
+
+    let obj = db.object_with_index(ObjectShape {
+        symbol_index: Some(IndexSignature {
+            key_type: TypeId::SYMBOL,
+            value_type: TypeId::BOOLEAN,
+            readonly: false,
+            param_name: None,
+        }),
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let resolver = IndexSignatureResolver::new(&db);
+    assert_eq!(resolver.resolve_symbol_index(obj), Some(TypeId::BOOLEAN));
+    assert_eq!(resolver.resolve_string_index(obj), Some(TypeId::NUMBER));
+}
+
+#[test]
+fn test_resolve_symbol_index_from_property_key_slot() {
+    let db = TypeInterner::new();
+    let property_key = db.union(vec![TypeId::STRING, TypeId::NUMBER, TypeId::SYMBOL]);
+
+    let obj = db.object_with_index(ObjectShape {
+        symbol_index: None,
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: property_key,
+            value_type: TypeId::STRING,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let resolver = IndexSignatureResolver::new(&db);
+    assert_eq!(resolver.resolve_symbol_index(obj), Some(TypeId::STRING));
+    assert_eq!(resolver.resolve_string_index(obj), Some(TypeId::STRING));
+}
+
+#[test]
+fn test_resolve_symbol_index_legacy_string_slot_encoding() {
+    let db = TypeInterner::new();
+
+    let obj = db.object_with_index(ObjectShape {
+        symbol_index: None,
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::SYMBOL,
+            value_type: TypeId::STRING,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let resolver = IndexSignatureResolver::new(&db);
+    assert_eq!(resolver.resolve_symbol_index(obj), Some(TypeId::STRING));
+    assert_eq!(resolver.resolve_string_index(obj), None);
+}
+
+#[test]
+fn test_resolve_symbol_index_none_for_plain_string() {
+    let db = TypeInterner::new();
+
+    let obj = db.object_with_index(ObjectShape {
+        symbol_index: None,
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let resolver = IndexSignatureResolver::new(&db);
+    assert_eq!(resolver.resolve_symbol_index(obj), None);
+    assert_eq!(resolver.resolve_string_index(obj), Some(TypeId::NUMBER));
+}
+
+#[test]
 fn test_resolve_number_index() {
     let db = TypeInterner::new();
 
@@ -164,6 +285,72 @@ fn test_resolve_string_index_from_application_mapped_record() {
         "application-wrapped Record<string, unknown> aliases should expose their string index"
     );
     assert_eq!(resolver.resolve_number_index(applied_record), None);
+}
+
+#[test]
+fn test_resolve_symbol_index_from_application_mapped_record() {
+    struct AliasResolver {
+        def_id: DefId,
+        body: TypeId,
+        params: Vec<TypeParamInfo>,
+    }
+
+    impl TypeResolver for AliasResolver {
+        fn resolve_ref(
+            &self,
+            _symbol: crate::types::SymbolRef,
+            _interner: &dyn crate::construction::TypeDatabase,
+        ) -> Option<TypeId> {
+            None
+        }
+
+        fn resolve_lazy(
+            &self,
+            def_id: DefId,
+            _interner: &dyn crate::construction::TypeDatabase,
+        ) -> Option<TypeId> {
+            (def_id == self.def_id).then_some(self.body)
+        }
+
+        fn get_lazy_type_params(&self, def_id: DefId) -> Option<Vec<TypeParamInfo>> {
+            (def_id == self.def_id).then(|| self.params.clone())
+        }
+    }
+
+    let db = TypeInterner::new();
+    let key_param = TypeParamInfo {
+        name: db.intern_string("SymbolKey"),
+        constraint: Some(TypeId::SYMBOL),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    };
+    let value_param = TypeParamInfo {
+        name: db.intern_string("Value"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    };
+    let key_type = db.type_param(key_param);
+    let value_type = db.type_param(value_param);
+    let body = mapped_record(&db, key_type, value_type);
+    let def_id = DefId(95);
+    let alias = db.lazy(def_id);
+    let applied_record = db.application(alias, vec![TypeId::SYMBOL, TypeId::BOOLEAN]);
+    let alias_resolver = AliasResolver {
+        def_id,
+        body,
+        params: vec![key_param, value_param],
+    };
+
+    let resolver = IndexSignatureResolver::with_resolver(&db, &alias_resolver);
+    assert_eq!(
+        resolver.resolve_symbol_index(applied_record),
+        Some(TypeId::BOOLEAN),
+        "application-wrapped Record<symbol, boolean> aliases should expose their symbol index"
+    );
+    assert_eq!(resolver.resolve_string_index(applied_record), None);
 }
 
 #[test]


### PR DESCRIPTION
Goal: hold

## Summary
- Treat mapped/index key spaces that include `symbol` as symbol-accepting index signatures in the solver resolver, including `Record<symbol, V>` applications and `PropertyKey`-style composite keys.
- Normalize receiver index-signature key aliases before the checker decides that a symbol key only falls through to a plain string index.
- Salvage the non-conflicting #15465 coverage on top of current `main`, including exact TS2538 message checks, callable string-index witnesses, real unique-symbol member controls, and direct solver resolver tests.

## Structural Rule
When an element-access key is `symbol` or `unique symbol`, `tsc` reports TS2538 only if the receiver resolves through a plain `string` index and has no symbol-accepting index or exact symbol member. `Record<symbol, V>` and `{ [key: PropertyKey]: V }` expose a symbol-accepting surface, so tsz owns the distinction through the solver `IndexSignatureResolver` plus the checker TS2538 fallthrough gate.

## Adjacent Matrix
- `symbol` and `unique symbol` keys on a plain string index still report TS2538, with exact message coverage.
- Callable interfaces with only a string index report TS2538.
- Real unique-symbol members beside a string index stay clean.
- `Record<symbol, V>` and `PropertyKey` indexes accept symbol keys.
- Plain string indexes are not mistaken for symbol indexes.

## Verification
- `cargo fmt --all --check`
- `scripts/safe-run.sh --limit 88% -- cargo nextest run -p tsz-solver test_resolve_symbol_index`
- `scripts/safe-run.sh --limit 88% -- cargo nextest run -p tsz-checker --test symbol_index_signature_tests record_symbol_and_property_key_accept_symbol_values`
- `scripts/safe-run.sh --limit 88% -- cargo nextest run -p tsz-checker --test symbol_index_signature_tests`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high

Supersedes the conflicted implementation branch in #15465; this keeps the salvageable coverage and the missing `Record<symbol>` / `PropertyKey` behavior on current `main` without replaying the stale overlap with merged #15412.