### PR TITLE
perf(solver): preserve annotation widen no-op identity (#14351)

### DIFF
--- a/crates/tsz-solver/src/operations/widening/annotation.rs
+++ b/crates/tsz-solver/src/operations/widening/annotation.rs
@@ -2,7 +2,7 @@ use crate::diagnostics::display_provenance::{
     self, AliasApplicationPriority, AliasApplicationProvenance,
     FreshObjectLiteralDisplayProvenance, UnionOriginProvenance,
 };
-use crate::types::{TypeData, TypeId};
+use crate::types::{CallSignature, CallableShape, FunctionShape, ObjectShape, TypeData, TypeId};
 
 /// Which literal kinds an annotation-position display widening pass rewrites.
 ///
@@ -331,6 +331,234 @@ fn propagate_widened_annotation_alias(
     }
 }
 
+fn widen_annotation_object_shape(
+    db: &dyn crate::construction::TypeDatabase,
+    shape: &ObjectShape,
+    mode: AnnotationWidenMode,
+    policy: AnnotationLiteralWideningPolicy,
+    st: &mut AnnotationWidenState<'_>,
+) -> Option<ObjectShape> {
+    let mut new_shape: Option<ObjectShape> = None;
+    for (index, prop) in shape.properties.iter().enumerate() {
+        let (widened, widened_write) = if mode == AnnotationWidenMode::Active {
+            (
+                widen_annotation_property_type(db, prop.type_id, prop.is_method, policy, st),
+                widen_annotation_property_type(db, prop.write_type, prop.is_method, policy, st),
+            )
+        } else {
+            (
+                widen_annotation_walk(db, prop.type_id, mode, policy, st),
+                widen_annotation_walk(db, prop.write_type, mode, policy, st),
+            )
+        };
+        if widened != prop.type_id || widened_write != prop.write_type {
+            let target = new_shape.get_or_insert_with(|| shape.clone());
+            target.properties[index].type_id = widened;
+            target.properties[index].write_type = widened_write;
+        }
+    }
+
+    if mode == AnnotationWidenMode::Active {
+        if let Some(index) = shape.string_index {
+            let widened = widen_annotation_position(db, index.value_type, mode, policy, st);
+            if widened != index.value_type {
+                let target = new_shape.get_or_insert_with(|| shape.clone());
+                if let Some(target_index) = &mut target.string_index {
+                    target_index.value_type = widened;
+                }
+            }
+        }
+        if let Some(index) = shape.number_index {
+            let widened = widen_annotation_position(db, index.value_type, mode, policy, st);
+            if widened != index.value_type {
+                let target = new_shape.get_or_insert_with(|| shape.clone());
+                if let Some(target_index) = &mut target.number_index {
+                    target_index.value_type = widened;
+                }
+            }
+        }
+        if let Some(index) = shape.symbol_index {
+            let widened = widen_annotation_position(db, index.value_type, mode, policy, st);
+            if widened != index.value_type {
+                let target = new_shape.get_or_insert_with(|| shape.clone());
+                if let Some(target_index) = &mut target.symbol_index {
+                    target_index.value_type = widened;
+                }
+            }
+        }
+    }
+
+    new_shape
+}
+
+fn widen_annotation_signature_fields(
+    db: &dyn crate::construction::TypeDatabase,
+    params: &[crate::ParamInfo],
+    this_type: Option<TypeId>,
+    return_type: TypeId,
+    return_is_method: bool,
+    policy: AnnotationLiteralWideningPolicy,
+    st: &mut AnnotationWidenState<'_>,
+) -> Option<(Vec<crate::ParamInfo>, Option<TypeId>, TypeId)> {
+    let mode = AnnotationWidenMode::Active;
+    let mut changed = false;
+    let mut new_params: Option<Vec<crate::ParamInfo>> = None;
+    for (index, param) in params.iter().enumerate() {
+        let widened = widen_annotation_position(db, param.type_id, mode, policy, st);
+        if widened != param.type_id {
+            let target = new_params.get_or_insert_with(|| params.to_vec());
+            target[index].type_id = widened;
+            changed = true;
+        }
+    }
+
+    let widened_this = if let Some(this_ty) = this_type {
+        let widened = widen_annotation_position(db, this_ty, mode, policy, st);
+        changed |= widened != this_ty;
+        Some(widened)
+    } else {
+        None
+    };
+    let widened_return = if return_is_method {
+        widen_annotation_position(db, return_type, mode, policy, st)
+    } else {
+        widen_annotation_walk(db, return_type, mode, policy, st)
+    };
+    changed |= widened_return != return_type;
+
+    if changed {
+        Some((
+            new_params.unwrap_or_else(|| params.to_vec()),
+            widened_this,
+            widened_return,
+        ))
+    } else {
+        None
+    }
+}
+
+fn widen_annotation_function_shape(
+    db: &dyn crate::construction::TypeDatabase,
+    shape: &FunctionShape,
+    return_is_method: bool,
+    policy: AnnotationLiteralWideningPolicy,
+    st: &mut AnnotationWidenState<'_>,
+) -> Option<FunctionShape> {
+    widen_annotation_signature_fields(
+        db,
+        &shape.params,
+        shape.this_type,
+        shape.return_type,
+        return_is_method,
+        policy,
+        st,
+    )
+    .map(|(params, this_type, return_type)| {
+        let mut new_shape = shape.clone();
+        new_shape.params = params;
+        new_shape.this_type = this_type;
+        new_shape.return_type = return_type;
+        new_shape
+    })
+}
+
+fn widen_annotation_call_signature(
+    db: &dyn crate::construction::TypeDatabase,
+    sig: &CallSignature,
+    return_is_method: bool,
+    policy: AnnotationLiteralWideningPolicy,
+    st: &mut AnnotationWidenState<'_>,
+) -> Option<CallSignature> {
+    widen_annotation_signature_fields(
+        db,
+        &sig.params,
+        sig.this_type,
+        sig.return_type,
+        return_is_method,
+        policy,
+        st,
+    )
+    .map(|(params, this_type, return_type)| {
+        let mut new_sig = sig.clone();
+        new_sig.params = params;
+        new_sig.this_type = this_type;
+        new_sig.return_type = return_type;
+        new_sig
+    })
+}
+
+fn widen_annotation_callable_shape(
+    db: &dyn crate::construction::TypeDatabase,
+    shape: &CallableShape,
+    force_method_returns: bool,
+    policy: AnnotationLiteralWideningPolicy,
+    st: &mut AnnotationWidenState<'_>,
+) -> Option<CallableShape> {
+    let mut new_shape: Option<CallableShape> = None;
+    for (index, sig) in shape.call_signatures.iter().enumerate() {
+        let return_is_method = force_method_returns || sig.is_method;
+        if let Some(widened) =
+            widen_annotation_call_signature(db, sig, return_is_method, policy, st)
+        {
+            new_shape
+                .get_or_insert_with(|| shape.clone())
+                .call_signatures[index] = widened;
+        }
+    }
+    for (index, sig) in shape.construct_signatures.iter().enumerate() {
+        let return_is_method = force_method_returns || sig.is_method;
+        if let Some(widened) =
+            widen_annotation_call_signature(db, sig, return_is_method, policy, st)
+        {
+            new_shape
+                .get_or_insert_with(|| shape.clone())
+                .construct_signatures[index] = widened;
+        }
+    }
+    for (index, prop) in shape.properties.iter().enumerate() {
+        let widened = widen_annotation_property_type(db, prop.type_id, prop.is_method, policy, st);
+        let widened_write =
+            widen_annotation_property_type(db, prop.write_type, prop.is_method, policy, st);
+        if widened != prop.type_id || widened_write != prop.write_type {
+            let target = new_shape.get_or_insert_with(|| shape.clone());
+            target.properties[index].type_id = widened;
+            target.properties[index].write_type = widened_write;
+        }
+    }
+    if let Some(index) = shape.string_index {
+        let widened = widen_annotation_position(
+            db,
+            index.value_type,
+            AnnotationWidenMode::Active,
+            policy,
+            st,
+        );
+        if widened != index.value_type {
+            let target = new_shape.get_or_insert_with(|| shape.clone());
+            if let Some(target_index) = &mut target.string_index {
+                target_index.value_type = widened;
+            }
+        }
+    }
+    if let Some(index) = shape.number_index {
+        let widened = widen_annotation_position(
+            db,
+            index.value_type,
+            AnnotationWidenMode::Active,
+            policy,
+            st,
+        );
+        if widened != index.value_type {
+            let target = new_shape.get_or_insert_with(|| shape.clone());
+            if let Some(target_index) = &mut target.number_index {
+                target_index.value_type = widened;
+            }
+        }
+    }
+
+    new_shape
+}
+
 /// Structural walk for [`widen_annotation_literals_for_display`]: descends
 /// into compounds rebuilding only what changed, widening literals solely
 /// through [`widen_annotation_position`].
@@ -357,48 +585,7 @@ fn widen_annotation_walk(
                 other => other,
             };
             let shape = db.object_shape(shape_id);
-            let mut new_shape = (*shape).clone();
-            let mut changed = false;
-            if mode == AnnotationWidenMode::Active {
-                for prop in &mut new_shape.properties {
-                    // Method properties render as `m(): R`, putting the return
-                    // type in annotation position; pass that context down.
-                    let widened = widen_annotation_property_type(
-                        db,
-                        prop.type_id,
-                        prop.is_method,
-                        policy,
-                        st,
-                    );
-                    let widened_write = widen_annotation_property_type(
-                        db,
-                        prop.write_type,
-                        prop.is_method,
-                        policy,
-                        st,
-                    );
-                    changed |= widened != prop.type_id || widened_write != prop.write_type;
-                    prop.type_id = widened;
-                    prop.write_type = widened_write;
-                }
-                for index in [&mut new_shape.string_index, &mut new_shape.number_index]
-                    .into_iter()
-                    .flatten()
-                {
-                    let widened = widen_annotation_position(db, index.value_type, mode, policy, st);
-                    changed |= widened != index.value_type;
-                    index.value_type = widened;
-                }
-            } else {
-                for prop in &mut new_shape.properties {
-                    let widened = widen_annotation_walk(db, prop.type_id, mode, policy, st);
-                    let widened_write =
-                        widen_annotation_walk(db, prop.write_type, mode, policy, st);
-                    changed |= widened != prop.type_id || widened_write != prop.write_type;
-                    prop.type_id = widened;
-                    prop.write_type = widened_write;
-                }
-            }
+            let new_shape = widen_annotation_object_shape(db, shape.as_ref(), mode, policy, st);
             // Fresh-object-literal *display properties* (literal spellings
             // recorded as provenance) print instead of the canonical shape,
             // so widen those spellings too.
@@ -434,15 +621,17 @@ fn widen_annotation_walk(
             let display_changed = widened_display
                 .as_ref()
                 .is_some_and(|(_, display_changed)| *display_changed);
-            if changed {
+            if let Some(new_shape) = new_shape {
                 let symbol = new_shape.symbol;
                 let flags = new_shape.flags;
-                let widened_id =
-                    if new_shape.string_index.is_some() || new_shape.number_index.is_some() {
-                        db.object_with_index(new_shape)
-                    } else {
-                        db.object_with_flags_and_symbol(new_shape.properties, flags, symbol)
-                    };
+                let widened_id = if new_shape.string_index.is_some()
+                    || new_shape.number_index.is_some()
+                    || new_shape.symbol_index.is_some()
+                {
+                    db.object_with_index(new_shape)
+                } else {
+                    db.object_with_flags_and_symbol(new_shape.properties, flags, symbol)
+                };
                 if let Some((display_properties, _)) = widened_display {
                     display_provenance::record_fresh_object_literal_display(
                         db,
@@ -473,17 +662,9 @@ fn widen_annotation_walk(
         // (`m(): 1` renders with a colon).
         Some(TypeData::Function(shape_id)) if mode == AnnotationWidenMode::Active => {
             let shape = db.function_shape(shape_id);
-            let mut new_shape = (*shape).clone();
-            let changed = widen_annotation_signature_parts(
-                db,
-                &mut new_shape.params,
-                &mut new_shape.this_type,
-                &mut new_shape.return_type,
-                new_shape.is_method,
-                policy,
-                st,
-            );
-            if changed {
+            if let Some(new_shape) =
+                widen_annotation_function_shape(db, shape.as_ref(), shape.is_method, policy, st)
+            {
                 db.function(new_shape)
             } else {
                 type_id
@@ -492,31 +673,9 @@ fn widen_annotation_walk(
 
         Some(TypeData::Callable(shape_id)) if mode == AnnotationWidenMode::Active => {
             let shape = db.callable_shape(shape_id);
-            let mut new_shape = (*shape).clone();
-            let mut changed = false;
-            for sig in new_shape
-                .call_signatures
-                .iter_mut()
-                .chain(new_shape.construct_signatures.iter_mut())
+            if let Some(new_shape) =
+                widen_annotation_callable_shape(db, shape.as_ref(), false, policy, st)
             {
-                let is_method = sig.is_method;
-                changed |= widen_annotation_signature_parts(
-                    db,
-                    &mut sig.params,
-                    &mut sig.this_type,
-                    &mut sig.return_type,
-                    is_method,
-                    policy,
-                    st,
-                );
-            }
-            for prop in &mut new_shape.properties {
-                let widened =
-                    widen_annotation_property_type(db, prop.type_id, prop.is_method, policy, st);
-                changed |= widened != prop.type_id;
-                prop.type_id = widened;
-            }
-            if changed {
                 db.callable(new_shape)
             } else {
                 type_id
@@ -646,40 +805,6 @@ fn widen_annotation_walk(
     result
 }
 
-/// Widen the annotation-position parts of one function/call signature:
-/// parameters and `this` always render with a colon; the return type renders
-/// with a colon only in method form (`m(): R`).
-fn widen_annotation_signature_parts(
-    db: &dyn crate::construction::TypeDatabase,
-    params: &mut [crate::ParamInfo],
-    this_type: &mut Option<TypeId>,
-    return_type: &mut TypeId,
-    is_method: bool,
-    policy: AnnotationLiteralWideningPolicy,
-    st: &mut AnnotationWidenState<'_>,
-) -> bool {
-    let mode = AnnotationWidenMode::Active;
-    let mut changed = false;
-    for param in params {
-        let widened = widen_annotation_position(db, param.type_id, mode, policy, st);
-        changed |= widened != param.type_id;
-        param.type_id = widened;
-    }
-    if let Some(this_ty) = this_type {
-        let widened = widen_annotation_position(db, *this_ty, mode, policy, st);
-        changed |= widened != *this_ty;
-        *this_ty = widened;
-    }
-    let widened_return = if is_method {
-        widen_annotation_position(db, *return_type, mode, policy, st)
-    } else {
-        widen_annotation_walk(db, *return_type, mode, policy, st)
-    };
-    changed |= widened_return != *return_type;
-    *return_type = widened_return;
-    changed
-}
-
 /// Widen an object property's type: the property annotation itself is an
 /// annotation position; method properties additionally place their return
 /// type in annotation position (`m(): R`).
@@ -699,17 +824,9 @@ fn widen_annotation_property_type(
     match db.lookup(type_id) {
         Some(TypeData::Function(shape_id)) => {
             let shape = db.function_shape(shape_id);
-            let mut new_shape = (*shape).clone();
-            let changed = widen_annotation_signature_parts(
-                db,
-                &mut new_shape.params,
-                &mut new_shape.this_type,
-                &mut new_shape.return_type,
-                true,
-                policy,
-                st,
-            );
-            if changed {
+            if let Some(new_shape) =
+                widen_annotation_function_shape(db, shape.as_ref(), true, policy, st)
+            {
                 let widened_fn = db.function(new_shape);
                 propagate_widened_annotation_alias(
                     db,
@@ -726,30 +843,9 @@ fn widen_annotation_property_type(
         }
         Some(TypeData::Callable(shape_id)) => {
             let shape = db.callable_shape(shape_id);
-            let mut new_shape = (*shape).clone();
-            let mut changed = false;
-            for sig in new_shape
-                .call_signatures
-                .iter_mut()
-                .chain(new_shape.construct_signatures.iter_mut())
+            if let Some(new_shape) =
+                widen_annotation_callable_shape(db, shape.as_ref(), true, policy, st)
             {
-                changed |= widen_annotation_signature_parts(
-                    db,
-                    &mut sig.params,
-                    &mut sig.this_type,
-                    &mut sig.return_type,
-                    true,
-                    policy,
-                    st,
-                );
-            }
-            for prop in &mut new_shape.properties {
-                let widened =
-                    widen_annotation_property_type(db, prop.type_id, prop.is_method, policy, st);
-                changed |= widened != prop.type_id;
-                prop.type_id = widened;
-            }
-            if changed {
                 let widened_callable = db.callable(new_shape);
                 propagate_widened_annotation_alias(
                     db,

--- a/crates/tsz-solver/tests/widening_tests.rs
+++ b/crates/tsz-solver/tests/widening_tests.rs
@@ -407,7 +407,10 @@ fn test_widen_readonly_array_widens_element_type() {
 // failure rather than a cascade.
 // ============================================================================
 
-use crate::types::{FunctionShape, ParamInfo, TemplateSpan, TupleElement};
+use crate::types::{
+    CallSignature, CallableShape, FunctionShape, IndexSignature, ObjectShape, ParamInfo,
+    TemplateSpan, TupleElement,
+};
 
 // -------- widen_type: bigint and boolean intrinsic edge cases ----------------
 
@@ -1211,6 +1214,153 @@ fn annotation_widen_object_property_literals() {
     assert_eq!(property_type(&interner, &shape, "s"), TypeId::STRING);
     assert_eq!(property_type(&interner, &shape, "n"), TypeId::NUMBER);
     assert_eq!(property_type(&interner, &shape, "b"), TypeId::BOOLEAN);
+}
+
+#[test]
+fn annotation_widen_object_index_signature_literals() {
+    let interner = TypeInterner::new();
+    let obj = interner.object_with_index(ObjectShape {
+        flags: ObjectFlags::empty(),
+        properties: Vec::new(),
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: interner.literal_string("x"),
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: Some(IndexSignature {
+            key_type: TypeId::NUMBER,
+            value_type: interner.literal_number(1.0),
+            readonly: false,
+            param_name: None,
+        }),
+        symbol_index: Some(IndexSignature {
+            key_type: TypeId::SYMBOL,
+            value_type: TypeId::BOOLEAN_TRUE,
+            readonly: false,
+            param_name: None,
+        }),
+        symbol: None,
+    });
+
+    let outcome = annotation_widen_all(&interner, obj);
+    let shape = match interner.lookup(outcome.type_id) {
+        Some(TypeData::ObjectWithIndex(id)) => interner.object_shape(id),
+        other => panic!("expected object-with-index, got {other:?}"),
+    };
+
+    assert_eq!(shape.string_index.unwrap().value_type, TypeId::STRING);
+    assert_eq!(shape.number_index.unwrap().value_type, TypeId::NUMBER);
+    assert_eq!(shape.symbol_index.unwrap().value_type, TypeId::BOOLEAN);
+}
+
+#[test]
+fn annotation_widen_callable_index_and_write_literals() {
+    let interner = TypeInterner::new();
+    let mut prop = PropertyInfo::new(interner.intern_string("p"), TypeId::STRING);
+    prop.write_type = interner.literal_string("write");
+    let callable = interner.callable(CallableShape {
+        call_signatures: vec![CallSignature::new(
+            vec![ParamInfo::unnamed(TypeId::STRING)],
+            TypeId::NUMBER,
+        )],
+        construct_signatures: Vec::new(),
+        properties: vec![prop],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: interner.literal_string("x"),
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: Some(IndexSignature {
+            key_type: TypeId::NUMBER,
+            value_type: TypeId::BOOLEAN_TRUE,
+            readonly: false,
+            param_name: None,
+        }),
+        symbol: None,
+        is_abstract: false,
+    });
+
+    let outcome = annotation_widen_all(&interner, callable);
+    let shape = match interner.lookup(outcome.type_id) {
+        Some(TypeData::Callable(id)) => interner.callable_shape(id),
+        other => panic!("expected callable, got {other:?}"),
+    };
+
+    assert_eq!(shape.properties[0].type_id, TypeId::STRING);
+    assert_eq!(shape.properties[0].write_type, TypeId::STRING);
+    assert_eq!(shape.string_index.unwrap().value_type, TypeId::STRING);
+    assert_eq!(shape.number_index.unwrap().value_type, TypeId::BOOLEAN);
+}
+
+#[test]
+fn annotation_widen_noop_compounds_preserve_type_id() {
+    let interner = TypeInterner::new();
+    let obj = interner.object_with_index(ObjectShape {
+        flags: ObjectFlags::empty(),
+        properties: vec![PropertyInfo::new(
+            interner.intern_string("value"),
+            TypeId::STRING,
+        )],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+        symbol_index: Some(IndexSignature {
+            key_type: TypeId::SYMBOL,
+            value_type: TypeId::BOOLEAN,
+            readonly: false,
+            param_name: None,
+        }),
+        symbol: None,
+    });
+    let func = interner.function(FunctionShape {
+        type_params: Vec::new(),
+        params: vec![ParamInfo::unnamed(TypeId::STRING)],
+        this_type: Some(TypeId::NUMBER),
+        return_type: TypeId::BOOLEAN,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let callable = interner.callable(CallableShape {
+        call_signatures: vec![CallSignature::new(
+            vec![ParamInfo::unnamed(TypeId::STRING)],
+            TypeId::NUMBER,
+        )],
+        construct_signatures: Vec::new(),
+        properties: vec![PropertyInfo::new(
+            interner.intern_string("p"),
+            TypeId::BOOLEAN,
+        )],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::STRING,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+        symbol: None,
+        is_abstract: false,
+    });
+
+    interner.store_display_properties(
+        obj,
+        vec![PropertyInfo::new(
+            interner.intern_string("value"),
+            TypeId::STRING,
+        )],
+    );
+
+    let obj_outcome = annotation_widen_all(&interner, obj);
+    assert_eq!(obj_outcome.type_id, obj);
+    assert!(!obj_outcome.display_residue);
+    assert_eq!(annotation_widen_all(&interner, func).type_id, func);
+    assert_eq!(annotation_widen_all(&interner, callable).type_id, callable);
 }
 
 #[test]


### PR DESCRIPTION
Goal: fast

## Summary
- Preserve the original `TypeId` when annotation-display widening walks object, function, or callable compounds and every reachable annotation child is unchanged.
- Route object `symbol` index values plus callable property write/index values through the same solver annotation-position widening path.
- Add solver coverage for object/callable index values, property write types, and no-op identity preservation.

## Structural Rule
When annotation-display widening reaches a compound type and every child walk returns the same `TypeId`, the printed annotation surface is unchanged; tsz preserves identity through `tsz_solver::operations::widening` instead of rebuilding an equivalent shape.

When index-signature values or callable write types are in annotation position and carry widenable literals, tsc displays the primitive annotation; tsz performs that rewrite through the solver annotation-position helper.

## Owner Layer
Solver: `crates/tsz-solver/src/operations/widening/annotation.rs` owns the traversal, no checker display heuristics or rendered-string predicates added.

## Adjacent Matrix
- Object properties: read/write annotation values still widen.
- Object indexes: string, number, and symbol value annotations widen.
- Function/callable signatures: parameter, `this`, and method-return annotations still widen; non-method returns remain bare.
- Callable properties: read/write property annotations and string/number index values widen.
- No-op compounds: object-with-index, function, callable, and already-widened display properties preserve their original `TypeId` and avoid display residue.

## Verification
- `git diff --check`
- `scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-solver annotation_widen`
- `scripts/safe-run.sh -- cargo check -p tsz-solver --tests`
- `scripts/safe-run.sh -- cargo clippy -p tsz-solver --tests -- -D warnings`
- `scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test operator_literal_annotation_widen_tests numeric_literal_annotation_shows_widened_number`
- `python3 scripts/perf/cache-visibility-report.py --json`

Known baseline caveat: full `operator_literal_annotation_widen_tests` currently fails the two alias-name cases (`type_alias_annotation_does_not_show_raw_alias_name*`) on this branch and on detached `origin/main`; the operator path does not call annotation widening.

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high