### PR TITLE
refactor(checker): route jsdoc shape construction (#14351)

### DIFF
--- a/crates/tsz-checker/src/jsdoc/params_type_strings.rs
+++ b/crates/tsz-checker/src/jsdoc/params_type_strings.rs
@@ -8,6 +8,7 @@
 //! - `JsdocParamTagInfo` assembly helpers
 
 use super::types::JsdocParamTagInfo;
+use crate::query_boundaries::jsdoc_construction::jsdoc_object_type;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 
@@ -611,7 +612,7 @@ impl<'a> CheckerState<'a> {
         if properties.is_empty() {
             return None;
         }
-        let obj_type = self.ctx.types.factory().object(properties);
+        let obj_type = jsdoc_object_type(self.ctx.types, properties, None, None)?;
         if is_array {
             Some(self.ctx.types.factory().array(obj_type))
         } else {

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -13,6 +13,7 @@
 //! - Arrow function parsing (`parse_jsdoc_arrow_function_type`)
 
 use crate::context::{is_declaration_file_name, is_js_file_name};
+use crate::query_boundaries::jsdoc_construction::{jsdoc_function_type, jsdoc_object_index_type};
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::symbol_flags;
@@ -20,7 +21,7 @@ use tsz_common::numeric::parse_numeric_literal_value;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{IndexSignature, ObjectShape, TypeId, TypePredicate};
+use tsz_solver::{TypeId, TypePredicate};
 
 /// Strip a leading and matching trailing `"` or `'` from `s` if both are
 /// present. Returns the bare inner string when stripped, otherwise `None`.
@@ -552,25 +553,10 @@ impl<'a> CheckerState<'a> {
                     if let (Some(key_type), Some(value_type)) = (
                         self.jsdoc_type_from_expression(key_str),
                         self.jsdoc_type_from_expression(value_str),
-                    ) {
-                        let mut shape = ObjectShape::default();
-                        if key_type == TypeId::STRING {
-                            shape.string_index = Some(IndexSignature {
-                                key_type,
-                                value_type,
-                                readonly: false,
-                                param_name: None,
-                            });
-                            return Some(factory.object_with_index(shape));
-                        } else if key_type == TypeId::NUMBER {
-                            shape.number_index = Some(IndexSignature {
-                                key_type,
-                                value_type,
-                                readonly: false,
-                                param_name: None,
-                            });
-                            return Some(factory.object_with_index(shape));
-                        }
+                    ) && let Some(object_type) =
+                        jsdoc_object_index_type(self.ctx.types, key_type, value_type, false, None)
+                    {
+                        return Some(object_type);
                     }
                 }
                 if type_expr.starts_with("{[")
@@ -587,9 +573,7 @@ impl<'a> CheckerState<'a> {
                             let t_name = &expr[in_idx + "inkeyof".len()..close_bracket];
                             let k_atom = self.ctx.types.intern_string(k_name);
                             if let Some(&t_id) = self.ctx.type_parameter_scope.get(t_name) {
-                                use crate::query_boundaries::common::{
-                                    FunctionShape, MappedType, ParamInfo,
-                                };
+                                use crate::query_boundaries::common::{MappedType, ParamInfo};
                                 use tsz_solver::TypeParamInfo;
                                 let keyof_t_id = factory.keyof(t_id);
                                 let k_param = TypeParamInfo {
@@ -601,21 +585,21 @@ impl<'a> CheckerState<'a> {
                                 };
                                 let k_id = factory.type_param(k_param);
                                 let t_k_id = factory.index_access(t_id, k_id);
-                                let func_shape = FunctionShape {
-                                    type_params: Vec::new(),
-                                    params: vec![ParamInfo {
+                                let template_id = jsdoc_function_type(
+                                    self.ctx.types,
+                                    Vec::new(),
+                                    vec![ParamInfo {
                                         name: Some(self.ctx.types.intern_string("value")),
                                         type_id: t_k_id,
                                         optional: false,
                                         rest: false,
                                     }],
-                                    this_type: None,
-                                    return_type: TypeId::VOID,
-                                    type_predicate: None,
-                                    is_constructor: false,
-                                    is_method: false,
-                                };
-                                let template_id = factory.function(func_shape);
+                                    None,
+                                    TypeId::VOID,
+                                    None,
+                                    false,
+                                    false,
+                                );
                                 return Some(factory.mapped(MappedType {
                                     type_param: k_param,
                                     constraint: keyof_t_id,
@@ -666,7 +650,7 @@ impl<'a> CheckerState<'a> {
                         let return_type = self
                             .resolve_jsdoc_reference(return_type_str)
                             .unwrap_or(TypeId::VOID);
-                        use tsz_solver::{FunctionShape, ParamInfo};
+                        use tsz_solver::ParamInfo;
                         let mut params = Vec::new();
                         let mut this_type = None;
                         let mut ok = true;
@@ -717,16 +701,16 @@ impl<'a> CheckerState<'a> {
                             } else {
                                 return_type
                             };
-                            let shape = FunctionShape {
-                                type_params: Vec::new(),
+                            return Some(jsdoc_function_type(
+                                self.ctx.types,
+                                Vec::new(),
                                 params,
                                 this_type,
-                                return_type: final_return,
-                                type_predicate: None,
+                                final_return,
+                                None,
                                 is_constructor,
-                                is_method: false,
-                            };
-                            return Some(factory.function(shape));
+                                false,
+                            ));
                         }
                     }
                 }
@@ -795,7 +779,7 @@ impl<'a> CheckerState<'a> {
     /// - `(x: boolean) => asserts x` (assertion predicates)
     /// - `(x: unknown) => x is string` (type predicates)
     fn parse_jsdoc_arrow_function_type(&mut self, type_expr: &str) -> Option<TypeId> {
-        use tsz_solver::{FunctionShape, ParamInfo};
+        use tsz_solver::ParamInfo;
 
         // Extract generic type parameters if present: `<T, U>(params) => ReturnType`
         let (type_params_str, rest) = if type_expr.starts_with('<') {
@@ -913,17 +897,16 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let factory = self.ctx.types.factory();
-        let shape = FunctionShape {
-            type_params: jsdoc_type_params,
+        Some(jsdoc_function_type(
+            self.ctx.types,
+            jsdoc_type_params,
             params,
             this_type,
             return_type,
             type_predicate,
-            is_constructor: false,
-            is_method: false,
-        };
-        Some(factory.function(shape))
+            false,
+            false,
+        ))
     }
 
     /// Parse the return type of a JSDoc arrow function, handling type predicates.

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -13,13 +13,16 @@
 //! - Typedef/callback type construction (`type_from_jsdoc_typedef`, `type_from_jsdoc_callback`)
 
 use super::super::types::{JsdocCallbackInfo, JsdocTypedefInfo};
+use crate::query_boundaries::jsdoc_construction::{
+    JsdocObjectIndexFact, JsdocObjectIndexKind, jsdoc_empty_object_type, jsdoc_function_type,
+    jsdoc_object_index_fact, jsdoc_object_type,
+};
 use crate::state::CheckerState;
 use std::sync::Arc;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::{
-    FunctionShape, IndexSignature, ObjectShape, ParamInfo, PropertyInfo, TupleElement, TypeId,
-    TypePredicate, TypePredicateTarget, Visibility,
+    ParamInfo, PropertyInfo, TupleElement, TypeId, TypePredicate, TypePredicateTarget, Visibility,
 };
 impl<'a> CheckerState<'a> {
     pub(crate) fn jsdoc_enum_annotation_type_for_symbol_decl(
@@ -903,15 +906,15 @@ impl<'a> CheckerState<'a> {
             return Some(mapped);
         }
 
-        let factory = self.ctx.types.factory();
         let inner = type_expr[1..type_expr.len() - 1].trim();
         if inner.is_empty() {
-            return Some(factory.object(Vec::new()));
+            return Some(jsdoc_empty_object_type(self.ctx.types));
         }
         // Split properties by ',' or ';' at top level
         let prop_strs = Self::split_object_properties(inner);
         let mut properties = Vec::new();
-        let mut object_shape = ObjectShape::default();
+        let mut string_index: Option<JsdocObjectIndexFact> = None;
+        let mut number_index: Option<JsdocObjectIndexFact> = None;
         for prop_str in &prop_strs {
             let prop_str = prop_str.trim();
             if prop_str.is_empty() {
@@ -943,16 +946,13 @@ impl<'a> CheckerState<'a> {
                 };
                 if raw_name.starts_with('[')
                     && raw_name.ends_with(']')
-                    && let Some(mut index_sig) =
+                    && let Some((index_kind, mut index_fact)) =
                         self.parse_jsdoc_object_literal_index_signature(raw_name, type_str)
                 {
-                    index_sig.readonly |= readonly;
-                    match index_sig.key_type {
-                        TypeId::STRING | TypeId::SYMBOL => {
-                            object_shape.string_index = Some(index_sig);
-                        }
-                        TypeId::NUMBER => object_shape.number_index = Some(index_sig),
-                        _ => {}
+                    index_fact.readonly |= readonly;
+                    match index_kind {
+                        JsdocObjectIndexKind::String => string_index = Some(index_fact),
+                        JsdocObjectIndexKind::Number => number_index = Some(index_fact),
                     }
                     continue;
                 }
@@ -983,25 +983,14 @@ impl<'a> CheckerState<'a> {
                 }
             }
         }
-        if properties.is_empty()
-            && object_shape.string_index.is_none()
-            && object_shape.number_index.is_none()
-        {
-            return None;
-        }
-        if object_shape.string_index.is_some() || object_shape.number_index.is_some() {
-            object_shape.properties = properties;
-            Some(factory.object_with_index(object_shape))
-        } else {
-            Some(factory.object(properties))
-        }
+        jsdoc_object_type(self.ctx.types, properties, string_index, number_index)
     }
 
     fn parse_jsdoc_object_literal_index_signature(
         &mut self,
         raw_name: &str,
         type_str: &str,
-    ) -> Option<IndexSignature> {
+    ) -> Option<(JsdocObjectIndexKind, JsdocObjectIndexFact)> {
         let (raw_name, readonly) = if let Some(rest) = Self::strip_jsdoc_readonly_modifier(raw_name)
         {
             (rest, true)
@@ -1039,12 +1028,12 @@ impl<'a> CheckerState<'a> {
         };
 
         let value_type = self.resolve_jsdoc_type_str(type_str).unwrap_or(TypeId::ANY);
-        Some(IndexSignature {
+        jsdoc_object_index_fact(
             key_type,
             value_type,
             readonly,
-            param_name: (!param_name.is_empty()).then(|| self.ctx.types.intern_string(param_name)),
-        })
+            (!param_name.is_empty()).then(|| self.ctx.types.intern_string(param_name)),
+        )
     }
 
     fn emit_jsdoc_index_signature_diagnostic_once(
@@ -1268,7 +1257,6 @@ impl<'a> CheckerState<'a> {
     /// Parse a named method signature from a JSDoc object property string.
     /// Parse a call signature `(params): RetType` and return a function TypeId.
     fn parse_jsdoc_call_signature(&mut self, prop_str: &str) -> Option<TypeId> {
-        use tsz_solver::{FunctionShape, ParamInfo};
         let after_open = &prop_str[1..];
         let mut depth = 1u32;
         let mut close_idx = None;
@@ -1316,16 +1304,16 @@ impl<'a> CheckerState<'a> {
                 });
             }
         }
-        let shape = FunctionShape {
-            type_params: Vec::new(),
+        Some(jsdoc_function_type(
+            self.ctx.types,
+            Vec::new(),
             params,
-            this_type: None,
+            None,
             return_type,
-            type_predicate: None,
-            is_constructor: false,
-            is_method: false,
-        };
-        Some(self.ctx.types.factory().function(shape))
+            None,
+            false,
+            false,
+        ))
     }
     fn parse_jsdoc_method_signature(
         &mut self,
@@ -1333,7 +1321,6 @@ impl<'a> CheckerState<'a> {
         paren_idx: usize,
         existing_props: &[PropertyInfo],
     ) -> Option<PropertyInfo> {
-        use tsz_solver::{FunctionShape, ParamInfo};
         let method_name = prop_str[..paren_idx].trim();
         if method_name.is_empty() {
             return None;
@@ -1395,16 +1382,16 @@ impl<'a> CheckerState<'a> {
                 });
             }
         }
-        let shape = FunctionShape {
-            type_params: Vec::new(),
+        let method_type = jsdoc_function_type(
+            self.ctx.types,
+            Vec::new(),
             params,
-            this_type: None,
+            None,
             return_type,
-            type_predicate: None,
-            is_constructor: false,
-            is_method: true,
-        };
-        let method_type = self.ctx.types.factory().function(shape);
+            None,
+            false,
+            true,
+        );
         let name_atom = self.ctx.types.intern_string(method_name);
         Some(PropertyInfo {
             name: name_atom,
@@ -1807,15 +1794,16 @@ impl<'a> CheckerState<'a> {
         // `type B<T> = () => T`, not `<T>() => T`. Keeping those parameters on
         // the function body makes alias instantiation shadow them, so `B<string>`
         // still formats and behaves like the uninstantiated `B`.
-        Some(factory.function(FunctionShape {
-            type_params: Vec::new(),
+        Some(jsdoc_function_type(
+            self.ctx.types,
+            Vec::new(),
             params,
             this_type,
             return_type,
             type_predicate,
-            is_constructor: false,
-            is_method: false,
-        }))
+            false,
+            false,
+        ))
     }
 
     fn type_from_jsdoc_object_typedef(&mut self, info: JsdocTypedefInfo) -> Option<TypeId> {
@@ -1888,11 +1876,7 @@ impl<'a> CheckerState<'a> {
                 non_widening: false,
             });
         }
-        let object_type = if !prop_infos.is_empty() {
-            Some(factory.object(prop_infos))
-        } else {
-            None
-        };
+        let object_type = jsdoc_object_type(self.ctx.types, prop_infos, None, None);
         match (object_type, base_type) {
             (Some(obj), Some(base)) => Some(factory.intersection2(obj, base)),
             (Some(obj), None) => Some(obj),

--- a/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
@@ -1,0 +1,120 @@
+//! JSDoc construction boundary.
+//!
+//! JSDoc resolution code parses source text and gathers structural facts. This
+//! module owns the solver shape literals and interning for the object/function
+//! types those facts describe.
+
+use tsz_common::Atom;
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{
+    FunctionShape, IndexSignature, ObjectShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
+    TypePredicate,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum JsdocObjectIndexKind {
+    String,
+    Number,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct JsdocObjectIndexFact {
+    pub(crate) key_type: TypeId,
+    pub(crate) value_type: TypeId,
+    pub(crate) readonly: bool,
+    pub(crate) param_name: Option<Atom>,
+}
+
+impl JsdocObjectIndexFact {
+    const fn into_index_signature(self) -> IndexSignature {
+        IndexSignature {
+            key_type: self.key_type,
+            value_type: self.value_type,
+            readonly: self.readonly,
+            param_name: self.param_name,
+        }
+    }
+}
+
+pub(crate) const fn jsdoc_object_index_fact(
+    key_type: TypeId,
+    value_type: TypeId,
+    readonly: bool,
+    param_name: Option<Atom>,
+) -> Option<(JsdocObjectIndexKind, JsdocObjectIndexFact)> {
+    let kind = match key_type {
+        TypeId::STRING | TypeId::SYMBOL => JsdocObjectIndexKind::String,
+        TypeId::NUMBER => JsdocObjectIndexKind::Number,
+        _ => return None,
+    };
+    Some((
+        kind,
+        JsdocObjectIndexFact {
+            key_type,
+            value_type,
+            readonly,
+            param_name,
+        },
+    ))
+}
+
+pub(crate) fn jsdoc_empty_object_type(db: &dyn TypeDatabase) -> TypeId {
+    db.object(Vec::new())
+}
+
+pub(crate) fn jsdoc_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<JsdocObjectIndexFact>,
+    number_index: Option<JsdocObjectIndexFact>,
+) -> Option<TypeId> {
+    if properties.is_empty() && string_index.is_none() && number_index.is_none() {
+        return None;
+    }
+    if string_index.is_some() || number_index.is_some() {
+        Some(db.object_with_index(ObjectShape {
+            properties,
+            string_index: string_index.map(JsdocObjectIndexFact::into_index_signature),
+            number_index: number_index.map(JsdocObjectIndexFact::into_index_signature),
+            ..ObjectShape::default()
+        }))
+    } else {
+        Some(db.object(properties))
+    }
+}
+
+pub(crate) fn jsdoc_object_index_type(
+    db: &dyn TypeDatabase,
+    key_type: TypeId,
+    value_type: TypeId,
+    readonly: bool,
+    param_name: Option<Atom>,
+) -> Option<TypeId> {
+    let (kind, fact) = jsdoc_object_index_fact(key_type, value_type, readonly, param_name)?;
+    let (string_index, number_index) = match kind {
+        JsdocObjectIndexKind::String => (Some(fact), None),
+        JsdocObjectIndexKind::Number => (None, Some(fact)),
+    };
+    jsdoc_object_type(db, Vec::new(), string_index, number_index)
+}
+
+pub(crate) fn jsdoc_function_type(
+    db: &dyn TypeDatabase,
+    type_params: Vec<TypeParamInfo>,
+    params: Vec<ParamInfo>,
+    this_type: Option<TypeId>,
+    return_type: TypeId,
+    type_predicate: Option<TypePredicate>,
+    is_constructor: bool,
+    is_method: bool,
+) -> TypeId {
+    db.function(FunctionShape {
+        type_params,
+        params,
+        this_type,
+        return_type,
+        type_predicate,
+        is_constructor,
+        is_method,
+    })
+}

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -41,6 +41,7 @@ pub(crate) mod index_signature;
 pub(crate) mod inference;
 pub(crate) mod intersection_display;
 pub(crate) mod js_exports;
+pub(crate) mod jsdoc_construction;
 pub(crate) mod key_constraints;
 pub(crate) mod lib_augmentations;
 pub(crate) mod name_resolution;

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -28,6 +28,8 @@
 //! - `index_signature_boundary_scans`: production checker index-signature
 //!   queries go through `query_boundaries::index_signature` rather than
 //!   constructing the raw solver resolver at call sites.
+//! - `jsdoc_construction_boundary_scans`: JSDoc type-resolution callers route
+//!   solver shape construction through `query_boundaries::jsdoc_construction`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -39,6 +41,8 @@ mod construction_boundary_signature_scans;
 mod cross_arena_delegation_scope_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
+#[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]
+mod jsdoc_construction_boundary_scans;
 #[path = "arch_source_scans/lazy_resolution_session_scans.rs"]
 mod lazy_resolution_session_scans;
 #[path = "arch_source_scans/object_flags_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
@@ -1,0 +1,95 @@
+//! JSDoc construction boundary scans.
+//!
+//! JSDoc resolution code parses source text and gathers facts. Raw solver
+//! `FunctionShape`, `ObjectShape`, and indexed-object construction belongs in
+//! `query_boundaries::jsdoc_construction`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const JSDOC_CONSTRUCTION_CALLERS: &[&str] = &[
+    "src/jsdoc/resolution/type_construction.rs",
+    "src/jsdoc/resolution/name_resolution.rs",
+    "src/jsdoc/params_type_strings.rs",
+];
+
+const JSDOC_CONSTRUCTION_BOUNDARY: &str = "src/query_boundaries/jsdoc_construction.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn jsdoc_callers_route_solver_shape_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        "FunctionShape",
+        "ObjectShape",
+        "IndexSignature",
+        ".function(",
+        ".object(",
+        ".object_with_index(",
+        ".callable(",
+    ];
+
+    let mut violations = Vec::new();
+    for module in JSDOC_CONSTRUCTION_CALLERS {
+        scan_for_patterns(module, FORBIDDEN_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "JSDoc construction callers must route solver shape construction \
+         through query_boundaries::jsdoc_construction:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
+    let source = fs::read_to_string(checker_path(JSDOC_CONSTRUCTION_BOUNDARY))
+        .expect("failed to read query_boundaries/jsdoc_construction.rs");
+    let common = fs::read_to_string(checker_path("src/query_boundaries/common.rs"))
+        .expect("failed to read query_boundaries/common.rs");
+
+    for helper in [
+        "jsdoc_object_index_fact",
+        "jsdoc_empty_object_type",
+        "jsdoc_object_type",
+        "jsdoc_object_index_type",
+        "jsdoc_function_type",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::jsdoc_construction must own `{helper}`"
+        );
+        assert!(
+            !common.contains(&format!("fn {helper}(")),
+            "JSDoc construction helper `{helper}` must not drift into common.rs"
+        );
+    }
+
+    for shape_pattern in ["FunctionShape {", "ObjectShape {", "IndexSignature {"] {
+        assert!(
+            source.contains(shape_pattern),
+            "query_boundaries::jsdoc_construction should own `{shape_pattern}`"
+        );
+    }
+}


### PR DESCRIPTION
Goal: fast

## Summary
- add `query_boundaries::jsdoc_construction` for JSDoc object/index/function shape interning
- route JSDoc object literals, `Object<K,V>`, call/method signatures, callback typedefs, closure/arrow function types, and nested `@param` object construction through that boundary
- add an architecture source scan so the migrated JSDoc callers cannot reintroduce raw solver shape literals or direct shape interning

## Structural Rule
When a JSDoc expression denotes a record, indexed object, callback/function, method signature, constructor function, `this` function, rest parameter, or type predicate, checker code parses the source facts and preserves them; `query_boundaries::jsdoc_construction` owns solver `FunctionShape`, `ObjectShape`, `IndexSignature`, and interning.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test arch_source_scans -E 'test(jsdoc_construction)'`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test jsdoc_type_expression_tests --test jsdoc_type_tag_tests --test jsdoc_constructor_typeof_source_display_tests --test jsdoc_param_return_ts2314_tests --test jsdoc_template_variance_function_tests --test jsdoc_extends_constraint_tests --test jsdoc_cross_file_typedef_tests --test jsdoc_nested_generic_missing_name_tests --test js_jsdoc_diagnostics_tests --test jsdoc_implements_tests --test jsdoc_prototype_assignment_target_display -E 'not test(jsdoc_class_self_param_uses_instance_type_across_commonjs_file)'`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test jsdoc_class_template_arena_direct_tests --test jsdoc_class_template_cross_comment_tests --test jsdoc_template_constraint_enforcement_tests --test jsdoc_template_in_body_scope_tests --test jsdoc_typedef_lib_global_conflict_tests --test jsdoc_class_property_target_display --test jsdoc_tag_boundary_tests --test jsdoc_augments_empty_tests --test jsdoc_import_multiline_tests --test jsdoc_import_default_and_named_tests --test jsdoc_import_runtime_duplicate_tests --test jsdoc_enum_member_assignability_tests`
- `scripts/safe-run.sh -- cargo check -p tsz-checker`
- `scripts/safe-run.sh -- cargo clippy -p tsz-checker --lib --tests -- -D warnings`

Note: `jsdoc_cross_file_typedef_tests::jsdoc_class_self_param_uses_instance_type_across_commonjs_file` was checked separately and fails the same way on `origin/main` (`[2322, 2345]` instead of `[2322]`), so it is excluded as a baseline-local failure rather than a regression from this boundary slice.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
