### PR TITLE
refactor(checker): route formatting display construction (#14351)

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
@@ -394,7 +394,10 @@ impl<'a> CheckerState<'a> {
         if get_conditional_type_id(self.ctx.types, props_type).is_some()
             && let Some(shape) = object_shape_for_type(self.ctx.types, props_type)
         {
-            let object = self.ctx.types.factory().object(shape.properties.clone());
+            let object = crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                shape.properties.clone(),
+            );
             return Some(self.format_type_skip_object_display_alias(object));
         }
 
@@ -462,7 +465,12 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        Some(self.format_type(self.ctx.types.factory().object(filtered_props)))
+        Some(self.format_type(
+            crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                filtered_props,
+            ),
+        ))
     }
 
     fn jsx_conditional_display_has_lma_infer_metadata(display: &str) -> bool {
@@ -544,7 +552,12 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        Some(self.format_type(self.ctx.types.factory().object(filtered_props)))
+        Some(self.format_type(
+            crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                filtered_props,
+            ),
+        ))
     }
 
     fn jsx_final_conditional_else_display(display: &str) -> Option<String> {

--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -334,11 +334,10 @@ impl<'a> CheckerState<'a> {
             && !shape.is_constructor
         {
             return Some(
-                shape
-                    .params
-                    .first()
-                    .map(|p| p.type_id)
-                    .unwrap_or_else(|| self.ctx.types.factory().object(vec![])),
+                crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                    self.ctx.types,
+                    &shape.params,
+                ),
             );
         }
 
@@ -352,11 +351,10 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         Some(
-            non_generic[0]
-                .params
-                .first()
-                .map(|p| p.type_id)
-                .unwrap_or_else(|| self.ctx.types.factory().object(vec![])),
+            crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                self.ctx.types,
+                &non_generic[0].params,
+            ),
         )
     }
 
@@ -1189,11 +1187,10 @@ impl<'a> CheckerState<'a> {
             if !shape.type_params.is_empty() {
                 return None;
             }
-            let props = shape
-                .params
-                .first()
-                .map(|p| p.type_id)
-                .unwrap_or_else(|| self.ctx.types.factory().object(vec![]));
+            let props = crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                self.ctx.types,
+                &shape.params,
+            );
             // Check for type parameters BEFORE evaluation, since evaluation may
             // collapse `T & {children?: ReactNode}` into a concrete object type
             // that loses the type parameter information.
@@ -1234,11 +1231,10 @@ impl<'a> CheckerState<'a> {
             if non_generic.next().is_some() {
                 return None;
             }
-            let props = sig
-                .params
-                .first()
-                .map(|p| p.type_id)
-                .unwrap_or_else(|| self.ctx.types.factory().object(vec![]));
+            let props = crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                self.ctx.types,
+                &sig.params,
+            );
             let raw_has_type_params =
                 crate::query_boundaries::common::contains_type_parameters(self.ctx.types, props);
             let evaluated = if should_preserve_contextual_application_shape(self.ctx.types, props) {
@@ -1320,11 +1316,10 @@ impl<'a> CheckerState<'a> {
             && !shape.is_constructor
             && !shape.type_params.is_empty()
         {
-            let props = shape
-                .params
-                .first()
-                .map(|param| param.type_id)
-                .unwrap_or_else(|| self.ctx.types.factory().object(vec![]));
+            let props = crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                self.ctx.types,
+                &shape.params,
+            );
             return self.instantiate_jsx_generic_sfc_props_with_defaults(
                 component_type,
                 props,
@@ -1342,11 +1337,10 @@ impl<'a> CheckerState<'a> {
                 .collect();
             if generic.len() == 1 {
                 let sig = generic[0];
-                let props = sig
-                    .params
-                    .first()
-                    .map(|param| param.type_id)
-                    .unwrap_or_else(|| self.ctx.types.factory().object(vec![]));
+                let props = crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                    self.ctx.types,
+                    &sig.params,
+                );
                 return self.instantiate_jsx_generic_sfc_props_with_defaults(
                     component_type,
                     props,
@@ -1651,8 +1645,11 @@ impl<'a> CheckerState<'a> {
                                 self.resolve_property_access_with_env(component_type, "propTypes"),
                                 PropertyAccessResult::Success { .. }
                             );
-                            has_managed_props_metadata
-                                .then(|| self.ctx.types.factory().object(vec![]))
+                            has_managed_props_metadata.then(|| {
+                                crate::query_boundaries::checkers::jsx::empty_props_object_type(
+                                    self.ctx.types,
+                                )
+                            })
                         }),
                 }
             }

--- a/crates/tsz-checker/src/checkers/jsx/extraction_class_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction_class_props.rs
@@ -108,7 +108,10 @@ impl<'a> CheckerState<'a> {
                 .cloned()
                 .collect();
             if filtered_props.len() != shape.properties.len() {
-                return self.ctx.types.factory().object(filtered_props);
+                return crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                    self.ctx.types,
+                    filtered_props,
+                );
             }
         }
 
@@ -209,7 +212,12 @@ impl<'a> CheckerState<'a> {
             return Some(props_type);
         }
 
-        Some(self.ctx.types.factory().object(properties))
+        Some(
+            crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                properties,
+            ),
+        )
     }
 
     /// Get the property name from `JSX.ElementAttributesProperty`.

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
@@ -21,39 +21,14 @@ impl<'a> CheckerState<'a> {
             return type_id;
         };
 
-        let normalized = tsz_solver::FunctionShape {
-            type_params: shape.type_params.clone(),
-            params: shape
-                .params
-                .iter()
-                .map(|param| tsz_solver::ParamInfo {
-                    name: param.name,
-                    type_id: crate::query_boundaries::common::unwrap_readonly_or_noinfer(
-                        self.ctx.types,
-                        param.type_id,
-                    )
-                    .unwrap_or(param.type_id),
-                    optional: param.optional,
-                    rest: param.rest,
-                })
-                .collect(),
-            this_type: shape.this_type.map(|this_type| {
-                crate::query_boundaries::common::unwrap_readonly_or_noinfer(
-                    self.ctx.types,
-                    this_type,
-                )
-                .unwrap_or(this_type)
-            }),
-            return_type: crate::query_boundaries::common::unwrap_readonly_or_noinfer(
-                self.ctx.types,
-                shape.return_type,
-            )
-            .unwrap_or(shape.return_type),
-            type_predicate: shape.type_predicate,
-            is_constructor: shape.is_constructor,
-            is_method: shape.is_method,
-        };
-        self.ctx.types.factory().function(normalized)
+        crate::query_boundaries::checkers::jsx::function_type_with_mapped_component_types(
+            self.ctx.types,
+            shape.as_ref(),
+            |type_id| {
+                crate::query_boundaries::common::unwrap_readonly_or_noinfer(self.ctx.types, type_id)
+                    .unwrap_or(type_id)
+            },
+        )
     }
 
     pub(in crate::checkers_domain::jsx) fn refine_jsx_callable_contextual_type(
@@ -314,7 +289,10 @@ impl<'a> CheckerState<'a> {
                 }
             }
             if !metadata_props.is_empty() {
-                return self.ctx.types.factory().object(metadata_props);
+                return crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                    self.ctx.types,
+                    metadata_props,
+                );
             }
         }
 
@@ -1093,58 +1071,11 @@ impl<'a> CheckerState<'a> {
         func: &tsz_solver::FunctionShape,
         substitution: &crate::query_boundaries::common::TypeSubstitution,
     ) -> tsz_solver::FunctionShape {
-        let mut full_substitution = substitution.clone();
-        for type_param in &func.type_params {
-            if full_substitution.get(type_param.name).is_none() {
-                let preserved_type_param = self.ctx.types.factory().type_param(*type_param);
-                full_substitution.insert(type_param.name, preserved_type_param);
-            }
-        }
-        tsz_solver::FunctionShape {
-            params: func
-                .params
-                .iter()
-                .map(|param| tsz_solver::ParamInfo {
-                    name: param.name,
-                    type_id: crate::query_boundaries::common::instantiate_type(
-                        self.ctx.types,
-                        param.type_id,
-                        &full_substitution,
-                    ),
-                    optional: param.optional,
-                    rest: param.rest,
-                })
-                .collect(),
-            return_type: crate::query_boundaries::common::instantiate_type(
-                self.ctx.types,
-                func.return_type,
-                &full_substitution,
-            ),
-            this_type: func.this_type.map(|this_type| {
-                crate::query_boundaries::common::instantiate_type(
-                    self.ctx.types,
-                    this_type,
-                    &full_substitution,
-                )
-            }),
-            type_params: vec![],
-            type_predicate: func.type_predicate.as_ref().map(|predicate| {
-                tsz_solver::TypePredicate {
-                    asserts: predicate.asserts,
-                    target: predicate.target,
-                    type_id: predicate.type_id.map(|tid| {
-                        crate::query_boundaries::common::instantiate_type(
-                            self.ctx.types,
-                            tid,
-                            &full_substitution,
-                        )
-                    }),
-                    parameter_index: predicate.parameter_index,
-                }
-            }),
-            is_constructor: func.is_constructor,
-            is_method: func.is_method,
-        }
+        crate::query_boundaries::checkers::jsx::instantiate_function_shape_preserving_unresolved_params(
+            self.ctx.types,
+            func,
+            substitution,
+        )
     }
 
     pub(in crate::checkers_domain::jsx) fn infer_jsx_generic_component_props_type(
@@ -1504,20 +1435,13 @@ impl<'a> CheckerState<'a> {
                 _ => continue,
             };
             let expected_type = self.refine_jsx_callable_contextual_type(expected_type);
-            let synthetic_shape = tsz_solver::FunctionShape {
-                type_params: function_shape.type_params.clone(),
-                params: vec![tsz_solver::ParamInfo {
-                    name: Some(self.ctx.types.intern_string(attr_name)),
-                    type_id: expected_type,
-                    optional: false,
-                    rest: false,
-                }],
-                this_type: None,
-                return_type: TypeId::VOID,
-                type_predicate: None,
-                is_constructor: false,
-                is_method: false,
-            };
+            let synthetic_shape =
+                crate::query_boundaries::checkers::jsx::synthetic_single_param_function_shape(
+                    function_shape.type_params.clone(),
+                    self.ctx.types.intern_string(attr_name),
+                    expected_type,
+                    TypeId::VOID,
+                );
             let attr_sub = {
                 let env = self.ctx.type_env.borrow();
                 crate::query_boundaries::checkers::call::compute_contextual_types_with_context(

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
@@ -174,15 +174,8 @@ impl<'a> CheckerState<'a> {
         )?
         .first()?
         .clone();
-        let mut function_shape = tsz_solver::FunctionShape {
-            type_params: call_sig.type_params,
-            params: call_sig.params,
-            this_type: call_sig.this_type,
-            return_type: call_sig.return_type,
-            type_predicate: call_sig.type_predicate,
-            is_constructor: true,
-            is_method: call_sig.is_method,
-        };
+        let mut function_shape =
+            crate::query_boundaries::checkers::jsx::construct_signature_function_shape(call_sig);
         if function_shape.type_params.is_empty() {
             return None;
         }
@@ -223,9 +216,11 @@ impl<'a> CheckerState<'a> {
 
             if let Some(type_id) = synthesized_param_type {
                 let props_name = self.ctx.types.intern_string("props");
-                function_shape
-                    .params
-                    .push(tsz_solver::ParamInfo::required(props_name, type_id));
+                crate::query_boundaries::checkers::jsx::push_required_param(
+                    &mut function_shape,
+                    props_name,
+                    type_id,
+                );
             }
         }
 

--- a/crates/tsz-checker/src/checkers/jsx/overloads.rs
+++ b/crates/tsz-checker/src/checkers/jsx/overloads.rs
@@ -729,6 +729,9 @@ impl<'a> CheckerState<'a> {
                 }
             })
             .collect();
-        self.ctx.types.factory().object(properties)
+        crate::query_boundaries::checkers::jsx::object_type_from_properties(
+            self.ctx.types,
+            properties,
+        )
     }
 }

--- a/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
@@ -51,7 +51,12 @@ impl<'a> CheckerState<'a> {
                 }
             })
             .collect();
-        let source_type = self.format_type(self.ctx.types.factory().object(properties));
+        let source_type = self.format_type(
+            crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                properties,
+            ),
+        );
         let base = format_message(
             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             &[&source_type, display_target],
@@ -265,7 +270,10 @@ impl<'a> CheckerState<'a> {
                 }
             })
             .collect();
-        let attrs_type = self.ctx.types.factory().object(properties);
+        let attrs_type = crate::query_boundaries::checkers::jsx::object_type_from_properties(
+            self.ctx.types,
+            properties,
+        );
         if crate::query_boundaries::checkers::jsx::props_are_assignable(
             self, attrs_type, props_type,
         ) {

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -135,7 +135,10 @@ impl<'a> CheckerState<'a> {
                 }
             })
             .collect();
-        self.ctx.types.factory().object(properties)
+        crate::query_boundaries::checkers::jsx::object_type_from_properties(
+            self.ctx.types,
+            properties,
+        )
     }
 
     pub(in crate::checkers_domain::jsx) fn check_jsx_generic_spread_attrs_assignability(
@@ -881,7 +884,12 @@ impl<'a> CheckerState<'a> {
                 .cloned()
                 .collect();
             if filtered_props.len() != shape.properties.len() {
-                return self.format_type(self.ctx.types.factory().object(filtered_props));
+                return self.format_type(
+                    crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                        self.ctx.types,
+                        filtered_props,
+                    ),
+                );
             }
         }
 
@@ -1148,14 +1156,12 @@ impl<'a> CheckerState<'a> {
 
         let instance_type = self.get_class_instance_type_for_component(component_type)?;
         let param_name = self.ctx.types.intern_string("instance");
-        let callback = self
-            .ctx
-            .types
-            .factory()
-            .function(tsz_solver::FunctionShape::new(
-                vec![tsz_solver::ParamInfo::required(param_name, instance_type)],
-                TypeId::ANY,
-            ));
+        let callback = crate::query_boundaries::checkers::jsx::single_required_param_function_type(
+            self.ctx.types,
+            param_name,
+            instance_type,
+            TypeId::ANY,
+        );
         Some(self.ctx.types.factory().union2(TypeId::STRING, callback))
     }
 
@@ -1630,19 +1636,10 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
             && shape.is_method
         {
-            return self
-                .ctx
-                .types
-                .factory()
-                .function(tsz_solver::FunctionShape {
-                    type_params: shape.type_params.clone(),
-                    params: shape.params.clone(),
-                    this_type: None,
-                    return_type: shape.return_type,
-                    type_predicate: shape.type_predicate,
-                    is_constructor: shape.is_constructor,
-                    is_method: false,
-                });
+            return crate::query_boundaries::checkers::jsx::function_type_without_this(
+                self.ctx.types,
+                shape.as_ref(),
+            );
         }
 
         type_id

--- a/crates/tsz-checker/src/checkers/jsx/spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/spread.rs
@@ -637,7 +637,10 @@ impl<'a> CheckerState<'a> {
                 .cloned()
                 .collect();
             if filtered.len() != shape.properties.len() {
-                return self.ctx.types.factory().object(filtered);
+                return crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                    self.ctx.types,
+                    filtered,
+                );
             }
         }
         props_type

--- a/crates/tsz-checker/src/error_reporter/core/excess_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/excess_display.rs
@@ -340,7 +340,7 @@ impl<'a> CheckerState<'a> {
         }
 
         Some(if changed {
-            self.ctx.types.factory().object_with_index(normalized)
+            query::object_type_from_shape(self.ctx.types, normalized)
         } else {
             ty
         })
@@ -385,7 +385,7 @@ impl<'a> CheckerState<'a> {
             index.readonly = false;
         }
 
-        let normalized_ty = self.ctx.types.factory().object_with_index(normalized);
+        let normalized_ty = query::object_type_from_shape(self.ctx.types, normalized);
         if let Some(props) = display_props {
             let mut props = props.as_ref().clone();
             for prop in &mut props {
@@ -442,7 +442,7 @@ impl<'a> CheckerState<'a> {
             prop.write_type = write;
         }
         if changed {
-            self.ctx.types.factory().object_with_index(normalized)
+            query::object_type_from_shape(self.ctx.types, normalized)
         } else {
             ty
         }
@@ -549,7 +549,7 @@ impl<'a> CheckerState<'a> {
         }
 
         if changed {
-            self.ctx.types.factory().object_with_index(normalized)
+            query::object_type_from_shape(self.ctx.types, normalized)
         } else {
             ty
         }

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -233,18 +233,7 @@ impl<'a> CheckerState<'a> {
             if params.iter().zip(shape.params.iter()).all(|(a, b)| a == b) {
                 ty
             } else {
-                self.ctx
-                    .types
-                    .factory()
-                    .function(tsz_solver::FunctionShape {
-                        type_params: shape.type_params.clone(),
-                        params,
-                        this_type: shape.this_type,
-                        return_type: shape.return_type,
-                        type_predicate: shape.type_predicate,
-                        is_constructor: shape.is_constructor,
-                        is_method: shape.is_method,
-                    })
+                query::function_type_with_params_replaced(self.ctx.types, shape.as_ref(), params)
             }
         } else {
             ty
@@ -329,19 +318,11 @@ impl<'a> CheckerState<'a> {
             let widened_return =
                 self.widen_fresh_object_literal_properties_for_display(shape.return_type);
             if widened_return != shape.return_type {
-                widened = self
-                    .ctx
-                    .types
-                    .factory()
-                    .function(tsz_solver::FunctionShape {
-                        type_params: shape.type_params.clone(),
-                        params: shape.params.clone(),
-                        this_type: shape.this_type,
-                        return_type: widened_return,
-                        type_predicate: shape.type_predicate,
-                        is_constructor: shape.is_constructor,
-                        is_method: shape.is_method,
-                    });
+                widened = query::function_type_with_return_replaced(
+                    self.ctx.types,
+                    shape.as_ref(),
+                    widened_return,
+                );
             }
         } else if let Some(shape) =
             crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, widened)
@@ -367,7 +348,7 @@ impl<'a> CheckerState<'a> {
             }
 
             if changed {
-                widened = self.ctx.types.factory().callable(widened_shape);
+                widened = query::callable_type_from_shape(self.ctx.types, widened_shape);
             }
         }
         if let Some(def_id) = constructor_display_def {
@@ -411,7 +392,7 @@ impl<'a> CheckerState<'a> {
         if !changed {
             return ty;
         }
-        self.ctx.types.factory().object_with_index(widened_shape)
+        query::object_type_from_shape(self.ctx.types, widened_shape)
     }
 
     pub(in crate::error_reporter) fn normalize_property_receiver_application_display_type(
@@ -556,7 +537,7 @@ impl<'a> CheckerState<'a> {
         }
 
         if changed {
-            let new_ty = self.ctx.types.factory().object_with_index(normalized_shape);
+            let new_ty = query::object_type_from_shape(self.ctx.types, normalized_shape);
             if let Some(alias_origin) = self.ctx.types.get_display_alias(ty) {
                 let alias_origin =
                     self.normalize_property_receiver_application_display_type(alias_origin);
@@ -611,18 +592,12 @@ impl<'a> CheckerState<'a> {
             {
                 ty
             } else {
-                self.ctx
-                    .types
-                    .factory()
-                    .function(tsz_solver::FunctionShape {
-                        type_params: shape.type_params.clone(),
-                        params,
-                        this_type: shape.this_type,
-                        return_type,
-                        type_predicate: shape.type_predicate,
-                        is_constructor: shape.is_constructor,
-                        is_method: shape.is_method,
-                    })
+                query::function_type_with_params_and_return_replaced(
+                    self.ctx.types,
+                    shape.as_ref(),
+                    params,
+                    return_type,
+                )
             }
         } else if let Some(members) = query::union_members(self.ctx.types, ty) {
             self.ctx.types.factory().union_preserve_members(
@@ -916,18 +891,12 @@ impl<'a> CheckerState<'a> {
                     {
                         evaluated
                     } else {
-                        self.ctx
-                            .types
-                            .factory()
-                            .function(tsz_solver::FunctionShape {
-                                type_params: shape.type_params.clone(),
-                                params,
-                                this_type: shape.this_type,
-                                return_type,
-                                type_predicate: shape.type_predicate,
-                                is_constructor: shape.is_constructor,
-                                is_method: shape.is_method,
-                            })
+                        query::function_type_with_params_and_return_replaced(
+                            self.ctx.types,
+                            shape.as_ref(),
+                            params,
+                            return_type,
+                        )
                     }
                 } else if let Some(shape) = crate::query_boundaries::common::object_shape_for_type(
                     self.ctx.types,
@@ -982,14 +951,11 @@ impl<'a> CheckerState<'a> {
                         index.value_type = normalized;
                     }
                     if changed {
-                        let new_ty = self.ctx.types.factory().object_with_index(shape);
-                        if let Some(display_props) =
-                            self.ctx.types.get_display_properties(evaluated)
-                        {
-                            self.ctx
-                                .types
-                                .store_display_properties(new_ty, display_props.as_ref().clone());
-                        }
+                        let new_ty = query::object_type_preserving_display_properties(
+                            self.ctx.types,
+                            evaluated,
+                            shape,
+                        );
                         // Propagate display_alias so the formatter can still
                         // recover the named form (e.g., `Array<string>`) for
                         // types whose property types changed during normalization.
@@ -1202,18 +1168,12 @@ impl<'a> CheckerState<'a> {
                 {
                     evaluated
                 } else {
-                    self.ctx
-                        .types
-                        .factory()
-                        .function(tsz_solver::FunctionShape {
-                            type_params: shape.type_params.clone(),
-                            params,
-                            this_type: shape.this_type,
-                            return_type,
-                            type_predicate: shape.type_predicate,
-                            is_constructor: shape.is_constructor,
-                            is_method: shape.is_method,
-                        })
+                    query::function_type_with_params_and_return_replaced(
+                        self.ctx.types,
+                        shape.as_ref(),
+                        params,
+                        return_type,
+                    )
                 }
             } else if let Some(shape) =
                 crate::query_boundaries::common::object_shape_for_type(self.ctx.types, evaluated)
@@ -1267,12 +1227,11 @@ impl<'a> CheckerState<'a> {
                     index.value_type = normalized;
                 }
                 if changed {
-                    let new_ty = self.ctx.types.factory().object_with_index(shape);
-                    if let Some(display_props) = self.ctx.types.get_display_properties(evaluated) {
-                        self.ctx
-                            .types
-                            .store_display_properties(new_ty, display_props.as_ref().clone());
-                    }
+                    let new_ty = query::object_type_preserving_display_properties(
+                        self.ctx.types,
+                        evaluated,
+                        shape,
+                    );
                     // Propagate display_alias and def-store registration so the
                     // formatter can still show named types (Date, Error, etc.)
                     // after normalization modifies property types.
@@ -1357,8 +1316,8 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let named_obj = self.ctx.types.factory().object(named_props);
-        let wildcard_obj = self.ctx.types.factory().object(wildcard_props);
+        let named_obj = query::object_type_from_properties(self.ctx.types, named_props);
+        let wildcard_obj = query::object_type_from_properties(self.ctx.types, wildcard_props);
         Some(format!(
             "{} & {}",
             self.format_type_diagnostic(named_obj),
@@ -1409,7 +1368,10 @@ impl<'a> CheckerState<'a> {
                 properties.push(property);
             }
 
-            Some(self.ctx.types.factory().object(properties))
+            Some(query::object_type_from_properties(
+                self.ctx.types,
+                properties,
+            ))
         } else if let Some(members) = query::intersection_members(self.ctx.types, ty) {
             let mut changed = false;
             let remapped: Vec<_> = members

--- a/crates/tsz-checker/src/error_reporter/generics.rs
+++ b/crates/tsz-checker/src/error_reporter/generics.rs
@@ -7,13 +7,14 @@ use crate::query_boundaries::assignability::{
 };
 use crate::query_boundaries::common;
 use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{NodeAccess, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::CallSignature;
 use tsz_solver::TypeId;
-use tsz_solver::{CallSignature, CallableShape};
 
 impl<'a> CheckerState<'a> {
     fn widen_function_like_assertion_source(&self, type_id: TypeId) -> TypeId {
@@ -74,15 +75,12 @@ impl<'a> CheckerState<'a> {
                 .collect();
 
             if changed {
-                return self.ctx.types.callable(tsz_solver::CallableShape {
+                return diagnostic_query::callable_type_with_signatures_replaced(
+                    self.ctx.types,
+                    shape.as_ref(),
                     call_signatures,
                     construct_signatures,
-                    properties: shape.properties.clone(),
-                    string_index: shape.string_index,
-                    number_index: shape.number_index,
-                    symbol: shape.symbol,
-                    is_abstract: shape.is_abstract,
-                });
+                );
             }
         }
 
@@ -169,16 +167,9 @@ impl<'a> CheckerState<'a> {
         let prototype_symbol_name = prototype_symbol.escaped_name.as_str();
         let prototype_display = format!("{prototype_symbol_name}<any>");
         let call_return_type = call_sig.return_type;
-        let call_display =
-            self.format_type_for_assignability_message(self.ctx.types.callable(CallableShape {
-                call_signatures: vec![call_sig],
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            }));
+        let call_display = self.format_type_for_assignability_message(
+            diagnostic_query::call_only_callable_type(self.ctx.types, vec![call_sig]),
+        );
         let construct_display = format!(
             "{prototype_symbol_name}<{}>",
             self.format_type_for_assignability_message(call_return_type)
@@ -222,17 +213,9 @@ impl<'a> CheckerState<'a> {
 
         let symbol_name = symbol.escaped_name.as_str();
         let call_sig = &shape.call_signatures[0];
-        let call_display = self.format_type_for_assignability_message(self.ctx.types.callable(
-            tsz_solver::CallableShape {
-                call_signatures: vec![call_sig.clone()],
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            },
-        ));
+        let call_display = self.format_type_for_assignability_message(
+            diagnostic_query::call_only_callable_type(self.ctx.types, vec![call_sig.clone()]),
+        );
         let call_return_display = self.format_type_for_assignability_message(call_sig.return_type);
         let prototype_display = format!("{symbol_name}<any>");
         let construct_display = format!("{symbol_name}<{call_return_display}>");

--- a/crates/tsz-checker/src/jsdoc/params_type_strings.rs
+++ b/crates/tsz-checker/src/jsdoc/params_type_strings.rs
@@ -8,6 +8,7 @@
 //! - `JsdocParamTagInfo` assembly helpers
 
 use super::types::JsdocParamTagInfo;
+use crate::query_boundaries::jsdoc_construction::jsdoc_object_type;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 
@@ -611,7 +612,7 @@ impl<'a> CheckerState<'a> {
         if properties.is_empty() {
             return None;
         }
-        let obj_type = self.ctx.types.factory().object(properties);
+        let obj_type = jsdoc_object_type(self.ctx.types, properties, None, None)?;
         if is_array {
             Some(self.ctx.types.factory().array(obj_type))
         } else {

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -13,6 +13,7 @@
 //! - Arrow function parsing (`parse_jsdoc_arrow_function_type`)
 
 use crate::context::{is_declaration_file_name, is_js_file_name};
+use crate::query_boundaries::jsdoc_construction::{jsdoc_function_type, jsdoc_object_index_type};
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::symbol_flags;
@@ -20,7 +21,7 @@ use tsz_common::numeric::parse_numeric_literal_value;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{IndexSignature, ObjectShape, TypeId, TypePredicate};
+use tsz_solver::{TypeId, TypePredicate};
 
 /// Strip a leading and matching trailing `"` or `'` from `s` if both are
 /// present. Returns the bare inner string when stripped, otherwise `None`.
@@ -552,25 +553,10 @@ impl<'a> CheckerState<'a> {
                     if let (Some(key_type), Some(value_type)) = (
                         self.jsdoc_type_from_expression(key_str),
                         self.jsdoc_type_from_expression(value_str),
-                    ) {
-                        let mut shape = ObjectShape::default();
-                        if key_type == TypeId::STRING {
-                            shape.string_index = Some(IndexSignature {
-                                key_type,
-                                value_type,
-                                readonly: false,
-                                param_name: None,
-                            });
-                            return Some(factory.object_with_index(shape));
-                        } else if key_type == TypeId::NUMBER {
-                            shape.number_index = Some(IndexSignature {
-                                key_type,
-                                value_type,
-                                readonly: false,
-                                param_name: None,
-                            });
-                            return Some(factory.object_with_index(shape));
-                        }
+                    ) && let Some(object_type) =
+                        jsdoc_object_index_type(self.ctx.types, key_type, value_type, false, None)
+                    {
+                        return Some(object_type);
                     }
                 }
                 if type_expr.starts_with("{[")
@@ -587,9 +573,7 @@ impl<'a> CheckerState<'a> {
                             let t_name = &expr[in_idx + "inkeyof".len()..close_bracket];
                             let k_atom = self.ctx.types.intern_string(k_name);
                             if let Some(&t_id) = self.ctx.type_parameter_scope.get(t_name) {
-                                use crate::query_boundaries::common::{
-                                    FunctionShape, MappedType, ParamInfo,
-                                };
+                                use crate::query_boundaries::common::{MappedType, ParamInfo};
                                 use tsz_solver::TypeParamInfo;
                                 let keyof_t_id = factory.keyof(t_id);
                                 let k_param = TypeParamInfo {
@@ -601,21 +585,21 @@ impl<'a> CheckerState<'a> {
                                 };
                                 let k_id = factory.type_param(k_param);
                                 let t_k_id = factory.index_access(t_id, k_id);
-                                let func_shape = FunctionShape {
-                                    type_params: Vec::new(),
-                                    params: vec![ParamInfo {
+                                let template_id = jsdoc_function_type(
+                                    self.ctx.types,
+                                    Vec::new(),
+                                    vec![ParamInfo {
                                         name: Some(self.ctx.types.intern_string("value")),
                                         type_id: t_k_id,
                                         optional: false,
                                         rest: false,
                                     }],
-                                    this_type: None,
-                                    return_type: TypeId::VOID,
-                                    type_predicate: None,
-                                    is_constructor: false,
-                                    is_method: false,
-                                };
-                                let template_id = factory.function(func_shape);
+                                    None,
+                                    TypeId::VOID,
+                                    None,
+                                    false,
+                                    false,
+                                );
                                 return Some(factory.mapped(MappedType {
                                     type_param: k_param,
                                     constraint: keyof_t_id,
@@ -666,7 +650,7 @@ impl<'a> CheckerState<'a> {
                         let return_type = self
                             .resolve_jsdoc_reference(return_type_str)
                             .unwrap_or(TypeId::VOID);
-                        use tsz_solver::{FunctionShape, ParamInfo};
+                        use tsz_solver::ParamInfo;
                         let mut params = Vec::new();
                         let mut this_type = None;
                         let mut ok = true;
@@ -717,16 +701,16 @@ impl<'a> CheckerState<'a> {
                             } else {
                                 return_type
                             };
-                            let shape = FunctionShape {
-                                type_params: Vec::new(),
+                            return Some(jsdoc_function_type(
+                                self.ctx.types,
+                                Vec::new(),
                                 params,
                                 this_type,
-                                return_type: final_return,
-                                type_predicate: None,
+                                final_return,
+                                None,
                                 is_constructor,
-                                is_method: false,
-                            };
-                            return Some(factory.function(shape));
+                                false,
+                            ));
                         }
                     }
                 }
@@ -795,7 +779,7 @@ impl<'a> CheckerState<'a> {
     /// - `(x: boolean) => asserts x` (assertion predicates)
     /// - `(x: unknown) => x is string` (type predicates)
     fn parse_jsdoc_arrow_function_type(&mut self, type_expr: &str) -> Option<TypeId> {
-        use tsz_solver::{FunctionShape, ParamInfo};
+        use tsz_solver::ParamInfo;
 
         // Extract generic type parameters if present: `<T, U>(params) => ReturnType`
         let (type_params_str, rest) = if type_expr.starts_with('<') {
@@ -913,17 +897,16 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let factory = self.ctx.types.factory();
-        let shape = FunctionShape {
-            type_params: jsdoc_type_params,
+        Some(jsdoc_function_type(
+            self.ctx.types,
+            jsdoc_type_params,
             params,
             this_type,
             return_type,
             type_predicate,
-            is_constructor: false,
-            is_method: false,
-        };
-        Some(factory.function(shape))
+            false,
+            false,
+        ))
     }
 
     /// Parse the return type of a JSDoc arrow function, handling type predicates.

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -13,13 +13,16 @@
 //! - Typedef/callback type construction (`type_from_jsdoc_typedef`, `type_from_jsdoc_callback`)
 
 use super::super::types::{JsdocCallbackInfo, JsdocTypedefInfo};
+use crate::query_boundaries::jsdoc_construction::{
+    JsdocObjectIndexFact, JsdocObjectIndexKind, jsdoc_empty_object_type, jsdoc_function_type,
+    jsdoc_object_index_fact, jsdoc_object_type,
+};
 use crate::state::CheckerState;
 use std::sync::Arc;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::{
-    FunctionShape, IndexSignature, ObjectShape, ParamInfo, PropertyInfo, TupleElement, TypeId,
-    TypePredicate, TypePredicateTarget, Visibility,
+    ParamInfo, PropertyInfo, TupleElement, TypeId, TypePredicate, TypePredicateTarget, Visibility,
 };
 impl<'a> CheckerState<'a> {
     pub(crate) fn jsdoc_enum_annotation_type_for_symbol_decl(
@@ -903,15 +906,15 @@ impl<'a> CheckerState<'a> {
             return Some(mapped);
         }
 
-        let factory = self.ctx.types.factory();
         let inner = type_expr[1..type_expr.len() - 1].trim();
         if inner.is_empty() {
-            return Some(factory.object(Vec::new()));
+            return Some(jsdoc_empty_object_type(self.ctx.types));
         }
         // Split properties by ',' or ';' at top level
         let prop_strs = Self::split_object_properties(inner);
         let mut properties = Vec::new();
-        let mut object_shape = ObjectShape::default();
+        let mut string_index: Option<JsdocObjectIndexFact> = None;
+        let mut number_index: Option<JsdocObjectIndexFact> = None;
         for prop_str in &prop_strs {
             let prop_str = prop_str.trim();
             if prop_str.is_empty() {
@@ -943,16 +946,13 @@ impl<'a> CheckerState<'a> {
                 };
                 if raw_name.starts_with('[')
                     && raw_name.ends_with(']')
-                    && let Some(mut index_sig) =
+                    && let Some((index_kind, mut index_fact)) =
                         self.parse_jsdoc_object_literal_index_signature(raw_name, type_str)
                 {
-                    index_sig.readonly |= readonly;
-                    match index_sig.key_type {
-                        TypeId::STRING | TypeId::SYMBOL => {
-                            object_shape.string_index = Some(index_sig);
-                        }
-                        TypeId::NUMBER => object_shape.number_index = Some(index_sig),
-                        _ => {}
+                    index_fact.readonly |= readonly;
+                    match index_kind {
+                        JsdocObjectIndexKind::String => string_index = Some(index_fact),
+                        JsdocObjectIndexKind::Number => number_index = Some(index_fact),
                     }
                     continue;
                 }
@@ -983,25 +983,14 @@ impl<'a> CheckerState<'a> {
                 }
             }
         }
-        if properties.is_empty()
-            && object_shape.string_index.is_none()
-            && object_shape.number_index.is_none()
-        {
-            return None;
-        }
-        if object_shape.string_index.is_some() || object_shape.number_index.is_some() {
-            object_shape.properties = properties;
-            Some(factory.object_with_index(object_shape))
-        } else {
-            Some(factory.object(properties))
-        }
+        jsdoc_object_type(self.ctx.types, properties, string_index, number_index)
     }
 
     fn parse_jsdoc_object_literal_index_signature(
         &mut self,
         raw_name: &str,
         type_str: &str,
-    ) -> Option<IndexSignature> {
+    ) -> Option<(JsdocObjectIndexKind, JsdocObjectIndexFact)> {
         let (raw_name, readonly) = if let Some(rest) = Self::strip_jsdoc_readonly_modifier(raw_name)
         {
             (rest, true)
@@ -1039,12 +1028,12 @@ impl<'a> CheckerState<'a> {
         };
 
         let value_type = self.resolve_jsdoc_type_str(type_str).unwrap_or(TypeId::ANY);
-        Some(IndexSignature {
+        jsdoc_object_index_fact(
             key_type,
             value_type,
             readonly,
-            param_name: (!param_name.is_empty()).then(|| self.ctx.types.intern_string(param_name)),
-        })
+            (!param_name.is_empty()).then(|| self.ctx.types.intern_string(param_name)),
+        )
     }
 
     fn emit_jsdoc_index_signature_diagnostic_once(
@@ -1268,7 +1257,6 @@ impl<'a> CheckerState<'a> {
     /// Parse a named method signature from a JSDoc object property string.
     /// Parse a call signature `(params): RetType` and return a function TypeId.
     fn parse_jsdoc_call_signature(&mut self, prop_str: &str) -> Option<TypeId> {
-        use tsz_solver::{FunctionShape, ParamInfo};
         let after_open = &prop_str[1..];
         let mut depth = 1u32;
         let mut close_idx = None;
@@ -1316,16 +1304,16 @@ impl<'a> CheckerState<'a> {
                 });
             }
         }
-        let shape = FunctionShape {
-            type_params: Vec::new(),
+        Some(jsdoc_function_type(
+            self.ctx.types,
+            Vec::new(),
             params,
-            this_type: None,
+            None,
             return_type,
-            type_predicate: None,
-            is_constructor: false,
-            is_method: false,
-        };
-        Some(self.ctx.types.factory().function(shape))
+            None,
+            false,
+            false,
+        ))
     }
     fn parse_jsdoc_method_signature(
         &mut self,
@@ -1333,7 +1321,6 @@ impl<'a> CheckerState<'a> {
         paren_idx: usize,
         existing_props: &[PropertyInfo],
     ) -> Option<PropertyInfo> {
-        use tsz_solver::{FunctionShape, ParamInfo};
         let method_name = prop_str[..paren_idx].trim();
         if method_name.is_empty() {
             return None;
@@ -1395,16 +1382,16 @@ impl<'a> CheckerState<'a> {
                 });
             }
         }
-        let shape = FunctionShape {
-            type_params: Vec::new(),
+        let method_type = jsdoc_function_type(
+            self.ctx.types,
+            Vec::new(),
             params,
-            this_type: None,
+            None,
             return_type,
-            type_predicate: None,
-            is_constructor: false,
-            is_method: true,
-        };
-        let method_type = self.ctx.types.factory().function(shape);
+            None,
+            false,
+            true,
+        );
         let name_atom = self.ctx.types.intern_string(method_name);
         Some(PropertyInfo {
             name: name_atom,
@@ -1807,15 +1794,16 @@ impl<'a> CheckerState<'a> {
         // `type B<T> = () => T`, not `<T>() => T`. Keeping those parameters on
         // the function body makes alias instantiation shadow them, so `B<string>`
         // still formats and behaves like the uninstantiated `B`.
-        Some(factory.function(FunctionShape {
-            type_params: Vec::new(),
+        Some(jsdoc_function_type(
+            self.ctx.types,
+            Vec::new(),
             params,
             this_type,
             return_type,
             type_predicate,
-            is_constructor: false,
-            is_method: false,
-        }))
+            false,
+            false,
+        ))
     }
 
     fn type_from_jsdoc_object_typedef(&mut self, info: JsdocTypedefInfo) -> Option<TypeId> {
@@ -1888,11 +1876,7 @@ impl<'a> CheckerState<'a> {
                 non_widening: false,
             });
         }
-        let object_type = if !prop_infos.is_empty() {
-            Some(factory.object(prop_infos))
-        } else {
-            None
-        };
+        let object_type = jsdoc_object_type(self.ctx.types, prop_infos, None, None);
         match (object_type, base_type) {
             (Some(obj), Some(base)) => Some(factory.intersection2(obj, base)),
             (Some(obj), None) => Some(obj),

--- a/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
@@ -1,8 +1,12 @@
 //! JSX checker query boundaries.
 
 use crate::state::CheckerState;
+use tsz_common::Atom;
+use tsz_solver::computation::TypeSubstitution;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
-use tsz_solver::{DefinitionStore, TypeId, TypeParamInfo};
+use tsz_solver::{
+    CallSignature, DefinitionStore, FunctionShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
+};
 
 pub(crate) struct SingleArgTypeApplication {
     pub(crate) base: TypeId,
@@ -186,6 +190,130 @@ pub(crate) fn props_are_assignable(
     target: TypeId,
 ) -> bool {
     checker.jsx_props_relation_outcome(source, target).related
+}
+
+pub(crate) fn object_type_from_properties(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn empty_props_object_type(db: &dyn TypeDatabase) -> TypeId {
+    object_type_from_properties(db, Vec::new())
+}
+
+pub(crate) fn props_param_type_or_empty(db: &dyn TypeDatabase, params: &[ParamInfo]) -> TypeId {
+    params
+        .first()
+        .map(|param| param.type_id)
+        .unwrap_or_else(|| empty_props_object_type(db))
+}
+
+pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {
+    crate::query_boundaries::construct_signatures::function_type_from_shape(db, shape)
+}
+
+pub(crate) fn function_type_from_parts(
+    db: &dyn TypeDatabase,
+    params: Vec<ParamInfo>,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_shape(db, FunctionShape::new(params, return_type))
+}
+
+pub(crate) fn single_required_param_function_type(
+    db: &dyn TypeDatabase,
+    param_name: Atom,
+    param_type: TypeId,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_parts(
+        db,
+        vec![ParamInfo::required(param_name, param_type)],
+        return_type,
+    )
+}
+
+pub(crate) fn function_type_with_mapped_component_types(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    mut map_type: impl FnMut(TypeId) -> TypeId,
+) -> TypeId {
+    let mapped = crate::query_boundaries::construct_signatures::map_function_shape_types(
+        shape,
+        |_, type_id| map_type(type_id),
+    )
+    .unwrap_or_else(|| shape.clone());
+    function_type_from_shape(db, mapped)
+}
+
+pub(crate) fn function_type_without_this(db: &dyn TypeDatabase, shape: &FunctionShape) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params: shape.params.clone(),
+            this_type: None,
+            return_type: shape.return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: false,
+        },
+    )
+}
+
+pub(crate) fn construct_signature_function_shape(sig: CallSignature) -> FunctionShape {
+    FunctionShape {
+        type_params: sig.type_params,
+        params: sig.params,
+        this_type: sig.this_type,
+        return_type: sig.return_type,
+        type_predicate: sig.type_predicate,
+        is_constructor: true,
+        is_method: sig.is_method,
+    }
+}
+
+pub(crate) fn push_required_param(shape: &mut FunctionShape, name: Atom, type_id: TypeId) {
+    shape.params.push(ParamInfo::required(name, type_id));
+}
+
+pub(crate) fn synthetic_single_param_function_shape(
+    type_params: Vec<TypeParamInfo>,
+    param_name: Atom,
+    param_type: TypeId,
+    return_type: TypeId,
+) -> FunctionShape {
+    FunctionShape {
+        type_params,
+        params: vec![ParamInfo {
+            name: Some(param_name),
+            type_id: param_type,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    }
+}
+
+pub(crate) fn instantiate_function_shape_preserving_unresolved_params(
+    db: &dyn QueryDatabase,
+    func: &FunctionShape,
+    substitution: &TypeSubstitution,
+) -> FunctionShape {
+    let mut full_substitution = substitution.clone();
+    for type_param in &func.type_params {
+        if full_substitution.get(type_param.name).is_none() {
+            let preserved_type_param = db.as_type_database().type_param(*type_param);
+            full_substitution.insert(type_param.name, preserved_type_param);
+        }
+    }
+    crate::query_boundaries::common::instantiate_function_shape(db, func, &full_substitution)
 }
 
 pub(crate) fn has_object_shape(db: &dyn TypeDatabase, type_id: TypeId) -> bool {

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -1,7 +1,9 @@
 use super::state::checking as state_checking;
-use tsz_solver::TypeId;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::def::{DefKind, DefinitionStore};
+use tsz_solver::{
+    CallSignature, CallableShape, FunctionShape, ObjectShape, ParamInfo, PropertyInfo, TypeId,
+};
 
 pub(crate) use super::common::{
     PropertyAccessResult, TypeResolver, TypeSubstitution, application_info, array_element_type,
@@ -39,6 +41,116 @@ pub(crate) fn get_object_symbol(
     type_id: TypeId,
 ) -> Option<tsz_binder::SymbolId> {
     tsz_solver::type_queries::get_object_symbol(db, type_id)
+}
+
+pub(crate) fn object_type_from_properties(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn object_type_from_shape(db: &dyn TypeDatabase, shape: ObjectShape) -> TypeId {
+    db.object_with_index(shape)
+}
+
+pub(crate) fn object_type_preserving_display_properties(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    shape: ObjectShape,
+) -> TypeId {
+    let new_ty = object_type_from_shape(db, shape);
+    if let Some(display_props) = db.get_display_properties(source) {
+        db.store_display_properties(new_ty, display_props.as_ref().clone());
+    }
+    new_ty
+}
+
+pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {
+    crate::query_boundaries::construct_signatures::function_type_from_shape(db, shape)
+}
+
+pub(crate) fn function_type_with_params_replaced(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    params: Vec<ParamInfo>,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params,
+            this_type: shape.this_type,
+            return_type: shape.return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
+pub(crate) fn function_type_with_return_replaced(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params: shape.params.clone(),
+            this_type: shape.this_type,
+            return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
+pub(crate) fn function_type_with_params_and_return_replaced(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    params: Vec<ParamInfo>,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params,
+            this_type: shape.this_type,
+            return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
+pub(crate) fn callable_type_from_shape(db: &dyn TypeDatabase, shape: CallableShape) -> TypeId {
+    db.callable(shape)
+}
+
+pub(crate) fn call_only_callable_type(
+    db: &dyn TypeDatabase,
+    call_signatures: Vec<CallSignature>,
+) -> TypeId {
+    crate::query_boundaries::construct_signatures::call_only_callable_type(db, call_signatures)
+}
+
+pub(crate) fn callable_type_with_signatures_replaced(
+    db: &dyn TypeDatabase,
+    base: &CallableShape,
+    call_signatures: Vec<CallSignature>,
+    construct_signatures: Vec<CallSignature>,
+) -> TypeId {
+    crate::query_boundaries::construct_signatures::callable_with_signatures_replaced(
+        db,
+        base,
+        call_signatures,
+        construct_signatures,
+    )
 }
 
 pub(crate) fn assignment_numeric_display_children(

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -128,6 +128,43 @@ pub(crate) fn function_type_with_params_and_return_replaced(
     )
 }
 
+pub(crate) fn function_type_without_type_params(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: Vec::new(),
+            params: shape.params.clone(),
+            this_type: shape.this_type,
+            return_type: shape.return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
+pub(crate) fn function_type_from_call_signature_without_type_params(
+    db: &dyn TypeDatabase,
+    sig: &CallSignature,
+    is_constructor: bool,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: Vec::new(),
+            params: sig.params.clone(),
+            this_type: sig.this_type,
+            return_type: sig.return_type,
+            type_predicate: sig.type_predicate,
+            is_constructor,
+            is_method: sig.is_method,
+        },
+    )
+}
+
 pub(crate) fn callable_type_from_shape(db: &dyn TypeDatabase, shape: CallableShape) -> TypeId {
     db.callable(shape)
 }

--- a/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
@@ -1,0 +1,120 @@
+//! JSDoc construction boundary.
+//!
+//! JSDoc resolution code parses source text and gathers structural facts. This
+//! module owns the solver shape literals and interning for the object/function
+//! types those facts describe.
+
+use tsz_common::Atom;
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{
+    FunctionShape, IndexSignature, ObjectShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
+    TypePredicate,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum JsdocObjectIndexKind {
+    String,
+    Number,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct JsdocObjectIndexFact {
+    pub(crate) key_type: TypeId,
+    pub(crate) value_type: TypeId,
+    pub(crate) readonly: bool,
+    pub(crate) param_name: Option<Atom>,
+}
+
+impl JsdocObjectIndexFact {
+    const fn into_index_signature(self) -> IndexSignature {
+        IndexSignature {
+            key_type: self.key_type,
+            value_type: self.value_type,
+            readonly: self.readonly,
+            param_name: self.param_name,
+        }
+    }
+}
+
+pub(crate) const fn jsdoc_object_index_fact(
+    key_type: TypeId,
+    value_type: TypeId,
+    readonly: bool,
+    param_name: Option<Atom>,
+) -> Option<(JsdocObjectIndexKind, JsdocObjectIndexFact)> {
+    let kind = match key_type {
+        TypeId::STRING | TypeId::SYMBOL => JsdocObjectIndexKind::String,
+        TypeId::NUMBER => JsdocObjectIndexKind::Number,
+        _ => return None,
+    };
+    Some((
+        kind,
+        JsdocObjectIndexFact {
+            key_type,
+            value_type,
+            readonly,
+            param_name,
+        },
+    ))
+}
+
+pub(crate) fn jsdoc_empty_object_type(db: &dyn TypeDatabase) -> TypeId {
+    db.object(Vec::new())
+}
+
+pub(crate) fn jsdoc_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<JsdocObjectIndexFact>,
+    number_index: Option<JsdocObjectIndexFact>,
+) -> Option<TypeId> {
+    if properties.is_empty() && string_index.is_none() && number_index.is_none() {
+        return None;
+    }
+    if string_index.is_some() || number_index.is_some() {
+        Some(db.object_with_index(ObjectShape {
+            properties,
+            string_index: string_index.map(JsdocObjectIndexFact::into_index_signature),
+            number_index: number_index.map(JsdocObjectIndexFact::into_index_signature),
+            ..ObjectShape::default()
+        }))
+    } else {
+        Some(db.object(properties))
+    }
+}
+
+pub(crate) fn jsdoc_object_index_type(
+    db: &dyn TypeDatabase,
+    key_type: TypeId,
+    value_type: TypeId,
+    readonly: bool,
+    param_name: Option<Atom>,
+) -> Option<TypeId> {
+    let (kind, fact) = jsdoc_object_index_fact(key_type, value_type, readonly, param_name)?;
+    let (string_index, number_index) = match kind {
+        JsdocObjectIndexKind::String => (Some(fact), None),
+        JsdocObjectIndexKind::Number => (None, Some(fact)),
+    };
+    jsdoc_object_type(db, Vec::new(), string_index, number_index)
+}
+
+pub(crate) fn jsdoc_function_type(
+    db: &dyn TypeDatabase,
+    type_params: Vec<TypeParamInfo>,
+    params: Vec<ParamInfo>,
+    this_type: Option<TypeId>,
+    return_type: TypeId,
+    type_predicate: Option<TypePredicate>,
+    is_constructor: bool,
+    is_method: bool,
+) -> TypeId {
+    db.function(FunctionShape {
+        type_params,
+        params,
+        this_type,
+        return_type,
+        type_predicate,
+        is_constructor,
+        is_method,
+    })
+}

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -41,6 +41,7 @@ pub(crate) mod index_signature;
 pub(crate) mod inference;
 pub(crate) mod intersection_display;
 pub(crate) mod js_exports;
+pub(crate) mod jsdoc_construction;
 pub(crate) mod key_constraints;
 pub(crate) mod lib_augmentations;
 pub(crate) mod name_resolution;

--- a/crates/tsz-checker/src/state/type_environment/formatting.rs
+++ b/crates/tsz-checker/src/state/type_environment/formatting.rs
@@ -3,6 +3,7 @@
 //! Extracted from `core.rs` to keep module size manageable.
 
 use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
@@ -404,7 +405,8 @@ impl<'a> CheckerState<'a> {
                 crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
             {
                 let anonymous = self.evaluate_function_shape_for_instantiation_display(&shape);
-                let anonymous_type = self.ctx.types.factory().function(anonymous);
+                let anonymous_type =
+                    diagnostic_query::function_type_from_shape(self.ctx.types, anonymous);
                 let mut structural_formatter = self.ctx.create_instantiation_display_formatter();
                 return structural_formatter.format(anonymous_type).into_owned();
             }
@@ -443,7 +445,8 @@ impl<'a> CheckerState<'a> {
                 && shape.construct_signatures.is_empty()
             {
                 let anonymous = self.evaluate_callable_shape_for_instantiation_display(&shape);
-                let anonymous_type = self.ctx.types.factory().callable(anonymous);
+                let anonymous_type =
+                    diagnostic_query::callable_type_from_shape(self.ctx.types, anonymous);
                 let mut structural_formatter = self.ctx.create_instantiation_display_formatter();
                 return structural_formatter.format(anonymous_type).into_owned();
             }
@@ -455,19 +458,8 @@ impl<'a> CheckerState<'a> {
                     .iter()
                     .map(|sig| self.evaluate_call_signature_for_instantiation_display(sig))
                     .collect();
-                let anonymous_type = self
-                    .ctx
-                    .types
-                    .factory()
-                    .callable(tsz_solver::CallableShape {
-                        call_signatures,
-                        construct_signatures: Vec::new(),
-                        properties: Vec::new(),
-                        string_index: None,
-                        number_index: None,
-                        symbol: None,
-                        is_abstract: false,
-                    });
+                let anonymous_type =
+                    diagnostic_query::call_only_callable_type(self.ctx.types, call_signatures);
                 let mut structural_formatter = self.ctx.create_instantiation_display_formatter();
                 return structural_formatter.format(anonymous_type).into_owned();
             }
@@ -607,19 +599,8 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
             && !shape.type_params.is_empty()
         {
-            let display_type = self
-                .ctx
-                .types
-                .factory()
-                .function(tsz_solver::FunctionShape {
-                    type_params: Vec::new(),
-                    params: shape.params.clone(),
-                    this_type: shape.this_type,
-                    return_type: shape.return_type,
-                    type_predicate: shape.type_predicate,
-                    is_constructor: shape.is_constructor,
-                    is_method: shape.is_method,
-                });
+            let display_type =
+                diagnostic_query::function_type_without_type_params(self.ctx.types, shape.as_ref());
             return self.format_type_diagnostic(display_type);
         }
 
@@ -633,19 +614,12 @@ impl<'a> CheckerState<'a> {
         {
             let sig = &shape.call_signatures[0];
             if !sig.type_params.is_empty() {
-                let display_type = self
-                    .ctx
-                    .types
-                    .factory()
-                    .function(tsz_solver::FunctionShape {
-                        type_params: Vec::new(),
-                        params: sig.params.clone(),
-                        this_type: sig.this_type,
-                        return_type: sig.return_type,
-                        type_predicate: sig.type_predicate,
-                        is_constructor: false,
-                        is_method: sig.is_method,
-                    });
+                let display_type =
+                    diagnostic_query::function_type_from_call_signature_without_type_params(
+                        self.ctx.types,
+                        sig,
+                        false,
+                    );
                 return self.format_type_diagnostic(display_type);
             }
         }
@@ -780,6 +754,6 @@ impl<'a> CheckerState<'a> {
             })
             .collect();
         new_props.sort_by_key(|p| p.name);
-        self.ctx.types.factory().object(new_props)
+        diagnostic_query::object_type_from_properties(self.ctx.types, new_props)
     }
 }

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -21,6 +21,9 @@
 //!   constructs signature-bearing solver types only through
 //!   `query_boundaries::construct_signatures`, never via inline shape
 //!   literals or direct interning calls.
+//! - `diagnostic_construction_boundary_scans`: diagnostic reporters route
+//!   display-only solver shape construction through
+//!   `query_boundaries::diagnostics`.
 //! - `class_instance_walk_state_scans`: class instance base traversal uses a
 //!   named checker-owned walk state instead of paired raw visited sets.
 //! - `cross_arena_delegation_scope_scans`: cross-arena delegation depth uses a
@@ -41,6 +44,8 @@ mod common_boundary_export_ratchets;
 mod construction_boundary_signature_scans;
 #[path = "arch_source_scans/cross_arena_delegation_scope_scans.rs"]
 mod cross_arena_delegation_scope_scans;
+#[path = "arch_source_scans/diagnostic_construction_boundary_scans.rs"]
+mod diagnostic_construction_boundary_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
 #[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -28,6 +28,8 @@
 //! - `index_signature_boundary_scans`: production checker index-signature
 //!   queries go through `query_boundaries::index_signature` rather than
 //!   constructing the raw solver resolver at call sites.
+//! - `jsdoc_construction_boundary_scans`: JSDoc type-resolution callers route
+//!   solver shape construction through `query_boundaries::jsdoc_construction`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -39,6 +41,8 @@ mod construction_boundary_signature_scans;
 mod cross_arena_delegation_scope_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
+#[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]
+mod jsdoc_construction_boundary_scans;
 #[path = "arch_source_scans/lazy_resolution_session_scans.rs"]
 mod lazy_resolution_session_scans;
 #[path = "arch_source_scans/object_flags_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -30,6 +30,8 @@
 //!   constructing the raw solver resolver at call sites.
 //! - `jsdoc_construction_boundary_scans`: JSDoc type-resolution callers route
 //!   solver shape construction through `query_boundaries::jsdoc_construction`.
+//! - `jsx_construction_boundary_scans`: JSX checker callers route object and
+//!   function shape construction through `query_boundaries::checkers::jsx`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -43,6 +45,8 @@ mod cross_arena_delegation_scope_scans;
 mod index_signature_boundary_scans;
 #[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]
 mod jsdoc_construction_boundary_scans;
+#[path = "arch_source_scans/jsx_construction_boundary_scans.rs"]
+mod jsx_construction_boundary_scans;
 #[path = "arch_source_scans/lazy_resolution_session_scans.rs"]
 mod lazy_resolution_session_scans;
 #[path = "arch_source_scans/object_flags_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -8,14 +8,22 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const DIAGNOSTICS_BOUNDARY: &str = "src/query_boundaries/diagnostics.rs";
-const DIAGNOSTIC_REPORTER_CONSTRUCTION_MODULES: &[&str] = &[
+const DIAGNOSTIC_CONSTRUCTION_MODULES: &[&str] = &[
     "src/error_reporter/core/type_display.rs",
     "src/error_reporter/core/excess_display.rs",
     "src/error_reporter/generics.rs",
+    "src/state/type_environment/formatting.rs",
 ];
 
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn is_allowed_shape_return_signature(trimmed: &str) -> bool {
+    matches!(
+        trimmed,
+        ") -> tsz_solver::FunctionShape {" | ") -> tsz_solver::CallableShape {"
+    )
 }
 
 fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
@@ -23,7 +31,7 @@ fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<Str
         .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
     for (line_index, line) in source.lines().enumerate() {
         let trimmed = line.trim_start();
-        if trimmed.starts_with("//") {
+        if trimmed.starts_with("//") || is_allowed_shape_return_signature(trimmed) {
             continue;
         }
         for pattern in patterns {
@@ -38,7 +46,7 @@ fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<Str
 }
 
 #[test]
-fn error_reporters_route_solver_shape_construction_through_diagnostics_boundary() {
+fn diagnostic_display_callers_route_solver_shape_construction_through_diagnostics_boundary() {
     const FORBIDDEN_PATTERNS: &[&str] = &[
         ".factory().object(",
         ".factory().object_with_index(",
@@ -61,13 +69,13 @@ fn error_reporters_route_solver_shape_construction_through_diagnostics_boundary(
     ];
 
     let mut violations = Vec::new();
-    for relative in DIAGNOSTIC_REPORTER_CONSTRUCTION_MODULES {
+    for relative in DIAGNOSTIC_CONSTRUCTION_MODULES {
         scan_for_patterns(relative, FORBIDDEN_PATTERNS, &mut violations);
     }
 
     assert!(
         violations.is_empty(),
-        "error_reporter modules must route diagnostic solver shape construction \
+        "diagnostic display callers must route solver shape construction \
          through query_boundaries::diagnostics:\n{}",
         violations.join("\n")
     );
@@ -85,6 +93,8 @@ fn diagnostics_boundary_owns_construction_helpers() {
         "function_type_with_params_replaced",
         "function_type_with_return_replaced",
         "function_type_with_params_and_return_replaced",
+        "function_type_without_type_params",
+        "function_type_from_call_signature_without_type_params",
         "callable_type_from_shape",
         "call_only_callable_type",
         "callable_type_with_signatures_replaced",

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -1,0 +1,97 @@
+//! Diagnostic construction boundary scans.
+//!
+//! Reporter modules choose display policy and source locations. Interning
+//! diagnostic-only object/function/callable solver surfaces belongs in
+//! `query_boundaries::diagnostics`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DIAGNOSTICS_BOUNDARY: &str = "src/query_boundaries/diagnostics.rs";
+const DIAGNOSTIC_REPORTER_CONSTRUCTION_MODULES: &[&str] = &[
+    "src/error_reporter/core/type_display.rs",
+    "src/error_reporter/core/excess_display.rs",
+    "src/error_reporter/generics.rs",
+];
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn error_reporters_route_solver_shape_construction_through_diagnostics_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory().object(",
+        ".factory().object_with_index(",
+        ".factory().function(",
+        ".factory().callable(",
+        ".factory.object(",
+        ".factory.object_with_index(",
+        ".factory.function(",
+        ".factory.callable(",
+        ".types.object(",
+        ".types.object_with_index(",
+        ".types.function(",
+        ".types.callable(",
+        "FunctionShape {",
+        "FunctionShape::new(",
+        "CallableShape {",
+        "ObjectShape {",
+        "IndexSignature {",
+        "ParamInfo::required(",
+    ];
+
+    let mut violations = Vec::new();
+    for relative in DIAGNOSTIC_REPORTER_CONSTRUCTION_MODULES {
+        scan_for_patterns(relative, FORBIDDEN_PATTERNS, &mut violations);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "error_reporter modules must route diagnostic solver shape construction \
+         through query_boundaries::diagnostics:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn diagnostics_boundary_owns_construction_helpers() {
+    let source = fs::read_to_string(checker_path(DIAGNOSTICS_BOUNDARY))
+        .expect("failed to read query_boundaries/diagnostics.rs");
+    for helper in [
+        "object_type_from_properties",
+        "object_type_from_shape",
+        "object_type_preserving_display_properties",
+        "function_type_from_shape",
+        "function_type_with_params_replaced",
+        "function_type_with_return_replaced",
+        "function_type_with_params_and_return_replaced",
+        "callable_type_from_shape",
+        "call_only_callable_type",
+        "callable_type_with_signatures_replaced",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::diagnostics must own `{helper}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
@@ -1,0 +1,95 @@
+//! JSDoc construction boundary scans.
+//!
+//! JSDoc resolution code parses source text and gathers facts. Raw solver
+//! `FunctionShape`, `ObjectShape`, and indexed-object construction belongs in
+//! `query_boundaries::jsdoc_construction`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const JSDOC_CONSTRUCTION_CALLERS: &[&str] = &[
+    "src/jsdoc/resolution/type_construction.rs",
+    "src/jsdoc/resolution/name_resolution.rs",
+    "src/jsdoc/params_type_strings.rs",
+];
+
+const JSDOC_CONSTRUCTION_BOUNDARY: &str = "src/query_boundaries/jsdoc_construction.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn jsdoc_callers_route_solver_shape_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        "FunctionShape",
+        "ObjectShape",
+        "IndexSignature",
+        ".function(",
+        ".object(",
+        ".object_with_index(",
+        ".callable(",
+    ];
+
+    let mut violations = Vec::new();
+    for module in JSDOC_CONSTRUCTION_CALLERS {
+        scan_for_patterns(module, FORBIDDEN_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "JSDoc construction callers must route solver shape construction \
+         through query_boundaries::jsdoc_construction:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
+    let source = fs::read_to_string(checker_path(JSDOC_CONSTRUCTION_BOUNDARY))
+        .expect("failed to read query_boundaries/jsdoc_construction.rs");
+    let common = fs::read_to_string(checker_path("src/query_boundaries/common.rs"))
+        .expect("failed to read query_boundaries/common.rs");
+
+    for helper in [
+        "jsdoc_object_index_fact",
+        "jsdoc_empty_object_type",
+        "jsdoc_object_type",
+        "jsdoc_object_index_type",
+        "jsdoc_function_type",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::jsdoc_construction must own `{helper}`"
+        );
+        assert!(
+            !common.contains(&format!("fn {helper}(")),
+            "JSDoc construction helper `{helper}` must not drift into common.rs"
+        );
+    }
+
+    for shape_pattern in ["FunctionShape {", "ObjectShape {", "IndexSignature {"] {
+        assert!(
+            source.contains(shape_pattern),
+            "query_boundaries::jsdoc_construction should own `{shape_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/jsx_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsx_construction_boundary_scans.rs
@@ -1,0 +1,128 @@
+//! JSX construction boundary scans.
+//!
+//! JSX checker modules gather JSX syntax, prop, and callback facts. Interning
+//! object/function/callable solver types and rebuilding `FunctionShape`
+//! literals belongs in `query_boundaries::checkers::jsx`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const JSX_CHECKER_ROOT: &str = "src/checkers/jsx";
+const JSX_CONSTRUCTION_BOUNDARY: &str = "src/query_boundaries/checkers/jsx.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn collect_rust_files(dir: &Path, files: &mut Vec<PathBuf>) {
+    for entry in
+        fs::read_dir(dir).unwrap_or_else(|err| panic!("failed to read {}: {err}", dir.display()))
+    {
+        let path = entry
+            .unwrap_or_else(|err| panic!("failed to read entry under {}: {err}", dir.display()))
+            .path();
+        if path.is_dir() {
+            collect_rust_files(&path, files);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            files.push(path);
+        }
+    }
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        // Return types and argument types may mention shape structs as
+        // read-only data. This scan guards construction, not type signatures.
+        if trimmed.contains("->") || trimmed.ends_with("&tsz_solver::FunctionShape,") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn jsx_checkers_route_solver_shape_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory().object(",
+        ".factory().function(",
+        ".factory().callable(",
+        "factory().object(",
+        "factory().function(",
+        "factory().callable(",
+        ".factory.object(",
+        ".factory.function(",
+        ".factory.callable(",
+        "FunctionShape {",
+        "FunctionShape::new(",
+        "CallableShape {",
+        "ObjectShape {",
+        "ParamInfo::required(",
+    ];
+
+    let root = checker_path(JSX_CHECKER_ROOT);
+    let mut files = Vec::new();
+    collect_rust_files(&root, &mut files);
+    files.sort();
+
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut violations = Vec::new();
+    for file in files {
+        let relative = file
+            .strip_prefix(manifest_dir)
+            .unwrap_or_else(|err| {
+                panic!(
+                    "failed to strip manifest dir {} from {}: {err}",
+                    manifest_dir.display(),
+                    file.display()
+                )
+            })
+            .to_str()
+            .expect("checker path is valid UTF-8");
+        scan_for_patterns(relative, FORBIDDEN_PATTERNS, &mut violations);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "JSX checker modules must route solver shape construction through \
+         query_boundaries::checkers::jsx:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn jsx_boundary_owns_construction_helpers() {
+    let source = fs::read_to_string(checker_path(JSX_CONSTRUCTION_BOUNDARY))
+        .expect("failed to read query_boundaries/checkers/jsx.rs");
+    for helper in [
+        "object_type_from_properties",
+        "empty_props_object_type",
+        "props_param_type_or_empty",
+        "function_type_from_shape",
+        "function_type_from_parts",
+        "single_required_param_function_type",
+        "function_type_with_mapped_component_types",
+        "function_type_without_this",
+        "construct_signature_function_shape",
+        "push_required_param",
+        "synthetic_single_param_function_shape",
+        "instantiate_function_shape_preserving_unresolved_params",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::checkers::jsx must own `{helper}`"
+        );
+    }
+}


### PR DESCRIPTION
Goal: fast

## Summary
- route diagnostic-only object/function/callable construction in `state/type_environment/formatting.rs` through `query_boundaries::diagnostics`
- add diagnostics helpers for function display surfaces with function type parameters suppressed
- extend the diagnostic construction arch scan from reporter modules to diagnostic display callers, including formatting

## Structural Rule
When diagnostic formatting synthesizes anonymous structural surfaces only for display, `tsc` preserves the evaluated display shape without changing semantic meaning. `tsz` keeps `state/type_environment/formatting.rs` responsible for display policy and selection, while `query_boundaries::diagnostics` owns solver object/function/callable interning.

## Owner Layer
- `state/type_environment/formatting.rs`: chooses the diagnostic display surface for TS2635, iterator diagnostics, and display-property restoration.
- `query_boundaries::diagnostics`: constructs diagnostic-only object/function/callable type surfaces.
- `query_boundaries::construct_signatures`: remains the signature-bearing construction owner used by diagnostics helpers.

## Adjacent Matrix
- Anonymous function display for instantiation expressions routes through diagnostics helpers.
- Anonymous callable display for instantiation expressions routes through diagnostics helpers.
- Single-call-signature callable display routes through `call_only_callable_type`.
- Function and callable signature displays that suppress type parameters route through diagnostics helpers.
- Boolean-literal display-property object rebuild routes through diagnostics helpers.
- Fallback/no-change cases continue returning or formatting the original `TypeId`.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test arch_source_scans -E 'test(diagnostic_construction)'`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --lib -E 'test(instantiation_expression_lib_display) or test(ts2635_instantiation_expression_displays_evaluated_indexed_parameter_type) or test(ts2635_instantiation_expression_treats_failed_typeof_as_any_in_alias_display) or test(destructuring_declaration_widens_boolean_literals_for_ts2488) or test(destructuring_assignment_preserves_boolean_literals_for_ts2488)'`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test typeof_instantiation_expression_tests -E 'not test(return_type_of_array_map_instantiation_does_not_resolve_numbers_as_namespace)'`
- Base-local note: `return_type_of_array_map_instantiation_does_not_resolve_numbers_as_namespace` fails identically on #15533 head `0632e3ae2c`.
- `scripts/safe-run.sh -- cargo check -p tsz-checker`
- `scripts/safe-run.sh -- cargo clippy -p tsz-checker --lib --tests -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
