### PR TITLE
perf(checker): split lazy readiness fuel (#14351)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -763,8 +763,6 @@ impl<'a> CheckerState<'a> {
                     continue;
                 }
                 eval_session.increment_refs_resolution_fuel();
-                eval_session.increment_lazy_resolution_fuel();
-                let at_fuel_limit = eval_session.lazy_resolution_fuel_exhausted();
                 // Always call resolve_and_insert_def_type even when global fuel is
                 // exhausted: the call is typically a fast cache hit for lib types that
                 // were computed during type-environment building, and the resolver needs
@@ -787,7 +785,12 @@ impl<'a> CheckerState<'a> {
                 // byte-parity. With the kill-switch set, `transitive` is always true
                 // (legacy eager pre-walk).
                 let push_tail = transitive || !self.force_eligible_lib_def(def_id);
-                if let Some(result) = self.resolve_and_insert_def_type(def_id)
+                let shared_fuel_exhausted_before_resolution =
+                    eval_session.lazy_resolution_fuel_exhausted();
+                let resolved = self.resolve_and_insert_def_type(def_id);
+                let at_fuel_limit = shared_fuel_exhausted_before_resolution
+                    || eval_session.lazy_resolution_fuel_exhausted();
+                if let Some(result) = resolved
                     && result != TypeId::ERROR
                     && result != TypeId::ANY
                     && !at_fuel_limit

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -1628,9 +1628,10 @@ impl CheckerState<'_> {
                     continue;
                 }
 
-                // Consume fuel for each DefId resolution (the expensive part)
+                // Consume only readiness-local fuel here. The resolver's
+                // actual type-resolution work charges the shared lazy fuel
+                // through `CheckerContext::consume_fuel`.
                 eval_session.increment_app_symbol_resolution_fuel();
-                eval_session.increment_lazy_resolution_fuel();
                 match application_resolution_post_consume_state(
                     eval_session.lazy_resolution_fuel_exhausted(),
                 ) {
@@ -1674,9 +1675,9 @@ impl CheckerState<'_> {
                     continue;
                 }
 
-                // Consume fuel for enum resolution too
+                // Consume only readiness-local fuel here. The resolver's
+                // actual type-resolution work charges the shared lazy fuel.
                 eval_session.increment_app_symbol_resolution_fuel();
-                eval_session.increment_lazy_resolution_fuel();
                 match application_resolution_post_consume_state(
                     eval_session.lazy_resolution_fuel_exhausted(),
                 ) {
@@ -1723,9 +1724,9 @@ impl CheckerState<'_> {
                     continue;
                 }
 
-                // Consume fuel for type query resolution
+                // Consume only readiness-local fuel here. The symbol resolver's
+                // actual type-resolution work charges the shared lazy fuel.
                 eval_session.increment_app_symbol_resolution_fuel();
-                eval_session.increment_lazy_resolution_fuel();
                 match application_resolution_post_consume_state(
                     eval_session.lazy_resolution_fuel_exhausted(),
                 ) {

--- a/crates/tsz-checker/src/tests/unresolved_def_eval_cache_backstop_tests.rs
+++ b/crates/tsz-checker/src/tests/unresolved_def_eval_cache_backstop_tests.rs
@@ -23,7 +23,7 @@
 
 use crate::context::{CheckerContext, CheckerOptions};
 use crate::state::CheckerState;
-use tsz_binder::BinderState;
+use tsz_binder::{BinderState, symbol_flags};
 use tsz_parser::parser::ParserState;
 use tsz_solver::TypeId;
 use tsz_solver::construction::TypeInterner;
@@ -35,10 +35,19 @@ fn with_trivial_checker<R>(
     types: &TypeInterner,
     probe: impl FnOnce(&mut CheckerState<'_>) -> R,
 ) -> R {
+    with_seeded_trivial_checker(types, |_| (), |checker, ()| probe(checker))
+}
+
+fn with_seeded_trivial_checker<R, S>(
+    types: &TypeInterner,
+    seed_binder: impl FnOnce(&mut BinderState) -> S,
+    probe: impl FnOnce(&mut CheckerState<'_>, S) -> R,
+) -> R {
     let mut parser = ParserState::new("fixture.ts".to_string(), "export {};".to_string());
     let root = parser.parse_source_file();
     let mut binder = BinderState::new();
     binder.bind_source_file(parser.get_arena(), root);
+    let seed = seed_binder(&mut binder);
     let arena = parser.get_arena().clone();
     let mut checker = CheckerState {
         ctx: CheckerContext::new(
@@ -50,7 +59,7 @@ fn with_trivial_checker<R>(
         ),
     };
     checker.check_source_file(root);
-    probe(&mut checker)
+    probe(&mut checker, seed)
 }
 
 /// An `Application` over a `Lazy(DefId)` whose base has nothing registered is the
@@ -170,4 +179,124 @@ fn resolvable_index_access_is_still_persisted_to_env_eval_cache() {
              must not suppress its env_eval_cache write (issue #14347)",
         );
     });
+}
+
+/// Relation-readiness prewalks have their own local fuel counters. They must
+/// not also spend the session-global lazy-resolution fuel that guards actual
+/// type-resolution work in [`CheckerContext::consume_fuel`]; otherwise a
+/// prewalk over many references can starve the resolver before it reaches the
+/// semantic operation that needs the budget.
+#[test]
+fn application_readiness_spends_local_fuel_without_global_lazy_fuel() {
+    let types = TypeInterner::new();
+    let unregistered = types.lazy(DefId(987_656));
+
+    with_trivial_checker(&types, |checker| {
+        checker.ctx.eval_session.reset_lazy_readiness_guards();
+        checker.ctx.eval_session.reset_lazy_resolution_fuel();
+
+        checker.ensure_application_symbols_resolved(unregistered);
+
+        assert_eq!(
+            checker.ctx.eval_session.app_symbol_resolution_fuel(),
+            1,
+            "application-symbol readiness should charge its local prewalk budget",
+        );
+        assert_eq!(
+            checker.ctx.eval_session.lazy_resolution_fuel_value(),
+            0,
+            "application-symbol readiness must not spend the shared lazy-resolution budget",
+        );
+    });
+}
+
+/// The refs prewalk has the same ownership boundary as application-symbol
+/// readiness: local prewalk fuel bounds graph walking, while the shared lazy
+/// fuel belongs to actual type-resolution calls.
+#[test]
+fn refs_readiness_spends_local_fuel_without_global_lazy_fuel() {
+    let types = TypeInterner::new();
+    let unregistered = types.lazy(DefId(987_657));
+
+    with_trivial_checker(&types, |checker| {
+        checker.ctx.eval_session.reset_lazy_readiness_guards();
+        checker.ctx.eval_session.reset_lazy_resolution_fuel();
+
+        checker.ensure_refs_resolved(unregistered);
+
+        assert_eq!(
+            checker.ctx.eval_session.refs_resolution_fuel(),
+            1,
+            "refs readiness should charge its local prewalk budget",
+        );
+        assert_eq!(
+            checker.ctx.eval_session.lazy_resolution_fuel_value(),
+            0,
+            "refs readiness must not spend the shared lazy-resolution budget",
+        );
+    });
+}
+
+/// At the local refs-fuel edge, readiness must still register the direct
+/// `DefId` body needed by the current relation input, but the transitive tail
+/// stays bounded. This preserves the #12144 direct-resolution fix while keeping
+/// the shared lazy-resolution fuel owned by actual type-resolution work.
+#[test]
+fn refs_readiness_resolves_direct_def_at_local_fuel_edge_without_tail() {
+    let types = TypeInterner::new();
+
+    with_seeded_trivial_checker(
+        &types,
+        |binder| {
+            let root_sym = binder
+                .symbols
+                .alloc(symbol_flags::TYPE_ALIAS, "Root".to_string());
+            let leaf_sym = binder
+                .symbols
+                .alloc(symbol_flags::TYPE_ALIAS, "Leaf".to_string());
+            (root_sym, leaf_sym)
+        },
+        |checker, (root_sym, leaf_sym)| {
+            let root_def = checker.ctx.get_or_create_def_id(root_sym);
+            let leaf_def = checker.ctx.get_or_create_def_id(leaf_sym);
+            let root_lazy = types.lazy(root_def);
+            let leaf_lazy = types.lazy(leaf_def);
+
+            checker.ctx.symbol_types.insert(root_sym, leaf_lazy);
+            checker.ctx.eval_session.reset_lazy_readiness_guards();
+            checker.ctx.eval_session.reset_lazy_resolution_fuel();
+
+            {
+                let eval_session = std::rc::Rc::clone(&checker.ctx.eval_session);
+                let _refs_scope = eval_session.enter_refs_resolution_scope();
+                for _ in 0..eval_session.refs_resolution_fuel_limit().saturating_sub(1) {
+                    eval_session.increment_refs_resolution_fuel();
+                }
+
+                checker.ensure_refs_resolved(root_lazy);
+            }
+
+            assert_eq!(
+                checker.ctx.eval_session.refs_resolution_fuel(),
+                checker.ctx.eval_session.refs_resolution_fuel_limit(),
+                "refs readiness should spend exactly the final local fuel unit on the direct def",
+            );
+            assert_eq!(
+                checker.ctx.eval_session.lazy_resolution_fuel_value(),
+                0,
+                "refs readiness at its local fuel edge must not spend shared lazy-resolution fuel",
+            );
+            let type_env = checker.ctx.type_env.borrow();
+            assert_eq!(
+                type_env.get_def(root_def),
+                Some(leaf_lazy),
+                "the direct root def should still be registered at the refs-fuel edge",
+            );
+            assert_eq!(
+                type_env.get_def(leaf_def),
+                None,
+                "the transitive tail should not be walked after local refs fuel is exhausted",
+            );
+        },
+    );
 }

--- a/crates/tsz-checker/tests/arch_source_scans/lazy_resolution_session_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/lazy_resolution_session_scans.rs
@@ -31,6 +31,17 @@ fn strip_line_comments(source: &str) -> String {
         .join("\n")
 }
 
+fn source_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+    let start_idx = source
+        .find(start)
+        .unwrap_or_else(|| panic!("failed to find start marker {start:?}"));
+    let rest = &source[start_idx..];
+    let end_idx = rest
+        .find(end)
+        .unwrap_or_else(|| panic!("failed to find end marker {end:?} after {start:?}"));
+    &rest[..end_idx]
+}
+
 #[test]
 fn global_resolution_fuel_is_checker_session_owned() {
     let source = read_checker_source("src/state/type_environment/lazy_fuel.rs");
@@ -120,5 +131,51 @@ fn relation_input_readiness_keeps_both_steps_without_outer_fuel_gate() {
         !function_body.contains("lazy_resolution_fuel_exhausted")
             && !function_body.contains("refs_resolution_fuel_exhausted"),
         "relation input readiness should not have an outer fuel gate before the readiness steps"
+    );
+}
+
+#[test]
+fn readiness_prewalks_do_not_charge_global_lazy_resolution_fuel() {
+    let lazy = strip_line_comments(&read_checker_source("src/state/type_environment/lazy.rs"));
+    let app_body = source_between(
+        &lazy,
+        "pub(crate) fn ensure_application_symbols_resolved_inner",
+        "fn resolve_lazy_def_for_type_env",
+    );
+    assert!(
+        app_body.contains("increment_app_symbol_resolution_fuel();"),
+        "application readiness should still charge its local prewalk fuel",
+    );
+    assert!(
+        !app_body.contains("increment_lazy_resolution_fuel();"),
+        "application readiness must not double-charge the shared lazy-resolution fuel"
+    );
+
+    let assignability = strip_line_comments(&read_checker_source(
+        "src/assignability/assignability_checker.rs",
+    ));
+    let refs_body = source_between(
+        &assignability,
+        "pub(crate) fn ensure_refs_resolved",
+        "pub(crate) fn assignability_eval_memo_stamp",
+    );
+    assert!(
+        refs_body.contains("increment_refs_resolution_fuel();"),
+        "refs readiness should still charge its local prewalk fuel",
+    );
+    assert!(
+        !refs_body.contains("increment_lazy_resolution_fuel();"),
+        "refs readiness must not double-charge the shared lazy-resolution fuel",
+    );
+
+    let direct_resolution = refs_body
+        .find("resolve_and_insert_def_type(def_id)")
+        .expect("refs readiness should still resolve the direct DefId");
+    let fuel_tail_gate = refs_body
+        .find("if at_fuel_limit")
+        .expect("refs readiness should still gate transitive tail work at the fuel edge");
+    assert!(
+        direct_resolution < fuel_tail_gate,
+        "refs readiness should preserve direct resolution before stopping transitive tail work",
     );
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Stop checker readiness prewalks from spending `lazy_resolution_fuel` in addition to their local app-symbol/refs budgets.
- Preserve refs direct-def registration at the local fuel edge while keeping transitive tail work bounded.
- Add runtime fuel-boundary tests and source ratchets for the readiness ownership rule.

Structural rule: when checker relation-readiness walks force application symbols or direct lazy refs, tsz bounds that prewalk through the readiness-local counters; actual lazy type-resolution work spends the shared session `lazy_resolution_fuel` through `CheckerContext::consume_fuel`.

Owner layer: checker readiness (`ensure_application_symbols_resolved_inner`, `ensure_refs_resolved`) owns app/refs prewalk fuel; checker type resolution owns shared lazy-resolution fuel.

Adjacent matrix: application lazy/enum/type-query readiness, unresolved bare lazy refs, direct symbol-backed refs, local refs-fuel edge with direct registration and no transitive tail.

Fallback: if shared lazy fuel is already exhausted by actual resolution work, refs readiness still registers the direct `DefId` as before, then skips transitive expansion.

## Verification
- `cargo fmt --all --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(application_readiness_spends_local_fuel_without_global_lazy_fuel) or test(refs_readiness_spends_local_fuel_without_global_lazy_fuel) or test(refs_readiness_resolves_direct_def_at_local_fuel_edge_without_tail) or test(unresolved_base_application_is_not_persisted_to_env_eval_cache) or test(unresolved_bare_lazy_is_not_persisted_to_env_eval_cache) or test(unresolved_lazy_index_access_is_not_persisted_to_env_eval_cache) or test(identical_dom_call_assignments_all_report_no_fuel_drop)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test arch_source_scans -E 'test(readiness_prewalks_do_not_charge_global_lazy_resolution_fuel) or test(relation_input_readiness_keeps_both_steps_without_outer_fuel_gate) or test(lazy_readiness_guards_are_checker_session_owned)'`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo clippy -p tsz-checker --lib --tests -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high