### PR TITLE
refactor(lsp): journal member completion traversal (#14351)

### DIFF
--- a/crates/tsz-lsp/src/completions/member.rs
+++ b/crates/tsz-lsp/src/completions/member.rs
@@ -3,12 +3,14 @@
 
 mod contextual_type;
 mod member_filters;
+mod traversal_state;
 
 use super::*;
 use member_filters::{
     OBJECT_PROTOTYPE_ONLY_MEMBERS, dot_access_member_label_is_completion_eligible,
     primitive_member_is_completion_eligible,
 };
+use traversal_state::MemberTraversalState;
 use tsz_scanner::{is_ecmascript_identifier_part, is_ecmascript_identifier_start};
 
 #[derive(Clone, Copy, Debug)]
@@ -307,7 +309,15 @@ impl<'a> Completions<'a> {
         visited: &mut FxHashSet<TypeId>,
         props: &mut FxHashMap<String, PropertyCompletion>,
     ) {
-        self.collect_properties_for_type_inner(type_id, interner, checker, visited, props, false);
+        let mut traversal = MemberTraversalState::new(visited);
+        self.collect_properties_for_type_inner(
+            type_id,
+            interner,
+            checker,
+            &mut traversal,
+            props,
+            false,
+        );
     }
 
     /// Collect properties including private/protected members.
@@ -320,7 +330,15 @@ impl<'a> Completions<'a> {
         visited: &mut FxHashSet<TypeId>,
         props: &mut FxHashMap<String, PropertyCompletion>,
     ) {
-        self.collect_properties_for_type_inner(type_id, interner, checker, visited, props, true);
+        let mut traversal = MemberTraversalState::new(visited);
+        self.collect_properties_for_type_inner(
+            type_id,
+            interner,
+            checker,
+            &mut traversal,
+            props,
+            true,
+        );
     }
 
     fn collect_properties_for_type_inner(
@@ -328,11 +346,11 @@ impl<'a> Completions<'a> {
         type_id: TypeId,
         interner: &TypeInterner,
         checker: &mut CheckerState,
-        visited: &mut FxHashSet<TypeId>,
+        traversal: &mut MemberTraversalState<'_>,
         props: &mut FxHashMap<String, PropertyCompletion>,
         include_private: bool,
     ) {
-        if !visited.insert(type_id) {
+        if !traversal.enter(type_id) {
             return;
         }
 
@@ -343,7 +361,7 @@ impl<'a> Completions<'a> {
                 evaluated,
                 interner,
                 checker,
-                visited,
+                traversal,
                 props,
                 include_private,
             );
@@ -356,7 +374,7 @@ impl<'a> Completions<'a> {
                 inner,
                 interner,
                 checker,
-                visited,
+                traversal,
                 props,
                 include_private,
             );
@@ -392,7 +410,7 @@ impl<'a> Completions<'a> {
                 IntrinsicKind::Function,
                 interner,
                 checker,
-                visited,
+                traversal,
                 props,
             );
             return;
@@ -409,7 +427,7 @@ impl<'a> Completions<'a> {
                 self.collect_array_prototype_props(
                     array_base,
                     interner,
-                    visited,
+                    traversal,
                     props,
                     include_private,
                 );
@@ -429,15 +447,16 @@ impl<'a> Completions<'a> {
                     Vec::with_capacity(members.len());
                 for &member in members.iter() {
                     let mut member_props = FxHashMap::default();
-                    let mut member_visited = visited.clone();
+                    let checkpoint = traversal.checkpoint();
                     self.collect_properties_for_type_inner(
                         member,
                         interner,
                         checker,
-                        &mut member_visited,
+                        traversal,
                         &mut member_props,
                         include_private,
                     );
+                    traversal.rollback(checkpoint);
                     per_member_props.push(member_props);
                 }
                 // Intersect: keep only properties present in ALL members,
@@ -473,7 +492,7 @@ impl<'a> Completions<'a> {
                         member,
                         interner,
                         checker,
-                        visited,
+                        traversal,
                         props,
                         include_private,
                     );
@@ -490,7 +509,7 @@ impl<'a> Completions<'a> {
                     member,
                     interner,
                     checker,
-                    visited,
+                    traversal,
                     props,
                     include_private,
                 );
@@ -504,7 +523,7 @@ impl<'a> Completions<'a> {
                 self.collect_array_prototype_props(
                     app.base,
                     interner,
-                    visited,
+                    traversal,
                     props,
                     include_private,
                 );
@@ -513,7 +532,7 @@ impl<'a> Completions<'a> {
                     app.base,
                     interner,
                     checker,
-                    visited,
+                    traversal,
                     props,
                     include_private,
                 );
@@ -526,14 +545,14 @@ impl<'a> Completions<'a> {
                 IntrinsicKind::String,
                 interner,
                 checker,
-                visited,
+                traversal,
                 props,
             );
             return;
         }
 
         if let Some(kind) = tsz_solver::apparent_intrinsic_kind(interner, evaluated) {
-            self.collect_intrinsic_members_or_boxed(kind, interner, checker, visited, props);
+            self.collect_intrinsic_members_or_boxed(kind, interner, checker, traversal, props);
         }
     }
 
@@ -1320,11 +1339,11 @@ impl<'a> Completions<'a> {
         &self,
         type_id: TypeId,
         interner: &TypeInterner,
-        visited: &mut FxHashSet<TypeId>,
+        traversal: &mut MemberTraversalState<'_>,
         props: &mut FxHashMap<String, PropertyCompletion>,
         include_private: bool,
     ) {
-        if !visited.insert(type_id) {
+        if !traversal.enter(type_id) {
             return;
         }
         if let Some(id) = visitor::callable_shape_id(interner, type_id) {
@@ -1345,7 +1364,7 @@ impl<'a> Completions<'a> {
                 self.collect_array_prototype_props(
                     member,
                     interner,
-                    visited,
+                    traversal,
                     props,
                     include_private,
                 );
@@ -1419,12 +1438,12 @@ impl<'a> Completions<'a> {
         kind: IntrinsicKind,
         interner: &TypeInterner,
         checker: &mut CheckerState,
-        visited: &mut FxHashSet<TypeId>,
+        traversal: &mut MemberTraversalState<'_>,
         props: &mut FxHashMap<String, PropertyCompletion>,
     ) {
         if let Some(boxed_type) = interner.get_boxed_type(kind) {
             self.collect_properties_for_type_inner(
-                boxed_type, interner, checker, visited, props, false,
+                boxed_type, interner, checker, traversal, props, false,
             );
             Self::remove_hidden_primitive_boxed_completions(props);
         } else {

--- a/crates/tsz-lsp/src/completions/member/traversal_state.rs
+++ b/crates/tsz-lsp/src/completions/member/traversal_state.rs
@@ -1,0 +1,37 @@
+use rustc_hash::FxHashSet;
+use tsz_solver::TypeId;
+
+pub(super) struct MemberTraversalState<'a> {
+    visited: &'a mut FxHashSet<TypeId>,
+    journal: Vec<TypeId>,
+}
+
+impl<'a> MemberTraversalState<'a> {
+    pub(super) const fn new(visited: &'a mut FxHashSet<TypeId>) -> Self {
+        Self {
+            visited,
+            journal: Vec::new(),
+        }
+    }
+
+    pub(super) fn enter(&mut self, type_id: TypeId) -> bool {
+        if self.visited.insert(type_id) {
+            self.journal.push(type_id);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(super) const fn checkpoint(&self) -> usize {
+        self.journal.len()
+    }
+
+    pub(super) fn rollback(&mut self, checkpoint: usize) {
+        while self.journal.len() > checkpoint {
+            if let Some(type_id) = self.journal.pop() {
+                self.visited.remove(&type_id);
+            }
+        }
+    }
+}

--- a/crates/tsz-lsp/tests/completions_tests_parts/part_02.rs
+++ b/crates/tsz-lsp/tests/completions_tests_parts/part_02.rs
@@ -268,6 +268,54 @@ fn test_completions_function_prototype_members_on_function_expression() {
     );
 }
 
+#[test]
+fn test_completions_union_shared_intersection_members_survive_arm_traversal() {
+    let names = member_names_at_end(
+        "type Core = { shared: string; common(): number };\n\
+         type LeftBox = Core & { leftOnly: number };\n\
+         type RightBox = Core & { rightOnly: boolean };\n\
+         declare const value: LeftBox | RightBox;\n\
+         value.",
+    );
+
+    for expected in ["shared", "common"] {
+        assert!(
+            names.contains(&expected.to_string()),
+            "Expected shared union member '{expected}', got: {names:?}"
+        );
+    }
+    for forbidden in ["leftOnly", "rightOnly"] {
+        assert!(
+            !names.contains(&forbidden.to_string()),
+            "Union completions must exclude arm-only member '{forbidden}', got: {names:?}"
+        );
+    }
+}
+
+#[test]
+fn test_completions_union_shared_intersection_members_survive_renamed_aliases() {
+    let names = member_names_at_end(
+        "type Payload = { alphaShared: number; alphaMethod(): void };\n\
+         type FirstArm = Payload & { firstOnly: string };\n\
+         type SecondArm = Payload & { secondOnly: string };\n\
+         declare const subject: FirstArm | SecondArm;\n\
+         subject.",
+    );
+
+    for expected in ["alphaShared", "alphaMethod"] {
+        assert!(
+            names.contains(&expected.to_string()),
+            "Expected renamed shared union member '{expected}', got: {names:?}"
+        );
+    }
+    for forbidden in ["firstOnly", "secondOnly"] {
+        assert!(
+            !names.contains(&forbidden.to_string()),
+            "Union completions must exclude renamed arm-only member '{forbidden}', got: {names:?}"
+        );
+    }
+}
+
 // ── Array member completions ─────────────────────────────────────────────────
 
 /// Build member completions using a custom interner that has a mock

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -963,10 +963,6 @@ BRANCH_LOCAL_VISITED_CLONE_CHECKS = [
                 "let mut type_only_visited = visited.clone();",
             ),
             (
-                "crates/tsz-lsp/src/completions/member.rs",
-                "let mut member_visited = visited.clone();",
-            ),
-            (
                 "crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs",
                 "let mut alias_visited = visited.clone();",
             ),

--- a/scripts/arch/arch_guard_counts.py
+++ b/scripts/arch/arch_guard_counts.py
@@ -858,7 +858,13 @@ def scan_regex_line_count(
     return []
 
 
-VISITED_CLONE_PATTERN = re.compile(r"\bvisited\.clone\s*\(")
+VISITED_CLONE_PATTERN = re.compile(
+    r"\b(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\.\s*clone\s*\("
+)
+
+
+def strip_line_comment(line: str) -> str:
+    return line.split("//", 1)[0]
 
 
 def scan_branch_local_visited_clones(
@@ -895,10 +901,14 @@ def scan_branch_local_visited_clones(
             except OSError:
                 continue
             for line_no, line in enumerate(text.splitlines(), start=1):
-                stripped = line.strip()
+                stripped = strip_line_comment(line).strip()
                 if stripped.startswith("//"):
                     continue
-                if not VISITED_CLONE_PATTERN.search(stripped):
+                matches_visited_clone = any(
+                    "visited" in match.group("name").lower()
+                    for match in VISITED_CLONE_PATTERN.finditer(stripped)
+                )
+                if not matches_visited_clone:
                     continue
 
                 key = (rel_to_root, stripped)

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1057,11 +1057,6 @@ FILE_LINE_LIMIT_CHECKS = [
         2198,
     ),
     (
-        "LSP boundary: completions/member.rs size ratchet",
-        ROOT / "crates" / "tsz-lsp" / "src" / "completions" / "member.rs",
-        2117,
-    ),
-    (
         "LSP boundary: hierarchy/call_hierarchy.rs size ratchet",
         ROOT / "crates" / "tsz-lsp" / "src" / "hierarchy" / "call_hierarchy.rs",
         2091,
@@ -1753,10 +1748,6 @@ BRANCH_LOCAL_VISITED_CLONE_CHECKS = [
             (
                 "crates/tsz-checker/src/types/queries/type_only.rs",
                 "let mut type_only_visited = visited.clone();",
-            ),
-            (
-                "crates/tsz-lsp/src/completions/member.rs",
-                "let mut member_visited = visited.clone();",
             ),
             (
                 "crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs",

--- a/scripts/arch/test_arch_guard_misc.py
+++ b/scripts/arch/test_arch_guard_misc.py
@@ -149,6 +149,29 @@ class ArchGuardVisitedCloneTests(unittest.TestCase):
         self.assertIn("new_predicate.rs:2", hits[0])
         self.assertIn("memoized DP", hits[0])
 
+    def test_flags_clones_of_renamed_visited_state(self):
+        root = self._make_tree(
+            {
+                "crates/tsz-checker/src/flow/new_predicate.rs": (
+                    "fn walk(visited: Vec<u32>) {\n"
+                    "    let mut branch_visited = visited.clone();\n"
+                    "    let mut fork = branch_visited.clone();\n"
+                    "    let other = names.clone();\n"
+                    "}\n"
+                ),
+            }
+        )
+        allowlist = (
+            (
+                "crates/tsz-checker/src/flow/new_predicate.rs",
+                "let mut branch_visited = visited.clone();",
+            ),
+        )
+        hits = self.arch_guard.scan_branch_local_visited_clones([root], allowlist)
+        self.assertEqual(len(hits), 1, f"unexpected hits: {hits!r}")
+        self.assertIn("new_predicate.rs:3", hits[0])
+        self.assertIn("memoized DP", hits[0])
+
     def test_allows_pinned_site_by_file_and_statement_text(self):
         root = self._make_tree(
             {
@@ -201,6 +224,9 @@ class ArchGuardVisitedCloneTests(unittest.TestCase):
                 ),
                 "crates/tsz-checker/src/commented.rs": (
                     "// let mut branch_visited = visited.clone();\n"
+                ),
+                "crates/tsz-checker/src/inline_commented.rs": (
+                    "let other = names.clone(); // let x = visited.clone();\n"
                 ),
             }
         )

--- a/scripts/arch/test_arch_guard_policy.py
+++ b/scripts/arch/test_arch_guard_policy.py
@@ -630,6 +630,29 @@ class ArchGuardVisitedCloneTests(unittest.TestCase):
         self.assertIn("new_predicate.rs:2", hits[0])
         self.assertIn("memoized DP", hits[0])
 
+    def test_flags_clones_of_renamed_visited_state(self):
+        root = self._make_tree(
+            {
+                "crates/tsz-checker/src/flow/new_predicate.rs": (
+                    "fn walk(visited: Vec<u32>) {\n"
+                    "    let mut branch_visited = visited.clone();\n"
+                    "    let mut fork = branch_visited.clone();\n"
+                    "    let other = names.clone();\n"
+                    "}\n"
+                ),
+            }
+        )
+        allowlist = (
+            (
+                "crates/tsz-checker/src/flow/new_predicate.rs",
+                "let mut branch_visited = visited.clone();",
+            ),
+        )
+        hits = self.arch_guard.scan_branch_local_visited_clones([root], allowlist)
+        self.assertEqual(len(hits), 1, f"unexpected hits: {hits!r}")
+        self.assertIn("new_predicate.rs:3", hits[0])
+        self.assertIn("memoized DP", hits[0])
+
     def test_allows_pinned_site_by_file_and_statement_text(self):
         root = self._make_tree(
             {
@@ -682,6 +705,9 @@ class ArchGuardVisitedCloneTests(unittest.TestCase):
                 ),
                 "crates/tsz-checker/src/commented.rs": (
                     "// let mut branch_visited = visited.clone();\n"
+                ),
+                "crates/tsz-checker/src/inline_commented.rs": (
+                    "let other = names.clone(); // let x = visited.clone();\n"
                 ),
             }
         )

--- a/scripts/perf/test_visited_clone_report.py
+++ b/scripts/perf/test_visited_clone_report.py
@@ -97,6 +97,11 @@ class VisitedCloneReportTests(unittest.TestCase):
         ]
         self.assertEqual(infer_pattern_hits, [])
 
+    def test_lsp_completions_avoid_branch_local_visited_clone(self):
+        candidates = self.module.scan([ROOT / "crates/tsz-lsp/src/completions"])
+
+        self.assertEqual(candidates, [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Goal: fast

## Summary
- Replace the LSP member-completion union-arm `visited.clone()` with a journaled traversal state.
- Add shared-union/intersection completion regressions, including renamed aliases and arm-only exclusions.
- Ratchet Track 10 guardrails by removing the LSP visited-clone allowlist and stale `member.rs` size cap.
- Align the hard arch guard with the perf report so clones of renamed visited state like `branch_visited.clone()` are also caught.

## Structural Rule
When a completion receiver is a union, `tsc` exposes only properties available on every arm. `tsz` now handles that in LSP completions by traversing each arm with the same ancestor visited set, then rolling back only arm-local visits after the arm completes. Checker and solver semantics are unchanged.

## Owner Layer
LSP completions owns the member-traversal state. The checker/solver boundary is unchanged; this is not a type relation, inference, narrowing, or diagnostic change. The arch/perf scripts own the Track 10 visited-clone ratchet.

## Adjacent Matrix
- Shared members through intersection aliases: preserved.
- Renamed binders and aliases: covered.
- Arm-only union members: still excluded.
- Function, array, computed-symbol, and map member regressions: checked.
- Fallback behavior: single-arm unions and intersections keep the existing shared traversal path.
- Guard fallback: non-visited clones and visited-like text in comments are ignored; renamed visited-state clones are flagged.

## Performance
- Removed the branch-local `visited.clone()` from `crates/tsz-lsp/src/completions/member.rs`.
- Replaced O(|visited|) clone-per-union-arm work with O(k) journal rollback for arm-local visits.
- The hard arch guard now matches the perf report's variable-name contract for `*visited*.clone()` sites.
- No cache key, invalidation, fuel, or residency changes.
- `visited-clone-report.py --json` now reports `total: 0`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/perf/visited-clone-report.py --json`
- `python3 -m unittest scripts/perf/test_visited_clone_report.py`
- `python3 scripts/arch/test_arch_guard_misc.py ArchGuardVisitedCloneTests && python3 scripts/arch/test_arch_guard_policy.py ArchGuardVisitedCloneTests`
- `PYTHONPATH=scripts/perf python3 -m unittest test_visited_clone_report.VisitedCloneReportTests.test_lsp_completions_avoid_branch_local_visited_clone`
- `python3 scripts/perf/visited-clone-report.py --root crates/tsz-lsp/src/completions --json`
- `scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-lsp --lib -E 'test(test_completions_union_shared_intersection_members_survive_arm_traversal) or test(test_completions_union_shared_intersection_members_survive_renamed_aliases) or test(test_completions_array_with_lib_intersection_base) or test(test_completions_function_prototype_members_on_function_expression)'`
- `scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-lsp --lib completions::completions_tests::test_completions_function_prototype_members_on_named_function completions::completions_tests::test_completions_function_prototype_members_on_arrow_function completions::completions_tests::test_completions_function_prototype_members_on_function_expression completions::completions_tests::test_completions_union_shared_intersection_members_survive_arm_traversal completions::completions_tests::test_completions_union_shared_intersection_members_survive_renamed_aliases completions::completions_tests::test_completions_array_with_lib_callable_base_includes_instance_methods completions::completions_tests::test_completions_array_with_lib_callable_base_excludes_function_prototype completions::completions_tests::test_completions_array_with_lib_intersection_base_includes_all_members completions::completions_tests::test_completions_array_with_lib_intersection_base_excludes_function_prototype completions::completions_tests::test_completions_array_prototype_methods_on_array_literal completions::completions_tests::test_completions_map_excludes_symbol_iterator_on_dot_access completions::completions_tests::test_completions_excludes_other_computed_symbol_members_on_dot_access`
- `scripts/safe-run.sh -- cargo check -p tsz-lsp`
- `scripts/safe-run.sh -- cargo clippy -p tsz-lsp --lib --tests -- -D warnings`
- `wc -l crates/tsz-lsp/src/completions/member.rs crates/tsz-lsp/src/completions/member/*.rs crates/tsz-lsp/tests/completions_tests_parts/part_02.rs`

Known inherited local failure: `PYTHONPATH=scripts/arch python3 -m unittest test_arch_guard.ArchGuardAllFileLimitChecksPassTests ...` fails on five unrelated pre-existing oversized production files (`tsz-emitter` helpers/class/core, `tsz-solver` explain, `tsz-checker` access). `crates/tsz-lsp/src/completions/member.rs` is not in that failure list and is now 1876 lines.

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high
