### PR TITLE
test(checker): clear ts2322 unit blockers

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -80,6 +80,7 @@ impl<'a> CheckerState<'a> {
             Some(RelationFailure::MissingProperty { .. })
                 | Some(RelationFailure::MissingProperties { .. })
                 | Some(RelationFailure::IncompatiblePropertyValue { .. })
+                | Some(RelationFailure::IndexAccessTypeParameterMismatch { .. })
         )
     }
 

--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -239,11 +239,17 @@ impl<'a> CheckerState<'a> {
             };
         }
 
+        let raw_failure = self
+            .raw_input_failure_reason(source, target)
+            .map(crate::query_boundaries::relation_types::RelationFailure::from_solver_reason);
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request =
             crate::query_boundaries::assignability::RelationRequest::assign(source, target);
         let mut outcome = self.execute_relation_request(&request);
         outcome.related = false;
+        if outcome.failure.is_none() {
+            outcome.failure = raw_failure;
+        }
         outcome
     }
 

--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -11,11 +11,14 @@ impl<'a> CheckerState<'a> {
         target: TypeId,
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         if self.pre_evaluation_index_access_relation_rejects(source, target) {
+            let failure = self
+                .raw_input_failure_reason(source, target)
+                .map(crate::query_boundaries::relation_types::RelationFailure::from_solver_reason);
             return crate::query_boundaries::assignability::RelationOutcome {
                 related: false,
                 depth_exceeded: false,
                 iteration_exceeded: false,
-                failure: None,
+                failure,
                 weak_union_violation: false,
                 property_classification: None,
             };

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -205,10 +205,6 @@ impl<'a> CheckerState<'a> {
             return self.format_assignability_type_for_message(source, target);
         }
 
-        if let Some(display) = self.tuple_structural_source_display(source, target) {
-            return display;
-        }
-
         // Preserve the literal surface of a plain `as T` / `<T>` assertion source
         // before the widening fallbacks below; see
         // `assertion_source_literal_display`.
@@ -230,6 +226,10 @@ impl<'a> CheckerState<'a> {
             && let Some(display) =
                 self.array_literal_tuple_source_type_display(expr_idx, source, target)
         {
+            return display;
+        }
+
+        if let Some(display) = self.tuple_structural_source_display(source, target) {
             return display;
         }
 

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -779,7 +779,12 @@ pub(crate) fn index_access_pair_distinct_type_param_keys_failure_reason(
 ) -> Option<SubtypeFailureReason> {
     let (s_obj, s_idx) = tsz_solver::index_access_parts(db, source)?;
     let (t_obj, t_idx) = tsz_solver::index_access_parts(db, target)?;
-    if s_obj != t_obj {
+    let same_object = s_obj == t_obj
+        || def_store
+            .find_def_for_type(s_obj)
+            .zip(def_store.find_def_for_type(t_obj))
+            .is_some_and(|(source_def, target_def)| source_def == target_def);
+    if !same_object {
         return None;
     }
     tsz_solver::type_param_info(db, s_idx)?;

--- a/crates/tsz-checker/tests/ts2322_tests/part_01.rs
+++ b/crates/tsz-checker/tests/ts2322_tests/part_01.rs
@@ -26,7 +26,7 @@ class Test {
 }
 "#;
 
-    let diagnostics = compile_with_options(
+    let diagnostics = compile_with_libs_for_ts(
         source,
         "test.ts",
         CheckerOptions {

--- a/crates/tsz-checker/tests/ts2322_tests/part_04.rs
+++ b/crates/tsz-checker/tests/ts2322_tests/part_04.rs
@@ -1306,7 +1306,7 @@ const cwp: CallableWithProps = Object.assign(
   { version: "1.0" }
 );
 "#;
-    let diagnostics = tsz_checker::test_utils::check_source_diagnostics(source);
+    let diagnostics = compile_with_libs_for_ts(source, "test.ts", CheckerOptions::default());
     assert!(
         diagnostics.is_empty(),
         "Expected no errors: fn-object intersection should satisfy callable interface with matching properties. Got: {diagnostics:#?}"
@@ -1428,7 +1428,7 @@ const fc: FullCallable = Object.assign(
   { name: "fn", version: 1 }
 );
 "#;
-    let diagnostics = tsz_checker::test_utils::check_source_diagnostics(source);
+    let diagnostics = compile_with_libs_for_ts(source, "test.ts", CheckerOptions::default());
     assert!(
         diagnostics.is_empty(),
         "Expected no errors: fn-object intersection with all props should satisfy callable interface. Got: {diagnostics:#?}"
@@ -1447,7 +1447,7 @@ interface CallableWithProps {
 function myFn(x: number): string { return x.toString(); }
 const cwp: CallableWithProps = Object.assign(myFn, { version: "1.0" });
 "#;
-    let diagnostics = tsz_checker::test_utils::check_source_diagnostics(source);
+    let diagnostics = compile_with_libs_for_ts(source, "test.ts", CheckerOptions::default());
     assert!(
         diagnostics.is_empty(),
         "Expected no errors: named function + Object.assign should satisfy callable interface. Got: {diagnostics:#?}"

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/application_infer.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/application_infer.rs
@@ -75,26 +75,32 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
             return None;
         }
 
-        // Try infer pattern matching with unevaluated types.
-        // match_infer_pattern handles Application vs Application matching
-        // by comparing base types and recursing on type arguments.
-        let mut checker = self.conditional_subtype_checker();
-        checker.allow_bivariant_rest = true;
-        let mut bindings = FxHashMap::default();
-        let mut visited = InferPatternVisited::default();
-        let matched = self.match_infer_pattern(
-            check_type,
-            cond.extends_type,
-            &mut bindings,
-            &mut visited,
-            &mut checker,
-        );
-        if matched && !bindings.is_empty() {
-            let substituted_true = self.substitute_infer(cond.true_type, &bindings);
-            return Some(self.evaluate(substituted_true));
-        }
-        if self.application_infer_bases_match(check_type, cond.extends_type, &mut checker) {
-            return Some(self.evaluate(cond.false_type));
+        let direct_application_bases_match =
+            get_application_base(self.interner(), check_type) == Some(pattern_base);
+        if direct_application_bases_match {
+            // Try infer pattern matching with unevaluated same-base applications.
+            // Positional argument binding is only sound once the source and pattern
+            // share the same generic base. Different-base applications such as
+            // `ReturnType<F>` vs `Promise<infer T>` must fall through to the alias
+            // reducer below so `ReturnType` can expose its return application first.
+            let mut checker = self.conditional_subtype_checker();
+            checker.allow_bivariant_rest = true;
+            let mut bindings = FxHashMap::default();
+            let mut visited = InferPatternVisited::default();
+            let matched = self.match_infer_pattern(
+                check_type,
+                cond.extends_type,
+                &mut bindings,
+                &mut visited,
+                &mut checker,
+            );
+            if matched && !bindings.is_empty() {
+                let substituted_true = self.substitute_infer(cond.true_type, &bindings);
+                return Some(self.evaluate(substituted_true));
+            }
+            if self.application_infer_bases_match(check_type, cond.extends_type, &mut checker) {
+                return Some(self.evaluate(cond.false_type));
+            }
         }
 
         // Last-chance recovery: reduce the source through generic-alias bodies


### PR DESCRIPTION
Goal: hold

## Summary
- Preserve index-access type-parameter mismatch elaboration through the TS2322 relation-outcome path.
- Require same-base application matching before positional `infer` binding so `ReturnType<F>` can reduce before matching `Promise<infer T>`.
- Keep tuple/array literal source display and lib-backed Object.assign/array-method repros aligned with tsc behavior.

## Structural Rule
When an application conditional matches `Application(SourceBase, args)` against `Application(PatternBase, infer args)`, tsc binds infer positions positionally only after the source is reduced to the same generic base as the pattern. tsz now keeps that ownership in the solver conditional application-infer path, letting alias reduction expose `ReturnType<F>` as a `Promise<...>` before binding.

When a pre-evaluation indexed-access relation rejects because two generic keys are distinct, tsz preserves the solver failure reason through the checker relation-outcome boundary so the TS2322 diagnostic keeps its TS5075 elaboration chain.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh --limit 88% -- cargo nextest run -p tsz-checker --test ts2322_tests`
- `scripts/safe-run.sh --limit 88% -- cargo nextest run -p tsz-checker --test conditional_alias_lib_application_tests`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
