### PR TITLE
perf(solver): memoize private brand override probes (#14351)

### DIFF
--- a/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
+++ b/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
@@ -46,7 +46,7 @@ impl<'a> CheckerState<'a> {
         if is_cacheable {
             // Note: For subtype checks in the checker, we use AnyPropagationMode::All (0)
             // since the checker doesn't track depth like SubtypeChecker does
-            let cache_key = subtype_cache_key(source, target, flags);
+            let cache_key = subtype_cache_key(source, target, flags, &self.ctx.inheritance_graph);
 
             if let Some(cached) = self.ctx.types.lookup_subtype_cache(cache_key) {
                 return cached;
@@ -93,7 +93,7 @@ impl<'a> CheckerState<'a> {
 
         // Cache the result for non-inference types
         if is_cacheable {
-            let cache_key = subtype_cache_key(source, target, flags);
+            let cache_key = subtype_cache_key(source, target, flags, &self.ctx.inheritance_graph);
 
             self.ctx.types.insert_subtype_cache(cache_key, result);
         }

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -711,7 +711,10 @@ mod final_relation;
 mod overload_subtype_pass;
 mod relation_kind_variants;
 mod shape;
-pub(crate) use cache_key::{RelationFlags, assignability_cache_key, subtype_cache_key};
+pub(crate) use cache_key::{
+    RelationFlags, assignability_cache_key, assignability_cache_key_for_policy,
+    checker_final_assignability_cache_key, subtype_cache_key,
+};
 pub(crate) use final_relation::cached_final_assignability;
 pub(crate) use overload_subtype_pass::cached_overload_subtype_pass_assignability;
 pub(crate) use relation_kind_variants::{
@@ -928,7 +931,12 @@ pub(crate) fn cached_assignability_with_overrides<
     let is_cacheable =
         is_relation_cacheable(inputs.db.as_type_database(), inputs.source, inputs.target);
     if is_cacheable {
-        let cache_key = assignability_cache_key(inputs.source, inputs.target, inputs.flags);
+        let cache_key = assignability_cache_key(
+            inputs.source,
+            inputs.target,
+            inputs.flags,
+            inputs.inheritance_graph,
+        );
         if let Some(cached) = inputs.db.lookup_assignability_cache(cache_key) {
             return tsz_solver::relations::relation_queries::RelationResult::complete(
                 tsz_solver::relations::relation_queries::RelationKind::Assignable,
@@ -940,7 +948,12 @@ pub(crate) fn cached_assignability_with_overrides<
     let relation_result = is_assignable_with_overrides(inputs, overrides);
 
     if is_cacheable {
-        let cache_key = assignability_cache_key(inputs.source, inputs.target, inputs.flags);
+        let cache_key = assignability_cache_key(
+            inputs.source,
+            inputs.target,
+            inputs.flags,
+            inputs.inheritance_graph,
+        );
         inputs
             .db
             .insert_assignability_cache(cache_key, relation_result.is_related());

--- a/crates/tsz-checker/src/query_boundaries/assignability/cache_key.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/cache_key.rs
@@ -4,6 +4,8 @@
 //! boundary still owns cache-key policy.
 
 use tsz_solver::TypeId;
+use tsz_solver::classes::inheritance::InheritanceGraph;
+use tsz_solver::relations::relation_queries::RelationPolicy;
 
 use super::relation_policy;
 
@@ -48,15 +50,52 @@ pub(crate) use tsz_solver::RelationCacheKey;
 /// The resulting config is produced by the solver's typed `RelationPolicy`
 /// bridge, so this write path lands in the same cache slot as the solver's
 /// internal write path.
+const fn with_inheritance_graph_context(
+    key: RelationCacheKey,
+    inheritance_graph: &InheritanceGraph,
+) -> RelationCacheKey {
+    key.with_inheritance_graph_context(inheritance_graph.identity(), inheritance_graph.generation())
+}
+
+pub(crate) const fn assignability_cache_key_for_policy(
+    source: TypeId,
+    target: TypeId,
+    policy: RelationPolicy,
+    inheritance_graph: &InheritanceGraph,
+) -> RelationCacheKey {
+    with_inheritance_graph_context(
+        RelationCacheKey::for_assignability(source, target, policy.cache_config()),
+        inheritance_graph,
+    )
+}
+
 pub(crate) const fn assignability_cache_key(
     source: TypeId,
     target: TypeId,
     flags: u16,
+    inheritance_graph: &InheritanceGraph,
 ) -> RelationCacheKey {
-    RelationCacheKey::for_assignability(
+    assignability_cache_key_for_policy(
         source,
         target,
-        relation_policy::from_checker_flags_u16(flags).cache_config(),
+        relation_policy::from_checker_flags_u16(flags),
+        inheritance_graph,
+    )
+}
+
+pub(crate) const fn checker_final_assignability_cache_key(
+    source: TypeId,
+    target: TypeId,
+    flags: u16,
+    inheritance_graph: &InheritanceGraph,
+) -> RelationCacheKey {
+    with_inheritance_graph_context(
+        RelationCacheKey::for_checker_assignability(
+            source,
+            target,
+            relation_policy::from_checker_flags_u16(flags).cache_config(),
+        ),
+        inheritance_graph,
     )
 }
 
@@ -65,10 +104,51 @@ pub(crate) const fn subtype_cache_key(
     source: TypeId,
     target: TypeId,
     flags: u16,
+    inheritance_graph: &InheritanceGraph,
 ) -> RelationCacheKey {
-    RelationCacheKey::for_subtype(
-        source,
-        target,
-        relation_policy::from_checker_flags_u16(flags).cache_config(),
+    with_inheritance_graph_context(
+        RelationCacheKey::for_subtype(
+            source,
+            target,
+            relation_policy::from_checker_flags_u16(flags).cache_config(),
+        ),
+        inheritance_graph,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsz_binder::SymbolId;
+
+    #[test]
+    fn checker_relation_cache_keys_partition_by_inheritance_graph_generation() {
+        let graph = InheritanceGraph::new();
+        let before_assignability =
+            assignability_cache_key(TypeId::STRING, TypeId::NUMBER, 0, &graph);
+        let before_final =
+            checker_final_assignability_cache_key(TypeId::STRING, TypeId::NUMBER, 0, &graph);
+        let before_subtype = subtype_cache_key(TypeId::STRING, TypeId::NUMBER, 0, &graph);
+
+        assert_eq!(before_assignability.inheritance_graph_id, graph.identity());
+        assert_eq!(before_final.inheritance_graph_id, graph.identity());
+        assert_eq!(before_subtype.inheritance_graph_id, graph.identity());
+        assert_eq!(
+            before_assignability.inheritance_graph_generation,
+            graph.generation()
+        );
+
+        graph.add_inheritance(SymbolId(1), &[SymbolId(2)]);
+
+        let after_assignability =
+            assignability_cache_key(TypeId::STRING, TypeId::NUMBER, 0, &graph);
+        let after_final =
+            checker_final_assignability_cache_key(TypeId::STRING, TypeId::NUMBER, 0, &graph);
+        let after_subtype = subtype_cache_key(TypeId::STRING, TypeId::NUMBER, 0, &graph);
+
+        assert_eq!(after_assignability.inheritance_graph_id, graph.identity());
+        assert_ne!(before_assignability, after_assignability);
+        assert_ne!(before_final, after_final);
+        assert_ne!(before_subtype, after_subtype);
+    }
 }

--- a/crates/tsz-checker/src/query_boundaries/assignability/final_relation.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/final_relation.rs
@@ -14,28 +14,13 @@
 //! poison each other.
 
 use tracing::trace;
-use tsz_solver::{RelationCacheKey, TypeId};
+use tsz_solver::TypeId;
 
-use super::{AssignabilityQueryInputs, is_assignable_with_overrides, is_relation_cacheable};
-use crate::query_boundaries::relation_policy;
+use super::{
+    AssignabilityQueryInputs, checker_final_assignability_cache_key, is_assignable_with_overrides,
+    is_relation_cacheable,
+};
 use crate::state::{CheckerOverrideProvider, CheckerState};
-
-/// Build a cache key for a checker-final assignability verdict.
-///
-/// Same typed `RelationCacheConfig` derivation as `assignability_cache_key`,
-/// but under `RelationCacheKind::CheckerAssignable` so checker-final entries
-/// never share a slot with raw Lawyer-relation entries.
-const fn checker_final_assignability_cache_key(
-    source: TypeId,
-    target: TypeId,
-    flags: u16,
-) -> RelationCacheKey {
-    RelationCacheKey::for_checker_assignability(
-        source,
-        target,
-        relation_policy::from_checker_flags_u16(flags).cache_config(),
-    )
-}
 
 /// Execute the checker-final assignability relation for prepared (evaluated)
 /// source/target types: cache lookup → relation execution → post-relation
@@ -58,7 +43,12 @@ pub(crate) fn cached_final_assignability(
 ) -> bool {
     let flags = checker.ctx.pack_relation_flags();
     let is_cacheable = is_relation_cacheable(checker.ctx.types.as_type_database(), source, target);
-    let cache_key = checker_final_assignability_cache_key(source, target, flags);
+    let cache_key = checker_final_assignability_cache_key(
+        source,
+        target,
+        flags,
+        &checker.ctx.inheritance_graph,
+    );
     if is_cacheable && let Some(cached) = checker.ctx.types.lookup_assignability_cache(cache_key) {
         trace!(
             source = source.0,

--- a/crates/tsz-checker/src/query_boundaries/assignability/overload_subtype_pass.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/overload_subtype_pass.rs
@@ -3,11 +3,10 @@
 //! Submodule keeps the assignability boundary under its LOC ceiling while the
 //! boundary still owns the cache-key construction and relation execution.
 
-use tsz_solver::RelationCacheKey;
-
 use super::relation_policy;
 use super::{
-    AssignabilityQueryInputs, RelationQueryInputs, SolverRelationKind, is_relation_cacheable,
+    AssignabilityQueryInputs, RelationQueryInputs, SolverRelationKind,
+    assignability_cache_key_for_policy, is_relation_cacheable,
 };
 
 /// Overload-resolution subtype pass (tsc `chooseOverload` with
@@ -33,8 +32,12 @@ pub(crate) fn cached_overload_subtype_pass_assignability<
         );
     let is_cacheable =
         is_relation_cacheable(inputs.db.as_type_database(), inputs.source, inputs.target);
-    let cache_key =
-        RelationCacheKey::for_assignability(inputs.source, inputs.target, policy.cache_config());
+    let cache_key = assignability_cache_key_for_policy(
+        inputs.source,
+        inputs.target,
+        policy,
+        inputs.inheritance_graph,
+    );
     if is_cacheable && let Some(cached) = inputs.db.lookup_assignability_cache(cache_key) {
         return tsz_solver::relations::relation_queries::RelationResult::complete(
             tsz_solver::relations::relation_queries::RelationKind::Assignable,

--- a/crates/tsz-checker/src/query_boundaries/assignability/relation_kind_variants.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/relation_kind_variants.rs
@@ -57,7 +57,7 @@ pub(crate) fn cached_bivariant_assignability_with_resolver<
 ) -> tsz_solver::relations::relation_queries::RelationResult {
     let is_cacheable = is_relation_cacheable(db.as_type_database(), source, target);
     if is_cacheable {
-        let cache_key = assignability_cache_key(source, target, flags);
+        let cache_key = assignability_cache_key(source, target, flags, inheritance_graph);
         if let Some(cached) = db.lookup_assignability_cache(cache_key) {
             return tsz_solver::relations::relation_queries::RelationResult::complete(
                 tsz_solver::relations::relation_queries::RelationKind::AssignableBivariantCallbacks,
@@ -78,7 +78,7 @@ pub(crate) fn cached_bivariant_assignability_with_resolver<
     );
 
     if is_cacheable {
-        let cache_key = assignability_cache_key(source, target, flags);
+        let cache_key = assignability_cache_key(source, target, flags, inheritance_graph);
         db.insert_assignability_cache(cache_key, relation_result.is_related());
     }
 

--- a/crates/tsz-solver/src/classes/inheritance.rs
+++ b/crates/tsz-solver/src/classes/inheritance.rs
@@ -8,7 +8,10 @@ use fixedbitset::FixedBitSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tsz_binder::SymbolId;
+
+static NEXT_INHERITANCE_GRAPH_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Represents a node in the inheritance graph.
 #[derive(Debug, Clone, Default)]
@@ -24,12 +27,16 @@ struct ClassNode {
     mro: Option<Vec<SymbolId>>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct InheritanceGraph {
+    /// Process-local identity for relation cache partitioning.
+    identity: u64,
     /// Map from `SymbolId` to graph node data
     nodes: RefCell<FxHashMap<SymbolId, ClassNode>>,
     /// Maximum `SymbolId` seen so far (for `BitSet` sizing)
     max_symbol_id: Cell<usize>,
+    /// Monotonic stamp for behavior-affecting edge changes.
+    generation: Cell<u64>,
 }
 
 #[derive(Debug, Default)]
@@ -83,9 +90,19 @@ impl MroVisitState {
 impl InheritanceGraph {
     pub fn new() -> Self {
         Self {
+            identity: NEXT_INHERITANCE_GRAPH_ID.fetch_add(1, Ordering::Relaxed),
             nodes: RefCell::new(FxHashMap::default()),
             max_symbol_id: Cell::new(0),
+            generation: Cell::new(0),
         }
+    }
+
+    pub const fn identity(&self) -> u64 {
+        self.identity
+    }
+
+    pub const fn generation(&self) -> u64 {
+        self.generation.get()
     }
 
     /// Register a class or interface and its direct parents.
@@ -134,6 +151,7 @@ impl InheritanceGraph {
         }
 
         DescendantInvalidationState::default().invalidate_from(&mut nodes, child);
+        self.generation.set(self.generation.get().saturating_add(1));
     }
 
     /// Checks if `child` is a subtype of `ancestor` nominally.
@@ -308,6 +326,7 @@ impl InheritanceGraph {
     pub fn clear(&self) {
         self.nodes.borrow_mut().clear();
         self.max_symbol_id.set(0);
+        self.generation.set(self.generation.get().saturating_add(1));
     }
 
     /// Get the number of nodes in the graph
@@ -318,6 +337,12 @@ impl InheritanceGraph {
     /// Check if the graph is empty
     pub fn is_empty(&self) -> bool {
         self.nodes.borrow().is_empty()
+    }
+}
+
+impl Default for InheritanceGraph {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -1,5 +1,7 @@
 //! TypeScript compatibility layer for assignability rules.
 
+use std::cell::RefCell;
+
 use crate::caches::db::QueryDatabase;
 use crate::construction::TypeDatabase;
 use crate::diagnostics::SubtypeFailureReason;
@@ -18,6 +20,8 @@ use crate::visitor::{
 };
 use rustc_hash::FxHashMap;
 use tsz_common::interner::Atom;
+
+type CompatCacheKey = (TypeId, TypeId, u64, Option<(u64, u64)>);
 
 #[path = "compat_mapped.rs"]
 mod compat_mapped;
@@ -263,7 +267,13 @@ pub struct CompatChecker<'a, R: TypeResolver = NoopResolver> {
     /// include the weak type check. The weak type check is only applied
     /// at specific diagnostic sites in tsc.
     skip_weak_type_checks: bool,
-    cache: FxHashMap<(TypeId, TypeId), bool>,
+    cache: FxHashMap<CompatCacheKey, bool>,
+    /// Operation-local memo for recursive private/protected brand override
+    /// probes. Keyed by resolver and inheritance-graph generations because the
+    /// walk can resolve `Lazy(DefId)` references and protected/ES-private
+    /// origin checks can consult the class graph. See
+    /// `private_brand_assignability_override`.
+    private_brand_cache: RefCell<FxHashMap<CompatCacheKey, Option<bool>>>,
 }
 
 /// Operation-local cache statistics for [`CompatChecker`].
@@ -273,8 +283,10 @@ pub struct CompatChecker<'a, R: TypeResolver = NoopResolver> {
 /// checker.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CompatCheckerCacheStatistics {
-    /// Entries in the compatibility relation memo keyed by source and target `TypeId`.
+    /// Entries in the compatibility relation memo keyed by type pair plus resolver/graph stamp.
     pub relation_entries: usize,
+    /// Entries in the private/protected brand override memo keyed by type pair plus resolver/graph stamp.
+    pub private_brand_entries: usize,
     estimated_size_bytes: usize,
 }
 
@@ -306,6 +318,7 @@ impl<'a> CompatChecker<'a, NoopResolver> {
             disable_method_bivariance: false,
             skip_weak_type_checks: false,
             cache: FxHashMap::default(),
+            private_brand_cache: RefCell::new(FxHashMap::default()),
         }
     }
 }
@@ -315,10 +328,16 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     #[must_use]
     pub fn cache_statistics(&self) -> CompatCheckerCacheStatistics {
         let relation_entries = self.cache.len();
-        let estimated_size_bytes =
-            relation_entries.saturating_mul(std::mem::size_of::<((TypeId, TypeId), bool)>());
+        let private_brand_entries = self.private_brand_cache.borrow().len();
+        let estimated_size_bytes = relation_entries
+            .saturating_mul(std::mem::size_of::<(CompatCacheKey, bool)>())
+            .saturating_add(
+                private_brand_entries
+                    .saturating_mul(std::mem::size_of::<(CompatCacheKey, Option<bool>)>()),
+            );
         CompatCheckerCacheStatistics {
             relation_entries,
+            private_brand_entries,
             estimated_size_bytes,
         }
     }
@@ -635,7 +654,43 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             disable_method_bivariance: false,
             skip_weak_type_checks: false,
             cache: FxHashMap::default(),
+            private_brand_cache: RefCell::new(FxHashMap::default()),
         }
+    }
+
+    fn clear_operation_caches(&mut self) {
+        self.cache.clear();
+        self.private_brand_cache.borrow_mut().clear();
+    }
+
+    pub(crate) fn lookup_private_brand_override_cache(
+        &self,
+        source: TypeId,
+        target: TypeId,
+    ) -> Option<Option<bool>> {
+        let key = self.compat_cache_key(source, target);
+        self.private_brand_cache.borrow().get(&key).copied()
+    }
+
+    pub(crate) fn cache_private_brand_override_result(
+        &self,
+        source: TypeId,
+        target: TypeId,
+        result: Option<bool>,
+    ) {
+        let key = self.compat_cache_key(source, target);
+        self.private_brand_cache.borrow_mut().insert(key, result);
+    }
+
+    fn compat_cache_key(&self, source: TypeId, target: TypeId) -> CompatCacheKey {
+        (
+            source,
+            target,
+            self.subtype.resolver.resolver_generation(),
+            self.subtype
+                .inheritance_graph
+                .map(|graph| (graph.identity(), graph.generation())),
+        )
     }
 
     /// Set the query database for Salsa-backed memoization.
@@ -643,20 +698,23 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     pub fn set_query_db(&mut self, db: &'a dyn QueryDatabase) {
         self.query_db = Some(db);
         self.subtype.query_db = Some(db);
+        self.clear_operation_caches();
     }
 
     /// Set the class-symbol classifier used by nested subtype checks.
     pub fn set_class_check(&mut self, check: &'a dyn Fn(SymbolRef) -> bool) {
         self.subtype.is_class_symbol = Some(check);
+        self.clear_operation_caches();
     }
 
     /// Set the inheritance graph for nominal class subtype checking.
     /// Propagates to the internal `SubtypeChecker`.
-    pub const fn set_inheritance_graph(
+    pub fn set_inheritance_graph(
         &mut self,
         graph: Option<&'a crate::classes::inheritance::InheritanceGraph>,
     ) {
         self.subtype.inheritance_graph = graph;
+        self.clear_operation_caches();
     }
 
     /// Configure strict function parameter checking.
@@ -664,7 +722,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     pub fn set_strict_function_types(&mut self, strict: bool) {
         if self.strict_function_types != strict {
             self.strict_function_types = strict;
-            self.cache.clear();
+            self.clear_operation_caches();
         }
     }
 
@@ -672,7 +730,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     pub fn set_strict_null_checks(&mut self, strict: bool) {
         if self.strict_null_checks != strict {
             self.strict_null_checks = strict;
-            self.cache.clear();
+            self.clear_operation_caches();
         }
     }
 
@@ -680,7 +738,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     pub fn set_no_unchecked_indexed_access(&mut self, enabled: bool) {
         if self.no_unchecked_indexed_access != enabled {
             self.no_unchecked_indexed_access = enabled;
-            self.cache.clear();
+            self.clear_operation_caches();
         }
     }
 
@@ -689,14 +747,14 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     pub fn set_exact_optional_property_types(&mut self, exact: bool) {
         if self.exact_optional_property_types != exact {
             self.exact_optional_property_types = exact;
-            self.cache.clear();
+            self.clear_operation_caches();
         }
     }
 
     pub fn set_allow_bivariant_rest(&mut self, allow: bool) {
         if self.allow_bivariant_rest != allow {
             self.allow_bivariant_rest = allow;
-            self.cache.clear();
+            self.clear_operation_caches();
         }
     }
 
@@ -709,21 +767,21 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     pub fn set_strict_subtype_checking(&mut self, strict: bool) {
         if self.strict_subtype_checking != strict {
             self.strict_subtype_checking = strict;
-            self.cache.clear();
+            self.clear_operation_caches();
         }
     }
 
     pub fn set_disable_method_bivariance(&mut self, disable: bool) {
         if self.disable_method_bivariance != disable {
             self.disable_method_bivariance = disable;
-            self.cache.clear();
+            self.clear_operation_caches();
         }
     }
 
     pub fn set_assume_related_on_cycle(&mut self, assume: bool) {
         if self.subtype.assume_related_on_cycle != assume {
             self.subtype.assume_related_on_cycle = assume;
-            self.cache.clear();
+            self.clear_operation_caches();
         }
     }
 
@@ -736,7 +794,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     pub fn set_erase_generics(&mut self, erase: bool) {
         if self.subtype.erase_generics != erase {
             self.subtype.erase_generics = erase;
-            self.cache.clear();
+            self.clear_operation_caches();
         }
     }
 
@@ -748,7 +806,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     pub fn set_skip_weak_type_checks(&mut self, skip: bool) {
         if self.skip_weak_type_checks != skip {
             self.skip_weak_type_checks = skip;
-            self.cache.clear();
+            self.clear_operation_caches();
         }
     }
 
@@ -758,7 +816,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     /// if there's a real structural mismatch.
     pub fn set_strict_any_propagation(&mut self, strict: bool) {
         self.lawyer.set_allow_any_suppression(!strict);
-        self.cache.clear();
+        self.clear_operation_caches();
     }
 
     /// Toggle the overload subtype-pass mode (tsc `chooseOverload` with
@@ -768,7 +826,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     pub fn set_any_source_not_related(&mut self, enabled: bool) {
         if self.lawyer.any_source_not_related != enabled {
             self.lawyer.set_any_source_not_related(enabled);
-            self.cache.clear();
+            self.clear_operation_caches();
         }
     }
 
@@ -803,8 +861,8 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         // of function parameters. Sound mode is the opt-in for stricter `any` behavior.
         self.lawyer.allow_any_suppression = !config.sound_mode;
 
-        // Clear cache as configuration changed
-        self.cache.clear();
+        // Clear caches as configuration changed
+        self.clear_operation_caches();
     }
 
     /// Check if `source` is assignable to `target` using TS compatibility rules.
@@ -820,7 +878,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return true;
         }
 
-        let key = (source, target);
+        let key = self.compat_cache_key(source, target);
         if let Some(&cached) = self.cache.get(&key) {
             return cached;
         }

--- a/crates/tsz-solver/src/relations/compat_overrides.rs
+++ b/crates/tsz-solver/src/relations/compat_overrides.rs
@@ -25,6 +25,28 @@ use rustc_hash::FxHashSet;
 
 use super::compat::CompatChecker;
 
+#[derive(Clone, Copy)]
+struct PrivateBrandOverrideEval {
+    result: Option<bool>,
+    complete: bool,
+}
+
+impl PrivateBrandOverrideEval {
+    const fn complete(result: Option<bool>) -> Self {
+        Self {
+            result,
+            complete: true,
+        }
+    }
+
+    const fn incomplete(result: Option<bool>) -> Self {
+        Self {
+            result,
+            complete: false,
+        }
+    }
+}
+
 // =============================================================================
 // Assignability Override Functions
 // =============================================================================
@@ -83,6 +105,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         stacker::maybe_grow(256 * 1024, 2 * 1024 * 1024, || {
             let mut visiting = FxHashSet::default();
             self.private_brand_assignability_override_inner(source, target, &mut visiting)
+                .result
         })
     }
 
@@ -91,14 +114,20 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         source: TypeId,
         target: TypeId,
         visiting: &mut FxHashSet<(TypeId, TypeId)>,
-    ) -> Option<bool> {
+    ) -> PrivateBrandOverrideEval {
         let pair = (source, target);
+        if let Some(result) = self.lookup_private_brand_override_cache(source, target) {
+            return PrivateBrandOverrideEval::complete(result);
+        }
         if !visiting.insert(pair) {
-            return None;
+            return PrivateBrandOverrideEval::incomplete(None);
         }
 
         let result = self.private_brand_assignability_override_body(source, target, visiting);
         visiting.remove(&pair);
+        if result.complete {
+            self.cache_private_brand_override_result(source, target, result.result);
+        }
         result
     }
 
@@ -107,20 +136,20 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         source: TypeId,
         target: TypeId,
         visiting: &mut FxHashSet<(TypeId, TypeId)>,
-    ) -> Option<bool> {
+    ) -> PrivateBrandOverrideEval {
         use crate::types::Visibility;
 
         // Fast path: identical types don't need nominal brand override logic.
         // Let the regular assignability path decide.
         if source == target {
-            return None;
+            return PrivateBrandOverrideEval::complete(None);
         }
 
         // Fast path: intrinsics never resolve to Union/Intersection/Lazy/Object,
         // so there's no nominal brand to enforce. Skip the cascade of dyn-
         // dispatched lookups and let the regular path decide.
         if source.is_intrinsic() && target.is_intrinsic() {
-            return None;
+            return PrivateBrandOverrideEval::complete(None);
         }
 
         // 1. Handle Source Union (AND logic) — MUST run before target union.
@@ -131,14 +160,20 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         // require the entire source union to match a single target member.
         if let Some(TypeData::Union(members)) = self.interner.lookup(source) {
             let members = self.interner.type_list(members);
+            let mut complete = true;
             for &member in members.iter() {
-                if let Some(false) =
-                    self.private_brand_assignability_override_inner(member, target, visiting)
-                {
-                    return Some(false); // Fail if any member fails
+                let member_result =
+                    self.private_brand_assignability_override_inner(member, target, visiting);
+                complete &= member_result.complete;
+                if let Some(false) = member_result.result {
+                    return PrivateBrandOverrideEval::complete(Some(false)); // Fail if any member fails
                 }
             }
-            return None; // All passed or fell back
+            return if complete {
+                PrivateBrandOverrideEval::complete(None)
+            } else {
+                PrivateBrandOverrideEval::incomplete(None)
+            }; // All passed or fell back
         }
 
         // 2. Handle Target Union (OR logic)
@@ -147,26 +182,40 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             let members = self.interner.type_list(members);
             // If source matches ANY target member, it's valid
             for &member in members.iter() {
-                match self.private_brand_assignability_override_inner(source, member, visiting) {
-                    Some(true) | None => return None, // Pass (or structural fallback)
-                    Some(false) => {}                 // Keep checking other members
+                let member_result =
+                    self.private_brand_assignability_override_inner(source, member, visiting);
+                match member_result.result {
+                    Some(true) | None => {
+                        return if member_result.complete {
+                            PrivateBrandOverrideEval::complete(None)
+                        } else {
+                            PrivateBrandOverrideEval::incomplete(None)
+                        };
+                    } // Pass (or structural fallback)
+                    Some(false) => {} // Keep checking other members
                 }
             }
-            return Some(false); // Failed against all members
+            return PrivateBrandOverrideEval::complete(Some(false)); // Failed against all members
         }
 
         // 3. Handle Target Intersection (AND logic)
         // S -> (A & B) : Valid if S -> A AND S -> B
         if let Some(TypeData::Intersection(members)) = self.interner.lookup(target) {
             let members = self.interner.type_list(members);
+            let mut complete = true;
             for &member in members.iter() {
-                if let Some(false) =
-                    self.private_brand_assignability_override_inner(source, member, visiting)
-                {
-                    return Some(false); // Fail if any member fails
+                let member_result =
+                    self.private_brand_assignability_override_inner(source, member, visiting);
+                complete &= member_result.complete;
+                if let Some(false) = member_result.result {
+                    return PrivateBrandOverrideEval::complete(Some(false)); // Fail if any member fails
                 }
             }
-            return None; // All passed or fell back
+            return if complete {
+                PrivateBrandOverrideEval::complete(None)
+            } else {
+                PrivateBrandOverrideEval::incomplete(None)
+            }; // All passed or fell back
         }
 
         // 4. Handle Source Intersection (OR logic)
@@ -174,12 +223,20 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         if let Some(TypeData::Intersection(members)) = self.interner.lookup(source) {
             let members = self.interner.type_list(members);
             for &member in members.iter() {
-                match self.private_brand_assignability_override_inner(member, target, visiting) {
-                    Some(true) | None => return None, // Pass (or structural fallback)
-                    Some(false) => {}                 // Keep checking other members
+                let member_result =
+                    self.private_brand_assignability_override_inner(member, target, visiting);
+                match member_result.result {
+                    Some(true) | None => {
+                        return if member_result.complete {
+                            PrivateBrandOverrideEval::complete(None)
+                        } else {
+                            PrivateBrandOverrideEval::incomplete(None)
+                        };
+                    } // Pass (or structural fallback)
+                    Some(false) => {} // Keep checking other members
                 }
             }
-            return Some(false); // Failed against all members
+            return PrivateBrandOverrideEval::complete(Some(false)); // Failed against all members
         }
 
         // 5. Handle Lazy types (recursive resolution)
@@ -189,7 +246,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             // Guard against non-progressing lazy resolution (e.g. DefId -> same Lazy type),
             // which would otherwise recurse forever.
             if resolved == source {
-                return None;
+                return PrivateBrandOverrideEval::complete(None);
             }
             return self.private_brand_assignability_override_inner(resolved, target, visiting);
         }
@@ -199,7 +256,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         {
             // Same non-progress guard for target-side lazy resolution.
             if resolved == target {
-                return None;
+                return PrivateBrandOverrideEval::complete(None);
             }
             return self.private_brand_assignability_override_inner(source, resolved, visiting);
         }
@@ -208,14 +265,18 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         let mut extractor = ShapeExtractor::new(self.interner, self.subtype.resolver);
 
         // Get source shape
-        let source_shape_id = extractor.extract(source)?;
+        let Some(source_shape_id) = extractor.extract(source) else {
+            return PrivateBrandOverrideEval::complete(None);
+        };
         let source_shape = self
             .interner
             .object_shape(crate::types::ObjectShapeId(source_shape_id));
 
         // Get target shape
         let mut extractor = ShapeExtractor::new(self.interner, self.subtype.resolver);
-        let target_shape_id = extractor.extract(target)?;
+        let Some(target_shape_id) = extractor.extract(target) else {
+            return PrivateBrandOverrideEval::complete(None);
+        };
         let target_shape = self
             .interner
             .object_shape(crate::types::ObjectShapeId(target_shape_id));
@@ -248,11 +309,11 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
                         target_prop.parent_id,
                         target_prop.visibility,
                     ) {
-                        return Some(false);
+                        return PrivateBrandOverrideEval::complete(Some(false));
                     }
                 }
                 None => {
-                    return Some(false);
+                    return PrivateBrandOverrideEval::complete(Some(false));
                 }
             }
         }
@@ -271,11 +332,11 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
                 )
                 && target_prop.visibility == Visibility::Public
             {
-                return Some(false);
+                return PrivateBrandOverrideEval::complete(Some(false));
             }
         }
 
-        None
+        PrivateBrandOverrideEval::complete(None)
     }
 
     /// Enum member assignability override.

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -354,6 +354,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         target: TypeId,
         this_context: TypeId,
     ) -> RelationCacheKey {
+        let (inheritance_graph_id, inheritance_graph_generation) = self
+            .inheritance_graph
+            .map_or((0, 0), |graph| (graph.identity(), graph.generation()));
         RelationCacheKey::for_subtype(
             source,
             target,
@@ -361,6 +364,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 .cache_config_with_cached_any_mode(self.effective_cached_any_mode()),
         )
         .with_this_context(this_context)
+        .with_inheritance_graph_context(inheritance_graph_id, inheritance_graph_generation)
     }
 
     /// Resolve the polymorphic-`this` discriminator for a `(source, target)`

--- a/crates/tsz-solver/src/types/relation_cache.rs
+++ b/crates/tsz-solver/src/types/relation_cache.rs
@@ -175,6 +175,8 @@ impl RelationCacheConfig {
 /// - `target`: The target type being compared.
 /// - `relation`: Which relation is being cached. See [`RelationCacheKind`].
 /// - `config`:   The behavior-affecting configuration. See [`RelationCacheConfig`].
+/// - `inheritance_graph_id` / `inheritance_graph_generation`: Class graph
+///   context for nominal protected/private-origin checks.
 ///
 /// ## Construction
 ///
@@ -195,10 +197,14 @@ pub struct RelationCacheKey {
     /// receiver. Encoding the resolved binding here lets such verdicts live in
     /// the cross-checker shared cache without poisoning a sibling checker that
     /// compares the same `(source, target)` under a different receiver (issue
-    /// #13828). It is [`TypeId::NONE`] for every non-`this` pair, so ordinary
-    /// keys are byte-identical to the pre-`this`-context protocol and share
-    /// their existing cache slots unchanged.
+    /// #13828). It is [`TypeId::NONE`] for every non-`this` pair.
     pub this_context: TypeId,
+    /// Process-local identity of the active inheritance graph, or `0` when no
+    /// graph participates in this relation verdict.
+    pub inheritance_graph_id: u64,
+    /// Mutation generation of the active inheritance graph. This partitions
+    /// protected/ES-private origin verdicts across graph edge changes.
+    pub inheritance_graph_generation: u64,
 }
 
 impl RelationCacheKey {
@@ -236,6 +242,8 @@ impl RelationCacheKey {
             relation: RelationCacheKind::Subtype,
             config,
             this_context: TypeId::NONE,
+            inheritance_graph_id: 0,
+            inheritance_graph_generation: 0,
         }
     }
 
@@ -251,6 +259,8 @@ impl RelationCacheKey {
             relation: RelationCacheKind::Assignable,
             config,
             this_context: TypeId::NONE,
+            inheritance_graph_id: 0,
+            inheritance_graph_generation: 0,
         }
     }
 
@@ -270,6 +280,8 @@ impl RelationCacheKey {
             relation: RelationCacheKind::CheckerAssignable,
             config,
             this_context: TypeId::NONE,
+            inheritance_graph_id: 0,
+            inheritance_graph_generation: 0,
         }
     }
 
@@ -285,16 +297,27 @@ impl RelationCacheKey {
             relation: RelationCacheKind::Identical,
             config,
             this_context: TypeId::NONE,
+            inheritance_graph_id: 0,
+            inheritance_graph_generation: 0,
         }
     }
 
     /// Return this key discriminated by a resolved polymorphic-`this` binding.
     ///
-    /// Passing [`TypeId::NONE`] (the default) is a no-op, leaving the key
-    /// byte-identical to the undiscriminated form. See [`Self::this_context`].
+    /// Passing [`TypeId::NONE`] (the default) leaves the key in the
+    /// receiver-free partition. See [`Self::this_context`].
     #[must_use]
     pub const fn with_this_context(mut self, this_context: TypeId) -> Self {
         self.this_context = this_context;
+        self
+    }
+
+    /// Return this key discriminated by an inheritance graph identity and
+    /// mutation generation. Passing `(0, 0)` is the graph-free default.
+    #[must_use]
+    pub const fn with_inheritance_graph_context(mut self, identity: u64, generation: u64) -> Self {
+        self.inheritance_graph_id = identity;
+        self.inheritance_graph_generation = generation;
         self
     }
 }

--- a/crates/tsz-solver/tests/compat_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/compat_tests_parts/part_00.rs
@@ -14,11 +14,13 @@ fn compat_checker_cache_statistics_account_for_relation_entries() {
 
     let empty = checker.cache_statistics();
     assert_eq!(empty.relation_entries, 0);
+    assert_eq!(empty.private_brand_entries, 0);
     assert_eq!(empty.estimated_size_bytes(), 0);
 
     assert!(!checker.is_assignable(TypeId::STRING, TypeId::NUMBER));
     let populated = checker.cache_statistics();
     assert_eq!(populated.relation_entries, 1);
+    assert_eq!(populated.private_brand_entries, 0);
     assert!(
         populated.estimated_size_bytes() > empty.estimated_size_bytes(),
         "populated compatibility cache should report nonzero estimated residency"
@@ -28,12 +30,116 @@ fn compat_checker_cache_statistics_account_for_relation_entries() {
     let repeated = checker.cache_statistics();
     assert_eq!(repeated.relation_entries, populated.relation_entries);
     assert_eq!(
+        repeated.private_brand_entries,
+        populated.private_brand_entries
+    );
+    assert_eq!(
         repeated.estimated_size_bytes(),
         populated.estimated_size_bytes()
     );
 
     checker.set_strict_function_types(true);
     assert_eq!(checker.cache_statistics().relation_entries, 0);
+    assert_eq!(checker.cache_statistics().private_brand_entries, 0);
+}
+
+#[test]
+fn private_brand_override_cache_statistics_account_for_brand_entries() {
+    let interner = TypeInterner::new();
+    let checker = CompatChecker::new(&interner);
+    let brand_a = interner.intern_string("__private_brand_A");
+    let brand_b = interner.intern_string("__private_brand_B");
+    let mut source_prop = PropertyInfo::new(brand_a, TypeId::NEVER);
+    source_prop.visibility = Visibility::Private;
+    let mut target_prop = PropertyInfo::new(brand_b, TypeId::NEVER);
+    target_prop.visibility = Visibility::Private;
+    let source = interner.object(vec![source_prop]);
+    let target = interner.object(vec![target_prop]);
+
+    assert_eq!(checker.cache_statistics().private_brand_entries, 0);
+    assert_eq!(
+        checker.private_brand_assignability_override(source, target),
+        Some(false)
+    );
+    let populated = checker.cache_statistics();
+    assert_eq!(populated.relation_entries, 0);
+    assert_eq!(populated.private_brand_entries, 1);
+
+    assert_eq!(
+        checker.private_brand_assignability_override(source, target),
+        Some(false)
+    );
+    assert_eq!(
+        checker.cache_statistics().private_brand_entries,
+        populated.private_brand_entries
+    );
+}
+
+#[test]
+fn private_brand_override_cache_partitions_by_inheritance_graph_generation() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+    let graph = crate::classes::inheritance::InheritanceGraph::new();
+    checker.set_inheritance_graph(Some(&graph));
+
+    let protected_name = interner.intern_string("value");
+    let base = tsz_binder::SymbolId(1);
+    let derived = tsz_binder::SymbolId(2);
+    let mut source_prop = PropertyInfo::new(protected_name, TypeId::STRING);
+    source_prop.visibility = Visibility::Protected;
+    source_prop.parent_id = Some(derived);
+    let mut target_prop = PropertyInfo::new(protected_name, TypeId::STRING);
+    target_prop.visibility = Visibility::Protected;
+    target_prop.parent_id = Some(base);
+    let source = interner.object(vec![source_prop]);
+    let target = interner.object(vec![target_prop]);
+
+    assert_eq!(
+        checker.private_brand_assignability_override(source, target),
+        Some(false)
+    );
+    let cached_miss = checker.cache_statistics().private_brand_entries;
+    assert_eq!(cached_miss, 1);
+
+    graph.add_inheritance(derived, &[base]);
+
+    assert_eq!(
+        checker.private_brand_assignability_override(source, target),
+        None,
+        "a graph mutation must not reuse the stale pre-inheritance brand result"
+    );
+    assert_eq!(checker.cache_statistics().private_brand_entries, 2);
+}
+
+#[test]
+fn compat_relation_cache_partitions_by_inheritance_graph_generation() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+    let graph = crate::classes::inheritance::InheritanceGraph::new();
+    checker.set_inheritance_graph(Some(&graph));
+
+    let protected_name = interner.intern_string("value");
+    let base = tsz_binder::SymbolId(10);
+    let derived = tsz_binder::SymbolId(11);
+    let mut source_prop = PropertyInfo::new(protected_name, TypeId::STRING);
+    source_prop.visibility = Visibility::Protected;
+    source_prop.parent_id = Some(derived);
+    let mut target_prop = PropertyInfo::new(protected_name, TypeId::STRING);
+    target_prop.visibility = Visibility::Protected;
+    target_prop.parent_id = Some(base);
+    let source = interner.object(vec![source_prop]);
+    let target = interner.object(vec![target_prop]);
+
+    assert!(!checker.is_assignable(source, target));
+    assert_eq!(checker.cache_statistics().relation_entries, 1);
+
+    graph.add_inheritance(derived, &[base]);
+
+    assert!(
+        checker.is_assignable(source, target),
+        "public assignability must not reuse the stale pre-inheritance verdict"
+    );
+    assert_eq!(checker.cache_statistics().relation_entries, 2);
 }
 
 #[test]

--- a/crates/tsz-solver/tests/compat_tests_parts/part_02.rs
+++ b/crates/tsz-solver/tests/compat_tests_parts/part_02.rs
@@ -1586,6 +1586,11 @@ fn test_private_brand_lazy_cycle_does_not_recurse() {
         checker.private_brand_assignability_override(first_type, target),
         None
     );
+    assert_eq!(
+        checker.cache_statistics().private_brand_entries,
+        0,
+        "cycle-truncated private-brand probes must not be cached"
+    );
 }
 
 #[test]
@@ -1754,4 +1759,3 @@ fn test_private_brand_neither_has_brand_falls_through() {
     // Structural check passes
     assert!(checker.is_assignable(source, target));
 }
-

--- a/crates/tsz-solver/tests/subtype_cache_tests.rs
+++ b/crates/tsz-solver/tests/subtype_cache_tests.rs
@@ -15,7 +15,9 @@ use crate::construction::RelationCacheProbe;
 use crate::intern::TypeInterner;
 use crate::relations::relation_queries::RelationPolicy;
 use crate::relations::subtype::SubtypeChecker;
-use crate::types::{PropertyInfo, RelationCacheConfig, RelationCacheKey, RelationFlags, TypeId};
+use crate::types::{
+    PropertyInfo, RelationCacheConfig, RelationCacheKey, RelationFlags, TypeId, Visibility,
+};
 
 fn assert_repeated_subtype_check_reuses_entries(
     db: &QueryCache<'_>,
@@ -76,6 +78,49 @@ fn cache_hit_with_literal_types() {
     let hello = interner.literal_string("hello");
 
     assert_repeated_subtype_check_reuses_entries(&db, hello, TypeId::STRING, true);
+}
+
+#[test]
+fn subtype_relation_cache_partitions_by_inheritance_graph_generation() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let graph = crate::classes::inheritance::InheritanceGraph::new();
+
+    let protected_name = interner.intern_string("value");
+    let base = tsz_binder::SymbolId(20);
+    let derived = tsz_binder::SymbolId(21);
+    let mut source_prop = PropertyInfo::new(protected_name, TypeId::STRING);
+    source_prop.visibility = Visibility::Protected;
+    source_prop.parent_id = Some(derived);
+    let mut target_prop = PropertyInfo::new(protected_name, TypeId::STRING);
+    target_prop.visibility = Visibility::Protected;
+    target_prop.parent_id = Some(base);
+    let source = interner.object(vec![source_prop]);
+    let target = interner.object(vec![target_prop]);
+
+    let mut before = SubtypeChecker::new(&interner)
+        .with_query_db(&db)
+        .with_inheritance_graph(&graph);
+    let before_key = before.debug_cache_key_for(source, target);
+    assert_eq!(before_key.inheritance_graph_id, graph.identity());
+    assert_eq!(before_key.inheritance_graph_generation, graph.generation());
+    assert!(!before.is_subtype_of(source, target));
+    assert_eq!(db.lookup_subtype_cache(before_key), Some(false));
+
+    graph.add_inheritance(derived, &[base]);
+
+    let mut after = SubtypeChecker::new(&interner)
+        .with_query_db(&db)
+        .with_inheritance_graph(&graph);
+    let after_key = after.debug_cache_key_for(source, target);
+    assert_eq!(after_key.inheritance_graph_id, graph.identity());
+    assert_eq!(after_key.inheritance_graph_generation, graph.generation());
+    assert_ne!(
+        before_key, after_key,
+        "graph mutation must partition shared relation cache entries"
+    );
+    assert!(after.is_subtype_of(source, target));
+    assert_eq!(db.lookup_subtype_cache(after_key), Some(true));
 }
 
 #[test]


### PR DESCRIPTION
Goal: fast

## Summary
- Add an operation-local `CompatChecker` memo for recursive private/protected brand override probes.
- Key the memo and outer compatibility relation memo by `(source, target, resolver_generation, inheritance_graph_identity, inheritance_graph_generation)`, clear it with relation-mode/config changes, and skip cycle-truncated results.
- Partition shared subtype relation cache keys by inheritance graph identity/generation so protected/ES-private origin verdicts cannot survive graph mutation under the wrong key.
- Stamp checker-owned assignability, checker-final assignability, overload-subtype, and subtype identity cache keys with inheritance graph identity/generation; graph `clear()` now bumps generation.
- Expose the memo through `CompatChecker::cache_statistics` and cover cache residency, recursive-lazy safety, public assignability reuse, and shared relation-cache mutation safety in solver tests.

## Structural Rule
When repeated solver relation probes ask the same private/protected-brand override question under unchanged resolver generation and inheritance graph identity/generation, the nominal brand answer is the same solver relation fact. tsz now reuses that fact in the solver-owned `CompatChecker` while preserving structural fallback and diagnostic explanation behavior.

## Performance Evidence
The combined TypeBox sample after #15482 still timed out CPU-bound and showed flow narrowing relation probes dominated by recursive `private_brand_assignability_override_inner` frames (`/tmp/tsz-typebox-combined-15482.sample.txt`: 4097 samples under the flow relation path, 1576 same-collapsed top-of-stack samples). This PR targets that repeated solver-owned override walk without adding checker policy.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(private_brand) or test(compat_checker_cache_statistics) or test(inheritance)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(checker_relation_cache_keys_partition_by_inheritance_graph_generation)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test private_brands -E 'test(private_brand) or test(protected)'`
- `scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `scripts/safe-run.sh cargo clippy -p tsz-solver --lib --tests -- -D warnings`
- `scripts/safe-run.sh cargo clippy -p tsz-checker --lib --tests -- -D warnings`
- `python3 scripts/perf/cache-visibility-report.py --json`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
