### PR TITLE
perf(solver): memoize template span expansion (#14351)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/template_literal.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/template_literal.rs
@@ -4,13 +4,17 @@
 
 use crate::relations::subtype::TypeResolver;
 use crate::types::{LiteralValue, TemplateLiteralId, TemplateSpan, TypeData, TypeId};
+use rustc_hash::FxHashMap;
 
 use super::super::evaluate::TypeEvaluator;
 
+#[derive(Clone)]
 struct TemplateSpanExpansion {
     cardinality: Option<usize>,
     strings: Vec<String>,
 }
+
+type TemplateSpanExpansionCache = FxHashMap<(TypeId, u32), TemplateSpanExpansion>;
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Evaluate a template literal type: `hello${T}world`
@@ -51,6 +55,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let mut evaluated_strings = Vec::with_capacity(span_list.len());
         let mut normalized_spans = Vec::with_capacity(span_list.len());
         let mut total_combinations: usize = 1;
+        let mut span_expansion_cache = TemplateSpanExpansionCache::default();
 
         let mut can_fully_expand = true;
         for span in span_list.iter() {
@@ -62,7 +67,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 TemplateSpan::Type(type_id) => {
                     let evaluated = self.evaluate(*type_id);
                     normalized_spans.push(TemplateSpan::Type(evaluated));
-                    let expansion = self.template_span_expansion(evaluated);
+                    let expansion =
+                        self.template_span_expansion(evaluated, &mut span_expansion_cache);
 
                     if let Some(span_count) = expansion.cardinality {
                         total_combinations = total_combinations.saturating_mul(span_count);
@@ -153,11 +159,20 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Maximum recursion depth for template literal evaluation to prevent stack overflow.
     const MAX_LITERAL_COUNT_DEPTH: u32 = 50;
 
-    fn template_span_expansion(&self, type_id: TypeId) -> TemplateSpanExpansion {
-        self.template_span_expansion_impl(type_id, 0)
+    fn template_span_expansion(
+        &self,
+        type_id: TypeId,
+        cache: &mut TemplateSpanExpansionCache,
+    ) -> TemplateSpanExpansion {
+        self.template_span_expansion_impl(type_id, 0, cache)
     }
 
-    fn template_span_expansion_impl(&self, type_id: TypeId, depth: u32) -> TemplateSpanExpansion {
+    fn template_span_expansion_impl(
+        &self,
+        type_id: TypeId,
+        depth: u32,
+        cache: &mut TemplateSpanExpansionCache,
+    ) -> TemplateSpanExpansion {
         if depth > Self::MAX_LITERAL_COUNT_DEPTH {
             return TemplateSpanExpansion {
                 cardinality: None,
@@ -165,109 +180,114 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             };
         }
 
-        if type_id == TypeId::BOOLEAN {
-            return TemplateSpanExpansion {
+        let cache_key = (type_id, depth);
+        if let Some(expansion) = cache.get(&cache_key) {
+            return expansion.clone();
+        }
+
+        let expansion = if type_id == TypeId::BOOLEAN {
+            TemplateSpanExpansion {
                 cardinality: Some(2),
                 strings: Vec::new(),
-            };
-        }
-        if type_id == TypeId::BOOLEAN_TRUE {
-            return TemplateSpanExpansion {
+            }
+        } else if type_id == TypeId::BOOLEAN_TRUE {
+            TemplateSpanExpansion {
                 cardinality: Some(1),
                 strings: vec!["true".to_string()],
-            };
-        }
-        if type_id == TypeId::BOOLEAN_FALSE {
-            return TemplateSpanExpansion {
+            }
+        } else if type_id == TypeId::BOOLEAN_FALSE {
+            TemplateSpanExpansion {
                 cardinality: Some(1),
                 strings: vec!["false".to_string()],
-            };
-        }
-        if type_id == TypeId::NULL || type_id == TypeId::UNDEFINED || type_id == TypeId::VOID {
-            return TemplateSpanExpansion {
+            }
+        } else if type_id == TypeId::NULL || type_id == TypeId::UNDEFINED || type_id == TypeId::VOID
+        {
+            TemplateSpanExpansion {
                 cardinality: Some(1),
                 strings: Vec::new(),
-            };
-        }
-        if type_id.is_intrinsic() {
-            return TemplateSpanExpansion {
+            }
+        } else if type_id.is_intrinsic() {
+            TemplateSpanExpansion {
                 cardinality: None,
                 strings: Vec::new(),
-            };
-        }
-
-        match self.interner().lookup(type_id) {
-            Some(TypeData::Literal(lit)) => TemplateSpanExpansion {
-                cardinality: Some(1),
-                strings: Self::literal_template_string(self, lit)
-                    .into_iter()
-                    .collect(),
-            },
-            Some(TypeData::StringIntrinsic { .. }) => TemplateSpanExpansion {
-                cardinality: Some(1),
-                strings: Vec::new(),
-            },
-            Some(TypeData::Enum(_, structural_type)) => {
-                self.template_span_expansion_impl(structural_type, depth + 1)
             }
-            Some(TypeData::Union(members_id)) => {
-                let members = self.interner().type_list(members_id);
-                let mut count = 0usize;
-                let mut count_known = true;
-                let mut strings = Vec::with_capacity(members.len());
-                let mut all_stringifiable = true;
+        } else {
+            match self.interner().lookup(type_id) {
+                Some(TypeData::Literal(lit)) => TemplateSpanExpansion {
+                    cardinality: Some(1),
+                    strings: Self::literal_template_string(self, lit)
+                        .into_iter()
+                        .collect(),
+                },
+                Some(TypeData::StringIntrinsic { .. }) => TemplateSpanExpansion {
+                    cardinality: Some(1),
+                    strings: Vec::new(),
+                },
+                Some(TypeData::Enum(_, structural_type)) => {
+                    self.template_span_expansion_impl(structural_type, depth + 1, cache)
+                }
+                Some(TypeData::Union(members_id)) => {
+                    let members = self.interner().type_list(members_id);
+                    let mut count = 0usize;
+                    let mut count_known = true;
+                    let mut strings = Vec::with_capacity(members.len());
+                    let mut all_stringifiable = true;
 
-                for &member in members.iter() {
-                    let expansion = self.template_span_expansion_impl(member, depth + 1);
-                    if let Some(cardinality) = expansion.cardinality {
-                        if let Some(next_count) = count.checked_add(cardinality) {
-                            count = next_count;
+                    for &member in members.iter() {
+                        let expansion = self.template_span_expansion_impl(member, depth + 1, cache);
+                        if let Some(cardinality) = expansion.cardinality {
+                            if let Some(next_count) = count.checked_add(cardinality) {
+                                count = next_count;
+                            } else {
+                                count_known = false;
+                            }
                         } else {
                             count_known = false;
                         }
-                    } else {
-                        count_known = false;
+
+                        if expansion.strings.is_empty() {
+                            all_stringifiable = false;
+                        } else if all_stringifiable {
+                            strings.extend(expansion.strings);
+                        }
                     }
 
-                    if expansion.strings.is_empty() {
-                        all_stringifiable = false;
-                    } else if all_stringifiable {
-                        strings.extend(expansion.strings);
+                    TemplateSpanExpansion {
+                        cardinality: count_known.then_some(count),
+                        strings: if all_stringifiable {
+                            strings
+                        } else {
+                            Vec::new()
+                        },
                     }
                 }
-
-                TemplateSpanExpansion {
-                    cardinality: count_known.then_some(count),
-                    strings: if all_stringifiable {
-                        strings
-                    } else {
-                        Vec::new()
-                    },
+                Some(TypeData::TemplateLiteral(spans_id)) => {
+                    let spans = self.interner().template_list(spans_id);
+                    let mut total = 1usize;
+                    for span in spans.iter() {
+                        let span_count = match span {
+                            TemplateSpan::Text(_) => 1,
+                            TemplateSpan::Type(type_id) => self
+                                .template_span_expansion_impl(*type_id, depth + 1, cache)
+                                .cardinality
+                                .unwrap_or(1),
+                        };
+                        total = total.saturating_mul(span_count);
+                    }
+                    TemplateSpanExpansion {
+                        cardinality: Some(total),
+                        strings: Vec::new(),
+                    }
                 }
-            }
-            Some(TypeData::TemplateLiteral(spans_id)) => {
-                let spans = self.interner().template_list(spans_id);
-                let mut total = 1usize;
-                for span in spans.iter() {
-                    let span_count = match span {
-                        TemplateSpan::Text(_) => 1,
-                        TemplateSpan::Type(type_id) => self
-                            .template_span_expansion_impl(*type_id, depth + 1)
-                            .cardinality
-                            .unwrap_or(1),
-                    };
-                    total = total.saturating_mul(span_count);
-                }
-                TemplateSpanExpansion {
-                    cardinality: Some(total),
+                _ => TemplateSpanExpansion {
+                    cardinality: None,
                     strings: Vec::new(),
-                }
+                },
             }
-            _ => TemplateSpanExpansion {
-                cardinality: None,
-                strings: Vec::new(),
-            },
-        }
+        };
+
+        cache.insert(cache_key, expansion.clone());
+        expansion
     }
 
     fn literal_template_string(&self, lit: LiteralValue) -> Option<String> {

--- a/crates/tsz-solver/tests/evaluate_tests_parts/indexed_access_template_recursive.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/indexed_access_template_recursive.rs
@@ -858,6 +858,53 @@ fn test_keyof_template_literal_union_interpolation() {
     assert_eq!(result, expected);
 }
 
+#[test]
+fn test_template_span_expansion_memo_reuses_repeated_evaluated_keyof_union() {
+    use crate::TypeEvaluator;
+    use crate::def::DefId;
+    use crate::relations::subtype::TypeEnvironment;
+    use std::collections::BTreeSet;
+
+    let interner = TypeInterner::new();
+    let alpha = interner.intern_string("alpha");
+    let beta = interner.intern_string("beta");
+    let object = interner.object(vec![
+        PropertyInfo::new(alpha, TypeId::STRING),
+        PropertyInfo::new(beta, TypeId::NUMBER),
+    ]);
+    let keys = evaluate_keyof(&interner, object);
+
+    let mut env = TypeEnvironment::new();
+    let keys_def = DefId(1);
+    env.insert_def(keys_def, keys);
+    let lazy_keys = interner.lazy(keys_def);
+    let template = interner.template_literal(vec![
+        TemplateSpan::Type(lazy_keys),
+        TemplateSpan::Text(interner.intern_string(":")),
+        TemplateSpan::Type(lazy_keys),
+    ]);
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    let result = evaluator.evaluate(template);
+
+    let Some(TypeData::Union(members_id)) = interner.lookup(result) else {
+        panic!("expected repeated lazy keyof union to expand, got {result:?}");
+    };
+    let actual = interner
+        .type_list(members_id)
+        .iter()
+        .map(|member| match interner.lookup(*member) {
+            Some(TypeData::Literal(LiteralValue::String(atom))) => interner.resolve_atom(atom),
+            other => panic!("expected literal string member, got {other:?}"),
+        })
+        .collect::<BTreeSet<_>>();
+    let expected = ["alpha:alpha", "alpha:beta", "beta:alpha", "beta:beta"]
+        .into_iter()
+        .map(String::from)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(actual, expected);
+}
+
 /// Test keyof with union of template literals
 /// keyof (`foo${string}` | `bar${string}`) should return keyof string (apparent keys)
 #[test]

--- a/crates/tsz-solver/tests/template_literal_subtype_tests.rs
+++ b/crates/tsz-solver/tests/template_literal_subtype_tests.rs
@@ -255,6 +255,51 @@ fn test_large_template_cross_product_sets_flag_after_lazy_resolution() {
 }
 
 #[test]
+fn test_repeated_lazy_template_span_expansion_preserves_all_string_combinations() {
+    use crate::TypeEvaluator;
+    use crate::def::DefId;
+    use crate::relations::subtype::TypeEnvironment;
+    use std::collections::BTreeSet;
+
+    let interner = TypeInterner::new();
+    let palette = interner.union(vec![
+        interner.literal_string("red"),
+        interner.literal_string("blue"),
+    ]);
+
+    let mut env = TypeEnvironment::new();
+    let palette_def = DefId(1);
+    env.insert_def(palette_def, palette);
+    let lazy_palette = interner.lazy(palette_def);
+    let template = interner.template_literal(vec![
+        TemplateSpan::Type(lazy_palette),
+        TemplateSpan::Text(interner.intern_string("-")),
+        TemplateSpan::Type(lazy_palette),
+    ]);
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    let result = evaluator.evaluate(template);
+
+    let Some(TypeData::Union(members_id)) = interner.lookup(result) else {
+        panic!("expected repeated lazy string union to expand, got {result:?}");
+    };
+    let actual = interner
+        .type_list(members_id)
+        .iter()
+        .map(|member| match interner.lookup(*member) {
+            Some(TypeData::Literal(LiteralValue::String(atom))) => interner.resolve_atom(atom),
+            other => panic!("expected literal string member, got {other:?}"),
+        })
+        .collect::<BTreeSet<_>>();
+
+    let expected = ["blue-blue", "blue-red", "red-blue", "red-red"]
+        .into_iter()
+        .map(String::from)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(actual, expected);
+}
+
+#[test]
 fn test_mixed_template_union_counts_lazy_template_alternatives_for_complexity() {
     use crate::TypeEvaluator;
     use crate::def::DefId;


### PR DESCRIPTION
Goal: fast

## Summary
- Add a request-local memo for template-literal span expansion inside `TypeEvaluator::evaluate_template_literal`.
- Key the memo by `(evaluated TypeId, recursion depth)` so the existing depth cap remains part of the answer.
- Add repeated lazy-union and repeated lazy-`keyof` regressions that verify both repeated span positions still receive the full string Cartesian product.

## Structural Rule
When a template literal reuses the same evaluated interpolation type, `tsc` observes the same expansion/cardinality for each position. `tsz` now computes that expansion once per evaluator request/depth and reuses it while preserving the same TS2590 limit checks and deferred-template fallback.

## Owner Layer
Solver evaluator owns this. No checker, binder, LSP, emitter, shared query cache, resolver-generation, cache-visibility, or diagnostic formatting surface changes.

## Adjacent Matrix
- Repeated lazy string-union interpolation: preserves all literal combinations.
- Repeated lazy `keyof` interpolation: preserves all key-pair literal combinations after evaluation.
- Lazy repeated large union: still widens to `string` and marks `union_too_complex`.
- Mixed finite/deferred template alternatives: still counts lazy template alternatives for TS2590.
- Already-evaluated template pattern spans: still preserved.
- Expansion-limit compat path: still widens to `string`.

## Performance
- Replaces repeated recursive span-expansion walks for the same evaluated interpolation within one `evaluate_template_literal` request with an `FxHashMap<(TypeId, depth), TemplateSpanExpansion>` lookup.
- Cache is request-local only; no persistent residency, invalidation, option, or resolver-mode changes.
- For stringifiable finite unions, cached hits clone the already-computed string vector so each interpolation still owns its expansion values.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-solver --lib -E 'test(template_span_expansion_memo_reuses_repeated_evaluated_keyof_union) or test(repeated_lazy_template_span_expansion) or test(large_template_cross_product_sets_flag_after_lazy_resolution) or test(mixed_template_union_counts_lazy_template_alternatives_for_complexity) or test(template_literal_evaluation_preserves_evaluated_pattern_spans) or test(test_template_literal_expansion_limit_widens_to_string)'`
- `scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-solver --lib -E 'test(test_template_literal_nested_template_limit) or test(test_recursive_template_literal_application_with_string_intrinsics)'`
- `scripts/safe-run.sh -- cargo check -p tsz-solver`
- `scripts/safe-run.sh -- cargo clippy -p tsz-solver --lib --tests -- -D warnings`
- `scripts/setup/disk-worktree-guard.sh`

Attempted but blocked locally: `cargo nextest list -p tsz-checker | rg 'recursive_template_literal_with_string_intrinsics_resolves_to_literal|recursive_split_slash_preserves_literal_tuple_segments|template_literal_recursive_replace|conditional_infer'` tried to link broad checker test binaries and failed with `ld: write() failed, errno=28`. I recovered disk using the repo ladder: `scripts/setup/disk-worktree-guard.sh --auto-prune`, `scripts/setup/clean.sh --quiet`, then `scripts/setup/clean.sh --full --quiet` in this worktree. Disk recovered from ~247 MB free to ~47 GB free; this deleted this worktree's build cache only. After the final amend, the guard reports ~44 GB free.

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high
