### PR TITLE
refactor(checker): route type literal shape construction (#14351)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -609,14 +609,13 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::function_shape_for_type(self.ctx.types, callee_type)
             && self.call_return_is_lazy_lib_deferrable(shape.return_type)
         {
+            let mut inputs_probe_shape = (*shape).clone();
+            inputs_probe_shape.return_type = TypeId::UNKNOWN;
             let inputs_probe =
-                self.ctx
-                    .types
-                    .factory()
-                    .function(crate::query_boundaries::common::FunctionShape {
-                        return_type: TypeId::UNKNOWN,
-                        ..(*shape).clone()
-                    });
+                crate::query_boundaries::construct_signatures::function_type_from_shape(
+                    self.ctx.types,
+                    inputs_probe_shape,
+                );
             self.ensure_relation_input_ready(inputs_probe);
             return;
         }

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -19,7 +19,8 @@
 
 use tsz_solver::construction::TypeDatabase;
 use tsz_solver::{
-    CallSignature, CallableShape, CallableShapeId, FunctionShape, ParamInfo, TypeId, TypePredicate,
+    CallSignature, CallableShape, CallableShapeId, FunctionShape, IndexSignature, ParamInfo,
+    PropertyInfo, TypeId, TypePredicate,
 };
 
 pub(crate) fn construct_signatures_for_type(
@@ -117,6 +118,20 @@ pub(crate) fn function_type_from_call_signature(
     db.function(function_shape_from_call_signature(sig, is_constructor))
 }
 
+/// Intern a method function type for a type-literal method signature.
+///
+/// Method-ness is represented on the `FunctionShape` for single-signature
+/// method properties; overload sets keep their method flag on each
+/// `CallSignature` inside the callable shape.
+pub(crate) fn method_function_type_from_call_signature(
+    db: &dyn TypeDatabase,
+    sig: &CallSignature,
+) -> TypeId {
+    let mut shape = function_shape_from_call_signature(sig, false);
+    shape.is_method = true;
+    db.function(shape)
+}
+
 /// Intern a bare callable carrying only call signatures.
 pub(crate) fn call_only_callable_type(
     db: &dyn TypeDatabase,
@@ -136,6 +151,33 @@ pub(crate) fn construct_only_callable_type(
     db.callable(CallableShape {
         construct_signatures,
         ..CallableShape::default()
+    })
+}
+
+/// Intern the callable/object hybrid produced by an inline type literal.
+///
+/// The checker assembles `CallSignature`, `PropertyInfo`, and `IndexSignature`
+/// facts from the AST; this boundary owns the solver shape convention for the
+/// resulting callable, including the single index slot where a symbol index is
+/// carried in `string_index` when no string index is present.
+pub(crate) fn type_literal_callable_type(
+    db: &dyn TypeDatabase,
+    call_signatures: Vec<CallSignature>,
+    construct_signatures: Vec<CallSignature>,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    symbol_index: Option<IndexSignature>,
+    is_abstract: bool,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures,
+        construct_signatures,
+        properties,
+        string_index: string_index.or(symbol_index),
+        number_index,
+        symbol: None,
+        is_abstract,
     })
 }
 

--- a/crates/tsz-checker/src/query_boundaries/type_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_construction.rs
@@ -75,6 +75,54 @@ pub(crate) fn enum_namespace_object_with_number_reverse_map(
     })
 }
 
+/// Intern the indexed object produced by an inline type literal.
+pub(crate) fn type_literal_object_with_index(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    symbol_index: Option<IndexSignature>,
+    has_late_bound_members: bool,
+) -> TypeId {
+    let mut shape = ObjectShape {
+        properties,
+        string_index,
+        number_index,
+        symbol_index,
+        ..ObjectShape::default()
+    };
+    if has_late_bound_members {
+        shape.mark_has_late_bound_members();
+    }
+    db.object_with_index(shape)
+}
+
+/// Intern the extra number-index object intersected into a type literal when
+/// multiple number index signatures must be preserved.
+pub(crate) fn type_literal_extra_number_index_object(
+    db: &dyn TypeDatabase,
+    number_index: IndexSignature,
+) -> TypeId {
+    db.object_with_index(ObjectShape {
+        number_index: Some(number_index),
+        ..ObjectShape::default()
+    })
+}
+
+/// Intern the plain object produced by an inline type literal.
+pub(crate) fn type_literal_object(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    has_late_bound_members: bool,
+) -> TypeId {
+    let flags = if has_late_bound_members {
+        ObjectFlags::HAS_LATE_BOUND_MEMBERS
+    } else {
+        ObjectFlags::empty()
+    };
+    db.object_with_flags_and_symbol(properties, flags, None)
+}
+
 /// Create a string intrinsic type from a validated lib intrinsic name.
 pub(crate) fn string_intrinsic_by_name(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -1106,12 +1106,18 @@ impl<'a> CheckerState<'a> {
     /// - **`ObjectWithIndex`**: If has index signatures
     /// - **Object**: Plain object type otherwise
     pub(crate) fn get_type_from_type_literal(&mut self, idx: NodeIndex) -> TypeId {
+        use crate::query_boundaries::construct_signatures::{
+            call_only_callable_type, method_function_type_from_call_signature,
+            type_literal_callable_type,
+        };
+        use crate::query_boundaries::type_construction::{
+            type_literal_extra_number_index_object, type_literal_object,
+            type_literal_object_with_index,
+        };
         use tsz_parser::parser::syntax_kind_ext::{
             CALL_SIGNATURE, CONSTRUCT_SIGNATURE, METHOD_SIGNATURE, PROPERTY_SIGNATURE,
         };
-        use tsz_solver::{
-            CallSignature, CallableShape, FunctionShape, IndexSignature, ObjectShape, PropertyInfo,
-        };
+        use tsz_solver::{CallSignature, IndexSignature, PropertyInfo};
         let factory = self.ctx.types.factory();
 
         let Some(node) = self.ctx.arena.get(idx) else {
@@ -1649,27 +1655,11 @@ impl<'a> CheckerState<'a> {
                         .next()
                         .expect("sigs.len() == 1 guard ensures at least one element")
                         .signature;
-                    factory.function(FunctionShape {
-                        type_params: sig.type_params,
-                        params: sig.params,
-                        this_type: sig.this_type,
-                        return_type: sig.return_type,
-                        type_predicate: sig.type_predicate,
-                        is_constructor: false,
-                        is_method: true,
-                    })
+                    method_function_type_from_call_signature(self.ctx.types, &sig)
                 } else {
                     let merged_sigs: Vec<CallSignature> =
                         sigs.into_iter().map(|entry| entry.signature).collect();
-                    factory.callable(CallableShape {
-                        call_signatures: merged_sigs,
-                        construct_signatures: Vec::new(),
-                        properties: Vec::new(),
-                        string_index: None,
-                        number_index: None,
-                        symbol: None,
-                        is_abstract: false,
-                    })
+                    call_only_callable_type(self.ctx.types, merged_sigs)
                 };
                 properties.push(PropertyInfo {
                     name: key.name,
@@ -1691,58 +1681,44 @@ impl<'a> CheckerState<'a> {
         }
 
         if !call_signatures.is_empty() || !construct_signatures.is_empty() {
-            // `CallableShape` keeps the single-slot index convention: a `symbol`
-            // index rides in `string_index` (its `key_type` discriminates it).
-            let mut result = factory.callable(CallableShape {
+            let mut result = type_literal_callable_type(
+                self.ctx.types,
                 call_signatures,
                 construct_signatures,
                 properties,
-                string_index: string_index.or(symbol_index),
+                string_index,
                 number_index,
-                symbol: None,
-                is_abstract: has_abstract_construct_sig,
-            });
+                symbol_index,
+                has_abstract_construct_sig,
+            );
             for idx in extra_number_indices {
-                let member = factory.object_with_index(ObjectShape {
-                    number_index: Some(idx),
-                    ..ObjectShape::default()
-                });
+                let member = type_literal_extra_number_index_object(self.ctx.types, idx);
                 result = self.ctx.types.intersect_types_raw2(result, member);
             }
             return result;
         }
 
         if string_index.is_some() || number_index.is_some() || symbol_index.is_some() {
-            let mut shape = ObjectShape {
+            let mut result = type_literal_object_with_index(
+                self.ctx.types,
                 properties,
                 string_index,
                 number_index,
                 symbol_index,
-                ..ObjectShape::default()
-            };
-            if has_late_bound_members {
-                shape.mark_has_late_bound_members();
-            }
-            let mut result = factory.object_with_index(shape);
+                has_late_bound_members,
+            );
             // Record the hand-written `{ ... }` annotation so the printer never
             // repaints it with a utility-application display alias that shares
             // this content-interned id.
             self.ctx.types.mark_literal_object_annotation(result);
             for idx in extra_number_indices {
-                let member = factory.object_with_index(ObjectShape {
-                    number_index: Some(idx),
-                    ..ObjectShape::default()
-                });
+                let member = type_literal_extra_number_index_object(self.ctx.types, idx);
                 result = self.ctx.types.intersect_types_raw2(result, member);
             }
             return result;
         }
 
-        let result = if has_late_bound_members {
-            factory.object_with_late_bound_members(properties, None)
-        } else {
-            factory.object_with_symbol(properties, None)
-        };
+        let result = type_literal_object(self.ctx.types, properties, has_late_bound_members);
         self.ctx.types.mark_literal_object_annotation(result);
         result
     }

--- a/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
@@ -34,6 +34,10 @@ const SIGNATURE_CONSTRUCTION_CLEAN_MODULES: &[&str] = &[
 /// The designated checker-side `CallSignature` data assembler.
 const SIGNATURE_DATA_BUILDER: &str = "src/checkers/signature_builder.rs";
 
+/// Type literals assemble AST-derived signature/index/property facts, but the
+/// solver shape construction belongs to query boundaries.
+const TYPE_LITERAL_CHECKER: &str = "src/types/type_literal_checker.rs";
+
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
 }
@@ -46,13 +50,11 @@ fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<Str
         if trimmed.starts_with("//") {
             continue;
         }
-        // A `Shape {` token in return-type position (`fn f(..) -> Shape {`)
-        // is a function header, not a shape-literal construction.
-        if trimmed.contains("->") {
-            continue;
-        }
         for pattern in patterns {
             if line.contains(pattern) {
+                if pattern_is_return_type_header(line, pattern) {
+                    continue;
+                }
                 violations.push(format!(
                     "{relative}:{} contains `{pattern}`",
                     line_index + 1
@@ -60,6 +62,16 @@ fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<Str
             }
         }
     }
+}
+
+fn pattern_is_return_type_header(line: &str, pattern: &str) -> bool {
+    let Some(arrow_pos) = line.find("->") else {
+        return false;
+    };
+    let Some(pattern_pos) = line.find(pattern) else {
+        return false;
+    };
+    pattern_pos > arrow_pos && line[pattern_pos + pattern.len()..].trim().is_empty()
 }
 
 /// The issue #13022 modules must not intern signature-bearing (or
@@ -127,6 +139,35 @@ fn call_signature_literals_stay_in_signature_builder() {
     );
 }
 
+/// Type-literal lowering may collect `CallSignature`, `IndexSignature`, and
+/// `PropertyInfo` facts from AST members, but it must not directly intern
+/// solver `FunctionShape`/`CallableShape`/`ObjectShape` instances.
+#[test]
+fn type_literal_checker_routes_shape_construction_through_boundaries() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".function(",
+        ".callable(",
+        ".object_with_index(",
+        ".object_with_flags_and_symbol(",
+        ".object_with_late_bound_members(",
+        ".object_with_symbol(",
+        "CallableShape {",
+        "CallableShape::default()",
+        "FunctionShape {",
+        "ObjectShape {",
+        "ObjectShape::default()",
+    ];
+
+    let mut violations = Vec::new();
+    scan_for_patterns(TYPE_LITERAL_CHECKER, FORBIDDEN_PATTERNS, &mut violations);
+    assert!(
+        violations.is_empty(),
+        "type literal checker must route solver shape construction through \
+         query_boundaries helpers while keeping AST fact assembly local:\n{}",
+        violations.join("\n")
+    );
+}
+
 /// The boundary helpers this campaign introduced must keep their definitions
 /// in `query_boundaries/construct_signatures.rs` (not drift back into
 /// `common.rs` or call sites).
@@ -139,8 +180,10 @@ fn construct_signatures_boundary_owns_construction_helpers() {
         "call_signature_from_function_shape",
         "function_type_from_shape",
         "function_type_from_call_signature",
+        "method_function_type_from_call_signature",
         "call_only_callable_type",
         "construct_only_callable_type",
+        "type_literal_callable_type",
         "callable_with_signatures_replaced",
         "instantiated_callable_from_base",
         "map_function_shape_types",
@@ -156,6 +199,7 @@ fn construct_signatures_boundary_owns_construction_helpers() {
     for helper in [
         "call_only_callable_type",
         "construct_only_callable_type",
+        "type_literal_callable_type",
         "callable_with_signatures_replaced",
         "instantiated_callable_from_base",
         "map_function_shape_types",
@@ -163,6 +207,24 @@ fn construct_signatures_boundary_owns_construction_helpers() {
         assert!(
             !common.contains(&format!("fn {helper}(")),
             "construction helper `{helper}` must not migrate into common.rs"
+        );
+    }
+}
+
+/// Object-shape helpers for inline type literals live in the construction
+/// boundary, not in checker call sites.
+#[test]
+fn type_construction_boundary_owns_type_literal_object_helpers() {
+    let source = fs::read_to_string(checker_path("src/query_boundaries/type_construction.rs"))
+        .expect("failed to read query_boundaries/type_construction.rs");
+    for helper in [
+        "type_literal_object_with_index",
+        "type_literal_extra_number_index_object",
+        "type_literal_object",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::type_construction must own the `{helper}` helper"
         );
     }
 }


### PR DESCRIPTION
Goal: fast

## Summary
- route inline type-literal function/callable/object solver-shape construction through query-boundary helpers
- keep checker-owned AST fact collection for `CallSignature`, `IndexSignature`, and `PropertyInfo`
- tighten construction boundary source scans, including the type-literal checker and an adjacent direct function-shape interning leak

## Structural Rule
When an inline type literal lowers AST members into a callable or object type, `tsc` preserves method bivariant flags, call/construct signatures, index signatures, late-bound member flags, and extra number-index intersections. tsz now keeps AST fact collection in checker, but interns solver `FunctionShape`, `CallableShape`, and `ObjectShape` values through `query_boundaries::construct_signatures` and `query_boundaries::type_construction`.

## Adjacent Matrix
- single type-literal method signatures route through `method_function_type_from_call_signature`
- overloaded type-literal methods route through `call_only_callable_type`
- callable/construct hybrid literals route through `type_literal_callable_type`, preserving the symbol-index single-slot convention
- indexed, plain, late-bound, and extra-number-index object fragments route through `type_construction` helpers
- callee-readiness probing in assignability reuses `function_type_from_shape` instead of direct `factory().function(...)`

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test arch_source_scans -E 'test(construction_boundary_signature_scans)'`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test type_literal_method_overload_tests --test type_literal_overload_optionality_tests --test ts2314_in_type_literal_suppresses_ts2322_tests --test type_alias_signature_body_validation_tests`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test typeof_function_like_flow_tests --test callable_interface_index_tests --test construct_signature_boundary_matrix_tests --test construct_signature_param_variance_tests`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test symbol_index_signature_tests --test non_unique_symbol_late_bound_member_tests -E 'test(symbol_only_index_callable_string_literal_access_reports_ts7053) or test(type_literal_non_unique_symbol_property_no_false_positive) or test(keyof_inline_type_literal_unique_symbol_key_symbol_only) or test(keyof_inline_type_literal_unique_symbol_key_mixed_keys) or test(keyof_inline_type_literal_named_alias_and_inline_agree)'`
- `scripts/safe-run.sh -- cargo check -p tsz-checker`
- `scripts/safe-run.sh -- cargo clippy -p tsz-checker --lib --tests -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
