### PR TITLE
fix(checker): narrow keyof-typed bindings to the assigned key literal (#15476)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1219,6 +1219,9 @@ mod jsx_union_props_relation_routing_arch_tests;
 #[path = "tests/keyof_alias_composite_display_tests.rs"]
 mod keyof_alias_composite_display_tests;
 #[cfg(test)]
+#[path = "tests/keyof_binding_assignment_narrowing_tests.rs"]
+mod keyof_binding_assignment_narrowing_tests;
+#[cfg(test)]
 #[path = "../tests/keyof_function_type_is_never_tests.rs"]
 mod keyof_function_type_is_never_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -3,6 +3,7 @@ use smallvec::SmallVec;
 use tsz_solver::TypeId;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::narrowing::{GuardSense, NarrowingContext, TypeGuard};
+use tsz_solver::type_queries::TypeIdList;
 
 use super::{
     assignability::{RelationFlags, RelationOutcome},
@@ -892,7 +893,19 @@ pub(crate) fn narrow_assignment(
         );
     }
 
-    let Some(members) = union_members_for_type(db, resolved_initial) else {
+    // `union_members_for_type` returns `None` for any declared type that is not
+    // a stored union — including an unevaluated `keyof T` operator, whose keys
+    // form a union but are not materialized until the operator is evaluated.
+    // Without the `keyof` fallback the reduction bails and keeps the whole
+    // `keyof T` type, surfacing a spurious assignment error at later reads (e.g.
+    // reading a `keyof number[]` binding initialized to `"length"` where a
+    // `string` is expected). Mirror tsc's `getAssignmentReducedType`, which
+    // resolves `keyof T` to its key set before reducing. Other unevaluated
+    // operators (a generic `T[K]`, a conditional) stay non-enumerable after
+    // evaluation, so they still bail here with byte-identical behaviour.
+    let Some(members) = union_members_for_type(db, resolved_initial)
+        .or_else(|| keyof_key_union_members(db, env, resolved_initial))
+    else {
         return initial_type;
     };
     if members.len() <= 1 {
@@ -921,6 +934,36 @@ pub(crate) fn narrow_assignment(
     } else {
         union_types(db, kept)
     }
+}
+
+/// Enumerate the key literals of a `keyof T` declared type for assignment
+/// reduction.
+///
+/// `keyof T` is interned as an unevaluated `KeyOf` operator whose key set is not
+/// a stored union, so [`union_members_for_type`] returns `None` for it and
+/// [`narrow_assignment`] cannot reduce it against an assigned key. Evaluating the
+/// operator to its concrete key union (through the flow `TypeEnvironment` so a
+/// `Lazy(DefId)` operand such as `keyof Arr` where `type Arr = number[]` resolves
+/// too) recovers those members. Returns `None` for any non-`keyof` type, or when
+/// the operator does not reduce to an enumerable union (e.g. a still-generic
+/// `keyof T` or a single-key `keyof { a: 1 }` that already equals its sole key),
+/// leaving those declarations' narrowing untouched.
+fn keyof_key_union_members(
+    db: &dyn TypeDatabase,
+    env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
+    type_id: TypeId,
+) -> Option<TypeIdList> {
+    if !is_keyof_type(db, type_id) {
+        return None;
+    }
+    let evaluated = match env {
+        Some(environment) => evaluate_type_structure_with_resolver(db, environment, type_id),
+        None => evaluate_type_structure(db, type_id),
+    };
+    if evaluated == type_id {
+        return None;
+    }
+    union_members_for_type(db, evaluated)
 }
 
 pub(crate) fn are_types_mutually_subtype(
@@ -1107,6 +1150,27 @@ pub(crate) fn get_application_info(
 /// resolved structure but should not call `tsz_solver::computation::evaluate_type()` directly.
 pub(crate) fn evaluate_type_structure(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
     tsz_solver::computation::evaluate_type(db, type_id)
+}
+
+/// Env-aware variant of [`evaluate_type_structure`].
+///
+/// Evaluates a type to its structural form using the flow `TypeEnvironment` as
+/// the lazy-alias resolver, so a type operator whose operand is a `Lazy(DefId)`
+/// alias (e.g. `keyof Arr` where `type Arr = number[]`) resolves through to its
+/// concrete form. Callers should use this boundary instead of constructing a
+/// `TypeEvaluator` directly.
+///
+/// This is the `TypeDatabase`-only sibling of the `QueryDatabase`-based
+/// `evaluate_type_with_resolver` boundaries (`dispatch`,
+/// `state::type_environment`); use those when a `QueryDatabase` is in scope, and
+/// this one on flow paths that only hold a `TypeDatabase` (e.g.
+/// [`narrow_assignment`]).
+pub(crate) fn evaluate_type_structure_with_resolver(
+    db: &dyn TypeDatabase,
+    resolver: &tsz_solver::relations::subtype::TypeEnvironment,
+    type_id: TypeId,
+) -> TypeId {
+    tsz_solver::computation::TypeEvaluator::with_resolver(db, resolver).evaluate(type_id)
 }
 
 /// If `type_id` is a promise-like application type, return the inner type argument.

--- a/crates/tsz-checker/src/tests/keyof_binding_assignment_narrowing_tests.rs
+++ b/crates/tsz-checker/src/tests/keyof_binding_assignment_narrowing_tests.rs
@@ -1,0 +1,186 @@
+//! Regression tests: a binding declared with a `keyof T` type must narrow to
+//! the assigned key literal, exactly as tsc's `getAssignmentReducedType` does.
+//!
+//! Structural rule: when a binding's declared type is a `keyof T` operator and
+//! its assigned value is a key of `T`, tsc resolves `keyof T` to its concrete
+//! key set before assignment reduction and narrows the binding to the assigned
+//! key. tsz previously left `keyof T` as an unevaluated `KeyOf` operator, whose
+//! keys are not enumerable as union members, so the assignment reduction bailed
+//! and kept the whole `keyof T` type — surfacing a spurious TS2322 at any later
+//! read that expected the narrowed key (e.g. reading a `keyof number[]` binding
+//! initialized to `"length"` where a `string` is expected). tsz now owns this
+//! through the assignment-reduction boundary
+//! (`query_boundaries::flow_analysis::narrow_assignment`), evaluating the `keyof`
+//! operator to its key union before reducing.
+//!
+//! The reduction only *adds* precision for `keyof` declared types that formerly
+//! bailed, so genuinely invalid keys still report TS2322 and non-`keyof`
+//! declarations keep their prior narrowing.
+
+use crate::test_utils::check_source_strict_codes;
+
+/// `let` binding: `keyof number[]` narrows to the assigned key literal, so a
+/// later read into a `string` slot is accepted.
+#[test]
+fn let_binding_keyof_array_narrows_to_assigned_key() {
+    let source = "\
+type Arr = number[];
+type K = keyof Arr;
+let v: K = \"length\";
+const w: string = v;
+";
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.is_empty(),
+        "`let v: keyof number[] = \"length\"` must narrow v to \"length\" (assignable \
+         to string); expected no diagnostics, got: {codes:?}",
+    );
+}
+
+/// The `keyof` operator applied inline (operand not behind an alias) narrows
+/// identically — the operand-resolution path is not the trigger.
+#[test]
+fn let_binding_inline_keyof_array_narrows_to_assigned_key() {
+    let source = "\
+type K = keyof number[];
+let v: K = \"length\";
+const w: string = v;
+";
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.is_empty(),
+        "inline `keyof number[]` must narrow the same way; got: {codes:?}",
+    );
+}
+
+/// `const` binding: same reduction path, so the initializer narrows too.
+#[test]
+fn const_binding_keyof_array_narrows_to_assigned_key() {
+    let source = "\
+type Arr = number[];
+type K = keyof Arr;
+const v: K = \"length\";
+const w: string = v;
+";
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.is_empty(),
+        "`const v: keyof number[] = \"length\"` must narrow v to \"length\"; got: {codes:?}",
+    );
+}
+
+/// `keyof` of an object type narrows to a single string-literal key.
+#[test]
+fn let_binding_keyof_object_narrows_to_assigned_key() {
+    let source = "\
+type O = { a: 1; b: 2 };
+type K = keyof O;
+let v: K = \"a\";
+const w: \"a\" = v;
+";
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.is_empty(),
+        "`let v: keyof {{ a; b }} = \"a\"` must narrow v to \"a\"; got: {codes:?}",
+    );
+}
+
+/// Return position uses the same assignment-reduction narrowing on the local.
+#[test]
+fn return_position_keyof_binding_narrows_to_assigned_key() {
+    let source = "\
+type Arr = number[];
+type K = keyof Arr;
+function f(): string {
+  let v: K = \"length\";
+  return v;
+}
+";
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.is_empty(),
+        "returning a `keyof number[]` local narrowed to \"length\" from a `string` \
+         function must be accepted; got: {codes:?}",
+    );
+}
+
+/// Reassignment (not just the initializer) narrows a `keyof`-typed `let`.
+#[test]
+fn reassignment_of_keyof_binding_narrows_to_assigned_key() {
+    let source = "\
+type O = { a: 1; b: 2 };
+let v: keyof O;
+v = \"a\";
+const w: \"a\" = v;
+";
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.is_empty(),
+        "reassigning a `keyof` binding to a key literal must narrow it; got: {codes:?}",
+    );
+}
+
+/// Renamed binders (no reliance on identifier spelling): the same shape with
+/// different alias/binding names must behave identically.
+#[test]
+fn keyof_binding_narrowing_is_not_binder_name_specific() {
+    let source = "\
+type Collection = string[];
+type Member = keyof Collection;
+let selected: Member = \"length\";
+const asText: string = selected;
+";
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.is_empty(),
+        "renamed binders must not change keyof-binding narrowing; got: {codes:?}",
+    );
+}
+
+/// Control: a value that is *not* a key of `T` still reports TS2322 — the
+/// reduction adds precision without hiding genuine errors.
+#[test]
+fn keyof_binding_rejects_non_key_literal() {
+    let source = "\
+type Arr = number[];
+type K = keyof Arr;
+const k: K = \"notamethod\";
+";
+    let codes = check_source_strict_codes(source);
+    assert_eq!(
+        codes,
+        vec![2322],
+        "assigning a non-key literal to a `keyof` binding must still report TS2322; \
+         got: {codes:?}",
+    );
+}
+
+/// Control: assigning a valid key was already accepted and must stay accepted.
+#[test]
+fn keyof_binding_accepts_valid_key_literal() {
+    let source = "\
+type Arr = number[];
+type K = keyof Arr;
+const k: K = \"push\";
+";
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.is_empty(),
+        "assigning a valid key to a `keyof` binding must be accepted; got: {codes:?}",
+    );
+}
+
+/// Control: a plain literal union (not a `keyof`) narrows exactly as before —
+/// the new path is gated to `keyof` operators.
+#[test]
+fn plain_literal_union_binding_narrowing_unchanged() {
+    let source = "\
+let v: \"a\" | \"b\" | number = \"a\";
+const w: \"a\" | \"b\" = v;
+";
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.is_empty(),
+        "plain literal-union narrowing must be unchanged; got: {codes:?}",
+    );
+}


### PR DESCRIPTION
Fixes #15476.

When a binding's declared type is a `keyof T` operator and its assigned value is
a key of `T`, `tsc` resolves `keyof T` to its concrete key set before assignment
reduction (`getAssignmentReducedType`) and narrows the binding to the assigned
key; tsz kept the whole `keyof T` type, so a later read expecting the narrowed
key surfaced a spurious `TS2322`. Fixed through the checker's assignment-reduction
boundary (`query_boundaries::flow_analysis::narrow_assignment`).

Root cause: `keyof T` is interned as an unevaluated `KeyOf` operator whose keys
are not a stored union, so `union_members_for_type(resolved_initial)` returned
`None`, the reduction bailed, and the declared type was preserved. When member
enumeration fails, the fix now evaluates a `keyof` operator to its key union
(through the flow `TypeEnvironment`, so a `Lazy(DefId)` operand such as
`keyof Arr` where `type Arr = number[]` resolves too) and reduces against that.
The evaluation is delegated to the solver; the checker only orchestrates.

The change is additive: it only runs on the `union_members == None` bail branch,
and the `evaluated == type_id` / `union_members(evaluated) == None` guards keep
non-`keyof` (and still-generic `keyof T`, single-key `keyof { a: 1 }`) declared
types byte-identical, so it can only add precision (remove false positives),
never introduce new errors.

Repro (`tsc` 6.0.2 vs tsz `--noEmit --strict`):

```ts
type Arr = number[];
type K = keyof Arr;
let v: K = "length";
const w: string = v; // tsc: ok (v narrows to "length"); tsz before: TS2322
```

Adjacent matrix covered (all differential-verified against `tsc` 6.0.2): `let`/
`const` initializer, return-position local, and reassignment narrowing; `keyof`
of arrays and objects; aliased (`keyof Arr`) and inline (`keyof number[]`)
operands; renamed binders; plus controls (a non-key literal still reports
`TS2322`, a valid key stays accepted, a plain literal-union binding narrows as
before).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib keyof_binding_assignment_narrowing` — new shard, 10/10 pass (let/const/return/reassign × keyof-array/keyof-object × aliased/inline × renamed binders × valid-key/non-key/plain-union controls).
- `cargo clippy -p tsz-checker --lib` — clean.
- End-to-end CLI differential vs `tsc` 6.0.2 on the repro matrix: full parity (previously-spurious TS2322 cleared; genuine errors and valid keys unchanged).
- The two adjacent narrowing tests failing on this run pre-exist on clean `origin/main` (verified by stashing the change and rebuilding); neither involves `keyof`.
- Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_015YerJU6EcPbfvCR342BjoN)_