### PR TITLE
perf(solver): expose interner cache residency (#14351)

### DIFF
--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -1869,6 +1869,36 @@ impl TypeInterner {
         // --- Auxiliary caches ---
         size += self.identity_comparable_cache.len()
             * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
+        size += self.widen_type_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() * 2);
+        size += self
+            .extract_type_params_cache
+            .iter()
+            .map(|entry| {
+                DASHMAP_ENTRY_OVERHEAD
+                    + std::mem::size_of::<TypeId>()
+                    + std::mem::size_of::<Arc<[TypeParamInfo]>>()
+                    + entry.value().len() * std::mem::size_of::<TypeParamInfo>()
+            })
+            .sum::<usize>();
+        size += self.proto_instantiation_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD
+                + std::mem::size_of::<crate::caches::instantiation_cache::InstantiationCacheKey>()
+                + std::mem::size_of::<TypeId>());
+        size += self
+            .contravariant_infer_names_cache
+            .iter()
+            .map(|entry| {
+                DASHMAP_ENTRY_OVERHEAD
+                    + std::mem::size_of::<TypeId>()
+                    + std::mem::size_of::<Arc<[Atom]>>()
+                    + entry.value().len() * std::mem::size_of::<Atom>()
+            })
+            .sum::<usize>();
+        size += self.contains_type_by_id_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<(TypeId, TypeId)>() + 1);
+        size += self.prune_union_members_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() * 2);
         size += self.predicate_cache.len()
             * (DASHMAP_ENTRY_OVERHEAD
                 + std::mem::size_of::<TypeId>()

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -510,6 +510,14 @@ pub struct TypeInterner {
 pub struct TypePredicateCacheStatistics {
     /// Number of memoized identity-comparability predicate results.
     pub identity_comparable_cache_entries: usize,
+    /// Number of memoized canonical `widen_type` results.
+    pub widen_type_cache_entries: usize,
+    /// Number of memoized `extract_type_params_from_type` results.
+    pub extract_type_params_cache_entries: usize,
+    /// Number of project-wide instantiation results.
+    pub proto_instantiation_cache_entries: usize,
+    /// Number of memoized contravariant `infer` name-list results.
+    pub contravariant_infer_names_cache_entries: usize,
     /// Number of memoized union-normalization results.
     pub union_normalize_cache_entries: usize,
     /// Number of `TypeId` member slots retained by union-normalization keys.
@@ -582,6 +590,10 @@ impl TypeInterner {
     pub fn type_predicate_cache_statistics(&self) -> TypePredicateCacheStatistics {
         TypePredicateCacheStatistics {
             identity_comparable_cache_entries: self.identity_comparable_cache.len(),
+            widen_type_cache_entries: self.widen_type_cache.len(),
+            extract_type_params_cache_entries: self.extract_type_params_cache.len(),
+            proto_instantiation_cache_entries: self.proto_instantiation_cache.len(),
+            contravariant_infer_names_cache_entries: self.contravariant_infer_names_cache.len(),
             union_normalize_cache_entries: self.union_normalize_cache.len(),
             union_normalize_cache_member_slots: self.union_normalize_cache_member_slots(),
             contains_this_cache_entries: self

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::caches::db::{TypeDatabase, TypePredicateCache};
+use crate::caches::instantiation_cache::{CanonicalSubst, InstantiationCacheKey};
+use crate::types::{TypeParamInfo, TypeParamOrigin};
 
 #[test]
 fn interned_type_limit_fallback_poison_returns_error() {
@@ -75,6 +77,58 @@ fn estimated_size_accounts_for_retained_predicate_caches() {
         interner.estimated_size_bytes() > before,
         "retained TypeInterner predicate cache entries must be visible to residency estimates",
     );
+}
+
+#[test]
+fn estimated_size_accounts_for_retained_pure_function_memos() {
+    let interner = TypeInterner::new();
+    let before = interner.estimated_size_bytes();
+    let t_atom = interner.intern_string("T");
+    let t_info = TypeParamInfo {
+        name: t_atom,
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::User,
+    };
+    let proto_key = InstantiationCacheKey::new(TypeId::STRING, CanonicalSubst::empty(), 0, None);
+
+    interner.set_widen_type_memo(TypeId::BOOLEAN_TRUE, TypeId::BOOLEAN);
+    interner.set_extract_type_params_memo(TypeId::STRING, vec![t_info].into());
+    interner.set_proto_instantiation_memo(proto_key, TypeId::NUMBER);
+    interner.set_contravariant_infer_names_memo(TypeId::OBJECT, vec![t_atom].into());
+    interner.set_contains_type_by_id_memo(TypeId::STRING, TypeId::NUMBER, false);
+    interner.set_prune_union_members_memo(TypeId::BOOLEAN, TypeId::BOOLEAN);
+
+    assert!(
+        interner.estimated_size_bytes() > before,
+        "retained TypeInterner pure-function memo entries must be visible to residency estimates",
+    );
+}
+
+#[test]
+fn type_predicate_cache_statistics_reports_pure_function_memos() {
+    let interner = TypeInterner::new();
+    let t_atom = interner.intern_string("T");
+    let t_info = TypeParamInfo {
+        name: t_atom,
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::User,
+    };
+    let proto_key = InstantiationCacheKey::new(TypeId::STRING, CanonicalSubst::empty(), 0, None);
+
+    interner.set_widen_type_memo(TypeId::BOOLEAN_TRUE, TypeId::BOOLEAN);
+    interner.set_extract_type_params_memo(TypeId::STRING, vec![t_info].into());
+    interner.set_proto_instantiation_memo(proto_key, TypeId::NUMBER);
+    interner.set_contravariant_infer_names_memo(TypeId::OBJECT, vec![t_atom].into());
+
+    let stats = interner.type_predicate_cache_statistics();
+    assert_eq!(stats.widen_type_cache_entries, 1);
+    assert_eq!(stats.extract_type_params_cache_entries, 1);
+    assert_eq!(stats.proto_instantiation_cache_entries, 1);
+    assert_eq!(stats.contravariant_infer_names_cache_entries, 1);
 }
 
 #[test]

--- a/scripts/perf/test_cache_visibility_report.py
+++ b/scripts/perf/test_cache_visibility_report.py
@@ -413,6 +413,26 @@ class CacheVisibilityReportTests(unittest.TestCase):
             predicate_memos,
         )
 
+    def test_type_interner_retained_pure_function_memos_are_visible(self):
+        root = Path(__file__).resolve().parents[2]
+        candidates = self.module.scan([root / "crates/tsz-solver/src/intern/core"])
+        by_name = {
+            candidate.name: candidate
+            for candidate in candidates
+            if candidate.path == "crates/tsz-solver/src/intern/core/interner.rs"
+            and candidate.owner == "TypeInterner"
+        }
+
+        for name in (
+            "widen_type_cache",
+            "extract_type_params_cache",
+            "proto_instantiation_cache",
+            "contravariant_infer_names_cache",
+        ):
+            with self.subTest(name=name):
+                self.assertIn(name, by_name)
+                self.assertFalse(by_name[name].needs_review, by_name[name])
+
     def test_default_roots_include_binder_cache_surfaces(self):
         self.assertIn("crates/tsz-binder/src", self.module.DEFAULT_ROOTS)
 


### PR DESCRIPTION
Goal: fast

## Summary
- Expose retained `TypeInterner` pure-function memo entry counts through `TypePredicateCacheStatistics`.
- Include retained interner memo maps in `estimated_size_bytes()`, including variable `Arc<[TypeParamInfo]>` and `Arc<[Atom]>` payloads.
- Add Rust and Python guard tests so the cache visibility report keeps these retained residency surfaces covered.

## Structural Rule
When retained solver pure-function memos survive across requests, tsz exposes their entry counts and estimated resident size through the solver-owned interner observability surface. This PR does not change cache keys, invalidation, reset behavior, or semantic answers; it makes existing retained residency measurable for #14351.

## Verification
- `git diff --check`
- `scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-solver pure_function_memos`
- `python3 -m unittest scripts/perf/test_cache_visibility_report.py`
- `python3 scripts/perf/cache-visibility-report.py --json` plus a focused JSON probe for the four retained `TypeInterner` memo rows
- `scripts/safe-run.sh -- cargo check -p tsz-solver --tests`
- `scripts/safe-run.sh -- cargo clippy -p tsz-solver --tests -- -D warnings`
- Full PR CI owns broad conformance, emit, fourslash, and unit gates.

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high
