### PR TITLE
refactor(checker): extract global keyed access helpers (#14351)

### DIFF
--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1,12 +1,11 @@
 use self::global_this_keyed::{
-    GlobalThisAccessKind, GlobalThisFlowMode, GlobalThisKeyStatus, GlobalThisReceiverStatus,
-    GlobalThisStringLikeElementAccess,
+    GlobalThisAccessKind, GlobalThisFlowMode, GlobalThisKeyStatus, GlobalThisLiteralKeyAccess,
+    GlobalThisReceiverStatus, GlobalThisStringLikeElementAccess, GlobalThisWindowKeyUnionAccess,
 };
 use crate::context::TypingRequest;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use crate::symbols_domain::name_text::property_access_chain_text_in_arena;
-use crate::types_domain::queries::core::GlobalReceiver;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -274,142 +273,65 @@ impl<'a> CheckerState<'a> {
         let is_declared_window_global_this =
             self.is_window_and_global_this_declared_expression(access.expression);
         if let Some(name) = literal_string.as_deref()
-            && (self.is_global_this_like_expression(access.expression)
-                || is_this_global
-                || is_declared_window_global_this)
-        {
-            let targets_global_this =
-                self.is_global_this_expression(access.expression) || is_this_global;
-            let receiver = GlobalReceiver::from_targets_global_this(targets_global_this);
-            let allow_unknown_property_fallback =
-                targets_global_this && !is_declared_window_global_this;
-            if is_declared_window_global_this
-                && node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
-            {
-                if let Some(window_type) = self.resolve_lib_type_by_name("Window") {
-                    let prop_result =
-                        crate::query_boundaries::property_access::resolve_property_access(
-                            self.ctx.types,
-                            window_type,
-                            self.ctx.types.intern_string(name),
-                        );
-                    if let Some(type_id) = prop_result.success_type() {
-                        return if skip_flow_narrowing {
-                            type_id
-                        } else {
-                            self.apply_flow_narrowing(idx, type_id)
-                        };
-                    }
-                }
-                if self.ctx.no_implicit_any() && !self.is_js_file() {
-                    use crate::diagnostics::diagnostic_codes;
-                    self.error_at_node(
-                        access.name_or_argument,
-                        "Element implicitly has an 'any' type because index expression is not of type 'number'.",
-                        diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE,
-                    );
-                }
-                return TypeId::ANY;
-            }
-            // For element access (globalThis['y']), tsc reports TS2339 at the full
-            // expression span. For property access (globalThis.y), at the property name.
-            let error_node = if node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
-                idx
-            } else {
-                access.name_or_argument
-            };
-            let property_type = self.resolve_global_this_property_type(
-                name,
-                error_node,
-                allow_unknown_property_fallback,
-                receiver,
-            );
-            if property_type == TypeId::ERROR {
-                return TypeId::ERROR;
-            }
-            // TS7053: When noImplicitAny is enabled and the access target is
-            // `typeof globalThis` (via `this` resolving to global, or a direct
-            // `globalThis['x']`), and the property is not found, emit the
-            // can't-index diagnostic.
-            let access_targets_global_this =
-                is_this_global || self.is_global_this_expression(access.expression);
-            if access_targets_global_this
-                && property_type == TypeId::ANY
-                && self.ctx.no_implicit_any()
-                && !self.is_js_file()
-                && node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
-            {
-                use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
-                let index_str = format!("\"{name}\"");
-                self.error_at_node(
+            && let Some(result) =
+                self.try_global_this_literal_key_access(GlobalThisLiteralKeyAccess {
                     idx,
-                    &format_message(
-                        diagnostic_messages::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
-                        &[&index_str, "typeof globalThis"],
-                    ),
-                    diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
-                );
-            }
-            return if skip_flow_narrowing {
-                property_type
-            } else {
-                self.apply_flow_narrowing(idx, property_type)
-            };
+                    access_kind: if node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+                        GlobalThisAccessKind::Element
+                    } else {
+                        GlobalThisAccessKind::Other
+                    },
+                    access_expression: access.expression,
+                    key_node: access.name_or_argument,
+                    name,
+                    is_global_this_like_receiver: self
+                        .is_global_this_like_expression(access.expression),
+                    receiver_status: if is_this_global {
+                        GlobalThisReceiverStatus::GlobalThisLike
+                    } else {
+                        GlobalThisReceiverStatus::Other
+                    },
+                    is_declared_window_global_this,
+                    flow_mode: if skip_flow_narrowing {
+                        GlobalThisFlowMode::SkipFlowNarrowing
+                    } else {
+                        GlobalThisFlowMode::ApplyFlowNarrowing
+                    },
+                })
+        {
+            return result;
         }
 
-        // Handle `window[k]` where `k` is a typed identifier whose type is a
-        // single string literal or a union of string literals, e.g.
-        // `const k: 'resizeTo' | 'resizeBy'`. The literal-string branch above
-        // only fires when the AST argument is a string literal node, so
-        // variable indices fall through to the general union-keys path. That
-        // path resolves the property on the full `Window & typeof globalThis`
-        // intersection, where the structural callable shape contributed by
-        // `Window`'s methods is lost during evaluation and the contextual
-        // arrow-function callback collapses to implicit-any. Resolving each
-        // key directly against the `Window` lib type — mirroring the literal
-        // branch above — yields a usable callable shape for the assignment
-        // target so callbacks like `(x, y) => {}` are contextually typed.
-        if literal_string.is_none()
-            && node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
-            && (self.is_global_this_like_expression(access.expression)
-                || is_this_global
-                || is_declared_window_global_this)
-            && let Some((string_keys, number_keys)) =
-                self.get_literal_key_union_from_type(index_type)
-            && !string_keys.is_empty()
-            && number_keys.is_empty()
-            && let Some(window_type) = self.resolve_lib_type_by_name("Window")
+        if let Some(result) =
+            self.try_global_this_window_key_union_access(GlobalThisWindowKeyUnionAccess {
+                idx,
+                access_kind: if node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+                    GlobalThisAccessKind::Element
+                } else {
+                    GlobalThisAccessKind::Other
+                },
+                key_status: if literal_string.is_none() {
+                    GlobalThisKeyStatus::NoLiteralStringKey
+                } else {
+                    GlobalThisKeyStatus::HasLiteralStringKey
+                },
+                index_type,
+                is_global_this_like_receiver: self
+                    .is_global_this_like_expression(access.expression),
+                receiver_status: if is_this_global {
+                    GlobalThisReceiverStatus::GlobalThisLike
+                } else {
+                    GlobalThisReceiverStatus::Other
+                },
+                is_declared_window_global_this,
+                flow_mode: if skip_flow_narrowing {
+                    GlobalThisFlowMode::SkipFlowNarrowing
+                } else {
+                    GlobalThisFlowMode::ApplyFlowNarrowing
+                },
+            })
         {
-            let mut resolved_types: Vec<TypeId> = Vec::with_capacity(string_keys.len());
-            let mut all_resolved = true;
-            for key_atom in &string_keys {
-                let prop_result = crate::query_boundaries::property_access::resolve_property_access(
-                    self.ctx.types,
-                    window_type,
-                    *key_atom,
-                );
-                if let Some(type_id) = prop_result.success_type() {
-                    resolved_types.push(type_id);
-                } else {
-                    all_resolved = false;
-                    break;
-                }
-            }
-            if all_resolved && !resolved_types.is_empty() {
-                // Write context: value must satisfy every possible key →
-                // intersection. Read context: result is one of the keyed
-                // properties → union.
-                let combined = if skip_flow_narrowing {
-                    tsz_solver::utils::intersection_or_single(self.ctx.types, resolved_types)
-                } else {
-                    tsz_solver::utils::union_or_single(self.ctx.types, resolved_types)
-                };
-                return if skip_flow_narrowing {
-                    combined
-                } else {
-                    self.apply_flow_narrowing(idx, combined)
-                };
-            }
+            return result;
         }
 
         if let Some(result) =

--- a/crates/tsz-checker/src/types/computation/access/global_this_keyed.rs
+++ b/crates/tsz-checker/src/types/computation/access/global_this_keyed.rs
@@ -34,7 +34,151 @@ pub(super) struct GlobalThisStringLikeElementAccess {
     pub(super) flow_mode: GlobalThisFlowMode,
 }
 
+pub(super) struct GlobalThisLiteralKeyAccess<'a> {
+    pub(super) idx: NodeIndex,
+    pub(super) access_kind: GlobalThisAccessKind,
+    pub(super) access_expression: NodeIndex,
+    pub(super) key_node: NodeIndex,
+    pub(super) name: &'a str,
+    pub(super) is_global_this_like_receiver: bool,
+    pub(super) receiver_status: GlobalThisReceiverStatus,
+    pub(super) is_declared_window_global_this: bool,
+    pub(super) flow_mode: GlobalThisFlowMode,
+}
+
+pub(super) struct GlobalThisWindowKeyUnionAccess {
+    pub(super) idx: NodeIndex,
+    pub(super) access_kind: GlobalThisAccessKind,
+    pub(super) key_status: GlobalThisKeyStatus,
+    pub(super) index_type: TypeId,
+    pub(super) is_global_this_like_receiver: bool,
+    pub(super) receiver_status: GlobalThisReceiverStatus,
+    pub(super) is_declared_window_global_this: bool,
+    pub(super) flow_mode: GlobalThisFlowMode,
+}
+
 impl<'a> CheckerState<'a> {
+    pub(super) fn try_global_this_literal_key_access(
+        &mut self,
+        request: GlobalThisLiteralKeyAccess<'_>,
+    ) -> Option<TypeId> {
+        let is_this_global = matches!(
+            request.receiver_status,
+            GlobalThisReceiverStatus::GlobalThisLike
+        );
+        if !request.is_global_this_like_receiver
+            && !is_this_global
+            && !request.is_declared_window_global_this
+        {
+            return None;
+        }
+
+        let targets_global_this =
+            self.is_global_this_expression(request.access_expression) || is_this_global;
+        if request.is_declared_window_global_this
+            && matches!(request.access_kind, GlobalThisAccessKind::Element)
+        {
+            return Some(self.resolve_declared_window_literal_key(request));
+        }
+
+        // For element access (`globalThis["y"]`), tsc reports TS2339 at the
+        // full expression span. For property access (`globalThis.y`), at the
+        // property name.
+        let error_node = if matches!(request.access_kind, GlobalThisAccessKind::Element) {
+            request.idx
+        } else {
+            request.key_node
+        };
+        let property_type = self.resolve_global_this_property_type(
+            request.name,
+            error_node,
+            targets_global_this && !request.is_declared_window_global_this,
+            GlobalReceiver::from_targets_global_this(targets_global_this),
+        );
+        if property_type == TypeId::ERROR {
+            return Some(TypeId::ERROR);
+        }
+
+        // TS7053: When noImplicitAny is enabled and the access target is
+        // `typeof globalThis` (via `this` resolving to global, or a direct
+        // `globalThis["x"]`), and the property is not found, emit the
+        // can't-index diagnostic.
+        if targets_global_this
+            && property_type == TypeId::ANY
+            && self.ctx.no_implicit_any()
+            && !self.is_js_file()
+            && matches!(request.access_kind, GlobalThisAccessKind::Element)
+        {
+            let index_str = format!("\"{}\"", request.name);
+            self.error_at_node(
+                request.idx,
+                &format_message(
+                    diagnostic_messages::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
+                    &[&index_str, "typeof globalThis"],
+                ),
+                diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
+            );
+        }
+
+        Some(self.apply_global_this_flow_mode(request.idx, property_type, request.flow_mode))
+    }
+
+    pub(super) fn try_global_this_window_key_union_access(
+        &mut self,
+        request: GlobalThisWindowKeyUnionAccess,
+    ) -> Option<TypeId> {
+        // Handle `window[k]` where `k` is a typed identifier whose type is a
+        // single string literal or a union of string literals, e.g.
+        // `const k: 'resizeTo' | 'resizeBy'`. The literal-string branch only
+        // fires when the AST argument is a string literal node, so variable
+        // indices fall through to the general union-keys path. Resolving each
+        // key directly against the `Window` lib type preserves callable shapes
+        // for assignment targets and callback contextual typing.
+        if !matches!(request.key_status, GlobalThisKeyStatus::NoLiteralStringKey)
+            || !matches!(request.access_kind, GlobalThisAccessKind::Element)
+            || !(request.is_global_this_like_receiver
+                || matches!(
+                    request.receiver_status,
+                    GlobalThisReceiverStatus::GlobalThisLike
+                )
+                || request.is_declared_window_global_this)
+        {
+            return None;
+        }
+
+        let (string_keys, number_keys) =
+            self.get_literal_key_union_from_type(request.index_type)?;
+        if string_keys.is_empty() || !number_keys.is_empty() {
+            return None;
+        }
+        let window_type = self.resolve_lib_type_by_name("Window")?;
+        let mut resolved_types: Vec<TypeId> = Vec::with_capacity(string_keys.len());
+        for key_atom in &string_keys {
+            let prop_result = crate::query_boundaries::property_access::resolve_property_access(
+                self.ctx.types,
+                window_type,
+                *key_atom,
+            );
+            if let Some(type_id) = prop_result.success_type() {
+                resolved_types.push(type_id);
+            } else {
+                return None;
+            }
+        }
+        if resolved_types.is_empty() {
+            return None;
+        }
+
+        // Write context: value must satisfy every possible key -> intersection.
+        // Read context: result is one of the keyed properties -> union.
+        let combined = if matches!(request.flow_mode, GlobalThisFlowMode::SkipFlowNarrowing) {
+            tsz_solver::utils::intersection_or_single(self.ctx.types, resolved_types)
+        } else {
+            tsz_solver::utils::union_or_single(self.ctx.types, resolved_types)
+        };
+        Some(self.apply_global_this_flow_mode(request.idx, combined, request.flow_mode))
+    }
+
     pub(super) fn try_global_this_string_like_element_access(
         &mut self,
         request: GlobalThisStringLikeElementAccess,
@@ -103,5 +247,42 @@ impl<'a> CheckerState<'a> {
             diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
         );
         Some(TypeId::ANY)
+    }
+
+    fn resolve_declared_window_literal_key(
+        &mut self,
+        request: GlobalThisLiteralKeyAccess<'_>,
+    ) -> TypeId {
+        if let Some(window_type) = self.resolve_lib_type_by_name("Window") {
+            let prop_result = crate::query_boundaries::property_access::resolve_property_access(
+                self.ctx.types,
+                window_type,
+                self.ctx.types.intern_string(request.name),
+            );
+            if let Some(type_id) = prop_result.success_type() {
+                return self.apply_global_this_flow_mode(request.idx, type_id, request.flow_mode);
+            }
+        }
+        if self.ctx.no_implicit_any() && !self.is_js_file() {
+            self.error_at_node(
+                request.key_node,
+                "Element implicitly has an 'any' type because index expression is not of type 'number'.",
+                diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE,
+            );
+        }
+        TypeId::ANY
+    }
+
+    fn apply_global_this_flow_mode(
+        &mut self,
+        idx: NodeIndex,
+        type_id: TypeId,
+        flow_mode: GlobalThisFlowMode,
+    ) -> TypeId {
+        if matches!(flow_mode, GlobalThisFlowMode::SkipFlowNarrowing) {
+            type_id
+        } else {
+            self.apply_flow_narrowing(idx, type_id)
+        }
     }
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Extract `globalThis`/global `this`/declared `window` literal-key and literal-union element access handling out of the oversized `access.rs` hot path into `access/global_this_keyed.rs`.
- Preserve the existing `window[k]` write/read behavior: write context intersects matching `Window` methods, read context unions them, and both paths retain the prior flow-narrowing mode.
- Drop `access.rs` below the 2000-line architecture guard limit for this file without changing solver semantics or diagnostic policy.

## Structural Rule
When keyed access targets `typeof globalThis`, global `this`, or a declared `Window & typeof globalThis` value, `tsc` resolves literal and literal-union keys through the global/window surface before general index-signature diagnostics. TSZ owns this routing in checker element-access orchestration via `types/computation/access/global_this_keyed.rs`; solver relations and diagnostic text remain unchanged.

## Adjacent Matrix
- Direct literal key: `globalThis["missing"]` still emits TS7053 at the full element access span.
- Global `this`: `this["missing"]` follows the same `typeof globalThis` missing-key route.
- Declared window/global intersection: `window["resizeTo"]` resolves through `Window` before fallback diagnostics.
- Typed literal/union index: `window[k]` keeps intersection-in-write and union-in-read behavior for callback contextual typing.
- Fallback: unresolved/non-string-like keys continue into the existing general element-access path.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh -- cargo check -p tsz-checker --lib`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh -- cargo clippy -p tsz-checker --lib -- -D warnings`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test window_indexed_access_callback_contextual_typing_tests --test global_this_property_access_diagnostics_tests --test global_this_block_scoped_local_tests --test global_this_const_property_tests`
- `python3 scripts/arch/arch_guard.py --json` (expected inherited failures only: direct `query_boundaries::common` cap 3101 > 3098, snapshot rollback caller cap 5 > 4; this PR removes the prior `access.rs` >2000-line failure)

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high