### PR TITLE
perf(solver): partition conditional subtype cache (#14351)

### DIFF
--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -236,6 +236,38 @@ pub trait TypeApplicationEvalCache {
         _verdict: bool,
     ) {
     }
+
+    /// Look up a cached result for tsc's permissive-instantiation
+    /// false-branch gate (`getConditionalType`).
+    ///
+    /// The key is the original `(check, extends)` pair plus both compiler
+    /// option bits. The caller must publish only when the helper's instantiated
+    /// permissive relation was certified by the conditional-branch verdict cache
+    /// and the surrounding evaluation request stayed stable. Default returns
+    /// `None` so raw-interner backends opt out.
+    fn lookup_permissive_false_branch_verdict(
+        &self,
+        _check: TypeId,
+        _extends: TypeId,
+        _no_unchecked_indexed_access: bool,
+        _exact_optional_property_types: bool,
+    ) -> Option<bool> {
+        None
+    }
+
+    /// Store a cached result for tsc's permissive-instantiation false-branch
+    /// gate. Default is a no-op. See
+    /// [`Self::lookup_permissive_false_branch_verdict`] for the required
+    /// publication gates.
+    fn insert_permissive_false_branch_verdict(
+        &self,
+        _check: TypeId,
+        _extends: TypeId,
+        _no_unchecked_indexed_access: bool,
+        _exact_optional_property_types: bool,
+        _verdict: bool,
+    ) {
+    }
 }
 
 /// Cache for the canonical `widen_type` result keyed by `TypeId`.

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -53,6 +53,7 @@ mod resolver;
 type ElementAccessTypeCacheKey = (TypeId, TypeId, Option<u32>, bool);
 type PropertyAccessCacheKey = (TypeId, Atom, bool, bool);
 type ConditionalBranchVerdictCacheKey = (TypeId, TypeId, bool, bool);
+type PermissiveFalseBranchCacheKey = (TypeId, TypeId, bool, bool);
 
 const SUBTYPE_POLICY_TRACE_OP: &str = "is_subtype_of_with_policy";
 const ASSIGNABILITY_POLICY_TRACE_OP: &str = "is_assignable_to_with_policy";
@@ -241,6 +242,10 @@ pub struct QueryCache<'a> {
     /// that is dropped on every evaluator construction. Shares this cache's
     /// `clear()`/file lifecycle envelope.
     conditional_branch_verdict_cache: RefCell<FxHashMap<ConditionalBranchVerdictCacheKey, bool>>,
+    /// Persistent results for tsc's permissive-instantiation false-branch gate.
+    /// Writes are guarded by the conditional-branch verdict cache for the
+    /// instantiated permissive pair.
+    permissive_false_branch_cache: RefCell<FxHashMap<PermissiveFalseBranchCacheKey, bool>>,
     application_eval_cache: RefCell<FxHashMap<ApplicationEvalCacheKey, TypeId>>,
     application_eval_dependency_index: ApplicationEvalDependencyIndex,
     element_access_cache: RefCell<FxHashMap<ElementAccessTypeCacheKey, TypeId>>,
@@ -345,6 +350,7 @@ impl<'a> QueryCache<'a> {
             closed_eval_cache: RefCell::new(FxHashMap::default()),
             closed_eval_dependency_index: RefCell::new(EvalDependencyIndexState::default()),
             conditional_branch_verdict_cache: RefCell::new(FxHashMap::default()),
+            permissive_false_branch_cache: RefCell::new(FxHashMap::default()),
             application_eval_cache: RefCell::new(FxHashMap::default()),
             application_eval_dependency_index: RefCell::new(
                 ApplicationEvalDependencyIndexState::default(),
@@ -408,6 +414,7 @@ impl<'a> QueryCache<'a> {
         self.closed_eval_cache.borrow_mut().clear();
         self.closed_eval_dependency_index.borrow_mut().clear();
         self.conditional_branch_verdict_cache.borrow_mut().clear();
+        self.permissive_false_branch_cache.borrow_mut().clear();
         self.element_access_cache.borrow_mut().clear();
         self.application_eval_cache.borrow_mut().clear();
         self.application_eval_dependency_index.borrow_mut().clear();
@@ -447,6 +454,10 @@ impl<'a> QueryCache<'a> {
             closed_eval_cache_entries: self.closed_eval_cache.borrow().len(),
             conditional_branch_verdict_cache_entries: self
                 .conditional_branch_verdict_cache
+                .borrow()
+                .len(),
+            permissive_false_branch_cache_entries: self
+                .permissive_false_branch_cache
                 .borrow()
                 .len(),
             application_eval_cache_entries: self.application_eval_cache.borrow().len(),

--- a/crates/tsz-solver/src/caches/query_cache_application_eval.rs
+++ b/crates/tsz-solver/src/caches/query_cache_application_eval.rs
@@ -180,4 +180,41 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
             verdict,
         );
     }
+
+    fn lookup_permissive_false_branch_verdict(
+        &self,
+        check: TypeId,
+        extends: TypeId,
+        no_unchecked_indexed_access: bool,
+        exact_optional_property_types: bool,
+    ) -> Option<bool> {
+        self.permissive_false_branch_cache
+            .borrow()
+            .get(&(
+                check,
+                extends,
+                no_unchecked_indexed_access,
+                exact_optional_property_types,
+            ))
+            .copied()
+    }
+
+    fn insert_permissive_false_branch_verdict(
+        &self,
+        check: TypeId,
+        extends: TypeId,
+        no_unchecked_indexed_access: bool,
+        exact_optional_property_types: bool,
+        verdict: bool,
+    ) {
+        self.permissive_false_branch_cache.borrow_mut().insert(
+            (
+                check,
+                extends,
+                no_unchecked_indexed_access,
+                exact_optional_property_types,
+            ),
+            verdict,
+        );
+    }
 }

--- a/crates/tsz-solver/src/caches/query_cache_size.rs
+++ b/crates/tsz-solver/src/caches/query_cache_size.rs
@@ -85,6 +85,15 @@ impl QueryCache<'_> {
                     + std::mem::size_of::<bool>());
         }
 
+        // permissive_false_branch_cache: (TypeId, TypeId, bool, bool) -> bool
+        {
+            let map = self.permissive_false_branch_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<PermissiveFalseBranchCacheKey>()
+                    + std::mem::size_of::<bool>());
+        }
+
         // application_eval_cache: (DefId, SmallVec<[TypeId; 4]>, bool) -> TypeId
         {
             let map = self.application_eval_cache.borrow();

--- a/crates/tsz-solver/src/caches/query_cache_statistics.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics.rs
@@ -22,6 +22,8 @@ pub struct QueryCacheStatistics {
     pub closed_eval_cache_entries: usize,
     /// Number of memoized conditional-branch subtype verdicts (#8356 / #13097).
     pub conditional_branch_verdict_cache_entries: usize,
+    /// Number of memoized permissive-instantiation false-branch gate results.
+    pub permissive_false_branch_cache_entries: usize,
     /// Number of memoized application evaluation results.
     pub application_eval_cache_entries: usize,
     /// Number of times the application eval cache returned a hit.
@@ -79,6 +81,7 @@ impl QueryCacheStatistics {
         self.closed_eval_cache_entries += other.closed_eval_cache_entries;
         self.conditional_branch_verdict_cache_entries +=
             other.conditional_branch_verdict_cache_entries;
+        self.permissive_false_branch_cache_entries += other.permissive_false_branch_cache_entries;
         self.application_eval_cache_entries += other.application_eval_cache_entries;
         self.application_eval_cache_hits += other.application_eval_cache_hits;
         self.application_eval_cache_misses += other.application_eval_cache_misses;
@@ -123,6 +126,7 @@ impl QueryCacheStatistics {
         // (TypeId, TypeId, bool, bool) key + bool value ≈ 12 bytes.
         let conditional_verdict =
             self.conditional_branch_verdict_cache_entries * (BUCKET_OVERHEAD + 12);
+        let permissive_false = self.permissive_false_branch_cache_entries * (BUCKET_OVERHEAD + 12);
         let app_eval = self.application_eval_cache_entries * (BUCKET_OVERHEAD + 37);
         let elem = self.element_access_cache_entries * (BUCKET_OVERHEAD + 21);
         let spread = self.object_spread_cache_entries * (BUCKET_OVERHEAD + 4 + 24 + 256);
@@ -137,6 +141,7 @@ impl QueryCacheStatistics {
 
         eval + closed_eval
             + conditional_verdict
+            + permissive_false
             + app_eval
             + elem
             + spread
@@ -164,6 +169,11 @@ impl std::fmt::Display for QueryCacheStatistics {
             f,
             "  cond_branch_verdict:    {}",
             self.conditional_branch_verdict_cache_entries
+        )?;
+        writeln!(
+            f,
+            "  permissive_false_branch:{}",
+            self.permissive_false_branch_cache_entries
         )?;
         writeln!(
             f,

--- a/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
@@ -451,6 +451,82 @@ fn conditional_branch_verdict_cache_defaults_off_for_raw_interner() {
 }
 
 #[test]
+fn permissive_false_branch_cache_round_trips_and_is_key_partitioned() {
+    // Structural rule (#14351): the permissive-instantiation false-branch
+    // wrapper cache is keyed by the original `(check, extends)` operands plus
+    // both compiler option bits. It is cleared with the `QueryCache` and is
+    // distinct from the instantiated conditional-branch verdict cache that
+    // certifies publication safety.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let before = db.statistics();
+    assert_eq!(before.permissive_false_branch_cache_entries, 0);
+
+    assert_eq!(
+        db.lookup_permissive_false_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, false),
+        None
+    );
+
+    db.insert_permissive_false_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, false, true);
+    assert_eq!(
+        db.lookup_permissive_false_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, false),
+        Some(true)
+    );
+
+    let after = db.statistics();
+    assert_eq!(after.permissive_false_branch_cache_entries, 1);
+    assert!(after.estimated_size_bytes() > before.estimated_size_bytes());
+    assert!(after.to_string().contains("permissive_false_branch"));
+
+    assert_eq!(
+        db.lookup_permissive_false_branch_verdict(TypeId::STRING, TypeId::NUMBER, true, false),
+        None
+    );
+    assert_eq!(
+        db.lookup_permissive_false_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, true),
+        None
+    );
+
+    db.insert_permissive_false_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, true, false);
+    assert_eq!(
+        db.lookup_permissive_false_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, true),
+        Some(false)
+    );
+    assert_eq!(
+        db.lookup_permissive_false_branch_verdict(TypeId::NUMBER, TypeId::STRING, false, false),
+        None
+    );
+
+    db.clear();
+    assert_eq!(db.statistics().permissive_false_branch_cache_entries, 0);
+    assert_eq!(
+        db.lookup_permissive_false_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, false),
+        None
+    );
+}
+
+#[test]
+fn permissive_false_branch_cache_defaults_off_for_raw_interner() {
+    let interner = TypeInterner::new();
+    interner.insert_permissive_false_branch_verdict(
+        TypeId::STRING,
+        TypeId::NUMBER,
+        false,
+        false,
+        true,
+    );
+    assert_eq!(
+        interner.lookup_permissive_false_branch_verdict(
+            TypeId::STRING,
+            TypeId::NUMBER,
+            false,
+            false,
+        ),
+        None
+    );
+}
+
+#[test]
 fn application_eval_cache_is_per_file_isolated() {
     // Structural rule: `application_eval_cache` is intentionally NOT shared
     // cross-file. Parallel file checking can observe incomplete lib-merge state
@@ -1054,14 +1130,17 @@ fn query_cache_statistics_merge_includes_intersection_merge_cache() {
 fn query_cache_statistics_merge_includes_closed_eval_cache() {
     let mut left = QueryCacheStatistics {
         closed_eval_cache_entries: 2,
+        permissive_false_branch_cache_entries: 3,
         ..Default::default()
     };
     let right = QueryCacheStatistics {
         closed_eval_cache_entries: 7,
+        permissive_false_branch_cache_entries: 11,
         ..Default::default()
     };
 
     left.merge(&right);
 
     assert_eq!(left.closed_eval_cache_entries, 9);
+    assert_eq!(left.permissive_false_branch_cache_entries, 14);
 }

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -109,11 +109,12 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// individual members instead of the full intersection type.
     suppress_this_binding: bool,
     /// PERF: Cache for subtype check results used in conditional type evaluation.
-    /// Key: (`check_type`, `extends_type`), Value: `is_subtype`.
+    /// Key: (`check_type`, `extends_type`, `noUncheckedIndexedAccess`,
+    /// `exactOptionalPropertyTypes`), Value: `is_subtype`.
     /// Deeply recursive conditional types (`DeepReadonly`, `Compute`, etc.) often check
     /// the same (check, extends) pair many times across distributed branches and
     /// tail-recursion iterations. Caching avoids redundant structural comparison.
-    conditional_subtype_cache: FxHashMap<(TypeId, TypeId), bool>,
+    conditional_subtype_cache: FxHashMap<ConditionalSubtypeCacheKey, bool>,
     /// PERF: Cache whether a type contains `infer`.
     /// Recursive conditionals can revisit the same application-shaped `extends`
     /// pattern thousands of times while checking whether the application-level
@@ -284,7 +285,7 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
 /// are never shared across resolver, substitution, or compiler-option modes.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct TypeEvaluatorCacheStatistics {
-    /// Entries in the conditional subtype memo keyed by `(check_type, extends_type)`.
+    /// Entries in the option-sensitive conditional subtype memo.
     pub conditional_subtype_entries: usize,
     /// Entries in the `contains infer` predicate memo keyed by `TypeId`.
     pub contains_infer_entries: usize,
@@ -332,6 +333,15 @@ impl CompoundSubtypePairKey {
 /// gate in conditional type evaluation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct PermissiveFalseBranchKey {
+    check_type: TypeId,
+    extends_type: TypeId,
+    no_unchecked_indexed_access: bool,
+    exact_optional_property_types: bool,
+}
+
+/// Operation-local cache key for definitive conditional branch subtype probes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct ConditionalSubtypeCacheKey {
     check_type: TypeId,
     extends_type: TypeId,
     no_unchecked_indexed_access: bool,
@@ -422,7 +432,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let compound_subtype_entries = self.compound_subtype_cache.len();
         let permissive_false_branch_entries = self.permissive_false_branch_cache.len();
         let type_evaluator_cache_estimated_size_bytes = conditional_subtype_entries
-            .saturating_mul(std::mem::size_of::<((TypeId, TypeId), bool)>())
+            .saturating_mul(std::mem::size_of::<(ConditionalSubtypeCacheKey, bool)>())
             .saturating_add(
                 contains_infer_entries.saturating_mul(std::mem::size_of::<(TypeId, bool)>()),
             )
@@ -831,7 +841,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         extends: TypeId,
     ) -> Option<bool> {
         self.conditional_subtype_cache
-            .get(&(check, extends))
+            .get(&self.conditional_subtype_cache_key(check, extends))
             .copied()
     }
 
@@ -843,8 +853,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         extends: TypeId,
         result: bool,
     ) {
-        self.conditional_subtype_cache
-            .insert((check, extends), result);
+        let key = self.conditional_subtype_cache_key(check, extends);
+        self.conditional_subtype_cache.insert(key, result);
+    }
+
+    #[inline]
+    const fn conditional_subtype_cache_key(
+        &self,
+        check_type: TypeId,
+        extends_type: TypeId,
+    ) -> ConditionalSubtypeCacheKey {
+        ConditionalSubtypeCacheKey {
+            check_type,
+            extends_type,
+            no_unchecked_indexed_access: self.no_unchecked_indexed_access,
+            exact_optional_property_types: self.exact_optional_property_types,
+        }
     }
 
     /// PERF: Look up whether a type contains `infer`.

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -124,6 +124,14 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// evaluator and keyed by the full relation configuration plus the
     /// simplifier-specific bypass/depth mode.
     compound_subtype_cache: FxHashMap<CompoundSubtypePairKey, bool>,
+    /// PERF: Cache tsc's permissive-instantiation false-branch probe for
+    /// conditional types. The helper substitutes every reachable type parameter
+    /// with `any`, evaluates both sides, then asks the conditional relation
+    /// gateway whether the false branch is definitive. That whole operation can
+    /// be requested several times while one conditional reduction is deciding
+    /// whether to defer. Entries are evaluator-local and published only when the
+    /// probe did not move the evaluator's limit/unresolved/request state.
+    permissive_false_branch_cache: FxHashMap<PermissiveFalseBranchKey, bool>,
     /// Ceiling for eager mapped-key expansion before bailing out.
     max_mapped_keys: usize,
     /// When true, flag `depth_exceeded` on Application cycle detection.
@@ -282,6 +290,8 @@ pub struct TypeEvaluatorCacheStatistics {
     pub contains_infer_entries: usize,
     /// Entries in the compound simplification subtype memo.
     pub compound_subtype_entries: usize,
+    /// Entries in the permissive-instantiation false-branch probe memo.
+    pub permissive_false_branch_entries: usize,
     estimated_size_bytes: usize,
 }
 
@@ -316,6 +326,25 @@ impl CompoundSubtypePairKey {
             max_depth: checker.max_depth,
         }
     }
+}
+
+/// Operation-local cache key for tsc's permissive-instantiation false-branch
+/// gate in conditional type evaluation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct PermissiveFalseBranchKey {
+    check_type: TypeId,
+    extends_type: TypeId,
+    no_unchecked_indexed_access: bool,
+    exact_optional_property_types: bool,
+}
+
+/// Snapshot of evaluator state that makes a probe result cacheable only when
+/// unchanged across the probe.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct EvaluationProbeState {
+    limit_epoch: u32,
+    unresolved_def_epoch: u32,
+    request_termination_kind: Option<TerminationKind>,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -361,6 +390,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             conditional_subtype_cache: FxHashMap::default(),
             contains_infer_cache: FxHashMap::default(),
             compound_subtype_cache: FxHashMap::default(),
+            permissive_false_branch_cache: FxHashMap::default(),
             max_mapped_keys: DEFAULT_MAX_MAPPED_KEYS,
             flag_depth_on_app_cycle: false,
             expand_application_display_alias_args: false,
@@ -390,6 +420,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let conditional_subtype_entries = self.conditional_subtype_cache.len();
         let contains_infer_entries = self.contains_infer_cache.len();
         let compound_subtype_entries = self.compound_subtype_cache.len();
+        let permissive_false_branch_entries = self.permissive_false_branch_cache.len();
         let type_evaluator_cache_estimated_size_bytes = conditional_subtype_entries
             .saturating_mul(std::mem::size_of::<((TypeId, TypeId), bool)>())
             .saturating_add(
@@ -398,12 +429,17 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             .saturating_add(
                 compound_subtype_entries
                     .saturating_mul(std::mem::size_of::<(CompoundSubtypePairKey, bool)>()),
+            )
+            .saturating_add(
+                permissive_false_branch_entries
+                    .saturating_mul(std::mem::size_of::<(PermissiveFalseBranchKey, bool)>()),
             );
 
         TypeEvaluatorCacheStatistics {
             conditional_subtype_entries,
             contains_infer_entries,
             compound_subtype_entries,
+            permissive_false_branch_entries,
             estimated_size_bytes: type_evaluator_cache_estimated_size_bytes,
         }
     }
@@ -627,6 +663,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             self.cache.clear();
             self.tainted.clear();
             self.compound_subtype_cache.clear();
+            self.permissive_false_branch_cache.clear();
         }
         self.no_unchecked_indexed_access = enabled;
     }
@@ -636,6 +673,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             self.cache.clear();
             self.tainted.clear();
             self.compound_subtype_cache.clear();
+            self.permissive_false_branch_cache.clear();
         }
         self.exact_optional_property_types = enabled;
     }
@@ -669,6 +707,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.unresolved_def_seen = false;
         self.unresolved_def_epoch = 0;
         self.app_body_unresolved_def_epoch = 0;
+        self.permissive_false_branch_cache.clear();
         self.compound_subtype_cache.clear();
     }
 
@@ -818,6 +857,71 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     #[inline]
     pub(crate) fn cache_contains_infer(&mut self, type_id: TypeId, result: bool) {
         self.contains_infer_cache.insert(type_id, result);
+    }
+
+    /// Build the option-sensitive cache key for tsc's permissive-instantiation
+    /// false-branch gate.
+    #[inline]
+    pub(crate) const fn permissive_false_branch_key(
+        &self,
+        check_type: TypeId,
+        extends_type: TypeId,
+    ) -> PermissiveFalseBranchKey {
+        PermissiveFalseBranchKey {
+            check_type,
+            extends_type,
+            no_unchecked_indexed_access: self.no_unchecked_indexed_access,
+            exact_optional_property_types: self.exact_optional_property_types,
+        }
+    }
+
+    /// Look up a cached permissive false-branch probe result.
+    #[inline]
+    pub(crate) fn cached_permissive_false_branch(
+        &self,
+        key: &PermissiveFalseBranchKey,
+    ) -> Option<bool> {
+        self.permissive_false_branch_cache.get(key).copied()
+    }
+
+    /// Cache a permissive false-branch probe result.
+    #[inline]
+    pub(crate) fn cache_permissive_false_branch(
+        &mut self,
+        key: PermissiveFalseBranchKey,
+        result: bool,
+    ) {
+        self.permissive_false_branch_cache.insert(key, result);
+    }
+
+    /// True when the shared permissive false-branch cache has the same
+    /// resolver-independent semantics as this evaluator.
+    ///
+    /// Resolver-backed and limited evaluators can evaluate the instantiated
+    /// permissive operands differently from the plain `NoopResolver` path, so
+    /// they keep using only the operation-local mirror.
+    #[inline]
+    pub(crate) fn permissive_false_branch_shared_cache_allowed(&self) -> bool {
+        self.persistent_memo_reads && !self.limited_resolver && self.resolver.is_noop()
+    }
+
+    /// Snapshot limit/unresolved/request state before an optional cache write.
+    #[inline]
+    pub(crate) const fn evaluation_probe_state(&self) -> EvaluationProbeState {
+        EvaluationProbeState {
+            limit_epoch: self.limit_epoch,
+            unresolved_def_epoch: self.unresolved_def_epoch,
+            request_termination_kind: self.request_termination_kind,
+        }
+    }
+
+    /// True when a probe did not observe a new unresolved body or budget/limit
+    /// event and therefore may publish an operation-local memo result.
+    #[inline]
+    pub(crate) fn evaluation_probe_state_is_unchanged(&self, state: EvaluationProbeState) -> bool {
+        self.limit_epoch == state.limit_epoch
+            && self.unresolved_def_epoch == state.unresolved_def_epoch
+            && self.request_termination_kind == state.request_termination_kind
     }
 
     /// PERF: Exact `TypeId` containment, memoized project-wide on the interner.
@@ -1493,7 +1597,8 @@ impl<R: TypeResolver> Drop for TypeEvaluator<'_, R> {
         tsz_common::perf_counters::record_eval_dropped_aux_entries(
             (self.conditional_subtype_cache.len()
                 + self.contains_infer_cache.len()
-                + self.compound_subtype_cache.len()) as u64,
+                + self.compound_subtype_cache.len()
+                + self.permissive_false_branch_cache.len()) as u64,
         );
     }
 }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -7,6 +7,7 @@ mod application_infer;
 mod application_reduction;
 mod array_infer;
 mod object_infer;
+mod permissive;
 mod phases;
 
 use crate::instantiation::instantiate::{
@@ -27,6 +28,7 @@ use tsz_common::interner::Atom;
 use super::super::evaluate::TypeEvaluator;
 use super::infer_pattern::InferPatternVisited;
 use crate::type_queries::get_application_base;
+use permissive::PermissiveFalseBranchProbe;
 use phases::TailCallStep;
 pub(in crate::evaluation::evaluate_rules::conditional) use phases::{
     BranchRelation, classify_branch_relation,
@@ -192,6 +194,59 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         check_type: TypeId,
         extends_type: TypeId,
     ) -> bool {
+        let cache_key = self.permissive_false_branch_key(check_type, extends_type);
+        if let Some(cached) = self.cached_permissive_false_branch(&cache_key) {
+            return cached;
+        }
+        let shared_cache_allowed = self.permissive_false_branch_shared_cache_allowed();
+        if shared_cache_allowed
+            && let Some(cached) = self.interner().lookup_permissive_false_branch_verdict(
+                check_type,
+                extends_type,
+                self.no_unchecked_indexed_access(),
+                self.exact_optional_property_types(),
+            )
+        {
+            self.cache_permissive_false_branch(cache_key, cached);
+            return cached;
+        }
+
+        let probe_state = self.evaluation_probe_state();
+        let probe = self.permissive_false_branch_is_definitive_uncached(check_type, extends_type);
+        if probe.cacheable
+            && self.evaluation_probe_state_is_unchanged(probe_state)
+            && self.request_state_is_depth_agnostic_cache_stable()
+        {
+            self.cache_permissive_false_branch(cache_key, probe.definitive_false);
+            if shared_cache_allowed
+                && let Some((permissive_check, permissive_extends)) = probe.permissive_pair
+                && self
+                    .interner()
+                    .lookup_conditional_branch_verdict(
+                        permissive_check,
+                        permissive_extends,
+                        self.no_unchecked_indexed_access(),
+                        self.exact_optional_property_types(),
+                    )
+                    .is_some()
+            {
+                self.interner().insert_permissive_false_branch_verdict(
+                    check_type,
+                    extends_type,
+                    self.no_unchecked_indexed_access(),
+                    self.exact_optional_property_types(),
+                    probe.definitive_false,
+                );
+            }
+        }
+        probe.definitive_false
+    }
+
+    fn permissive_false_branch_is_definitive_uncached(
+        &mut self,
+        check_type: TypeId,
+        extends_type: TypeId,
+    ) -> PermissiveFalseBranchProbe {
         use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
         let mut params = self.extract_type_params_from_type(check_type).to_vec();
         for &param in self.extract_type_params_from_type(extends_type).iter() {
@@ -207,9 +262,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 self.interner().lookup(check_type),
                 Some(TypeData::IndexAccess(_, _) | TypeData::KeyOf(_) | TypeData::Conditional(_))
             ) {
-                return false;
+                return PermissiveFalseBranchProbe::unshared(false);
             }
-            return true;
+            return PermissiveFalseBranchProbe::unshared(true);
         }
         let mut substitution = TypeSubstitution::new();
         for param in &params {
@@ -234,15 +289,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 permissive_extends,
             )
         {
-            return false;
+            return PermissiveFalseBranchProbe::unshared(false);
         }
         // Only a definitive `Fails` makes the false branch definitive. `Holds`
         // relates under the permissive form, and `Undetermined` consumed an
         // unregistered `Lazy` body — both keep the conditional deferred (#14238).
-        matches!(
-            self.conditional_subtype_relation(permissive_check, permissive_extends),
-            BranchRelation::Fails
-        )
+        match self.conditional_subtype_relation(permissive_check, permissive_extends) {
+            BranchRelation::Fails => PermissiveFalseBranchProbe::with_permissive_pair(
+                true,
+                permissive_check,
+                permissive_extends,
+            ),
+            BranchRelation::Holds => PermissiveFalseBranchProbe::with_permissive_pair(
+                false,
+                permissive_check,
+                permissive_extends,
+            ),
+            BranchRelation::Undetermined => PermissiveFalseBranchProbe::uncacheable(false),
+        }
     }
 
     fn generic_extends_can_use_permissive_false_branch(&self, extends_type: TypeId) -> bool {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/permissive.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/permissive.rs
@@ -1,0 +1,38 @@
+use crate::types::TypeId;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct PermissiveFalseBranchProbe {
+    pub(super) definitive_false: bool,
+    pub(super) cacheable: bool,
+    pub(super) permissive_pair: Option<(TypeId, TypeId)>,
+}
+
+impl PermissiveFalseBranchProbe {
+    pub(super) const fn unshared(definitive_false: bool) -> Self {
+        Self {
+            definitive_false,
+            cacheable: true,
+            permissive_pair: None,
+        }
+    }
+
+    pub(super) const fn uncacheable(definitive_false: bool) -> Self {
+        Self {
+            definitive_false,
+            cacheable: false,
+            permissive_pair: None,
+        }
+    }
+
+    pub(super) const fn with_permissive_pair(
+        definitive_false: bool,
+        permissive_check: TypeId,
+        permissive_extends: TypeId,
+    ) -> Self {
+        Self {
+            definitive_false,
+            cacheable: true,
+            permissive_pair: Some((permissive_check, permissive_extends)),
+        }
+    }
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/tests.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/tests.rs
@@ -332,3 +332,150 @@ fn conditional_subtype_relation_tracks_exact_optional_property_types() {
         BranchRelation::Holds
     );
 }
+
+fn test_type_parameter(interner: &TypeInterner, name: &str) -> TypeId {
+    interner.type_param(crate::types::TypeParamInfo::simple(
+        interner.intern_string(name),
+    ))
+}
+
+#[test]
+fn permissive_false_branch_cache_publishes_after_stable_relation_probe() {
+    // Structural rule (#14351): for a generic conditional whose ordinary
+    // relation failed, the false branch is definitive only when the permissive
+    // instantiation also fails. Cache the original `(check, extends)` wrapper
+    // only after the instantiated permissive relation has a stable verdict.
+    let interner = TypeInterner::new();
+    let cache = QueryCache::new(&interner);
+    let check = test_type_parameter(&interner, "Value");
+
+    let mut evaluator = TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&cache);
+    assert!(evaluator.permissive_false_branch_is_definitive(check, TypeId::NEVER));
+    assert_eq!(
+        evaluator.cache_statistics().permissive_false_branch_entries,
+        1
+    );
+    assert_eq!(
+        cache.lookup_conditional_branch_verdict(TypeId::ANY, TypeId::NEVER, false, false),
+        Some(false)
+    );
+    assert_eq!(cache.statistics().permissive_false_branch_cache_entries, 1);
+
+    let mut shared_hit = TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&cache);
+    assert!(shared_hit.permissive_false_branch_is_definitive(check, TypeId::NEVER));
+    let stats = shared_hit.cache_statistics();
+    assert_eq!(
+        stats.permissive_false_branch_entries, 1,
+        "shared hit should seed the evaluator-local mirror"
+    );
+    assert_eq!(
+        stats.conditional_subtype_entries, 0,
+        "shared wrapper hit should avoid rebuilding the permissive relation"
+    );
+}
+
+#[test]
+fn permissive_false_branch_cache_is_name_independent() {
+    let interner = TypeInterner::new();
+    let cache = QueryCache::new(&interner);
+    let renamed_check = test_type_parameter(&interner, "Renamed");
+
+    let mut evaluator = TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&cache);
+    assert!(evaluator.permissive_false_branch_is_definitive(renamed_check, TypeId::NEVER));
+    assert_eq!(cache.statistics().permissive_false_branch_cache_entries, 1);
+}
+
+#[test]
+fn permissive_false_branch_shared_cache_skips_limited_resolver_mode() {
+    let interner = TypeInterner::new();
+    let cache = QueryCache::new(&interner);
+    let polluted_check = test_type_parameter(&interner, "Polluted");
+
+    cache.insert_permissive_false_branch_verdict(
+        polluted_check,
+        TypeId::NEVER,
+        false,
+        false,
+        false,
+    );
+
+    let mut limited_hit = TypeEvaluator::with_resolver(&cache, &cache)
+        .with_query_db(&cache)
+        .with_limited_resolver();
+    assert!(
+        limited_hit.permissive_false_branch_is_definitive(polluted_check, TypeId::NEVER),
+        "limited resolver mode must recompute instead of consuming the shared wrapper cache"
+    );
+    assert_eq!(
+        cache.lookup_permissive_false_branch_verdict(polluted_check, TypeId::NEVER, false, false),
+        Some(false),
+        "limited resolver mode must not overwrite shared wrapper cache entries"
+    );
+
+    let fresh_check = test_type_parameter(&interner, "FreshLimited");
+    let mut limited_publish = TypeEvaluator::with_resolver(&cache, &cache)
+        .with_query_db(&cache)
+        .with_limited_resolver();
+    assert!(limited_publish.permissive_false_branch_is_definitive(fresh_check, TypeId::NEVER));
+    assert_eq!(
+        cache.lookup_permissive_false_branch_verdict(fresh_check, TypeId::NEVER, false, false),
+        None,
+        "limited resolver mode must not publish shared wrapper cache entries"
+    );
+}
+
+#[test]
+fn permissive_false_branch_cache_skips_unstable_request_state() {
+    let interner = TypeInterner::new();
+    let cache = QueryCache::new(&interner);
+    let check = test_type_parameter(&interner, "Input");
+
+    let mut evaluator = TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&cache);
+    evaluator.simulate_incomplete_request_verdict_for_test(TerminationKind::QueryOpBudget);
+    assert!(evaluator.permissive_false_branch_is_definitive(check, TypeId::NEVER));
+    assert_eq!(
+        evaluator.cache_statistics().permissive_false_branch_entries,
+        0,
+        "incomplete request state must not seed the evaluator-local mirror"
+    );
+    assert_eq!(
+        cache.statistics().permissive_false_branch_cache_entries,
+        0,
+        "incomplete request state must not publish a shared wrapper verdict"
+    );
+    assert_eq!(
+        cache.lookup_conditional_branch_verdict(TypeId::ANY, TypeId::NEVER, false, false),
+        None,
+        "the existing branch-verdict cache remains the stability certificate"
+    );
+}
+
+#[test]
+fn permissive_false_branch_cache_clears_on_reset_and_option_flip() {
+    let interner = TypeInterner::new();
+    let check = test_type_parameter(&interner, "State");
+
+    let mut evaluator = TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&interner);
+    assert!(evaluator.permissive_false_branch_is_definitive(check, TypeId::NEVER));
+    assert_eq!(
+        evaluator.cache_statistics().permissive_false_branch_entries,
+        1
+    );
+
+    evaluator.reset();
+    assert_eq!(
+        evaluator.cache_statistics().permissive_false_branch_entries,
+        0
+    );
+
+    assert!(evaluator.permissive_false_branch_is_definitive(check, TypeId::NEVER));
+    assert_eq!(
+        evaluator.cache_statistics().permissive_false_branch_entries,
+        1
+    );
+    evaluator.set_no_unchecked_indexed_access(true);
+    assert_eq!(
+        evaluator.cache_statistics().permissive_false_branch_entries,
+        0
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/tests.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/tests.rs
@@ -333,6 +333,75 @@ fn conditional_subtype_relation_tracks_exact_optional_property_types() {
     );
 }
 
+#[test]
+fn local_conditional_subtype_cache_partitions_exact_optional_property_types() {
+    let interner = TypeInterner::new();
+    let name = interner.intern_string("x");
+    let source = interner.object(vec![PropertyInfo::new(name, TypeId::UNDEFINED)]);
+    let target = interner.object(vec![PropertyInfo::opt(name, TypeId::NUMBER)]);
+    let mut evaluator = TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&interner);
+
+    evaluator.set_exact_optional_property_types(false);
+    assert_eq!(
+        evaluator.conditional_subtype_relation(source, target),
+        BranchRelation::Holds
+    );
+    assert_eq!(evaluator.cache_statistics().conditional_subtype_entries, 1);
+
+    evaluator.set_exact_optional_property_types(true);
+    assert_eq!(
+        evaluator.conditional_subtype_relation(source, target),
+        BranchRelation::Fails,
+        "the same evaluator must not reuse the non-exact optional-property verdict",
+    );
+    assert_eq!(
+        evaluator.cache_statistics().conditional_subtype_entries,
+        2,
+        "local branch verdicts should be partitioned by exact optional mode",
+    );
+
+    evaluator.set_exact_optional_property_types(false);
+    assert_eq!(
+        evaluator.conditional_subtype_relation(source, target),
+        BranchRelation::Holds
+    );
+    assert_eq!(evaluator.cache_statistics().conditional_subtype_entries, 2);
+}
+
+#[test]
+fn local_conditional_subtype_cache_partitions_no_unchecked_indexed_access() {
+    let interner = TypeInterner::new();
+    let array = interner.array(TypeId::STRING);
+    let indexed = interner.index_access(array, TypeId::NUMBER);
+    let mut evaluator = TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&interner);
+
+    evaluator.set_no_unchecked_indexed_access(false);
+    assert_eq!(
+        evaluator.conditional_subtype_relation(indexed, TypeId::STRING),
+        BranchRelation::Holds
+    );
+    assert_eq!(evaluator.cache_statistics().conditional_subtype_entries, 1);
+
+    evaluator.set_no_unchecked_indexed_access(true);
+    assert_eq!(
+        evaluator.conditional_subtype_relation(indexed, TypeId::STRING),
+        BranchRelation::Fails,
+        "the same evaluator must not reuse the unchecked indexed-access verdict",
+    );
+    assert_eq!(
+        evaluator.cache_statistics().conditional_subtype_entries,
+        2,
+        "local branch verdicts should be partitioned by noUncheckedIndexedAccess",
+    );
+
+    evaluator.set_no_unchecked_indexed_access(false);
+    assert_eq!(
+        evaluator.conditional_subtype_relation(indexed, TypeId::STRING),
+        BranchRelation::Holds
+    );
+    assert_eq!(evaluator.cache_statistics().conditional_subtype_entries, 2);
+}
+
 fn test_type_parameter(interner: &TypeInterner, name: &str) -> TypeId {
     interner.type_param(crate::types::TypeParamInfo::simple(
         interner.intern_string(name),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_core.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_core.rs
@@ -6,15 +6,19 @@ fn evaluator_cache_statistics_report_entries_and_size() {
     let empty = evaluator.cache_statistics();
     assert_eq!(empty.conditional_subtype_entries, 0);
     assert_eq!(empty.contains_infer_entries, 0);
+    assert_eq!(empty.permissive_false_branch_entries, 0);
     assert_eq!(empty.estimated_size_bytes(), 0);
 
     evaluator.cache_conditional_subtype(TypeId::STRING, TypeId::UNKNOWN, true);
     evaluator.cache_conditional_subtype(TypeId::NUMBER, TypeId::STRING, false);
     evaluator.cache_contains_infer(TypeId::BOOLEAN, false);
+    let permissive_key = evaluator.permissive_false_branch_key(TypeId::BOOLEAN, TypeId::NEVER);
+    evaluator.cache_permissive_false_branch(permissive_key, true);
 
     let populated = evaluator.cache_statistics();
     assert_eq!(populated.conditional_subtype_entries, 2);
     assert_eq!(populated.contains_infer_entries, 1);
+    assert_eq!(populated.permissive_false_branch_entries, 1);
     assert!(
         populated.estimated_size_bytes() > empty.estimated_size_bytes(),
         "populated evaluator caches should report nonzero estimated residency"


### PR DESCRIPTION
Goal: fast

## Summary
- Give the evaluator-local conditional subtype cache the same option identity as the shared conditional branch verdict cache.
- Partition local branch probes by `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` instead of only `(check, extends)`.
- Add same-evaluator option-flip witnesses for exact optional property assignability and no-unchecked indexed access.

Structural rule: when a conditional branch probe depends on compiler option-sensitive relation/evaluation semantics, tsz caches the definitive branch verdict under `(check, extends, noUncheckedIndexedAccess, exactOptionalPropertyTypes)`.

Owner layer: solver evaluator-local conditional subtype memo; the shared #15481 conditional branch verdict cache already uses the same option partition.

Adjacent matrix: exact optional false→true→false on `{ x: undefined } extends { x?: number }`, no-unchecked false→true→false on `Array<string>[number] extends string`, existing shared branch-verdict partition test, and permissive false-branch cache reset coverage.

Fallback: none needed; cache miss recomputes through the existing subtype relation path with the evaluator's current option flags.

## Verification
- `cargo fmt --all --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(local_conditional_subtype_cache_partitions_exact_optional_property_types) or test(local_conditional_subtype_cache_partitions_no_unchecked_indexed_access) or test(conditional_subtype_relation_tracks_exact_optional_property_types) or test(conditional_branch_verdict_cache_round_trips_and_is_key_partitioned) or test(permissive_false_branch_cache_clears_on_reset_and_option_flip)'`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy -p tsz-solver --lib --tests -- -D warnings`
- `python3 scripts/perf/cache-visibility-report.py --json`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high