### PR TITLE
perf(checker): expose checker cache residency (#14351)

### DIFF
--- a/crates/tsz-checker/src/context/aliases.rs
+++ b/crates/tsz-checker/src/context/aliases.rs
@@ -31,12 +31,42 @@ pub(crate) type AccessorLevelsCacheValue = Option<(
 pub(crate) type AccessorLevelsCache =
     RefCell<FxHashMap<(NodeIndex, Atom, bool), AccessorLevelsCacheValue>>;
 
+#[must_use]
+pub(crate) fn accessor_levels_cache_entries(cache: &AccessorLevelsCache) -> usize {
+    cache.borrow().len()
+}
+
+#[must_use]
+pub(crate) fn accessor_levels_cache_estimated_size_bytes(cache: &AccessorLevelsCache) -> usize {
+    let cache = cache.borrow();
+    cache.capacity()
+        * (std::mem::size_of::<(NodeIndex, Atom, bool)>()
+            + std::mem::size_of::<AccessorLevelsCacheValue>()
+            + 8)
+}
+
 /// Per-file memo mapping `(class node, member-name Atom, is_static)` to the
 /// access-restriction classification produced by `find_member_access_info`,
 /// or `None` when the member is public/absent. Backs
 /// [`crate::context::CheckerContext::member_access_info_cache`].
 pub(crate) type MemberAccessInfoCache =
     RefCell<FxHashMap<(NodeIndex, Atom, bool), Option<crate::state::MemberAccessInfo>>>;
+
+#[must_use]
+pub(crate) fn member_access_info_cache_entries(cache: &MemberAccessInfoCache) -> usize {
+    cache.borrow().len()
+}
+
+#[must_use]
+pub(crate) fn member_access_info_cache_estimated_size_bytes(
+    cache: &MemberAccessInfoCache,
+) -> usize {
+    let cache = cache.borrow();
+    cache.capacity()
+        * (std::mem::size_of::<(NodeIndex, Atom, bool)>()
+            + std::mem::size_of::<Option<crate::state::MemberAccessInfo>>()
+            + 8)
+}
 
 /// Per-file memo for the contextual-callback return-type mismatch derivation
 /// (`raw_block_body_callback_mismatch`). Maps the inline callback argument node
@@ -45,9 +75,35 @@ pub(crate) type MemberAccessInfoCache =
 /// forced. Backs [`crate::context::CheckerContext::callback_mismatch_memo`].
 pub type CallbackMismatchMemo = FxHashMap<(NodeIndex, TypeId), Option<(usize, TypeId, TypeId)>>;
 
+#[must_use]
+pub(crate) fn callback_mismatch_memo_entries(cache: &CallbackMismatchMemo) -> usize {
+    cache.len()
+}
+
+#[must_use]
+pub(crate) fn callback_mismatch_memo_estimated_size_bytes(cache: &CallbackMismatchMemo) -> usize {
+    cache.capacity()
+        * (std::mem::size_of::<(NodeIndex, TypeId)>()
+            + std::mem::size_of::<Option<(usize, TypeId, TypeId)>>()
+            + 8)
+}
+
 /// Flow-analysis result memo: `(FlowNodeId, SymbolId, InitialTypeId) ->
 /// NarrowedTypeId`.
 pub type FlowAnalysisCacheMap = FxHashMap<(tsz_binder::FlowNodeId, SymbolId, TypeId), TypeId>;
+
+#[must_use]
+pub(crate) fn flow_analysis_cache_map_entries(cache: &FlowAnalysisCacheMap) -> usize {
+    cache.len()
+}
+
+#[must_use]
+pub(crate) fn flow_analysis_cache_map_estimated_size_bytes(cache: &FlowAnalysisCacheMap) -> usize {
+    cache.capacity()
+        * (std::mem::size_of::<(tsz_binder::FlowNodeId, SymbolId, TypeId)>()
+            + std::mem::size_of::<TypeId>()
+            + 8)
+}
 
 /// Stable-flow confirmation memo: `(SymbolId, DeclaredTypeId)` to the last
 /// `FlowNodeId` where flow analysis confirmed no narrowing.
@@ -116,6 +172,25 @@ pub type NamespaceExportsCache = FxHashMap<(usize, String), Option<SymbolTable>>
 /// programs (e.g. `ts-morph`) otherwise re-walk the entire `export *` graph
 /// from scratch for every distinct name, costing `O(names × export-edges)`.
 pub type ReexportResolutionCache = FxHashMap<(usize, String), Option<(SymbolId, usize)>>;
+
+#[must_use]
+pub(crate) fn reexport_resolution_cache_entries(cache: &ReexportResolutionCache) -> usize {
+    cache.len()
+}
+
+#[must_use]
+pub(crate) fn reexport_resolution_cache_estimated_size_bytes(
+    cache: &ReexportResolutionCache,
+) -> usize {
+    let mut size = cache.capacity()
+        * (std::mem::size_of::<(usize, String)>()
+            + std::mem::size_of::<Option<(SymbolId, usize)>>()
+            + 8);
+    for (_, export_name) in cache.keys() {
+        size += export_name.capacity();
+    }
+    size
+}
 
 #[must_use]
 pub(crate) fn namespace_exports_cache_entries(cache: &NamespaceExportsCache) -> usize {
@@ -279,6 +354,69 @@ mod tests {
                 >= 2 * (std::mem::size_of::<(usize, String)>()
                     + std::mem::size_of::<Option<SymbolTable>>())
         );
+    }
+
+    #[test]
+    fn file_session_alias_caches_report_entries_and_size() {
+        let accessor_cache = AccessorLevelsCache::default();
+        assert_eq!(accessor_levels_cache_entries(&accessor_cache), 0);
+        assert_eq!(
+            accessor_levels_cache_estimated_size_bytes(&accessor_cache),
+            0
+        );
+        accessor_cache
+            .borrow_mut()
+            .insert((NodeIndex(1), Atom(2), false), None);
+        assert_eq!(accessor_levels_cache_entries(&accessor_cache), 1);
+        assert!(accessor_levels_cache_estimated_size_bytes(&accessor_cache) > 0);
+
+        let member_cache = MemberAccessInfoCache::default();
+        assert_eq!(member_access_info_cache_entries(&member_cache), 0);
+        assert_eq!(
+            member_access_info_cache_estimated_size_bytes(&member_cache),
+            0
+        );
+        member_cache
+            .borrow_mut()
+            .insert((NodeIndex(3), Atom(4), true), None);
+        assert_eq!(member_access_info_cache_entries(&member_cache), 1);
+        assert!(member_access_info_cache_estimated_size_bytes(&member_cache) > 0);
+
+        let mut callback_cache = CallbackMismatchMemo::default();
+        assert_eq!(callback_mismatch_memo_entries(&callback_cache), 0);
+        assert_eq!(
+            callback_mismatch_memo_estimated_size_bytes(&callback_cache),
+            0
+        );
+        callback_cache.insert(
+            (NodeIndex(5), TypeId::STRING),
+            Some((1, TypeId::NUMBER, TypeId::BOOLEAN)),
+        );
+        assert_eq!(callback_mismatch_memo_entries(&callback_cache), 1);
+        assert!(callback_mismatch_memo_estimated_size_bytes(&callback_cache) > 0);
+    }
+
+    #[test]
+    fn retained_alias_caches_report_entries_and_size() {
+        let mut flow_cache = FlowAnalysisCacheMap::default();
+        assert_eq!(flow_analysis_cache_map_entries(&flow_cache), 0);
+        assert_eq!(flow_analysis_cache_map_estimated_size_bytes(&flow_cache), 0);
+        flow_cache.insert(
+            (tsz_binder::FlowNodeId(1), SymbolId(2), TypeId::STRING),
+            TypeId::NUMBER,
+        );
+        assert_eq!(flow_analysis_cache_map_entries(&flow_cache), 1);
+        assert!(flow_analysis_cache_map_estimated_size_bytes(&flow_cache) > 0);
+
+        let mut reexport_cache = ReexportResolutionCache::default();
+        assert_eq!(reexport_resolution_cache_entries(&reexport_cache), 0);
+        assert_eq!(
+            reexport_resolution_cache_estimated_size_bytes(&reexport_cache),
+            0
+        );
+        reexport_cache.insert((3, "value".to_string()), Some((SymbolId(4), 5)));
+        assert_eq!(reexport_resolution_cache_entries(&reexport_cache), 1);
+        assert!(reexport_resolution_cache_estimated_size_bytes(&reexport_cache) > 0);
     }
 
     #[test]

--- a/crates/tsz-checker/src/context/cache_statistics.rs
+++ b/crates/tsz-checker/src/context/cache_statistics.rs
@@ -8,12 +8,15 @@ use tsz_solver::def::DefId;
 use tsz_solver::{TypeId, TypeParamInfo};
 
 use super::{
-    CheckerContext, cross_file_type_params_cache_statistics, env_eval_cache,
-    export_equals_named_cache_entries, export_equals_named_cache_estimated_size_bytes,
-    namespace_member_resolution_cache_entries,
+    CheckerContext, accessor_levels_cache_entries, accessor_levels_cache_estimated_size_bytes,
+    callback_mismatch_memo_entries, callback_mismatch_memo_estimated_size_bytes,
+    cross_file_type_params_cache_statistics, env_eval_cache, export_equals_named_cache_entries,
+    export_equals_named_cache_estimated_size_bytes, member_access_info_cache_entries,
+    member_access_info_cache_estimated_size_bytes, namespace_member_resolution_cache_entries,
     namespace_member_resolution_cache_estimated_size_bytes,
     nested_namespace_candidates_cache_entries,
-    nested_namespace_candidates_cache_estimated_size_bytes,
+    nested_namespace_candidates_cache_estimated_size_bytes, reexport_resolution_cache_entries,
+    reexport_resolution_cache_estimated_size_bytes,
 };
 
 const HASH_MAP_ENTRY_OVERHEAD_ESTIMATE: usize = 8;
@@ -36,6 +39,8 @@ pub struct CheckerContextCacheStatistics {
     pub lazy_lib_member_resolution_cache_estimated_size_bytes: usize,
     pub symbol_name_candidates_cache_entries: usize,
     pub symbol_name_candidates_cache_estimated_size_bytes: usize,
+    pub suggestion_scan_cache_entries: usize,
+    pub suggestion_scan_cache_estimated_size_bytes: usize,
     pub namespace_member_resolution_cache_entries: usize,
     pub namespace_member_resolution_cache_estimated_size_bytes: usize,
     pub export_equals_named_cache_entries: usize,
@@ -44,6 +49,14 @@ pub struct CheckerContextCacheStatistics {
     pub nested_namespace_candidates_cache_estimated_size_bytes: usize,
     pub lowering_entity_name_resolution_cache_entries: usize,
     pub lowering_entity_name_resolution_cache_estimated_size_bytes: usize,
+    pub reexport_resolution_cache_entries: usize,
+    pub reexport_resolution_cache_estimated_size_bytes: usize,
+    pub member_access_info_cache_entries: usize,
+    pub member_access_info_cache_estimated_size_bytes: usize,
+    pub enclosing_class_declares_member_cache_entries: usize,
+    pub enclosing_class_declares_member_cache_estimated_size_bytes: usize,
+    pub accessor_levels_cache_entries: usize,
+    pub accessor_levels_cache_estimated_size_bytes: usize,
     pub shared_lib_type_cache_entries: usize,
     pub shared_lib_type_cache_estimated_size_bytes: usize,
     pub flow_analysis_cache_entries: usize,
@@ -52,6 +65,10 @@ pub struct CheckerContextCacheStatistics {
     pub flow_switch_reference_cache_estimated_size_bytes: usize,
     pub flow_numeric_atom_cache_entries: usize,
     pub flow_numeric_atom_cache_estimated_size_bytes: usize,
+    pub flow_switch_case_literal_cache_entries: usize,
+    pub flow_switch_case_literal_cache_estimated_size_bytes: usize,
+    pub flow_switch_all_distinct_literals_cache_entries: usize,
+    pub flow_switch_all_distinct_literals_cache_estimated_size_bytes: usize,
     pub flow_reference_match_cache_entries: usize,
     pub flow_reference_match_cache_estimated_size_bytes: usize,
     pub flow_alias_base_assignment_cache_entries: usize,
@@ -70,6 +87,14 @@ pub struct CheckerContextCacheStatistics {
     pub env_eval_cache_estimated_size_bytes: usize,
     pub contextual_signature_normalization_cache_entries: usize,
     pub contextual_signature_normalization_cache_estimated_size_bytes: usize,
+    pub lazy_def_ids_cache_entries: usize,
+    pub lazy_def_ids_cache_estimated_size_bytes: usize,
+    pub type_queries_cache_entries: usize,
+    pub type_queries_cache_estimated_size_bytes: usize,
+    pub type_position_resolution_cache_entries: usize,
+    pub type_position_resolution_cache_estimated_size_bytes: usize,
+    pub package_json_cache_entries: usize,
+    pub package_json_cache_estimated_size_bytes: usize,
     pub class_symbol_to_decl_cache_entries: usize,
     pub class_symbol_to_decl_cache_estimated_size_bytes: usize,
     pub heritage_symbol_cache_entries: usize,
@@ -78,6 +103,10 @@ pub struct CheckerContextCacheStatistics {
     pub base_constructor_expr_cache_estimated_size_bytes: usize,
     pub base_instance_expr_cache_entries: usize,
     pub base_instance_expr_cache_estimated_size_bytes: usize,
+    pub inferred_return_type_memo_entries: usize,
+    pub inferred_return_type_memo_estimated_size_bytes: usize,
+    pub callback_mismatch_memo_entries: usize,
+    pub callback_mismatch_memo_estimated_size_bytes: usize,
     pub jsx_intrinsic_props_cache_entries: usize,
     pub jsx_intrinsic_props_cache_estimated_size_bytes: usize,
 }
@@ -91,14 +120,21 @@ impl CheckerContextCacheStatistics {
             + self.lib_type_resolution_cache_estimated_size_bytes
             + self.lazy_lib_member_resolution_cache_estimated_size_bytes
             + self.symbol_name_candidates_cache_estimated_size_bytes
+            + self.suggestion_scan_cache_estimated_size_bytes
             + self.namespace_member_resolution_cache_estimated_size_bytes
             + self.export_equals_named_cache_estimated_size_bytes
             + self.nested_namespace_candidates_cache_estimated_size_bytes
             + self.lowering_entity_name_resolution_cache_estimated_size_bytes
+            + self.reexport_resolution_cache_estimated_size_bytes
+            + self.member_access_info_cache_estimated_size_bytes
+            + self.enclosing_class_declares_member_cache_estimated_size_bytes
+            + self.accessor_levels_cache_estimated_size_bytes
             + self.shared_lib_type_cache_estimated_size_bytes
             + self.flow_analysis_cache_estimated_size_bytes
             + self.flow_switch_reference_cache_estimated_size_bytes
             + self.flow_numeric_atom_cache_estimated_size_bytes
+            + self.flow_switch_case_literal_cache_estimated_size_bytes
+            + self.flow_switch_all_distinct_literals_cache_estimated_size_bytes
             + self.flow_reference_match_cache_estimated_size_bytes
             + self.flow_alias_base_assignment_cache_estimated_size_bytes
             + self.flow_alias_path_assignment_cache_estimated_size_bytes
@@ -108,10 +144,16 @@ impl CheckerContextCacheStatistics {
             + self.class_chain_summary_cache_estimated_size_bytes
             + self.env_eval_cache_estimated_size_bytes
             + self.contextual_signature_normalization_cache_estimated_size_bytes
+            + self.lazy_def_ids_cache_estimated_size_bytes
+            + self.type_queries_cache_estimated_size_bytes
+            + self.type_position_resolution_cache_estimated_size_bytes
+            + self.package_json_cache_estimated_size_bytes
             + self.class_symbol_to_decl_cache_estimated_size_bytes
             + self.heritage_symbol_cache_estimated_size_bytes
             + self.base_constructor_expr_cache_estimated_size_bytes
             + self.base_instance_expr_cache_estimated_size_bytes
+            + self.inferred_return_type_memo_estimated_size_bytes
+            + self.callback_mismatch_memo_estimated_size_bytes
             + self.jsx_intrinsic_props_cache_estimated_size_bytes
     }
 
@@ -123,14 +165,21 @@ impl CheckerContextCacheStatistics {
             + self.lib_type_resolution_cache_entries
             + self.lazy_lib_member_resolution_cache_entries
             + self.symbol_name_candidates_cache_entries
+            + self.suggestion_scan_cache_entries
             + self.namespace_member_resolution_cache_entries
             + self.export_equals_named_cache_entries
             + self.nested_namespace_candidates_cache_entries
             + self.lowering_entity_name_resolution_cache_entries
+            + self.reexport_resolution_cache_entries
+            + self.member_access_info_cache_entries
+            + self.enclosing_class_declares_member_cache_entries
+            + self.accessor_levels_cache_entries
             + self.shared_lib_type_cache_entries
             + self.flow_analysis_cache_entries
             + self.flow_switch_reference_cache_entries
             + self.flow_numeric_atom_cache_entries
+            + self.flow_switch_case_literal_cache_entries
+            + self.flow_switch_all_distinct_literals_cache_entries
             + self.flow_reference_match_cache_entries
             + self.flow_alias_base_assignment_cache_entries
             + self.flow_alias_path_assignment_cache_entries
@@ -140,10 +189,16 @@ impl CheckerContextCacheStatistics {
             + self.class_chain_summary_cache_entries
             + self.env_eval_cache_entries
             + self.contextual_signature_normalization_cache_entries
+            + self.lazy_def_ids_cache_entries
+            + self.type_queries_cache_entries
+            + self.type_position_resolution_cache_entries
+            + self.package_json_cache_entries
             + self.class_symbol_to_decl_cache_entries
             + self.heritage_symbol_cache_entries
             + self.base_constructor_expr_cache_entries
             + self.base_instance_expr_cache_entries
+            + self.inferred_return_type_memo_entries
+            + self.callback_mismatch_memo_entries
             + self.jsx_intrinsic_props_cache_entries
     }
 }
@@ -168,14 +223,27 @@ impl<'a> CheckerContext<'a> {
             .lazy_member_receiver_properties
             .borrow();
         let symbol_name_candidates_cache = self.symbol_name_candidates_cache.borrow();
+        let suggestion_scan_cache = self
+            .name_resolution_diagnostics
+            .suggestion_scan_cache
+            .borrow();
         let namespace_member_resolution_cache = self.namespace_member_resolution_cache.borrow();
         let export_equals_named_cache = self.export_equals_named_cache.borrow();
         let nested_namespace_candidates_cache = self.nested_namespace_candidates_cache.borrow();
         let lowering_entity_name_resolution_cache =
             self.lowering_entity_name_resolution_cache.borrow();
+        let reexport_resolution_cache = self.reexport_resolution_cache.borrow();
+        let enclosing_class_declares_member_cache =
+            self.enclosing_class_declares_member_cache.borrow();
         let flow_analysis_cache = self.flow_shared.flow_analysis_cache.borrow();
         let flow_switch_reference_cache = self.flow_shared.flow_switch_reference_cache.borrow();
         let flow_numeric_atom_cache = self.flow_shared.flow_numeric_atom_cache.borrow();
+        let flow_switch_case_literal_cache =
+            self.flow_shared.flow_switch_case_literal_cache.borrow();
+        let flow_switch_all_distinct_literals_cache = self
+            .flow_shared
+            .flow_switch_all_distinct_literals_cache
+            .borrow();
         let flow_reference_match_cache = self.flow_shared.flow_reference_match_cache.borrow();
         let flow_alias_base_assignment_cache = self
             .flow_shared
@@ -191,6 +259,10 @@ impl<'a> CheckerContext<'a> {
         let class_constructor_type_cache = self.class_constructor_type_cache.borrow();
         let class_chain_summary_cache = self.class_chain_summary_cache.borrow();
         let env_eval_cache = self.env_eval_cache.borrow();
+        let lazy_def_ids_cache = self.lazy_def_ids_cache.borrow();
+        let type_queries_cache = self.type_queries_cache.borrow();
+        let type_position_resolution_cache = self.type_position_resolution_cache.borrow();
+        let package_json_cache = self.package_json_cache.borrow();
         let class_symbol_to_decl_cache = self.class_symbol_to_decl_cache.borrow();
         let heritage_symbol_cache = self.heritage_symbol_cache.borrow();
         let base_constructor_expr_cache = self.base_constructor_expr_cache.borrow();
@@ -242,6 +314,10 @@ impl<'a> CheckerContext<'a> {
             symbol_name_candidates_cache_entries: symbol_name_candidates_cache.len(),
             symbol_name_candidates_cache_estimated_size_bytes:
                 string_symbol_vec_cache_estimated_size_bytes(&symbol_name_candidates_cache),
+            suggestion_scan_cache_entries: suggestion_scan_cache.len(),
+            suggestion_scan_cache_estimated_size_bytes: keyed_string_vec_cache_estimated_size_bytes(
+                &suggestion_scan_cache,
+            ),
             namespace_member_resolution_cache_entries: namespace_member_resolution_cache_entries(
                 &namespace_member_resolution_cache,
             ),
@@ -265,6 +341,26 @@ impl<'a> CheckerContext<'a> {
                 .len(),
             lowering_entity_name_resolution_cache_estimated_size_bytes:
                 string_option_def_cache_estimated_size_bytes(&lowering_entity_name_resolution_cache),
+            reexport_resolution_cache_entries: reexport_resolution_cache_entries(
+                &reexport_resolution_cache,
+            ),
+            reexport_resolution_cache_estimated_size_bytes:
+                reexport_resolution_cache_estimated_size_bytes(&reexport_resolution_cache),
+            member_access_info_cache_entries: member_access_info_cache_entries(
+                &self.member_access_info_cache,
+            ),
+            member_access_info_cache_estimated_size_bytes:
+                member_access_info_cache_estimated_size_bytes(&self.member_access_info_cache),
+            enclosing_class_declares_member_cache_entries: enclosing_class_declares_member_cache
+                .len(),
+            enclosing_class_declares_member_cache_estimated_size_bytes:
+                fx_hash_map_estimated_size_bytes(&enclosing_class_declares_member_cache),
+            accessor_levels_cache_entries: accessor_levels_cache_entries(
+                &self.accessor_levels_cache,
+            ),
+            accessor_levels_cache_estimated_size_bytes: accessor_levels_cache_estimated_size_bytes(
+                &self.accessor_levels_cache,
+            ),
             shared_lib_type_cache_entries,
             shared_lib_type_cache_estimated_size_bytes,
             flow_analysis_cache_entries: flow_analysis_cache.len(),
@@ -279,6 +375,14 @@ impl<'a> CheckerContext<'a> {
             flow_numeric_atom_cache_estimated_size_bytes: fx_hash_map_estimated_size_bytes(
                 &flow_numeric_atom_cache,
             ),
+            flow_switch_case_literal_cache_entries: flow_switch_case_literal_cache.len(),
+            flow_switch_case_literal_cache_estimated_size_bytes: fx_hash_map_estimated_size_bytes(
+                &flow_switch_case_literal_cache,
+            ),
+            flow_switch_all_distinct_literals_cache_entries:
+                flow_switch_all_distinct_literals_cache.len(),
+            flow_switch_all_distinct_literals_cache_estimated_size_bytes:
+                fx_hash_map_estimated_size_bytes(&flow_switch_all_distinct_literals_cache),
             flow_reference_match_cache_entries: flow_reference_match_cache.len(),
             flow_reference_match_cache_estimated_size_bytes: fx_hash_map_estimated_size_bytes(
                 &flow_reference_match_cache,
@@ -325,6 +429,22 @@ impl<'a> CheckerContext<'a> {
                         .saturating_add(mem::size_of::<TypeId>())
                         .saturating_add(HASH_MAP_ENTRY_OVERHEAD_ESTIMATE),
                 ),
+            lazy_def_ids_cache_entries: lazy_def_ids_cache.len(),
+            lazy_def_ids_cache_estimated_size_bytes: type_id_rc_slice_cache_estimated_size_bytes(
+                &lazy_def_ids_cache,
+            ),
+            type_queries_cache_entries: type_queries_cache.len(),
+            type_queries_cache_estimated_size_bytes: type_id_rc_slice_cache_estimated_size_bytes(
+                &type_queries_cache,
+            ),
+            type_position_resolution_cache_entries: type_position_resolution_cache.len(),
+            type_position_resolution_cache_estimated_size_bytes: fx_hash_map_estimated_size_bytes(
+                &type_position_resolution_cache,
+            ),
+            package_json_cache_entries: package_json_cache.len(),
+            package_json_cache_estimated_size_bytes: package_json_cache_estimated_size_bytes(
+                &package_json_cache,
+            ),
             class_symbol_to_decl_cache_entries: class_symbol_to_decl_cache.len(),
             class_symbol_to_decl_cache_estimated_size_bytes: fx_hash_map_estimated_size_bytes(
                 &class_symbol_to_decl_cache,
@@ -341,6 +461,15 @@ impl<'a> CheckerContext<'a> {
             base_instance_expr_cache_estimated_size_bytes: fx_hash_map_estimated_size_bytes(
                 &base_instance_expr_cache,
             ),
+            inferred_return_type_memo_entries: self.inferred_return_type_memo.len(),
+            inferred_return_type_memo_estimated_size_bytes: fx_hash_map_estimated_size_bytes(
+                &self.inferred_return_type_memo,
+            ),
+            callback_mismatch_memo_entries: callback_mismatch_memo_entries(
+                &self.callback_mismatch_memo,
+            ),
+            callback_mismatch_memo_estimated_size_bytes:
+                callback_mismatch_memo_estimated_size_bytes(&self.callback_mismatch_memo),
             jsx_intrinsic_props_cache_entries: self.jsx_intrinsic_props_cache.len(),
             jsx_intrinsic_props_cache_estimated_size_bytes: fx_hash_map_estimated_size_bytes(
                 &self.jsx_intrinsic_props_cache,
@@ -354,6 +483,28 @@ fn fx_hash_map_estimated_size_bytes<K, V>(cache: &FxHashMap<K, V>) -> usize {
         mem::size_of::<K>()
             .saturating_add(mem::size_of::<V>())
             .saturating_add(HASH_MAP_ENTRY_OVERHEAD_ESTIMATE),
+    )
+}
+
+fn type_id_rc_slice_cache_estimated_size_bytes<T>(
+    cache: &FxHashMap<TypeId, std::rc::Rc<[T]>>,
+) -> usize {
+    fx_hash_map_estimated_size_bytes(cache).saturating_add(
+        cache
+            .values()
+            .map(|items| items.len().saturating_mul(mem::size_of::<T>()))
+            .sum::<usize>(),
+    )
+}
+
+fn package_json_cache_estimated_size_bytes(
+    cache: &FxHashMap<std::path::PathBuf, Option<std::rc::Rc<serde_json::Value>>>,
+) -> usize {
+    fx_hash_map_estimated_size_bytes(cache).saturating_add(
+        cache
+            .keys()
+            .map(|path| path.as_os_str().len())
+            .sum::<usize>(),
     )
 }
 
@@ -380,6 +531,20 @@ fn def_atom_option_type_cache_estimated_size_bytes(
     cache: &FxHashMap<(DefId, Atom), Option<TypeId>>,
 ) -> usize {
     fx_hash_map_estimated_size_bytes(cache)
+}
+
+fn keyed_string_vec_cache_estimated_size_bytes<K>(cache: &FxHashMap<K, Vec<String>>) -> usize {
+    fx_hash_map_estimated_size_bytes(cache).saturating_add(
+        cache
+            .values()
+            .map(|values| {
+                values
+                    .capacity()
+                    .saturating_mul(mem::size_of::<String>())
+                    .saturating_add(values.iter().map(String::len).sum::<usize>())
+            })
+            .sum::<usize>(),
+    )
 }
 
 fn string_symbol_vec_cache_estimated_size_bytes(cache: &FxHashMap<String, Vec<SymbolId>>) -> usize {
@@ -416,5 +581,32 @@ mod tests {
 
         assert_eq!(cache.len(), 1);
         assert!(type_param_node_cache_estimated_size_bytes(&cache) > 0);
+    }
+
+    #[test]
+    fn suggestion_scan_cache_statistics_report_entries_and_size() {
+        let mut cache = FxHashMap::default();
+        assert_eq!(keyed_string_vec_cache_estimated_size_bytes(&cache), 0);
+
+        cache.insert((7, 1), vec!["candidate".to_string()]);
+
+        assert_eq!(cache.len(), 1);
+        assert!(keyed_string_vec_cache_estimated_size_bytes(&cache) > 0);
+    }
+
+    #[test]
+    fn checker_context_cache_statistics_roll_up_diagnostic_and_switch_caches() {
+        let stats = CheckerContextCacheStatistics {
+            suggestion_scan_cache_entries: 1,
+            suggestion_scan_cache_estimated_size_bytes: 2,
+            flow_switch_case_literal_cache_entries: 4,
+            flow_switch_case_literal_cache_estimated_size_bytes: 8,
+            flow_switch_all_distinct_literals_cache_entries: 16,
+            flow_switch_all_distinct_literals_cache_estimated_size_bytes: 32,
+            ..CheckerContextCacheStatistics::default()
+        };
+
+        assert_eq!(stats.entries(), 21);
+        assert_eq!(stats.estimated_size_bytes(), 42);
     }
 }

--- a/crates/tsz-checker/src/error_reporter/display_budget.rs
+++ b/crates/tsz-checker/src/error_reporter/display_budget.rs
@@ -32,6 +32,7 @@
 
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
+use std::mem;
 use tsz_solver::TypeId;
 
 /// Maximum normalization-tree node visits per rendered type.
@@ -129,6 +130,9 @@ impl Drop for DisplayBudgetScope {
                         tracing::debug!(
                             visits_left = budget.visits,
                             eval_fuel_left = budget.eval_fuel,
+                            eval_memo_entries = budget.eval_memo.len(),
+                            eval_memo_estimated_size_bytes =
+                                eval_memo_estimated_size_bytes(&budget.eval_memo),
                             "display normalization budget exhausted; type rendered truncated"
                         );
                     }
@@ -221,6 +225,14 @@ pub(crate) fn record_eval(type_id: TypeId, result: TypeId) {
     });
 }
 
+fn eval_memo_estimated_size_bytes(cache: &FxHashMap<TypeId, TypeId>) -> usize {
+    cache.capacity().saturating_mul(
+        mem::size_of::<TypeId>()
+            .saturating_add(mem::size_of::<TypeId>())
+            .saturating_add(8),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -288,6 +300,18 @@ mod tests {
         }
         let _scope = DisplayBudgetScope::enter();
         assert_eq!(cached_eval(TypeId::STRING), None);
+    }
+
+    #[test]
+    fn eval_memo_statistics_report_entries_and_size() {
+        let mut eval_memo = FxHashMap::default();
+        assert_eq!(eval_memo.len(), 0);
+        assert_eq!(eval_memo_estimated_size_bytes(&eval_memo), 0);
+
+        eval_memo.insert(TypeId::STRING, TypeId::NUMBER);
+
+        assert_eq!(eval_memo.len(), 1);
+        assert!(eval_memo_estimated_size_bytes(&eval_memo) > 0);
     }
 
     #[test]

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -379,6 +379,34 @@ type AliasBaseAssignmentCache = RefCell<FxHashMap<AliasBaseAssignmentKey, bool>>
 type AliasPathAssignmentKey = (u32, u32, u32);
 type AliasPathAssignmentCache = RefCell<FxHashMap<AliasPathAssignmentKey, bool>>;
 
+#[must_use]
+pub(crate) fn alias_base_assignment_cache_entries(cache: &AliasBaseAssignmentCache) -> usize {
+    cache.borrow().len()
+}
+
+#[must_use]
+pub(crate) fn alias_base_assignment_cache_estimated_size_bytes(
+    cache: &AliasBaseAssignmentCache,
+) -> usize {
+    let cache = cache.borrow();
+    cache.capacity()
+        * (std::mem::size_of::<AliasBaseAssignmentKey>() + std::mem::size_of::<bool>() + 8)
+}
+
+#[must_use]
+pub(crate) fn alias_path_assignment_cache_entries(cache: &AliasPathAssignmentCache) -> usize {
+    cache.borrow().len()
+}
+
+#[must_use]
+pub(crate) fn alias_path_assignment_cache_estimated_size_bytes(
+    cache: &AliasPathAssignmentCache,
+) -> usize {
+    let cache = cache.borrow();
+    cache.capacity()
+        * (std::mem::size_of::<AliasPathAssignmentKey>() + std::mem::size_of::<bool>() + 8)
+}
+
 /// Flow analyzer for control flow-based type narrowing.
 ///
 /// Walks the control flow graph backwards from a reference point to determine

--- a/crates/tsz-checker/src/flow/control_flow/core_tests.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core_tests.rs
@@ -1,6 +1,8 @@
-use super::{FLOW_STEP_BUDGET_MAX, FLOW_STEP_BUDGET_MIN, FLOW_STEP_BUDGET_SCALE, flow_step_budget};
 use super::{
-    FlowCache, ReferenceMatchCache, ReferenceSymbolCache, flow_cache_entries,
+    AliasBaseAssignmentCache, AliasPathAssignmentCache, FlowCache, ReferenceMatchCache,
+    ReferenceSymbolCache, alias_base_assignment_cache_entries,
+    alias_base_assignment_cache_estimated_size_bytes, alias_path_assignment_cache_entries,
+    alias_path_assignment_cache_estimated_size_bytes, flow_cache_entries,
     flow_cache_estimated_size_bytes, numeric_atom_cache_entries,
     numeric_atom_cache_estimated_size_bytes, reference_match_cache_entries,
     reference_match_cache_estimated_size_bytes, reference_symbol_cache_entries,
@@ -8,6 +10,7 @@ use super::{
     shared_numeric_atom_cache_estimated_size_bytes, switch_reference_cache_entries,
     switch_reference_cache_estimated_size_bytes,
 };
+use super::{FLOW_STEP_BUDGET_MAX, FLOW_STEP_BUDGET_MIN, FLOW_STEP_BUDGET_SCALE, flow_step_budget};
 use rustc_hash::FxHashMap;
 use std::cell::RefCell;
 use tsz_binder::{FlowNodeId, SymbolId};
@@ -142,4 +145,27 @@ fn shared_numeric_atom_cache_statistics_report_borrowed_entries_and_zero_owned_s
         shared_numeric_atom_cache_estimated_size_bytes(Some(&cache)),
         0
     );
+}
+
+#[test]
+fn alias_assignment_cache_statistics_report_entries_and_size() {
+    let base_cache = AliasBaseAssignmentCache::default();
+    assert_eq!(alias_base_assignment_cache_entries(&base_cache), 0);
+    assert_eq!(
+        alias_base_assignment_cache_estimated_size_bytes(&base_cache),
+        0
+    );
+    base_cache.borrow_mut().insert((1, 2), true);
+    assert_eq!(alias_base_assignment_cache_entries(&base_cache), 1);
+    assert!(alias_base_assignment_cache_estimated_size_bytes(&base_cache) > 0);
+
+    let path_cache = AliasPathAssignmentCache::default();
+    assert_eq!(alias_path_assignment_cache_entries(&path_cache), 0);
+    assert_eq!(
+        alias_path_assignment_cache_estimated_size_bytes(&path_cache),
+        0
+    );
+    path_cache.borrow_mut().insert((1, 2, 3), false);
+    assert_eq!(alias_path_assignment_cache_entries(&path_cache), 1);
+    assert!(alias_path_assignment_cache_estimated_size_bytes(&path_cache) > 0);
 }

--- a/scripts/perf/cache-visibility-report.py
+++ b/scripts/perf/cache-visibility-report.py
@@ -271,23 +271,40 @@ def scan_file(path: Path, signal_text: str | None = None) -> list[CacheCandidate
     signal_text = signal_text if signal_text is not None else file_text
     rel = relative(path)
     owner = "<module>"
+    pending_owner: str | None = None
     struct_depth = 0
     candidates: list[CacheCandidate] = []
     index = 0
     while index < len(code_lines):
         line = code_lines[index]
         line_no = index + 1
+        opened_pending_on_line = False
+        if pending_owner is not None and "{" in line:
+            owner = pending_owner
+            pending_owner = None
+            struct_depth = line.count("{") - line.count("}")
+            opened_pending_on_line = True
+            if struct_depth <= 0:
+                owner = "<module>"
+                struct_depth = 0
+
         struct_match = STRUCT_RE.search(line)
         if struct_match:
-            owner = struct_match.group(1)
-            struct_depth = max(1, line.count("{") - line.count("}"))
+            if "{" in line:
+                owner = struct_match.group(1)
+                struct_depth = line.count("{") - line.count("}")
+                if struct_depth <= 0:
+                    owner = "<module>"
+                    struct_depth = 0
+            elif ";" not in line:
+                pending_owner = struct_match.group(1)
 
         alias_match = TYPE_ALIAS_RE.search(line)
         match = alias_match
         if match is None and struct_depth > 0:
             match = FIELD_RE.search(line)
         if not match:
-            if struct_depth > 0 and not struct_match:
+            if struct_depth > 0 and not struct_match and not opened_pending_on_line:
                 struct_depth += line.count("{") - line.count("}")
                 if struct_depth <= 0:
                     owner = "<module>"
@@ -296,7 +313,7 @@ def scan_file(path: Path, signal_text: str | None = None) -> list[CacheCandidate
         name = match.group("name")
         type_text, end_index = collect_type_text(code_lines, index, match.group("type"))
         if not is_cache_type(type_text):
-            if struct_depth > 0 and not struct_match:
+            if struct_depth > 0 and not struct_match and not opened_pending_on_line:
                 for depth_line in code_lines[index : end_index + 1]:
                     struct_depth += depth_line.count("{") - depth_line.count("}")
                 if struct_depth <= 0:
@@ -315,7 +332,7 @@ def scan_file(path: Path, signal_text: str | None = None) -> list[CacheCandidate
                 size_signal=has_size_signal(signal_text, name),
             )
         )
-        if struct_depth > 0 and not struct_match:
+        if struct_depth > 0 and not struct_match and not opened_pending_on_line:
             for depth_line in code_lines[index : end_index + 1]:
                 struct_depth += depth_line.count("{") - depth_line.count("}")
             if struct_depth <= 0:

--- a/scripts/perf/test_cache_visibility_report.py
+++ b/scripts/perf/test_cache_visibility_report.py
@@ -222,6 +222,38 @@ class CacheVisibilityReportTests(unittest.TestCase):
         self.assertEqual(candidates[0].owner, "<module>")
         self.assertEqual(candidates[0].name, "Cache")
 
+    def test_unit_structs_do_not_capture_later_local_maps(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write(
+                root,
+                "src/lib.rs",
+                "\n".join(
+                    [
+                        "pub struct DisplayBudget {",
+                        "    eval_memo: FxHashMap<TypeId, TypeId>,",
+                        "}",
+                        "pub struct DisplayBudgetScope;",
+                        "impl DisplayBudgetScope {",
+                        "    pub fn enter() {",
+                        "        let _budget = DisplayBudget {",
+                        "            eval_memo: FxHashMap::default(),",
+                        "        };",
+                        "    }",
+                        "}",
+                        "fn helper(memo: &mut FxHashMap<TypeId, bool>) {",
+                        "    memo.insert(TypeId::STRING, true);",
+                        "}",
+                    ]
+                )
+                + "\n",
+            )
+            candidates = self.module.scan([root / "src"])
+
+        self.assertEqual([(candidate.owner, candidate.name) for candidate in candidates], [
+            ("DisplayBudget", "eval_memo")
+        ])
+
     def test_multiline_cache_field_type_is_reported(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -390,6 +422,131 @@ class CacheVisibilityReportTests(unittest.TestCase):
 
         self.assertEqual(len(candidates), 1)
         self.assertFalse(candidates[0].needs_review)
+
+    def test_checker_retained_cache_surfaces_are_visible(self):
+        root = Path(__file__).resolve().parents[2]
+        candidates = self.module.scan(
+            [
+                root / "crates/tsz-checker/src/context",
+                root / "crates/tsz-checker/src/flow/control_flow",
+            ]
+        )
+        by_key = {
+            (candidate.path, candidate.owner, candidate.name): candidate
+            for candidate in candidates
+        }
+
+        expected = {
+            (
+                "crates/tsz-checker/src/context/aliases.rs",
+                "<module>",
+                "AccessorLevelsCache",
+            ),
+            (
+                "crates/tsz-checker/src/context/aliases.rs",
+                "<module>",
+                "MemberAccessInfoCache",
+            ),
+            (
+                "crates/tsz-checker/src/context/aliases.rs",
+                "<module>",
+                "CallbackMismatchMemo",
+            ),
+            (
+                "crates/tsz-checker/src/context/aliases.rs",
+                "<module>",
+                "FlowAnalysisCacheMap",
+            ),
+            (
+                "crates/tsz-checker/src/context/aliases.rs",
+                "<module>",
+                "ReexportResolutionCache",
+            ),
+            (
+                "crates/tsz-checker/src/context/mod.rs",
+                "CheckerContext",
+                "enclosing_class_declares_member_cache",
+            ),
+            (
+                "crates/tsz-checker/src/context/mod.rs",
+                "NameResolutionDiagnostics",
+                "suggestion_scan_cache",
+            ),
+            (
+                "crates/tsz-checker/src/context/mod.rs",
+                "FlowSharedCaches",
+                "flow_switch_case_literal_cache",
+            ),
+            (
+                "crates/tsz-checker/src/context/mod.rs",
+                "FlowSharedCaches",
+                "flow_switch_all_distinct_literals_cache",
+            ),
+            (
+                "crates/tsz-checker/src/context/mod.rs",
+                "CheckerContext",
+                "lazy_def_ids_cache",
+            ),
+            (
+                "crates/tsz-checker/src/context/mod.rs",
+                "CheckerContext",
+                "type_queries_cache",
+            ),
+            (
+                "crates/tsz-checker/src/context/mod.rs",
+                "CheckerContext",
+                "type_position_resolution_cache",
+            ),
+            (
+                "crates/tsz-checker/src/context/mod.rs",
+                "CheckerContext",
+                "package_json_cache",
+            ),
+            (
+                "crates/tsz-checker/src/context/mod.rs",
+                "CheckerContext",
+                "inferred_return_type_memo",
+            ),
+            (
+                "crates/tsz-checker/src/flow/control_flow/core.rs",
+                "<module>",
+                "AliasBaseAssignmentCache",
+            ),
+            (
+                "crates/tsz-checker/src/flow/control_flow/core.rs",
+                "<module>",
+                "AliasPathAssignmentCache",
+            ),
+        }
+
+        for key in expected:
+            with self.subTest(key=key):
+                self.assertIn(key, by_key)
+                self.assertFalse(by_key[key].needs_review, by_key[key])
+
+    def test_display_budget_eval_memo_is_visible(self):
+        root = Path(__file__).resolve().parents[2]
+        candidates = self.module.scan([root / "crates/tsz-checker/src/error_reporter"])
+        by_key = {
+            (candidate.path, candidate.owner, candidate.name): candidate
+            for candidate in candidates
+        }
+
+        key = (
+            "crates/tsz-checker/src/error_reporter/display_budget.rs",
+            "DisplayBudget",
+            "eval_memo",
+        )
+        self.assertIn(key, by_key)
+        self.assertFalse(by_key[key].needs_review, by_key[key])
+        self.assertNotIn(
+            (
+                "crates/tsz-checker/src/error_reporter/display_budget.rs",
+                "DisplayBudgetScope",
+                "eval_memo",
+            ),
+            by_key,
+        )
 
     def test_solver_visitor_predicate_memos_are_visible(self):
         root = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
Goal: fast

## Summary
- Add entry-count and estimated-size helpers for retained checker alias caches in `context/aliases.rs`, flow alias-assignment caches in `flow/control_flow/core.rs`, and retained `CheckerContext` cache statistics.
- Extend checker-side cache visibility to the remaining meaningful diagnostic/flow rows: `suggestion_scan_cache`, switch literal/distinct caches, and display-budget `eval_memo`.
- Tighten `cache-visibility-report.py` so unit structs do not falsely own later function-local memo variables; `DisplayBudgetScope.eval_memo` and `NeverPredicate.memo` no longer appear as artifact rows.
- Add focused Rust helper tests and Python guards so the checker-side visibility rows report stats and size signals.

## Structural Rule
When checker caches survive a file/session boundary or a bounded diagnostic display request, tsz exposes their entry counts and estimated resident size through checker-owned statistics or trace-only accounting helpers. This PR does not change cache keys, reset boundaries, invalidation, lookup behavior, semantic answers, or diagnostic text; it only makes existing checker/cache-report residency measurable for #14351.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `python3 -m unittest scripts/perf/test_cache_visibility_report.py`
- `python3 scripts/perf/cache-visibility-report.py --json` plus a focused JSON probe: `total_candidates=112`, `needs_review=11`; `suggestion_scan_cache`, both switch caches, and `DisplayBudget.eval_memo` have stats/size signals; `DisplayBudgetScope.eval_memo` and `NeverPredicate.memo` are absent artifact rows
- `scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --lib -E 'test(file_session_alias_caches_report_entries_and_size) or test(retained_alias_caches_report_entries_and_size) or test(alias_assignment_cache_statistics_report_entries_and_size) or test(type_param_node_cache_statistics_report_entries_and_size) or test(suggestion_scan_cache_statistics_report_entries_and_size) or test(checker_context_cache_statistics_roll_up_diagnostic_and_switch_caches) or test(eval_memo_statistics_report_entries_and_size)'`
- `scripts/safe-run.sh -- cargo check -p tsz-checker --lib`
- `scripts/safe-run.sh -- cargo clippy -p tsz-checker --lib -- -D warnings`
- `scripts/setup/disk-worktree-guard.sh` after recovery: `disk_status=ok`, about 59 GiB free
- Full PR CI owns broad conformance, emit, fourslash, and unit gates.

## Notes
A first local `cargo nextest run -p tsz-checker -E ...` attempt built too many checker test binaries before filtering and failed during linking with `errno=28` / no space left on device. I recovered space by deleting only `.target` build caches from clean inactive sister worktrees, then reran the corrected `--lib` targets successfully.

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high
