### PR TITLE
perf(solver): retain iteration-bounded partials in the window-scoped per-query memo (#15398)

### DIFF
--- a/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
+++ b/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
@@ -25,7 +25,7 @@
 //! holding the real work — converge and breaks the churn.
 
 use crate::evaluation::request::{EvaluationCacheKey, EvaluationRequest};
-use crate::evaluation::result::EvaluationMemoResult;
+use crate::evaluation::result::{EvaluationMemoResult, EvaluationResult};
 use crate::evaluation::session::EvaluationSession;
 use crate::types::TypeId;
 
@@ -37,16 +37,24 @@ use crate::types::TypeId;
 pub(crate) fn query_memo_get(
     session: &EvaluationSession,
     key: EvaluationCacheKey,
-) -> Option<TypeId> {
+) -> Option<EvaluationResult> {
     session.query_memo_get(key)
 }
 
-/// Record a stable fresh-evaluator result for the current top-level query.
+/// Record a window-scoped fresh-evaluator result for the current top-level
+/// query.
 ///
-/// Callers must only store results that did not hit a recursion/budget limit
-/// (`TypeEvaluator::recursion_limit_hit`), so an opaque cycle/budget bail is
-/// never cached and reused as if it were the converged answer.
-pub(crate) fn query_memo_put(session: &EvaluationSession, key: EvaluationCacheKey, result: TypeId) {
+/// Callers store either a converged result or a *boundary-intrinsic* bail — a
+/// partial reproducible from the key alone (see
+/// [`EvaluationMemoResult::is_stable_for_per_query_memo`]). Ambient/global-budget
+/// bails are never stored, and a stored partial keeps its incomplete verdict
+/// (via [`EvaluationResult`]) so a hit is never promoted into a durable cache as
+/// if it were the converged answer.
+pub(crate) fn query_memo_put(
+    session: &EvaluationSession,
+    key: EvaluationCacheKey,
+    result: EvaluationResult,
+) {
     session.query_memo_put(key, result);
 }
 
@@ -91,7 +99,10 @@ pub(crate) fn memoized_eval_with_stability(
 ) -> Option<EvaluationMemoResult> {
     let key = request.cache_key();
     if let Some(cached) = query_memo_get(session, key) {
-        return Some(EvaluationMemoResult::cached(cached));
+        // Reconstruct from the stored result so a retained boundary-intrinsic
+        // partial keeps its incomplete verdict on the way out (and thus stays
+        // out of durable caches), while a converged result round-trips stable.
+        return Some(EvaluationMemoResult::from_memoized_result(cached));
     }
     let _cross = match CrossEvalExpansionGuard::enter(session, request.type_id()) {
         CrossEvalExpansionState::Entered(guard) => guard,
@@ -99,7 +110,7 @@ pub(crate) fn memoized_eval_with_stability(
     };
     let memo_result = compute();
     if memo_result.is_stable_for_per_query_memo() {
-        query_memo_put(session, key, memo_result.type_id());
+        query_memo_put(session, key, memo_result.result());
     }
     Some(memo_result)
 }
@@ -161,14 +172,32 @@ mod tests {
         let no_unchecked_key = EvaluationCacheKey::new(t, true, false);
         let exact_optional_key = EvaluationCacheKey::new(t, false, true);
         let both_key = EvaluationCacheKey::new(t, true, true);
-        query_memo_put(&session, default_key, TypeId(70));
-        query_memo_put(&session, no_unchecked_key, TypeId(71));
-        query_memo_put(&session, exact_optional_key, TypeId(72));
-        assert_eq!(query_memo_get(&session, default_key), Some(TypeId(70)));
-        assert_eq!(query_memo_get(&session, no_unchecked_key), Some(TypeId(71)));
+        query_memo_put(
+            &session,
+            default_key,
+            EvaluationResult::complete(TypeId(70)),
+        );
+        query_memo_put(
+            &session,
+            no_unchecked_key,
+            EvaluationResult::complete(TypeId(71)),
+        );
+        query_memo_put(
+            &session,
+            exact_optional_key,
+            EvaluationResult::complete(TypeId(72)),
+        );
+        assert_eq!(
+            query_memo_get(&session, default_key),
+            Some(EvaluationResult::complete(TypeId(70)))
+        );
+        assert_eq!(
+            query_memo_get(&session, no_unchecked_key),
+            Some(EvaluationResult::complete(TypeId(71)))
+        );
         assert_eq!(
             query_memo_get(&session, exact_optional_key),
-            Some(TypeId(72))
+            Some(EvaluationResult::complete(TypeId(72)))
         );
         assert_eq!(query_memo_get(&session, both_key), None);
         reset_query_memo(&session);
@@ -197,7 +226,7 @@ mod tests {
         assert_eq!(second, Some(TypeId(81)));
         assert_eq!(
             query_memo_get(&session, request.cache_key()),
-            Some(TypeId(81))
+            Some(EvaluationResult::complete(TypeId(81)))
         );
         reset_query_memo(&session);
     }
@@ -221,7 +250,7 @@ mod tests {
         assert_eq!(first, Some(TypeId(90)));
         assert_eq!(
             query_memo_get(&session, request.cache_key()),
-            Some(TypeId(90))
+            Some(EvaluationResult::complete(TypeId(90)))
         );
 
         let second = memoized_eval(&session, request, || {
@@ -233,7 +262,7 @@ mod tests {
         assert_eq!(calls, 1);
         assert_eq!(
             query_memo_get(&session, request.cache_key()),
-            Some(TypeId(90))
+            Some(EvaluationResult::complete(TypeId(90)))
         );
         reset_query_memo(&session);
     }

--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -66,6 +66,42 @@ pub enum TerminationKind {
     IterationExceeded,
 }
 
+impl TerminationKind {
+    /// Whether this bail class is a function of the evaluated *key alone*.
+    ///
+    /// A fresh evaluator (spun up at every cross-evaluator boundary —
+    /// `SubtypeChecker::evaluate_type`, infer-pattern matching,
+    /// `relations::judge`) starts its per-instance recursion guard with the
+    /// iteration counter at zero. [`IterationExceeded`](Self::IterationExceeded)
+    /// counts that evaluator's *total* enter attempts, so for a given boundary
+    /// key it trips at the same point no matter which evaluator walks it: the
+    /// opaque partial it surfaces is *reproducible from the key*, and retaining
+    /// it in the window-scoped per-query memo cannot change the emitted type —
+    /// it only removes the redundant cross-evaluator re-walk.
+    ///
+    /// The other kinds are excluded:
+    /// - [`DepthExceeded`](Self::DepthExceeded) is per-evaluator too, but its
+    ///   bail point is the *current stack nesting*, which depends on how the
+    ///   node was reached rather than on the node alone, so a fresh boundary
+    ///   walk of the same key can converge where an inline one bailed. It stays
+    ///   excluded until that reproducibility is established.
+    /// - [`FuelExhausted`](Self::FuelExhausted),
+    ///   [`SolverStackFrames`](Self::SolverStackFrames),
+    ///   [`CrossEvalCycle`](Self::CrossEvalCycle), and
+    ///   [`QueryOpBudget`](Self::QueryOpBudget) are driven by process- or
+    ///   run-global budgets a fresh evaluator does **not** reset; their bail
+    ///   point moves with ambient state, so their partial is not reproducible
+    ///   from the key and must never be reused as if it were.
+    ///
+    /// Used to decide whether a guard-truncated partial may be retained in the
+    /// window-scoped per-query memo (see
+    /// [`EvaluationMemoResult::is_stable_for_per_query_memo`]). Durable,
+    /// depth-agnostic caches refuse every incomplete result regardless.
+    pub(crate) const fn is_boundary_intrinsic(self) -> bool {
+        matches!(self, Self::IterationExceeded)
+    }
+}
+
 /// Whether an evaluation walk ran to completion or was bounded short.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Termination {
@@ -248,6 +284,11 @@ impl EvaluationMemoResult {
 
     /// Construct a completed memo result read from a cache that stores only
     /// stable entries.
+    ///
+    /// Superseded in the per-query memo read path by [`Self::from_memoized_result`],
+    /// which preserves the stored termination verdict; retained for tests that
+    /// pin the stable-complete shape directly.
+    #[cfg(test)]
     pub(crate) const fn cached(type_id: TypeId) -> Self {
         Self {
             result: EvaluationResult::complete(type_id),
@@ -264,11 +305,6 @@ impl EvaluationMemoResult {
             request_stability: EvaluationRequestStability::IncompleteVerdict,
             cache_stability: EvaluationMemoStability::Unstable,
         }
-    }
-
-    #[cfg(test)]
-    pub(crate) const fn evaluation_result(self) -> EvaluationResult {
-        self.result
     }
 
     /// Whether the underlying evaluation walk was cut short by a guard
@@ -290,11 +326,54 @@ impl EvaluationMemoResult {
 
     /// Whether this result can be stored in the thread-local per-query memo.
     ///
-    /// `UnresolvedDef` remains visible to run-state gates such as closed-eval
-    /// publication, but a complete memo result is reusable within the same
-    /// coherent analysis window.
+    /// The per-query memo is window-scoped (cleared when a fresh top-level query
+    /// begins) and read only at cross-evaluator boundaries, where every walk
+    /// starts from a fresh per-instance guard. Two families qualify:
+    ///
+    /// * a converged result whose request state is window-safe (`Stable` /
+    ///   `UnresolvedDef`) — `UnresolvedDef` remains visible to run-state gates
+    ///   such as closed-eval publication, but a complete memo result is reusable
+    ///   within the same coherent analysis window; and
+    /// * a guard-truncated result whose bail is *boundary-intrinsic*
+    ///   ([`TerminationKind::is_boundary_intrinsic`]) — a fresh evaluator
+    ///   re-walking the same boundary key reproduces the identical opaque
+    ///   partial, so serving it from the window memo removes the cross-evaluator
+    ///   re-walk storm on deep recursive template-literal / conditional aliases
+    ///   without changing the emitted type. A hit reconstructs the incomplete
+    ///   verdict (see [`Self::from_memoized_result`]), so the partial stays out
+    ///   of durable, depth-agnostic caches exactly as an in-line bail would.
     pub(crate) const fn is_stable_for_per_query_memo(self) -> bool {
-        self.result.is_complete() && self.request_stability.is_stable_for_per_query_memo()
+        match self.result.termination() {
+            Termination::Complete => self.request_stability.is_stable_for_per_query_memo(),
+            Termination::Incomplete { kind, .. } => kind.is_boundary_intrinsic(),
+        }
+    }
+
+    /// The typed evaluation result this memo wraps.
+    pub(crate) const fn result(self) -> EvaluationResult {
+        self.result
+    }
+
+    /// Reconstruct a memo result from an [`EvaluationResult`] previously stored
+    /// in the window-scoped per-query memo.
+    ///
+    /// The stored result's termination verdict is preserved, so an opaque
+    /// boundary-intrinsic partial keeps its incomplete verdict on the way out:
+    /// [`Self::is_stable_for_depth_agnostic_cache`] stays `false` and downstream
+    /// consumers (the subtype checker's `eval_cache`, closed-eval publication)
+    /// refuse to promote it into a durable cache — identical to how they treat a
+    /// freshly-computed bail. A converged result round-trips as `Stable`.
+    pub(crate) const fn from_memoized_result(result: EvaluationResult) -> Self {
+        // A converged hit round-trips `Stable` (matching the pre-existing
+        // `cached()` read path); a stored boundary-intrinsic partial round-trips
+        // `IncompleteVerdict` so it keeps its taint and stays out of durable
+        // caches. `for_depth_agnostic_memo` owns the cache-stability derivation.
+        let request_stability = if result.is_complete() {
+            EvaluationRequestStability::Stable
+        } else {
+            EvaluationRequestStability::IncompleteVerdict
+        };
+        Self::for_depth_agnostic_memo(result, request_stability)
     }
 
     /// Collapse to the request's `TypeId` while preserving today's behavior for
@@ -354,7 +433,7 @@ mod tests {
             EvaluationRequestStability::Stable,
         );
 
-        assert_eq!(stable.evaluation_result(), complete);
+        assert_eq!(stable.result(), complete);
         assert_eq!(stable.type_id(), TypeId::STRING);
         assert_eq!(stable.into_type_id(), TypeId::STRING);
         assert_eq!(stable.cache_stability, EvaluationMemoStability::Stable);
@@ -438,10 +517,7 @@ mod tests {
 
         assert_eq!(cached.type_id(), TypeId::BOOLEAN);
         assert!(cached.is_stable_for_depth_agnostic_cache());
-        assert_eq!(
-            cached.evaluation_result().termination(),
-            Termination::Complete
-        );
+        assert_eq!(cached.result().termination(), Termination::Complete);
     }
 
     #[test]
@@ -452,5 +528,96 @@ mod tests {
         assert_eq!(result.into_type_id(), TypeId::STRING);
         assert!(!result.is_stable_for_depth_agnostic_cache());
         assert!(!result.is_stable_for_per_query_memo());
+    }
+
+    #[test]
+    fn boundary_intrinsic_names_the_iteration_bail_only() {
+        // The per-evaluator total-work counter resets at every fresh-evaluator
+        // boundary, so an iteration bail reproduces from the key alone.
+        assert!(TerminationKind::IterationExceeded.is_boundary_intrinsic());
+        // Depth is per-evaluator but reach-dependent; ambient/global budgets do
+        // not reset per evaluator — all stay excluded.
+        assert!(!TerminationKind::DepthExceeded.is_boundary_intrinsic());
+        assert!(!TerminationKind::FuelExhausted.is_boundary_intrinsic());
+        assert!(!TerminationKind::SolverStackFrames.is_boundary_intrinsic());
+        assert!(!TerminationKind::CrossEvalCycle.is_boundary_intrinsic());
+        assert!(!TerminationKind::QueryOpBudget.is_boundary_intrinsic());
+    }
+
+    #[test]
+    fn per_query_memo_retains_boundary_intrinsic_partials_but_never_durably() {
+        // A converged result keeps the pre-existing behavior: window- and
+        // depth-agnostic-cacheable.
+        let complete = EvaluationMemoResult::for_depth_agnostic_memo(
+            EvaluationResult::complete(TypeId::STRING),
+            EvaluationRequestStability::Stable,
+        );
+        assert!(complete.is_stable_for_per_query_memo());
+        assert!(complete.is_stable_for_depth_agnostic_cache());
+
+        // A boundary-intrinsic bail is retained in the window memo (kills the
+        // re-walk storm) but stays out of every durable cache.
+        let partial = EvaluationMemoResult::for_depth_agnostic_memo(
+            EvaluationResult::incomplete(TypeId::NUMBER, TerminationKind::IterationExceeded),
+            EvaluationRequestStability::IncompleteVerdict,
+        );
+        assert!(
+            partial.is_stable_for_per_query_memo(),
+            "iteration-exceeded partial should be window-retainable"
+        );
+        assert!(
+            !partial.is_stable_for_depth_agnostic_cache(),
+            "iteration-exceeded partial must never reach a durable cache"
+        );
+        assert_eq!(partial.into_type_id(), TypeId::NUMBER);
+
+        // Reach-dependent and ambient/global-budget bails stay excluded from the
+        // window memo too, so a budget-dependent partial is never reused as a
+        // converged answer.
+        for kind in [
+            TerminationKind::DepthExceeded,
+            TerminationKind::FuelExhausted,
+            TerminationKind::SolverStackFrames,
+            TerminationKind::CrossEvalCycle,
+            TerminationKind::QueryOpBudget,
+        ] {
+            let partial = EvaluationMemoResult::for_depth_agnostic_memo(
+                EvaluationResult::incomplete(TypeId::NUMBER, kind),
+                EvaluationRequestStability::IncompleteVerdict,
+            );
+            assert!(
+                !partial.is_stable_for_per_query_memo(),
+                "{kind:?} partial must not be window-retained"
+            );
+            assert!(!partial.is_stable_for_depth_agnostic_cache());
+        }
+    }
+
+    #[test]
+    fn from_memoized_result_preserves_the_stored_verdict() {
+        // A converged stored result round-trips as fully stable.
+        let complete =
+            EvaluationMemoResult::from_memoized_result(EvaluationResult::complete(TypeId::BOOLEAN));
+        assert_eq!(complete.type_id(), TypeId::BOOLEAN);
+        assert!(complete.is_stable_for_depth_agnostic_cache());
+        assert!(complete.is_stable_for_per_query_memo());
+
+        // A stored boundary-intrinsic partial comes back out still incomplete:
+        // window-retainable but refused by durable caches, so a hit is never
+        // promoted into a depth-agnostic cache as if it were converged.
+        let partial = EvaluationMemoResult::from_memoized_result(EvaluationResult::incomplete(
+            TypeId::NUMBER,
+            TerminationKind::IterationExceeded,
+        ));
+        assert_eq!(partial.into_type_id(), TypeId::NUMBER);
+        assert!(!partial.is_stable_for_depth_agnostic_cache());
+        assert!(partial.is_stable_for_per_query_memo());
+        assert_eq!(
+            partial.result().termination(),
+            Termination::Incomplete {
+                kind: TerminationKind::IterationExceeded,
+                partial: TypeId::NUMBER,
+            }
+        );
     }
 }

--- a/crates/tsz-solver/src/evaluation/session.rs
+++ b/crates/tsz-solver/src/evaluation/session.rs
@@ -10,6 +10,7 @@
 //! delegation without implicit global state.
 
 use crate::evaluation::request::EvaluationCacheKey;
+use crate::evaluation::result::EvaluationResult;
 use crate::types::TypeId;
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
@@ -213,7 +214,13 @@ pub struct EvaluationSession {
     /// `TypeId`s currently expanded by fresh evaluators in this session.
     cross_eval_active: InFlightTypeCounter,
     /// Per-top-level-query memo for stable fresh-evaluator results.
-    query_memo: RefCell<FxHashMap<EvaluationCacheKey, TypeId>>,
+    ///
+    /// Stores the full [`EvaluationResult`] — not just the `TypeId` — so a
+    /// retained boundary-intrinsic partial (see
+    /// [`EvaluationMemoResult::is_stable_for_per_query_memo`](crate::evaluation::result::EvaluationMemoResult::is_stable_for_per_query_memo))
+    /// carries its termination verdict back out on a hit and never leaks into a
+    /// durable cache as if it were converged.
+    query_memo: RefCell<FxHashMap<EvaluationCacheKey, EvaluationResult>>,
     /// In-flight expansion count per `Application` node across every
     /// evaluator instance in this session. A fresh evaluator re-entering a
     /// node that [`MAX_CROSS_EVAL_APPLICATION_EXPANSION`] instances are
@@ -644,13 +651,13 @@ impl EvaluationSession {
 
     /// Look up a stable fresh-evaluator result for the current top-level query.
     #[inline]
-    pub(crate) fn query_memo_get(&self, key: EvaluationCacheKey) -> Option<TypeId> {
+    pub(crate) fn query_memo_get(&self, key: EvaluationCacheKey) -> Option<EvaluationResult> {
         self.query_memo.borrow().get(&key).copied()
     }
 
     /// Record a stable fresh-evaluator result for the current top-level query.
     #[inline]
-    pub(crate) fn query_memo_put(&self, key: EvaluationCacheKey, result: TypeId) {
+    pub(crate) fn query_memo_put(&self, key: EvaluationCacheKey, result: EvaluationResult) {
         self.query_memo.borrow_mut().insert(key, result);
     }
 
@@ -886,15 +893,21 @@ mod tests {
         let exact_optional_key = EvaluationCacheKey::new(type_id, false, true);
         let both_key = EvaluationCacheKey::new(type_id, true, true);
 
-        session.query_memo_put(default_key, TypeId(210));
-        session.query_memo_put(no_unchecked_key, TypeId(211));
-        session.query_memo_put(exact_optional_key, TypeId(212));
+        session.query_memo_put(default_key, EvaluationResult::complete(TypeId(210)));
+        session.query_memo_put(no_unchecked_key, EvaluationResult::complete(TypeId(211)));
+        session.query_memo_put(exact_optional_key, EvaluationResult::complete(TypeId(212)));
 
-        assert_eq!(session.query_memo_get(default_key), Some(TypeId(210)));
-        assert_eq!(session.query_memo_get(no_unchecked_key), Some(TypeId(211)));
+        assert_eq!(
+            session.query_memo_get(default_key),
+            Some(EvaluationResult::complete(TypeId(210)))
+        );
+        assert_eq!(
+            session.query_memo_get(no_unchecked_key),
+            Some(EvaluationResult::complete(TypeId(211)))
+        );
         assert_eq!(
             session.query_memo_get(exact_optional_key),
-            Some(TypeId(212))
+            Some(EvaluationResult::complete(TypeId(212)))
         );
         assert_eq!(session.query_memo_get(both_key), None);
 


### PR DESCRIPTION
When checking deep recursive template-literal / conditional type-level programs (hotscript), the per-query fresh-evaluator memo refuses every guard-truncated result; tsc/tsgo converge in ~250ms while tsz spun into an O(references × deep-walk) re-walk storm. When a fresh evaluator hits its per-instance iteration budget (`RecursionResult::IterationExceeded`) it surfaces an opaque, relation-preserving partial and marks the result `Termination::Incomplete`. `is_stable_for_per_query_memo` required `is_complete()`, so that partial was never memoized — every repeated cross-evaluator reference to the same recursive alias spun up a fresh evaluator and re-walked from scratch, and each re-walk re-blew the iteration budget.

**Structural rule:** when a fresh evaluator's per-instance iteration counter (which begins at zero at every cross-evaluator boundary) trips on a boundary key, tsc reuses the already-computed result; tsz now retains that opaque partial in the window-scoped per-query memo through the solver's `TypeEvaluator` / `cross_eval_guard` owner layer. An `IterationExceeded` bail is *boundary-intrinsic*: the counter measures that evaluator's total enter attempts, so for a given key it trips at the same point no matter which evaluator walks it — the partial is reproducible from the key, and retaining it cannot change the emitted type.

### Owner layer
Solver evaluation / per-query memo (`crates/tsz-solver/src/evaluation/{result.rs, session.rs, cross_eval_guard.rs}`).

### What changed
- Add `TerminationKind::is_boundary_intrinsic` (home: the discriminant that names which guard fired). Only `IterationExceeded` qualifies today; `DepthExceeded` is per-evaluator but reach-dependent, and the fuel / solver-stack-frame / cross-eval-cycle / query-op budgets are process- or run-global and do not reset per evaluator, so all stay excluded.
- Store the full `EvaluationResult` (verdict + type) in the per-query memo instead of a bare `TypeId`, and reconstruct via `from_memoized_result` on a hit, so a retained partial keeps its incomplete verdict on the way out. Durable, depth-agnostic caches (the subtype checker's `eval_cache`, closed-eval publication) refuse it exactly as they refuse a freshly-computed bail — no partial leaks into a run-global cache as if it were converged.

### Adjacent cases
`from_memoized_result` / `is_stable_for_per_query_memo` are exercised across all six `TerminationKind`s plus the converged and `UnresolvedDef` paths: retain (`IterationExceeded`), refuse-window (the other five kinds), refuse-durable (every incomplete kind), and round-trip verdict preservation.

## Goal
Goal: fast

## Verification
- `cargo test -p tsz-solver --lib` — same failure set as `main` (5 pre-existing failures tracked in #15398's sibling #15338: `test_conditional_infer_optional_property_present_distributive`, `literal_mask_preserves_object_vs_literal_reduction`, two `array_isarray_narrows_readonly_array_application_*`, `free_infer_policy_skips_generic_signature_bodies`), **plus 3 new passing tests** pinning the retain / refuse-durable / round-trip contract. No new failures.
- `cargo clippy -p tsz-solver --lib --all-targets` — clean.
- Verdict-preserving by construction: a stored partial round-trips `IncompleteVerdict`, so emit/diagnostics are unchanged; ready-review CI owns the broad conformance/emit/fourslash parity floor.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_017G1ccnFqmsX8cTvkCLFika)_