### PR TITLE
refactor(checker): assert env reconcile completeness (#14351)

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -746,32 +746,11 @@ impl CheckerContext<'_> {
         def_id
     }
 
-    /// Ensure both `TypeEnvironment` instances end up with a reference to the
-    /// shared `DefinitionStore`, by writing it to the authoritative evaluator
-    /// env and letting reconcile propagate it to the flow-analyzer env.
-    ///
-    /// `type_env` (primary evaluator) needs the `DefinitionStore` fallback so
-    /// that `get_def_kind` can locate entries not written directly due to
-    /// `RefCell` borrow conflicts during recursive resolution; it is written
-    /// here (race-safe, via the same deferral discipline as every other
-    /// evaluator-env registration).
-    ///
-    /// The flow-analyzer env (`type_environment`) receives the *same* `Arc`
-    /// through `overlay_missing_from` at the file-prep reconcile boundary
-    /// (`reconcile_flow_and_evaluator_envs`), which runs before flow analysis
-    /// reads the env. The `DefinitionStore` is a single content-identical shared
-    /// pointer regardless of which env holds it, so eagerly *mirroring* it into
-    /// the flow env is pure redundancy with the reconcile vacancy-fill. Dropping
-    /// that mirror removes the `SetDefinitionStore` op from the flow-env mirror
-    /// set as the first provably zero-delta step of the dual-`TypeEnvironment`
-    /// collapse (#14348) — the eager mirror added work (and a possible deferred
-    /// replay) for a pointer reconcile already installs.
-    ///
-    /// `set_definition_store` is idempotent when the same `Arc` pointer is
-    /// reinstalled (checked via `Arc::ptr_eq`), so calling this function
-    /// multiple times across registration sites is safe.
+    /// Wire the shared `DefinitionStore` fallback into both `TypeEnvironment`
+    /// instances through the same race-safe deferred-write authority as ordinary
+    /// env registrations.
     pub fn ensure_both_envs_have_definition_store(&self) {
-        self.apply_to_eval_env(DeferredFlowEnvWrite::SetDefinitionStore(Arc::clone(
+        self.register_in_envs(DeferredFlowEnvWrite::SetDefinitionStore(Arc::clone(
             &self.definition_store,
         )));
     }
@@ -859,9 +838,9 @@ impl CheckerContext<'_> {
 
     /// Replay any deferred evaluator-env (`type_env`) writes that lost the
     /// borrow race during recursive resolution. Called at the file-preparation
-    /// boundary, before the flow-analyzer env is reconciled from `type_env`, so
+    /// boundary, before the flow-analyzer env is checked against `type_env`, so
     /// the authoritative env holds every class-instance / def entry before any
-    /// consumer (method-body checking, `overlay_missing_from`) reads it. A no-op
+    /// consumer (method-body checking, flow-env assertions) reads it. A no-op
     /// when nothing was deferred or `type_env` is momentarily unborrowable.
     pub fn flush_deferred_eval_env_writes(&self) {
         flush_env_write_queue(&self.type_env, &self.deferred_eval_env_writes);

--- a/crates/tsz-checker/src/context/def_mapping_tests.rs
+++ b/crates/tsz-checker/src/context/def_mapping_tests.rs
@@ -26,12 +26,8 @@ fn minimal_checker_ctx() -> (
 }
 
 /// Pins the dual-env store-wiring invariant as updated for #14348: the shared
-/// `DefinitionStore` reaches the authoritative evaluator env (`type_env`)
-/// EAGERLY, and the flow-analyzer env (`type_environment`) receives the same
-/// `Arc` through the reconcile-boundary `overlay_missing_from` (not an eager
-/// mirror). `get_def_kind` must work in both — `type_env` immediately, and
-/// `type_environment` after reconcile — without relying on the clone-over in
-/// `source_file.rs`.
+/// `DefinitionStore` reaches both envs through the deferred-write authority,
+/// including when the flow-analyzer env is borrowed and must receive replay.
 #[test]
 fn ensure_both_envs_wires_store_into_type_environment() {
     use tsz_common::interner::Atom;
@@ -64,38 +60,32 @@ fn ensure_both_envs_wires_store_into_type_environment() {
         "type_environment must not find a store-only DefKind before wiring"
     );
 
-    // Wire the store into the authoritative evaluator env.
-    ctx.ensure_both_envs_have_definition_store();
-
-    // The evaluator env reaches the kind via the store fallback immediately.
-    assert_eq!(
-        ctx.type_env.borrow().get_def_kind(def_id),
-        Some(DefKind::TypeAlias),
-        "type_env (authoritative) must find store-only DefKind eagerly"
-    );
-
-    // The flow-analyzer env is no longer eagerly mirrored (#14348): it still
-    // lacks the store until the reconcile-boundary overlay runs.
-    assert_eq!(
-        ctx.type_environment.borrow().get_def_kind(def_id),
-        None,
-        "type_environment is no longer eagerly mirrored; the store arrives via reconcile overlay"
-    );
-
-    // Drive the reconcile overlay exactly as `reconcile_flow_and_evaluator_envs`
-    // does (overlay the evaluator env into the flow env).
     {
-        let eval_snapshot = ctx.type_env.borrow();
-        ctx.type_environment
-            .borrow_mut()
-            .overlay_missing_from(&eval_snapshot);
+        let held_flow = ctx.type_environment.borrow();
+        ctx.ensure_both_envs_have_definition_store();
+        assert_eq!(
+            ctx.type_env.borrow().get_def_kind(def_id),
+            Some(DefKind::TypeAlias),
+            "type_env (authoritative) must find store-only DefKind eagerly"
+        );
+        assert_eq!(
+            held_flow.get_def_kind(def_id),
+            None,
+            "held flow env must not see the store before deferred replay"
+        );
+        assert_eq!(
+            ctx.deferred_flow_env_write_count(),
+            1,
+            "flow-env store wiring must queue when the flow env is borrowed"
+        );
     }
 
-    // Now type_environment reaches the kind via the same shared-Arc fallback.
+    ctx.flush_deferred_flow_env_writes();
+
     assert_eq!(
         ctx.type_environment.borrow().get_def_kind(def_id),
         Some(DefKind::TypeAlias),
-        "type_environment must find store-only DefKind via reconcile overlay after ensure_both_envs_have_definition_store"
+        "type_environment must find store-only DefKind after deferred replay"
     );
 }
 
@@ -1008,12 +998,6 @@ fn augmented_def_registration_uses_store_only_params_on_replay() {
     // Attach the shared store to both envs, but leave their local param maps
     // empty. `get_def_params_owned` can see the params; `get_def_params` cannot.
     ctx.ensure_both_envs_have_definition_store();
-    {
-        let eval_snapshot = ctx.type_env.borrow();
-        ctx.type_environment
-            .borrow_mut()
-            .overlay_missing_from(&eval_snapshot);
-    }
     assert_eq!(ctx.type_env.borrow().get_def_params(def_id), None);
     assert_eq!(ctx.type_environment.borrow().get_def_params(def_id), None);
     assert_eq!(
@@ -1207,29 +1191,26 @@ fn unresolved_resolution_write_reaches_both_envs_and_defers_under_borrow() {
     );
 }
 
-/// #14348: `overlay_missing_from` reports whether it had to repair anything —
-/// the deletion-readiness signal. A fully-authority-routed pair of envs must
-/// report `false`; a bypassing eval-env-only write must report `true`.
+/// #14348: file-prep reconciliation must assert missing flow-env entries
+/// instead of repairing them by copying from the evaluator env.
 #[test]
-fn overlay_missing_from_reports_repairs() {
-    let mut source = tsz_solver::computation::TypeEnvironment::new();
-    let mut target = tsz_solver::computation::TypeEnvironment::new();
-    assert!(
-        !target.overlay_missing_from(&source),
-        "identical empty envs need no repair"
-    );
+fn reconcile_uses_missing_entry_probe_not_overlay_repair() {
+    let source_file =
+        std::fs::read_to_string("src/state/state_checking/source_file_env_reconcile.rs")
+            .expect("failed to read source_file_env_reconcile.rs");
+    let state_file = std::fs::read_to_string("src/state/state_checking/source_file.rs")
+        .expect("failed to read source_file.rs");
 
-    source.insert_unresolved_resolution("OnlyInEval".to_string(), tsz_solver::def::DefId(7));
     assert!(
-        target.overlay_missing_from(&source),
-        "an eval-only entry must be reported as a repair"
-    );
-    assert_eq!(
-        target.unresolved_resolution("OnlyInEval"),
-        Some(tsz_solver::def::DefId(7))
+        !source_file.contains(".overlay_missing_from("),
+        "flow/evaluator reconcile must not repair missing entries with overlay_missing_from"
     );
     assert!(
-        !target.overlay_missing_from(&source),
-        "second overlay finds nothing left to repair"
+        source_file.contains("first_missing_entry_from("),
+        "flow/evaluator reconcile should assert missing entries through a read-only probe"
+    );
+    assert!(
+        state_file.contains("flush_deferred_flow_env_writes();"),
+        "file preparation must replay deferred flow-env writes before reconcile assertions"
     );
 }

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -892,10 +892,9 @@ pub struct CheckerContext<'a> {
     /// one cell would make that mutable borrow fail and silently drop writes.
     /// The dual-write registration helpers (`register_*_in_envs`) mirror every
     /// `DefId`-keyed registration into both envs (deferring the mirror when this
-    /// cell is borrowed, never dropping it), and `overlay_missing_from` performs
-    /// a vacancy-fill reconciliation at the file-preparation boundary. After
-    /// that boundary the two envs must agree on every shared `DefId` entry; the
-    /// debug assertion in `prepare_source_file_for_checking` enforces it.
+    /// cell is borrowed, never dropping it). After file preparation the two envs
+    /// must agree on shared entries and the flow env must not be missing entries
+    /// from the evaluator env; debug assertions enforce that boundary.
     pub type_environment: RefCell<TypeEnvironment>,
 
     /// Dual-env registrations whose mirror-write into `type_environment` lost

--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -1674,7 +1674,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
         // having to bounce back into the wider CheckerContext path. Routed
         // through the env-write authority (deferring on borrow races instead
         // of silently skipping, and mirroring into the flow-analyzer env so
-        // `overlay_missing_from` has nothing left to repair — #14348).
+        // reconcile has nothing left to repair — #14348).
         self.register_unresolved_resolution_in_envs(name.to_string(), def_id);
         Some(def_id)
     }

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -93,21 +93,24 @@ impl CheckerState<'_> {
         // by the recursive heritage resolution that triggered it). These were
         // previously dropped, collapsing the instance/def body to `never` for
         // every later consumer. Replay them before the flow-analyzer env is
-        // reconciled below so `overlay_missing_from` copies a complete env.
+        // checked against it below.
         self.ctx.flush_deferred_eval_env_writes();
+        debug_assert_eq!(
+            self.ctx.deferred_eval_env_write_count(),
+            0,
+            "evaluator env writes must be fully reconciled at file preparation"
+        );
 
-        // Reconcile the flow-analyzer environment (`type_environment`) with the
+        // Verify the flow-analyzer environment (`type_environment`) against the
         // evaluator environment (`type_env`) before flow analysis reads it.
         //
         // Dual-env registration helpers (`register_*_in_envs`) write the
         // evaluator env directly and mirror into the flow-analyzer env; a mirror
         // that loses the `RefCell` borrow race during recursive resolution is
         // deferred rather than dropped (issue #8269), so first replay the
-        // deferred queue. A few local fields can still arrive via evaluator-env
-        // setup or shared-store/scalar wiring; fill those into the flow-analyzer
-        // env with a vacancy-only overlay. Unlike
-        // the previous unconditional full `clone()`, this neither reallocates
-        // already-mirrored maps nor discards flow-analyzer-env-only entries.
+        // deferred queue. Reconciliation now canonicalizes only benign
+        // present-but-different `def_types` entries and debug-asserts that no
+        // writer still relies on evaluator-only vacancy repair (#14348).
         self.ctx.flush_deferred_flow_env_writes();
         self.reconcile_flow_and_evaluator_envs();
         debug_assert_eq!(

--- a/crates/tsz-checker/src/state/state_checking/source_file_env_reconcile.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file_env_reconcile.rs
@@ -4,29 +4,11 @@ use crate::state::CheckerState;
 
 impl CheckerState<'_> {
     pub(crate) fn reconcile_flow_and_evaluator_envs(&mut self) {
-        let (overlay_filled, divergences): (
-            bool,
-            Vec<(u32, tsz_solver::TypeId, tsz_solver::TypeId)>,
-        ) = {
+        let divergences: Vec<(u32, tsz_solver::TypeId, tsz_solver::TypeId)> = {
             let type_env_snapshot = self.ctx.type_env.borrow();
-            let mut flow_env = self.ctx.type_environment.borrow_mut();
-            let overlay_filled = flow_env.overlay_missing_from(&type_env_snapshot);
-            (
-                overlay_filled,
-                flow_env.collect_def_type_divergences_from(&type_env_snapshot),
-            )
+            let flow_env = self.ctx.type_environment.borrow();
+            flow_env.collect_def_type_divergences_from(&type_env_snapshot)
         };
-        if overlay_filled {
-            // Every env write should reach both environments through the
-            // authority helpers; the overlay is the legacy repair for writes
-            // that bypassed it. Surface survivors so the repair can eventually
-            // be deleted (#14348) — this firing means some write path still
-            // touches only the evaluator env.
-            tracing::warn!(
-                target: "tsz::env_authority",
-                "reconcile overlay filled flow-env entries the authority missed (#14348)"
-            );
-        }
 
         if !divergences.is_empty() {
             self.ctx.eval_session.reset_lazy_resolution_fuel();
@@ -55,6 +37,13 @@ impl CheckerState<'_> {
         if cfg!(debug_assertions) {
             let type_env_snapshot = self.ctx.type_env.borrow();
             let flow_env = self.ctx.type_environment.borrow();
+            if let Some((map, key)) = flow_env.first_missing_entry_from(&type_env_snapshot) {
+                debug_assert!(
+                    false,
+                    "flow-analyzer env is missing evaluator env entry after deferred replay \
+                     (#14348): {map}[{key}]"
+                );
+            }
             if let Some((map, key, lhs, rhs)) =
                 flow_env.first_def_divergence_from(&type_env_snapshot)
             {

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -1339,8 +1339,7 @@ impl CheckerState<'_> {
                 // body the shared store published). The helper rewrites both
                 // envs with the same body (deferring flow-env writes on a borrow
                 // race), avoiding a present-but-different `DefId -> TypeId`
-                // divergence that the vacancy-only `overlay_missing_from`
-                // cannot reconcile.
+                // divergence that missing-entry reconciliation cannot repair.
                 let type_params = self
                     .ctx
                     .definition_store

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -1214,114 +1214,74 @@ impl TypeEnvironment {
         }
     }
 
-    /// Vacancy-fill every local registration map from `source` into `self`.
+    /// Return the first local registration present in `source` but absent here.
     ///
-    /// This is the comprehensive reconciliation used to make the flow-analyzer
-    /// environment (`type_environment`) a complete mirror of the evaluator
-    /// environment (`type_env`) after a file's type environment is built. Unlike
-    /// a full `clone()` it never reallocates maps that are already populated and
-    /// never discards entries that only exist in `self` (e.g. mappings written
-    /// directly into the flow-analyzer env), so it is a strict superset merge:
-    /// `self := self ∪ source`, keeping `self`'s value on key collisions.
-    ///
-    /// Entries are copied only where `self` lacks the key, so the common case
-    /// (where `source` and `self` were kept in lock-step by the dual-write
-    /// registration helpers) touches nothing. The shared `DefinitionStore`,
-    /// `this_type`, and array-base scalars are filled only when `self` has no
-    /// value, mirroring the previous full-snapshot behavior at the file
-    /// preparation boundary where those scalars are otherwise unset.
-    ///
-    /// Maintenance contract: this overlay must list **every** local field so it
-    /// can reconcile registrations that the checker writes into the evaluator
-    /// env only (for example symbol-keyed `types`, `enum_parents`,
-    /// `numeric_enums`, and `unresolved_name_resolutions`), which are never
-    /// dual-written and therefore never reach the deferred-replay queue. When a
-    /// new field is added to `TypeEnvironment`, add it here too or the
-    /// flow-analyzer env will silently diverge from the evaluator env.
-    pub fn overlay_missing_from(&mut self, source: &Self) -> bool {
-        use std::collections::hash_map::Entry;
-        let mut changed = false;
-
-        // `copy` for `Copy` values, `clone` for owned (`Vec`/`Arc`) values.
-        macro_rules! fill_map {
-            ($field:ident, copy) => {
-                for (key, value) in &source.$field {
-                    if let Entry::Vacant(entry) = self.$field.entry(key.clone()) {
-                        entry.insert(*value);
-                        changed = true;
-                    }
-                }
-            };
-            ($field:ident, clone) => {
-                for (key, value) in &source.$field {
-                    if let Entry::Vacant(entry) = self.$field.entry(key.clone()) {
-                        entry.insert(value.clone());
-                        changed = true;
+    /// The checker keeps evaluator and flow-analysis environments in sync by
+    /// writing every registration through its dual-env authority and replaying
+    /// deferred mirrors before flow reads. This read-only probe replaces the old
+    /// vacancy-fill repair: a missing entry means a writer bypassed that
+    /// authority and should be fixed at the writer, not copied over here.
+    #[must_use]
+    pub fn first_missing_entry_from(&self, source: &Self) -> Option<(&'static str, String)> {
+        macro_rules! first_missing_map_key {
+            ($field:ident) => {
+                for key in source.$field.keys() {
+                    if !self.$field.contains_key(key) {
+                        return Some((stringify!($field), format!("{key:?}")));
                     }
                 }
             };
         }
 
-        fill_map!(types, copy);
-        fill_map!(type_params, clone);
-        fill_map!(boxed_types, copy);
-        fill_map!(def_types, copy);
-        fill_map!(def_type_params, clone);
-        fill_map!(declared_variances, clone);
-        fill_map!(def_to_symbol, copy);
-        fill_map!(symbol_to_def, copy);
-        fill_map!(def_kinds, copy);
-        fill_map!(enum_namespace_types, copy);
-        fill_map!(enum_parents, copy);
-        fill_map!(enum_members, clone);
-        fill_map!(class_instance_types, copy);
-        fill_map!(boxed_def_ids, clone);
-        fill_map!(class_extends, copy);
-        fill_map!(instance_type_to_class, copy);
-        fill_map!(unresolved_name_resolutions, copy);
-        fill_map!(well_known_symbol_name_to_ref, copy);
-        fill_map!(typeof_value_types, copy);
+        first_missing_map_key!(types);
+        first_missing_map_key!(type_params);
+        first_missing_map_key!(boxed_types);
+        first_missing_map_key!(def_types);
+        first_missing_map_key!(def_type_params);
+        first_missing_map_key!(declared_variances);
+        first_missing_map_key!(def_to_symbol);
+        first_missing_map_key!(symbol_to_def);
+        first_missing_map_key!(def_kinds);
+        first_missing_map_key!(enum_namespace_types);
+        first_missing_map_key!(enum_parents);
+        first_missing_map_key!(enum_members);
+        first_missing_map_key!(class_instance_types);
+        first_missing_map_key!(boxed_def_ids);
+        first_missing_map_key!(class_extends);
+        first_missing_map_key!(instance_type_to_class);
+        first_missing_map_key!(unresolved_name_resolutions);
+        first_missing_map_key!(well_known_symbol_name_to_ref);
+        first_missing_map_key!(typeof_value_types);
 
         for value in &source.numeric_enums {
-            if self.numeric_enums.insert(*value) {
-                changed = true;
+            if !self.numeric_enums.contains(value) {
+                return Some(("numeric_enums", value.to_string()));
             }
         }
-
         if self.array_base_type.is_none() && source.array_base_type.is_some() {
-            self.array_base_type = source.array_base_type;
-            self.array_base_type_params = source.array_base_type_params.clone();
-            changed = true;
+            return Some(("array_base_type", "scalar".to_string()));
+        }
+        if self.array_base_type_params.is_empty() && !source.array_base_type_params.is_empty() {
+            return Some(("array_base_type_params", "scalar".to_string()));
         }
         if self.readonly_array_base_type.is_none() && source.readonly_array_base_type.is_some() {
-            self.readonly_array_base_type = source.readonly_array_base_type;
-            changed = true;
+            return Some(("readonly_array_base_type", "scalar".to_string()));
         }
         if self.this_type.is_none() && source.this_type.is_some() {
-            self.this_type = source.this_type;
-            changed = true;
+            return Some(("this_type", "scalar".to_string()));
         }
-        if self.definition_store.is_none()
-            && let Some(store) = source.definition_store.as_ref()
-        {
-            self.definition_store = Some(Arc::clone(store));
-            changed = true;
+        if self.definition_store.is_none() && source.definition_store.is_some() {
+            return Some(("definition_store", "shared".to_string()));
         }
-
-        if changed {
-            self.bump_generation();
-        }
-        changed
+        None
     }
 
     /// Return the first `DefId`-keyed entry on which `self` and `other` disagree.
     ///
     /// The checker owns two `TypeEnvironment` instances with distinct
     /// lifecycles: the evaluator env (`type_env`, authoritative) and the
-    /// flow-analyzer env (`type_environment`, reconciled from the evaluator env
-    /// via [`Self::overlay_missing_from`] at the file-preparation boundary).
-    /// Because `overlay_missing_from` is a vacancy-only superset merge that
-    /// keeps `self`'s value on key collisions, after reconciliation the two
+    /// flow-analyzer env (`type_environment`, checked against the evaluator env
+    /// at the file-preparation boundary). After deferred mirrors replay, the two
     /// envs must *agree* on every shared `DefId -> TypeId` (and the related
     /// `DefId`-keyed structural) entry. A disagreement means a mirror-write was
     /// applied to one env but not the other with a different value — exactly the
@@ -1334,8 +1294,8 @@ impl TypeEnvironment {
     /// assertion; it never mutates either env and is not on any hot path.
     #[must_use]
     pub fn first_def_divergence_from(&self, other: &Self) -> Option<(&'static str, u32, u32, u32)> {
-        // Only keys present in *both* maps can disagree; vacancy-fill cannot
-        // create a conflicting value, so missing-on-one-side is not divergence.
+        // Only keys present in *both* maps can disagree; missing-on-one-side
+        // entries are handled by `first_missing_entry_from`.
         for (&key, &value) in &self.def_types {
             if let Some(&other_value) = other.def_types.get(&key)
                 && other_value != value
@@ -1367,9 +1327,9 @@ impl TypeEnvironment {
     /// returns only the first disagreement for a debug assertion, this returns
     /// the full set so the checker can converge the benign (structurally
     /// identical) subset at the file-preparation reconciliation boundary before
-    /// re-probing the residual. `overlay_missing_from` is a vacancy-only merge
-    /// and therefore cannot touch a `DefId` that is present-but-different in
-    /// both envs; that residual class is dominated by recursive
+    /// re-probing the residual. Missing-entry reconciliation is read-only, so
+    /// this helper still owns the present-but-different residual class dominated
+    /// by recursive
     /// self-referential interfaces whose self-reference is materialized at
     /// different resolution points and so interns to distinct — but
     /// coinductively equal — `TypeId`s per env (#13944).

--- a/crates/tsz-solver/src/def/resolver_tests.rs
+++ b/crates/tsz-solver/src/def/resolver_tests.rs
@@ -497,64 +497,48 @@ fn get_def_kind_falls_back_to_definition_store() {
     );
 }
 
-/// `overlay_missing_from` must fill flow-analyzer-env-local maps that only
-/// the evaluator env carries (e.g. `enum_parents`, `class_extends`, and the
-/// symbol-keyed `types` map) while preserving entries unique to the target
-/// and not overwriting existing keys.
+/// `first_missing_entry_from` reports evaluator-only registrations without
+/// repairing the flow-analyzer env. Missing entries must be fixed by routing
+/// the writer through the checker's dual-env authority.
 #[test]
-fn overlay_missing_from_fills_evaluator_only_maps_without_clobbering() {
-    let source_def = DefId(10);
-    let parent_def = DefId(11);
-    let child_def = DefId(12);
-    let shared_def = DefId(13);
+fn first_missing_entry_from_reports_evaluator_only_maps_without_repairing() {
+    let mut evaluator = TypeEnvironment::new();
+    evaluator.insert(SymbolRef(7), TypeId(200));
 
-    let mut source = TypeEnvironment::new();
-    source.insert_def(source_def, TypeId(100));
-    source.register_enum_parent(child_def, parent_def);
-    source.register_class_extends(child_def, parent_def);
-    source.insert(SymbolRef(7), TypeId(200));
-    // A key both envs already agree on, but with the target's own value kept.
-    source.insert_def(shared_def, TypeId(300));
+    let flow = TypeEnvironment::new();
+    assert_eq!(
+        flow.first_missing_entry_from(&evaluator),
+        Some(("types", "7".to_string())),
+        "evaluator-only symbol-keyed type must be reported"
+    );
+    assert_eq!(
+        flow.get(SymbolRef(7)),
+        None,
+        "missing-entry probe must not mutate the flow env"
+    );
 
-    let mut target = TypeEnvironment::new();
-    // Target keeps a flow-analyzer-only mapping the evaluator never wrote.
-    target.register_class_extends(DefId(99), DefId(98));
-    // Target already has `shared_def` with a different value; overlay must
-    // not clobber it.
-    target.insert_def(shared_def, TypeId(301));
+    let mut mirrored = TypeEnvironment::new();
+    mirrored.insert(SymbolRef(7), TypeId(200));
+    assert_eq!(mirrored.first_missing_entry_from(&evaluator), None);
+}
 
-    target.overlay_missing_from(&source);
+#[test]
+fn first_missing_entry_from_reports_missing_definition_store_without_repairing() {
+    let store = Arc::new(DefinitionStore::new());
 
+    let mut evaluator = TypeEnvironment::new();
+    evaluator.set_definition_store(Arc::clone(&store));
+
+    let flow = TypeEnvironment::new();
     assert_eq!(
-        target.get_def(source_def),
-        Some(TypeId(100)),
-        "evaluator-only def body must be filled"
+        flow.first_missing_entry_from(&evaluator),
+        Some(("definition_store", "shared".to_string())),
+        "missing shared DefinitionStore must be reported as an evaluator-only scalar"
     );
-    assert_eq!(
-        target.get_enum_parent(child_def),
-        Some(parent_def),
-        "evaluator-only enum-parent must be filled"
-    );
-    assert_eq!(
-        target.get_class_extends_def(child_def),
-        Some(parent_def),
-        "evaluator-only class-extends must be filled"
-    );
-    assert_eq!(
-        target.get(SymbolRef(7)),
-        Some(TypeId(200)),
-        "evaluator-only symbol-keyed type must be filled"
-    );
-    assert_eq!(
-        target.get_class_extends_def(DefId(99)),
-        Some(DefId(98)),
-        "flow-analyzer-only entry must be preserved"
-    );
-    assert_eq!(
-        target.get_def(shared_def),
-        Some(TypeId(301)),
-        "existing target value must not be overwritten on key collision"
-    );
+
+    let mut mirrored = TypeEnvironment::new();
+    mirrored.set_definition_store(Arc::clone(&store));
+    assert_eq!(mirrored.first_missing_entry_from(&evaluator), None);
 }
 
 #[test]
@@ -579,27 +563,27 @@ fn first_def_divergence_from_detects_conflicting_shared_def_body() {
 }
 
 #[test]
-fn first_def_divergence_from_clean_after_overlay() {
+fn first_def_divergence_from_clean_after_mirrored_entries() {
     let shared_def = DefId(42);
-    let eval_only_def = DefId(7);
     let flow_only_class = DefId(99);
 
     let mut evaluator = TypeEnvironment::new();
     evaluator.insert_def(shared_def, TypeId(100));
-    evaluator.insert_def(eval_only_def, TypeId(101));
 
     let mut flow = TypeEnvironment::new();
+    flow.insert_def(shared_def, TypeId(100));
     // Flow-analyzer-only mapping the evaluator never wrote.
     flow.register_class_extends(flow_only_class, DefId(98));
-    // After the production reconciliation step, the flow env is overlaid
-    // from the evaluator env. With no conflicting writes this must leave the
-    // two envs consistent on every shared key.
-    flow.overlay_missing_from(&evaluator);
 
     assert_eq!(
         flow.first_def_divergence_from(&evaluator),
         None,
-        "post-overlay envs must agree on every shared DefId entry"
+        "mirrored envs must agree on every shared DefId entry"
+    );
+    assert_eq!(
+        flow.first_missing_entry_from(&evaluator),
+        None,
+        "mirrored envs must not need evaluator-to-flow repair"
     );
 }
 

--- a/docs/how-tsz-works/internals/checker-context-and-state.md
+++ b/docs/how-tsz-works/internals/checker-context-and-state.md
@@ -227,9 +227,10 @@ during recursive resolution), the operation is **reified** into
 symmetric `deferred_eval_env_writes` queue does the same for the authoritative
 `type_env` side — a dropped write there used to collapse a class-instance / def
 body to `never` for every later consumer (the xstate `Actor` `this` collapse).
-Both queues are flushed at file-preparation time, and a `debug_assert_eq!`
-enforces that the flow-env queue is empty once
-`prepare_source_file_for_checking` returns.
+Both queues are flushed at file-preparation time. `debug_assert_eq!` guards
+enforce that the evaluator and flow queues are empty before statements run, and
+the reconcile step asserts that the flow env is not missing evaluator-env
+entries after deferred replay.
 
 ## The per-file checking lifecycle
 

--- a/docs/how-tsz-works/internals/checker-type-of-symbol-and-symbol-types.md
+++ b/docs/how-tsz-works/internals/checker-type-of-symbol-and-symbol-types.md
@@ -293,9 +293,10 @@ The same `DefId` body is then *mirrored* into the second environment
 The mirror **defers** on a borrow race (it is replayed at
 `flush_deferred_flow_env_writes`) rather than dropping — a dropped mirror left
 the two envs holding two *distinctly interned* materializations of a recursive
-self-referential interface, a divergence the vacancy-only `overlay_missing_from`
-cannot reconcile (#13944). The two-environment split is described in
-[checker-context-and-state](checker-context-and-state.md) and
+self-referential interface. File preparation now canonicalizes benign
+present-but-different `def_types` entries and asserts that no evaluator-only
+entry remains after deferred replay (#13944/#14348). The two-environment split
+is described in [checker-context-and-state](checker-context-and-state.md) and
 [checker-flow-and-narrowing](checker-flow-and-narrowing.md); this kernel is the
 single writer that keeps them coherent.
 


### PR DESCRIPTION
Goal: hold

## Summary
- Route shared `DefinitionStore` wiring through the same dual-env deferred-write authority as ordinary checker env registrations.
- Remove the mutating `TypeEnvironment::overlay_missing_from` repair path and replace it with a read-only missing-entry probe used by file-prep assertions.
- Assert both deferred env queues are drained before statement checking, and update tests/docs around the #14348 env-reconcile contract.

## Structural Rule
When checker env writes are routed through `register_*_in_envs` and both deferred queues have replayed, `tsc` has one effective type-environment view; TSZ owns this in checker env-write orchestration. The flow env must already contain evaluator-env registrations after replay. Reconcile may canonicalize benign present-but-different `def_types`, but evaluator-only missing entries are assertion failures, not solver-side vacancy-fill repairs.

## Adjacent Matrix
- Shared store scalar: borrowed flow env queues `SetDefinitionStore`, then `flush_deferred_flow_env_writes` installs it.
- Missing map entry: `first_missing_entry_from` reports evaluator-only `types` entries without mutating the flow env.
- Existing mirrored envs: missing probe returns `None`, and present-but-different `def_types` still use the existing structural convergence path.
- Production guard: checker reconcile source no longer calls `.overlay_missing_from(` and source-scan coverage pins that.

## Cache/Order
No cache key changes. File preparation now flushes evaluator deferred writes, asserts that queue is empty, flushes flow deferred writes, then runs read-only missing-entry and divergence assertions. The read-only probe does not bump `TypeEnvironment` generation; shared store wiring now follows normal deferred-write ordering.

## Verification
- `cargo fmt --all`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 scripts/safe-run.sh -- cargo nextest run -p tsz-solver --lib -E 'test(first_missing_entry_from) or test(first_def_divergence_from_clean_after_mirrored_entries) or test(first_def_divergence_from_detects_conflicting_shared_def_body) or test(collect_def_type_divergences_reports_every_present_but_different_shared_def)'` (5 passed)
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 scripts/safe-run.sh -- cargo nextest run -p tsz-checker --lib -E 'test(ensure_both_envs) or test(augmented_def_registration_uses_store_only_params_on_replay) or test(reconcile_uses_missing_entry_probe_not_overlay_repair) or test(unresolved_resolution_write_reaches_both_envs_and_defers_under_borrow)'` (5 passed)
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 scripts/safe-run.sh -- cargo nextest run -p tsz-checker --lib -E 'test(class_property_initializer_this_uses_ast_owner_during_type_environment) or test(static_property_initializer_this_uses_constructor_owner_during_type_environment) or test(test_object_literal_spread_basic)'` (3 passed)
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 scripts/safe-run.sh -- cargo check -p tsz-solver -p tsz-checker`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 scripts/safe-run.sh -- cargo clippy -p tsz-solver -p tsz-checker --lib --tests -- -D warnings`
- `git diff --check && git diff --cached --check && cargo fmt --all --check`
- `python3 scripts/arch/arch_guard.py --json` (expected inherited failures on this base: `access.rs` 2026 > 2000; direct `query_boundaries::common` count 3101 > cap 3098; snapshot rollback callers 5 > cap 4)
- `scripts/arch/check-checker-boundaries.sh` (same expected inherited failures)

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high