### PR TITLE
perf(solver): expose operation-local cache residency (#14351)

### DIFF
--- a/crates/tsz-solver/src/diagnostics/format/cache_accounting.rs
+++ b/crates/tsz-solver/src/diagnostics/format/cache_accounting.rs
@@ -1,0 +1,33 @@
+use super::{TypeFormatter, TypeFormatterCacheStatistics};
+use crate::def::DefId;
+use crate::types::TypeId;
+use std::mem::size_of;
+use std::sync::Arc;
+use tsz_common::interner::Atom;
+
+impl<'a> TypeFormatter<'a> {
+    /// Return cache entry and residency accounting for this formatter.
+    pub fn cache_statistics(&self) -> TypeFormatterCacheStatistics {
+        let application_reduction_cache_entries = self.application_reduction_cache.borrow().len();
+        let recursive_alias_base_cache_entries = self.recursive_alias_base_cache.borrow().len();
+        TypeFormatterCacheStatistics {
+            atom_cache_entries: self.atom_cache.len(),
+            application_reduction_cache_entries,
+            recursive_alias_base_cache_entries,
+            estimated_size_bytes: self.estimated_size_bytes(),
+        }
+    }
+
+    /// Estimate memory retained by this operation-local formatter.
+    pub fn estimated_size_bytes(&self) -> usize {
+        size_of::<Self>()
+            + self.atom_cache.capacity() * size_of::<(Atom, Arc<str>)>()
+            + self.display_alias_visiting.capacity() * size_of::<TypeId>()
+            + self.format_visiting.capacity() * size_of::<TypeId>()
+            + self.skip_type_alias_def_ids.capacity() * size_of::<DefId>()
+            + self.skipped_type_alias_expansion_visiting.capacity() * size_of::<DefId>()
+            + self.application_reduction_cache.borrow().capacity()
+                * size_of::<(TypeId, Option<TypeId>)>()
+            + self.recursive_alias_base_cache.borrow().capacity() * size_of::<(TypeId, bool)>()
+    }
+}

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -3,6 +3,7 @@
 
 mod alias_underlying;
 mod array;
+mod cache_accounting;
 mod compound;
 mod display_simplification;
 mod intrinsic;
@@ -36,7 +37,6 @@ use crate::diagnostics::{
 use crate::types::{MappedModifier, ObjectShape, TypeData, TypeId};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
-use std::mem::size_of;
 use std::sync::Arc;
 use tsz_common::interner::Atom;
 
@@ -45,6 +45,10 @@ use tsz_common::interner::Atom;
 pub struct TypeFormatterCacheStatistics {
     /// Cached atom-to-string display entries.
     pub atom_cache_entries: usize,
+    /// Cached generic application display-reduction decisions.
+    pub application_reduction_cache_entries: usize,
+    /// Cached recursive-alias base predicate decisions.
+    pub recursive_alias_base_cache_entries: usize,
     /// Approximate heap and struct residency owned by the formatter.
     pub estimated_size_bytes: usize,
 }
@@ -693,24 +697,6 @@ impl<'a> TypeFormatter<'a> {
             recursive_alias_base_cache: std::cell::RefCell::new(FxHashMap::default()),
             format_node_budget: None,
         }
-    }
-
-    /// Return cache entry and residency accounting for this formatter.
-    pub fn cache_statistics(&self) -> TypeFormatterCacheStatistics {
-        TypeFormatterCacheStatistics {
-            atom_cache_entries: self.atom_cache.len(),
-            estimated_size_bytes: self.estimated_size_bytes(),
-        }
-    }
-
-    /// Estimate memory retained by this operation-local formatter.
-    pub fn estimated_size_bytes(&self) -> usize {
-        size_of::<Self>()
-            + self.atom_cache.capacity() * size_of::<(Atom, Arc<str>)>()
-            + self.display_alias_visiting.capacity() * size_of::<TypeId>()
-            + self.format_visiting.capacity() * size_of::<TypeId>()
-            + self.skip_type_alias_def_ids.capacity() * size_of::<DefId>()
-            + self.skipped_type_alias_expansion_visiting.capacity() * size_of::<DefId>()
     }
 
     fn distributed_conditional_application_display(

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_00.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_00.rs
@@ -6,6 +6,8 @@ fn type_formatter_cache_statistics_account_for_atom_cache_entries_and_size() {
 
     let empty_stats = fmt.cache_statistics();
     assert_eq!(empty_stats.atom_cache_entries, 0);
+    assert_eq!(empty_stats.application_reduction_cache_entries, 0);
+    assert_eq!(empty_stats.recursive_alias_base_cache_entries, 0);
     assert!(empty_stats.estimated_size_bytes > 0);
 
     assert_eq!(&*fmt.atom(atom), "cachedName");
@@ -17,6 +19,31 @@ fn type_formatter_cache_statistics_account_for_atom_cache_entries_and_size() {
     assert_eq!(
         fmt.cache_statistics().atom_cache_entries,
         populated_stats.atom_cache_entries
+    );
+}
+
+#[test]
+fn type_formatter_cache_statistics_account_for_application_memos() {
+    let db = TypeInterner::new();
+    let fmt = TypeFormatter::new(&db);
+
+    let empty_stats = fmt.cache_statistics();
+    assert_eq!(empty_stats.application_reduction_cache_entries, 0);
+    assert_eq!(empty_stats.recursive_alias_base_cache_entries, 0);
+
+    fmt.application_reduction_cache
+        .borrow_mut()
+        .insert(TypeId::STRING, Some(TypeId::NUMBER));
+    fmt.recursive_alias_base_cache
+        .borrow_mut()
+        .insert(TypeId::OBJECT, false);
+
+    let populated_stats = fmt.cache_statistics();
+    assert_eq!(populated_stats.application_reduction_cache_entries, 1);
+    assert_eq!(populated_stats.recursive_alias_base_cache_entries, 1);
+    assert!(
+        populated_stats.estimated_size_bytes > empty_stats.estimated_size_bytes,
+        "populated formatter application memo caches must be visible to residency estimates",
     );
 }
 

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -742,6 +742,8 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
 pub struct SubtypeCheckerCacheStatistics {
     /// Entries in the evaluation memo keyed by input `TypeId` and evaluation mode.
     pub eval_entries: usize,
+    /// Entries in the instance-local relation memo for unshared relation verdicts.
+    pub local_relation_entries: usize,
     estimated_size_bytes: usize,
 }
 
@@ -1093,18 +1095,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     #[must_use]
     pub fn cache_statistics(&self) -> SubtypeCheckerCacheStatistics {
         let eval_entries = self.eval_cache.len();
+        let local_relation_entries = self.local_relation_cache.len();
         let estimated_size_bytes = eval_entries
             .saturating_mul(std::mem::size_of::<(
                 EvaluationCacheKey,
                 RelationEvaluationResult,
             )>())
             .saturating_add(
-                self.local_relation_cache
-                    .len()
+                local_relation_entries
                     .saturating_mul(std::mem::size_of::<(RelationCacheKey, bool)>()),
             );
         SubtypeCheckerCacheStatistics {
             eval_entries,
+            local_relation_entries,
             estimated_size_bytes,
         }
     }

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_00.rs
@@ -30,6 +30,7 @@ fn subtype_checker_cache_statistics_account_for_eval_entries() {
 
     let empty = checker.cache_statistics();
     assert_eq!(empty.eval_entries, 0);
+    assert_eq!(empty.local_relation_entries, 0);
     assert_eq!(empty.estimated_size_bytes(), 0);
 
     let union = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
@@ -51,6 +52,32 @@ fn subtype_checker_cache_statistics_account_for_eval_entries() {
 
     checker.reset();
     assert_eq!(checker.cache_statistics().eval_entries, 0);
+}
+
+#[test]
+fn subtype_checker_cache_statistics_account_for_local_relation_entries_and_reset() {
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+    let key = checker.debug_cache_key_for(TypeId::STRING, TypeId::NUMBER);
+
+    let empty = checker.cache_statistics();
+    assert_eq!(empty.local_relation_entries, 0);
+    assert_eq!(empty.estimated_size_bytes(), 0);
+
+    checker.local_relation_cache.insert(key, false);
+
+    let populated = checker.cache_statistics();
+    assert_eq!(populated.eval_entries, 0);
+    assert_eq!(populated.local_relation_entries, 1);
+    assert!(
+        populated.estimated_size_bytes() > empty.estimated_size_bytes(),
+        "populated subtype local relation cache should report nonzero estimated residency",
+    );
+
+    checker.reset();
+    let reset = checker.cache_statistics();
+    assert_eq!(reset.local_relation_entries, 0);
+    assert_eq!(reset.estimated_size_bytes(), 0);
 }
 
 #[test]

--- a/scripts/perf/test_cache_visibility_report.py
+++ b/scripts/perf/test_cache_visibility_report.py
@@ -433,6 +433,35 @@ class CacheVisibilityReportTests(unittest.TestCase):
                 self.assertIn(name, by_name)
                 self.assertFalse(by_name[name].needs_review, by_name[name])
 
+    def test_subtype_checker_local_relation_cache_is_visible(self):
+        root = Path(__file__).resolve().parents[2]
+        candidates = self.module.scan([root / "crates/tsz-solver/src/relations/subtype"])
+        local_relation_cache = [
+            candidate
+            for candidate in candidates
+            if candidate.path == "crates/tsz-solver/src/relations/subtype/core.rs"
+            and candidate.owner == "SubtypeChecker"
+            and candidate.name == "local_relation_cache"
+        ]
+
+        self.assertEqual(len(local_relation_cache), 1)
+        self.assertFalse(local_relation_cache[0].needs_review, local_relation_cache[0])
+
+    def test_type_formatter_application_memos_are_visible(self):
+        root = Path(__file__).resolve().parents[2]
+        candidates = self.module.scan([root / "crates/tsz-solver/src/diagnostics/format"])
+        by_name = {
+            candidate.name: candidate
+            for candidate in candidates
+            if candidate.path == "crates/tsz-solver/src/diagnostics/format/mod.rs"
+            and candidate.owner == "TypeFormatter"
+        }
+
+        for name in ("application_reduction_cache", "recursive_alias_base_cache"):
+            with self.subTest(name=name):
+                self.assertIn(name, by_name)
+                self.assertFalse(by_name[name].needs_review, by_name[name])
+
     def test_default_roots_include_binder_cache_surfaces(self):
         self.assertIn("crates/tsz-binder/src", self.module.DEFAULT_ROOTS)
 


### PR DESCRIPTION
Goal: fast

## Summary
- Expose `SubtypeChecker.local_relation_cache` entry counts through operation-local subtype cache statistics.
- Expose `TypeFormatter` application-reduction and recursive-alias memo entry counts, and include both memo maps in formatter size accounting.
- Move formatter cache accounting into a small sibling module so `format/mod.rs` stays below the 2000-line cap while adding the observability fields.
- Add Rust and Python guard tests so `cache-visibility-report.py` sees all three operation-local solver cache surfaces as covered.

## Structural Rule
When operation-local solver caches live for one relation or diagnostic-formatting request, tsz exposes their entry counts and estimated resident size through the owning solver statistics surface. This PR does not change cache keys, invalidation, reset behavior, or semantic answers; it only makes existing request-local residency measurable for #14351.

## Verification
- `git diff --check`
- `scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-solver -E 'test(subtype_checker_cache_statistics_account_for_local_relation_entries_and_reset) or test(type_formatter_cache_statistics_account_for_application_memos)'`
- `python3 -m unittest scripts/perf/test_cache_visibility_report.py`
- `python3 scripts/perf/cache-visibility-report.py --json` plus a focused JSON probe for `SubtypeChecker.local_relation_cache` and the two `TypeFormatter` memo rows
- `scripts/safe-run.sh -- cargo check -p tsz-solver --tests`
- `scripts/safe-run.sh -- cargo clippy -p tsz-solver --tests -- -D warnings`
- `wc -l crates/tsz-solver/src/diagnostics/format/mod.rs crates/tsz-solver/src/diagnostics/format/cache_accounting.rs` (`format/mod.rs` is 1981 lines)
- Full PR CI owns broad conformance, emit, fourslash, and unit gates.

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high
