### PR TITLE
refactor(checker): centralize child checker attribution (#14351)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/child_checker.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/child_checker.rs
@@ -1,0 +1,67 @@
+use crate::state::CheckerState;
+use tsz_common::perf_counters::CheckerCreationReason;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn with_commonjs_child_checker_for_file<R>(
+        &mut self,
+        target_file_idx: usize,
+        f: impl FnOnce(&mut CheckerState<'_>) -> R,
+    ) -> Option<R> {
+        self.with_commonjs_child_checker_for_file_inner(target_file_idx, true, f, || {})
+    }
+
+    pub(super) fn with_commonjs_child_checker_for_file_without_merge<R>(
+        &mut self,
+        target_file_idx: usize,
+        f: impl FnOnce(&mut CheckerState<'_>) -> R,
+    ) -> Option<R> {
+        self.with_commonjs_child_checker_for_file_inner(target_file_idx, false, f, || {})
+    }
+
+    pub(super) fn with_commonjs_child_checker_for_file_before_merge<R>(
+        &mut self,
+        target_file_idx: usize,
+        f: impl FnOnce(&mut CheckerState<'_>) -> R,
+        before_merge: impl FnOnce(),
+    ) -> Option<R> {
+        self.with_commonjs_child_checker_for_file_inner(target_file_idx, true, f, before_merge)
+    }
+
+    fn with_commonjs_child_checker_for_file_inner<R>(
+        &mut self,
+        target_file_idx: usize,
+        merge_symbol_file_targets: bool,
+        f: impl FnOnce(&mut CheckerState<'_>) -> R,
+        before_merge: impl FnOnce(),
+    ) -> Option<R> {
+        let all_arenas = self.ctx.all_arenas.clone()?;
+        let all_binders = self.ctx.all_binders.clone()?;
+        let arena = all_arenas.get(target_file_idx)?;
+        let binder = all_binders.get(target_file_idx)?;
+        let source_file = arena.source_files.first()?;
+
+        let mut checker = Box::new(CheckerState::with_parent_cache_attributed(
+            arena.as_ref(),
+            binder.as_ref(),
+            self.ctx.types,
+            source_file.file_name.clone(),
+            self.ctx.compiler_options.clone(),
+            self,
+            CheckerCreationReason::CjsExports,
+        ));
+        checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
+        checker.ctx.copy_cross_file_state_from(&self.ctx);
+        checker.ctx.current_file_idx = target_file_idx;
+        self.ctx.copy_symbol_file_targets_to_attributed(
+            &mut checker.ctx,
+            CheckerCreationReason::CjsExports,
+        );
+
+        let result = f(&mut checker);
+        if merge_symbol_file_targets {
+            before_merge();
+            self.ctx.merge_symbol_file_targets_from(&checker.ctx);
+        }
+        Some(result)
+    }
+}

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
@@ -426,63 +426,31 @@ impl<'a> CheckerState<'a> {
             return crate::query_boundaries::common::widen_freshness(self.ctx.types, ty);
         }
 
-        let Some(all_arenas) = self.ctx.all_arenas.clone() else {
-            return TypeId::ANY;
-        };
-        let Some(all_binders) = self.ctx.all_binders.clone() else {
-            return TypeId::ANY;
-        };
-        let Some(arena) = all_arenas.get(target_file_idx) else {
-            return TypeId::ANY;
-        };
-        let Some(binder) = all_binders.get(target_file_idx) else {
-            return TypeId::ANY;
-        };
-        let Some(source_file) = arena.source_files.first() else {
-            return TypeId::ANY;
-        };
-
-        let mut checker = Box::new(CheckerState::with_parent_cache_attributed(
-            arena.as_ref(),
-            binder.as_ref(),
-            self.ctx.types,
-            source_file.file_name.clone(),
-            self.ctx.compiler_options.clone(),
-            self,
-            tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-        ));
-        checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
-        checker.ctx.copy_cross_file_state_from(&self.ctx);
-        checker.ctx.current_file_idx = target_file_idx;
-        self.ctx.copy_symbol_file_targets_to_attributed(
-            &mut checker.ctx,
-            tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-        );
-
-        let mut ty = checker
-            .literal_type_from_initializer(rhs_expr)
-            .or_else(|| checker.commonjs_export_rhs_symbol_type(rhs_expr))
-            .unwrap_or_else(|| checker.get_type_of_node(rhs_expr));
-        ty = checker.upgrade_commonjs_export_constructor_type(rhs_expr, ty);
-        ty = checker.augment_commonjs_export_object_type_with_expandos(
-            target_file_idx,
-            expando_root,
-            ty,
-        );
-        ty = checker.augment_commonjs_export_callable_type_with_expandos(
-            target_file_idx,
-            expando_root,
-            ty,
-        );
-        ty = checker.widen_fresh_object_literal_properties_for_display(ty);
-        ty = crate::query_boundaries::common::widen_freshness(checker.ctx.types, ty);
-        ty = if crate::query_boundaries::common::is_unique_symbol_type(checker.ctx.types, ty) {
-            ty
-        } else {
-            crate::query_boundaries::common::widen_type(checker.ctx.types, ty)
-        };
-        self.ctx.merge_symbol_file_targets_from(&checker.ctx);
-        ty
+        self.with_commonjs_child_checker_for_file(target_file_idx, |checker| {
+            let mut ty = checker
+                .literal_type_from_initializer(rhs_expr)
+                .or_else(|| checker.commonjs_export_rhs_symbol_type(rhs_expr))
+                .unwrap_or_else(|| checker.get_type_of_node(rhs_expr));
+            ty = checker.upgrade_commonjs_export_constructor_type(rhs_expr, ty);
+            ty = checker.augment_commonjs_export_object_type_with_expandos(
+                target_file_idx,
+                expando_root,
+                ty,
+            );
+            ty = checker.augment_commonjs_export_callable_type_with_expandos(
+                target_file_idx,
+                expando_root,
+                ty,
+            );
+            ty = checker.widen_fresh_object_literal_properties_for_display(ty);
+            ty = crate::query_boundaries::common::widen_freshness(checker.ctx.types, ty);
+            if crate::query_boundaries::common::is_unique_symbol_type(checker.ctx.types, ty) {
+                ty
+            } else {
+                crate::query_boundaries::common::widen_type(checker.ctx.types, ty)
+            }
+        })
+        .unwrap_or(TypeId::ANY)
     }
 
     pub(crate) fn current_file_commonjs_late_bound_named_export_type(
@@ -654,29 +622,9 @@ impl<'a> CheckerState<'a> {
         let literal = if target_file_idx == self.ctx.current_file_idx {
             self.literal_type_from_initializer(rhs_expr)
         } else {
-            let all_arenas = self.ctx.all_arenas.clone()?;
-            let all_binders = self.ctx.all_binders.clone()?;
-            let arena = all_arenas.get(target_file_idx)?;
-            let binder = all_binders.get(target_file_idx)?;
-            let source_file = arena.source_files.first()?;
-
-            let mut checker = Box::new(CheckerState::with_parent_cache_attributed(
-                arena.as_ref(),
-                binder.as_ref(),
-                self.ctx.types,
-                source_file.file_name.clone(),
-                self.ctx.compiler_options.clone(),
-                self,
-                tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-            ));
-            checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
-            checker.ctx.copy_cross_file_state_from(&self.ctx);
-            checker.ctx.current_file_idx = target_file_idx;
-            self.ctx.copy_symbol_file_targets_to_attributed(
-                &mut checker.ctx,
-                tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-            );
-            checker.literal_type_from_initializer(rhs_expr)
+            self.with_commonjs_child_checker_for_file_without_merge(target_file_idx, |checker| {
+                checker.literal_type_from_initializer(rhs_expr)
+            })?
         }?;
 
         crate::query_boundaries::common::string_literal_value(self.ctx.types, literal)
@@ -971,43 +919,11 @@ impl<'a> CheckerState<'a> {
             return self.get_type_of_function_impl(method_idx, &request);
         }
 
-        let Some(all_arenas) = self.ctx.all_arenas.clone() else {
-            return TypeId::ANY;
-        };
-        let Some(all_binders) = self.ctx.all_binders.clone() else {
-            return TypeId::ANY;
-        };
-        let Some(arena) = all_arenas.get(target_file_idx) else {
-            return TypeId::ANY;
-        };
-        let Some(binder) = all_binders.get(target_file_idx) else {
-            return TypeId::ANY;
-        };
-        let Some(source_file) = arena.source_files.first() else {
-            return TypeId::ANY;
-        };
-
-        let mut checker = Box::new(CheckerState::with_parent_cache_attributed(
-            arena.as_ref(),
-            binder.as_ref(),
-            self.ctx.types,
-            source_file.file_name.clone(),
-            self.ctx.compiler_options.clone(),
-            self,
-            tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-        ));
-        checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
-        checker.ctx.copy_cross_file_state_from(&self.ctx);
-        checker.ctx.current_file_idx = target_file_idx;
-        self.ctx.copy_symbol_file_targets_to_attributed(
-            &mut checker.ctx,
-            tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-        );
-
-        let request = TypingRequest::NONE.contextual_opt(contextual_type);
-        let ty = checker.get_type_of_function_impl(method_idx, &request);
-        self.ctx.merge_symbol_file_targets_from(&checker.ctx);
-        ty
+        self.with_commonjs_child_checker_for_file(target_file_idx, |checker| {
+            let request = TypingRequest::NONE.contextual_opt(contextual_type);
+            checker.get_type_of_function_impl(method_idx, &request)
+        })
+        .unwrap_or(TypeId::ANY)
     }
 }
 

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
@@ -70,42 +70,10 @@ impl<'a> CheckerState<'a> {
             return cached_type;
         }
 
-        let Some(all_arenas) = self.ctx.all_arenas.clone() else {
-            return TypeId::ANY;
-        };
-        let Some(all_binders) = self.ctx.all_binders.clone() else {
-            return TypeId::ANY;
-        };
-        let Some(arena) = all_arenas.get(target_file_idx) else {
-            return TypeId::ANY;
-        };
-        let Some(binder) = all_binders.get(target_file_idx) else {
-            return TypeId::ANY;
-        };
-        let Some(source_file) = arena.source_files.first() else {
-            return TypeId::ANY;
-        };
-
-        let mut checker = Box::new(CheckerState::with_parent_cache_attributed(
-            arena.as_ref(),
-            binder.as_ref(),
-            self.ctx.types,
-            source_file.file_name.clone(),
-            self.ctx.compiler_options.clone(),
-            self,
-            tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-        ));
-        checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
-        checker.ctx.copy_cross_file_state_from(&self.ctx);
-        checker.ctx.current_file_idx = target_file_idx;
-        self.ctx.copy_symbol_file_targets_to_attributed(
-            &mut checker.ctx,
-            tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-        );
-
-        let ty = checker.get_type_of_symbol(sym_id);
-        self.ctx.merge_symbol_file_targets_from(&checker.ctx);
-        ty
+        self.with_commonjs_child_checker_for_file(target_file_idx, |checker| {
+            checker.get_type_of_symbol(sym_id)
+        })
+        .unwrap_or(TypeId::ANY)
     }
 
     pub(crate) fn commonjs_export_assignment_expression_value_type(
@@ -126,9 +94,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let all_arenas = self.ctx.all_arenas.clone()?;
-        let all_binders = self.ctx.all_binders.clone()?;
         let target_arena = all_arenas.get(target_file_idx)?;
-        let target_binder = all_binders.get(target_file_idx)?;
         let source_file = target_arena.source_files.first()?;
         let expr_idx = source_file.statements.nodes.iter().find_map(|&stmt_idx| {
             let stmt = target_arena.get(stmt_idx)?;
@@ -140,26 +106,11 @@ impl<'a> CheckerState<'a> {
         })?;
 
         let cross_arena_guard = Self::enter_cross_arena_delegation()?;
-        let mut checker = Box::new(CheckerState::with_parent_cache_attributed(
-            target_arena.as_ref(),
-            target_binder.as_ref(),
-            self.ctx.types,
-            source_file.file_name.clone(),
-            self.ctx.compiler_options.clone(),
-            self,
-            tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-        ));
-        checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
-        checker.ctx.copy_cross_file_state_from(&self.ctx);
-        checker.ctx.current_file_idx = target_file_idx;
-        self.ctx.copy_symbol_file_targets_to_attributed(
-            &mut checker.ctx,
-            tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-        );
-
-        let ty = checker.get_type_of_node(expr_idx);
-        drop(cross_arena_guard);
-        self.ctx.merge_symbol_file_targets_from(&checker.ctx);
+        let ty = self.with_commonjs_child_checker_for_file_before_merge(
+            target_file_idx,
+            |checker| checker.get_type_of_node(expr_idx),
+            || drop(cross_arena_guard),
+        )?;
 
         (ty != TypeId::UNKNOWN && ty != TypeId::ERROR).then_some(ty)
     }
@@ -192,42 +143,10 @@ impl<'a> CheckerState<'a> {
             return self.infer_descriptor_parameter_type_in_current_checker(owner_idx, param_idx);
         }
 
-        let Some(all_arenas) = self.ctx.all_arenas.clone() else {
-            return TypeId::ANY;
-        };
-        let Some(all_binders) = self.ctx.all_binders.clone() else {
-            return TypeId::ANY;
-        };
-        let Some(arena) = all_arenas.get(target_file_idx) else {
-            return TypeId::ANY;
-        };
-        let Some(binder) = all_binders.get(target_file_idx) else {
-            return TypeId::ANY;
-        };
-        let Some(source_file) = arena.source_files.first() else {
-            return TypeId::ANY;
-        };
-
-        let mut checker = Box::new(CheckerState::with_parent_cache_attributed(
-            arena.as_ref(),
-            binder.as_ref(),
-            self.ctx.types,
-            source_file.file_name.clone(),
-            self.ctx.compiler_options.clone(),
-            self,
-            tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-        ));
-        checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
-        checker.ctx.copy_cross_file_state_from(&self.ctx);
-        checker.ctx.current_file_idx = target_file_idx;
-        self.ctx.copy_symbol_file_targets_to_attributed(
-            &mut checker.ctx,
-            tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-        );
-
-        let ty = checker.infer_descriptor_parameter_type_in_current_checker(owner_idx, param_idx);
-        self.ctx.merge_symbol_file_targets_from(&checker.ctx);
-        ty
+        self.with_commonjs_child_checker_for_file(target_file_idx, |checker| {
+            checker.infer_descriptor_parameter_type_in_current_checker(owner_idx, param_idx)
+        })
+        .unwrap_or(TypeId::ANY)
     }
 
     fn infer_getter_return_type_for_file(
@@ -239,42 +158,10 @@ impl<'a> CheckerState<'a> {
             return self.infer_getter_return_type(body_idx);
         }
 
-        let Some(all_arenas) = self.ctx.all_arenas.clone() else {
-            return TypeId::ANY;
-        };
-        let Some(all_binders) = self.ctx.all_binders.clone() else {
-            return TypeId::ANY;
-        };
-        let Some(arena) = all_arenas.get(target_file_idx) else {
-            return TypeId::ANY;
-        };
-        let Some(binder) = all_binders.get(target_file_idx) else {
-            return TypeId::ANY;
-        };
-        let Some(source_file) = arena.source_files.first() else {
-            return TypeId::ANY;
-        };
-
-        let mut checker = Box::new(CheckerState::with_parent_cache_attributed(
-            arena.as_ref(),
-            binder.as_ref(),
-            self.ctx.types,
-            source_file.file_name.clone(),
-            self.ctx.compiler_options.clone(),
-            self,
-            tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-        ));
-        checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
-        checker.ctx.copy_cross_file_state_from(&self.ctx);
-        checker.ctx.current_file_idx = target_file_idx;
-        self.ctx.copy_symbol_file_targets_to_attributed(
-            &mut checker.ctx,
-            tsz_common::perf_counters::CheckerCreationReason::CjsExports,
-        );
-
-        let ty = checker.infer_getter_return_type(body_idx);
-        self.ctx.merge_symbol_file_targets_from(&checker.ctx);
-        ty
+        self.with_commonjs_child_checker_for_file(target_file_idx, |checker| {
+            checker.infer_getter_return_type(body_idx)
+        })
+        .unwrap_or(TypeId::ANY)
     }
 
     /// tsc's binder-time recognition of `Object.defineProperty(exports, X, ...)`

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/mod.rs
@@ -1,3 +1,4 @@
+mod child_checker;
 mod exports_collection;
 mod exports_destructuring;
 mod exports_detection;

--- a/crates/tsz-checker/src/types/module_augmentation_value.rs
+++ b/crates/tsz-checker/src/types/module_augmentation_value.rs
@@ -12,6 +12,7 @@
 //! `delegate_cross_arena_interface_member_simple_types`.
 
 use crate::state::CheckerState;
+use tsz_common::perf_counters::CheckerCreationReason;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
@@ -54,19 +55,23 @@ impl<'a> CheckerState<'a> {
         tsz_common::perf_counters::record_delegate_cross_arena_miss();
         let _delegate_depth_guard = tsz_common::perf_counters::enter_delegate();
 
-        let mut checker = Box::new(CheckerState::with_parent_cache(
+        let mut checker = Box::new(CheckerState::with_parent_cache_attributed(
             arena,
             delegate_binder,
             self.ctx.types,
             delegate_file_name,
             self.ctx.compiler_options.clone(),
             self,
+            CheckerCreationReason::ModuleAugmentationValue,
         ));
         // Transient delegation child: diagnostics are discarded at teardown.
         checker.ctx.diagnostics_discarded = true;
         checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
         checker.ctx.copy_cross_file_state_from(&self.ctx);
-        self.ctx.copy_symbol_file_targets_to(&mut checker.ctx);
+        self.ctx.copy_symbol_file_targets_to_attributed(
+            &mut checker.ctx,
+            CheckerCreationReason::ModuleAugmentationValue,
+        );
         checker.ctx.current_file_idx = delegate_file_idx.unwrap_or(self.ctx.current_file_idx);
 
         let result = checker.augmentation_node_value_type_local(node);

--- a/crates/tsz-common/src/perf_counters/definitions.rs
+++ b/crates/tsz-common/src/perf_counters/definitions.rs
@@ -149,8 +149,10 @@ perf_counter_enum! {
         BindingHelpers = 14 => "BindingHelpers",
         /// `class_abstract_checker` cross-file abstract-method check.
         ClassAbstract = 15 => "ClassAbstract",
+        /// Module augmentation export value recovery in a delegate checker.
+        ModuleAugmentationValue = 16 => "ModuleAugmentationValue",
         /// Anything not explicitly classified above.
-        Other = 16 => "Other",
+        Other = 17 => "Other",
     }
 
     pub const CHECKER_CREATION_REASON_COUNT;

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -839,7 +839,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"^(?!\s*(?:pub(?:\([^)]*\))?\s+)?fn\b)"
             r".*\bwith_parent_cache_attributed\s*\("
         ),
-        33,
+        28,
     ),
     (
         "Checker residency boundary: copy_symbol_file_targets_to_attributed migration callsites (Track 10)",
@@ -848,7 +848,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"^(?!\s*(?:pub(?:\([^)]*\))?\s+)?fn\b)"
             r".*\bcopy_symbol_file_targets_to_attributed\s*\("
         ),
-        23,
+        18,
     ),
     (
         "Checker relation boundary: diagnostic-local RelationRequest constructors (#8227)",

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1631,7 +1631,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"^(?!\s*(?:pub(?:\([^)]*\))?\s+)?fn\b)"
             r".*\bwith_parent_cache_attributed\s*\("
         ),
-        33,
+        28,
     ),
     (
         "Checker residency boundary: copy_symbol_file_targets_to_attributed migration callsites (Track 10)",
@@ -1640,7 +1640,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"^(?!\s*(?:pub(?:\([^)]*\))?\s+)?fn\b)"
             r".*\bcopy_symbol_file_targets_to_attributed\s*\("
         ),
-        23,
+        18,
     ),
     (
         "Checker relation boundary: diagnostic-local RelationRequest constructors (#8227)",


### PR DESCRIPTION
Goal: fast

## Summary
- Centralize CommonJS export child-checker construction under a checker-owned helper while preserving current-file fast paths, CJS merge/no-merge behavior, and cross-arena guard drop ordering.
- Attribute module-augmentation value delegation with `CheckerCreationReason::ModuleAugmentationValue`, removing the last production raw `copy_symbol_file_targets_to` callsite.
- Ratchet Track 10 static caps to `with_parent_cache_attributed=28` and `copy_symbol_file_targets_to_attributed=18` after collapsing duplicated CJS callsites.

## Structural Rule
When CommonJS export synthesis or module-augmentation value recovery needs a type from another file, `tsc` answers in the target declaration context; tsz delegates through checker-owned child-checker boundaries with explicit cache/overlay attribution. This PR changes construction plumbing and counters only, not solver semantics.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/perf/migration_callsite_counts.py --json` (`with_parent_cache=1`, `with_parent_cache_attributed=28`, `copy_symbol_file_targets_to=0`, `copy_symbol_file_targets_to_attributed=18`)
- `python3 -m unittest scripts/perf/test_migration_callsite_counts.py`
- `python3 scripts/arch/test_arch_guard_policy.py && python3 scripts/arch/test_arch_guard_project.py`
- `scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-common perf_counters`
- `scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test js_export_surface_tests -E 'test(test_define_property_export_cross_file) or test(test_define_property_export_preserves_write_type_and_readonly_cross_file) or test(test_define_property_export_malformed_descriptor_is_readonly_cross_file) or test(test_full_commonjs_pattern_mix)'`
- `scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test commonjs_module_export_alias_tests -E 'test(test_module_exports_function_expando_assignments_no_ts2339) or test(test_module_exports_nested_class_property_preserves_instance_member_types) or test(test_jsdoc_import_type_uses_commonjs_exported_constructor_instance)'`
- `scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test ambient_module_augmentation_new_export_tests`
- `scripts/safe-run.sh -- cargo check -p tsz-common -p tsz-checker`
- `scripts/safe-run.sh -- cargo clippy -p tsz-common -p tsz-checker --lib --tests -- -D warnings`

Note: full `python3 scripts/arch/arch_guard.py` currently reports unrelated pre-existing ratchets (`access.rs` over 2000 LOC, #8225 common-boundary references, and speculation boundary cap). The Track 10 policy/project guard tests above pass with the new lower caps.

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high