### PR TITLE
refactor(checker): drop dead type-guard fixture rewrite; cover narrowing natively (#14141)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2243,6 +2243,9 @@ path = "tests/ts2315_imported_generic_tests.rs"
 name = "type_guard_mutable_field_probe_tests"
 path = "tests/type_guard_mutable_field_probe_tests.rs"
 [[test]]
+name = "type_guard_union_interface_narrowing_tests"
+path = "tests/type_guard_union_interface_narrowing_tests.rs"
+[[test]]
 name = "index_signature_type_check_probe_tests"
 path = "tests/index_signature_type_check_probe_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -773,7 +773,6 @@ impl CheckerState<'_> {
         self.align_awaited_type_instantiation_diagnostics(&sf.text);
         self.align_evolving_array_inference_diagnostics(&sf.text);
         self.align_type_inference_literal_union_diagnostics(&sf.text);
-        self.align_type_guard_interface_diagnostics(&sf.text);
         self.align_complex_recursive_collections_diagnostics(&sf.text);
         self.align_jsx_element_type_diagnostics(&sf.text);
     }
@@ -1106,50 +1105,6 @@ impl CheckerState<'_> {
                         .message_text
                         .contains("[Primitive | Numeric, Primitive | Numeric]"))
         });
-    }
-
-    fn align_type_guard_interface_diagnostics(&mut self, source_text: &str) {
-        use tsz_common::diagnostics::{Diagnostic, diagnostic_codes};
-
-        if !Self::fixture_has_markers(
-            source_text,
-            &[
-                "function isC2(x: any): x is C2",
-                "var c1Orc2: C1 | C2;",
-                "num = isC2(c1Orc2) && c1Orc2.p2;",
-            ],
-        ) {
-            return;
-        }
-
-        self.ctx.diagnostics.retain(|diag| {
-            !(diag.code == diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE
-                && diag.message_text == "Property 'p2' does not exist on type 'C1 | C2'.")
-        });
-
-        let Some(start) = source_text
-            .find("num = isC2(c1Orc2) && c1Orc2.p2;")
-            .map(|pos| pos as u32)
-        else {
-            return;
-        };
-        let code = diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE;
-        let message = "Type 'number | false' is not assignable to type 'number'.";
-        if self
-            .ctx
-            .diagnostics
-            .iter()
-            .any(|diag| diag.code == code && diag.start == start && diag.message_text == message)
-        {
-            return;
-        }
-        self.ctx.diagnostics.push(Diagnostic::error(
-            self.ctx.file_name.clone(),
-            start,
-            3,
-            message,
-            code,
-        ));
     }
 
     fn align_complex_recursive_collections_diagnostics(&mut self, source_text: &str) {

--- a/crates/tsz-checker/tests/type_guard_union_interface_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/type_guard_union_interface_narrowing_tests.rs
@@ -1,0 +1,110 @@
+//! Native narrowing coverage for the `guard(x) && x.member` pattern over a
+//! union of interface types.
+//!
+//! Rule under test:
+//!
+//! > When a user-defined type guard `g(x): x is T` gates the right operand of
+//! > `&&`, the union-typed operand narrows to `T` in that operand, so a member
+//! > access that only exists on `T` is valid, and the `&&` expression's type is
+//! > `false | <member type>`.
+//!
+//! This behavior used to be faked for one TypeScript conformance fixture
+//! (`typeGuardOfFormIsTypeOnInterfaces`) by a source-text-gated diagnostic
+//! rewrite (`align_type_guard_interface_diagnostics`) in
+//! `state_checking/source_file.rs`, matching hardcoded identifier strings
+//! (`isC2`, `c1Orc2`, `C1 | C2`). The solver now narrows this pattern
+//! natively, so that rewrite was dead and has been removed (see #14141). These
+//! tests pin the *structural* rule with distinct binder spellings so no future
+//! regression can silently reintroduce the need for a fixture-scoped hack.
+
+use tsz_checker::test_utils::{
+    check_source_strict_messages as check_strict, has_any_diagnostic_code,
+    has_diagnostic_code_message,
+};
+
+/// A "property does not exist" error (TS2339, or TS7053 implicit-any index)
+/// on the guarded member would mean narrowing never reached it.
+fn assert_narrowing_reached_member(diags: &[(u32, String)]) {
+    assert!(
+        !has_any_diagnostic_code(diags, &[2339, 7053]),
+        "narrowing should reach the guarded member; got: {diags:?}"
+    );
+}
+
+/// The guarded member access is valid and the `&&` result (`false | number`)
+/// is rejected against a `number` annotation.
+fn assert_false_number_mismatch(diags: &[(u32, String)]) {
+    assert_narrowing_reached_member(diags);
+    assert!(
+        diags.iter().any(|(code, msg)| *code == 2322
+            && msg.contains("'number | false'")
+            && msg.contains("'number'")),
+        "expected TS2322 for `number | false` vs `number`; got: {diags:?}"
+    );
+}
+
+/// Two-member union, guard narrows to the member carrying the accessed
+/// property. Binders deliberately differ from the conformance fixture.
+#[test]
+fn guard_and_member_narrows_two_member_union_and_reports_false_union_mismatch() {
+    let source = r#"
+interface Alpha { a: string; }
+interface Beta { b: number; }
+declare function isBeta(x: unknown): x is Beta;
+function f(ab: Alpha | Beta) {
+    const n: number = isBeta(ab) && ab.b;
+    return n;
+}
+"#;
+    assert_false_number_mismatch(&check_strict(source));
+}
+
+/// Same rule where the guard target extends another union member; the unique
+/// property lives on the extending interface.
+#[test]
+fn guard_and_member_narrows_to_extending_interface_member() {
+    let source = r#"
+interface One { p1: string; }
+interface Two { p2: number; }
+interface Three extends One { p3: number; }
+declare function isThree(x: unknown): x is Three;
+function g(u: Two | Three) {
+    const m: number = isThree(u) && u.p3;
+    return m;
+}
+"#;
+    assert_false_number_mismatch(&check_strict(source));
+}
+
+/// Pure narrowing: when the `&&` result is not constrained by an annotation,
+/// the guarded member access alone must be clean.
+#[test]
+fn guard_and_member_access_alone_is_clean() {
+    let source = r#"
+interface Dog { bark(): void; }
+interface Cat { meow(): void; }
+declare function isCat(x: unknown): x is Cat;
+function h(pet: Dog | Cat) {
+    const ok = isCat(pet) && pet.meow;
+    return ok;
+}
+"#;
+    assert_narrowing_reached_member(&check_strict(source));
+}
+
+/// The pre-narrowing member access (outside the guard) still fails, proving the
+/// narrowing is scoped to the `&&` right operand and not a blanket suppression.
+#[test]
+fn member_access_without_guard_still_errors() {
+    let source = r#"
+interface Shape { kind: string; }
+interface Circle { kind: string; radius: number; }
+function area(s: Shape | Circle) {
+    return s.radius;
+}
+"#;
+    assert!(
+        has_diagnostic_code_message(&check_strict(source), 2339, "radius"),
+        "unguarded access to a non-common member must still error"
+    );
+}


### PR DESCRIPTION
Removes `align_type_guard_interface_diagnostics` from `state_checking/source_file.rs` — a source-text-gated diagnostic rewrite that matched the hardcoded identifier strings `isC2` / `c1Orc2` / `C1 | C2` to (a) drop a `Property 'p2' does not exist on type 'C1 | C2'.` error and (b) inject a TS2322, purely so the `typeGuardOfFormIsTypeOnInterfaces` conformance fixture would match `tsc`. It trips several Anti-Hardcoding Gate prohibitions at once (single-fixture suppression, user-identifier string checks, formatted-message-as-predicate) and is one of the rewrites tracked for removal by #14141.

**Structural rule:** when a user-defined type guard `g(x): x is T` gates the right operand of `&&`, the union-typed operand narrows to `T` in that operand, so a member that only exists on `T` is accessible and the `&&` expression has type `false | <member type>`. tsc does this via flow narrowing; tsz now does it natively through solver narrowing (the checker only orchestrates). The rewrite was therefore **dead** — verified below.

What changed:
- Deleted the function and its dispatch call. The shared `fixture_has_markers` gate stays (still used by the remaining, genuinely load-bearing align/rewrite functions, which are untouched).
- Added `type_guard_union_interface_narrowing_tests` pinning the rule natively with distinct binder spellings (`Alpha`/`Beta`, `One`/`Two`/`Three`, `Dog`/`Cat`, `Shape`/`Circle`) plus a fallback case (unguarded access still errors TS2339), so no future regression silently reintroduces the need for a fixture-scoped hack.

## Goal
Goal: hold

## Verification
- Conformance (tsc 6.0.3 cache, pinned lib): `typeGuardOfFormIsTypeOnInterfaces` **PASS** with the rewrite removed (fingerprint-for-fingerprint); the six other fixtures gated by the sibling load-bearing rewrites are unchanged.
- Full `typeGuards` conformance area: **66/66 PASS** with the rewrite removed (no regression from this deletion).
- `cargo test -p tsz-checker --test type_guard_union_interface_narrowing_tests` → 4 passed.
- Empirically confirmed load-bearing status of the sibling rewrites (disabling all fixture-gated rewrites regresses `inferenceShouldFailOnEvolvingArrays`, `typeInferenceLiteralUnion`, `awaitedType`, `complexRecursiveCollections`, `conditionalTypes1`, `inferFromGenericFunctionReturnTypes3`) — only the type-guard one was dead, so only it is removed here.
- Broad conformance/emit/fourslash parity is owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sq5ivLUEMvNVCtZ8GcJgdH)_