### PR TITLE
perf(solver): cache flow assignability relations (#14351)

### DIFF
--- a/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
+++ b/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
@@ -42,11 +42,19 @@ impl<'a> CheckerState<'a> {
         // Construct RelationCacheKey with Lawyer-layer flags to prevent cache poisoning
         let is_cacheable = is_relation_cacheable(self.ctx.types, source, target);
         let flags = self.ctx.pack_relation_flags();
+        let resolver_generation =
+            tsz_solver::relations::subtype::TypeResolver::resolver_generation(&self.ctx);
 
         if is_cacheable {
             // Note: For subtype checks in the checker, we use AnyPropagationMode::All (0)
             // since the checker doesn't track depth like SubtypeChecker does
-            let cache_key = subtype_cache_key(source, target, flags, &self.ctx.inheritance_graph);
+            let cache_key = subtype_cache_key(
+                source,
+                target,
+                flags,
+                resolver_generation,
+                &self.ctx.inheritance_graph,
+            );
 
             if let Some(cached) = self.ctx.types.lookup_subtype_cache(cache_key) {
                 return cached;
@@ -93,7 +101,13 @@ impl<'a> CheckerState<'a> {
 
         // Cache the result for non-inference types
         if is_cacheable {
-            let cache_key = subtype_cache_key(source, target, flags, &self.ctx.inheritance_graph);
+            let cache_key = subtype_cache_key(
+                source,
+                target,
+                flags,
+                resolver_generation,
+                &self.ctx.inheritance_graph,
+            );
 
             self.ctx.types.insert_subtype_cache(cache_key, result);
         }

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -935,6 +935,7 @@ pub(crate) fn cached_assignability_with_overrides<
             inputs.source,
             inputs.target,
             inputs.flags,
+            inputs.resolver.resolver_generation(),
             inputs.inheritance_graph,
         );
         if let Some(cached) = inputs.db.lookup_assignability_cache(cache_key) {
@@ -952,6 +953,7 @@ pub(crate) fn cached_assignability_with_overrides<
             inputs.source,
             inputs.target,
             inputs.flags,
+            inputs.resolver.resolver_generation(),
             inputs.inheritance_graph,
         );
         inputs

--- a/crates/tsz-checker/src/query_boundaries/assignability/cache_key.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/cache_key.rs
@@ -50,21 +50,28 @@ pub(crate) use tsz_solver::RelationCacheKey;
 /// The resulting config is produced by the solver's typed `RelationPolicy`
 /// bridge, so this write path lands in the same cache slot as the solver's
 /// internal write path.
-const fn with_inheritance_graph_context(
+const fn with_relation_context(
     key: RelationCacheKey,
+    resolver_generation: u64,
     inheritance_graph: &InheritanceGraph,
 ) -> RelationCacheKey {
-    key.with_inheritance_graph_context(inheritance_graph.identity(), inheritance_graph.generation())
+    key.with_resolver_generation(resolver_generation)
+        .with_inheritance_graph_context(
+            inheritance_graph.identity(),
+            inheritance_graph.generation(),
+        )
 }
 
 pub(crate) const fn assignability_cache_key_for_policy(
     source: TypeId,
     target: TypeId,
     policy: RelationPolicy,
+    resolver_generation: u64,
     inheritance_graph: &InheritanceGraph,
 ) -> RelationCacheKey {
-    with_inheritance_graph_context(
+    with_relation_context(
         RelationCacheKey::for_assignability(source, target, policy.cache_config()),
+        resolver_generation,
         inheritance_graph,
     )
 }
@@ -73,12 +80,14 @@ pub(crate) const fn assignability_cache_key(
     source: TypeId,
     target: TypeId,
     flags: u16,
+    resolver_generation: u64,
     inheritance_graph: &InheritanceGraph,
 ) -> RelationCacheKey {
     assignability_cache_key_for_policy(
         source,
         target,
         relation_policy::from_checker_flags_u16(flags),
+        resolver_generation,
         inheritance_graph,
     )
 }
@@ -87,14 +96,16 @@ pub(crate) const fn checker_final_assignability_cache_key(
     source: TypeId,
     target: TypeId,
     flags: u16,
+    resolver_generation: u64,
     inheritance_graph: &InheritanceGraph,
 ) -> RelationCacheKey {
-    with_inheritance_graph_context(
+    with_relation_context(
         RelationCacheKey::for_checker_assignability(
             source,
             target,
             relation_policy::from_checker_flags_u16(flags).cache_config(),
         ),
+        resolver_generation,
         inheritance_graph,
     )
 }
@@ -104,14 +115,16 @@ pub(crate) const fn subtype_cache_key(
     source: TypeId,
     target: TypeId,
     flags: u16,
+    resolver_generation: u64,
     inheritance_graph: &InheritanceGraph,
 ) -> RelationCacheKey {
-    with_inheritance_graph_context(
+    with_relation_context(
         RelationCacheKey::for_subtype(
             source,
             target,
             relation_policy::from_checker_flags_u16(flags).cache_config(),
         ),
+        resolver_generation,
         inheritance_graph,
     )
 }
@@ -125,14 +138,15 @@ mod tests {
     fn checker_relation_cache_keys_partition_by_inheritance_graph_generation() {
         let graph = InheritanceGraph::new();
         let before_assignability =
-            assignability_cache_key(TypeId::STRING, TypeId::NUMBER, 0, &graph);
+            assignability_cache_key(TypeId::STRING, TypeId::NUMBER, 0, 11, &graph);
         let before_final =
-            checker_final_assignability_cache_key(TypeId::STRING, TypeId::NUMBER, 0, &graph);
-        let before_subtype = subtype_cache_key(TypeId::STRING, TypeId::NUMBER, 0, &graph);
+            checker_final_assignability_cache_key(TypeId::STRING, TypeId::NUMBER, 0, 11, &graph);
+        let before_subtype = subtype_cache_key(TypeId::STRING, TypeId::NUMBER, 0, 11, &graph);
 
         assert_eq!(before_assignability.inheritance_graph_id, graph.identity());
         assert_eq!(before_final.inheritance_graph_id, graph.identity());
         assert_eq!(before_subtype.inheritance_graph_id, graph.identity());
+        assert_eq!(before_assignability.resolver_generation, 11);
         assert_eq!(
             before_assignability.inheritance_graph_generation,
             graph.generation()
@@ -141,14 +155,17 @@ mod tests {
         graph.add_inheritance(SymbolId(1), &[SymbolId(2)]);
 
         let after_assignability =
-            assignability_cache_key(TypeId::STRING, TypeId::NUMBER, 0, &graph);
+            assignability_cache_key(TypeId::STRING, TypeId::NUMBER, 0, 11, &graph);
         let after_final =
-            checker_final_assignability_cache_key(TypeId::STRING, TypeId::NUMBER, 0, &graph);
-        let after_subtype = subtype_cache_key(TypeId::STRING, TypeId::NUMBER, 0, &graph);
+            checker_final_assignability_cache_key(TypeId::STRING, TypeId::NUMBER, 0, 11, &graph);
+        let after_subtype = subtype_cache_key(TypeId::STRING, TypeId::NUMBER, 0, 11, &graph);
 
         assert_eq!(after_assignability.inheritance_graph_id, graph.identity());
         assert_ne!(before_assignability, after_assignability);
         assert_ne!(before_final, after_final);
         assert_ne!(before_subtype, after_subtype);
+
+        let after_resolver = assignability_cache_key(TypeId::STRING, TypeId::NUMBER, 0, 12, &graph);
+        assert_ne!(after_assignability, after_resolver);
     }
 }

--- a/crates/tsz-checker/src/query_boundaries/assignability/final_relation.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/final_relation.rs
@@ -15,6 +15,7 @@
 
 use tracing::trace;
 use tsz_solver::TypeId;
+use tsz_solver::relations::subtype::TypeResolver;
 
 use super::{
     AssignabilityQueryInputs, checker_final_assignability_cache_key, is_assignable_with_overrides,
@@ -43,10 +44,16 @@ pub(crate) fn cached_final_assignability(
 ) -> bool {
     let flags = checker.ctx.pack_relation_flags();
     let is_cacheable = is_relation_cacheable(checker.ctx.types.as_type_database(), source, target);
+    let resolver_generation = if use_env_resolver {
+        checker.ctx.type_env.borrow().resolver_generation()
+    } else {
+        checker.ctx.resolver_generation()
+    };
     let cache_key = checker_final_assignability_cache_key(
         source,
         target,
         flags,
+        resolver_generation,
         &checker.ctx.inheritance_graph,
     );
     if is_cacheable && let Some(cached) = checker.ctx.types.lookup_assignability_cache(cache_key) {

--- a/crates/tsz-checker/src/query_boundaries/assignability/overload_subtype_pass.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/overload_subtype_pass.rs
@@ -36,6 +36,7 @@ pub(crate) fn cached_overload_subtype_pass_assignability<
         inputs.source,
         inputs.target,
         policy,
+        inputs.resolver.resolver_generation(),
         inputs.inheritance_graph,
     );
     if is_cacheable && let Some(cached) = inputs.db.lookup_assignability_cache(cache_key) {

--- a/crates/tsz-checker/src/query_boundaries/assignability/relation_kind_variants.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/relation_kind_variants.rs
@@ -57,7 +57,13 @@ pub(crate) fn cached_bivariant_assignability_with_resolver<
 ) -> tsz_solver::relations::relation_queries::RelationResult {
     let is_cacheable = is_relation_cacheable(db.as_type_database(), source, target);
     if is_cacheable {
-        let cache_key = assignability_cache_key(source, target, flags, inheritance_graph);
+        let cache_key = assignability_cache_key(
+            source,
+            target,
+            flags,
+            resolver.resolver_generation(),
+            inheritance_graph,
+        );
         if let Some(cached) = db.lookup_assignability_cache(cache_key) {
             return tsz_solver::relations::relation_queries::RelationResult::complete(
                 tsz_solver::relations::relation_queries::RelationKind::AssignableBivariantCallbacks,
@@ -78,7 +84,13 @@ pub(crate) fn cached_bivariant_assignability_with_resolver<
     );
 
     if is_cacheable {
-        let cache_key = assignability_cache_key(source, target, flags, inheritance_graph);
+        let cache_key = assignability_cache_key(
+            source,
+            target,
+            flags,
+            resolver.resolver_generation(),
+            inheritance_graph,
+        );
         db.insert_assignability_cache(cache_key, relation_result.is_related());
     }
 

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -702,7 +702,7 @@ fn resolve_assignment_reduction_type(
 }
 
 fn assignment_source_assignable_to_member(
-    db: &dyn TypeDatabase,
+    db: &dyn QueryDatabase,
     env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
     source: TypeId,
     member: TypeId,
@@ -711,7 +711,7 @@ fn assignment_source_assignable_to_member(
 }
 
 fn non_nullish_constraint_reduction_for_assignment(
-    db: &dyn TypeDatabase,
+    db: &dyn QueryDatabase,
     env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
     initial_type: TypeId,
     assigned_type: TypeId,
@@ -858,7 +858,7 @@ pub(crate) fn narrow_enum_assignment_target(
 /// enum identity, and filtering union members by one-way assignability from the
 /// assigned type.
 pub(crate) fn narrow_assignment(
-    db: &dyn TypeDatabase,
+    db: &dyn QueryDatabase,
     env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
     initial_type: TypeId,
     assigned_type: TypeId,
@@ -933,7 +933,7 @@ pub(crate) fn are_types_mutually_subtype(
 }
 
 fn flow_relation_related(
-    db: &dyn TypeDatabase,
+    db: &dyn QueryDatabase,
     env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
     source: TypeId,
     target: TypeId,
@@ -946,18 +946,21 @@ fn flow_relation_related(
     }
 
     tsz_solver::relations::relation_queries::query_relation(
-        db,
+        db.as_type_database(),
         source,
         target,
         tsz_solver::relations::relation_queries::RelationKind::Assignable,
         tsz_solver::relations::relation_queries::RelationPolicy::default(),
-        tsz_solver::relations::relation_queries::RelationContext::default(),
+        tsz_solver::relations::relation_queries::RelationContext {
+            query_db: Some(db),
+            ..Default::default()
+        },
     )
     .is_related()
 }
 
 fn flow_relation_outcome(
-    db: &dyn TypeDatabase,
+    db: &dyn QueryDatabase,
     env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
     source: TypeId,
     target: TypeId,
@@ -985,13 +988,7 @@ pub(crate) fn flow_assignability_outcome(
 ) -> RelationOutcome {
     let source = substitute_flow_this_type(db, concrete_this_type, source);
     let target = substitute_flow_this_type(db, concrete_this_type, target);
-    flow_relation_outcome(
-        db.as_type_database(),
-        env,
-        source,
-        target,
-        strict_null_checks,
-    )
+    flow_relation_outcome(db, env, source, target, strict_null_checks)
 }
 
 fn substitute_flow_this_type(
@@ -1062,7 +1059,7 @@ pub(crate) fn are_types_mutually_subtype_with_env(
 }
 
 pub(crate) fn is_assignable_with_env(
-    db: &dyn TypeDatabase,
+    db: &dyn QueryDatabase,
     env: &tsz_solver::relations::subtype::TypeEnvironment,
     source: TypeId,
     target: TypeId,
@@ -1074,13 +1071,16 @@ pub(crate) fn is_assignable_with_env(
     }
 
     tsz_solver::relations::relation_queries::query_relation_with_resolver(
-        db,
+        db.as_type_database(),
         env,
         source,
         target,
         tsz_solver::relations::relation_queries::RelationKind::Assignable,
         relation_policy::from_checker_flags_u16(flags),
-        tsz_solver::relations::relation_queries::RelationContext::default(),
+        tsz_solver::relations::relation_queries::RelationContext {
+            query_db: Some(db),
+            ..Default::default()
+        },
     )
     .is_related()
 }

--- a/crates/tsz-checker/src/tests/flow_assignment_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_assignment_relation_routing_arch_tests.rs
@@ -63,7 +63,9 @@ fn flow_assignment_and_predicate_exclusion_use_relation_outcome_boundary() {
     assert!(
         compact_boundary.contains("fnflow_relation_outcome(")
             && compact_boundary.contains("fnflow_relation_related(")
+            && compact_boundary.contains("db:&dynQueryDatabase")
             && compact_boundary.contains("query_relation_with_resolver(")
+            && compact_boundary.contains("query_db:Some(db)")
             && compact_boundary
                 .contains("flow_relation_outcome(db,env,source,member,true).related")
             && compact_boundary.contains(

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -13,7 +13,9 @@ use crate::relations::compat::{
     AssignabilityOverrideProvider, CompatChecker, NoopOverrideProvider,
 };
 use crate::relations::subtype::{AnyPropagationMode, NoopResolver, SubtypeChecker, TypeResolver};
-use crate::types::{CachedAnyMode, RelationCacheConfig, RelationFlags, SymbolRef, TypeId};
+use crate::types::{
+    CachedAnyMode, RelationCacheConfig, RelationCacheKey, RelationFlags, SymbolRef, TypeId,
+};
 
 /// Relation categories supported by the unified query API.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -625,6 +627,14 @@ pub fn query_relation_with_resolver<'a, R: TypeResolver>(
     policy: RelationPolicy,
     context: RelationContext<'a>,
 ) -> RelationResult {
+    if matches!(kind, RelationKind::Assignable)
+        && let Some(result) = query_cached_assignability_with_resolver(
+            interner, resolver, source, target, policy, context,
+        )
+    {
+        return result;
+    }
+
     let overrides = NoopOverrideProvider;
     query_relation_with_overrides(RelationQueryInputs {
         interner,
@@ -636,6 +646,74 @@ pub fn query_relation_with_resolver<'a, R: TypeResolver>(
         context,
         overrides: &overrides,
     })
+}
+
+fn query_cached_assignability_with_resolver<'a, R: TypeResolver>(
+    interner: &'a dyn TypeDatabase,
+    resolver: &'a R,
+    source: TypeId,
+    target: TypeId,
+    policy: RelationPolicy,
+    context: RelationContext<'a>,
+) -> Option<RelationResult> {
+    let query_db = context.query_db?;
+    let cache_key =
+        assignability_relation_cache_key(interner, resolver, source, target, policy, context)?;
+    if let Some(cached) = query_db.lookup_assignability_cache(cache_key) {
+        return Some(RelationResult::complete(RelationKind::Assignable, cached));
+    }
+
+    let mut checker = configured_compat_checker(interner, resolver, policy, context);
+    let lazy_events_at_entry = checker.subtype.unresolved_lazy_relation_event_count();
+    let weak_sensitivity_at_entry = crate::limits::weak_type_sensitivity_count();
+    let overrides = NoopOverrideProvider;
+    let related = checker.is_assignable_with_overrides(source, target, &overrides);
+    let result = relation_result_from_compat_checker(RelationKind::Assignable, related, &checker);
+
+    if matches!(result.termination(), RelationTermination::Complete)
+        && !checker.subtype.bypass_evaluation
+        && checker.subtype.type_param_equivalences.is_empty()
+        && checker.subtype.unresolved_lazy_relation_event_count() == lazy_events_at_entry
+        && crate::limits::weak_type_sensitivity_count() == weak_sensitivity_at_entry
+    {
+        query_db.insert_assignability_cache(cache_key, result.related);
+    }
+
+    Some(result)
+}
+
+fn assignability_relation_cache_key<R: TypeResolver>(
+    interner: &dyn TypeDatabase,
+    resolver: &R,
+    source: TypeId,
+    target: TypeId,
+    policy: RelationPolicy,
+    context: RelationContext<'_>,
+) -> Option<RelationCacheKey> {
+    if context.class_check.is_some()
+        || crate::type_queries::contains_infer_types_db(interner, source)
+        || crate::type_queries::contains_infer_types_db(interner, target)
+    {
+        return None;
+    }
+
+    let has_this_type =
+        crate::contains_this_type(interner, source) || crate::contains_this_type(interner, target);
+    let this_context = if has_this_type {
+        resolver.resolve_this_type(interner)?
+    } else {
+        TypeId::NONE
+    };
+    let (inheritance_graph_id, inheritance_graph_generation) = context
+        .inheritance_graph
+        .map_or((0, 0), |graph| (graph.identity(), graph.generation()));
+
+    Some(
+        RelationCacheKey::for_assignability(source, target, policy.cache_config())
+            .with_this_context(this_context)
+            .with_resolver_generation(resolver.resolver_generation())
+            .with_inheritance_graph_context(inheritance_graph_id, inheritance_graph_generation),
+    )
 }
 
 /// Query a relation using a custom resolver and checker-provided overrides.
@@ -747,6 +825,9 @@ pub(crate) fn configured_compat_checker<'a, R: TypeResolver>(
     checker.set_inheritance_graph(context.inheritance_graph);
     if let Some(query_db) = context.query_db {
         checker.set_query_db(query_db);
+    }
+    if let Some(session) = context.evaluation_session {
+        checker.subtype.eval_session = Some(session);
     }
     if let Some(class_check) = context.class_check {
         checker.set_class_check(class_check);

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -364,6 +364,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 .cache_config_with_cached_any_mode(self.effective_cached_any_mode()),
         )
         .with_this_context(this_context)
+        .with_resolver_generation(self.resolver.resolver_generation())
         .with_inheritance_graph_context(inheritance_graph_id, inheritance_graph_generation)
     }
 

--- a/crates/tsz-solver/src/types/relation_cache.rs
+++ b/crates/tsz-solver/src/types/relation_cache.rs
@@ -175,6 +175,7 @@ impl RelationCacheConfig {
 /// - `target`: The target type being compared.
 /// - `relation`: Which relation is being cached. See [`RelationCacheKind`].
 /// - `config`:   The behavior-affecting configuration. See [`RelationCacheConfig`].
+/// - `resolver_generation`: Resolver-visible type environment generation.
 /// - `inheritance_graph_id` / `inheritance_graph_generation`: Class graph
 ///   context for nominal protected/private-origin checks.
 ///
@@ -199,6 +200,12 @@ pub struct RelationCacheKey {
     /// compares the same `(source, target)` under a different receiver (issue
     /// #13828). It is [`TypeId::NONE`] for every non-`this` pair.
     pub this_context: TypeId,
+    /// Monotonic generation of the resolver state under which this verdict was
+    /// computed, or `0` for resolver-free checks. Lazy `DefId`, type-query, and
+    /// merged-environment lookups can change as the checker publishes more
+    /// bodies; this stamp prevents relation verdicts from surviving such
+    /// resolver-visible mutations under the same type pair.
+    pub resolver_generation: u64,
     /// Process-local identity of the active inheritance graph, or `0` when no
     /// graph participates in this relation verdict.
     pub inheritance_graph_id: u64,
@@ -242,6 +249,7 @@ impl RelationCacheKey {
             relation: RelationCacheKind::Subtype,
             config,
             this_context: TypeId::NONE,
+            resolver_generation: 0,
             inheritance_graph_id: 0,
             inheritance_graph_generation: 0,
         }
@@ -259,6 +267,7 @@ impl RelationCacheKey {
             relation: RelationCacheKind::Assignable,
             config,
             this_context: TypeId::NONE,
+            resolver_generation: 0,
             inheritance_graph_id: 0,
             inheritance_graph_generation: 0,
         }
@@ -280,6 +289,7 @@ impl RelationCacheKey {
             relation: RelationCacheKind::CheckerAssignable,
             config,
             this_context: TypeId::NONE,
+            resolver_generation: 0,
             inheritance_graph_id: 0,
             inheritance_graph_generation: 0,
         }
@@ -297,6 +307,7 @@ impl RelationCacheKey {
             relation: RelationCacheKind::Identical,
             config,
             this_context: TypeId::NONE,
+            resolver_generation: 0,
             inheritance_graph_id: 0,
             inheritance_graph_generation: 0,
         }
@@ -309,6 +320,14 @@ impl RelationCacheKey {
     #[must_use]
     pub const fn with_this_context(mut self, this_context: TypeId) -> Self {
         self.this_context = this_context;
+        self
+    }
+
+    /// Return this key discriminated by the resolver-visible environment
+    /// generation. Passing `0` is the resolver-free default.
+    #[must_use]
+    pub const fn with_resolver_generation(mut self, generation: u64) -> Self {
+        self.resolver_generation = generation;
         self
     }
 

--- a/crates/tsz-solver/tests/relation_queries_tests.rs
+++ b/crates/tsz-solver/tests/relation_queries_tests.rs
@@ -1,6 +1,19 @@
 use super::*;
-use crate::construction::TypeInterner;
-use crate::{FunctionShape, ParamInfo, PropertyInfo};
+use crate::construction::{QueryCache, QueryDatabase, TypeDatabase, TypeInterner};
+use crate::types::RelationCacheKey;
+use crate::{FunctionShape, ParamInfo, PropertyInfo, SymbolRef};
+
+struct GenerationResolver(u64);
+
+impl TypeResolver for GenerationResolver {
+    fn resolver_generation(&self) -> u64 {
+        self.0
+    }
+
+    fn resolve_ref(&self, _symbol: SymbolRef, _interner: &dyn TypeDatabase) -> Option<TypeId> {
+        None
+    }
+}
 
 fn make_animal_dog(interner: &TypeInterner) -> (TypeId, TypeId) {
     let name = interner.intern_string("name");
@@ -60,6 +73,113 @@ fn query_relation_assignable_respects_strict_null_flags() {
 
     assert!(!strict_result.is_related());
     assert!(non_strict_result.is_related());
+}
+
+#[test]
+fn query_relation_assignability_uses_query_cache_for_no_override_path() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let policy = RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS);
+    let context = RelationContext {
+        query_db: Some(&db),
+        ..Default::default()
+    };
+
+    let first = query_relation(
+        db.as_type_database(),
+        TypeId::STRING,
+        TypeId::NUMBER,
+        RelationKind::Assignable,
+        policy,
+        context,
+    );
+    assert!(!first.is_related());
+    let after_first = db.statistics();
+    assert_eq!(after_first.relation.assignability_entries, 1);
+    assert_eq!(after_first.relation.assignability_misses, 1);
+    assert_eq!(after_first.relation.assignability_hits, 0);
+
+    let second = query_relation(
+        db.as_type_database(),
+        TypeId::STRING,
+        TypeId::NUMBER,
+        RelationKind::Assignable,
+        policy,
+        context,
+    );
+    assert!(!second.is_related());
+    let after_second = db.statistics();
+    assert_eq!(after_second.relation.assignability_entries, 1);
+    assert_eq!(after_second.relation.assignability_misses, 1);
+    assert_eq!(after_second.relation.assignability_hits, 1);
+}
+
+#[test]
+fn query_relation_assignability_cache_partitions_by_resolver_generation() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let policy = RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS);
+    let context = RelationContext {
+        query_db: Some(&db),
+        ..Default::default()
+    };
+    let generation_one = GenerationResolver(1);
+    let generation_two = GenerationResolver(2);
+    let key_one =
+        RelationCacheKey::for_assignability(TypeId::STRING, TypeId::NUMBER, policy.cache_config())
+            .with_resolver_generation(1);
+    let key_two =
+        RelationCacheKey::for_assignability(TypeId::STRING, TypeId::NUMBER, policy.cache_config())
+            .with_resolver_generation(2);
+
+    let first = query_relation_with_resolver(
+        db.as_type_database(),
+        &generation_one,
+        TypeId::STRING,
+        TypeId::NUMBER,
+        RelationKind::Assignable,
+        policy,
+        context,
+    );
+    assert!(!first.is_related());
+    assert_eq!(db.lookup_assignability_cache(key_one), Some(false));
+    assert_eq!(db.lookup_assignability_cache(key_two), None);
+
+    let second = query_relation_with_resolver(
+        db.as_type_database(),
+        &generation_two,
+        TypeId::STRING,
+        TypeId::NUMBER,
+        RelationKind::Assignable,
+        policy,
+        context,
+    );
+    assert!(!second.is_related());
+    assert_eq!(db.lookup_assignability_cache(key_two), Some(false));
+}
+
+#[test]
+fn query_relation_assignability_skips_cache_for_unbound_this_type() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let this_type = interner.this_type();
+    let policy = RelationPolicy::from_relation_flags(RelationFlags::STRICT_NULL_CHECKS);
+    let context = RelationContext {
+        query_db: Some(&db),
+        ..Default::default()
+    };
+
+    let result = query_relation(
+        db.as_type_database(),
+        this_type,
+        TypeId::STRING,
+        RelationKind::Assignable,
+        policy,
+        context,
+    );
+
+    assert!(!result.is_related());
+    assert_eq!(db.statistics().relation.assignability_entries, 0);
 }
 
 #[test]


### PR DESCRIPTION
Goal: fast

## Summary

- Add `resolver_generation` to `RelationCacheKey` and stamp checker/subtype assignability keys with the resolver generation alongside existing `this` and inheritance-graph context.
- Add a solver-owned no-overrides assignability cache path in `query_relation_with_resolver`, gated on `query_db`, non-class checks, no infer-containing operands, bound `this`, complete relation results, and unchanged lazy/weak/equivalence/bypass state.
- Keep checker flow relation routing on `QueryDatabase` so flow assignability can reach the solver `QueryCache` instead of dropping to a type-database-only path.
- Cover cache hits, resolver-generation partitioning, unbound-`this` cache skips, and flow boundary routing.

## Structural Rule

When flow narrowing asks the same assignability question for the same source/target, relation policy, resolver generation, `this` binding, and inheritance graph stamp, `tsc` treats it as the same semantic relation; tsz now reuses the solver-owned `QueryCache` relation fact through the relation query boundary instead of adding a checker-local semantic shortcut.

Owner layer: solver relation queries own the cacheable semantic relation fact; checker flow analysis only preserves the `QueryDatabase` boundary needed to use that solver cache.

Fallback: the cache is skipped for class checks, infer-containing operands, unbound `this`, missing query DB, relation overrides, bivariant callback paths, incomplete results, bypassed evaluation, active type-parameter equivalences, lazy-unresolved movement, or weak-sensitivity movement.

## Performance Evidence

- This is a cache-plumbing/runtime-blocker slice for #14351, not a claimed TypeBox speed win.
- Context run before normalizing the stacked branch: `typebox-project` still timed out after 120s wall with 118.28s process CPU (~99% CPU share).
- Sample from that context run: `/tmp/tsz-typebox-flow-relation-cache-14351.sample.txt`.
- Residual hot area from that sample is still evaluator/subtype/compound simplification work (`TypeEvaluator`, `evaluate_guarded_inner`, `check_subtype`, `compound_subtype_cached`, `remove_redundant_members`), so the next #14351 slice should stay in that larger runtime family.

## Verification

- `cargo fmt --all --check`
- `git diff --check origin/fast/14351-private-brand-flow-cache-20260703..HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(flow_assignment_relation_routing_arch) or test(flow_guard_boundary)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(query_relation_assignability) or test(relation_cache_key)'`
- `scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `scripts/safe-run.sh cargo clippy -p tsz-solver --lib --tests -- -D warnings`
- `scripts/safe-run.sh cargo clippy -p tsz-checker --lib --tests -- -D warnings`
- `python3 scripts/perf/cache-visibility-report.py --json`

## Provenance

Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
