### PR TITLE
refactor(checker): preserve interface symbol index shapes (#14351)

### DIFF
--- a/crates/tsz-checker/src/checkers/promise_checker_object_normalization.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker_object_normalization.rs
@@ -139,12 +139,13 @@ impl<'a> CheckerState<'a> {
             self.ctx
                 .types
                 .factory()
-                .object_with_index(tsz_solver::ObjectShape {
-                    properties: evaluated_properties,
-                    string_index: evaluated_string_index,
-                    number_index: evaluated_number_index,
-                    ..(*shape).clone()
-                })
+                .object_with_shape_metadata_and_index_signatures(
+                    evaluated_properties,
+                    &shape,
+                    evaluated_string_index,
+                    evaluated_number_index,
+                    shape.symbol_index,
+                )
         })
     }
     pub(crate) fn evaluate_awaited_application_for_assignability(

--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -282,6 +282,7 @@ impl<'a> CheckerState<'a> {
         // and is labeled by the pattern rather than `string`.
         let mut derived_string_index_type: Option<(TypeId, TypeId, NodeIndex)> = None;
         let mut derived_number_index_type: Option<(TypeId, NodeIndex)> = None;
+        let mut derived_symbol_index_type: Option<(TypeId, NodeIndex)> = None;
         for &decl_idx in &all_iface_decls {
             let Some(sym_id) = iface_sym_id else {
                 continue;
@@ -322,6 +323,8 @@ impl<'a> CheckerState<'a> {
                         };
                         if key_type == TypeId::NUMBER {
                             derived_number_index_type = Some((value_type, member_idx));
+                        } else if key_type == TypeId::SYMBOL {
+                            derived_symbol_index_type = Some((value_type, member_idx));
                         } else {
                             derived_string_index_type = Some((value_type, key_type, member_idx));
                         }
@@ -346,6 +349,7 @@ impl<'a> CheckerState<'a> {
         // index signature, the interface "incorrectly extends" that base.
         let mut inherited_string_index: Option<(NodeIndex, String, TypeId)> = None;
         let mut inherited_number_index: Option<(NodeIndex, String, TypeId)> = None;
+        let mut inherited_symbol_index: Option<(NodeIndex, String, TypeId)> = None;
 
         // Collect ALL heritage clauses across ALL declarations of this interface.
         // When an interface is declaration-merged with a class, the class's `extends`
@@ -919,10 +923,12 @@ impl<'a> CheckerState<'a> {
                         let value_type =
                             instantiate_type(self.ctx.types, value_type, &substitution);
 
-                        let inherited_slot = if key_type == TypeId::NUMBER {
-                            &mut inherited_number_index
+                        let (inherited_slot, index_kind) = if key_type == TypeId::NUMBER {
+                            (&mut inherited_number_index, "number")
+                        } else if key_type == TypeId::SYMBOL {
+                            (&mut inherited_symbol_index, "symbol")
                         } else {
-                            &mut inherited_string_index
+                            (&mut inherited_string_index, "string")
                         };
 
                         if let Some((prev_heritage_idx, ref _prev_base_name, prev_val)) =
@@ -941,11 +947,6 @@ impl<'a> CheckerState<'a> {
                                         )
                                         .related
                                 {
-                                    let index_kind = if key_type == TypeId::NUMBER {
-                                        "number"
-                                    } else {
-                                        "string"
-                                    };
                                     let prev_type_str = self.format_type(prev_val);
                                     let value_type_str = self.format_type(value_type);
                                     self.error_at_node(
@@ -1805,18 +1806,24 @@ impl<'a> CheckerState<'a> {
             // an index signature, the base interface's index signature (if any) must be
             // compatible. E.g., `interface F extends E` where F has `[s: string]: number`
             // and E has `[s: string]: string` → TS2430.
-            if derived_string_index_type.is_some() || derived_number_index_type.is_some() {
+            if derived_string_index_type.is_some()
+                || derived_number_index_type.is_some()
+                || derived_symbol_index_type.is_some()
+            {
                 let mut base_string_index_value: Option<TypeId> = None;
                 let mut base_number_index_value: Option<TypeId> = None;
+                let mut base_symbol_index_value: Option<TypeId> = None;
 
                 if let Some(shape) = crate::query_boundaries::common::object_shape_for_type(
                     self.ctx.types,
                     base_type_for_relation,
                 ) {
                     base_string_index_value =
-                        shape.string_index.as_ref().map(|index| index.value_type);
+                        shape.string_index_signature().map(|index| index.value_type);
                     base_number_index_value =
                         shape.number_index.as_ref().map(|index| index.value_type);
+                    base_symbol_index_value =
+                        shape.symbol_index_signature().map(|index| index.value_type);
                 }
 
                 for &base_iface_idx in &base_iface_indices {
@@ -1860,6 +1867,8 @@ impl<'a> CheckerState<'a> {
                                 instantiate_type(self.ctx.types, value_type, &substitution);
                             if key_type == TypeId::NUMBER {
                                 base_number_index_value = Some(value_type);
+                            } else if key_type == TypeId::SYMBOL {
+                                base_symbol_index_value = Some(value_type);
                             } else {
                                 base_string_index_value = Some(value_type);
                             }
@@ -1892,6 +1901,21 @@ impl<'a> CheckerState<'a> {
                         iface_data.name,
                         &format!(
                             "Interface '{derived_name}' incorrectly extends interface '{base_name}'.\n  'number' index signatures are incompatible.\n    Type '{derived_type_str}' is not assignable to type '{base_type_str}'."
+                        ),
+                        diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE,
+                    );
+                }
+
+                if let (Some((derived_val, _)), Some(base_val)) =
+                    (derived_symbol_index_type, base_symbol_index_value)
+                    && !self.index_value_assignable_for_interface_extends(derived_val, base_val)
+                {
+                    let derived_type_str = self.format_type(derived_val);
+                    let base_type_str = self.format_type(base_val);
+                    self.error_at_node(
+                        iface_data.name,
+                        &format!(
+                            "Interface '{derived_name}' incorrectly extends interface '{base_name}'.\n  'symbol' index signatures are incompatible.\n    Type '{derived_type_str}' is not assignable to type '{base_type_str}'."
                         ),
                         diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE,
                     );

--- a/crates/tsz-checker/src/query_boundaries/js_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports.rs
@@ -19,7 +19,7 @@ use tsz_binder::{SymbolId, symbol_flags};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{CallableShape, ObjectShape, PropertyInfo, TypeId, Visibility};
+use tsz_solver::{CallableShape, PropertyInfo, TypeId, Visibility};
 
 pub(crate) fn commonjs_direct_export_supports_named_props(
     types: &dyn tsz_solver::construction::TypeDatabase,
@@ -197,28 +197,12 @@ impl JsExportSurface {
             merged_props.extend(overlay_by_name.into_values());
             Self::normalize_property_declaration_order(&mut merged_props);
 
-            let merged_shape = ObjectShape {
-                flags: shape.flags,
-                properties: merged_props,
-                string_index: shape.string_index,
-                number_index: shape.number_index,
-                symbol_index: shape.symbol_index,
-                symbol: shape.symbol,
-            };
-
             return Some(
-                if shape.string_index.is_some()
-                    || shape.number_index.is_some()
-                    || shape.symbol_index.is_some()
-                {
-                    checker.ctx.types.factory().object_with_index(merged_shape)
-                } else {
-                    checker.ctx.types.factory().object_with_flags_and_symbol(
-                        merged_shape.properties,
-                        merged_shape.flags,
-                        merged_shape.symbol,
-                    )
-                },
+                checker
+                    .ctx
+                    .types
+                    .factory()
+                    .object_with_shape_metadata(merged_props, &shape),
             );
         }
 

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
@@ -5,7 +5,7 @@ use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{ObjectShape, PropertyInfo, TypeId, Visibility};
+use tsz_solver::{PropertyInfo, TypeId, Visibility};
 
 impl<'a> CheckerState<'a> {
     fn infer_descriptor_parameter_type_in_current_checker(
@@ -759,7 +759,7 @@ impl<'a> CheckerState<'a> {
                         .map(|shape| shape.as_ref().clone())
                 });
         if let Some(shape) = base_shape {
-            let mut merged_props = shape.properties;
+            let mut merged_props = shape.properties.clone();
             for prop in props {
                 if let Some(existing) = merged_props
                     .iter_mut()
@@ -771,25 +771,11 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            if shape.string_index.is_some()
-                || shape.number_index.is_some()
-                || shape.symbol_index.is_some()
-            {
-                return self.ctx.types.factory().object_with_index(ObjectShape {
-                    flags: shape.flags,
-                    properties: merged_props,
-                    string_index: shape.string_index,
-                    number_index: shape.number_index,
-                    symbol_index: shape.symbol_index,
-                    symbol: shape.symbol,
-                });
-            }
-
-            return self.ctx.types.factory().object_with_flags_and_symbol(
-                merged_props,
-                shape.flags,
-                shape.symbol,
-            );
+            return self
+                .ctx
+                .types
+                .factory()
+                .object_with_shape_metadata(merged_props, &shape);
         }
 
         let define_property_type = self.ctx.types.factory().object(props);

--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -768,7 +768,7 @@ impl<'a> CheckerState<'a> {
         sym_id: SymbolId,
         base_type: TypeId,
     ) -> TypeId {
-        use tsz_solver::{ObjectShape, PropertyInfo};
+        use tsz_solver::PropertyInfo;
 
         if !self.is_js_file() || !self.ctx.compiler_options.check_js {
             return base_type;
@@ -821,14 +821,14 @@ impl<'a> CheckerState<'a> {
             return base_type;
         }
 
-        self.ctx.types.factory().object_with_index(ObjectShape {
-            flags: shape.flags,
-            properties,
-            string_index: shape.string_index,
-            number_index: shape.number_index,
-            symbol_index: shape.symbol_index,
-            symbol: shape.symbol.or(Some(sym_id)),
-        })
+        self.ctx
+            .types
+            .factory()
+            .object_with_shape_metadata_and_symbol(
+                properties,
+                &shape,
+                shape.symbol.or(Some(sym_id)),
+            )
     }
 
     pub(crate) fn get_global_this_type(&mut self, error_node: NodeIndex) -> TypeId {

--- a/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
+++ b/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
@@ -331,18 +331,10 @@ impl<'a> CheckerState<'a> {
         // Preserve index signatures and object flags for object-rest types.
         // Rest results are structural copies, so they must not retain the
         // source type's nominal symbol (e.g. class identity).
-        if shape.string_index.is_some() || shape.number_index.is_some() {
-            let mut rest_shape = shape.as_ref().clone();
-            rest_shape.properties = remaining_props;
-            rest_shape.symbol = None;
-            self.ctx.types.factory().object_with_index(rest_shape)
-        } else {
-            self.ctx.types.factory().object_with_flags_and_symbol(
-                remaining_props,
-                shape.flags,
-                None,
-            )
-        }
+        self.ctx
+            .types
+            .factory()
+            .structural_object_with_shape_metadata(remaining_props, &shape)
     }
 
     /// Rest bindings from tuple members should produce an array type.

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1375,46 +1375,20 @@ impl<'a> CheckerState<'a> {
                 }
             }
         }
-
-        // Match const `symbol` computed members stored under stable binding keys.
         if result_type.is_none()
-            && index_type == TypeId::SYMBOL
-            && !crate::query_boundaries::common::is_type_parameter(
-                self.ctx.types,
+            && let Some(symbol_result) = self.wide_symbol_binding_access_type(
+                access.name_or_argument,
                 pre_resolution_object_type,
+                object_type_for_access,
+                index_type,
+                index_type_for_access,
+                skip_flow_narrowing,
+                write_presence_only,
             )
-            && let Some(property_name) =
-                self.symbol_valued_binding_property_name(access.name_or_argument, index_type)
         {
-            let resolved_type = self.resolve_type_for_property_access(object_type_for_access);
-            let result = self.resolve_property_access_with_env(resolved_type, &property_name);
-            if let PropertyAccessResult::Success {
-                type_id,
-                write_type,
-                ..
-            } = result
-            {
-                use_index_signature_check = false;
-                result_type = Some(effective_write_result(type_id, write_type));
-            }
+            result_type = Some(symbol_result);
+            use_index_signature_check = false;
         }
-
-        // A wide `symbol` index made through a symbol-typed identifier may carry
-        // a binding-identity key for exact computed-member lookup. Once that
-        // exact lookup misses, a receiver with a broad symbol index signature
-        // should resolve through `receiver[symbol]`, not through the binding key.
-        if result_type.is_none()
-            && index_type == TypeId::SYMBOL
-            && index_type_for_access != index_type
-        {
-            let symbol_index_result =
-                self.get_element_access_type(object_type_for_access, TypeId::SYMBOL, None);
-            if symbol_index_result != TypeId::UNDEFINED && symbol_index_result != TypeId::ERROR {
-                result_type = Some(symbol_index_result);
-                use_index_signature_check = false;
-            }
-        }
-
         // Late-bound symbol members are not stored as named properties.
         if result_type.is_none()
             && index_type == TypeId::SYMBOL

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -276,6 +276,49 @@ impl<'a> CheckerState<'a> {
             .resolve_element_access_type(object_type, solver_index_type, literal_index)
     }
 
+    pub(crate) fn wide_symbol_binding_access_type(
+        &mut self,
+        index_node: NodeIndex,
+        pre_resolution_object_type: TypeId,
+        object_type_for_access: TypeId,
+        index_type: TypeId,
+        index_type_for_access: TypeId,
+        skip_flow_narrowing: bool,
+        write_presence_only: bool,
+    ) -> Option<TypeId> {
+        if index_type != TypeId::SYMBOL {
+            return None;
+        }
+        if !crate::query_boundaries::common::is_type_parameter(
+            self.ctx.types,
+            pre_resolution_object_type,
+        ) && let Some(property_name) =
+            self.symbol_valued_binding_property_name(index_node, index_type)
+        {
+            let resolved_type = self.resolve_type_for_property_access(object_type_for_access);
+            if let Some(prop) = crate::query_boundaries::common::find_property_by_str(
+                self.ctx.types,
+                resolved_type,
+                &property_name,
+            ) {
+                return Some(if skip_flow_narrowing {
+                    if write_presence_only {
+                        TypeId::ANY
+                    } else {
+                        prop.write_type
+                    }
+                } else {
+                    prop.type_id
+                });
+            }
+        }
+        if index_type_for_access == index_type {
+            return None;
+        }
+        let result = self.get_element_access_type(object_type_for_access, TypeId::SYMBOL, None);
+        (result != TypeId::UNDEFINED && result != TypeId::ERROR).then_some(result)
+    }
+
     /// Resolve a tuple's spread (`rest`) element types and rebuild it so the
     /// solver's resolver-less element-access evaluator sees a flat tuple.
     ///

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -1354,7 +1354,7 @@ impl<'a> CheckerState<'a> {
     ) -> TypeId {
         use crate::query_boundaries::common::{InterfaceMergeKind, classify_for_interface_merge};
         use tracing::trace;
-        use tsz_solver::{CallableShape, ObjectShape};
+        use tsz_solver::CallableShape;
 
         // Bail out if type resolution fuel is exhausted to prevent
         // expensive merges from hanging on augmented module interfaces
@@ -1526,14 +1526,13 @@ impl<'a> CheckerState<'a> {
                 );
                 let properties =
                     self.merge_properties(&derived_shape.properties, &base_shape.properties, mode);
-                let result = factory.object_with_index(ObjectShape {
+                let result = factory.object_with_shape_metadata_and_index_signatures(
                     properties,
-                    string_index: base_shape.string_index,
-                    number_index: base_shape.number_index,
-                    symbol_index: base_shape.symbol_index,
-                    symbol: derived_shape.symbol,
-                    ..ObjectShape::default()
-                });
+                    &derived_shape,
+                    base_shape.string_index_signature().copied(),
+                    base_shape.number_index,
+                    base_shape.symbol_index_signature().copied(),
+                );
                 tracing::trace!(result_type = %result.0, "merge_interface_types: created merged type");
                 result
             }
@@ -1545,14 +1544,7 @@ impl<'a> CheckerState<'a> {
                 let base_shape = self.ctx.types.object_shape(base_shape_id);
                 let properties =
                     self.merge_properties(&derived_shape.properties, &base_shape.properties, mode);
-                factory.object_with_index(ObjectShape {
-                    properties,
-                    string_index: derived_shape.string_index,
-                    number_index: derived_shape.number_index,
-                    symbol_index: derived_shape.symbol_index,
-                    symbol: derived_shape.symbol,
-                    ..ObjectShape::default()
-                })
+                factory.object_with_shape_metadata(properties, &derived_shape)
             }
             (
                 InterfaceMergeKind::ObjectWithIndex(derived_shape_id),
@@ -1562,20 +1554,21 @@ impl<'a> CheckerState<'a> {
                 let base_shape = self.ctx.types.object_shape(base_shape_id);
                 let properties =
                     self.merge_properties(&derived_shape.properties, &base_shape.properties, mode);
-                factory.object_with_index(ObjectShape {
+                factory.object_with_shape_metadata_and_index_signatures(
                     properties,
-                    string_index: derived_shape
-                        .string_index
-                        .or_else(|| base_shape.string_index),
-                    number_index: derived_shape
+                    &derived_shape,
+                    derived_shape
+                        .string_index_signature()
+                        .copied()
+                        .or_else(|| base_shape.string_index_signature().copied()),
+                    derived_shape
                         .number_index
                         .or_else(|| base_shape.number_index),
-                    symbol_index: derived_shape
-                        .symbol_index
-                        .or_else(|| base_shape.symbol_index),
-                    symbol: derived_shape.symbol,
-                    ..ObjectShape::default()
-                })
+                    derived_shape
+                        .symbol_index_signature()
+                        .copied()
+                        .or_else(|| base_shape.symbol_index_signature().copied()),
+                )
             }
             // When one side is an intersection (e.g., from global augmentation merging
             // an interface with additional properties), decompose it and merge the
@@ -1657,13 +1650,21 @@ impl<'a> CheckerState<'a> {
                             &base_shape.properties,
                             mode,
                         );
-                        factory.object_with_index(ObjectShape {
+                        factory.object_with_shape_metadata_and_index_signatures(
                             properties,
-                            string_index: derived_shape.string_index,
-                            number_index: derived_shape.number_index,
-                            symbol: derived_shape.symbol,
-                            ..ObjectShape::default()
-                        })
+                            &derived_shape,
+                            derived_shape
+                                .string_index_signature()
+                                .copied()
+                                .or_else(|| base_shape.string_index_signature().copied()),
+                            derived_shape
+                                .number_index
+                                .or_else(|| base_shape.number_index),
+                            derived_shape
+                                .symbol_index_signature()
+                                .copied()
+                                .or_else(|| base_shape.symbol_index_signature().copied()),
+                        )
                     }
                     _ => derived,
                 }

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -1192,7 +1192,7 @@ impl<'a> CheckerState<'a> {
     ) -> tsz_solver::TypeId {
         use crate::query_boundaries::common::{AugmentationTargetKind, classify_for_augmentation};
         use crate::query_boundaries::state::type_resolution as query;
-        use tsz_solver::{CallableShape, ObjectShape};
+        use tsz_solver::CallableShape;
 
         // Fast-path: avoids string allocations and hashset bookkeeping when
         // no augmentations are registered anywhere in the program.
@@ -1286,11 +1286,7 @@ impl<'a> CheckerState<'a> {
                 // object-level flags so the augmented type keeps its canonical
                 // declaration name (e.g. `Tool` rather than an expanded
                 // `{ ... }` literal) and stays a single interned identity.
-                let augmented = factory.object_with_flags_and_symbol(
-                    merged_properties,
-                    base_shape.flags,
-                    base_shape.symbol,
-                );
+                let augmented = factory.object_with_shape_metadata(merged_properties, &base_shape);
                 if let Some(def_id) = base_def_id
                     && base_shape.symbol.is_some()
                     && self
@@ -1320,14 +1316,7 @@ impl<'a> CheckerState<'a> {
                         .definition_store
                         .register_module_augmentation_symbol_def_if_enabled(symbol.0, def_id);
                 }
-                factory.object_with_index(ObjectShape {
-                    flags: base_shape.flags,
-                    properties: merged_properties,
-                    string_index: base_shape.string_index,
-                    number_index: base_shape.number_index,
-                    symbol_index: base_shape.symbol_index,
-                    symbol: base_shape.symbol,
-                })
+                factory.object_with_shape_metadata(merged_properties, &base_shape)
             }
             AugmentationTargetKind::Callable(shape_id) => {
                 let base_shape = self.ctx.types.callable_shape(shape_id);

--- a/crates/tsz-checker/src/types/property_access_helpers/iterator_methods.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/iterator_methods.rs
@@ -5,7 +5,7 @@ use crate::query_boundaries::common::{
     object_shape_for_type,
 };
 use crate::state::CheckerState;
-use tsz_solver::{FunctionShape, ObjectShape, TupleElement, TypeId};
+use tsz_solver::{FunctionShape, TupleElement, TypeId};
 
 impl<'a> CheckerState<'a> {
     pub(in crate::types_domain) fn synthesized_array_iterator_method_type(
@@ -77,14 +77,16 @@ impl<'a> CheckerState<'a> {
                 && let Some(array_iterator_sym) = self.ctx.binder.file_locals.get("ArrayIterator")
                 && let Some(shape) = object_shape_for_type(self.ctx.types, instantiated)
             {
-                Some(self.ctx.types.factory().object_with_index(ObjectShape {
-                    flags: shape.flags,
-                    properties: shape.properties.clone(),
-                    string_index: shape.string_index,
-                    number_index: shape.number_index,
-                    symbol_index: shape.symbol_index,
-                    symbol: Some(array_iterator_sym),
-                }))
+                Some(
+                    self.ctx
+                        .types
+                        .factory()
+                        .object_with_shape_metadata_and_symbol(
+                            shape.properties.clone(),
+                            &shape,
+                            Some(array_iterator_sym),
+                        ),
+                )
             } else {
                 Some(instantiated)
             }

--- a/crates/tsz-checker/tests/arch_source_scans/object_flags_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/object_flags_boundary_scans.rs
@@ -14,6 +14,8 @@ const OBJECT_FLAG_BOUNDARIES: &[&str] = &[
     "src/query_boundaries/lib_augmentations.rs",
 ];
 
+const OBJECT_FLAG_FACTORY_BOUNDARIES: &[&str] = &["src/query_boundaries/type_construction.rs"];
+
 const RAW_OBJECT_FLAG_PATTERNS: &[&str] = &[
     "ObjectFlags::",
     "tsz_solver::ObjectFlags",
@@ -21,8 +23,53 @@ const RAW_OBJECT_FLAG_PATTERNS: &[&str] = &[
     "query_boundaries::common::ObjectFlags",
 ];
 
+const RAW_OBJECT_FLAG_FACTORY_PATTERNS: &[&str] = &["object_with_flags_and_symbol("];
+
 fn checker_src_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+#[test]
+fn production_object_shape_rebuilds_avoid_raw_flag_factory() {
+    let src_root = checker_src_root();
+    let mut violations = Vec::new();
+
+    for path in rust_sources_under(&src_root) {
+        let relative_path = format!(
+            "src/{}",
+            path.strip_prefix(&src_root)
+                .expect("scanned path is under the src root")
+                .to_string_lossy()
+                .replace('\\', "/")
+        );
+        if OBJECT_FLAG_FACTORY_BOUNDARIES.contains(&relative_path.as_str()) {
+            continue;
+        }
+
+        let source = fs::read_to_string(&path).expect("failed to read Rust source");
+        for (line_index, line) in source.lines().enumerate() {
+            if is_comment_or_doc_line(line) {
+                continue;
+            }
+            for pattern in RAW_OBJECT_FLAG_FACTORY_PATTERNS {
+                if line.contains(pattern) {
+                    violations.push(format!(
+                        "{}:{} calls raw object flag factory `{}`",
+                        relative_path,
+                        line_index + 1,
+                        pattern
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "checker production code should rebuild object metadata through named \
+         factory/query-boundary helpers instead of passing raw flags:\n{}",
+        violations.join("\n")
+    );
 }
 
 fn rust_sources_under(dir: &Path) -> Vec<PathBuf> {

--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -203,6 +203,112 @@ const _symi: boolean = symi[sym];
     );
 }
 
+fn assert_interface_symbol_index_merge_is_clean(codes: &[u32], context: &str) {
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "{context}: interface merge should not produce TS2322, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_CANNOT_BE_USED_TO_INDEX_TYPE),
+        "{context}: symbol index access should not produce TS2536, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_CANNOT_BE_USED_AS_AN_INDEX_TYPE),
+        "{context}: symbol index access should not produce TS2538, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN),
+        "{context}: symbol index access should not produce TS7053, got {codes:?}",
+    );
+}
+
+#[test]
+fn interface_extends_plain_base_preserves_derived_symbol_index_signature() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const key: symbol;
+
+interface Base {
+    base: number;
+}
+
+interface Derived extends Base {
+    [k: symbol]: boolean;
+    own: string;
+}
+
+declare const d: Derived;
+const indexed: boolean = d[key];
+const inherited: number = d.base;
+const own: string = d.own;
+const keyofIncludesSymbol: keyof Derived = key;
+"#,
+    );
+
+    assert_interface_symbol_index_merge_is_clean(&codes, "derived symbol index plus plain base");
+}
+
+#[test]
+fn interface_extends_base_symbol_index_preserves_base_symbol_index_signature() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const key: symbol;
+
+interface Base {
+    [k: symbol]: boolean;
+    base: number;
+}
+
+interface Derived extends Base {
+    own: string;
+}
+
+declare const d: Derived;
+const indexed: boolean = d[key];
+const inherited: number = d.base;
+const own: string = d.own;
+const keyofIncludesSymbol: keyof Derived = key;
+"#,
+    );
+
+    assert_interface_symbol_index_merge_is_clean(&codes, "plain derived plus base symbol index");
+}
+
+#[test]
+fn interface_extends_base_symbol_index_and_derived_string_index_merges_both_key_spaces() {
+    let diagnostics = check_source_code_messages(
+        r#"
+declare const key: symbol;
+
+interface Base {
+    [k: symbol]: boolean;
+    base: number;
+}
+
+interface Derived extends Base {
+    [k: string]: number;
+    own: number;
+}
+
+declare const d: Derived;
+const symbolValue: boolean = d[key];
+const stringValue: number = d["anything"];
+const inherited: number = d.base;
+const symbolKey: keyof Derived = key;
+"#,
+    );
+    let codes: Vec<u32> = diagnostics.iter().map(|(code, _)| *code).collect();
+
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "base symbol index plus derived string index: interface merge should not produce TS2322, got {diagnostics:?}",
+    );
+    assert_interface_symbol_index_merge_is_clean(
+        &codes,
+        "base symbol index plus derived string index",
+    );
+}
+
 #[test]
 fn symbol_typed_computed_interface_member_access_uses_declared_type() {
     let codes = diagnostic_codes_for_ts(

--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -1522,6 +1522,27 @@ const ok: number = so[s];
     );
 }
 
+#[test]
+fn symbol_only_index_object_rest_preserves_symbol_key_access() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const sym: symbol;
+declare const source: { [entry: symbol]: boolean; drop: string };
+
+const { drop, ...rest } = source;
+const value: boolean = rest[sym];
+"#,
+    );
+    assert!(
+        !codes.contains(&TS7053),
+        "object rest from a symbol-indexed source must preserve the symbol index, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "rest[sym] must type as the symbol-index value, got {codes:?}",
+    );
+}
+
 // Control: when BOTH a string and a symbol index are present, a string-literal
 // key must resolve through the string index (not be rejected).
 #[test]

--- a/crates/tsz-solver/src/intern/type_factory.rs
+++ b/crates/tsz-solver/src/intern/type_factory.rs
@@ -159,6 +159,57 @@ impl<'db> TypeFactory<'db> {
         self.db.object_with_index(shape)
     }
 
+    /// Rebuild an object with replacement properties while preserving the
+    /// object-level metadata of an existing shape: flags, index signatures, and
+    /// nominal symbol identity.
+    ///
+    /// Callers in checker-facing code should use this instead of passing raw
+    /// shape flags back into the factory.
+    #[inline]
+    pub fn object_with_shape_metadata(
+        &self,
+        properties: Vec<PropertyInfo>,
+        shape: &ObjectShape,
+    ) -> TypeId {
+        self.object_with_shape_metadata_and_symbol(properties, shape, shape.symbol)
+    }
+
+    /// Rebuild a structural object with replacement properties while preserving
+    /// the source shape's flags and index signatures, but dropping nominal
+    /// symbol identity.
+    #[inline]
+    pub fn structural_object_with_shape_metadata(
+        &self,
+        properties: Vec<PropertyInfo>,
+        shape: &ObjectShape,
+    ) -> TypeId {
+        self.object_with_shape_metadata_and_symbol(properties, shape, None)
+    }
+
+    #[inline]
+    fn object_with_shape_metadata_and_symbol(
+        &self,
+        properties: Vec<PropertyInfo>,
+        shape: &ObjectShape,
+        symbol: Option<SymbolId>,
+    ) -> TypeId {
+        if shape.string_index.is_some()
+            || shape.number_index.is_some()
+            || shape.symbol_index.is_some()
+        {
+            self.object_with_index(ObjectShape {
+                flags: shape.flags,
+                properties,
+                string_index: shape.string_index,
+                number_index: shape.number_index,
+                symbol_index: shape.symbol_index,
+                symbol,
+            })
+        } else {
+            self.object_with_flags_and_symbol(properties, shape.flags, symbol)
+        }
+    }
+
     /// Create the synthetic `typeof globalThis` surface object. It carries the
     /// `GLOBAL_THIS_SURFACE` flag so diagnostics render it as `typeof
     /// globalThis` rather than its full member body. Builder method so checker
@@ -184,7 +235,7 @@ impl<'db> TypeFactory<'db> {
     }
 
     #[inline]
-    pub fn object_with_flags_and_symbol(
+    pub(crate) fn object_with_flags_and_symbol(
         &self,
         properties: Vec<PropertyInfo>,
         flags: ObjectFlags,

--- a/crates/tsz-solver/src/intern/type_factory.rs
+++ b/crates/tsz-solver/src/intern/type_factory.rs
@@ -5,8 +5,8 @@
 
 use crate::caches::db::TypeDatabase;
 use crate::types::{
-    CallableShape, ConditionalType, FunctionShape, MappedType, ObjectFlags, ObjectShape,
-    PropertyInfo, TemplateSpan, TupleElement, TypeId, TypeParamInfo,
+    CallableShape, ConditionalType, FunctionShape, IndexSignature, MappedType, ObjectFlags,
+    ObjectShape, PropertyInfo, TemplateSpan, TupleElement, TypeId, TypeParamInfo,
 };
 use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
@@ -174,6 +174,47 @@ impl<'db> TypeFactory<'db> {
         self.object_with_shape_metadata_and_symbol(properties, shape, shape.symbol)
     }
 
+    /// Rebuild an object with replacement properties while preserving the
+    /// source shape's flags and index signatures, and applying an explicit
+    /// nominal symbol policy.
+    #[inline]
+    pub fn object_with_shape_metadata_and_symbol(
+        &self,
+        properties: Vec<PropertyInfo>,
+        shape: &ObjectShape,
+        symbol: Option<SymbolId>,
+    ) -> TypeId {
+        self.object_with_shape_parts(
+            properties,
+            shape,
+            shape.string_index,
+            shape.number_index,
+            shape.symbol_index,
+            symbol,
+        )
+    }
+
+    /// Rebuild an object with replacement properties and index signatures while
+    /// preserving the source shape's object flags and nominal symbol identity.
+    #[inline]
+    pub fn object_with_shape_metadata_and_index_signatures(
+        &self,
+        properties: Vec<PropertyInfo>,
+        shape: &ObjectShape,
+        string_index: Option<IndexSignature>,
+        number_index: Option<IndexSignature>,
+        symbol_index: Option<IndexSignature>,
+    ) -> TypeId {
+        self.object_with_shape_parts(
+            properties,
+            shape,
+            string_index,
+            number_index,
+            symbol_index,
+            shape.symbol,
+        )
+    }
+
     /// Rebuild a structural object with replacement properties while preserving
     /// the source shape's flags and index signatures, but dropping nominal
     /// symbol identity.
@@ -187,22 +228,22 @@ impl<'db> TypeFactory<'db> {
     }
 
     #[inline]
-    fn object_with_shape_metadata_and_symbol(
+    fn object_with_shape_parts(
         &self,
         properties: Vec<PropertyInfo>,
         shape: &ObjectShape,
+        string_index: Option<IndexSignature>,
+        number_index: Option<IndexSignature>,
+        symbol_index: Option<IndexSignature>,
         symbol: Option<SymbolId>,
     ) -> TypeId {
-        if shape.string_index.is_some()
-            || shape.number_index.is_some()
-            || shape.symbol_index.is_some()
-        {
+        if string_index.is_some() || number_index.is_some() || symbol_index.is_some() {
             self.object_with_index(ObjectShape {
                 flags: shape.flags,
                 properties,
-                string_index: shape.string_index,
-                number_index: shape.number_index,
-                symbol_index: shape.symbol_index,
+                string_index,
+                number_index,
+                symbol_index,
                 symbol,
             })
         } else {

--- a/crates/tsz-solver/tests/intern_tests.rs
+++ b/crates/tsz-solver/tests/intern_tests.rs
@@ -146,7 +146,7 @@ fn type_factory_rebuilds_object_shape_metadata_with_symbol_policy() {
 
     let structural = interner
         .factory()
-        .structural_object_with_shape_metadata(vec![replacement_prop], &shape);
+        .structural_object_with_shape_metadata(vec![replacement_prop.clone()], &shape);
     let Some(TypeData::ObjectWithIndex(structural_shape_id)) = interner.lookup(structural) else {
         panic!("structural metadata rebuild with index signatures must produce ObjectWithIndex");
     };
@@ -156,6 +156,49 @@ fn type_factory_rebuilds_object_shape_metadata_with_symbol_policy() {
     assert_eq!(structural_shape.number_index, shape.number_index);
     assert_eq!(structural_shape.symbol_index, shape.symbol_index);
     assert_eq!(structural_shape.symbol, None);
+
+    let override_symbol = Some(SymbolId(88));
+    let stamped = interner.factory().object_with_shape_metadata_and_symbol(
+        vec![replacement_prop.clone()],
+        &shape,
+        override_symbol,
+    );
+    let Some(TypeData::ObjectWithIndex(stamped_shape_id)) = interner.lookup(stamped) else {
+        panic!("explicit-symbol metadata rebuild must produce ObjectWithIndex");
+    };
+    let stamped_shape = interner.object_shape(stamped_shape_id);
+    assert_eq!(stamped_shape.flags, shape.flags);
+    assert_eq!(stamped_shape.string_index, shape.string_index);
+    assert_eq!(stamped_shape.number_index, shape.number_index);
+    assert_eq!(stamped_shape.symbol_index, shape.symbol_index);
+    assert_eq!(stamped_shape.symbol, override_symbol);
+
+    let replacement_number_index = Some(IndexSignature {
+        key_type: TypeId::NUMBER,
+        value_type: TypeId::BOOLEAN,
+        readonly: true,
+        param_name: Some(number_name),
+    });
+    let reindexed = interner
+        .factory()
+        .object_with_shape_metadata_and_index_signatures(
+            vec![replacement_prop],
+            &shape,
+            None,
+            replacement_number_index,
+            shape.symbol_index,
+        );
+    let Some(TypeData::ObjectWithIndex(reindexed_shape_id)) = interner.lookup(reindexed) else {
+        panic!("replacement-index metadata rebuild must produce ObjectWithIndex");
+    };
+    let reindexed_shape = interner.object_shape(reindexed_shape_id);
+    assert_eq!(reindexed_shape.flags, shape.flags);
+    // With no string index, interning canonicalizes a symbol-only index into
+    // the historical string-index slot where `key_type == symbol`.
+    assert_eq!(reindexed_shape.string_index, shape.symbol_index);
+    assert_eq!(reindexed_shape.number_index, replacement_number_index);
+    assert_eq!(reindexed_shape.symbol_index, None);
+    assert_eq!(reindexed_shape.symbol, shape_symbol);
 }
 
 #[test]

--- a/crates/tsz-solver/tests/intern_tests.rs
+++ b/crates/tsz-solver/tests/intern_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::caches::db::QueryDatabase;
 use crate::intern::PROPERTY_MAP_THRESHOLD;
 use crate::relations::freshness::{is_fresh_object_type, widen_freshness};
 use tsz_binder::SymbolId;
@@ -93,6 +94,68 @@ fn test_interner_preserves_index_signature_parameter_names_for_display() {
         shape.string_index.and_then(|idx| idx.param_name),
         Some(x_name)
     );
+}
+
+#[test]
+fn type_factory_rebuilds_object_shape_metadata_with_symbol_policy() {
+    let interner = TypeInterner::new();
+    let base_prop = PropertyInfo::new(interner.intern_string("base"), TypeId::STRING);
+    let replacement_prop = PropertyInfo::new(interner.intern_string("replacement"), TypeId::NUMBER);
+    let string_name = interner.intern_string("textKey");
+    let number_name = interner.intern_string("indexKey");
+    let symbol_name = interner.intern_string("symbolKey");
+    let shape_symbol = Some(SymbolId(77));
+
+    let shape = ObjectShape {
+        flags: ObjectFlags::FRESH_LITERAL | ObjectFlags::PRESERVE_DECLARATION_ORDER,
+        properties: vec![base_prop],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::STRING,
+            readonly: true,
+            param_name: Some(string_name),
+        }),
+        number_index: Some(IndexSignature {
+            key_type: TypeId::NUMBER,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: Some(number_name),
+        }),
+        symbol_index: Some(IndexSignature {
+            key_type: TypeId::SYMBOL,
+            value_type: TypeId::BOOLEAN,
+            readonly: true,
+            param_name: Some(symbol_name),
+        }),
+        symbol: shape_symbol,
+    };
+
+    let rebuilt = interner
+        .factory()
+        .object_with_shape_metadata(vec![replacement_prop.clone()], &shape);
+    let Some(TypeData::ObjectWithIndex(rebuilt_shape_id)) = interner.lookup(rebuilt) else {
+        panic!("metadata rebuild with index signatures must produce ObjectWithIndex");
+    };
+    let rebuilt_shape = interner.object_shape(rebuilt_shape_id);
+    assert_eq!(rebuilt_shape.flags, shape.flags);
+    assert_eq!(rebuilt_shape.properties, vec![replacement_prop.clone()]);
+    assert_eq!(rebuilt_shape.string_index, shape.string_index);
+    assert_eq!(rebuilt_shape.number_index, shape.number_index);
+    assert_eq!(rebuilt_shape.symbol_index, shape.symbol_index);
+    assert_eq!(rebuilt_shape.symbol, shape_symbol);
+
+    let structural = interner
+        .factory()
+        .structural_object_with_shape_metadata(vec![replacement_prop], &shape);
+    let Some(TypeData::ObjectWithIndex(structural_shape_id)) = interner.lookup(structural) else {
+        panic!("structural metadata rebuild with index signatures must produce ObjectWithIndex");
+    };
+    let structural_shape = interner.object_shape(structural_shape_id);
+    assert_eq!(structural_shape.flags, shape.flags);
+    assert_eq!(structural_shape.string_index, shape.string_index);
+    assert_eq!(structural_shape.number_index, shape.number_index);
+    assert_eq!(structural_shape.symbol_index, shape.symbol_index);
+    assert_eq!(structural_shape.symbol, None);
 }
 
 #[test]


### PR DESCRIPTION
Goal: fast

## Summary
- Route interface object-shape rebuilds through the TypeFactory metadata helpers so string, number, and symbol index slots stay distinct across heritage merges and fallback shape incorporation.
- Split symbol index compatibility buckets from string index buckets in interface heritage checks.
- Treat wide-symbol binding element access as an exact computed-symbol member probe before falling back to broad symbol-index access, so a synthetic symbol key cannot accidentally resolve through a string index signature.
- Add regression coverage for derived/base symbol index preservation and mixed inherited symbol plus derived string index key spaces.

## Structural Rule
When an interface merge rebuilds object-index shapes, `tsc` keeps string and symbol key spaces separate across `extends`; tsz now chooses the checker merge intent while solver `TypeFactory` owns shape metadata/index reconstruction, using `string_index_signature()` and `symbol_index_signature()` accessors for legacy symbol-in-string encodings. When a `symbol`-typed value access carries a synthetic binding key, tsz probes only exact computed-symbol members before retrying the broad `symbol` index, so `[k: string]` cannot masquerade as a symbol member.

## Verification
- `cargo fmt --all --check && git diff --check`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 scripts/safe-run.sh -- cargo check -p tsz-checker`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 scripts/safe-run.sh -- cargo clippy -p tsz-checker --lib --tests -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 scripts/safe-run.sh -- cargo nextest run -p tsz-checker --lib symbol_index_signature_tests::interface_extends_plain_base_preserves_derived_symbol_index_signature symbol_index_signature_tests::interface_extends_base_symbol_index_preserves_base_symbol_index_signature symbol_index_signature_tests::interface_extends_base_symbol_index_and_derived_string_index_merges_both_key_spaces symbol_index_signature_tests::wide_symbol_value_access_on_string_index_reports_ts2538 symbol_index_signature_tests::wide_symbol_value_access_with_symbol_index_is_clean types_domain::computation::access::tests::renamed_wide_symbol_identifier_read_uses_symbol_index_signature_value_type types_domain::computation::access::tests::wide_symbol_identifier_write_uses_symbol_index_signature_value_type`
- `python3 scripts/arch/arch_guard.py` (fails on pre-existing repo-wide direct `query_boundaries::common` quarantine refs and speculation caller cap; this branch removes the local `access.rs` line-cap failure)
- `scripts/arch/check-checker-boundaries.sh` (same pre-existing repo-wide ratchets as above)

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
