### PR TITLE
perf(solver): route narrowing subtype probes through relation query cache (#14351)

### DIFF
--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -4,9 +4,12 @@ use crate::def::DefId;
 use crate::narrowing::cache::{NarrowExcludingKey, NarrowExcludingStableKey, NarrowingCache};
 use crate::narrowing::guard::{GuardSense, TypeGuard};
 use crate::narrowing::request::{NarrowingOptions, NarrowingRequest};
-use crate::relations::subtype::{SubtypeChecker, TypeResolver};
+use crate::relations::relation_queries::{
+    RelationContext, RelationKind, RelationPolicy, query_relation, query_relation_with_resolver,
+};
+use crate::relations::subtype::TypeResolver;
 use crate::type_queries::{UnionMembersKind, classify_for_union_members};
-use crate::types::{FunctionShape, LiteralValue, ParamInfo, TypeData, TypeId};
+use crate::types::{FunctionShape, LiteralValue, ParamInfo, RelationFlags, TypeData, TypeId};
 use crate::utils::{TypeIdExt, union_or_single};
 use crate::visitor::{
     application_id, index_access_parts, intersection_list_id,

--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -987,12 +987,34 @@ impl<'a> NarrowingContext<'a> {
         {
             return cached;
         }
+        let policy = RelationPolicy::from_relation_flags(
+            RelationFlags::STRICT_NULL_CHECKS | RelationFlags::STRICT_FUNCTION_TYPES,
+        );
+        let context = RelationContext {
+            query_db: Some(self.db),
+            ..Default::default()
+        };
         let result = if let Some(resolver) = self.resolver {
-            let mut checker = SubtypeChecker::with_resolver(self.db.as_type_database(), &resolver)
-                .with_query_db(self.db);
-            checker.is_subtype_of(source, target)
+            query_relation_with_resolver(
+                self.db.as_type_database(),
+                &resolver,
+                source,
+                target,
+                RelationKind::Subtype,
+                policy,
+                context,
+            )
+            .is_related()
         } else {
-            crate::relations::subtype::is_subtype_of_with_db(self.db, source, target)
+            query_relation(
+                self.db.as_type_database(),
+                source,
+                target,
+                RelationKind::Subtype,
+                policy,
+                context,
+            )
+            .is_related()
         };
         self.cache
             .narrow_subtype_cache

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -627,6 +627,12 @@ pub fn query_relation_with_resolver<'a, R: TypeResolver>(
     policy: RelationPolicy,
     context: RelationContext<'a>,
 ) -> RelationResult {
+    if matches!(kind, RelationKind::Subtype)
+        && let Some(result) =
+            query_cached_subtype_with_resolver(interner, resolver, source, target, policy, context)
+    {
+        return result;
+    }
     if matches!(kind, RelationKind::Assignable)
         && let Some(result) = query_cached_assignability_with_resolver(
             interner, resolver, source, target, policy, context,
@@ -646,6 +652,73 @@ pub fn query_relation_with_resolver<'a, R: TypeResolver>(
         context,
         overrides: &overrides,
     })
+}
+
+fn query_cached_subtype_with_resolver<'a, R: TypeResolver>(
+    interner: &'a dyn TypeDatabase,
+    resolver: &'a R,
+    source: TypeId,
+    target: TypeId,
+    policy: RelationPolicy,
+    context: RelationContext<'a>,
+) -> Option<RelationResult> {
+    let query_db = context.query_db?;
+    let cache_key =
+        subtype_relation_cache_key(interner, resolver, source, target, policy, context)?;
+    if let Some(cached) = query_db.lookup_subtype_cache(cache_key) {
+        return Some(RelationResult::complete(RelationKind::Subtype, cached));
+    }
+
+    let mut checker = configured_subtype_checker(interner, resolver, policy, context);
+    let lazy_events_at_entry = checker.unresolved_lazy_relation_event_count();
+    let weak_sensitivity_at_entry = crate::limits::weak_type_sensitivity_count();
+    let related = checker.is_subtype_of(source, target);
+    let result = relation_result_from_subtype_checker(RelationKind::Subtype, related, &checker);
+
+    if matches!(result.termination(), RelationTermination::Complete)
+        && !checker.bypass_evaluation
+        && checker.type_param_equivalences.is_empty()
+        && checker.unresolved_lazy_relation_event_count() == lazy_events_at_entry
+        && crate::limits::weak_type_sensitivity_count() == weak_sensitivity_at_entry
+    {
+        query_db.insert_subtype_cache(cache_key, result.related);
+    }
+
+    Some(result)
+}
+
+fn subtype_relation_cache_key<R: TypeResolver>(
+    interner: &dyn TypeDatabase,
+    resolver: &R,
+    source: TypeId,
+    target: TypeId,
+    policy: RelationPolicy,
+    context: RelationContext<'_>,
+) -> Option<RelationCacheKey> {
+    // `SubtypeChecker` can cache class-context results by setting the
+    // `CLASS_CHECK_CONTEXT` bit. Keep this helper to the plain query shape
+    // until a caller needs top-level class-context subtype caching here.
+    if context.class_check.is_some() {
+        return None;
+    }
+
+    let has_this_type =
+        crate::contains_this_type(interner, source) || crate::contains_this_type(interner, target);
+    let this_context = if has_this_type {
+        resolver.resolve_this_type(interner)?
+    } else {
+        TypeId::NONE
+    };
+    let (inheritance_graph_id, inheritance_graph_generation) = context
+        .inheritance_graph
+        .map_or((0, 0), |graph| (graph.identity(), graph.generation()));
+
+    Some(
+        RelationCacheKey::for_subtype(source, target, policy.cache_config())
+            .with_this_context(this_context)
+            .with_resolver_generation(resolver.resolver_generation())
+            .with_inheritance_graph_context(inheritance_graph_id, inheritance_graph_generation),
+    )
 }
 
 fn query_cached_assignability_with_resolver<'a, R: TypeResolver>(

--- a/crates/tsz-solver/tests/narrowing_tests.rs
+++ b/crates/tsz-solver/tests/narrowing_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::construction::QueryCache;
 use crate::construction::TypeDatabase;
 use crate::construction::TypeInterner;
 use crate::def::resolver::TypeResolver;
@@ -10,3 +11,4 @@ use crate::types::SymbolRef;
 
 include!("narrowing_tests_parts/part_00.rs");
 include!("narrowing_tests_parts/part_01.rs");
+include!("narrowing_tests_parts/part_02.rs");

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_02.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_02.rs
@@ -1,0 +1,28 @@
+#[test]
+fn test_narrowing_subtype_probe_publishes_shared_relation_cache() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+    let animal = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let dog = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+
+    let first_cache = NarrowingCache::new();
+    let first_ctx = NarrowingContext::with_cache(&db, &first_cache);
+    assert_eq!(first_ctx.narrow_to_type(dog, animal), dog);
+    let after_first = db.statistics();
+    assert_eq!(after_first.relation.subtype_entries, 1);
+
+    let second_cache = NarrowingCache::new();
+    let second_ctx = NarrowingContext::with_cache(&db, &second_cache);
+    assert_eq!(second_ctx.narrow_to_type(dog, animal), dog);
+    let after_second = db.statistics();
+    assert_eq!(after_second.relation.subtype_entries, 1);
+    assert!(
+        after_second.relation.subtype_hits > after_first.relation.subtype_hits,
+        "a fresh narrowing cache should still reuse the shared subtype relation answer",
+    );
+}

--- a/crates/tsz-solver/tests/relation_queries_tests.rs
+++ b/crates/tsz-solver/tests/relation_queries_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::construction::{QueryCache, QueryDatabase, TypeDatabase, TypeInterner};
-use crate::types::RelationCacheKey;
+use crate::types::{RelationCacheKey, RelationFlags};
 use crate::{FunctionShape, ParamInfo, PropertyInfo, SymbolRef};
 
 struct GenerationResolver(u64);
@@ -115,6 +115,48 @@ fn query_relation_assignability_uses_query_cache_for_no_override_path() {
 }
 
 #[test]
+fn query_relation_subtype_uses_query_cache_for_no_override_path() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_NULL_CHECKS | RelationFlags::STRICT_FUNCTION_TYPES,
+    );
+    let context = RelationContext {
+        query_db: Some(&db),
+        ..Default::default()
+    };
+    let (animal, dog) = make_animal_dog(&interner);
+
+    let first = query_relation(
+        db.as_type_database(),
+        dog,
+        animal,
+        RelationKind::Subtype,
+        policy,
+        context,
+    );
+    assert!(first.is_related());
+    let after_first = db.statistics();
+    assert_eq!(after_first.relation.subtype_entries, 1);
+
+    let second = query_relation(
+        db.as_type_database(),
+        dog,
+        animal,
+        RelationKind::Subtype,
+        policy,
+        context,
+    );
+    assert!(second.is_related());
+    let after_second = db.statistics();
+    assert_eq!(after_second.relation.subtype_entries, 1);
+    assert!(
+        after_second.relation.subtype_hits > after_first.relation.subtype_hits,
+        "second top-level subtype query should read the shared relation cache",
+    );
+}
+
+#[test]
 fn query_relation_assignability_cache_partitions_by_resolver_generation() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);
@@ -156,6 +198,52 @@ fn query_relation_assignability_cache_partitions_by_resolver_generation() {
     );
     assert!(!second.is_related());
     assert_eq!(db.lookup_assignability_cache(key_two), Some(false));
+}
+
+#[test]
+fn query_relation_subtype_cache_partitions_by_resolver_generation() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let policy = RelationPolicy::from_relation_flags(
+        RelationFlags::STRICT_NULL_CHECKS | RelationFlags::STRICT_FUNCTION_TYPES,
+    );
+    let context = RelationContext {
+        query_db: Some(&db),
+        ..Default::default()
+    };
+    let generation_one = GenerationResolver(1);
+    let generation_two = GenerationResolver(2);
+    let key_one =
+        RelationCacheKey::for_subtype(TypeId::STRING, TypeId::NUMBER, policy.cache_config())
+            .with_resolver_generation(1);
+    let key_two =
+        RelationCacheKey::for_subtype(TypeId::STRING, TypeId::NUMBER, policy.cache_config())
+            .with_resolver_generation(2);
+
+    let first = query_relation_with_resolver(
+        db.as_type_database(),
+        &generation_one,
+        TypeId::STRING,
+        TypeId::NUMBER,
+        RelationKind::Subtype,
+        policy,
+        context,
+    );
+    assert!(!first.is_related());
+    assert_eq!(db.lookup_subtype_cache(key_one), Some(false));
+    assert_eq!(db.lookup_subtype_cache(key_two), None);
+
+    let second = query_relation_with_resolver(
+        db.as_type_database(),
+        &generation_two,
+        TypeId::STRING,
+        TypeId::NUMBER,
+        RelationKind::Subtype,
+        policy,
+        context,
+    );
+    assert!(!second.is_related());
+    assert_eq!(db.lookup_subtype_cache(key_two), Some(false));
 }
 
 #[test]


### PR DESCRIPTION
Goal: fast

## Summary
- Add a top-level cached `RelationKind::Subtype` query path beside the existing assignability query cache.
- Route narrowing subtype probes through that solver relation-query boundary while preserving the local `NarrowingCache` probe memo.
- Cover cache hit reuse, resolver-generation partitioning, and fresh-narrowing-cache reuse through the shared query cache.

## Structural Rule
When narrowing asks the same structural subtype question for the same source, target, relation policy, resolver generation, and graph/`this` context, `tsc` observes the same semantic relation answer; tsz now computes and reuses that answer through the solver-owned relation query cache. Narrowing remains the caller/owner of guard reduction, and relation semantics/cache safety stay in the solver relation boundary.

## Adjacent Matrix
- Direct subtype query: first query populates `QueryCache.subtype_cache`, second query hits it.
- Resolver variation: subtype cache keys partition by resolver generation.
- Narrowing caller: two fresh `NarrowingCache` instances over the same `QueryCache` reuse the shared subtype relation answer.
- Existing narrowing behavior: predicate false-branch, positive-subset, and `narrow_type` cases remain covered by the focused solver test filter.

## Cache And Fallback
- Cache key uses `RelationCacheKey::for_subtype(source, target, policy.cache_config())` plus resolver generation, inheritance graph identity/generation, and bound `this` context when needed.
- No new retained cache map is introduced; this reuses the existing `QueryCache` subtype relation cache and preserves the operation-local narrowing memo.
- Class-check contexts and unbound `this` types fall back to the existing configured subtype checker path instead of publishing an under-keyed top-level query-cache entry.
- Completed, non-bypass, non-equivalence, non-lazy-sensitive, non-weak-sensitive relation answers are the only entries published.

## Verification
- `cargo fmt --all --check`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(query_relation_subtype) or test(query_relation_assignability_uses_query_cache_for_no_override_path) or test(query_relation_assignability_cache_partitions_by_resolver_generation) or test(narrowing_subtype_probe_publishes_shared_relation_cache)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(query_relation_subtype) or test(query_relation_assignability) or test(narrowing_subtype_probe_publishes_shared_relation_cache) or test(narrow_excluding_positive_subset) or test(predicate_false_branch) or test(narrow_type)'`
- `scripts/safe-run.sh cargo clippy -p tsz-solver --lib --tests -- -D warnings`
- `git diff --check`
- `python3 scripts/perf/cache-visibility-report.py --json` (summary: `total_candidates=117`, `needs_review=30`; no new retained cache surface)
- `wc -l crates/tsz-solver/src/narrowing/core.rs crates/tsz-solver/src/narrowing/core/helpers.rs crates/tsz-solver/src/relations/relation_queries.rs crates/tsz-solver/tests/narrowing_tests.rs crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs crates/tsz-solver/tests/narrowing_tests_parts/part_01.rs crates/tsz-solver/tests/narrowing_tests_parts/part_02.rs crates/tsz-solver/tests/relation_queries_tests.rs`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
