### PR TITLE
perf(bench): add large-ts-repo attribution gauge (#14351)

### DIFF
--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -65,6 +65,8 @@ TSC_NPM_SPEC="${TSC_NPM_SPEC:-}"
 EXTERNAL_BENCH_DIR="${EXTERNAL_BENCH_DIR:-$BENCH_TARGET_DIR/external}"
 # shellcheck source=scripts/bench/project-fixtures.sh
 source "$SCRIPT_DIR/project-fixtures.sh"
+# shellcheck source=scripts/bench/lib/large-ts-repo-fixture.sh
+source "$SCRIPT_DIR/lib/large-ts-repo-fixture.sh"
 # Keep benchmark/CI project metadata aligned with a single source of truth.
 tsz_sync_project_row_groups
 if command -v node >/dev/null 2>&1; then
@@ -119,18 +121,7 @@ NEVERTHROW_DIR="$EXTERNAL_BENCH_DIR/neverthrow"
 XSTATE_DIR="$EXTERNAL_BENCH_DIR/xstate"
 MOBX_DIR="$EXTERNAL_BENCH_DIR/mobx"
 LARGE_TS_LOCAL_DIR="${HOME}/code/large-ts-repo"
-# The local fallback was previously implicit, which silently contaminated
-# PR-quality numbers on any developer machine that happened to have a
-# checkout. Gate it behind TSZ_BENCH_ALLOW_LOCAL_FIXTURE=1 so the default
-# is the pinned external clone. See docs/plan/PERFORMANCE_PLAN.md §3.5.1.
-if [ -n "${LARGE_TS_DIR:-}" ]; then
-    LARGE_TS_DIR="$LARGE_TS_DIR"
-elif [ "${TSZ_BENCH_ALLOW_LOCAL_FIXTURE:-0}" = "1" ] \
-     && [ -d "$LARGE_TS_LOCAL_DIR/.git" ]; then
-    LARGE_TS_DIR="$LARGE_TS_LOCAL_DIR"
-else
-    LARGE_TS_DIR="$EXTERNAL_BENCH_DIR/large-ts-repo"
-fi
+LARGE_TS_DIR="$(tsz_large_ts_repo_default_dir "$EXTERNAL_BENCH_DIR")"
 LARGE_TS_NODE_OPTIONS="${LARGE_TS_NODE_OPTIONS:---max-old-space-size=8192}"
 # Deep project fixtures can exhaust Rust's default worker-thread stack before
 # producing a benchmark result. Keep the default overrideable for local runs.
@@ -1521,34 +1512,6 @@ run_vite_app_project_benchmarks() {
 }
 
 ensure_large_ts_repo_fixture() {
-    mkdir -p "$EXTERNAL_BENCH_DIR"
-
-    if [ ! -d "$LARGE_TS_DIR/.git" ]; then
-        echo -e "${CYAN}Cloning large-ts-repo fixture...${NC}"
-        git clone --quiet --no-tags --depth 1 "$LARGE_TS_REPO" "$LARGE_TS_DIR"
-    fi
-
-    if [ -n "$LARGE_TS_REF" ]; then
-        local current_ref
-        current_ref="$(git -C "$LARGE_TS_DIR" rev-parse HEAD 2>/dev/null || echo "")"
-        if [ "$current_ref" != "$LARGE_TS_REF" ]; then
-            echo -e "${CYAN}Pinning large-ts-repo to ${LARGE_TS_REF:0:12}...${NC}"
-            git -C "$LARGE_TS_DIR" fetch --quiet --depth 1 origin "$LARGE_TS_REF"
-            git -C "$LARGE_TS_DIR" checkout --quiet --detach FETCH_HEAD
-        fi
-    fi
-
-    if ! command -v pnpm &>/dev/null; then
-        echo -e "${RED}✗ pnpm not found. Install pnpm to prepare large-ts-repo dependencies.${NC}"
-        return
-    fi
-
-    local deps_stamp="$LARGE_TS_DIR/.deps-installed"
-    if [ ! -f "$deps_stamp" ] || [ "$LARGE_TS_DIR/pnpm-lock.yaml" -nt "$deps_stamp" ] || [ "$LARGE_TS_DIR/package.json" -nt "$deps_stamp" ] || [ "$LARGE_TS_DIR/pnpm-workspace.yaml" -nt "$deps_stamp" ]; then
-        echo -e "${CYAN}Installing large-ts-repo dependencies...${NC}"
-        pnpm --dir "$LARGE_TS_DIR" install --frozen-lockfile --silent
-        touch "$deps_stamp"
-    fi
     # The root tsconfig.json in large-ts-repo uses project references, so
     # `tsc/tsgo/tsz --noEmit -p tsconfig.json` exits almost immediately
     # without type-checking anything. Use a flat tsconfig that directly
@@ -1558,36 +1521,7 @@ ensure_large_ts_repo_fixture() {
     # extends tsconfig.base.json which contains the 200+ `paths` mappings
     # for cross-package @scope/pkg imports. Without those paths, tsc itself
     # emits resolution errors and the benchmark is skipped.
-    if [ -f "$LARGE_TS_DIR/tsconfig.flat.bench.json" ]; then
-        return
-    fi
-    local flat_tsconfig="$LARGE_TS_DIR/tsconfig.flat.json"
-    if [ ! -f "$flat_tsconfig" ]; then
-        local extends_base=""
-        if [ -f "$LARGE_TS_DIR/tsconfig.base.json" ]; then
-            extends_base='"extends": "./tsconfig.base.json",'
-        fi
-        cat > "$flat_tsconfig" << FLATEOF
-{
-  ${extends_base}
-  "compilerOptions": {
-    "target": "ES2023",
-    "lib": ["ES2024", "esnext.disposable"],
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "noEmit": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false
-  },
-  "include": ["packages/**/src/**/*.ts"]
-}
-FLATEOF
-    fi
+    tsz_ensure_large_ts_repo_fixture "$LARGE_TS_DIR" "$LARGE_TS_REPO" "$LARGE_TS_REF"
 }
 
 run_large_ts_repo_benchmarks() {
@@ -1605,11 +1539,7 @@ run_large_ts_repo_benchmarks() {
     # Prefer tsconfig.flat.bench.json (ships with the repo, extends base
     # with full path mappings) over our generated tsconfig.flat.json.
     local tsconfig
-    if [ -f "$LARGE_TS_DIR/tsconfig.flat.bench.json" ]; then
-        tsconfig="$LARGE_TS_DIR/tsconfig.flat.bench.json"
-    elif [ -f "$LARGE_TS_DIR/tsconfig.flat.json" ]; then
-        tsconfig="$LARGE_TS_DIR/tsconfig.flat.json"
-    else
+    if ! tsconfig="$(tsz_large_ts_repo_select_tsconfig "$LARGE_TS_DIR")"; then
         echo -e "${RED}✗ No flat tsconfig found (ensure_large_ts_repo_fixture should have created one)${NC}"
         return
     fi

--- a/scripts/bench/large-ts-repo-attribution-gauge.sh
+++ b/scripts/bench/large-ts-repo-attribution-gauge.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+#
+# Emit and optionally run a repeatable attribution plan for the #14351
+# large-ts-repo timeout path.
+#
+# Usage:
+#   scripts/bench/large-ts-repo-attribution-gauge.sh --json-file /tmp/large.json
+#   scripts/bench/large-ts-repo-attribution-gauge.sh --prepare --run-measure
+#   scripts/bench/large-ts-repo-attribution-gauge.sh --prepare --run-profile --iterations 6
+#
+# Plan-only mode is the default so low-disk workers can verify the gauge without
+# building symbol-retaining artifacts. `--prepare` fetches/deps the fixture;
+# `--run-measure` uses measure-tsz's snapshot+CPU-share protocol; `--run-profile`
+# delegates to perf-flat-profile.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BENCH_TARGET_DIR="$PROJECT_ROOT/.target-bench"
+EXTERNAL_BENCH_DIR="${EXTERNAL_BENCH_DIR:-$BENCH_TARGET_DIR/external}"
+
+# shellcheck source=scripts/bench/project-fixtures.sh
+source "$SCRIPT_DIR/project-fixtures.sh"
+# shellcheck source=scripts/bench/lib/large-ts-repo-fixture.sh
+source "$SCRIPT_DIR/lib/large-ts-repo-fixture.sh"
+
+LARGE_TS_LOCAL_DIR="${LARGE_TS_LOCAL_DIR:-${HOME}/code/large-ts-repo}"
+LARGE_TS_DIR="$(tsz_large_ts_repo_default_dir "$EXTERNAL_BENCH_DIR")"
+LARGE_TS_NODE_OPTIONS="${LARGE_TS_NODE_OPTIONS:---max-old-space-size=8192}"
+TSZ_RUST_MIN_STACK="${TSZ_RUST_MIN_STACK:-536870912}"
+
+TARGET_DIR="${CARGO_TARGET_DIR:-$PROJECT_ROOT/.target}"
+TSZ_BIN="${TSZ:-$TARGET_DIR/dist-fast/tsz}"
+JSON_FILE="$PROJECT_ROOT/artifacts/perf/large-ts-repo-attribution-$(date +%Y%m%d-%H%M%S).json"
+TSCONFIG_OVERRIDE=""
+ITERATIONS=4
+TOP=25
+TIMEOUT=1500
+RUNS=1
+PREPARE=false
+RUN_MEASURE=false
+RUN_PROFILE=false
+MEASURE_EXIT_CODE=""
+PROFILE_EXIT_CODE=""
+
+usage() {
+    awk 'NR > 1 { if (!/^#/) exit; sub(/^# ?/, ""); print }' "${BASH_SOURCE[0]}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --json-file) JSON_FILE="$2"; shift 2 ;;
+        --fixture-dir) LARGE_TS_DIR="$2"; shift 2 ;;
+        --tsconfig) TSCONFIG_OVERRIDE="$2"; shift 2 ;;
+        --tsz-bin) TSZ_BIN="$2"; shift 2 ;;
+        --iterations) ITERATIONS="$2"; shift 2 ;;
+        --top) TOP="$2"; shift 2 ;;
+        --timeout) TIMEOUT="$2"; shift 2 ;;
+        --runs) RUNS="$2"; shift 2 ;;
+        --prepare) PREPARE=true; shift ;;
+        --run-measure) RUN_MEASURE=true; shift ;;
+        --run-profile) RUN_PROFILE=true; shift ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "large-ts-repo-attribution-gauge: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+for numeric in "$ITERATIONS" "$TOP" "$TIMEOUT" "$RUNS"; do
+    if ! [[ "$numeric" =~ ^[0-9]+$ ]] || [ "$numeric" -le 0 ]; then
+        echo "large-ts-repo-attribution-gauge: numeric options must be positive integers" >&2
+        exit 2
+    fi
+done
+
+if [[ "$PREPARE" == true ]]; then
+    tsz_ensure_large_ts_repo_fixture "$LARGE_TS_DIR" "$LARGE_TS_REPO" "$LARGE_TS_REF"
+fi
+
+TSCONFIG="$TSCONFIG_OVERRIDE"
+if [ -z "$TSCONFIG" ]; then
+    TSCONFIG="$(tsz_large_ts_repo_select_tsconfig "$LARGE_TS_DIR" 2>/dev/null || true)"
+fi
+FIXTURE_READY=false
+if [ -d "$LARGE_TS_DIR/.git" ] && [ -n "$TSCONFIG" ] && [ -f "$TSCONFIG" ]; then
+    FIXTURE_READY=true
+fi
+
+write_plan_json() {
+    mkdir -p "$(dirname "$JSON_FILE")"
+    TSZ_GAUGE_JSON_FILE="$JSON_FILE" \
+    TSZ_GAUGE_PROJECT_ROOT="$PROJECT_ROOT" \
+    TSZ_GAUGE_FIXTURE_DIR="$LARGE_TS_DIR" \
+    TSZ_GAUGE_TSCONFIG="$TSCONFIG" \
+    TSZ_GAUGE_FIXTURE_READY="$FIXTURE_READY" \
+    TSZ_GAUGE_TSZ_BIN="$TSZ_BIN" \
+    TSZ_GAUGE_NODE_OPTIONS="$LARGE_TS_NODE_OPTIONS" \
+    TSZ_GAUGE_RUST_MIN_STACK="$TSZ_RUST_MIN_STACK" \
+    TSZ_GAUGE_ITERATIONS="$ITERATIONS" \
+    TSZ_GAUGE_TOP="$TOP" \
+    TSZ_GAUGE_TIMEOUT="$TIMEOUT" \
+    TSZ_GAUGE_RUNS="$RUNS" \
+    TSZ_GAUGE_PREPARE="$PREPARE" \
+    TSZ_GAUGE_RUN_MEASURE="$RUN_MEASURE" \
+    TSZ_GAUGE_RUN_PROFILE="$RUN_PROFILE" \
+    TSZ_GAUGE_MEASURE_EXIT_CODE="$MEASURE_EXIT_CODE" \
+    TSZ_GAUGE_PROFILE_EXIT_CODE="$PROFILE_EXIT_CODE" \
+    python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+root = Path(os.environ["TSZ_GAUGE_PROJECT_ROOT"])
+json_file = Path(os.environ["TSZ_GAUGE_JSON_FILE"])
+fixture_dir = os.environ["TSZ_GAUGE_FIXTURE_DIR"]
+tsconfig = os.environ["TSZ_GAUGE_TSCONFIG"] or None
+tsz_bin = os.environ["TSZ_GAUGE_TSZ_BIN"]
+bench_json = str(json_file.with_suffix(".bench.json"))
+measure_json = str(json_file.with_suffix(".measure.json"))
+profile_json = str(json_file.with_suffix(".profile.json"))
+
+def rel(path):
+    try:
+        return str(Path(path).resolve().relative_to(root.resolve()))
+    except ValueError:
+        return str(path)
+
+def int_env(name):
+    value = os.environ.get(name, "")
+    return int(value) if value else None
+
+commands = {
+    "bench_row": [
+        "scripts/bench/bench-vs-tsgo.sh",
+        "--quick",
+        "--filter",
+        "^large-ts-repo$",
+        "--json-file",
+        bench_json,
+    ],
+    "measure": None,
+    "profile": None,
+}
+if tsconfig:
+    commands["measure"] = [
+        "scripts/bench/measure-tsz.sh",
+        "--bin",
+        tsz_bin,
+        "--timeout",
+        os.environ["TSZ_GAUGE_TIMEOUT"],
+        "--runs",
+        os.environ["TSZ_GAUGE_RUNS"],
+        "--json-file",
+        measure_json,
+        "--label",
+        "large-ts-repo",
+        "--",
+        "--noEmit",
+        "-p",
+        tsconfig,
+    ]
+    commands["profile"] = [
+        "scripts/bench/perf-flat-profile.sh",
+        "--json-file",
+        profile_json,
+        "--no-build",
+        "--bin",
+        tsz_bin,
+        "--iterations",
+        os.environ["TSZ_GAUGE_ITERATIONS"],
+        "--top",
+        os.environ["TSZ_GAUGE_TOP"],
+        "-p",
+        tsconfig,
+    ]
+
+payload = {
+    "schema_version": 1,
+    "row": "large-ts-repo",
+    "goal": "profile #14351 P2 evaluator-recursion vs variance attribution",
+    "fixture": {
+        "dir": fixture_dir,
+        "ready": os.environ["TSZ_GAUGE_FIXTURE_READY"] == "true",
+        "tsconfig": tsconfig,
+        "source_dir": str(Path(fixture_dir) / "packages"),
+        "repo_env": "LARGE_TS_REPO",
+        "ref_env": "LARGE_TS_REF",
+    },
+    "environment": {
+        "node_options": os.environ["TSZ_GAUGE_NODE_OPTIONS"],
+        "rust_min_stack": os.environ["TSZ_GAUGE_RUST_MIN_STACK"],
+        "tsz_bin": tsz_bin,
+        "tsz_bin_exists": Path(tsz_bin).is_file(),
+    },
+    "settings": {
+        "iterations": int(os.environ["TSZ_GAUGE_ITERATIONS"]),
+        "top": int(os.environ["TSZ_GAUGE_TOP"]),
+        "timeout_s": int(os.environ["TSZ_GAUGE_TIMEOUT"]),
+        "runs": int(os.environ["TSZ_GAUGE_RUNS"]),
+    },
+    "artifacts": {
+        "bench_json": bench_json,
+        "measure_json": measure_json if tsconfig else None,
+        "profile_json": profile_json if tsconfig else None,
+    },
+    "commands": commands,
+    "run": {
+        "prepare_requested": os.environ["TSZ_GAUGE_PREPARE"] == "true",
+        "measure_requested": os.environ["TSZ_GAUGE_RUN_MEASURE"] == "true",
+        "profile_requested": os.environ["TSZ_GAUGE_RUN_PROFILE"] == "true",
+        "measure_exit_code": int_env("TSZ_GAUGE_MEASURE_EXIT_CODE"),
+        "profile_exit_code": int_env("TSZ_GAUGE_PROFILE_EXIT_CODE"),
+    },
+}
+
+json_file.parent.mkdir(parents=True, exist_ok=True)
+json_file.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf8")
+print(f"large-ts-repo attribution plan written to {rel(json_file)}")
+PY
+}
+
+write_plan_json
+
+if [[ "$RUN_MEASURE" == false && "$RUN_PROFILE" == false ]]; then
+    exit 0
+fi
+if [ -z "$TSCONFIG" ] || [ ! -f "$TSCONFIG" ]; then
+    echo "large-ts-repo-attribution-gauge: no flat tsconfig found; rerun with --prepare or --tsconfig" >&2
+    exit 2
+fi
+if [ ! -x "$TSZ_BIN" ]; then
+    echo "large-ts-repo-attribution-gauge: tsz binary not executable: $TSZ_BIN" >&2
+    exit 2
+fi
+
+RUN_EXIT=0
+if [[ "$RUN_MEASURE" == true ]]; then
+    set +e
+    NODE_OPTIONS="$LARGE_TS_NODE_OPTIONS" RUST_MIN_STACK="$TSZ_RUST_MIN_STACK" \
+        "$SCRIPT_DIR/measure-tsz.sh" \
+        --bin "$TSZ_BIN" \
+        --timeout "$TIMEOUT" \
+        --runs "$RUNS" \
+        --json-file "${JSON_FILE%.json}.measure.json" \
+        --label "large-ts-repo" \
+        -- --noEmit -p "$TSCONFIG"
+    MEASURE_EXIT_CODE=$?
+    set -e
+    if [ "$MEASURE_EXIT_CODE" -ne 0 ] && [ "$RUN_EXIT" -eq 0 ]; then
+        RUN_EXIT="$MEASURE_EXIT_CODE"
+    fi
+fi
+
+if [[ "$RUN_PROFILE" == true ]]; then
+    set +e
+    NODE_OPTIONS="$LARGE_TS_NODE_OPTIONS" RUST_MIN_STACK="$TSZ_RUST_MIN_STACK" \
+        "$SCRIPT_DIR/perf-flat-profile.sh" \
+        --json-file "${JSON_FILE%.json}.profile.json" \
+        --no-build \
+        --bin "$TSZ_BIN" \
+        --iterations "$ITERATIONS" \
+        --top "$TOP" \
+        -p "$TSCONFIG"
+    PROFILE_EXIT_CODE=$?
+    set -e
+    if [ "$PROFILE_EXIT_CODE" -ne 0 ] && [ "$RUN_EXIT" -eq 0 ]; then
+        RUN_EXIT="$PROFILE_EXIT_CODE"
+    fi
+fi
+
+write_plan_json
+exit "$RUN_EXIT"

--- a/scripts/bench/lib/large-ts-repo-fixture.sh
+++ b/scripts/bench/lib/large-ts-repo-fixture.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Shared large-ts-repo fixture helpers for benchmark and attribution tooling.
+
+tsz_large_ts_repo_default_dir() {
+    local external_bench_dir="$1"
+    local local_dir="${LARGE_TS_LOCAL_DIR:-${HOME}/code/large-ts-repo}"
+
+    if [ -n "${LARGE_TS_DIR:-}" ]; then
+        printf '%s\n' "$LARGE_TS_DIR"
+    elif [ "${TSZ_BENCH_ALLOW_LOCAL_FIXTURE:-0}" = "1" ] && [ -d "$local_dir/.git" ]; then
+        printf '%s\n' "$local_dir"
+    else
+        printf '%s/large-ts-repo\n' "$external_bench_dir"
+    fi
+}
+
+tsz_large_ts_repo_write_flat_tsconfig() {
+    local fixture_dir="$1"
+    local flat_tsconfig="$fixture_dir/tsconfig.flat.json"
+
+    if [ -f "$fixture_dir/tsconfig.flat.bench.json" ] || [ -f "$flat_tsconfig" ]; then
+        return 0
+    fi
+
+    local extends_base=""
+    if [ -f "$fixture_dir/tsconfig.base.json" ]; then
+        extends_base='"extends": "./tsconfig.base.json",'
+    fi
+
+    cat > "$flat_tsconfig" << FLATEOF
+{
+  ${extends_base}
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2024", "esnext.disposable"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["packages/**/src/**/*.ts"]
+}
+FLATEOF
+}
+
+tsz_large_ts_repo_select_tsconfig() {
+    local fixture_dir="$1"
+
+    if [ -f "$fixture_dir/tsconfig.flat.bench.json" ]; then
+        printf '%s\n' "$fixture_dir/tsconfig.flat.bench.json"
+    elif [ -f "$fixture_dir/tsconfig.flat.json" ]; then
+        printf '%s\n' "$fixture_dir/tsconfig.flat.json"
+    else
+        return 1
+    fi
+}
+
+tsz_ensure_large_ts_repo_fixture() {
+    local fixture_dir="$1"
+    local repo="$2"
+    local ref="$3"
+
+    mkdir -p "$(dirname "$fixture_dir")"
+
+    if [ ! -d "$fixture_dir/.git" ]; then
+        echo "Cloning large-ts-repo fixture..."
+        git clone --quiet --no-tags --depth 1 "$repo" "$fixture_dir"
+    fi
+
+    if [ -n "$ref" ]; then
+        local current_ref
+        current_ref="$(git -C "$fixture_dir" rev-parse HEAD 2>/dev/null || echo "")"
+        if [ "$current_ref" != "$ref" ]; then
+            echo "Pinning large-ts-repo to ${ref:0:12}..."
+            git -C "$fixture_dir" fetch --quiet --depth 1 origin "$ref"
+            git -C "$fixture_dir" checkout --quiet --detach FETCH_HEAD
+        fi
+    fi
+
+    if ! command -v pnpm >/dev/null 2>&1; then
+        echo "error: pnpm not found. Install pnpm to prepare large-ts-repo dependencies." >&2
+        return 1
+    fi
+
+    local deps_stamp="$fixture_dir/.deps-installed"
+    if [ ! -f "$deps_stamp" ] \
+        || [ "$fixture_dir/pnpm-lock.yaml" -nt "$deps_stamp" ] \
+        || [ "$fixture_dir/package.json" -nt "$deps_stamp" ] \
+        || [ "$fixture_dir/pnpm-workspace.yaml" -nt "$deps_stamp" ]; then
+        echo "Installing large-ts-repo dependencies..."
+        pnpm --dir "$fixture_dir" install --frozen-lockfile --silent
+        touch "$deps_stamp"
+    fi
+
+    tsz_large_ts_repo_write_flat_tsconfig "$fixture_dir"
+}

--- a/scripts/bench/perf-flat-profile.sh
+++ b/scripts/bench/perf-flat-profile.sh
@@ -18,6 +18,7 @@
 #   scripts/bench/perf-flat-profile.sh path/to/file.ts
 #   scripts/bench/perf-flat-profile.sh -p path/to/tsconfig.json
 #   scripts/bench/perf-flat-profile.sh -p tsconfig.json --iterations 12 --top 30
+#   scripts/bench/perf-flat-profile.sh -p tsconfig.json --json-file /tmp/profile.json
 #   scripts/bench/perf-flat-profile.sh --no-build -p tsconfig.json   # reuse symbol build
 #
 # Options:
@@ -27,6 +28,7 @@
 #   --top N            Rows to print (default 25).
 #   --no-build         Skip the symbol-retaining build; reuse the existing binary.
 #   --bin <path>       Use this tsz binary instead of building.
+#   --json-file <path> Write the ranked flat profile as JSON.
 #   --help
 #
 # macOS only for symbol resolution (uses `atos`). On Linux, swap the resolver
@@ -52,6 +54,7 @@ ITERATIONS=8
 TOP=25
 NO_BUILD=false
 BIN_OVERRIDE=""
+JSON_FILE=""
 declare -a TSZ_ARGS=()
 
 usage() { sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
@@ -63,6 +66,7 @@ while [[ $# -gt 0 ]]; do
         --top) TOP="$2"; shift 2 ;;
         --no-build) NO_BUILD=true; shift ;;
         --bin) BIN_OVERRIDE="$2"; shift 2 ;;
+        --json-file) JSON_FILE="$2"; shift 2 ;;
         --help|-h) usage; exit 0 ;;
         *) TSZ_ARGS+=("$1"); shift ;;
     esac
@@ -110,10 +114,12 @@ samply record --save-only -o "$PROFILE_JSON" -- \
 #             the resolved name (not the frame/func index) is essential: inlining
 #             splits one source function across many frames, and counting those
 #             separately would push a function past 100% inclusive.
-python3 - "$PROFILE_JSON" "$TSZ_BIN" "$TEXT_BASE" "$TOP" <<'PY'
+python3 - "$PROFILE_JSON" "$TSZ_BIN" "$TEXT_BASE" "$TOP" "$JSON_FILE" "${TSZ_ARGS[@]}" <<'PY'
 import gzip, json, sys, re, subprocess, collections
+from pathlib import Path
 prof = json.load(gzip.open(sys.argv[1]))
-binary, base, top = sys.argv[2], int(sys.argv[3], 16), int(sys.argv[4])
+binary, base, top, json_file = sys.argv[2], int(sys.argv[3], 16), int(sys.argv[4]), sys.argv[5]
+tsz_args = sys.argv[6:]
 
 # Per-thread frame address arrays differ, so resolve names per (thread, frame).
 threads = []
@@ -175,6 +181,32 @@ if total == 0:
 print()
 print(f"=== tsz flat profile: {total} samples (self / inclusive) ===")
 print(f"{'self%':>7} {'incl%':>7}  function")
+rows = []
 for nm, sc in self_ct.most_common(top):
-    print(f"{100 * sc / total:6.1f}% {100 * incl_ct.get(nm, 0) / total:6.1f}%  {nm}")
+    incl = incl_ct.get(nm, 0)
+    self_pct = 100 * sc / total
+    incl_pct = 100 * incl / total
+    rows.append({
+        "function": nm,
+        "self_samples": sc,
+        "inclusive_samples": incl,
+        "self_percent": self_pct,
+        "inclusive_percent": incl_pct,
+    })
+    print(f"{self_pct:6.1f}% {incl_pct:6.1f}%  {nm}")
+
+if json_file:
+    payload = {
+        "schema_version": 1,
+        "samples": total,
+        "binary": binary,
+        "text_base": hex(base),
+        "args": tsz_args,
+        "top": top,
+        "rows": rows,
+    }
+    path = Path(json_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf8")
+    print(f"flat profile JSON written to {json_file}")
 PY

--- a/scripts/bench/test-large-ts-repo-attribution-gauge.mjs
+++ b/scripts/bench/test-large-ts-repo-attribution-gauge.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const gauge = path.join(scriptDir, "large-ts-repo-attribution-gauge.sh");
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-large-ts-gauge-"));
+
+function runGauge(args) {
+  return spawnSync("bash", [gauge, ...args], {
+    cwd: path.resolve(scriptDir, "..", ".."),
+    encoding: "utf8",
+  });
+}
+
+function runBash(script) {
+  return spawnSync("bash", ["-lc", script], {
+    cwd: path.resolve(scriptDir, "..", ".."),
+    encoding: "utf8",
+  });
+}
+
+try {
+  const fixtureDir = path.join(tmpDir, "fixture");
+  fs.mkdirSync(path.join(fixtureDir, ".git"), { recursive: true });
+  fs.mkdirSync(path.join(fixtureDir, "packages"), { recursive: true });
+  const tsconfig = path.join(fixtureDir, "tsconfig.flat.bench.json");
+  fs.writeFileSync(tsconfig, "{}\n", "utf8");
+  const fakeTsz = path.join(tmpDir, "tsz");
+  fs.writeFileSync(fakeTsz, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+  const jsonFile = path.join(tmpDir, "plan.json");
+  const result = runGauge([
+    "--json-file", jsonFile,
+    "--fixture-dir", fixtureDir,
+    "--tsz-bin", fakeTsz,
+    "--iterations", "3",
+    "--top", "7",
+    "--timeout", "9",
+    "--runs", "2",
+  ]);
+  assert.equal(result.status, 0, `plan-only gauge failed:\n${result.stderr}\n${result.stdout}`);
+  assert.match(result.stdout, /large-ts-repo attribution plan written/);
+
+  const plan = JSON.parse(fs.readFileSync(jsonFile, "utf8"));
+  assert.equal(plan.schema_version, 1);
+  assert.equal(plan.row, "large-ts-repo");
+  assert.equal(plan.fixture.ready, true);
+  assert.equal(plan.fixture.tsconfig, tsconfig);
+  assert.equal(plan.environment.tsz_bin, fakeTsz);
+  assert.equal(plan.environment.tsz_bin_exists, true);
+  assert.equal(plan.settings.iterations, 3);
+  assert.equal(plan.settings.top, 7);
+  assert.equal(plan.settings.timeout_s, 9);
+  assert.equal(plan.settings.runs, 2);
+  assert.equal(plan.artifacts.bench_json, path.join(tmpDir, "plan.bench.json"));
+  assert.equal(plan.artifacts.measure_json, path.join(tmpDir, "plan.measure.json"));
+  assert.equal(plan.artifacts.profile_json, path.join(tmpDir, "plan.profile.json"));
+  assert.equal(plan.run.measure_requested, false);
+  assert.equal(plan.run.profile_requested, false);
+  assert.deepEqual(plan.commands.bench_row.slice(0, 4), [
+    "scripts/bench/bench-vs-tsgo.sh",
+    "--quick",
+    "--filter",
+    "^large-ts-repo$",
+  ]);
+  assert.ok(plan.commands.measure.includes("scripts/bench/measure-tsz.sh"));
+  assert.ok(plan.commands.measure.includes("--noEmit"));
+  assert.ok(plan.commands.profile.includes("scripts/bench/perf-flat-profile.sh"));
+  assert.ok(plan.commands.profile.includes("--json-file"));
+  assert.ok(plan.commands.profile.includes(path.join(tmpDir, "plan.profile.json")));
+  assert.ok(plan.commands.profile.includes("--no-build"));
+
+  const missingFixture = path.join(tmpDir, "missing-fixture");
+  const missingJson = path.join(tmpDir, "missing.json");
+  const missing = runGauge([
+    "--json-file", missingJson,
+    "--fixture-dir", missingFixture,
+    "--tsz-bin", fakeTsz,
+  ]);
+  assert.equal(missing.status, 0, `missing-fixture plan should not run heavy setup:\n${missing.stderr}`);
+  const missingPlan = JSON.parse(fs.readFileSync(missingJson, "utf8"));
+  assert.equal(missingPlan.fixture.ready, false);
+  assert.equal(missingPlan.fixture.tsconfig, null);
+  assert.equal(missingPlan.artifacts.measure_json, null);
+  assert.equal(missingPlan.artifacts.profile_json, null);
+  assert.equal(missingPlan.commands.measure, null);
+  assert.equal(missingPlan.commands.profile, null);
+
+  const generatedFixture = path.join(tmpDir, "generated");
+  fs.mkdirSync(path.join(generatedFixture, "packages"), { recursive: true });
+  fs.writeFileSync(path.join(generatedFixture, "tsconfig.base.json"), "{}\n", "utf8");
+  const helperResult = runBash(`
+set -euo pipefail
+source scripts/bench/lib/large-ts-repo-fixture.sh
+tsz_large_ts_repo_write_flat_tsconfig "${generatedFixture}"
+tsz_large_ts_repo_select_tsconfig "${generatedFixture}"
+`);
+  assert.equal(helperResult.status, 0, helperResult.stderr);
+  assert.equal(
+    helperResult.stdout.trim(),
+    path.join(generatedFixture, "tsconfig.flat.json"),
+    "helper should select generated flat tsconfig when fixture lacks tsconfig.flat.bench.json",
+  );
+  const generatedConfig = fs.readFileSync(path.join(generatedFixture, "tsconfig.flat.json"), "utf8");
+  assert.match(generatedConfig, /"extends": "\.\/tsconfig\.base\.json"/);
+  assert.match(generatedConfig, /"include": \["packages\/\*\*\/src\/\*\*\/\*\.ts"\]/);
+} finally {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+console.log("large-ts-repo attribution gauge tests passed");

--- a/scripts/bench/test-perf-flat-profile.mjs
+++ b/scripts/bench/test-perf-flat-profile.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..", "..");
+const profileScript = path.join(scriptDir, "perf-flat-profile.sh");
+const script = fs.readFileSync(profileScript, "utf8");
+
+assert.match(script, /--json-file <path>/, "help text should document JSON output");
+assert.match(script, /--json-file\) JSON_FILE="\$2"; shift 2 ;;/, "CLI should parse --json-file");
+assert.match(
+  script,
+  /python3 - "\$PROFILE_JSON" "\$TSZ_BIN" "\$TEXT_BASE" "\$TOP" "\$JSON_FILE" "\$\{TSZ_ARGS\[@\]\}"/,
+  "profile parser should receive the output path and original tsz args",
+);
+assert.match(script, /"schema_version": 1/, "JSON payload should be schema-versioned");
+assert.match(script, /"self_samples": sc/, "JSON rows should include self sample counts");
+assert.match(
+  script,
+  /path\.write_text\(json\.dumps\(payload, indent=2\) \+ "\\n", encoding="utf8"\)/,
+  "JSON output should be deterministic pretty-printed UTF-8",
+);
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-flat-profile-"));
+try {
+  const toolsDir = path.join(tmpDir, "bin");
+  fs.mkdirSync(toolsDir);
+
+  fs.writeFileSync(
+    path.join(toolsDir, "otool"),
+    `#!/usr/bin/env bash
+cat <<'OUT'
+segname __TEXT
+    vmaddr 0x100000000
+OUT
+`,
+    { mode: 0o755 },
+  );
+
+  fs.writeFileSync(
+    path.join(toolsDir, "atos"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+skip=false
+idx=0
+for arg in "$@"; do
+  if [[ "$skip" == true ]]; then skip=false; continue; fi
+  if [[ "$arg" == "-l" ]]; then skip=true; continue; fi
+  if [[ "$arg" == 0x* ]]; then
+    if [[ "$idx" -eq 0 ]]; then
+      echo "tsz_checker::root::h1111111111111111 (in tsz) (root.rs:1)"
+    else
+      echo "tsz_solver::hot_leaf::h2222222222222222 (in tsz) (leaf.rs:1)"
+    fi
+    idx=$((idx + 1))
+  fi
+done
+`,
+    { mode: 0o755 },
+  );
+
+  fs.writeFileSync(
+    path.join(toolsDir, "samply"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    --) break ;;
+    *) shift ;;
+  esac
+done
+python3 - "$out" <<'PY'
+import gzip
+import json
+import sys
+
+payload = {
+    "threads": [
+        {
+            "frameTable": {"address": [1, 2]},
+            "stackTable": {"frame": [0, 1], "prefix": [None, 0]},
+            "samples": {"stack": [1, 1, 0]},
+        }
+    ]
+}
+with gzip.open(sys.argv[1], "wt", encoding="utf8") as f:
+    json.dump(payload, f)
+PY
+`,
+    { mode: 0o755 },
+  );
+
+  const fakeTsz = path.join(tmpDir, "tsz");
+  fs.writeFileSync(fakeTsz, "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+  const jsonFile = path.join(tmpDir, "profile.json");
+  const result = spawnSync(
+    "bash",
+    [
+      profileScript,
+      "--no-build",
+      "--bin",
+      fakeTsz,
+      "--iterations",
+      "2",
+      "--top",
+      "2",
+      "--json-file",
+      jsonFile,
+      "input.ts",
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${toolsDir}${path.delimiter}${process.env.PATH}` },
+    },
+  );
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  assert.match(result.stdout, /flat profile JSON written/);
+
+  const payload = JSON.parse(fs.readFileSync(jsonFile, "utf8"));
+  assert.equal(payload.schema_version, 1);
+  assert.equal(payload.samples, 3);
+  assert.equal(payload.binary, fakeTsz);
+  assert.deepEqual(payload.args, ["input.ts"]);
+  assert.equal(payload.rows[0].function, "tsz_solver::hot_leaf");
+  assert.equal(payload.rows[0].self_samples, 2);
+  assert.equal(payload.rows[1].function, "tsz_checker::root");
+  assert.equal(payload.rows[1].inclusive_samples, 3);
+} finally {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+console.log("perf flat profile JSON contract checks passed");


### PR DESCRIPTION
Goal: fast

## Summary
- Factor the `large-ts-repo` fixture preparation and flat-tsconfig selection into a shared benchmark helper.
- Add `scripts/bench/large-ts-repo-attribution-gauge.sh`, a plan-first gauge for the #14351 P2 `large-ts-repo` timeout path.
- Keep real fixture setup, measurement, and symbol-heavy profiling opt-in via `--prepare`, `--run-measure`, and `--run-profile`, so low-disk workers can still verify the committed plan JSON.
- Teach `scripts/bench/perf-flat-profile.sh` to emit a schema-versioned JSON flat-profile artifact via `--json-file`, and wire the large-ts-repo gauge to record the planned `.profile.json` output.
- Add fake-fixture/fake-tooling Node tests covering plan JSON, command templates, missing-fixture fallback, generated flat-tsconfig helper behavior, and flat-profile JSON output.

## Structural Rule
When #14351 work needs to decide whether `large-ts-repo` is evaluator-recursion growth or a competing variance storm, tsz should use a repeatable benchmark-row attribution plan with machine-readable timing and flat-profile artifacts instead of ad hoc local commands. The row remains benchmark-only (`guard_set: null`), and this PR does not change compile-guard semantics or compiler behavior.

## Gauge Invariant
- Row: `large-ts-repo`, filter `^large-ts-repo$`.
- Fixture identity: pinned through `scripts/bench/project-rows.mjs` via `LARGE_TS_REPO`/`LARGE_TS_REF`; local checkout fallback remains gated by `TSZ_BENCH_ALLOW_LOCAL_FIXTURE=1`.
- Flat config: prefer fixture-provided `tsconfig.flat.bench.json`; otherwise generate/select `tsconfig.flat.json` with `packages/**/src/**/*.ts`.
- Artifacts: plan JSON records `.bench.json`, `.measure.json`, and `.profile.json` paths; `perf-flat-profile.sh --json-file` writes ranked self/inclusive sample rows with the sampled binary and tsz args.
- Measurement mode: plan-only by default; `measure-tsz.sh` preserves snapshot+CPU-share classification, while `perf-flat-profile.sh` remains explicit and opt-in.
- Disk safety: no clone, install, build, measure, or profile happens unless `--prepare` or run flags are passed.

## Verification
- `bash -n scripts/bench/large-ts-repo-attribution-gauge.sh scripts/bench/lib/large-ts-repo-fixture.sh scripts/bench/bench-vs-tsgo.sh scripts/bench/perf-flat-profile.sh`
- `git diff --check`
- `node scripts/bench/test-large-ts-repo-attribution-gauge.mjs`
- `node scripts/bench/test-perf-flat-profile.mjs`
- `node scripts/bench/test-project-rows.mjs`
- `node scripts/bench/test-project-row-summary.mjs`
- `node scripts/bench/validate-project-metadata.mjs`
- `node scripts/bench/test-validate-project-metadata.mjs`
- `node scripts/bench/test-measure-tsz.mjs`
- `node scripts/bench/test-perf-hotspots.mjs`
- `python3 scripts/perf/test_cache_visibility_report.py`
- `scripts/bench/bench-vs-tsgo.sh --help`
- `scripts/bench/perf-flat-profile.sh --help`
- `scripts/bench/large-ts-repo-attribution-gauge.sh --json-file /tmp/large-ts-repo-attribution-plan.json --fixture-dir /tmp/no-such-large-ts-repo-fixture --tsz-bin /tmp/no-such-tsz-bin`
- `python3 scripts/arch/test_arch_guard_project.py`
- `python3 scripts/arch/test_arch_guard_projects.py`
- `python3 scripts/arch/arch_guard_project.py`
- `python3 scripts/arch/arch_guard_projects.py`
- `python3 scripts/arch/arch_guard.py` (fails only on pre-existing checker guard debt: `access.rs` LOC, direct `query_boundaries::common` quarantine refs, and snapshot rollback cap)

Known overlapping bench workflow tests remain covered by open PRs #15420 and #15427; this PR does not change their workflow contract surfaces.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high