### PR TITLE
perf(checker): guard indexed-access walk caches (#14351)

### DIFF
--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -5,10 +5,134 @@ use crate::query_boundaries::type_checking_utilities as query;
 use crate::state::{CheckerState, EnumKind};
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use crate::symbols_domain::name_text::property_access_chain_text_in_arena;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::mem;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{SymbolRef, TypeId};
+
+const MAX_NUMERIC_INDEX_SURFACE_DEPTH: u32 = 1000;
+const HASH_MAP_ENTRY_OVERHEAD_ESTIMATE: usize = 8;
+
+type NumericIndexSurface = Option<(bool, bool)>;
+
+struct NumericIndexSurfaceWalk<'state, 'ctx> {
+    checker: &'state CheckerState<'ctx>,
+    visiting: FxHashSet<TypeId>,
+    memo: FxHashMap<TypeId, NumericIndexSurface>,
+    cut_seen: bool,
+}
+
+impl<'state, 'ctx> NumericIndexSurfaceWalk<'state, 'ctx> {
+    fn new(checker: &'state CheckerState<'ctx>) -> Self {
+        Self {
+            checker,
+            visiting: FxHashSet::default(),
+            memo: FxHashMap::default(),
+            cut_seen: false,
+        }
+    }
+
+    fn surface(&mut self, object_type: TypeId) -> NumericIndexSurface {
+        self.surface_inner(object_type, 0)
+    }
+
+    fn surface_inner(&mut self, object_type: TypeId, depth: u32) -> NumericIndexSurface {
+        if let Some(&cached) = self.memo.get(&object_type) {
+            return cached;
+        }
+        if depth >= MAX_NUMERIC_INDEX_SURFACE_DEPTH || !self.visiting.insert(object_type) {
+            self.cut_seen = true;
+            return None;
+        }
+
+        // Use the resolver-aware classifier so wrapped `Record`/application
+        // surfaces participate without name or source-text shortcuts.
+        let result = match query::classify_element_indexable_with_resolver(
+            self.checker.ctx.types,
+            &self.checker.ctx,
+            object_type,
+        ) {
+            query::ElementIndexableKind::ObjectWithIndex {
+                has_string,
+                has_number,
+            } => Some((has_string, has_number)),
+            query::ElementIndexableKind::Intersection(members) => {
+                let mut has_string = false;
+                let mut has_number = false;
+                for member in members {
+                    if let Some((member_string, member_number)) =
+                        self.surface_inner(member, depth + 1)
+                    {
+                        has_string |= member_string;
+                        has_number |= member_number;
+                    }
+                    if self.cut_seen {
+                        break;
+                    }
+                }
+                (!self.cut_seen && (has_string || has_number)).then_some((has_string, has_number))
+            }
+            query::ElementIndexableKind::Union(members) => {
+                let mut all_have_string_surface = true;
+                let mut all_have_number_surface = true;
+                let mut saw_indexed_member = false;
+
+                for member in members {
+                    let Some((has_string, has_number)) = self.surface_inner(member, depth + 1)
+                    else {
+                        self.visiting.remove(&object_type);
+                        if !self.cut_seen {
+                            self.memo.insert(object_type, None);
+                        }
+                        return None;
+                    };
+                    saw_indexed_member = true;
+                    all_have_string_surface &= has_string;
+                    all_have_number_surface &= has_number;
+                }
+
+                saw_indexed_member.then_some((all_have_string_surface, all_have_number_surface))
+            }
+            query::ElementIndexableKind::Array
+            | query::ElementIndexableKind::Tuple
+            | query::ElementIndexableKind::StringLike
+            | query::ElementIndexableKind::Other => None,
+        };
+
+        self.visiting.remove(&object_type);
+        if !self.cut_seen {
+            self.memo.insert(object_type, result);
+        }
+        result
+    }
+
+    fn entry_count(&self) -> usize {
+        self.memo.len()
+    }
+
+    fn estimated_size_bytes(&self) -> usize {
+        self.memo.capacity().saturating_mul(
+            mem::size_of::<TypeId>()
+                .saturating_add(mem::size_of::<NumericIndexSurface>())
+                .saturating_add(HASH_MAP_ENTRY_OVERHEAD_ESTIMATE),
+        )
+    }
+
+    fn trace_union_result(&self, object_type: TypeId, result: Option<bool>) {
+        if tracing::enabled!(tracing::Level::TRACE) {
+            tracing::trace!(
+                object_type = object_type.0,
+                result = ?result,
+                cut_seen = self.cut_seen,
+                memo_entries = self.entry_count(),
+                memo_estimated_size_bytes = self.estimated_size_bytes(),
+                "numeric_index_surface_walk"
+            );
+        }
+    }
+}
 
 impl<'a> CheckerState<'a> {
     /// Whether the element-access receiver resolves (through aliases /
@@ -615,12 +739,14 @@ impl<'a> CheckerState<'a> {
         let mut all_have_string_surface = true;
         let mut all_have_number_surface = true;
         let mut saw_indexed_member = false;
+        let mut surfaces = NumericIndexSurfaceWalk::new(self);
 
         for &member in &members {
             if !self.is_index_signature_only_member(member) {
                 return false;
             }
-            let Some((has_string, has_number)) = self.numeric_index_surfaces(member) else {
+            let Some((has_string, has_number)) = surfaces.surface(member) else {
+                surfaces.trace_union_result(object_type, None);
                 return false;
             };
             saw_indexed_member = true;
@@ -628,54 +754,9 @@ impl<'a> CheckerState<'a> {
             all_have_number_surface &= has_number;
         }
 
-        saw_indexed_member && !all_have_string_surface && !all_have_number_surface
-    }
-
-    fn numeric_index_surfaces(&self, object_type: TypeId) -> Option<(bool, bool)> {
-        // Resolver-aware so that intersection/union members containing
-        // `Application(Lazy(DefId), args)` wrappers (e.g. `Record<string, V>`)
-        // resolve to their structural index surface instead of `Other`.
-        match query::classify_element_indexable_with_resolver(
-            self.ctx.types,
-            &self.ctx,
-            object_type,
-        ) {
-            query::ElementIndexableKind::ObjectWithIndex {
-                has_string,
-                has_number,
-            } => Some((has_string, has_number)),
-            query::ElementIndexableKind::Intersection(members) => {
-                let mut has_string = false;
-                let mut has_number = false;
-                for member in members {
-                    if let Some((member_string, member_number)) =
-                        self.numeric_index_surfaces(member)
-                    {
-                        has_string |= member_string;
-                        has_number |= member_number;
-                    }
-                }
-                (has_string || has_number).then_some((has_string, has_number))
-            }
-            query::ElementIndexableKind::Union(members) => {
-                let mut all_have_string_surface = true;
-                let mut all_have_number_surface = true;
-                let mut saw_indexed_member = false;
-
-                for member in members {
-                    let (has_string, has_number) = self.numeric_index_surfaces(member)?;
-                    saw_indexed_member = true;
-                    all_have_string_surface &= has_string;
-                    all_have_number_surface &= has_number;
-                }
-
-                saw_indexed_member.then_some((all_have_string_surface, all_have_number_surface))
-            }
-            query::ElementIndexableKind::Array
-            | query::ElementIndexableKind::Tuple
-            | query::ElementIndexableKind::StringLike
-            | query::ElementIndexableKind::Other => None,
-        }
+        let result = saw_indexed_member && !all_have_string_surface && !all_have_number_surface;
+        surfaces.trace_union_result(object_type, Some(result));
+        result
     }
 
     fn is_index_signature_only_member(&self, object_type: TypeId) -> bool {

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -733,11 +733,7 @@ impl<'a> CheckerState<'a> {
             {
                 return;
             }
-            let supports_string_index =
-                self.is_element_indexable(object_type_for_check, true, false);
-            let supports_number_index =
-                self.is_element_indexable(object_type_for_check, false, true);
-            if !supports_string_index && !supports_number_index {
+            if !self.is_element_indexable_by_any_key(object_type_for_check) {
                 // tsc keeps the index syntactically generic when the AST node
                 // is a bare type-parameter reference, even when our resolution
                 // evaluated the parameter to `any` (typically via a constraint

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/concrete_index_error.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/concrete_index_error.rs
@@ -116,9 +116,7 @@ impl CheckerState<'_> {
         }
 
         if index_type == TypeId::ANY {
-            if self.is_element_indexable(concrete_object_type, true, false)
-                || self.is_element_indexable(concrete_object_type, false, true)
-            {
+            if self.is_element_indexable_by_any_key(concrete_object_type) {
                 return false;
             }
             self.emit_index_type_not_usable(error_anchor, "any");

--- a/crates/tsz-checker/src/types/utilities/element_indexable.rs
+++ b/crates/tsz-checker/src/types/utilities/element_indexable.rs
@@ -3,6 +3,7 @@
 use crate::query_boundaries::type_checking_utilities as query;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::mem;
 use tsz_solver::TypeId;
 
 /// Maximum union/intersection member-nesting depth walked by
@@ -12,13 +13,54 @@ use tsz_solver::TypeId;
 /// chain of *distinct* instantiations. Set well above any legitimate finite
 /// index-signature nesting so a real verdict is never masked.
 const MAX_ELEMENT_INDEXABLE_DEPTH: u32 = 1000;
+const HASH_MAP_ENTRY_OVERHEAD_ESTIMATE: usize = 8;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct ElementIndexableMemoStats {
+    entries: usize,
+    estimated_size_bytes: usize,
+}
+
+#[derive(Debug, Default)]
+struct ElementIndexableMemo {
+    memo: FxHashMap<TypeId, bool>,
+}
+
+impl ElementIndexableMemo {
+    fn get(&self, type_id: TypeId) -> Option<bool> {
+        self.memo.get(&type_id).copied()
+    }
+
+    fn insert(&mut self, type_id: TypeId, result: bool) {
+        self.memo.insert(type_id, result);
+    }
+
+    fn entry_count(&self) -> usize {
+        self.memo.len()
+    }
+
+    fn estimated_size_bytes(&self) -> usize {
+        self.memo.capacity().saturating_mul(
+            mem::size_of::<TypeId>()
+                .saturating_add(mem::size_of::<bool>())
+                .saturating_add(HASH_MAP_ENTRY_OVERHEAD_ESTIMATE),
+        )
+    }
+
+    fn stats(&self) -> ElementIndexableMemoStats {
+        ElementIndexableMemoStats {
+            entries: self.entry_count(),
+            estimated_size_bytes: self.estimated_size_bytes(),
+        }
+    }
+}
 
 struct ElementIndexableWalk<'state, 'ctx> {
     checker: &'state CheckerState<'ctx>,
     wants_string: bool,
     wants_number: bool,
     visiting: FxHashSet<TypeId>,
-    memo: FxHashMap<TypeId, bool>,
+    memo: ElementIndexableMemo,
 }
 
 impl<'state, 'ctx> ElementIndexableWalk<'state, 'ctx> {
@@ -55,7 +97,7 @@ impl<'state, 'ctx> ElementIndexableWalk<'state, 'ctx> {
     /// once and reuses — so caching it per `TypeId` is sound even when the cut
     /// value seeded a member along the way.
     fn classify(&mut self, object_type: TypeId, depth: u32) -> bool {
-        if let Some(&cached) = self.memo.get(&object_type) {
+        if let Some(cached) = self.memo.get(object_type) {
             return cached;
         }
         // Use the resolver-aware classifier so that `Application(Lazy(DefId), args)`
@@ -160,13 +202,75 @@ impl<'a> CheckerState<'a> {
     ) -> bool {
         // `wants_string` / `wants_number` are invariant across the whole descent,
         // so the per-call `memo` can key on `TypeId` alone.
-        ElementIndexableWalk {
+        let mut walk = ElementIndexableWalk {
             checker: self,
             wants_string,
             wants_number,
             visiting: FxHashSet::default(),
-            memo: FxHashMap::default(),
+            memo: ElementIndexableMemo::default(),
+        };
+        let result = walk.classify(object_type, 0);
+        if tracing::enabled!(tracing::Level::TRACE) {
+            let memo_stats = walk.memo.stats();
+            tracing::trace!(
+                object_type = object_type.0,
+                wants_string,
+                wants_number,
+                result,
+                memo_entries = memo_stats.entries,
+                memo_estimated_size_bytes = memo_stats.estimated_size_bytes,
+                "element_indexable_walk"
+            );
         }
-        .classify(object_type, 0)
+        result
+    }
+
+    /// Check whether a type supports either string or number indexing for an
+    /// `any` key. This is semantically equivalent to separate string/number
+    /// probes because string index signatures accept numeric keys, but it keeps
+    /// recursive union/intersection classification to one guarded walk.
+    pub(crate) fn is_element_indexable_by_any_key(&self, object_type: TypeId) -> bool {
+        self.is_element_indexable(object_type, true, true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn element_indexable_memo_records_entries_and_size() {
+        let mut memo = ElementIndexableMemo::default();
+
+        assert_eq!(
+            memo.stats(),
+            ElementIndexableMemoStats {
+                entries: 0,
+                estimated_size_bytes: 0,
+            }
+        );
+
+        assert_eq!(memo.get(TypeId::STRING), None);
+        memo.insert(TypeId::STRING, true);
+        assert_eq!(memo.get(TypeId::STRING), Some(true));
+
+        let stats = memo.stats();
+        assert_eq!(stats.entries, 1);
+        assert!(
+            stats.estimated_size_bytes >= mem::size_of::<TypeId>() + mem::size_of::<bool>(),
+            "estimated size should account for stored key/value bytes: {stats:?}"
+        );
+    }
+
+    #[test]
+    fn element_indexable_memo_overwrites_finished_result_without_entry_growth() {
+        let mut memo = ElementIndexableMemo::default();
+
+        memo.insert(TypeId::NUMBER, false);
+        memo.insert(TypeId::NUMBER, true);
+
+        assert_eq!(memo.get(TypeId::NUMBER), Some(true));
+        let stats = memo.stats();
+        assert_eq!(stats.entries, 1);
     }
 }

--- a/crates/tsz-checker/tests/conformance_issues/types/membership_semantics.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/membership_semantics.rs
@@ -170,6 +170,47 @@ numeric[42];
 }
 
 #[test]
+fn test_union_numeric_index_common_surfaces_are_repeatable_and_order_independent() {
+    let diagnostics = compile_and_get_diagnostics_named(
+        "test.ts",
+        r#"
+interface StrIdx { [k: string]: string; }
+interface StrIdx2 { [key: string]: boolean; }
+interface NumIdx { [k: number]: number; }
+interface NumIdx2 { [n: number]: boolean; }
+
+type StringIdxUnion = StrIdx | StrIdx2;
+type ReversedStringIdxUnion = StrIdx2 | StrIdx;
+type NumberIdxUnion = NumIdx | NumIdx2;
+type ReversedNumberIdxUnion = NumIdx2 | NumIdx;
+
+declare const stringIndexed: StringIdxUnion;
+declare const stringIndexedReversed: ReversedStringIdxUnion;
+declare const numeric: NumberIdxUnion;
+declare const numericReversed: ReversedNumberIdxUnion;
+
+const stringFirst: string | boolean = stringIndexed[42];
+const stringAgain: string | boolean = stringIndexed[42];
+const stringReversed: string | boolean = stringIndexedReversed[42];
+const numberFirst: number | boolean = numeric[42];
+const numberAgain: number | boolean = numeric[42];
+const numberReversed: number | boolean = numericReversed[42];
+"#,
+        CheckerOptions {
+            strict: true,
+            no_implicit_any: true,
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        !has_error(&diagnostics, 7053),
+        "Did not expect TS7053 for repeated or reversed unions with a common numeric index surface. Actual diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
 fn test_parenthesized_nullish_and_logical_expressions_do_not_emit_false_ts2322() {
     let diagnostics = compile_and_get_diagnostics_named(
         "test.ts",

--- a/scripts/perf/cache-visibility-report.py
+++ b/scripts/perf/cache-visibility-report.py
@@ -72,6 +72,7 @@ OPERATION_LOCAL_OWNERS = {
     "FreeTypeParamCollector",
     "InferenceContext",
     "PropertyAccessEvaluator",
+    "NumericIndexSurfaceWalk",
     "SubtypeChecker",
     "TypeEvaluator",
     "TypeFormatter",

--- a/scripts/perf/cache-visibility-report.py
+++ b/scripts/perf/cache-visibility-report.py
@@ -67,6 +67,7 @@ OPERATION_LOCAL_OWNERS = {
     "CompatChecker",
     "DeepContainsChecker",
     "DefaultJudge",
+    "ElementIndexableMemo",
     "FlowAnalyzer",
     "FreeTypeParamCollector",
     "InferenceContext",


### PR DESCRIPTION
Goal: fast

## Summary
- Wrap the checker element-indexability walk memo in an operation-local owner with entry/size observability and trace-only reporting.
- Collapse `any` indexed-access support probes from separate string and number walks into one guarded element-indexability walk.
- Add an operation-local `NumericIndexSurfaceWalk` for union numeric-index-surface checks, with cycle/depth cuts falling back conservatively instead of publishing partial answers.
- Classify both `ElementIndexableMemo` and `NumericIndexSurfaceWalk` in the cache visibility report as operation-local with stats and size signals.

## Structural Rule
When TS7053/indexed-access diagnostics repeatedly classify the same immutable `TypeId` during one checker request, `tsc` reuses the same structural indexability/index-surface answer. `tsz` now keeps that reuse inside checker-owned request-local walks while still asking the existing resolver-aware query boundary for structural classification.

## Cache Invariant
- Keys: `TypeId` inside a single checker request-local walk.
- Reset/residency: both memos are dropped when their walk finishes; no retained checker context state is added.
- Modes: element-indexability keeps `wants_string`/`wants_number` invariant for one walk, so those modes stay outside the local memo key.
- Fallback: element-indexability keeps its existing cycle/depth behavior; numeric-index-surface cuts return indeterminate and are not stored as finished results, avoiding fabricated TS7053 decisions.
- Observability: both owners expose trace-only entry counts and estimated heap footprint, and the cache visibility report marks them as operation-local with size/stat signals.

## Adjacent Cases
- Positive: `Record`/mapped/readonly wrapper constraints still suppress false TS7053.
- Negative: unconstrained and object-only constraints still emit TS7053.
- Numeric index surfaces: repeated and reversed unions with common string or number index surfaces stay TS7053-clean.
- Mixed string-index/number-index unions continue to emit TS7053 for numeric literal access, matching local TypeScript 6.0.3 behavior.
- `any` index: receivers with and without applicable index signatures keep existing NUIA and implicit-any behavior.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/perf/test_cache_visibility_report.py`
- `python3 scripts/perf/cache-visibility-report.py --json | rg -n 'NumericIndexSurfaceWalk|ElementIndexableMemo|total_candidates|needs_review|with_size_signal|with_stats_signal'`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test conformance_issues_types -E 'test(test_union_numeric_index_requires_common_number_index_surface) or test(test_union_numeric_index_common_surfaces_are_repeatable_and_order_independent)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(element_indexable_memo)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts7053_record_constrained_type_param_index_tests --test ts7053_record_constraint_index_tests --test ts7053_unconstrained_type_param_index_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts7053_intersection_record_constrained_param_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(nuia_read_with_any_index_to_t_or_undefined_slot_does_not_emit_ts2322) or test(no_index_signature_with_any_index_falls_back_to_any) or test(nuia_string_index_signature_accepts_numeric_literal_union_without_ts7053) or test(type_level_t_any_does_not_widen_to_undefined_under_nuia)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test object_keyword_any_index_tests`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo clippy -p tsz-checker --lib --tests -- -D warnings`
- `python3 scripts/arch/arch_guard.py` (fails only on pre-existing checker guard debt: `access.rs` LOC, direct `query_boundaries::common` quarantine refs, and snapshot rollback cap)

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
