### PR TITLE
refactor(checker): route unresolved env writes through authority (#14351)

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping_env_writes.rs
+++ b/crates/tsz-checker/src/context/def_mapping_env_writes.rs
@@ -63,6 +63,12 @@ impl CheckerContext<'_> {
         self.register_in_envs(DeferredFlowEnvWrite::InsertTypeofValueType { symbol, value_type });
     }
 
+    /// Cache an unresolved type-name resolution in **both** type environments
+    /// through the race-safe deferral discipline.
+    pub(crate) fn register_unresolved_resolution_in_envs(&self, name: String, def_id: DefId) {
+        self.register_in_envs(DeferredFlowEnvWrite::InsertUnresolvedResolution { name, def_id });
+    }
+
     /// Register the boxed interface type for a primitive in **both** type
     /// environments through the race-safe deferral discipline.
     pub(crate) fn register_boxed_type_in_envs(

--- a/crates/tsz-checker/src/context/def_mapping_tests.rs
+++ b/crates/tsz-checker/src/context/def_mapping_tests.rs
@@ -1163,12 +1163,7 @@ fn unresolved_resolution_write_reaches_both_envs_and_defers_under_borrow() {
     ));
 
     // Uncontended: both envs receive the cache entry directly.
-    ctx.register_in_envs(
-        super::super::DeferredFlowEnvWrite::InsertUnresolvedResolution {
-            name: "AliasedName".to_string(),
-            def_id: def_a,
-        },
-    );
+    ctx.register_unresolved_resolution_in_envs("AliasedName".to_string(), def_a);
     assert_eq!(
         ctx.type_env.borrow().unresolved_resolution("AliasedName"),
         Some(def_a),
@@ -1185,12 +1180,7 @@ fn unresolved_resolution_write_reaches_both_envs_and_defers_under_borrow() {
     // Contended: the flow-env write defers and replays instead of skipping.
     {
         let held = ctx.type_environment.borrow();
-        ctx.register_in_envs(
-            super::super::DeferredFlowEnvWrite::InsertUnresolvedResolution {
-                name: "RenamedBinder".to_string(),
-                def_id: def_b,
-            },
-        );
+        ctx.register_unresolved_resolution_in_envs("RenamedBinder".to_string(), def_b);
         assert_eq!(
             ctx.type_env.borrow().unresolved_resolution("RenamedBinder"),
             Some(def_b),

--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -1675,12 +1675,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
         // through the env-write authority (deferring on borrow races instead
         // of silently skipping, and mirroring into the flow-analyzer env so
         // `overlay_missing_from` has nothing left to repair — #14348).
-        self.register_in_envs(
-            crate::context::DeferredFlowEnvWrite::InsertUnresolvedResolution {
-                name: name.to_string(),
-                def_id,
-            },
-        );
+        self.register_unresolved_resolution_in_envs(name.to_string(), def_id);
         Some(def_id)
     }
 

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -345,9 +345,8 @@ impl CheckerState<'_> {
             else {
                 continue;
             };
-            if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
-                env.insert_unresolved_resolution(name.clone(), def_id);
-            }
+            self.ctx
+                .register_unresolved_resolution_in_envs(name.clone(), def_id);
             if self.ctx.definition_store.get_body(def_id).is_some() {
                 continue;
             }

--- a/crates/tsz-checker/src/tests/type_analysis_env_merge_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/type_analysis_env_merge_arch_tests.rs
@@ -43,3 +43,35 @@ fn type_analysis_env_merges_use_deferred_helpers() {
         "enum member parent publication should route through register_enum_parent_in_envs"
     );
 }
+
+#[test]
+fn unresolved_resolution_env_writes_use_deferred_authority() {
+    let resolver =
+        fs::read_to_string("src/context/resolver.rs").expect("failed to read context/resolver.rs");
+    let lazy =
+        fs::read_to_string("src/state/type_environment/lazy.rs").expect("failed to read lazy.rs");
+    let env_writes = fs::read_to_string("src/context/def_mapping_env_writes.rs")
+        .expect("failed to read def_mapping_env_writes.rs");
+    let deferred = fs::read_to_string("src/context/deferred_flow_env_write.rs")
+        .expect("failed to read deferred_flow_env_write.rs");
+
+    for (label, source) in [("context resolver", resolver), ("lazy evaluation", lazy)] {
+        assert!(
+            !source.contains(".insert_unresolved_resolution("),
+            "{label} must not mutate only one TypeEnvironment for unresolved-name caches"
+        );
+        assert!(
+            source.contains("register_unresolved_resolution_in_envs("),
+            "{label} should route unresolved-name cache writes through register_unresolved_resolution_in_envs"
+        );
+    }
+
+    assert!(
+        env_writes.contains("register_unresolved_resolution_in_envs("),
+        "unresolved-name cache writes should have a named env authority wrapper"
+    );
+    assert!(
+        deferred.contains("InsertUnresolvedResolution"),
+        "deferred replay must retain the unresolved-name write operation"
+    );
+}


### PR DESCRIPTION
Goal: fast

## Summary
- Add a named `register_unresolved_resolution_in_envs` wrapper for unresolved-name `TypeEnvironment` cache writes.
- Route the context resolver and lazy environment pre-resolution path through the shared dual-env deferred write authority instead of mutating only `type_env`.
- Add an architecture regression test so unresolved-name cache writes stay on the same authority path as the rest of the #14348 Slice A env-write cleanup.

## Structural Rule
When a checker resolves an unresolved type-name application to a `DefId`, both evaluator and flow `TypeEnvironment` views must receive the same cache entry through checker-owned deferred env-write authority. TSZ owns this in checker context/env-write orchestration; solver resolution semantics and type construction are unchanged.

## Adjacent Matrix
- Context resolver path: `resolve_unresolved_type_name_from_file` now uses the named env authority wrapper.
- Lazy evaluation path: unresolved application body pre-resolution now mirrors into both envs and defers on borrow races.
- Contended flow env: existing regression still proves the flow write queues and replays.
- Guardrail: source-scan test prevents direct production `.insert_unresolved_resolution` writes in resolver/lazy code.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --lib -E 'test(unresolved_resolution_write_reaches_both_envs_and_defers_under_borrow) or test(unresolved_resolution_env_writes_use_deferred_authority) or test(type_analysis_env_merges_use_deferred_helpers)'`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh -- cargo check -p tsz-checker --lib`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh -- cargo clippy -p tsz-checker --lib --tests -- -D warnings`
- `python3 scripts/arch/arch_guard.py --json` (expected inherited failures on this base: `access.rs` >2000 until #15504 lands, direct `query_boundaries::common` cap 3101 > 3098, snapshot rollback caller cap 5 > 4)

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high