### PR TITLE
perf(solver): cache top-level narrowing guards (#14351)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -346,12 +346,11 @@ pub(crate) fn narrow_call_predicate_guard(
             // recursive-schema unions (typebox / ts-morph `value is T`, where
             // each nested schema is a distinct `TypeId` so the
             // `(source, excluded)` memo never hits). Take tsc's cheap shallow
-            // path; when it cannot reduce the source, fall through to the
-            // structural top-level-member pass below (tsc's
-            // `directlyRelated`/intersection step) rather than the deep recursion.
-            if let Some(excluded) = narrowing.narrow_excluding_positive_subset(type_id, positive)
-                && excluded != type_id
-            {
+            // path. `Some(type_id)` is a terminal tsc-shaped unchanged result:
+            // it means the solver deliberately deferred recursive/evaluator-
+            // sensitive structural repair instead of sending the false branch
+            // through the relation fallback below.
+            if let Some(excluded) = narrowing.narrow_excluding_positive_subset(type_id, positive) {
                 return excluded;
             }
         }

--- a/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
@@ -49,6 +49,27 @@ function use(value: string | number) {
 }
 
 #[test]
+fn predicate_false_branch_accepts_terminal_positive_subset_result() {
+    let boundary_source = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read flow analysis boundary source");
+    let compact_boundary: String = boundary_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+
+    assert!(
+        compact_boundary
+            .contains("ifletSome(excluded)=narrowing.narrow_excluding_positive_subset(type_id,positive){returnexcluded;}"),
+        "predicate false-branch boundary should return the solver's positive-subset result directly"
+    );
+    assert!(
+        !compact_boundary
+            .contains("narrow_excluding_positive_subset(type_id,positive)&&excluded!=type_id"),
+        "predicate false-branch boundary must not fall through after terminal unchanged results"
+    );
+}
+
+#[test]
 fn type_predicate_true_branch_removes_null_before_property_access() {
     let codes = check_strict(
         r#"

--- a/crates/tsz-solver/src/narrowing/cache.rs
+++ b/crates/tsz-solver/src/narrowing/cache.rs
@@ -68,6 +68,7 @@ pub struct NarrowingCacheStatistics {
     pub contextual_resolve_cache_entries: usize,
     pub discriminant_index_entries: usize,
     pub narrow_type_cache_entries: usize,
+    pub narrow_positive_subset_cache_entries: usize,
     pub narrow_excluding_cache_entries: usize,
     pub narrow_assignable_cache_entries: usize,
     pub narrow_subtype_cache_entries: usize,
@@ -89,6 +90,7 @@ impl NarrowingCacheStatistics {
             + self.contextual_resolve_cache_entries
             + self.discriminant_index_entries
             + self.narrow_type_cache_entries
+            + self.narrow_positive_subset_cache_entries
             + self.narrow_excluding_cache_entries
             + self.narrow_assignable_cache_entries
             + self.narrow_subtype_cache_entries
@@ -142,14 +144,22 @@ pub struct NarrowingCache {
     /// Built once per (union, property) pair, then O(1) lookup per case clause.
     /// Without this, each case clause iterates ALL union members (O(N) per case = O(N^2) total).
     pub discriminant_index: RefCell<DiscriminantIndex>,
-    /// Cache for applying a semantic predicate guard to an input type.
+    /// Cache for applying a semantic guard to an input type.
     ///
-    /// Keyed by input `TypeId`, predicate payload, branch sense, compiler
-    /// option bits, and resolver generation so lazy alias changes cannot reuse
-    /// stale predicate results. Other guard kinds keep their existing dynamic
-    /// paths because their results depend on structural lookups that are already
-    /// cached at narrower query boundaries.
+    /// Keyed by input `TypeId`, guard payload, branch sense, compiler option
+    /// bits, and resolver generation so lazy alias changes cannot reuse stale
+    /// narrowing results. Publication is policy-gated by guard shape, cache
+    /// residency, and exclusion-fuel truncation.
     pub(crate) narrow_type_cache: RefCell<GenerationMemo<NarrowTypeStableCacheKey, TypeId>>,
+    /// Memo for the shallow false-branch predicate exclusion:
+    /// `(source, positive-branch type, resolver generation) -> source without
+    /// the positive subset`, or `None` when the shallow pass cannot reduce.
+    pub(crate) narrow_positive_subset_cache:
+        RefCell<GenerationMemo<NarrowExcludingStableKey, Option<TypeId>>>,
+    /// Request-local taint for a top-level guard narrow whose nested exclusion
+    /// walk spent or exceeded its work budget. Such results are conservative
+    /// and must not be published into `narrow_type_cache`.
+    pub(crate) narrow_type_request_truncated: Cell<bool>,
     /// Memo for `NarrowingContext::narrow_excluding_type` keyed by
     /// `(source, excluded, resolver_generation)`.
     ///
@@ -272,6 +282,8 @@ impl NarrowingCache {
             )),
             discriminant_index: RefCell::new(FxHashMap::default()),
             narrow_type_cache: RefCell::new(GenerationMemo::default()),
+            narrow_positive_subset_cache: RefCell::new(GenerationMemo::default()),
+            narrow_type_request_truncated: Cell::new(false),
             narrow_excluding_cache: RefCell::new(GenerationMemo::default()),
             narrow_excluding_visiting: RefCell::new(FxHashSet::default()),
             narrow_assignable_cache: RefCell::new(GenerationMemo::default()),
@@ -287,6 +299,7 @@ impl NarrowingCache {
         let property_cache = self.property_cache.borrow();
         let required_property_cache = self.required_property_cache.borrow();
         let narrow_type_cache = self.narrow_type_cache.borrow();
+        let narrow_positive_subset_cache = self.narrow_positive_subset_cache.borrow();
         let narrow_excluding_cache = self.narrow_excluding_cache.borrow();
         let narrow_assignable_cache = self.narrow_assignable_cache.borrow();
         let narrow_subtype_cache = self.narrow_subtype_cache.borrow();
@@ -295,6 +308,7 @@ impl NarrowingCache {
             + self.optional_chain_cache.borrow().key_count()
             + self.optional_property_chain_cache.borrow().key_count()
             + narrow_type_cache.key_count()
+            + narrow_positive_subset_cache.key_count()
             + narrow_excluding_cache.key_count()
             + narrow_assignable_cache.key_count()
             + narrow_subtype_cache.key_count();
@@ -306,6 +320,7 @@ impl NarrowingCache {
                 .borrow()
                 .max_slots_per_key(),
             narrow_type_cache.max_slots_per_key(),
+            narrow_positive_subset_cache.max_slots_per_key(),
             narrow_excluding_cache.max_slots_per_key(),
             narrow_assignable_cache.max_slots_per_key(),
             narrow_subtype_cache.max_slots_per_key(),
@@ -331,6 +346,7 @@ impl NarrowingCache {
             contextual_resolve_cache_entries: self.contextual_resolve_cache.borrow().len(),
             discriminant_index_entries: self.discriminant_index.borrow().len(),
             narrow_type_cache_entries: narrow_type_cache.len(),
+            narrow_positive_subset_cache_entries: narrow_positive_subset_cache.len(),
             narrow_excluding_cache_entries: narrow_excluding_cache.len(),
             narrow_assignable_cache_entries: narrow_assignable_cache.len(),
             narrow_subtype_cache_entries: narrow_subtype_cache.len(),
@@ -410,6 +426,10 @@ impl NarrowingCache {
             size += map.estimated_size_bytes(BUCKET_OVERHEAD);
         }
         {
+            let map = self.narrow_positive_subset_cache.borrow();
+            size += map.estimated_size_bytes(BUCKET_OVERHEAD);
+        }
+        {
             let map = self.narrow_excluding_cache.borrow();
             size += map.estimated_size_bytes(BUCKET_OVERHEAD);
         }
@@ -451,14 +471,27 @@ impl NarrowingCache {
     pub(in crate::narrowing) fn charge_exclusion_work(&self) -> bool {
         let fuel = self.narrow_excluding_fuel.get();
         if fuel == 0 {
+            self.narrow_type_request_truncated.set(true);
             return false;
         }
-        self.narrow_excluding_fuel.set(fuel - 1);
+        let remaining = fuel - 1;
+        self.narrow_excluding_fuel.set(remaining);
+        if remaining == 0 {
+            self.narrow_type_request_truncated.set(true);
+        }
         true
     }
 
     pub(in crate::narrowing) const fn exclusion_within_budget(&self) -> bool {
         self.narrow_excluding_fuel.get() > 0
+    }
+
+    pub(in crate::narrowing) fn begin_narrow_type_request(&self) {
+        self.narrow_type_request_truncated.set(false);
+    }
+
+    pub(in crate::narrowing) const fn narrow_type_request_truncated(&self) -> bool {
+        self.narrow_type_request_truncated.get()
     }
 
     #[cfg(test)]

--- a/crates/tsz-solver/src/narrowing/cache/cache_visibility_tests.rs
+++ b/crates/tsz-solver/src/narrowing/cache/cache_visibility_tests.rs
@@ -69,6 +69,14 @@ fn narrowing_cache_statistics_report_entries_and_size() {
         0,
         TypeId::STRING,
     );
+    let relation_key = NarrowExcludingStableKey {
+        source: TypeId::STRING,
+        excluded: TypeId::NUMBER,
+    };
+    cache
+        .narrow_positive_subset_cache
+        .borrow_mut()
+        .insert(relation_key, 0, Some(TypeId::STRING));
 
     let stats = cache.cache_statistics();
     assert_eq!(stats.resolve_cache_entries, 1);
@@ -81,7 +89,8 @@ fn narrowing_cache_statistics_report_entries_and_size() {
     assert_eq!(stats.contextual_resolve_cache_entries, 1);
     assert_eq!(stats.discriminant_index_entries, 1);
     assert_eq!(stats.narrow_type_cache_entries, 1);
-    assert_eq!(stats.total_entries(), 10);
+    assert_eq!(stats.narrow_positive_subset_cache_entries, 1);
+    assert_eq!(stats.total_entries(), 11);
     assert!(stats.estimated_size_bytes > empty.estimated_size_bytes);
     assert!(cache.estimated_size_bytes() >= stats.estimated_size_bytes);
 }
@@ -130,6 +139,11 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
             generation,
             TypeId::STRING,
         );
+        cache.narrow_positive_subset_cache.borrow_mut().insert(
+            relation_key,
+            generation,
+            Some(TypeId::STRING),
+        );
         cache
             .narrow_excluding_cache
             .borrow_mut()
@@ -145,7 +159,7 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
     }
 
     let stats = cache.cache_statistics();
-    assert_eq!(stats.generation_stamped_cache_keys, 8);
+    assert_eq!(stats.generation_stamped_cache_keys, 9);
     assert_eq!(
         stats.max_generation_slots_per_cache_key,
         MAX_GENERATIONS_PER_NARROWING_KEY
@@ -168,6 +182,10 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
     );
     assert_eq!(
         stats.narrow_type_cache_entries,
+        MAX_GENERATIONS_PER_NARROWING_KEY
+    );
+    assert_eq!(
+        stats.narrow_positive_subset_cache_entries,
         MAX_GENERATIONS_PER_NARROWING_KEY
     );
     assert_eq!(
@@ -214,6 +232,20 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
     assert_eq!(
         cache.narrow_type_cache.borrow().get(&request_key, 7),
         Some(TypeId::STRING)
+    );
+    assert_eq!(
+        cache
+            .narrow_positive_subset_cache
+            .borrow()
+            .get(&relation_key, 1),
+        None
+    );
+    assert_eq!(
+        cache
+            .narrow_positive_subset_cache
+            .borrow()
+            .get(&relation_key, 7),
+        Some(Some(TypeId::STRING))
     );
 }
 
@@ -278,6 +310,24 @@ fn exclusion_frame_clears_request_fuel_on_outer_drop() {
 
     assert_eq!(cache.narrow_excluding_depth.get(), 0);
     assert_eq!(cache.narrow_excluding_fuel.get(), 0);
+}
+
+#[test]
+fn exclusion_budget_spent_taints_narrow_type_request() {
+    let cache = NarrowingCache::new();
+    cache.set_narrow_excluding_budget(1);
+    cache.begin_narrow_type_request();
+
+    {
+        let _frame = cache.enter_exclusion_frame();
+        assert!(!cache.narrow_type_request_truncated());
+        assert!(cache.charge_exclusion_work());
+        assert!(cache.narrow_type_request_truncated());
+        assert!(!cache.charge_exclusion_work());
+    }
+
+    cache.begin_narrow_type_request();
+    assert!(!cache.narrow_type_request_truncated());
 }
 
 #[test]

--- a/crates/tsz-solver/src/narrowing/cache_policy.rs
+++ b/crates/tsz-solver/src/narrowing/cache_policy.rs
@@ -1,0 +1,31 @@
+use crate::narrowing::guard::TypeGuard;
+
+/// Stable-key budget for the top-level guard narrowing memo.
+///
+/// Generation slots are already bounded per stable key by `GenerationMemo`;
+/// this cap bounds the number of distinct guard payloads retained when the
+/// cache is widened beyond predicate guards.
+pub(crate) const MAX_NARROW_TYPE_CACHE_KEYS: usize = 4096;
+
+/// Long discriminant paths embed a `Vec<Atom>` in the stable key. Cache only
+/// short semantic paths and let longer paths use the existing discriminant index
+/// and property caches.
+pub(crate) const MAX_CACHED_DISCRIMINANT_PATH_LEN: usize = 4;
+
+pub(crate) const fn guard_can_use_narrow_type_cache(guard: &TypeGuard) -> bool {
+    match guard {
+        TypeGuard::Typeof(_)
+        | TypeGuard::Instanceof(_, _)
+        | TypeGuard::LiteralEquality(_)
+        | TypeGuard::NullishEquality
+        | TypeGuard::Truthy
+        | TypeGuard::InProperty(_)
+        | TypeGuard::Predicate { .. }
+        | TypeGuard::Array
+        | TypeGuard::ArrayElementPredicate { .. }
+        | TypeGuard::Constructor(_) => true,
+        TypeGuard::Discriminant { property_path, .. } => {
+            property_path.len() <= MAX_CACHED_DISCRIMINANT_PATH_LEN
+        }
+    }
+}

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -2,17 +2,20 @@ use crate::caches::db::TypeCompilerOptions;
 use crate::construction::{QueryDatabase, TypeDatabase};
 use crate::def::DefId;
 use crate::narrowing::cache::{NarrowExcludingKey, NarrowExcludingStableKey, NarrowingCache};
+use crate::narrowing::cache_policy::{MAX_NARROW_TYPE_CACHE_KEYS, guard_can_use_narrow_type_cache};
 use crate::narrowing::guard::{GuardSense, TypeGuard};
 use crate::narrowing::request::{NarrowingOptions, NarrowingRequest};
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
-use crate::type_queries::{UnionMembersKind, classify_for_union_members};
+use crate::type_queries::{
+    UnionMembersKind, classify_for_union_members, is_structurally_eval_inert,
+};
 use crate::types::{FunctionShape, LiteralValue, ParamInfo, TypeData, TypeId};
 use crate::utils::{TypeIdExt, union_or_single};
 use crate::visitor::{
     application_id, index_access_parts, intersection_list_id,
-    is_function_type_through_type_constraints, is_object_like_type_through_type_constraints,
-    lazy_def_id, literal_value, object_shape_id, object_with_index_shape_id, template_literal_id,
-    type_param_info, union_list_id,
+    is_function_type_through_type_constraints, is_object_like_type,
+    is_object_like_type_through_type_constraints, lazy_def_id, literal_value, object_shape_id,
+    object_with_index_shape_id, template_literal_id, type_param_info, union_list_id,
 };
 use tracing::{Level, span, trace};
 use tsz_common::interner::Atom;
@@ -898,10 +901,13 @@ impl<'a> NarrowingContext<'a> {
     /// recursion is exponential and was the dominant non-termination frame.
     ///
     /// This boundary keeps the false-branch predicate exclusion on tsc's cheap
-    /// O(N) shallow path. It returns `None` when the shallow filter cannot
-    /// reduce the source (every member survives `isTypeSubsetOf`), so the caller
-    /// can fall back to its structural-assignability member pass for the cases
-    /// tsc covers through `directlyRelated`/intersection construction.
+    /// O(N) shallow path. It returns `Some(source_type)` as a terminal unchanged
+    /// answer when a potential structural repair would require evaluating a
+    /// recursive/deferred member; callers must not then fall through to the deep
+    /// relation fallback. It returns `None` only when no shallow reduction and no
+    /// deferred structural repair candidate exists, so the caller can use its
+    /// structural-assignability member pass for cases tsc covers through
+    /// `directlyRelated`/intersection construction.
     pub fn narrow_excluding_positive_subset(
         &self,
         source_type: TypeId,
@@ -913,6 +919,34 @@ impl<'a> NarrowingContext<'a> {
             return None;
         }
 
+        let resolver_generation = self.resolver_generation();
+        let stable_key = NarrowExcludingStableKey {
+            source: source_type,
+            excluded: positive_type,
+        };
+        if let Some(cached) = self
+            .cache
+            .narrow_positive_subset_cache
+            .borrow()
+            .get(&stable_key, resolver_generation)
+        {
+            return cached;
+        }
+
+        let result = self.narrow_excluding_positive_subset_uncached(source_type, positive_type);
+        self.cache.narrow_positive_subset_cache.borrow_mut().insert(
+            stable_key,
+            resolver_generation,
+            result,
+        );
+        result
+    }
+
+    fn narrow_excluding_positive_subset_uncached(
+        &self,
+        source_type: TypeId,
+        positive_type: TypeId,
+    ) -> Option<TypeId> {
         let resolved_source = self.resolve_type(source_type);
         let Some(members) = union_list_id(self.db, resolved_source) else {
             // A non-union source is dropped to `never` iff it is a subset of the
@@ -924,42 +958,86 @@ impl<'a> NarrowingContext<'a> {
         };
 
         let members = self.db.type_list(members);
-        let remaining: Vec<TypeId> = members
-            .iter()
-            .copied()
-            .filter(|&member| !self.is_type_subset_of(member, positive_type))
-            .collect();
+        let positive_members: Vec<TypeId> = union_list_id(self.db, positive_type)
+            .map(|positive_members| self.db.type_list(positive_members).to_vec())
+            .unwrap_or_else(|| vec![positive_type]);
 
-        if remaining.len() == members.len()
-            || remaining
-                .iter()
-                .any(|&member| self.is_assignable_to(member, positive_type))
-        {
-            // Identity/containment did not catch every positive-branch member.
-            // Keep the pass top-level-only, but allow structural equivalence
-            // against the already-computed positive type. This covers freshly
-            // materialized true-branch shapes such as #52984 deep-path
-            // predicates without returning to recursive intersection descent.
-            let structurally_remaining: Vec<TypeId> = members
-                .iter()
-                .copied()
-                .filter(|&member| !self.is_assignable_to(member, positive_type))
-                .collect();
-            if structurally_remaining.len() == members.len() {
-                return None;
+        let mut remaining = Vec::with_capacity(members.len());
+        let mut dropped_member = false;
+        let mut deferred_structural_probe = false;
+
+        for &member in members.iter() {
+            if self.is_type_subset_of(member, positive_type) {
+                dropped_member = true;
+                continue;
             }
-            return Some(match structurally_remaining.as_slice() {
+
+            let mut structurally_dropped = false;
+            for &positive_member in &positive_members {
+                if self.can_probe_positive_subset_structurally(member, positive_member) {
+                    if self.is_assignable_to(member, positive_member) {
+                        structurally_dropped = true;
+                        break;
+                    }
+                } else if self
+                    .should_defer_positive_subset_structural_probe(member, positive_member)
+                {
+                    deferred_structural_probe = true;
+                }
+            }
+
+            if structurally_dropped {
+                dropped_member = true;
+            } else {
+                remaining.push(member);
+            }
+        }
+
+        if dropped_member {
+            return Some(match remaining.as_slice() {
                 [] => TypeId::NEVER,
                 [single] => *single,
-                _ => self.db.union(structurally_remaining),
+                _ => self.db.union(remaining),
             });
         }
-        // The pure identity/containment filter handled the positive members.
-        Some(match remaining.as_slice() {
-            [] => TypeId::NEVER,
-            [single] => *single,
-            _ => self.db.union(remaining),
-        })
+        if deferred_structural_probe {
+            return Some(source_type);
+        }
+        None
+    }
+
+    fn can_probe_positive_subset_structurally(
+        &self,
+        source_member: TypeId,
+        positive_member: TypeId,
+    ) -> bool {
+        // Structural repair is only for already materialized object-like pairs.
+        // Deferred/evaluator-sensitive pairs stay on the tsc false-branch
+        // subset path so recursive schema unions do not re-enter relation/eval.
+        self.positive_subset_structural_candidate(source_member, positive_member)
+            && is_structurally_eval_inert(self.db, source_member)
+            && is_structurally_eval_inert(self.db, positive_member)
+    }
+
+    fn should_defer_positive_subset_structural_probe(
+        &self,
+        source_member: TypeId,
+        positive_member: TypeId,
+    ) -> bool {
+        self.positive_subset_structural_candidate(source_member, positive_member)
+            && (!is_structurally_eval_inert(self.db, source_member)
+                || !is_structurally_eval_inert(self.db, positive_member))
+    }
+
+    fn positive_subset_structural_candidate(
+        &self,
+        source_member: TypeId,
+        positive_member: TypeId,
+    ) -> bool {
+        !source_member.is_intrinsic()
+            && !positive_member.is_intrinsic()
+            && is_object_like_type(self.db, source_member)
+            && is_object_like_type(self.db, positive_member)
     }
 
     /// tsc's `isTypeSubsetOf`: a pure identity/containment relation used by
@@ -1373,37 +1451,39 @@ impl<'a> NarrowingContext<'a> {
     }
 
     pub fn narrow_type(&self, source_type: TypeId, guard: &TypeGuard, sense: GuardSense) -> TypeId {
-        if !matches!(guard, TypeGuard::Predicate { .. }) {
-            return self.narrow_type_uncached(source_type, guard, sense);
-        }
         let request = NarrowingRequest::new(source_type, guard.clone(), sense);
-        self.narrow_predicate_cached(&request)
+        self.narrow_type_with_request(&request)
     }
 
     /// Avoids re-cloning the guard when the caller already holds a `NarrowingRequest`.
     pub fn narrow_type_with_request(&self, request: &NarrowingRequest) -> TypeId {
-        if !matches!(request.guard(), TypeGuard::Predicate { .. }) {
+        if !guard_can_use_narrow_type_cache(request.guard()) {
             return self.narrow_type_uncached(
                 request.source_type(),
                 request.guard(),
                 request.sense(),
             );
         }
-        self.narrow_predicate_cached(request)
+        self.narrow_type_cached(request)
     }
 
-    fn narrow_predicate_cached(&self, request: &NarrowingRequest) -> TypeId {
+    fn narrow_type_cached(&self, request: &NarrowingRequest) -> TypeId {
         let generation = self.resolver_generation();
         let key = request.stable_cache_key(self.narrowing_options());
         if let Some(cached) = self.cache.narrow_type_cache.borrow().get(&key, generation) {
             return cached;
         }
+        self.cache.begin_narrow_type_request();
         let narrowed =
             self.narrow_type_uncached(request.source_type(), request.guard(), request.sense());
-        self.cache
-            .narrow_type_cache
-            .borrow_mut()
-            .insert(key, generation, narrowed);
+        if self.cache.narrow_type_request_truncated() {
+            return narrowed;
+        }
+        let mut cache = self.cache.narrow_type_cache.borrow_mut();
+        if cache.key_count() >= MAX_NARROW_TYPE_CACHE_KEYS && !cache.contains_key(&key) {
+            return narrowed;
+        }
+        cache.insert(key, generation, narrowed);
         narrowed
     }
 

--- a/crates/tsz-solver/src/narrowing/generation_memo.rs
+++ b/crates/tsz-solver/src/narrowing/generation_memo.rs
@@ -64,6 +64,10 @@ where
         self.entries.len()
     }
 
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.entries.contains_key(key)
+    }
+
     pub fn max_slots_per_key(&self) -> usize {
         self.entries.values().map(SmallVec::len).max().unwrap_or(0)
     }

--- a/crates/tsz-solver/src/narrowing/mod.rs
+++ b/crates/tsz-solver/src/narrowing/mod.rs
@@ -28,6 +28,7 @@
 //! - **Solver**: Applies `TypeGuard` to types (WHAT)
 
 mod cache;
+mod cache_policy;
 mod compound;
 mod core;
 mod discriminants;

--- a/crates/tsz-solver/tests/narrowing_tests.rs
+++ b/crates/tsz-solver/tests/narrowing_tests.rs
@@ -10,3 +10,4 @@ use crate::types::SymbolRef;
 
 include!("narrowing_tests_parts/part_00.rs");
 include!("narrowing_tests_parts/part_01.rs");
+include!("narrowing_tests_parts/part_02.rs");

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs
@@ -189,8 +189,8 @@ fn test_narrow_type_cache_keys_predicate_payload_flags_and_resolver_generation()
     );
     assert_eq!(
         cache.narrow_type_cache.borrow().len(),
-        1,
-        "non-predicate guards keep their existing dynamic narrowing path"
+        2,
+        "typeof guards now share the top-level semantic narrowing cache"
     );
 
     let number_predicate = TypeGuard::Predicate {
@@ -201,7 +201,7 @@ fn test_narrow_type_cache_keys_predicate_payload_flags_and_resolver_generation()
         ctx.narrow_type(TypeId::UNKNOWN, &number_predicate, GuardSense::Positive),
         TypeId::NUMBER
     );
-    assert_eq!(cache.narrow_type_cache.borrow().len(), 2);
+    assert_eq!(cache.narrow_type_cache.borrow().len(), 3);
 
     interner.set_no_unchecked_indexed_access(true);
     let flags_ctx = NarrowingContext::with_cache(&interner, &cache);
@@ -209,7 +209,7 @@ fn test_narrow_type_cache_keys_predicate_payload_flags_and_resolver_generation()
         flags_ctx.narrow_type(TypeId::UNKNOWN, &string_predicate, GuardSense::Positive),
         TypeId::STRING
     );
-    assert_eq!(cache.narrow_type_cache.borrow().len(), 3);
+    assert_eq!(cache.narrow_type_cache.borrow().len(), 4);
 
     let resolver_one = GenerationResolver(1);
     let resolver_ctx = NarrowingContext::with_cache(&interner, &cache).with_resolver(&resolver_one);
@@ -217,7 +217,7 @@ fn test_narrow_type_cache_keys_predicate_payload_flags_and_resolver_generation()
         resolver_ctx.narrow_type(TypeId::UNKNOWN, &string_predicate, GuardSense::Positive),
         TypeId::STRING
     );
-    assert_eq!(cache.narrow_type_cache.borrow().len(), 4);
+    assert_eq!(cache.narrow_type_cache.borrow().len(), 5);
 
     let resolver_two = GenerationResolver(2);
     let resolver_ctx = NarrowingContext::with_cache(&interner, &cache).with_resolver(&resolver_two);
@@ -225,7 +225,7 @@ fn test_narrow_type_cache_keys_predicate_payload_flags_and_resolver_generation()
         resolver_ctx.narrow_type(TypeId::UNKNOWN, &string_predicate, GuardSense::Positive),
         TypeId::STRING
     );
-    assert_eq!(cache.narrow_type_cache.borrow().len(), 5);
+    assert_eq!(cache.narrow_type_cache.borrow().len(), 6);
 }
 
 #[test]

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_01.rs
@@ -580,6 +580,48 @@ fn test_in_then_typeof_object_independent_of_property_name() {
     }
 }
 
+#[test]
+fn test_narrow_type_with_request_reuses_general_guard_cache() {
+    let interner = TypeInterner::new();
+    let cache = NarrowingCache::new();
+    let ctx = NarrowingContext::with_cache(&interner, &cache);
+    let source = interner.union(vec![TypeId::STRING, TypeId::NULL]);
+    let request = NarrowingRequest::new(source, TypeGuard::Truthy, GuardSense::Positive);
+
+    assert_eq!(ctx.narrow_type_with_request(&request), TypeId::STRING);
+    assert_eq!(cache.narrow_type_cache.borrow().len(), 1);
+    assert_eq!(ctx.narrow_type_with_request(&request), TypeId::STRING);
+    assert_eq!(
+        cache.narrow_type_cache.borrow().len(),
+        1,
+        "repeated request-object guards should hit without growing the cache"
+    );
+}
+
+#[test]
+fn test_narrow_type_cache_bypasses_long_discriminant_paths() {
+    let interner = TypeInterner::new();
+    let cache = NarrowingCache::new();
+    let ctx = NarrowingContext::with_cache(&interner, &cache);
+    let property_path = (0..=super::cache_policy::MAX_CACHED_DISCRIMINANT_PATH_LEN)
+        .map(|index| interner.intern_string(&format!("p{index}")))
+        .collect();
+    let guard = TypeGuard::Discriminant {
+        property_path,
+        value_type: TypeId::STRING,
+    };
+
+    assert_eq!(
+        ctx.narrow_type(TypeId::UNKNOWN, &guard, GuardSense::Positive),
+        TypeId::UNKNOWN
+    );
+    assert_eq!(
+        cache.narrow_type_cache.borrow().len(),
+        0,
+        "long discriminant payloads bypass instead of truncating cache keys"
+    );
+}
+
 // =============================================================================
 // narrow_excluding_type per-request cumulative work budget (issue #13806, theme C)
 // =============================================================================
@@ -625,6 +667,50 @@ fn test_narrow_excluding_budget_bounds_constraint_refinement() {
     assert_eq!(
         bounded_ctx.narrow_excluding_type(union, TypeId::STRING),
         union,
+    );
+}
+
+#[test]
+fn test_narrow_type_cache_skips_budget_truncated_predicate_exclusion() {
+    let interner = TypeInterner::new();
+    let cache = NarrowingCache::new();
+    let constraint = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    let param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    }));
+    let union = interner.union(vec![param, TypeId::BOOLEAN]);
+    let guard = TypeGuard::Predicate {
+        type_id: Some(TypeId::STRING),
+        asserts: false,
+    };
+
+    let ctx = NarrowingContext::with_cache(&interner, &cache);
+    ctx.set_narrow_excluding_budget(1);
+    assert_eq!(
+        ctx.narrow_type(union, &guard, GuardSense::Negative),
+        union
+    );
+    assert_eq!(
+        cache.narrow_type_cache.borrow().len(),
+        0,
+        "budget-truncated guard results must remain request-local"
+    );
+
+    ctx.set_narrow_excluding_budget(0);
+    let expected_param = interner.intersection(vec![param, TypeId::NUMBER]);
+    let expected_full = interner.union(vec![expected_param, TypeId::BOOLEAN]);
+    assert_eq!(
+        ctx.narrow_type(union, &guard, GuardSense::Negative),
+        expected_full
+    );
+    assert_eq!(
+        cache.narrow_type_cache.borrow().len(),
+        1,
+        "the fully budgeted rerun may publish the guard result"
     );
 }
 

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_02.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_02.rs
@@ -1,0 +1,221 @@
+#[test]
+fn test_narrow_excluding_positive_subset_memoizes_reduced_result() {
+    let interner = TypeInterner::new();
+    let cache = NarrowingCache::new();
+    let ctx = NarrowingContext::with_cache(&interner, &cache);
+    let source = interner.union(vec![TypeId::STRING, TypeId::NUMBER, TypeId::BOOLEAN]);
+    let positive = interner.union(vec![TypeId::STRING, TypeId::BOOLEAN]);
+
+    assert_eq!(
+        ctx.narrow_excluding_positive_subset(source, positive),
+        Some(TypeId::NUMBER)
+    );
+    assert_eq!(cache.narrow_positive_subset_cache.borrow().len(), 1);
+    assert_eq!(
+        ctx.narrow_excluding_positive_subset(source, positive),
+        Some(TypeId::NUMBER)
+    );
+    assert_eq!(
+        cache.narrow_positive_subset_cache.borrow().len(),
+        1,
+        "repeated shallow predicate exclusion should hit without growing the cache"
+    );
+}
+
+#[test]
+fn test_narrow_excluding_positive_subset_memoizes_no_reduction() {
+    let interner = TypeInterner::new();
+    let cache = NarrowingCache::new();
+    let ctx = NarrowingContext::with_cache(&interner, &cache);
+    let source = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+
+    assert_eq!(
+        ctx.narrow_excluding_positive_subset(source, TypeId::BOOLEAN),
+        None
+    );
+    assert_eq!(cache.narrow_positive_subset_cache.borrow().len(), 1);
+    assert_eq!(
+        ctx.narrow_excluding_positive_subset(source, TypeId::BOOLEAN),
+        None
+    );
+    assert_eq!(
+        cache.narrow_positive_subset_cache.borrow().len(),
+        1,
+        "no-reduction predicate exclusion results should be cached too"
+    );
+}
+
+#[test]
+fn test_narrow_excluding_positive_subset_memoizes_structural_filter() {
+    let interner = TypeInterner::new();
+    let cache = NarrowingCache::new();
+    let ctx = NarrowingContext::with_cache(&interner, &cache);
+    let member_a = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+    let member_b = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("b"),
+        TypeId::NUMBER,
+    )]);
+    let source = interner.union(vec![member_a, member_b]);
+    let positive_b = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("b"),
+        TypeId::NUMBER,
+    )]);
+
+    assert_eq!(
+        ctx.narrow_excluding_positive_subset(source, positive_b),
+        Some(member_a)
+    );
+    assert_eq!(cache.narrow_positive_subset_cache.borrow().len(), 1);
+    assert_eq!(
+        ctx.narrow_excluding_positive_subset(source, positive_b),
+        Some(member_a)
+    );
+    assert_eq!(
+        cache.narrow_positive_subset_cache.borrow().len(),
+        1,
+        "structural positive-subset filters should reuse their memo entry"
+    );
+}
+
+#[test]
+fn test_narrow_excluding_positive_subset_filters_inert_structural_member_inside_positive_union() {
+    let interner = TypeInterner::new();
+    let cache = NarrowingCache::new();
+    let ctx = NarrowingContext::with_cache(&interner, &cache);
+    let tag_name = interner.intern_string("tag");
+    let value_name = interner.intern_string("value");
+    let count_name = interner.intern_string("count");
+    let tag_a = interner.literal_string("a");
+    let tag_b = interner.literal_string("b");
+    let member_a = interner.object(vec![
+        PropertyInfo::new(tag_name, tag_a),
+        PropertyInfo::new(value_name, TypeId::STRING),
+    ]);
+    let member_b = interner.object(vec![
+        PropertyInfo::new(tag_name, tag_b),
+        PropertyInfo::new(count_name, TypeId::NUMBER),
+    ]);
+    let positive_b = interner.object(vec![PropertyInfo::new(tag_name, tag_b)]);
+    let source = interner.union(vec![TypeId::STRING, member_a, member_b]);
+    let positive = interner.union(vec![TypeId::STRING, positive_b]);
+
+    assert_eq!(
+        ctx.narrow_excluding_positive_subset(source, positive),
+        Some(member_a)
+    );
+    assert_eq!(
+        cache.cache_statistics().narrow_assignable_cache_entries,
+        2,
+        "only inert object members should be structurally probed against the positive object"
+    );
+}
+
+#[test]
+fn test_narrow_excluding_positive_subset_defers_recursive_structural_probe_after_identity_drop() {
+    let interner = TypeInterner::new();
+    let cache = NarrowingCache::new();
+    let ctx = NarrowingContext::with_cache(&interner, &cache);
+    let tag_name = interner.intern_string("kind");
+    let next_name = interner.intern_string("next");
+    let extra_name = interner.intern_string("count");
+    let tag_value = interner.literal_string("branch");
+    let recursive = interner.recursive(0);
+    let recursive_member = interner.object(vec![
+        PropertyInfo::new(tag_name, tag_value),
+        PropertyInfo::new(next_name, recursive),
+        PropertyInfo::new(extra_name, TypeId::NUMBER),
+    ]);
+    let positive_recursive = interner.object(vec![
+        PropertyInfo::new(tag_name, tag_value),
+        PropertyInfo::new(next_name, recursive),
+    ]);
+    let source = interner.union(vec![TypeId::STRING, recursive_member]);
+    let positive = interner.union(vec![TypeId::STRING, positive_recursive]);
+
+    assert_eq!(
+        ctx.narrow_excluding_positive_subset(source, positive),
+        Some(recursive_member)
+    );
+    let stats = cache.cache_statistics();
+    assert_eq!(
+        stats.narrow_assignable_cache_entries, 0,
+        "recursive/evaluator-sensitive survivors should not enter structural assignability"
+    );
+    assert_eq!(
+        stats.narrow_subtype_cache_entries, 0,
+        "recursive/evaluator-sensitive survivors should stay on the tsc subset path"
+    );
+}
+
+#[test]
+fn test_narrow_excluding_positive_subset_deferred_no_reduction_returns_source() {
+    let interner = TypeInterner::new();
+    let cache = NarrowingCache::new();
+    let ctx = NarrowingContext::with_cache(&interner, &cache);
+    let tag_name = interner.intern_string("shape");
+    let next_name = interner.intern_string("child");
+    let extra_name = interner.intern_string("rank");
+    let tag_value = interner.literal_string("node");
+    let recursive = interner.recursive(0);
+    let recursive_member = interner.object(vec![
+        PropertyInfo::new(tag_name, tag_value),
+        PropertyInfo::new(next_name, recursive),
+        PropertyInfo::new(extra_name, TypeId::NUMBER),
+    ]);
+    let unrelated_member = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("other"),
+        TypeId::BOOLEAN,
+    )]);
+    let source = interner.union(vec![recursive_member, unrelated_member]);
+    let positive_recursive = interner.object(vec![
+        PropertyInfo::new(tag_name, tag_value),
+        PropertyInfo::new(next_name, recursive),
+    ]);
+
+    assert_eq!(
+        ctx.narrow_excluding_positive_subset(source, positive_recursive),
+        Some(source),
+        "deferred structural repair is a terminal unchanged predicate false branch"
+    );
+    let stats = cache.cache_statistics();
+    assert_eq!(stats.narrow_positive_subset_cache_entries, 1);
+    assert_eq!(stats.narrow_assignable_cache_entries, 0);
+    assert_eq!(stats.narrow_subtype_cache_entries, 0);
+}
+
+#[test]
+fn test_predicate_false_branch_publishes_positive_subset_memo() {
+    let interner = TypeInterner::new();
+    let cache = NarrowingCache::new();
+    let ctx = NarrowingContext::with_cache(&interner, &cache);
+    let member_a = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("left"),
+        TypeId::STRING,
+    )]);
+    let member_b = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("right"),
+        TypeId::NUMBER,
+    )]);
+    let source = interner.union(vec![member_a, member_b]);
+    let predicate_target = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("right"),
+        TypeId::NUMBER,
+    )]);
+    let guard = TypeGuard::Predicate {
+        type_id: Some(predicate_target),
+        asserts: false,
+    };
+
+    assert_eq!(
+        ctx.narrow_type(source, &guard, GuardSense::Negative),
+        member_a
+    );
+    assert_eq!(
+        cache.narrow_positive_subset_cache.borrow().len(),
+        1,
+        "predicate false-branch should memoize the shallow positive-subset exclusion"
+    );
+}


### PR DESCRIPTION
Goal: fast

## Summary
- Generalize the solver-owned top-level narrowing memo from predicate-only guards to a cache-policy-gated set of structural guards: typeof, truthy/nullish/literal equality, in-property, array, instanceof, constructor, array element predicates, predicates, and short discriminant paths.
- Add a solver-owned positive-subset memo for the shallow predicate false-branch operation so repeated `source minus positive branch` checks reuse the same exclusion answer.
- Gate positive-subset structural repair to already materialized, evaluator-inert object-like pairs; recursive/deferred/evaluator-sensitive pairs now stay on the tsc false-branch subset path and return an unchanged terminal result instead of falling into relation/eval.
- Add a request-local exclusion-budget taint so conservative fuel-spent narrowing results are computed for the current request but not published into `narrow_type_cache`.
- Bound the widened cache by stable-key count and bypass long discriminant paths instead of truncating their payloads into unsound keys.

## Structural Rule
When the same semantic source `TypeId` is narrowed by the same `TypeGuard`, branch sense, compiler options, and resolver generation, `tsc` observes the same narrowed type. `tsz` now serves that repeated semantic question through solver-owned `NarrowingContext` memoization.

When a predicate false branch excludes the positive predicate subset from the same source type, tsc first uses a shallow `filterType(type, t => !isTypeSubsetOf(t, trueType))` pass over top-level union members. `tsz` now keeps that false-branch boundary shallow: identity/containment reductions are cached, structural repair is only attempted for materialized evaluator-inert object-like source/positive pairs, and recursive/deferred/evaluator-sensitive pairs return the source unchanged as a terminal solver result. No checker-owned semantic branch, fixture-name gate, rendered-type predicate, or source-text shortcut is added.

## Cache Invariant
- Top-level key: source `TypeId`, full `TypeGuard` payload, `GuardSense`, `NarrowingOptions`, plus resolver generation as the `GenerationMemo` stamp.
- Positive-subset key: source `TypeId`, positive-branch `TypeId`, plus resolver generation as the `GenerationMemo` stamp; value is `Option<TypeId>`, including cached `None` for complete no-reduction/no-deferred-candidate passes and cached `Some(source)` for terminal deferred structural repair.
- Invalidation/reset: resolver-generation partitioning and existing per-generation slot bound remain unchanged.
- Residency: distinct stable guard keys are capped at `MAX_NARROW_TYPE_CACHE_KEYS`; the positive-subset memo is reported through `NarrowingCacheStatistics` and cache-visibility sizing.
- Fuel behavior: nested exclusion narrowing that spends or exceeds the per-request budget taints the top-level guard request, so the conservative result is not inserted into `narrow_type_cache`.

## Adjacent Matrix
- Repeated `NarrowingRequest` truthy guards hit the generalized top-level cache without growing entries.
- `typeof` guards share the same cache while predicate payload, compiler options, and resolver generation still partition entries.
- Long discriminant paths bypass cache publication instead of truncating their path payload.
- Starved false-branch predicate exclusion returns the conservative source but leaves the top-level cache empty; a full-budget rerun computes and caches the refined result.
- Positive-subset memo coverage includes reduced result, complete no-reduction result, inert structural member filtering, inert structural repair inside a positive union, recursive/deferred structural repair deferral, and the public predicate false-branch path.
- Checker flow boundary now returns the solver's positive-subset result directly, so terminal unchanged false-branch results cannot fall through into the relation fallback.
- Existing generation-stamped narrowing cache statistics and exclusion-budget guard tests continue to pass.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `git diff HEAD^..HEAD --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(narrow_excluding_positive_subset)'` (10 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(flow_guard_boundary) or test(flow_assignment_relation_routing_arch)'` (19 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(narrow_excluding) or test(predicate_false_branch) or test(narrow_type)'` (29 passed)
- `scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `scripts/safe-run.sh cargo clippy -p tsz-solver -p tsz-checker --lib --tests -- -D warnings`
- `python3 scripts/perf/cache-visibility-report.py --json`
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz`
- TypeBox canary remains red after this production delta: `TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_FILTER='^typebox-project$' TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 TSZ_PROJECT_COMPILE_TIMEOUT=120 TSZ_PROJECT_COMPILE_RESULT_CACHE=0 TSZ_PROJECT_COMPILE_TSC_ORACLE=0 scripts/safe-run.sh --limit 75% -- scripts/ci/project-compile-guard.sh` reported `typebox-project wall timeout after 120s with 120.38s process CPU (~100% CPU share): CPU-bound timeout`.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
