### PR TITLE
refactor(checker): route object shape metadata rebuilds (#14351)

### DIFF
--- a/crates/tsz-checker/src/checkers/promise_checker_object_normalization.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker_object_normalization.rs
@@ -139,12 +139,13 @@ impl<'a> CheckerState<'a> {
             self.ctx
                 .types
                 .factory()
-                .object_with_index(tsz_solver::ObjectShape {
-                    properties: evaluated_properties,
-                    string_index: evaluated_string_index,
-                    number_index: evaluated_number_index,
-                    ..(*shape).clone()
-                })
+                .object_with_shape_metadata_and_index_signatures(
+                    evaluated_properties,
+                    &shape,
+                    evaluated_string_index,
+                    evaluated_number_index,
+                    shape.symbol_index,
+                )
         })
     }
     pub(crate) fn evaluate_awaited_application_for_assignability(

--- a/crates/tsz-checker/src/query_boundaries/js_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports.rs
@@ -19,7 +19,7 @@ use tsz_binder::{SymbolId, symbol_flags};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{CallableShape, ObjectShape, PropertyInfo, TypeId, Visibility};
+use tsz_solver::{CallableShape, PropertyInfo, TypeId, Visibility};
 
 pub(crate) fn commonjs_direct_export_supports_named_props(
     types: &dyn tsz_solver::construction::TypeDatabase,
@@ -197,28 +197,12 @@ impl JsExportSurface {
             merged_props.extend(overlay_by_name.into_values());
             Self::normalize_property_declaration_order(&mut merged_props);
 
-            let merged_shape = ObjectShape {
-                flags: shape.flags,
-                properties: merged_props,
-                string_index: shape.string_index,
-                number_index: shape.number_index,
-                symbol_index: shape.symbol_index,
-                symbol: shape.symbol,
-            };
-
             return Some(
-                if shape.string_index.is_some()
-                    || shape.number_index.is_some()
-                    || shape.symbol_index.is_some()
-                {
-                    checker.ctx.types.factory().object_with_index(merged_shape)
-                } else {
-                    checker.ctx.types.factory().object_with_flags_and_symbol(
-                        merged_shape.properties,
-                        merged_shape.flags,
-                        merged_shape.symbol,
-                    )
-                },
+                checker
+                    .ctx
+                    .types
+                    .factory()
+                    .object_with_shape_metadata(merged_props, &shape),
             );
         }
 

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
@@ -5,7 +5,7 @@ use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{ObjectShape, PropertyInfo, TypeId, Visibility};
+use tsz_solver::{PropertyInfo, TypeId, Visibility};
 
 impl<'a> CheckerState<'a> {
     fn infer_descriptor_parameter_type_in_current_checker(
@@ -759,7 +759,7 @@ impl<'a> CheckerState<'a> {
                         .map(|shape| shape.as_ref().clone())
                 });
         if let Some(shape) = base_shape {
-            let mut merged_props = shape.properties;
+            let mut merged_props = shape.properties.clone();
             for prop in props {
                 if let Some(existing) = merged_props
                     .iter_mut()
@@ -771,25 +771,11 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            if shape.string_index.is_some()
-                || shape.number_index.is_some()
-                || shape.symbol_index.is_some()
-            {
-                return self.ctx.types.factory().object_with_index(ObjectShape {
-                    flags: shape.flags,
-                    properties: merged_props,
-                    string_index: shape.string_index,
-                    number_index: shape.number_index,
-                    symbol_index: shape.symbol_index,
-                    symbol: shape.symbol,
-                });
-            }
-
-            return self.ctx.types.factory().object_with_flags_and_symbol(
-                merged_props,
-                shape.flags,
-                shape.symbol,
-            );
+            return self
+                .ctx
+                .types
+                .factory()
+                .object_with_shape_metadata(merged_props, &shape);
         }
 
         let define_property_type = self.ctx.types.factory().object(props);

--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -768,7 +768,7 @@ impl<'a> CheckerState<'a> {
         sym_id: SymbolId,
         base_type: TypeId,
     ) -> TypeId {
-        use tsz_solver::{ObjectShape, PropertyInfo};
+        use tsz_solver::PropertyInfo;
 
         if !self.is_js_file() || !self.ctx.compiler_options.check_js {
             return base_type;
@@ -821,14 +821,14 @@ impl<'a> CheckerState<'a> {
             return base_type;
         }
 
-        self.ctx.types.factory().object_with_index(ObjectShape {
-            flags: shape.flags,
-            properties,
-            string_index: shape.string_index,
-            number_index: shape.number_index,
-            symbol_index: shape.symbol_index,
-            symbol: shape.symbol.or(Some(sym_id)),
-        })
+        self.ctx
+            .types
+            .factory()
+            .object_with_shape_metadata_and_symbol(
+                properties,
+                &shape,
+                shape.symbol.or(Some(sym_id)),
+            )
     }
 
     pub(crate) fn get_global_this_type(&mut self, error_node: NodeIndex) -> TypeId {

--- a/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
+++ b/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
@@ -331,18 +331,10 @@ impl<'a> CheckerState<'a> {
         // Preserve index signatures and object flags for object-rest types.
         // Rest results are structural copies, so they must not retain the
         // source type's nominal symbol (e.g. class identity).
-        if shape.string_index.is_some() || shape.number_index.is_some() {
-            let mut rest_shape = shape.as_ref().clone();
-            rest_shape.properties = remaining_props;
-            rest_shape.symbol = None;
-            self.ctx.types.factory().object_with_index(rest_shape)
-        } else {
-            self.ctx.types.factory().object_with_flags_and_symbol(
-                remaining_props,
-                shape.flags,
-                None,
-            )
-        }
+        self.ctx
+            .types
+            .factory()
+            .structural_object_with_shape_metadata(remaining_props, &shape)
     }
 
     /// Rest bindings from tuple members should produce an array type.

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -1192,7 +1192,7 @@ impl<'a> CheckerState<'a> {
     ) -> tsz_solver::TypeId {
         use crate::query_boundaries::common::{AugmentationTargetKind, classify_for_augmentation};
         use crate::query_boundaries::state::type_resolution as query;
-        use tsz_solver::{CallableShape, ObjectShape};
+        use tsz_solver::CallableShape;
 
         // Fast-path: avoids string allocations and hashset bookkeeping when
         // no augmentations are registered anywhere in the program.
@@ -1286,11 +1286,7 @@ impl<'a> CheckerState<'a> {
                 // object-level flags so the augmented type keeps its canonical
                 // declaration name (e.g. `Tool` rather than an expanded
                 // `{ ... }` literal) and stays a single interned identity.
-                let augmented = factory.object_with_flags_and_symbol(
-                    merged_properties,
-                    base_shape.flags,
-                    base_shape.symbol,
-                );
+                let augmented = factory.object_with_shape_metadata(merged_properties, &base_shape);
                 if let Some(def_id) = base_def_id
                     && base_shape.symbol.is_some()
                     && self
@@ -1320,14 +1316,7 @@ impl<'a> CheckerState<'a> {
                         .definition_store
                         .register_module_augmentation_symbol_def_if_enabled(symbol.0, def_id);
                 }
-                factory.object_with_index(ObjectShape {
-                    flags: base_shape.flags,
-                    properties: merged_properties,
-                    string_index: base_shape.string_index,
-                    number_index: base_shape.number_index,
-                    symbol_index: base_shape.symbol_index,
-                    symbol: base_shape.symbol,
-                })
+                factory.object_with_shape_metadata(merged_properties, &base_shape)
             }
             AugmentationTargetKind::Callable(shape_id) => {
                 let base_shape = self.ctx.types.callable_shape(shape_id);

--- a/crates/tsz-checker/src/types/property_access_helpers/iterator_methods.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/iterator_methods.rs
@@ -5,7 +5,7 @@ use crate::query_boundaries::common::{
     object_shape_for_type,
 };
 use crate::state::CheckerState;
-use tsz_solver::{FunctionShape, ObjectShape, TupleElement, TypeId};
+use tsz_solver::{FunctionShape, TupleElement, TypeId};
 
 impl<'a> CheckerState<'a> {
     pub(in crate::types_domain) fn synthesized_array_iterator_method_type(
@@ -77,14 +77,16 @@ impl<'a> CheckerState<'a> {
                 && let Some(array_iterator_sym) = self.ctx.binder.file_locals.get("ArrayIterator")
                 && let Some(shape) = object_shape_for_type(self.ctx.types, instantiated)
             {
-                Some(self.ctx.types.factory().object_with_index(ObjectShape {
-                    flags: shape.flags,
-                    properties: shape.properties.clone(),
-                    string_index: shape.string_index,
-                    number_index: shape.number_index,
-                    symbol_index: shape.symbol_index,
-                    symbol: Some(array_iterator_sym),
-                }))
+                Some(
+                    self.ctx
+                        .types
+                        .factory()
+                        .object_with_shape_metadata_and_symbol(
+                            shape.properties.clone(),
+                            &shape,
+                            Some(array_iterator_sym),
+                        ),
+                )
             } else {
                 Some(instantiated)
             }

--- a/crates/tsz-checker/tests/arch_source_scans/object_flags_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/object_flags_boundary_scans.rs
@@ -14,6 +14,8 @@ const OBJECT_FLAG_BOUNDARIES: &[&str] = &[
     "src/query_boundaries/lib_augmentations.rs",
 ];
 
+const OBJECT_FLAG_FACTORY_BOUNDARIES: &[&str] = &["src/query_boundaries/type_construction.rs"];
+
 const RAW_OBJECT_FLAG_PATTERNS: &[&str] = &[
     "ObjectFlags::",
     "tsz_solver::ObjectFlags",
@@ -21,8 +23,53 @@ const RAW_OBJECT_FLAG_PATTERNS: &[&str] = &[
     "query_boundaries::common::ObjectFlags",
 ];
 
+const RAW_OBJECT_FLAG_FACTORY_PATTERNS: &[&str] = &["object_with_flags_and_symbol("];
+
 fn checker_src_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+#[test]
+fn production_object_shape_rebuilds_avoid_raw_flag_factory() {
+    let src_root = checker_src_root();
+    let mut violations = Vec::new();
+
+    for path in rust_sources_under(&src_root) {
+        let relative_path = format!(
+            "src/{}",
+            path.strip_prefix(&src_root)
+                .expect("scanned path is under the src root")
+                .to_string_lossy()
+                .replace('\\', "/")
+        );
+        if OBJECT_FLAG_FACTORY_BOUNDARIES.contains(&relative_path.as_str()) {
+            continue;
+        }
+
+        let source = fs::read_to_string(&path).expect("failed to read Rust source");
+        for (line_index, line) in source.lines().enumerate() {
+            if is_comment_or_doc_line(line) {
+                continue;
+            }
+            for pattern in RAW_OBJECT_FLAG_FACTORY_PATTERNS {
+                if line.contains(pattern) {
+                    violations.push(format!(
+                        "{}:{} calls raw object flag factory `{}`",
+                        relative_path,
+                        line_index + 1,
+                        pattern
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "checker production code should rebuild object metadata through named \
+         factory/query-boundary helpers instead of passing raw flags:\n{}",
+        violations.join("\n")
+    );
 }
 
 fn rust_sources_under(dir: &Path) -> Vec<PathBuf> {

--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -1522,6 +1522,27 @@ const ok: number = so[s];
     );
 }
 
+#[test]
+fn symbol_only_index_object_rest_preserves_symbol_key_access() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const sym: symbol;
+declare const source: { [entry: symbol]: boolean; drop: string };
+
+const { drop, ...rest } = source;
+const value: boolean = rest[sym];
+"#,
+    );
+    assert!(
+        !codes.contains(&TS7053),
+        "object rest from a symbol-indexed source must preserve the symbol index, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "rest[sym] must type as the symbol-index value, got {codes:?}",
+    );
+}
+
 // Control: when BOTH a string and a symbol index are present, a string-literal
 // key must resolve through the string index (not be rejected).
 #[test]

--- a/crates/tsz-solver/src/intern/type_factory.rs
+++ b/crates/tsz-solver/src/intern/type_factory.rs
@@ -159,6 +159,57 @@ impl<'db> TypeFactory<'db> {
         self.db.object_with_index(shape)
     }
 
+    /// Rebuild an object with replacement properties while preserving the
+    /// object-level metadata of an existing shape: flags, index signatures, and
+    /// nominal symbol identity.
+    ///
+    /// Callers in checker-facing code should use this instead of passing raw
+    /// shape flags back into the factory.
+    #[inline]
+    pub fn object_with_shape_metadata(
+        &self,
+        properties: Vec<PropertyInfo>,
+        shape: &ObjectShape,
+    ) -> TypeId {
+        self.object_with_shape_metadata_and_symbol(properties, shape, shape.symbol)
+    }
+
+    /// Rebuild a structural object with replacement properties while preserving
+    /// the source shape's flags and index signatures, but dropping nominal
+    /// symbol identity.
+    #[inline]
+    pub fn structural_object_with_shape_metadata(
+        &self,
+        properties: Vec<PropertyInfo>,
+        shape: &ObjectShape,
+    ) -> TypeId {
+        self.object_with_shape_metadata_and_symbol(properties, shape, None)
+    }
+
+    #[inline]
+    fn object_with_shape_metadata_and_symbol(
+        &self,
+        properties: Vec<PropertyInfo>,
+        shape: &ObjectShape,
+        symbol: Option<SymbolId>,
+    ) -> TypeId {
+        if shape.string_index.is_some()
+            || shape.number_index.is_some()
+            || shape.symbol_index.is_some()
+        {
+            self.object_with_index(ObjectShape {
+                flags: shape.flags,
+                properties,
+                string_index: shape.string_index,
+                number_index: shape.number_index,
+                symbol_index: shape.symbol_index,
+                symbol,
+            })
+        } else {
+            self.object_with_flags_and_symbol(properties, shape.flags, symbol)
+        }
+    }
+
     /// Create the synthetic `typeof globalThis` surface object. It carries the
     /// `GLOBAL_THIS_SURFACE` flag so diagnostics render it as `typeof
     /// globalThis` rather than its full member body. Builder method so checker
@@ -184,7 +235,7 @@ impl<'db> TypeFactory<'db> {
     }
 
     #[inline]
-    pub fn object_with_flags_and_symbol(
+    pub(crate) fn object_with_flags_and_symbol(
         &self,
         properties: Vec<PropertyInfo>,
         flags: ObjectFlags,

--- a/crates/tsz-solver/src/intern/type_factory.rs
+++ b/crates/tsz-solver/src/intern/type_factory.rs
@@ -5,8 +5,8 @@
 
 use crate::caches::db::TypeDatabase;
 use crate::types::{
-    CallableShape, ConditionalType, FunctionShape, MappedType, ObjectFlags, ObjectShape,
-    PropertyInfo, TemplateSpan, TupleElement, TypeId, TypeParamInfo,
+    CallableShape, ConditionalType, FunctionShape, IndexSignature, MappedType, ObjectFlags,
+    ObjectShape, PropertyInfo, TemplateSpan, TupleElement, TypeId, TypeParamInfo,
 };
 use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
@@ -174,6 +174,47 @@ impl<'db> TypeFactory<'db> {
         self.object_with_shape_metadata_and_symbol(properties, shape, shape.symbol)
     }
 
+    /// Rebuild an object with replacement properties while preserving the
+    /// source shape's flags and index signatures, and applying an explicit
+    /// nominal symbol policy.
+    #[inline]
+    pub fn object_with_shape_metadata_and_symbol(
+        &self,
+        properties: Vec<PropertyInfo>,
+        shape: &ObjectShape,
+        symbol: Option<SymbolId>,
+    ) -> TypeId {
+        self.object_with_shape_parts(
+            properties,
+            shape,
+            shape.string_index,
+            shape.number_index,
+            shape.symbol_index,
+            symbol,
+        )
+    }
+
+    /// Rebuild an object with replacement properties and index signatures while
+    /// preserving the source shape's object flags and nominal symbol identity.
+    #[inline]
+    pub fn object_with_shape_metadata_and_index_signatures(
+        &self,
+        properties: Vec<PropertyInfo>,
+        shape: &ObjectShape,
+        string_index: Option<IndexSignature>,
+        number_index: Option<IndexSignature>,
+        symbol_index: Option<IndexSignature>,
+    ) -> TypeId {
+        self.object_with_shape_parts(
+            properties,
+            shape,
+            string_index,
+            number_index,
+            symbol_index,
+            shape.symbol,
+        )
+    }
+
     /// Rebuild a structural object with replacement properties while preserving
     /// the source shape's flags and index signatures, but dropping nominal
     /// symbol identity.
@@ -187,22 +228,22 @@ impl<'db> TypeFactory<'db> {
     }
 
     #[inline]
-    fn object_with_shape_metadata_and_symbol(
+    fn object_with_shape_parts(
         &self,
         properties: Vec<PropertyInfo>,
         shape: &ObjectShape,
+        string_index: Option<IndexSignature>,
+        number_index: Option<IndexSignature>,
+        symbol_index: Option<IndexSignature>,
         symbol: Option<SymbolId>,
     ) -> TypeId {
-        if shape.string_index.is_some()
-            || shape.number_index.is_some()
-            || shape.symbol_index.is_some()
-        {
+        if string_index.is_some() || number_index.is_some() || symbol_index.is_some() {
             self.object_with_index(ObjectShape {
                 flags: shape.flags,
                 properties,
-                string_index: shape.string_index,
-                number_index: shape.number_index,
-                symbol_index: shape.symbol_index,
+                string_index,
+                number_index,
+                symbol_index,
                 symbol,
             })
         } else {

--- a/crates/tsz-solver/tests/intern_tests.rs
+++ b/crates/tsz-solver/tests/intern_tests.rs
@@ -146,7 +146,7 @@ fn type_factory_rebuilds_object_shape_metadata_with_symbol_policy() {
 
     let structural = interner
         .factory()
-        .structural_object_with_shape_metadata(vec![replacement_prop], &shape);
+        .structural_object_with_shape_metadata(vec![replacement_prop.clone()], &shape);
     let Some(TypeData::ObjectWithIndex(structural_shape_id)) = interner.lookup(structural) else {
         panic!("structural metadata rebuild with index signatures must produce ObjectWithIndex");
     };
@@ -156,6 +156,49 @@ fn type_factory_rebuilds_object_shape_metadata_with_symbol_policy() {
     assert_eq!(structural_shape.number_index, shape.number_index);
     assert_eq!(structural_shape.symbol_index, shape.symbol_index);
     assert_eq!(structural_shape.symbol, None);
+
+    let override_symbol = Some(SymbolId(88));
+    let stamped = interner.factory().object_with_shape_metadata_and_symbol(
+        vec![replacement_prop.clone()],
+        &shape,
+        override_symbol,
+    );
+    let Some(TypeData::ObjectWithIndex(stamped_shape_id)) = interner.lookup(stamped) else {
+        panic!("explicit-symbol metadata rebuild must produce ObjectWithIndex");
+    };
+    let stamped_shape = interner.object_shape(stamped_shape_id);
+    assert_eq!(stamped_shape.flags, shape.flags);
+    assert_eq!(stamped_shape.string_index, shape.string_index);
+    assert_eq!(stamped_shape.number_index, shape.number_index);
+    assert_eq!(stamped_shape.symbol_index, shape.symbol_index);
+    assert_eq!(stamped_shape.symbol, override_symbol);
+
+    let replacement_number_index = Some(IndexSignature {
+        key_type: TypeId::NUMBER,
+        value_type: TypeId::BOOLEAN,
+        readonly: true,
+        param_name: Some(number_name),
+    });
+    let reindexed = interner
+        .factory()
+        .object_with_shape_metadata_and_index_signatures(
+            vec![replacement_prop],
+            &shape,
+            None,
+            replacement_number_index,
+            shape.symbol_index,
+        );
+    let Some(TypeData::ObjectWithIndex(reindexed_shape_id)) = interner.lookup(reindexed) else {
+        panic!("replacement-index metadata rebuild must produce ObjectWithIndex");
+    };
+    let reindexed_shape = interner.object_shape(reindexed_shape_id);
+    assert_eq!(reindexed_shape.flags, shape.flags);
+    // With no string index, interning canonicalizes a symbol-only index into
+    // the historical string-index slot where `key_type == symbol`.
+    assert_eq!(reindexed_shape.string_index, shape.symbol_index);
+    assert_eq!(reindexed_shape.number_index, replacement_number_index);
+    assert_eq!(reindexed_shape.symbol_index, None);
+    assert_eq!(reindexed_shape.symbol, shape_symbol);
 }
 
 #[test]

--- a/crates/tsz-solver/tests/intern_tests.rs
+++ b/crates/tsz-solver/tests/intern_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::caches::db::QueryDatabase;
 use crate::intern::PROPERTY_MAP_THRESHOLD;
 use crate::relations::freshness::{is_fresh_object_type, widen_freshness};
 use tsz_binder::SymbolId;
@@ -93,6 +94,68 @@ fn test_interner_preserves_index_signature_parameter_names_for_display() {
         shape.string_index.and_then(|idx| idx.param_name),
         Some(x_name)
     );
+}
+
+#[test]
+fn type_factory_rebuilds_object_shape_metadata_with_symbol_policy() {
+    let interner = TypeInterner::new();
+    let base_prop = PropertyInfo::new(interner.intern_string("base"), TypeId::STRING);
+    let replacement_prop = PropertyInfo::new(interner.intern_string("replacement"), TypeId::NUMBER);
+    let string_name = interner.intern_string("textKey");
+    let number_name = interner.intern_string("indexKey");
+    let symbol_name = interner.intern_string("symbolKey");
+    let shape_symbol = Some(SymbolId(77));
+
+    let shape = ObjectShape {
+        flags: ObjectFlags::FRESH_LITERAL | ObjectFlags::PRESERVE_DECLARATION_ORDER,
+        properties: vec![base_prop],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::STRING,
+            readonly: true,
+            param_name: Some(string_name),
+        }),
+        number_index: Some(IndexSignature {
+            key_type: TypeId::NUMBER,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: Some(number_name),
+        }),
+        symbol_index: Some(IndexSignature {
+            key_type: TypeId::SYMBOL,
+            value_type: TypeId::BOOLEAN,
+            readonly: true,
+            param_name: Some(symbol_name),
+        }),
+        symbol: shape_symbol,
+    };
+
+    let rebuilt = interner
+        .factory()
+        .object_with_shape_metadata(vec![replacement_prop.clone()], &shape);
+    let Some(TypeData::ObjectWithIndex(rebuilt_shape_id)) = interner.lookup(rebuilt) else {
+        panic!("metadata rebuild with index signatures must produce ObjectWithIndex");
+    };
+    let rebuilt_shape = interner.object_shape(rebuilt_shape_id);
+    assert_eq!(rebuilt_shape.flags, shape.flags);
+    assert_eq!(rebuilt_shape.properties, vec![replacement_prop.clone()]);
+    assert_eq!(rebuilt_shape.string_index, shape.string_index);
+    assert_eq!(rebuilt_shape.number_index, shape.number_index);
+    assert_eq!(rebuilt_shape.symbol_index, shape.symbol_index);
+    assert_eq!(rebuilt_shape.symbol, shape_symbol);
+
+    let structural = interner
+        .factory()
+        .structural_object_with_shape_metadata(vec![replacement_prop], &shape);
+    let Some(TypeData::ObjectWithIndex(structural_shape_id)) = interner.lookup(structural) else {
+        panic!("structural metadata rebuild with index signatures must produce ObjectWithIndex");
+    };
+    let structural_shape = interner.object_shape(structural_shape_id);
+    assert_eq!(structural_shape.flags, shape.flags);
+    assert_eq!(structural_shape.string_index, shape.string_index);
+    assert_eq!(structural_shape.number_index, shape.number_index);
+    assert_eq!(structural_shape.symbol_index, shape.symbol_index);
+    assert_eq!(structural_shape.symbol, None);
 }
 
 #[test]


### PR DESCRIPTION
Goal: fast

## Summary
- add solver-owned `TypeFactory` helpers for rebuilding object shapes with replacement properties, index-signature replacements, and explicit symbol policy
- route module augmentation, CommonJS export merging, JS export overlays, object rest construction, ArrayIterator stamping, JS expando augmentation, and Awaited object normalization through those helpers instead of rebuilding raw `ObjectShape` metadata in checker code
- add source-scan, solver unit, and symbol-index object-rest coverage so the boundary stays pinned

## Structural Rule
When checker rebuilds an existing object-like shape by replacing properties or evaluated index signatures, `tsc` preserves object metadata according to the operation intent: identity rebuilds keep the nominal symbol, structural rest copies drop nominal identity, stamping operations intentionally override symbol identity, and Awaited normalization preserves symbol identity while replacing evaluated string/number index value types. In tsz, solver construction owns that metadata rebuild through `TypeFactory`; checker code supplies replacement properties and the symbol/index policy but no longer reconstructs raw shape metadata locally.

Owner layer: solver construction (`TypeFactory`). Checker remains orchestration.

Adjacent matrix:
- identity rebuilds preserve declaration symbol, object flags, and string/number/symbol index signatures
- structural object-rest rebuilds drop nominal symbol identity while preserving all index signatures, including symbol-only indexes
- ArrayIterator synthesis overrides the instantiated iterator symbol with `ArrayIterator` while preserving shape metadata
- JS expando augmentation preserves an existing symbol and otherwise stamps the global value symbol
- Awaited object normalization preserves flags/symbol/symbol index while replacing evaluated string/number index signatures
- enum namespace and `typeof globalThis` metadata paths stay covered by focused checker suites
- source scan now rejects checker production calls to `object_with_flags_and_symbol(` outside the enum namespace construction boundary

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh -- cargo check -p tsz-solver -p tsz-checker`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh -- cargo clippy -p tsz-solver -p tsz-checker --lib --tests -- -D warnings`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test arch_source_scans production_object_flags_use_type_construction_boundary production_object_shape_rebuilds_avoid_raw_flag_factory`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test symbol_index_signature_tests symbol_only_index_object_rest_preserves_symbol_key_access`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-solver --lib type_factory_rebuilds_object_shape_metadata_with_symbol_policy`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test enum_keyof_excludes_number_tests --test ts2403_enum_object_redeclaration_tests --test module_augmentation_isolation_tests --test module_augmentation_declaration_identity_tests --test ambient_module_augmentation_new_export_tests --test export_star_module_augmentation_tests --test cjs_direct_object_export_no_typeof_import_display_tests --test cjs_object_export_module_augmentation_merge_tests --test typeof_import_commonjs_object_literal_export_tests --test destructuring_rest_omit_unspreadable_tests --test destructuring_rest_computed_key_omit_tests --test destructuring_spread_rest_tuple_source_display_tests --test tuple_rest_destructuring_slice_tests`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --lib -E 'test(window_self_globalthis_resolution_tests) or test(global_this_property_access_diagnostics_tests)'`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test lib_resolution_identity_tests --test cross_file_js_ts_class_merge_ts2451_suppression_tests --test awaited_generic_application_fold_tests`
- `python3 scripts/arch/arch_guard.py --json` (red on inherited baseline: `access.rs` 2026 lines, direct-common cap 3102 hits over cap, snapshot rollback cap 5 over 4)
- `scripts/arch/check-checker-boundaries.sh` (same inherited baseline failures)
- `python3 scripts/arch/test_arch_guard.py` (same inherited oversized/cap assertions)

## Provenance
Machine: Mac
Assistant: codex
Model: gpt-5
Effort: high
