### PR TITLE
perf(solver): reuse relation queries across narrowing probes (#14351)

### DIFF
--- a/crates/tsz-solver/src/narrowing/compound.rs
+++ b/crates/tsz-solver/src/narrowing/compound.rs
@@ -19,7 +19,6 @@ pub enum NullishFilter {
     /// Exclude the nullish part, keeping everything else.
     ExcludeNullish,
 }
-use crate::relations::subtype::{SubtypeChecker, is_subtype_of};
 use crate::type_queries::{UnionMembersKind, classify_for_union_members};
 use crate::types::{LiteralValue, TypeData, TypeId};
 use crate::visitor::{
@@ -644,15 +643,15 @@ impl<'a> NarrowingContext<'a> {
             tracing::debug_span!("narrow", ty = type_id.0, narrower = narrower.0,).entered();
 
         // Fast path: already a subtype
-        if is_subtype_of(self.db, type_id, narrower) {
+        if self.is_subtype_for_narrowing(type_id, narrower) {
             return type_id;
         }
 
         // Use visitor to perform narrowing
         let mut visitor = NarrowingVisitor {
+            ctx: self,
             db: self.db,
             narrower,
-            checker: SubtypeChecker::new(self.db.as_type_database()),
         };
         visitor.visit_type(self.db, type_id)
     }
@@ -718,7 +717,7 @@ impl<'a> NarrowingContext<'a> {
                     let resolved_member = self.resolve_type(member);
                     if !self.is_array_like(resolved_member)
                         && (self.is_any_array_compat(resolved_member)
-                            || is_subtype_of(self.db, any_array, resolved_member))
+                            || self.is_subtype_for_narrowing(any_array, resolved_member))
                     {
                         has_any_compat = true;
                         return Some(any_array);
@@ -799,7 +798,9 @@ impl<'a> NarrowingContext<'a> {
         // interface — i.e. `any[] <: source`. Without the supertype case these
         // object-like guards narrowed to `never`, producing false TS2339 on every
         // member access in the true branch.
-        if self.is_any_array_compat(source_type) || is_subtype_of(self.db, any_array, source_type) {
+        if self.is_any_array_compat(source_type)
+            || self.is_subtype_for_narrowing(any_array, source_type)
+        {
             return any_array;
         }
 

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -698,16 +698,11 @@ impl<'a> NarrowingContext<'a> {
                     // Reverse subtype check: target <: member.
                     // Handles narrowing \`string | number\` by \`"hello"\` where
                     // \`"hello" <: string\` so the member should be kept.
-                    // Guard: only use the bare is_subtype_of_with_db (which lacks a
-                    // TypeResolver) for primitive/literal types. For interface/class
-                    // Lazy(DefId) types, the global subtype cache can contain stale
-                    // results that cause false positives.
+                    // Keep this path to primitive/literal reverse narrowing, but
+                    // route the actual relation through the shared query boundary
+                    // so repeated guards reuse the same subtype answer.
                     if (self.is_js_primitive(target_type) || self.is_js_primitive(member))
-                        && crate::relations::subtype::is_subtype_of_with_db(
-                            self.db,
-                            target_type,
-                            member,
-                        )
+                        && self.is_subtype_for_narrowing(target_type, member)
                     {
                         // Keep a wide `symbol` member over a `unique symbol`
                         // value; resolved target also catches aliases.

--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -1131,11 +1131,7 @@ impl<'a> NarrowingContext<'a> {
                 sp.name == t_prop.name
                     // Optional source can't satisfy required target
                     && (!sp.optional || t_prop.optional)
-                    && crate::relations::subtype::is_subtype_of_with_db(
-                        self.db,
-                        sp.type_id,
-                        t_prop.type_id,
-                    )
+                    && self.is_subtype_for_narrowing(sp.type_id, t_prop.type_id)
             });
             if !found {
                 return false;

--- a/crates/tsz-solver/src/narrowing/instanceof.rs
+++ b/crates/tsz-solver/src/narrowing/instanceof.rs
@@ -196,14 +196,10 @@ impl<'a> NarrowingContext<'a> {
             // Handle Union: filter members based on instanceof relationship
             if let Some(members_id) = union_list_id(self.db, resolved_source) {
                 let members = self.db.type_list(members_id);
-                // PERF: Reuse a single SubtypeChecker across all member checks
-                // instead of allocating 4 hash sets per is_subtype_of call.
-                let mut checker = SubtypeChecker::new(self.db.as_type_database());
                 let mut filtered_members: SmallVec<[TypeId; 4]> = SmallVec::new();
                 for &member in &*members {
                     // Check if member is assignable to instance type
-                    checker.reset();
-                    if checker.is_subtype_of(member, instance_type) {
+                    if self.is_subtype_for_narrowing(member, instance_type) {
                         trace!(
                             "Union member {} is assignable to instance type {}, keeping",
                             member.0, instance_type.0
@@ -214,8 +210,7 @@ impl<'a> NarrowingContext<'a> {
 
                     // Check if instance type is assignable to member (subclass case)
                     // If we have a Dog and instanceof Animal, Dog is an instance of Animal
-                    checker.reset();
-                    if checker.is_subtype_of(instance_type, member) {
+                    if self.is_subtype_for_narrowing(instance_type, member) {
                         trace!(
                             "Instance type {} is assignable to union member {} (subclass), narrowing to instance type",
                             instance_type.0, member.0
@@ -352,13 +347,10 @@ impl<'a> NarrowingContext<'a> {
             // For unions, exclude members that are subtypes of the instance type
             if let Some(members_id) = union_list_id(self.db, resolved_source) {
                 let members = self.db.type_list(members_id);
-                // PERF: Reuse a single SubtypeChecker across all member checks
-                let mut checker = SubtypeChecker::new(self.db.as_type_database());
                 let mut filtered_members: SmallVec<[TypeId; 4]> = SmallVec::new();
                 for &member in &*members {
                     // Exclude members that are definitely subtypes of the instance type
-                    checker.reset();
-                    if !checker.is_subtype_of(member, instance_type) {
+                    if !self.is_subtype_for_narrowing(member, instance_type) {
                         filtered_members.push(member);
                     }
                 }
@@ -464,17 +456,9 @@ impl<'a> NarrowingContext<'a> {
                         );
                         continue;
                     }
-                    if crate::relations::subtype::is_subtype_of_with_db(
-                        self.db,
-                        member,
-                        instance_type,
-                    ) {
+                    if self.is_subtype_for_narrowing(member, instance_type) {
                         result.push(member);
-                    } else if crate::relations::subtype::is_subtype_of_with_db(
-                        self.db,
-                        instance_type,
-                        member,
-                    ) {
+                    } else if self.is_subtype_for_narrowing(instance_type, member) {
                         result.push(instance_type);
                     }
                 }
@@ -1116,11 +1100,7 @@ impl<'a> NarrowingContext<'a> {
         // and primitives) have no private constructor identity. `tsc` keeps the
         // source iff it is a subtype of the constructor's instance type.
         let resolved_member = self.resolve_type(member);
-        crate::relations::subtype::is_subtype_of_with_db(
-            self.db,
-            resolved_member,
-            resolved_instance,
-        )
+        self.is_subtype_for_narrowing(resolved_member, resolved_instance)
     }
 
     /// Narrow by `x.constructor !== SomeClass` (false branch).

--- a/crates/tsz-solver/src/narrowing/utils.rs
+++ b/crates/tsz-solver/src/narrowing/utils.rs
@@ -5,20 +5,18 @@
 
 use super::{DiscriminantInfo, NarrowingContext};
 use crate::construction::{QueryDatabase, TypeDatabase};
-use crate::relations::subtype::SubtypeChecker;
 use crate::types::{IntrinsicKind, LiteralValue, TypeData, TypeId, TypeListId, TypeParamInfo};
 use crate::visitor::{TypeVisitor, is_object_like_type_through_type_constraints};
 use tsz_common::interner::Atom;
 
 /// Visitor that narrows a type by filtering/intersecting with a narrower type.
-pub(crate) struct NarrowingVisitor<'a> {
-    pub(crate) db: &'a dyn QueryDatabase,
+pub(crate) struct NarrowingVisitor<'ctx, 'db> {
+    pub(crate) ctx: &'ctx NarrowingContext<'db>,
+    pub(crate) db: &'db dyn QueryDatabase,
     pub(crate) narrower: TypeId,
-    /// PERF: Reusable `SubtypeChecker` to avoid per-call hash allocations
-    pub(crate) checker: SubtypeChecker<'a>,
 }
 
-impl<'a> TypeVisitor for NarrowingVisitor<'a> {
+impl<'ctx, 'db> TypeVisitor for NarrowingVisitor<'ctx, 'db> {
     type Output = TypeId;
 
     /// Override `visit_type` to handle types that need special handling.
@@ -49,14 +47,12 @@ impl<'a> TypeVisitor for NarrowingVisitor<'a> {
                 TypeData::Object(_) => {
                     // Case 1: type_id is subtype of narrower (e.g., { a: "foo" } narrowed by { a: string })
                     // Result: type_id (keep the more specific type)
-                    self.checker.reset();
-                    if self.checker.is_subtype_of(type_id, self.narrower) {
+                    if self.ctx.is_subtype_for_narrowing(type_id, self.narrower) {
                         return type_id;
                     }
                     // Case 2: narrower is subtype of type_id (e.g., { a: string } narrowed by { a: "foo" })
                     // Result: narrower (narrow down to the more specific type)
-                    self.checker.reset();
-                    if self.checker.is_subtype_of(self.narrower, type_id) {
+                    if self.ctx.is_subtype_for_narrowing(self.narrower, type_id) {
                         return self.narrower;
                     }
                     // Case 3: Both are object types but not directly related
@@ -71,13 +67,11 @@ impl<'a> TypeVisitor for NarrowingVisitor<'a> {
                 // Function types: check subtype relationships
                 TypeData::Function(_) => {
                     // Case 1: type_id is subtype of narrower (keep specific)
-                    self.checker.reset();
-                    if self.checker.is_subtype_of(type_id, self.narrower) {
+                    if self.ctx.is_subtype_for_narrowing(type_id, self.narrower) {
                         return type_id;
                     }
                     // Case 2: narrower is subtype of type_id (narrow down)
-                    self.checker.reset();
-                    if self.checker.is_subtype_of(self.narrower, type_id) {
+                    if self.ctx.is_subtype_for_narrowing(self.narrower, type_id) {
                         return self.narrower;
                     }
                     // Case 3: Disjoint function types
@@ -113,15 +107,13 @@ impl<'a> TypeVisitor for NarrowingVisitor<'a> {
 
                 // Case 1: narrower is subtype of type_id (e.g., narrow(string, "foo"))
                 // Result: narrower
-                self.checker.reset();
-                if self.checker.is_subtype_of(self.narrower, type_id) {
+                if self.ctx.is_subtype_for_narrowing(self.narrower, type_id) {
                     self.narrower
                 }
                 // Case 2: type_id is subtype of narrower (e.g., narrow("foo", string))
                 // Result: type_id (the original)
                 else {
-                    self.checker.reset();
-                    if self.checker.is_subtype_of(type_id, self.narrower) {
+                    if self.ctx.is_subtype_for_narrowing(type_id, self.narrower) {
                         type_id
                     }
                     // Case 3: Disjoint types (e.g., narrow(string, number))

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_02.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_02.rs
@@ -26,3 +26,67 @@ fn test_narrowing_subtype_probe_publishes_shared_relation_cache() {
         "a fresh narrowing cache should still reuse the shared subtype relation answer",
     );
 }
+
+#[test]
+fn test_instanceof_member_filter_reuses_shared_relation_cache() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+    let animal = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let dog = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+    let source = interner.union2(dog, TypeId::NUMBER);
+
+    let first_cache = NarrowingCache::new();
+    let first_ctx = NarrowingContext::with_cache(&db, &first_cache);
+    assert_eq!(first_ctx.narrow_by_instance_type(source, animal), dog);
+    let after_first = db.statistics();
+    assert!(after_first.relation.subtype_entries > 0);
+
+    let second_cache = NarrowingCache::new();
+    let second_ctx = NarrowingContext::with_cache(&db, &second_cache);
+    assert_eq!(second_ctx.narrow_by_instance_type(source, animal), dog);
+    let after_second = db.statistics();
+    assert_eq!(
+        after_second.relation.subtype_entries,
+        after_first.relation.subtype_entries
+    );
+    assert!(
+        after_second.relation.subtype_hits > after_first.relation.subtype_hits,
+        "fresh instanceof narrowing should reuse shared subtype relation answers",
+    );
+}
+
+#[test]
+fn test_structural_narrowing_visitor_reuses_shared_relation_cache() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+    let animal = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let dog = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+    let first_cache = NarrowingCache::new();
+    let first_ctx = NarrowingContext::with_cache(&db, &first_cache);
+    assert_eq!(first_ctx.narrow(animal, dog), dog);
+    let after_first = db.statistics();
+    assert!(after_first.relation.subtype_entries > 0);
+
+    let second_cache = NarrowingCache::new();
+    let second_ctx = NarrowingContext::with_cache(&db, &second_cache);
+    assert_eq!(second_ctx.narrow(animal, dog), dog);
+    let after_second = db.statistics();
+    assert_eq!(
+        after_second.relation.subtype_entries,
+        after_first.relation.subtype_entries
+    );
+    assert!(
+        after_second.relation.subtype_hits > after_first.relation.subtype_hits,
+        "fresh structural narrowing visitor should reuse shared subtype relation answers",
+    );
+}


### PR DESCRIPTION
Goal: fast

## Summary
- Route remaining solver-narrowing subtype verdict probes through the cache-aware `is_subtype_for_narrowing` helper.
- Cover `narrow_to_type`, `narrow_by_instance_type`, constructor-identity structural fallback, object-property fallback, `NarrowingVisitor`, and `narrow_to_array` subtype checks.
- Leave the `instanceof` overlap checker on its dedicated `SubtypeChecker::are_types_overlapping` path because it asks a different relation question.

## Structural Rule
When narrowing asks a structural subtype question for the same source, target, relation policy, resolver generation, and graph/`this` context, `tsc` observes the same relation answer; tsz now answers those narrowing probes through the solver relation-query/cache boundary instead of local raw subtype checker instances. Narrowing still owns guard interpretation and branch shaping; relation truth and cache safety stay in the solver relation layer.

## Adjacent Matrix
- `instanceof` positive and false-branch union member filtering now reuse the shared subtype relation answer.
- Constructor identity true-branch structural fallback now reuses the same subtype query path.
- `NarrowingVisitor` object/function/intrinsic relation probes now use the cache-aware helper rather than carrying its own raw checker.
- `narrow_to_array` supertype probes for `any[] <: source` now share the same relation query path.
- Primitive/literal reverse narrowing remains gated to the same primitive guard while routing the relation answer through the shared query boundary.
- Object-property structural fallback keeps the same property/option checks but queries property-type compatibility through the shared helper.

## Cache And Fallback
- No new cache map is introduced; this reuses the `QueryCache.subtype_cache` path added by the parent PR plus the existing local `NarrowingCache` generation memo.
- The parent subtype query helper still owns resolver-generation, inheritance graph, `this`, termination, lazy-event, weak-sensitivity, and active-equivalence write gates.
- Overlap detection remains separate and uncached by this PR because overlap is not a subtype verdict.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `wc -l crates/tsz-solver/tests/narrowing_tests_parts/part_02.rs crates/tsz-solver/src/narrowing/compound.rs crates/tsz-solver/src/narrowing/utils.rs crates/tsz-solver/src/narrowing/instanceof.rs`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(narrowing_subtype_probe_publishes_shared_relation_cache) or test(instanceof_member_filter_reuses_shared_relation_cache) or test(structural_narrowing_visitor_reuses_shared_relation_cache) or test(narrow_by_instance_type) or test(narrow_by_instanceof) or test(narrow_to_array) or test(narrow_to_type)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(query_relation_subtype) or test(query_relation_assignability) or test(narrowing_subtype_probe_publishes_shared_relation_cache) or test(instanceof_member_filter_reuses_shared_relation_cache) or test(structural_narrowing_visitor_reuses_shared_relation_cache) or test(narrow_by_instance_type) or test(narrow_by_instanceof) or test(narrow_to_array) or test(narrow_to_type) or test(cache_visibility_tests)'`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy -p tsz-solver --lib --tests -- -D warnings`
- `python3 scripts/perf/cache-visibility-report.py --json` (summary: `total_candidates=117`, `needs_review=30`; no new retained cache surface)

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
