### PR TITLE
fix(checker): drill satisfies elaboration into nested object/array/arrow property values

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2002,6 +2002,9 @@ path = "tests/issue_9785_const_type_param_satisfies_repro.rs"
 name = "issue_9730_readonly_array_element_inference_repro"
 path = "tests/issue_9730_readonly_array_element_inference_repro.rs"
 [[test]]
+name = "satisfies_nested_source_elaboration_tests"
+path = "tests/satisfies_nested_source_elaboration_tests.rs"
+[[test]]
 name = "satisfies_object_property_position_tests"
 path = "tests/satisfies_object_property_position_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -381,14 +381,19 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // For array literal sources, drill into element-level errors, matching
-        // tsc's `elaborateElementwise` behavior. Check the unwrapped source so
-        // equivalent forms like `([10, "20"]) satisfies number[]` and
-        // `([10, "20"] as (number | string)[]) satisfies number[]` use the same
-        // element elaboration path.
-        let unwrapped_source_idx = self.ctx.arena.skip_parenthesized_and_assertions(source_idx);
-        if let Some(node) = self.ctx.arena.get(unwrapped_source_idx)
-            && node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+        // For the other fresh source kinds that tsc's `elaborateError` drills into
+        // — array literals and expression-bodied arrow / function expressions —
+        // route through the same assignment-source elaboration boundary the
+        // direct-assignment path uses. tsc runs the identical `elaborateError` for
+        // a `satisfies` operand as for an assignment (only the outer error code and
+        // keyword anchor differ), so `[10, "20"] satisfies number[]` reports TS2322
+        // at the offending element and `(() => 1) satisfies () => string` reports
+        // TS2322 at the arrow's returned expression, instead of the coarse
+        // whole-expression TS1360. Block-bodied functions (where tsc keeps the
+        // coarse TS1360) and every non-drilling source fall through to the TS1360
+        // report below. (Object-literal sources took the dedicated
+        // `elaborate_satisfies_object_literal` path above.)
+        if self.satisfies_source_drills_to_inner_anchor(source_idx)
             && self.try_elaborate_assignment_source_error(source_idx, target)
         {
             return false;
@@ -396,6 +401,42 @@ impl<'a> CheckerState<'a> {
 
         self.error_type_does_not_satisfy_the_expected_type(source, target, diag_idx, keyword_pos);
         false
+    }
+
+    /// Whether a `satisfies` source expression drills into an inner node under
+    /// tsc's `elaborateElementwise` / `elaborateArrowFunction`, producing a
+    /// nested `TS2322` anchor (rather than the coarse whole-expression frame).
+    ///
+    /// Object and array literals always drill (into a property or an element).
+    /// A function expression drills only when its body is an *expression* — tsc's
+    /// `elaborateArrowFunction` bails on a block body and keeps the
+    /// function-level frame, so a block-bodied arrow/function value must fall
+    /// through to the coarse report (`TS1360` at the keyword for a direct source,
+    /// or the function-level `TS2322` at the property name for an object-literal
+    /// member) instead of being drilled here. Parentheses and assertions are
+    /// transparent, matching the boundary's own `skip_parenthesized_and_assertions`.
+    fn satisfies_source_drills_to_inner_anchor(&self, source_idx: NodeIndex) -> bool {
+        let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(source_idx);
+        let Some(node) = self.ctx.arena.get(expr_idx) else {
+            return false;
+        };
+        match node.kind {
+            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                || k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION =>
+            {
+                true
+            }
+            k if k == syntax_kind_ext::ARROW_FUNCTION
+                || k == syntax_kind_ext::FUNCTION_EXPRESSION =>
+            {
+                self.ctx
+                    .arena
+                    .get_function(node)
+                    .and_then(|func| self.ctx.arena.get(func.body))
+                    .is_some_and(|body| body.kind != syntax_kind_ext::BLOCK)
+            }
+            _ => false,
+        }
     }
 
     /// Elaborate a `satisfies` failure for object literal expressions by checking
@@ -503,6 +544,24 @@ impl<'a> CheckerState<'a> {
                     // Excess property errors were reported — skip assignability check
                     continue;
                 }
+            }
+
+            // tsc's `elaborateElementwise` recurses into a property value that is
+            // itself a fresh object/array literal or an expression-bodied arrow,
+            // anchoring the mismatch at the innermost node — a nested property, an
+            // array element, or the arrow's returned expression — rather than
+            // reporting the whole property-value type. Route those values through
+            // the same assignment-source elaboration boundary the direct-assignment
+            // path uses so `satisfies` and assignment stay in lockstep. It is
+            // relation-gated (emits only on a genuine nested mismatch), so a passing
+            // value falls through to the leaf report below. Values that do not drill
+            // (a leaf primitive, a block-bodied function whose function-level frame
+            // tsc keeps at the property name) are excluded so the leaf report owns
+            // their anchor and elaboration chain.
+            if self.satisfies_source_drills_to_inner_anchor(prop_value_idx)
+                && self.try_elaborate_assignment_source_error(prop_value_idx, target_prop_type)
+            {
+                continue;
             }
 
             let _ = self.check_assignable_or_report_at_exact_anchor_without_source_elaboration(

--- a/crates/tsz-checker/tests/satisfies_nested_source_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/satisfies_nested_source_elaboration_tests.rs
@@ -1,0 +1,281 @@
+//! Regression tests: `satisfies` elaboration drills into nested literal / array
+//! / arrow-function property values the same way a direct assignment does.
+//!
+//! Structural rule: tsc runs the *same* `elaborateError` for a `satisfies`
+//! operand as for an assignment (only the outer error code / keyword anchor
+//! differ). When a property value is itself a fresh object literal, an array
+//! literal, or an expression-bodied arrow, tsc's `elaborateElementwise` /
+//! `elaborateArrowFunction` recurse and anchor the `TS2322` at the innermost
+//! mismatch — a nested property name, an array element, or the arrow's returned
+//! expression — instead of the coarse whole-property (or whole-expression
+//! `TS1360`) frame. tsz previously stopped one level in for `satisfies`, so it
+//! reported the whole property-value type mismatch while assignment drilled.
+//!
+//! Owner layer: checker assignability elaboration
+//! (`elaborate_satisfies_object_literal` /
+//! `check_satisfies_assignable_or_report` routing through the shared
+//! `try_elaborate_assignment_source_error` boundary).
+//!
+//! All fixtures vary binder names and pair every drilled case against the
+//! divergence witnessed with `tsc` 6.0.2; positive controls (leaf primitive at
+//! property name, excess property TS2353, direct-primitive TS1360,
+//! annotated-param / method function-level frame) and valid no-error cases are
+//! included so the drill cannot over-reach.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source;
+
+fn diagnostics(source: &str) -> Vec<Diagnostic> {
+    check_source(source, "test.ts", CheckerOptions::default())
+}
+
+fn with_code(source: &str, code: u32) -> Vec<Diagnostic> {
+    diagnostics(source)
+        .into_iter()
+        .filter(|diag| diag.code == code)
+        .collect()
+}
+
+fn line_col(source: &str, start: u32) -> (usize, usize) {
+    let start = start as usize;
+    let line = source[..start].bytes().filter(|b| *b == b'\n').count() + 1;
+    let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);
+    (line, start - line_start + 1)
+}
+
+/// The `TS2322` must anchor exactly at `needle` in `source` (0-based byte
+/// offset of the innermost mismatch), with no residual `TS1360`.
+fn assert_single_ts2322_at(source: &str, needle: &str) {
+    let ts2322 = with_code(source, 2322);
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322, got: {ts2322:?}"
+    );
+    let expected = source.find(needle).expect("fixture contains the anchor");
+    assert_eq!(
+        ts2322[0].start as usize,
+        expected,
+        "TS2322 anchored at {:?}, expected the innermost node at {:?}",
+        line_col(source, ts2322[0].start),
+        line_col(source, expected as u32),
+    );
+    assert!(
+        with_code(source, 1360).is_empty(),
+        "nested drill-in must suppress the coarse TS1360"
+    );
+}
+
+#[test]
+fn nested_object_property_value_drills_to_inner_property() {
+    // `{ a: { b: 1 } } satisfies { a: { b: string } }` — tsc anchors at inner `b`.
+    let source = "const cfg = { outer: { leaf: 1 } } satisfies { outer: { leaf: string } };\n";
+    assert_single_ts2322_at(source, "leaf: 1");
+    // The anchor is the inner property name, not the outer one.
+    let ts2322 = with_code(source, 2322);
+    assert_eq!(line_col(source, ts2322[0].start), (1, 24));
+}
+
+#[test]
+fn three_level_nested_object_drills_to_deepest_property() {
+    let source = "const deep = { p: { q: { r: 1 } } } satisfies { p: { q: { r: string } } };\n";
+    assert_single_ts2322_at(source, "r: 1");
+}
+
+#[test]
+fn arrow_property_value_drills_to_returned_expression() {
+    // `{ handler: () => 7 } satisfies { handler: () => string }`.
+    let source = "const svc = { handler: () => 7 } satisfies { handler: () => string };\n";
+    assert_single_ts2322_at(source, "7");
+    assert!(
+        with_code(source, 2322)[0].message_text.contains("'number'"),
+        "message drills to the returned number, not the function type"
+    );
+}
+
+#[test]
+fn renamed_arrow_property_value_uses_same_path() {
+    // Varied binder names — the drill is structural, not name-driven.
+    let source = "const widget = { onTick: () => true } satisfies { onTick: () => string };\n";
+    assert_single_ts2322_at(source, "true");
+    assert!(
+        with_code(source, 2322)[0]
+            .message_text
+            .contains("'boolean'")
+    );
+}
+
+#[test]
+fn nested_arrow_property_value_drills_two_levels() {
+    let source =
+        "const shell = { inner: { run: () => 1 } } satisfies { inner: { run: () => string } };\n";
+    assert_single_ts2322_at(source, "1");
+}
+
+#[test]
+fn array_literal_property_element_drills_to_offending_element() {
+    let source = "const bag = { items: [3, \"z\"] } satisfies { items: number[] };\n";
+    assert_single_ts2322_at(source, "\"z\"");
+    assert!(
+        with_code(source, 2322)[0].message_text.contains("'string'"),
+        "drills to the string element, not the whole array"
+    );
+}
+
+#[test]
+fn direct_parenthesized_arrow_satisfies_drills_to_body() {
+    // Non-object-literal source: the whole `satisfies` operand is an arrow.
+    let source = "const fn = (() => 5) satisfies (() => string);\n";
+    assert_single_ts2322_at(source, "5");
+}
+
+// ---- controls: leaf anchoring and coarse frames that must NOT change ----
+
+#[test]
+fn primitive_property_value_anchors_at_property_name() {
+    // Leaf primitive value: tsc anchors at the property name, still TS2322.
+    let source = "const okish = { count: 1 } satisfies { count: string };\n";
+    let ts2322 = with_code(source, 2322);
+    assert_eq!(ts2322.len(), 1, "got: {ts2322:?}");
+    assert_eq!(
+        ts2322[0].start as usize,
+        source.find("count: 1").expect("fixture"),
+        "primitive leaf stays anchored at the property name"
+    );
+    assert!(with_code(source, 1360).is_empty());
+}
+
+#[test]
+fn excess_property_still_reports_ts2353() {
+    let source = "const extra = { x: 1, y: 2 } satisfies { x: number };\n";
+    assert_eq!(
+        with_code(source, 2353).len(),
+        1,
+        "excess property TS2353 preserved"
+    );
+    assert!(
+        with_code(source, 2322).is_empty() && with_code(source, 1360).is_empty(),
+        "TS2353 suppresses the assignability frames"
+    );
+}
+
+#[test]
+fn direct_primitive_satisfies_keeps_ts1360() {
+    // No nested structure to drill into: the coarse TS1360 must remain.
+    let source = "const s = \"hello\" satisfies number;\n";
+    assert_eq!(
+        with_code(source, 1360).len(),
+        1,
+        "primitive satisfies stays TS1360"
+    );
+    assert!(with_code(source, 2322).is_empty());
+}
+
+#[test]
+fn index_signature_reports_each_property() {
+    // Inline index signature (no lib dependency) — each property value is
+    // checked against the string index value type and drills to its own TS2322.
+    let source = "const rec = { a: 1, b: 2 } satisfies { [k: string]: string };\n";
+    assert_eq!(
+        with_code(source, 2322).len(),
+        2,
+        "each index-signature property value mismatches"
+    );
+    assert!(with_code(source, 1360).is_empty());
+}
+
+#[test]
+fn annotated_param_arrow_keeps_function_level_frame() {
+    // tsc's `elaborateArrowFunction` bails when a parameter is annotated, so the
+    // mismatch stays at the function-type level anchored at the property name.
+    let source = "const a = { fn: (n: number) => 1 } satisfies { fn: (n: number) => string };\n";
+    let ts2322 = with_code(source, 2322);
+    assert_eq!(ts2322.len(), 1, "got: {ts2322:?}");
+    assert_eq!(
+        ts2322[0].start as usize,
+        source.find("fn: (n").expect("fixture"),
+        "annotated-param arrow anchors at the property name, function-level"
+    );
+    assert!(
+        ts2322[0].message_text.contains("=>"),
+        "message is the whole function type, not the drilled return"
+    );
+}
+
+#[test]
+fn method_shorthand_keeps_function_level_frame() {
+    // Method (block body) — tsc keeps the function-level frame at the method name.
+    let source = "const o = { m() { return 1; } } satisfies { m: () => string };\n";
+    let ts2322 = with_code(source, 2322);
+    assert_eq!(ts2322.len(), 1, "got: {ts2322:?}");
+    assert_eq!(
+        ts2322[0].start as usize,
+        source.find("m()").expect("fixture"),
+        "method anchors at the method name"
+    );
+}
+
+#[test]
+fn block_bodied_arrow_property_keeps_function_level_frame() {
+    // tsc's `elaborateArrowFunction` only elaborates *expression* bodies; a block
+    // body keeps the function-level TS2322 anchored at the property name (with the
+    // nested return chain), never drilling to the `return` statement.
+    let source = "const o = { fn: () => { return 1; } } satisfies { fn: () => string };\n";
+    let ts2322 = with_code(source, 2322);
+    assert_eq!(ts2322.len(), 1, "got: {ts2322:?}");
+    assert_eq!(
+        ts2322[0].start as usize,
+        source.find("fn: () =>").expect("fixture"),
+        "block-bodied arrow anchors at the property name, function-level"
+    );
+    assert!(
+        ts2322[0].message_text.contains("=>"),
+        "message is the whole function type, not a drilled return"
+    );
+    assert!(with_code(source, 1360).is_empty());
+}
+
+#[test]
+fn direct_block_bodied_arrow_satisfies_keeps_ts1360() {
+    // A direct block-bodied arrow does not drill, so the coarse TS1360 remains.
+    let source = "const f = (() => { return 1; }) satisfies (() => string);\n";
+    assert_eq!(
+        with_code(source, 1360).len(),
+        1,
+        "block-body direct arrow stays TS1360"
+    );
+    assert!(with_code(source, 2322).is_empty());
+}
+
+// ---- valid cases: must stay completely error-free ----
+
+#[test]
+fn valid_nested_object_satisfies_reports_nothing() {
+    let source = "const good = { a: { b: \"x\" } } satisfies { a: { b: string } };\n";
+    assert!(
+        diagnostics(source).is_empty(),
+        "got: {:?}",
+        diagnostics(source)
+    );
+}
+
+#[test]
+fn valid_arrow_property_satisfies_reports_nothing() {
+    let source = "const good = { fn: () => \"x\" } satisfies { fn: () => string };\n";
+    assert!(
+        diagnostics(source).is_empty(),
+        "got: {:?}",
+        diagnostics(source)
+    );
+}
+
+#[test]
+fn valid_array_property_satisfies_reports_nothing() {
+    let source = "const good = { items: [1, 2, 3] } satisfies { items: number[] };\n";
+    assert!(
+        diagnostics(source).is_empty(),
+        "got: {:?}",
+        diagnostics(source)
+    );
+}


### PR DESCRIPTION
Fixes #15471.

`tsc` runs the *same* `elaborateError` for a `satisfies` operand as for a direct
assignment — only the outer error code (`TS1360` vs `TS2322`/`TS2345`) and the
keyword anchor differ. tsz's `satisfies` path stopped one level in:
`elaborate_satisfies_object_literal` checked each property value **without source
elaboration** (function-level frame at the property), and
`check_satisfies_assignable_or_report` only drilled array-literal sources. So a
property value that is itself a nested object literal, an array literal, or an
expression-bodied arrow — and a direct expression-bodied arrow source — reported
the coarse whole-property (or whole-expression `TS1360`) frame where `tsc` drills
to the inner mismatch and where plain assignment **already** drilled.

**Structural rule:** when a `satisfies` source (or an object-literal property
value inside it) drills under tsc's `elaborateElementwise` / `elaborateArrowFunction`
— an object literal (into a property), an array literal (into an element), or a
function expression **with an expression body** (into the returned expression) —
`tsc` anchors the inner `TS2322` there and suppresses the coarse frame. tsz now
routes those through the shared `try_elaborate_assignment_source_error` boundary
the assignment path already uses, gated by a new
`satisfies_source_drills_to_inner_anchor` predicate. Block-bodied arrows/functions
(where `tsc`'s `elaborateArrowFunction` bails and keeps the function-level frame),
leaf primitives, and non-drilling sources fall through to the existing coarse
report unchanged. Display-only plus anchor placement; no relation-semantics change.

**Owner layer:** checker assignability elaboration
(`crates/tsz-checker/src/assignability/assignability_diagnostics.rs`).

### Divergence matrix (tsc 6.0.2 — parity after fix)

| case | tsc / tsz-after | tsz-before |
|---|---|---|
| `{ a: { b: 1 } } satisfies { a: { b: string } }` | inner `b`, TS2322 | outer `a`, TS2322 + chain |
| `{ p: { q: { r: 1 } } } satisfies …` (3 levels) | deepest `r` | outer `p` |
| `{ handler: () => 7 } satisfies { handler: () => string }` | returned `7` | property, function-level |
| `{ a: { fn: () => 1 } } satisfies …` | returned `1` | outer `a` |
| `{ items: [3, "z"] } satisfies { items: number[] }` | element `"z"` | property, whole array |
| `(() => 5) satisfies (() => string)` (direct) | returned `5`, TS2322 | TS1360 whole function |
| **controls (unchanged)** | | |
| `{ x: 1 } satisfies { x: string }` (leaf primitive) | property name, TS2322 | ✓ |
| `{ x: 1, y: 2 } satisfies { x: number }` (excess) | TS2353 | ✓ |
| `"hello" satisfies number` (direct primitive) | TS1360 | ✓ |
| `{ fn: (n: number) => 1 } satisfies …` (annotated param) | property, function-level | ✓ |
| `{ m() { return 1 } } satisfies …` (method / block) | method name, function-level | ✓ |
| `{ fn: () => { return 1; } } satisfies …` (block body) | property, function-level | ✓ |
| `(() => { return 1; }) satisfies (() => string)` (direct block) | TS1360 | ✓ |

### Adjacent-case matrix (varied binder names, controls)
New regression suite `satisfies_nested_source_elaboration_tests` (18 tests): nested
object (2 levels + 3 levels), arrow-return (renamed binders), array element,
two-level nested arrow, direct expression arrow; controls for leaf primitive,
excess `TS2353`, direct primitive `TS1360`, index-signature per-property,
annotated-param and method function-level frames, block-bodied arrow (object-member
and direct); and three valid no-error cases.

### Follow-up (out of scope)
The block-body policy could alternatively be threaded as an `allow_block_function_bodies`
option through the shared `try_elaborate_assignment_source_error` boundary
(mirroring `allow_unresolved_holes`) instead of a caller-side predicate. Deferred:
it changes the shared assignment/call-arg boundary signature and all its callers
(broader blast radius), and the explicit object/array/expression-function
enumeration faithfully mirrors tsc's fixed satisfies drill set.

## Goal
Goal: hold

## Verification
- New suite `cargo test -p tsz-checker --test satisfies_nested_source_elaboration_tests` — 18 passed.
- Adjacent suites unchanged: `satisfies_object_property_position_tests` (6), `satisfies_elaboration_chain_tests` (3), `arrow_conditional_body_return_elaboration_tests` (5), `union_source_structural_elaboration_tests` (21), `array_source_tuple_target_elaboration_tests` (10), `elaboration_wrapper_init_tests` (6), `deep_partial_optional_leaf_elaboration_tests` (8).
- `cargo clippy -p tsz-checker --lib --tests` — clean.
- Differential vs `tsc` 6.0.2 across the full matrix above — parity (line, column, message).
- Pre-existing local failures in `optional_property_required_elaboration_tests` (5) were confirmed identical on clean `origin/main` (plain `b = a` assignments, untouched by this change; part of the #15338 CI-disabled local-red set).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01NE6krFf18CNap3Tgy5FWFd)_