### PR TITLE
refactor(checker): route declaration function shapes (#14351)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -609,14 +609,13 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::function_shape_for_type(self.ctx.types, callee_type)
             && self.call_return_is_lazy_lib_deferrable(shape.return_type)
         {
+            let mut inputs_probe_shape = (*shape).clone();
+            inputs_probe_shape.return_type = TypeId::UNKNOWN;
             let inputs_probe =
-                self.ctx
-                    .types
-                    .factory()
-                    .function(crate::query_boundaries::common::FunctionShape {
-                        return_type: TypeId::UNKNOWN,
-                        ..(*shape).clone()
-                    });
+                crate::query_boundaries::construct_signatures::function_type_from_shape(
+                    self.ctx.types,
+                    inputs_probe_shape,
+                );
             self.ensure_relation_input_ready(inputs_probe);
             return;
         }

--- a/crates/tsz-checker/src/classes/class_member_info.rs
+++ b/crates/tsz-checker/src/classes/class_member_info.rs
@@ -10,6 +10,7 @@ use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
 use crate::query_boundaries::class::{
     should_report_member_type_mismatch_bivariant, should_report_own_member_type_mismatch,
 };
+use crate::query_boundaries::construct_signatures::method_function_type_from_call_signature;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -843,18 +844,9 @@ impl<'a> CheckerState<'a> {
                     MemberVisibility::Public
                 };
                 let is_static = self.has_static_modifier(&method.modifiers);
-                let factory = self.ctx.types.factory();
-                use tsz_solver::FunctionShape;
                 let signature = self.call_signature_from_method(method, member_idx);
-                let method_type = factory.function(FunctionShape {
-                    type_params: signature.type_params,
-                    params: signature.params,
-                    this_type: signature.this_type,
-                    return_type: signature.return_type,
-                    type_predicate: signature.type_predicate,
-                    is_constructor: false,
-                    is_method: true,
-                });
+                let method_type =
+                    method_function_type_from_call_signature(self.ctx.types, &signature);
                 let is_abstract = self.has_abstract_modifier(&method.modifiers);
                 Some(ClassMemberInfo {
                     name,

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -3,6 +3,7 @@ use crate::flow_analysis::{ComputedKey, PropertyKey};
 use crate::query_boundaries::common::{
     TypeSubstitution, callable_shape_for_type, object_shape_for_type,
 };
+use crate::query_boundaries::construct_signatures::call_only_callable_type;
 use crate::query_boundaries::definite_assignment::constructor_assigned_properties;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -97,7 +98,7 @@ pub(crate) struct ClassChainSummary {
     /// Externally-visible overload-method types per instance method name.
     /// An entry exists for each method that has multiple `METHOD_DECLARATION`
     /// nodes at the level of the chain that first declares it. The TypeId
-    /// is a `CallableShape` whose `call_signatures` are the externally
+    /// is a callable type whose `call_signatures` are the externally
     /// visible overload signatures (bodyless declarations if any, otherwise
     /// the single implementation signature). Types are substituted into the
     /// root class's type-parameter scope by the chain summary.
@@ -361,7 +362,7 @@ impl<'a> CheckerState<'a> {
     /// Build externally-visible overload-method types for a class, keyed by
     /// method name and partitioned by static-ness. An entry exists only for
     /// methods with multiple `METHOD_DECLARATION` nodes (overloaded methods).
-    /// The resulting `TypeId` is a `CallableShape` whose `call_signatures`
+    /// The resulting `TypeId` is a callable type whose `call_signatures`
     /// are the externally visible overload signatures: bodyless declarations
     /// if any exist on the class, otherwise the single implementation
     /// signature. Signatures are built with `is_method = true` for bivariant
@@ -370,8 +371,6 @@ impl<'a> CheckerState<'a> {
         &mut self,
         class: &tsz_parser::parser::node::ClassData,
     ) -> (FxHashMap<String, TypeId>, FxHashMap<String, TypeId>) {
-        use tsz_solver::CallableShape;
-
         // Single-pass groupby: walk members once and route each declaration
         // into `singletons` (only one observed) or `groups` (two or more
         // observed). Non-overloaded classes pay only N hashmap inserts and
@@ -434,11 +433,7 @@ impl<'a> CheckerState<'a> {
             if sigs.is_empty() {
                 continue;
             }
-            let factory = self.ctx.types.factory();
-            let type_id = factory.callable(CallableShape {
-                call_signatures: sigs,
-                ..CallableShape::default()
-            });
+            let type_id = call_only_callable_type(self.ctx.types, sigs);
             if is_static {
                 static_overloads.insert(name, type_id);
             } else {

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -20,7 +20,7 @@
 use tsz_solver::construction::TypeDatabase;
 use tsz_solver::{
     CallSignature, CallableShape, CallableShapeId, FunctionShape, IndexSignature, ParamInfo,
-    PropertyInfo, TypeId, TypePredicate,
+    PropertyInfo, TypeId, TypeParamInfo, TypePredicate,
 };
 
 pub(crate) fn construct_signatures_for_type(
@@ -106,6 +106,28 @@ pub(crate) fn call_signature_from_function_shape(
 /// Intern a function type from an explicit, helper-built shape.
 pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {
     db.function(shape)
+}
+
+/// Intern a function type from declaration-lowered signature parts.
+pub(crate) fn function_type_from_parts(
+    db: &dyn TypeDatabase,
+    type_params: Vec<TypeParamInfo>,
+    params: Vec<ParamInfo>,
+    this_type: Option<TypeId>,
+    return_type: TypeId,
+    type_predicate: Option<TypePredicate>,
+    is_constructor: bool,
+    is_method: bool,
+) -> TypeId {
+    db.function(FunctionShape {
+        type_params,
+        params,
+        this_type,
+        return_type,
+        type_predicate,
+        is_constructor,
+        is_method,
+    })
 }
 
 /// Intern the standalone function type for one signature (a constructor
@@ -198,6 +220,16 @@ pub(crate) fn callable_with_signatures_replaced(
         symbol: base.symbol,
         is_abstract: base.is_abstract,
     })
+}
+
+/// Re-intern `base` with replacement call signatures and detached nominal
+/// callable metadata.
+pub(crate) fn callable_with_call_signatures_and_erased_metadata(
+    db: &dyn TypeDatabase,
+    base: &CallableShape,
+    call_signatures: Vec<CallSignature>,
+) -> TypeId {
+    instantiated_callable_from_base(db, base, call_signatures, base.construct_signatures.clone())
 }
 
 /// Re-intern `base` with instantiated signature lists for type-argument

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -19,7 +19,8 @@
 
 use tsz_solver::construction::TypeDatabase;
 use tsz_solver::{
-    CallSignature, CallableShape, CallableShapeId, FunctionShape, ParamInfo, TypeId, TypePredicate,
+    CallSignature, CallableShape, CallableShapeId, FunctionShape, IndexSignature, ParamInfo,
+    PropertyInfo, TypeId, TypePredicate,
 };
 
 pub(crate) fn construct_signatures_for_type(
@@ -117,6 +118,20 @@ pub(crate) fn function_type_from_call_signature(
     db.function(function_shape_from_call_signature(sig, is_constructor))
 }
 
+/// Intern a method function type for a type-literal method signature.
+///
+/// Method-ness is represented on the `FunctionShape` for single-signature
+/// method properties; overload sets keep their method flag on each
+/// `CallSignature` inside the callable shape.
+pub(crate) fn method_function_type_from_call_signature(
+    db: &dyn TypeDatabase,
+    sig: &CallSignature,
+) -> TypeId {
+    let mut shape = function_shape_from_call_signature(sig, false);
+    shape.is_method = true;
+    db.function(shape)
+}
+
 /// Intern a bare callable carrying only call signatures.
 pub(crate) fn call_only_callable_type(
     db: &dyn TypeDatabase,
@@ -136,6 +151,33 @@ pub(crate) fn construct_only_callable_type(
     db.callable(CallableShape {
         construct_signatures,
         ..CallableShape::default()
+    })
+}
+
+/// Intern the callable/object hybrid produced by an inline type literal.
+///
+/// The checker assembles `CallSignature`, `PropertyInfo`, and `IndexSignature`
+/// facts from the AST; this boundary owns the solver shape convention for the
+/// resulting callable, including the single index slot where a symbol index is
+/// carried in `string_index` when no string index is present.
+pub(crate) fn type_literal_callable_type(
+    db: &dyn TypeDatabase,
+    call_signatures: Vec<CallSignature>,
+    construct_signatures: Vec<CallSignature>,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    symbol_index: Option<IndexSignature>,
+    is_abstract: bool,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures,
+        construct_signatures,
+        properties,
+        string_index: string_index.or(symbol_index),
+        number_index,
+        symbol: None,
+        is_abstract,
     })
 }
 

--- a/crates/tsz-checker/src/query_boundaries/type_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_construction.rs
@@ -75,6 +75,54 @@ pub(crate) fn enum_namespace_object_with_number_reverse_map(
     })
 }
 
+/// Intern the indexed object produced by an inline type literal.
+pub(crate) fn type_literal_object_with_index(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    symbol_index: Option<IndexSignature>,
+    has_late_bound_members: bool,
+) -> TypeId {
+    let mut shape = ObjectShape {
+        properties,
+        string_index,
+        number_index,
+        symbol_index,
+        ..ObjectShape::default()
+    };
+    if has_late_bound_members {
+        shape.mark_has_late_bound_members();
+    }
+    db.object_with_index(shape)
+}
+
+/// Intern the extra number-index object intersected into a type literal when
+/// multiple number index signatures must be preserved.
+pub(crate) fn type_literal_extra_number_index_object(
+    db: &dyn TypeDatabase,
+    number_index: IndexSignature,
+) -> TypeId {
+    db.object_with_index(ObjectShape {
+        number_index: Some(number_index),
+        ..ObjectShape::default()
+    })
+}
+
+/// Intern the plain object produced by an inline type literal.
+pub(crate) fn type_literal_object(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    has_late_bound_members: bool,
+) -> TypeId {
+    let flags = if has_late_bound_members {
+        ObjectFlags::HAS_LATE_BOUND_MEMBERS
+    } else {
+        ObjectFlags::empty()
+    };
+    db.object_with_flags_and_symbol(properties, flags, None)
+}
+
 /// Create a string intrinsic type from a validated lib intrinsic name.
 pub(crate) fn string_intrinsic_by_name(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -8,6 +8,7 @@ mod type_alias_merged_value;
 mod type_alias_variable_alias;
 
 use crate::query_boundaries::common::{contains_infer_types, contains_type_parameters};
+use crate::query_boundaries::construct_signatures::call_only_callable_type;
 
 struct SymbolAliasCtx<'a> {
     sym_id: SymbolId,
@@ -826,7 +827,6 @@ impl<'a> CheckerState<'a> {
         sym_id: SymbolId,
     ) -> (TypeId, Vec<tsz_solver::TypeParamInfo>) {
         use tsz_lowering::TypeLowering;
-        use tsz_solver::CallableShape;
 
         // PERF: see `docs/plan/PERFORMANCE_PLAN.md`. Counts every entry to
         // type-of-symbol computation; attribution uses this against
@@ -1511,16 +1511,7 @@ impl<'a> CheckerState<'a> {
             }
 
             let function_type = if !overloads.is_empty() {
-                let shape = CallableShape {
-                    call_signatures: overloads,
-                    construct_signatures: Vec::new(),
-                    properties: Vec::new(),
-                    string_index: None,
-                    number_index: None,
-                    symbol: None,
-                    is_abstract: false,
-                };
-                factory.callable(shape)
+                call_only_callable_type(self.ctx.types, overloads)
             } else if value_decl.is_some() {
                 self.get_type_of_function(value_decl)
             } else if implementation_decl.is_some() {

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
@@ -1,6 +1,7 @@
 use super::computed_helpers_namespace_display::trim_namespace_display_path;
 use crate::context::TypingRequest;
 use crate::query_boundaries::common::object_shape_for_type;
+use crate::query_boundaries::construct_signatures::callable_with_call_signatures_and_erased_metadata;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::{SymbolId, symbol_flags};
@@ -718,16 +719,7 @@ impl<'a> CheckerState<'a> {
             return ctor_type;
         };
 
-        let factory = self.ctx.types.factory();
-        factory.callable(tsz_solver::CallableShape {
-            call_signatures,
-            construct_signatures: shape.construct_signatures.clone(),
-            properties: shape.properties.clone(),
-            string_index: shape.string_index,
-            number_index: shape.number_index,
-            symbol: None,
-            is_abstract: false,
-        })
+        callable_with_call_signatures_and_erased_metadata(self.ctx.types, &shape, call_signatures)
     }
 
     /// Compute the type of an enum member symbol.

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_functions.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_functions.rs
@@ -1,5 +1,6 @@
 //! Direct source-file function declaration fast paths.
 
+use crate::query_boundaries::construct_signatures::function_type_from_parts;
 use crate::state::CheckerState;
 use tsz_binder::{BinderState, SymbolId, symbol_flags};
 use tsz_lowering::TypeLowering;
@@ -7,7 +8,7 @@ use tsz_parser::NodeIndex;
 use tsz_parser::parser::base::NodeList;
 use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{FunctionShape, ParamInfo, TypeId, TypePredicate, TypePredicateTarget};
+use tsz_solver::{ParamInfo, TypeId, TypePredicate, TypePredicateTarget};
 
 use super::cross_file_direct::is_direct_lowering_source_file_arena;
 
@@ -238,15 +239,16 @@ impl<'a> CheckerState<'a> {
             function.type_annotation,
             &params,
         )?;
-        let ty = self.ctx.types.factory().function(FunctionShape {
-            type_params: Vec::new(),
+        let ty = function_type_from_parts(
+            self.ctx.types,
+            Vec::new(),
             params,
-            this_type: None,
+            None,
             return_type,
             type_predicate,
-            is_constructor: false,
-            is_method: false,
-        });
+            false,
+            false,
+        );
         Some(ty)
     }
 

--- a/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
@@ -2,6 +2,9 @@
 //! type parameter identity checks, provisional function types, and numeric enum registration.
 
 use crate::query_boundaries::common::type_param_info;
+use crate::query_boundaries::construct_signatures::{
+    call_only_callable_type, function_type_from_call_signature,
+};
 use crate::state::CheckerState;
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
@@ -290,8 +293,6 @@ impl<'a> CheckerState<'a> {
         &mut self,
         sym_id: SymbolId,
     ) -> Option<TypeId> {
-        use tsz_solver::{CallableShape, FunctionShape};
-
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
         if !symbol.has_any_flags(symbol_flags::FUNCTION)
             || symbol.has_any_flags(symbol_flags::INTERFACE)
@@ -300,7 +301,6 @@ impl<'a> CheckerState<'a> {
         }
 
         let declarations = symbol.declarations.clone();
-        let factory = self.ctx.types.factory();
         let mut overloads = Vec::new();
         let mut implementation_sig = None;
 
@@ -329,27 +329,11 @@ impl<'a> CheckerState<'a> {
         }
 
         if !overloads.is_empty() {
-            return Some(factory.callable(CallableShape {
-                call_signatures: overloads,
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            }));
+            return Some(call_only_callable_type(self.ctx.types, overloads));
         }
 
         let sig = implementation_sig?;
-        let func_type = factory.function(FunctionShape {
-            type_params: sig.type_params,
-            params: sig.params,
-            this_type: sig.this_type,
-            return_type: sig.return_type,
-            type_predicate: sig.type_predicate,
-            is_constructor: false,
-            is_method: false,
-        });
+        let func_type = function_type_from_call_signature(self.ctx.types, &sig, false);
         Some(func_type)
     }
 
@@ -372,8 +356,6 @@ impl<'a> CheckerState<'a> {
         &mut self,
         sym_id: SymbolId,
     ) -> Option<TypeId> {
-        use tsz_solver::FunctionShape;
-
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
         // Plain value variables only; entities with their own provisional /
         // lazy handling (functions, classes, interfaces, type aliases, enums,
@@ -413,15 +395,11 @@ impl<'a> CheckerState<'a> {
             }
 
             let sig = self.call_signature_from_function(func, init_idx);
-            return Some(self.ctx.types.factory().function(FunctionShape {
-                type_params: sig.type_params,
-                params: sig.params,
-                this_type: sig.this_type,
-                return_type: sig.return_type,
-                type_predicate: sig.type_predicate,
-                is_constructor: false,
-                is_method: false,
-            }));
+            return Some(function_type_from_call_signature(
+                self.ctx.types,
+                &sig,
+                false,
+            ));
         }
         None
     }

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -1106,12 +1106,18 @@ impl<'a> CheckerState<'a> {
     /// - **`ObjectWithIndex`**: If has index signatures
     /// - **Object**: Plain object type otherwise
     pub(crate) fn get_type_from_type_literal(&mut self, idx: NodeIndex) -> TypeId {
+        use crate::query_boundaries::construct_signatures::{
+            call_only_callable_type, method_function_type_from_call_signature,
+            type_literal_callable_type,
+        };
+        use crate::query_boundaries::type_construction::{
+            type_literal_extra_number_index_object, type_literal_object,
+            type_literal_object_with_index,
+        };
         use tsz_parser::parser::syntax_kind_ext::{
             CALL_SIGNATURE, CONSTRUCT_SIGNATURE, METHOD_SIGNATURE, PROPERTY_SIGNATURE,
         };
-        use tsz_solver::{
-            CallSignature, CallableShape, FunctionShape, IndexSignature, ObjectShape, PropertyInfo,
-        };
+        use tsz_solver::{CallSignature, IndexSignature, PropertyInfo};
         let factory = self.ctx.types.factory();
 
         let Some(node) = self.ctx.arena.get(idx) else {
@@ -1649,27 +1655,11 @@ impl<'a> CheckerState<'a> {
                         .next()
                         .expect("sigs.len() == 1 guard ensures at least one element")
                         .signature;
-                    factory.function(FunctionShape {
-                        type_params: sig.type_params,
-                        params: sig.params,
-                        this_type: sig.this_type,
-                        return_type: sig.return_type,
-                        type_predicate: sig.type_predicate,
-                        is_constructor: false,
-                        is_method: true,
-                    })
+                    method_function_type_from_call_signature(self.ctx.types, &sig)
                 } else {
                     let merged_sigs: Vec<CallSignature> =
                         sigs.into_iter().map(|entry| entry.signature).collect();
-                    factory.callable(CallableShape {
-                        call_signatures: merged_sigs,
-                        construct_signatures: Vec::new(),
-                        properties: Vec::new(),
-                        string_index: None,
-                        number_index: None,
-                        symbol: None,
-                        is_abstract: false,
-                    })
+                    call_only_callable_type(self.ctx.types, merged_sigs)
                 };
                 properties.push(PropertyInfo {
                     name: key.name,
@@ -1691,58 +1681,44 @@ impl<'a> CheckerState<'a> {
         }
 
         if !call_signatures.is_empty() || !construct_signatures.is_empty() {
-            // `CallableShape` keeps the single-slot index convention: a `symbol`
-            // index rides in `string_index` (its `key_type` discriminates it).
-            let mut result = factory.callable(CallableShape {
+            let mut result = type_literal_callable_type(
+                self.ctx.types,
                 call_signatures,
                 construct_signatures,
                 properties,
-                string_index: string_index.or(symbol_index),
+                string_index,
                 number_index,
-                symbol: None,
-                is_abstract: has_abstract_construct_sig,
-            });
+                symbol_index,
+                has_abstract_construct_sig,
+            );
             for idx in extra_number_indices {
-                let member = factory.object_with_index(ObjectShape {
-                    number_index: Some(idx),
-                    ..ObjectShape::default()
-                });
+                let member = type_literal_extra_number_index_object(self.ctx.types, idx);
                 result = self.ctx.types.intersect_types_raw2(result, member);
             }
             return result;
         }
 
         if string_index.is_some() || number_index.is_some() || symbol_index.is_some() {
-            let mut shape = ObjectShape {
+            let mut result = type_literal_object_with_index(
+                self.ctx.types,
                 properties,
                 string_index,
                 number_index,
                 symbol_index,
-                ..ObjectShape::default()
-            };
-            if has_late_bound_members {
-                shape.mark_has_late_bound_members();
-            }
-            let mut result = factory.object_with_index(shape);
+                has_late_bound_members,
+            );
             // Record the hand-written `{ ... }` annotation so the printer never
             // repaints it with a utility-application display alias that shares
             // this content-interned id.
             self.ctx.types.mark_literal_object_annotation(result);
             for idx in extra_number_indices {
-                let member = factory.object_with_index(ObjectShape {
-                    number_index: Some(idx),
-                    ..ObjectShape::default()
-                });
+                let member = type_literal_extra_number_index_object(self.ctx.types, idx);
                 result = self.ctx.types.intersect_types_raw2(result, member);
             }
             return result;
         }
 
-        let result = if has_late_bound_members {
-            factory.object_with_late_bound_members(properties, None)
-        } else {
-            factory.object_with_symbol(properties, None)
-        };
+        let result = type_literal_object(self.ctx.types, properties, has_late_bound_members);
         self.ctx.types.mark_literal_object_annotation(result);
         result
     }

--- a/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
@@ -38,6 +38,17 @@ const SIGNATURE_DATA_BUILDER: &str = "src/checkers/signature_builder.rs";
 /// solver shape construction belongs to query boundaries.
 const TYPE_LITERAL_CHECKER: &str = "src/types/type_literal_checker.rs";
 
+/// Declaration/member type analysis may assemble call signatures from syntax,
+/// but function/callable shape interning belongs to the construction boundary.
+const DECLARATION_FUNCTION_CONSTRUCTION_CLEAN_MODULES: &[&str] = &[
+    "src/classes/class_member_info.rs",
+    "src/classes/class_summary.rs",
+    "src/state/type_analysis/computed/mod.rs",
+    "src/state/type_analysis/computed_helpers_binding.rs",
+    "src/state/type_analysis/cross_file_direct_functions.rs",
+    "src/state/type_analysis/symbol_type_helpers.rs",
+];
+
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
 }
@@ -168,6 +179,32 @@ fn type_literal_checker_routes_shape_construction_through_boundaries() {
     );
 }
 
+/// Declaration/member type paths can build `CallSignature` data with existing
+/// checker helpers, but direct solver function/callable shape interning stays
+/// behind `query_boundaries::construct_signatures`.
+#[test]
+fn declaration_function_paths_route_shape_construction_through_boundaries() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".function(",
+        ".callable(",
+        "CallableShape {",
+        "CallableShape::default()",
+        "FunctionShape {",
+        "FunctionShape::new(",
+    ];
+
+    let mut violations = Vec::new();
+    for module in DECLARATION_FUNCTION_CONSTRUCTION_CLEAN_MODULES {
+        scan_for_patterns(module, FORBIDDEN_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "declaration/member type paths must route function/callable solver \
+         shape construction through query_boundaries::construct_signatures:\n{}",
+        violations.join("\n")
+    );
+}
+
 /// The boundary helpers this campaign introduced must keep their definitions
 /// in `query_boundaries/construct_signatures.rs` (not drift back into
 /// `common.rs` or call sites).
@@ -179,12 +216,14 @@ fn construct_signatures_boundary_owns_construction_helpers() {
         "function_shape_from_call_signature",
         "call_signature_from_function_shape",
         "function_type_from_shape",
+        "function_type_from_parts",
         "function_type_from_call_signature",
         "method_function_type_from_call_signature",
         "call_only_callable_type",
         "construct_only_callable_type",
         "type_literal_callable_type",
         "callable_with_signatures_replaced",
+        "callable_with_call_signatures_and_erased_metadata",
         "instantiated_callable_from_base",
         "map_function_shape_types",
     ] {
@@ -201,6 +240,7 @@ fn construct_signatures_boundary_owns_construction_helpers() {
         "construct_only_callable_type",
         "type_literal_callable_type",
         "callable_with_signatures_replaced",
+        "callable_with_call_signatures_and_erased_metadata",
         "instantiated_callable_from_base",
         "map_function_shape_types",
     ] {

--- a/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
@@ -34,6 +34,10 @@ const SIGNATURE_CONSTRUCTION_CLEAN_MODULES: &[&str] = &[
 /// The designated checker-side `CallSignature` data assembler.
 const SIGNATURE_DATA_BUILDER: &str = "src/checkers/signature_builder.rs";
 
+/// Type literals assemble AST-derived signature/index/property facts, but the
+/// solver shape construction belongs to query boundaries.
+const TYPE_LITERAL_CHECKER: &str = "src/types/type_literal_checker.rs";
+
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
 }
@@ -46,13 +50,11 @@ fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<Str
         if trimmed.starts_with("//") {
             continue;
         }
-        // A `Shape {` token in return-type position (`fn f(..) -> Shape {`)
-        // is a function header, not a shape-literal construction.
-        if trimmed.contains("->") {
-            continue;
-        }
         for pattern in patterns {
             if line.contains(pattern) {
+                if pattern_is_return_type_header(line, pattern) {
+                    continue;
+                }
                 violations.push(format!(
                     "{relative}:{} contains `{pattern}`",
                     line_index + 1
@@ -60,6 +62,16 @@ fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<Str
             }
         }
     }
+}
+
+fn pattern_is_return_type_header(line: &str, pattern: &str) -> bool {
+    let Some(arrow_pos) = line.find("->") else {
+        return false;
+    };
+    let Some(pattern_pos) = line.find(pattern) else {
+        return false;
+    };
+    pattern_pos > arrow_pos && line[pattern_pos + pattern.len()..].trim().is_empty()
 }
 
 /// The issue #13022 modules must not intern signature-bearing (or
@@ -127,6 +139,35 @@ fn call_signature_literals_stay_in_signature_builder() {
     );
 }
 
+/// Type-literal lowering may collect `CallSignature`, `IndexSignature`, and
+/// `PropertyInfo` facts from AST members, but it must not directly intern
+/// solver `FunctionShape`/`CallableShape`/`ObjectShape` instances.
+#[test]
+fn type_literal_checker_routes_shape_construction_through_boundaries() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".function(",
+        ".callable(",
+        ".object_with_index(",
+        ".object_with_flags_and_symbol(",
+        ".object_with_late_bound_members(",
+        ".object_with_symbol(",
+        "CallableShape {",
+        "CallableShape::default()",
+        "FunctionShape {",
+        "ObjectShape {",
+        "ObjectShape::default()",
+    ];
+
+    let mut violations = Vec::new();
+    scan_for_patterns(TYPE_LITERAL_CHECKER, FORBIDDEN_PATTERNS, &mut violations);
+    assert!(
+        violations.is_empty(),
+        "type literal checker must route solver shape construction through \
+         query_boundaries helpers while keeping AST fact assembly local:\n{}",
+        violations.join("\n")
+    );
+}
+
 /// The boundary helpers this campaign introduced must keep their definitions
 /// in `query_boundaries/construct_signatures.rs` (not drift back into
 /// `common.rs` or call sites).
@@ -139,8 +180,10 @@ fn construct_signatures_boundary_owns_construction_helpers() {
         "call_signature_from_function_shape",
         "function_type_from_shape",
         "function_type_from_call_signature",
+        "method_function_type_from_call_signature",
         "call_only_callable_type",
         "construct_only_callable_type",
+        "type_literal_callable_type",
         "callable_with_signatures_replaced",
         "instantiated_callable_from_base",
         "map_function_shape_types",
@@ -156,6 +199,7 @@ fn construct_signatures_boundary_owns_construction_helpers() {
     for helper in [
         "call_only_callable_type",
         "construct_only_callable_type",
+        "type_literal_callable_type",
         "callable_with_signatures_replaced",
         "instantiated_callable_from_base",
         "map_function_shape_types",
@@ -163,6 +207,24 @@ fn construct_signatures_boundary_owns_construction_helpers() {
         assert!(
             !common.contains(&format!("fn {helper}(")),
             "construction helper `{helper}` must not migrate into common.rs"
+        );
+    }
+}
+
+/// Object-shape helpers for inline type literals live in the construction
+/// boundary, not in checker call sites.
+#[test]
+fn type_construction_boundary_owns_type_literal_object_helpers() {
+    let source = fs::read_to_string(checker_path("src/query_boundaries/type_construction.rs"))
+        .expect("failed to read query_boundaries/type_construction.rs");
+    for helper in [
+        "type_literal_object_with_index",
+        "type_literal_extra_number_index_object",
+        "type_literal_object",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::type_construction must own the `{helper}` helper"
         );
     }
 }


### PR DESCRIPTION
Goal: fast

## Summary
- route declaration/member function and callable construction through `query_boundaries::construct_signatures`
- clean class member summaries, provisional function symbol types, direct source-file function lowering, and merged callable helpers of inline `FunctionShape` / `CallableShape` interning
- add a declaration-function source-scan ratchet to keep the converted modules behind the construction boundary

## Structural Rule
When checker builds declaration-derived function or callable types, `tsc` preserves the syntactic signature facts: method bivariant flags for class methods, overload call signatures for class/function declarations, lowered params/return predicates for direct source-file functions, and callable metadata erasure where existing merged-constructor repair intentionally detached nominal identity. tsz now keeps signature collection in checker but interns solver function/callable shapes through `query_boundaries::construct_signatures`.

## Adjacent Matrix
- class method member types route through `method_function_type_from_call_signature`
- class overload summaries and function declaration overloads route through `call_only_callable_type`
- provisional circular function and variable-function paths route through `function_type_from_call_signature`
- direct source-file annotated function lowering routes through `function_type_from_parts`
- constructor callable call-signature replacement routes through `callable_with_call_signatures_and_erased_metadata`, preserving the previous symbol/abstract erasure convention
- declaration-function source scans now reject direct function/callable shape construction in the converted modules

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test arch_source_scans -E 'test(construction_boundary_signature_scans)'`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test abstract_method_overload_ts2416_tests --test class_implements_overloaded_method_ts2416_tests --test overload_modifier_tests --test construct_signature_boundary_matrix_tests`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --lib -E 'test(direct_source_file_function_declaration)'`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test cross_file_function_node_index_collision_tests --test node_esm_default_import_export_equals_callable_tests --test cjs_direct_object_export_no_typeof_import_display_tests --test cjs_object_export_module_augmentation_merge_tests --test typeof_import_commonjs_object_literal_export_tests --test generic_self_circular_alias_tests --test type_alias_typeof_circular_tests --test keyof_self_circular_alias_tests --test tuple_spread_circular_alias_tests`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --lib -E 'test(jsdoc_overload_call) or test(provisional_circular)'`
- `scripts/safe-run.sh -- cargo check -p tsz-checker`
- `scripts/safe-run.sh -- cargo clippy -p tsz-checker --lib --tests -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
