### PR TITLE
refactor(checker): route import attribute construction (#14351)

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/children.rs
+++ b/crates/tsz-checker/src/checkers/jsx/children.rs
@@ -38,7 +38,7 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => TypeId::NEVER,
                 [element_type] => self.evaluate_type_with_env(*element_type),
-                _ => self.ctx.types.factory().union(element_types),
+                _ => jsx_query::union_type_from_members(self.ctx.types, element_types),
             };
         }
 
@@ -71,7 +71,7 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => TypeId::NEVER,
                 [element_type] => self.evaluate_type_with_env(*element_type),
-                _ => self.ctx.types.factory().union(element_types),
+                _ => jsx_query::union_type_from_members(self.ctx.types, element_types),
             };
         }
 
@@ -678,7 +678,10 @@ impl<'a> CheckerState<'a> {
         match multiple_candidates.as_slice() {
             [] => None,
             [candidate] => Some(*candidate),
-            _ => Some(self.ctx.types.factory().union(multiple_candidates)),
+            _ => Some(jsx_query::union_type_from_members(
+                self.ctx.types,
+                multiple_candidates,
+            )),
         }
     }
 
@@ -842,7 +845,10 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => None,
                 [element_type] => Some(*element_type),
-                _ => Some(self.ctx.types.factory().union(element_types)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    element_types,
+                )),
             };
         }
 
@@ -862,7 +868,10 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => None,
                 [element_type] => Some(*element_type),
-                _ => Some(self.ctx.types.factory().union(element_types)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    element_types,
+                )),
             };
         }
 
@@ -917,7 +926,10 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => None,
                 [e] => Some(*e),
-                _ => Some(self.ctx.types.factory().union(element_types)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    element_types,
+                )),
             };
         }
 
@@ -936,7 +948,7 @@ impl<'a> CheckerState<'a> {
         mut element_types: Vec<TypeId>,
     ) -> TypeId {
         self.order_react_node_multiple_children_union_for_display(&mut element_types);
-        let union = self.ctx.types.factory().union(element_types.clone());
+        let union = jsx_query::union_type_from_members(self.ctx.types, element_types.clone());
         if element_types.len() > 1 {
             self.ctx
                 .types
@@ -1047,15 +1059,22 @@ impl<'a> CheckerState<'a> {
             0 => match other_candidates.len() {
                 0 => None,
                 1 => other_candidates.into_iter().next(),
-                _ => Some(self.ctx.types.factory().union(other_candidates)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    other_candidates,
+                )),
             },
             1 if other_candidates.is_empty() => callable_candidates.into_iter().next(),
-            _ if other_candidates.is_empty() => {
-                Some(self.ctx.types.factory().union(callable_candidates))
-            }
+            _ if other_candidates.is_empty() => Some(jsx_query::union_type_from_members(
+                self.ctx.types,
+                callable_candidates,
+            )),
             _ => {
                 callable_candidates.extend(other_candidates);
-                Some(self.ctx.types.factory().union(callable_candidates))
+                Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    callable_candidates,
+                ))
             }
         }
     }
@@ -1086,14 +1105,20 @@ impl<'a> CheckerState<'a> {
         if !callable_candidates.is_empty() {
             return match callable_candidates.len() {
                 1 => callable_candidates.into_iter().next(),
-                _ => Some(self.ctx.types.factory().union(callable_candidates)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    callable_candidates,
+                )),
             };
         }
 
         match multiple_candidates.len() {
             0 => None,
             1 => multiple_candidates.into_iter().next(),
-            _ => Some(self.ctx.types.factory().union(multiple_candidates)),
+            _ => Some(jsx_query::union_type_from_members(
+                self.ctx.types,
+                multiple_candidates,
+            )),
         }
     }
 
@@ -1591,24 +1616,21 @@ impl<'a> CheckerState<'a> {
             .collect();
 
         if self.type_has_tuple_like_multiple_children(children_type) {
-            let elements = child_types
-                .into_iter()
-                .map(|type_id| tsz_solver::TupleElement {
-                    type_id,
-                    name: None,
-                    optional: false,
-                    rest: false,
-                })
-                .collect();
-            return Some(self.ctx.types.factory().tuple(elements));
+            return Some(jsx_query::tuple_type_from_required_element_types(
+                self.ctx.types,
+                child_types,
+            ));
         }
 
         let element_type = match child_types.len() {
             0 => TypeId::NEVER,
             1 => child_types[0],
-            _ => self.ctx.types.factory().union(child_types),
+            _ => jsx_query::union_type_from_members(self.ctx.types, child_types),
         };
-        Some(self.ctx.types.factory().array(element_type))
+        Some(jsx_query::array_type_from_element(
+            self.ctx.types,
+            element_type,
+        ))
     }
     pub(super) fn get_jsx_body_child_nodes(
         &self,
@@ -1702,7 +1724,7 @@ impl<'a> CheckerState<'a> {
         // children type. This handles cases like `ReactNode` where `ReactNodeArray extends
         // Array<ReactNode>` is a member of the union, but we can't detect it structurally
         // because it's an interface extending Array rather than a direct Array type.
-        let array_of_children = self.ctx.types.factory().array(type_id);
+        let array_of_children = jsx_query::array_type_from_element(self.ctx.types, type_id);
         if self
             .jsx_children_relation_outcome(array_of_children, type_id)
             .related

--- a/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
@@ -1,6 +1,7 @@
 //! JSX diagnostics rendering: display target building, type formatting for
 //! error messages, tag name text extraction, and text-children checks.
 
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use crate::symbol_resolver::TypeSymbolResolution;
 use tsz_binder::SymbolId;
@@ -83,7 +84,7 @@ impl<'a> CheckerState<'a> {
     ) -> Option<TypeId> {
         let ica = self.get_intrinsic_class_attributes_lazy_type()?;
         let inst = self.get_class_instance_type_for_component(component_type)?;
-        let app = self.ctx.types.factory().application(ica, vec![inst]);
+        let app = jsx_query::type_application_from_args(self.ctx.types, ica, vec![inst]);
         let evaluated = self.normalize_jsx_required_props_target(app);
         if evaluated == TypeId::ANY || evaluated == TypeId::ERROR {
             return None;

--- a/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
@@ -394,7 +394,10 @@ impl<'a> CheckerState<'a> {
         if get_conditional_type_id(self.ctx.types, props_type).is_some()
             && let Some(shape) = object_shape_for_type(self.ctx.types, props_type)
         {
-            let object = self.ctx.types.factory().object(shape.properties.clone());
+            let object = crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                shape.properties.clone(),
+            );
             return Some(self.format_type_skip_object_display_alias(object));
         }
 
@@ -462,7 +465,12 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        Some(self.format_type(self.ctx.types.factory().object(filtered_props)))
+        Some(self.format_type(
+            crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                filtered_props,
+            ),
+        ))
     }
 
     fn jsx_conditional_display_has_lma_infer_metadata(display: &str) -> bool {
@@ -544,7 +552,12 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        Some(self.format_type(self.ctx.types.factory().object(filtered_props)))
+        Some(self.format_type(
+            crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                filtered_props,
+            ),
+        ))
     }
 
     fn jsx_final_conditional_else_display(display: &str) -> Option<String> {

--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -48,11 +48,11 @@ impl<'a> CheckerState<'a> {
             && jsx_boundary::is_type_parameter_like(self.ctx.types, component_type)
         {
             let lma_ref = self.resolve_symbol_as_lazy_type(lma_sym_id);
-            return self
-                .ctx
-                .types
-                .factory()
-                .application(lma_ref, vec![component_type, props_type]);
+            return jsx_boundary::type_application_from_args(
+                self.ctx.types,
+                lma_ref,
+                vec![component_type, props_type],
+            );
         }
         if jsx_boundary::contains_type_parameters(self.ctx.types, props_type) {
             return props_type;
@@ -230,7 +230,8 @@ impl<'a> CheckerState<'a> {
                 0 => return None,
                 1 => return candidates.pop(),
                 _ => {
-                    let props_union = self.ctx.types.factory().union(
+                    let props_union = jsx_boundary::union_type_from_members(
+                        self.ctx.types,
                         candidates
                             .into_iter()
                             .map(|(props_type, _)| props_type)

--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -334,11 +334,10 @@ impl<'a> CheckerState<'a> {
             && !shape.is_constructor
         {
             return Some(
-                shape
-                    .params
-                    .first()
-                    .map(|p| p.type_id)
-                    .unwrap_or_else(|| self.ctx.types.factory().object(vec![])),
+                crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                    self.ctx.types,
+                    &shape.params,
+                ),
             );
         }
 
@@ -352,11 +351,10 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         Some(
-            non_generic[0]
-                .params
-                .first()
-                .map(|p| p.type_id)
-                .unwrap_or_else(|| self.ctx.types.factory().object(vec![])),
+            crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                self.ctx.types,
+                &non_generic[0].params,
+            ),
         )
     }
 
@@ -1189,11 +1187,10 @@ impl<'a> CheckerState<'a> {
             if !shape.type_params.is_empty() {
                 return None;
             }
-            let props = shape
-                .params
-                .first()
-                .map(|p| p.type_id)
-                .unwrap_or_else(|| self.ctx.types.factory().object(vec![]));
+            let props = crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                self.ctx.types,
+                &shape.params,
+            );
             // Check for type parameters BEFORE evaluation, since evaluation may
             // collapse `T & {children?: ReactNode}` into a concrete object type
             // that loses the type parameter information.
@@ -1234,11 +1231,10 @@ impl<'a> CheckerState<'a> {
             if non_generic.next().is_some() {
                 return None;
             }
-            let props = sig
-                .params
-                .first()
-                .map(|p| p.type_id)
-                .unwrap_or_else(|| self.ctx.types.factory().object(vec![]));
+            let props = crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                self.ctx.types,
+                &sig.params,
+            );
             let raw_has_type_params =
                 crate::query_boundaries::common::contains_type_parameters(self.ctx.types, props);
             let evaluated = if should_preserve_contextual_application_shape(self.ctx.types, props) {
@@ -1320,11 +1316,10 @@ impl<'a> CheckerState<'a> {
             && !shape.is_constructor
             && !shape.type_params.is_empty()
         {
-            let props = shape
-                .params
-                .first()
-                .map(|param| param.type_id)
-                .unwrap_or_else(|| self.ctx.types.factory().object(vec![]));
+            let props = crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                self.ctx.types,
+                &shape.params,
+            );
             return self.instantiate_jsx_generic_sfc_props_with_defaults(
                 component_type,
                 props,
@@ -1342,11 +1337,10 @@ impl<'a> CheckerState<'a> {
                 .collect();
             if generic.len() == 1 {
                 let sig = generic[0];
-                let props = sig
-                    .params
-                    .first()
-                    .map(|param| param.type_id)
-                    .unwrap_or_else(|| self.ctx.types.factory().object(vec![]));
+                let props = crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                    self.ctx.types,
+                    &sig.params,
+                );
                 return self.instantiate_jsx_generic_sfc_props_with_defaults(
                     component_type,
                     props,
@@ -1651,8 +1645,11 @@ impl<'a> CheckerState<'a> {
                                 self.resolve_property_access_with_env(component_type, "propTypes"),
                                 PropertyAccessResult::Success { .. }
                             );
-                            has_managed_props_metadata
-                                .then(|| self.ctx.types.factory().object(vec![]))
+                            has_managed_props_metadata.then(|| {
+                                crate::query_boundaries::checkers::jsx::empty_props_object_type(
+                                    self.ctx.types,
+                                )
+                            })
                         }),
                 }
             }

--- a/crates/tsz-checker/src/checkers/jsx/extraction_class_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction_class_props.rs
@@ -108,7 +108,10 @@ impl<'a> CheckerState<'a> {
                 .cloned()
                 .collect();
             if filtered_props.len() != shape.properties.len() {
-                return self.ctx.types.factory().object(filtered_props);
+                return crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                    self.ctx.types,
+                    filtered_props,
+                );
             }
         }
 
@@ -209,7 +212,12 @@ impl<'a> CheckerState<'a> {
             return Some(props_type);
         }
 
-        Some(self.ctx.types.factory().object(properties))
+        Some(
+            crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                properties,
+            ),
+        )
     }
 
     /// Get the property name from `JSX.ElementAttributesProperty`.

--- a/crates/tsz-checker/src/checkers/jsx/extraction_class_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction_class_props.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
@@ -140,7 +141,7 @@ impl<'a> CheckerState<'a> {
         match filtered.len() {
             0 => props_type,
             1 => filtered[0],
-            _ => self.ctx.types.factory().intersection(filtered),
+            _ => jsx_query::intersection_type_from_members(self.ctx.types, filtered),
         }
     }
 

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
@@ -21,39 +21,14 @@ impl<'a> CheckerState<'a> {
             return type_id;
         };
 
-        let normalized = tsz_solver::FunctionShape {
-            type_params: shape.type_params.clone(),
-            params: shape
-                .params
-                .iter()
-                .map(|param| tsz_solver::ParamInfo {
-                    name: param.name,
-                    type_id: crate::query_boundaries::common::unwrap_readonly_or_noinfer(
-                        self.ctx.types,
-                        param.type_id,
-                    )
-                    .unwrap_or(param.type_id),
-                    optional: param.optional,
-                    rest: param.rest,
-                })
-                .collect(),
-            this_type: shape.this_type.map(|this_type| {
-                crate::query_boundaries::common::unwrap_readonly_or_noinfer(
-                    self.ctx.types,
-                    this_type,
-                )
-                .unwrap_or(this_type)
-            }),
-            return_type: crate::query_boundaries::common::unwrap_readonly_or_noinfer(
-                self.ctx.types,
-                shape.return_type,
-            )
-            .unwrap_or(shape.return_type),
-            type_predicate: shape.type_predicate,
-            is_constructor: shape.is_constructor,
-            is_method: shape.is_method,
-        };
-        self.ctx.types.factory().function(normalized)
+        crate::query_boundaries::checkers::jsx::function_type_with_mapped_component_types(
+            self.ctx.types,
+            shape.as_ref(),
+            |type_id| {
+                crate::query_boundaries::common::unwrap_readonly_or_noinfer(self.ctx.types, type_id)
+                    .unwrap_or(type_id)
+            },
+        )
     }
 
     pub(in crate::checkers_domain::jsx) fn refine_jsx_callable_contextual_type(
@@ -314,7 +289,10 @@ impl<'a> CheckerState<'a> {
                 }
             }
             if !metadata_props.is_empty() {
-                return self.ctx.types.factory().object(metadata_props);
+                return crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                    self.ctx.types,
+                    metadata_props,
+                );
             }
         }
 
@@ -1093,58 +1071,11 @@ impl<'a> CheckerState<'a> {
         func: &tsz_solver::FunctionShape,
         substitution: &crate::query_boundaries::common::TypeSubstitution,
     ) -> tsz_solver::FunctionShape {
-        let mut full_substitution = substitution.clone();
-        for type_param in &func.type_params {
-            if full_substitution.get(type_param.name).is_none() {
-                let preserved_type_param = self.ctx.types.factory().type_param(*type_param);
-                full_substitution.insert(type_param.name, preserved_type_param);
-            }
-        }
-        tsz_solver::FunctionShape {
-            params: func
-                .params
-                .iter()
-                .map(|param| tsz_solver::ParamInfo {
-                    name: param.name,
-                    type_id: crate::query_boundaries::common::instantiate_type(
-                        self.ctx.types,
-                        param.type_id,
-                        &full_substitution,
-                    ),
-                    optional: param.optional,
-                    rest: param.rest,
-                })
-                .collect(),
-            return_type: crate::query_boundaries::common::instantiate_type(
-                self.ctx.types,
-                func.return_type,
-                &full_substitution,
-            ),
-            this_type: func.this_type.map(|this_type| {
-                crate::query_boundaries::common::instantiate_type(
-                    self.ctx.types,
-                    this_type,
-                    &full_substitution,
-                )
-            }),
-            type_params: vec![],
-            type_predicate: func.type_predicate.as_ref().map(|predicate| {
-                tsz_solver::TypePredicate {
-                    asserts: predicate.asserts,
-                    target: predicate.target,
-                    type_id: predicate.type_id.map(|tid| {
-                        crate::query_boundaries::common::instantiate_type(
-                            self.ctx.types,
-                            tid,
-                            &full_substitution,
-                        )
-                    }),
-                    parameter_index: predicate.parameter_index,
-                }
-            }),
-            is_constructor: func.is_constructor,
-            is_method: func.is_method,
-        }
+        crate::query_boundaries::checkers::jsx::instantiate_function_shape_preserving_unresolved_params(
+            self.ctx.types,
+            func,
+            substitution,
+        )
     }
 
     pub(in crate::checkers_domain::jsx) fn infer_jsx_generic_component_props_type(
@@ -1504,20 +1435,13 @@ impl<'a> CheckerState<'a> {
                 _ => continue,
             };
             let expected_type = self.refine_jsx_callable_contextual_type(expected_type);
-            let synthetic_shape = tsz_solver::FunctionShape {
-                type_params: function_shape.type_params.clone(),
-                params: vec![tsz_solver::ParamInfo {
-                    name: Some(self.ctx.types.intern_string(attr_name)),
-                    type_id: expected_type,
-                    optional: false,
-                    rest: false,
-                }],
-                this_type: None,
-                return_type: TypeId::VOID,
-                type_predicate: None,
-                is_constructor: false,
-                is_method: false,
-            };
+            let synthetic_shape =
+                crate::query_boundaries::checkers::jsx::synthetic_single_param_function_shape(
+                    function_shape.type_params.clone(),
+                    self.ctx.types.intern_string(attr_name),
+                    expected_type,
+                    TypeId::VOID,
+                );
             let attr_sub = {
                 let env = self.ctx.type_env.borrow();
                 crate::query_boundaries::checkers::call::compute_contextual_types_with_context(

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
@@ -2,6 +2,7 @@
 //! function-valued attributes, intrinsic props lookup, and component props
 //! recovery.
 
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -64,7 +65,7 @@ impl<'a> CheckerState<'a> {
             return match callable_members.len() {
                 0 => type_id,
                 1 => callable_members[0],
-                _ => self.ctx.types.factory().union(callable_members),
+                _ => jsx_query::union_type_from_members(self.ctx.types, callable_members),
             };
         }
 
@@ -96,7 +97,7 @@ impl<'a> CheckerState<'a> {
         match callable_members.len() {
             0 => type_id,
             1 => callable_members[0],
-            _ => self.ctx.types.factory().union(callable_members),
+            _ => jsx_query::union_type_from_members(self.ctx.types, callable_members),
         }
     }
 
@@ -122,7 +123,7 @@ impl<'a> CheckerState<'a> {
             return match single_members.as_slice() {
                 [] => type_id,
                 [single_member] => *single_member,
-                _ => self.ctx.types.factory().union(single_members),
+                _ => jsx_query::union_type_from_members(self.ctx.types, single_members),
             };
         }
 
@@ -142,7 +143,7 @@ impl<'a> CheckerState<'a> {
         match single_members.as_slice() {
             [] => resolved,
             [single_member] => *single_member,
-            _ => self.ctx.types.factory().union(single_members),
+            _ => jsx_query::union_type_from_members(self.ctx.types, single_members),
         }
     }
 
@@ -166,7 +167,7 @@ impl<'a> CheckerState<'a> {
         match multiple_members.as_slice() {
             [] => resolved,
             [multiple_member] => *multiple_member,
-            _ => self.ctx.types.factory().union(multiple_members),
+            _ => jsx_query::union_type_from_members(self.ctx.types, multiple_members),
         }
     }
 
@@ -194,7 +195,10 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => None,
                 [element_type] => Some(*element_type),
-                _ => Some(self.ctx.types.factory().union(element_types)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    element_types,
+                )),
             };
         }
 
@@ -216,7 +220,10 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => None,
                 [element_type] => Some(*element_type),
-                _ => Some(self.ctx.types.factory().union(element_types)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    element_types,
+                )),
             };
         }
 
@@ -285,7 +292,7 @@ impl<'a> CheckerState<'a> {
                     let atom = self.ctx.types.intern_string(prop_name);
                     let type_id =
                         self.declared_expando_property_type_for_root(sym_id, &name, prop_name);
-                    metadata_props.push(tsz_solver::PropertyInfo::new(atom, type_id));
+                    metadata_props.push(jsx_query::property_info(atom, type_id));
                 }
             }
             if !metadata_props.is_empty() {
@@ -388,12 +395,11 @@ impl<'a> CheckerState<'a> {
     ) -> Option<TypeId> {
         let lma_sym_id = self.get_jsx_namespace_export_symbol_id("LibraryManagedAttributes")?;
         let lma_ref = self.resolve_symbol_as_lazy_type(lma_sym_id);
-        Some(
-            self.ctx
-                .types
-                .factory()
-                .application(lma_ref, vec![component_type, props_type]),
-        )
+        Some(jsx_query::type_application_from_args(
+            self.ctx.types,
+            lma_ref,
+            vec![component_type, props_type],
+        ))
     }
 
     pub(in crate::checkers_domain::jsx) fn get_jsx_dynamic_intrinsic_display_props_type(
@@ -536,11 +542,8 @@ impl<'a> CheckerState<'a> {
         component_type: TypeId,
     ) -> Option<(TypeId, bool, String)> {
         let intrinsic_elements_type = self.get_intrinsic_elements_type()?;
-        let raw_props_type = self
-            .ctx
-            .types
-            .factory()
-            .index_access(intrinsic_elements_type, component_type);
+        let raw_props_type =
+            jsx_query::index_access_type(self.ctx.types, intrinsic_elements_type, component_type);
         let normalized_props = self.normalize_jsx_required_props_target(raw_props_type);
         if matches!(normalized_props, TypeId::ANY | TypeId::ERROR) {
             return None;
@@ -778,14 +781,13 @@ impl<'a> CheckerState<'a> {
         match best_matches.len() {
             0 => None,
             1 => best_matches.first().map(|(_, value_type)| *value_type),
-            _ => Some(
-                self.ctx.types.factory().union(
-                    best_matches
-                        .into_iter()
-                        .map(|(_, value_type)| value_type)
-                        .collect(),
-                ),
-            ),
+            _ => Some(jsx_query::union_type_from_members(
+                self.ctx.types,
+                best_matches
+                    .into_iter()
+                    .map(|(_, value_type)| value_type)
+                    .collect(),
+            )),
         }
     }
 
@@ -1702,8 +1704,8 @@ impl<'a> CheckerState<'a> {
         let synthesized_type = if child_types.len() == 1 && !has_spread_child {
             child_types[0]
         } else {
-            let element_type = self.ctx.types.factory().union(child_types);
-            self.ctx.types.factory().array(element_type)
+            let element_type = jsx_query::union_type_from_members(self.ctx.types, child_types);
+            jsx_query::array_type_from_element(self.ctx.types, element_type)
         };
         out.push((children_prop_name.to_string(), synthesized_type));
     }

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
@@ -1,6 +1,7 @@
 //! JSX namespace resolution, intrinsic elements, closing checks, and attributes.
 
 use crate::context::TypingRequest;
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use crate::symbols_domain::name_text::entity_name_text_in_arena;
 use tsz_binder::{SymbolId, symbol_flags};
@@ -1974,8 +1975,6 @@ impl<'a> CheckerState<'a> {
 
         // Fallback: create Application for class components, type aliases,
         // and overloaded SFCs (Callable types)
-        self.ctx
-            .types
-            .application(component_type, type_args.to_vec())
+        jsx_query::type_application_from_args(self.ctx.types, component_type, type_args.to_vec())
     }
 }

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
@@ -174,15 +174,8 @@ impl<'a> CheckerState<'a> {
         )?
         .first()?
         .clone();
-        let mut function_shape = tsz_solver::FunctionShape {
-            type_params: call_sig.type_params,
-            params: call_sig.params,
-            this_type: call_sig.this_type,
-            return_type: call_sig.return_type,
-            type_predicate: call_sig.type_predicate,
-            is_constructor: true,
-            is_method: call_sig.is_method,
-        };
+        let mut function_shape =
+            crate::query_boundaries::checkers::jsx::construct_signature_function_shape(call_sig);
         if function_shape.type_params.is_empty() {
             return None;
         }
@@ -223,9 +216,11 @@ impl<'a> CheckerState<'a> {
 
             if let Some(type_id) = synthesized_param_type {
                 let props_name = self.ctx.types.intern_string("props");
-                function_shape
-                    .params
-                    .push(tsz_solver::ParamInfo::required(props_name, type_id));
+                crate::query_boundaries::checkers::jsx::push_required_param(
+                    &mut function_shape,
+                    props_name,
+                    type_id,
+                );
             }
         }
 

--- a/crates/tsz-checker/src/checkers/jsx/overloads.rs
+++ b/crates/tsz-checker/src/checkers/jsx/overloads.rs
@@ -729,6 +729,9 @@ impl<'a> CheckerState<'a> {
                 }
             })
             .collect();
-        self.ctx.types.factory().object(properties)
+        crate::query_boundaries::checkers::jsx::object_type_from_properties(
+            self.ctx.types,
+            properties,
+        )
     }
 }

--- a/crates/tsz-checker/src/checkers/jsx/overloads.rs
+++ b/crates/tsz-checker/src/checkers/jsx/overloads.rs
@@ -5,6 +5,7 @@
 //! matches, emits TS2769 ("No overload matches this call.").
 
 use crate::context::speculation::FullSpeculationSnapshot;
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -711,22 +712,7 @@ impl<'a> CheckerState<'a> {
             .iter()
             .map(|attr| {
                 let name_atom = self.ctx.types.intern_string(&attr.name);
-                tsz_solver::PropertyInfo {
-                    name: name_atom,
-                    type_id: attr.type_id,
-                    write_type: attr.type_id,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: tsz_solver::Visibility::Public,
-                    parent_id: None,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                }
+                jsx_query::property_info_with_write_type(name_atom, attr.type_id, attr.type_id)
             })
             .collect();
         crate::query_boundaries::checkers::jsx::object_type_from_properties(

--- a/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
@@ -1,5 +1,6 @@
 //! JSX generic spread whole-object assignability diagnostics.
 
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
@@ -50,7 +51,7 @@ impl<'a> CheckerState<'a> {
         let explicit_attrs_type = self.build_jsx_provided_attrs_object_type(provided_attrs);
         let mut members = generic_spread_types;
         members.push(explicit_attrs_type);
-        let attrs_type = self.ctx.types.factory().intersection(members);
+        let attrs_type = jsx_query::intersection_type_from_members(self.ctx.types, members);
 
         let props_for_access = self.normalize_jsx_required_props_target(props_type);
 

--- a/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
@@ -3,6 +3,7 @@
 use crate::context::TypingRequest;
 use crate::context::speculation::DiagnosticSpeculationSnapshot;
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
@@ -207,7 +208,7 @@ impl<'a> CheckerState<'a> {
                     match compatible_members.len() {
                         0 => props_type,
                         1 => compatible_members[0],
-                        _ => self.ctx.types.factory().union(compatible_members),
+                        _ => jsx_query::union_type_from_members(self.ctx.types, compatible_members),
                     }
                 }
             }
@@ -225,7 +226,7 @@ impl<'a> CheckerState<'a> {
                 match normalized_members.len() {
                     0 => props_type,
                     1 => normalized_members[0],
-                    _ => self.ctx.types.factory().union(normalized_members),
+                    _ => jsx_query::union_type_from_members(self.ctx.types, normalized_members),
                 }
             }
         }

--- a/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
@@ -51,7 +51,12 @@ impl<'a> CheckerState<'a> {
                 }
             })
             .collect();
-        let source_type = self.format_type(self.ctx.types.factory().object(properties));
+        let source_type = self.format_type(
+            crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                properties,
+            ),
+        );
         let base = format_message(
             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             &[&source_type, display_target],
@@ -265,7 +270,10 @@ impl<'a> CheckerState<'a> {
                 }
             })
             .collect();
-        let attrs_type = self.ctx.types.factory().object(properties);
+        let attrs_type = crate::query_boundaries::checkers::jsx::object_type_from_properties(
+            self.ctx.types,
+            properties,
+        );
         if crate::query_boundaries::checkers::jsx::props_are_assignable(
             self, attrs_type, props_type,
         ) {

--- a/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
@@ -1,6 +1,7 @@
 //! JSX union prop compatibility and display helpers.
 
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
@@ -33,22 +34,7 @@ impl<'a> CheckerState<'a> {
                 } else {
                     *type_id
                 };
-                tsz_solver::PropertyInfo {
-                    name: name_atom,
-                    type_id: display_type,
-                    write_type: display_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: tsz_solver::Visibility::Public,
-                    parent_id: None,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                }
+                jsx_query::property_info_with_write_type(name_atom, display_type, display_type)
             })
             .collect();
         let source_type = self.format_type(
@@ -252,22 +238,7 @@ impl<'a> CheckerState<'a> {
                 } else {
                     *type_id
                 };
-                tsz_solver::PropertyInfo {
-                    name: name_atom,
-                    type_id: display_type,
-                    write_type: display_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: tsz_solver::Visibility::Public,
-                    parent_id: None,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                }
+                jsx_query::property_info_with_write_type(name_atom, display_type, display_type)
             })
             .collect();
         let attrs_type = crate::query_boundaries::checkers::jsx::object_type_from_properties(

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -135,7 +135,10 @@ impl<'a> CheckerState<'a> {
                 }
             })
             .collect();
-        self.ctx.types.factory().object(properties)
+        crate::query_boundaries::checkers::jsx::object_type_from_properties(
+            self.ctx.types,
+            properties,
+        )
     }
 
     pub(in crate::checkers_domain::jsx) fn check_jsx_generic_spread_attrs_assignability(
@@ -881,7 +884,12 @@ impl<'a> CheckerState<'a> {
                 .cloned()
                 .collect();
             if filtered_props.len() != shape.properties.len() {
-                return self.format_type(self.ctx.types.factory().object(filtered_props));
+                return self.format_type(
+                    crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                        self.ctx.types,
+                        filtered_props,
+                    ),
+                );
             }
         }
 
@@ -1148,14 +1156,12 @@ impl<'a> CheckerState<'a> {
 
         let instance_type = self.get_class_instance_type_for_component(component_type)?;
         let param_name = self.ctx.types.intern_string("instance");
-        let callback = self
-            .ctx
-            .types
-            .factory()
-            .function(tsz_solver::FunctionShape::new(
-                vec![tsz_solver::ParamInfo::required(param_name, instance_type)],
-                TypeId::ANY,
-            ));
+        let callback = crate::query_boundaries::checkers::jsx::single_required_param_function_type(
+            self.ctx.types,
+            param_name,
+            instance_type,
+            TypeId::ANY,
+        );
         Some(self.ctx.types.factory().union2(TypeId::STRING, callback))
     }
 
@@ -1630,19 +1636,10 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
             && shape.is_method
         {
-            return self
-                .ctx
-                .types
-                .factory()
-                .function(tsz_solver::FunctionShape {
-                    type_params: shape.type_params.clone(),
-                    params: shape.params.clone(),
-                    this_type: None,
-                    return_type: shape.return_type,
-                    type_predicate: shape.type_predicate,
-                    is_constructor: shape.is_constructor,
-                    is_method: false,
-                });
+            return crate::query_boundaries::checkers::jsx::function_type_without_this(
+                self.ctx.types,
+                shape.as_ref(),
+            );
         }
 
         type_id

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -117,22 +117,7 @@ impl<'a> CheckerState<'a> {
                 } else {
                     *type_id
                 };
-                tsz_solver::PropertyInfo {
-                    name: name_atom,
-                    type_id: display_type,
-                    write_type: display_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: tsz_solver::Visibility::Public,
-                    parent_id: None,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                }
+                jsx_queries::property_info_with_write_type(name_atom, display_type, display_type)
             })
             .collect();
         crate::query_boundaries::checkers::jsx::object_type_from_properties(
@@ -261,7 +246,8 @@ impl<'a> CheckerState<'a> {
             .any(|&spread_type| self.jsx_relation_operand_defers(spread_type));
         let explicit_type = self.build_jsx_provided_attrs_object_type(&explicit_attrs);
         generic_spreads.push(explicit_type);
-        let attrs_type = self.ctx.types.factory().intersection(generic_spreads);
+        let attrs_type =
+            jsx_queries::intersection_type_from_members(self.ctx.types, generic_spreads);
         if !has_explicit_mismatch {
             if spread_source_is_deferred {
                 return;
@@ -761,9 +747,9 @@ impl<'a> CheckerState<'a> {
         let array_element = if element_types.len() == 1 {
             element_types[0]
         } else {
-            self.ctx.types.factory().union(element_types)
+            jsx_queries::union_type_from_members(self.ctx.types, element_types)
         };
-        self.ctx.types.factory().array(array_element)
+        jsx_queries::array_type_from_element(self.ctx.types, array_element)
     }
 
     fn format_jsx_provided_attrs_source_type(
@@ -1162,7 +1148,11 @@ impl<'a> CheckerState<'a> {
             instance_type,
             TypeId::ANY,
         );
-        Some(self.ctx.types.factory().union2(TypeId::STRING, callback))
+        Some(jsx_queries::union_type_from_pair(
+            self.ctx.types,
+            TypeId::STRING,
+            callback,
+        ))
     }
 
     fn get_jsx_intrinsic_class_attribute_from_heritage(
@@ -1750,7 +1740,8 @@ impl<'a> CheckerState<'a> {
             }
 
             // Build target: IntrinsicAttributes & spread_type
-            let target = self.ctx.types.factory().intersection2(ia_type, spread_type);
+            let target =
+                jsx_queries::intersection_type_from_pair(self.ctx.types, ia_type, spread_type);
 
             if !crate::query_boundaries::checkers::jsx::props_are_assignable(
                 self,
@@ -1868,10 +1859,7 @@ impl<'a> CheckerState<'a> {
         let display_type = if !prop_is_optional_in_anonymous_source {
             write_check_type
         } else if write_check_type == declared_type_id {
-            self.ctx
-                .types
-                .factory()
-                .union2(write_check_type, TypeId::UNDEFINED)
+            jsx_queries::union_type_from_pair(self.ctx.types, write_check_type, TypeId::UNDEFINED)
         } else {
             declared_type_id
         };

--- a/crates/tsz-checker/src/checkers/jsx/spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/spread.rs
@@ -637,7 +637,10 @@ impl<'a> CheckerState<'a> {
                 .cloned()
                 .collect();
             if filtered.len() != shape.properties.len() {
-                return self.ctx.types.factory().object(filtered);
+                return crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                    self.ctx.types,
+                    filtered,
+                );
             }
         }
         props_type

--- a/crates/tsz-checker/src/checkers/jsx/spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/spread.rs
@@ -3,6 +3,7 @@
 
 use crate::context::TypingRequest;
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -619,7 +620,7 @@ impl<'a> CheckerState<'a> {
                 return match kept.len() {
                     0 => props_type, // pathological — keep original
                     1 => kept[0],
-                    _ => self.ctx.types.factory().intersection(kept),
+                    _ => jsx_query::intersection_type_from_members(self.ctx.types, kept),
                 };
             }
         }

--- a/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
+++ b/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
@@ -1,5 +1,6 @@
 //! Dynamic import validation: specifier type, options type, attributes, module resolution.
 
+use crate::query_boundaries::import_attributes as import_attribute_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
@@ -110,10 +111,12 @@ impl<'a> CheckerState<'a> {
         // property references the base ImportAttributes (without user augmentations).
         let with_atom = self.ctx.types.intern_string("with");
         let assert_atom = self.ctx.types.intern_string("assert");
-        let import_call_options_type = self.ctx.types.factory().object(vec![
-            tsz_solver::PropertyInfo::opt(with_atom, import_attributes_type),
-            tsz_solver::PropertyInfo::opt(assert_atom, import_attributes_type),
-        ]);
+        let import_call_options_type = import_attribute_query::import_call_options_type(
+            self.ctx.types,
+            with_atom,
+            assert_atom,
+            import_attributes_type,
+        );
 
         // Build the options type manually from the AST with string literal types.
         let Some(options_node) = self.ctx.arena.get(options_idx) else {
@@ -258,7 +261,9 @@ impl<'a> CheckerState<'a> {
                 };
 
                 let name_atom = self.ctx.types.intern_string(&name);
-                properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+                properties.push(import_attribute_query::import_attribute_property(
+                    name_atom, value_type,
+                ));
             }
         }
 
@@ -266,7 +271,7 @@ impl<'a> CheckerState<'a> {
             return self.get_type_of_node(obj_idx);
         }
 
-        self.ctx.types.factory().object(properties)
+        import_attribute_query::import_attribute_object_type(self.ctx.types, properties)
     }
 
     /// Build an object type from an object literal using string literal types for
@@ -294,13 +299,18 @@ impl<'a> CheckerState<'a> {
                 let value_type = if let Some(val_node) = self.ctx.arena.get(prop.initializer)
                     && let Some(lit) = self.ctx.arena.get_literal(val_node)
                 {
-                    self.ctx.types.factory().literal_string(&lit.text)
+                    import_attribute_query::import_attribute_literal_string_type(
+                        self.ctx.types,
+                        &lit.text,
+                    )
                 } else {
                     self.get_type_of_node(prop.initializer)
                 };
 
                 let name_atom = self.ctx.types.intern_string(&name);
-                properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+                properties.push(import_attribute_query::import_attribute_property(
+                    name_atom, value_type,
+                ));
             }
         }
 
@@ -308,7 +318,7 @@ impl<'a> CheckerState<'a> {
             return self.get_type_of_node(obj_idx);
         }
 
-        self.ctx.types.factory().object(properties)
+        import_attribute_query::import_attribute_object_type(self.ctx.types, properties)
     }
 
     /// TS2880: Check for deprecated `assert` property in an import options object literal.

--- a/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
@@ -387,6 +387,7 @@ impl<'a> CheckerState<'a> {
     /// has augmented `ImportAttributes` (e.g., `interface ImportAttributes { type: "json" }`),
     /// mismatched values will produce TS2322.
     pub(crate) fn check_import_attributes_assignability(&mut self, attributes_idx: NodeIndex) {
+        use crate::query_boundaries::import_attributes as import_attribute_query;
         use tsz_solver::TypeId;
 
         if attributes_idx.is_none() {
@@ -449,7 +450,10 @@ impl<'a> CheckerState<'a> {
             let value_type = if let Some(val_node) = self.ctx.arena.get(attr_data.value) {
                 if val_node.kind == tsz_scanner::SyntaxKind::StringLiteral as u16 {
                     if let Some(lit) = self.ctx.arena.get_literal(val_node) {
-                        self.ctx.types.factory().literal_string(&lit.text)
+                        import_attribute_query::import_attribute_literal_string_type(
+                            self.ctx.types,
+                            &lit.text,
+                        )
                     } else {
                         self.get_type_of_node(attr_data.value)
                     }
@@ -488,14 +492,17 @@ impl<'a> CheckerState<'a> {
             };
 
             let name_atom = self.ctx.types.intern_string(&name);
-            properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+            properties.push(import_attribute_query::import_attribute_property(
+                name_atom, value_type,
+            ));
         }
 
         if properties.is_empty() {
             return;
         }
 
-        let source_type = self.ctx.types.factory().object(properties);
+        let source_type =
+            import_attribute_query::import_attribute_object_type(self.ctx.types, properties);
 
         // Don't check if source or target are any/error
         if source_type == TypeId::ANY

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1,9 +1,9 @@
 //! Module import/export validation and circular re-export detection.
 
+use crate::query_boundaries::declaration_exports;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_parser::parser::NodeIndex;
-use tsz_solver::Visibility;
 
 mod verbatim_module_syntax;
 
@@ -709,8 +709,6 @@ impl<'a> CheckerState<'a> {
         &mut self,
         call: &tsz_parser::parser::node::CallExprData,
     ) -> tsz_solver::TypeId {
-        use tsz_solver::PropertyInfo;
-
         // Get the first argument (module specifier)
         let args = match call.arguments.as_ref() {
             Some(a) => a.nodes.as_slice(),
@@ -756,7 +754,7 @@ impl<'a> CheckerState<'a> {
             let ordered_exports = self.ordered_namespace_export_entries(&exports_table);
 
             // Create an object type with all module exports
-            let mut props: Vec<PropertyInfo> = Vec::new();
+            let mut props: Vec<tsz_solver::PropertyInfo> = Vec::new();
             for &(name, export_sym_id) in &ordered_exports {
                 if name == "export=" {
                     continue;
@@ -768,22 +766,11 @@ impl<'a> CheckerState<'a> {
                     props.len() as u32 + 2
                 };
                 let name_atom = self.ctx.types.intern_string(name);
-                props.push(PropertyInfo {
-                    name: name_atom,
-                    type_id: prop_type,
-                    write_type: prop_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: None,
+                props.push(declaration_exports::declaration_export_property(
+                    name_atom,
+                    prop_type,
                     declaration_order,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                });
+                ));
             }
 
             // Merge module augmentations
@@ -804,26 +791,17 @@ impl<'a> CheckerState<'a> {
                     // Check if this augments an existing export
                     if let Some(existing) = props.iter_mut().find(|p| p.name == name_atom) {
                         // Merge types - for interfaces, this creates an intersection
-                        existing.type_id = self.ctx.types.intersection2(existing.type_id, aug_type);
+                        existing.type_id = declaration_exports::module_export_augmented_type(
+                            self.ctx.types,
+                            existing.type_id,
+                            aug_type,
+                        );
                         existing.write_type = existing.type_id;
                     } else {
                         // New export from augmentation
-                        props.push(PropertyInfo {
-                            name: name_atom,
-                            type_id: aug_type,
-                            write_type: aug_type,
-                            optional: false,
-                            readonly: false,
-                            is_method: false,
-                            is_class_prototype: false,
-                            visibility: Visibility::Public,
-                            parent_id: None,
-                            declaration_order: 0,
-                            is_string_named: false,
-                            is_symbol_named: false,
-                            single_quoted_name: false,
-                            non_widening: false,
-                        });
+                        props.push(declaration_exports::declaration_export_property(
+                            name_atom, aug_type, 0,
+                        ));
                     }
                 }
             }
@@ -836,28 +814,17 @@ impl<'a> CheckerState<'a> {
             {
                 let default_atom = self.ctx.types.intern_string("default");
                 if !props.iter().any(|p| p.name == default_atom) {
-                    props.push(PropertyInfo {
-                        name: default_atom,
-                        type_id: eq_type,
-                        write_type: eq_type,
-                        optional: false,
-                        readonly: false,
-                        is_method: false,
-                        is_class_prototype: false,
-                        visibility: Visibility::Public,
-                        parent_id: None,
-                        declaration_order: 1,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                    props.push(declaration_exports::declaration_export_property(
+                        default_atom,
+                        eq_type,
+                        1,
+                    ));
                 }
             }
 
             Self::normalize_namespace_export_declaration_order(&mut props);
-            let factory = self.ctx.types.factory();
-            let module_type = factory.object(props);
+            let module_type =
+                declaration_exports::dynamic_import_module_object_type(self.ctx.types, props);
             let display_module_name =
                 self.resolve_namespace_display_module_name(&exports_table, module_name);
             self.ctx
@@ -885,8 +852,6 @@ impl<'a> CheckerState<'a> {
         // Resolve Promise as Lazy(DefId), the same form that type annotations use.
         // `var p: Promise<T>` goes through create_lazy_type_ref → Application(Lazy(DefId), [T]).
         // We must do the same here so that `import()` returns a structurally compatible type.
-        let factory = self.ctx.types.factory();
-
         if let Some(sym_id) = self.ctx.lib_promise_sym_id() {
             let _ = self.get_type_of_symbol(sym_id);
             // Ensure the Promise DefId has its type parameters and body registered
@@ -897,11 +862,19 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .lib_promise_type_ref()
                 .unwrap_or_else(|| self.ctx.create_lazy_type_ref(sym_id));
-            return factory.application(promise_base, vec![inner_type]);
+            return declaration_exports::dynamic_import_promise_type(
+                self.ctx.types,
+                promise_base,
+                inner_type,
+            );
         }
 
         // Fallback: use synthetic PROMISE_BASE (works without lib files)
-        factory.application(TypeId::PROMISE_BASE, vec![inner_type])
+        declaration_exports::dynamic_import_promise_type(
+            self.ctx.types,
+            TypeId::PROMISE_BASE,
+            inner_type,
+        )
     }
 
     /// Check `export { x };` (local named exports)

--- a/crates/tsz-checker/src/declarations/namespace_checker.rs
+++ b/crates/tsz-checker/src/declarations/namespace_checker.rs
@@ -1,6 +1,7 @@
 //! Namespace type merging and re-export resolution for declaration merging.
 
 use crate::query_boundaries::class_type as query;
+use crate::query_boundaries::declaration_exports;
 use crate::query_boundaries::type_construction;
 use crate::state::{CheckerState, EnumKind};
 use std::sync::Arc;
@@ -9,7 +10,7 @@ use tsz_common::interner::Atom;
 use tsz_parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{TypeId, Visibility};
+use tsz_solver::TypeId;
 
 /// Maximum recursion depth for namespace export merging.
 ///
@@ -142,7 +143,6 @@ impl<'a> CheckerState<'a> {
         check_prototype: bool,
     ) {
         use tsz_common::diagnostics::diagnostic_codes;
-        use tsz_solver::PropertyInfo;
 
         let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
             return;
@@ -227,22 +227,7 @@ impl<'a> CheckerState<'a> {
 
             props.insert(
                 name_atom,
-                PropertyInfo {
-                    name: name_atom,
-                    type_id,
-                    write_type: type_id,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: None,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                },
+                declaration_exports::declaration_export_property(name_atom, type_id, 0),
             );
         }
     }
@@ -256,11 +241,10 @@ impl<'a> CheckerState<'a> {
                 == 0;
 
         if is_pure_namespace || self.ctx.is_declaration_file() {
-            return self
-                .ctx
-                .types
-                .factory()
-                .lazy(self.ctx.get_or_create_def_id(member_id));
+            return declaration_exports::declaration_lazy_export_type(
+                self.ctx.types,
+                self.ctx.get_or_create_def_id(member_id),
+            );
         }
 
         // For merged INTERFACE+VARIABLE symbols (e.g., `export interface Point { ... }`
@@ -288,8 +272,6 @@ impl<'a> CheckerState<'a> {
     /// By constructing a real `Object { prop: type, ... }` type we give the solver
     /// concrete structural types it can compare property-by-property.
     pub(crate) fn build_namespace_object_type(&mut self, sym_id: SymbolId) -> TypeId {
-        use tsz_solver::PropertyInfo;
-
         // For namespace+interface merged symbols, skip the symbol_instance_types
         // cache. It may contain the INTERFACE type (from type-position resolution
         // like `x: Point`) which is the wrong type for the namespace VALUE side.
@@ -319,13 +301,13 @@ impl<'a> CheckerState<'a> {
             return self.get_type_of_symbol(sym_id);
         };
         let Some(exports) = symbol.exports.as_ref().cloned() else {
-            return self.ctx.types.factory().object(vec![]);
+            return declaration_exports::empty_namespace_object_type(self.ctx.types);
         };
 
-        let placeholder = self.ctx.types.factory().object(vec![]);
+        let placeholder = declaration_exports::namespace_object_placeholder_type(self.ctx.types);
         self.ctx.symbol_instance_types.insert(sym_id, placeholder);
         self.ctx.symbol_resolution_depth.set(depth + 1);
-        let mut props: Vec<PropertyInfo> = Vec::new();
+        let mut props: Vec<tsz_solver::PropertyInfo> = Vec::new();
         for (name, member_id) in self.ordered_namespace_export_entries(&exports) {
             if self.ctx.symbol_resolution_set.contains(&member_id) {
                 continue;
@@ -383,32 +365,18 @@ impl<'a> CheckerState<'a> {
                 props.len() as u32 + 2
             };
             let name_atom = self.ctx.types.intern_string(name);
-            props.push(PropertyInfo {
-                name: name_atom,
-                type_id: member_type,
-                write_type: member_type,
-                optional: false,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
+            props.push(declaration_exports::declaration_export_property(
+                name_atom,
+                member_type,
                 declaration_order,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+            ));
         }
         self.ctx.symbol_resolution_depth.set(depth);
         Self::normalize_namespace_export_declaration_order(&mut props);
         // Preserve the namespace's SymbolId so the type formatter displays the
         // value surface as `typeof M` instead of expanding its object shape.
-        let namespace_type = self
-            .ctx
-            .types
-            .factory()
-            .object_with_symbol(props, Some(sym_id));
+        let namespace_type =
+            declaration_exports::namespace_object_type(self.ctx.types, props, sym_id);
         self.ctx
             .symbol_instance_types
             .insert(sym_id, namespace_type);
@@ -510,7 +478,6 @@ impl<'a> CheckerState<'a> {
         ctor_type: TypeId,
     ) -> TypeId {
         use rustc_hash::FxHashMap;
-        use tsz_solver::CallableShape;
 
         // Check recursion depth to prevent stack overflow
         let depth = self.ctx.symbol_resolution_depth.get();
@@ -535,15 +502,12 @@ impl<'a> CheckerState<'a> {
         // `typeof C` (the value+namespace identity) instead of expanding the
         // structural shape. tsc displays a class merged with a namespace as
         // `typeof C`.
-        self.ctx.types.factory().callable(CallableShape {
-            call_signatures: shape.call_signatures.clone(),
-            construct_signatures: shape.construct_signatures.clone(),
+        declaration_exports::namespace_merged_constructor_callable_type(
+            self.ctx.types,
+            &shape,
             properties,
-            string_index: shape.string_index,
-            number_index: shape.number_index,
-            symbol: Some(sym_id),
-            is_abstract: false,
-        })
+            sym_id,
+        )
     }
 
     /// Merge namespace exports into a function type for function+namespace merging.
@@ -565,7 +529,6 @@ impl<'a> CheckerState<'a> {
         function_type: TypeId,
     ) -> (TypeId, Vec<tsz_solver::TypeParamInfo>) {
         use rustc_hash::FxHashMap;
-        use tsz_solver::CallableShape;
 
         // Get a unified CallableShape for the function type.
         // Solver query handles both Callable (overloaded) and Function (single-signature)
@@ -586,16 +549,11 @@ impl<'a> CheckerState<'a> {
         self.merge_exports_into_props(sym_id, &mut props, false);
 
         let properties = props.into_values().collect();
-        let factory = self.ctx.types.factory();
-        let merged_type = factory.callable(CallableShape {
-            call_signatures: shape.call_signatures.clone(),
-            construct_signatures: shape.construct_signatures.clone(),
+        let merged_type = declaration_exports::namespace_merged_function_callable_type(
+            self.ctx.types,
+            &shape,
             properties,
-            string_index: shape.string_index,
-            number_index: shape.number_index,
-            symbol: None,
-            is_abstract: false,
-        });
+        );
 
         (merged_type, Vec::new())
     }
@@ -839,10 +797,10 @@ impl<'a> CheckerState<'a> {
                 && !member_symbol.has_any_flags(symbol_flags::CLASS | symbol_flags::FUNCTION);
 
             let mut type_id = if is_pure_namespace {
-                self.ctx
-                    .types
-                    .factory()
-                    .lazy(self.ctx.get_or_create_def_id(*member_id))
+                declaration_exports::declaration_lazy_export_type(
+                    self.ctx.types,
+                    self.ctx.get_or_create_def_id(*member_id),
+                )
             } else {
                 self.get_type_of_symbol(*member_id)
             };
@@ -876,22 +834,11 @@ impl<'a> CheckerState<'a> {
                 }
             }
             let name_atom = self.ctx.types.intern_string(name);
-            props.entry(name_atom).or_insert(PropertyInfo {
-                name: name_atom,
-                type_id,
-                write_type: type_id,
-                optional: false,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: 0,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+            props
+                .entry(name_atom)
+                .or_insert(declaration_exports::declaration_export_property(
+                    name_atom, type_id, 0,
+                ));
         }
 
         let properties: Vec<PropertyInfo> = props.into_values().collect();

--- a/crates/tsz-checker/src/dispatch/jsx.rs
+++ b/crates/tsz-checker/src/dispatch/jsx.rs
@@ -4,6 +4,7 @@
 //! Handles `JSX_ELEMENT` children synthesis, contextual typing, and component-type resolution.
 
 use crate::context::TypingRequest;
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
@@ -167,22 +168,18 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                 let synthesized_type = if child_types.len() == 1 && !has_spread_child {
                     child_types[0]
                 } else if !has_spread_child {
-                    let elements = child_types
-                        .iter()
-                        .copied()
-                        .map(|type_id| tsz_solver::TupleElement {
-                            type_id,
-                            name: None,
-                            optional: false,
-                            rest: false,
-                        })
-                        .collect();
-                    self.checker.ctx.types.factory().tuple(elements)
+                    jsx_query::tuple_type_from_required_element_types(
+                        self.checker.ctx.types,
+                        child_types.to_vec(),
+                    )
                 } else {
                     // Multiple children: synthesize as an array type.
                     // tsc uses the union of all child types as the element type.
-                    let element_type = self.checker.ctx.types.factory().union(child_types.clone());
-                    self.checker.ctx.types.factory().array(element_type)
+                    let element_type = jsx_query::union_type_from_members(
+                        self.checker.ctx.types,
+                        child_types.clone(),
+                    );
+                    jsx_query::array_type_from_element(self.checker.ctx.types, element_type)
                 };
                 let normalized_child_count = if has_spread_child {
                     child_count.max(2)

--- a/crates/tsz-checker/src/error_reporter/assignability_contextual_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_contextual_display.rs
@@ -96,7 +96,8 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let display_app = self.ctx.types.factory().application(app.base, display_args);
+        let display_app =
+            query_diagnostics::display_application_type(self.ctx.types, app.base, display_args);
         Some(self.format_type_for_assignability_message(display_app))
     }
 }

--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -9,6 +9,7 @@ use crate::error_reporter::fingerprint_policy::{
     DiagnosticAnchorKind, DiagnosticRenderRequest, RelatedInformationPolicy,
 };
 use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::{CheckerState, MemberAccessLevel};
 use rustc_hash::FxHashMap;
 use tsz_parser::parser::NodeIndex;
@@ -92,7 +93,7 @@ impl<'a> CheckerState<'a> {
                 return source;
             }
 
-            let recovered = self.ctx.types.array(widened);
+            let recovered = diagnostic_query::display_array_type(self.ctx.types, widened);
             if recovered != source {
                 return recovered;
             }

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -494,29 +494,10 @@ impl<'a> CheckerState<'a> {
     }
 
     fn widen_object_property_literals_for_call_parameter_display(&mut self, ty: TypeId) -> TypeId {
-        let Some(shape) =
-            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty)
-        else {
-            return ty;
-        };
-        let mut widened_shape = shape.as_ref().clone();
-        let mut changed = false;
-        for prop in &mut widened_shape.properties {
-            let widened_read =
-                crate::query_boundaries::common::widen_literal_type(self.ctx.types, prop.type_id);
-            let widened_write = crate::query_boundaries::common::widen_literal_type(
-                self.ctx.types,
-                prop.write_type,
-            );
-            changed |= widened_read != prop.type_id || widened_write != prop.write_type;
-            prop.type_id = widened_read;
-            prop.write_type = widened_write;
-        }
-        if changed {
-            self.ctx.types.factory().object_with_index(widened_shape)
-        } else {
-            ty
-        }
+        crate::query_boundaries::diagnostics::shallow_object_property_literals_widened_for_call_parameter_display(
+            self.ctx.types,
+            ty,
+        )
     }
 
     pub(in crate::error_reporter::call_errors) fn property_access_call_parameter_annotation_display(

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -4,7 +4,7 @@ use crate::context::TypingRequest;
 use crate::query_boundaries::assignability::{
     get_function_return_type, replace_function_return_type,
 };
-use crate::query_boundaries::common as query_common;
+use crate::query_boundaries::{common as query_common, diagnostics as query_diagnostics};
 use crate::state::CheckerState;
 use crate::symbol_resolver::TypeSymbolResolution;
 use rustc_hash::FxHashMap;
@@ -808,7 +808,10 @@ impl<'a> CheckerState<'a> {
             return match property_types.as_slice() {
                 [] => None,
                 [single] => Some(*single),
-                _ => Some(self.ctx.types.factory().union(property_types)),
+                _ => Some(query_diagnostics::display_union_type(
+                    self.ctx.types,
+                    property_types,
+                )),
             };
         }
 
@@ -854,7 +857,10 @@ impl<'a> CheckerState<'a> {
             return match property_types.as_slice() {
                 [] => None,
                 [single] => Some(*single),
-                _ => Some(self.ctx.types.factory().union(property_types)),
+                _ => Some(query_diagnostics::display_union_type(
+                    self.ctx.types,
+                    property_types,
+                )),
             };
         }
 
@@ -914,7 +920,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let key_literal = self.ctx.types.literal_string(prop_name);
+        let key_literal = query_diagnostics::display_string_literal_type(self.ctx.types, prop_name);
         let mut display_type =
             crate::query_boundaries::state::checking::instantiate_mapped_template_for_property(
                 self.ctx.types,
@@ -944,7 +950,11 @@ impl<'a> CheckerState<'a> {
                             || crate::query_boundaries::class_type::type_includes_undefined(
                                 self.ctx.types,
                                 self.evaluate_type_with_env(
-                                    self.ctx.types.factory().index_access(member, index_type),
+                                    query_diagnostics::display_index_access_type(
+                                        self.ctx.types,
+                                        member,
+                                        index_type,
+                                    ),
                                 ),
                             )
                     }))
@@ -957,7 +967,8 @@ impl<'a> CheckerState<'a> {
                     self.evaluate_type_with_env(display_type),
                 ))
         {
-            display_type = self.ctx.types.union2(display_type, TypeId::UNDEFINED);
+            display_type =
+                query_diagnostics::display_union_with_undefined(self.ctx.types, display_type);
         }
         Some(display_type)
     }
@@ -1045,10 +1056,16 @@ impl<'a> CheckerState<'a> {
                                 if members.contains(&TypeId::UNDEFINED) {
                                     p.type_id
                                 } else {
-                                    self.ctx.types.union2(p.type_id, TypeId::UNDEFINED)
+                                    query_diagnostics::display_union_with_undefined(
+                                        self.ctx.types,
+                                        p.type_id,
+                                    )
                                 }
                             } else {
-                                self.ctx.types.union2(p.type_id, TypeId::UNDEFINED)
+                                query_diagnostics::display_union_with_undefined(
+                                    self.ctx.types,
+                                    p.type_id,
+                                )
                             }
                         })
             });

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
@@ -90,7 +90,7 @@ impl<'a> CheckerState<'a> {
                 if kept.is_empty() {
                     return false;
                 }
-                self.ctx.types.factory().union_preserve_members(kept)
+                query_diagnostics::display_union_preserve_members_type(self.ctx.types, kept)
             }
             None => return false,
         };
@@ -309,15 +309,13 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let factory = self.ctx.types.factory();
-        let display_type = if is_rest {
-            let elem = factory.index_access(last_param.type_id, TypeId::NUMBER);
-            factory.array(elem)
-        } else {
-            let offset = index - rest_start;
-            let index_type = factory.literal_number(offset as f64);
-            factory.index_access(last_param.type_id, index_type)
-        };
+        let display_type = query_diagnostics::display_rest_parameter_type(
+            self.ctx.types,
+            last_param.type_id,
+            rest_start,
+            index,
+            is_rest,
+        );
         Some(self.format_type_for_assignability_message(display_type))
     }
 
@@ -557,7 +555,7 @@ impl<'a> CheckerState<'a> {
                 }) {
                 param_type
             } else {
-                self.ctx.types.union2(param_type, TypeId::UNDEFINED)
+                query_diagnostics::display_union_with_undefined(self.ctx.types, param_type)
             };
             let display = self.format_assignability_type_for_message(widened_param_type, arg_type);
             return self.strip_synthetic_optional_from_display_for_arg(display, arg_type);
@@ -657,9 +655,12 @@ impl<'a> CheckerState<'a> {
                     mapped_id,
                     &property_name,
                 )?;
-            let mut property = tsz_solver::PropertyInfo::new(name, type_id);
-            property.optional = mapped.optional_modifier == Some(tsz_solver::MappedModifier::Add);
-            property.readonly = mapped.readonly_modifier == Some(tsz_solver::MappedModifier::Add);
+            let property = query_diagnostics::mapped_display_property(
+                name,
+                type_id,
+                mapped.optional_modifier,
+                mapped.readonly_modifier,
+            );
             properties.push(property);
         }
 
@@ -774,7 +775,7 @@ impl<'a> CheckerState<'a> {
             }) {
             param_type
         } else {
-            self.ctx.types.union2(param_type, TypeId::UNDEFINED)
+            query_diagnostics::display_union_with_undefined(self.ctx.types, param_type)
         };
 
         Some(self.format_type_for_assignability_message(widened))

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
@@ -663,7 +663,10 @@ impl<'a> CheckerState<'a> {
             properties.push(property);
         }
 
-        Some(self.ctx.types.factory().object(properties))
+        Some(query_diagnostics::object_type_from_properties(
+            self.ctx.types,
+            properties,
+        ))
     }
 
     fn simple_function_call_parameter_annotation_display(

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -4,6 +4,7 @@ use crate::context::TypingRequest;
 use crate::context::speculation::FullSpeculationSnapshot;
 use crate::diagnostics::diagnostic_codes;
 use crate::query_boundaries::common as query_common;
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -195,42 +196,8 @@ impl<'a> CheckerState<'a> {
         let evaluated_arg = self.evaluate_type_for_assignability(arg_type);
         let arg_shape =
             crate::query_boundaries::common::object_shape_for_type(self.ctx.types, evaluated_arg)?;
-        if arg_shape.properties.is_empty()
-            && arg_shape.string_index.is_none()
-            && arg_shape.number_index.is_none()
-        {
-            return None;
-        }
-
-        let mut unknown_properties = Vec::with_capacity(arg_shape.properties.len());
-        for prop in &arg_shape.properties {
-            let mut unknown_prop = tsz_solver::PropertyInfo::new(prop.name, TypeId::UNKNOWN);
-            unknown_prop.optional = prop.optional;
-            unknown_prop.readonly = prop.readonly;
-            unknown_properties.push(unknown_prop);
-        }
-        let unknown_object = if arg_shape.string_index.is_some() || arg_shape.number_index.is_some()
-        {
-            let unknown_shape = tsz_solver::ObjectShape {
-                properties: unknown_properties,
-                string_index: arg_shape.string_index.as_ref().map(|sig| {
-                    tsz_solver::IndexSignature {
-                        value_type: TypeId::UNKNOWN,
-                        ..*sig
-                    }
-                }),
-                number_index: arg_shape.number_index.as_ref().map(|sig| {
-                    tsz_solver::IndexSignature {
-                        value_type: TypeId::UNKNOWN,
-                        ..*sig
-                    }
-                }),
-                ..Default::default()
-            };
-            self.ctx.types.factory().object_with_index(unknown_shape)
-        } else {
-            self.ctx.types.factory().object(unknown_properties)
-        };
+        let unknown_object =
+            diagnostic_query::object_type_with_unknown_display_members(self.ctx.types, &arg_shape)?;
 
         let evaluated_param = self.evaluate_type_for_assignability(param_type);
         let mut current = arg_idx;

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -1,5 +1,6 @@
 //! Array-literal mismatch elaboration helpers for call errors.
 
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
@@ -24,7 +25,10 @@ impl<'a> CheckerState<'a> {
             // elaboration would emit TS2322 on `let x: [string, number?] =
             // ["foo", undefined]` even though tsc accepts it.
             if element.optional {
-                return Some(self.ctx.types.union2(element.type_id, TypeId::UNDEFINED));
+                return Some(diagnostic_query::display_union_with_undefined(
+                    self.ctx.types,
+                    element.type_id,
+                ));
             }
             return Some(element.type_id);
         }

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -632,19 +632,13 @@ impl<'a> CheckerState<'a> {
             return None;
         };
 
-        let mut property = tsz_solver::PropertyInfo::new(*property_name, *target_property_type);
-        property.optional = Self::type_includes_undefined(self.ctx.types, *target_property_type);
-        let display_type = self.ctx.types.factory().object(vec![property]);
+        let display_type =
+            crate::query_boundaries::diagnostics::mapped_property_mismatch_parameter_display_type(
+                self.ctx.types,
+                *property_name,
+                *target_property_type,
+            );
         Some(self.format_type_for_assignability_message(display_type))
-    }
-
-    fn type_includes_undefined(
-        db: &dyn tsz_solver::construction::TypeDatabase,
-        ty: TypeId,
-    ) -> bool {
-        ty == TypeId::UNDEFINED
-            || crate::query_boundaries::common::union_members(db, ty)
-                .is_some_and(|members| members.contains(&TypeId::UNDEFINED))
     }
 
     /// Report an argument count mismatch error using solver diagnostics with source tracking.

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1293,19 +1293,11 @@ impl<'a> CheckerState<'a> {
                             ..*value_param
                         })
                         .collect();
-                    let merged = self
-                        .ctx
-                        .types
-                        .factory()
-                        .function(tsz_solver::FunctionShape {
-                            type_params: value_shape.type_params.clone(),
-                            params: merged_params,
-                            this_type: value_shape.this_type,
-                            return_type: value_shape.return_type,
-                            type_predicate: value_shape.type_predicate,
-                            is_constructor: value_shape.is_constructor,
-                            is_method: value_shape.is_method,
-                        });
+                    let merged = diagnostic_query::function_type_with_params_replaced(
+                        self.ctx.types,
+                        &value_shape,
+                        merged_params,
+                    );
                     Some(merged)
                 })
                 .unwrap_or(value_type);

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -4,6 +4,7 @@
 //! file under the LOC ceiling. Pure file-organization move; no logic changes.
 
 use super::literal_widening_helpers::literal_display_appropriate_for_undefined_null_target;
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
@@ -1866,10 +1867,10 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let recovered = self
-            .ctx
-            .types
-            .array(self.widen_type_for_display(element_type));
+        let recovered = diagnostic_query::display_array_type(
+            self.ctx.types,
+            self.widen_type_for_display(element_type),
+        );
         Some(self.format_assignability_type_for_message(recovered, target))
     }
 

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/collection_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/collection_source_display.rs
@@ -121,17 +121,11 @@ impl<'a> CheckerState<'a> {
                 element_type,
             ),
         );
-        let rebuilt = self.ctx.types.array(widened_element);
-        // Preserve the readonly modifier: tsc displays `readonly number[]` not `number[]`
-        // when the source type was a readonly array (ReadonlyType(Array(...))).
-        let rebuilt = if crate::query_boundaries::type_computation::complex::is_readonly_type(
+        let rebuilt = diagnostic_query::rebuilt_array_source_display_type(
             self.ctx.types,
             source_type,
-        ) {
-            self.ctx.types.readonly_type(rebuilt)
-        } else {
-            rebuilt
-        };
+            widened_element,
+        );
         Some(self.format_assignability_type_for_message(rebuilt, target))
     }
 

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/computed_index_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/computed_index_source_display.rs
@@ -58,11 +58,10 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let value_type = if computed_value_types.len() == 1 {
-            computed_value_types[0]
-        } else {
-            self.ctx.types.factory().union(computed_value_types)
-        };
+        let value_type = crate::query_boundaries::diagnostics::source_display_union_type(
+            self.ctx.types,
+            computed_value_types,
+        );
         let value_display = self.format_type_for_assignability_message(value_type);
         Some(format!("{{ [x: {key_kind}]: {value_display}; }}"))
     }

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/contextual_index_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/contextual_index_display.rs
@@ -42,10 +42,10 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         let key_kind = contextual_index_key_kind?;
-        let value_type = match contextual_index_value_types.as_slice() {
-            [single] => *single,
-            _ => self.ctx.types.factory().union(contextual_index_value_types),
-        };
+        let value_type = crate::query_boundaries::diagnostics::source_display_union_type(
+            self.ctx.types,
+            contextual_index_value_types,
+        );
         let value_display = self.format_type_for_assignability_message(value_type);
         Some(format!("{{ [x: {key_kind}]: {value_display}; }}"))
     }

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_targets.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_targets.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -137,8 +138,9 @@ impl<'a> CheckerState<'a> {
                         target,
                     )
                 {
-                    raw_call_param_property_target =
-                        Some(self.ctx.types.union2(target, TypeId::UNDEFINED));
+                    raw_call_param_property_target = Some(
+                        diagnostic_query::display_union_with_undefined(self.ctx.types, target),
+                    );
                 }
             }
         }
@@ -315,14 +317,14 @@ impl<'a> CheckerState<'a> {
 
         let shared_index = shared_index?;
         let combined_object =
-            tsz_solver::utils::intersection_or_single(self.ctx.types, object_members);
-        let mut combined = self
-            .ctx
-            .types
-            .factory()
-            .index_access(combined_object, shared_index);
+            diagnostic_query::display_intersection_or_single_type(self.ctx.types, object_members);
+        let mut combined = diagnostic_query::display_index_access_type(
+            self.ctx.types,
+            combined_object,
+            shared_index,
+        );
         if has_optional_property && self.ctx.strict_null_checks() {
-            combined = self.ctx.types.union2(combined, TypeId::UNDEFINED);
+            combined = diagnostic_query::display_union_with_undefined(self.ctx.types, combined);
         }
 
         Some(self.format_type_for_assignability_message(combined))

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
@@ -326,10 +326,8 @@ impl<'a> CheckerState<'a> {
         let mut properties = Vec::with_capacity(shape.properties.len());
         for prop in &shape.properties {
             let prop_type = self.typebox_schema_static_type(prop.type_id, depth + 1)?;
-            let mut static_prop = tsz_solver::PropertyInfo::new(prop.name, prop_type);
-            static_prop.optional = prop.optional;
-            static_prop.readonly = prop.readonly;
-            static_prop.declaration_order = prop.declaration_order;
+            let static_prop =
+                diagnostic_query::static_schema_display_property_from_source(prop, prop_type);
             properties.push(static_prop);
         }
         Some(diagnostic_query::object_type_from_properties(
@@ -485,7 +483,7 @@ impl<'a> CheckerState<'a> {
         let element_type = self.evaluate_type_for_assignability(element_type);
         let element_type = self.widen_type_for_display(element_type);
         let element_type = self.normalize_assignability_display_type(element_type);
-        self.ctx.types.array(element_type)
+        diagnostic_query::display_array_type(self.ctx.types, element_type)
     }
 
     fn format_static_schema_array_structural_type(

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
@@ -332,7 +332,10 @@ impl<'a> CheckerState<'a> {
             static_prop.declaration_order = prop.declaration_order;
             properties.push(static_prop);
         }
-        Some(self.ctx.types.factory().object(properties))
+        Some(diagnostic_query::object_type_from_properties(
+            self.ctx.types,
+            properties,
+        ))
     }
 
     fn rewrite_nested_static_projection_members(
@@ -362,7 +365,7 @@ impl<'a> CheckerState<'a> {
             }
             properties.push(next);
         }
-        changed.then(|| self.ctx.types.factory().object(properties))
+        changed.then(|| diagnostic_query::object_type_from_properties(self.ctx.types, properties))
     }
 
     fn schema_property_type(&mut self, schema_type: TypeId, property: &str) -> Option<TypeId> {

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/tuple_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/tuple_source_display.rs
@@ -260,7 +260,6 @@ impl<'a> CheckerState<'a> {
             }
             per_member.push(elements);
         }
-        let factory = self.ctx.types.factory();
         // Precompute optional flags to avoid an O(members) scan per position.
         let optional_at: Vec<bool> = (0..arity)
             .map(|pos| per_member.iter().any(|e| e[pos].optional))
@@ -271,11 +270,11 @@ impl<'a> CheckerState<'a> {
         for position in 0..arity {
             type_ids_buf.clear();
             type_ids_buf.extend(per_member.iter().map(|elems| elems[position].type_id));
-            let union_type = if type_ids_buf.len() == 1 {
-                type_ids_buf[0]
-            } else {
-                factory.union_from_slice(&type_ids_buf)
-            };
+            let union_type =
+                crate::query_boundaries::diagnostics::source_display_union_type_from_slice(
+                    self.ctx.types,
+                    &type_ids_buf,
+                );
             result.push(tsz_solver::TupleElement {
                 type_id: union_type,
                 name: None,

--- a/crates/tsz-checker/src/error_reporter/core/excess_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/excess_display.rs
@@ -340,7 +340,7 @@ impl<'a> CheckerState<'a> {
         }
 
         Some(if changed {
-            self.ctx.types.factory().object_with_index(normalized)
+            query::object_type_from_shape(self.ctx.types, normalized)
         } else {
             ty
         })
@@ -385,7 +385,7 @@ impl<'a> CheckerState<'a> {
             index.readonly = false;
         }
 
-        let normalized_ty = self.ctx.types.factory().object_with_index(normalized);
+        let normalized_ty = query::object_type_from_shape(self.ctx.types, normalized);
         if let Some(props) = display_props {
             let mut props = props.as_ref().clone();
             for prop in &mut props {
@@ -442,7 +442,7 @@ impl<'a> CheckerState<'a> {
             prop.write_type = write;
         }
         if changed {
-            self.ctx.types.factory().object_with_index(normalized)
+            query::object_type_from_shape(self.ctx.types, normalized)
         } else {
             ty
         }
@@ -549,7 +549,7 @@ impl<'a> CheckerState<'a> {
         }
 
         if changed {
-            self.ctx.types.factory().object_with_index(normalized)
+            query::object_type_from_shape(self.ctx.types, normalized)
         } else {
             ty
         }

--- a/crates/tsz-checker/src/error_reporter/core/excess_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/excess_display.rs
@@ -77,7 +77,7 @@ impl<'a> CheckerState<'a> {
                 if object_like.len() == 1 {
                     return object_like[0];
                 }
-                return tsz_solver::utils::union_or_single(self.ctx.types, object_like);
+                return query::display_union_or_single_type(self.ctx.types, object_like);
             }
         }
         ty
@@ -564,7 +564,7 @@ impl<'a> CheckerState<'a> {
         // overflow the stack while narrowing an excess-property function
         // parameter for display (issue #12455).
         let _display_guard = super::type_display::DisplayRecursionGuard::enter()?;
-        let key_type = self.ctx.types.literal_string_atom(prop_name);
+        let key_type = query::display_string_literal_atom_type(self.ctx.types, prop_name);
         if let Some(app) = crate::query_boundaries::common::type_application(self.ctx.types, ty) {
             let mut changed = false;
             let args = app
@@ -581,7 +581,8 @@ impl<'a> CheckerState<'a> {
                     }
                 })
                 .collect::<Vec<_>>();
-            return changed.then(|| self.ctx.types.factory().application(app.base, args));
+            return changed
+                .then(|| query::display_application_type(self.ctx.types, app.base, args));
         }
 
         let members = crate::query_boundaries::common::union_members(self.ctx.types, ty)?;
@@ -603,7 +604,7 @@ impl<'a> CheckerState<'a> {
             })
             .collect::<Vec<_>>();
         (!narrowed.is_empty() && narrowed.len() < members.len())
-            .then(|| tsz_solver::utils::union_or_single(self.ctx.types, narrowed))
+            .then(|| query::display_union_or_single_type(self.ctx.types, narrowed))
     }
 
     pub(in crate::error_reporter) fn normalize_assignability_union_display_order(

--- a/crates/tsz-checker/src/error_reporter/core/identifier_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/identifier_source_display.rs
@@ -146,11 +146,10 @@ impl<'a> CheckerState<'a> {
                     .into_iter()
                     .map(|ty| self.widen_type_for_display(ty))
                     .collect::<Vec<_>>();
-                let value_type = if widened_types.len() == 1 {
-                    widened_types[0]
-                } else {
-                    self.ctx.types.factory().union(widened_types)
-                };
+                let value_type = crate::query_boundaries::diagnostics::source_display_union_type(
+                    self.ctx.types,
+                    widened_types,
+                );
                 let display = self.format_assignability_type_for_message(value_type, target);
                 format!("{name}: {display}")
             })

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -172,13 +172,13 @@ impl<'a> CheckerState<'a> {
 
     fn param_matches_property_key_literal(&self, prop_name: Atom, ty: TypeId) -> bool {
         let prop_name = self.ctx.types.resolve_atom_ref(prop_name);
-        if self.ctx.types.literal_string(prop_name.as_ref()) == ty {
+        if query::display_string_literal_type(self.ctx.types, prop_name.as_ref()) == ty {
             return true;
         }
         prop_name
             .parse::<f64>()
             .ok()
-            .is_some_and(|num| self.ctx.types.literal_number(num) == ty)
+            .is_some_and(|num| query::display_number_literal_type(self.ctx.types, num) == ty)
     }
 
     fn normalize_excess_display_type_for_property(
@@ -419,7 +419,7 @@ impl<'a> CheckerState<'a> {
         if args == app.args {
             ty
         } else {
-            self.ctx.types.factory().application(app.base, args)
+            query::display_application_type(self.ctx.types, app.base, args)
         }
     }
 
@@ -449,7 +449,7 @@ impl<'a> CheckerState<'a> {
             return if args == app.args {
                 ty
             } else {
-                self.ctx.types.factory().application(app.base, args)
+                query::display_application_type(self.ctx.types, app.base, args)
             };
         }
 
@@ -461,7 +461,7 @@ impl<'a> CheckerState<'a> {
             return if normalized == members {
                 ty
             } else {
-                self.ctx.types.factory().union_preserve_members(normalized)
+                query::display_union_preserve_members_type(self.ctx.types, normalized)
             };
         }
 
@@ -473,7 +473,7 @@ impl<'a> CheckerState<'a> {
             return if normalized == members {
                 ty
             } else {
-                self.ctx.types.factory().intersection(normalized)
+                query::display_intersection_type(self.ctx.types, normalized)
             };
         }
 
@@ -575,7 +575,7 @@ impl<'a> CheckerState<'a> {
             if args == app.args {
                 ty
             } else {
-                self.ctx.types.factory().application(app.base, args)
+                query::display_application_type(self.ctx.types, app.base, args)
             }
         } else if let Some(shape) = query::function_shape(self.ctx.types, ty) {
             let params: Vec<_> = shape
@@ -600,14 +600,16 @@ impl<'a> CheckerState<'a> {
                 )
             }
         } else if let Some(members) = query::union_members(self.ctx.types, ty) {
-            self.ctx.types.factory().union_preserve_members(
+            query::display_union_preserve_members_type(
+                self.ctx.types,
                 members
                     .iter()
                     .map(|&member| self.normalize_excess_display_type(member))
                     .collect(),
             )
         } else if let Some(members) = query::intersection_members(self.ctx.types, ty) {
-            self.ctx.types.factory().intersection(
+            query::display_intersection_type(
+                self.ctx.types,
                 members
                     .iter()
                     .map(|&member| self.normalize_excess_display_type(member))
@@ -788,7 +790,7 @@ impl<'a> CheckerState<'a> {
                 if normalized == members {
                     ty
                 } else {
-                    self.ctx.types.factory().union_preserve_members(normalized)
+                    query::display_union_preserve_members_type(self.ctx.types, normalized)
                 }
             } else if query::function_shape(self.ctx.types, ty).is_some_and(|shape| {
                 crate::query_boundaries::common::is_conditional_type(
@@ -836,7 +838,7 @@ impl<'a> CheckerState<'a> {
                     if args == app.args {
                         evaluated
                     } else {
-                        self.ctx.types.factory().application(app.base, args)
+                        query::display_application_type(self.ctx.types, app.base, args)
                     }
                 } else if let Some(shape) = query::function_shape(self.ctx.types, evaluated) {
                     let mut params = Vec::with_capacity(shape.params.len());
@@ -990,7 +992,7 @@ impl<'a> CheckerState<'a> {
                             return evaluated;
                         }
                     }
-                    self.ctx.types.factory().union_preserve_members(normalized)
+                    query::display_union_preserve_members_type(self.ctx.types, normalized)
                 } else if let Some(members) = query::intersection_members(self.ctx.types, evaluated)
                 {
                     let mut normalized = Vec::with_capacity(members.len());
@@ -1005,7 +1007,7 @@ impl<'a> CheckerState<'a> {
                             return evaluated;
                         }
                     }
-                    self.ctx.types.factory().intersection(normalized)
+                    query::display_intersection_type(self.ctx.types, normalized)
                 } else {
                     evaluated
                 }
@@ -1026,7 +1028,7 @@ impl<'a> CheckerState<'a> {
             if normalized == members {
                 ty
             } else {
-                self.ctx.types.factory().union_preserve_members(normalized)
+                query::display_union_preserve_members_type(self.ctx.types, normalized)
             }
         } else if let Some(app) = query::type_application(self.ctx.types, ty) {
             if query::preserves_named_application_base(self.ctx.types, app.base) {
@@ -1045,7 +1047,7 @@ impl<'a> CheckerState<'a> {
                 if args == app.args {
                     ty
                 } else {
-                    self.ctx.types.factory().application(app.base, args)
+                    query::display_application_type(self.ctx.types, app.base, args)
                 }
             } else {
                 let evaluated =
@@ -1121,7 +1123,7 @@ impl<'a> CheckerState<'a> {
                 if args == app.args {
                     evaluated
                 } else {
-                    self.ctx.types.factory().application(app.base, args)
+                    query::display_application_type(self.ctx.types, app.base, args)
                 }
             } else if let Some(shape) = query::function_shape(self.ctx.types, evaluated) {
                 let mut params = Vec::with_capacity(shape.params.len());
@@ -1260,7 +1262,7 @@ impl<'a> CheckerState<'a> {
                         return evaluated;
                     }
                 }
-                self.ctx.types.factory().intersection(normalized)
+                query::display_intersection_type(self.ctx.types, normalized)
             } else {
                 evaluated
             }
@@ -1360,11 +1362,12 @@ impl<'a> CheckerState<'a> {
                         &property_name,
                     )?;
                 let type_id = self.normalize_excess_display_type_for_property(Some(name), type_id);
-                let mut property = tsz_solver::PropertyInfo::new(name, type_id);
-                property.optional =
-                    mapped.optional_modifier == Some(tsz_solver::MappedModifier::Add);
-                property.readonly =
-                    mapped.readonly_modifier == Some(tsz_solver::MappedModifier::Add);
+                let property = query::mapped_display_property(
+                    name,
+                    type_id,
+                    mapped.optional_modifier,
+                    mapped.readonly_modifier,
+                );
                 properties.push(property);
             }
 
@@ -1390,7 +1393,7 @@ impl<'a> CheckerState<'a> {
                     }
                 })
                 .collect();
-            changed.then(|| self.ctx.types.factory().intersection(remapped))
+            changed.then(|| query::display_intersection_type(self.ctx.types, remapped))
         } else if let Some(members) = query::union_members(self.ctx.types, ty) {
             let mut changed = false;
             let remapped: Vec<_> = members
@@ -1409,7 +1412,7 @@ impl<'a> CheckerState<'a> {
                     }
                 })
                 .collect();
-            changed.then(|| self.ctx.types.factory().union(remapped))
+            changed.then(|| query::display_union_type(self.ctx.types, remapped))
         } else {
             None
         }

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -233,18 +233,7 @@ impl<'a> CheckerState<'a> {
             if params.iter().zip(shape.params.iter()).all(|(a, b)| a == b) {
                 ty
             } else {
-                self.ctx
-                    .types
-                    .factory()
-                    .function(tsz_solver::FunctionShape {
-                        type_params: shape.type_params.clone(),
-                        params,
-                        this_type: shape.this_type,
-                        return_type: shape.return_type,
-                        type_predicate: shape.type_predicate,
-                        is_constructor: shape.is_constructor,
-                        is_method: shape.is_method,
-                    })
+                query::function_type_with_params_replaced(self.ctx.types, shape.as_ref(), params)
             }
         } else {
             ty
@@ -329,19 +318,11 @@ impl<'a> CheckerState<'a> {
             let widened_return =
                 self.widen_fresh_object_literal_properties_for_display(shape.return_type);
             if widened_return != shape.return_type {
-                widened = self
-                    .ctx
-                    .types
-                    .factory()
-                    .function(tsz_solver::FunctionShape {
-                        type_params: shape.type_params.clone(),
-                        params: shape.params.clone(),
-                        this_type: shape.this_type,
-                        return_type: widened_return,
-                        type_predicate: shape.type_predicate,
-                        is_constructor: shape.is_constructor,
-                        is_method: shape.is_method,
-                    });
+                widened = query::function_type_with_return_replaced(
+                    self.ctx.types,
+                    shape.as_ref(),
+                    widened_return,
+                );
             }
         } else if let Some(shape) =
             crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, widened)
@@ -367,7 +348,7 @@ impl<'a> CheckerState<'a> {
             }
 
             if changed {
-                widened = self.ctx.types.factory().callable(widened_shape);
+                widened = query::callable_type_from_shape(self.ctx.types, widened_shape);
             }
         }
         if let Some(def_id) = constructor_display_def {
@@ -411,7 +392,7 @@ impl<'a> CheckerState<'a> {
         if !changed {
             return ty;
         }
-        self.ctx.types.factory().object_with_index(widened_shape)
+        query::object_type_from_shape(self.ctx.types, widened_shape)
     }
 
     pub(in crate::error_reporter) fn normalize_property_receiver_application_display_type(
@@ -556,7 +537,7 @@ impl<'a> CheckerState<'a> {
         }
 
         if changed {
-            let new_ty = self.ctx.types.factory().object_with_index(normalized_shape);
+            let new_ty = query::object_type_from_shape(self.ctx.types, normalized_shape);
             if let Some(alias_origin) = self.ctx.types.get_display_alias(ty) {
                 let alias_origin =
                     self.normalize_property_receiver_application_display_type(alias_origin);
@@ -611,18 +592,12 @@ impl<'a> CheckerState<'a> {
             {
                 ty
             } else {
-                self.ctx
-                    .types
-                    .factory()
-                    .function(tsz_solver::FunctionShape {
-                        type_params: shape.type_params.clone(),
-                        params,
-                        this_type: shape.this_type,
-                        return_type,
-                        type_predicate: shape.type_predicate,
-                        is_constructor: shape.is_constructor,
-                        is_method: shape.is_method,
-                    })
+                query::function_type_with_params_and_return_replaced(
+                    self.ctx.types,
+                    shape.as_ref(),
+                    params,
+                    return_type,
+                )
             }
         } else if let Some(members) = query::union_members(self.ctx.types, ty) {
             self.ctx.types.factory().union_preserve_members(
@@ -916,18 +891,12 @@ impl<'a> CheckerState<'a> {
                     {
                         evaluated
                     } else {
-                        self.ctx
-                            .types
-                            .factory()
-                            .function(tsz_solver::FunctionShape {
-                                type_params: shape.type_params.clone(),
-                                params,
-                                this_type: shape.this_type,
-                                return_type,
-                                type_predicate: shape.type_predicate,
-                                is_constructor: shape.is_constructor,
-                                is_method: shape.is_method,
-                            })
+                        query::function_type_with_params_and_return_replaced(
+                            self.ctx.types,
+                            shape.as_ref(),
+                            params,
+                            return_type,
+                        )
                     }
                 } else if let Some(shape) = crate::query_boundaries::common::object_shape_for_type(
                     self.ctx.types,
@@ -982,14 +951,11 @@ impl<'a> CheckerState<'a> {
                         index.value_type = normalized;
                     }
                     if changed {
-                        let new_ty = self.ctx.types.factory().object_with_index(shape);
-                        if let Some(display_props) =
-                            self.ctx.types.get_display_properties(evaluated)
-                        {
-                            self.ctx
-                                .types
-                                .store_display_properties(new_ty, display_props.as_ref().clone());
-                        }
+                        let new_ty = query::object_type_preserving_display_properties(
+                            self.ctx.types,
+                            evaluated,
+                            shape,
+                        );
                         // Propagate display_alias so the formatter can still
                         // recover the named form (e.g., `Array<string>`) for
                         // types whose property types changed during normalization.
@@ -1202,18 +1168,12 @@ impl<'a> CheckerState<'a> {
                 {
                     evaluated
                 } else {
-                    self.ctx
-                        .types
-                        .factory()
-                        .function(tsz_solver::FunctionShape {
-                            type_params: shape.type_params.clone(),
-                            params,
-                            this_type: shape.this_type,
-                            return_type,
-                            type_predicate: shape.type_predicate,
-                            is_constructor: shape.is_constructor,
-                            is_method: shape.is_method,
-                        })
+                    query::function_type_with_params_and_return_replaced(
+                        self.ctx.types,
+                        shape.as_ref(),
+                        params,
+                        return_type,
+                    )
                 }
             } else if let Some(shape) =
                 crate::query_boundaries::common::object_shape_for_type(self.ctx.types, evaluated)
@@ -1267,12 +1227,11 @@ impl<'a> CheckerState<'a> {
                     index.value_type = normalized;
                 }
                 if changed {
-                    let new_ty = self.ctx.types.factory().object_with_index(shape);
-                    if let Some(display_props) = self.ctx.types.get_display_properties(evaluated) {
-                        self.ctx
-                            .types
-                            .store_display_properties(new_ty, display_props.as_ref().clone());
-                    }
+                    let new_ty = query::object_type_preserving_display_properties(
+                        self.ctx.types,
+                        evaluated,
+                        shape,
+                    );
                     // Propagate display_alias and def-store registration so the
                     // formatter can still show named types (Date, Error, etc.)
                     // after normalization modifies property types.
@@ -1357,8 +1316,8 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let named_obj = self.ctx.types.factory().object(named_props);
-        let wildcard_obj = self.ctx.types.factory().object(wildcard_props);
+        let named_obj = query::object_type_from_properties(self.ctx.types, named_props);
+        let wildcard_obj = query::object_type_from_properties(self.ctx.types, wildcard_props);
         Some(format!(
             "{} & {}",
             self.format_type_diagnostic(named_obj),
@@ -1409,7 +1368,10 @@ impl<'a> CheckerState<'a> {
                 properties.push(property);
             }
 
-            Some(self.ctx.types.factory().object(properties))
+            Some(query::object_type_from_properties(
+                self.ctx.types,
+                properties,
+            ))
         } else if let Some(members) = query::intersection_members(self.ctx.types, ty) {
             let mut changed = false;
             let remapped: Vec<_> = members

--- a/crates/tsz-checker/src/error_reporter/core_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core_alias_display.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
@@ -180,7 +181,12 @@ impl<'a> CheckerState<'a> {
         }
         let constraint = match param_info.constraint {
             Some(c) => c,
-            None => return Some(self.ctx.types.union2(cond.true_type, cond.false_type)),
+            None => {
+                return Some(diagnostic_query::display_union_type(
+                    self.ctx.types,
+                    vec![cond.true_type, cond.false_type],
+                ));
+            }
         };
         if crate::query_boundaries::assignability::is_fresh_subtype_of(
             db,
@@ -196,7 +202,10 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::assignability::is_fresh_subtype_of(db, m, constraint)
         });
         if has_overlap {
-            Some(self.ctx.types.union2(cond.true_type, cond.false_type))
+            Some(diagnostic_query::display_union_type(
+                self.ctx.types,
+                vec![cond.true_type, cond.false_type],
+            ))
         } else {
             None
         }

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -1,4 +1,5 @@
 //! Type formatting and diagnostic anchor helpers for error reporter.
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::{CheckerState, MemberAccessLevel};
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
@@ -1283,7 +1284,7 @@ impl<'a> CheckerState<'a> {
         // the source's base constraint is nullable.  Example:
         //   source `T & U` where constraints are `string | ... | undefined`
         //   target `string | null` must stay `string | null` (not `string`).
-        let other_base = crate::query_boundaries::diagnostics::get_base_constraint_for_display(
+        let other_base = diagnostic_query::get_base_constraint_for_display(
             self.ctx.types.as_type_database(),
             other,
         );

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -206,27 +206,7 @@ impl DiagnosticRenderRequest {
 
 impl<'a> CheckerState<'a> {
     fn widen_display_property_literals_for_related_info(&mut self, type_id: TypeId) -> TypeId {
-        if self.ctx.types.get_display_properties(type_id).is_none() {
-            return type_id;
-        }
-        let Some(shape) = query_common::object_shape_for_type(self.ctx.types, type_id) else {
-            return type_id;
-        };
-
-        let mut widened_shape = shape.as_ref().clone();
-        let mut changed = false;
-        for prop in &mut widened_shape.properties {
-            let widened_read = query_common::widen_literal_type(self.ctx.types, prop.type_id);
-            let widened_write = query_common::widen_literal_type(self.ctx.types, prop.write_type);
-            changed |= widened_read != prop.type_id || widened_write != prop.write_type;
-            prop.type_id = widened_read;
-            prop.write_type = widened_write;
-        }
-        if changed {
-            self.ctx.types.factory().object_with_index(widened_shape)
-        } else {
-            type_id
-        }
+        diagnostics::display_property_literals_widened_for_related_info(self.ctx.types, type_id)
     }
 
     /// Re-render an anonymous object display with its literal annotations

--- a/crates/tsz-checker/src/error_reporter/generics.rs
+++ b/crates/tsz-checker/src/error_reporter/generics.rs
@@ -7,13 +7,14 @@ use crate::query_boundaries::assignability::{
 };
 use crate::query_boundaries::common;
 use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{NodeAccess, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::CallSignature;
 use tsz_solver::TypeId;
-use tsz_solver::{CallSignature, CallableShape};
 
 impl<'a> CheckerState<'a> {
     fn widen_function_like_assertion_source(&self, type_id: TypeId) -> TypeId {
@@ -74,15 +75,12 @@ impl<'a> CheckerState<'a> {
                 .collect();
 
             if changed {
-                return self.ctx.types.callable(tsz_solver::CallableShape {
+                return diagnostic_query::callable_type_with_signatures_replaced(
+                    self.ctx.types,
+                    shape.as_ref(),
                     call_signatures,
                     construct_signatures,
-                    properties: shape.properties.clone(),
-                    string_index: shape.string_index,
-                    number_index: shape.number_index,
-                    symbol: shape.symbol,
-                    is_abstract: shape.is_abstract,
-                });
+                );
             }
         }
 
@@ -169,16 +167,9 @@ impl<'a> CheckerState<'a> {
         let prototype_symbol_name = prototype_symbol.escaped_name.as_str();
         let prototype_display = format!("{prototype_symbol_name}<any>");
         let call_return_type = call_sig.return_type;
-        let call_display =
-            self.format_type_for_assignability_message(self.ctx.types.callable(CallableShape {
-                call_signatures: vec![call_sig],
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            }));
+        let call_display = self.format_type_for_assignability_message(
+            diagnostic_query::call_only_callable_type(self.ctx.types, vec![call_sig]),
+        );
         let construct_display = format!(
             "{prototype_symbol_name}<{}>",
             self.format_type_for_assignability_message(call_return_type)
@@ -222,17 +213,9 @@ impl<'a> CheckerState<'a> {
 
         let symbol_name = symbol.escaped_name.as_str();
         let call_sig = &shape.call_signatures[0];
-        let call_display = self.format_type_for_assignability_message(self.ctx.types.callable(
-            tsz_solver::CallableShape {
-                call_signatures: vec![call_sig.clone()],
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            },
-        ));
+        let call_display = self.format_type_for_assignability_message(
+            diagnostic_query::call_only_callable_type(self.ctx.types, vec![call_sig.clone()]),
+        );
         let call_return_display = self.format_type_for_assignability_message(call_sig.return_type);
         let prototype_display = format!("{symbol_name}<any>");
         let construct_display = format!("{symbol_name}<{call_return_display}>");

--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -4,6 +4,7 @@ use crate::diagnostics::diagnostic_codes;
 use crate::error_reporter::fingerprint_policy::{DiagnosticAnchorKind, DiagnosticRenderRequest};
 use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
 use crate::query_boundaries::common as query;
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_common::file_extensions::strip_known_extension;
@@ -1126,7 +1127,10 @@ impl<'a> CheckerState<'a> {
                 prop.write_type = TypeId::ANY;
             }
         }
-        Some(self.ctx.types.factory().callable(rewritten))
+        Some(diagnostic_query::callable_type_from_shape(
+            self.ctx.types,
+            rewritten,
+        ))
     }
 
     // =========================================================================

--- a/crates/tsz-checker/src/error_reporter/property_receiver_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/property_receiver_formatting.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -60,7 +61,10 @@ impl<'a> CheckerState<'a> {
                             match element_types.as_slice() {
                                 [] => TypeId::NEVER,
                                 [element_type] => *element_type,
-                                _ => self.ctx.types.factory().union(element_types),
+                                _ => diagnostic_query::display_union_type(
+                                    self.ctx.types,
+                                    element_types,
+                                ),
                             }
                         })
                 })?;

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -3,6 +3,7 @@
 use crate::diagnostics::{Diagnostic, diagnostic_codes, diagnostic_messages, format_message};
 use crate::error_reporter::fingerprint_policy::DiagnosticAnchorKind;
 use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::query_boundaries::type_checking_utilities as query_utils;
 use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
@@ -94,7 +95,10 @@ impl<'a> CheckerState<'a> {
             let mut shape = (*shape).clone();
             shape.params[param_index].type_id =
                 self.strict_callback_param_display_type(shape.params[param_index].type_id);
-            return Some(self.ctx.types.factory().function(shape));
+            return Some(diagnostic_query::function_type_from_shape(
+                self.ctx.types,
+                shape,
+            ));
         }
 
         let shape = crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, ty)?;
@@ -107,20 +111,11 @@ impl<'a> CheckerState<'a> {
         let mut sig = shape.call_signatures[0].clone();
         sig.params[param_index].type_id =
             self.strict_callback_param_display_type(sig.params[param_index].type_id);
-        Some(
-            self.ctx
-                .types
-                .factory()
-                .function(tsz_solver::FunctionShape {
-                    type_params: sig.type_params,
-                    params: sig.params,
-                    this_type: sig.this_type,
-                    return_type: sig.return_type,
-                    type_predicate: sig.type_predicate,
-                    is_constructor: false,
-                    is_method: sig.is_method,
-                }),
-        )
+        Some(diagnostic_query::function_type_from_call_signature(
+            self.ctx.types,
+            &sig,
+            false,
+        ))
     }
 
     fn strict_callback_assignment_display_pair(

--- a/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
@@ -17,7 +17,7 @@ use crate::types_domain::queries::lib_resolution::{
 use tsz_common::interner::Atom;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{CallSignature, CallableShape, ParamInfo, PropertyInfo, SymbolRef, TypeId};
+use tsz_solver::{CallSignature, ParamInfo, PropertyInfo, SymbolRef, TypeId};
 
 impl<'a> FlowAnalyzer<'a> {
     pub(super) fn assigned_type_for_await_rhs(
@@ -263,7 +263,12 @@ impl<'a> FlowAnalyzer<'a> {
                         PropertyInfo::new(name_atom, member_type)
                     });
                 }
-                Some(self.interner.factory().object(properties))
+                Some(
+                    crate::query_boundaries::flow_analysis::object_type_from_properties(
+                        self.interner,
+                        properties,
+                    ),
+                )
             }
             k if k == syntax_kind_ext::TYPE_REFERENCE => {
                 let type_ref = self.arena.get_type_ref(node)?;
@@ -413,7 +418,12 @@ impl<'a> FlowAnalyzer<'a> {
             return None;
         }
 
-        Some(self.interner.factory().object(properties))
+        Some(
+            crate::query_boundaries::flow_analysis::object_type_from_properties(
+                self.interner,
+                properties,
+            ),
+        )
     }
 
     fn fallback_object_property_name_atom(&self, name_idx: NodeIndex) -> Option<Atom> {
@@ -802,30 +812,29 @@ impl<'a> FlowAnalyzer<'a> {
             });
         }
 
-        Some(self.interner.factory().callable(CallableShape {
-            call_signatures: vec![CallSignature {
-                type_params: Vec::new(),
-                params,
-                this_type,
-                return_type: self
-                    .arena
-                    .get(decl)
-                    .and_then(|node| self.arena.get_function(node))
-                    .and_then(|func| {
-                        func.type_annotation.is_some().then_some(func.type_annotation)
-                    })
-                    .and_then(|type_ann| self.fallback_type_from_type_node_syntax(type_ann))
-                    .unwrap_or(TypeId::ANY),
-                type_predicate: None,
-                is_method: false,
-            }],
-            construct_signatures: Vec::new(),
-            properties: Vec::new(),
-            string_index: None,
-            number_index: None,
-            symbol: None,
-            is_abstract: false,
-        }))
+        Some(
+            crate::query_boundaries::flow_analysis::call_only_callable_type(
+                self.interner,
+                vec![CallSignature {
+                    type_params: Vec::new(),
+                    params,
+                    this_type,
+                    return_type: self
+                        .arena
+                        .get(decl)
+                        .and_then(|node| self.arena.get_function(node))
+                        .and_then(|func| {
+                            func.type_annotation
+                                .is_some()
+                                .then_some(func.type_annotation)
+                        })
+                        .and_then(|type_ann| self.fallback_type_from_type_node_syntax(type_ann))
+                        .unwrap_or(TypeId::ANY),
+                    type_predicate: None,
+                    is_method: false,
+                }],
+            ),
+        )
     }
 
     fn declared_return_type_from_declaration(&self, decl: NodeIndex) -> Option<TypeId> {

--- a/crates/tsz-checker/src/jsdoc/diagnostics_import_type_constraints.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics_import_type_constraints.rs
@@ -2,6 +2,7 @@
 
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use crate::jsdoc::types::JsdocTypedefInfo;
+use crate::query_boundaries::jsdoc_construction::{jsdoc_type_param_info, jsdoc_type_param_type};
 use crate::state::CheckerState;
 
 pub(super) struct JsdocImportTypeConstraintDiagnostic<'a> {
@@ -32,7 +33,6 @@ impl<'a> CheckerState<'a> {
             comment_end,
             source_text,
         } = request;
-        let factory = self.ctx.types.factory();
         let mut scope_updates = Vec::new();
         for tp in &typedef_info.template_params {
             let constraint = tp
@@ -40,14 +40,8 @@ impl<'a> CheckerState<'a> {
                 .as_deref()
                 .and_then(|c| self.resolve_jsdoc_type_str(c));
             let atom = self.ctx.types.intern_string(&tp.name);
-            let param = tsz_solver::TypeParamInfo {
-                name: atom,
-                constraint,
-                default: None,
-                is_const: false,
-                origin: tsz_solver::TypeParamOrigin::User,
-            };
-            let type_id = factory.type_param(param);
+            let param = jsdoc_type_param_info(atom, constraint, None);
+            let type_id = jsdoc_type_param_type(self.ctx.types, param);
             let previous = self
                 .ctx
                 .type_parameter_scope

--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -16,6 +16,7 @@
 //! - Scoping helpers (`is_in_different_function_scope`, `find_function_body_end`)
 
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::query_boundaries::jsdoc_construction::jsdoc_application_type;
 use crate::query_boundaries::type_checking_utilities as query;
 use crate::state::CheckerState;
 use tsz_binder::symbol_flags;
@@ -591,7 +592,7 @@ impl<'a> CheckerState<'a> {
                 if let Ok(mut stack) = self.ctx.typeof_resolution_stack.try_borrow_mut() {
                     stack.remove(&sym_id);
                 }
-                self.ctx.types.application(base, args)
+                jsdoc_application_type(self.ctx.types, base, args)
             }
             query::TypeQueryKind::Application { .. } | query::TypeQueryKind::Other => type_id,
         }

--- a/crates/tsz-checker/src/jsdoc/params_type_strings.rs
+++ b/crates/tsz-checker/src/jsdoc/params_type_strings.rs
@@ -8,7 +8,9 @@
 //! - `JsdocParamTagInfo` assembly helpers
 
 use super::types::JsdocParamTagInfo;
-use crate::query_boundaries::jsdoc_construction::jsdoc_object_type;
+use crate::query_boundaries::jsdoc_construction::{
+    jsdoc_array_type, jsdoc_object_type, jsdoc_union_pair_type,
+};
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 
@@ -268,7 +270,7 @@ impl<'a> CheckerState<'a> {
 
         // For rest params ({...Type}), wrap in array
         if is_rest {
-            base_type = self.ctx.types.factory().array(base_type);
+            base_type = jsdoc_array_type(self.ctx.types, base_type);
         }
 
         // Check if parameter is optional via bracket syntax [name] or [name=default]
@@ -278,12 +280,11 @@ impl<'a> CheckerState<'a> {
             && base_type != tsz_solver::TypeId::ANY
             && base_type != tsz_solver::TypeId::UNDEFINED
         {
-            Some(
-                self.ctx
-                    .types
-                    .factory()
-                    .union2(base_type, tsz_solver::TypeId::UNDEFINED),
-            )
+            Some(jsdoc_union_pair_type(
+                self.ctx.types,
+                base_type,
+                tsz_solver::TypeId::UNDEFINED,
+            ))
         } else {
             Some(base_type)
         }
@@ -584,11 +585,11 @@ impl<'a> CheckerState<'a> {
                     && prop_type_id != tsz_solver::TypeId::ANY
                     && prop_type_id != tsz_solver::TypeId::UNDEFINED
                 {
-                    prop_type_id = self
-                        .ctx
-                        .types
-                        .factory()
-                        .union2(prop_type_id, tsz_solver::TypeId::UNDEFINED);
+                    prop_type_id = jsdoc_union_pair_type(
+                        self.ctx.types,
+                        prop_type_id,
+                        tsz_solver::TypeId::UNDEFINED,
+                    );
                 }
                 let name_atom = self.ctx.types.intern_string(prop_name);
                 properties.push(tsz_solver::PropertyInfo {
@@ -614,7 +615,7 @@ impl<'a> CheckerState<'a> {
         }
         let obj_type = jsdoc_object_type(self.ctx.types, properties, None, None)?;
         if is_array {
-            Some(self.ctx.types.factory().array(obj_type))
+            Some(jsdoc_array_type(self.ctx.types, obj_type))
         } else {
             Some(obj_type)
         }

--- a/crates/tsz-checker/src/jsdoc/params_type_strings.rs
+++ b/crates/tsz-checker/src/jsdoc/params_type_strings.rs
@@ -8,6 +8,7 @@
 //! - `JsdocParamTagInfo` assembly helpers
 
 use super::types::JsdocParamTagInfo;
+use crate::query_boundaries::jsdoc_construction::jsdoc_object_type;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 
@@ -611,7 +612,7 @@ impl<'a> CheckerState<'a> {
         if properties.is_empty() {
             return None;
         }
-        let obj_type = self.ctx.types.factory().object(properties);
+        let obj_type = jsdoc_object_type(self.ctx.types, properties, None, None)?;
         if is_array {
             Some(self.ctx.types.factory().array(obj_type))
         } else {

--- a/crates/tsz-checker/src/jsdoc/params_type_strings.rs
+++ b/crates/tsz-checker/src/jsdoc/params_type_strings.rs
@@ -9,7 +9,7 @@
 
 use super::types::JsdocParamTagInfo;
 use crate::query_boundaries::jsdoc_construction::{
-    jsdoc_array_type, jsdoc_object_type, jsdoc_union_pair_type,
+    jsdoc_array_type, jsdoc_object_type, jsdoc_property_info, jsdoc_union_pair_type,
 };
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
@@ -592,22 +592,14 @@ impl<'a> CheckerState<'a> {
                     );
                 }
                 let name_atom = self.ctx.types.intern_string(prop_name);
-                properties.push(tsz_solver::PropertyInfo {
-                    name: name_atom,
-                    type_id: prop_type_id,
-                    write_type: prop_type_id,
-                    optional: is_optional,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: tsz_solver::Visibility::Public,
-                    parent_id: None,
-                    declaration_order: (properties.len() + 1) as u32,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                });
+                properties.push(jsdoc_property_info(
+                    name_atom,
+                    prop_type_id,
+                    is_optional,
+                    false,
+                    false,
+                    (properties.len() + 1) as u32,
+                ));
             }
         }
         if properties.is_empty() {

--- a/crates/tsz-checker/src/jsdoc/resolution/generic_typedef.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/generic_typedef.rs
@@ -6,6 +6,7 @@
 //! to `Application(Lazy(DefId), args)` and the solver resolves it
 //! coinductively instead of re-expanding the body until the stack overflows.
 
+use crate::query_boundaries::jsdoc_construction::jsdoc_application_type;
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
@@ -33,11 +34,7 @@ impl<'a> CheckerState<'a> {
             if type_args.is_empty() {
                 return Some(base);
             }
-            let app = self
-                .ctx
-                .types
-                .factory()
-                .application(base, type_args.to_vec());
+            let app = jsdoc_application_type(self.ctx.types, base, type_args.to_vec());
             self.register_jsdoc_generic_display_name(base_name, type_args, app);
             return Some(app);
         }

--- a/crates/tsz-checker/src/jsdoc/resolution/generic_typedef.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/generic_typedef.rs
@@ -6,7 +6,7 @@
 //! to `Application(Lazy(DefId), args)` and the solver resolves it
 //! coinductively instead of re-expanding the body until the stack overflows.
 
-use crate::query_boundaries::jsdoc_construction::jsdoc_application_type;
+use crate::query_boundaries::jsdoc_construction::{jsdoc_application_type, jsdoc_lazy_type};
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
@@ -30,7 +30,7 @@ impl<'a> CheckerState<'a> {
             .get(base_name)
             .copied();
         if let Some(def_id) = in_progress_def {
-            let base = self.ctx.types.factory().lazy(def_id);
+            let base = jsdoc_lazy_type(self.ctx.types, def_id);
             if type_args.is_empty() {
                 return Some(base);
             }

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -14,7 +14,7 @@
 
 use crate::context::{is_declaration_file_name, is_js_file_name};
 use crate::query_boundaries::jsdoc_construction::{
-    self as jsdoc_construct, jsdoc_function_type, jsdoc_object_index_type,
+    self as jsdoc_construct, jsdoc_function_type, jsdoc_object_index_type, jsdoc_param_info,
 };
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -592,7 +592,6 @@ impl<'a> CheckerState<'a> {
                             let t_name = &expr[in_idx + "inkeyof".len()..close_bracket];
                             let k_atom = self.ctx.types.intern_string(k_name);
                             if let Some(&t_id) = self.ctx.type_parameter_scope.get(t_name) {
-                                use tsz_solver::ParamInfo;
                                 let keyof_t_id =
                                     jsdoc_construct::jsdoc_keyof_type(self.ctx.types, t_id);
                                 let k_param = jsdoc_construct::jsdoc_type_param_info(
@@ -610,12 +609,12 @@ impl<'a> CheckerState<'a> {
                                 let template_id = jsdoc_function_type(
                                     self.ctx.types,
                                     Vec::new(),
-                                    vec![ParamInfo {
-                                        name: Some(self.ctx.types.intern_string("value")),
-                                        type_id: t_k_id,
-                                        optional: false,
-                                        rest: false,
-                                    }],
+                                    vec![jsdoc_param_info(
+                                        Some(self.ctx.types.intern_string("value")),
+                                        t_k_id,
+                                        false,
+                                        false,
+                                    )],
                                     None,
                                     TypeId::VOID,
                                     None,
@@ -671,7 +670,6 @@ impl<'a> CheckerState<'a> {
                         let return_type = self
                             .resolve_jsdoc_reference(return_type_str)
                             .unwrap_or(TypeId::VOID);
-                        use tsz_solver::ParamInfo;
                         let mut params = Vec::new();
                         let mut this_type = None;
                         let mut ok = true;
@@ -703,12 +701,12 @@ impl<'a> CheckerState<'a> {
                                     let name =
                                         self.ctx.types.intern_string(&format!("arg{arg_index}"));
                                     arg_index += 1;
-                                    params.push(ParamInfo {
-                                        name: Some(name),
+                                    params.push(jsdoc_param_info(
+                                        Some(name),
                                         type_id,
-                                        optional: false,
-                                        rest: is_rest,
-                                    });
+                                        false,
+                                        is_rest,
+                                    ));
                                 } else {
                                     ok = false;
                                     break;
@@ -800,8 +798,6 @@ impl<'a> CheckerState<'a> {
     /// - `(x: boolean) => asserts x` (assertion predicates)
     /// - `(x: unknown) => x is string` (type predicates)
     fn parse_jsdoc_arrow_function_type(&mut self, type_expr: &str) -> Option<TypeId> {
-        use tsz_solver::ParamInfo;
-
         // Extract generic type parameters if present: `<T, U>(params) => ReturnType`
         let (type_params_str, rest) = if type_expr.starts_with('<') {
             // Find the matching `>` (respecting nesting)
@@ -884,12 +880,7 @@ impl<'a> CheckerState<'a> {
                         continue;
                     }
                     let atom = name.map(|n| self.ctx.types.intern_string(n));
-                    params.push(ParamInfo {
-                        name: atom,
-                        type_id: p_type,
-                        optional: false,
-                        rest: is_rest,
-                    });
+                    params.push(jsdoc_param_info(atom, p_type, false, is_rest));
                 } else {
                     params_ok = false;
                     break;

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -14,7 +14,9 @@
 
 use crate::context::{is_declaration_file_name, is_js_file_name};
 use crate::query_boundaries::jsdoc_construction::{
-    self as jsdoc_construct, jsdoc_function_type, jsdoc_object_index_type, jsdoc_param_info,
+    self as jsdoc_construct, jsdoc_function_type, jsdoc_lazy_type, jsdoc_literal_boolean_type,
+    jsdoc_literal_number_type, jsdoc_literal_string_type, jsdoc_object_index_type,
+    jsdoc_param_info, jsdoc_readonly_type, jsdoc_type_predicate,
 };
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -23,7 +25,7 @@ use tsz_common::numeric::parse_numeric_literal_value;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{TypeId, TypePredicate};
+use tsz_solver::TypeId;
 
 /// Strip a leading and matching trailing `"` or `'` from `s` if both are
 /// present. Returns the bare inner string when stripped, otherwise `None`.
@@ -348,7 +350,7 @@ impl<'a> CheckerState<'a> {
         }
         if let Some(inner) = type_expr.strip_prefix("readonly ") {
             let inner_type = self.resolve_jsdoc_type_str(inner.trim())?;
-            return Some(self.ctx.types.factory().readonly_type(inner_type));
+            return Some(jsdoc_readonly_type(self.ctx.types, inner_type));
         }
         if let Some(inner) = type_expr.strip_prefix('?') {
             let inner = inner.trim();
@@ -481,22 +483,18 @@ impl<'a> CheckerState<'a> {
             && type_expr.len() >= 2
         {
             let inner = &type_expr[1..type_expr.len() - 1];
-            let factory = self.ctx.types.factory();
-            return Some(factory.literal_string(inner));
+            return Some(jsdoc_literal_string_type(self.ctx.types, inner));
         }
         if type_expr == "true" {
-            let factory = self.ctx.types.factory();
-            return Some(factory.literal_boolean(true));
+            return Some(jsdoc_literal_boolean_type(self.ctx.types, true));
         }
         if type_expr == "false" {
-            let factory = self.ctx.types.factory();
-            return Some(factory.literal_boolean(false));
+            return Some(jsdoc_literal_boolean_type(self.ctx.types, false));
         }
         if Self::jsdoc_type_expr_may_be_numeric_literal(type_expr)
             && let Some(n) = parse_numeric_literal_value(type_expr)
         {
-            let factory = self.ctx.types.factory();
-            return Some(factory.literal_number(n));
+            return Some(jsdoc_literal_number_type(self.ctx.types, n));
         }
         if let Some(ty) = self.resolve_jsdoc_implicit_any_builtin_type(type_expr) {
             return Some(ty);
@@ -935,24 +933,14 @@ impl<'a> CheckerState<'a> {
                 let pred_type = self.jsdoc_type_from_expression(type_str);
                 let (target, parameter_index) =
                     self.jsdoc_type_predicate_target(param_name, params_inner);
-                let predicate = TypePredicate {
-                    asserts: true,
-                    target,
-                    type_id: pred_type,
-                    parameter_index,
-                };
+                let predicate = jsdoc_type_predicate(true, target, pred_type, parameter_index);
                 return (Some(TypeId::VOID), Some(predicate));
             }
             // `asserts param` (no type)
             let param_name = rest;
             let (target, parameter_index) =
                 self.jsdoc_type_predicate_target(param_name, params_inner);
-            let predicate = TypePredicate {
-                asserts: true,
-                target,
-                type_id: None,
-                parameter_index,
-            };
+            let predicate = jsdoc_type_predicate(true, target, None, parameter_index);
             return (Some(TypeId::VOID), Some(predicate));
         }
 
@@ -968,12 +956,7 @@ impl<'a> CheckerState<'a> {
                 let pred_type = self.jsdoc_type_from_expression(type_str);
                 let (target, parameter_index) =
                     self.jsdoc_type_predicate_target(param_name, params_inner);
-                let predicate = TypePredicate {
-                    asserts: false,
-                    target,
-                    type_id: pred_type,
-                    parameter_index,
-                };
+                let predicate = jsdoc_type_predicate(false, target, pred_type, parameter_index);
                 return (Some(TypeId::BOOLEAN), Some(predicate));
             }
         }
@@ -1652,7 +1635,7 @@ impl<'a> CheckerState<'a> {
             let constructor_type = self.get_type_of_symbol(sym_id);
             if !self.ctx.class_instance_resolution_set.insert(sym_id) {
                 let def_id = self.ctx.get_or_create_def_id(sym_id);
-                return self.ctx.types.factory().lazy(def_id);
+                return jsdoc_lazy_type(self.ctx.types, def_id);
             }
             let instance_type = self.synthesize_js_constructor_instance_type(
                 symbol.value_declaration,

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -13,7 +13,9 @@
 //! - Arrow function parsing (`parse_jsdoc_arrow_function_type`)
 
 use crate::context::{is_declaration_file_name, is_js_file_name};
-use crate::query_boundaries::jsdoc_construction::{jsdoc_function_type, jsdoc_object_index_type};
+use crate::query_boundaries::jsdoc_construction::{
+    self as jsdoc_construct, jsdoc_function_type, jsdoc_object_index_type,
+};
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::symbol_flags;
@@ -90,9 +92,11 @@ impl<'a> CheckerState<'a> {
         &mut self,
         type_expr: &str,
     ) -> Option<TypeId> {
-        let factory = self.ctx.types.factory();
         match type_expr {
-            "Array" | "array" => Some(factory.array(TypeId::ANY)),
+            "Array" | "array" => Some(jsdoc_construct::jsdoc_array_type(
+                self.ctx.types,
+                TypeId::ANY,
+            )),
             "Function" | "function" => self.resolve_jsdoc_global_implicit_any_type("Function"),
             "Object" => {
                 if self.ctx.no_implicit_any() {
@@ -322,8 +326,7 @@ impl<'a> CheckerState<'a> {
             return if members.len() == 1 {
                 Some(members.remove(0))
             } else {
-                let factory = self.ctx.types.factory();
-                Some(factory.union(members))
+                Some(jsdoc_construct::jsdoc_union_type(self.ctx.types, members))
             };
         }
         if !starts_with_function && let Some(parts) = Self::split_top_level_binary(type_expr, '&') {
@@ -334,8 +337,10 @@ impl<'a> CheckerState<'a> {
             return if members.len() == 1 {
                 Some(members.remove(0))
             } else {
-                let factory = self.ctx.types.factory();
-                Some(factory.intersection(members))
+                Some(jsdoc_construct::jsdoc_intersection_type(
+                    self.ctx.types,
+                    members,
+                ))
             };
         }
         if type_expr == "?" {
@@ -350,8 +355,11 @@ impl<'a> CheckerState<'a> {
             if !inner.is_empty()
                 && let Some(inner_type) = self.resolve_jsdoc_type_str(inner)
             {
-                let factory = self.ctx.types.factory();
-                return Some(factory.union2(inner_type, TypeId::NULL));
+                return Some(jsdoc_construct::jsdoc_union_pair_type(
+                    self.ctx.types,
+                    inner_type,
+                    TypeId::NULL,
+                ));
             }
         }
         if let Some(inner) = type_expr.strip_prefix('!') {
@@ -363,13 +371,19 @@ impl<'a> CheckerState<'a> {
         if type_expr.len() > 1 && !type_expr.ends_with("[]") {
             if let Some(inner) = type_expr.strip_suffix('?') {
                 if let Some(inner_type) = self.resolve_jsdoc_type_str(inner) {
-                    let factory = self.ctx.types.factory();
-                    return Some(factory.union2(inner_type, TypeId::NULL));
+                    return Some(jsdoc_construct::jsdoc_union_pair_type(
+                        self.ctx.types,
+                        inner_type,
+                        TypeId::NULL,
+                    ));
                 }
             } else if let Some(inner) = type_expr.strip_suffix('=') {
                 if let Some(inner_type) = self.resolve_jsdoc_type_str(inner) {
-                    let factory = self.ctx.types.factory();
-                    return Some(factory.union2(inner_type, TypeId::UNDEFINED));
+                    return Some(jsdoc_construct::jsdoc_union_pair_type(
+                        self.ctx.types,
+                        inner_type,
+                        TypeId::UNDEFINED,
+                    ));
                 }
             } else if let Some(inner) = type_expr.strip_suffix('!') {
                 return self.resolve_jsdoc_type_str(inner);
@@ -383,8 +397,10 @@ impl<'a> CheckerState<'a> {
                 inner
             };
             let element_type = self.resolve_jsdoc_type_str(inner)?;
-            let factory = self.ctx.types.factory();
-            return Some(factory.array(element_type));
+            return Some(jsdoc_construct::jsdoc_array_type(
+                self.ctx.types,
+                element_type,
+            ));
         }
         if !type_expr.starts_with('[')
             && type_expr.ends_with(']')
@@ -451,7 +467,11 @@ impl<'a> CheckerState<'a> {
                     return Some(TypeId::ERROR);
                 }
             }
-            return Some(self.ctx.types.factory().index_access(base_type, index_type));
+            return Some(jsdoc_construct::jsdoc_index_access_type(
+                self.ctx.types,
+                base_type,
+                index_type,
+            ));
         }
         if type_expr.starts_with('[') && type_expr.ends_with(']') {
             return self.parse_jsdoc_tuple_type(type_expr);
@@ -481,7 +501,6 @@ impl<'a> CheckerState<'a> {
         if let Some(ty) = self.resolve_jsdoc_implicit_any_builtin_type(type_expr) {
             return Some(ty);
         }
-        let factory = self.ctx.types.factory();
         match type_expr {
             "string" | "String" => Some(TypeId::STRING),
             "number" | "Number" => Some(TypeId::NUMBER),
@@ -573,18 +592,21 @@ impl<'a> CheckerState<'a> {
                             let t_name = &expr[in_idx + "inkeyof".len()..close_bracket];
                             let k_atom = self.ctx.types.intern_string(k_name);
                             if let Some(&t_id) = self.ctx.type_parameter_scope.get(t_name) {
-                                use crate::query_boundaries::common::{MappedType, ParamInfo};
-                                use tsz_solver::TypeParamInfo;
-                                let keyof_t_id = factory.keyof(t_id);
-                                let k_param = TypeParamInfo {
-                                    name: k_atom,
-                                    constraint: Some(keyof_t_id),
-                                    default: None,
-                                    is_const: false,
-                                    origin: tsz_solver::TypeParamOrigin::User,
-                                };
-                                let k_id = factory.type_param(k_param);
-                                let t_k_id = factory.index_access(t_id, k_id);
+                                use tsz_solver::ParamInfo;
+                                let keyof_t_id =
+                                    jsdoc_construct::jsdoc_keyof_type(self.ctx.types, t_id);
+                                let k_param = jsdoc_construct::jsdoc_type_param_info(
+                                    k_atom,
+                                    Some(keyof_t_id),
+                                    None,
+                                );
+                                let k_id =
+                                    jsdoc_construct::jsdoc_type_param_type(self.ctx.types, k_param);
+                                let t_k_id = jsdoc_construct::jsdoc_index_access_type(
+                                    self.ctx.types,
+                                    t_id,
+                                    k_id,
+                                );
                                 let template_id = jsdoc_function_type(
                                     self.ctx.types,
                                     Vec::new(),
@@ -600,14 +622,13 @@ impl<'a> CheckerState<'a> {
                                     false,
                                     false,
                                 );
-                                return Some(factory.mapped(MappedType {
-                                    type_param: k_param,
-                                    constraint: keyof_t_id,
-                                    name_type: None,
-                                    template: template_id,
-                                    readonly_modifier: None,
-                                    optional_modifier: None,
-                                }));
+                                return Some(jsdoc_construct::jsdoc_mapped_type(
+                                    self.ctx.types,
+                                    k_param,
+                                    keyof_t_id,
+                                    template_id,
+                                    None,
+                                ));
                             }
                         }
                     }
@@ -675,8 +696,7 @@ impl<'a> CheckerState<'a> {
                                 let effective_p = if is_rest { &p[3..] } else { p };
                                 if let Some(p_type) = self.resolve_jsdoc_reference(effective_p) {
                                     let type_id = if is_rest {
-                                        let factory = self.ctx.types.factory();
-                                        factory.array(p_type)
+                                        jsdoc_construct::jsdoc_array_type(self.ctx.types, p_type)
                                     } else {
                                         p_type
                                     };
@@ -742,7 +762,8 @@ impl<'a> CheckerState<'a> {
                                 if operand == TypeId::ERROR {
                                     continue;
                                 }
-                                let keyof = factory.keyof(operand);
+                                let keyof =
+                                    jsdoc_construct::jsdoc_keyof_type(self.ctx.types, operand);
                                 return Some(self.judge_evaluate(keyof));
                             }
                         }
@@ -750,7 +771,7 @@ impl<'a> CheckerState<'a> {
                     if !rest.is_empty()
                         && let Some(operand) = self.resolve_jsdoc_type_str(rest)
                     {
-                        let keyof = factory.keyof(operand);
+                        let keyof = jsdoc_construct::jsdoc_keyof_type(self.ctx.types, operand);
                         return Some(self.judge_evaluate(keyof));
                     }
                 }
@@ -820,7 +841,6 @@ impl<'a> CheckerState<'a> {
         let mut type_param_updates = Vec::new();
         let mut jsdoc_type_params = Vec::new();
         if let Some(tp_str) = type_params_str {
-            let factory = self.ctx.types.factory();
             for tp_name in tp_str.split(',') {
                 let tp_name = tp_name.trim();
                 if tp_name.is_empty() {
@@ -829,14 +849,8 @@ impl<'a> CheckerState<'a> {
                 let (name, constraint_str) = Self::split_jsdoc_type_param_constraint(tp_name);
                 let constraint = constraint_str.and_then(|s| self.jsdoc_type_from_expression(s));
                 let atom = self.ctx.types.intern_string(name);
-                let info = tsz_solver::TypeParamInfo {
-                    name: atom,
-                    constraint,
-                    default: None,
-                    is_const: false,
-                    origin: tsz_solver::TypeParamOrigin::User,
-                };
-                let ty = factory.type_param(info);
+                let info = jsdoc_construct::jsdoc_type_param_info(atom, constraint, None);
+                let ty = jsdoc_construct::jsdoc_type_param_type(self.ctx.types, info);
                 jsdoc_type_params.push(info);
                 let previous = self.ctx.type_parameter_scope.insert(name.to_string(), ty);
                 type_param_updates.push((name.to_string(), previous));

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -13,6 +13,7 @@
 //! - Arrow function parsing (`parse_jsdoc_arrow_function_type`)
 
 use crate::context::{is_declaration_file_name, is_js_file_name};
+use crate::query_boundaries::jsdoc_construction::{jsdoc_function_type, jsdoc_object_index_type};
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::symbol_flags;
@@ -20,7 +21,7 @@ use tsz_common::numeric::parse_numeric_literal_value;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{IndexSignature, ObjectShape, TypeId, TypePredicate};
+use tsz_solver::{TypeId, TypePredicate};
 
 /// Strip a leading and matching trailing `"` or `'` from `s` if both are
 /// present. Returns the bare inner string when stripped, otherwise `None`.
@@ -552,25 +553,10 @@ impl<'a> CheckerState<'a> {
                     if let (Some(key_type), Some(value_type)) = (
                         self.jsdoc_type_from_expression(key_str),
                         self.jsdoc_type_from_expression(value_str),
-                    ) {
-                        let mut shape = ObjectShape::default();
-                        if key_type == TypeId::STRING {
-                            shape.string_index = Some(IndexSignature {
-                                key_type,
-                                value_type,
-                                readonly: false,
-                                param_name: None,
-                            });
-                            return Some(factory.object_with_index(shape));
-                        } else if key_type == TypeId::NUMBER {
-                            shape.number_index = Some(IndexSignature {
-                                key_type,
-                                value_type,
-                                readonly: false,
-                                param_name: None,
-                            });
-                            return Some(factory.object_with_index(shape));
-                        }
+                    ) && let Some(object_type) =
+                        jsdoc_object_index_type(self.ctx.types, key_type, value_type, false, None)
+                    {
+                        return Some(object_type);
                     }
                 }
                 if type_expr.starts_with("{[")
@@ -587,9 +573,7 @@ impl<'a> CheckerState<'a> {
                             let t_name = &expr[in_idx + "inkeyof".len()..close_bracket];
                             let k_atom = self.ctx.types.intern_string(k_name);
                             if let Some(&t_id) = self.ctx.type_parameter_scope.get(t_name) {
-                                use crate::query_boundaries::common::{
-                                    FunctionShape, MappedType, ParamInfo,
-                                };
+                                use crate::query_boundaries::common::{MappedType, ParamInfo};
                                 use tsz_solver::TypeParamInfo;
                                 let keyof_t_id = factory.keyof(t_id);
                                 let k_param = TypeParamInfo {
@@ -601,21 +585,21 @@ impl<'a> CheckerState<'a> {
                                 };
                                 let k_id = factory.type_param(k_param);
                                 let t_k_id = factory.index_access(t_id, k_id);
-                                let func_shape = FunctionShape {
-                                    type_params: Vec::new(),
-                                    params: vec![ParamInfo {
+                                let template_id = jsdoc_function_type(
+                                    self.ctx.types,
+                                    Vec::new(),
+                                    vec![ParamInfo {
                                         name: Some(self.ctx.types.intern_string("value")),
                                         type_id: t_k_id,
                                         optional: false,
                                         rest: false,
                                     }],
-                                    this_type: None,
-                                    return_type: TypeId::VOID,
-                                    type_predicate: None,
-                                    is_constructor: false,
-                                    is_method: false,
-                                };
-                                let template_id = factory.function(func_shape);
+                                    None,
+                                    TypeId::VOID,
+                                    None,
+                                    false,
+                                    false,
+                                );
                                 return Some(factory.mapped(MappedType {
                                     type_param: k_param,
                                     constraint: keyof_t_id,
@@ -666,7 +650,7 @@ impl<'a> CheckerState<'a> {
                         let return_type = self
                             .resolve_jsdoc_reference(return_type_str)
                             .unwrap_or(TypeId::VOID);
-                        use tsz_solver::{FunctionShape, ParamInfo};
+                        use tsz_solver::ParamInfo;
                         let mut params = Vec::new();
                         let mut this_type = None;
                         let mut ok = true;
@@ -717,16 +701,16 @@ impl<'a> CheckerState<'a> {
                             } else {
                                 return_type
                             };
-                            let shape = FunctionShape {
-                                type_params: Vec::new(),
+                            return Some(jsdoc_function_type(
+                                self.ctx.types,
+                                Vec::new(),
                                 params,
                                 this_type,
-                                return_type: final_return,
-                                type_predicate: None,
+                                final_return,
+                                None,
                                 is_constructor,
-                                is_method: false,
-                            };
-                            return Some(factory.function(shape));
+                                false,
+                            ));
                         }
                     }
                 }
@@ -795,7 +779,7 @@ impl<'a> CheckerState<'a> {
     /// - `(x: boolean) => asserts x` (assertion predicates)
     /// - `(x: unknown) => x is string` (type predicates)
     fn parse_jsdoc_arrow_function_type(&mut self, type_expr: &str) -> Option<TypeId> {
-        use tsz_solver::{FunctionShape, ParamInfo};
+        use tsz_solver::ParamInfo;
 
         // Extract generic type parameters if present: `<T, U>(params) => ReturnType`
         let (type_params_str, rest) = if type_expr.starts_with('<') {
@@ -913,17 +897,16 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let factory = self.ctx.types.factory();
-        let shape = FunctionShape {
-            type_params: jsdoc_type_params,
+        Some(jsdoc_function_type(
+            self.ctx.types,
+            jsdoc_type_params,
             params,
             this_type,
             return_type,
             type_predicate,
-            is_constructor: false,
-            is_method: false,
-        };
-        Some(factory.function(shape))
+            false,
+            false,
+        ))
     }
 
     /// Parse the return type of a JSDoc arrow function, handling type predicates.

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -15,13 +15,14 @@
 use super::super::types::{JsdocCallbackInfo, JsdocTypedefInfo};
 use crate::query_boundaries::jsdoc_construction::{
     self as jsdoc_construct, JsdocObjectIndexFact, JsdocObjectIndexKind, jsdoc_empty_object_type,
-    jsdoc_function_type, jsdoc_object_index_fact, jsdoc_object_type,
+    jsdoc_function_type, jsdoc_object_index_fact, jsdoc_object_type, jsdoc_param_info,
+    jsdoc_property_info,
 };
 use crate::state::CheckerState;
 use std::sync::Arc;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
-use tsz_solver::{ParamInfo, PropertyInfo, TypeId, TypePredicate, TypePredicateTarget, Visibility};
+use tsz_solver::{PropertyInfo, TypeId, TypePredicate, TypePredicateTarget};
 impl<'a> CheckerState<'a> {
     pub(crate) fn jsdoc_enum_annotation_type_for_symbol_decl(
         &mut self,
@@ -959,22 +960,14 @@ impl<'a> CheckerState<'a> {
                 if !name.is_empty() {
                     let prop_type = self.resolve_jsdoc_type_str(type_str).unwrap_or(TypeId::ANY);
                     let name_atom = self.ctx.types.intern_string(name);
-                    properties.push(PropertyInfo {
-                        name: name_atom,
-                        type_id: prop_type,
-                        write_type: prop_type,
+                    properties.push(jsdoc_property_info(
+                        name_atom,
+                        prop_type,
                         optional,
                         readonly,
-                        is_method: false,
-                        is_class_prototype: false,
-                        visibility: Visibility::Public,
-                        parent_id: None,
-                        declaration_order: (properties.len() + 1) as u32,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                        false,
+                        (properties.len() + 1) as u32,
+                    ));
                 }
             }
         }
@@ -1279,12 +1272,7 @@ impl<'a> CheckerState<'a> {
                 };
                 let p_type = self.resolve_jsdoc_reference(t_str).unwrap_or(TypeId::ANY);
                 let atom = name.map(|n| self.ctx.types.intern_string(n));
-                params.push(ParamInfo {
-                    name: atom,
-                    type_id: p_type,
-                    optional: false,
-                    rest: false,
-                });
+                params.push(jsdoc_param_info(atom, p_type, false, false));
             }
         }
         Some(jsdoc_function_type(
@@ -1357,12 +1345,7 @@ impl<'a> CheckerState<'a> {
                 };
                 let p_type = self.resolve_jsdoc_reference(t_str).unwrap_or(TypeId::ANY);
                 let atom = name.map(|n| self.ctx.types.intern_string(n));
-                params.push(ParamInfo {
-                    name: atom,
-                    type_id: p_type,
-                    optional: false,
-                    rest: false,
-                });
+                params.push(jsdoc_param_info(atom, p_type, false, false));
             }
         }
         let method_type = jsdoc_function_type(
@@ -1376,22 +1359,14 @@ impl<'a> CheckerState<'a> {
             true,
         );
         let name_atom = self.ctx.types.intern_string(method_name);
-        Some(PropertyInfo {
-            name: name_atom,
-            type_id: method_type,
-            write_type: method_type,
+        Some(jsdoc_property_info(
+            name_atom,
+            method_type,
             optional,
-            readonly: false,
-            is_method: true,
-            is_class_prototype: false,
-            visibility: Visibility::Public,
-            parent_id: None,
-            declaration_order: (existing_props.len() + 1) as u32,
-            is_string_named: false,
-            is_symbol_named: false,
-            single_quoted_name: false,
-            non_widening: false,
-        })
+            false,
+            true,
+            (existing_props.len() + 1) as u32,
+        ))
     }
     /// Resolve a `@typedef` referenced by name from JSDoc comments.
     ///
@@ -1714,12 +1689,12 @@ impl<'a> CheckerState<'a> {
             }
 
             let name_atom = self.ctx.types.intern_string(&param.name);
-            params.push(ParamInfo {
-                name: Some(name_atom),
+            params.push(jsdoc_param_info(
+                Some(name_atom),
                 type_id,
-                optional: param.optional,
-                rest: param.rest,
-            });
+                param.optional,
+                param.rest,
+            ));
         }
 
         let mut type_predicate = None;
@@ -1837,22 +1812,14 @@ impl<'a> CheckerState<'a> {
                 );
             }
             let name_atom = self.ctx.types.intern_string(&prop.name);
-            prop_infos.push(PropertyInfo {
-                name: name_atom,
-                type_id: prop_type,
-                write_type: prop_type,
-                optional: prop.optional,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: 0,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+            prop_infos.push(jsdoc_property_info(
+                name_atom,
+                prop_type,
+                prop.optional,
+                false,
+                false,
+                0,
+            ));
         }
         let object_type = jsdoc_object_type(self.ctx.types, prop_infos, None, None);
         match (object_type, base_type) {

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -13,13 +13,16 @@
 //! - Typedef/callback type construction (`type_from_jsdoc_typedef`, `type_from_jsdoc_callback`)
 
 use super::super::types::{JsdocCallbackInfo, JsdocTypedefInfo};
+use crate::query_boundaries::jsdoc_construction::{
+    JsdocObjectIndexFact, JsdocObjectIndexKind, jsdoc_empty_object_type, jsdoc_function_type,
+    jsdoc_object_index_fact, jsdoc_object_type,
+};
 use crate::state::CheckerState;
 use std::sync::Arc;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::{
-    FunctionShape, IndexSignature, ObjectShape, ParamInfo, PropertyInfo, TupleElement, TypeId,
-    TypePredicate, TypePredicateTarget, Visibility,
+    ParamInfo, PropertyInfo, TupleElement, TypeId, TypePredicate, TypePredicateTarget, Visibility,
 };
 impl<'a> CheckerState<'a> {
     pub(crate) fn jsdoc_enum_annotation_type_for_symbol_decl(
@@ -903,15 +906,15 @@ impl<'a> CheckerState<'a> {
             return Some(mapped);
         }
 
-        let factory = self.ctx.types.factory();
         let inner = type_expr[1..type_expr.len() - 1].trim();
         if inner.is_empty() {
-            return Some(factory.object(Vec::new()));
+            return Some(jsdoc_empty_object_type(self.ctx.types));
         }
         // Split properties by ',' or ';' at top level
         let prop_strs = Self::split_object_properties(inner);
         let mut properties = Vec::new();
-        let mut object_shape = ObjectShape::default();
+        let mut string_index: Option<JsdocObjectIndexFact> = None;
+        let mut number_index: Option<JsdocObjectIndexFact> = None;
         for prop_str in &prop_strs {
             let prop_str = prop_str.trim();
             if prop_str.is_empty() {
@@ -943,16 +946,13 @@ impl<'a> CheckerState<'a> {
                 };
                 if raw_name.starts_with('[')
                     && raw_name.ends_with(']')
-                    && let Some(mut index_sig) =
+                    && let Some((index_kind, mut index_fact)) =
                         self.parse_jsdoc_object_literal_index_signature(raw_name, type_str)
                 {
-                    index_sig.readonly |= readonly;
-                    match index_sig.key_type {
-                        TypeId::STRING | TypeId::SYMBOL => {
-                            object_shape.string_index = Some(index_sig);
-                        }
-                        TypeId::NUMBER => object_shape.number_index = Some(index_sig),
-                        _ => {}
+                    index_fact.readonly |= readonly;
+                    match index_kind {
+                        JsdocObjectIndexKind::String => string_index = Some(index_fact),
+                        JsdocObjectIndexKind::Number => number_index = Some(index_fact),
                     }
                     continue;
                 }
@@ -983,25 +983,14 @@ impl<'a> CheckerState<'a> {
                 }
             }
         }
-        if properties.is_empty()
-            && object_shape.string_index.is_none()
-            && object_shape.number_index.is_none()
-        {
-            return None;
-        }
-        if object_shape.string_index.is_some() || object_shape.number_index.is_some() {
-            object_shape.properties = properties;
-            Some(factory.object_with_index(object_shape))
-        } else {
-            Some(factory.object(properties))
-        }
+        jsdoc_object_type(self.ctx.types, properties, string_index, number_index)
     }
 
     fn parse_jsdoc_object_literal_index_signature(
         &mut self,
         raw_name: &str,
         type_str: &str,
-    ) -> Option<IndexSignature> {
+    ) -> Option<(JsdocObjectIndexKind, JsdocObjectIndexFact)> {
         let (raw_name, readonly) = if let Some(rest) = Self::strip_jsdoc_readonly_modifier(raw_name)
         {
             (rest, true)
@@ -1039,12 +1028,12 @@ impl<'a> CheckerState<'a> {
         };
 
         let value_type = self.resolve_jsdoc_type_str(type_str).unwrap_or(TypeId::ANY);
-        Some(IndexSignature {
+        jsdoc_object_index_fact(
             key_type,
             value_type,
             readonly,
-            param_name: (!param_name.is_empty()).then(|| self.ctx.types.intern_string(param_name)),
-        })
+            (!param_name.is_empty()).then(|| self.ctx.types.intern_string(param_name)),
+        )
     }
 
     fn emit_jsdoc_index_signature_diagnostic_once(
@@ -1268,7 +1257,6 @@ impl<'a> CheckerState<'a> {
     /// Parse a named method signature from a JSDoc object property string.
     /// Parse a call signature `(params): RetType` and return a function TypeId.
     fn parse_jsdoc_call_signature(&mut self, prop_str: &str) -> Option<TypeId> {
-        use tsz_solver::{FunctionShape, ParamInfo};
         let after_open = &prop_str[1..];
         let mut depth = 1u32;
         let mut close_idx = None;
@@ -1316,16 +1304,16 @@ impl<'a> CheckerState<'a> {
                 });
             }
         }
-        let shape = FunctionShape {
-            type_params: Vec::new(),
+        Some(jsdoc_function_type(
+            self.ctx.types,
+            Vec::new(),
             params,
-            this_type: None,
+            None,
             return_type,
-            type_predicate: None,
-            is_constructor: false,
-            is_method: false,
-        };
-        Some(self.ctx.types.factory().function(shape))
+            None,
+            false,
+            false,
+        ))
     }
     fn parse_jsdoc_method_signature(
         &mut self,
@@ -1333,7 +1321,6 @@ impl<'a> CheckerState<'a> {
         paren_idx: usize,
         existing_props: &[PropertyInfo],
     ) -> Option<PropertyInfo> {
-        use tsz_solver::{FunctionShape, ParamInfo};
         let method_name = prop_str[..paren_idx].trim();
         if method_name.is_empty() {
             return None;
@@ -1395,16 +1382,16 @@ impl<'a> CheckerState<'a> {
                 });
             }
         }
-        let shape = FunctionShape {
-            type_params: Vec::new(),
+        let method_type = jsdoc_function_type(
+            self.ctx.types,
+            Vec::new(),
             params,
-            this_type: None,
+            None,
             return_type,
-            type_predicate: None,
-            is_constructor: false,
-            is_method: true,
-        };
-        let method_type = self.ctx.types.factory().function(shape);
+            None,
+            false,
+            true,
+        );
         let name_atom = self.ctx.types.intern_string(method_name);
         Some(PropertyInfo {
             name: name_atom,
@@ -1807,15 +1794,16 @@ impl<'a> CheckerState<'a> {
         // `type B<T> = () => T`, not `<T>() => T`. Keeping those parameters on
         // the function body makes alias instantiation shadow them, so `B<string>`
         // still formats and behaves like the uninstantiated `B`.
-        Some(factory.function(FunctionShape {
-            type_params: Vec::new(),
+        Some(jsdoc_function_type(
+            self.ctx.types,
+            Vec::new(),
             params,
             this_type,
             return_type,
             type_predicate,
-            is_constructor: false,
-            is_method: false,
-        }))
+            false,
+            false,
+        ))
     }
 
     fn type_from_jsdoc_object_typedef(&mut self, info: JsdocTypedefInfo) -> Option<TypeId> {
@@ -1888,11 +1876,7 @@ impl<'a> CheckerState<'a> {
                 non_widening: false,
             });
         }
-        let object_type = if !prop_infos.is_empty() {
-            Some(factory.object(prop_infos))
-        } else {
-            None
-        };
+        let object_type = jsdoc_object_type(self.ctx.types, prop_infos, None, None);
         match (object_type, base_type) {
             (Some(obj), Some(base)) => Some(factory.intersection2(obj, base)),
             (Some(obj), None) => Some(obj),

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -15,14 +15,14 @@
 use super::super::types::{JsdocCallbackInfo, JsdocTypedefInfo};
 use crate::query_boundaries::jsdoc_construction::{
     self as jsdoc_construct, JsdocObjectIndexFact, JsdocObjectIndexKind, jsdoc_empty_object_type,
-    jsdoc_function_type, jsdoc_object_index_fact, jsdoc_object_type, jsdoc_param_info,
-    jsdoc_property_info,
+    jsdoc_function_type, jsdoc_lazy_type, jsdoc_object_index_fact, jsdoc_object_type,
+    jsdoc_param_info, jsdoc_property_info, jsdoc_type_predicate,
 };
 use crate::state::CheckerState;
 use std::sync::Arc;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
-use tsz_solver::{PropertyInfo, TypeId, TypePredicate, TypePredicateTarget};
+use tsz_solver::{PropertyInfo, TypeId, TypePredicateTarget};
 impl<'a> CheckerState<'a> {
     pub(crate) fn jsdoc_enum_annotation_type_for_symbol_decl(
         &mut self,
@@ -349,9 +349,8 @@ impl<'a> CheckerState<'a> {
 
         let def_id = self.ensure_jsdoc_assigned_value_def(display_name, ty);
         self.ctx.definition_store.register_type_to_def(ty, def_id);
-        self.ctx
-            .types
-            .store_display_alias(ty, self.ctx.types.factory().lazy(def_id));
+        let alias_lazy = jsdoc_lazy_type(self.ctx.types, def_id);
+        self.ctx.types.store_display_alias(ty, alias_lazy);
         ty
     }
 
@@ -590,7 +589,7 @@ impl<'a> CheckerState<'a> {
         // No-op when `body_type == lazy(def_id)` (e.g. recursive typedefs)
         // or when storing would alias an intrinsic — `store_display_alias`
         // applies its own safety guards.
-        let alias_lazy = self.ctx.types.factory().lazy(def_id);
+        let alias_lazy = jsdoc_lazy_type(self.ctx.types, def_id);
         self.ctx.types.store_display_alias(body_type, alias_lazy);
 
         def_id
@@ -627,7 +626,7 @@ impl<'a> CheckerState<'a> {
         self.ctx
             .definition_store
             .register_type_to_def(type_id, def_id);
-        let alias_lazy = self.ctx.types.factory().lazy(def_id);
+        let alias_lazy = jsdoc_lazy_type(self.ctx.types, def_id);
         self.ctx.types.store_display_alias(type_id, alias_lazy);
         def_id
     }
@@ -1717,12 +1716,12 @@ impl<'a> CheckerState<'a> {
             } else {
                 None
             };
-            type_predicate = Some(TypePredicate {
-                asserts: is_asserts,
+            type_predicate = Some(jsdoc_type_predicate(
+                is_asserts,
                 target,
-                type_id: pred_type,
+                pred_type,
                 parameter_index,
-            });
+            ));
             if is_asserts {
                 TypeId::VOID
             } else {

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -14,16 +14,14 @@
 
 use super::super::types::{JsdocCallbackInfo, JsdocTypedefInfo};
 use crate::query_boundaries::jsdoc_construction::{
-    JsdocObjectIndexFact, JsdocObjectIndexKind, jsdoc_empty_object_type, jsdoc_function_type,
-    jsdoc_object_index_fact, jsdoc_object_type,
+    self as jsdoc_construct, JsdocObjectIndexFact, JsdocObjectIndexKind, jsdoc_empty_object_type,
+    jsdoc_function_type, jsdoc_object_index_fact, jsdoc_object_type,
 };
 use crate::state::CheckerState;
 use std::sync::Arc;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
-use tsz_solver::{
-    ParamInfo, PropertyInfo, TupleElement, TypeId, TypePredicate, TypePredicateTarget, Visibility,
-};
+use tsz_solver::{ParamInfo, PropertyInfo, TypeId, TypePredicate, TypePredicateTarget, Visibility};
 impl<'a> CheckerState<'a> {
     pub(crate) fn jsdoc_enum_annotation_type_for_symbol_decl(
         &mut self,
@@ -534,10 +532,7 @@ impl<'a> CheckerState<'a> {
             return instance_type;
         }
 
-        self.ctx
-            .types
-            .factory()
-            .intersection2(instance_type, prototype_type)
+        jsdoc_construct::jsdoc_intersection_pair_type(self.ctx.types, instance_type, prototype_type)
     }
     fn ensure_jsdoc_typedef_def(
         &mut self,
@@ -659,11 +654,11 @@ impl<'a> CheckerState<'a> {
             if body_type == TypeId::ERROR {
                 if !type_args.is_empty() && !type_params.is_empty() {
                     let base_type = self.ctx.create_lazy_type_ref(sym_id);
-                    let instantiated = self
-                        .ctx
-                        .types
-                        .factory()
-                        .application(base_type, type_args.clone());
+                    let instantiated = jsdoc_construct::jsdoc_application_type(
+                        self.ctx.types,
+                        base_type,
+                        type_args.clone(),
+                    );
                     self.register_jsdoc_generic_display_name(base_name, &type_args, instantiated);
                     return Some(instantiated);
                 }
@@ -731,11 +726,11 @@ impl<'a> CheckerState<'a> {
         if body_type == TypeId::ERROR {
             if !type_args.is_empty() && !type_params.is_empty() {
                 let base_type = self.ctx.create_lazy_type_ref(sym_id);
-                let instantiated = self
-                    .ctx
-                    .types
-                    .factory()
-                    .application(base_type, type_args.clone());
+                let instantiated = jsdoc_construct::jsdoc_application_type(
+                    self.ctx.types,
+                    base_type,
+                    type_args.clone(),
+                );
                 self.register_jsdoc_generic_display_name(base_name, &type_args, instantiated);
                 return Some(instantiated);
             }
@@ -797,11 +792,11 @@ impl<'a> CheckerState<'a> {
             instantiate_generic(self.ctx.types, body_type, type_params, type_args);
         if contains_this_type(self.ctx.types, instantiated) {
             let base_type = self.ctx.create_lazy_type_ref(sym_id);
-            let self_type = self
-                .ctx
-                .types
-                .factory()
-                .application(base_type, type_args.to_vec());
+            let self_type = jsdoc_construct::jsdoc_application_type(
+                self.ctx.types,
+                base_type,
+                type_args.to_vec(),
+            );
             instantiated = substitute_this_type(self.ctx.types, instantiated, self_type);
         }
         instantiated
@@ -812,7 +807,10 @@ impl<'a> CheckerState<'a> {
     ) -> Option<TypeId> {
         let inner = type_expr[1..type_expr.len() - 1].trim();
         if inner.is_empty() {
-            return Some(self.ctx.types.factory().tuple(Vec::new()));
+            return Some(jsdoc_construct::jsdoc_tuple_type(
+                self.ctx.types,
+                Vec::new(),
+            ));
         }
 
         let mut elements = Vec::new();
@@ -847,15 +845,12 @@ impl<'a> CheckerState<'a> {
             };
 
             let type_id = self.resolve_jsdoc_type_str(type_str)?;
-            elements.push(TupleElement {
-                type_id,
-                name,
-                optional,
-                rest,
-            });
+            elements.push(jsdoc_construct::jsdoc_tuple_element(
+                type_id, name, optional, rest,
+            ));
         }
 
-        Some(self.ctx.types.factory().tuple(elements))
+        Some(jsdoc_construct::jsdoc_tuple_type(self.ctx.types, elements))
     }
 
     pub(in crate::jsdoc::resolution) fn parse_jsdoc_index_access_segments(
@@ -1117,19 +1112,13 @@ impl<'a> CheckerState<'a> {
         let constraint = if let Some(operand_str) = Self::strip_jsdoc_keyof_keyword(constraint_str)
         {
             let operand = self.resolve_jsdoc_type_str(operand_str)?;
-            self.ctx.types.factory().keyof(operand)
+            jsdoc_construct::jsdoc_keyof_type(self.ctx.types, operand)
         } else {
             self.resolve_jsdoc_type_str(constraint_str)?
         };
         let atom = self.ctx.types.intern_string(type_param_name);
-        let type_param = tsz_solver::TypeParamInfo {
-            name: atom,
-            constraint: Some(constraint),
-            default: None,
-            is_const: false,
-            origin: tsz_solver::TypeParamOrigin::User,
-        };
-        let type_param_id = self.ctx.types.factory().type_param(type_param);
+        let type_param = jsdoc_construct::jsdoc_type_param_info(atom, Some(constraint), None);
+        let type_param_id = jsdoc_construct::jsdoc_type_param_type(self.ctx.types, type_param);
         let previous = self
             .ctx
             .type_parameter_scope
@@ -1146,14 +1135,13 @@ impl<'a> CheckerState<'a> {
         }
 
         template.map(|template| {
-            self.ctx.types.factory().mapped(tsz_solver::MappedType {
+            jsdoc_construct::jsdoc_mapped_type(
+                self.ctx.types,
                 type_param,
                 constraint,
-                name_type: None,
                 template,
-                readonly_modifier: None,
                 optional_modifier,
-            })
+            )
         })
     }
 
@@ -1190,18 +1178,13 @@ impl<'a> CheckerState<'a> {
         let true_type =
             self.resolve_jsdoc_type_str(type_expr[question_idx + 1..colon_idx].trim())?;
         let false_type = self.resolve_jsdoc_type_str(type_expr[colon_idx + 1..].trim())?;
-        Some(
-            self.ctx
-                .types
-                .factory()
-                .conditional(tsz_solver::ConditionalType {
-                    check_type,
-                    extends_type,
-                    true_type,
-                    false_type,
-                    is_distributive: true,
-                }),
-        )
+        Some(jsdoc_construct::jsdoc_conditional_type(
+            self.ctx.types,
+            check_type,
+            extends_type,
+            true_type,
+            false_type,
+        ))
     }
 
     fn find_jsdoc_conditional_separators(type_expr: &str) -> Option<(usize, usize, usize)> {
@@ -1600,7 +1583,6 @@ impl<'a> CheckerState<'a> {
         info: JsdocTypedefInfo,
         recursive_alias_name: Option<&str>,
     ) -> Option<(TypeId, Vec<tsz_solver::TypeParamInfo>)> {
-        let factory = self.ctx.types.factory();
         let import_alias_body = info
             .base_type
             .as_deref()
@@ -1613,14 +1595,8 @@ impl<'a> CheckerState<'a> {
                 .as_deref()
                 .and_then(|expr| self.resolve_jsdoc_type_str(expr));
             let atom = self.ctx.types.intern_string(&template.name);
-            let param = tsz_solver::TypeParamInfo {
-                name: atom,
-                constraint,
-                default: None,
-                is_const: false,
-                origin: tsz_solver::TypeParamOrigin::User,
-            };
-            let type_id = factory.type_param(param);
+            let param = jsdoc_construct::jsdoc_type_param_info(atom, constraint, None);
+            let type_id = jsdoc_construct::jsdoc_type_param_type(self.ctx.types, param);
             let previous = self
                 .ctx
                 .type_parameter_scope
@@ -1679,7 +1655,6 @@ impl<'a> CheckerState<'a> {
     }
 
     fn type_from_jsdoc_callback(&mut self, cb: JsdocCallbackInfo) -> Option<TypeId> {
-        let factory = self.ctx.types.factory();
         let mut params = Vec::new();
         let mut this_type = None;
         let nested_entries: Vec<(String, String, bool)> = cb
@@ -1730,7 +1705,7 @@ impl<'a> CheckerState<'a> {
                 };
 
             if param.rest {
-                type_id = factory.array(type_id);
+                type_id = jsdoc_construct::jsdoc_array_type(self.ctx.types, type_id);
             }
 
             if param.name == "this" {
@@ -1807,7 +1782,6 @@ impl<'a> CheckerState<'a> {
     }
 
     fn type_from_jsdoc_object_typedef(&mut self, info: JsdocTypedefInfo) -> Option<TypeId> {
-        let factory = self.ctx.types.factory();
         let base_type = if let Some(base_type_expr) = &info.base_type {
             let expr = base_type_expr.trim();
             if expr != "Object" && expr != "object" {
@@ -1856,7 +1830,11 @@ impl<'a> CheckerState<'a> {
                 && prop_type != TypeId::ANY
                 && prop_type != TypeId::UNDEFINED
             {
-                prop_type = factory.union2(prop_type, TypeId::UNDEFINED);
+                prop_type = jsdoc_construct::jsdoc_union_pair_type(
+                    self.ctx.types,
+                    prop_type,
+                    TypeId::UNDEFINED,
+                );
             }
             let name_atom = self.ctx.types.intern_string(&prop.name);
             prop_infos.push(PropertyInfo {
@@ -1878,7 +1856,11 @@ impl<'a> CheckerState<'a> {
         }
         let object_type = jsdoc_object_type(self.ctx.types, prop_infos, None, None);
         match (object_type, base_type) {
-            (Some(obj), Some(base)) => Some(factory.intersection2(obj, base)),
+            (Some(obj), Some(base)) => Some(jsdoc_construct::jsdoc_intersection_pair_type(
+                self.ctx.types,
+                obj,
+                base,
+            )),
             (Some(obj), None) => Some(obj),
             (None, Some(base)) => Some(base),
             (None, None) => None,

--- a/crates/tsz-checker/src/query_boundaries/checkers/class_properties.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/class_properties.rs
@@ -1,0 +1,139 @@
+//! JS class-property construction boundary.
+//!
+//! JS class-property scanning gathers AST, JSDoc, modifier, and source-order
+//! facts. This module owns the solver shape literals those facts become.
+
+use tsz_binder::SymbolId;
+use tsz_common::{Atom, Visibility};
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{
+    CallSignature, CallableShape, ObjectShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
+    TypeParamOrigin,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct JsClassPropertyFact {
+    pub(crate) name: Atom,
+    pub(crate) type_id: TypeId,
+    pub(crate) write_type: TypeId,
+    pub(crate) optional: bool,
+    pub(crate) readonly: bool,
+    pub(crate) is_method: bool,
+    pub(crate) is_class_prototype: bool,
+    pub(crate) visibility: Visibility,
+    pub(crate) parent_id: Option<SymbolId>,
+}
+
+impl JsClassPropertyFact {
+    pub(crate) const fn new(name: Atom, type_id: TypeId) -> Self {
+        Self {
+            name,
+            type_id,
+            write_type: type_id,
+            optional: false,
+            readonly: false,
+            is_method: false,
+            is_class_prototype: false,
+            visibility: Visibility::Public,
+            parent_id: None,
+        }
+    }
+}
+
+pub(crate) const fn js_class_type_param_info(
+    name: Atom,
+    constraint: Option<TypeId>,
+    default: Option<TypeId>,
+    is_const: bool,
+) -> TypeParamInfo {
+    TypeParamInfo {
+        name,
+        constraint,
+        default,
+        is_const,
+        origin: TypeParamOrigin::User,
+    }
+}
+
+pub(crate) fn js_class_type_param_type(
+    db: &dyn TypeDatabase,
+    name: Atom,
+    constraint: Option<TypeId>,
+    default: Option<TypeId>,
+    is_const: bool,
+) -> TypeId {
+    db.type_param(js_class_type_param_info(
+        name, constraint, default, is_const,
+    ))
+}
+
+pub(crate) fn js_class_array_type(db: &dyn TypeDatabase, element: TypeId) -> TypeId {
+    db.array(element)
+}
+
+pub(crate) fn js_class_union_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn js_class_union_pair_type(
+    db: &dyn TypeDatabase,
+    left: TypeId,
+    right: TypeId,
+) -> TypeId {
+    db.union2(left, right)
+}
+
+pub(crate) const fn js_class_property_info(fact: JsClassPropertyFact) -> PropertyInfo {
+    PropertyInfo {
+        name: fact.name,
+        type_id: fact.type_id,
+        write_type: fact.write_type,
+        optional: fact.optional,
+        readonly: fact.readonly,
+        is_method: fact.is_method,
+        is_class_prototype: fact.is_class_prototype,
+        visibility: fact.visibility,
+        parent_id: fact.parent_id,
+        declaration_order: 0,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+pub(crate) fn js_class_method_callable_type(db: &dyn TypeDatabase) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures: vec![CallSignature {
+            type_params: Vec::new(),
+            params: vec![ParamInfo {
+                name: None,
+                type_id: TypeId::ANY,
+                optional: false,
+                rest: true,
+            }],
+            this_type: None,
+            return_type: TypeId::ANY,
+            type_predicate: None,
+            is_method: true,
+        }],
+        construct_signatures: Vec::new(),
+        properties: Vec::new(),
+        string_index: None,
+        number_index: None,
+        symbol: None,
+        is_abstract: false,
+    })
+}
+
+pub(crate) fn js_class_instance_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    symbol: Option<SymbolId>,
+) -> TypeId {
+    db.object_with_index(ObjectShape {
+        properties,
+        symbol,
+        ..ObjectShape::default()
+    })
+}

--- a/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
@@ -1,8 +1,12 @@
 //! JSX checker query boundaries.
 
 use crate::state::CheckerState;
+use tsz_common::Atom;
+use tsz_solver::computation::TypeSubstitution;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
-use tsz_solver::{DefinitionStore, TypeId, TypeParamInfo};
+use tsz_solver::{
+    CallSignature, DefinitionStore, FunctionShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
+};
 
 pub(crate) struct SingleArgTypeApplication {
     pub(crate) base: TypeId,
@@ -186,6 +190,130 @@ pub(crate) fn props_are_assignable(
     target: TypeId,
 ) -> bool {
     checker.jsx_props_relation_outcome(source, target).related
+}
+
+pub(crate) fn object_type_from_properties(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn empty_props_object_type(db: &dyn TypeDatabase) -> TypeId {
+    object_type_from_properties(db, Vec::new())
+}
+
+pub(crate) fn props_param_type_or_empty(db: &dyn TypeDatabase, params: &[ParamInfo]) -> TypeId {
+    params
+        .first()
+        .map(|param| param.type_id)
+        .unwrap_or_else(|| empty_props_object_type(db))
+}
+
+pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {
+    crate::query_boundaries::construct_signatures::function_type_from_shape(db, shape)
+}
+
+pub(crate) fn function_type_from_parts(
+    db: &dyn TypeDatabase,
+    params: Vec<ParamInfo>,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_shape(db, FunctionShape::new(params, return_type))
+}
+
+pub(crate) fn single_required_param_function_type(
+    db: &dyn TypeDatabase,
+    param_name: Atom,
+    param_type: TypeId,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_parts(
+        db,
+        vec![ParamInfo::required(param_name, param_type)],
+        return_type,
+    )
+}
+
+pub(crate) fn function_type_with_mapped_component_types(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    mut map_type: impl FnMut(TypeId) -> TypeId,
+) -> TypeId {
+    let mapped = crate::query_boundaries::construct_signatures::map_function_shape_types(
+        shape,
+        |_, type_id| map_type(type_id),
+    )
+    .unwrap_or_else(|| shape.clone());
+    function_type_from_shape(db, mapped)
+}
+
+pub(crate) fn function_type_without_this(db: &dyn TypeDatabase, shape: &FunctionShape) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params: shape.params.clone(),
+            this_type: None,
+            return_type: shape.return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: false,
+        },
+    )
+}
+
+pub(crate) fn construct_signature_function_shape(sig: CallSignature) -> FunctionShape {
+    FunctionShape {
+        type_params: sig.type_params,
+        params: sig.params,
+        this_type: sig.this_type,
+        return_type: sig.return_type,
+        type_predicate: sig.type_predicate,
+        is_constructor: true,
+        is_method: sig.is_method,
+    }
+}
+
+pub(crate) fn push_required_param(shape: &mut FunctionShape, name: Atom, type_id: TypeId) {
+    shape.params.push(ParamInfo::required(name, type_id));
+}
+
+pub(crate) fn synthetic_single_param_function_shape(
+    type_params: Vec<TypeParamInfo>,
+    param_name: Atom,
+    param_type: TypeId,
+    return_type: TypeId,
+) -> FunctionShape {
+    FunctionShape {
+        type_params,
+        params: vec![ParamInfo {
+            name: Some(param_name),
+            type_id: param_type,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    }
+}
+
+pub(crate) fn instantiate_function_shape_preserving_unresolved_params(
+    db: &dyn QueryDatabase,
+    func: &FunctionShape,
+    substitution: &TypeSubstitution,
+) -> FunctionShape {
+    let mut full_substitution = substitution.clone();
+    for type_param in &func.type_params {
+        if full_substitution.get(type_param.name).is_none() {
+            let preserved_type_param = db.as_type_database().type_param(*type_param);
+            full_substitution.insert(type_param.name, preserved_type_param);
+        }
+    }
+    crate::query_boundaries::common::instantiate_function_shape(db, func, &full_substitution)
 }
 
 pub(crate) fn has_object_shape(db: &dyn TypeDatabase, type_id: TypeId) -> bool {

--- a/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
@@ -5,7 +5,8 @@ use tsz_common::Atom;
 use tsz_solver::computation::TypeSubstitution;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::{
-    CallSignature, DefinitionStore, FunctionShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
+    CallSignature, DefinitionStore, FunctionShape, ParamInfo, PropertyInfo, TupleElement, TypeId,
+    TypeParamInfo,
 };
 
 pub(crate) struct SingleArgTypeApplication {
@@ -199,6 +200,33 @@ pub(crate) fn object_type_from_properties(
     db.object(properties)
 }
 
+pub(crate) const fn property_info(name: Atom, type_id: TypeId) -> PropertyInfo {
+    PropertyInfo::new(name, type_id)
+}
+
+pub(crate) const fn property_info_with_write_type(
+    name: Atom,
+    type_id: TypeId,
+    write_type: TypeId,
+) -> PropertyInfo {
+    PropertyInfo {
+        name,
+        type_id,
+        write_type,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: tsz_solver::Visibility::Public,
+        parent_id: None,
+        declaration_order: 0,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
 pub(crate) fn empty_props_object_type(db: &dyn TypeDatabase) -> TypeId {
     object_type_from_properties(db, Vec::new())
 }
@@ -208,6 +236,72 @@ pub(crate) fn props_param_type_or_empty(db: &dyn TypeDatabase, params: &[ParamIn
         .first()
         .map(|param| param.type_id)
         .unwrap_or_else(|| empty_props_object_type(db))
+}
+
+pub(crate) fn union_type_from_members(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn union_type_from_pair(db: &dyn TypeDatabase, left: TypeId, right: TypeId) -> TypeId {
+    db.union2(left, right)
+}
+
+pub(crate) fn intersection_type_from_members(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> TypeId {
+    db.intersection(members)
+}
+
+pub(crate) fn intersection_type_from_pair(
+    db: &dyn TypeDatabase,
+    left: TypeId,
+    right: TypeId,
+) -> TypeId {
+    db.intersection2(left, right)
+}
+
+pub(crate) fn array_type_from_element(db: &dyn TypeDatabase, element: TypeId) -> TypeId {
+    db.array(element)
+}
+
+pub(crate) fn tuple_type_from_elements(
+    db: &dyn TypeDatabase,
+    elements: Vec<TupleElement>,
+) -> TypeId {
+    db.tuple(elements)
+}
+
+pub(crate) fn tuple_type_from_required_element_types(
+    db: &dyn TypeDatabase,
+    element_types: Vec<TypeId>,
+) -> TypeId {
+    let elements = element_types
+        .into_iter()
+        .map(|type_id| TupleElement {
+            type_id,
+            name: None,
+            optional: false,
+            rest: false,
+        })
+        .collect();
+    tuple_type_from_elements(db, elements)
+}
+
+pub(crate) fn type_application_from_args(
+    db: &dyn TypeDatabase,
+    base: TypeId,
+    args: Vec<TypeId>,
+) -> TypeId {
+    db.application(base, args)
+}
+
+pub(crate) fn index_access_type(
+    db: &dyn TypeDatabase,
+    object_type: TypeId,
+    index_type: TypeId,
+) -> TypeId {
+    db.index_access(object_type, index_type)
 }
 
 pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {

--- a/crates/tsz-checker/src/query_boundaries/checkers/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod call;
+pub(crate) mod class_properties;
 pub(crate) mod constructor;
 pub(crate) mod generic;
 pub(crate) mod iterable;

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -23,8 +23,8 @@ pub(crate) use tsz_solver::type_queries::{
     remapped_mapped_index_access_result,
 };
 pub(crate) use tsz_solver::{
-    FunctionShape, IntrinsicKind, MappedType, ParamInfo, PendingDiagnosticBuilder, SourceLocation,
-    SubtypeFailureReason, TypeFormatter,
+    FunctionShape, IntrinsicKind, MappedType, ParamInfo, PendingDiagnostic, PendingDiagnosticBuilder,
+    SourceLocation, SubtypeFailureReason, TypeFormatter,
     computation::{ContextualTypeContext, TypeSubstitution},
 };
 

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -116,6 +116,26 @@ pub(crate) fn function_type_from_parts(
     function_type_from_shape(db, FunctionShape::new(params, return_type))
 }
 
+/// Intern a function type preserving `shape` metadata with a new parameter list.
+pub(crate) fn function_type_with_params_replaced(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    params: Vec<ParamInfo>,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params,
+            this_type: shape.this_type,
+            return_type: shape.return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
 /// Intern the standalone function type for one signature (a constructor
 /// function when `is_constructor` is set).
 pub(crate) fn function_type_from_call_signature(

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -107,6 +107,15 @@ pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionSha
     db.function(shape)
 }
 
+/// Intern a simple function type from explicit parameter and return slots.
+pub(crate) fn function_type_from_parts(
+    db: &dyn TypeDatabase,
+    params: Vec<ParamInfo>,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_shape(db, FunctionShape::new(params, return_type))
+}
+
 /// Intern the standalone function type for one signature (a constructor
 /// function when `is_constructor` is set).
 pub(crate) fn function_type_from_call_signature(

--- a/crates/tsz-checker/src/query_boundaries/declaration_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/declaration_exports.rs
@@ -1,0 +1,110 @@
+//! Declaration export surface construction boundary.
+//!
+//! Declaration checkers collect AST, binder, visibility, duplicate-diagnostic,
+//! and source-order facts. This module owns the solver types those facts become
+//! for namespace/module value surfaces.
+
+use tsz_binder::SymbolId;
+use tsz_common::{Atom, Visibility};
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::def::DefId;
+use tsz_solver::{CallableShape, ObjectFlags, PropertyInfo, TypeId};
+
+pub(crate) const fn declaration_export_property(
+    name: Atom,
+    type_id: TypeId,
+    declaration_order: u32,
+) -> PropertyInfo {
+    PropertyInfo {
+        name,
+        type_id,
+        write_type: type_id,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+pub(crate) fn declaration_lazy_export_type(db: &dyn TypeDatabase, def_id: DefId) -> TypeId {
+    db.lazy(def_id)
+}
+
+pub(crate) fn module_export_augmented_type(
+    db: &dyn TypeDatabase,
+    existing_type: TypeId,
+    augmentation_type: TypeId,
+) -> TypeId {
+    db.intersection2(existing_type, augmentation_type)
+}
+
+pub(crate) fn dynamic_import_module_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn dynamic_import_promise_type(
+    db: &dyn TypeDatabase,
+    promise_base: TypeId,
+    inner_type: TypeId,
+) -> TypeId {
+    db.application(promise_base, vec![inner_type])
+}
+
+pub(crate) fn empty_namespace_object_type(db: &dyn TypeDatabase) -> TypeId {
+    db.object(Vec::new())
+}
+
+pub(crate) fn namespace_object_placeholder_type(db: &dyn TypeDatabase) -> TypeId {
+    empty_namespace_object_type(db)
+}
+
+pub(crate) fn namespace_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    symbol: SymbolId,
+) -> TypeId {
+    db.object_with_flags_and_symbol(properties, ObjectFlags::empty(), Some(symbol))
+}
+
+pub(crate) fn namespace_merged_constructor_callable_type(
+    db: &dyn TypeDatabase,
+    shape: &CallableShape,
+    properties: Vec<PropertyInfo>,
+    symbol: SymbolId,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures: shape.call_signatures.clone(),
+        construct_signatures: shape.construct_signatures.clone(),
+        properties,
+        string_index: shape.string_index,
+        number_index: shape.number_index,
+        symbol: Some(symbol),
+        is_abstract: false,
+    })
+}
+
+pub(crate) fn namespace_merged_function_callable_type(
+    db: &dyn TypeDatabase,
+    shape: &CallableShape,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures: shape.call_signatures.clone(),
+        construct_signatures: shape.construct_signatures.clone(),
+        properties,
+        string_index: shape.string_index,
+        number_index: shape.number_index,
+        symbol: None,
+        is_abstract: false,
+    })
+}

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -66,6 +66,69 @@ pub(crate) fn object_type_preserving_display_properties(
     new_ty
 }
 
+pub(crate) fn shallow_object_property_literals_widened_for_call_parameter_display(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> TypeId {
+    let Some(shape) = object_shape_for_type(db, type_id) else {
+        return type_id;
+    };
+    let mut widened_shape = shape.as_ref().clone();
+    let mut changed = false;
+    for prop in &mut widened_shape.properties {
+        let widened_read = super::common::widen_literal_type(db, prop.type_id);
+        let widened_write = super::common::widen_literal_type(db, prop.write_type);
+        changed |= widened_read != prop.type_id || widened_write != prop.write_type;
+        prop.type_id = widened_read;
+        prop.write_type = widened_write;
+    }
+    if changed {
+        object_type_from_shape(db, widened_shape)
+    } else {
+        type_id
+    }
+}
+
+pub(crate) fn object_type_with_unknown_display_members(
+    db: &dyn TypeDatabase,
+    shape: &ObjectShape,
+) -> Option<TypeId> {
+    if shape.properties.is_empty() && shape.string_index.is_none() && shape.number_index.is_none() {
+        return None;
+    }
+
+    let properties = shape
+        .properties
+        .iter()
+        .map(|prop| {
+            let mut unknown_prop = PropertyInfo::new(prop.name, TypeId::UNKNOWN);
+            unknown_prop.optional = prop.optional;
+            unknown_prop.readonly = prop.readonly;
+            unknown_prop
+        })
+        .collect();
+
+    if shape.string_index.is_some() || shape.number_index.is_some() {
+        Some(object_type_from_shape(
+            db,
+            ObjectShape {
+                properties,
+                string_index: shape.string_index.map(|sig| tsz_solver::IndexSignature {
+                    value_type: TypeId::UNKNOWN,
+                    ..sig
+                }),
+                number_index: shape.number_index.map(|sig| tsz_solver::IndexSignature {
+                    value_type: TypeId::UNKNOWN,
+                    ..sig
+                }),
+                ..Default::default()
+            },
+        ))
+    } else {
+        Some(object_type_from_properties(db, properties))
+    }
+}
+
 pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {
     crate::query_boundaries::construct_signatures::function_type_from_shape(db, shape)
 }

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -165,6 +165,25 @@ pub(crate) fn function_type_from_call_signature_without_type_params(
     )
 }
 
+pub(crate) fn function_type_from_call_signature(
+    db: &dyn TypeDatabase,
+    sig: &CallSignature,
+    is_constructor: bool,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: sig.type_params.clone(),
+            params: sig.params.clone(),
+            this_type: sig.this_type,
+            return_type: sig.return_type,
+            type_predicate: sig.type_predicate,
+            is_constructor,
+            is_method: sig.is_method,
+        },
+    )
+}
+
 pub(crate) fn callable_type_from_shape(db: &dyn TypeDatabase, shape: CallableShape) -> TypeId {
     db.callable(shape)
 }

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -1,7 +1,9 @@
 use super::state::checking as state_checking;
-use tsz_solver::TypeId;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::def::{DefKind, DefinitionStore};
+use tsz_solver::{
+    CallSignature, CallableShape, FunctionShape, ObjectShape, ParamInfo, PropertyInfo, TypeId,
+};
 
 pub(crate) use super::common::{
     PropertyAccessResult, TypeResolver, TypeSubstitution, application_info, array_element_type,
@@ -39,6 +41,116 @@ pub(crate) fn get_object_symbol(
     type_id: TypeId,
 ) -> Option<tsz_binder::SymbolId> {
     tsz_solver::type_queries::get_object_symbol(db, type_id)
+}
+
+pub(crate) fn object_type_from_properties(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn object_type_from_shape(db: &dyn TypeDatabase, shape: ObjectShape) -> TypeId {
+    db.object_with_index(shape)
+}
+
+pub(crate) fn object_type_preserving_display_properties(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    shape: ObjectShape,
+) -> TypeId {
+    let new_ty = object_type_from_shape(db, shape);
+    if let Some(display_props) = db.get_display_properties(source) {
+        db.store_display_properties(new_ty, display_props.as_ref().clone());
+    }
+    new_ty
+}
+
+pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {
+    crate::query_boundaries::construct_signatures::function_type_from_shape(db, shape)
+}
+
+pub(crate) fn function_type_with_params_replaced(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    params: Vec<ParamInfo>,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params,
+            this_type: shape.this_type,
+            return_type: shape.return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
+pub(crate) fn function_type_with_return_replaced(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params: shape.params.clone(),
+            this_type: shape.this_type,
+            return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
+pub(crate) fn function_type_with_params_and_return_replaced(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    params: Vec<ParamInfo>,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params,
+            this_type: shape.this_type,
+            return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
+pub(crate) fn callable_type_from_shape(db: &dyn TypeDatabase, shape: CallableShape) -> TypeId {
+    db.callable(shape)
+}
+
+pub(crate) fn call_only_callable_type(
+    db: &dyn TypeDatabase,
+    call_signatures: Vec<CallSignature>,
+) -> TypeId {
+    crate::query_boundaries::construct_signatures::call_only_callable_type(db, call_signatures)
+}
+
+pub(crate) fn callable_type_with_signatures_replaced(
+    db: &dyn TypeDatabase,
+    base: &CallableShape,
+    call_signatures: Vec<CallSignature>,
+    construct_signatures: Vec<CallSignature>,
+) -> TypeId {
+    crate::query_boundaries::construct_signatures::callable_with_signatures_replaced(
+        db,
+        base,
+        call_signatures,
+        construct_signatures,
+    )
 }
 
 pub(crate) fn assignment_numeric_display_children(

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -128,6 +128,43 @@ pub(crate) fn function_type_with_params_and_return_replaced(
     )
 }
 
+pub(crate) fn function_type_without_type_params(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: Vec::new(),
+            params: shape.params.clone(),
+            this_type: shape.this_type,
+            return_type: shape.return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
+pub(crate) fn function_type_from_call_signature_without_type_params(
+    db: &dyn TypeDatabase,
+    sig: &CallSignature,
+    is_constructor: bool,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: Vec::new(),
+            params: sig.params.clone(),
+            this_type: sig.this_type,
+            return_type: sig.return_type,
+            type_predicate: sig.type_predicate,
+            is_constructor,
+            is_method: sig.is_method,
+        },
+    )
+}
+
 pub(crate) fn callable_type_from_shape(db: &dyn TypeDatabase, shape: CallableShape) -> TypeId {
     db.callable(shape)
 }

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -167,6 +167,36 @@ pub(crate) fn display_property_literals_widened_for_related_info(
     }
 }
 
+pub(crate) fn source_display_union_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    match members.as_slice() {
+        [single] => *single,
+        _ => db.union(members),
+    }
+}
+
+pub(crate) fn source_display_union_type_from_slice(
+    db: &dyn TypeDatabase,
+    members: &[TypeId],
+) -> TypeId {
+    match members {
+        [single] => *single,
+        _ => db.union_from_slice(members),
+    }
+}
+
+pub(crate) fn rebuilt_array_source_display_type(
+    db: &dyn TypeDatabase,
+    source_type: TypeId,
+    element_type: TypeId,
+) -> TypeId {
+    let rebuilt = db.array(element_type);
+    if tsz_solver::type_queries::is_readonly_type(db, source_type) {
+        db.readonly_type(rebuilt)
+    } else {
+        rebuilt
+    }
+}
+
 fn type_includes_undefined(db: &dyn TypeDatabase, ty: TypeId) -> bool {
     ty == TypeId::UNDEFINED
         || super::common::union_members(db, ty)

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -170,7 +170,7 @@ pub(crate) fn display_property_literals_widened_for_related_info(
 pub(crate) fn source_display_union_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
     match members.as_slice() {
         [single] => *single,
-        _ => db.union(members),
+        _ => display_union_type(db, members),
     }
 }
 
@@ -184,17 +184,123 @@ pub(crate) fn source_display_union_type_from_slice(
     }
 }
 
+pub(crate) fn display_application_type(
+    db: &dyn TypeDatabase,
+    base: TypeId,
+    args: Vec<TypeId>,
+) -> TypeId {
+    db.application(base, args)
+}
+
+pub(crate) fn display_union_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn display_union_or_single_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    tsz_solver::utils::union_or_single(db, members)
+}
+
+pub(crate) fn display_union_preserve_members_type(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> TypeId {
+    db.union_preserve_members(members)
+}
+
+pub(crate) fn display_intersection_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.intersection(members)
+}
+
+pub(crate) fn display_intersection_or_single_type(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> TypeId {
+    tsz_solver::utils::intersection_or_single(db, members)
+}
+
 pub(crate) fn rebuilt_array_source_display_type(
     db: &dyn TypeDatabase,
     source_type: TypeId,
     element_type: TypeId,
 ) -> TypeId {
-    let rebuilt = db.array(element_type);
+    let rebuilt = display_array_type(db, element_type);
     if tsz_solver::type_queries::is_readonly_type(db, source_type) {
         db.readonly_type(rebuilt)
     } else {
         rebuilt
     }
+}
+
+pub(crate) fn display_array_type(db: &dyn TypeDatabase, element_type: TypeId) -> TypeId {
+    db.array(element_type)
+}
+
+pub(crate) fn display_index_access_type(
+    db: &dyn TypeDatabase,
+    object_type: TypeId,
+    index_type: TypeId,
+) -> TypeId {
+    db.index_access(object_type, index_type)
+}
+
+pub(crate) fn display_union_with_undefined(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    db.union2(type_id, TypeId::UNDEFINED)
+}
+
+pub(crate) fn display_string_literal_type(db: &dyn TypeDatabase, value: &str) -> TypeId {
+    db.literal_string(value)
+}
+
+pub(crate) fn display_string_literal_atom_type(db: &dyn TypeDatabase, atom: Atom) -> TypeId {
+    db.literal_string_atom(atom)
+}
+
+pub(crate) fn display_number_literal_type(db: &dyn TypeDatabase, value: f64) -> TypeId {
+    db.literal_number(value)
+}
+
+pub(crate) fn display_rest_parameter_type(
+    db: &dyn TypeDatabase,
+    rest_param_type: TypeId,
+    rest_start: usize,
+    index: usize,
+    is_rest: bool,
+) -> TypeId {
+    if is_rest {
+        let element = display_index_access_type(db, rest_param_type, TypeId::NUMBER);
+        display_array_type(db, element)
+    } else {
+        let offset = index - rest_start;
+        let index_type = display_number_literal_type(db, offset as f64);
+        display_index_access_type(db, rest_param_type, index_type)
+    }
+}
+
+pub(crate) const fn display_property(name: Atom, type_id: TypeId) -> PropertyInfo {
+    PropertyInfo::new(name, type_id)
+}
+
+pub(crate) fn mapped_display_property(
+    name: Atom,
+    type_id: TypeId,
+    optional_modifier: Option<tsz_solver::MappedModifier>,
+    readonly_modifier: Option<tsz_solver::MappedModifier>,
+) -> PropertyInfo {
+    let mut property = display_property(name, type_id);
+    property.optional = optional_modifier == Some(tsz_solver::MappedModifier::Add);
+    property.readonly = readonly_modifier == Some(tsz_solver::MappedModifier::Add);
+    property
+}
+
+pub(crate) const fn static_schema_display_property_from_source(
+    source: &PropertyInfo,
+    type_id: TypeId,
+) -> PropertyInfo {
+    let mut property = display_property(source.name, type_id);
+    property.optional = source.optional;
+    property.readonly = source.readonly;
+    property.declaration_order = source.declaration_order;
+    property
 }
 
 fn type_includes_undefined(db: &dyn TypeDatabase, ty: TypeId) -> bool {

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -1,4 +1,5 @@
 use super::state::checking as state_checking;
+use tsz_common::interner::Atom;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::def::{DefKind, DefinitionStore};
 use tsz_solver::{
@@ -127,6 +128,49 @@ pub(crate) fn object_type_with_unknown_display_members(
     } else {
         Some(object_type_from_properties(db, properties))
     }
+}
+
+pub(crate) fn mapped_property_mismatch_parameter_display_type(
+    db: &dyn TypeDatabase,
+    property_name: Atom,
+    target_property_type: TypeId,
+) -> TypeId {
+    let mut property = PropertyInfo::new(property_name, target_property_type);
+    property.optional = type_includes_undefined(db, target_property_type);
+    object_type_from_properties(db, vec![property])
+}
+
+pub(crate) fn display_property_literals_widened_for_related_info(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> TypeId {
+    if db.get_display_properties(type_id).is_none() {
+        return type_id;
+    }
+    let Some(shape) = object_shape_for_type(db, type_id) else {
+        return type_id;
+    };
+
+    let mut widened_shape = shape.as_ref().clone();
+    let mut changed = false;
+    for prop in &mut widened_shape.properties {
+        let widened_read = super::common::widen_literal_type(db, prop.type_id);
+        let widened_write = super::common::widen_literal_type(db, prop.write_type);
+        changed |= widened_read != prop.type_id || widened_write != prop.write_type;
+        prop.type_id = widened_read;
+        prop.write_type = widened_write;
+    }
+    if changed {
+        object_type_from_shape(db, widened_shape)
+    } else {
+        type_id
+    }
+}
+
+fn type_includes_undefined(db: &dyn TypeDatabase, ty: TypeId) -> bool {
+    ty == TypeId::UNDEFINED
+        || super::common::union_members(db, ty)
+            .is_some_and(|members| members.contains(&TypeId::UNDEFINED))
 }
 
 pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -1,8 +1,8 @@
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
-use tsz_solver::TypeId;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::narrowing::{GuardSense, NarrowingContext, TypeGuard};
+use tsz_solver::{CallSignature, PropertyInfo, TypeId};
 
 use super::{
     assignability::{RelationFlags, RelationOutcome},
@@ -37,6 +37,20 @@ pub(crate) fn array_type(db: &dyn QueryDatabase, element: TypeId) -> TypeId {
 
 pub(crate) fn empty_object_type(db: &dyn QueryDatabase) -> TypeId {
     db.object(Vec::new())
+}
+
+pub(crate) fn object_type_from_properties(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn call_only_callable_type(
+    db: &dyn TypeDatabase,
+    call_signatures: Vec<CallSignature>,
+) -> TypeId {
+    super::construct_signatures::call_only_callable_type(db, call_signatures)
 }
 
 pub(crate) fn tuple_type(

--- a/crates/tsz-checker/src/query_boundaries/import_attributes.rs
+++ b/crates/tsz-checker/src/query_boundaries/import_attributes.rs
@@ -1,0 +1,44 @@
+//! Import attribute/options construction boundary.
+//!
+//! Import declaration and dynamic-import checkers own AST traversal, grammar
+//! diagnostics, and relation anchors. This module owns the synthetic solver
+//! object shapes those syntax facts become for `ImportAttributes` and
+//! `ImportCallOptions` checks.
+
+use tsz_common::Atom;
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{PropertyInfo, TypeId};
+
+pub(crate) fn import_attribute_literal_string_type(db: &dyn TypeDatabase, value: &str) -> TypeId {
+    db.literal_string(value)
+}
+
+pub(crate) const fn import_attribute_property(name: Atom, type_id: TypeId) -> PropertyInfo {
+    PropertyInfo::new(name, type_id)
+}
+
+pub(crate) const fn optional_import_option_property(name: Atom, type_id: TypeId) -> PropertyInfo {
+    PropertyInfo::opt(name, type_id)
+}
+
+pub(crate) fn import_attribute_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn import_call_options_type(
+    db: &dyn TypeDatabase,
+    with_name: Atom,
+    assert_name: Atom,
+    import_attributes_type: TypeId,
+) -> TypeId {
+    import_attribute_object_type(
+        db,
+        vec![
+            optional_import_option_property(with_name, import_attributes_type),
+            optional_import_option_property(assert_name, import_attributes_type),
+        ],
+    )
+}

--- a/crates/tsz-checker/src/query_boundaries/intersection_display.rs
+++ b/crates/tsz-checker/src/query_boundaries/intersection_display.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use tsz_solver::construction::TypeDatabase;
 use tsz_solver::relations::subtype::TypeResolver;
 use tsz_solver::{ObjectShape, TypeId};
@@ -40,6 +41,28 @@ pub(crate) fn collected_properties_object_type<R: TypeResolver>(
                 Some(db.object(properties))
             }
         }
+        _ => None,
+    }
+}
+
+pub(crate) fn collected_properties_object_shape<R: TypeResolver>(
+    db: &dyn TypeDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> Option<Arc<ObjectShape>> {
+    match collect_properties(type_id, db, resolver) {
+        PropertyCollectionResult::Properties {
+            properties,
+            string_index,
+            number_index,
+            symbol_index,
+        } => Some(Arc::new(ObjectShape {
+            properties,
+            string_index,
+            number_index,
+            symbol_index,
+            ..ObjectShape::default()
+        })),
         _ => None,
     }
 }

--- a/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
@@ -1,0 +1,120 @@
+//! JSDoc construction boundary.
+//!
+//! JSDoc resolution code parses source text and gathers structural facts. This
+//! module owns the solver shape literals and interning for the object/function
+//! types those facts describe.
+
+use tsz_common::Atom;
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{
+    FunctionShape, IndexSignature, ObjectShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
+    TypePredicate,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum JsdocObjectIndexKind {
+    String,
+    Number,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct JsdocObjectIndexFact {
+    pub(crate) key_type: TypeId,
+    pub(crate) value_type: TypeId,
+    pub(crate) readonly: bool,
+    pub(crate) param_name: Option<Atom>,
+}
+
+impl JsdocObjectIndexFact {
+    const fn into_index_signature(self) -> IndexSignature {
+        IndexSignature {
+            key_type: self.key_type,
+            value_type: self.value_type,
+            readonly: self.readonly,
+            param_name: self.param_name,
+        }
+    }
+}
+
+pub(crate) const fn jsdoc_object_index_fact(
+    key_type: TypeId,
+    value_type: TypeId,
+    readonly: bool,
+    param_name: Option<Atom>,
+) -> Option<(JsdocObjectIndexKind, JsdocObjectIndexFact)> {
+    let kind = match key_type {
+        TypeId::STRING | TypeId::SYMBOL => JsdocObjectIndexKind::String,
+        TypeId::NUMBER => JsdocObjectIndexKind::Number,
+        _ => return None,
+    };
+    Some((
+        kind,
+        JsdocObjectIndexFact {
+            key_type,
+            value_type,
+            readonly,
+            param_name,
+        },
+    ))
+}
+
+pub(crate) fn jsdoc_empty_object_type(db: &dyn TypeDatabase) -> TypeId {
+    db.object(Vec::new())
+}
+
+pub(crate) fn jsdoc_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<JsdocObjectIndexFact>,
+    number_index: Option<JsdocObjectIndexFact>,
+) -> Option<TypeId> {
+    if properties.is_empty() && string_index.is_none() && number_index.is_none() {
+        return None;
+    }
+    if string_index.is_some() || number_index.is_some() {
+        Some(db.object_with_index(ObjectShape {
+            properties,
+            string_index: string_index.map(JsdocObjectIndexFact::into_index_signature),
+            number_index: number_index.map(JsdocObjectIndexFact::into_index_signature),
+            ..ObjectShape::default()
+        }))
+    } else {
+        Some(db.object(properties))
+    }
+}
+
+pub(crate) fn jsdoc_object_index_type(
+    db: &dyn TypeDatabase,
+    key_type: TypeId,
+    value_type: TypeId,
+    readonly: bool,
+    param_name: Option<Atom>,
+) -> Option<TypeId> {
+    let (kind, fact) = jsdoc_object_index_fact(key_type, value_type, readonly, param_name)?;
+    let (string_index, number_index) = match kind {
+        JsdocObjectIndexKind::String => (Some(fact), None),
+        JsdocObjectIndexKind::Number => (None, Some(fact)),
+    };
+    jsdoc_object_type(db, Vec::new(), string_index, number_index)
+}
+
+pub(crate) fn jsdoc_function_type(
+    db: &dyn TypeDatabase,
+    type_params: Vec<TypeParamInfo>,
+    params: Vec<ParamInfo>,
+    this_type: Option<TypeId>,
+    return_type: TypeId,
+    type_predicate: Option<TypePredicate>,
+    is_constructor: bool,
+    is_method: bool,
+) -> TypeId {
+    db.function(FunctionShape {
+        type_params,
+        params,
+        this_type,
+        return_type,
+        type_predicate,
+        is_constructor,
+        is_method,
+    })
+}

--- a/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
@@ -6,9 +6,11 @@
 
 use tsz_common::Atom;
 use tsz_solver::construction::TypeDatabase;
+use tsz_solver::def::DefId;
 use tsz_solver::{
     ConditionalType, FunctionShape, IndexSignature, MappedModifier, MappedType, ObjectShape,
     ParamInfo, PropertyInfo, TupleElement, TypeId, TypeParamInfo, TypeParamOrigin, TypePredicate,
+    TypePredicateTarget,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -106,6 +108,26 @@ pub(crate) fn jsdoc_keyof_type(db: &dyn TypeDatabase, operand: TypeId) -> TypeId
     db.keyof(operand)
 }
 
+pub(crate) fn jsdoc_lazy_type(db: &dyn TypeDatabase, def_id: DefId) -> TypeId {
+    db.lazy(def_id)
+}
+
+pub(crate) fn jsdoc_readonly_type(db: &dyn TypeDatabase, inner: TypeId) -> TypeId {
+    db.readonly_type(inner)
+}
+
+pub(crate) fn jsdoc_literal_string_type(db: &dyn TypeDatabase, value: &str) -> TypeId {
+    db.literal_string(value)
+}
+
+pub(crate) fn jsdoc_literal_boolean_type(db: &dyn TypeDatabase, value: bool) -> TypeId {
+    db.literal_boolean(value)
+}
+
+pub(crate) fn jsdoc_literal_number_type(db: &dyn TypeDatabase, value: f64) -> TypeId {
+    db.literal_number(value)
+}
+
 pub(crate) const fn jsdoc_type_param_info(
     name: Atom,
     constraint: Option<TypeId>,
@@ -179,6 +201,20 @@ pub(crate) const fn jsdoc_property_info(
         is_symbol_named: false,
         single_quoted_name: false,
         non_widening: false,
+    }
+}
+
+pub(crate) const fn jsdoc_type_predicate(
+    asserts: bool,
+    target: TypePredicateTarget,
+    type_id: Option<TypeId>,
+    parameter_index: Option<usize>,
+) -> TypePredicate {
+    TypePredicate {
+        asserts,
+        target,
+        type_id,
+        parameter_index,
     }
 }
 

--- a/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
@@ -142,6 +142,46 @@ pub(crate) const fn jsdoc_tuple_element(
     }
 }
 
+pub(crate) const fn jsdoc_param_info(
+    name: Option<Atom>,
+    type_id: TypeId,
+    optional: bool,
+    rest: bool,
+) -> ParamInfo {
+    ParamInfo {
+        name,
+        type_id,
+        optional,
+        rest,
+    }
+}
+
+pub(crate) const fn jsdoc_property_info(
+    name: Atom,
+    type_id: TypeId,
+    optional: bool,
+    readonly: bool,
+    is_method: bool,
+    declaration_order: u32,
+) -> PropertyInfo {
+    PropertyInfo {
+        name,
+        type_id,
+        write_type: type_id,
+        optional,
+        readonly,
+        is_method,
+        is_class_prototype: false,
+        visibility: tsz_solver::Visibility::Public,
+        parent_id: None,
+        declaration_order,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
 pub(crate) fn jsdoc_mapped_type(
     db: &dyn TypeDatabase,
     type_param: TypeParamInfo,

--- a/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
@@ -7,8 +7,8 @@
 use tsz_common::Atom;
 use tsz_solver::construction::TypeDatabase;
 use tsz_solver::{
-    FunctionShape, IndexSignature, ObjectShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
-    TypePredicate,
+    ConditionalType, FunctionShape, IndexSignature, MappedModifier, MappedType, ObjectShape,
+    ParamInfo, PropertyInfo, TupleElement, TypeId, TypeParamInfo, TypeParamOrigin, TypePredicate,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -60,6 +60,119 @@ pub(crate) const fn jsdoc_object_index_fact(
 
 pub(crate) fn jsdoc_empty_object_type(db: &dyn TypeDatabase) -> TypeId {
     db.object(Vec::new())
+}
+
+pub(crate) fn jsdoc_array_type(db: &dyn TypeDatabase, element: TypeId) -> TypeId {
+    db.array(element)
+}
+
+pub(crate) fn jsdoc_union_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn jsdoc_union_pair_type(db: &dyn TypeDatabase, left: TypeId, right: TypeId) -> TypeId {
+    db.union2(left, right)
+}
+
+pub(crate) fn jsdoc_intersection_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.intersection(members)
+}
+
+pub(crate) fn jsdoc_intersection_pair_type(
+    db: &dyn TypeDatabase,
+    left: TypeId,
+    right: TypeId,
+) -> TypeId {
+    db.intersection2(left, right)
+}
+
+pub(crate) fn jsdoc_application_type(
+    db: &dyn TypeDatabase,
+    base: TypeId,
+    args: Vec<TypeId>,
+) -> TypeId {
+    db.application(base, args)
+}
+
+pub(crate) fn jsdoc_index_access_type(
+    db: &dyn TypeDatabase,
+    object_type: TypeId,
+    index_type: TypeId,
+) -> TypeId {
+    db.index_access(object_type, index_type)
+}
+
+pub(crate) fn jsdoc_keyof_type(db: &dyn TypeDatabase, operand: TypeId) -> TypeId {
+    db.keyof(operand)
+}
+
+pub(crate) const fn jsdoc_type_param_info(
+    name: Atom,
+    constraint: Option<TypeId>,
+    default: Option<TypeId>,
+) -> TypeParamInfo {
+    TypeParamInfo {
+        name,
+        constraint,
+        default,
+        is_const: false,
+        origin: TypeParamOrigin::User,
+    }
+}
+
+pub(crate) fn jsdoc_type_param_type(db: &dyn TypeDatabase, type_param: TypeParamInfo) -> TypeId {
+    db.type_param(type_param)
+}
+
+pub(crate) fn jsdoc_tuple_type(db: &dyn TypeDatabase, elements: Vec<TupleElement>) -> TypeId {
+    db.tuple(elements)
+}
+
+pub(crate) const fn jsdoc_tuple_element(
+    type_id: TypeId,
+    name: Option<Atom>,
+    optional: bool,
+    rest: bool,
+) -> TupleElement {
+    TupleElement {
+        type_id,
+        name,
+        optional,
+        rest,
+    }
+}
+
+pub(crate) fn jsdoc_mapped_type(
+    db: &dyn TypeDatabase,
+    type_param: TypeParamInfo,
+    constraint: TypeId,
+    template: TypeId,
+    optional_modifier: Option<MappedModifier>,
+) -> TypeId {
+    db.mapped(MappedType {
+        type_param,
+        constraint,
+        name_type: None,
+        template,
+        readonly_modifier: None,
+        optional_modifier,
+    })
+}
+
+pub(crate) fn jsdoc_conditional_type(
+    db: &dyn TypeDatabase,
+    check_type: TypeId,
+    extends_type: TypeId,
+    true_type: TypeId,
+    false_type: TypeId,
+) -> TypeId {
+    db.conditional(ConditionalType {
+        check_type,
+        extends_type,
+        true_type,
+        false_type,
+        is_distributive: true,
+    })
 }
 
 pub(crate) fn jsdoc_object_type(

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -38,6 +38,7 @@ pub(crate) mod flow;
 pub(crate) mod flow_analysis;
 pub(crate) mod function_returns;
 pub(crate) mod generic_instantiation;
+pub(crate) mod import_attributes;
 pub(crate) mod index_signature;
 pub(crate) mod inference;
 pub(crate) mod intersection_display;

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod conditional;
 pub(crate) mod conditional_constraints;
 pub(crate) mod conditional_infer_alias;
 pub(crate) mod construct_signatures;
+pub(crate) mod declaration_exports;
 pub(crate) mod definite_assignment;
 pub(crate) mod definition_identity;
 pub(crate) mod diagnostics;

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -41,6 +41,7 @@ pub(crate) mod index_signature;
 pub(crate) mod inference;
 pub(crate) mod intersection_display;
 pub(crate) mod js_exports;
+pub(crate) mod jsdoc_construction;
 pub(crate) mod key_constraints;
 pub(crate) mod lib_augmentations;
 pub(crate) mod name_resolution;

--- a/crates/tsz-checker/src/query_boundaries/property_access.rs
+++ b/crates/tsz-checker/src/query_boundaries/property_access.rs
@@ -1,6 +1,9 @@
 use tsz_common::Atom;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
-use tsz_solver::{FunctionShape, TypeId};
+use tsz_solver::{
+    CallSignature, CallableShape, FunctionShape, ParamInfo, TupleElement, TypeId, TypeParamInfo,
+    TypeParamOrigin, TypePredicate,
+};
 
 pub(crate) use super::common::PropertyAccessResult;
 pub(crate) use super::common::intersection_members;
@@ -174,6 +177,190 @@ pub(crate) fn function_shape(
     type_id: TypeId,
 ) -> Option<std::sync::Arc<FunctionShape>> {
     tsz_solver::type_queries::get_function_shape(db, type_id)
+}
+
+pub(crate) const fn strict_bind_call_apply_param_with_type(
+    param: ParamInfo,
+    type_id: TypeId,
+) -> ParamInfo {
+    ParamInfo { type_id, ..param }
+}
+
+pub(crate) const fn strict_bind_call_apply_type_param_with_constraint(
+    type_param: TypeParamInfo,
+    constraint: Option<TypeId>,
+) -> TypeParamInfo {
+    TypeParamInfo {
+        constraint,
+        ..type_param
+    }
+}
+
+pub(crate) const fn strict_bind_call_apply_call_signature(
+    type_params: Vec<TypeParamInfo>,
+    params: Vec<ParamInfo>,
+    this_type: Option<TypeId>,
+    return_type: TypeId,
+    type_predicate: Option<TypePredicate>,
+    is_method: bool,
+) -> CallSignature {
+    CallSignature {
+        type_params,
+        params,
+        this_type,
+        return_type,
+        type_predicate,
+        is_method,
+    }
+}
+
+pub(crate) fn strict_bind_call_apply_signature_from_function_shape(
+    shape: &FunctionShape,
+) -> CallSignature {
+    strict_bind_call_apply_call_signature(
+        shape.type_params.clone(),
+        shape.params.clone(),
+        shape.this_type,
+        shape.return_type,
+        shape.type_predicate,
+        shape.is_method,
+    )
+}
+
+pub(crate) fn strict_bind_call_apply_params_tuple_type(
+    db: &dyn TypeDatabase,
+    params: &[ParamInfo],
+) -> TypeId {
+    let tuple_elements: Vec<TupleElement> = params
+        .iter()
+        .map(|param| TupleElement {
+            type_id: param.type_id,
+            name: param.name,
+            optional: param.optional && !param.rest,
+            rest: param.rest,
+        })
+        .collect();
+    db.tuple(tuple_elements)
+}
+
+pub(crate) fn strict_bind_call_apply_bound_return_type(
+    db: &dyn TypeDatabase,
+    sig: &CallSignature,
+    remaining_params: Vec<ParamInfo>,
+    is_constructor: bool,
+) -> TypeId {
+    if is_constructor {
+        return db.callable(CallableShape {
+            call_signatures: Vec::new(),
+            construct_signatures: vec![strict_bind_call_apply_call_signature(
+                sig.type_params.clone(),
+                remaining_params,
+                None,
+                sig.return_type,
+                None,
+                false,
+            )],
+            properties: Vec::new(),
+            string_index: None,
+            number_index: None,
+            symbol: None,
+            is_abstract: false,
+        });
+    }
+
+    db.function(FunctionShape {
+        type_params: sig.type_params.clone(),
+        params: remaining_params,
+        this_type: None,
+        return_type: sig.return_type,
+        type_predicate: sig.type_predicate,
+        is_constructor: false,
+        is_method: false,
+    })
+}
+
+pub(crate) fn strict_bind_call_apply_call_only_callable_type(
+    db: &dyn TypeDatabase,
+    call_signatures: Vec<CallSignature>,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures,
+        construct_signatures: Vec::new(),
+        properties: Vec::new(),
+        string_index: None,
+        number_index: None,
+        symbol: None,
+        is_abstract: false,
+    })
+}
+
+pub(crate) fn strict_bind_call_apply_this_arg_param(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> ParamInfo {
+    ParamInfo {
+        name: Some(db.intern_string("thisArg")),
+        type_id,
+        optional: false,
+        rest: false,
+    }
+}
+
+pub(crate) fn strict_bind_call_apply_args_param(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> ParamInfo {
+    ParamInfo {
+        name: Some(db.intern_string("args")),
+        type_id,
+        optional: true,
+        rest: false,
+    }
+}
+
+pub(crate) fn strict_bind_call_apply_generic_this_param(
+    db: &dyn TypeDatabase,
+    constraint: TypeId,
+) -> (TypeParamInfo, TypeId) {
+    let info = TypeParamInfo {
+        name: db.intern_string("TThis"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::User,
+    };
+    let type_id = db.type_param(info);
+    (info, type_id)
+}
+
+pub(crate) fn strict_bind_call_apply_method_type(
+    db: &dyn TypeDatabase,
+    method_signatures: Vec<CallSignature>,
+) -> Option<TypeId> {
+    match method_signatures.len() {
+        0 => None,
+        1 => {
+            let sig = method_signatures.into_iter().next()?;
+            Some(db.function(FunctionShape {
+                type_params: sig.type_params,
+                params: sig.params,
+                this_type: None,
+                return_type: sig.return_type,
+                type_predicate: sig.type_predicate,
+                is_constructor: false,
+                is_method: false,
+            }))
+        }
+        _ => Some(db.callable(CallableShape {
+            call_signatures: method_signatures,
+            construct_signatures: Vec::new(),
+            properties: Vec::new(),
+            string_index: None,
+            number_index: None,
+            symbol: None,
+            is_abstract: false,
+        })),
+    }
 }
 
 /// Check if a type has a named property accessible on all branches.

--- a/crates/tsz-checker/src/query_boundaries/state/checking.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/checking.rs
@@ -1,8 +1,8 @@
 use tsz_common::Atom;
 #[cfg(test)]
 use tsz_solver::TupleElement;
-use tsz_solver::TypeId;
 use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{PropertyInfo, TypeId};
 
 pub(crate) use super::super::common::{
     array_element_type, callable_shape_for_type as callable_shape, intersection_members,
@@ -126,6 +126,23 @@ pub(crate) fn collect_finite_mapped_property_names(
     mapped_id: tsz_solver::MappedTypeId,
 ) -> Option<rustc_hash::FxHashSet<Atom>> {
     tsz_solver::type_queries::collect_finite_mapped_property_names(db, mapped_id)
+}
+
+pub(crate) fn excess_property_any_object_type_from_names(
+    db: &dyn TypeDatabase,
+    prop_names: Vec<Atom>,
+) -> Option<TypeId> {
+    let mut props = Vec::with_capacity(prop_names.len());
+    for name in prop_names {
+        if props.iter().any(|prop: &PropertyInfo| prop.name == name) {
+            continue;
+        }
+        let mut prop = PropertyInfo::new(name, TypeId::ANY);
+        prop.declaration_order = props.len() as u32;
+        props.push(prop);
+    }
+
+    (!props.is_empty()).then(|| db.object(props))
 }
 
 pub(crate) fn get_finite_mapped_property_type(

--- a/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
@@ -752,21 +752,11 @@ impl<'a> CheckerState<'a> {
         // Only fall back for intersections; other shapes are handled by the
         // direct `query::object_shape` path on the call site.
         query::intersection_members(self.ctx.types, type_id)?;
-        match tsz_solver::objects::collect_properties(type_id, self.ctx.types, &self.ctx) {
-            tsz_solver::objects::PropertyCollectionResult::Properties {
-                properties,
-                string_index,
-                number_index,
-                symbol_index,
-            } => Some(std::sync::Arc::new(tsz_solver::ObjectShape {
-                properties,
-                string_index,
-                number_index,
-                symbol_index,
-                ..tsz_solver::ObjectShape::default()
-            })),
-            _ => None,
-        }
+        crate::query_boundaries::intersection_display::collected_properties_object_shape(
+            self.ctx.types,
+            &self.ctx,
+            type_id,
+        )
     }
 
     pub(super) fn try_emit_nested_discriminated_union_assignability_error(
@@ -1566,36 +1556,6 @@ impl<'a> CheckerState<'a> {
             prop_names.extend(property_names);
         }
 
-        if prop_names.is_empty() {
-            return None;
-        }
-
-        let mut props = Vec::with_capacity(prop_names.len());
-        for name in prop_names {
-            if props
-                .iter()
-                .any(|prop: &tsz_solver::PropertyInfo| prop.name == name)
-            {
-                continue;
-            }
-            props.push(tsz_solver::PropertyInfo {
-                name,
-                type_id: TypeId::ANY,
-                write_type: TypeId::ANY,
-                optional: false,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: tsz_common::Visibility::Public,
-                parent_id: None,
-                declaration_order: props.len() as u32,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
-        }
-
-        Some(self.ctx.types.factory().object(props))
+        query::excess_property_any_object_type_from_names(self.ctx.types, prop_names)
     }
 }

--- a/crates/tsz-checker/src/state/type_environment/formatting.rs
+++ b/crates/tsz-checker/src/state/type_environment/formatting.rs
@@ -3,6 +3,7 @@
 //! Extracted from `core.rs` to keep module size manageable.
 
 use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
@@ -404,7 +405,8 @@ impl<'a> CheckerState<'a> {
                 crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
             {
                 let anonymous = self.evaluate_function_shape_for_instantiation_display(&shape);
-                let anonymous_type = self.ctx.types.factory().function(anonymous);
+                let anonymous_type =
+                    diagnostic_query::function_type_from_shape(self.ctx.types, anonymous);
                 let mut structural_formatter = self.ctx.create_instantiation_display_formatter();
                 return structural_formatter.format(anonymous_type).into_owned();
             }
@@ -443,7 +445,8 @@ impl<'a> CheckerState<'a> {
                 && shape.construct_signatures.is_empty()
             {
                 let anonymous = self.evaluate_callable_shape_for_instantiation_display(&shape);
-                let anonymous_type = self.ctx.types.factory().callable(anonymous);
+                let anonymous_type =
+                    diagnostic_query::callable_type_from_shape(self.ctx.types, anonymous);
                 let mut structural_formatter = self.ctx.create_instantiation_display_formatter();
                 return structural_formatter.format(anonymous_type).into_owned();
             }
@@ -455,19 +458,8 @@ impl<'a> CheckerState<'a> {
                     .iter()
                     .map(|sig| self.evaluate_call_signature_for_instantiation_display(sig))
                     .collect();
-                let anonymous_type = self
-                    .ctx
-                    .types
-                    .factory()
-                    .callable(tsz_solver::CallableShape {
-                        call_signatures,
-                        construct_signatures: Vec::new(),
-                        properties: Vec::new(),
-                        string_index: None,
-                        number_index: None,
-                        symbol: None,
-                        is_abstract: false,
-                    });
+                let anonymous_type =
+                    diagnostic_query::call_only_callable_type(self.ctx.types, call_signatures);
                 let mut structural_formatter = self.ctx.create_instantiation_display_formatter();
                 return structural_formatter.format(anonymous_type).into_owned();
             }
@@ -607,19 +599,8 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
             && !shape.type_params.is_empty()
         {
-            let display_type = self
-                .ctx
-                .types
-                .factory()
-                .function(tsz_solver::FunctionShape {
-                    type_params: Vec::new(),
-                    params: shape.params.clone(),
-                    this_type: shape.this_type,
-                    return_type: shape.return_type,
-                    type_predicate: shape.type_predicate,
-                    is_constructor: shape.is_constructor,
-                    is_method: shape.is_method,
-                });
+            let display_type =
+                diagnostic_query::function_type_without_type_params(self.ctx.types, shape.as_ref());
             return self.format_type_diagnostic(display_type);
         }
 
@@ -633,19 +614,12 @@ impl<'a> CheckerState<'a> {
         {
             let sig = &shape.call_signatures[0];
             if !sig.type_params.is_empty() {
-                let display_type = self
-                    .ctx
-                    .types
-                    .factory()
-                    .function(tsz_solver::FunctionShape {
-                        type_params: Vec::new(),
-                        params: sig.params.clone(),
-                        this_type: sig.this_type,
-                        return_type: sig.return_type,
-                        type_predicate: sig.type_predicate,
-                        is_constructor: false,
-                        is_method: sig.is_method,
-                    });
+                let display_type =
+                    diagnostic_query::function_type_from_call_signature_without_type_params(
+                        self.ctx.types,
+                        sig,
+                        false,
+                    );
                 return self.format_type_diagnostic(display_type);
             }
         }
@@ -780,6 +754,6 @@ impl<'a> CheckerState<'a> {
             })
             .collect();
         new_props.sort_by_key(|p| p.name);
-        self.ctx.types.factory().object(new_props)
+        diagnostic_query::object_type_from_properties(self.ctx.types, new_props)
     }
 }

--- a/crates/tsz-checker/src/types/class_type/js_class_properties.rs
+++ b/crates/tsz-checker/src/types/class_type/js_class_properties.rs
@@ -2,6 +2,9 @@
 //! assignments that serve as implicit property declarations.
 
 use crate::context::speculation::DiagnosticSpeculationSnapshot;
+use crate::query_boundaries::checkers::class_properties::{
+    self as class_property_query, JsClassPropertyFact,
+};
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_binder::SymbolId;
@@ -9,10 +12,7 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{
-    CallSignature, CallableShape, ObjectShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
-    Visibility,
-};
+use tsz_solver::{PropertyInfo, TypeId, Visibility};
 
 /// Structural classification of an implicit-`any` constructor property, carried
 /// as a fact rather than re-derived from its rendered display string. The
@@ -149,16 +149,13 @@ impl CheckerState<'_> {
                         .get(&name)
                         .and_then(|s| self.resolve_jsdoc_reference(s));
                     template_types.entry(name).or_insert_with(|| {
-                        self.ctx
-                            .types
-                            .factory()
-                            .type_param(tsz_solver::TypeParamInfo {
-                                name: atom,
-                                constraint,
-                                default,
-                                is_const,
-                                origin: tsz_solver::TypeParamOrigin::User,
-                            })
+                        class_property_query::js_class_type_param_type(
+                            self.ctx.types,
+                            atom,
+                            constraint,
+                            default,
+                            is_const,
+                        )
                     });
                 }
                 return template_types;
@@ -220,16 +217,13 @@ impl CheckerState<'_> {
                     .get(&name)
                     .and_then(|s| self.resolve_jsdoc_reference(s));
                 function_template_types.entry(name).or_insert_with(|| {
-                    self.ctx
-                        .types
-                        .factory()
-                        .type_param(tsz_solver::TypeParamInfo {
-                            name: atom,
-                            constraint,
-                            default,
-                            is_const,
-                            origin: tsz_solver::TypeParamOrigin::User,
-                        })
+                    class_property_query::js_class_type_param_type(
+                        self.ctx.types,
+                        atom,
+                        constraint,
+                        default,
+                        is_const,
+                    )
                 });
             }
         }
@@ -444,14 +438,12 @@ impl CheckerState<'_> {
                             let constraint = constraint_strs
                                 .get(&name)
                                 .and_then(|s| self.resolve_jsdoc_reference(s));
-                            return Some(self.ctx.types.factory().type_param(
-                                tsz_solver::TypeParamInfo {
-                                    name: atom,
-                                    constraint,
-                                    default,
-                                    is_const,
-                                    origin: tsz_solver::TypeParamOrigin::User,
-                                },
+                            return Some(class_property_query::js_class_type_param_type(
+                                self.ctx.types,
+                                atom,
+                                constraint,
+                                default,
+                                is_const,
                             ));
                         }
                     }
@@ -524,13 +516,13 @@ impl CheckerState<'_> {
                         let constraint = constraint_strs
                             .get(&name)
                             .and_then(|s| self.resolve_jsdoc_reference(s));
-                        return Some(self.ctx.types.factory().type_param(TypeParamInfo {
-                            name: atom,
+                        return Some(class_property_query::js_class_type_param_type(
+                            self.ctx.types,
+                            atom,
                             constraint,
                             default,
                             is_const,
-                            origin: tsz_solver::TypeParamOrigin::User,
-                        }));
+                        ));
                     }
                 }
             }
@@ -664,7 +656,8 @@ impl CheckerState<'_> {
                     && crate::query_boundaries::common::array_element_type(self.ctx.types, rhs_type)
                         == Some(TypeId::NEVER)
                 {
-                    rhs_type = self.ctx.types.factory().array(TypeId::ANY);
+                    rhs_type =
+                        class_property_query::js_class_array_type(self.ctx.types, TypeId::ANY);
                     provisional_open = true;
                 }
                 if rhs_type == TypeId::NULL || rhs_type == TypeId::UNDEFINED {
@@ -743,7 +736,11 @@ impl CheckerState<'_> {
                         existing.type_id = type_id;
                         existing.write_type = type_id;
                     } else {
-                        let merged = self.ctx.types.factory().union2(existing.type_id, type_id);
+                        let merged = class_property_query::js_class_union_pair_type(
+                            self.ctx.types,
+                            existing.type_id,
+                            type_id,
+                        );
                         existing.type_id = merged;
                         existing.write_type = if provisional_open {
                             TypeId::ANY
@@ -759,7 +756,7 @@ impl CheckerState<'_> {
             constructor_collected_props.insert(name_atom);
             properties.insert(
                 name_atom,
-                PropertyInfo {
+                class_property_query::js_class_property_info(JsClassPropertyFact {
                     name: name_atom,
                     type_id,
                     write_type: if provisional_open {
@@ -769,16 +766,10 @@ impl CheckerState<'_> {
                     },
                     optional: false,
                     readonly: is_readonly,
-                    is_method: false,
-                    is_class_prototype: false,
                     visibility: Visibility::Public,
                     parent_id: parent_sym,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                },
+                    ..JsClassPropertyFact::new(name_atom, type_id)
+                }),
             );
         }
 
@@ -797,7 +788,8 @@ impl CheckerState<'_> {
 
             if let Some(property) = properties.get_mut(&name_atom) {
                 if implicit_kind == ImplicitAnyKind::AnyArray {
-                    let any_array = self.ctx.types.factory().array(TypeId::ANY);
+                    let any_array =
+                        class_property_query::js_class_array_type(self.ctx.types, TypeId::ANY);
                     let nullish_part = if property.type_id.is_nullable() {
                         Some(property.type_id)
                     } else {
@@ -814,12 +806,19 @@ impl CheckerState<'_> {
                             match nullish_members.as_slice() {
                                 [] => None,
                                 [single] => Some(*single),
-                                _ => Some(self.ctx.types.factory().union(nullish_members)),
+                                _ => Some(class_property_query::js_class_union_type(
+                                    self.ctx.types,
+                                    nullish_members,
+                                )),
                             }
                         })
                     };
                     if let Some(nullish_part) = nullish_part {
-                        property.type_id = self.ctx.types.factory().union2(any_array, nullish_part);
+                        property.type_id = class_property_query::js_class_union_pair_type(
+                            self.ctx.types,
+                            any_array,
+                            nullish_part,
+                        );
                     } else {
                         property.type_id = any_array;
                         property.write_type = any_array;
@@ -1158,7 +1157,6 @@ impl CheckerState<'_> {
         class_idx: NodeIndex,
         class: &tsz_parser::parser::node::ClassData,
     ) -> TypeId {
-        let factory = self.ctx.types.factory();
         let class_sym = self.ctx.binder.get_node_symbol(class_idx);
         let mut props: Vec<PropertyInfo> = Vec::new();
 
@@ -1201,22 +1199,18 @@ impl CheckerState<'_> {
                         TypeId::ANY
                     };
 
-                    props.push(PropertyInfo {
-                        name: name_atom,
-                        type_id,
-                        write_type: type_id,
-                        optional: prop.question_token,
-                        readonly: is_readonly,
-                        is_method: false,
-                        is_class_prototype: false,
-                        visibility,
-                        parent_id: class_sym,
-                        declaration_order: 0,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                    props.push(class_property_query::js_class_property_info(
+                        JsClassPropertyFact {
+                            name: name_atom,
+                            type_id,
+                            write_type: type_id,
+                            optional: prop.question_token,
+                            readonly: is_readonly,
+                            visibility,
+                            parent_id: class_sym,
+                            ..JsClassPropertyFact::new(name_atom, type_id)
+                        },
+                    ));
                 }
                 k if k == syntax_kind_ext::CONSTRUCTOR => {
                     let Some(ctor) = self.ctx.arena.get_constructor(member_node) else {
@@ -1250,22 +1244,18 @@ impl CheckerState<'_> {
                             TypeId::ANY
                         };
                         let visibility = self.get_visibility_from_modifiers(&param.modifiers);
-                        props.push(PropertyInfo {
-                            name: name_atom,
-                            type_id,
-                            write_type: type_id,
-                            optional: param.question_token,
-                            readonly: is_readonly,
-                            is_method: false,
-                            is_class_prototype: false,
-                            visibility,
-                            parent_id: class_sym,
-                            declaration_order: 0,
-                            is_string_named: false,
-                            is_symbol_named: false,
-                            single_quoted_name: false,
-                            non_widening: false,
-                        });
+                        props.push(class_property_query::js_class_property_info(
+                            JsClassPropertyFact {
+                                name: name_atom,
+                                type_id,
+                                write_type: type_id,
+                                optional: param.question_token,
+                                readonly: is_readonly,
+                                visibility,
+                                parent_id: class_sym,
+                                ..JsClassPropertyFact::new(name_atom, type_id)
+                            },
+                        ));
                     }
                 }
                 k if k == syntax_kind_ext::METHOD_DECLARATION => {
@@ -1280,43 +1270,21 @@ impl CheckerState<'_> {
                     };
                     let name_atom = self.ctx.types.intern_string(&name);
                     let visibility = self.get_member_visibility(&method.modifiers, method.name);
-                    let method_type = factory.callable(CallableShape {
-                        call_signatures: vec![CallSignature {
-                            type_params: Vec::new(),
-                            params: vec![ParamInfo {
-                                name: None,
-                                type_id: TypeId::ANY,
-                                optional: false,
-                                rest: true,
-                            }],
-                            this_type: None,
-                            return_type: TypeId::ANY,
-                            type_predicate: None,
+                    let method_type =
+                        class_property_query::js_class_method_callable_type(self.ctx.types);
+                    props.push(class_property_query::js_class_property_info(
+                        JsClassPropertyFact {
+                            name: name_atom,
+                            type_id: method_type,
+                            write_type: method_type,
+                            optional: method.question_token,
                             is_method: true,
-                        }],
-                        construct_signatures: Vec::new(),
-                        properties: Vec::new(),
-                        string_index: None,
-                        number_index: None,
-                        symbol: None,
-                        is_abstract: false,
-                    });
-                    props.push(PropertyInfo {
-                        name: name_atom,
-                        type_id: method_type,
-                        write_type: method_type,
-                        optional: method.question_token,
-                        readonly: false,
-                        is_method: true,
-                        is_class_prototype: true,
-                        visibility,
-                        parent_id: class_sym,
-                        declaration_order: 0,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                            is_class_prototype: true,
+                            visibility,
+                            parent_id: class_sym,
+                            ..JsClassPropertyFact::new(name_atom, method_type)
+                        },
+                    ));
                 }
                 k if matches!(
                     k,
@@ -1356,22 +1324,18 @@ impl CheckerState<'_> {
                     } else {
                         TypeId::ANY
                     };
-                    props.push(PropertyInfo {
-                        name: name_atom,
-                        type_id,
-                        write_type: TypeId::ANY,
-                        optional: false,
-                        readonly: false,
-                        is_method: false,
-                        is_class_prototype: true,
-                        visibility,
-                        parent_id: class_sym,
-                        declaration_order: 0,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                    props.push(class_property_query::js_class_property_info(
+                        JsClassPropertyFact {
+                            name: name_atom,
+                            type_id,
+                            write_type: TypeId::ANY,
+                            optional: false,
+                            is_class_prototype: true,
+                            visibility,
+                            parent_id: class_sym,
+                            ..JsClassPropertyFact::new(name_atom, type_id)
+                        },
+                    ));
                 }
                 _ => {}
             }
@@ -1486,11 +1450,8 @@ impl CheckerState<'_> {
             return TypeId::ERROR;
         }
 
-        let result = factory.object_with_index(ObjectShape {
-            properties: props,
-            symbol: class_sym,
-            ..ObjectShape::default()
-        });
+        let result =
+            class_property_query::js_class_instance_object_type(self.ctx.types, props, class_sym);
         // Cache the partial type so subsequent nested class expressions can use it
         self.ctx
             .class_instance_type_cache

--- a/crates/tsz-checker/src/types/computation/call_display.rs
+++ b/crates/tsz-checker/src/types/computation/call_display.rs
@@ -12,6 +12,7 @@ use crate::call_checker::CallableContext;
 use crate::context::TypingRequest;
 use crate::query_boundaries::checkers::call as call_checker;
 use crate::query_boundaries::common;
+use crate::query_boundaries::construct_signatures as signature_construction;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -83,8 +84,14 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        let source_fn = self.ctx.types.factory().function(normalize(source_shape));
-        let target_fn = self.ctx.types.factory().function(normalize(target_shape));
+        let source_fn = signature_construction::function_type_from_shape(
+            self.ctx.types,
+            normalize(source_shape),
+        );
+        let target_fn = signature_construction::function_type_from_shape(
+            self.ctx.types,
+            normalize(target_shape),
+        );
         self.call_arg_relation_outcome_with_env(source_fn, target_fn)
             .related
     }
@@ -242,11 +249,11 @@ impl<'a> CheckerState<'a> {
             };
             // Wrap contextual type as `() => ctx_type` so the function expression
             // resolver can use get_return_type() to extract the expected return type.
-            let wrapper_fn = self
-                .ctx
-                .types
-                .factory()
-                .function(FunctionShape::new(vec![], body_context_type));
+            let wrapper_fn = signature_construction::function_type_from_parts(
+                self.ctx.types,
+                vec![],
+                body_context_type,
+            );
             Some((wrapper_fn, ctx_type))
         } else {
             None

--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -9,6 +9,7 @@ use crate::context::TypingRequest;
 use crate::query_boundaries::checkers::call as call_checker;
 use crate::query_boundaries::common::ContextualTypeContext;
 use crate::query_boundaries::common::instantiate_type;
+use crate::query_boundaries::construct_signatures as signature_construction;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -224,12 +225,16 @@ impl<'a> CheckerState<'a> {
                 .or_else(|| {
                     call_checker::get_contextual_signature(self.ctx.types, call_target_type)
                 })
-                .map(|shape| self.ctx.types.factory().function(shape))
+                .map(|shape| {
+                    signature_construction::function_type_from_shape(self.ctx.types, shape)
+                })
                 .unwrap_or(call_target_type)
         } else {
             callee_shape
                 .as_ref()
-                .map(|shape| self.ctx.types.factory().function(shape.clone()))
+                .map(|shape| {
+                    signature_construction::function_type_from_shape(self.ctx.types, shape.clone())
+                })
                 .unwrap_or(callee_type_for_context)
         };
         let selected_callee_type = if tagged.type_arguments.is_some() {
@@ -292,19 +297,11 @@ impl<'a> CheckerState<'a> {
 
             if needs_two_pass {
                 // === Round 1: Collect non-contextual substitution types ===
-                let factory = self.ctx.types.factory();
-                let placeholder = {
-                    let fshape = tsz_solver::FunctionShape {
-                        params: vec![],
-                        return_type: TypeId::ANY,
-                        this_type: None,
-                        type_params: vec![],
-                        type_predicate: None,
-                        is_constructor: false,
-                        is_method: false,
-                    };
-                    factory.function(fshape)
-                };
+                let placeholder = signature_construction::function_type_from_parts(
+                    self.ctx.types,
+                    vec![],
+                    TypeId::ANY,
+                );
 
                 // Build argument types for Round 1: TemplateStringsArray + substitutions
                 // Use ANY as stand-in for TemplateStringsArray since it's a fixed

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -9,6 +9,7 @@ use crate::context::TypingRequest;
 use crate::context::speculation::DiagnosticSpeculationSnapshot;
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use crate::query_boundaries::common::ContextualTypeContext;
+use crate::query_boundaries::construct_signatures as signature_construction;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -230,7 +231,9 @@ impl<'a> CheckerState<'a> {
                     self.ctx.types,
                     evaluated_type,
                 )
-                .map(|shape| self.ctx.types.factory().function(shape))
+                .map(|shape| {
+                    signature_construction::function_type_from_shape(self.ctx.types, shape)
+                })
                 .unwrap_or(evaluated_type)
             } else {
                 evaluated_type
@@ -1515,17 +1518,11 @@ impl<'a> CheckerState<'a> {
             .expect("new_params cloned from non-empty shape.params")
             .type_id = evaluated_rest;
 
-        let new_shape = tsz_solver::FunctionShape {
-            type_params: shape.type_params.clone(),
-            params: new_params,
-            this_type: shape.this_type,
-            return_type: shape.return_type,
-            type_predicate: shape.type_predicate,
-            is_constructor: shape.is_constructor,
-            is_method: shape.is_method,
-        };
-
-        self.ctx.types.function(new_shape)
+        signature_construction::function_type_with_params_replaced(
+            self.ctx.types,
+            &shape,
+            new_params,
+        )
     }
 
     /// TS2366/TS2355/TS7030: Check that all code paths return a value when required.

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -4,6 +4,7 @@
 //! checks, and const expando key resolution.
 
 use crate::FlowAnalyzer;
+use crate::query_boundaries::property_access as property_access_query;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use crate::symbols_domain::name_text::property_access_chain_text_in_arena;
@@ -1020,9 +1021,11 @@ impl<'a> CheckerState<'a> {
         let params = sig
             .params
             .iter()
-            .map(|param| tsz_solver::ParamInfo {
-                type_id: instantiate_type(self.ctx.types, param.type_id, &collapse_subst),
-                ..*param
+            .map(|param| {
+                property_access_query::strict_bind_call_apply_param_with_type(
+                    *param,
+                    instantiate_type(self.ctx.types, param.type_id, &collapse_subst),
+                )
             })
             .collect();
         let return_type = instantiate_type(self.ctx.types, sig.return_type, &collapse_subst);
@@ -1031,22 +1034,25 @@ impl<'a> CheckerState<'a> {
             .type_params
             .iter()
             .filter(|tp| !collapsed_names.contains(&tp.name))
-            .map(|tp| tsz_solver::TypeParamInfo {
-                constraint: tp
-                    .constraint
-                    .map(|c| instantiate_type(self.ctx.types, c, &collapse_subst)),
-                ..*tp
+            .map(|tp| {
+                property_access_query::strict_bind_call_apply_type_param_with_constraint(
+                    *tp,
+                    tp.constraint
+                        .map(|c| instantiate_type(self.ctx.types, c, &collapse_subst)),
+                )
             })
             .collect();
 
-        Some(tsz_solver::CallSignature {
-            type_params,
-            params,
-            this_type,
-            return_type,
-            type_predicate: sig.type_predicate,
-            is_method: sig.is_method,
-        })
+        Some(
+            property_access_query::strict_bind_call_apply_call_signature(
+                type_params,
+                params,
+                this_type,
+                return_type,
+                sig.type_predicate,
+                sig.is_method,
+            ),
+        )
     }
 
     pub(in crate::types_domain) fn strict_bind_call_apply_method_type(
@@ -1087,71 +1093,6 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        fn signature_to_call_signature(
-            shape: &tsz_solver::FunctionShape,
-        ) -> tsz_solver::CallSignature {
-            tsz_solver::CallSignature {
-                type_params: shape.type_params.clone(),
-                params: shape.params.clone(),
-                this_type: shape.this_type,
-                return_type: shape.return_type,
-                type_predicate: shape.type_predicate,
-                is_method: shape.is_method,
-            }
-        }
-
-        fn signature_params_as_tuple(
-            factory: tsz_solver::construction::TypeFactory<'_>,
-            params: &[tsz_solver::ParamInfo],
-        ) -> TypeId {
-            let tuple_elements: Vec<tsz_solver::TupleElement> = params
-                .iter()
-                .map(|param| tsz_solver::TupleElement {
-                    type_id: param.type_id,
-                    name: param.name,
-                    optional: param.optional && !param.rest,
-                    rest: param.rest,
-                })
-                .collect();
-            factory.tuple(tuple_elements)
-        }
-
-        fn bound_callable_return_type(
-            factory: tsz_solver::construction::TypeFactory<'_>,
-            sig: &tsz_solver::CallSignature,
-            remaining_params: Vec<tsz_solver::ParamInfo>,
-            is_constructor: bool,
-        ) -> TypeId {
-            if is_constructor {
-                return factory.callable(tsz_solver::CallableShape {
-                    call_signatures: Vec::new(),
-                    construct_signatures: vec![tsz_solver::CallSignature {
-                        type_params: sig.type_params.clone(),
-                        params: remaining_params,
-                        this_type: None,
-                        return_type: sig.return_type,
-                        type_predicate: None,
-                        is_method: false,
-                    }],
-                    properties: Vec::new(),
-                    string_index: None,
-                    number_index: None,
-                    symbol: None,
-                    is_abstract: false,
-                });
-            }
-
-            factory.function(tsz_solver::FunctionShape {
-                type_params: sig.type_params.clone(),
-                params: remaining_params,
-                this_type: None,
-                return_type: sig.return_type,
-                type_predicate: sig.type_predicate,
-                is_constructor: false,
-                is_method: false,
-            })
-        }
-
         let mut candidates = vec![object_type];
         if let Some(sym_id) = self.resolve_identifier_symbol(object_expr_idx) {
             let sym_type = self.get_type_of_symbol(sym_id);
@@ -1174,7 +1115,10 @@ impl<'a> CheckerState<'a> {
             if let Some(shape) =
                 crate::query_boundaries::property_access::function_shape(self.ctx.types, candidate)
             {
-                let sig = signature_to_call_signature(&shape);
+                let sig =
+                    property_access_query::strict_bind_call_apply_signature_from_function_shape(
+                        &shape,
+                    );
                 if !call_targets.contains(&sig) {
                     call_targets.push(sig);
                 }
@@ -1209,7 +1153,6 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let factory = self.ctx.types.factory();
         let mut method_signatures = Vec::new();
 
         // `tsc` parity: `.bind(thisArg)` on an overloaded function whose call
@@ -1230,28 +1173,26 @@ impl<'a> CheckerState<'a> {
             && construct_targets.is_empty()
             && call_targets.iter().all(|sig| sig.this_type.is_none())
         {
-            let full_receiver = factory.callable(tsz_solver::CallableShape {
-                call_signatures: call_targets.clone(),
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            });
-            method_signatures.push(tsz_solver::CallSignature {
-                type_params: Vec::new(),
-                params: vec![tsz_solver::ParamInfo {
-                    name: Some(self.ctx.types.intern_string("thisArg")),
-                    type_id: TypeId::ANY,
-                    optional: false,
-                    rest: false,
-                }],
-                this_type: None,
-                return_type: full_receiver,
-                type_predicate: None,
-                is_method: false,
-            });
+            let full_receiver =
+                property_access_query::strict_bind_call_apply_call_only_callable_type(
+                    self.ctx.types,
+                    call_targets.clone(),
+                );
+            method_signatures.push(
+                property_access_query::strict_bind_call_apply_call_signature(
+                    Vec::new(),
+                    vec![
+                        property_access_query::strict_bind_call_apply_this_arg_param(
+                            self.ctx.types,
+                            TypeId::ANY,
+                        ),
+                    ],
+                    None,
+                    full_receiver,
+                    None,
+                    false,
+                ),
+            );
         }
 
         for (sig, is_constructor) in call_targets
@@ -1261,61 +1202,56 @@ impl<'a> CheckerState<'a> {
         {
             match property_name {
                 "apply" => {
-                    let method_sig = tsz_solver::CallSignature {
-                        type_params: sig.type_params.clone(),
-                        params: vec![
-                            tsz_solver::ParamInfo {
-                                name: Some(self.ctx.types.intern_string("thisArg")),
-                                type_id: method_this_arg_type(
-                                    sig,
-                                    is_constructor,
-                                    receiver_this_type,
+                    let method_sig = property_access_query::strict_bind_call_apply_call_signature(
+                        sig.type_params.clone(),
+                        vec![
+                            property_access_query::strict_bind_call_apply_this_arg_param(
+                                self.ctx.types,
+                                method_this_arg_type(sig, is_constructor, receiver_this_type),
+                            ),
+                            property_access_query::strict_bind_call_apply_args_param(
+                                self.ctx.types,
+                                property_access_query::strict_bind_call_apply_params_tuple_type(
+                                    self.ctx.types,
+                                    &sig.params,
                                 ),
-                                optional: false,
-                                rest: false,
-                            },
-                            tsz_solver::ParamInfo {
-                                name: Some(self.ctx.types.intern_string("args")),
-                                type_id: signature_params_as_tuple(factory, &sig.params),
-                                optional: true,
-                                rest: false,
-                            },
+                            ),
                         ],
-                        this_type: None,
-                        return_type: if is_constructor {
+                        None,
+                        if is_constructor {
                             TypeId::VOID
                         } else {
                             sig.return_type
                         },
-                        type_predicate: None,
-                        is_method: false,
-                    };
+                        None,
+                        false,
+                    );
                     if !method_signatures.contains(&method_sig) {
                         method_signatures.push(method_sig);
                     }
                 }
                 "call" => {
                     let mut params = Vec::with_capacity(1 + sig.params.len());
-                    params.push(tsz_solver::ParamInfo {
-                        name: Some(self.ctx.types.intern_string("thisArg")),
-                        type_id: method_this_arg_type(sig, is_constructor, receiver_this_type),
-                        optional: false,
-                        rest: false,
-                    });
+                    params.push(
+                        property_access_query::strict_bind_call_apply_this_arg_param(
+                            self.ctx.types,
+                            method_this_arg_type(sig, is_constructor, receiver_this_type),
+                        ),
+                    );
                     params.extend(sig.params.clone());
 
-                    let method_sig = tsz_solver::CallSignature {
-                        type_params: sig.type_params.clone(),
+                    let method_sig = property_access_query::strict_bind_call_apply_call_signature(
+                        sig.type_params.clone(),
                         params,
-                        this_type: None,
-                        return_type: if is_constructor {
+                        None,
+                        if is_constructor {
                             TypeId::VOID
                         } else {
                             sig.return_type
                         },
-                        type_predicate: None,
-                        is_method: false,
-                    };
+                        None,
+                        false,
+                    );
                     if !method_signatures.contains(&method_sig) {
                         method_signatures.push(method_sig);
                     }
@@ -1327,62 +1263,61 @@ impl<'a> CheckerState<'a> {
                         let this_arg_type =
                             bind_this_arg_type(sig, is_constructor, receiver_this_type);
                         let mut params = Vec::with_capacity(1 + prefix_len);
-                        params.push(tsz_solver::ParamInfo {
-                            name: Some(self.ctx.types.intern_string("thisArg")),
-                            type_id: this_arg_type,
-                            optional: false,
-                            rest: false,
-                        });
+                        params.push(
+                            property_access_query::strict_bind_call_apply_this_arg_param(
+                                self.ctx.types,
+                                this_arg_type,
+                            ),
+                        );
                         params.extend(sig.params.iter().take(prefix_len).cloned());
 
                         let remaining_params =
                             sig.params.iter().skip(prefix_len).cloned().collect();
-                        let method_sig = tsz_solver::CallSignature {
-                            type_params: sig.type_params.clone(),
-                            params,
-                            this_type: None,
-                            return_type: bound_callable_return_type(
-                                factory,
-                                sig,
-                                remaining_params,
-                                is_constructor,
-                            ),
-                            type_predicate: None,
-                            is_method: false,
-                        };
+                        let method_sig =
+                            property_access_query::strict_bind_call_apply_call_signature(
+                                sig.type_params.clone(),
+                                params,
+                                None,
+                                property_access_query::strict_bind_call_apply_bound_return_type(
+                                    self.ctx.types,
+                                    sig,
+                                    remaining_params,
+                                    is_constructor,
+                                ),
+                                None,
+                                false,
+                            );
                         if !method_signatures.contains(&method_sig) {
                             method_signatures.push(method_sig);
                         }
 
                         if prefix_len == 0 && sig.this_type.is_some() && !is_constructor {
-                            let generic_this_param = tsz_solver::TypeParamInfo {
-                                name: self.ctx.types.intern_string("TThis"),
-                                constraint: Some(this_arg_type),
-                                default: None,
-                                is_const: false,
-                                origin: tsz_solver::TypeParamOrigin::User,
-                            };
-                            let generic_this_type = factory.type_param(generic_this_param);
-                            let generic_bind_sig = tsz_solver::CallSignature {
-                                type_params: std::iter::once(generic_this_param)
+                            let (generic_this_param, generic_this_type) =
+                                property_access_query::strict_bind_call_apply_generic_this_param(
+                                    self.ctx.types,
+                                    this_arg_type,
+                                );
+                            let generic_bind_sig =
+                                property_access_query::strict_bind_call_apply_call_signature(
+                                    std::iter::once(generic_this_param)
                                     .chain(sig.type_params.clone())
                                     .collect(),
-                                params: vec![tsz_solver::ParamInfo {
-                                    name: Some(self.ctx.types.intern_string("thisArg")),
-                                    type_id: generic_this_type,
-                                    optional: false,
-                                    rest: false,
-                                }],
-                                this_type: None,
-                                return_type: bound_callable_return_type(
-                                    factory,
+                                    vec![
+                                        property_access_query::strict_bind_call_apply_this_arg_param(
+                                            self.ctx.types,
+                                            generic_this_type,
+                                        ),
+                                    ],
+                                    None,
+                                    property_access_query::strict_bind_call_apply_bound_return_type(
+                                        self.ctx.types,
                                     sig,
                                     sig.params.clone(),
                                     is_constructor,
-                                ),
-                                type_predicate: None,
-                                is_method: false,
-                            };
+                                    ),
+                                    None,
+                                    false,
+                                );
                             if !method_signatures.contains(&generic_bind_sig) {
                                 method_signatures.push(generic_bind_sig);
                             }
@@ -1393,27 +1328,7 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        match method_signatures.len() {
-            0 => None,
-            1 => Some(factory.function(tsz_solver::FunctionShape {
-                type_params: method_signatures[0].type_params.clone(),
-                params: method_signatures[0].params.clone(),
-                this_type: None,
-                return_type: method_signatures[0].return_type,
-                type_predicate: method_signatures[0].type_predicate,
-                is_constructor: false,
-                is_method: false,
-            })),
-            _ => Some(factory.callable(tsz_solver::CallableShape {
-                call_signatures: method_signatures,
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            })),
-        }
+        property_access_query::strict_bind_call_apply_method_type(self.ctx.types, method_signatures)
     }
 
     /// Report the module-compatibility error for `import.meta` when the

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -21,6 +21,9 @@
 //!   constructs signature-bearing solver types only through
 //!   `query_boundaries::construct_signatures`, never via inline shape
 //!   literals or direct interning calls.
+//! - `diagnostic_construction_boundary_scans`: diagnostic reporters route
+//!   display-only solver shape construction through
+//!   `query_boundaries::diagnostics`.
 //! - `class_instance_walk_state_scans`: class instance base traversal uses a
 //!   named checker-owned walk state instead of paired raw visited sets.
 //! - `cross_arena_delegation_scope_scans`: cross-arena delegation depth uses a
@@ -41,6 +44,8 @@ mod common_boundary_export_ratchets;
 mod construction_boundary_signature_scans;
 #[path = "arch_source_scans/cross_arena_delegation_scope_scans.rs"]
 mod cross_arena_delegation_scope_scans;
+#[path = "arch_source_scans/diagnostic_construction_boundary_scans.rs"]
+mod diagnostic_construction_boundary_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
 #[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -46,6 +46,9 @@
 //! - `declaration_export_construction_boundary_scans`: namespace/module
 //!   declaration checkers route export-surface construction through
 //!   `query_boundaries::declaration_exports`.
+//! - `import_attribute_construction_boundary_scans`: static and dynamic import
+//!   callers route import-attribute object construction through
+//!   `query_boundaries::import_attributes`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -61,6 +64,8 @@ mod declaration_export_construction_boundary_scans;
 mod diagnostic_construction_boundary_scans;
 #[path = "arch_source_scans/excess_property_construction_boundary_scans.rs"]
 mod excess_property_construction_boundary_scans;
+#[path = "arch_source_scans/import_attribute_construction_boundary_scans.rs"]
+mod import_attribute_construction_boundary_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
 #[path = "arch_source_scans/js_class_property_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -24,6 +24,8 @@
 //! - `diagnostic_construction_boundary_scans`: diagnostic reporters route
 //!   display-only solver shape construction through
 //!   `query_boundaries::diagnostics`.
+//! - `excess_property_construction_boundary_scans`: excess-property checking
+//!   routes object shape construction through query boundaries.
 //! - `class_instance_walk_state_scans`: class instance base traversal uses a
 //!   named checker-owned walk state instead of paired raw visited sets.
 //! - `cross_arena_delegation_scope_scans`: cross-arena delegation depth uses a
@@ -46,6 +48,8 @@ mod construction_boundary_signature_scans;
 mod cross_arena_delegation_scope_scans;
 #[path = "arch_source_scans/diagnostic_construction_boundary_scans.rs"]
 mod diagnostic_construction_boundary_scans;
+#[path = "arch_source_scans/excess_property_construction_boundary_scans.rs"]
+mod excess_property_construction_boundary_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
 #[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -43,6 +43,9 @@
 //! - `strict_bind_call_apply_construction_boundary_scans`: property-access
 //!   helpers route strict bind/call/apply signature construction through
 //!   `query_boundaries::property_access`.
+//! - `declaration_export_construction_boundary_scans`: namespace/module
+//!   declaration checkers route export-surface construction through
+//!   `query_boundaries::declaration_exports`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -52,6 +55,8 @@ mod common_boundary_export_ratchets;
 mod construction_boundary_signature_scans;
 #[path = "arch_source_scans/cross_arena_delegation_scope_scans.rs"]
 mod cross_arena_delegation_scope_scans;
+#[path = "arch_source_scans/declaration_export_construction_boundary_scans.rs"]
+mod declaration_export_construction_boundary_scans;
 #[path = "arch_source_scans/diagnostic_construction_boundary_scans.rs"]
 mod diagnostic_construction_boundary_scans;
 #[path = "arch_source_scans/excess_property_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -37,6 +37,9 @@
 //!   solver shape construction through `query_boundaries::jsdoc_construction`.
 //! - `jsx_construction_boundary_scans`: JSX checker callers route object and
 //!   function shape construction through `query_boundaries::checkers::jsx`.
+//! - `js_class_property_construction_boundary_scans`: JS class-property
+//!   scanning routes type-parameter, array/union, property, callable, and object
+//!   construction through `query_boundaries::checkers::class_properties`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -52,6 +55,8 @@ mod diagnostic_construction_boundary_scans;
 mod excess_property_construction_boundary_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
+#[path = "arch_source_scans/js_class_property_construction_boundary_scans.rs"]
+mod js_class_property_construction_boundary_scans;
 #[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]
 mod jsdoc_construction_boundary_scans;
 #[path = "arch_source_scans/jsx_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -28,6 +28,8 @@
 //! - `index_signature_boundary_scans`: production checker index-signature
 //!   queries go through `query_boundaries::index_signature` rather than
 //!   constructing the raw solver resolver at call sites.
+//! - `jsdoc_construction_boundary_scans`: JSDoc type-resolution callers route
+//!   solver shape construction through `query_boundaries::jsdoc_construction`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -39,6 +41,8 @@ mod construction_boundary_signature_scans;
 mod cross_arena_delegation_scope_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
+#[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]
+mod jsdoc_construction_boundary_scans;
 #[path = "arch_source_scans/lazy_resolution_session_scans.rs"]
 mod lazy_resolution_session_scans;
 #[path = "arch_source_scans/object_flags_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -30,6 +30,8 @@
 //!   constructing the raw solver resolver at call sites.
 //! - `jsdoc_construction_boundary_scans`: JSDoc type-resolution callers route
 //!   solver shape construction through `query_boundaries::jsdoc_construction`.
+//! - `jsx_construction_boundary_scans`: JSX checker callers route object and
+//!   function shape construction through `query_boundaries::checkers::jsx`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -43,6 +45,8 @@ mod cross_arena_delegation_scope_scans;
 mod index_signature_boundary_scans;
 #[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]
 mod jsdoc_construction_boundary_scans;
+#[path = "arch_source_scans/jsx_construction_boundary_scans.rs"]
+mod jsx_construction_boundary_scans;
 #[path = "arch_source_scans/lazy_resolution_session_scans.rs"]
 mod lazy_resolution_session_scans;
 #[path = "arch_source_scans/object_flags_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -40,6 +40,9 @@
 //! - `js_class_property_construction_boundary_scans`: JS class-property
 //!   scanning routes type-parameter, array/union, property, callable, and object
 //!   construction through `query_boundaries::checkers::class_properties`.
+//! - `strict_bind_call_apply_construction_boundary_scans`: property-access
+//!   helpers route strict bind/call/apply signature construction through
+//!   `query_boundaries::property_access`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -73,6 +76,8 @@ mod relation_boundary_session_scans;
 mod relation_routing_residual_arch_tests;
 #[path = "arch_source_scans/spelling_suggestion_gateway_scans.rs"]
 mod spelling_suggestion_gateway_scans;
+#[path = "arch_source_scans/strict_bind_call_apply_construction_boundary_scans.rs"]
+mod strict_bind_call_apply_construction_boundary_scans;
 #[path = "arch_source_scans/type_guard_walk_state.rs"]
 mod type_guard_walk_state;
 #[path = "arch_source_scans/type_reference_depth_session_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
@@ -33,6 +33,7 @@ const SIGNATURE_CONSTRUCTION_CLEAN_MODULES: &[&str] = &[
 
 /// The designated checker-side `CallSignature` data assembler.
 const SIGNATURE_DATA_BUILDER: &str = "src/checkers/signature_builder.rs";
+const CALL_DISPLAY_MODULE: &str = "src/types/computation/call_display.rs";
 
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
@@ -106,6 +107,29 @@ fn issue_13022_modules_do_not_build_type_shape_literals() {
     );
 }
 
+/// `call_display.rs` also builds temporary function surfaces for relation and
+/// contextual-return checks. Those function types are signature-bearing
+/// construction and must stay behind the same boundary, but the module still
+/// assembles read-only `CallSignature` data for display skeletons.
+#[test]
+fn call_display_routes_function_type_construction_through_boundary() {
+    const PATTERNS: &[&str] = &[
+        ".factory().function(",
+        ".factory.function(",
+        ".types.function(",
+        "FunctionShape::new(",
+    ];
+
+    let mut violations = Vec::new();
+    scan_for_patterns(CALL_DISPLAY_MODULE, PATTERNS, &mut violations);
+    assert!(
+        violations.is_empty(),
+        "call_display.rs must intern temporary function types through \
+         query_boundaries::construct_signatures:\n{}",
+        violations.join("\n")
+    );
+}
+
 /// `CallSignature` literals are signature *data* assembly and belong to the
 /// designated builder module (`checkers/signature_builder.rs`) or the
 /// boundary itself; the other issue #13022 modules round-trip through
@@ -138,6 +162,7 @@ fn construct_signatures_boundary_owns_construction_helpers() {
         "function_shape_from_call_signature",
         "call_signature_from_function_shape",
         "function_type_from_shape",
+        "function_type_from_parts",
         "function_type_from_call_signature",
         "call_only_callable_type",
         "construct_only_callable_type",

--- a/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
@@ -34,6 +34,10 @@ const SIGNATURE_CONSTRUCTION_CLEAN_MODULES: &[&str] = &[
 /// The designated checker-side `CallSignature` data assembler.
 const SIGNATURE_DATA_BUILDER: &str = "src/checkers/signature_builder.rs";
 const CALL_DISPLAY_MODULE: &str = "src/types/computation/call_display.rs";
+const CONTEXTUAL_FUNCTION_MATERIALIZATION_MODULES: &[&str] = &[
+    "src/types/computation/tagged_template.rs",
+    "src/types/function_type_helpers.rs",
+];
 
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
@@ -130,6 +134,30 @@ fn call_display_routes_function_type_construction_through_boundary() {
     );
 }
 
+/// Contextual typing helpers may assemble `FunctionShape` request data, but
+/// interned function types must flow through `construct_signatures`.
+#[test]
+fn contextual_function_materialization_routes_interning_through_boundary() {
+    const PATTERNS: &[&str] = &[
+        ".factory().function(",
+        ".factory.function(",
+        ".types.function(",
+        ".ctx.types.function(",
+        "FunctionShape::new(",
+    ];
+
+    let mut violations = Vec::new();
+    for module in CONTEXTUAL_FUNCTION_MATERIALIZATION_MODULES {
+        scan_for_patterns(module, PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "contextual function helpers must intern temporary function types through \
+         query_boundaries::construct_signatures:\n{}",
+        violations.join("\n")
+    );
+}
+
 /// `CallSignature` literals are signature *data* assembly and belong to the
 /// designated builder module (`checkers/signature_builder.rs`) or the
 /// boundary itself; the other issue #13022 modules round-trip through
@@ -163,6 +191,7 @@ fn construct_signatures_boundary_owns_construction_helpers() {
         "call_signature_from_function_shape",
         "function_type_from_shape",
         "function_type_from_parts",
+        "function_type_with_params_replaced",
         "function_type_from_call_signature",
         "call_only_callable_type",
         "construct_only_callable_type",

--- a/crates/tsz-checker/tests/arch_source_scans/declaration_export_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/declaration_export_construction_boundary_scans.rs
@@ -1,0 +1,121 @@
+//! Declaration export construction boundary scans.
+//!
+//! Namespace/module declaration checkers collect AST and binder facts. Solver
+//! property, object, callable, lazy-ref, intersection, and application
+//! construction for export surfaces belongs in
+//! `query_boundaries::declaration_exports`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DECLARATION_EXPORT_CALLERS: &[&str] = &[
+    "src/declarations/module_checker.rs",
+    "src/declarations/namespace_checker.rs",
+];
+const DECLARATION_EXPORT_BOUNDARY: &str = "src/query_boundaries/declaration_exports.rs";
+const COMMON_BOUNDARY: &str = "src/query_boundaries/common.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}(")) || source.contains(&format!("fn {name}<"))
+}
+
+#[test]
+fn declaration_export_callers_route_solver_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        "PropertyInfo {",
+        "PropertyInfo::new(",
+        "CallableShape {",
+        "CallableShape::default()",
+        ".factory().object(",
+        ".ctx.types.factory().object(",
+        "factory.object(",
+        ".object_with_symbol(",
+        ".factory().callable(",
+        ".callable(",
+        ".application(",
+        ".lazy(",
+        ".intersection2(",
+    ];
+
+    let mut violations = Vec::new();
+    for caller in DECLARATION_EXPORT_CALLERS {
+        scan_for_patterns(caller, FORBIDDEN_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "declaration export-surface callers must route solver construction \
+         through query_boundaries::declaration_exports:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn declaration_exports_boundary_owns_export_surface_construction_helpers() {
+    let source = fs::read_to_string(checker_path(DECLARATION_EXPORT_BOUNDARY))
+        .expect("failed to read query_boundaries/declaration_exports.rs");
+    let common =
+        fs::read_to_string(checker_path(COMMON_BOUNDARY)).expect("failed to read common.rs");
+
+    for helper in [
+        "declaration_export_property",
+        "declaration_lazy_export_type",
+        "module_export_augmented_type",
+        "dynamic_import_module_object_type",
+        "dynamic_import_promise_type",
+        "empty_namespace_object_type",
+        "namespace_object_placeholder_type",
+        "namespace_object_type",
+        "namespace_merged_constructor_callable_type",
+        "namespace_merged_function_callable_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::declaration_exports must own `{helper}`"
+        );
+        assert!(
+            !defines_fn(&common, helper),
+            "query_boundaries::common must not define `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "PropertyInfo {",
+        "Visibility::Public",
+        "db.lazy(",
+        "db.intersection2(",
+        "db.object(",
+        "db.object_with_flags_and_symbol(",
+        "db.application(",
+        "db.callable(",
+        "CallableShape {",
+        "ObjectFlags::empty()",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::declaration_exports should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -8,14 +8,22 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const DIAGNOSTICS_BOUNDARY: &str = "src/query_boundaries/diagnostics.rs";
-const DIAGNOSTIC_REPORTER_CONSTRUCTION_MODULES: &[&str] = &[
+const DIAGNOSTIC_CONSTRUCTION_MODULES: &[&str] = &[
     "src/error_reporter/core/type_display.rs",
     "src/error_reporter/core/excess_display.rs",
     "src/error_reporter/generics.rs",
+    "src/state/type_environment/formatting.rs",
 ];
 
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn is_allowed_shape_return_signature(trimmed: &str) -> bool {
+    matches!(
+        trimmed,
+        ") -> tsz_solver::FunctionShape {" | ") -> tsz_solver::CallableShape {"
+    )
 }
 
 fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
@@ -23,7 +31,7 @@ fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<Str
         .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
     for (line_index, line) in source.lines().enumerate() {
         let trimmed = line.trim_start();
-        if trimmed.starts_with("//") {
+        if trimmed.starts_with("//") || is_allowed_shape_return_signature(trimmed) {
             continue;
         }
         for pattern in patterns {
@@ -38,7 +46,7 @@ fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<Str
 }
 
 #[test]
-fn error_reporters_route_solver_shape_construction_through_diagnostics_boundary() {
+fn diagnostic_display_callers_route_solver_shape_construction_through_diagnostics_boundary() {
     const FORBIDDEN_PATTERNS: &[&str] = &[
         ".factory().object(",
         ".factory().object_with_index(",
@@ -61,13 +69,13 @@ fn error_reporters_route_solver_shape_construction_through_diagnostics_boundary(
     ];
 
     let mut violations = Vec::new();
-    for relative in DIAGNOSTIC_REPORTER_CONSTRUCTION_MODULES {
+    for relative in DIAGNOSTIC_CONSTRUCTION_MODULES {
         scan_for_patterns(relative, FORBIDDEN_PATTERNS, &mut violations);
     }
 
     assert!(
         violations.is_empty(),
-        "error_reporter modules must route diagnostic solver shape construction \
+        "diagnostic display callers must route solver shape construction \
          through query_boundaries::diagnostics:\n{}",
         violations.join("\n")
     );
@@ -85,6 +93,8 @@ fn diagnostics_boundary_owns_construction_helpers() {
         "function_type_with_params_replaced",
         "function_type_with_return_replaced",
         "function_type_with_params_and_return_replaced",
+        "function_type_without_type_params",
+        "function_type_from_call_signature_without_type_params",
         "callable_type_from_shape",
         "call_only_callable_type",
         "callable_type_with_signatures_replaced",

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -11,9 +11,13 @@ const DIAGNOSTICS_BOUNDARY: &str = "src/query_boundaries/diagnostics.rs";
 const DIAGNOSTIC_CONSTRUCTION_MODULES: &[&str] = &[
     "src/error_reporter/core/type_display.rs",
     "src/error_reporter/core/excess_display.rs",
+    "src/error_reporter/core/diagnostic_source/static_schema.rs",
     "src/error_reporter/generics.rs",
+    "src/error_reporter/properties.rs",
+    "src/error_reporter/call_errors/display_formatting_parameters.rs",
     "src/state/type_environment/formatting.rs",
 ];
+const DIAGNOSTIC_FUNCTION_CONSTRUCTION_MODULES: &[&str] = &["src/error_reporter/render_failure.rs"];
 
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
@@ -73,6 +77,17 @@ fn diagnostic_display_callers_route_solver_shape_construction_through_diagnostic
         scan_for_patterns(relative, FORBIDDEN_PATTERNS, &mut violations);
     }
 
+    const FUNCTION_FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory().function(",
+        ".factory.function(",
+        ".types.function(",
+        "FunctionShape {",
+        "FunctionShape::new(",
+    ];
+    for relative in DIAGNOSTIC_FUNCTION_CONSTRUCTION_MODULES {
+        scan_for_patterns(relative, FUNCTION_FORBIDDEN_PATTERNS, &mut violations);
+    }
+
     assert!(
         violations.is_empty(),
         "diagnostic display callers must route solver shape construction \
@@ -95,6 +110,7 @@ fn diagnostics_boundary_owns_construction_helpers() {
         "function_type_with_params_and_return_replaced",
         "function_type_without_type_params",
         "function_type_from_call_signature_without_type_params",
+        "function_type_from_call_signature",
         "callable_type_from_shape",
         "call_only_callable_type",
         "callable_type_with_signatures_replaced",

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -11,10 +11,13 @@ const DIAGNOSTICS_BOUNDARY: &str = "src/query_boundaries/diagnostics.rs";
 const DIAGNOSTIC_CONSTRUCTION_MODULES: &[&str] = &[
     "src/error_reporter/core/type_display.rs",
     "src/error_reporter/core/excess_display.rs",
+    "src/error_reporter/core/diagnostic_source.rs",
     "src/error_reporter/core/diagnostic_source/static_schema.rs",
     "src/error_reporter/generics.rs",
     "src/error_reporter/properties.rs",
+    "src/error_reporter/call_errors/display_formatting.rs",
     "src/error_reporter/call_errors/display_formatting_parameters.rs",
+    "src/error_reporter/call_errors/elaboration.rs",
     "src/state/type_environment/formatting.rs",
 ];
 const DIAGNOSTIC_FUNCTION_CONSTRUCTION_MODULES: &[&str] = &["src/error_reporter/render_failure.rs"];
@@ -104,6 +107,8 @@ fn diagnostics_boundary_owns_construction_helpers() {
         "object_type_from_properties",
         "object_type_from_shape",
         "object_type_preserving_display_properties",
+        "shallow_object_property_literals_widened_for_call_parameter_display",
+        "object_type_with_unknown_display_members",
         "function_type_from_shape",
         "function_type_with_params_replaced",
         "function_type_with_return_replaced",

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -13,10 +13,12 @@ const DIAGNOSTIC_CONSTRUCTION_MODULES: &[&str] = &[
     "src/error_reporter/core/excess_display.rs",
     "src/error_reporter/core/diagnostic_source.rs",
     "src/error_reporter/core/diagnostic_source/static_schema.rs",
+    "src/error_reporter/fingerprint_policy.rs",
     "src/error_reporter/generics.rs",
     "src/error_reporter/properties.rs",
     "src/error_reporter/call_errors/display_formatting.rs",
     "src/error_reporter/call_errors/display_formatting_parameters.rs",
+    "src/error_reporter/call_errors/error_emission.rs",
     "src/error_reporter/call_errors/elaboration.rs",
     "src/state/type_environment/formatting.rs",
 ];
@@ -33,12 +35,19 @@ fn is_allowed_shape_return_signature(trimmed: &str) -> bool {
     )
 }
 
+fn is_allowed_failure_reason_match(line: &str) -> bool {
+    line.contains("SubtypeFailureReason::MissingIndexSignature {")
+}
+
 fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
     let source = fs::read_to_string(checker_path(relative))
         .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
     for (line_index, line) in source.lines().enumerate() {
         let trimmed = line.trim_start();
-        if trimmed.starts_with("//") || is_allowed_shape_return_signature(trimmed) {
+        if trimmed.starts_with("//")
+            || is_allowed_shape_return_signature(trimmed)
+            || is_allowed_failure_reason_match(line)
+        {
             continue;
         }
         for pattern in patterns {
@@ -109,6 +118,8 @@ fn diagnostics_boundary_owns_construction_helpers() {
         "object_type_preserving_display_properties",
         "shallow_object_property_literals_widened_for_call_parameter_display",
         "object_type_with_unknown_display_members",
+        "mapped_property_mismatch_parameter_display_type",
+        "display_property_literals_widened_for_related_info",
         "function_type_from_shape",
         "function_type_with_params_replaced",
         "function_type_with_return_replaced",

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -23,6 +23,13 @@ const DIAGNOSTIC_CONSTRUCTION_MODULES: &[&str] = &[
     "src/state/type_environment/formatting.rs",
 ];
 const DIAGNOSTIC_FUNCTION_CONSTRUCTION_MODULES: &[&str] = &["src/error_reporter/render_failure.rs"];
+const DIAGNOSTIC_SOURCE_COLLECTION_MODULES: &[&str] = &[
+    "src/error_reporter/core/identifier_source_display.rs",
+    "src/error_reporter/core/diagnostic_source/contextual_index_display.rs",
+    "src/error_reporter/core/diagnostic_source/computed_index_source_display.rs",
+    "src/error_reporter/core/diagnostic_source/collection_source_display.rs",
+    "src/error_reporter/core/diagnostic_source/tuple_source_display.rs",
+];
 
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
@@ -109,6 +116,32 @@ fn diagnostic_display_callers_route_solver_shape_construction_through_diagnostic
 }
 
 #[test]
+fn diagnostic_source_collection_routes_collection_construction_through_diagnostics_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory().union(",
+        ".factory().union_from_slice(",
+        ".factory.union(",
+        ".factory.union_from_slice(",
+        ".types.union(",
+        ".types.union_from_slice(",
+        ".types.array(",
+        ".types.readonly_type(",
+    ];
+
+    let mut violations = Vec::new();
+    for relative in DIAGNOSTIC_SOURCE_COLLECTION_MODULES {
+        scan_for_patterns(relative, FORBIDDEN_PATTERNS, &mut violations);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "diagnostic source collection display callers must route union/array \
+         construction through query_boundaries::diagnostics:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
 fn diagnostics_boundary_owns_construction_helpers() {
     let source = fs::read_to_string(checker_path(DIAGNOSTICS_BOUNDARY))
         .expect("failed to read query_boundaries/diagnostics.rs");
@@ -120,6 +153,9 @@ fn diagnostics_boundary_owns_construction_helpers() {
         "object_type_with_unknown_display_members",
         "mapped_property_mismatch_parameter_display_type",
         "display_property_literals_widened_for_related_info",
+        "source_display_union_type",
+        "source_display_union_type_from_slice",
+        "rebuilt_array_source_display_type",
         "function_type_from_shape",
         "function_type_with_params_replaced",
         "function_type_with_return_replaced",

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -1,8 +1,8 @@
 //! Diagnostic construction boundary scans.
 //!
 //! Reporter modules choose display policy and source locations. Interning
-//! diagnostic-only object/function/callable solver surfaces belongs in
-//! `query_boundaries::diagnostics`.
+//! diagnostic-only object/function/callable/compound solver surfaces belongs
+//! in `query_boundaries::diagnostics`.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -11,13 +11,21 @@ const DIAGNOSTICS_BOUNDARY: &str = "src/query_boundaries/diagnostics.rs";
 const DIAGNOSTIC_CONSTRUCTION_MODULES: &[&str] = &[
     "src/error_reporter/core/type_display.rs",
     "src/error_reporter/core/excess_display.rs",
+    "src/error_reporter/core_alias_display.rs",
+    "src/error_reporter/core_formatting.rs",
     "src/error_reporter/core/diagnostic_source.rs",
+    "src/error_reporter/core/diagnostic_source/assignment_formatting.rs",
+    "src/error_reporter/core/diagnostic_source/object_literal_targets.rs",
     "src/error_reporter/core/diagnostic_source/static_schema.rs",
+    "src/error_reporter/assignability_contextual_display.rs",
+    "src/error_reporter/assignability_helpers.rs",
     "src/error_reporter/fingerprint_policy.rs",
     "src/error_reporter/generics.rs",
+    "src/error_reporter/property_receiver_formatting.rs",
     "src/error_reporter/properties.rs",
     "src/error_reporter/call_errors/display_formatting.rs",
     "src/error_reporter/call_errors/display_formatting_parameters.rs",
+    "src/error_reporter/call_errors/elaboration_array_mismatch.rs",
     "src/error_reporter/call_errors/error_emission.rs",
     "src/error_reporter/call_errors/elaboration.rs",
     "src/state/type_environment/formatting.rs",
@@ -75,14 +83,42 @@ fn diagnostic_display_callers_route_solver_shape_construction_through_diagnostic
         ".factory().object_with_index(",
         ".factory().function(",
         ".factory().callable(",
+        ".factory().application(",
+        ".factory().union(",
+        ".factory().union_preserve_members(",
+        ".factory().intersection(",
+        ".factory().index_access(",
+        ".factory().array(",
+        ".factory().literal_string(",
+        ".factory().literal_string_atom(",
+        ".factory().literal_number(",
         ".factory.object(",
         ".factory.object_with_index(",
         ".factory.function(",
         ".factory.callable(",
+        ".factory.application(",
+        ".factory.union(",
+        ".factory.union_preserve_members(",
+        ".factory.intersection(",
+        ".factory.index_access(",
+        ".factory.array(",
+        ".factory.literal_string(",
+        ".factory.literal_string_atom(",
+        ".factory.literal_number(",
         ".types.object(",
         ".types.object_with_index(",
         ".types.function(",
         ".types.callable(",
+        ".types.array(",
+        ".types.union(",
+        ".types.union2(",
+        ".types.readonly_type(",
+        ".types.literal_string(",
+        ".types.literal_string_atom(",
+        ".types.literal_number(",
+        "PropertyInfo::new(",
+        "tsz_solver::utils::union_or_single(",
+        "tsz_solver::utils::intersection_or_single(",
         "FunctionShape {",
         "FunctionShape::new(",
         "CallableShape {",
@@ -109,7 +145,8 @@ fn diagnostic_display_callers_route_solver_shape_construction_through_diagnostic
 
     assert!(
         violations.is_empty(),
-        "diagnostic display callers must route solver shape construction \
+        "diagnostic display callers must route solver shape and compound \
+         construction \
          through query_boundaries::diagnostics:\n{}",
         violations.join("\n")
     );
@@ -156,6 +193,22 @@ fn diagnostics_boundary_owns_construction_helpers() {
         "source_display_union_type",
         "source_display_union_type_from_slice",
         "rebuilt_array_source_display_type",
+        "display_application_type",
+        "display_union_type",
+        "display_union_or_single_type",
+        "display_union_preserve_members_type",
+        "display_intersection_type",
+        "display_intersection_or_single_type",
+        "display_array_type",
+        "display_index_access_type",
+        "display_union_with_undefined",
+        "display_string_literal_type",
+        "display_string_literal_atom_type",
+        "display_number_literal_type",
+        "display_rest_parameter_type",
+        "display_property",
+        "mapped_display_property",
+        "static_schema_display_property_from_source",
         "function_type_from_shape",
         "function_type_with_params_replaced",
         "function_type_with_return_replaced",

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -1,0 +1,97 @@
+//! Diagnostic construction boundary scans.
+//!
+//! Reporter modules choose display policy and source locations. Interning
+//! diagnostic-only object/function/callable solver surfaces belongs in
+//! `query_boundaries::diagnostics`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DIAGNOSTICS_BOUNDARY: &str = "src/query_boundaries/diagnostics.rs";
+const DIAGNOSTIC_REPORTER_CONSTRUCTION_MODULES: &[&str] = &[
+    "src/error_reporter/core/type_display.rs",
+    "src/error_reporter/core/excess_display.rs",
+    "src/error_reporter/generics.rs",
+];
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn error_reporters_route_solver_shape_construction_through_diagnostics_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory().object(",
+        ".factory().object_with_index(",
+        ".factory().function(",
+        ".factory().callable(",
+        ".factory.object(",
+        ".factory.object_with_index(",
+        ".factory.function(",
+        ".factory.callable(",
+        ".types.object(",
+        ".types.object_with_index(",
+        ".types.function(",
+        ".types.callable(",
+        "FunctionShape {",
+        "FunctionShape::new(",
+        "CallableShape {",
+        "ObjectShape {",
+        "IndexSignature {",
+        "ParamInfo::required(",
+    ];
+
+    let mut violations = Vec::new();
+    for relative in DIAGNOSTIC_REPORTER_CONSTRUCTION_MODULES {
+        scan_for_patterns(relative, FORBIDDEN_PATTERNS, &mut violations);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "error_reporter modules must route diagnostic solver shape construction \
+         through query_boundaries::diagnostics:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn diagnostics_boundary_owns_construction_helpers() {
+    let source = fs::read_to_string(checker_path(DIAGNOSTICS_BOUNDARY))
+        .expect("failed to read query_boundaries/diagnostics.rs");
+    for helper in [
+        "object_type_from_properties",
+        "object_type_from_shape",
+        "object_type_preserving_display_properties",
+        "function_type_from_shape",
+        "function_type_with_params_replaced",
+        "function_type_with_return_replaced",
+        "function_type_with_params_and_return_replaced",
+        "callable_type_from_shape",
+        "call_only_callable_type",
+        "callable_type_with_signatures_replaced",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::diagnostics must own `{helper}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/excess_property_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/excess_property_construction_boundary_scans.rs
@@ -1,0 +1,59 @@
+//! Excess-property construction boundary scans.
+//!
+//! State checking owns excess-property policy and source traversal. Solver
+//! object shape construction and interning belong behind query boundaries.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const EXCESS_PROPERTY_TAIL: &str = "src/state/state_checking/property/excess_property_tail.rs";
+const STATE_CHECKING_BOUNDARY: &str = "src/query_boundaries/state/checking.rs";
+const INTERSECTION_DISPLAY_BOUNDARY: &str = "src/query_boundaries/intersection_display.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+#[test]
+fn excess_property_tail_routes_object_construction_through_boundaries() {
+    let source =
+        fs::read_to_string(checker_path(EXCESS_PROPERTY_TAIL)).expect("failed to read source");
+
+    for forbidden in [
+        "tsz_solver::ObjectShape {",
+        "ObjectShape::default()",
+        "tsz_solver::PropertyInfo {",
+        "PropertyInfo::new(",
+        ".factory().object(",
+        ".factory.object(",
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "excess_property_tail must route object construction through query \
+             boundaries, found `{forbidden}`"
+        );
+    }
+
+    assert!(
+        source.contains("intersection_display::collected_properties_object_shape(")
+            && source.contains("query::excess_property_any_object_type_from_names("),
+        "excess_property_tail should call the intersection/display and state-checking boundaries"
+    );
+}
+
+#[test]
+fn excess_property_boundaries_own_construction_helpers() {
+    let state_boundary = fs::read_to_string(checker_path(STATE_CHECKING_BOUNDARY))
+        .expect("failed to read state checking boundary");
+    assert!(
+        state_boundary.contains("fn excess_property_any_object_type_from_names("),
+        "state checking boundary must own synthetic excess-property object construction"
+    );
+
+    let intersection_boundary = fs::read_to_string(checker_path(INTERSECTION_DISPLAY_BOUNDARY))
+        .expect("failed to read intersection display boundary");
+    assert!(
+        intersection_boundary.contains("fn collected_properties_object_shape"),
+        "intersection display boundary must own collected-property object shape construction"
+    );
+}

--- a/crates/tsz-checker/tests/arch_source_scans/import_attribute_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/import_attribute_construction_boundary_scans.rs
@@ -1,0 +1,102 @@
+//! Import attribute construction boundary scans.
+//!
+//! Static and dynamic import checkers gather syntax facts and issue grammar or
+//! assignability diagnostics. Solver property/object construction for
+//! `ImportAttributes` and `ImportCallOptions` belongs in
+//! `query_boundaries::import_attributes`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const IMPORT_ATTRIBUTE_CALLERS: &[&str] = &[
+    "src/declarations/import/declaration_attributes.rs",
+    "src/declarations/dynamic_import_checker.rs",
+];
+const IMPORT_ATTRIBUTE_BOUNDARY: &str = "src/query_boundaries/import_attributes.rs";
+const COMMON_BOUNDARY: &str = "src/query_boundaries/common.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}(")) || source.contains(&format!("fn {name}<"))
+}
+
+#[test]
+fn import_attribute_callers_route_solver_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        "PropertyInfo {",
+        "PropertyInfo::new(",
+        "PropertyInfo::opt(",
+        ".factory().object(",
+        ".factory().literal_string(",
+    ];
+
+    let mut violations = Vec::new();
+    for caller in IMPORT_ATTRIBUTE_CALLERS {
+        scan_for_patterns(caller, FORBIDDEN_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "import attribute/options callers must route solver construction \
+         through query_boundaries::import_attributes:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn import_attributes_boundary_owns_import_attribute_construction_helpers() {
+    let source = fs::read_to_string(checker_path(IMPORT_ATTRIBUTE_BOUNDARY))
+        .expect("failed to read query_boundaries/import_attributes.rs");
+    let common =
+        fs::read_to_string(checker_path(COMMON_BOUNDARY)).expect("failed to read common.rs");
+
+    for helper in [
+        "import_attribute_literal_string_type",
+        "import_attribute_property",
+        "optional_import_option_property",
+        "import_attribute_object_type",
+        "import_call_options_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::import_attributes must own `{helper}`"
+        );
+        assert!(
+            !defines_fn(&common, helper),
+            "query_boundaries::common must not define `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "db.literal_string(",
+        "PropertyInfo::new(",
+        "PropertyInfo::opt(",
+        "db.object(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::import_attributes should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/js_class_property_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/js_class_property_construction_boundary_scans.rs
@@ -1,0 +1,105 @@
+//! JS class-property construction boundary scans.
+//!
+//! JS class-property scanning gathers AST, JSDoc, modifier, and source-order
+//! facts. Solver type-parameter, array/union, property, callable, and object
+//! construction belongs in `query_boundaries::checkers::class_properties`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const JS_CLASS_PROPERTIES: &str = "src/types/class_type/js_class_properties.rs";
+const JS_CLASS_PROPERTY_BOUNDARY: &str = "src/query_boundaries/checkers/class_properties.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn js_class_property_scanner_routes_solver_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".array(",
+        ".type_param(",
+        ".union(",
+        ".union2(",
+        ".callable(",
+        ".object(",
+        ".object_with_index(",
+        "TypeParamInfo {",
+        "TypeParamInfo::simple(",
+        "TypeParamOrigin::User",
+        "PropertyInfo {",
+        "PropertyInfo::new(",
+        "ParamInfo {",
+        "ParamInfo::required(",
+        "CallSignature {",
+        "CallableShape {",
+        "CallableShape::default()",
+        "ObjectShape {",
+        "ObjectShape::default()",
+    ];
+
+    let mut violations = Vec::new();
+    scan_for_patterns(JS_CLASS_PROPERTIES, FORBIDDEN_PATTERNS, &mut violations);
+    assert!(
+        violations.is_empty(),
+        "JS class-property scanning must route solver shape construction \
+         through query_boundaries::checkers::class_properties:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn js_class_property_boundary_owns_construction_helpers_and_literals() {
+    let source = fs::read_to_string(checker_path(JS_CLASS_PROPERTY_BOUNDARY))
+        .expect("failed to read query_boundaries/checkers/class_properties.rs");
+
+    for helper in [
+        "js_class_type_param_info",
+        "js_class_type_param_type",
+        "js_class_array_type",
+        "js_class_union_type",
+        "js_class_union_pair_type",
+        "js_class_property_info",
+        "js_class_method_callable_type",
+        "js_class_instance_object_type",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::checkers::class_properties must own `{helper}`"
+        );
+    }
+
+    for shape_pattern in [
+        "TypeParamInfo {",
+        "TypeParamOrigin::User",
+        "PropertyInfo {",
+        "ParamInfo {",
+        "CallSignature {",
+        "CallableShape {",
+        "ObjectShape {",
+    ] {
+        assert!(
+            source.contains(shape_pattern),
+            "query_boundaries::checkers::class_properties should own `{shape_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
@@ -1,16 +1,19 @@
 //! JSDoc construction boundary scans.
 //!
 //! JSDoc resolution code parses source text and gathers facts. Raw solver
-//! `FunctionShape`, `ObjectShape`, and indexed-object construction belongs in
-//! `query_boundaries::jsdoc_construction`.
+//! `FunctionShape`, `ObjectShape`, indexed-object construction, and expression
+//! type construction belongs in `query_boundaries::jsdoc_construction`.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 const JSDOC_CONSTRUCTION_CALLERS: &[&str] = &[
+    "src/jsdoc/resolution/generic_typedef.rs",
     "src/jsdoc/resolution/type_construction.rs",
     "src/jsdoc/resolution/name_resolution.rs",
     "src/jsdoc/params_type_strings.rs",
+    "src/jsdoc/diagnostics_import_type_constraints.rs",
+    "src/jsdoc/lookup.rs",
 ];
 
 const JSDOC_CONSTRUCTION_BOUNDARY: &str = "src/query_boundaries/jsdoc_construction.rs";
@@ -48,6 +51,23 @@ fn jsdoc_callers_route_solver_shape_construction_through_boundary() {
         ".object(",
         ".object_with_index(",
         ".callable(",
+        ".array(",
+        ".union(",
+        ".union2(",
+        ".intersection(",
+        ".intersection2(",
+        ".application(",
+        ".tuple(",
+        ".index_access(",
+        ".keyof(",
+        ".mapped(",
+        ".conditional(",
+        ".type_param(",
+        "TupleElement {",
+        "MappedType {",
+        "ConditionalType {",
+        "TypeParamInfo {",
+        "TypeParamOrigin::User",
     ];
 
     let mut violations = Vec::new();
@@ -75,6 +95,20 @@ fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
         "jsdoc_object_type",
         "jsdoc_object_index_type",
         "jsdoc_function_type",
+        "jsdoc_array_type",
+        "jsdoc_union_type",
+        "jsdoc_union_pair_type",
+        "jsdoc_intersection_type",
+        "jsdoc_intersection_pair_type",
+        "jsdoc_application_type",
+        "jsdoc_index_access_type",
+        "jsdoc_keyof_type",
+        "jsdoc_type_param_info",
+        "jsdoc_type_param_type",
+        "jsdoc_tuple_type",
+        "jsdoc_tuple_element",
+        "jsdoc_mapped_type",
+        "jsdoc_conditional_type",
     ] {
         assert!(
             source.contains(&format!("fn {helper}(")),
@@ -86,7 +120,16 @@ fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
         );
     }
 
-    for shape_pattern in ["FunctionShape {", "ObjectShape {", "IndexSignature {"] {
+    for shape_pattern in [
+        "FunctionShape {",
+        "ObjectShape {",
+        "IndexSignature {",
+        "TupleElement {",
+        "MappedType {",
+        "ConditionalType {",
+        "TypeParamInfo {",
+        "TypeParamOrigin::User",
+    ] {
         assert!(
             source.contains(shape_pattern),
             "query_boundaries::jsdoc_construction should own `{shape_pattern}`"

--- a/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
@@ -1,0 +1,95 @@
+//! JSDoc construction boundary scans.
+//!
+//! JSDoc resolution code parses source text and gathers facts. Raw solver
+//! `FunctionShape`, `ObjectShape`, and indexed-object construction belongs in
+//! `query_boundaries::jsdoc_construction`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const JSDOC_CONSTRUCTION_CALLERS: &[&str] = &[
+    "src/jsdoc/resolution/type_construction.rs",
+    "src/jsdoc/resolution/name_resolution.rs",
+    "src/jsdoc/params_type_strings.rs",
+];
+
+const JSDOC_CONSTRUCTION_BOUNDARY: &str = "src/query_boundaries/jsdoc_construction.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn jsdoc_callers_route_solver_shape_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        "FunctionShape",
+        "ObjectShape",
+        "IndexSignature",
+        ".function(",
+        ".object(",
+        ".object_with_index(",
+        ".callable(",
+    ];
+
+    let mut violations = Vec::new();
+    for module in JSDOC_CONSTRUCTION_CALLERS {
+        scan_for_patterns(module, FORBIDDEN_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "JSDoc construction callers must route solver shape construction \
+         through query_boundaries::jsdoc_construction:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
+    let source = fs::read_to_string(checker_path(JSDOC_CONSTRUCTION_BOUNDARY))
+        .expect("failed to read query_boundaries/jsdoc_construction.rs");
+    let common = fs::read_to_string(checker_path("src/query_boundaries/common.rs"))
+        .expect("failed to read query_boundaries/common.rs");
+
+    for helper in [
+        "jsdoc_object_index_fact",
+        "jsdoc_empty_object_type",
+        "jsdoc_object_type",
+        "jsdoc_object_index_type",
+        "jsdoc_function_type",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::jsdoc_construction must own `{helper}`"
+        );
+        assert!(
+            !common.contains(&format!("fn {helper}(")),
+            "JSDoc construction helper `{helper}` must not drift into common.rs"
+        );
+    }
+
+    for shape_pattern in ["FunctionShape {", "ObjectShape {", "IndexSignature {"] {
+        assert!(
+            source.contains(shape_pattern),
+            "query_boundaries::jsdoc_construction should own `{shape_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
@@ -60,6 +60,16 @@ fn jsdoc_callers_route_solver_shape_construction_through_boundary() {
         ".tuple(",
         ".index_access(",
         ".keyof(",
+        "factory().lazy(",
+        ".lazy(",
+        "factory().readonly_type(",
+        ".readonly_type(",
+        "factory().literal_string(",
+        ".literal_string(",
+        "factory().literal_boolean(",
+        ".literal_boolean(",
+        "factory().literal_number(",
+        ".literal_number(",
         ".mapped(",
         ".conditional(",
         ".type_param(",
@@ -75,6 +85,7 @@ fn jsdoc_callers_route_solver_shape_construction_through_boundary() {
         "ParamInfo::unnamed(",
         "PropertyInfo::new(",
         "PropertyInfo {",
+        "TypePredicate {",
     ];
 
     let mut violations = Vec::new();
@@ -110,12 +121,18 @@ fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
         "jsdoc_application_type",
         "jsdoc_index_access_type",
         "jsdoc_keyof_type",
+        "jsdoc_lazy_type",
+        "jsdoc_readonly_type",
+        "jsdoc_literal_string_type",
+        "jsdoc_literal_boolean_type",
+        "jsdoc_literal_number_type",
         "jsdoc_type_param_info",
         "jsdoc_type_param_type",
         "jsdoc_tuple_type",
         "jsdoc_tuple_element",
         "jsdoc_param_info",
         "jsdoc_property_info",
+        "jsdoc_type_predicate",
         "jsdoc_mapped_type",
         "jsdoc_conditional_type",
     ] {
@@ -140,6 +157,7 @@ fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
         "TypeParamOrigin::User",
         "ParamInfo {",
         "PropertyInfo {",
+        "TypePredicate {",
     ] {
         assert!(
             source.contains(shape_pattern),

--- a/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
@@ -68,6 +68,13 @@ fn jsdoc_callers_route_solver_shape_construction_through_boundary() {
         "ConditionalType {",
         "TypeParamInfo {",
         "TypeParamOrigin::User",
+        "ParamInfo {",
+        "ParamInfo::required(",
+        "ParamInfo::optional(",
+        "ParamInfo::rest(",
+        "ParamInfo::unnamed(",
+        "PropertyInfo::new(",
+        "PropertyInfo {",
     ];
 
     let mut violations = Vec::new();
@@ -107,6 +114,8 @@ fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
         "jsdoc_type_param_type",
         "jsdoc_tuple_type",
         "jsdoc_tuple_element",
+        "jsdoc_param_info",
+        "jsdoc_property_info",
         "jsdoc_mapped_type",
         "jsdoc_conditional_type",
     ] {
@@ -129,6 +138,8 @@ fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
         "ConditionalType {",
         "TypeParamInfo {",
         "TypeParamOrigin::User",
+        "ParamInfo {",
+        "PropertyInfo {",
     ] {
         assert!(
             source.contains(shape_pattern),

--- a/crates/tsz-checker/tests/arch_source_scans/jsx_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsx_construction_boundary_scans.rs
@@ -1,13 +1,15 @@
 //! JSX construction boundary scans.
 //!
 //! JSX checker modules gather JSX syntax, prop, and callback facts. Interning
-//! object/function/callable solver types and rebuilding `FunctionShape`
-//! literals belongs in `query_boundaries::checkers::jsx`.
+//! object/function/callable and compound solver types, rebuilding
+//! `FunctionShape` literals, and creating synthetic solver properties belongs
+//! in `query_boundaries::checkers::jsx`.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 const JSX_CHECKER_ROOT: &str = "src/checkers/jsx";
+const JSX_ADDITIONAL_CONSTRUCTION_MODULES: &[&str] = &["src/dispatch/jsx.rs"];
 const JSX_CONSTRUCTION_BOUNDARY: &str = "src/query_boundaries/checkers/jsx.rs";
 
 fn checker_path(relative: &str) -> PathBuf {
@@ -56,25 +58,58 @@ fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<Str
 #[test]
 fn jsx_checkers_route_solver_shape_construction_through_boundary() {
     const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory()",
         ".factory().object(",
         ".factory().function(",
         ".factory().callable(",
+        ".factory().union(",
+        ".factory().union2(",
+        ".factory().intersection(",
+        ".factory().intersection2(",
+        ".factory().application(",
+        ".factory().index_access(",
+        ".factory().array(",
+        ".factory().tuple(",
         "factory().object(",
         "factory().function(",
         "factory().callable(",
+        "factory().union(",
+        "factory().union2(",
+        "factory().intersection(",
+        "factory().intersection2(",
+        "factory().application(",
+        "factory().index_access(",
+        "factory().array(",
+        "factory().tuple(",
         ".factory.object(",
         ".factory.function(",
         ".factory.callable(",
+        ".types.union(",
+        ".types.union2(",
+        ".types.intersection(",
+        ".types.intersection2(",
+        ".types.application(",
+        ".types.index_access(",
+        ".types.array(",
+        ".types.tuple(",
         "FunctionShape {",
         "FunctionShape::new(",
         "CallableShape {",
         "ObjectShape {",
         "ParamInfo::required(",
+        "PropertyInfo::new(",
+        "PropertyInfo {",
+        "TupleElement {",
     ];
 
     let root = checker_path(JSX_CHECKER_ROOT);
     let mut files = Vec::new();
     collect_rust_files(&root, &mut files);
+    files.extend(
+        JSX_ADDITIONAL_CONSTRUCTION_MODULES
+            .iter()
+            .map(|relative| checker_path(relative)),
+    );
     files.sort();
 
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -110,6 +145,17 @@ fn jsx_boundary_owns_construction_helpers() {
         "object_type_from_properties",
         "empty_props_object_type",
         "props_param_type_or_empty",
+        "property_info",
+        "property_info_with_write_type",
+        "union_type_from_members",
+        "union_type_from_pair",
+        "intersection_type_from_members",
+        "intersection_type_from_pair",
+        "array_type_from_element",
+        "tuple_type_from_elements",
+        "tuple_type_from_required_element_types",
+        "type_application_from_args",
+        "index_access_type",
         "function_type_from_shape",
         "function_type_from_parts",
         "single_required_param_function_type",

--- a/crates/tsz-checker/tests/arch_source_scans/jsx_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsx_construction_boundary_scans.rs
@@ -1,0 +1,128 @@
+//! JSX construction boundary scans.
+//!
+//! JSX checker modules gather JSX syntax, prop, and callback facts. Interning
+//! object/function/callable solver types and rebuilding `FunctionShape`
+//! literals belongs in `query_boundaries::checkers::jsx`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const JSX_CHECKER_ROOT: &str = "src/checkers/jsx";
+const JSX_CONSTRUCTION_BOUNDARY: &str = "src/query_boundaries/checkers/jsx.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn collect_rust_files(dir: &Path, files: &mut Vec<PathBuf>) {
+    for entry in
+        fs::read_dir(dir).unwrap_or_else(|err| panic!("failed to read {}: {err}", dir.display()))
+    {
+        let path = entry
+            .unwrap_or_else(|err| panic!("failed to read entry under {}: {err}", dir.display()))
+            .path();
+        if path.is_dir() {
+            collect_rust_files(&path, files);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            files.push(path);
+        }
+    }
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        // Return types and argument types may mention shape structs as
+        // read-only data. This scan guards construction, not type signatures.
+        if trimmed.contains("->") || trimmed.ends_with("&tsz_solver::FunctionShape,") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn jsx_checkers_route_solver_shape_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory().object(",
+        ".factory().function(",
+        ".factory().callable(",
+        "factory().object(",
+        "factory().function(",
+        "factory().callable(",
+        ".factory.object(",
+        ".factory.function(",
+        ".factory.callable(",
+        "FunctionShape {",
+        "FunctionShape::new(",
+        "CallableShape {",
+        "ObjectShape {",
+        "ParamInfo::required(",
+    ];
+
+    let root = checker_path(JSX_CHECKER_ROOT);
+    let mut files = Vec::new();
+    collect_rust_files(&root, &mut files);
+    files.sort();
+
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut violations = Vec::new();
+    for file in files {
+        let relative = file
+            .strip_prefix(manifest_dir)
+            .unwrap_or_else(|err| {
+                panic!(
+                    "failed to strip manifest dir {} from {}: {err}",
+                    manifest_dir.display(),
+                    file.display()
+                )
+            })
+            .to_str()
+            .expect("checker path is valid UTF-8");
+        scan_for_patterns(relative, FORBIDDEN_PATTERNS, &mut violations);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "JSX checker modules must route solver shape construction through \
+         query_boundaries::checkers::jsx:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn jsx_boundary_owns_construction_helpers() {
+    let source = fs::read_to_string(checker_path(JSX_CONSTRUCTION_BOUNDARY))
+        .expect("failed to read query_boundaries/checkers/jsx.rs");
+    for helper in [
+        "object_type_from_properties",
+        "empty_props_object_type",
+        "props_param_type_or_empty",
+        "function_type_from_shape",
+        "function_type_from_parts",
+        "single_required_param_function_type",
+        "function_type_with_mapped_component_types",
+        "function_type_without_this",
+        "construct_signature_function_shape",
+        "push_required_param",
+        "synthetic_single_param_function_shape",
+        "instantiate_function_shape_preserving_unresolved_params",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::checkers::jsx must own `{helper}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/strict_bind_call_apply_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/strict_bind_call_apply_construction_boundary_scans.rs
@@ -1,0 +1,109 @@
+//! Strict bind/call/apply construction boundary scans.
+//!
+//! Property-access helpers own receiver lookup, `this` collapse, and method
+//! selection. Solver parameter, type-parameter, tuple, signature, function, and
+//! callable construction belongs in `query_boundaries::property_access`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const ACCESS_SEMANTICS: &str = "src/types/property_access_helpers/access_semantics.rs";
+const PROPERTY_ACCESS_BOUNDARY: &str = "src/query_boundaries/property_access.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn strict_bind_call_apply_routes_solver_construction_through_property_access_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".type_param(",
+        ".tuple(",
+        ".function(",
+        ".callable(",
+        "TypeParamInfo {",
+        "TypeParamOrigin::User",
+        "TupleElement {",
+        "ParamInfo {",
+        "CallSignature {",
+        "FunctionShape {",
+        "CallableShape {",
+        "FunctionShape::new(",
+        "CallableShape::default()",
+        "intern_string(\"thisArg\")",
+        "intern_string(\"args\")",
+        "intern_string(\"TThis\")",
+    ];
+
+    let mut violations = Vec::new();
+    scan_for_patterns(ACCESS_SEMANTICS, FORBIDDEN_PATTERNS, &mut violations);
+    assert!(
+        violations.is_empty(),
+        "strict bind/call/apply synthesis must route solver shape construction \
+         through query_boundaries::property_access:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn property_access_boundary_owns_strict_bind_call_apply_construction_helpers() {
+    let source = fs::read_to_string(checker_path(PROPERTY_ACCESS_BOUNDARY))
+        .expect("failed to read query_boundaries/property_access.rs");
+
+    for helper in [
+        "strict_bind_call_apply_param_with_type",
+        "strict_bind_call_apply_type_param_with_constraint",
+        "strict_bind_call_apply_call_signature",
+        "strict_bind_call_apply_signature_from_function_shape",
+        "strict_bind_call_apply_params_tuple_type",
+        "strict_bind_call_apply_bound_return_type",
+        "strict_bind_call_apply_call_only_callable_type",
+        "strict_bind_call_apply_this_arg_param",
+        "strict_bind_call_apply_args_param",
+        "strict_bind_call_apply_generic_this_param",
+        "strict_bind_call_apply_method_type",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::property_access must own `{helper}`"
+        );
+    }
+
+    for shape_pattern in [
+        "db.tuple(",
+        "db.function(",
+        "db.callable(",
+        "db.type_param(",
+        "TypeParamInfo {",
+        "TypeParamOrigin::User",
+        "TupleElement {",
+        "ParamInfo {",
+        "CallSignature {",
+        "FunctionShape {",
+        "CallableShape {",
+    ] {
+        assert!(
+            source.contains(shape_pattern),
+            "query_boundaries::property_access should own `{shape_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/flow_boundary_contract_tests.rs
+++ b/crates/tsz-checker/tests/flow_boundary_contract_tests.rs
@@ -126,3 +126,38 @@ fn assignment_reduction_uses_flow_query_boundary() {
         "assignment member filtering belongs in query_boundaries::flow_analysis"
     );
 }
+
+#[test]
+fn assignment_fallback_shape_construction_uses_flow_query_boundary() {
+    let src = fs::read_to_string("src/flow/control_flow/assignment_fallback.rs")
+        .expect("failed to read src/flow/control_flow/assignment_fallback.rs");
+
+    for forbidden in [
+        ".factory().object(",
+        ".factory().callable(",
+        ".factory.object(",
+        ".factory.callable(",
+        "CallableShape {",
+        "CallableShape::default()",
+    ] {
+        assert!(
+            !src.contains(forbidden),
+            "assignment fallback must route solver shape construction through \
+             query_boundaries::flow_analysis, found `{forbidden}`"
+        );
+    }
+
+    assert!(
+        src.contains("flow_analysis::object_type_from_properties(")
+            && src.contains("flow_analysis::call_only_callable_type("),
+        "assignment fallback object/callable construction should route through flow_analysis"
+    );
+
+    let boundary = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read src/query_boundaries/flow_analysis.rs");
+    assert!(
+        boundary.contains("fn object_type_from_properties(")
+            && boundary.contains("fn call_only_callable_type("),
+        "flow_analysis must own assignment-fallback object/callable construction helpers"
+    );
+}

--- a/crates/tsz-checker/tests/ts2322_literal_source_display_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_literal_source_display_tests.rs
@@ -191,3 +191,23 @@ var o: I = {
         "TS2322 should not expose expanded computed number key text, got: {ts2322:?}",
     );
 }
+
+#[test]
+fn ts2322_identifier_array_object_literal_source_display_unions_property_values() {
+    let diagnostics = diagnostic_messages(
+        r#"
+const rows = [{ name: "a" }, { name: 1 }];
+const out: { name: boolean }[] = rows;
+"#,
+    );
+
+    let ts2322 = diagnostics
+        .iter()
+        .find(|(code, _)| *code == 2322)
+        .expect("expected TS2322 for identifier array-object source display");
+
+    assert!(
+        ts2322.1.contains("Type '{ name: string | number; }[]'"),
+        "identifier array-object source should display unioned property values, got: {ts2322:?}",
+    );
+}


### PR DESCRIPTION
Goal: fast

## Summary
- Add `query_boundaries::import_attributes` as the construction owner for synthetic `ImportAttributes` and `ImportCallOptions` object types.
- Route static import attribute and dynamic import options property/object/string-literal construction through that boundary.
- Add an architecture source scan that keeps the static/dynamic import callers from reintroducing inline solver construction for this syntax surface.

## Structural Rule
When static or dynamic import syntax has produced import-attribute/options facts, `tsc` checks those facts against `ImportAttributes` / `ImportCallOptions`; tsz keeps AST traversal, grammar diagnostics, relation anchors, property-name extraction, and fallback type lookups in checker declarations while `query_boundaries::import_attributes` owns solver string-literal, property, optional-property, and object construction.

## Adjacent Matrix
- Static import attributes: string-literal attribute values, collected attribute properties, and source object construction are routed through the boundary.
- Dynamic import options: synthetic optional `with`/`assert` properties, nested literal attribute objects, and options object construction are routed through the boundary.
- Fallbacks: non-object options, empty object literals, widened nested object display properties, and TS2858/TS2880 diagnostic anchors stay checker-owned and unchanged.
- Performance: behavior-only routing refactor; no new traversal or cache key.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test arch_source_scans -E 'test(import_attribute_callers_route_solver_construction_through_boundary) or test(import_attributes_boundary_owns_import_attribute_construction_helpers)'`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --test import_attributes_resolution_mode_tests`
- `CARGO_INCREMENTAL=0 scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run -p tsz-checker --lib -E 'test(import_attributes_relation_routing_arch_tests)'`
- `scripts/safe-run.sh -- cargo check -p tsz-checker`
- `scripts/safe-run.sh -- cargo clippy -p tsz-checker --lib --tests -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high