### PR TITLE
refactor(checker): route interface type-literal surfaces (#14351)

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/children.rs
+++ b/crates/tsz-checker/src/checkers/jsx/children.rs
@@ -38,7 +38,7 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => TypeId::NEVER,
                 [element_type] => self.evaluate_type_with_env(*element_type),
-                _ => self.ctx.types.factory().union(element_types),
+                _ => jsx_query::union_type_from_members(self.ctx.types, element_types),
             };
         }
 
@@ -71,7 +71,7 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => TypeId::NEVER,
                 [element_type] => self.evaluate_type_with_env(*element_type),
-                _ => self.ctx.types.factory().union(element_types),
+                _ => jsx_query::union_type_from_members(self.ctx.types, element_types),
             };
         }
 
@@ -678,7 +678,10 @@ impl<'a> CheckerState<'a> {
         match multiple_candidates.as_slice() {
             [] => None,
             [candidate] => Some(*candidate),
-            _ => Some(self.ctx.types.factory().union(multiple_candidates)),
+            _ => Some(jsx_query::union_type_from_members(
+                self.ctx.types,
+                multiple_candidates,
+            )),
         }
     }
 
@@ -842,7 +845,10 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => None,
                 [element_type] => Some(*element_type),
-                _ => Some(self.ctx.types.factory().union(element_types)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    element_types,
+                )),
             };
         }
 
@@ -862,7 +868,10 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => None,
                 [element_type] => Some(*element_type),
-                _ => Some(self.ctx.types.factory().union(element_types)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    element_types,
+                )),
             };
         }
 
@@ -917,7 +926,10 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => None,
                 [e] => Some(*e),
-                _ => Some(self.ctx.types.factory().union(element_types)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    element_types,
+                )),
             };
         }
 
@@ -936,7 +948,7 @@ impl<'a> CheckerState<'a> {
         mut element_types: Vec<TypeId>,
     ) -> TypeId {
         self.order_react_node_multiple_children_union_for_display(&mut element_types);
-        let union = self.ctx.types.factory().union(element_types.clone());
+        let union = jsx_query::union_type_from_members(self.ctx.types, element_types.clone());
         if element_types.len() > 1 {
             self.ctx
                 .types
@@ -1047,15 +1059,22 @@ impl<'a> CheckerState<'a> {
             0 => match other_candidates.len() {
                 0 => None,
                 1 => other_candidates.into_iter().next(),
-                _ => Some(self.ctx.types.factory().union(other_candidates)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    other_candidates,
+                )),
             },
             1 if other_candidates.is_empty() => callable_candidates.into_iter().next(),
-            _ if other_candidates.is_empty() => {
-                Some(self.ctx.types.factory().union(callable_candidates))
-            }
+            _ if other_candidates.is_empty() => Some(jsx_query::union_type_from_members(
+                self.ctx.types,
+                callable_candidates,
+            )),
             _ => {
                 callable_candidates.extend(other_candidates);
-                Some(self.ctx.types.factory().union(callable_candidates))
+                Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    callable_candidates,
+                ))
             }
         }
     }
@@ -1086,14 +1105,20 @@ impl<'a> CheckerState<'a> {
         if !callable_candidates.is_empty() {
             return match callable_candidates.len() {
                 1 => callable_candidates.into_iter().next(),
-                _ => Some(self.ctx.types.factory().union(callable_candidates)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    callable_candidates,
+                )),
             };
         }
 
         match multiple_candidates.len() {
             0 => None,
             1 => multiple_candidates.into_iter().next(),
-            _ => Some(self.ctx.types.factory().union(multiple_candidates)),
+            _ => Some(jsx_query::union_type_from_members(
+                self.ctx.types,
+                multiple_candidates,
+            )),
         }
     }
 
@@ -1591,24 +1616,21 @@ impl<'a> CheckerState<'a> {
             .collect();
 
         if self.type_has_tuple_like_multiple_children(children_type) {
-            let elements = child_types
-                .into_iter()
-                .map(|type_id| tsz_solver::TupleElement {
-                    type_id,
-                    name: None,
-                    optional: false,
-                    rest: false,
-                })
-                .collect();
-            return Some(self.ctx.types.factory().tuple(elements));
+            return Some(jsx_query::tuple_type_from_required_element_types(
+                self.ctx.types,
+                child_types,
+            ));
         }
 
         let element_type = match child_types.len() {
             0 => TypeId::NEVER,
             1 => child_types[0],
-            _ => self.ctx.types.factory().union(child_types),
+            _ => jsx_query::union_type_from_members(self.ctx.types, child_types),
         };
-        Some(self.ctx.types.factory().array(element_type))
+        Some(jsx_query::array_type_from_element(
+            self.ctx.types,
+            element_type,
+        ))
     }
     pub(super) fn get_jsx_body_child_nodes(
         &self,
@@ -1702,7 +1724,7 @@ impl<'a> CheckerState<'a> {
         // children type. This handles cases like `ReactNode` where `ReactNodeArray extends
         // Array<ReactNode>` is a member of the union, but we can't detect it structurally
         // because it's an interface extending Array rather than a direct Array type.
-        let array_of_children = self.ctx.types.factory().array(type_id);
+        let array_of_children = jsx_query::array_type_from_element(self.ctx.types, type_id);
         if self
             .jsx_children_relation_outcome(array_of_children, type_id)
             .related

--- a/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
@@ -1,6 +1,7 @@
 //! JSX diagnostics rendering: display target building, type formatting for
 //! error messages, tag name text extraction, and text-children checks.
 
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use crate::symbol_resolver::TypeSymbolResolution;
 use tsz_binder::SymbolId;
@@ -83,7 +84,7 @@ impl<'a> CheckerState<'a> {
     ) -> Option<TypeId> {
         let ica = self.get_intrinsic_class_attributes_lazy_type()?;
         let inst = self.get_class_instance_type_for_component(component_type)?;
-        let app = self.ctx.types.factory().application(ica, vec![inst]);
+        let app = jsx_query::type_application_from_args(self.ctx.types, ica, vec![inst]);
         let evaluated = self.normalize_jsx_required_props_target(app);
         if evaluated == TypeId::ANY || evaluated == TypeId::ERROR {
             return None;

--- a/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
@@ -394,7 +394,10 @@ impl<'a> CheckerState<'a> {
         if get_conditional_type_id(self.ctx.types, props_type).is_some()
             && let Some(shape) = object_shape_for_type(self.ctx.types, props_type)
         {
-            let object = self.ctx.types.factory().object(shape.properties.clone());
+            let object = crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                shape.properties.clone(),
+            );
             return Some(self.format_type_skip_object_display_alias(object));
         }
 
@@ -462,7 +465,12 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        Some(self.format_type(self.ctx.types.factory().object(filtered_props)))
+        Some(self.format_type(
+            crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                filtered_props,
+            ),
+        ))
     }
 
     fn jsx_conditional_display_has_lma_infer_metadata(display: &str) -> bool {
@@ -544,7 +552,12 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        Some(self.format_type(self.ctx.types.factory().object(filtered_props)))
+        Some(self.format_type(
+            crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                filtered_props,
+            ),
+        ))
     }
 
     fn jsx_final_conditional_else_display(display: &str) -> Option<String> {

--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -48,11 +48,11 @@ impl<'a> CheckerState<'a> {
             && jsx_boundary::is_type_parameter_like(self.ctx.types, component_type)
         {
             let lma_ref = self.resolve_symbol_as_lazy_type(lma_sym_id);
-            return self
-                .ctx
-                .types
-                .factory()
-                .application(lma_ref, vec![component_type, props_type]);
+            return jsx_boundary::type_application_from_args(
+                self.ctx.types,
+                lma_ref,
+                vec![component_type, props_type],
+            );
         }
         if jsx_boundary::contains_type_parameters(self.ctx.types, props_type) {
             return props_type;
@@ -230,7 +230,8 @@ impl<'a> CheckerState<'a> {
                 0 => return None,
                 1 => return candidates.pop(),
                 _ => {
-                    let props_union = self.ctx.types.factory().union(
+                    let props_union = jsx_boundary::union_type_from_members(
+                        self.ctx.types,
                         candidates
                             .into_iter()
                             .map(|(props_type, _)| props_type)

--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -334,11 +334,10 @@ impl<'a> CheckerState<'a> {
             && !shape.is_constructor
         {
             return Some(
-                shape
-                    .params
-                    .first()
-                    .map(|p| p.type_id)
-                    .unwrap_or_else(|| self.ctx.types.factory().object(vec![])),
+                crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                    self.ctx.types,
+                    &shape.params,
+                ),
             );
         }
 
@@ -352,11 +351,10 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         Some(
-            non_generic[0]
-                .params
-                .first()
-                .map(|p| p.type_id)
-                .unwrap_or_else(|| self.ctx.types.factory().object(vec![])),
+            crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                self.ctx.types,
+                &non_generic[0].params,
+            ),
         )
     }
 
@@ -1189,11 +1187,10 @@ impl<'a> CheckerState<'a> {
             if !shape.type_params.is_empty() {
                 return None;
             }
-            let props = shape
-                .params
-                .first()
-                .map(|p| p.type_id)
-                .unwrap_or_else(|| self.ctx.types.factory().object(vec![]));
+            let props = crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                self.ctx.types,
+                &shape.params,
+            );
             // Check for type parameters BEFORE evaluation, since evaluation may
             // collapse `T & {children?: ReactNode}` into a concrete object type
             // that loses the type parameter information.
@@ -1234,11 +1231,10 @@ impl<'a> CheckerState<'a> {
             if non_generic.next().is_some() {
                 return None;
             }
-            let props = sig
-                .params
-                .first()
-                .map(|p| p.type_id)
-                .unwrap_or_else(|| self.ctx.types.factory().object(vec![]));
+            let props = crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                self.ctx.types,
+                &sig.params,
+            );
             let raw_has_type_params =
                 crate::query_boundaries::common::contains_type_parameters(self.ctx.types, props);
             let evaluated = if should_preserve_contextual_application_shape(self.ctx.types, props) {
@@ -1320,11 +1316,10 @@ impl<'a> CheckerState<'a> {
             && !shape.is_constructor
             && !shape.type_params.is_empty()
         {
-            let props = shape
-                .params
-                .first()
-                .map(|param| param.type_id)
-                .unwrap_or_else(|| self.ctx.types.factory().object(vec![]));
+            let props = crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                self.ctx.types,
+                &shape.params,
+            );
             return self.instantiate_jsx_generic_sfc_props_with_defaults(
                 component_type,
                 props,
@@ -1342,11 +1337,10 @@ impl<'a> CheckerState<'a> {
                 .collect();
             if generic.len() == 1 {
                 let sig = generic[0];
-                let props = sig
-                    .params
-                    .first()
-                    .map(|param| param.type_id)
-                    .unwrap_or_else(|| self.ctx.types.factory().object(vec![]));
+                let props = crate::query_boundaries::checkers::jsx::props_param_type_or_empty(
+                    self.ctx.types,
+                    &sig.params,
+                );
                 return self.instantiate_jsx_generic_sfc_props_with_defaults(
                     component_type,
                     props,
@@ -1651,8 +1645,11 @@ impl<'a> CheckerState<'a> {
                                 self.resolve_property_access_with_env(component_type, "propTypes"),
                                 PropertyAccessResult::Success { .. }
                             );
-                            has_managed_props_metadata
-                                .then(|| self.ctx.types.factory().object(vec![]))
+                            has_managed_props_metadata.then(|| {
+                                crate::query_boundaries::checkers::jsx::empty_props_object_type(
+                                    self.ctx.types,
+                                )
+                            })
                         }),
                 }
             }

--- a/crates/tsz-checker/src/checkers/jsx/extraction_class_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction_class_props.rs
@@ -108,7 +108,10 @@ impl<'a> CheckerState<'a> {
                 .cloned()
                 .collect();
             if filtered_props.len() != shape.properties.len() {
-                return self.ctx.types.factory().object(filtered_props);
+                return crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                    self.ctx.types,
+                    filtered_props,
+                );
             }
         }
 
@@ -209,7 +212,12 @@ impl<'a> CheckerState<'a> {
             return Some(props_type);
         }
 
-        Some(self.ctx.types.factory().object(properties))
+        Some(
+            crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                properties,
+            ),
+        )
     }
 
     /// Get the property name from `JSX.ElementAttributesProperty`.

--- a/crates/tsz-checker/src/checkers/jsx/extraction_class_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction_class_props.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
@@ -140,7 +141,7 @@ impl<'a> CheckerState<'a> {
         match filtered.len() {
             0 => props_type,
             1 => filtered[0],
-            _ => self.ctx.types.factory().intersection(filtered),
+            _ => jsx_query::intersection_type_from_members(self.ctx.types, filtered),
         }
     }
 

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
@@ -21,39 +21,14 @@ impl<'a> CheckerState<'a> {
             return type_id;
         };
 
-        let normalized = tsz_solver::FunctionShape {
-            type_params: shape.type_params.clone(),
-            params: shape
-                .params
-                .iter()
-                .map(|param| tsz_solver::ParamInfo {
-                    name: param.name,
-                    type_id: crate::query_boundaries::common::unwrap_readonly_or_noinfer(
-                        self.ctx.types,
-                        param.type_id,
-                    )
-                    .unwrap_or(param.type_id),
-                    optional: param.optional,
-                    rest: param.rest,
-                })
-                .collect(),
-            this_type: shape.this_type.map(|this_type| {
-                crate::query_boundaries::common::unwrap_readonly_or_noinfer(
-                    self.ctx.types,
-                    this_type,
-                )
-                .unwrap_or(this_type)
-            }),
-            return_type: crate::query_boundaries::common::unwrap_readonly_or_noinfer(
-                self.ctx.types,
-                shape.return_type,
-            )
-            .unwrap_or(shape.return_type),
-            type_predicate: shape.type_predicate,
-            is_constructor: shape.is_constructor,
-            is_method: shape.is_method,
-        };
-        self.ctx.types.factory().function(normalized)
+        crate::query_boundaries::checkers::jsx::function_type_with_mapped_component_types(
+            self.ctx.types,
+            shape.as_ref(),
+            |type_id| {
+                crate::query_boundaries::common::unwrap_readonly_or_noinfer(self.ctx.types, type_id)
+                    .unwrap_or(type_id)
+            },
+        )
     }
 
     pub(in crate::checkers_domain::jsx) fn refine_jsx_callable_contextual_type(
@@ -314,7 +289,10 @@ impl<'a> CheckerState<'a> {
                 }
             }
             if !metadata_props.is_empty() {
-                return self.ctx.types.factory().object(metadata_props);
+                return crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                    self.ctx.types,
+                    metadata_props,
+                );
             }
         }
 
@@ -1093,58 +1071,11 @@ impl<'a> CheckerState<'a> {
         func: &tsz_solver::FunctionShape,
         substitution: &crate::query_boundaries::common::TypeSubstitution,
     ) -> tsz_solver::FunctionShape {
-        let mut full_substitution = substitution.clone();
-        for type_param in &func.type_params {
-            if full_substitution.get(type_param.name).is_none() {
-                let preserved_type_param = self.ctx.types.factory().type_param(*type_param);
-                full_substitution.insert(type_param.name, preserved_type_param);
-            }
-        }
-        tsz_solver::FunctionShape {
-            params: func
-                .params
-                .iter()
-                .map(|param| tsz_solver::ParamInfo {
-                    name: param.name,
-                    type_id: crate::query_boundaries::common::instantiate_type(
-                        self.ctx.types,
-                        param.type_id,
-                        &full_substitution,
-                    ),
-                    optional: param.optional,
-                    rest: param.rest,
-                })
-                .collect(),
-            return_type: crate::query_boundaries::common::instantiate_type(
-                self.ctx.types,
-                func.return_type,
-                &full_substitution,
-            ),
-            this_type: func.this_type.map(|this_type| {
-                crate::query_boundaries::common::instantiate_type(
-                    self.ctx.types,
-                    this_type,
-                    &full_substitution,
-                )
-            }),
-            type_params: vec![],
-            type_predicate: func.type_predicate.as_ref().map(|predicate| {
-                tsz_solver::TypePredicate {
-                    asserts: predicate.asserts,
-                    target: predicate.target,
-                    type_id: predicate.type_id.map(|tid| {
-                        crate::query_boundaries::common::instantiate_type(
-                            self.ctx.types,
-                            tid,
-                            &full_substitution,
-                        )
-                    }),
-                    parameter_index: predicate.parameter_index,
-                }
-            }),
-            is_constructor: func.is_constructor,
-            is_method: func.is_method,
-        }
+        crate::query_boundaries::checkers::jsx::instantiate_function_shape_preserving_unresolved_params(
+            self.ctx.types,
+            func,
+            substitution,
+        )
     }
 
     pub(in crate::checkers_domain::jsx) fn infer_jsx_generic_component_props_type(
@@ -1504,20 +1435,13 @@ impl<'a> CheckerState<'a> {
                 _ => continue,
             };
             let expected_type = self.refine_jsx_callable_contextual_type(expected_type);
-            let synthetic_shape = tsz_solver::FunctionShape {
-                type_params: function_shape.type_params.clone(),
-                params: vec![tsz_solver::ParamInfo {
-                    name: Some(self.ctx.types.intern_string(attr_name)),
-                    type_id: expected_type,
-                    optional: false,
-                    rest: false,
-                }],
-                this_type: None,
-                return_type: TypeId::VOID,
-                type_predicate: None,
-                is_constructor: false,
-                is_method: false,
-            };
+            let synthetic_shape =
+                crate::query_boundaries::checkers::jsx::synthetic_single_param_function_shape(
+                    function_shape.type_params.clone(),
+                    self.ctx.types.intern_string(attr_name),
+                    expected_type,
+                    TypeId::VOID,
+                );
             let attr_sub = {
                 let env = self.ctx.type_env.borrow();
                 crate::query_boundaries::checkers::call::compute_contextual_types_with_context(

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
@@ -2,6 +2,7 @@
 //! function-valued attributes, intrinsic props lookup, and component props
 //! recovery.
 
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -64,7 +65,7 @@ impl<'a> CheckerState<'a> {
             return match callable_members.len() {
                 0 => type_id,
                 1 => callable_members[0],
-                _ => self.ctx.types.factory().union(callable_members),
+                _ => jsx_query::union_type_from_members(self.ctx.types, callable_members),
             };
         }
 
@@ -96,7 +97,7 @@ impl<'a> CheckerState<'a> {
         match callable_members.len() {
             0 => type_id,
             1 => callable_members[0],
-            _ => self.ctx.types.factory().union(callable_members),
+            _ => jsx_query::union_type_from_members(self.ctx.types, callable_members),
         }
     }
 
@@ -122,7 +123,7 @@ impl<'a> CheckerState<'a> {
             return match single_members.as_slice() {
                 [] => type_id,
                 [single_member] => *single_member,
-                _ => self.ctx.types.factory().union(single_members),
+                _ => jsx_query::union_type_from_members(self.ctx.types, single_members),
             };
         }
 
@@ -142,7 +143,7 @@ impl<'a> CheckerState<'a> {
         match single_members.as_slice() {
             [] => resolved,
             [single_member] => *single_member,
-            _ => self.ctx.types.factory().union(single_members),
+            _ => jsx_query::union_type_from_members(self.ctx.types, single_members),
         }
     }
 
@@ -166,7 +167,7 @@ impl<'a> CheckerState<'a> {
         match multiple_members.as_slice() {
             [] => resolved,
             [multiple_member] => *multiple_member,
-            _ => self.ctx.types.factory().union(multiple_members),
+            _ => jsx_query::union_type_from_members(self.ctx.types, multiple_members),
         }
     }
 
@@ -194,7 +195,10 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => None,
                 [element_type] => Some(*element_type),
-                _ => Some(self.ctx.types.factory().union(element_types)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    element_types,
+                )),
             };
         }
 
@@ -216,7 +220,10 @@ impl<'a> CheckerState<'a> {
             return match element_types.as_slice() {
                 [] => None,
                 [element_type] => Some(*element_type),
-                _ => Some(self.ctx.types.factory().union(element_types)),
+                _ => Some(jsx_query::union_type_from_members(
+                    self.ctx.types,
+                    element_types,
+                )),
             };
         }
 
@@ -285,7 +292,7 @@ impl<'a> CheckerState<'a> {
                     let atom = self.ctx.types.intern_string(prop_name);
                     let type_id =
                         self.declared_expando_property_type_for_root(sym_id, &name, prop_name);
-                    metadata_props.push(tsz_solver::PropertyInfo::new(atom, type_id));
+                    metadata_props.push(jsx_query::property_info(atom, type_id));
                 }
             }
             if !metadata_props.is_empty() {
@@ -388,12 +395,11 @@ impl<'a> CheckerState<'a> {
     ) -> Option<TypeId> {
         let lma_sym_id = self.get_jsx_namespace_export_symbol_id("LibraryManagedAttributes")?;
         let lma_ref = self.resolve_symbol_as_lazy_type(lma_sym_id);
-        Some(
-            self.ctx
-                .types
-                .factory()
-                .application(lma_ref, vec![component_type, props_type]),
-        )
+        Some(jsx_query::type_application_from_args(
+            self.ctx.types,
+            lma_ref,
+            vec![component_type, props_type],
+        ))
     }
 
     pub(in crate::checkers_domain::jsx) fn get_jsx_dynamic_intrinsic_display_props_type(
@@ -536,11 +542,8 @@ impl<'a> CheckerState<'a> {
         component_type: TypeId,
     ) -> Option<(TypeId, bool, String)> {
         let intrinsic_elements_type = self.get_intrinsic_elements_type()?;
-        let raw_props_type = self
-            .ctx
-            .types
-            .factory()
-            .index_access(intrinsic_elements_type, component_type);
+        let raw_props_type =
+            jsx_query::index_access_type(self.ctx.types, intrinsic_elements_type, component_type);
         let normalized_props = self.normalize_jsx_required_props_target(raw_props_type);
         if matches!(normalized_props, TypeId::ANY | TypeId::ERROR) {
             return None;
@@ -778,14 +781,13 @@ impl<'a> CheckerState<'a> {
         match best_matches.len() {
             0 => None,
             1 => best_matches.first().map(|(_, value_type)| *value_type),
-            _ => Some(
-                self.ctx.types.factory().union(
-                    best_matches
-                        .into_iter()
-                        .map(|(_, value_type)| value_type)
-                        .collect(),
-                ),
-            ),
+            _ => Some(jsx_query::union_type_from_members(
+                self.ctx.types,
+                best_matches
+                    .into_iter()
+                    .map(|(_, value_type)| value_type)
+                    .collect(),
+            )),
         }
     }
 
@@ -1702,8 +1704,8 @@ impl<'a> CheckerState<'a> {
         let synthesized_type = if child_types.len() == 1 && !has_spread_child {
             child_types[0]
         } else {
-            let element_type = self.ctx.types.factory().union(child_types);
-            self.ctx.types.factory().array(element_type)
+            let element_type = jsx_query::union_type_from_members(self.ctx.types, child_types);
+            jsx_query::array_type_from_element(self.ctx.types, element_type)
         };
         out.push((children_prop_name.to_string(), synthesized_type));
     }

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
@@ -1,6 +1,7 @@
 //! JSX namespace resolution, intrinsic elements, closing checks, and attributes.
 
 use crate::context::TypingRequest;
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use crate::symbols_domain::name_text::entity_name_text_in_arena;
 use tsz_binder::{SymbolId, symbol_flags};
@@ -1974,8 +1975,6 @@ impl<'a> CheckerState<'a> {
 
         // Fallback: create Application for class components, type aliases,
         // and overloaded SFCs (Callable types)
-        self.ctx
-            .types
-            .application(component_type, type_args.to_vec())
+        jsx_query::type_application_from_args(self.ctx.types, component_type, type_args.to_vec())
     }
 }

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
@@ -174,15 +174,8 @@ impl<'a> CheckerState<'a> {
         )?
         .first()?
         .clone();
-        let mut function_shape = tsz_solver::FunctionShape {
-            type_params: call_sig.type_params,
-            params: call_sig.params,
-            this_type: call_sig.this_type,
-            return_type: call_sig.return_type,
-            type_predicate: call_sig.type_predicate,
-            is_constructor: true,
-            is_method: call_sig.is_method,
-        };
+        let mut function_shape =
+            crate::query_boundaries::checkers::jsx::construct_signature_function_shape(call_sig);
         if function_shape.type_params.is_empty() {
             return None;
         }
@@ -223,9 +216,11 @@ impl<'a> CheckerState<'a> {
 
             if let Some(type_id) = synthesized_param_type {
                 let props_name = self.ctx.types.intern_string("props");
-                function_shape
-                    .params
-                    .push(tsz_solver::ParamInfo::required(props_name, type_id));
+                crate::query_boundaries::checkers::jsx::push_required_param(
+                    &mut function_shape,
+                    props_name,
+                    type_id,
+                );
             }
         }
 

--- a/crates/tsz-checker/src/checkers/jsx/overloads.rs
+++ b/crates/tsz-checker/src/checkers/jsx/overloads.rs
@@ -729,6 +729,9 @@ impl<'a> CheckerState<'a> {
                 }
             })
             .collect();
-        self.ctx.types.factory().object(properties)
+        crate::query_boundaries::checkers::jsx::object_type_from_properties(
+            self.ctx.types,
+            properties,
+        )
     }
 }

--- a/crates/tsz-checker/src/checkers/jsx/overloads.rs
+++ b/crates/tsz-checker/src/checkers/jsx/overloads.rs
@@ -5,6 +5,7 @@
 //! matches, emits TS2769 ("No overload matches this call.").
 
 use crate::context::speculation::FullSpeculationSnapshot;
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -711,22 +712,7 @@ impl<'a> CheckerState<'a> {
             .iter()
             .map(|attr| {
                 let name_atom = self.ctx.types.intern_string(&attr.name);
-                tsz_solver::PropertyInfo {
-                    name: name_atom,
-                    type_id: attr.type_id,
-                    write_type: attr.type_id,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: tsz_solver::Visibility::Public,
-                    parent_id: None,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                }
+                jsx_query::property_info_with_write_type(name_atom, attr.type_id, attr.type_id)
             })
             .collect();
         crate::query_boundaries::checkers::jsx::object_type_from_properties(

--- a/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
@@ -1,5 +1,6 @@
 //! JSX generic spread whole-object assignability diagnostics.
 
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
@@ -50,7 +51,7 @@ impl<'a> CheckerState<'a> {
         let explicit_attrs_type = self.build_jsx_provided_attrs_object_type(provided_attrs);
         let mut members = generic_spread_types;
         members.push(explicit_attrs_type);
-        let attrs_type = self.ctx.types.factory().intersection(members);
+        let attrs_type = jsx_query::intersection_type_from_members(self.ctx.types, members);
 
         let props_for_access = self.normalize_jsx_required_props_target(props_type);
 

--- a/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
@@ -3,6 +3,7 @@
 use crate::context::TypingRequest;
 use crate::context::speculation::DiagnosticSpeculationSnapshot;
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
@@ -207,7 +208,7 @@ impl<'a> CheckerState<'a> {
                     match compatible_members.len() {
                         0 => props_type,
                         1 => compatible_members[0],
-                        _ => self.ctx.types.factory().union(compatible_members),
+                        _ => jsx_query::union_type_from_members(self.ctx.types, compatible_members),
                     }
                 }
             }
@@ -225,7 +226,7 @@ impl<'a> CheckerState<'a> {
                 match normalized_members.len() {
                     0 => props_type,
                     1 => normalized_members[0],
-                    _ => self.ctx.types.factory().union(normalized_members),
+                    _ => jsx_query::union_type_from_members(self.ctx.types, normalized_members),
                 }
             }
         }

--- a/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
@@ -51,7 +51,12 @@ impl<'a> CheckerState<'a> {
                 }
             })
             .collect();
-        let source_type = self.format_type(self.ctx.types.factory().object(properties));
+        let source_type = self.format_type(
+            crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                self.ctx.types,
+                properties,
+            ),
+        );
         let base = format_message(
             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             &[&source_type, display_target],
@@ -265,7 +270,10 @@ impl<'a> CheckerState<'a> {
                 }
             })
             .collect();
-        let attrs_type = self.ctx.types.factory().object(properties);
+        let attrs_type = crate::query_boundaries::checkers::jsx::object_type_from_properties(
+            self.ctx.types,
+            properties,
+        );
         if crate::query_boundaries::checkers::jsx::props_are_assignable(
             self, attrs_type, props_type,
         ) {

--- a/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
@@ -1,6 +1,7 @@
 //! JSX union prop compatibility and display helpers.
 
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
@@ -33,22 +34,7 @@ impl<'a> CheckerState<'a> {
                 } else {
                     *type_id
                 };
-                tsz_solver::PropertyInfo {
-                    name: name_atom,
-                    type_id: display_type,
-                    write_type: display_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: tsz_solver::Visibility::Public,
-                    parent_id: None,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                }
+                jsx_query::property_info_with_write_type(name_atom, display_type, display_type)
             })
             .collect();
         let source_type = self.format_type(
@@ -252,22 +238,7 @@ impl<'a> CheckerState<'a> {
                 } else {
                     *type_id
                 };
-                tsz_solver::PropertyInfo {
-                    name: name_atom,
-                    type_id: display_type,
-                    write_type: display_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: tsz_solver::Visibility::Public,
-                    parent_id: None,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                }
+                jsx_query::property_info_with_write_type(name_atom, display_type, display_type)
             })
             .collect();
         let attrs_type = crate::query_boundaries::checkers::jsx::object_type_from_properties(

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -135,7 +135,10 @@ impl<'a> CheckerState<'a> {
                 }
             })
             .collect();
-        self.ctx.types.factory().object(properties)
+        crate::query_boundaries::checkers::jsx::object_type_from_properties(
+            self.ctx.types,
+            properties,
+        )
     }
 
     pub(in crate::checkers_domain::jsx) fn check_jsx_generic_spread_attrs_assignability(
@@ -881,7 +884,12 @@ impl<'a> CheckerState<'a> {
                 .cloned()
                 .collect();
             if filtered_props.len() != shape.properties.len() {
-                return self.format_type(self.ctx.types.factory().object(filtered_props));
+                return self.format_type(
+                    crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                        self.ctx.types,
+                        filtered_props,
+                    ),
+                );
             }
         }
 
@@ -1148,14 +1156,12 @@ impl<'a> CheckerState<'a> {
 
         let instance_type = self.get_class_instance_type_for_component(component_type)?;
         let param_name = self.ctx.types.intern_string("instance");
-        let callback = self
-            .ctx
-            .types
-            .factory()
-            .function(tsz_solver::FunctionShape::new(
-                vec![tsz_solver::ParamInfo::required(param_name, instance_type)],
-                TypeId::ANY,
-            ));
+        let callback = crate::query_boundaries::checkers::jsx::single_required_param_function_type(
+            self.ctx.types,
+            param_name,
+            instance_type,
+            TypeId::ANY,
+        );
         Some(self.ctx.types.factory().union2(TypeId::STRING, callback))
     }
 
@@ -1630,19 +1636,10 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
             && shape.is_method
         {
-            return self
-                .ctx
-                .types
-                .factory()
-                .function(tsz_solver::FunctionShape {
-                    type_params: shape.type_params.clone(),
-                    params: shape.params.clone(),
-                    this_type: None,
-                    return_type: shape.return_type,
-                    type_predicate: shape.type_predicate,
-                    is_constructor: shape.is_constructor,
-                    is_method: false,
-                });
+            return crate::query_boundaries::checkers::jsx::function_type_without_this(
+                self.ctx.types,
+                shape.as_ref(),
+            );
         }
 
         type_id

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -117,22 +117,7 @@ impl<'a> CheckerState<'a> {
                 } else {
                     *type_id
                 };
-                tsz_solver::PropertyInfo {
-                    name: name_atom,
-                    type_id: display_type,
-                    write_type: display_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: tsz_solver::Visibility::Public,
-                    parent_id: None,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                }
+                jsx_queries::property_info_with_write_type(name_atom, display_type, display_type)
             })
             .collect();
         crate::query_boundaries::checkers::jsx::object_type_from_properties(
@@ -261,7 +246,8 @@ impl<'a> CheckerState<'a> {
             .any(|&spread_type| self.jsx_relation_operand_defers(spread_type));
         let explicit_type = self.build_jsx_provided_attrs_object_type(&explicit_attrs);
         generic_spreads.push(explicit_type);
-        let attrs_type = self.ctx.types.factory().intersection(generic_spreads);
+        let attrs_type =
+            jsx_queries::intersection_type_from_members(self.ctx.types, generic_spreads);
         if !has_explicit_mismatch {
             if spread_source_is_deferred {
                 return;
@@ -761,9 +747,9 @@ impl<'a> CheckerState<'a> {
         let array_element = if element_types.len() == 1 {
             element_types[0]
         } else {
-            self.ctx.types.factory().union(element_types)
+            jsx_queries::union_type_from_members(self.ctx.types, element_types)
         };
-        self.ctx.types.factory().array(array_element)
+        jsx_queries::array_type_from_element(self.ctx.types, array_element)
     }
 
     fn format_jsx_provided_attrs_source_type(
@@ -1162,7 +1148,11 @@ impl<'a> CheckerState<'a> {
             instance_type,
             TypeId::ANY,
         );
-        Some(self.ctx.types.factory().union2(TypeId::STRING, callback))
+        Some(jsx_queries::union_type_from_pair(
+            self.ctx.types,
+            TypeId::STRING,
+            callback,
+        ))
     }
 
     fn get_jsx_intrinsic_class_attribute_from_heritage(
@@ -1750,7 +1740,8 @@ impl<'a> CheckerState<'a> {
             }
 
             // Build target: IntrinsicAttributes & spread_type
-            let target = self.ctx.types.factory().intersection2(ia_type, spread_type);
+            let target =
+                jsx_queries::intersection_type_from_pair(self.ctx.types, ia_type, spread_type);
 
             if !crate::query_boundaries::checkers::jsx::props_are_assignable(
                 self,
@@ -1868,10 +1859,7 @@ impl<'a> CheckerState<'a> {
         let display_type = if !prop_is_optional_in_anonymous_source {
             write_check_type
         } else if write_check_type == declared_type_id {
-            self.ctx
-                .types
-                .factory()
-                .union2(write_check_type, TypeId::UNDEFINED)
+            jsx_queries::union_type_from_pair(self.ctx.types, write_check_type, TypeId::UNDEFINED)
         } else {
             declared_type_id
         };

--- a/crates/tsz-checker/src/checkers/jsx/spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/spread.rs
@@ -637,7 +637,10 @@ impl<'a> CheckerState<'a> {
                 .cloned()
                 .collect();
             if filtered.len() != shape.properties.len() {
-                return self.ctx.types.factory().object(filtered);
+                return crate::query_boundaries::checkers::jsx::object_type_from_properties(
+                    self.ctx.types,
+                    filtered,
+                );
             }
         }
         props_type

--- a/crates/tsz-checker/src/checkers/jsx/spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/spread.rs
@@ -3,6 +3,7 @@
 
 use crate::context::TypingRequest;
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -619,7 +620,7 @@ impl<'a> CheckerState<'a> {
                 return match kept.len() {
                     0 => props_type, // pathological — keep original
                     1 => kept[0],
-                    _ => self.ctx.types.factory().intersection(kept),
+                    _ => jsx_query::intersection_type_from_members(self.ctx.types, kept),
                 };
             }
         }

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -710,11 +710,8 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let awaited_type = match callback_value_types.as_slice() {
-            [] => None,
-            [only] => Some(*only),
-            types => Some(self.ctx.types.factory().union(types.to_vec())),
-        };
+        let awaited_type =
+            query::thenable_callback_value_union(self.ctx.types, callback_value_types);
 
         ThenableAwaitInfo {
             awaited_type,
@@ -1830,7 +1827,7 @@ impl<'a> CheckerState<'a> {
                     new_members.push(*member);
                 }
             }
-            return self.ctx.types.factory().union(new_members);
+            return query::async_return_body_union(self.ctx.types, new_members);
         }
         return_type
     }

--- a/crates/tsz-checker/src/classes/constructor_checker.rs
+++ b/crates/tsz-checker/src/classes/constructor_checker.rs
@@ -8,9 +8,9 @@
 use crate::query_boundaries::common::TypeEnvironment;
 use crate::query_boundaries::{
     checkers::constructor::{
-        AbstractConstructorAnchor, ConstructorAccessKind, ConstructorReturnMergeKind,
-        InstanceTypeKind, classify_for_constructor_access, classify_for_constructor_return_merge,
-        classify_for_instance_type, construct_return_type_for_display, has_construct_signatures,
+        AbstractConstructorAnchor, ConstructorAccessKind, InstanceTypeKind,
+        classify_for_constructor_access, classify_for_instance_type,
+        construct_return_type_for_display, has_construct_signatures,
         resolve_abstract_constructor_anchor,
     },
     common,
@@ -144,8 +144,12 @@ impl<'a> CheckerState<'a> {
         let type_param_substitution =
             self.mixin_call_type_parameter_substitution(callee_type, arg_types);
 
-        let factory = self.ctx.types.factory();
-        let mut refined_return = factory.intersection2(return_type, base_arg_type);
+        let mut refined_return =
+            crate::query_boundaries::checkers::constructor::mixin_return_type_with_base_constructor(
+                self.ctx.types,
+                return_type,
+                base_arg_type,
+            );
 
         if let Some(mixin_instance_type) =
             self.mixin_instance_type_from_construct_returns(return_type, base_arg_type)
@@ -215,43 +219,19 @@ impl<'a> CheckerState<'a> {
             returns.push(base_instance);
         }
 
-        Some(tsz_solver::utils::intersection_or_single(
-            self.ctx.types,
-            returns,
-        ))
+        Some(
+            crate::query_boundaries::checkers::constructor::constructor_return_intersection_or_single(
+                self.ctx.types,
+                returns,
+            ),
+        )
     }
 
     fn clear_constructor_abstract_flag(&self, ctor_type: TypeId) -> TypeId {
-        match classify_for_constructor_return_merge(self.ctx.types, ctor_type) {
-            ConstructorReturnMergeKind::Callable(shape_id) => {
-                let shape = self.ctx.types.callable_shape(shape_id);
-                if !shape.is_abstract {
-                    return ctor_type;
-                }
-                let mut new_shape = (*shape).clone();
-                new_shape.is_abstract = false;
-                self.ctx.types.factory().callable(new_shape)
-            }
-            ConstructorReturnMergeKind::Intersection(members) => {
-                let mut updated_members = Vec::with_capacity(members.len());
-                let mut changed = false;
-                for member in members {
-                    let updated = self.clear_constructor_abstract_flag(member);
-                    if updated != member {
-                        changed = true;
-                    }
-                    updated_members.push(updated);
-                }
-                if changed {
-                    self.ctx.types.factory().intersection(updated_members)
-                } else {
-                    ctor_type
-                }
-            }
-            ConstructorReturnMergeKind::Function(_) | ConstructorReturnMergeKind::Other => {
-                ctor_type
-            }
-        }
+        crate::query_boundaries::checkers::constructor::constructor_type_without_abstract_flag(
+            self.ctx.types,
+            ctor_type,
+        )
     }
 
     fn mixin_call_type_parameter_substitution(
@@ -302,10 +282,11 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         Some(
-            self.ctx
-                .types
-                .factory()
-                .intersection2(returned_instance, base_instance),
+            crate::query_boundaries::checkers::constructor::mixin_returned_class_instance_type(
+                self.ctx.types,
+                returned_instance,
+                base_instance,
+            ),
         )
     }
 
@@ -330,50 +311,21 @@ impl<'a> CheckerState<'a> {
         if returns.windows(2).all(|w| w[0] == w[1]) {
             return None;
         }
-        Some(tsz_solver::utils::intersection_or_single(
-            self.ctx.types,
-            returns,
-        ))
+        Some(
+            crate::query_boundaries::checkers::constructor::constructor_return_intersection_or_single(
+                self.ctx.types,
+                returns,
+            ),
+        )
     }
 
     /// Set all construct signature return types to the given type.
     fn set_all_construct_return_types(&self, ctor_type: TypeId, instance_type: TypeId) -> TypeId {
-        match classify_for_constructor_return_merge(self.ctx.types, ctor_type) {
-            ConstructorReturnMergeKind::Callable(shape_id) => {
-                let shape = self.ctx.types.callable_shape(shape_id);
-                let mut new_shape = (*shape).clone();
-                for sig in &mut new_shape.construct_signatures {
-                    sig.return_type = instance_type;
-                }
-                self.ctx.types.factory().callable(new_shape)
-            }
-            ConstructorReturnMergeKind::Function(shape_id) => {
-                let shape = self.ctx.types.function_shape(shape_id);
-                if !shape.is_constructor {
-                    return ctor_type;
-                }
-                let mut new_shape = (*shape).clone();
-                new_shape.return_type = instance_type;
-                self.ctx.types.factory().function(new_shape)
-            }
-            ConstructorReturnMergeKind::Intersection(members) => {
-                let mut updated_members = Vec::with_capacity(members.len());
-                let mut changed = false;
-                for member in members {
-                    let updated = self.set_all_construct_return_types(member, instance_type);
-                    if updated != member {
-                        changed = true;
-                    }
-                    updated_members.push(updated);
-                }
-                if changed {
-                    self.ctx.types.factory().intersection(updated_members)
-                } else {
-                    ctor_type
-                }
-            }
-            ConstructorReturnMergeKind::Other => ctor_type,
-        }
+        crate::query_boundaries::checkers::constructor::constructor_type_with_construct_return(
+            self.ctx.types,
+            ctor_type,
+            instance_type,
+        )
     }
 
     fn mixin_base_param_index(
@@ -969,7 +921,10 @@ impl<'a> CheckerState<'a> {
                         return None;
                     }
                     let instance_type =
-                        tsz_solver::utils::intersection_or_single(self.ctx.types, instance_types);
+                        crate::query_boundaries::checkers::constructor::constructor_instance_intersection_or_single(
+                            self.ctx.types,
+                            instance_types,
+                        );
                     return Some(self.resolve_type_for_property_access(instance_type));
                 }
                 InstanceTypeKind::Union(members) => {
@@ -1047,39 +1002,11 @@ impl<'a> CheckerState<'a> {
                 ctor_type
             }
         };
-        match classify_for_constructor_return_merge(self.ctx.types, ctor_type) {
-            ConstructorReturnMergeKind::Callable(_) | ConstructorReturnMergeKind::Function(_) => {
-                // Delegate to solver: intersect construct/function return types
-                // with the base instance type.
-                let result = crate::query_boundaries::common::intersect_constructor_returns(
-                    self.ctx.types,
-                    ctor_type,
-                    base_instance_type,
-                );
-                if result != ctor_type {
-                    return result;
-                }
-                ctor_type
-            }
-            ConstructorReturnMergeKind::Intersection(members) => {
-                let mut updated_members = Vec::with_capacity(members.len());
-                let mut changed = false;
-                for member in members {
-                    let updated = self
-                        .merge_base_instance_into_constructor_return(member, base_instance_type);
-                    if updated != member {
-                        changed = true;
-                    }
-                    updated_members.push(updated);
-                }
-                if changed {
-                    self.ctx.types.factory().intersection(updated_members)
-                } else {
-                    ctor_type
-                }
-            }
-            ConstructorReturnMergeKind::Other => ctor_type,
-        }
+        crate::query_boundaries::checkers::constructor::constructor_type_with_base_instance_return(
+            self.ctx.types,
+            ctor_type,
+            base_instance_type,
+        )
     }
 
     fn merge_base_constructor_properties_into_constructor_return(
@@ -1087,7 +1014,6 @@ impl<'a> CheckerState<'a> {
         ctor_type: TypeId,
         base_props: &rustc_hash::FxHashMap<Atom, tsz_solver::PropertyInfo>,
     ) -> TypeId {
-        use rustc_hash::FxHashMap;
         if base_props.is_empty() {
             return ctor_type;
         }
@@ -1101,43 +1027,11 @@ impl<'a> CheckerState<'a> {
                 ctor_type
             }
         };
-        match classify_for_constructor_return_merge(self.ctx.types, ctor_type) {
-            ConstructorReturnMergeKind::Callable(shape_id) => {
-                let shape = self.ctx.types.callable_shape(shape_id);
-                let mut prop_map: FxHashMap<Atom, tsz_solver::PropertyInfo> = shape
-                    .properties
-                    .iter()
-                    .map(|prop| (prop.name, prop.clone()))
-                    .collect();
-                for (name, prop) in base_props {
-                    prop_map.entry(*name).or_insert_with(|| prop.clone());
-                }
-                let mut new_shape = (*shape).clone();
-                new_shape.properties = prop_map.into_values().collect();
-                self.ctx.types.factory().callable(new_shape)
-            }
-            ConstructorReturnMergeKind::Intersection(members) => {
-                let mut updated_members = Vec::with_capacity(members.len());
-                let mut changed = false;
-                for member in members {
-                    let updated = self.merge_base_constructor_properties_into_constructor_return(
-                        member, base_props,
-                    );
-                    if updated != member {
-                        changed = true;
-                    }
-                    updated_members.push(updated);
-                }
-                if changed {
-                    self.ctx.types.factory().intersection(updated_members)
-                } else {
-                    ctor_type
-                }
-            }
-            ConstructorReturnMergeKind::Function(_) | ConstructorReturnMergeKind::Other => {
-                ctor_type
-            }
-        }
+        crate::query_boundaries::checkers::constructor::constructor_type_with_base_properties(
+            self.ctx.types,
+            ctor_type,
+            base_props,
+        )
     }
 
     // =========================================================================

--- a/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
+++ b/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
@@ -1,5 +1,6 @@
 //! Dynamic import validation: specifier type, options type, attributes, module resolution.
 
+use crate::query_boundaries::import_attributes as import_attribute_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
@@ -110,10 +111,12 @@ impl<'a> CheckerState<'a> {
         // property references the base ImportAttributes (without user augmentations).
         let with_atom = self.ctx.types.intern_string("with");
         let assert_atom = self.ctx.types.intern_string("assert");
-        let import_call_options_type = self.ctx.types.factory().object(vec![
-            tsz_solver::PropertyInfo::opt(with_atom, import_attributes_type),
-            tsz_solver::PropertyInfo::opt(assert_atom, import_attributes_type),
-        ]);
+        let import_call_options_type = import_attribute_query::import_call_options_type(
+            self.ctx.types,
+            with_atom,
+            assert_atom,
+            import_attributes_type,
+        );
 
         // Build the options type manually from the AST with string literal types.
         let Some(options_node) = self.ctx.arena.get(options_idx) else {
@@ -258,7 +261,9 @@ impl<'a> CheckerState<'a> {
                 };
 
                 let name_atom = self.ctx.types.intern_string(&name);
-                properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+                properties.push(import_attribute_query::import_attribute_property(
+                    name_atom, value_type,
+                ));
             }
         }
 
@@ -266,7 +271,7 @@ impl<'a> CheckerState<'a> {
             return self.get_type_of_node(obj_idx);
         }
 
-        self.ctx.types.factory().object(properties)
+        import_attribute_query::import_attribute_object_type(self.ctx.types, properties)
     }
 
     /// Build an object type from an object literal using string literal types for
@@ -294,13 +299,18 @@ impl<'a> CheckerState<'a> {
                 let value_type = if let Some(val_node) = self.ctx.arena.get(prop.initializer)
                     && let Some(lit) = self.ctx.arena.get_literal(val_node)
                 {
-                    self.ctx.types.factory().literal_string(&lit.text)
+                    import_attribute_query::import_attribute_literal_string_type(
+                        self.ctx.types,
+                        &lit.text,
+                    )
                 } else {
                     self.get_type_of_node(prop.initializer)
                 };
 
                 let name_atom = self.ctx.types.intern_string(&name);
-                properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+                properties.push(import_attribute_query::import_attribute_property(
+                    name_atom, value_type,
+                ));
             }
         }
 
@@ -308,7 +318,7 @@ impl<'a> CheckerState<'a> {
             return self.get_type_of_node(obj_idx);
         }
 
-        self.ctx.types.factory().object(properties)
+        import_attribute_query::import_attribute_object_type(self.ctx.types, properties)
     }
 
     /// TS2880: Check for deprecated `assert` property in an import options object literal.

--- a/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
@@ -387,6 +387,7 @@ impl<'a> CheckerState<'a> {
     /// has augmented `ImportAttributes` (e.g., `interface ImportAttributes { type: "json" }`),
     /// mismatched values will produce TS2322.
     pub(crate) fn check_import_attributes_assignability(&mut self, attributes_idx: NodeIndex) {
+        use crate::query_boundaries::import_attributes as import_attribute_query;
         use tsz_solver::TypeId;
 
         if attributes_idx.is_none() {
@@ -449,7 +450,10 @@ impl<'a> CheckerState<'a> {
             let value_type = if let Some(val_node) = self.ctx.arena.get(attr_data.value) {
                 if val_node.kind == tsz_scanner::SyntaxKind::StringLiteral as u16 {
                     if let Some(lit) = self.ctx.arena.get_literal(val_node) {
-                        self.ctx.types.factory().literal_string(&lit.text)
+                        import_attribute_query::import_attribute_literal_string_type(
+                            self.ctx.types,
+                            &lit.text,
+                        )
                     } else {
                         self.get_type_of_node(attr_data.value)
                     }
@@ -488,14 +492,17 @@ impl<'a> CheckerState<'a> {
             };
 
             let name_atom = self.ctx.types.intern_string(&name);
-            properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+            properties.push(import_attribute_query::import_attribute_property(
+                name_atom, value_type,
+            ));
         }
 
         if properties.is_empty() {
             return;
         }
 
-        let source_type = self.ctx.types.factory().object(properties);
+        let source_type =
+            import_attribute_query::import_attribute_object_type(self.ctx.types, properties);
 
         // Don't check if source or target are any/error
         if source_type == TypeId::ANY

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1,9 +1,9 @@
 //! Module import/export validation and circular re-export detection.
 
+use crate::query_boundaries::declaration_exports;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_parser::parser::NodeIndex;
-use tsz_solver::Visibility;
 
 mod verbatim_module_syntax;
 
@@ -709,8 +709,6 @@ impl<'a> CheckerState<'a> {
         &mut self,
         call: &tsz_parser::parser::node::CallExprData,
     ) -> tsz_solver::TypeId {
-        use tsz_solver::PropertyInfo;
-
         // Get the first argument (module specifier)
         let args = match call.arguments.as_ref() {
             Some(a) => a.nodes.as_slice(),
@@ -756,7 +754,7 @@ impl<'a> CheckerState<'a> {
             let ordered_exports = self.ordered_namespace_export_entries(&exports_table);
 
             // Create an object type with all module exports
-            let mut props: Vec<PropertyInfo> = Vec::new();
+            let mut props: Vec<tsz_solver::PropertyInfo> = Vec::new();
             for &(name, export_sym_id) in &ordered_exports {
                 if name == "export=" {
                     continue;
@@ -768,22 +766,11 @@ impl<'a> CheckerState<'a> {
                     props.len() as u32 + 2
                 };
                 let name_atom = self.ctx.types.intern_string(name);
-                props.push(PropertyInfo {
-                    name: name_atom,
-                    type_id: prop_type,
-                    write_type: prop_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: None,
+                props.push(declaration_exports::declaration_export_property(
+                    name_atom,
+                    prop_type,
                     declaration_order,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                });
+                ));
             }
 
             // Merge module augmentations
@@ -804,26 +791,17 @@ impl<'a> CheckerState<'a> {
                     // Check if this augments an existing export
                     if let Some(existing) = props.iter_mut().find(|p| p.name == name_atom) {
                         // Merge types - for interfaces, this creates an intersection
-                        existing.type_id = self.ctx.types.intersection2(existing.type_id, aug_type);
+                        existing.type_id = declaration_exports::module_export_augmented_type(
+                            self.ctx.types,
+                            existing.type_id,
+                            aug_type,
+                        );
                         existing.write_type = existing.type_id;
                     } else {
                         // New export from augmentation
-                        props.push(PropertyInfo {
-                            name: name_atom,
-                            type_id: aug_type,
-                            write_type: aug_type,
-                            optional: false,
-                            readonly: false,
-                            is_method: false,
-                            is_class_prototype: false,
-                            visibility: Visibility::Public,
-                            parent_id: None,
-                            declaration_order: 0,
-                            is_string_named: false,
-                            is_symbol_named: false,
-                            single_quoted_name: false,
-                            non_widening: false,
-                        });
+                        props.push(declaration_exports::declaration_export_property(
+                            name_atom, aug_type, 0,
+                        ));
                     }
                 }
             }
@@ -836,28 +814,17 @@ impl<'a> CheckerState<'a> {
             {
                 let default_atom = self.ctx.types.intern_string("default");
                 if !props.iter().any(|p| p.name == default_atom) {
-                    props.push(PropertyInfo {
-                        name: default_atom,
-                        type_id: eq_type,
-                        write_type: eq_type,
-                        optional: false,
-                        readonly: false,
-                        is_method: false,
-                        is_class_prototype: false,
-                        visibility: Visibility::Public,
-                        parent_id: None,
-                        declaration_order: 1,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                    props.push(declaration_exports::declaration_export_property(
+                        default_atom,
+                        eq_type,
+                        1,
+                    ));
                 }
             }
 
             Self::normalize_namespace_export_declaration_order(&mut props);
-            let factory = self.ctx.types.factory();
-            let module_type = factory.object(props);
+            let module_type =
+                declaration_exports::dynamic_import_module_object_type(self.ctx.types, props);
             let display_module_name =
                 self.resolve_namespace_display_module_name(&exports_table, module_name);
             self.ctx
@@ -885,8 +852,6 @@ impl<'a> CheckerState<'a> {
         // Resolve Promise as Lazy(DefId), the same form that type annotations use.
         // `var p: Promise<T>` goes through create_lazy_type_ref → Application(Lazy(DefId), [T]).
         // We must do the same here so that `import()` returns a structurally compatible type.
-        let factory = self.ctx.types.factory();
-
         if let Some(sym_id) = self.ctx.lib_promise_sym_id() {
             let _ = self.get_type_of_symbol(sym_id);
             // Ensure the Promise DefId has its type parameters and body registered
@@ -897,11 +862,19 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .lib_promise_type_ref()
                 .unwrap_or_else(|| self.ctx.create_lazy_type_ref(sym_id));
-            return factory.application(promise_base, vec![inner_type]);
+            return declaration_exports::dynamic_import_promise_type(
+                self.ctx.types,
+                promise_base,
+                inner_type,
+            );
         }
 
         // Fallback: use synthetic PROMISE_BASE (works without lib files)
-        factory.application(TypeId::PROMISE_BASE, vec![inner_type])
+        declaration_exports::dynamic_import_promise_type(
+            self.ctx.types,
+            TypeId::PROMISE_BASE,
+            inner_type,
+        )
     }
 
     /// Check `export { x };` (local named exports)

--- a/crates/tsz-checker/src/declarations/namespace_checker.rs
+++ b/crates/tsz-checker/src/declarations/namespace_checker.rs
@@ -1,6 +1,7 @@
 //! Namespace type merging and re-export resolution for declaration merging.
 
 use crate::query_boundaries::class_type as query;
+use crate::query_boundaries::declaration_exports;
 use crate::query_boundaries::type_construction;
 use crate::state::{CheckerState, EnumKind};
 use std::sync::Arc;
@@ -9,7 +10,7 @@ use tsz_common::interner::Atom;
 use tsz_parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{TypeId, Visibility};
+use tsz_solver::TypeId;
 
 /// Maximum recursion depth for namespace export merging.
 ///
@@ -142,7 +143,6 @@ impl<'a> CheckerState<'a> {
         check_prototype: bool,
     ) {
         use tsz_common::diagnostics::diagnostic_codes;
-        use tsz_solver::PropertyInfo;
 
         let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
             return;
@@ -227,22 +227,7 @@ impl<'a> CheckerState<'a> {
 
             props.insert(
                 name_atom,
-                PropertyInfo {
-                    name: name_atom,
-                    type_id,
-                    write_type: type_id,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: None,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                },
+                declaration_exports::declaration_export_property(name_atom, type_id, 0),
             );
         }
     }
@@ -256,11 +241,10 @@ impl<'a> CheckerState<'a> {
                 == 0;
 
         if is_pure_namespace || self.ctx.is_declaration_file() {
-            return self
-                .ctx
-                .types
-                .factory()
-                .lazy(self.ctx.get_or_create_def_id(member_id));
+            return declaration_exports::declaration_lazy_export_type(
+                self.ctx.types,
+                self.ctx.get_or_create_def_id(member_id),
+            );
         }
 
         // For merged INTERFACE+VARIABLE symbols (e.g., `export interface Point { ... }`
@@ -288,8 +272,6 @@ impl<'a> CheckerState<'a> {
     /// By constructing a real `Object { prop: type, ... }` type we give the solver
     /// concrete structural types it can compare property-by-property.
     pub(crate) fn build_namespace_object_type(&mut self, sym_id: SymbolId) -> TypeId {
-        use tsz_solver::PropertyInfo;
-
         // For namespace+interface merged symbols, skip the symbol_instance_types
         // cache. It may contain the INTERFACE type (from type-position resolution
         // like `x: Point`) which is the wrong type for the namespace VALUE side.
@@ -319,13 +301,13 @@ impl<'a> CheckerState<'a> {
             return self.get_type_of_symbol(sym_id);
         };
         let Some(exports) = symbol.exports.as_ref().cloned() else {
-            return self.ctx.types.factory().object(vec![]);
+            return declaration_exports::empty_namespace_object_type(self.ctx.types);
         };
 
-        let placeholder = self.ctx.types.factory().object(vec![]);
+        let placeholder = declaration_exports::namespace_object_placeholder_type(self.ctx.types);
         self.ctx.symbol_instance_types.insert(sym_id, placeholder);
         self.ctx.symbol_resolution_depth.set(depth + 1);
-        let mut props: Vec<PropertyInfo> = Vec::new();
+        let mut props: Vec<tsz_solver::PropertyInfo> = Vec::new();
         for (name, member_id) in self.ordered_namespace_export_entries(&exports) {
             if self.ctx.symbol_resolution_set.contains(&member_id) {
                 continue;
@@ -383,32 +365,18 @@ impl<'a> CheckerState<'a> {
                 props.len() as u32 + 2
             };
             let name_atom = self.ctx.types.intern_string(name);
-            props.push(PropertyInfo {
-                name: name_atom,
-                type_id: member_type,
-                write_type: member_type,
-                optional: false,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
+            props.push(declaration_exports::declaration_export_property(
+                name_atom,
+                member_type,
                 declaration_order,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+            ));
         }
         self.ctx.symbol_resolution_depth.set(depth);
         Self::normalize_namespace_export_declaration_order(&mut props);
         // Preserve the namespace's SymbolId so the type formatter displays the
         // value surface as `typeof M` instead of expanding its object shape.
-        let namespace_type = self
-            .ctx
-            .types
-            .factory()
-            .object_with_symbol(props, Some(sym_id));
+        let namespace_type =
+            declaration_exports::namespace_object_type(self.ctx.types, props, sym_id);
         self.ctx
             .symbol_instance_types
             .insert(sym_id, namespace_type);
@@ -510,7 +478,6 @@ impl<'a> CheckerState<'a> {
         ctor_type: TypeId,
     ) -> TypeId {
         use rustc_hash::FxHashMap;
-        use tsz_solver::CallableShape;
 
         // Check recursion depth to prevent stack overflow
         let depth = self.ctx.symbol_resolution_depth.get();
@@ -535,15 +502,12 @@ impl<'a> CheckerState<'a> {
         // `typeof C` (the value+namespace identity) instead of expanding the
         // structural shape. tsc displays a class merged with a namespace as
         // `typeof C`.
-        self.ctx.types.factory().callable(CallableShape {
-            call_signatures: shape.call_signatures.clone(),
-            construct_signatures: shape.construct_signatures.clone(),
+        declaration_exports::namespace_merged_constructor_callable_type(
+            self.ctx.types,
+            &shape,
             properties,
-            string_index: shape.string_index,
-            number_index: shape.number_index,
-            symbol: Some(sym_id),
-            is_abstract: false,
-        })
+            sym_id,
+        )
     }
 
     /// Merge namespace exports into a function type for function+namespace merging.
@@ -565,7 +529,6 @@ impl<'a> CheckerState<'a> {
         function_type: TypeId,
     ) -> (TypeId, Vec<tsz_solver::TypeParamInfo>) {
         use rustc_hash::FxHashMap;
-        use tsz_solver::CallableShape;
 
         // Get a unified CallableShape for the function type.
         // Solver query handles both Callable (overloaded) and Function (single-signature)
@@ -586,16 +549,11 @@ impl<'a> CheckerState<'a> {
         self.merge_exports_into_props(sym_id, &mut props, false);
 
         let properties = props.into_values().collect();
-        let factory = self.ctx.types.factory();
-        let merged_type = factory.callable(CallableShape {
-            call_signatures: shape.call_signatures.clone(),
-            construct_signatures: shape.construct_signatures.clone(),
+        let merged_type = declaration_exports::namespace_merged_function_callable_type(
+            self.ctx.types,
+            &shape,
             properties,
-            string_index: shape.string_index,
-            number_index: shape.number_index,
-            symbol: None,
-            is_abstract: false,
-        });
+        );
 
         (merged_type, Vec::new())
     }
@@ -839,10 +797,10 @@ impl<'a> CheckerState<'a> {
                 && !member_symbol.has_any_flags(symbol_flags::CLASS | symbol_flags::FUNCTION);
 
             let mut type_id = if is_pure_namespace {
-                self.ctx
-                    .types
-                    .factory()
-                    .lazy(self.ctx.get_or_create_def_id(*member_id))
+                declaration_exports::declaration_lazy_export_type(
+                    self.ctx.types,
+                    self.ctx.get_or_create_def_id(*member_id),
+                )
             } else {
                 self.get_type_of_symbol(*member_id)
             };
@@ -876,22 +834,11 @@ impl<'a> CheckerState<'a> {
                 }
             }
             let name_atom = self.ctx.types.intern_string(name);
-            props.entry(name_atom).or_insert(PropertyInfo {
-                name: name_atom,
-                type_id,
-                write_type: type_id,
-                optional: false,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: 0,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+            props
+                .entry(name_atom)
+                .or_insert(declaration_exports::declaration_export_property(
+                    name_atom, type_id, 0,
+                ));
         }
 
         let properties: Vec<PropertyInfo> = props.into_values().collect();

--- a/crates/tsz-checker/src/dispatch/jsx.rs
+++ b/crates/tsz-checker/src/dispatch/jsx.rs
@@ -4,6 +4,7 @@
 //! Handles `JSX_ELEMENT` children synthesis, contextual typing, and component-type resolution.
 
 use crate::context::TypingRequest;
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
@@ -167,22 +168,18 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                 let synthesized_type = if child_types.len() == 1 && !has_spread_child {
                     child_types[0]
                 } else if !has_spread_child {
-                    let elements = child_types
-                        .iter()
-                        .copied()
-                        .map(|type_id| tsz_solver::TupleElement {
-                            type_id,
-                            name: None,
-                            optional: false,
-                            rest: false,
-                        })
-                        .collect();
-                    self.checker.ctx.types.factory().tuple(elements)
+                    jsx_query::tuple_type_from_required_element_types(
+                        self.checker.ctx.types,
+                        child_types.to_vec(),
+                    )
                 } else {
                     // Multiple children: synthesize as an array type.
                     // tsc uses the union of all child types as the element type.
-                    let element_type = self.checker.ctx.types.factory().union(child_types.clone());
-                    self.checker.ctx.types.factory().array(element_type)
+                    let element_type = jsx_query::union_type_from_members(
+                        self.checker.ctx.types,
+                        child_types.clone(),
+                    );
+                    jsx_query::array_type_from_element(self.checker.ctx.types, element_type)
                 };
                 let normalized_child_count = if has_spread_child {
                     child_count.max(2)

--- a/crates/tsz-checker/src/dispatch/yield_.rs
+++ b/crates/tsz-checker/src/dispatch/yield_.rs
@@ -3,6 +3,7 @@
 use super::ExpressionDispatcher;
 use crate::context::TypingRequest;
 use crate::query_boundaries::common::ContextualTypeContext;
+use crate::query_boundaries::dispatch as dispatch_query;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
@@ -247,74 +248,77 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                 .current_yield_type()
                 .or_else(|| self.get_expected_yield_type(idx))
             {
-                let ctx_type =
-                    if yield_expr.asterisk_token {
-                        self.checker
-                            .ctx
-                            .arena
-                            .get(yield_expr.expression)
-                            .map(|n| n.kind)
-                            .and_then(|kind| {
-                                // Only direct call expressions (e.g. `yield* gen()`) should
-                                // receive a generator contextual type. Await expressions
-                                // (e.g. `yield* await promise.then(fn)`) must receive no
-                                // contextual type at all here: `await` propagates its
-                                // contextual type into the operand, and that would
-                                // over-constrain `.then()` callback inference, producing
-                                // spurious generic mismatches like TS2345/TS2504.
-                                if kind == syntax_kind_ext::AWAIT_EXPRESSION {
-                                    return Some(TypeId::UNKNOWN);
-                                }
-                                if kind != syntax_kind_ext::CALL_EXPRESSION {
-                                    return None;
-                                }
-                                if crate::query_boundaries::common::contains_type_parameters(
-                                    self.checker.ctx.types,
-                                    yield_ctx,
-                                ) || crate::query_boundaries::common::contains_infer_types(
-                                    self.checker.ctx.types,
-                                    yield_ctx,
-                                ) {
-                                    return Some(TypeId::UNKNOWN);
-                                }
-                                let expected_generator = self.get_expected_generator_type(idx)?;
-                                let result_ctx = outer_contextual.unwrap_or(TypeId::UNKNOWN);
-                                contextual_yield_star_return = Some(result_ctx);
-                                let generator_ctx = ContextualTypeContext::with_expected(
-                                    self.checker.ctx.types,
-                                    expected_generator,
-                                );
-                                let next_ctx = generator_ctx
-                                    .get_generator_next_type()
-                                    .unwrap_or(TypeId::UNKNOWN);
-                                let generator_name = if is_async_generator {
-                                    "AsyncGenerator"
-                                } else {
-                                    "Generator"
-                                };
-                                let lib_binders = self.checker.get_lib_binders();
-                                let generator_sym = self
-                                    .checker
-                                    .ctx
-                                    .binder
-                                    .get_global_type_with_libs(generator_name, &lib_binders)?;
-                                let generator_def =
-                                    self.checker.ctx.get_or_create_def_id(generator_sym);
-                                let generator_base =
-                                    self.checker.ctx.types.factory().lazy(generator_def);
-                                Some(self.checker.ctx.types.factory().application(
-                                    generator_base,
-                                    vec![yield_ctx, result_ctx, next_ctx],
-                                ))
-                            })
-                            .unwrap_or_else(|| {
-                                // yield *[x => ...] needs Array<TYield> as contextual type
-                                // so each array element gets TYield as its contextual type
-                                self.checker.ctx.types.factory().array(yield_ctx)
-                            })
-                    } else {
-                        yield_ctx
-                    };
+                let ctx_type = if yield_expr.asterisk_token {
+                    self.checker
+                        .ctx
+                        .arena
+                        .get(yield_expr.expression)
+                        .map(|n| n.kind)
+                        .and_then(|kind| {
+                            // Only direct call expressions (e.g. `yield* gen()`) should
+                            // receive a generator contextual type. Await expressions
+                            // (e.g. `yield* await promise.then(fn)`) must receive no
+                            // contextual type at all here: `await` propagates its
+                            // contextual type into the operand, and that would
+                            // over-constrain `.then()` callback inference, producing
+                            // spurious generic mismatches like TS2345/TS2504.
+                            if kind == syntax_kind_ext::AWAIT_EXPRESSION {
+                                return Some(TypeId::UNKNOWN);
+                            }
+                            if kind != syntax_kind_ext::CALL_EXPRESSION {
+                                return None;
+                            }
+                            if crate::query_boundaries::common::contains_type_parameters(
+                                self.checker.ctx.types,
+                                yield_ctx,
+                            ) || crate::query_boundaries::common::contains_infer_types(
+                                self.checker.ctx.types,
+                                yield_ctx,
+                            ) {
+                                return Some(TypeId::UNKNOWN);
+                            }
+                            let expected_generator = self.get_expected_generator_type(idx)?;
+                            let result_ctx = outer_contextual.unwrap_or(TypeId::UNKNOWN);
+                            contextual_yield_star_return = Some(result_ctx);
+                            let generator_ctx = ContextualTypeContext::with_expected(
+                                self.checker.ctx.types,
+                                expected_generator,
+                            );
+                            let next_ctx = generator_ctx
+                                .get_generator_next_type()
+                                .unwrap_or(TypeId::UNKNOWN);
+                            let generator_name = if is_async_generator {
+                                "AsyncGenerator"
+                            } else {
+                                "Generator"
+                            };
+                            let lib_binders = self.checker.get_lib_binders();
+                            let generator_sym = self
+                                .checker
+                                .ctx
+                                .binder
+                                .get_global_type_with_libs(generator_name, &lib_binders)?;
+                            let generator_def =
+                                self.checker.ctx.get_or_create_def_id(generator_sym);
+                            Some(dispatch_query::generator_context_application(
+                                self.checker.ctx.types,
+                                generator_def,
+                                yield_ctx,
+                                result_ctx,
+                                next_ctx,
+                            ))
+                        })
+                        .unwrap_or_else(|| {
+                            // yield *[x => ...] needs Array<TYield> as contextual type
+                            // so each array element gets TYield as its contextual type
+                            dispatch_query::yield_star_array_context(
+                                self.checker.ctx.types,
+                                yield_ctx,
+                            )
+                        })
+                } else {
+                    yield_ctx
+                };
                 self.checker
                     .clear_type_cache_recursive(yield_expr.expression);
                 request.read().normal_origin().contextual(ctx_type)

--- a/crates/tsz-checker/src/error_reporter/assignability_contextual_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_contextual_display.rs
@@ -96,7 +96,8 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let display_app = self.ctx.types.factory().application(app.base, display_args);
+        let display_app =
+            query_diagnostics::display_application_type(self.ctx.types, app.base, display_args);
         Some(self.format_type_for_assignability_message(display_app))
     }
 }

--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -9,6 +9,7 @@ use crate::error_reporter::fingerprint_policy::{
     DiagnosticAnchorKind, DiagnosticRenderRequest, RelatedInformationPolicy,
 };
 use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::{CheckerState, MemberAccessLevel};
 use rustc_hash::FxHashMap;
 use tsz_parser::parser::NodeIndex;
@@ -92,7 +93,7 @@ impl<'a> CheckerState<'a> {
                 return source;
             }
 
-            let recovered = self.ctx.types.array(widened);
+            let recovered = diagnostic_query::display_array_type(self.ctx.types, widened);
             if recovered != source {
                 return recovered;
             }

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -494,29 +494,10 @@ impl<'a> CheckerState<'a> {
     }
 
     fn widen_object_property_literals_for_call_parameter_display(&mut self, ty: TypeId) -> TypeId {
-        let Some(shape) =
-            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty)
-        else {
-            return ty;
-        };
-        let mut widened_shape = shape.as_ref().clone();
-        let mut changed = false;
-        for prop in &mut widened_shape.properties {
-            let widened_read =
-                crate::query_boundaries::common::widen_literal_type(self.ctx.types, prop.type_id);
-            let widened_write = crate::query_boundaries::common::widen_literal_type(
-                self.ctx.types,
-                prop.write_type,
-            );
-            changed |= widened_read != prop.type_id || widened_write != prop.write_type;
-            prop.type_id = widened_read;
-            prop.write_type = widened_write;
-        }
-        if changed {
-            self.ctx.types.factory().object_with_index(widened_shape)
-        } else {
-            ty
-        }
+        crate::query_boundaries::diagnostics::shallow_object_property_literals_widened_for_call_parameter_display(
+            self.ctx.types,
+            ty,
+        )
     }
 
     pub(in crate::error_reporter::call_errors) fn property_access_call_parameter_annotation_display(

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -4,7 +4,7 @@ use crate::context::TypingRequest;
 use crate::query_boundaries::assignability::{
     get_function_return_type, replace_function_return_type,
 };
-use crate::query_boundaries::common as query_common;
+use crate::query_boundaries::{common as query_common, diagnostics as query_diagnostics};
 use crate::state::CheckerState;
 use crate::symbol_resolver::TypeSymbolResolution;
 use rustc_hash::FxHashMap;
@@ -808,7 +808,10 @@ impl<'a> CheckerState<'a> {
             return match property_types.as_slice() {
                 [] => None,
                 [single] => Some(*single),
-                _ => Some(self.ctx.types.factory().union(property_types)),
+                _ => Some(query_diagnostics::display_union_type(
+                    self.ctx.types,
+                    property_types,
+                )),
             };
         }
 
@@ -854,7 +857,10 @@ impl<'a> CheckerState<'a> {
             return match property_types.as_slice() {
                 [] => None,
                 [single] => Some(*single),
-                _ => Some(self.ctx.types.factory().union(property_types)),
+                _ => Some(query_diagnostics::display_union_type(
+                    self.ctx.types,
+                    property_types,
+                )),
             };
         }
 
@@ -914,7 +920,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let key_literal = self.ctx.types.literal_string(prop_name);
+        let key_literal = query_diagnostics::display_string_literal_type(self.ctx.types, prop_name);
         let mut display_type =
             crate::query_boundaries::state::checking::instantiate_mapped_template_for_property(
                 self.ctx.types,
@@ -944,7 +950,11 @@ impl<'a> CheckerState<'a> {
                             || crate::query_boundaries::class_type::type_includes_undefined(
                                 self.ctx.types,
                                 self.evaluate_type_with_env(
-                                    self.ctx.types.factory().index_access(member, index_type),
+                                    query_diagnostics::display_index_access_type(
+                                        self.ctx.types,
+                                        member,
+                                        index_type,
+                                    ),
                                 ),
                             )
                     }))
@@ -957,7 +967,8 @@ impl<'a> CheckerState<'a> {
                     self.evaluate_type_with_env(display_type),
                 ))
         {
-            display_type = self.ctx.types.union2(display_type, TypeId::UNDEFINED);
+            display_type =
+                query_diagnostics::display_union_with_undefined(self.ctx.types, display_type);
         }
         Some(display_type)
     }
@@ -1045,10 +1056,16 @@ impl<'a> CheckerState<'a> {
                                 if members.contains(&TypeId::UNDEFINED) {
                                     p.type_id
                                 } else {
-                                    self.ctx.types.union2(p.type_id, TypeId::UNDEFINED)
+                                    query_diagnostics::display_union_with_undefined(
+                                        self.ctx.types,
+                                        p.type_id,
+                                    )
                                 }
                             } else {
-                                self.ctx.types.union2(p.type_id, TypeId::UNDEFINED)
+                                query_diagnostics::display_union_with_undefined(
+                                    self.ctx.types,
+                                    p.type_id,
+                                )
                             }
                         })
             });

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
@@ -90,7 +90,7 @@ impl<'a> CheckerState<'a> {
                 if kept.is_empty() {
                     return false;
                 }
-                self.ctx.types.factory().union_preserve_members(kept)
+                query_diagnostics::display_union_preserve_members_type(self.ctx.types, kept)
             }
             None => return false,
         };
@@ -309,15 +309,13 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let factory = self.ctx.types.factory();
-        let display_type = if is_rest {
-            let elem = factory.index_access(last_param.type_id, TypeId::NUMBER);
-            factory.array(elem)
-        } else {
-            let offset = index - rest_start;
-            let index_type = factory.literal_number(offset as f64);
-            factory.index_access(last_param.type_id, index_type)
-        };
+        let display_type = query_diagnostics::display_rest_parameter_type(
+            self.ctx.types,
+            last_param.type_id,
+            rest_start,
+            index,
+            is_rest,
+        );
         Some(self.format_type_for_assignability_message(display_type))
     }
 
@@ -557,7 +555,7 @@ impl<'a> CheckerState<'a> {
                 }) {
                 param_type
             } else {
-                self.ctx.types.union2(param_type, TypeId::UNDEFINED)
+                query_diagnostics::display_union_with_undefined(self.ctx.types, param_type)
             };
             let display = self.format_assignability_type_for_message(widened_param_type, arg_type);
             return self.strip_synthetic_optional_from_display_for_arg(display, arg_type);
@@ -657,9 +655,12 @@ impl<'a> CheckerState<'a> {
                     mapped_id,
                     &property_name,
                 )?;
-            let mut property = tsz_solver::PropertyInfo::new(name, type_id);
-            property.optional = mapped.optional_modifier == Some(tsz_solver::MappedModifier::Add);
-            property.readonly = mapped.readonly_modifier == Some(tsz_solver::MappedModifier::Add);
+            let property = query_diagnostics::mapped_display_property(
+                name,
+                type_id,
+                mapped.optional_modifier,
+                mapped.readonly_modifier,
+            );
             properties.push(property);
         }
 
@@ -774,7 +775,7 @@ impl<'a> CheckerState<'a> {
             }) {
             param_type
         } else {
-            self.ctx.types.union2(param_type, TypeId::UNDEFINED)
+            query_diagnostics::display_union_with_undefined(self.ctx.types, param_type)
         };
 
         Some(self.format_type_for_assignability_message(widened))

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
@@ -663,7 +663,10 @@ impl<'a> CheckerState<'a> {
             properties.push(property);
         }
 
-        Some(self.ctx.types.factory().object(properties))
+        Some(query_diagnostics::object_type_from_properties(
+            self.ctx.types,
+            properties,
+        ))
     }
 
     fn simple_function_call_parameter_annotation_display(

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -4,6 +4,7 @@ use crate::context::TypingRequest;
 use crate::context::speculation::FullSpeculationSnapshot;
 use crate::diagnostics::diagnostic_codes;
 use crate::query_boundaries::common as query_common;
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -195,42 +196,8 @@ impl<'a> CheckerState<'a> {
         let evaluated_arg = self.evaluate_type_for_assignability(arg_type);
         let arg_shape =
             crate::query_boundaries::common::object_shape_for_type(self.ctx.types, evaluated_arg)?;
-        if arg_shape.properties.is_empty()
-            && arg_shape.string_index.is_none()
-            && arg_shape.number_index.is_none()
-        {
-            return None;
-        }
-
-        let mut unknown_properties = Vec::with_capacity(arg_shape.properties.len());
-        for prop in &arg_shape.properties {
-            let mut unknown_prop = tsz_solver::PropertyInfo::new(prop.name, TypeId::UNKNOWN);
-            unknown_prop.optional = prop.optional;
-            unknown_prop.readonly = prop.readonly;
-            unknown_properties.push(unknown_prop);
-        }
-        let unknown_object = if arg_shape.string_index.is_some() || arg_shape.number_index.is_some()
-        {
-            let unknown_shape = tsz_solver::ObjectShape {
-                properties: unknown_properties,
-                string_index: arg_shape.string_index.as_ref().map(|sig| {
-                    tsz_solver::IndexSignature {
-                        value_type: TypeId::UNKNOWN,
-                        ..*sig
-                    }
-                }),
-                number_index: arg_shape.number_index.as_ref().map(|sig| {
-                    tsz_solver::IndexSignature {
-                        value_type: TypeId::UNKNOWN,
-                        ..*sig
-                    }
-                }),
-                ..Default::default()
-            };
-            self.ctx.types.factory().object_with_index(unknown_shape)
-        } else {
-            self.ctx.types.factory().object(unknown_properties)
-        };
+        let unknown_object =
+            diagnostic_query::object_type_with_unknown_display_members(self.ctx.types, &arg_shape)?;
 
         let evaluated_param = self.evaluate_type_for_assignability(param_type);
         let mut current = arg_idx;

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -1,5 +1,6 @@
 //! Array-literal mismatch elaboration helpers for call errors.
 
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
@@ -24,7 +25,10 @@ impl<'a> CheckerState<'a> {
             // elaboration would emit TS2322 on `let x: [string, number?] =
             // ["foo", undefined]` even though tsc accepts it.
             if element.optional {
-                return Some(self.ctx.types.union2(element.type_id, TypeId::UNDEFINED));
+                return Some(diagnostic_query::display_union_with_undefined(
+                    self.ctx.types,
+                    element.type_id,
+                ));
             }
             return Some(element.type_id);
         }

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -632,19 +632,13 @@ impl<'a> CheckerState<'a> {
             return None;
         };
 
-        let mut property = tsz_solver::PropertyInfo::new(*property_name, *target_property_type);
-        property.optional = Self::type_includes_undefined(self.ctx.types, *target_property_type);
-        let display_type = self.ctx.types.factory().object(vec![property]);
+        let display_type =
+            crate::query_boundaries::diagnostics::mapped_property_mismatch_parameter_display_type(
+                self.ctx.types,
+                *property_name,
+                *target_property_type,
+            );
         Some(self.format_type_for_assignability_message(display_type))
-    }
-
-    fn type_includes_undefined(
-        db: &dyn tsz_solver::construction::TypeDatabase,
-        ty: TypeId,
-    ) -> bool {
-        ty == TypeId::UNDEFINED
-            || crate::query_boundaries::common::union_members(db, ty)
-                .is_some_and(|members| members.contains(&TypeId::UNDEFINED))
     }
 
     /// Report an argument count mismatch error using solver diagnostics with source tracking.

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1293,19 +1293,11 @@ impl<'a> CheckerState<'a> {
                             ..*value_param
                         })
                         .collect();
-                    let merged = self
-                        .ctx
-                        .types
-                        .factory()
-                        .function(tsz_solver::FunctionShape {
-                            type_params: value_shape.type_params.clone(),
-                            params: merged_params,
-                            this_type: value_shape.this_type,
-                            return_type: value_shape.return_type,
-                            type_predicate: value_shape.type_predicate,
-                            is_constructor: value_shape.is_constructor,
-                            is_method: value_shape.is_method,
-                        });
+                    let merged = diagnostic_query::function_type_with_params_replaced(
+                        self.ctx.types,
+                        &value_shape,
+                        merged_params,
+                    );
                     Some(merged)
                 })
                 .unwrap_or(value_type);

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -4,6 +4,7 @@
 //! file under the LOC ceiling. Pure file-organization move; no logic changes.
 
 use super::literal_widening_helpers::literal_display_appropriate_for_undefined_null_target;
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
@@ -1866,10 +1867,10 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let recovered = self
-            .ctx
-            .types
-            .array(self.widen_type_for_display(element_type));
+        let recovered = diagnostic_query::display_array_type(
+            self.ctx.types,
+            self.widen_type_for_display(element_type),
+        );
         Some(self.format_assignability_type_for_message(recovered, target))
     }
 

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/collection_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/collection_source_display.rs
@@ -121,17 +121,11 @@ impl<'a> CheckerState<'a> {
                 element_type,
             ),
         );
-        let rebuilt = self.ctx.types.array(widened_element);
-        // Preserve the readonly modifier: tsc displays `readonly number[]` not `number[]`
-        // when the source type was a readonly array (ReadonlyType(Array(...))).
-        let rebuilt = if crate::query_boundaries::type_computation::complex::is_readonly_type(
+        let rebuilt = diagnostic_query::rebuilt_array_source_display_type(
             self.ctx.types,
             source_type,
-        ) {
-            self.ctx.types.readonly_type(rebuilt)
-        } else {
-            rebuilt
-        };
+            widened_element,
+        );
         Some(self.format_assignability_type_for_message(rebuilt, target))
     }
 

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/computed_index_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/computed_index_source_display.rs
@@ -58,11 +58,10 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let value_type = if computed_value_types.len() == 1 {
-            computed_value_types[0]
-        } else {
-            self.ctx.types.factory().union(computed_value_types)
-        };
+        let value_type = crate::query_boundaries::diagnostics::source_display_union_type(
+            self.ctx.types,
+            computed_value_types,
+        );
         let value_display = self.format_type_for_assignability_message(value_type);
         Some(format!("{{ [x: {key_kind}]: {value_display}; }}"))
     }

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/contextual_index_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/contextual_index_display.rs
@@ -42,10 +42,10 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         let key_kind = contextual_index_key_kind?;
-        let value_type = match contextual_index_value_types.as_slice() {
-            [single] => *single,
-            _ => self.ctx.types.factory().union(contextual_index_value_types),
-        };
+        let value_type = crate::query_boundaries::diagnostics::source_display_union_type(
+            self.ctx.types,
+            contextual_index_value_types,
+        );
         let value_display = self.format_type_for_assignability_message(value_type);
         Some(format!("{{ [x: {key_kind}]: {value_display}; }}"))
     }

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_targets.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_targets.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -137,8 +138,9 @@ impl<'a> CheckerState<'a> {
                         target,
                     )
                 {
-                    raw_call_param_property_target =
-                        Some(self.ctx.types.union2(target, TypeId::UNDEFINED));
+                    raw_call_param_property_target = Some(
+                        diagnostic_query::display_union_with_undefined(self.ctx.types, target),
+                    );
                 }
             }
         }
@@ -315,14 +317,14 @@ impl<'a> CheckerState<'a> {
 
         let shared_index = shared_index?;
         let combined_object =
-            tsz_solver::utils::intersection_or_single(self.ctx.types, object_members);
-        let mut combined = self
-            .ctx
-            .types
-            .factory()
-            .index_access(combined_object, shared_index);
+            diagnostic_query::display_intersection_or_single_type(self.ctx.types, object_members);
+        let mut combined = diagnostic_query::display_index_access_type(
+            self.ctx.types,
+            combined_object,
+            shared_index,
+        );
         if has_optional_property && self.ctx.strict_null_checks() {
-            combined = self.ctx.types.union2(combined, TypeId::UNDEFINED);
+            combined = diagnostic_query::display_union_with_undefined(self.ctx.types, combined);
         }
 
         Some(self.format_type_for_assignability_message(combined))

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
@@ -326,10 +326,8 @@ impl<'a> CheckerState<'a> {
         let mut properties = Vec::with_capacity(shape.properties.len());
         for prop in &shape.properties {
             let prop_type = self.typebox_schema_static_type(prop.type_id, depth + 1)?;
-            let mut static_prop = tsz_solver::PropertyInfo::new(prop.name, prop_type);
-            static_prop.optional = prop.optional;
-            static_prop.readonly = prop.readonly;
-            static_prop.declaration_order = prop.declaration_order;
+            let static_prop =
+                diagnostic_query::static_schema_display_property_from_source(prop, prop_type);
             properties.push(static_prop);
         }
         Some(diagnostic_query::object_type_from_properties(
@@ -485,7 +483,7 @@ impl<'a> CheckerState<'a> {
         let element_type = self.evaluate_type_for_assignability(element_type);
         let element_type = self.widen_type_for_display(element_type);
         let element_type = self.normalize_assignability_display_type(element_type);
-        self.ctx.types.array(element_type)
+        diagnostic_query::display_array_type(self.ctx.types, element_type)
     }
 
     fn format_static_schema_array_structural_type(

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
@@ -332,7 +332,10 @@ impl<'a> CheckerState<'a> {
             static_prop.declaration_order = prop.declaration_order;
             properties.push(static_prop);
         }
-        Some(self.ctx.types.factory().object(properties))
+        Some(diagnostic_query::object_type_from_properties(
+            self.ctx.types,
+            properties,
+        ))
     }
 
     fn rewrite_nested_static_projection_members(
@@ -362,7 +365,7 @@ impl<'a> CheckerState<'a> {
             }
             properties.push(next);
         }
-        changed.then(|| self.ctx.types.factory().object(properties))
+        changed.then(|| diagnostic_query::object_type_from_properties(self.ctx.types, properties))
     }
 
     fn schema_property_type(&mut self, schema_type: TypeId, property: &str) -> Option<TypeId> {

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/tuple_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/tuple_source_display.rs
@@ -260,7 +260,6 @@ impl<'a> CheckerState<'a> {
             }
             per_member.push(elements);
         }
-        let factory = self.ctx.types.factory();
         // Precompute optional flags to avoid an O(members) scan per position.
         let optional_at: Vec<bool> = (0..arity)
             .map(|pos| per_member.iter().any(|e| e[pos].optional))
@@ -271,11 +270,11 @@ impl<'a> CheckerState<'a> {
         for position in 0..arity {
             type_ids_buf.clear();
             type_ids_buf.extend(per_member.iter().map(|elems| elems[position].type_id));
-            let union_type = if type_ids_buf.len() == 1 {
-                type_ids_buf[0]
-            } else {
-                factory.union_from_slice(&type_ids_buf)
-            };
+            let union_type =
+                crate::query_boundaries::diagnostics::source_display_union_type_from_slice(
+                    self.ctx.types,
+                    &type_ids_buf,
+                );
             result.push(tsz_solver::TupleElement {
                 type_id: union_type,
                 name: None,

--- a/crates/tsz-checker/src/error_reporter/core/excess_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/excess_display.rs
@@ -340,7 +340,7 @@ impl<'a> CheckerState<'a> {
         }
 
         Some(if changed {
-            self.ctx.types.factory().object_with_index(normalized)
+            query::object_type_from_shape(self.ctx.types, normalized)
         } else {
             ty
         })
@@ -385,7 +385,7 @@ impl<'a> CheckerState<'a> {
             index.readonly = false;
         }
 
-        let normalized_ty = self.ctx.types.factory().object_with_index(normalized);
+        let normalized_ty = query::object_type_from_shape(self.ctx.types, normalized);
         if let Some(props) = display_props {
             let mut props = props.as_ref().clone();
             for prop in &mut props {
@@ -442,7 +442,7 @@ impl<'a> CheckerState<'a> {
             prop.write_type = write;
         }
         if changed {
-            self.ctx.types.factory().object_with_index(normalized)
+            query::object_type_from_shape(self.ctx.types, normalized)
         } else {
             ty
         }
@@ -549,7 +549,7 @@ impl<'a> CheckerState<'a> {
         }
 
         if changed {
-            self.ctx.types.factory().object_with_index(normalized)
+            query::object_type_from_shape(self.ctx.types, normalized)
         } else {
             ty
         }

--- a/crates/tsz-checker/src/error_reporter/core/excess_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/excess_display.rs
@@ -77,7 +77,7 @@ impl<'a> CheckerState<'a> {
                 if object_like.len() == 1 {
                     return object_like[0];
                 }
-                return tsz_solver::utils::union_or_single(self.ctx.types, object_like);
+                return query::display_union_or_single_type(self.ctx.types, object_like);
             }
         }
         ty
@@ -564,7 +564,7 @@ impl<'a> CheckerState<'a> {
         // overflow the stack while narrowing an excess-property function
         // parameter for display (issue #12455).
         let _display_guard = super::type_display::DisplayRecursionGuard::enter()?;
-        let key_type = self.ctx.types.literal_string_atom(prop_name);
+        let key_type = query::display_string_literal_atom_type(self.ctx.types, prop_name);
         if let Some(app) = crate::query_boundaries::common::type_application(self.ctx.types, ty) {
             let mut changed = false;
             let args = app
@@ -581,7 +581,8 @@ impl<'a> CheckerState<'a> {
                     }
                 })
                 .collect::<Vec<_>>();
-            return changed.then(|| self.ctx.types.factory().application(app.base, args));
+            return changed
+                .then(|| query::display_application_type(self.ctx.types, app.base, args));
         }
 
         let members = crate::query_boundaries::common::union_members(self.ctx.types, ty)?;
@@ -603,7 +604,7 @@ impl<'a> CheckerState<'a> {
             })
             .collect::<Vec<_>>();
         (!narrowed.is_empty() && narrowed.len() < members.len())
-            .then(|| tsz_solver::utils::union_or_single(self.ctx.types, narrowed))
+            .then(|| query::display_union_or_single_type(self.ctx.types, narrowed))
     }
 
     pub(in crate::error_reporter) fn normalize_assignability_union_display_order(

--- a/crates/tsz-checker/src/error_reporter/core/identifier_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/identifier_source_display.rs
@@ -146,11 +146,10 @@ impl<'a> CheckerState<'a> {
                     .into_iter()
                     .map(|ty| self.widen_type_for_display(ty))
                     .collect::<Vec<_>>();
-                let value_type = if widened_types.len() == 1 {
-                    widened_types[0]
-                } else {
-                    self.ctx.types.factory().union(widened_types)
-                };
+                let value_type = crate::query_boundaries::diagnostics::source_display_union_type(
+                    self.ctx.types,
+                    widened_types,
+                );
                 let display = self.format_assignability_type_for_message(value_type, target);
                 format!("{name}: {display}")
             })

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -172,13 +172,13 @@ impl<'a> CheckerState<'a> {
 
     fn param_matches_property_key_literal(&self, prop_name: Atom, ty: TypeId) -> bool {
         let prop_name = self.ctx.types.resolve_atom_ref(prop_name);
-        if self.ctx.types.literal_string(prop_name.as_ref()) == ty {
+        if query::display_string_literal_type(self.ctx.types, prop_name.as_ref()) == ty {
             return true;
         }
         prop_name
             .parse::<f64>()
             .ok()
-            .is_some_and(|num| self.ctx.types.literal_number(num) == ty)
+            .is_some_and(|num| query::display_number_literal_type(self.ctx.types, num) == ty)
     }
 
     fn normalize_excess_display_type_for_property(
@@ -419,7 +419,7 @@ impl<'a> CheckerState<'a> {
         if args == app.args {
             ty
         } else {
-            self.ctx.types.factory().application(app.base, args)
+            query::display_application_type(self.ctx.types, app.base, args)
         }
     }
 
@@ -449,7 +449,7 @@ impl<'a> CheckerState<'a> {
             return if args == app.args {
                 ty
             } else {
-                self.ctx.types.factory().application(app.base, args)
+                query::display_application_type(self.ctx.types, app.base, args)
             };
         }
 
@@ -461,7 +461,7 @@ impl<'a> CheckerState<'a> {
             return if normalized == members {
                 ty
             } else {
-                self.ctx.types.factory().union_preserve_members(normalized)
+                query::display_union_preserve_members_type(self.ctx.types, normalized)
             };
         }
 
@@ -473,7 +473,7 @@ impl<'a> CheckerState<'a> {
             return if normalized == members {
                 ty
             } else {
-                self.ctx.types.factory().intersection(normalized)
+                query::display_intersection_type(self.ctx.types, normalized)
             };
         }
 
@@ -575,7 +575,7 @@ impl<'a> CheckerState<'a> {
             if args == app.args {
                 ty
             } else {
-                self.ctx.types.factory().application(app.base, args)
+                query::display_application_type(self.ctx.types, app.base, args)
             }
         } else if let Some(shape) = query::function_shape(self.ctx.types, ty) {
             let params: Vec<_> = shape
@@ -600,14 +600,16 @@ impl<'a> CheckerState<'a> {
                 )
             }
         } else if let Some(members) = query::union_members(self.ctx.types, ty) {
-            self.ctx.types.factory().union_preserve_members(
+            query::display_union_preserve_members_type(
+                self.ctx.types,
                 members
                     .iter()
                     .map(|&member| self.normalize_excess_display_type(member))
                     .collect(),
             )
         } else if let Some(members) = query::intersection_members(self.ctx.types, ty) {
-            self.ctx.types.factory().intersection(
+            query::display_intersection_type(
+                self.ctx.types,
                 members
                     .iter()
                     .map(|&member| self.normalize_excess_display_type(member))
@@ -788,7 +790,7 @@ impl<'a> CheckerState<'a> {
                 if normalized == members {
                     ty
                 } else {
-                    self.ctx.types.factory().union_preserve_members(normalized)
+                    query::display_union_preserve_members_type(self.ctx.types, normalized)
                 }
             } else if query::function_shape(self.ctx.types, ty).is_some_and(|shape| {
                 crate::query_boundaries::common::is_conditional_type(
@@ -836,7 +838,7 @@ impl<'a> CheckerState<'a> {
                     if args == app.args {
                         evaluated
                     } else {
-                        self.ctx.types.factory().application(app.base, args)
+                        query::display_application_type(self.ctx.types, app.base, args)
                     }
                 } else if let Some(shape) = query::function_shape(self.ctx.types, evaluated) {
                     let mut params = Vec::with_capacity(shape.params.len());
@@ -990,7 +992,7 @@ impl<'a> CheckerState<'a> {
                             return evaluated;
                         }
                     }
-                    self.ctx.types.factory().union_preserve_members(normalized)
+                    query::display_union_preserve_members_type(self.ctx.types, normalized)
                 } else if let Some(members) = query::intersection_members(self.ctx.types, evaluated)
                 {
                     let mut normalized = Vec::with_capacity(members.len());
@@ -1005,7 +1007,7 @@ impl<'a> CheckerState<'a> {
                             return evaluated;
                         }
                     }
-                    self.ctx.types.factory().intersection(normalized)
+                    query::display_intersection_type(self.ctx.types, normalized)
                 } else {
                     evaluated
                 }
@@ -1026,7 +1028,7 @@ impl<'a> CheckerState<'a> {
             if normalized == members {
                 ty
             } else {
-                self.ctx.types.factory().union_preserve_members(normalized)
+                query::display_union_preserve_members_type(self.ctx.types, normalized)
             }
         } else if let Some(app) = query::type_application(self.ctx.types, ty) {
             if query::preserves_named_application_base(self.ctx.types, app.base) {
@@ -1045,7 +1047,7 @@ impl<'a> CheckerState<'a> {
                 if args == app.args {
                     ty
                 } else {
-                    self.ctx.types.factory().application(app.base, args)
+                    query::display_application_type(self.ctx.types, app.base, args)
                 }
             } else {
                 let evaluated =
@@ -1121,7 +1123,7 @@ impl<'a> CheckerState<'a> {
                 if args == app.args {
                     evaluated
                 } else {
-                    self.ctx.types.factory().application(app.base, args)
+                    query::display_application_type(self.ctx.types, app.base, args)
                 }
             } else if let Some(shape) = query::function_shape(self.ctx.types, evaluated) {
                 let mut params = Vec::with_capacity(shape.params.len());
@@ -1260,7 +1262,7 @@ impl<'a> CheckerState<'a> {
                         return evaluated;
                     }
                 }
-                self.ctx.types.factory().intersection(normalized)
+                query::display_intersection_type(self.ctx.types, normalized)
             } else {
                 evaluated
             }
@@ -1360,11 +1362,12 @@ impl<'a> CheckerState<'a> {
                         &property_name,
                     )?;
                 let type_id = self.normalize_excess_display_type_for_property(Some(name), type_id);
-                let mut property = tsz_solver::PropertyInfo::new(name, type_id);
-                property.optional =
-                    mapped.optional_modifier == Some(tsz_solver::MappedModifier::Add);
-                property.readonly =
-                    mapped.readonly_modifier == Some(tsz_solver::MappedModifier::Add);
+                let property = query::mapped_display_property(
+                    name,
+                    type_id,
+                    mapped.optional_modifier,
+                    mapped.readonly_modifier,
+                );
                 properties.push(property);
             }
 
@@ -1390,7 +1393,7 @@ impl<'a> CheckerState<'a> {
                     }
                 })
                 .collect();
-            changed.then(|| self.ctx.types.factory().intersection(remapped))
+            changed.then(|| query::display_intersection_type(self.ctx.types, remapped))
         } else if let Some(members) = query::union_members(self.ctx.types, ty) {
             let mut changed = false;
             let remapped: Vec<_> = members
@@ -1409,7 +1412,7 @@ impl<'a> CheckerState<'a> {
                     }
                 })
                 .collect();
-            changed.then(|| self.ctx.types.factory().union(remapped))
+            changed.then(|| query::display_union_type(self.ctx.types, remapped))
         } else {
             None
         }

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -233,18 +233,7 @@ impl<'a> CheckerState<'a> {
             if params.iter().zip(shape.params.iter()).all(|(a, b)| a == b) {
                 ty
             } else {
-                self.ctx
-                    .types
-                    .factory()
-                    .function(tsz_solver::FunctionShape {
-                        type_params: shape.type_params.clone(),
-                        params,
-                        this_type: shape.this_type,
-                        return_type: shape.return_type,
-                        type_predicate: shape.type_predicate,
-                        is_constructor: shape.is_constructor,
-                        is_method: shape.is_method,
-                    })
+                query::function_type_with_params_replaced(self.ctx.types, shape.as_ref(), params)
             }
         } else {
             ty
@@ -329,19 +318,11 @@ impl<'a> CheckerState<'a> {
             let widened_return =
                 self.widen_fresh_object_literal_properties_for_display(shape.return_type);
             if widened_return != shape.return_type {
-                widened = self
-                    .ctx
-                    .types
-                    .factory()
-                    .function(tsz_solver::FunctionShape {
-                        type_params: shape.type_params.clone(),
-                        params: shape.params.clone(),
-                        this_type: shape.this_type,
-                        return_type: widened_return,
-                        type_predicate: shape.type_predicate,
-                        is_constructor: shape.is_constructor,
-                        is_method: shape.is_method,
-                    });
+                widened = query::function_type_with_return_replaced(
+                    self.ctx.types,
+                    shape.as_ref(),
+                    widened_return,
+                );
             }
         } else if let Some(shape) =
             crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, widened)
@@ -367,7 +348,7 @@ impl<'a> CheckerState<'a> {
             }
 
             if changed {
-                widened = self.ctx.types.factory().callable(widened_shape);
+                widened = query::callable_type_from_shape(self.ctx.types, widened_shape);
             }
         }
         if let Some(def_id) = constructor_display_def {
@@ -411,7 +392,7 @@ impl<'a> CheckerState<'a> {
         if !changed {
             return ty;
         }
-        self.ctx.types.factory().object_with_index(widened_shape)
+        query::object_type_from_shape(self.ctx.types, widened_shape)
     }
 
     pub(in crate::error_reporter) fn normalize_property_receiver_application_display_type(
@@ -556,7 +537,7 @@ impl<'a> CheckerState<'a> {
         }
 
         if changed {
-            let new_ty = self.ctx.types.factory().object_with_index(normalized_shape);
+            let new_ty = query::object_type_from_shape(self.ctx.types, normalized_shape);
             if let Some(alias_origin) = self.ctx.types.get_display_alias(ty) {
                 let alias_origin =
                     self.normalize_property_receiver_application_display_type(alias_origin);
@@ -611,18 +592,12 @@ impl<'a> CheckerState<'a> {
             {
                 ty
             } else {
-                self.ctx
-                    .types
-                    .factory()
-                    .function(tsz_solver::FunctionShape {
-                        type_params: shape.type_params.clone(),
-                        params,
-                        this_type: shape.this_type,
-                        return_type,
-                        type_predicate: shape.type_predicate,
-                        is_constructor: shape.is_constructor,
-                        is_method: shape.is_method,
-                    })
+                query::function_type_with_params_and_return_replaced(
+                    self.ctx.types,
+                    shape.as_ref(),
+                    params,
+                    return_type,
+                )
             }
         } else if let Some(members) = query::union_members(self.ctx.types, ty) {
             self.ctx.types.factory().union_preserve_members(
@@ -916,18 +891,12 @@ impl<'a> CheckerState<'a> {
                     {
                         evaluated
                     } else {
-                        self.ctx
-                            .types
-                            .factory()
-                            .function(tsz_solver::FunctionShape {
-                                type_params: shape.type_params.clone(),
-                                params,
-                                this_type: shape.this_type,
-                                return_type,
-                                type_predicate: shape.type_predicate,
-                                is_constructor: shape.is_constructor,
-                                is_method: shape.is_method,
-                            })
+                        query::function_type_with_params_and_return_replaced(
+                            self.ctx.types,
+                            shape.as_ref(),
+                            params,
+                            return_type,
+                        )
                     }
                 } else if let Some(shape) = crate::query_boundaries::common::object_shape_for_type(
                     self.ctx.types,
@@ -982,14 +951,11 @@ impl<'a> CheckerState<'a> {
                         index.value_type = normalized;
                     }
                     if changed {
-                        let new_ty = self.ctx.types.factory().object_with_index(shape);
-                        if let Some(display_props) =
-                            self.ctx.types.get_display_properties(evaluated)
-                        {
-                            self.ctx
-                                .types
-                                .store_display_properties(new_ty, display_props.as_ref().clone());
-                        }
+                        let new_ty = query::object_type_preserving_display_properties(
+                            self.ctx.types,
+                            evaluated,
+                            shape,
+                        );
                         // Propagate display_alias so the formatter can still
                         // recover the named form (e.g., `Array<string>`) for
                         // types whose property types changed during normalization.
@@ -1202,18 +1168,12 @@ impl<'a> CheckerState<'a> {
                 {
                     evaluated
                 } else {
-                    self.ctx
-                        .types
-                        .factory()
-                        .function(tsz_solver::FunctionShape {
-                            type_params: shape.type_params.clone(),
-                            params,
-                            this_type: shape.this_type,
-                            return_type,
-                            type_predicate: shape.type_predicate,
-                            is_constructor: shape.is_constructor,
-                            is_method: shape.is_method,
-                        })
+                    query::function_type_with_params_and_return_replaced(
+                        self.ctx.types,
+                        shape.as_ref(),
+                        params,
+                        return_type,
+                    )
                 }
             } else if let Some(shape) =
                 crate::query_boundaries::common::object_shape_for_type(self.ctx.types, evaluated)
@@ -1267,12 +1227,11 @@ impl<'a> CheckerState<'a> {
                     index.value_type = normalized;
                 }
                 if changed {
-                    let new_ty = self.ctx.types.factory().object_with_index(shape);
-                    if let Some(display_props) = self.ctx.types.get_display_properties(evaluated) {
-                        self.ctx
-                            .types
-                            .store_display_properties(new_ty, display_props.as_ref().clone());
-                    }
+                    let new_ty = query::object_type_preserving_display_properties(
+                        self.ctx.types,
+                        evaluated,
+                        shape,
+                    );
                     // Propagate display_alias and def-store registration so the
                     // formatter can still show named types (Date, Error, etc.)
                     // after normalization modifies property types.
@@ -1357,8 +1316,8 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let named_obj = self.ctx.types.factory().object(named_props);
-        let wildcard_obj = self.ctx.types.factory().object(wildcard_props);
+        let named_obj = query::object_type_from_properties(self.ctx.types, named_props);
+        let wildcard_obj = query::object_type_from_properties(self.ctx.types, wildcard_props);
         Some(format!(
             "{} & {}",
             self.format_type_diagnostic(named_obj),
@@ -1409,7 +1368,10 @@ impl<'a> CheckerState<'a> {
                 properties.push(property);
             }
 
-            Some(self.ctx.types.factory().object(properties))
+            Some(query::object_type_from_properties(
+                self.ctx.types,
+                properties,
+            ))
         } else if let Some(members) = query::intersection_members(self.ctx.types, ty) {
             let mut changed = false;
             let remapped: Vec<_> = members

--- a/crates/tsz-checker/src/error_reporter/core_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core_alias_display.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
@@ -180,7 +181,12 @@ impl<'a> CheckerState<'a> {
         }
         let constraint = match param_info.constraint {
             Some(c) => c,
-            None => return Some(self.ctx.types.union2(cond.true_type, cond.false_type)),
+            None => {
+                return Some(diagnostic_query::display_union_type(
+                    self.ctx.types,
+                    vec![cond.true_type, cond.false_type],
+                ));
+            }
         };
         if crate::query_boundaries::assignability::is_fresh_subtype_of(
             db,
@@ -196,7 +202,10 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::assignability::is_fresh_subtype_of(db, m, constraint)
         });
         if has_overlap {
-            Some(self.ctx.types.union2(cond.true_type, cond.false_type))
+            Some(diagnostic_query::display_union_type(
+                self.ctx.types,
+                vec![cond.true_type, cond.false_type],
+            ))
         } else {
             None
         }

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -1,4 +1,5 @@
 //! Type formatting and diagnostic anchor helpers for error reporter.
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::{CheckerState, MemberAccessLevel};
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
@@ -1283,7 +1284,7 @@ impl<'a> CheckerState<'a> {
         // the source's base constraint is nullable.  Example:
         //   source `T & U` where constraints are `string | ... | undefined`
         //   target `string | null` must stay `string | null` (not `string`).
-        let other_base = crate::query_boundaries::diagnostics::get_base_constraint_for_display(
+        let other_base = diagnostic_query::get_base_constraint_for_display(
             self.ctx.types.as_type_database(),
             other,
         );

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -206,27 +206,7 @@ impl DiagnosticRenderRequest {
 
 impl<'a> CheckerState<'a> {
     fn widen_display_property_literals_for_related_info(&mut self, type_id: TypeId) -> TypeId {
-        if self.ctx.types.get_display_properties(type_id).is_none() {
-            return type_id;
-        }
-        let Some(shape) = query_common::object_shape_for_type(self.ctx.types, type_id) else {
-            return type_id;
-        };
-
-        let mut widened_shape = shape.as_ref().clone();
-        let mut changed = false;
-        for prop in &mut widened_shape.properties {
-            let widened_read = query_common::widen_literal_type(self.ctx.types, prop.type_id);
-            let widened_write = query_common::widen_literal_type(self.ctx.types, prop.write_type);
-            changed |= widened_read != prop.type_id || widened_write != prop.write_type;
-            prop.type_id = widened_read;
-            prop.write_type = widened_write;
-        }
-        if changed {
-            self.ctx.types.factory().object_with_index(widened_shape)
-        } else {
-            type_id
-        }
+        diagnostics::display_property_literals_widened_for_related_info(self.ctx.types, type_id)
     }
 
     /// Re-render an anonymous object display with its literal annotations

--- a/crates/tsz-checker/src/error_reporter/generics.rs
+++ b/crates/tsz-checker/src/error_reporter/generics.rs
@@ -7,13 +7,14 @@ use crate::query_boundaries::assignability::{
 };
 use crate::query_boundaries::common;
 use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{NodeAccess, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::CallSignature;
 use tsz_solver::TypeId;
-use tsz_solver::{CallSignature, CallableShape};
 
 impl<'a> CheckerState<'a> {
     fn widen_function_like_assertion_source(&self, type_id: TypeId) -> TypeId {
@@ -74,15 +75,12 @@ impl<'a> CheckerState<'a> {
                 .collect();
 
             if changed {
-                return self.ctx.types.callable(tsz_solver::CallableShape {
+                return diagnostic_query::callable_type_with_signatures_replaced(
+                    self.ctx.types,
+                    shape.as_ref(),
                     call_signatures,
                     construct_signatures,
-                    properties: shape.properties.clone(),
-                    string_index: shape.string_index,
-                    number_index: shape.number_index,
-                    symbol: shape.symbol,
-                    is_abstract: shape.is_abstract,
-                });
+                );
             }
         }
 
@@ -169,16 +167,9 @@ impl<'a> CheckerState<'a> {
         let prototype_symbol_name = prototype_symbol.escaped_name.as_str();
         let prototype_display = format!("{prototype_symbol_name}<any>");
         let call_return_type = call_sig.return_type;
-        let call_display =
-            self.format_type_for_assignability_message(self.ctx.types.callable(CallableShape {
-                call_signatures: vec![call_sig],
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            }));
+        let call_display = self.format_type_for_assignability_message(
+            diagnostic_query::call_only_callable_type(self.ctx.types, vec![call_sig]),
+        );
         let construct_display = format!(
             "{prototype_symbol_name}<{}>",
             self.format_type_for_assignability_message(call_return_type)
@@ -222,17 +213,9 @@ impl<'a> CheckerState<'a> {
 
         let symbol_name = symbol.escaped_name.as_str();
         let call_sig = &shape.call_signatures[0];
-        let call_display = self.format_type_for_assignability_message(self.ctx.types.callable(
-            tsz_solver::CallableShape {
-                call_signatures: vec![call_sig.clone()],
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            },
-        ));
+        let call_display = self.format_type_for_assignability_message(
+            diagnostic_query::call_only_callable_type(self.ctx.types, vec![call_sig.clone()]),
+        );
         let call_return_display = self.format_type_for_assignability_message(call_sig.return_type);
         let prototype_display = format!("{symbol_name}<any>");
         let construct_display = format!("{symbol_name}<{call_return_display}>");

--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -4,6 +4,7 @@ use crate::diagnostics::diagnostic_codes;
 use crate::error_reporter::fingerprint_policy::{DiagnosticAnchorKind, DiagnosticRenderRequest};
 use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
 use crate::query_boundaries::common as query;
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_common::file_extensions::strip_known_extension;
@@ -1126,7 +1127,10 @@ impl<'a> CheckerState<'a> {
                 prop.write_type = TypeId::ANY;
             }
         }
-        Some(self.ctx.types.factory().callable(rewritten))
+        Some(diagnostic_query::callable_type_from_shape(
+            self.ctx.types,
+            rewritten,
+        ))
     }
 
     // =========================================================================

--- a/crates/tsz-checker/src/error_reporter/property_receiver_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/property_receiver_formatting.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -60,7 +61,10 @@ impl<'a> CheckerState<'a> {
                             match element_types.as_slice() {
                                 [] => TypeId::NEVER,
                                 [element_type] => *element_type,
-                                _ => self.ctx.types.factory().union(element_types),
+                                _ => diagnostic_query::display_union_type(
+                                    self.ctx.types,
+                                    element_types,
+                                ),
                             }
                         })
                 })?;

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -3,6 +3,7 @@
 use crate::diagnostics::{Diagnostic, diagnostic_codes, diagnostic_messages, format_message};
 use crate::error_reporter::fingerprint_policy::DiagnosticAnchorKind;
 use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::query_boundaries::type_checking_utilities as query_utils;
 use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
@@ -94,7 +95,10 @@ impl<'a> CheckerState<'a> {
             let mut shape = (*shape).clone();
             shape.params[param_index].type_id =
                 self.strict_callback_param_display_type(shape.params[param_index].type_id);
-            return Some(self.ctx.types.factory().function(shape));
+            return Some(diagnostic_query::function_type_from_shape(
+                self.ctx.types,
+                shape,
+            ));
         }
 
         let shape = crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, ty)?;
@@ -107,20 +111,11 @@ impl<'a> CheckerState<'a> {
         let mut sig = shape.call_signatures[0].clone();
         sig.params[param_index].type_id =
             self.strict_callback_param_display_type(sig.params[param_index].type_id);
-        Some(
-            self.ctx
-                .types
-                .factory()
-                .function(tsz_solver::FunctionShape {
-                    type_params: sig.type_params,
-                    params: sig.params,
-                    this_type: sig.this_type,
-                    return_type: sig.return_type,
-                    type_predicate: sig.type_predicate,
-                    is_constructor: false,
-                    is_method: sig.is_method,
-                }),
-        )
+        Some(diagnostic_query::function_type_from_call_signature(
+            self.ctx.types,
+            &sig,
+            false,
+        ))
     }
 
     fn strict_callback_assignment_display_pair(

--- a/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
@@ -17,7 +17,7 @@ use crate::types_domain::queries::lib_resolution::{
 use tsz_common::interner::Atom;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{CallSignature, CallableShape, ParamInfo, PropertyInfo, SymbolRef, TypeId};
+use tsz_solver::{CallSignature, ParamInfo, PropertyInfo, SymbolRef, TypeId};
 
 impl<'a> FlowAnalyzer<'a> {
     pub(super) fn assigned_type_for_await_rhs(
@@ -263,7 +263,12 @@ impl<'a> FlowAnalyzer<'a> {
                         PropertyInfo::new(name_atom, member_type)
                     });
                 }
-                Some(self.interner.factory().object(properties))
+                Some(
+                    crate::query_boundaries::flow_analysis::object_type_from_properties(
+                        self.interner,
+                        properties,
+                    ),
+                )
             }
             k if k == syntax_kind_ext::TYPE_REFERENCE => {
                 let type_ref = self.arena.get_type_ref(node)?;
@@ -413,7 +418,12 @@ impl<'a> FlowAnalyzer<'a> {
             return None;
         }
 
-        Some(self.interner.factory().object(properties))
+        Some(
+            crate::query_boundaries::flow_analysis::object_type_from_properties(
+                self.interner,
+                properties,
+            ),
+        )
     }
 
     fn fallback_object_property_name_atom(&self, name_idx: NodeIndex) -> Option<Atom> {
@@ -802,30 +812,29 @@ impl<'a> FlowAnalyzer<'a> {
             });
         }
 
-        Some(self.interner.factory().callable(CallableShape {
-            call_signatures: vec![CallSignature {
-                type_params: Vec::new(),
-                params,
-                this_type,
-                return_type: self
-                    .arena
-                    .get(decl)
-                    .and_then(|node| self.arena.get_function(node))
-                    .and_then(|func| {
-                        func.type_annotation.is_some().then_some(func.type_annotation)
-                    })
-                    .and_then(|type_ann| self.fallback_type_from_type_node_syntax(type_ann))
-                    .unwrap_or(TypeId::ANY),
-                type_predicate: None,
-                is_method: false,
-            }],
-            construct_signatures: Vec::new(),
-            properties: Vec::new(),
-            string_index: None,
-            number_index: None,
-            symbol: None,
-            is_abstract: false,
-        }))
+        Some(
+            crate::query_boundaries::flow_analysis::call_only_callable_type(
+                self.interner,
+                vec![CallSignature {
+                    type_params: Vec::new(),
+                    params,
+                    this_type,
+                    return_type: self
+                        .arena
+                        .get(decl)
+                        .and_then(|node| self.arena.get_function(node))
+                        .and_then(|func| {
+                            func.type_annotation
+                                .is_some()
+                                .then_some(func.type_annotation)
+                        })
+                        .and_then(|type_ann| self.fallback_type_from_type_node_syntax(type_ann))
+                        .unwrap_or(TypeId::ANY),
+                    type_predicate: None,
+                    is_method: false,
+                }],
+            ),
+        )
     }
 
     fn declared_return_type_from_declaration(&self, decl: NodeIndex) -> Option<TypeId> {

--- a/crates/tsz-checker/src/jsdoc/diagnostics_import_type_constraints.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics_import_type_constraints.rs
@@ -2,6 +2,7 @@
 
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use crate::jsdoc::types::JsdocTypedefInfo;
+use crate::query_boundaries::jsdoc_construction::{jsdoc_type_param_info, jsdoc_type_param_type};
 use crate::state::CheckerState;
 
 pub(super) struct JsdocImportTypeConstraintDiagnostic<'a> {
@@ -32,7 +33,6 @@ impl<'a> CheckerState<'a> {
             comment_end,
             source_text,
         } = request;
-        let factory = self.ctx.types.factory();
         let mut scope_updates = Vec::new();
         for tp in &typedef_info.template_params {
             let constraint = tp
@@ -40,14 +40,8 @@ impl<'a> CheckerState<'a> {
                 .as_deref()
                 .and_then(|c| self.resolve_jsdoc_type_str(c));
             let atom = self.ctx.types.intern_string(&tp.name);
-            let param = tsz_solver::TypeParamInfo {
-                name: atom,
-                constraint,
-                default: None,
-                is_const: false,
-                origin: tsz_solver::TypeParamOrigin::User,
-            };
-            let type_id = factory.type_param(param);
+            let param = jsdoc_type_param_info(atom, constraint, None);
+            let type_id = jsdoc_type_param_type(self.ctx.types, param);
             let previous = self
                 .ctx
                 .type_parameter_scope

--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -16,6 +16,7 @@
 //! - Scoping helpers (`is_in_different_function_scope`, `find_function_body_end`)
 
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::query_boundaries::jsdoc_construction::jsdoc_application_type;
 use crate::query_boundaries::type_checking_utilities as query;
 use crate::state::CheckerState;
 use tsz_binder::symbol_flags;
@@ -591,7 +592,7 @@ impl<'a> CheckerState<'a> {
                 if let Ok(mut stack) = self.ctx.typeof_resolution_stack.try_borrow_mut() {
                     stack.remove(&sym_id);
                 }
-                self.ctx.types.application(base, args)
+                jsdoc_application_type(self.ctx.types, base, args)
             }
             query::TypeQueryKind::Application { .. } | query::TypeQueryKind::Other => type_id,
         }

--- a/crates/tsz-checker/src/jsdoc/params_type_strings.rs
+++ b/crates/tsz-checker/src/jsdoc/params_type_strings.rs
@@ -8,7 +8,9 @@
 //! - `JsdocParamTagInfo` assembly helpers
 
 use super::types::JsdocParamTagInfo;
-use crate::query_boundaries::jsdoc_construction::jsdoc_object_type;
+use crate::query_boundaries::jsdoc_construction::{
+    jsdoc_array_type, jsdoc_object_type, jsdoc_union_pair_type,
+};
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 
@@ -268,7 +270,7 @@ impl<'a> CheckerState<'a> {
 
         // For rest params ({...Type}), wrap in array
         if is_rest {
-            base_type = self.ctx.types.factory().array(base_type);
+            base_type = jsdoc_array_type(self.ctx.types, base_type);
         }
 
         // Check if parameter is optional via bracket syntax [name] or [name=default]
@@ -278,12 +280,11 @@ impl<'a> CheckerState<'a> {
             && base_type != tsz_solver::TypeId::ANY
             && base_type != tsz_solver::TypeId::UNDEFINED
         {
-            Some(
-                self.ctx
-                    .types
-                    .factory()
-                    .union2(base_type, tsz_solver::TypeId::UNDEFINED),
-            )
+            Some(jsdoc_union_pair_type(
+                self.ctx.types,
+                base_type,
+                tsz_solver::TypeId::UNDEFINED,
+            ))
         } else {
             Some(base_type)
         }
@@ -584,11 +585,11 @@ impl<'a> CheckerState<'a> {
                     && prop_type_id != tsz_solver::TypeId::ANY
                     && prop_type_id != tsz_solver::TypeId::UNDEFINED
                 {
-                    prop_type_id = self
-                        .ctx
-                        .types
-                        .factory()
-                        .union2(prop_type_id, tsz_solver::TypeId::UNDEFINED);
+                    prop_type_id = jsdoc_union_pair_type(
+                        self.ctx.types,
+                        prop_type_id,
+                        tsz_solver::TypeId::UNDEFINED,
+                    );
                 }
                 let name_atom = self.ctx.types.intern_string(prop_name);
                 properties.push(tsz_solver::PropertyInfo {
@@ -614,7 +615,7 @@ impl<'a> CheckerState<'a> {
         }
         let obj_type = jsdoc_object_type(self.ctx.types, properties, None, None)?;
         if is_array {
-            Some(self.ctx.types.factory().array(obj_type))
+            Some(jsdoc_array_type(self.ctx.types, obj_type))
         } else {
             Some(obj_type)
         }

--- a/crates/tsz-checker/src/jsdoc/params_type_strings.rs
+++ b/crates/tsz-checker/src/jsdoc/params_type_strings.rs
@@ -8,6 +8,7 @@
 //! - `JsdocParamTagInfo` assembly helpers
 
 use super::types::JsdocParamTagInfo;
+use crate::query_boundaries::jsdoc_construction::jsdoc_object_type;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 
@@ -611,7 +612,7 @@ impl<'a> CheckerState<'a> {
         if properties.is_empty() {
             return None;
         }
-        let obj_type = self.ctx.types.factory().object(properties);
+        let obj_type = jsdoc_object_type(self.ctx.types, properties, None, None)?;
         if is_array {
             Some(self.ctx.types.factory().array(obj_type))
         } else {

--- a/crates/tsz-checker/src/jsdoc/params_type_strings.rs
+++ b/crates/tsz-checker/src/jsdoc/params_type_strings.rs
@@ -9,7 +9,7 @@
 
 use super::types::JsdocParamTagInfo;
 use crate::query_boundaries::jsdoc_construction::{
-    jsdoc_array_type, jsdoc_object_type, jsdoc_union_pair_type,
+    jsdoc_array_type, jsdoc_object_type, jsdoc_property_info, jsdoc_union_pair_type,
 };
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
@@ -592,22 +592,14 @@ impl<'a> CheckerState<'a> {
                     );
                 }
                 let name_atom = self.ctx.types.intern_string(prop_name);
-                properties.push(tsz_solver::PropertyInfo {
-                    name: name_atom,
-                    type_id: prop_type_id,
-                    write_type: prop_type_id,
-                    optional: is_optional,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: tsz_solver::Visibility::Public,
-                    parent_id: None,
-                    declaration_order: (properties.len() + 1) as u32,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                });
+                properties.push(jsdoc_property_info(
+                    name_atom,
+                    prop_type_id,
+                    is_optional,
+                    false,
+                    false,
+                    (properties.len() + 1) as u32,
+                ));
             }
         }
         if properties.is_empty() {

--- a/crates/tsz-checker/src/jsdoc/resolution/generic_typedef.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/generic_typedef.rs
@@ -6,6 +6,7 @@
 //! to `Application(Lazy(DefId), args)` and the solver resolves it
 //! coinductively instead of re-expanding the body until the stack overflows.
 
+use crate::query_boundaries::jsdoc_construction::jsdoc_application_type;
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
@@ -33,11 +34,7 @@ impl<'a> CheckerState<'a> {
             if type_args.is_empty() {
                 return Some(base);
             }
-            let app = self
-                .ctx
-                .types
-                .factory()
-                .application(base, type_args.to_vec());
+            let app = jsdoc_application_type(self.ctx.types, base, type_args.to_vec());
             self.register_jsdoc_generic_display_name(base_name, type_args, app);
             return Some(app);
         }

--- a/crates/tsz-checker/src/jsdoc/resolution/generic_typedef.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/generic_typedef.rs
@@ -6,7 +6,7 @@
 //! to `Application(Lazy(DefId), args)` and the solver resolves it
 //! coinductively instead of re-expanding the body until the stack overflows.
 
-use crate::query_boundaries::jsdoc_construction::jsdoc_application_type;
+use crate::query_boundaries::jsdoc_construction::{jsdoc_application_type, jsdoc_lazy_type};
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
@@ -30,7 +30,7 @@ impl<'a> CheckerState<'a> {
             .get(base_name)
             .copied();
         if let Some(def_id) = in_progress_def {
-            let base = self.ctx.types.factory().lazy(def_id);
+            let base = jsdoc_lazy_type(self.ctx.types, def_id);
             if type_args.is_empty() {
                 return Some(base);
             }

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -14,7 +14,7 @@
 
 use crate::context::{is_declaration_file_name, is_js_file_name};
 use crate::query_boundaries::jsdoc_construction::{
-    self as jsdoc_construct, jsdoc_function_type, jsdoc_object_index_type,
+    self as jsdoc_construct, jsdoc_function_type, jsdoc_object_index_type, jsdoc_param_info,
 };
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -592,7 +592,6 @@ impl<'a> CheckerState<'a> {
                             let t_name = &expr[in_idx + "inkeyof".len()..close_bracket];
                             let k_atom = self.ctx.types.intern_string(k_name);
                             if let Some(&t_id) = self.ctx.type_parameter_scope.get(t_name) {
-                                use tsz_solver::ParamInfo;
                                 let keyof_t_id =
                                     jsdoc_construct::jsdoc_keyof_type(self.ctx.types, t_id);
                                 let k_param = jsdoc_construct::jsdoc_type_param_info(
@@ -610,12 +609,12 @@ impl<'a> CheckerState<'a> {
                                 let template_id = jsdoc_function_type(
                                     self.ctx.types,
                                     Vec::new(),
-                                    vec![ParamInfo {
-                                        name: Some(self.ctx.types.intern_string("value")),
-                                        type_id: t_k_id,
-                                        optional: false,
-                                        rest: false,
-                                    }],
+                                    vec![jsdoc_param_info(
+                                        Some(self.ctx.types.intern_string("value")),
+                                        t_k_id,
+                                        false,
+                                        false,
+                                    )],
                                     None,
                                     TypeId::VOID,
                                     None,
@@ -671,7 +670,6 @@ impl<'a> CheckerState<'a> {
                         let return_type = self
                             .resolve_jsdoc_reference(return_type_str)
                             .unwrap_or(TypeId::VOID);
-                        use tsz_solver::ParamInfo;
                         let mut params = Vec::new();
                         let mut this_type = None;
                         let mut ok = true;
@@ -703,12 +701,12 @@ impl<'a> CheckerState<'a> {
                                     let name =
                                         self.ctx.types.intern_string(&format!("arg{arg_index}"));
                                     arg_index += 1;
-                                    params.push(ParamInfo {
-                                        name: Some(name),
+                                    params.push(jsdoc_param_info(
+                                        Some(name),
                                         type_id,
-                                        optional: false,
-                                        rest: is_rest,
-                                    });
+                                        false,
+                                        is_rest,
+                                    ));
                                 } else {
                                     ok = false;
                                     break;
@@ -800,8 +798,6 @@ impl<'a> CheckerState<'a> {
     /// - `(x: boolean) => asserts x` (assertion predicates)
     /// - `(x: unknown) => x is string` (type predicates)
     fn parse_jsdoc_arrow_function_type(&mut self, type_expr: &str) -> Option<TypeId> {
-        use tsz_solver::ParamInfo;
-
         // Extract generic type parameters if present: `<T, U>(params) => ReturnType`
         let (type_params_str, rest) = if type_expr.starts_with('<') {
             // Find the matching `>` (respecting nesting)
@@ -884,12 +880,7 @@ impl<'a> CheckerState<'a> {
                         continue;
                     }
                     let atom = name.map(|n| self.ctx.types.intern_string(n));
-                    params.push(ParamInfo {
-                        name: atom,
-                        type_id: p_type,
-                        optional: false,
-                        rest: is_rest,
-                    });
+                    params.push(jsdoc_param_info(atom, p_type, false, is_rest));
                 } else {
                     params_ok = false;
                     break;

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -14,7 +14,9 @@
 
 use crate::context::{is_declaration_file_name, is_js_file_name};
 use crate::query_boundaries::jsdoc_construction::{
-    self as jsdoc_construct, jsdoc_function_type, jsdoc_object_index_type, jsdoc_param_info,
+    self as jsdoc_construct, jsdoc_function_type, jsdoc_lazy_type, jsdoc_literal_boolean_type,
+    jsdoc_literal_number_type, jsdoc_literal_string_type, jsdoc_object_index_type,
+    jsdoc_param_info, jsdoc_readonly_type, jsdoc_type_predicate,
 };
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -23,7 +25,7 @@ use tsz_common::numeric::parse_numeric_literal_value;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{TypeId, TypePredicate};
+use tsz_solver::TypeId;
 
 /// Strip a leading and matching trailing `"` or `'` from `s` if both are
 /// present. Returns the bare inner string when stripped, otherwise `None`.
@@ -348,7 +350,7 @@ impl<'a> CheckerState<'a> {
         }
         if let Some(inner) = type_expr.strip_prefix("readonly ") {
             let inner_type = self.resolve_jsdoc_type_str(inner.trim())?;
-            return Some(self.ctx.types.factory().readonly_type(inner_type));
+            return Some(jsdoc_readonly_type(self.ctx.types, inner_type));
         }
         if let Some(inner) = type_expr.strip_prefix('?') {
             let inner = inner.trim();
@@ -481,22 +483,18 @@ impl<'a> CheckerState<'a> {
             && type_expr.len() >= 2
         {
             let inner = &type_expr[1..type_expr.len() - 1];
-            let factory = self.ctx.types.factory();
-            return Some(factory.literal_string(inner));
+            return Some(jsdoc_literal_string_type(self.ctx.types, inner));
         }
         if type_expr == "true" {
-            let factory = self.ctx.types.factory();
-            return Some(factory.literal_boolean(true));
+            return Some(jsdoc_literal_boolean_type(self.ctx.types, true));
         }
         if type_expr == "false" {
-            let factory = self.ctx.types.factory();
-            return Some(factory.literal_boolean(false));
+            return Some(jsdoc_literal_boolean_type(self.ctx.types, false));
         }
         if Self::jsdoc_type_expr_may_be_numeric_literal(type_expr)
             && let Some(n) = parse_numeric_literal_value(type_expr)
         {
-            let factory = self.ctx.types.factory();
-            return Some(factory.literal_number(n));
+            return Some(jsdoc_literal_number_type(self.ctx.types, n));
         }
         if let Some(ty) = self.resolve_jsdoc_implicit_any_builtin_type(type_expr) {
             return Some(ty);
@@ -935,24 +933,14 @@ impl<'a> CheckerState<'a> {
                 let pred_type = self.jsdoc_type_from_expression(type_str);
                 let (target, parameter_index) =
                     self.jsdoc_type_predicate_target(param_name, params_inner);
-                let predicate = TypePredicate {
-                    asserts: true,
-                    target,
-                    type_id: pred_type,
-                    parameter_index,
-                };
+                let predicate = jsdoc_type_predicate(true, target, pred_type, parameter_index);
                 return (Some(TypeId::VOID), Some(predicate));
             }
             // `asserts param` (no type)
             let param_name = rest;
             let (target, parameter_index) =
                 self.jsdoc_type_predicate_target(param_name, params_inner);
-            let predicate = TypePredicate {
-                asserts: true,
-                target,
-                type_id: None,
-                parameter_index,
-            };
+            let predicate = jsdoc_type_predicate(true, target, None, parameter_index);
             return (Some(TypeId::VOID), Some(predicate));
         }
 
@@ -968,12 +956,7 @@ impl<'a> CheckerState<'a> {
                 let pred_type = self.jsdoc_type_from_expression(type_str);
                 let (target, parameter_index) =
                     self.jsdoc_type_predicate_target(param_name, params_inner);
-                let predicate = TypePredicate {
-                    asserts: false,
-                    target,
-                    type_id: pred_type,
-                    parameter_index,
-                };
+                let predicate = jsdoc_type_predicate(false, target, pred_type, parameter_index);
                 return (Some(TypeId::BOOLEAN), Some(predicate));
             }
         }
@@ -1652,7 +1635,7 @@ impl<'a> CheckerState<'a> {
             let constructor_type = self.get_type_of_symbol(sym_id);
             if !self.ctx.class_instance_resolution_set.insert(sym_id) {
                 let def_id = self.ctx.get_or_create_def_id(sym_id);
-                return self.ctx.types.factory().lazy(def_id);
+                return jsdoc_lazy_type(self.ctx.types, def_id);
             }
             let instance_type = self.synthesize_js_constructor_instance_type(
                 symbol.value_declaration,

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -13,7 +13,9 @@
 //! - Arrow function parsing (`parse_jsdoc_arrow_function_type`)
 
 use crate::context::{is_declaration_file_name, is_js_file_name};
-use crate::query_boundaries::jsdoc_construction::{jsdoc_function_type, jsdoc_object_index_type};
+use crate::query_boundaries::jsdoc_construction::{
+    self as jsdoc_construct, jsdoc_function_type, jsdoc_object_index_type,
+};
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::symbol_flags;
@@ -90,9 +92,11 @@ impl<'a> CheckerState<'a> {
         &mut self,
         type_expr: &str,
     ) -> Option<TypeId> {
-        let factory = self.ctx.types.factory();
         match type_expr {
-            "Array" | "array" => Some(factory.array(TypeId::ANY)),
+            "Array" | "array" => Some(jsdoc_construct::jsdoc_array_type(
+                self.ctx.types,
+                TypeId::ANY,
+            )),
             "Function" | "function" => self.resolve_jsdoc_global_implicit_any_type("Function"),
             "Object" => {
                 if self.ctx.no_implicit_any() {
@@ -322,8 +326,7 @@ impl<'a> CheckerState<'a> {
             return if members.len() == 1 {
                 Some(members.remove(0))
             } else {
-                let factory = self.ctx.types.factory();
-                Some(factory.union(members))
+                Some(jsdoc_construct::jsdoc_union_type(self.ctx.types, members))
             };
         }
         if !starts_with_function && let Some(parts) = Self::split_top_level_binary(type_expr, '&') {
@@ -334,8 +337,10 @@ impl<'a> CheckerState<'a> {
             return if members.len() == 1 {
                 Some(members.remove(0))
             } else {
-                let factory = self.ctx.types.factory();
-                Some(factory.intersection(members))
+                Some(jsdoc_construct::jsdoc_intersection_type(
+                    self.ctx.types,
+                    members,
+                ))
             };
         }
         if type_expr == "?" {
@@ -350,8 +355,11 @@ impl<'a> CheckerState<'a> {
             if !inner.is_empty()
                 && let Some(inner_type) = self.resolve_jsdoc_type_str(inner)
             {
-                let factory = self.ctx.types.factory();
-                return Some(factory.union2(inner_type, TypeId::NULL));
+                return Some(jsdoc_construct::jsdoc_union_pair_type(
+                    self.ctx.types,
+                    inner_type,
+                    TypeId::NULL,
+                ));
             }
         }
         if let Some(inner) = type_expr.strip_prefix('!') {
@@ -363,13 +371,19 @@ impl<'a> CheckerState<'a> {
         if type_expr.len() > 1 && !type_expr.ends_with("[]") {
             if let Some(inner) = type_expr.strip_suffix('?') {
                 if let Some(inner_type) = self.resolve_jsdoc_type_str(inner) {
-                    let factory = self.ctx.types.factory();
-                    return Some(factory.union2(inner_type, TypeId::NULL));
+                    return Some(jsdoc_construct::jsdoc_union_pair_type(
+                        self.ctx.types,
+                        inner_type,
+                        TypeId::NULL,
+                    ));
                 }
             } else if let Some(inner) = type_expr.strip_suffix('=') {
                 if let Some(inner_type) = self.resolve_jsdoc_type_str(inner) {
-                    let factory = self.ctx.types.factory();
-                    return Some(factory.union2(inner_type, TypeId::UNDEFINED));
+                    return Some(jsdoc_construct::jsdoc_union_pair_type(
+                        self.ctx.types,
+                        inner_type,
+                        TypeId::UNDEFINED,
+                    ));
                 }
             } else if let Some(inner) = type_expr.strip_suffix('!') {
                 return self.resolve_jsdoc_type_str(inner);
@@ -383,8 +397,10 @@ impl<'a> CheckerState<'a> {
                 inner
             };
             let element_type = self.resolve_jsdoc_type_str(inner)?;
-            let factory = self.ctx.types.factory();
-            return Some(factory.array(element_type));
+            return Some(jsdoc_construct::jsdoc_array_type(
+                self.ctx.types,
+                element_type,
+            ));
         }
         if !type_expr.starts_with('[')
             && type_expr.ends_with(']')
@@ -451,7 +467,11 @@ impl<'a> CheckerState<'a> {
                     return Some(TypeId::ERROR);
                 }
             }
-            return Some(self.ctx.types.factory().index_access(base_type, index_type));
+            return Some(jsdoc_construct::jsdoc_index_access_type(
+                self.ctx.types,
+                base_type,
+                index_type,
+            ));
         }
         if type_expr.starts_with('[') && type_expr.ends_with(']') {
             return self.parse_jsdoc_tuple_type(type_expr);
@@ -481,7 +501,6 @@ impl<'a> CheckerState<'a> {
         if let Some(ty) = self.resolve_jsdoc_implicit_any_builtin_type(type_expr) {
             return Some(ty);
         }
-        let factory = self.ctx.types.factory();
         match type_expr {
             "string" | "String" => Some(TypeId::STRING),
             "number" | "Number" => Some(TypeId::NUMBER),
@@ -573,18 +592,21 @@ impl<'a> CheckerState<'a> {
                             let t_name = &expr[in_idx + "inkeyof".len()..close_bracket];
                             let k_atom = self.ctx.types.intern_string(k_name);
                             if let Some(&t_id) = self.ctx.type_parameter_scope.get(t_name) {
-                                use crate::query_boundaries::common::{MappedType, ParamInfo};
-                                use tsz_solver::TypeParamInfo;
-                                let keyof_t_id = factory.keyof(t_id);
-                                let k_param = TypeParamInfo {
-                                    name: k_atom,
-                                    constraint: Some(keyof_t_id),
-                                    default: None,
-                                    is_const: false,
-                                    origin: tsz_solver::TypeParamOrigin::User,
-                                };
-                                let k_id = factory.type_param(k_param);
-                                let t_k_id = factory.index_access(t_id, k_id);
+                                use tsz_solver::ParamInfo;
+                                let keyof_t_id =
+                                    jsdoc_construct::jsdoc_keyof_type(self.ctx.types, t_id);
+                                let k_param = jsdoc_construct::jsdoc_type_param_info(
+                                    k_atom,
+                                    Some(keyof_t_id),
+                                    None,
+                                );
+                                let k_id =
+                                    jsdoc_construct::jsdoc_type_param_type(self.ctx.types, k_param);
+                                let t_k_id = jsdoc_construct::jsdoc_index_access_type(
+                                    self.ctx.types,
+                                    t_id,
+                                    k_id,
+                                );
                                 let template_id = jsdoc_function_type(
                                     self.ctx.types,
                                     Vec::new(),
@@ -600,14 +622,13 @@ impl<'a> CheckerState<'a> {
                                     false,
                                     false,
                                 );
-                                return Some(factory.mapped(MappedType {
-                                    type_param: k_param,
-                                    constraint: keyof_t_id,
-                                    name_type: None,
-                                    template: template_id,
-                                    readonly_modifier: None,
-                                    optional_modifier: None,
-                                }));
+                                return Some(jsdoc_construct::jsdoc_mapped_type(
+                                    self.ctx.types,
+                                    k_param,
+                                    keyof_t_id,
+                                    template_id,
+                                    None,
+                                ));
                             }
                         }
                     }
@@ -675,8 +696,7 @@ impl<'a> CheckerState<'a> {
                                 let effective_p = if is_rest { &p[3..] } else { p };
                                 if let Some(p_type) = self.resolve_jsdoc_reference(effective_p) {
                                     let type_id = if is_rest {
-                                        let factory = self.ctx.types.factory();
-                                        factory.array(p_type)
+                                        jsdoc_construct::jsdoc_array_type(self.ctx.types, p_type)
                                     } else {
                                         p_type
                                     };
@@ -742,7 +762,8 @@ impl<'a> CheckerState<'a> {
                                 if operand == TypeId::ERROR {
                                     continue;
                                 }
-                                let keyof = factory.keyof(operand);
+                                let keyof =
+                                    jsdoc_construct::jsdoc_keyof_type(self.ctx.types, operand);
                                 return Some(self.judge_evaluate(keyof));
                             }
                         }
@@ -750,7 +771,7 @@ impl<'a> CheckerState<'a> {
                     if !rest.is_empty()
                         && let Some(operand) = self.resolve_jsdoc_type_str(rest)
                     {
-                        let keyof = factory.keyof(operand);
+                        let keyof = jsdoc_construct::jsdoc_keyof_type(self.ctx.types, operand);
                         return Some(self.judge_evaluate(keyof));
                     }
                 }
@@ -820,7 +841,6 @@ impl<'a> CheckerState<'a> {
         let mut type_param_updates = Vec::new();
         let mut jsdoc_type_params = Vec::new();
         if let Some(tp_str) = type_params_str {
-            let factory = self.ctx.types.factory();
             for tp_name in tp_str.split(',') {
                 let tp_name = tp_name.trim();
                 if tp_name.is_empty() {
@@ -829,14 +849,8 @@ impl<'a> CheckerState<'a> {
                 let (name, constraint_str) = Self::split_jsdoc_type_param_constraint(tp_name);
                 let constraint = constraint_str.and_then(|s| self.jsdoc_type_from_expression(s));
                 let atom = self.ctx.types.intern_string(name);
-                let info = tsz_solver::TypeParamInfo {
-                    name: atom,
-                    constraint,
-                    default: None,
-                    is_const: false,
-                    origin: tsz_solver::TypeParamOrigin::User,
-                };
-                let ty = factory.type_param(info);
+                let info = jsdoc_construct::jsdoc_type_param_info(atom, constraint, None);
+                let ty = jsdoc_construct::jsdoc_type_param_type(self.ctx.types, info);
                 jsdoc_type_params.push(info);
                 let previous = self.ctx.type_parameter_scope.insert(name.to_string(), ty);
                 type_param_updates.push((name.to_string(), previous));

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -13,6 +13,7 @@
 //! - Arrow function parsing (`parse_jsdoc_arrow_function_type`)
 
 use crate::context::{is_declaration_file_name, is_js_file_name};
+use crate::query_boundaries::jsdoc_construction::{jsdoc_function_type, jsdoc_object_index_type};
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::symbol_flags;
@@ -20,7 +21,7 @@ use tsz_common::numeric::parse_numeric_literal_value;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{IndexSignature, ObjectShape, TypeId, TypePredicate};
+use tsz_solver::{TypeId, TypePredicate};
 
 /// Strip a leading and matching trailing `"` or `'` from `s` if both are
 /// present. Returns the bare inner string when stripped, otherwise `None`.
@@ -552,25 +553,10 @@ impl<'a> CheckerState<'a> {
                     if let (Some(key_type), Some(value_type)) = (
                         self.jsdoc_type_from_expression(key_str),
                         self.jsdoc_type_from_expression(value_str),
-                    ) {
-                        let mut shape = ObjectShape::default();
-                        if key_type == TypeId::STRING {
-                            shape.string_index = Some(IndexSignature {
-                                key_type,
-                                value_type,
-                                readonly: false,
-                                param_name: None,
-                            });
-                            return Some(factory.object_with_index(shape));
-                        } else if key_type == TypeId::NUMBER {
-                            shape.number_index = Some(IndexSignature {
-                                key_type,
-                                value_type,
-                                readonly: false,
-                                param_name: None,
-                            });
-                            return Some(factory.object_with_index(shape));
-                        }
+                    ) && let Some(object_type) =
+                        jsdoc_object_index_type(self.ctx.types, key_type, value_type, false, None)
+                    {
+                        return Some(object_type);
                     }
                 }
                 if type_expr.starts_with("{[")
@@ -587,9 +573,7 @@ impl<'a> CheckerState<'a> {
                             let t_name = &expr[in_idx + "inkeyof".len()..close_bracket];
                             let k_atom = self.ctx.types.intern_string(k_name);
                             if let Some(&t_id) = self.ctx.type_parameter_scope.get(t_name) {
-                                use crate::query_boundaries::common::{
-                                    FunctionShape, MappedType, ParamInfo,
-                                };
+                                use crate::query_boundaries::common::{MappedType, ParamInfo};
                                 use tsz_solver::TypeParamInfo;
                                 let keyof_t_id = factory.keyof(t_id);
                                 let k_param = TypeParamInfo {
@@ -601,21 +585,21 @@ impl<'a> CheckerState<'a> {
                                 };
                                 let k_id = factory.type_param(k_param);
                                 let t_k_id = factory.index_access(t_id, k_id);
-                                let func_shape = FunctionShape {
-                                    type_params: Vec::new(),
-                                    params: vec![ParamInfo {
+                                let template_id = jsdoc_function_type(
+                                    self.ctx.types,
+                                    Vec::new(),
+                                    vec![ParamInfo {
                                         name: Some(self.ctx.types.intern_string("value")),
                                         type_id: t_k_id,
                                         optional: false,
                                         rest: false,
                                     }],
-                                    this_type: None,
-                                    return_type: TypeId::VOID,
-                                    type_predicate: None,
-                                    is_constructor: false,
-                                    is_method: false,
-                                };
-                                let template_id = factory.function(func_shape);
+                                    None,
+                                    TypeId::VOID,
+                                    None,
+                                    false,
+                                    false,
+                                );
                                 return Some(factory.mapped(MappedType {
                                     type_param: k_param,
                                     constraint: keyof_t_id,
@@ -666,7 +650,7 @@ impl<'a> CheckerState<'a> {
                         let return_type = self
                             .resolve_jsdoc_reference(return_type_str)
                             .unwrap_or(TypeId::VOID);
-                        use tsz_solver::{FunctionShape, ParamInfo};
+                        use tsz_solver::ParamInfo;
                         let mut params = Vec::new();
                         let mut this_type = None;
                         let mut ok = true;
@@ -717,16 +701,16 @@ impl<'a> CheckerState<'a> {
                             } else {
                                 return_type
                             };
-                            let shape = FunctionShape {
-                                type_params: Vec::new(),
+                            return Some(jsdoc_function_type(
+                                self.ctx.types,
+                                Vec::new(),
                                 params,
                                 this_type,
-                                return_type: final_return,
-                                type_predicate: None,
+                                final_return,
+                                None,
                                 is_constructor,
-                                is_method: false,
-                            };
-                            return Some(factory.function(shape));
+                                false,
+                            ));
                         }
                     }
                 }
@@ -795,7 +779,7 @@ impl<'a> CheckerState<'a> {
     /// - `(x: boolean) => asserts x` (assertion predicates)
     /// - `(x: unknown) => x is string` (type predicates)
     fn parse_jsdoc_arrow_function_type(&mut self, type_expr: &str) -> Option<TypeId> {
-        use tsz_solver::{FunctionShape, ParamInfo};
+        use tsz_solver::ParamInfo;
 
         // Extract generic type parameters if present: `<T, U>(params) => ReturnType`
         let (type_params_str, rest) = if type_expr.starts_with('<') {
@@ -913,17 +897,16 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let factory = self.ctx.types.factory();
-        let shape = FunctionShape {
-            type_params: jsdoc_type_params,
+        Some(jsdoc_function_type(
+            self.ctx.types,
+            jsdoc_type_params,
             params,
             this_type,
             return_type,
             type_predicate,
-            is_constructor: false,
-            is_method: false,
-        };
-        Some(factory.function(shape))
+            false,
+            false,
+        ))
     }
 
     /// Parse the return type of a JSDoc arrow function, handling type predicates.

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -15,13 +15,14 @@
 use super::super::types::{JsdocCallbackInfo, JsdocTypedefInfo};
 use crate::query_boundaries::jsdoc_construction::{
     self as jsdoc_construct, JsdocObjectIndexFact, JsdocObjectIndexKind, jsdoc_empty_object_type,
-    jsdoc_function_type, jsdoc_object_index_fact, jsdoc_object_type,
+    jsdoc_function_type, jsdoc_object_index_fact, jsdoc_object_type, jsdoc_param_info,
+    jsdoc_property_info,
 };
 use crate::state::CheckerState;
 use std::sync::Arc;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
-use tsz_solver::{ParamInfo, PropertyInfo, TypeId, TypePredicate, TypePredicateTarget, Visibility};
+use tsz_solver::{PropertyInfo, TypeId, TypePredicate, TypePredicateTarget};
 impl<'a> CheckerState<'a> {
     pub(crate) fn jsdoc_enum_annotation_type_for_symbol_decl(
         &mut self,
@@ -959,22 +960,14 @@ impl<'a> CheckerState<'a> {
                 if !name.is_empty() {
                     let prop_type = self.resolve_jsdoc_type_str(type_str).unwrap_or(TypeId::ANY);
                     let name_atom = self.ctx.types.intern_string(name);
-                    properties.push(PropertyInfo {
-                        name: name_atom,
-                        type_id: prop_type,
-                        write_type: prop_type,
+                    properties.push(jsdoc_property_info(
+                        name_atom,
+                        prop_type,
                         optional,
                         readonly,
-                        is_method: false,
-                        is_class_prototype: false,
-                        visibility: Visibility::Public,
-                        parent_id: None,
-                        declaration_order: (properties.len() + 1) as u32,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                        false,
+                        (properties.len() + 1) as u32,
+                    ));
                 }
             }
         }
@@ -1279,12 +1272,7 @@ impl<'a> CheckerState<'a> {
                 };
                 let p_type = self.resolve_jsdoc_reference(t_str).unwrap_or(TypeId::ANY);
                 let atom = name.map(|n| self.ctx.types.intern_string(n));
-                params.push(ParamInfo {
-                    name: atom,
-                    type_id: p_type,
-                    optional: false,
-                    rest: false,
-                });
+                params.push(jsdoc_param_info(atom, p_type, false, false));
             }
         }
         Some(jsdoc_function_type(
@@ -1357,12 +1345,7 @@ impl<'a> CheckerState<'a> {
                 };
                 let p_type = self.resolve_jsdoc_reference(t_str).unwrap_or(TypeId::ANY);
                 let atom = name.map(|n| self.ctx.types.intern_string(n));
-                params.push(ParamInfo {
-                    name: atom,
-                    type_id: p_type,
-                    optional: false,
-                    rest: false,
-                });
+                params.push(jsdoc_param_info(atom, p_type, false, false));
             }
         }
         let method_type = jsdoc_function_type(
@@ -1376,22 +1359,14 @@ impl<'a> CheckerState<'a> {
             true,
         );
         let name_atom = self.ctx.types.intern_string(method_name);
-        Some(PropertyInfo {
-            name: name_atom,
-            type_id: method_type,
-            write_type: method_type,
+        Some(jsdoc_property_info(
+            name_atom,
+            method_type,
             optional,
-            readonly: false,
-            is_method: true,
-            is_class_prototype: false,
-            visibility: Visibility::Public,
-            parent_id: None,
-            declaration_order: (existing_props.len() + 1) as u32,
-            is_string_named: false,
-            is_symbol_named: false,
-            single_quoted_name: false,
-            non_widening: false,
-        })
+            false,
+            true,
+            (existing_props.len() + 1) as u32,
+        ))
     }
     /// Resolve a `@typedef` referenced by name from JSDoc comments.
     ///
@@ -1714,12 +1689,12 @@ impl<'a> CheckerState<'a> {
             }
 
             let name_atom = self.ctx.types.intern_string(&param.name);
-            params.push(ParamInfo {
-                name: Some(name_atom),
+            params.push(jsdoc_param_info(
+                Some(name_atom),
                 type_id,
-                optional: param.optional,
-                rest: param.rest,
-            });
+                param.optional,
+                param.rest,
+            ));
         }
 
         let mut type_predicate = None;
@@ -1837,22 +1812,14 @@ impl<'a> CheckerState<'a> {
                 );
             }
             let name_atom = self.ctx.types.intern_string(&prop.name);
-            prop_infos.push(PropertyInfo {
-                name: name_atom,
-                type_id: prop_type,
-                write_type: prop_type,
-                optional: prop.optional,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: 0,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+            prop_infos.push(jsdoc_property_info(
+                name_atom,
+                prop_type,
+                prop.optional,
+                false,
+                false,
+                0,
+            ));
         }
         let object_type = jsdoc_object_type(self.ctx.types, prop_infos, None, None);
         match (object_type, base_type) {

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -13,13 +13,16 @@
 //! - Typedef/callback type construction (`type_from_jsdoc_typedef`, `type_from_jsdoc_callback`)
 
 use super::super::types::{JsdocCallbackInfo, JsdocTypedefInfo};
+use crate::query_boundaries::jsdoc_construction::{
+    JsdocObjectIndexFact, JsdocObjectIndexKind, jsdoc_empty_object_type, jsdoc_function_type,
+    jsdoc_object_index_fact, jsdoc_object_type,
+};
 use crate::state::CheckerState;
 use std::sync::Arc;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::{
-    FunctionShape, IndexSignature, ObjectShape, ParamInfo, PropertyInfo, TupleElement, TypeId,
-    TypePredicate, TypePredicateTarget, Visibility,
+    ParamInfo, PropertyInfo, TupleElement, TypeId, TypePredicate, TypePredicateTarget, Visibility,
 };
 impl<'a> CheckerState<'a> {
     pub(crate) fn jsdoc_enum_annotation_type_for_symbol_decl(
@@ -903,15 +906,15 @@ impl<'a> CheckerState<'a> {
             return Some(mapped);
         }
 
-        let factory = self.ctx.types.factory();
         let inner = type_expr[1..type_expr.len() - 1].trim();
         if inner.is_empty() {
-            return Some(factory.object(Vec::new()));
+            return Some(jsdoc_empty_object_type(self.ctx.types));
         }
         // Split properties by ',' or ';' at top level
         let prop_strs = Self::split_object_properties(inner);
         let mut properties = Vec::new();
-        let mut object_shape = ObjectShape::default();
+        let mut string_index: Option<JsdocObjectIndexFact> = None;
+        let mut number_index: Option<JsdocObjectIndexFact> = None;
         for prop_str in &prop_strs {
             let prop_str = prop_str.trim();
             if prop_str.is_empty() {
@@ -943,16 +946,13 @@ impl<'a> CheckerState<'a> {
                 };
                 if raw_name.starts_with('[')
                     && raw_name.ends_with(']')
-                    && let Some(mut index_sig) =
+                    && let Some((index_kind, mut index_fact)) =
                         self.parse_jsdoc_object_literal_index_signature(raw_name, type_str)
                 {
-                    index_sig.readonly |= readonly;
-                    match index_sig.key_type {
-                        TypeId::STRING | TypeId::SYMBOL => {
-                            object_shape.string_index = Some(index_sig);
-                        }
-                        TypeId::NUMBER => object_shape.number_index = Some(index_sig),
-                        _ => {}
+                    index_fact.readonly |= readonly;
+                    match index_kind {
+                        JsdocObjectIndexKind::String => string_index = Some(index_fact),
+                        JsdocObjectIndexKind::Number => number_index = Some(index_fact),
                     }
                     continue;
                 }
@@ -983,25 +983,14 @@ impl<'a> CheckerState<'a> {
                 }
             }
         }
-        if properties.is_empty()
-            && object_shape.string_index.is_none()
-            && object_shape.number_index.is_none()
-        {
-            return None;
-        }
-        if object_shape.string_index.is_some() || object_shape.number_index.is_some() {
-            object_shape.properties = properties;
-            Some(factory.object_with_index(object_shape))
-        } else {
-            Some(factory.object(properties))
-        }
+        jsdoc_object_type(self.ctx.types, properties, string_index, number_index)
     }
 
     fn parse_jsdoc_object_literal_index_signature(
         &mut self,
         raw_name: &str,
         type_str: &str,
-    ) -> Option<IndexSignature> {
+    ) -> Option<(JsdocObjectIndexKind, JsdocObjectIndexFact)> {
         let (raw_name, readonly) = if let Some(rest) = Self::strip_jsdoc_readonly_modifier(raw_name)
         {
             (rest, true)
@@ -1039,12 +1028,12 @@ impl<'a> CheckerState<'a> {
         };
 
         let value_type = self.resolve_jsdoc_type_str(type_str).unwrap_or(TypeId::ANY);
-        Some(IndexSignature {
+        jsdoc_object_index_fact(
             key_type,
             value_type,
             readonly,
-            param_name: (!param_name.is_empty()).then(|| self.ctx.types.intern_string(param_name)),
-        })
+            (!param_name.is_empty()).then(|| self.ctx.types.intern_string(param_name)),
+        )
     }
 
     fn emit_jsdoc_index_signature_diagnostic_once(
@@ -1268,7 +1257,6 @@ impl<'a> CheckerState<'a> {
     /// Parse a named method signature from a JSDoc object property string.
     /// Parse a call signature `(params): RetType` and return a function TypeId.
     fn parse_jsdoc_call_signature(&mut self, prop_str: &str) -> Option<TypeId> {
-        use tsz_solver::{FunctionShape, ParamInfo};
         let after_open = &prop_str[1..];
         let mut depth = 1u32;
         let mut close_idx = None;
@@ -1316,16 +1304,16 @@ impl<'a> CheckerState<'a> {
                 });
             }
         }
-        let shape = FunctionShape {
-            type_params: Vec::new(),
+        Some(jsdoc_function_type(
+            self.ctx.types,
+            Vec::new(),
             params,
-            this_type: None,
+            None,
             return_type,
-            type_predicate: None,
-            is_constructor: false,
-            is_method: false,
-        };
-        Some(self.ctx.types.factory().function(shape))
+            None,
+            false,
+            false,
+        ))
     }
     fn parse_jsdoc_method_signature(
         &mut self,
@@ -1333,7 +1321,6 @@ impl<'a> CheckerState<'a> {
         paren_idx: usize,
         existing_props: &[PropertyInfo],
     ) -> Option<PropertyInfo> {
-        use tsz_solver::{FunctionShape, ParamInfo};
         let method_name = prop_str[..paren_idx].trim();
         if method_name.is_empty() {
             return None;
@@ -1395,16 +1382,16 @@ impl<'a> CheckerState<'a> {
                 });
             }
         }
-        let shape = FunctionShape {
-            type_params: Vec::new(),
+        let method_type = jsdoc_function_type(
+            self.ctx.types,
+            Vec::new(),
             params,
-            this_type: None,
+            None,
             return_type,
-            type_predicate: None,
-            is_constructor: false,
-            is_method: true,
-        };
-        let method_type = self.ctx.types.factory().function(shape);
+            None,
+            false,
+            true,
+        );
         let name_atom = self.ctx.types.intern_string(method_name);
         Some(PropertyInfo {
             name: name_atom,
@@ -1807,15 +1794,16 @@ impl<'a> CheckerState<'a> {
         // `type B<T> = () => T`, not `<T>() => T`. Keeping those parameters on
         // the function body makes alias instantiation shadow them, so `B<string>`
         // still formats and behaves like the uninstantiated `B`.
-        Some(factory.function(FunctionShape {
-            type_params: Vec::new(),
+        Some(jsdoc_function_type(
+            self.ctx.types,
+            Vec::new(),
             params,
             this_type,
             return_type,
             type_predicate,
-            is_constructor: false,
-            is_method: false,
-        }))
+            false,
+            false,
+        ))
     }
 
     fn type_from_jsdoc_object_typedef(&mut self, info: JsdocTypedefInfo) -> Option<TypeId> {
@@ -1888,11 +1876,7 @@ impl<'a> CheckerState<'a> {
                 non_widening: false,
             });
         }
-        let object_type = if !prop_infos.is_empty() {
-            Some(factory.object(prop_infos))
-        } else {
-            None
-        };
+        let object_type = jsdoc_object_type(self.ctx.types, prop_infos, None, None);
         match (object_type, base_type) {
             (Some(obj), Some(base)) => Some(factory.intersection2(obj, base)),
             (Some(obj), None) => Some(obj),

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -15,14 +15,14 @@
 use super::super::types::{JsdocCallbackInfo, JsdocTypedefInfo};
 use crate::query_boundaries::jsdoc_construction::{
     self as jsdoc_construct, JsdocObjectIndexFact, JsdocObjectIndexKind, jsdoc_empty_object_type,
-    jsdoc_function_type, jsdoc_object_index_fact, jsdoc_object_type, jsdoc_param_info,
-    jsdoc_property_info,
+    jsdoc_function_type, jsdoc_lazy_type, jsdoc_object_index_fact, jsdoc_object_type,
+    jsdoc_param_info, jsdoc_property_info, jsdoc_type_predicate,
 };
 use crate::state::CheckerState;
 use std::sync::Arc;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
-use tsz_solver::{PropertyInfo, TypeId, TypePredicate, TypePredicateTarget};
+use tsz_solver::{PropertyInfo, TypeId, TypePredicateTarget};
 impl<'a> CheckerState<'a> {
     pub(crate) fn jsdoc_enum_annotation_type_for_symbol_decl(
         &mut self,
@@ -349,9 +349,8 @@ impl<'a> CheckerState<'a> {
 
         let def_id = self.ensure_jsdoc_assigned_value_def(display_name, ty);
         self.ctx.definition_store.register_type_to_def(ty, def_id);
-        self.ctx
-            .types
-            .store_display_alias(ty, self.ctx.types.factory().lazy(def_id));
+        let alias_lazy = jsdoc_lazy_type(self.ctx.types, def_id);
+        self.ctx.types.store_display_alias(ty, alias_lazy);
         ty
     }
 
@@ -590,7 +589,7 @@ impl<'a> CheckerState<'a> {
         // No-op when `body_type == lazy(def_id)` (e.g. recursive typedefs)
         // or when storing would alias an intrinsic — `store_display_alias`
         // applies its own safety guards.
-        let alias_lazy = self.ctx.types.factory().lazy(def_id);
+        let alias_lazy = jsdoc_lazy_type(self.ctx.types, def_id);
         self.ctx.types.store_display_alias(body_type, alias_lazy);
 
         def_id
@@ -627,7 +626,7 @@ impl<'a> CheckerState<'a> {
         self.ctx
             .definition_store
             .register_type_to_def(type_id, def_id);
-        let alias_lazy = self.ctx.types.factory().lazy(def_id);
+        let alias_lazy = jsdoc_lazy_type(self.ctx.types, def_id);
         self.ctx.types.store_display_alias(type_id, alias_lazy);
         def_id
     }
@@ -1717,12 +1716,12 @@ impl<'a> CheckerState<'a> {
             } else {
                 None
             };
-            type_predicate = Some(TypePredicate {
-                asserts: is_asserts,
+            type_predicate = Some(jsdoc_type_predicate(
+                is_asserts,
                 target,
-                type_id: pred_type,
+                pred_type,
                 parameter_index,
-            });
+            ));
             if is_asserts {
                 TypeId::VOID
             } else {

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -14,16 +14,14 @@
 
 use super::super::types::{JsdocCallbackInfo, JsdocTypedefInfo};
 use crate::query_boundaries::jsdoc_construction::{
-    JsdocObjectIndexFact, JsdocObjectIndexKind, jsdoc_empty_object_type, jsdoc_function_type,
-    jsdoc_object_index_fact, jsdoc_object_type,
+    self as jsdoc_construct, JsdocObjectIndexFact, JsdocObjectIndexKind, jsdoc_empty_object_type,
+    jsdoc_function_type, jsdoc_object_index_fact, jsdoc_object_type,
 };
 use crate::state::CheckerState;
 use std::sync::Arc;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
-use tsz_solver::{
-    ParamInfo, PropertyInfo, TupleElement, TypeId, TypePredicate, TypePredicateTarget, Visibility,
-};
+use tsz_solver::{ParamInfo, PropertyInfo, TypeId, TypePredicate, TypePredicateTarget, Visibility};
 impl<'a> CheckerState<'a> {
     pub(crate) fn jsdoc_enum_annotation_type_for_symbol_decl(
         &mut self,
@@ -534,10 +532,7 @@ impl<'a> CheckerState<'a> {
             return instance_type;
         }
 
-        self.ctx
-            .types
-            .factory()
-            .intersection2(instance_type, prototype_type)
+        jsdoc_construct::jsdoc_intersection_pair_type(self.ctx.types, instance_type, prototype_type)
     }
     fn ensure_jsdoc_typedef_def(
         &mut self,
@@ -659,11 +654,11 @@ impl<'a> CheckerState<'a> {
             if body_type == TypeId::ERROR {
                 if !type_args.is_empty() && !type_params.is_empty() {
                     let base_type = self.ctx.create_lazy_type_ref(sym_id);
-                    let instantiated = self
-                        .ctx
-                        .types
-                        .factory()
-                        .application(base_type, type_args.clone());
+                    let instantiated = jsdoc_construct::jsdoc_application_type(
+                        self.ctx.types,
+                        base_type,
+                        type_args.clone(),
+                    );
                     self.register_jsdoc_generic_display_name(base_name, &type_args, instantiated);
                     return Some(instantiated);
                 }
@@ -731,11 +726,11 @@ impl<'a> CheckerState<'a> {
         if body_type == TypeId::ERROR {
             if !type_args.is_empty() && !type_params.is_empty() {
                 let base_type = self.ctx.create_lazy_type_ref(sym_id);
-                let instantiated = self
-                    .ctx
-                    .types
-                    .factory()
-                    .application(base_type, type_args.clone());
+                let instantiated = jsdoc_construct::jsdoc_application_type(
+                    self.ctx.types,
+                    base_type,
+                    type_args.clone(),
+                );
                 self.register_jsdoc_generic_display_name(base_name, &type_args, instantiated);
                 return Some(instantiated);
             }
@@ -797,11 +792,11 @@ impl<'a> CheckerState<'a> {
             instantiate_generic(self.ctx.types, body_type, type_params, type_args);
         if contains_this_type(self.ctx.types, instantiated) {
             let base_type = self.ctx.create_lazy_type_ref(sym_id);
-            let self_type = self
-                .ctx
-                .types
-                .factory()
-                .application(base_type, type_args.to_vec());
+            let self_type = jsdoc_construct::jsdoc_application_type(
+                self.ctx.types,
+                base_type,
+                type_args.to_vec(),
+            );
             instantiated = substitute_this_type(self.ctx.types, instantiated, self_type);
         }
         instantiated
@@ -812,7 +807,10 @@ impl<'a> CheckerState<'a> {
     ) -> Option<TypeId> {
         let inner = type_expr[1..type_expr.len() - 1].trim();
         if inner.is_empty() {
-            return Some(self.ctx.types.factory().tuple(Vec::new()));
+            return Some(jsdoc_construct::jsdoc_tuple_type(
+                self.ctx.types,
+                Vec::new(),
+            ));
         }
 
         let mut elements = Vec::new();
@@ -847,15 +845,12 @@ impl<'a> CheckerState<'a> {
             };
 
             let type_id = self.resolve_jsdoc_type_str(type_str)?;
-            elements.push(TupleElement {
-                type_id,
-                name,
-                optional,
-                rest,
-            });
+            elements.push(jsdoc_construct::jsdoc_tuple_element(
+                type_id, name, optional, rest,
+            ));
         }
 
-        Some(self.ctx.types.factory().tuple(elements))
+        Some(jsdoc_construct::jsdoc_tuple_type(self.ctx.types, elements))
     }
 
     pub(in crate::jsdoc::resolution) fn parse_jsdoc_index_access_segments(
@@ -1117,19 +1112,13 @@ impl<'a> CheckerState<'a> {
         let constraint = if let Some(operand_str) = Self::strip_jsdoc_keyof_keyword(constraint_str)
         {
             let operand = self.resolve_jsdoc_type_str(operand_str)?;
-            self.ctx.types.factory().keyof(operand)
+            jsdoc_construct::jsdoc_keyof_type(self.ctx.types, operand)
         } else {
             self.resolve_jsdoc_type_str(constraint_str)?
         };
         let atom = self.ctx.types.intern_string(type_param_name);
-        let type_param = tsz_solver::TypeParamInfo {
-            name: atom,
-            constraint: Some(constraint),
-            default: None,
-            is_const: false,
-            origin: tsz_solver::TypeParamOrigin::User,
-        };
-        let type_param_id = self.ctx.types.factory().type_param(type_param);
+        let type_param = jsdoc_construct::jsdoc_type_param_info(atom, Some(constraint), None);
+        let type_param_id = jsdoc_construct::jsdoc_type_param_type(self.ctx.types, type_param);
         let previous = self
             .ctx
             .type_parameter_scope
@@ -1146,14 +1135,13 @@ impl<'a> CheckerState<'a> {
         }
 
         template.map(|template| {
-            self.ctx.types.factory().mapped(tsz_solver::MappedType {
+            jsdoc_construct::jsdoc_mapped_type(
+                self.ctx.types,
                 type_param,
                 constraint,
-                name_type: None,
                 template,
-                readonly_modifier: None,
                 optional_modifier,
-            })
+            )
         })
     }
 
@@ -1190,18 +1178,13 @@ impl<'a> CheckerState<'a> {
         let true_type =
             self.resolve_jsdoc_type_str(type_expr[question_idx + 1..colon_idx].trim())?;
         let false_type = self.resolve_jsdoc_type_str(type_expr[colon_idx + 1..].trim())?;
-        Some(
-            self.ctx
-                .types
-                .factory()
-                .conditional(tsz_solver::ConditionalType {
-                    check_type,
-                    extends_type,
-                    true_type,
-                    false_type,
-                    is_distributive: true,
-                }),
-        )
+        Some(jsdoc_construct::jsdoc_conditional_type(
+            self.ctx.types,
+            check_type,
+            extends_type,
+            true_type,
+            false_type,
+        ))
     }
 
     fn find_jsdoc_conditional_separators(type_expr: &str) -> Option<(usize, usize, usize)> {
@@ -1600,7 +1583,6 @@ impl<'a> CheckerState<'a> {
         info: JsdocTypedefInfo,
         recursive_alias_name: Option<&str>,
     ) -> Option<(TypeId, Vec<tsz_solver::TypeParamInfo>)> {
-        let factory = self.ctx.types.factory();
         let import_alias_body = info
             .base_type
             .as_deref()
@@ -1613,14 +1595,8 @@ impl<'a> CheckerState<'a> {
                 .as_deref()
                 .and_then(|expr| self.resolve_jsdoc_type_str(expr));
             let atom = self.ctx.types.intern_string(&template.name);
-            let param = tsz_solver::TypeParamInfo {
-                name: atom,
-                constraint,
-                default: None,
-                is_const: false,
-                origin: tsz_solver::TypeParamOrigin::User,
-            };
-            let type_id = factory.type_param(param);
+            let param = jsdoc_construct::jsdoc_type_param_info(atom, constraint, None);
+            let type_id = jsdoc_construct::jsdoc_type_param_type(self.ctx.types, param);
             let previous = self
                 .ctx
                 .type_parameter_scope
@@ -1679,7 +1655,6 @@ impl<'a> CheckerState<'a> {
     }
 
     fn type_from_jsdoc_callback(&mut self, cb: JsdocCallbackInfo) -> Option<TypeId> {
-        let factory = self.ctx.types.factory();
         let mut params = Vec::new();
         let mut this_type = None;
         let nested_entries: Vec<(String, String, bool)> = cb
@@ -1730,7 +1705,7 @@ impl<'a> CheckerState<'a> {
                 };
 
             if param.rest {
-                type_id = factory.array(type_id);
+                type_id = jsdoc_construct::jsdoc_array_type(self.ctx.types, type_id);
             }
 
             if param.name == "this" {
@@ -1807,7 +1782,6 @@ impl<'a> CheckerState<'a> {
     }
 
     fn type_from_jsdoc_object_typedef(&mut self, info: JsdocTypedefInfo) -> Option<TypeId> {
-        let factory = self.ctx.types.factory();
         let base_type = if let Some(base_type_expr) = &info.base_type {
             let expr = base_type_expr.trim();
             if expr != "Object" && expr != "object" {
@@ -1856,7 +1830,11 @@ impl<'a> CheckerState<'a> {
                 && prop_type != TypeId::ANY
                 && prop_type != TypeId::UNDEFINED
             {
-                prop_type = factory.union2(prop_type, TypeId::UNDEFINED);
+                prop_type = jsdoc_construct::jsdoc_union_pair_type(
+                    self.ctx.types,
+                    prop_type,
+                    TypeId::UNDEFINED,
+                );
             }
             let name_atom = self.ctx.types.intern_string(&prop.name);
             prop_infos.push(PropertyInfo {
@@ -1878,7 +1856,11 @@ impl<'a> CheckerState<'a> {
         }
         let object_type = jsdoc_object_type(self.ctx.types, prop_infos, None, None);
         match (object_type, base_type) {
-            (Some(obj), Some(base)) => Some(factory.intersection2(obj, base)),
+            (Some(obj), Some(base)) => Some(jsdoc_construct::jsdoc_intersection_pair_type(
+                self.ctx.types,
+                obj,
+                base,
+            )),
             (Some(obj), None) => Some(obj),
             (None, Some(base)) => Some(base),
             (None, None) => None,

--- a/crates/tsz-checker/src/query_boundaries/binding_patterns.rs
+++ b/crates/tsz-checker/src/query_boundaries/binding_patterns.rs
@@ -4,9 +4,10 @@
 //! contextual typing policy, relation checks, and diagnostic anchors. This
 //! module owns the solver shapes synthesized from those binding facts.
 
+use tsz_binder::SymbolId;
 use tsz_common::Atom;
 use tsz_solver::construction::TypeDatabase;
-use tsz_solver::{PropertyInfo, TupleElement, TypeId};
+use tsz_solver::{ObjectFlags, ObjectShape, PropertyInfo, TupleElement, TypeId};
 
 pub(crate) fn binding_pattern_initializer_union_type(
     db: &dyn TypeDatabase,
@@ -58,4 +59,47 @@ pub(crate) fn binding_pattern_tuple_type(
     elements: Vec<TupleElement>,
 ) -> TypeId {
     db.tuple(elements)
+}
+
+pub(crate) fn binding_rest_omit_application(
+    db: &dyn TypeDatabase,
+    omit_type: TypeId,
+    parent_type: TypeId,
+    string_keys: &[String],
+    computed_key_type_ids: &[TypeId],
+) -> TypeId {
+    let mut key_args: Vec<TypeId> = string_keys
+        .iter()
+        .map(|name| db.literal_string(name))
+        .collect();
+    key_args.extend_from_slice(computed_key_type_ids);
+    let key_arg = if key_args.len() == 1 {
+        key_args[0]
+    } else {
+        db.union(key_args)
+    };
+    db.application(omit_type, vec![parent_type, key_arg])
+}
+
+pub(crate) fn binding_rest_indexed_object_type(
+    db: &dyn TypeDatabase,
+    mut shape: ObjectShape,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    shape.properties = properties;
+    shape.symbol = None;
+    db.object_with_index(shape)
+}
+
+pub(crate) fn binding_rest_object_with_flags(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    flags: ObjectFlags,
+    symbol: Option<SymbolId>,
+) -> TypeId {
+    db.object_with_flags_and_symbol(properties, flags, symbol)
+}
+
+pub(crate) fn binding_rest_array_type(db: &dyn TypeDatabase, element_type: TypeId) -> TypeId {
+    db.array(element_type)
 }

--- a/crates/tsz-checker/src/query_boundaries/binding_patterns.rs
+++ b/crates/tsz-checker/src/query_boundaries/binding_patterns.rs
@@ -1,0 +1,61 @@
+//! Binding/destructuring pattern construction boundary.
+//!
+//! Binding-pattern callers own AST traversal, property-name extraction,
+//! contextual typing policy, relation checks, and diagnostic anchors. This
+//! module owns the solver shapes synthesized from those binding facts.
+
+use tsz_common::Atom;
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{PropertyInfo, TupleElement, TypeId};
+
+pub(crate) fn binding_pattern_initializer_union_type(
+    db: &dyn TypeDatabase,
+    element_type: TypeId,
+    initializer_type: TypeId,
+) -> TypeId {
+    db.union2(element_type, initializer_type)
+}
+
+pub(crate) fn binding_pattern_member_union_type(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) const fn binding_pattern_property(
+    name: Atom,
+    type_id: TypeId,
+    optional: bool,
+) -> PropertyInfo {
+    let mut property = PropertyInfo::new(name, type_id);
+    property.optional = optional;
+    property
+}
+
+pub(crate) const fn binding_pattern_tuple_element(
+    type_id: TypeId,
+    optional: bool,
+    rest: bool,
+) -> TupleElement {
+    TupleElement {
+        type_id,
+        optional,
+        rest,
+        name: None,
+    }
+}
+
+pub(crate) fn binding_pattern_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn binding_pattern_tuple_type(
+    db: &dyn TypeDatabase,
+    elements: Vec<TupleElement>,
+) -> TypeId {
+    db.tuple(elements)
+}

--- a/crates/tsz-checker/src/query_boundaries/checkers/call.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/call.rs
@@ -486,3 +486,27 @@ pub(crate) fn call_inference_tuple_type(db: &dyn TypeDatabase, elements: Vec<Typ
             .collect(),
     )
 }
+
+pub(crate) fn call_result_correlated_union(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn call_result_optional_chain_return(
+    db: &dyn TypeDatabase,
+    return_type: TypeId,
+) -> TypeId {
+    db.union2(return_type, TypeId::UNDEFINED)
+}
+
+pub(crate) fn recursive_call_result_type(
+    db: &dyn TypeDatabase,
+    def_id: tsz_solver::DefId,
+    type_args: Vec<TypeId>,
+) -> TypeId {
+    let lazy = db.lazy(def_id);
+    if type_args.is_empty() {
+        lazy
+    } else {
+        db.application(lazy, type_args)
+    }
+}

--- a/crates/tsz-checker/src/query_boundaries/checkers/call.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/call.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
+use tsz_common::Atom;
 use tsz_solver::computation::{ContextualTypeContext, TypeSubstitution};
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::operations::{AssignabilityChecker, CallResult};
 use tsz_solver::relations::subtype::{TypeEnvironment, TypeResolver};
-use tsz_solver::{FunctionShape, ObjectShape, TupleElement, TypeId};
+use tsz_solver::{FunctionShape, ObjectShape, PropertyInfo, TupleElement, TypeId};
 
 pub(crate) use super::super::common::array_element_type as array_element_type_for_type;
 pub(crate) use super::super::common::is_type_parameter_like as is_type_parameter_type;
@@ -447,4 +448,41 @@ pub(crate) fn extract_predicate_signature(
     type_id: TypeId,
 ) -> Option<tsz_solver::type_queries::flow::ExtractedPredicateSignature> {
     tsz_solver::type_queries::flow::extract_predicate_signature(db, type_id)
+}
+
+pub(crate) fn call_inference_partial_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<(Atom, TypeId)>,
+) -> TypeId {
+    db.object_fresh(
+        properties
+            .into_iter()
+            .map(|(name, type_id)| PropertyInfo::new(name, type_id))
+            .collect(),
+    )
+}
+
+pub(crate) fn call_inference_zero_arg_function_type(
+    db: &dyn TypeDatabase,
+    return_type: TypeId,
+) -> TypeId {
+    db.function(FunctionShape::new(Vec::new(), return_type))
+}
+
+pub(crate) fn call_inference_string_key_type(db: &dyn TypeDatabase, name: &str) -> TypeId {
+    db.literal_string(name)
+}
+
+pub(crate) fn call_inference_tuple_type(db: &dyn TypeDatabase, elements: Vec<TypeId>) -> TypeId {
+    db.tuple(
+        elements
+            .into_iter()
+            .map(|type_id| TupleElement {
+                type_id,
+                optional: false,
+                rest: false,
+                name: None,
+            })
+            .collect(),
+    )
 }

--- a/crates/tsz-checker/src/query_boundaries/checkers/class_properties.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/class_properties.rs
@@ -1,0 +1,139 @@
+//! JS class-property construction boundary.
+//!
+//! JS class-property scanning gathers AST, JSDoc, modifier, and source-order
+//! facts. This module owns the solver shape literals those facts become.
+
+use tsz_binder::SymbolId;
+use tsz_common::{Atom, Visibility};
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{
+    CallSignature, CallableShape, ObjectShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
+    TypeParamOrigin,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct JsClassPropertyFact {
+    pub(crate) name: Atom,
+    pub(crate) type_id: TypeId,
+    pub(crate) write_type: TypeId,
+    pub(crate) optional: bool,
+    pub(crate) readonly: bool,
+    pub(crate) is_method: bool,
+    pub(crate) is_class_prototype: bool,
+    pub(crate) visibility: Visibility,
+    pub(crate) parent_id: Option<SymbolId>,
+}
+
+impl JsClassPropertyFact {
+    pub(crate) const fn new(name: Atom, type_id: TypeId) -> Self {
+        Self {
+            name,
+            type_id,
+            write_type: type_id,
+            optional: false,
+            readonly: false,
+            is_method: false,
+            is_class_prototype: false,
+            visibility: Visibility::Public,
+            parent_id: None,
+        }
+    }
+}
+
+pub(crate) const fn js_class_type_param_info(
+    name: Atom,
+    constraint: Option<TypeId>,
+    default: Option<TypeId>,
+    is_const: bool,
+) -> TypeParamInfo {
+    TypeParamInfo {
+        name,
+        constraint,
+        default,
+        is_const,
+        origin: TypeParamOrigin::User,
+    }
+}
+
+pub(crate) fn js_class_type_param_type(
+    db: &dyn TypeDatabase,
+    name: Atom,
+    constraint: Option<TypeId>,
+    default: Option<TypeId>,
+    is_const: bool,
+) -> TypeId {
+    db.type_param(js_class_type_param_info(
+        name, constraint, default, is_const,
+    ))
+}
+
+pub(crate) fn js_class_array_type(db: &dyn TypeDatabase, element: TypeId) -> TypeId {
+    db.array(element)
+}
+
+pub(crate) fn js_class_union_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn js_class_union_pair_type(
+    db: &dyn TypeDatabase,
+    left: TypeId,
+    right: TypeId,
+) -> TypeId {
+    db.union2(left, right)
+}
+
+pub(crate) const fn js_class_property_info(fact: JsClassPropertyFact) -> PropertyInfo {
+    PropertyInfo {
+        name: fact.name,
+        type_id: fact.type_id,
+        write_type: fact.write_type,
+        optional: fact.optional,
+        readonly: fact.readonly,
+        is_method: fact.is_method,
+        is_class_prototype: fact.is_class_prototype,
+        visibility: fact.visibility,
+        parent_id: fact.parent_id,
+        declaration_order: 0,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+pub(crate) fn js_class_method_callable_type(db: &dyn TypeDatabase) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures: vec![CallSignature {
+            type_params: Vec::new(),
+            params: vec![ParamInfo {
+                name: None,
+                type_id: TypeId::ANY,
+                optional: false,
+                rest: true,
+            }],
+            this_type: None,
+            return_type: TypeId::ANY,
+            type_predicate: None,
+            is_method: true,
+        }],
+        construct_signatures: Vec::new(),
+        properties: Vec::new(),
+        string_index: None,
+        number_index: None,
+        symbol: None,
+        is_abstract: false,
+    })
+}
+
+pub(crate) fn js_class_instance_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    symbol: Option<SymbolId>,
+) -> TypeId {
+    db.object_with_index(ObjectShape {
+        properties,
+        symbol,
+        ..ObjectShape::default()
+    })
+}

--- a/crates/tsz-checker/src/query_boundaries/checkers/constructor.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/constructor.rs
@@ -1,5 +1,7 @@
-use tsz_solver::TypeId;
-use tsz_solver::construction::TypeDatabase;
+use rustc_hash::FxHashMap;
+use tsz_common::interner::Atom;
+use tsz_solver::construction::{QueryDatabase, TypeDatabase};
+use tsz_solver::{PropertyInfo, TypeId};
 
 pub(crate) use super::super::common::has_construct_signatures;
 pub(crate) use tsz_solver::type_queries::{
@@ -43,4 +45,194 @@ pub(crate) fn construct_return_type_for_display(
     type_id: TypeId,
 ) -> Option<TypeId> {
     construct_return_type_for_type(db, type_id)
+}
+
+pub(crate) fn constructor_return_intersection_or_single(
+    db: &dyn TypeDatabase,
+    returns: Vec<TypeId>,
+) -> TypeId {
+    tsz_solver::utils::intersection_or_single(db, returns)
+}
+
+pub(crate) fn constructor_instance_intersection_or_single(
+    db: &dyn TypeDatabase,
+    instance_types: Vec<TypeId>,
+) -> TypeId {
+    tsz_solver::utils::intersection_or_single(db, instance_types)
+}
+
+pub(crate) fn mixin_returned_class_instance_type(
+    db: &dyn TypeDatabase,
+    returned_instance: TypeId,
+    base_instance: TypeId,
+) -> TypeId {
+    db.intersection2(returned_instance, base_instance)
+}
+
+pub(crate) fn mixin_return_type_with_base_constructor(
+    db: &dyn TypeDatabase,
+    return_type: TypeId,
+    base_arg_type: TypeId,
+) -> TypeId {
+    db.intersection2(return_type, base_arg_type)
+}
+
+pub(crate) fn constructor_type_without_abstract_flag(
+    db: &dyn TypeDatabase,
+    ctor_type: TypeId,
+) -> TypeId {
+    match classify_for_constructor_return_merge(db, ctor_type) {
+        ConstructorReturnMergeKind::Callable(shape_id) => {
+            let shape = db.callable_shape(shape_id);
+            if !shape.is_abstract {
+                return ctor_type;
+            }
+            let mut new_shape = (*shape).clone();
+            new_shape.is_abstract = false;
+            db.callable(new_shape)
+        }
+        ConstructorReturnMergeKind::Intersection(members) => {
+            let mut updated_members = Vec::with_capacity(members.len());
+            let mut changed = false;
+            for member in members {
+                let updated = constructor_type_without_abstract_flag(db, member);
+                if updated != member {
+                    changed = true;
+                }
+                updated_members.push(updated);
+            }
+            if changed {
+                db.intersection(updated_members)
+            } else {
+                ctor_type
+            }
+        }
+        ConstructorReturnMergeKind::Function(_) | ConstructorReturnMergeKind::Other => ctor_type,
+    }
+}
+
+pub(crate) fn constructor_type_with_construct_return(
+    db: &dyn TypeDatabase,
+    ctor_type: TypeId,
+    instance_type: TypeId,
+) -> TypeId {
+    match classify_for_constructor_return_merge(db, ctor_type) {
+        ConstructorReturnMergeKind::Callable(shape_id) => {
+            let shape = db.callable_shape(shape_id);
+            let mut new_shape = (*shape).clone();
+            for sig in &mut new_shape.construct_signatures {
+                sig.return_type = instance_type;
+            }
+            db.callable(new_shape)
+        }
+        ConstructorReturnMergeKind::Function(shape_id) => {
+            let shape = db.function_shape(shape_id);
+            if !shape.is_constructor {
+                return ctor_type;
+            }
+            let mut new_shape = (*shape).clone();
+            new_shape.return_type = instance_type;
+            db.function(new_shape)
+        }
+        ConstructorReturnMergeKind::Intersection(members) => {
+            let mut updated_members = Vec::with_capacity(members.len());
+            let mut changed = false;
+            for member in members {
+                let updated = constructor_type_with_construct_return(db, member, instance_type);
+                if updated != member {
+                    changed = true;
+                }
+                updated_members.push(updated);
+            }
+            if changed {
+                db.intersection(updated_members)
+            } else {
+                ctor_type
+            }
+        }
+        ConstructorReturnMergeKind::Other => ctor_type,
+    }
+}
+
+pub(crate) fn constructor_type_with_base_instance_return(
+    db: &dyn QueryDatabase,
+    ctor_type: TypeId,
+    base_instance_type: TypeId,
+) -> TypeId {
+    match classify_for_constructor_return_merge(db, ctor_type) {
+        ConstructorReturnMergeKind::Callable(_) | ConstructorReturnMergeKind::Function(_) => {
+            let result = tsz_solver::type_queries::data::intersect_constructor_returns(
+                db,
+                ctor_type,
+                base_instance_type,
+            );
+            if result != ctor_type {
+                result
+            } else {
+                ctor_type
+            }
+        }
+        ConstructorReturnMergeKind::Intersection(members) => {
+            let mut updated_members = Vec::with_capacity(members.len());
+            let mut changed = false;
+            for member in members {
+                let updated =
+                    constructor_type_with_base_instance_return(db, member, base_instance_type);
+                if updated != member {
+                    changed = true;
+                }
+                updated_members.push(updated);
+            }
+            if changed {
+                db.intersection(updated_members)
+            } else {
+                ctor_type
+            }
+        }
+        ConstructorReturnMergeKind::Other => ctor_type,
+    }
+}
+
+pub(crate) fn constructor_type_with_base_properties(
+    db: &dyn TypeDatabase,
+    ctor_type: TypeId,
+    base_props: &FxHashMap<Atom, PropertyInfo>,
+) -> TypeId {
+    if base_props.is_empty() {
+        return ctor_type;
+    }
+
+    match classify_for_constructor_return_merge(db, ctor_type) {
+        ConstructorReturnMergeKind::Callable(shape_id) => {
+            let shape = db.callable_shape(shape_id);
+            let mut prop_map: FxHashMap<Atom, PropertyInfo> = shape
+                .properties
+                .iter()
+                .map(|prop| (prop.name, prop.clone()))
+                .collect();
+            for (name, prop) in base_props {
+                prop_map.entry(*name).or_insert_with(|| prop.clone());
+            }
+            let mut new_shape = (*shape).clone();
+            new_shape.properties = prop_map.into_values().collect();
+            db.callable(new_shape)
+        }
+        ConstructorReturnMergeKind::Intersection(members) => {
+            let mut updated_members = Vec::with_capacity(members.len());
+            let mut changed = false;
+            for member in members {
+                let updated = constructor_type_with_base_properties(db, member, base_props);
+                if updated != member {
+                    changed = true;
+                }
+                updated_members.push(updated);
+            }
+            if changed {
+                db.intersection(updated_members)
+            } else {
+                ctor_type
+            }
+        }
+        ConstructorReturnMergeKind::Function(_) | ConstructorReturnMergeKind::Other => ctor_type,
+    }
 }

--- a/crates/tsz-checker/src/query_boundaries/checkers/decorators.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/decorators.rs
@@ -1,0 +1,66 @@
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::def::DefId;
+use tsz_solver::{FunctionShape, ParamInfo, TypeId, TypeParamInfo};
+
+pub(crate) fn decorator_global_type_ref(db: &dyn TypeDatabase, def_id: DefId) -> TypeId {
+    db.lazy(def_id)
+}
+
+pub(crate) fn class_accessor_decorator_target_any(
+    db: &dyn TypeDatabase,
+    target_def: DefId,
+) -> TypeId {
+    let base = db.lazy(target_def);
+    db.application(base, vec![TypeId::ANY, TypeId::ANY])
+}
+
+pub(crate) fn decorator_context_application(
+    db: &dyn TypeDatabase,
+    context_def: DefId,
+    args: Vec<TypeId>,
+) -> TypeId {
+    let base = db.lazy(context_def);
+    db.application(base, args)
+}
+
+pub(crate) fn method_decorator_value_type(
+    db: &dyn TypeDatabase,
+    type_params: Vec<TypeParamInfo>,
+    params: Vec<ParamInfo>,
+    this_type: Option<TypeId>,
+    return_type: TypeId,
+) -> TypeId {
+    db.function(FunctionShape {
+        type_params,
+        params,
+        this_type,
+        return_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: true,
+    })
+}
+
+pub(crate) fn accessor_decorator_value_type(
+    db: &dyn TypeDatabase,
+    params: Vec<ParamInfo>,
+    this_type: Option<TypeId>,
+    return_type: TypeId,
+) -> TypeId {
+    db.function(FunctionShape {
+        type_params: Vec::new(),
+        params,
+        this_type,
+        return_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: true,
+    })
+}
+
+pub(crate) fn decorator_void_or_replacement_type(
+    db: &dyn TypeDatabase,
+    replacement_type: TypeId,
+) -> TypeId {
+    db.union2(TypeId::VOID, replacement_type)
+}

--- a/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
@@ -1,8 +1,12 @@
 //! JSX checker query boundaries.
 
 use crate::state::CheckerState;
+use tsz_common::Atom;
+use tsz_solver::computation::TypeSubstitution;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
-use tsz_solver::{DefinitionStore, TypeId, TypeParamInfo};
+use tsz_solver::{
+    CallSignature, DefinitionStore, FunctionShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
+};
 
 pub(crate) struct SingleArgTypeApplication {
     pub(crate) base: TypeId,
@@ -186,6 +190,130 @@ pub(crate) fn props_are_assignable(
     target: TypeId,
 ) -> bool {
     checker.jsx_props_relation_outcome(source, target).related
+}
+
+pub(crate) fn object_type_from_properties(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn empty_props_object_type(db: &dyn TypeDatabase) -> TypeId {
+    object_type_from_properties(db, Vec::new())
+}
+
+pub(crate) fn props_param_type_or_empty(db: &dyn TypeDatabase, params: &[ParamInfo]) -> TypeId {
+    params
+        .first()
+        .map(|param| param.type_id)
+        .unwrap_or_else(|| empty_props_object_type(db))
+}
+
+pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {
+    crate::query_boundaries::construct_signatures::function_type_from_shape(db, shape)
+}
+
+pub(crate) fn function_type_from_parts(
+    db: &dyn TypeDatabase,
+    params: Vec<ParamInfo>,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_shape(db, FunctionShape::new(params, return_type))
+}
+
+pub(crate) fn single_required_param_function_type(
+    db: &dyn TypeDatabase,
+    param_name: Atom,
+    param_type: TypeId,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_parts(
+        db,
+        vec![ParamInfo::required(param_name, param_type)],
+        return_type,
+    )
+}
+
+pub(crate) fn function_type_with_mapped_component_types(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    mut map_type: impl FnMut(TypeId) -> TypeId,
+) -> TypeId {
+    let mapped = crate::query_boundaries::construct_signatures::map_function_shape_types(
+        shape,
+        |_, type_id| map_type(type_id),
+    )
+    .unwrap_or_else(|| shape.clone());
+    function_type_from_shape(db, mapped)
+}
+
+pub(crate) fn function_type_without_this(db: &dyn TypeDatabase, shape: &FunctionShape) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params: shape.params.clone(),
+            this_type: None,
+            return_type: shape.return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: false,
+        },
+    )
+}
+
+pub(crate) fn construct_signature_function_shape(sig: CallSignature) -> FunctionShape {
+    FunctionShape {
+        type_params: sig.type_params,
+        params: sig.params,
+        this_type: sig.this_type,
+        return_type: sig.return_type,
+        type_predicate: sig.type_predicate,
+        is_constructor: true,
+        is_method: sig.is_method,
+    }
+}
+
+pub(crate) fn push_required_param(shape: &mut FunctionShape, name: Atom, type_id: TypeId) {
+    shape.params.push(ParamInfo::required(name, type_id));
+}
+
+pub(crate) fn synthetic_single_param_function_shape(
+    type_params: Vec<TypeParamInfo>,
+    param_name: Atom,
+    param_type: TypeId,
+    return_type: TypeId,
+) -> FunctionShape {
+    FunctionShape {
+        type_params,
+        params: vec![ParamInfo {
+            name: Some(param_name),
+            type_id: param_type,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    }
+}
+
+pub(crate) fn instantiate_function_shape_preserving_unresolved_params(
+    db: &dyn QueryDatabase,
+    func: &FunctionShape,
+    substitution: &TypeSubstitution,
+) -> FunctionShape {
+    let mut full_substitution = substitution.clone();
+    for type_param in &func.type_params {
+        if full_substitution.get(type_param.name).is_none() {
+            let preserved_type_param = db.as_type_database().type_param(*type_param);
+            full_substitution.insert(type_param.name, preserved_type_param);
+        }
+    }
+    crate::query_boundaries::common::instantiate_function_shape(db, func, &full_substitution)
 }
 
 pub(crate) fn has_object_shape(db: &dyn TypeDatabase, type_id: TypeId) -> bool {

--- a/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
@@ -5,7 +5,8 @@ use tsz_common::Atom;
 use tsz_solver::computation::TypeSubstitution;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::{
-    CallSignature, DefinitionStore, FunctionShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
+    CallSignature, DefinitionStore, FunctionShape, ParamInfo, PropertyInfo, TupleElement, TypeId,
+    TypeParamInfo,
 };
 
 pub(crate) struct SingleArgTypeApplication {
@@ -199,6 +200,33 @@ pub(crate) fn object_type_from_properties(
     db.object(properties)
 }
 
+pub(crate) const fn property_info(name: Atom, type_id: TypeId) -> PropertyInfo {
+    PropertyInfo::new(name, type_id)
+}
+
+pub(crate) const fn property_info_with_write_type(
+    name: Atom,
+    type_id: TypeId,
+    write_type: TypeId,
+) -> PropertyInfo {
+    PropertyInfo {
+        name,
+        type_id,
+        write_type,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: tsz_solver::Visibility::Public,
+        parent_id: None,
+        declaration_order: 0,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
 pub(crate) fn empty_props_object_type(db: &dyn TypeDatabase) -> TypeId {
     object_type_from_properties(db, Vec::new())
 }
@@ -208,6 +236,72 @@ pub(crate) fn props_param_type_or_empty(db: &dyn TypeDatabase, params: &[ParamIn
         .first()
         .map(|param| param.type_id)
         .unwrap_or_else(|| empty_props_object_type(db))
+}
+
+pub(crate) fn union_type_from_members(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn union_type_from_pair(db: &dyn TypeDatabase, left: TypeId, right: TypeId) -> TypeId {
+    db.union2(left, right)
+}
+
+pub(crate) fn intersection_type_from_members(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> TypeId {
+    db.intersection(members)
+}
+
+pub(crate) fn intersection_type_from_pair(
+    db: &dyn TypeDatabase,
+    left: TypeId,
+    right: TypeId,
+) -> TypeId {
+    db.intersection2(left, right)
+}
+
+pub(crate) fn array_type_from_element(db: &dyn TypeDatabase, element: TypeId) -> TypeId {
+    db.array(element)
+}
+
+pub(crate) fn tuple_type_from_elements(
+    db: &dyn TypeDatabase,
+    elements: Vec<TupleElement>,
+) -> TypeId {
+    db.tuple(elements)
+}
+
+pub(crate) fn tuple_type_from_required_element_types(
+    db: &dyn TypeDatabase,
+    element_types: Vec<TypeId>,
+) -> TypeId {
+    let elements = element_types
+        .into_iter()
+        .map(|type_id| TupleElement {
+            type_id,
+            name: None,
+            optional: false,
+            rest: false,
+        })
+        .collect();
+    tuple_type_from_elements(db, elements)
+}
+
+pub(crate) fn type_application_from_args(
+    db: &dyn TypeDatabase,
+    base: TypeId,
+    args: Vec<TypeId>,
+) -> TypeId {
+    db.application(base, args)
+}
+
+pub(crate) fn index_access_type(
+    db: &dyn TypeDatabase,
+    object_type: TypeId,
+    index_type: TypeId,
+) -> TypeId {
+    db.index_access(object_type, index_type)
 }
 
 pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {

--- a/crates/tsz-checker/src/query_boundaries/checkers/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod call;
 pub(crate) mod class_properties;
 pub(crate) mod constructor;
+pub(crate) mod decorators;
 pub(crate) mod generic;
 pub(crate) mod iterable;
 pub(crate) mod jsx;

--- a/crates/tsz-checker/src/query_boundaries/checkers/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod call;
+pub(crate) mod class_properties;
 pub(crate) mod constructor;
 pub(crate) mod generic;
 pub(crate) mod iterable;

--- a/crates/tsz-checker/src/query_boundaries/checkers/promise.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/promise.rs
@@ -1,7 +1,9 @@
 use tsz_solver::construction::TypeDatabase;
 use tsz_solver::{CallSignature, FunctionShape, TypeId};
 
-pub(crate) use super::super::common::{application_info, lazy_def_id, union_members};
+pub(crate) use super::super::common::{
+    application_info, intersection_members, lazy_def_id, union_members,
+};
 pub(crate) use tsz_solver::type_queries::PromiseTypeKind;
 
 pub(crate) fn call_signatures_for_type(
@@ -27,4 +29,48 @@ pub(crate) fn type_application(
     type_id: TypeId,
 ) -> Option<std::sync::Arc<tsz_solver::TypeApplication>> {
     tsz_solver::type_queries::get_type_application(db, type_id)
+}
+
+pub(crate) fn promise_application_type(
+    db: &dyn TypeDatabase,
+    promise_base: TypeId,
+    type_arg: TypeId,
+) -> TypeId {
+    db.application(promise_base, vec![type_arg])
+}
+
+pub(crate) fn await_contextual_operand_type(
+    db: &dyn TypeDatabase,
+    contextual: TypeId,
+    promise_like: TypeId,
+    promise: Option<TypeId>,
+) -> TypeId {
+    let mut members = vec![contextual, promise_like];
+    if let Some(promise) = promise {
+        members.push(promise);
+    }
+    db.union(members)
+}
+
+pub(crate) fn awaited_union_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn awaited_intersection_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.intersection(members)
+}
+
+pub(crate) fn thenable_callback_value_union(
+    db: &dyn TypeDatabase,
+    values: Vec<TypeId>,
+) -> Option<TypeId> {
+    match values.as_slice() {
+        [] => None,
+        [only] => Some(*only),
+        _ => Some(db.union(values)),
+    }
+}
+
+pub(crate) fn async_return_body_union(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
 }

--- a/crates/tsz-checker/src/query_boundaries/class_type.rs
+++ b/crates/tsz-checker/src/query_boundaries/class_type.rs
@@ -1,5 +1,11 @@
-use tsz_solver::TypeId;
+use tsz_binder::SymbolId;
+use tsz_common::interner::Atom;
 use tsz_solver::construction::TypeDatabase;
+use tsz_solver::def::DefId;
+use tsz_solver::{
+    CallSignature, CallableShape, IndexSignature, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
+    TypePredicate, TypePredicateTarget, Visibility,
+};
 
 pub(crate) use super::common::{
     array_element_type, callable_shape_for_type, construct_signatures_for_type,
@@ -56,4 +62,200 @@ pub(crate) fn undefined_is_assignable_to(db: &dyn TypeDatabase, type_id: TypeId)
     }
 
     false
+}
+
+pub(crate) fn merged_static_late_bound_index_value_type(
+    db: &dyn TypeDatabase,
+    existing: TypeId,
+    incoming: TypeId,
+) -> TypeId {
+    db.union2(existing, incoming)
+}
+
+pub(crate) const fn static_late_bound_index_signature(
+    key_type: TypeId,
+    value_type: TypeId,
+) -> IndexSignature {
+    IndexSignature {
+        key_type,
+        value_type,
+        readonly: false,
+        param_name: None,
+    }
+}
+
+pub(crate) fn partial_static_method_type(
+    db: &dyn TypeDatabase,
+    signatures: &[CallSignature],
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures: signatures.to_vec(),
+        construct_signatures: Vec::new(),
+        properties: Vec::new(),
+        string_index: None,
+        number_index: None,
+        symbol: None,
+        is_abstract: false,
+    })
+}
+
+pub(crate) const fn partial_static_method_property(
+    name: Atom,
+    type_id: TypeId,
+    optional: bool,
+    visibility: Visibility,
+    parent_id: Option<SymbolId>,
+) -> PropertyInfo {
+    PropertyInfo {
+        name,
+        type_id,
+        write_type: type_id,
+        optional,
+        readonly: false,
+        is_method: true,
+        is_class_prototype: false,
+        visibility,
+        parent_id,
+        declaration_order: 0,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+pub(crate) const fn partial_static_accessor_property(
+    name: Atom,
+    read_type: TypeId,
+    write_type: TypeId,
+    readonly: bool,
+    visibility: Visibility,
+    parent_id: Option<SymbolId>,
+) -> PropertyInfo {
+    PropertyInfo {
+        name,
+        type_id: read_type,
+        write_type,
+        optional: false,
+        readonly,
+        is_method: false,
+        is_class_prototype: false,
+        visibility,
+        parent_id,
+        declaration_order: 0,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+pub(crate) const fn partial_static_placeholder_property(
+    name: Atom,
+    parent_id: Option<SymbolId>,
+) -> PropertyInfo {
+    PropertyInfo {
+        name,
+        type_id: TypeId::ANY,
+        write_type: TypeId::ANY,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id,
+        declaration_order: 0,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+pub(crate) fn partial_static_constructor_callable_type(
+    db: &dyn TypeDatabase,
+    symbol: Option<SymbolId>,
+    properties: Vec<PropertyInfo>,
+    construct_signatures: &[CallSignature],
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures: Vec::new(),
+        construct_signatures: construct_signatures.to_vec(),
+        properties,
+        string_index,
+        number_index,
+        symbol,
+        is_abstract: false,
+    })
+}
+
+pub(crate) fn class_constructor_companion_lazy_type(
+    db: &dyn TypeDatabase,
+    def_id: DefId,
+) -> TypeId {
+    db.lazy(def_id)
+}
+
+pub(crate) fn rough_self_instance_lazy_type(db: &dyn TypeDatabase, def_id: DefId) -> TypeId {
+    db.lazy(def_id)
+}
+
+pub(crate) fn rough_self_instance_application_type(
+    db: &dyn TypeDatabase,
+    lazy_ref: TypeId,
+    args: Vec<TypeId>,
+) -> TypeId {
+    db.application(lazy_ref, args)
+}
+
+pub(crate) const fn class_construct_param(
+    name: Option<Atom>,
+    type_id: TypeId,
+    optional: bool,
+    rest: bool,
+) -> ParamInfo {
+    ParamInfo {
+        name,
+        type_id,
+        optional,
+        rest,
+    }
+}
+
+pub(crate) const fn class_type_predicate(
+    asserts: bool,
+    target: TypePredicateTarget,
+    type_id: Option<TypeId>,
+    parameter_index: Option<usize>,
+) -> TypePredicate {
+    TypePredicate {
+        asserts,
+        target,
+        type_id,
+        parameter_index,
+    }
+}
+
+pub(crate) const fn class_construct_signature(
+    type_params: Vec<TypeParamInfo>,
+    params: Vec<ParamInfo>,
+    this_type: Option<TypeId>,
+    return_type: TypeId,
+    type_predicate: Option<TypePredicate>,
+    is_method: bool,
+) -> CallSignature {
+    CallSignature {
+        type_params,
+        params,
+        this_type,
+        return_type,
+        type_predicate,
+        is_method,
+    }
+}
+
+pub(crate) fn enclosing_function_type_param_type(db: &dyn TypeDatabase, name: Atom) -> TypeId {
+    db.type_param(TypeParamInfo::simple(name))
 }

--- a/crates/tsz-checker/src/query_boundaries/class_type.rs
+++ b/crates/tsz-checker/src/query_boundaries/class_type.rs
@@ -159,12 +159,114 @@ pub(crate) fn merged_class_instance_interface_type(
     }
 }
 
-pub(crate) fn partial_static_method_type(
+pub(crate) struct ClassMemberProperty {
+    name: Atom,
+    type_id: TypeId,
+    write_type: TypeId,
+    flags: u8,
+    visibility: Visibility,
+    parent_id: Option<SymbolId>,
+    declaration_order: u32,
+}
+
+impl ClassMemberProperty {
+    const OPTIONAL: u8 = 1 << 0;
+    const READONLY: u8 = 1 << 1;
+    const IS_METHOD: u8 = 1 << 2;
+    const IS_CLASS_PROTOTYPE: u8 = 1 << 3;
+    const IS_SYMBOL_NAMED: u8 = 1 << 4;
+
+    pub(crate) const fn new(name: Atom, type_id: TypeId) -> Self {
+        Self {
+            name,
+            type_id,
+            write_type: type_id,
+            flags: 0,
+            visibility: Visibility::Public,
+            parent_id: None,
+            declaration_order: 0,
+        }
+    }
+
+    const fn set_flag(&mut self, flag: u8, value: bool) {
+        if value {
+            self.flags |= flag;
+        } else {
+            self.flags &= !flag;
+        }
+    }
+
+    const fn flag(&self, flag: u8) -> bool {
+        self.flags & flag != 0
+    }
+
+    pub(crate) const fn with_write_type(mut self, write_type: TypeId) -> Self {
+        self.write_type = write_type;
+        self
+    }
+
+    pub(crate) const fn optional(mut self, optional: bool) -> Self {
+        self.set_flag(Self::OPTIONAL, optional);
+        self
+    }
+
+    pub(crate) const fn readonly(mut self, readonly: bool) -> Self {
+        self.set_flag(Self::READONLY, readonly);
+        self
+    }
+
+    pub(crate) const fn method(mut self, is_class_prototype: bool) -> Self {
+        self.set_flag(Self::IS_METHOD, true);
+        self.set_flag(Self::IS_CLASS_PROTOTYPE, is_class_prototype);
+        self
+    }
+
+    pub(crate) const fn visibility(mut self, visibility: Visibility) -> Self {
+        self.visibility = visibility;
+        self
+    }
+
+    pub(crate) const fn parent(mut self, parent_id: Option<SymbolId>) -> Self {
+        self.parent_id = parent_id;
+        self
+    }
+
+    pub(crate) const fn declaration_order(mut self, declaration_order: u32) -> Self {
+        self.declaration_order = declaration_order;
+        self
+    }
+
+    pub(crate) const fn symbol_named(mut self, is_symbol_named: bool) -> Self {
+        self.set_flag(Self::IS_SYMBOL_NAMED, is_symbol_named);
+        self
+    }
+}
+
+pub(crate) const fn class_member_property(surface: ClassMemberProperty) -> PropertyInfo {
+    PropertyInfo {
+        name: surface.name,
+        type_id: surface.type_id,
+        write_type: surface.write_type,
+        optional: surface.flag(ClassMemberProperty::OPTIONAL),
+        readonly: surface.flag(ClassMemberProperty::READONLY),
+        is_method: surface.flag(ClassMemberProperty::IS_METHOD),
+        is_class_prototype: surface.flag(ClassMemberProperty::IS_CLASS_PROTOTYPE),
+        visibility: surface.visibility,
+        parent_id: surface.parent_id,
+        declaration_order: surface.declaration_order,
+        is_string_named: false,
+        is_symbol_named: surface.flag(ClassMemberProperty::IS_SYMBOL_NAMED),
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+pub(crate) fn class_method_callable_type(
     db: &dyn TypeDatabase,
-    signatures: &[CallSignature],
+    signatures: Vec<CallSignature>,
 ) -> TypeId {
     db.callable(CallableShape {
-        call_signatures: signatures.to_vec(),
+        call_signatures: signatures,
         construct_signatures: Vec::new(),
         properties: Vec::new(),
         string_index: None,
@@ -174,6 +276,126 @@ pub(crate) fn partial_static_method_type(
     })
 }
 
+pub(crate) fn optional_class_member_type(
+    db: &dyn TypeDatabase,
+    member_type: TypeId,
+    optional: bool,
+) -> TypeId {
+    if optional {
+        db.union2(member_type, TypeId::UNDEFINED)
+    } else {
+        member_type
+    }
+}
+
+pub(crate) const fn class_rest_any_param() -> ParamInfo {
+    class_construct_param(None, TypeId::ANY, false, true)
+}
+
+pub(crate) const fn class_method_call_signature(
+    type_params: Vec<TypeParamInfo>,
+    params: Vec<ParamInfo>,
+    this_type: Option<TypeId>,
+    return_type: TypeId,
+    type_predicate: Option<TypePredicate>,
+) -> CallSignature {
+    class_construct_signature(
+        type_params,
+        params,
+        this_type,
+        return_type,
+        type_predicate,
+        true,
+    )
+}
+
+pub(crate) const fn class_declared_index_signature(
+    key_type: TypeId,
+    value_type: TypeId,
+    readonly: bool,
+    param_name: Option<Atom>,
+) -> IndexSignature {
+    IndexSignature {
+        key_type,
+        value_type,
+        readonly,
+        param_name,
+    }
+}
+
+pub(crate) fn class_member_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn class_member_object_with_indexes_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    symbol: Option<SymbolId>,
+) -> TypeId {
+    db.object_with_index(ObjectShape {
+        properties,
+        string_index,
+        number_index,
+        symbol,
+        ..ObjectShape::default()
+    })
+}
+
+pub(crate) fn class_member_partial_this_type(
+    db: &dyn TypeDatabase,
+    own_properties: Vec<PropertyInfo>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    symbol: Option<SymbolId>,
+    prescan_this_type: Option<TypeId>,
+) -> Option<TypeId> {
+    if own_properties.is_empty() {
+        return prescan_this_type;
+    }
+
+    let own_partial = class_member_object_with_indexes_type(
+        db,
+        own_properties,
+        string_index,
+        number_index,
+        symbol,
+    );
+    Some(if let Some(prescan) = prescan_this_type {
+        db.intersection(vec![own_partial, prescan])
+    } else {
+        own_partial
+    })
+}
+
+pub(crate) fn rough_class_instance_return_type(
+    db: &dyn TypeDatabase,
+    self_ref: Option<TypeId>,
+    rough_instance_return_type: TypeId,
+) -> TypeId {
+    match self_ref {
+        Some(self_ref)
+            if rough_instance_return_type != TypeId::ANY
+                && rough_instance_return_type != TypeId::ERROR =>
+        {
+            db.intersection2(self_ref, rough_instance_return_type)
+        }
+        Some(self_ref) => self_ref,
+        None => rough_instance_return_type,
+    }
+}
+
+pub(crate) fn partial_static_method_type(
+    db: &dyn TypeDatabase,
+    signatures: &[CallSignature],
+) -> TypeId {
+    class_method_callable_type(db, signatures.to_vec())
+}
+
 pub(crate) const fn partial_static_method_property(
     name: Atom,
     type_id: TypeId,
@@ -181,22 +403,13 @@ pub(crate) const fn partial_static_method_property(
     visibility: Visibility,
     parent_id: Option<SymbolId>,
 ) -> PropertyInfo {
-    PropertyInfo {
-        name,
-        type_id,
-        write_type: type_id,
-        optional,
-        readonly: false,
-        is_method: true,
-        is_class_prototype: false,
-        visibility,
-        parent_id,
-        declaration_order: 0,
-        is_string_named: false,
-        is_symbol_named: false,
-        single_quoted_name: false,
-        non_widening: false,
-    }
+    class_member_property(
+        ClassMemberProperty::new(name, type_id)
+            .optional(optional)
+            .method(false)
+            .visibility(visibility)
+            .parent(parent_id),
+    )
 }
 
 pub(crate) const fn partial_static_accessor_property(
@@ -207,44 +420,20 @@ pub(crate) const fn partial_static_accessor_property(
     visibility: Visibility,
     parent_id: Option<SymbolId>,
 ) -> PropertyInfo {
-    PropertyInfo {
-        name,
-        type_id: read_type,
-        write_type,
-        optional: false,
-        readonly,
-        is_method: false,
-        is_class_prototype: false,
-        visibility,
-        parent_id,
-        declaration_order: 0,
-        is_string_named: false,
-        is_symbol_named: false,
-        single_quoted_name: false,
-        non_widening: false,
-    }
+    class_member_property(
+        ClassMemberProperty::new(name, read_type)
+            .with_write_type(write_type)
+            .readonly(readonly)
+            .visibility(visibility)
+            .parent(parent_id),
+    )
 }
 
 pub(crate) const fn partial_static_placeholder_property(
     name: Atom,
     parent_id: Option<SymbolId>,
 ) -> PropertyInfo {
-    PropertyInfo {
-        name,
-        type_id: TypeId::ANY,
-        write_type: TypeId::ANY,
-        optional: false,
-        readonly: false,
-        is_method: false,
-        is_class_prototype: false,
-        visibility: Visibility::Public,
-        parent_id,
-        declaration_order: 0,
-        is_string_named: false,
-        is_symbol_named: false,
-        single_quoted_name: false,
-        non_widening: false,
-    }
+    class_member_property(ClassMemberProperty::new(name, TypeId::ANY).parent(parent_id))
 }
 
 pub(crate) fn partial_static_constructor_callable_type(

--- a/crates/tsz-checker/src/query_boundaries/class_type.rs
+++ b/crates/tsz-checker/src/query_boundaries/class_type.rs
@@ -3,8 +3,8 @@ use tsz_common::interner::Atom;
 use tsz_solver::construction::TypeDatabase;
 use tsz_solver::def::DefId;
 use tsz_solver::{
-    CallSignature, CallableShape, IndexSignature, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
-    TypePredicate, TypePredicateTarget, Visibility,
+    CallSignature, CallableShape, IndexSignature, ObjectShape, ParamInfo, PropertyInfo, TypeId,
+    TypeParamInfo, TypePredicate, TypePredicateTarget, Visibility,
 };
 
 pub(crate) use super::common::{
@@ -81,6 +81,81 @@ pub(crate) const fn static_late_bound_index_signature(
         value_type,
         readonly: false,
         param_name: None,
+    }
+}
+
+pub(crate) struct MergedClassInstanceInterfaceSurface {
+    result_is_callable: bool,
+    call_signatures: Vec<CallSignature>,
+    construct_signatures: Vec<CallSignature>,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    symbol: Option<SymbolId>,
+    plain_object_without_indexes: bool,
+}
+
+impl MergedClassInstanceInterfaceSurface {
+    pub(crate) const fn new(
+        result_is_callable: bool,
+        call_signatures: Vec<CallSignature>,
+        construct_signatures: Vec<CallSignature>,
+        properties: Vec<PropertyInfo>,
+        string_index: Option<IndexSignature>,
+        number_index: Option<IndexSignature>,
+        symbol: Option<SymbolId>,
+        plain_object_without_indexes: bool,
+    ) -> Self {
+        Self {
+            result_is_callable,
+            call_signatures,
+            construct_signatures,
+            properties,
+            string_index,
+            number_index,
+            symbol,
+            plain_object_without_indexes,
+        }
+    }
+}
+
+pub(crate) fn merged_class_instance_interface_type(
+    db: &dyn TypeDatabase,
+    surface: MergedClassInstanceInterfaceSurface,
+) -> TypeId {
+    let MergedClassInstanceInterfaceSurface {
+        result_is_callable,
+        call_signatures,
+        construct_signatures,
+        properties,
+        string_index,
+        number_index,
+        symbol,
+        plain_object_without_indexes,
+    } = surface;
+
+    if result_is_callable {
+        return db.callable(CallableShape {
+            call_signatures,
+            construct_signatures,
+            properties,
+            string_index,
+            number_index,
+            symbol,
+            is_abstract: false,
+        });
+    }
+
+    if plain_object_without_indexes {
+        db.object(properties)
+    } else {
+        db.object_with_index(ObjectShape {
+            properties,
+            string_index,
+            number_index,
+            symbol,
+            ..ObjectShape::default()
+        })
     }
 }
 
@@ -189,6 +264,34 @@ pub(crate) fn partial_static_constructor_callable_type(
         symbol,
         is_abstract: false,
     })
+}
+
+pub(crate) fn class_constructor_callable_type(
+    db: &dyn TypeDatabase,
+    symbol: Option<SymbolId>,
+    properties: Vec<PropertyInfo>,
+    construct_signatures: Vec<CallSignature>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    is_abstract: bool,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures: Vec::new(),
+        construct_signatures,
+        properties,
+        string_index,
+        number_index,
+        symbol,
+        is_abstract,
+    })
+}
+
+pub(crate) fn class_constructor_mixin_intersection(
+    db: &dyn TypeDatabase,
+    base_type_param: TypeId,
+    constructor_type: TypeId,
+) -> TypeId {
+    db.intersection2(base_type_param, constructor_type)
 }
 
 pub(crate) fn class_constructor_companion_lazy_type(

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -23,8 +23,8 @@ pub(crate) use tsz_solver::type_queries::{
     remapped_mapped_index_access_result,
 };
 pub(crate) use tsz_solver::{
-    FunctionShape, IntrinsicKind, MappedType, ParamInfo, PendingDiagnosticBuilder, SourceLocation,
-    SubtypeFailureReason, TypeFormatter,
+    FunctionShape, IntrinsicKind, MappedType, ParamInfo, PendingDiagnostic, PendingDiagnosticBuilder,
+    SourceLocation, SubtypeFailureReason, TypeFormatter,
     computation::{ContextualTypeContext, TypeSubstitution},
 };
 

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -116,6 +116,26 @@ pub(crate) fn function_type_from_parts(
     function_type_from_shape(db, FunctionShape::new(params, return_type))
 }
 
+/// Intern a function type preserving `shape` metadata with a new parameter list.
+pub(crate) fn function_type_with_params_replaced(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    params: Vec<ParamInfo>,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params,
+            this_type: shape.this_type,
+            return_type: shape.return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
 /// Intern the standalone function type for one signature (a constructor
 /// function when `is_constructor` is set).
 pub(crate) fn function_type_from_call_signature(

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -19,7 +19,8 @@
 
 use tsz_solver::construction::TypeDatabase;
 use tsz_solver::{
-    CallSignature, CallableShape, CallableShapeId, FunctionShape, ParamInfo, TypeId, TypePredicate,
+    CallSignature, CallableShape, CallableShapeId, FunctionShape, IndexSignature, ParamInfo,
+    PropertyInfo, TypeId, TypePredicate,
 };
 
 pub(crate) fn construct_signatures_for_type(
@@ -165,6 +166,15 @@ pub(crate) fn function_type_from_call_signature_preserving_method(
     })
 }
 
+/// Intern a type-literal method property as a function type.
+pub(crate) fn method_function_type_from_call_signature(
+    db: &dyn TypeDatabase,
+    mut sig: CallSignature,
+) -> TypeId {
+    sig.is_method = true;
+    function_type_from_call_signature_preserving_method(db, &sig, false)
+}
+
 /// Intern a bare callable carrying only call signatures.
 pub(crate) fn call_only_callable_type(
     db: &dyn TypeDatabase,
@@ -190,6 +200,27 @@ pub(crate) fn construct_only_callable_type(
 /// Intern a callable type from an explicit, helper-built shape.
 pub(crate) fn callable_type_from_shape(db: &dyn TypeDatabase, shape: CallableShape) -> TypeId {
     db.callable(shape)
+}
+
+/// Intern a type literal carrying call/construct signatures plus property and
+/// index members.
+pub(crate) fn type_literal_callable_type(
+    db: &dyn TypeDatabase,
+    call_signatures: Vec<CallSignature>,
+    construct_signatures: Vec<CallSignature>,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures,
+        construct_signatures,
+        properties,
+        string_index,
+        number_index,
+        symbol: None,
+        is_abstract: false,
+    })
 }
 
 /// Re-intern `base` with the given signature lists, preserving properties,

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -107,6 +107,15 @@ pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionSha
     db.function(shape)
 }
 
+/// Intern a simple function type from explicit parameter and return slots.
+pub(crate) fn function_type_from_parts(
+    db: &dyn TypeDatabase,
+    params: Vec<ParamInfo>,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_shape(db, FunctionShape::new(params, return_type))
+}
+
 /// Intern the standalone function type for one signature (a constructor
 /// function when `is_constructor` is set).
 pub(crate) fn function_type_from_call_signature(

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -17,6 +17,7 @@
 //! the one checker module that assembles `CallSignature` data from AST
 //! signatures.
 
+use tsz_binder::SymbolId;
 use tsz_solver::construction::TypeDatabase;
 use tsz_solver::{
     CallSignature, CallableShape, CallableShapeId, FunctionShape, IndexSignature, ParamInfo,
@@ -220,6 +221,39 @@ pub(crate) fn type_literal_callable_type(
         number_index,
         symbol: None,
         is_abstract: false,
+    })
+}
+
+pub(crate) fn declared_method_function_type(db: &dyn TypeDatabase, sig: CallSignature) -> TypeId {
+    db.function(FunctionShape {
+        type_params: sig.type_params,
+        params: sig.params,
+        this_type: sig.this_type,
+        return_type: sig.return_type,
+        type_predicate: sig.type_predicate,
+        is_constructor: false,
+        is_method: true,
+    })
+}
+
+pub(crate) fn declared_callable_surface_type(
+    db: &dyn TypeDatabase,
+    call_signatures: Vec<CallSignature>,
+    construct_signatures: Vec<CallSignature>,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    symbol: Option<SymbolId>,
+    is_abstract: bool,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures,
+        construct_signatures,
+        properties,
+        string_index,
+        number_index,
+        symbol,
+        is_abstract,
     })
 }
 

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -146,6 +146,25 @@ pub(crate) fn function_type_from_call_signature(
     db.function(function_shape_from_call_signature(sig, is_constructor))
 }
 
+/// Intern the standalone function type for one signature, preserving the
+/// signature's method-ness. Use this for fresh contextual call surfaces that
+/// originate from an AST declaration and must keep the declaration method flag.
+pub(crate) fn function_type_from_call_signature_preserving_method(
+    db: &dyn TypeDatabase,
+    sig: &CallSignature,
+    is_constructor: bool,
+) -> TypeId {
+    db.function(FunctionShape {
+        type_params: sig.type_params.clone(),
+        params: sig.params.clone(),
+        this_type: sig.this_type,
+        return_type: sig.return_type,
+        type_predicate: sig.type_predicate,
+        is_constructor,
+        is_method: sig.is_method,
+    })
+}
+
 /// Intern a bare callable carrying only call signatures.
 pub(crate) fn call_only_callable_type(
     db: &dyn TypeDatabase,
@@ -166,6 +185,11 @@ pub(crate) fn construct_only_callable_type(
         construct_signatures,
         ..CallableShape::default()
     })
+}
+
+/// Intern a callable type from an explicit, helper-built shape.
+pub(crate) fn callable_type_from_shape(db: &dyn TypeDatabase, shape: CallableShape) -> TypeId {
+    db.callable(shape)
 }
 
 /// Re-intern `base` with the given signature lists, preserving properties,

--- a/crates/tsz-checker/src/query_boundaries/declaration_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/declaration_exports.rs
@@ -1,0 +1,110 @@
+//! Declaration export surface construction boundary.
+//!
+//! Declaration checkers collect AST, binder, visibility, duplicate-diagnostic,
+//! and source-order facts. This module owns the solver types those facts become
+//! for namespace/module value surfaces.
+
+use tsz_binder::SymbolId;
+use tsz_common::{Atom, Visibility};
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::def::DefId;
+use tsz_solver::{CallableShape, ObjectFlags, PropertyInfo, TypeId};
+
+pub(crate) const fn declaration_export_property(
+    name: Atom,
+    type_id: TypeId,
+    declaration_order: u32,
+) -> PropertyInfo {
+    PropertyInfo {
+        name,
+        type_id,
+        write_type: type_id,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+pub(crate) fn declaration_lazy_export_type(db: &dyn TypeDatabase, def_id: DefId) -> TypeId {
+    db.lazy(def_id)
+}
+
+pub(crate) fn module_export_augmented_type(
+    db: &dyn TypeDatabase,
+    existing_type: TypeId,
+    augmentation_type: TypeId,
+) -> TypeId {
+    db.intersection2(existing_type, augmentation_type)
+}
+
+pub(crate) fn dynamic_import_module_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn dynamic_import_promise_type(
+    db: &dyn TypeDatabase,
+    promise_base: TypeId,
+    inner_type: TypeId,
+) -> TypeId {
+    db.application(promise_base, vec![inner_type])
+}
+
+pub(crate) fn empty_namespace_object_type(db: &dyn TypeDatabase) -> TypeId {
+    db.object(Vec::new())
+}
+
+pub(crate) fn namespace_object_placeholder_type(db: &dyn TypeDatabase) -> TypeId {
+    empty_namespace_object_type(db)
+}
+
+pub(crate) fn namespace_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    symbol: SymbolId,
+) -> TypeId {
+    db.object_with_flags_and_symbol(properties, ObjectFlags::empty(), Some(symbol))
+}
+
+pub(crate) fn namespace_merged_constructor_callable_type(
+    db: &dyn TypeDatabase,
+    shape: &CallableShape,
+    properties: Vec<PropertyInfo>,
+    symbol: SymbolId,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures: shape.call_signatures.clone(),
+        construct_signatures: shape.construct_signatures.clone(),
+        properties,
+        string_index: shape.string_index,
+        number_index: shape.number_index,
+        symbol: Some(symbol),
+        is_abstract: false,
+    })
+}
+
+pub(crate) fn namespace_merged_function_callable_type(
+    db: &dyn TypeDatabase,
+    shape: &CallableShape,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures: shape.call_signatures.clone(),
+        construct_signatures: shape.construct_signatures.clone(),
+        properties,
+        string_index: shape.string_index,
+        number_index: shape.number_index,
+        symbol: None,
+        is_abstract: false,
+    })
+}

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -66,6 +66,69 @@ pub(crate) fn object_type_preserving_display_properties(
     new_ty
 }
 
+pub(crate) fn shallow_object_property_literals_widened_for_call_parameter_display(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> TypeId {
+    let Some(shape) = object_shape_for_type(db, type_id) else {
+        return type_id;
+    };
+    let mut widened_shape = shape.as_ref().clone();
+    let mut changed = false;
+    for prop in &mut widened_shape.properties {
+        let widened_read = super::common::widen_literal_type(db, prop.type_id);
+        let widened_write = super::common::widen_literal_type(db, prop.write_type);
+        changed |= widened_read != prop.type_id || widened_write != prop.write_type;
+        prop.type_id = widened_read;
+        prop.write_type = widened_write;
+    }
+    if changed {
+        object_type_from_shape(db, widened_shape)
+    } else {
+        type_id
+    }
+}
+
+pub(crate) fn object_type_with_unknown_display_members(
+    db: &dyn TypeDatabase,
+    shape: &ObjectShape,
+) -> Option<TypeId> {
+    if shape.properties.is_empty() && shape.string_index.is_none() && shape.number_index.is_none() {
+        return None;
+    }
+
+    let properties = shape
+        .properties
+        .iter()
+        .map(|prop| {
+            let mut unknown_prop = PropertyInfo::new(prop.name, TypeId::UNKNOWN);
+            unknown_prop.optional = prop.optional;
+            unknown_prop.readonly = prop.readonly;
+            unknown_prop
+        })
+        .collect();
+
+    if shape.string_index.is_some() || shape.number_index.is_some() {
+        Some(object_type_from_shape(
+            db,
+            ObjectShape {
+                properties,
+                string_index: shape.string_index.map(|sig| tsz_solver::IndexSignature {
+                    value_type: TypeId::UNKNOWN,
+                    ..sig
+                }),
+                number_index: shape.number_index.map(|sig| tsz_solver::IndexSignature {
+                    value_type: TypeId::UNKNOWN,
+                    ..sig
+                }),
+                ..Default::default()
+            },
+        ))
+    } else {
+        Some(object_type_from_properties(db, properties))
+    }
+}
+
 pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {
     crate::query_boundaries::construct_signatures::function_type_from_shape(db, shape)
 }

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -165,6 +165,25 @@ pub(crate) fn function_type_from_call_signature_without_type_params(
     )
 }
 
+pub(crate) fn function_type_from_call_signature(
+    db: &dyn TypeDatabase,
+    sig: &CallSignature,
+    is_constructor: bool,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: sig.type_params.clone(),
+            params: sig.params.clone(),
+            this_type: sig.this_type,
+            return_type: sig.return_type,
+            type_predicate: sig.type_predicate,
+            is_constructor,
+            is_method: sig.is_method,
+        },
+    )
+}
+
 pub(crate) fn callable_type_from_shape(db: &dyn TypeDatabase, shape: CallableShape) -> TypeId {
     db.callable(shape)
 }

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -1,7 +1,9 @@
 use super::state::checking as state_checking;
-use tsz_solver::TypeId;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::def::{DefKind, DefinitionStore};
+use tsz_solver::{
+    CallSignature, CallableShape, FunctionShape, ObjectShape, ParamInfo, PropertyInfo, TypeId,
+};
 
 pub(crate) use super::common::{
     PropertyAccessResult, TypeResolver, TypeSubstitution, application_info, array_element_type,
@@ -39,6 +41,116 @@ pub(crate) fn get_object_symbol(
     type_id: TypeId,
 ) -> Option<tsz_binder::SymbolId> {
     tsz_solver::type_queries::get_object_symbol(db, type_id)
+}
+
+pub(crate) fn object_type_from_properties(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn object_type_from_shape(db: &dyn TypeDatabase, shape: ObjectShape) -> TypeId {
+    db.object_with_index(shape)
+}
+
+pub(crate) fn object_type_preserving_display_properties(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    shape: ObjectShape,
+) -> TypeId {
+    let new_ty = object_type_from_shape(db, shape);
+    if let Some(display_props) = db.get_display_properties(source) {
+        db.store_display_properties(new_ty, display_props.as_ref().clone());
+    }
+    new_ty
+}
+
+pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {
+    crate::query_boundaries::construct_signatures::function_type_from_shape(db, shape)
+}
+
+pub(crate) fn function_type_with_params_replaced(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    params: Vec<ParamInfo>,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params,
+            this_type: shape.this_type,
+            return_type: shape.return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
+pub(crate) fn function_type_with_return_replaced(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params: shape.params.clone(),
+            this_type: shape.this_type,
+            return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
+pub(crate) fn function_type_with_params_and_return_replaced(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+    params: Vec<ParamInfo>,
+    return_type: TypeId,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: shape.type_params.clone(),
+            params,
+            this_type: shape.this_type,
+            return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
+pub(crate) fn callable_type_from_shape(db: &dyn TypeDatabase, shape: CallableShape) -> TypeId {
+    db.callable(shape)
+}
+
+pub(crate) fn call_only_callable_type(
+    db: &dyn TypeDatabase,
+    call_signatures: Vec<CallSignature>,
+) -> TypeId {
+    crate::query_boundaries::construct_signatures::call_only_callable_type(db, call_signatures)
+}
+
+pub(crate) fn callable_type_with_signatures_replaced(
+    db: &dyn TypeDatabase,
+    base: &CallableShape,
+    call_signatures: Vec<CallSignature>,
+    construct_signatures: Vec<CallSignature>,
+) -> TypeId {
+    crate::query_boundaries::construct_signatures::callable_with_signatures_replaced(
+        db,
+        base,
+        call_signatures,
+        construct_signatures,
+    )
 }
 
 pub(crate) fn assignment_numeric_display_children(

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -128,6 +128,43 @@ pub(crate) fn function_type_with_params_and_return_replaced(
     )
 }
 
+pub(crate) fn function_type_without_type_params(
+    db: &dyn TypeDatabase,
+    shape: &FunctionShape,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: Vec::new(),
+            params: shape.params.clone(),
+            this_type: shape.this_type,
+            return_type: shape.return_type,
+            type_predicate: shape.type_predicate,
+            is_constructor: shape.is_constructor,
+            is_method: shape.is_method,
+        },
+    )
+}
+
+pub(crate) fn function_type_from_call_signature_without_type_params(
+    db: &dyn TypeDatabase,
+    sig: &CallSignature,
+    is_constructor: bool,
+) -> TypeId {
+    function_type_from_shape(
+        db,
+        FunctionShape {
+            type_params: Vec::new(),
+            params: sig.params.clone(),
+            this_type: sig.this_type,
+            return_type: sig.return_type,
+            type_predicate: sig.type_predicate,
+            is_constructor,
+            is_method: sig.is_method,
+        },
+    )
+}
+
 pub(crate) fn callable_type_from_shape(db: &dyn TypeDatabase, shape: CallableShape) -> TypeId {
     db.callable(shape)
 }

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -167,6 +167,36 @@ pub(crate) fn display_property_literals_widened_for_related_info(
     }
 }
 
+pub(crate) fn source_display_union_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    match members.as_slice() {
+        [single] => *single,
+        _ => db.union(members),
+    }
+}
+
+pub(crate) fn source_display_union_type_from_slice(
+    db: &dyn TypeDatabase,
+    members: &[TypeId],
+) -> TypeId {
+    match members {
+        [single] => *single,
+        _ => db.union_from_slice(members),
+    }
+}
+
+pub(crate) fn rebuilt_array_source_display_type(
+    db: &dyn TypeDatabase,
+    source_type: TypeId,
+    element_type: TypeId,
+) -> TypeId {
+    let rebuilt = db.array(element_type);
+    if tsz_solver::type_queries::is_readonly_type(db, source_type) {
+        db.readonly_type(rebuilt)
+    } else {
+        rebuilt
+    }
+}
+
 fn type_includes_undefined(db: &dyn TypeDatabase, ty: TypeId) -> bool {
     ty == TypeId::UNDEFINED
         || super::common::union_members(db, ty)

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -170,7 +170,7 @@ pub(crate) fn display_property_literals_widened_for_related_info(
 pub(crate) fn source_display_union_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
     match members.as_slice() {
         [single] => *single,
-        _ => db.union(members),
+        _ => display_union_type(db, members),
     }
 }
 
@@ -184,17 +184,123 @@ pub(crate) fn source_display_union_type_from_slice(
     }
 }
 
+pub(crate) fn display_application_type(
+    db: &dyn TypeDatabase,
+    base: TypeId,
+    args: Vec<TypeId>,
+) -> TypeId {
+    db.application(base, args)
+}
+
+pub(crate) fn display_union_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn display_union_or_single_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    tsz_solver::utils::union_or_single(db, members)
+}
+
+pub(crate) fn display_union_preserve_members_type(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> TypeId {
+    db.union_preserve_members(members)
+}
+
+pub(crate) fn display_intersection_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.intersection(members)
+}
+
+pub(crate) fn display_intersection_or_single_type(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> TypeId {
+    tsz_solver::utils::intersection_or_single(db, members)
+}
+
 pub(crate) fn rebuilt_array_source_display_type(
     db: &dyn TypeDatabase,
     source_type: TypeId,
     element_type: TypeId,
 ) -> TypeId {
-    let rebuilt = db.array(element_type);
+    let rebuilt = display_array_type(db, element_type);
     if tsz_solver::type_queries::is_readonly_type(db, source_type) {
         db.readonly_type(rebuilt)
     } else {
         rebuilt
     }
+}
+
+pub(crate) fn display_array_type(db: &dyn TypeDatabase, element_type: TypeId) -> TypeId {
+    db.array(element_type)
+}
+
+pub(crate) fn display_index_access_type(
+    db: &dyn TypeDatabase,
+    object_type: TypeId,
+    index_type: TypeId,
+) -> TypeId {
+    db.index_access(object_type, index_type)
+}
+
+pub(crate) fn display_union_with_undefined(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    db.union2(type_id, TypeId::UNDEFINED)
+}
+
+pub(crate) fn display_string_literal_type(db: &dyn TypeDatabase, value: &str) -> TypeId {
+    db.literal_string(value)
+}
+
+pub(crate) fn display_string_literal_atom_type(db: &dyn TypeDatabase, atom: Atom) -> TypeId {
+    db.literal_string_atom(atom)
+}
+
+pub(crate) fn display_number_literal_type(db: &dyn TypeDatabase, value: f64) -> TypeId {
+    db.literal_number(value)
+}
+
+pub(crate) fn display_rest_parameter_type(
+    db: &dyn TypeDatabase,
+    rest_param_type: TypeId,
+    rest_start: usize,
+    index: usize,
+    is_rest: bool,
+) -> TypeId {
+    if is_rest {
+        let element = display_index_access_type(db, rest_param_type, TypeId::NUMBER);
+        display_array_type(db, element)
+    } else {
+        let offset = index - rest_start;
+        let index_type = display_number_literal_type(db, offset as f64);
+        display_index_access_type(db, rest_param_type, index_type)
+    }
+}
+
+pub(crate) const fn display_property(name: Atom, type_id: TypeId) -> PropertyInfo {
+    PropertyInfo::new(name, type_id)
+}
+
+pub(crate) fn mapped_display_property(
+    name: Atom,
+    type_id: TypeId,
+    optional_modifier: Option<tsz_solver::MappedModifier>,
+    readonly_modifier: Option<tsz_solver::MappedModifier>,
+) -> PropertyInfo {
+    let mut property = display_property(name, type_id);
+    property.optional = optional_modifier == Some(tsz_solver::MappedModifier::Add);
+    property.readonly = readonly_modifier == Some(tsz_solver::MappedModifier::Add);
+    property
+}
+
+pub(crate) const fn static_schema_display_property_from_source(
+    source: &PropertyInfo,
+    type_id: TypeId,
+) -> PropertyInfo {
+    let mut property = display_property(source.name, type_id);
+    property.optional = source.optional;
+    property.readonly = source.readonly;
+    property.declaration_order = source.declaration_order;
+    property
 }
 
 fn type_includes_undefined(db: &dyn TypeDatabase, ty: TypeId) -> bool {

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -1,4 +1,5 @@
 use super::state::checking as state_checking;
+use tsz_common::interner::Atom;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::def::{DefKind, DefinitionStore};
 use tsz_solver::{
@@ -127,6 +128,49 @@ pub(crate) fn object_type_with_unknown_display_members(
     } else {
         Some(object_type_from_properties(db, properties))
     }
+}
+
+pub(crate) fn mapped_property_mismatch_parameter_display_type(
+    db: &dyn TypeDatabase,
+    property_name: Atom,
+    target_property_type: TypeId,
+) -> TypeId {
+    let mut property = PropertyInfo::new(property_name, target_property_type);
+    property.optional = type_includes_undefined(db, target_property_type);
+    object_type_from_properties(db, vec![property])
+}
+
+pub(crate) fn display_property_literals_widened_for_related_info(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> TypeId {
+    if db.get_display_properties(type_id).is_none() {
+        return type_id;
+    }
+    let Some(shape) = object_shape_for_type(db, type_id) else {
+        return type_id;
+    };
+
+    let mut widened_shape = shape.as_ref().clone();
+    let mut changed = false;
+    for prop in &mut widened_shape.properties {
+        let widened_read = super::common::widen_literal_type(db, prop.type_id);
+        let widened_write = super::common::widen_literal_type(db, prop.write_type);
+        changed |= widened_read != prop.type_id || widened_write != prop.write_type;
+        prop.type_id = widened_read;
+        prop.write_type = widened_write;
+    }
+    if changed {
+        object_type_from_shape(db, widened_shape)
+    } else {
+        type_id
+    }
+}
+
+fn type_includes_undefined(db: &dyn TypeDatabase, ty: TypeId) -> bool {
+    ty == TypeId::UNDEFINED
+        || super::common::union_members(db, ty)
+            .is_some_and(|members| members.contains(&TypeId::UNDEFINED))
 }
 
 pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {

--- a/crates/tsz-checker/src/query_boundaries/dispatch.rs
+++ b/crates/tsz-checker/src/query_boundaries/dispatch.rs
@@ -1,5 +1,6 @@
 use tsz_solver::TypeId;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
+use tsz_solver::def::DefId;
 use tsz_solver::relations::subtype::TypeResolver;
 
 pub(crate) use super::common::{intersection_members, is_type_parameter_like, union_members};
@@ -28,4 +29,19 @@ pub(crate) fn evaluate_type_with_resolver<R: TypeResolver>(
         tsz_solver::computation::TypeEvaluator::with_resolver(db.as_type_database(), resolver)
             .with_query_db(db);
     evaluator.evaluate(type_id)
+}
+
+pub(crate) fn generator_context_application(
+    db: &dyn TypeDatabase,
+    generator_def: DefId,
+    yield_type: TypeId,
+    result_type: TypeId,
+    next_type: TypeId,
+) -> TypeId {
+    let generator_base = db.lazy(generator_def);
+    db.application(generator_base, vec![yield_type, result_type, next_type])
+}
+
+pub(crate) fn yield_star_array_context(db: &dyn TypeDatabase, yield_type: TypeId) -> TypeId {
+    db.array(yield_type)
 }

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -1,8 +1,8 @@
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
-use tsz_solver::TypeId;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::narrowing::{GuardSense, NarrowingContext, TypeGuard};
+use tsz_solver::{CallSignature, PropertyInfo, TypeId};
 
 use super::{
     assignability::{RelationFlags, RelationOutcome},
@@ -37,6 +37,20 @@ pub(crate) fn array_type(db: &dyn QueryDatabase, element: TypeId) -> TypeId {
 
 pub(crate) fn empty_object_type(db: &dyn QueryDatabase) -> TypeId {
     db.object(Vec::new())
+}
+
+pub(crate) fn object_type_from_properties(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn call_only_callable_type(
+    db: &dyn TypeDatabase,
+    call_signatures: Vec<CallSignature>,
+) -> TypeId {
+    super::construct_signatures::call_only_callable_type(db, call_signatures)
 }
 
 pub(crate) fn tuple_type(

--- a/crates/tsz-checker/src/query_boundaries/import_attributes.rs
+++ b/crates/tsz-checker/src/query_boundaries/import_attributes.rs
@@ -1,0 +1,44 @@
+//! Import attribute/options construction boundary.
+//!
+//! Import declaration and dynamic-import checkers own AST traversal, grammar
+//! diagnostics, and relation anchors. This module owns the synthetic solver
+//! object shapes those syntax facts become for `ImportAttributes` and
+//! `ImportCallOptions` checks.
+
+use tsz_common::Atom;
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{PropertyInfo, TypeId};
+
+pub(crate) fn import_attribute_literal_string_type(db: &dyn TypeDatabase, value: &str) -> TypeId {
+    db.literal_string(value)
+}
+
+pub(crate) const fn import_attribute_property(name: Atom, type_id: TypeId) -> PropertyInfo {
+    PropertyInfo::new(name, type_id)
+}
+
+pub(crate) const fn optional_import_option_property(name: Atom, type_id: TypeId) -> PropertyInfo {
+    PropertyInfo::opt(name, type_id)
+}
+
+pub(crate) fn import_attribute_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn import_call_options_type(
+    db: &dyn TypeDatabase,
+    with_name: Atom,
+    assert_name: Atom,
+    import_attributes_type: TypeId,
+) -> TypeId {
+    import_attribute_object_type(
+        db,
+        vec![
+            optional_import_option_property(with_name, import_attributes_type),
+            optional_import_option_property(assert_name, import_attributes_type),
+        ],
+    )
+}

--- a/crates/tsz-checker/src/query_boundaries/indexed_access_key_space.rs
+++ b/crates/tsz-checker/src/query_boundaries/indexed_access_key_space.rs
@@ -1,0 +1,76 @@
+//! Indexed-access key-space construction boundary.
+//!
+//! Indexed-access validation owns source selection, diagnostics, and relation
+//! policy. This module owns the solver surfaces those checks compare, such as
+//! `keyof T`, `T[K]`, literal-key unions, and the `string | number` key space.
+
+use tsz_common::Atom;
+use tsz_solver::TypeId;
+use tsz_solver::construction::TypeDatabase;
+
+pub(crate) fn keyof_type(db: &dyn TypeDatabase, operand: TypeId) -> TypeId {
+    db.keyof(operand)
+}
+
+pub(crate) fn indexed_access_type(
+    db: &dyn TypeDatabase,
+    object_type: TypeId,
+    index_type: TypeId,
+) -> TypeId {
+    db.index_access(object_type, index_type)
+}
+
+pub(crate) fn literal_number_key(db: &dyn TypeDatabase, value: f64) -> TypeId {
+    db.literal_number(value)
+}
+
+pub(crate) fn literal_string_key(db: &dyn TypeDatabase, atom: Atom) -> TypeId {
+    db.literal_string_atom(atom)
+}
+
+pub(crate) fn literal_key_union(db: &dyn TypeDatabase, members: Vec<TypeId>) -> Option<TypeId> {
+    (!members.is_empty()).then(|| db.union(members))
+}
+
+pub(crate) fn key_space_union(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn string_or_number_key_space(db: &dyn TypeDatabase) -> TypeId {
+    db.union2(TypeId::STRING, TypeId::NUMBER)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsz_solver::construction::TypeInterner;
+
+    #[test]
+    fn constructs_indexed_access_key_space_surfaces() {
+        let db = TypeInterner::new();
+        let atom = db.intern_string("field");
+        let string_key = literal_string_key(&db, atom);
+        let number_key = literal_number_key(&db, 1.0);
+
+        assert_eq!(string_key, db.literal_string_atom(atom));
+        assert_eq!(number_key, db.literal_number(1.0));
+        assert_eq!(keyof_type(&db, TypeId::STRING), db.keyof(TypeId::STRING));
+        assert_eq!(
+            indexed_access_type(&db, TypeId::STRING, number_key),
+            db.index_access(TypeId::STRING, number_key)
+        );
+        assert_eq!(literal_key_union(&db, vec![]), None);
+        assert_eq!(
+            literal_key_union(&db, vec![string_key, number_key]),
+            Some(db.union(vec![string_key, number_key]))
+        );
+        assert_eq!(
+            key_space_union(&db, vec![TypeId::STRING, TypeId::NUMBER]),
+            db.union(vec![TypeId::STRING, TypeId::NUMBER])
+        );
+        assert_eq!(
+            string_or_number_key_space(&db),
+            db.union2(TypeId::STRING, TypeId::NUMBER)
+        );
+    }
+}

--- a/crates/tsz-checker/src/query_boundaries/intersection_display.rs
+++ b/crates/tsz-checker/src/query_boundaries/intersection_display.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use tsz_solver::construction::TypeDatabase;
 use tsz_solver::relations::subtype::TypeResolver;
 use tsz_solver::{ObjectShape, TypeId};
@@ -40,6 +41,28 @@ pub(crate) fn collected_properties_object_type<R: TypeResolver>(
                 Some(db.object(properties))
             }
         }
+        _ => None,
+    }
+}
+
+pub(crate) fn collected_properties_object_shape<R: TypeResolver>(
+    db: &dyn TypeDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> Option<Arc<ObjectShape>> {
+    match collect_properties(type_id, db, resolver) {
+        PropertyCollectionResult::Properties {
+            properties,
+            string_index,
+            number_index,
+            symbol_index,
+        } => Some(Arc::new(ObjectShape {
+            properties,
+            string_index,
+            number_index,
+            symbol_index,
+            ..ObjectShape::default()
+        })),
         _ => None,
     }
 }

--- a/crates/tsz-checker/src/query_boundaries/js_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports.rs
@@ -466,6 +466,156 @@ pub(crate) fn commonjs_export_constructor_type_with_instance(
     db.callable(new_shape)
 }
 
+pub(crate) struct CommonJsExpandoMember {
+    pub(crate) name: String,
+    pub(crate) type_id: TypeId,
+}
+
+fn commonjs_expando_property(
+    db: &dyn TypeDatabase,
+    member: &CommonJsExpandoMember,
+    declaration_order: u32,
+) -> PropertyInfo {
+    let type_id = crate::query_boundaries::common::widen_literal_type(db, member.type_id);
+    commonjs_namespace_export_property(db, &member.name, type_id, declaration_order)
+}
+
+pub(crate) fn commonjs_export_type_with_expando_members(
+    db: &dyn TypeDatabase,
+    base_type: TypeId,
+    members: &[CommonJsExpandoMember],
+) -> TypeId {
+    if members.is_empty() {
+        return base_type;
+    }
+
+    let object_type = commonjs_export_object_type_with_expando_members(db, base_type, members);
+    commonjs_export_callable_type_with_expando_members(db, object_type, members)
+}
+
+fn commonjs_export_object_type_with_expando_members(
+    db: &dyn TypeDatabase,
+    base_type: TypeId,
+    members: &[CommonJsExpandoMember],
+) -> TypeId {
+    let Some(shape) = crate::query_boundaries::common::object_shape_for_type(db, base_type) else {
+        return base_type;
+    };
+
+    let mut properties: FxHashMap<tsz_common::interner::Atom, PropertyInfo> = shape
+        .properties
+        .iter()
+        .map(|prop| (prop.name, prop.clone()))
+        .collect();
+    let mut changed = false;
+
+    for member in members {
+        let prop_atom = db.intern_string(&member.name);
+        if properties.contains_key(&prop_atom) {
+            continue;
+        }
+
+        properties.insert(
+            prop_atom,
+            commonjs_expando_property(db, member, properties.len() as u32),
+        );
+        changed = true;
+    }
+
+    if !changed {
+        return base_type;
+    }
+
+    db.object_with_index(ObjectShape {
+        flags: shape.flags,
+        properties: properties.into_values().collect(),
+        string_index: shape.string_index,
+        number_index: shape.number_index,
+        symbol_index: shape.symbol_index,
+        symbol: shape.symbol,
+    })
+}
+
+fn commonjs_export_callable_type_with_expando_members(
+    db: &dyn TypeDatabase,
+    base_type: TypeId,
+    members: &[CommonJsExpandoMember],
+) -> TypeId {
+    let (mut callable_shape, mut property_count) = if let Some(shape) =
+        crate::query_boundaries::common::callable_shape_for_type(db, base_type)
+    {
+        ((*shape).clone(), shape.properties.len())
+    } else if let Some(function_shape) =
+        crate::query_boundaries::common::function_shape_for_type(db, base_type)
+    {
+        let signature = CallSignature {
+            type_params: function_shape.type_params.clone(),
+            params: function_shape.params.clone(),
+            this_type: function_shape.this_type,
+            return_type: function_shape.return_type,
+            type_predicate: function_shape.type_predicate,
+            is_method: function_shape.is_method,
+        };
+        (
+            CallableShape {
+                call_signatures: if function_shape.is_constructor {
+                    Vec::new()
+                } else {
+                    vec![signature.clone()]
+                },
+                construct_signatures: if function_shape.is_constructor {
+                    vec![signature]
+                } else {
+                    Vec::new()
+                },
+                properties: Vec::new(),
+                string_index: None,
+                number_index: None,
+                symbol: None,
+                is_abstract: false,
+            },
+            0,
+        )
+    } else {
+        return base_type;
+    };
+
+    let mut properties: FxHashMap<tsz_common::interner::Atom, PropertyInfo> = callable_shape
+        .properties
+        .iter()
+        .map(|prop| (prop.name, prop.clone()))
+        .collect();
+    let mut changed = false;
+
+    for member in members {
+        let prop_type = crate::query_boundaries::common::widen_literal_type(db, member.type_id);
+        let prop_atom = db.intern_string(&member.name);
+        if let Some(existing) = properties.get_mut(&prop_atom) {
+            let existing_is_placeholder = existing.type_id.is_any_unknown_or_error();
+            if existing_is_placeholder && !matches!(prop_type, TypeId::ANY | TypeId::UNKNOWN) {
+                existing.type_id = prop_type;
+                existing.write_type = prop_type;
+                changed = true;
+            }
+            continue;
+        }
+
+        properties.insert(
+            prop_atom,
+            commonjs_expando_property(db, member, property_count as u32),
+        );
+        property_count += 1;
+        changed = true;
+    }
+
+    if !changed {
+        return base_type;
+    }
+
+    callable_shape.properties = properties.into_values().collect();
+    db.callable(callable_shape)
+}
+
 pub(crate) fn commonjs_empty_namespace_type(db: &dyn TypeDatabase) -> TypeId {
     db.object(Vec::new())
 }

--- a/crates/tsz-checker/src/query_boundaries/js_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports.rs
@@ -14,11 +14,13 @@
 //! The result is cached per target file index to avoid redundant computation.
 
 use crate::{context::is_js_file_name, state::CheckerState};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
+use serde_json::Value as JsonValue;
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
+use tsz_solver::construction::TypeDatabase;
 use tsz_solver::{CallableShape, ObjectShape, PropertyInfo, TypeId, Visibility};
 
 pub(crate) fn commonjs_direct_export_supports_named_props(
@@ -50,6 +52,241 @@ pub(crate) fn commonjs_direct_export_supports_named_props(
         || crate::query_boundaries::common::callable_shape_for_type(types, direct_export_type)
             .is_some()
         || tsz_solver::type_queries::get_function_shape(types, direct_export_type).is_some()
+}
+
+fn public_export_property(
+    db: &dyn TypeDatabase,
+    name: &str,
+    type_id: TypeId,
+    optional: bool,
+    declaration_order: u32,
+) -> PropertyInfo {
+    PropertyInfo {
+        name: db.intern_string(name),
+        type_id,
+        write_type: type_id,
+        optional,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+pub(crate) fn json_module_union(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn json_module_array_type(db: &dyn TypeDatabase, element_type: TypeId) -> TypeId {
+    db.array(element_type)
+}
+
+pub(crate) fn json_module_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn json_module_object_property(
+    db: &dyn TypeDatabase,
+    name: &str,
+    type_id: TypeId,
+    declaration_order: u32,
+) -> PropertyInfo {
+    public_export_property(db, name, type_id, false, declaration_order)
+}
+
+pub(crate) fn json_module_missing_property(
+    db: &dyn TypeDatabase,
+    name: &str,
+    declaration_order: u32,
+) -> PropertyInfo {
+    public_export_property(db, name, TypeId::UNDEFINED, true, declaration_order)
+}
+
+pub(crate) fn json_module_value_type(db: &dyn TypeDatabase, value: &JsonValue) -> TypeId {
+    match value {
+        JsonValue::Null => TypeId::NULL,
+        JsonValue::Bool(_) => TypeId::BOOLEAN,
+        JsonValue::Number(_) => TypeId::NUMBER,
+        JsonValue::String(_) => TypeId::STRING,
+        JsonValue::Array(elements) => json_array_type(db, elements),
+        JsonValue::Object(entries) => json_object_type(db, entries, None),
+    }
+}
+
+fn json_array_type(db: &dyn TypeDatabase, elements: &[JsonValue]) -> TypeId {
+    let object_property_order = json_array_object_property_order(elements);
+    let element_types: Vec<TypeId> = elements
+        .iter()
+        .map(|element| match element {
+            JsonValue::Object(entries) if !object_property_order.is_empty() => {
+                json_object_type(db, entries, Some(&object_property_order))
+            }
+            _ => json_module_value_type(db, element),
+        })
+        .collect();
+    let element_type = match element_types.as_slice() {
+        [] => TypeId::NEVER,
+        [single] => *single,
+        _ => json_module_union(db, element_types),
+    };
+    json_module_array_type(db, element_type)
+}
+
+fn json_array_object_property_order(elements: &[JsonValue]) -> Vec<String> {
+    let mut names = Vec::new();
+    for element in elements {
+        let JsonValue::Object(entries) = element else {
+            continue;
+        };
+        for name in entries.keys() {
+            if !names.iter().any(|existing| existing == name) {
+                names.push(name.clone());
+            }
+        }
+    }
+    names
+}
+
+fn json_object_type(
+    db: &dyn TypeDatabase,
+    entries: &serde_json::Map<String, JsonValue>,
+    complete_property_order: Option<&[String]>,
+) -> TypeId {
+    let mut props = Vec::with_capacity(entries.len());
+    let mut present_names = FxHashSet::default();
+    for (declaration_order, (name, entry_value)) in entries.iter().enumerate() {
+        let prop_type = json_module_value_type(db, entry_value);
+        present_names.insert(name.as_str());
+        props.push(json_module_object_property(
+            db,
+            name,
+            prop_type,
+            (declaration_order + 1) as u32,
+        ));
+    }
+
+    if let Some(all_names) = complete_property_order {
+        let mut declaration_order = props.len() as u32 + 1;
+        for name in all_names {
+            if present_names.contains(name.as_str()) {
+                continue;
+            }
+            props.push(json_module_missing_property(db, name, declaration_order));
+            declaration_order += 1;
+        }
+    }
+
+    json_module_object_type(db, props)
+}
+
+pub(crate) fn json_esm_namespace_type(db: &dyn TypeDatabase, json_type: TypeId) -> TypeId {
+    db.object(vec![public_export_property(
+        db, "default", json_type, false, 0,
+    )])
+}
+
+pub(crate) fn commonjs_json_namespace_type(db: &dyn TypeDatabase, json_type: TypeId) -> TypeId {
+    let default_atom = db.intern_string("default");
+    let Some(shape) = crate::query_boundaries::common::object_shape_for_type(db, json_type) else {
+        return json_type;
+    };
+    if !shape
+        .properties
+        .iter()
+        .any(|property| property.name == default_atom)
+    {
+        return json_type;
+    }
+
+    let mut properties = shape.properties.clone();
+    for property in &mut properties {
+        if property.name == default_atom {
+            property.type_id = json_type;
+            property.write_type = json_type;
+            property.optional = false;
+            property.readonly = false;
+            property.declaration_order = 0;
+        }
+    }
+    db.object(properties)
+}
+
+pub(crate) fn commonjs_namespace_any_property(
+    db: &dyn TypeDatabase,
+    name: &str,
+    declaration_order: u32,
+) -> PropertyInfo {
+    public_export_property(db, name, TypeId::ANY, false, declaration_order)
+}
+
+pub(crate) fn commonjs_empty_namespace_type(db: &dyn TypeDatabase) -> TypeId {
+    db.object(Vec::new())
+}
+
+pub(crate) fn commonjs_export_surface_can_merge_named_exports(
+    db: &dyn TypeDatabase,
+    surface: &JsExportSurface,
+) -> bool {
+    surface.direct_export_type.is_none_or(|direct_export_type| {
+        commonjs_direct_export_supports_named_props(db, direct_export_type)
+    })
+}
+
+pub(crate) fn current_file_commonjs_namespace_type(
+    checker: &mut CheckerState<'_>,
+    surface: JsExportSurface,
+    late_export_names: impl IntoIterator<Item = String>,
+    display_name: String,
+) -> TypeId {
+    let can_merge_named_exports =
+        commonjs_export_surface_can_merge_named_exports(checker.ctx.types, &surface);
+
+    let mut props = if can_merge_named_exports {
+        surface.named_exports
+    } else {
+        Vec::new()
+    };
+
+    if can_merge_named_exports {
+        for name in late_export_names {
+            let name_atom = checker.ctx.types.intern_string(&name);
+            if props.iter().any(|p| p.name == name_atom) {
+                continue;
+            }
+            props.push(commonjs_namespace_any_property(
+                checker.ctx.types,
+                &name,
+                props.len() as u32,
+            ));
+        }
+    }
+
+    let has_named_props = !props.is_empty();
+    JsExportSurface {
+        direct_export_type: surface.direct_export_type,
+        named_exports: props,
+        prototype_members: surface.prototype_members,
+        has_commonjs_exports: surface.has_commonjs_exports || has_named_props,
+        has_augmented_named_exports: surface.has_augmented_named_exports || has_named_props,
+    }
+    .to_type_id_with_display_name(checker, Some(display_name.clone()))
+    .unwrap_or_else(|| {
+        let empty_namespace = commonjs_empty_namespace_type(checker.ctx.types);
+        checker
+            .ctx
+            .namespace_module_names
+            .insert(empty_namespace, display_name);
+        empty_namespace
+    })
 }
 
 /// Represents the synthesized export surface of a JS/CommonJS module.
@@ -1052,7 +1289,7 @@ impl<'a> CheckerState<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::JsExportSurface;
+    use super::*;
     use tsz_solver::construction::TypeInterner;
     use tsz_solver::{PropertyInfo, TypeId, Visibility};
 
@@ -1099,5 +1336,74 @@ mod tests {
         assert_eq!(props[0].declaration_order, 1);
         assert_eq!(db.resolve_atom_ref(props[1].name).as_ref(), "configs");
         assert_eq!(props[1].declaration_order, 2);
+    }
+
+    #[test]
+    fn constructs_commonjs_json_export_surfaces() {
+        let db = TypeInterner::new();
+        let present = json_module_object_property(&db, "present", TypeId::STRING, 1);
+        assert_eq!(db.resolve_atom_ref(present.name).as_ref(), "present");
+        assert_eq!(present.type_id, TypeId::STRING);
+        assert!(!present.optional);
+        assert_eq!(present.declaration_order, 1);
+
+        let missing = json_module_missing_property(&db, "missing", 2);
+        assert_eq!(db.resolve_atom_ref(missing.name).as_ref(), "missing");
+        assert_eq!(missing.type_id, TypeId::UNDEFINED);
+        assert_eq!(missing.write_type, TypeId::UNDEFINED);
+        assert!(missing.optional);
+
+        let object = json_module_object_type(&db, vec![present.clone(), missing]);
+        assert_eq!(
+            object,
+            db.object(vec![
+                present,
+                json_module_missing_property(&db, "missing", 2)
+            ])
+        );
+        assert_eq!(
+            json_module_union(&db, vec![TypeId::STRING, TypeId::NUMBER]),
+            db.union(vec![TypeId::STRING, TypeId::NUMBER])
+        );
+        assert_eq!(
+            json_module_array_type(&db, TypeId::STRING),
+            db.array(TypeId::STRING)
+        );
+
+        let esm_namespace = json_esm_namespace_type(&db, TypeId::BOOLEAN);
+        let esm_shape = tsz_solver::type_queries::get_object_shape(&db, esm_namespace)
+            .expect("ESM JSON namespace should be an object");
+        assert_eq!(esm_shape.properties.len(), 1);
+        let default_prop = &esm_shape.properties[0];
+        assert_eq!(db.resolve_atom_ref(default_prop.name).as_ref(), "default");
+        assert_eq!(default_prop.type_id, TypeId::BOOLEAN);
+        assert!(!default_prop.optional);
+
+        assert_eq!(commonjs_json_namespace_type(&db, object), object);
+
+        let object_with_default = json_module_object_type(
+            &db,
+            vec![json_module_object_property(
+                &db,
+                "default",
+                TypeId::STRING,
+                1,
+            )],
+        );
+        let cjs_namespace = commonjs_json_namespace_type(&db, object_with_default);
+        let cjs_shape = tsz_solver::type_queries::get_object_shape(&db, cjs_namespace)
+            .expect("CJS JSON namespace should be an object");
+        assert_eq!(cjs_shape.properties.len(), 1);
+        assert_eq!(cjs_shape.properties[0].type_id, object_with_default);
+        assert_eq!(cjs_shape.properties[0].write_type, object_with_default);
+        assert!(!cjs_shape.properties[0].optional);
+        assert!(!cjs_shape.properties[0].readonly);
+
+        let late = commonjs_namespace_any_property(&db, "late", 3);
+        assert_eq!(db.resolve_atom_ref(late.name).as_ref(), "late");
+        assert_eq!(late.type_id, TypeId::ANY);
+        assert_eq!(late.write_type, TypeId::ANY);
+        assert!(!late.optional);
+        assert_eq!(commonjs_empty_namespace_type(&db), db.object(Vec::new()));
     }
 }

--- a/crates/tsz-checker/src/query_boundaries/js_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports.rs
@@ -21,7 +21,10 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::construction::TypeDatabase;
-use tsz_solver::{CallableShape, ObjectShape, PropertyInfo, TypeId, Visibility};
+use tsz_solver::{
+    CallSignature, CallableShape, FunctionShape, ObjectShape, ParamInfo, PropertyInfo, TypeId,
+    Visibility,
+};
 
 pub(crate) fn commonjs_direct_export_supports_named_props(
     types: &dyn tsz_solver::construction::TypeDatabase,
@@ -228,6 +231,241 @@ pub(crate) fn commonjs_namespace_any_property(
     public_export_property(db, name, TypeId::ANY, false, declaration_order)
 }
 
+pub(crate) fn commonjs_namespace_export_property(
+    db: &dyn TypeDatabase,
+    name: &str,
+    type_id: TypeId,
+    declaration_order: u32,
+) -> PropertyInfo {
+    public_export_property(db, name, type_id, false, declaration_order)
+}
+
+fn commonjs_export_property_with_write(
+    db: &dyn TypeDatabase,
+    name: &str,
+    type_id: TypeId,
+    write_type: TypeId,
+    readonly: bool,
+    is_method: bool,
+    declaration_order: u32,
+) -> PropertyInfo {
+    PropertyInfo {
+        name: db.intern_string(name),
+        type_id,
+        write_type,
+        optional: false,
+        readonly,
+        is_method,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+fn widen_commonjs_descriptor_type(db: &dyn TypeDatabase, ty: TypeId) -> TypeId {
+    crate::query_boundaries::common::widen_type(
+        db,
+        crate::query_boundaries::common::widen_freshness(db, ty),
+    )
+}
+
+pub(crate) fn commonjs_define_property_setter_contextual_function_type(
+    db: &dyn TypeDatabase,
+    getter_type: Option<TypeId>,
+) -> Option<TypeId> {
+    getter_type.map(|ty| {
+        db.function(FunctionShape::new(
+            vec![ParamInfo::unnamed(ty)],
+            TypeId::VOID,
+        ))
+    })
+}
+
+pub(crate) struct CommonJsDefinePropertyDescriptorFacts {
+    pub(crate) value_type: Option<TypeId>,
+    pub(crate) getter_type: Option<TypeId>,
+    pub(crate) setter_type: Option<TypeId>,
+    pub(crate) has_value: bool,
+    pub(crate) has_setter: bool,
+    pub(crate) writable_true: bool,
+}
+
+pub(crate) fn commonjs_define_property_descriptor_property(
+    db: &dyn TypeDatabase,
+    name: &str,
+    facts: CommonJsDefinePropertyDescriptorFacts,
+    declaration_order: u32,
+) -> PropertyInfo {
+    let has_getter = facts.getter_type.is_some();
+    let has_accessor_descriptor = has_getter || facts.has_setter;
+    let has_data_descriptor = facts.has_value || facts.writable_true;
+
+    if (!has_accessor_descriptor && !has_data_descriptor)
+        || (has_accessor_descriptor && has_data_descriptor)
+        || (facts.writable_true && !facts.has_value && !has_accessor_descriptor)
+    {
+        return commonjs_export_property_with_write(
+            db,
+            name,
+            TypeId::ANY,
+            TypeId::ANY,
+            true,
+            false,
+            declaration_order,
+        );
+    }
+
+    let value_type = facts
+        .value_type
+        .map(|ty| widen_commonjs_descriptor_type(db, ty));
+    let getter_type = facts
+        .getter_type
+        .map(|ty| widen_commonjs_descriptor_type(db, ty));
+    let mut setter_type = facts
+        .setter_type
+        .map(|ty| widen_commonjs_descriptor_type(db, ty));
+
+    if facts.has_setter && setter_type == Some(TypeId::ANY) && getter_type.is_some() {
+        setter_type = getter_type;
+    }
+
+    let writable = facts.has_setter || (facts.has_value && facts.writable_true);
+    let precise_setter_type = setter_type.filter(|&ty| ty != TypeId::ANY && ty != TypeId::UNKNOWN);
+    let read_type = value_type
+        .or(getter_type)
+        .or(setter_type)
+        .unwrap_or(TypeId::ANY);
+    let write_type = if writable {
+        precise_setter_type
+            .or(getter_type)
+            .or(value_type)
+            .unwrap_or(read_type)
+    } else {
+        read_type
+    };
+
+    commonjs_export_property_with_write(
+        db,
+        name,
+        read_type,
+        write_type,
+        !writable,
+        false,
+        declaration_order,
+    )
+}
+
+pub(crate) fn commonjs_type_with_define_property_members(
+    db: &dyn TypeDatabase,
+    base_type: TypeId,
+    props: Vec<PropertyInfo>,
+) -> TypeId {
+    if props.is_empty() {
+        return base_type;
+    }
+
+    let base_shape = crate::query_boundaries::common::object_shape_for_type(db, base_type)
+        .map(|shape| shape.as_ref().clone())
+        .or_else(|| {
+            let widened = crate::query_boundaries::common::widen_freshness(db, base_type);
+            crate::query_boundaries::common::object_shape_for_type(db, widened)
+                .map(|shape| shape.as_ref().clone())
+        });
+
+    if let Some(shape) = base_shape {
+        let mut merged_props = shape.properties;
+        for prop in props {
+            if let Some(existing) = merged_props
+                .iter_mut()
+                .find(|existing| existing.name == prop.name)
+            {
+                *existing = prop;
+            } else {
+                merged_props.push(prop);
+            }
+        }
+
+        if shape.string_index.is_some()
+            || shape.number_index.is_some()
+            || shape.symbol_index.is_some()
+        {
+            return db.object_with_index(ObjectShape {
+                flags: shape.flags,
+                properties: merged_props,
+                string_index: shape.string_index,
+                number_index: shape.number_index,
+                symbol_index: shape.symbol_index,
+                symbol: shape.symbol,
+            });
+        }
+
+        return db.object_with_flags_and_symbol(merged_props, shape.flags, shape.symbol);
+    }
+
+    let define_property_type = db.object(props);
+    if base_type.is_unknown_or_error() {
+        define_property_type
+    } else {
+        db.intersection2(base_type, define_property_type)
+    }
+}
+
+pub(crate) fn commonjs_export_constructor_type_with_instance(
+    db: &dyn TypeDatabase,
+    rhs_type: TypeId,
+    instance_type: TypeId,
+    symbol: Option<SymbolId>,
+) -> TypeId {
+    if let Some(func) = crate::query_boundaries::common::function_shape_for_type(db, rhs_type) {
+        if func.is_constructor {
+            return rhs_type;
+        }
+
+        let call_sig = CallSignature {
+            type_params: func.type_params.clone(),
+            params: func.params.clone(),
+            this_type: func.this_type,
+            return_type: func.return_type,
+            type_predicate: func.type_predicate,
+            is_method: func.is_method,
+        };
+        let construct_sig = CallSignature {
+            return_type: instance_type,
+            ..call_sig.clone()
+        };
+        return db.callable(CallableShape {
+            call_signatures: vec![call_sig],
+            construct_signatures: vec![construct_sig],
+            properties: Vec::new(),
+            string_index: None,
+            number_index: None,
+            symbol,
+            is_abstract: false,
+        });
+    }
+
+    let Some(shape) = crate::query_boundaries::common::callable_shape_for_type(db, rhs_type) else {
+        return rhs_type;
+    };
+    if !shape.construct_signatures.is_empty() || shape.call_signatures.is_empty() {
+        return rhs_type;
+    }
+
+    let mut new_shape = shape.as_ref().clone();
+    let mut construct_sig = new_shape.call_signatures[0].clone();
+    construct_sig.return_type = instance_type;
+    new_shape.construct_signatures.push(construct_sig);
+    if new_shape.symbol.is_none() {
+        new_shape.symbol = symbol;
+    }
+    db.callable(new_shape)
+}
+
 pub(crate) fn commonjs_empty_namespace_type(db: &dyn TypeDatabase) -> TypeId {
     db.object(Vec::new())
 }
@@ -287,6 +525,63 @@ pub(crate) fn current_file_commonjs_namespace_type(
             .insert(empty_namespace, display_name);
         empty_namespace
     })
+}
+
+pub(crate) fn commonjs_export_surface_type_with_display_name(
+    checker: &mut CheckerState<'_>,
+    surface: &JsExportSurface,
+    display_name: String,
+) -> Option<TypeId> {
+    surface.to_type_id_with_display_name(checker, Some(display_name))
+}
+
+pub(crate) fn commonjs_imported_module_value_type(
+    checker: &mut CheckerState<'_>,
+    mut props: Vec<PropertyInfo>,
+    export_equals_type: Option<TypeId>,
+    module_is_non_module_entity: bool,
+    display_module_name: Option<String>,
+) -> Option<TypeId> {
+    let namespace_type = (!props.is_empty()).then(|| {
+        JsExportSurface::normalize_property_declaration_order(&mut props);
+        let namespace_type = checker.ctx.types.object(props);
+        if let Some(display_module_name) = display_module_name.as_ref() {
+            checker
+                .ctx
+                .namespace_module_names
+                .insert(namespace_type, display_module_name.clone());
+        }
+        namespace_type
+    });
+
+    if let Some(export_equals_type) = export_equals_type {
+        let result = if module_is_non_module_entity {
+            if checker.ctx.allow_synthetic_default_imports() {
+                namespace_type.unwrap_or(export_equals_type)
+            } else {
+                export_equals_type
+            }
+        } else {
+            namespace_type
+                .map(|namespace_type| {
+                    checker
+                        .ctx
+                        .types
+                        .intersection2(export_equals_type, namespace_type)
+                })
+                .unwrap_or(export_equals_type)
+        };
+        if let Some(display_module_name) = display_module_name {
+            checker
+                .ctx
+                .namespace_module_names
+                .entry(result)
+                .or_insert(display_module_name);
+        }
+        return Some(result);
+    }
+
+    namespace_type
 }
 
 /// Represents the synthesized export surface of a JS/CommonJS module.

--- a/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
@@ -1,0 +1,120 @@
+//! JSDoc construction boundary.
+//!
+//! JSDoc resolution code parses source text and gathers structural facts. This
+//! module owns the solver shape literals and interning for the object/function
+//! types those facts describe.
+
+use tsz_common::Atom;
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{
+    FunctionShape, IndexSignature, ObjectShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
+    TypePredicate,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum JsdocObjectIndexKind {
+    String,
+    Number,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct JsdocObjectIndexFact {
+    pub(crate) key_type: TypeId,
+    pub(crate) value_type: TypeId,
+    pub(crate) readonly: bool,
+    pub(crate) param_name: Option<Atom>,
+}
+
+impl JsdocObjectIndexFact {
+    const fn into_index_signature(self) -> IndexSignature {
+        IndexSignature {
+            key_type: self.key_type,
+            value_type: self.value_type,
+            readonly: self.readonly,
+            param_name: self.param_name,
+        }
+    }
+}
+
+pub(crate) const fn jsdoc_object_index_fact(
+    key_type: TypeId,
+    value_type: TypeId,
+    readonly: bool,
+    param_name: Option<Atom>,
+) -> Option<(JsdocObjectIndexKind, JsdocObjectIndexFact)> {
+    let kind = match key_type {
+        TypeId::STRING | TypeId::SYMBOL => JsdocObjectIndexKind::String,
+        TypeId::NUMBER => JsdocObjectIndexKind::Number,
+        _ => return None,
+    };
+    Some((
+        kind,
+        JsdocObjectIndexFact {
+            key_type,
+            value_type,
+            readonly,
+            param_name,
+        },
+    ))
+}
+
+pub(crate) fn jsdoc_empty_object_type(db: &dyn TypeDatabase) -> TypeId {
+    db.object(Vec::new())
+}
+
+pub(crate) fn jsdoc_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<JsdocObjectIndexFact>,
+    number_index: Option<JsdocObjectIndexFact>,
+) -> Option<TypeId> {
+    if properties.is_empty() && string_index.is_none() && number_index.is_none() {
+        return None;
+    }
+    if string_index.is_some() || number_index.is_some() {
+        Some(db.object_with_index(ObjectShape {
+            properties,
+            string_index: string_index.map(JsdocObjectIndexFact::into_index_signature),
+            number_index: number_index.map(JsdocObjectIndexFact::into_index_signature),
+            ..ObjectShape::default()
+        }))
+    } else {
+        Some(db.object(properties))
+    }
+}
+
+pub(crate) fn jsdoc_object_index_type(
+    db: &dyn TypeDatabase,
+    key_type: TypeId,
+    value_type: TypeId,
+    readonly: bool,
+    param_name: Option<Atom>,
+) -> Option<TypeId> {
+    let (kind, fact) = jsdoc_object_index_fact(key_type, value_type, readonly, param_name)?;
+    let (string_index, number_index) = match kind {
+        JsdocObjectIndexKind::String => (Some(fact), None),
+        JsdocObjectIndexKind::Number => (None, Some(fact)),
+    };
+    jsdoc_object_type(db, Vec::new(), string_index, number_index)
+}
+
+pub(crate) fn jsdoc_function_type(
+    db: &dyn TypeDatabase,
+    type_params: Vec<TypeParamInfo>,
+    params: Vec<ParamInfo>,
+    this_type: Option<TypeId>,
+    return_type: TypeId,
+    type_predicate: Option<TypePredicate>,
+    is_constructor: bool,
+    is_method: bool,
+) -> TypeId {
+    db.function(FunctionShape {
+        type_params,
+        params,
+        this_type,
+        return_type,
+        type_predicate,
+        is_constructor,
+        is_method,
+    })
+}

--- a/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
@@ -6,9 +6,11 @@
 
 use tsz_common::Atom;
 use tsz_solver::construction::TypeDatabase;
+use tsz_solver::def::DefId;
 use tsz_solver::{
     ConditionalType, FunctionShape, IndexSignature, MappedModifier, MappedType, ObjectShape,
     ParamInfo, PropertyInfo, TupleElement, TypeId, TypeParamInfo, TypeParamOrigin, TypePredicate,
+    TypePredicateTarget,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -106,6 +108,26 @@ pub(crate) fn jsdoc_keyof_type(db: &dyn TypeDatabase, operand: TypeId) -> TypeId
     db.keyof(operand)
 }
 
+pub(crate) fn jsdoc_lazy_type(db: &dyn TypeDatabase, def_id: DefId) -> TypeId {
+    db.lazy(def_id)
+}
+
+pub(crate) fn jsdoc_readonly_type(db: &dyn TypeDatabase, inner: TypeId) -> TypeId {
+    db.readonly_type(inner)
+}
+
+pub(crate) fn jsdoc_literal_string_type(db: &dyn TypeDatabase, value: &str) -> TypeId {
+    db.literal_string(value)
+}
+
+pub(crate) fn jsdoc_literal_boolean_type(db: &dyn TypeDatabase, value: bool) -> TypeId {
+    db.literal_boolean(value)
+}
+
+pub(crate) fn jsdoc_literal_number_type(db: &dyn TypeDatabase, value: f64) -> TypeId {
+    db.literal_number(value)
+}
+
 pub(crate) const fn jsdoc_type_param_info(
     name: Atom,
     constraint: Option<TypeId>,
@@ -179,6 +201,20 @@ pub(crate) const fn jsdoc_property_info(
         is_symbol_named: false,
         single_quoted_name: false,
         non_widening: false,
+    }
+}
+
+pub(crate) const fn jsdoc_type_predicate(
+    asserts: bool,
+    target: TypePredicateTarget,
+    type_id: Option<TypeId>,
+    parameter_index: Option<usize>,
+) -> TypePredicate {
+    TypePredicate {
+        asserts,
+        target,
+        type_id,
+        parameter_index,
     }
 }
 

--- a/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
@@ -142,6 +142,46 @@ pub(crate) const fn jsdoc_tuple_element(
     }
 }
 
+pub(crate) const fn jsdoc_param_info(
+    name: Option<Atom>,
+    type_id: TypeId,
+    optional: bool,
+    rest: bool,
+) -> ParamInfo {
+    ParamInfo {
+        name,
+        type_id,
+        optional,
+        rest,
+    }
+}
+
+pub(crate) const fn jsdoc_property_info(
+    name: Atom,
+    type_id: TypeId,
+    optional: bool,
+    readonly: bool,
+    is_method: bool,
+    declaration_order: u32,
+) -> PropertyInfo {
+    PropertyInfo {
+        name,
+        type_id,
+        write_type: type_id,
+        optional,
+        readonly,
+        is_method,
+        is_class_prototype: false,
+        visibility: tsz_solver::Visibility::Public,
+        parent_id: None,
+        declaration_order,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
 pub(crate) fn jsdoc_mapped_type(
     db: &dyn TypeDatabase,
     type_param: TypeParamInfo,

--- a/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/jsdoc_construction.rs
@@ -7,8 +7,8 @@
 use tsz_common::Atom;
 use tsz_solver::construction::TypeDatabase;
 use tsz_solver::{
-    FunctionShape, IndexSignature, ObjectShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
-    TypePredicate,
+    ConditionalType, FunctionShape, IndexSignature, MappedModifier, MappedType, ObjectShape,
+    ParamInfo, PropertyInfo, TupleElement, TypeId, TypeParamInfo, TypeParamOrigin, TypePredicate,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -60,6 +60,119 @@ pub(crate) const fn jsdoc_object_index_fact(
 
 pub(crate) fn jsdoc_empty_object_type(db: &dyn TypeDatabase) -> TypeId {
     db.object(Vec::new())
+}
+
+pub(crate) fn jsdoc_array_type(db: &dyn TypeDatabase, element: TypeId) -> TypeId {
+    db.array(element)
+}
+
+pub(crate) fn jsdoc_union_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn jsdoc_union_pair_type(db: &dyn TypeDatabase, left: TypeId, right: TypeId) -> TypeId {
+    db.union2(left, right)
+}
+
+pub(crate) fn jsdoc_intersection_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.intersection(members)
+}
+
+pub(crate) fn jsdoc_intersection_pair_type(
+    db: &dyn TypeDatabase,
+    left: TypeId,
+    right: TypeId,
+) -> TypeId {
+    db.intersection2(left, right)
+}
+
+pub(crate) fn jsdoc_application_type(
+    db: &dyn TypeDatabase,
+    base: TypeId,
+    args: Vec<TypeId>,
+) -> TypeId {
+    db.application(base, args)
+}
+
+pub(crate) fn jsdoc_index_access_type(
+    db: &dyn TypeDatabase,
+    object_type: TypeId,
+    index_type: TypeId,
+) -> TypeId {
+    db.index_access(object_type, index_type)
+}
+
+pub(crate) fn jsdoc_keyof_type(db: &dyn TypeDatabase, operand: TypeId) -> TypeId {
+    db.keyof(operand)
+}
+
+pub(crate) const fn jsdoc_type_param_info(
+    name: Atom,
+    constraint: Option<TypeId>,
+    default: Option<TypeId>,
+) -> TypeParamInfo {
+    TypeParamInfo {
+        name,
+        constraint,
+        default,
+        is_const: false,
+        origin: TypeParamOrigin::User,
+    }
+}
+
+pub(crate) fn jsdoc_type_param_type(db: &dyn TypeDatabase, type_param: TypeParamInfo) -> TypeId {
+    db.type_param(type_param)
+}
+
+pub(crate) fn jsdoc_tuple_type(db: &dyn TypeDatabase, elements: Vec<TupleElement>) -> TypeId {
+    db.tuple(elements)
+}
+
+pub(crate) const fn jsdoc_tuple_element(
+    type_id: TypeId,
+    name: Option<Atom>,
+    optional: bool,
+    rest: bool,
+) -> TupleElement {
+    TupleElement {
+        type_id,
+        name,
+        optional,
+        rest,
+    }
+}
+
+pub(crate) fn jsdoc_mapped_type(
+    db: &dyn TypeDatabase,
+    type_param: TypeParamInfo,
+    constraint: TypeId,
+    template: TypeId,
+    optional_modifier: Option<MappedModifier>,
+) -> TypeId {
+    db.mapped(MappedType {
+        type_param,
+        constraint,
+        name_type: None,
+        template,
+        readonly_modifier: None,
+        optional_modifier,
+    })
+}
+
+pub(crate) fn jsdoc_conditional_type(
+    db: &dyn TypeDatabase,
+    check_type: TypeId,
+    extends_type: TypeId,
+    true_type: TypeId,
+    false_type: TypeId,
+) -> TypeId {
+    db.conditional(ConditionalType {
+        check_type,
+        extends_type,
+        true_type,
+        false_type,
+        is_distributive: true,
+    })
 }
 
 pub(crate) fn jsdoc_object_type(

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -38,6 +38,7 @@ pub(crate) mod flow;
 pub(crate) mod flow_analysis;
 pub(crate) mod function_returns;
 pub(crate) mod generic_instantiation;
+pub(crate) mod import_attributes;
 pub(crate) mod index_signature;
 pub(crate) mod inference;
 pub(crate) mod intersection_display;

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod conditional;
 pub(crate) mod conditional_constraints;
 pub(crate) mod conditional_infer_alias;
 pub(crate) mod construct_signatures;
+pub(crate) mod declaration_exports;
 pub(crate) mod definite_assignment;
 pub(crate) mod definition_identity;
 pub(crate) mod diagnostics;

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -41,6 +41,7 @@ pub(crate) mod index_signature;
 pub(crate) mod inference;
 pub(crate) mod intersection_display;
 pub(crate) mod js_exports;
+pub(crate) mod jsdoc_construction;
 pub(crate) mod key_constraints;
 pub(crate) mod lib_augmentations;
 pub(crate) mod name_resolution;

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -48,6 +48,7 @@ pub(crate) mod js_exports;
 pub(crate) mod jsdoc_construction;
 pub(crate) mod key_constraints;
 pub(crate) mod lib_augmentations;
+pub(crate) mod module_augmentation;
 pub(crate) mod name_resolution;
 pub(crate) mod object_literal_context;
 pub(crate) mod operator_wrappers;

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod application_keyof;
 pub(crate) mod assignability;
 pub(crate) mod assignability_alias_display;
 pub(crate) mod assignability_suppression;
+pub(crate) mod binding_patterns;
 pub(crate) mod capabilities;
 pub(crate) mod checkers;
 pub(crate) mod class;

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -48,6 +48,7 @@ pub(crate) mod jsdoc_construction;
 pub(crate) mod key_constraints;
 pub(crate) mod lib_augmentations;
 pub(crate) mod name_resolution;
+pub(crate) mod object_literal_context;
 pub(crate) mod operator_wrappers;
 pub(crate) mod optional_chain;
 pub(crate) mod property_access;

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -65,6 +65,7 @@ pub(crate) mod type_defaults;
 pub(crate) mod type_origin;
 pub(crate) mod type_parameter_identity;
 pub(crate) mod type_predicates;
+pub(crate) mod type_query_construction;
 pub(crate) mod type_rewrite;
 pub(crate) mod variance;
 pub(crate) mod widening;

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -41,6 +41,7 @@ pub(crate) mod function_returns;
 pub(crate) mod generic_instantiation;
 pub(crate) mod import_attributes;
 pub(crate) mod index_signature;
+pub(crate) mod indexed_access_key_space;
 pub(crate) mod inference;
 pub(crate) mod intersection_display;
 pub(crate) mod js_exports;

--- a/crates/tsz-checker/src/query_boundaries/module_augmentation.rs
+++ b/crates/tsz-checker/src/query_boundaries/module_augmentation.rs
@@ -1,0 +1,134 @@
+use tsz_binder::SymbolId;
+use tsz_common::interner::Atom;
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{
+    CallSignature, CallableShape, IndexSignature, ObjectFlags, ObjectShape, PropertyInfo, TypeId,
+    Visibility,
+};
+
+pub(crate) const fn augmentation_member_property(
+    name: Atom,
+    type_id: TypeId,
+    optional: bool,
+    readonly: bool,
+    is_method: bool,
+    declaration_order: u32,
+) -> PropertyInfo {
+    PropertyInfo {
+        name,
+        type_id,
+        write_type: type_id,
+        optional,
+        readonly,
+        is_method,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+pub(crate) const fn augmentation_any_member_property(
+    name: Atom,
+    readonly: bool,
+    is_method: bool,
+    declaration_order: u32,
+) -> PropertyInfo {
+    augmentation_member_property(
+        name,
+        TypeId::ANY,
+        false,
+        readonly,
+        is_method,
+        declaration_order,
+    )
+}
+
+pub(crate) const fn augmentation_value_member_property(
+    name: Atom,
+    type_id: TypeId,
+) -> PropertyInfo {
+    augmentation_member_property(name, type_id, false, false, false, 0)
+}
+
+pub(crate) const fn augmentation_any_value_member_property(name: Atom) -> PropertyInfo {
+    augmentation_any_member_property(name, false, false, 0)
+}
+
+pub(crate) const fn augmentation_any_method_member_property(name: Atom) -> PropertyInfo {
+    augmentation_any_member_property(name, false, true, 0)
+}
+
+pub(crate) fn self_reference_application_type(
+    db: &dyn TypeDatabase,
+    base_type: TypeId,
+    type_args: Vec<TypeId>,
+) -> TypeId {
+    db.application(base_type, type_args)
+}
+
+pub(crate) fn augmented_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    flags: ObjectFlags,
+    symbol: Option<SymbolId>,
+) -> TypeId {
+    db.object_with_flags_and_symbol(properties, flags, symbol)
+}
+
+pub(crate) fn augmented_object_with_index_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    flags: ObjectFlags,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    symbol_index: Option<IndexSignature>,
+    symbol: Option<SymbolId>,
+) -> TypeId {
+    db.object_with_index(ObjectShape {
+        flags,
+        properties,
+        string_index,
+        number_index,
+        symbol_index,
+        symbol,
+    })
+}
+
+pub(crate) fn augmented_callable_type(
+    db: &dyn TypeDatabase,
+    call_signatures: Vec<CallSignature>,
+    construct_signatures: Vec<CallSignature>,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    symbol: Option<SymbolId>,
+    is_abstract: bool,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures,
+        construct_signatures,
+        properties,
+        string_index,
+        number_index,
+        symbol,
+        is_abstract,
+    })
+}
+
+pub(crate) fn other_target_with_augmentation_members(
+    db: &dyn TypeDatabase,
+    base_type: TypeId,
+    augmentation_members: Vec<PropertyInfo>,
+) -> TypeId {
+    if augmentation_members.is_empty() {
+        return base_type;
+    }
+
+    let augmentation_object = db.object(augmentation_members);
+    db.intersection2(base_type, augmentation_object)
+}

--- a/crates/tsz-checker/src/query_boundaries/object_literal_context.rs
+++ b/crates/tsz-checker/src/query_boundaries/object_literal_context.rs
@@ -1,0 +1,27 @@
+use tsz_solver::TypeId;
+use tsz_solver::construction::TypeDatabase;
+
+pub(crate) fn contextual_union_preserve_members(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> TypeId {
+    db.union_preserve_members(members)
+}
+
+pub(crate) fn contextual_intersection(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.intersection(members)
+}
+
+pub(crate) fn mapped_contextual_property_number_key_type(
+    db: &dyn TypeDatabase,
+    value: f64,
+) -> TypeId {
+    db.literal_number(value)
+}
+
+pub(crate) fn mapped_contextual_property_string_key_type(
+    db: &dyn TypeDatabase,
+    value: &str,
+) -> TypeId {
+    db.literal_string(value)
+}

--- a/crates/tsz-checker/src/query_boundaries/object_literal_context.rs
+++ b/crates/tsz-checker/src/query_boundaries/object_literal_context.rs
@@ -1,5 +1,6 @@
-use tsz_solver::TypeId;
+use tsz_common::Atom;
 use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{CallSignature, CallableShape, ParamInfo, PropertyInfo, TypeId, Visibility};
 
 pub(crate) fn contextual_union_preserve_members(
     db: &dyn TypeDatabase,
@@ -24,4 +25,77 @@ pub(crate) fn mapped_contextual_property_string_key_type(
     value: &str,
 ) -> TypeId {
     db.literal_string(value)
+}
+
+pub(crate) fn synthetic_this_method_callable(
+    db: &dyn TypeDatabase,
+    params: Vec<ParamInfo>,
+    return_type: TypeId,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures: vec![CallSignature {
+            type_params: Vec::new(),
+            params,
+            this_type: None,
+            return_type,
+            type_predicate: None,
+            is_method: true,
+        }],
+        construct_signatures: Vec::new(),
+        properties: Vec::new(),
+        string_index: None,
+        number_index: None,
+        symbol: None,
+        is_abstract: false,
+    })
+}
+
+pub(crate) const fn synthetic_this_method_property(
+    name: Atom,
+    method_type: TypeId,
+    write_type: TypeId,
+    readonly: bool,
+    declaration_order: u32,
+) -> PropertyInfo {
+    synthetic_this_property(
+        name,
+        method_type,
+        write_type,
+        readonly,
+        true,
+        declaration_order,
+    )
+}
+
+pub(crate) const fn synthetic_this_property(
+    name: Atom,
+    type_id: TypeId,
+    write_type: TypeId,
+    readonly: bool,
+    is_method: bool,
+    declaration_order: u32,
+) -> PropertyInfo {
+    PropertyInfo {
+        name,
+        type_id,
+        write_type,
+        optional: false,
+        readonly,
+        is_method,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+pub(crate) fn synthetic_this_object(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
 }

--- a/crates/tsz-checker/src/query_boundaries/property_access.rs
+++ b/crates/tsz-checker/src/query_boundaries/property_access.rs
@@ -1,6 +1,9 @@
 use tsz_common::Atom;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
-use tsz_solver::{FunctionShape, TypeId};
+use tsz_solver::{
+    CallSignature, CallableShape, FunctionShape, ParamInfo, TupleElement, TypeId, TypeParamInfo,
+    TypeParamOrigin, TypePredicate,
+};
 
 pub(crate) use super::common::PropertyAccessResult;
 pub(crate) use super::common::intersection_members;
@@ -174,6 +177,190 @@ pub(crate) fn function_shape(
     type_id: TypeId,
 ) -> Option<std::sync::Arc<FunctionShape>> {
     tsz_solver::type_queries::get_function_shape(db, type_id)
+}
+
+pub(crate) const fn strict_bind_call_apply_param_with_type(
+    param: ParamInfo,
+    type_id: TypeId,
+) -> ParamInfo {
+    ParamInfo { type_id, ..param }
+}
+
+pub(crate) const fn strict_bind_call_apply_type_param_with_constraint(
+    type_param: TypeParamInfo,
+    constraint: Option<TypeId>,
+) -> TypeParamInfo {
+    TypeParamInfo {
+        constraint,
+        ..type_param
+    }
+}
+
+pub(crate) const fn strict_bind_call_apply_call_signature(
+    type_params: Vec<TypeParamInfo>,
+    params: Vec<ParamInfo>,
+    this_type: Option<TypeId>,
+    return_type: TypeId,
+    type_predicate: Option<TypePredicate>,
+    is_method: bool,
+) -> CallSignature {
+    CallSignature {
+        type_params,
+        params,
+        this_type,
+        return_type,
+        type_predicate,
+        is_method,
+    }
+}
+
+pub(crate) fn strict_bind_call_apply_signature_from_function_shape(
+    shape: &FunctionShape,
+) -> CallSignature {
+    strict_bind_call_apply_call_signature(
+        shape.type_params.clone(),
+        shape.params.clone(),
+        shape.this_type,
+        shape.return_type,
+        shape.type_predicate,
+        shape.is_method,
+    )
+}
+
+pub(crate) fn strict_bind_call_apply_params_tuple_type(
+    db: &dyn TypeDatabase,
+    params: &[ParamInfo],
+) -> TypeId {
+    let tuple_elements: Vec<TupleElement> = params
+        .iter()
+        .map(|param| TupleElement {
+            type_id: param.type_id,
+            name: param.name,
+            optional: param.optional && !param.rest,
+            rest: param.rest,
+        })
+        .collect();
+    db.tuple(tuple_elements)
+}
+
+pub(crate) fn strict_bind_call_apply_bound_return_type(
+    db: &dyn TypeDatabase,
+    sig: &CallSignature,
+    remaining_params: Vec<ParamInfo>,
+    is_constructor: bool,
+) -> TypeId {
+    if is_constructor {
+        return db.callable(CallableShape {
+            call_signatures: Vec::new(),
+            construct_signatures: vec![strict_bind_call_apply_call_signature(
+                sig.type_params.clone(),
+                remaining_params,
+                None,
+                sig.return_type,
+                None,
+                false,
+            )],
+            properties: Vec::new(),
+            string_index: None,
+            number_index: None,
+            symbol: None,
+            is_abstract: false,
+        });
+    }
+
+    db.function(FunctionShape {
+        type_params: sig.type_params.clone(),
+        params: remaining_params,
+        this_type: None,
+        return_type: sig.return_type,
+        type_predicate: sig.type_predicate,
+        is_constructor: false,
+        is_method: false,
+    })
+}
+
+pub(crate) fn strict_bind_call_apply_call_only_callable_type(
+    db: &dyn TypeDatabase,
+    call_signatures: Vec<CallSignature>,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures,
+        construct_signatures: Vec::new(),
+        properties: Vec::new(),
+        string_index: None,
+        number_index: None,
+        symbol: None,
+        is_abstract: false,
+    })
+}
+
+pub(crate) fn strict_bind_call_apply_this_arg_param(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> ParamInfo {
+    ParamInfo {
+        name: Some(db.intern_string("thisArg")),
+        type_id,
+        optional: false,
+        rest: false,
+    }
+}
+
+pub(crate) fn strict_bind_call_apply_args_param(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> ParamInfo {
+    ParamInfo {
+        name: Some(db.intern_string("args")),
+        type_id,
+        optional: true,
+        rest: false,
+    }
+}
+
+pub(crate) fn strict_bind_call_apply_generic_this_param(
+    db: &dyn TypeDatabase,
+    constraint: TypeId,
+) -> (TypeParamInfo, TypeId) {
+    let info = TypeParamInfo {
+        name: db.intern_string("TThis"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+        origin: TypeParamOrigin::User,
+    };
+    let type_id = db.type_param(info);
+    (info, type_id)
+}
+
+pub(crate) fn strict_bind_call_apply_method_type(
+    db: &dyn TypeDatabase,
+    method_signatures: Vec<CallSignature>,
+) -> Option<TypeId> {
+    match method_signatures.len() {
+        0 => None,
+        1 => {
+            let sig = method_signatures.into_iter().next()?;
+            Some(db.function(FunctionShape {
+                type_params: sig.type_params,
+                params: sig.params,
+                this_type: None,
+                return_type: sig.return_type,
+                type_predicate: sig.type_predicate,
+                is_constructor: false,
+                is_method: false,
+            }))
+        }
+        _ => Some(db.callable(CallableShape {
+            call_signatures: method_signatures,
+            construct_signatures: Vec::new(),
+            properties: Vec::new(),
+            string_index: None,
+            number_index: None,
+            symbol: None,
+            is_abstract: false,
+        })),
+    }
 }
 
 /// Check if a type has a named property accessible on all branches.

--- a/crates/tsz-checker/src/query_boundaries/property_access.rs
+++ b/crates/tsz-checker/src/query_boundaries/property_access.rs
@@ -1,8 +1,8 @@
 use tsz_common::Atom;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::{
-    CallSignature, CallableShape, FunctionShape, ParamInfo, TupleElement, TypeId, TypeParamInfo,
-    TypeParamOrigin, TypePredicate,
+    CallSignature, CallableShape, FunctionShape, MappedModifier, ParamInfo, TupleElement, TypeId,
+    TypeParamInfo, TypeParamOrigin, TypePredicate,
 };
 
 pub(crate) use super::common::PropertyAccessResult;
@@ -128,6 +128,40 @@ pub(crate) fn is_function_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
 
 pub(crate) fn tuple_element_type_union(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
     tsz_solver::type_queries::get_tuple_element_type_union(db, type_id)
+}
+
+pub(crate) fn mapped_property_read_type(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    optional_modifier: Option<MappedModifier>,
+) -> TypeId {
+    match optional_modifier {
+        Some(MappedModifier::Add) => db.union2(type_id, TypeId::UNDEFINED),
+        Some(MappedModifier::Remove) | None => type_id,
+    }
+}
+
+pub(crate) fn union_property_access_success(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> Option<PropertyAccessResult> {
+    (!members.is_empty())
+        .then(|| PropertyAccessResult::simple(tsz_solver::utils::union_or_single(db, members)))
+}
+
+pub(crate) fn intersection_property_access_success(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+    from_index_signature: bool,
+) -> Option<PropertyAccessResult> {
+    (!members.is_empty()).then(|| {
+        let type_id = tsz_solver::utils::intersection_or_single(db, members);
+        if from_index_signature {
+            PropertyAccessResult::from_index(type_id)
+        } else {
+            PropertyAccessResult::simple(type_id)
+        }
+    })
 }
 
 pub(crate) fn application_first_arg(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {

--- a/crates/tsz-checker/src/query_boundaries/state/checking.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/checking.rs
@@ -145,6 +145,17 @@ pub(crate) fn excess_property_any_object_type_from_names(
     (!props.is_empty()).then(|| db.object(props))
 }
 
+pub(crate) fn excess_property_target_union(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    tsz_solver::utils::union_or_single(db, members)
+}
+
+pub(crate) fn excess_property_display_target_union(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> TypeId {
+    tsz_solver::utils::union_or_single_literal_reduce(db, members)
+}
+
 pub(crate) fn get_finite_mapped_property_type(
     db: &dyn TypeDatabase,
     mapped_id: tsz_solver::MappedTypeId,

--- a/crates/tsz-checker/src/query_boundaries/state/checking.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/checking.rs
@@ -1,8 +1,8 @@
 use tsz_common::Atom;
 #[cfg(test)]
 use tsz_solver::TupleElement;
-use tsz_solver::TypeId;
 use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{PropertyInfo, TypeId};
 
 pub(crate) use super::super::common::{
     array_element_type, callable_shape_for_type as callable_shape, intersection_members,
@@ -126,6 +126,23 @@ pub(crate) fn collect_finite_mapped_property_names(
     mapped_id: tsz_solver::MappedTypeId,
 ) -> Option<rustc_hash::FxHashSet<Atom>> {
     tsz_solver::type_queries::collect_finite_mapped_property_names(db, mapped_id)
+}
+
+pub(crate) fn excess_property_any_object_type_from_names(
+    db: &dyn TypeDatabase,
+    prop_names: Vec<Atom>,
+) -> Option<TypeId> {
+    let mut props = Vec::with_capacity(prop_names.len());
+    for name in prop_names {
+        if props.iter().any(|prop: &PropertyInfo| prop.name == name) {
+            continue;
+        }
+        let mut prop = PropertyInfo::new(name, TypeId::ANY);
+        prop.declaration_order = props.len() as u32;
+        props.push(prop);
+    }
+
+    (!props.is_empty()).then(|| db.object(props))
 }
 
 pub(crate) fn get_finite_mapped_property_type(

--- a/crates/tsz-checker/src/query_boundaries/state/checking.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/checking.rs
@@ -149,6 +149,34 @@ pub(crate) fn excess_property_target_union(db: &dyn TypeDatabase, members: Vec<T
     tsz_solver::utils::union_or_single(db, members)
 }
 
+pub(crate) fn excess_property_nested_target_intersection_or_single(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> TypeId {
+    tsz_solver::utils::intersection_or_single(db, members)
+}
+
+pub(crate) fn excess_property_annotation_intersection_or_single(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> TypeId {
+    let mut iter = members.into_iter();
+    let Some(mut result) = iter.next() else {
+        return TypeId::UNKNOWN;
+    };
+    for member in iter {
+        result = db.intersect_types_raw2(result, member);
+    }
+    result
+}
+
+pub(crate) fn optional_excess_property_nested_target(
+    db: &dyn TypeDatabase,
+    target: TypeId,
+) -> TypeId {
+    db.union(vec![target, TypeId::UNDEFINED])
+}
+
 pub(crate) fn excess_property_display_target_union(
     db: &dyn TypeDatabase,
     members: Vec<TypeId>,

--- a/crates/tsz-checker/src/query_boundaries/state/type_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/type_analysis.rs
@@ -1,7 +1,53 @@
 pub(crate) use super::super::common::{call_signatures_for_type, callable_shape_for_type};
 
-#[cfg(test)]
-use tsz_solver::TypeId;
+use tsz_common::interner::Atom;
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{PropertyInfo, TypeId, Visibility};
+
+pub(crate) const fn namespace_export_property(
+    name: Atom,
+    type_id: TypeId,
+    declaration_order: u32,
+) -> PropertyInfo {
+    PropertyInfo {
+        name,
+        type_id,
+        write_type: type_id,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+pub(crate) const fn namespace_any_export_property(
+    name: Atom,
+    declaration_order: u32,
+) -> PropertyInfo {
+    namespace_export_property(name, TypeId::ANY, declaration_order)
+}
+
+pub(crate) fn namespace_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) fn namespace_export_equals_intersection(
+    db: &dyn TypeDatabase,
+    export_equals_type: TypeId,
+    namespace_type: TypeId,
+) -> TypeId {
+    db.intersection2(export_equals_type, namespace_type)
+}
 
 #[cfg(test)]
 #[path = "../../../tests/state_type_analysis.rs"]

--- a/crates/tsz-checker/src/query_boundaries/type_checking.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_checking.rs
@@ -1,4 +1,6 @@
-use tsz_solver::TypeId;
+use tsz_common::Atom;
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{FunctionShape, ParamInfo, TypeId, TypeParamInfo, TypeParamOrigin};
 
 pub(crate) use super::common::{
     callable_shape_for_type, has_construct_signatures, is_symbol_or_unique_symbol, union_members,
@@ -6,23 +8,17 @@ pub(crate) use super::common::{
 pub(crate) use tsz_solver::type_queries::ConstructorCheckKind;
 
 pub(crate) fn classify_for_constructor_check(
-    db: &dyn tsz_solver::construction::TypeDatabase,
+    db: &dyn TypeDatabase,
     type_id: TypeId,
 ) -> ConstructorCheckKind {
     tsz_solver::type_queries::classify_for_constructor_check(db, type_id)
 }
 
-pub(crate) fn has_function_shape(
-    db: &dyn tsz_solver::construction::TypeDatabase,
-    type_id: TypeId,
-) -> bool {
+pub(crate) fn has_function_shape(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::type_queries::get_function_shape(db, type_id).is_some()
 }
 
-pub(crate) fn is_constructor_function_type(
-    db: &dyn tsz_solver::construction::TypeDatabase,
-    type_id: TypeId,
-) -> bool {
+pub(crate) fn is_constructor_function_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::type_queries::get_function_shape(db, type_id)
         .is_some_and(|shape| shape.is_constructor)
 }
@@ -36,9 +32,149 @@ pub(crate) fn is_constructor_function_type(
 /// those can mention `this` without making the receiver itself a `this`-relative
 /// wrapper.
 pub(crate) fn is_compound_this_relative_surface_type(
-    db: &dyn tsz_solver::construction::TypeDatabase,
+    db: &dyn TypeDatabase,
     type_id: TypeId,
     this_type: TypeId,
 ) -> bool {
     tsz_solver::type_queries::is_compound_this_relative_surface_type(db, type_id, this_type)
+}
+
+pub(crate) fn type_checking_union(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn type_checking_index_access(
+    db: &dyn TypeDatabase,
+    object_type: TypeId,
+    index_type: TypeId,
+) -> TypeId {
+    db.index_access(object_type, index_type)
+}
+
+pub(crate) fn type_checking_literal_number(db: &dyn TypeDatabase, value: f64) -> TypeId {
+    db.literal_number(value)
+}
+
+pub(crate) const fn user_type_param_info(
+    name: Atom,
+    constraint: Option<TypeId>,
+    default: Option<TypeId>,
+    is_const: bool,
+) -> TypeParamInfo {
+    TypeParamInfo {
+        name,
+        constraint,
+        default,
+        is_const,
+        origin: TypeParamOrigin::User,
+    }
+}
+
+pub(crate) fn user_type_param(
+    db: &dyn TypeDatabase,
+    name: Atom,
+    constraint: Option<TypeId>,
+    default: Option<TypeId>,
+    is_const: bool,
+) -> TypeId {
+    db.type_param(user_type_param_info(name, constraint, default, is_const))
+}
+
+pub(crate) const fn param_info(
+    name: Option<Atom>,
+    type_id: TypeId,
+    optional: bool,
+    rest: bool,
+) -> ParamInfo {
+    ParamInfo {
+        name,
+        type_id,
+        optional,
+        rest,
+    }
+}
+
+pub(crate) fn global_function_fallback_type(db: &dyn TypeDatabase, args_atom: Atom) -> TypeId {
+    let rest_param = param_info(Some(args_atom), TypeId::ANY, false, true);
+    db.function(FunctionShape {
+        params: vec![rest_param],
+        this_type: None,
+        return_type: TypeId::ANY,
+        type_params: vec![],
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    })
+}
+
+pub(crate) fn method_function_type(
+    db: &dyn TypeDatabase,
+    type_params: Vec<TypeParamInfo>,
+    params: Vec<ParamInfo>,
+    return_type: TypeId,
+) -> TypeId {
+    db.function(FunctionShape {
+        type_params,
+        params,
+        this_type: None,
+        return_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsz_solver::construction::TypeInterner;
+
+    #[test]
+    fn constructs_type_checking_surfaces() {
+        let db = TypeInterner::new();
+        let name = db.intern_string("T");
+        let type_param = user_type_param(&db, name, Some(TypeId::STRING), None, true);
+
+        assert_eq!(
+            type_param,
+            db.type_param(TypeParamInfo {
+                name,
+                constraint: Some(TypeId::STRING),
+                default: None,
+                is_const: true,
+                origin: TypeParamOrigin::User,
+            })
+        );
+        assert_eq!(
+            type_checking_union(&db, vec![TypeId::STRING, TypeId::NUMBER]),
+            db.union(vec![TypeId::STRING, TypeId::NUMBER])
+        );
+        assert_eq!(
+            type_checking_index_access(&db, TypeId::STRING, TypeId::NUMBER),
+            db.index_access(TypeId::STRING, TypeId::NUMBER)
+        );
+        assert_eq!(
+            type_checking_literal_number(&db, 1.0),
+            db.literal_number(1.0)
+        );
+
+        let param = param_info(
+            Some(db.intern_string("value")),
+            TypeId::BOOLEAN,
+            true,
+            false,
+        );
+        assert_eq!(param.type_id, TypeId::BOOLEAN);
+        assert!(param.optional);
+        assert!(!param.rest);
+
+        let global_function = global_function_fallback_type(&db, db.intern_string("args"));
+        assert!(has_function_shape(&db, global_function));
+
+        let method = method_function_type(&db, vec![], vec![param], TypeId::NUMBER);
+        let shape = tsz_solver::type_queries::get_function_shape(&db, method)
+            .expect("method function should have shape");
+        assert!(shape.is_method);
+        assert_eq!(shape.return_type, TypeId::NUMBER);
+    }
 }

--- a/crates/tsz-checker/src/query_boundaries/type_computation/expression_results.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/expression_results.rs
@@ -1,0 +1,41 @@
+//! Expression result construction boundary.
+//!
+//! Computation code owns AST classification, diagnostics, relation probes, and
+//! collapse policy. This module owns the solver result surfaces those decisions
+//! produce for expression operators.
+
+use tsz_solver::TypeId;
+use tsz_solver::construction::TypeDatabase;
+
+pub(crate) fn empty_object_type(db: &dyn TypeDatabase) -> TypeId {
+    db.object(Vec::new())
+}
+
+pub(crate) fn nullish_coalescing_union(
+    db: &dyn TypeDatabase,
+    left: TypeId,
+    right: TypeId,
+) -> TypeId {
+    db.union2(left, right)
+}
+
+pub(crate) fn conditional_branch_union(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn literal_index_access_union(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union_preserve_members(members)
+}
+
+pub(crate) fn typeof_result_union(db: &dyn TypeDatabase) -> TypeId {
+    db.union(vec![
+        db.literal_string("string"),
+        db.literal_string("number"),
+        db.literal_string("bigint"),
+        db.literal_string("boolean"),
+        db.literal_string("symbol"),
+        db.literal_string("undefined"),
+        db.literal_string("object"),
+        db.literal_string("function"),
+    ])
+}

--- a/crates/tsz-checker/src/query_boundaries/type_computation/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/mod.rs
@@ -3,3 +3,4 @@ pub(crate) mod complex;
 pub(crate) mod core;
 pub(crate) mod expression_results;
 pub(crate) mod in_operator;
+pub(crate) mod object_literals;

--- a/crates/tsz-checker/src/query_boundaries/type_computation/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod access;
 pub(crate) mod complex;
 pub(crate) mod core;
+pub(crate) mod expression_results;
 pub(crate) mod in_operator;

--- a/crates/tsz-checker/src/query_boundaries/type_computation/object_literals.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/object_literals.rs
@@ -1,0 +1,204 @@
+//! Object-literal result construction boundary.
+//!
+//! Object-literal computation owns AST traversal, spread policy, contextual
+//! typing, property ordering, and display normalization. This module owns the
+//! solver surfaces those decisions produce for final object literal results and
+//! mapped-spread fallbacks.
+
+use rustc_hash::FxHashSet;
+use tsz_common::interner::Atom;
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{IndexSignature, MappedType, ObjectFlags, ObjectShape, PropertyInfo, TypeId};
+
+pub(crate) struct ObjectLiteralIndexedType {
+    pub(crate) properties: Vec<PropertyInfo>,
+    pub(crate) string_index_types: Vec<TypeId>,
+    pub(crate) number_index_types: Vec<TypeId>,
+    pub(crate) symbol_index_types: Vec<TypeId>,
+    pub(crate) string_index_param_name: Option<Atom>,
+    pub(crate) number_index_param_name: Option<Atom>,
+    pub(crate) in_const_assertion: bool,
+    pub(crate) has_spread: bool,
+    pub(crate) all_properties_context_sensitive: bool,
+    pub(crate) display_properties: Option<Vec<PropertyInfo>>,
+}
+
+pub(crate) fn spread_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    display_properties: Vec<PropertyInfo>,
+) -> TypeId {
+    let result =
+        db.object_with_flags_and_symbol(properties, ObjectFlags::PRESERVE_DECLARATION_ORDER, None);
+    db.store_display_properties(result, display_properties);
+    result
+}
+
+pub(crate) fn fresh_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    all_properties_context_sensitive: bool,
+    display_properties: Option<Vec<PropertyInfo>>,
+) -> TypeId {
+    let flags = if all_properties_context_sensitive {
+        ObjectFlags::FRESH_LITERAL | ObjectFlags::ALL_PROPERTIES_CONTEXT_SENSITIVE
+    } else {
+        ObjectFlags::FRESH_LITERAL
+    };
+    let result = db.object_with_flags_and_symbol(properties, flags, None);
+    if let Some(display_properties) = display_properties {
+        db.store_display_properties(result, display_properties);
+    }
+    result
+}
+
+pub(crate) fn indexed_object_type(
+    db: &dyn TypeDatabase,
+    input: ObjectLiteralIndexedType,
+) -> TypeId {
+    let ObjectLiteralIndexedType {
+        properties,
+        mut string_index_types,
+        number_index_types,
+        symbol_index_types,
+        string_index_param_name,
+        number_index_param_name,
+        in_const_assertion,
+        has_spread,
+        all_properties_context_sensitive,
+        display_properties,
+    } = input;
+
+    if !string_index_types.is_empty() {
+        let prop_types = properties.iter().map(|prop| prop.type_id);
+        if in_const_assertion {
+            string_index_types = prop_types.chain(string_index_types).collect();
+        } else {
+            string_index_types.extend(prop_types);
+        }
+    }
+
+    let string_index = index_signature(
+        db,
+        TypeId::STRING,
+        string_index_types,
+        string_index_param_name,
+        in_const_assertion,
+    );
+    let number_index = index_signature(
+        db,
+        TypeId::NUMBER,
+        number_index_types,
+        number_index_param_name,
+        in_const_assertion,
+    );
+    let symbol_index = index_signature(
+        db,
+        TypeId::SYMBOL,
+        symbol_index_types,
+        None,
+        in_const_assertion,
+    );
+
+    let mut shape = ObjectShape {
+        properties,
+        string_index,
+        number_index,
+        symbol_index,
+        ..ObjectShape::default()
+    };
+    if has_spread {
+        shape.mark_preserve_declaration_order();
+    } else {
+        shape.mark_fresh_literal();
+        if all_properties_context_sensitive {
+            shape.mark_all_properties_context_sensitive();
+        }
+    }
+
+    let result = db.object_with_index(shape);
+    if let Some(display_properties) = display_properties {
+        db.store_display_properties(result, display_properties);
+    }
+    result
+}
+
+pub(crate) const fn spread_fallback_index_signature(
+    key_type: TypeId,
+    value_type: TypeId,
+) -> IndexSignature {
+    IndexSignature {
+        key_type,
+        value_type,
+        readonly: false,
+        param_name: None,
+    }
+}
+
+fn index_signature(
+    db: &dyn TypeDatabase,
+    key_type: TypeId,
+    value_types: Vec<TypeId>,
+    param_name: Option<Atom>,
+    preserve_order: bool,
+) -> Option<IndexSignature> {
+    if value_types.is_empty() {
+        return None;
+    }
+
+    let value_type = if preserve_order {
+        order_preserving_union(db, value_types)
+    } else {
+        db.union(value_types)
+    };
+    Some(IndexSignature {
+        key_type,
+        value_type,
+        readonly: false,
+        param_name,
+    })
+}
+
+fn order_preserving_union(db: &dyn TypeDatabase, mut members: Vec<TypeId>) -> TypeId {
+    let mut seen = FxHashSet::default();
+    members.retain(|id| *id != TypeId::NEVER && seen.insert(*id));
+    match members.as_slice() {
+        [] => TypeId::NEVER,
+        [only] => *only,
+        _ => db.union_from_sorted_vec(members),
+    }
+}
+
+pub(crate) fn union_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.union(members)
+}
+
+pub(crate) fn intersection_type(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    db.intersection(members)
+}
+
+pub(crate) fn mapped_type_with_constraint(
+    db: &dyn TypeDatabase,
+    mapped: &MappedType,
+    constraint: TypeId,
+) -> TypeId {
+    db.mapped(MappedType {
+        type_param: mapped.type_param,
+        constraint,
+        name_type: mapped.name_type,
+        template: mapped.template,
+        readonly_modifier: mapped.readonly_modifier,
+        optional_modifier: mapped.optional_modifier,
+    })
+}
+
+pub(crate) const fn mapped_spread_property(name: Atom, type_id: TypeId) -> PropertyInfo {
+    PropertyInfo::new(name, type_id)
+}
+
+pub(crate) fn mapped_spread_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}

--- a/crates/tsz-checker/src/query_boundaries/type_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_construction.rs
@@ -75,6 +75,40 @@ pub(crate) fn enum_namespace_object_with_number_reverse_map(
     })
 }
 
+/// Intern an intersection type produced from a type-node member list.
+pub(crate) fn type_node_intersection_or_single(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> TypeId {
+    tsz_solver::utils::intersection_or_single(db, members)
+}
+
+/// Intern and mark the plain object surface for a hand-written type literal.
+pub(crate) fn type_literal_object(db: &dyn TypeDatabase, properties: Vec<PropertyInfo>) -> TypeId {
+    let result = db.object(properties);
+    db.mark_literal_object_annotation(result);
+    result
+}
+
+/// Intern and mark the indexed object surface for a hand-written type literal.
+pub(crate) fn type_literal_object_with_indexes(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    symbol_index: Option<IndexSignature>,
+) -> TypeId {
+    let result = db.object_with_index(ObjectShape {
+        properties,
+        string_index,
+        number_index,
+        symbol_index,
+        ..ObjectShape::default()
+    });
+    db.mark_literal_object_annotation(result);
+    result
+}
+
 /// Create a string intrinsic type from a validated lib intrinsic name.
 pub(crate) fn string_intrinsic_by_name(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/query_boundaries/type_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_construction.rs
@@ -11,8 +11,131 @@ use tsz_solver::construction::TypeDatabase;
 #[cfg(test)]
 pub(crate) use tsz_solver::construction::TypeInterner;
 use tsz_solver::{
-    IndexSignature, ObjectFlags, ObjectShape, PropertyInfo, StringIntrinsicKind, TypeId,
+    IndexSignature, ObjectFlags, ObjectShape, PropertyInfo, StringIntrinsicKind, TypeId, Visibility,
 };
+
+pub(crate) struct DeclaredSurfaceProperty {
+    pub(crate) name: Atom,
+    pub(crate) type_id: TypeId,
+    pub(crate) write_type: TypeId,
+    pub(crate) optional: bool,
+    pub(crate) readonly: bool,
+    pub(crate) is_method: bool,
+    pub(crate) declaration_order: u32,
+    pub(crate) is_string_named: bool,
+    pub(crate) is_symbol_named: bool,
+    pub(crate) single_quoted_name: bool,
+}
+
+pub(crate) const fn declared_surface_property(input: DeclaredSurfaceProperty) -> PropertyInfo {
+    PropertyInfo {
+        name: input.name,
+        type_id: input.type_id,
+        write_type: input.write_type,
+        optional: input.optional,
+        readonly: input.readonly,
+        is_method: input.is_method,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order: input.declaration_order,
+        is_string_named: input.is_string_named,
+        is_symbol_named: input.is_symbol_named,
+        single_quoted_name: input.single_quoted_name,
+        non_widening: false,
+    }
+}
+
+pub(crate) const fn declared_index_signature(
+    key_type: TypeId,
+    value_type: TypeId,
+    readonly: bool,
+    param_name: Option<Atom>,
+) -> IndexSignature {
+    IndexSignature {
+        key_type,
+        value_type,
+        readonly,
+        param_name,
+    }
+}
+
+pub(crate) fn declared_object_with_symbol(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    symbol: Option<SymbolId>,
+) -> TypeId {
+    db.object_with_flags_and_symbol(properties, ObjectFlags::empty(), symbol)
+}
+
+pub(crate) fn declared_object_with_indexes(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    symbol_index: Option<IndexSignature>,
+    symbol: Option<SymbolId>,
+) -> TypeId {
+    db.object_with_index(ObjectShape {
+        properties,
+        string_index,
+        number_index,
+        symbol_index,
+        symbol,
+        ..ObjectShape::default()
+    })
+}
+
+pub(crate) fn type_literal_object_with_late_bound(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    has_late_bound_members: bool,
+) -> TypeId {
+    let mut flags = ObjectFlags::empty();
+    if has_late_bound_members {
+        flags |= ObjectFlags::HAS_LATE_BOUND_MEMBERS;
+    }
+    let result = db.object_with_flags_and_symbol(properties, flags, None);
+    db.mark_literal_object_annotation(result);
+    result
+}
+
+pub(crate) fn type_literal_object_with_indexes_and_late_bound(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    string_index: Option<IndexSignature>,
+    number_index: Option<IndexSignature>,
+    symbol_index: Option<IndexSignature>,
+    has_late_bound_members: bool,
+) -> TypeId {
+    let mut shape = ObjectShape {
+        properties,
+        string_index,
+        number_index,
+        symbol_index,
+        ..ObjectShape::default()
+    };
+    if has_late_bound_members {
+        shape.mark_has_late_bound_members();
+    }
+    let result = db.object_with_index(shape);
+    db.mark_literal_object_annotation(result);
+    result
+}
+
+pub(crate) fn type_literal_number_index_member(
+    db: &dyn TypeDatabase,
+    index: IndexSignature,
+) -> TypeId {
+    db.object_with_index(ObjectShape {
+        number_index: Some(index),
+        ..ObjectShape::default()
+    })
+}
+
+pub(crate) fn raw_intersection_pair(db: &dyn TypeDatabase, left: TypeId, right: TypeId) -> TypeId {
+    db.intersect_types_raw2(left, right)
+}
 
 /// Intern an object type carrying only a string index signature
 /// (`{ [key: string]: V }`).

--- a/crates/tsz-checker/src/query_boundaries/type_query_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_query_construction.rs
@@ -1,0 +1,74 @@
+//! Const value/type-query construction boundary.
+//!
+//! Type-query callers own syntax guards, symbol lookup, declaration checks,
+//! name matching, and fallback policy. This module owns the solver surfaces
+//! synthesized from accepted const literal facts.
+
+use tsz_common::{Atom, Visibility};
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{ObjectShape, PropertyInfo, TupleElement, TypeId};
+
+pub(crate) fn const_query_literal_string_type(db: &dyn TypeDatabase, value: &str) -> TypeId {
+    db.literal_string(value)
+}
+
+pub(crate) fn const_query_literal_number_type(db: &dyn TypeDatabase, value: f64) -> TypeId {
+    db.literal_number(value)
+}
+
+pub(crate) fn const_query_literal_boolean_type(db: &dyn TypeDatabase, value: bool) -> TypeId {
+    db.literal_boolean(value)
+}
+
+pub(crate) const fn const_query_readonly_property(
+    name: Atom,
+    type_id: TypeId,
+    declaration_order: u32,
+) -> PropertyInfo {
+    PropertyInfo {
+        name,
+        type_id,
+        write_type: type_id,
+        optional: false,
+        readonly: true,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    }
+}
+
+pub(crate) fn const_query_object_literal_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object_with_index(ObjectShape {
+        properties,
+        ..ObjectShape::default()
+    })
+}
+
+pub(crate) fn const_query_array_to_enum_object_type(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+) -> TypeId {
+    db.object(properties)
+}
+
+pub(crate) const fn const_query_tuple_element(type_id: TypeId) -> TupleElement {
+    TupleElement {
+        type_id,
+        name: None,
+        optional: false,
+        rest: false,
+    }
+}
+
+pub(crate) fn const_query_tuple_type(db: &dyn TypeDatabase, elements: Vec<TupleElement>) -> TypeId {
+    db.tuple(elements)
+}

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -482,7 +482,7 @@ impl<'a> CheckerState<'a> {
                     // Example: type T = { x: { a: number } } | { x: { b: number } }
                     // Assigning { x: { b: 1 } } should NOT error on 'b'.
                     // =============================================================
-                    let nested_target = tsz_solver::utils::union_or_single(
+                    let nested_target = query::excess_property_target_union(
                         self.ctx.types,
                         target_prop_types.clone(),
                     );

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -670,7 +670,10 @@ impl<'a> CheckerState<'a> {
 
                     if !all_nested.is_empty() {
                         let nested_target =
-                            tsz_solver::utils::intersection_or_single(self.ctx.types, all_nested);
+                            query::excess_property_nested_target_intersection_or_single(
+                                self.ctx.types,
+                                all_nested,
+                            );
                         let nested_target = self.nested_property_target_type(
                             effective_target,
                             source_prop.name,
@@ -850,8 +853,10 @@ impl<'a> CheckerState<'a> {
                     if nested_types.is_empty() {
                         continue;
                     }
-                    let nested_target =
-                        tsz_solver::utils::intersection_or_single(self.ctx.types, nested_types);
+                    let nested_target = query::excess_property_nested_target_intersection_or_single(
+                        self.ctx.types,
+                        nested_types,
+                    );
                     let nested_target = self.nested_property_target_type(
                         effective_target,
                         source_prop.name,

--- a/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
@@ -306,7 +306,7 @@ impl<'a> CheckerState<'a> {
                 .iter()
                 .map(|&member| self.excess_property_annotation_component_type(member, visited))
                 .collect::<Vec<_>>();
-            return Some(tsz_solver::utils::union_or_single_literal_reduce(
+            return Some(query::excess_property_display_target_union(
                 self.ctx.types,
                 member_types,
             ));
@@ -538,7 +538,7 @@ impl<'a> CheckerState<'a> {
         let display_target = if narrowed_member_types.len() == 1 {
             narrowed_member_types[0]
         } else {
-            tsz_solver::utils::union_or_single_literal_reduce(
+            query::excess_property_display_target_union(
                 self.ctx.types,
                 narrowed_member_types.clone(),
             )
@@ -1038,7 +1038,7 @@ impl<'a> CheckerState<'a> {
                 && !matching_members.is_empty()
                 && matching_members.len() < members.len()
             {
-                return tsz_solver::utils::union_or_single(self.ctx.types, matching_members);
+                return query::excess_property_target_union(self.ctx.types, matching_members);
             }
         }
 

--- a/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
@@ -752,21 +752,11 @@ impl<'a> CheckerState<'a> {
         // Only fall back for intersections; other shapes are handled by the
         // direct `query::object_shape` path on the call site.
         query::intersection_members(self.ctx.types, type_id)?;
-        match tsz_solver::objects::collect_properties(type_id, self.ctx.types, &self.ctx) {
-            tsz_solver::objects::PropertyCollectionResult::Properties {
-                properties,
-                string_index,
-                number_index,
-                symbol_index,
-            } => Some(std::sync::Arc::new(tsz_solver::ObjectShape {
-                properties,
-                string_index,
-                number_index,
-                symbol_index,
-                ..tsz_solver::ObjectShape::default()
-            })),
-            _ => None,
-        }
+        crate::query_boundaries::intersection_display::collected_properties_object_shape(
+            self.ctx.types,
+            &self.ctx,
+            type_id,
+        )
     }
 
     pub(super) fn try_emit_nested_discriminated_union_assignability_error(
@@ -1566,36 +1556,6 @@ impl<'a> CheckerState<'a> {
             prop_names.extend(property_names);
         }
 
-        if prop_names.is_empty() {
-            return None;
-        }
-
-        let mut props = Vec::with_capacity(prop_names.len());
-        for name in prop_names {
-            if props
-                .iter()
-                .any(|prop: &tsz_solver::PropertyInfo| prop.name == name)
-            {
-                continue;
-            }
-            props.push(tsz_solver::PropertyInfo {
-                name,
-                type_id: TypeId::ANY,
-                write_type: TypeId::ANY,
-                optional: false,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: tsz_common::Visibility::Public,
-                parent_id: None,
-                declaration_order: props.len() as u32,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
-        }
-
-        Some(self.ctx.types.factory().object(props))
+        query::excess_property_any_object_type_from_names(self.ctx.types, prop_names)
     }
 }

--- a/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
@@ -135,10 +135,10 @@ impl<'a> CheckerState<'a> {
         if let Some((candidate, true)) = self.single_non_undefined_member(nested_target)
             && self.is_recursive_self_reference(candidate, &outer_members)
         {
-            return self
-                .ctx
-                .types
-                .union(vec![outer_intersection, TypeId::UNDEFINED]);
+            return query::optional_excess_property_nested_target(
+                self.ctx.types,
+                outer_intersection,
+            );
         }
 
         nested_target
@@ -234,7 +234,7 @@ impl<'a> CheckerState<'a> {
         }
 
         if has_undef {
-            self.ctx.types.union(vec![outer_object, TypeId::UNDEFINED])
+            query::optional_excess_property_nested_target(self.ctx.types, outer_object)
         } else {
             outer_object
         }
@@ -344,7 +344,10 @@ impl<'a> CheckerState<'a> {
                 .iter()
                 .map(|&member| self.excess_property_annotation_component_type(member, visited))
                 .collect::<Vec<_>>();
-            return self.raw_intersection_or_single(member_types);
+            return query::excess_property_annotation_intersection_or_single(
+                self.ctx.types,
+                member_types,
+            );
         }
 
         if let Some(union_type) = self.excess_property_annotation_union_type(type_node, visited) {
@@ -373,17 +376,6 @@ impl<'a> CheckerState<'a> {
             return self.annotation_node_contains_intersection(wrapped.type_node);
         }
         false
-    }
-
-    pub(super) fn raw_intersection_or_single(&self, members: Vec<TypeId>) -> TypeId {
-        let mut iter = members.into_iter();
-        let Some(mut result) = iter.next() else {
-            return TypeId::UNKNOWN;
-        };
-        for member in iter {
-            result = self.ctx.types.intersect_types_raw2(result, member);
-        }
-        result
     }
 
     pub(super) fn named_type_reference_lazy_type(

--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -5,6 +5,7 @@
 //! (`property`) for LOC hygiene.
 
 use crate::query_boundaries::common::TypeResolver;
+use crate::query_boundaries::property_access as property_access_query;
 use crate::query_boundaries::state::checking as query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
@@ -141,14 +142,11 @@ impl<'a> CheckerState<'a> {
                 &subst,
             );
             let property_type = self.evaluate_type_with_env(property_type);
-            let property_type = match mapped.optional_modifier {
-                Some(tsz_solver::MappedModifier::Add) => self
-                    .ctx
-                    .types
-                    .factory()
-                    .union2(property_type, TypeId::UNDEFINED),
-                Some(tsz_solver::MappedModifier::Remove) | None => property_type,
-            };
+            let property_type = property_access_query::mapped_property_read_type(
+                self.ctx.types,
+                property_type,
+                mapped.optional_modifier,
+            );
             matched_property_types.push(property_type);
         }
 
@@ -161,17 +159,7 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        let type_id = match matched_property_types.len() {
-            1 => matched_property_types[0],
-            _ => self.ctx.types.factory().union(matched_property_types),
-        };
-        Some(
-            tsz_solver::operations::property::PropertyAccessResult::Success {
-                type_id,
-                write_type: None,
-                from_index_signature: false,
-            },
-        )
+        property_access_query::union_property_access_success(self.ctx.types, matched_property_types)
     }
 
     pub(crate) fn computed_property_display_name(&self, name_idx: NodeIndex) -> Option<String> {
@@ -675,18 +663,12 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            if !member_results.is_empty() {
-                let type_id = match member_results.len() {
-                    1 => member_results[0],
-                    _ => self.ctx.types.factory().intersection(member_results),
-                };
-                return self.resolve_unbound_property_result_defaults(
-                    tsz_solver::operations::property::PropertyAccessResult::Success {
-                        type_id,
-                        write_type: None,
-                        from_index_signature: any_from_index,
-                    },
-                );
+            if let Some(result) = property_access_query::intersection_property_access_success(
+                self.ctx.types,
+                member_results,
+                any_from_index,
+            ) {
+                return self.resolve_unbound_property_result_defaults(result);
             }
 
             if saw_deferred_any_fallback {
@@ -1087,22 +1069,17 @@ impl<'a> CheckerState<'a> {
         for source_key_atom in matching_source_keys {
             let property_type =
                 self.instantiate_mapped_property_template_with_env(&mapped, source_key_atom);
-            let property_type = match mapped.optional_modifier {
-                Some(tsz_solver::MappedModifier::Add) => self
-                    .ctx
-                    .types
-                    .factory()
-                    .union2(property_type, TypeId::UNDEFINED),
-                Some(tsz_solver::MappedModifier::Remove) | None => property_type,
-            };
+            let property_type = property_access_query::mapped_property_read_type(
+                self.ctx.types,
+                property_type,
+                mapped.optional_modifier,
+            );
             property_types.push(property_type);
         }
 
-        let property_type = match property_types.len() {
-            0 => return None,
-            1 => property_types[0],
-            _ => self.ctx.types.factory().union(property_types),
-        };
+        let result =
+            property_access_query::union_property_access_success(self.ctx.types, property_types)?;
+        let property_type = result.success_type().expect("union helper returns success");
 
         self.ctx
             .flow_shared
@@ -1117,13 +1094,7 @@ impl<'a> CheckerState<'a> {
                 )),
             );
 
-        Some(
-            tsz_solver::operations::property::PropertyAccessResult::Success {
-                type_id: property_type,
-                write_type: None,
-                from_index_signature: false,
-            },
-        )
+        Some(result)
     }
 }
 

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -1,6 +1,7 @@
 //! Class-member decorator signature validation helpers.
 
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::query_boundaries::checkers::decorators as decorator_query;
 use crate::query_boundaries::common::CallResult;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
@@ -171,7 +172,11 @@ impl<'a> CheckerState<'a> {
             .ctx
             .binder
             .get_global_type_with_libs("Function", &lib_binders)?;
-        Some(self.ctx.create_lazy_type_ref(sym_id))
+        let def_id = self.ctx.get_or_create_def_id(sym_id);
+        Some(decorator_query::decorator_global_type_ref(
+            self.ctx.types,
+            def_id,
+        ))
     }
 
     /// Resolve `ClassAccessorDecoratorTarget<any, any>` from the lib globals.
@@ -185,13 +190,11 @@ impl<'a> CheckerState<'a> {
             .ctx
             .binder
             .get_global_type_with_libs("ClassAccessorDecoratorTarget", &lib_binders)?;
-        let base = self.ctx.create_lazy_type_ref(sym_id);
-        Some(
-            self.ctx
-                .types
-                .factory()
-                .application(base, vec![TypeId::ANY, TypeId::ANY]),
-        )
+        let def_id = self.ctx.get_or_create_def_id(sym_id);
+        Some(decorator_query::class_accessor_decorator_target_any(
+            self.ctx.types,
+            def_id,
+        ))
     }
 
     /// tsc's `getDecoratorArgumentCount` for ES (TC39 stage-3) member
@@ -449,8 +452,12 @@ impl<'a> CheckerState<'a> {
             .ctx
             .binder
             .get_global_type_with_libs(name, &lib_binders)?;
-        let base = self.ctx.create_lazy_type_ref(sym_id);
-        Some(self.ctx.types.factory().application(base, args))
+        let def_id = self.ctx.get_or_create_def_id(sym_id);
+        Some(decorator_query::decorator_context_application(
+            self.ctx.types,
+            def_id,
+            args,
+        ))
     }
 
     fn method_decorator_value_type(&mut self, member_idx: NodeIndex) -> Option<TypeId> {
@@ -467,20 +474,13 @@ impl<'a> CheckerState<'a> {
         };
         self.pop_type_parameters(type_param_updates);
 
-        Some(
-            self.ctx
-                .types
-                .factory()
-                .function(tsz_solver::FunctionShape {
-                    type_params,
-                    params,
-                    this_type,
-                    return_type,
-                    type_predicate: None,
-                    is_constructor: false,
-                    is_method: true,
-                }),
-        )
+        Some(decorator_query::method_decorator_value_type(
+            self.ctx.types,
+            type_params,
+            params,
+            this_type,
+            return_type,
+        ))
     }
 
     fn accessor_decorator_value_type(&mut self, member_idx: NodeIndex) -> Option<TypeId> {
@@ -499,20 +499,12 @@ impl<'a> CheckerState<'a> {
             TypeId::VOID
         };
 
-        Some(
-            self.ctx
-                .types
-                .factory()
-                .function(tsz_solver::FunctionShape {
-                    type_params: Vec::new(),
-                    params,
-                    this_type,
-                    return_type,
-                    type_predicate: None,
-                    is_constructor: false,
-                    is_method: true,
-                }),
-        )
+        Some(decorator_query::accessor_decorator_value_type(
+            self.ctx.types,
+            params,
+            this_type,
+            return_type,
+        ))
     }
 
     fn accessor_value_type_argument(&mut self, member_idx: NodeIndex) -> Option<TypeId> {
@@ -583,16 +575,17 @@ impl<'a> CheckerState<'a> {
     ) -> Option<TypeId> {
         if !experimental_decorators {
             let value_type = self.method_or_accessor_decorator_value_type(member_idx)?;
-            return Some(self.ctx.types.factory().union2(TypeId::VOID, value_type));
+            return Some(decorator_query::decorator_void_or_replacement_type(
+                self.ctx.types,
+                value_type,
+            ));
         }
 
         let descriptor_type = self.legacy_method_or_accessor_descriptor_type(member_idx)?;
-        Some(
-            self.ctx
-                .types
-                .factory()
-                .union2(TypeId::VOID, descriptor_type),
-        )
+        Some(decorator_query::decorator_void_or_replacement_type(
+            self.ctx.types,
+            descriptor_type,
+        ))
     }
 
     fn method_or_accessor_decorator_value_type(&mut self, member_idx: NodeIndex) -> Option<TypeId> {

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -8,6 +8,7 @@ mod type_alias_merged_value;
 mod type_alias_variable_alias;
 
 use crate::query_boundaries::common::{contains_infer_types, contains_type_parameters};
+use crate::query_boundaries::state::type_analysis as type_analysis_boundary;
 
 struct SymbolAliasCtx<'a> {
     sym_id: SymbolId,
@@ -26,7 +27,7 @@ use tsz_binder::{SymbolId, symbol_flags};
 use tsz_common::ModuleKind;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{PropertyInfo, TypeId, Visibility};
+use tsz_solver::{PropertyInfo, TypeId};
 
 impl<'a> CheckerState<'a> {
     pub(crate) fn normalize_namespace_export_declaration_order(props: &mut [PropertyInfo]) {
@@ -166,29 +167,18 @@ impl<'a> CheckerState<'a> {
                     continue;
                 }
                 let prop_type = self.get_type_of_symbol(export_sym_id);
-                props.push(PropertyInfo {
-                    name: self.ctx.types.intern_string(name),
-                    type_id: prop_type,
-                    write_type: prop_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: None,
-                    declaration_order: if name == "default" {
+                props.push(type_analysis_boundary::namespace_export_property(
+                    self.ctx.types.intern_string(name),
+                    prop_type,
+                    if name == "default" {
                         1
                     } else {
                         props.len() as u32 + 2
                     },
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                });
+                ));
             }
             Self::normalize_namespace_export_declaration_order(&mut props);
-            let module_type = self.ctx.types.factory().object(props);
+            let module_type = type_analysis_boundary::namespace_object_type(self.ctx.types, props);
             self.ctx.namespace_module_names.insert(
                 module_type,
                 self.imported_namespace_display_module_name(module_name),
@@ -202,22 +192,14 @@ impl<'a> CheckerState<'a> {
             Some(self.ctx.current_file_idx),
         )?;
         let default_type = self.get_type_of_symbol(default_sym_id);
-        let module_type = self.ctx.types.factory().object(vec![PropertyInfo {
-            name: self.ctx.types.intern_string("default"),
-            type_id: default_type,
-            write_type: default_type,
-            optional: false,
-            readonly: false,
-            is_method: false,
-            is_class_prototype: false,
-            visibility: Visibility::Public,
-            parent_id: None,
-            declaration_order: 1,
-            is_string_named: false,
-            is_symbol_named: false,
-            single_quoted_name: false,
-            non_widening: false,
-        }]);
+        let module_type = type_analysis_boundary::namespace_object_type(
+            self.ctx.types,
+            vec![type_analysis_boundary::namespace_export_property(
+                self.ctx.types.intern_string("default"),
+                default_type,
+                1,
+            )],
+        );
         self.ctx.namespace_module_names.insert(
             module_type,
             self.imported_namespace_display_module_name(module_name),
@@ -442,26 +424,15 @@ impl<'a> CheckerState<'a> {
             let mut prop_type = self.get_type_of_symbol(export_sym_id);
             prop_type = self.apply_module_augmentations(module_name, name, prop_type);
             let name_atom = self.ctx.types.intern_string(name);
-            props.push(PropertyInfo {
-                name: name_atom,
-                type_id: prop_type,
-                write_type: prop_type,
-                optional: false,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: if name == "default" {
+            props.push(type_analysis_boundary::namespace_export_property(
+                name_atom,
+                prop_type,
+                if name == "default" {
                     1
                 } else {
                     props.len() as u32 + 2
                 },
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+            ));
         }
 
         if has_export_equals && let Some(export_equals_sym_id) = exports_table.get("export=") {
@@ -473,22 +444,11 @@ impl<'a> CheckerState<'a> {
                 existing_default.optional = false;
                 existing_default.readonly = false;
             } else {
-                props.push(PropertyInfo {
-                    name: default_atom,
-                    type_id: export_equals_type,
-                    write_type: export_equals_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: None,
-                    declaration_order: 1,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                });
+                props.push(type_analysis_boundary::namespace_export_property(
+                    default_atom,
+                    export_equals_type,
+                    1,
+                ));
             }
         }
 
@@ -497,7 +457,7 @@ impl<'a> CheckerState<'a> {
         }
 
         Self::normalize_namespace_export_declaration_order(&mut props);
-        let module_type = self.ctx.types.factory().object(props);
+        let module_type = type_analysis_boundary::namespace_object_type(self.ctx.types, props);
         self.ctx.namespace_module_names.insert(
             module_type,
             self.imported_namespace_display_module_name(module_name),
@@ -571,26 +531,15 @@ impl<'a> CheckerState<'a> {
                 self.namespace_import_export_property_type(module_name, export_sym_id, name)
             });
             prop_type = self.apply_module_augmentations(module_name, name, prop_type);
-            props.push(PropertyInfo {
-                name: self.ctx.types.intern_string(name),
-                type_id: prop_type,
-                write_type: prop_type,
-                optional: false,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: if name == "default" {
+            props.push(type_analysis_boundary::namespace_export_property(
+                self.ctx.types.intern_string(name),
+                prop_type,
+                if name == "default" {
                     1
                 } else {
                     props.len() as u32 + 2
                 },
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+            ));
         }
 
         if props.is_empty() {
@@ -598,7 +547,7 @@ impl<'a> CheckerState<'a> {
         }
 
         Self::normalize_namespace_export_declaration_order(&mut props);
-        let namespace_type = self.ctx.types.factory().object(props);
+        let namespace_type = type_analysis_boundary::namespace_object_type(self.ctx.types, props);
         self.ctx.namespace_module_names.insert(
             namespace_type,
             self.imported_namespace_display_module_name(module_name),
@@ -752,22 +701,11 @@ impl<'a> CheckerState<'a> {
                 props.len() as u32 + 2
             };
             let name_atom = self.ctx.types.intern_string(name);
-            props.push(PropertyInfo {
-                name: name_atom,
-                type_id: prop_type,
-                write_type: prop_type,
-                optional: false,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
+            props.push(type_analysis_boundary::namespace_export_property(
+                name_atom,
+                prop_type,
                 declaration_order,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+            ));
         }
         nested_module_specifier
     }

--- a/crates/tsz-checker/src/state/type_analysis/computed/tests/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/tests/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::query_boundaries::common::QueryDatabase;
+use tsz_solver::Visibility;
 
 fn make_prop(name: tsz_common::Atom, declaration_order: u32) -> PropertyInfo {
     PropertyInfo {

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -3,6 +3,7 @@
 use super::SymbolAliasCtx;
 use crate::query_boundaries::common::{array_element_type, is_generic_type};
 use crate::query_boundaries::flow as flow_boundary;
+use crate::query_boundaries::state::type_analysis as type_analysis_boundary;
 use crate::query_boundaries::state::type_environment;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -10,7 +11,7 @@ use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{TypeId, Visibility};
+use tsz_solver::{PropertyInfo, TypeId};
 
 mod helpers;
 
@@ -819,7 +820,6 @@ impl<'a> CheckerState<'a> {
                     let exports_table = self.resolve_effective_module_exports(&module_specifier);
 
                     if let Some(exports_table) = exports_table {
-                        use tsz_solver::PropertyInfo;
                         let module_is_non_module_entity = self
                             .ctx
                             .module_resolves_to_non_module_entity(&module_specifier);
@@ -921,22 +921,11 @@ impl<'a> CheckerState<'a> {
                                     props.len() as u32 + 2
                                 };
                                 let name_atom = self.ctx.types.intern_string(name);
-                                props.push(PropertyInfo {
-                                    name: name_atom,
-                                    type_id: prop_type,
-                                    write_type: prop_type,
-                                    optional: false,
-                                    readonly: false,
-                                    is_method: false,
-                                    is_class_prototype: false,
-                                    visibility: Visibility::Public,
-                                    parent_id: None,
+                                props.push(type_analysis_boundary::namespace_export_property(
+                                    name_atom,
+                                    prop_type,
                                     declaration_order,
-                                    is_string_named: false,
-                                    is_symbol_named: false,
-                                    single_quoted_name: false,
-                                    non_widening: false,
-                                });
+                                ));
                             }
                             props
                         };
@@ -949,27 +938,15 @@ impl<'a> CheckerState<'a> {
                                 if props.iter().any(|p| p.name == name_atom) {
                                     continue;
                                 }
-                                props.push(PropertyInfo {
-                                    name: name_atom,
-                                    type_id: TypeId::ANY,
-                                    write_type: TypeId::ANY,
-                                    optional: false,
-                                    readonly: false,
-                                    is_method: false,
-                                    is_class_prototype: false,
-                                    visibility: Visibility::Public,
-                                    parent_id: None,
-                                    declaration_order: 0,
-                                    is_string_named: false,
-                                    is_symbol_named: false,
-                                    single_quoted_name: false,
-                                    non_widening: false,
-                                });
+                                props.push(type_analysis_boundary::namespace_any_export_property(
+                                    name_atom, 0,
+                                ));
                             }
                         }
                         Self::normalize_namespace_export_declaration_order(&mut props);
                         let namespace_has_no_runtime_props = props.is_empty();
-                        let namespace_type = factory.object(props);
+                        let namespace_type =
+                            type_analysis_boundary::namespace_object_type(self.ctx.types, props);
                         // Store display name for error messages: TSC shows namespace
                         // types as `typeof import("module")` in diagnostics.
                         let display_module_name = self.resolve_namespace_display_module_name(
@@ -984,7 +961,11 @@ impl<'a> CheckerState<'a> {
                                 return (export_equals_type, Vec::new());
                             }
                             return (
-                                factory.intersection2(export_equals_type, namespace_type),
+                                type_analysis_boundary::namespace_export_equals_intersection(
+                                    self.ctx.types,
+                                    export_equals_type,
+                                    namespace_type,
+                                ),
                                 Vec::new(),
                             );
                         }
@@ -1179,7 +1160,6 @@ impl<'a> CheckerState<'a> {
                             self.record_cross_file_symbol_if_needed(sym_id, name, module_name);
                         }
 
-                        use tsz_solver::PropertyInfo;
                         let module_is_non_module_entity =
                             self.ctx.module_resolves_to_non_module_entity(module_name);
                         let exports_table_target =
@@ -1272,22 +1252,11 @@ impl<'a> CheckerState<'a> {
                                     props.len() as u32 + 2
                                 };
                                 let name_atom = self.ctx.types.intern_string(name);
-                                props.push(PropertyInfo {
-                                    name: name_atom,
-                                    type_id: prop_type,
-                                    write_type: prop_type,
-                                    optional: false,
-                                    readonly: false,
-                                    is_method: false,
-                                    is_class_prototype: false,
-                                    visibility: Visibility::Public,
-                                    parent_id: None,
+                                props.push(type_analysis_boundary::namespace_export_property(
+                                    name_atom,
+                                    prop_type,
                                     declaration_order,
-                                    is_string_named: false,
-                                    is_symbol_named: false,
-                                    single_quoted_name: false,
-                                    non_widening: false,
-                                });
+                                ));
                             }
                             props
                         };
@@ -1309,24 +1278,11 @@ impl<'a> CheckerState<'a> {
                                 if props.iter().any(|p| p.name == name_atom) {
                                     continue;
                                 }
-                                props.push(PropertyInfo {
-                                    name: name_atom,
-                                    // Cross-file augmentation declarations may live in a different
-                                    // arena; use `any` here to preserve namespace member visibility.
-                                    type_id: TypeId::ANY,
-                                    write_type: TypeId::ANY,
-                                    optional: false,
-                                    readonly: false,
-                                    is_method: false,
-                                    is_class_prototype: false,
-                                    visibility: Visibility::Public,
-                                    parent_id: None,
-                                    declaration_order: 0,
-                                    is_string_named: false,
-                                    is_symbol_named: false,
-                                    single_quoted_name: false,
-                                    non_widening: false,
-                                });
+                                // Cross-file augmentation declarations may live in a different
+                                // arena; use `any` here to preserve namespace member visibility.
+                                props.push(type_analysis_boundary::namespace_any_export_property(
+                                    name_atom, 0,
+                                ));
                             }
                         }
 
@@ -1343,22 +1299,9 @@ impl<'a> CheckerState<'a> {
                                 }
 
                                 let prop_type = self.get_type_of_symbol(member_sym_id);
-                                props.push(PropertyInfo {
-                                    name: name_atom,
-                                    type_id: prop_type,
-                                    write_type: prop_type,
-                                    optional: false,
-                                    readonly: false,
-                                    is_method: false,
-                                    is_class_prototype: false,
-                                    visibility: Visibility::Public,
-                                    parent_id: None,
-                                    declaration_order: 0,
-                                    is_string_named: false,
-                                    is_symbol_named: false,
-                                    single_quoted_name: false,
-                                    non_widening: false,
-                                });
+                                props.push(type_analysis_boundary::namespace_export_property(
+                                    name_atom, prop_type, 0,
+                                ));
                             }
                         }
 
@@ -1419,7 +1362,10 @@ impl<'a> CheckerState<'a> {
                                     Self::normalize_namespace_export_declaration_order(
                                         &mut synthetic_props,
                                     );
-                                    Some(factory.object(synthetic_props))
+                                    Some(type_analysis_boundary::namespace_object_type(
+                                        self.ctx.types,
+                                        synthetic_props,
+                                    ))
                                 } else {
                                     export_equals_type.or_else(|| {
                                         can_use_cjs_namespace_default.then(|| {
@@ -1427,7 +1373,10 @@ impl<'a> CheckerState<'a> {
                                             Self::normalize_namespace_export_declaration_order(
                                                 &mut synthetic_props,
                                             );
-                                            factory.object(synthetic_props)
+                                            type_analysis_boundary::namespace_object_type(
+                                                self.ctx.types,
+                                                synthetic_props,
+                                            )
                                         })
                                     })
                                 };
@@ -1440,29 +1389,19 @@ impl<'a> CheckerState<'a> {
                                     existing_default.optional = false;
                                     existing_default.readonly = false;
                                 } else {
-                                    props.push(PropertyInfo {
-                                        name: default_atom,
-                                        type_id: eq_type,
-                                        write_type: eq_type,
-                                        optional: false,
-                                        readonly: false,
-                                        is_method: false,
-                                        is_class_prototype: false,
-                                        visibility: Visibility::Public,
-                                        parent_id: None,
-                                        declaration_order: 1,
-                                        is_string_named: false,
-                                        is_symbol_named: false,
-                                        single_quoted_name: false,
-                                        non_widening: false,
-                                    });
+                                    props.push(type_analysis_boundary::namespace_export_property(
+                                        default_atom,
+                                        eq_type,
+                                        1,
+                                    ));
                                 }
                             }
                         }
 
                         Self::normalize_namespace_export_declaration_order(&mut props);
                         let namespace_has_no_runtime_props = props.is_empty();
-                        let namespace_type = factory.object(props);
+                        let namespace_type =
+                            type_analysis_boundary::namespace_object_type(self.ctx.types, props);
                         // Store display name for error messages: TSC shows namespace
                         // types as `typeof import("module")` in diagnostics.
                         let preserve_namespace_display =
@@ -1537,7 +1476,11 @@ impl<'a> CheckerState<'a> {
                                 return (export_equals_type, Vec::new());
                             }
                             return (
-                                factory.intersection2(export_equals_type, namespace_type),
+                                type_analysis_boundary::namespace_export_equals_intersection(
+                                    self.ctx.types,
+                                    export_equals_type,
+                                    namespace_type,
+                                ),
                                 Vec::new(),
                             );
                         }
@@ -1872,7 +1815,6 @@ impl<'a> CheckerState<'a> {
                             if let Some(exports_table) = exports_table {
                                 let ordered_exports =
                                     self.ordered_namespace_export_entries(&exports_table);
-                                use tsz_solver::PropertyInfo;
                                 let mut props: Vec<PropertyInfo> = Vec::new();
                                 for &(name, export_sym_id) in &ordered_exports {
                                     if self.should_skip_namespace_export_name(
@@ -1889,25 +1831,17 @@ impl<'a> CheckerState<'a> {
                                     };
                                     let prop_type = self.get_type_of_symbol(export_sym_id);
                                     let name_atom = self.ctx.types.intern_string(name);
-                                    props.push(PropertyInfo {
-                                        name: name_atom,
-                                        type_id: prop_type,
-                                        write_type: prop_type,
-                                        optional: false,
-                                        readonly: false,
-                                        is_method: false,
-                                        is_class_prototype: false,
-                                        visibility: Visibility::Public,
-                                        parent_id: None,
+                                    props.push(type_analysis_boundary::namespace_export_property(
+                                        name_atom,
+                                        prop_type,
                                         declaration_order,
-                                        is_string_named: false,
-                                        is_symbol_named: false,
-                                        single_quoted_name: false,
-                                        non_widening: false,
-                                    });
+                                    ));
                                 }
                                 Self::normalize_namespace_export_declaration_order(&mut props);
-                                let module_type = factory.object(props);
+                                let module_type = type_analysis_boundary::namespace_object_type(
+                                    self.ctx.types,
+                                    props,
+                                );
                                 self.ctx.namespace_module_names.insert(
                                     module_type,
                                     self.imported_namespace_display_module_name(module_name),

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias/helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias/helpers.rs
@@ -202,7 +202,6 @@ impl<'a> CheckerState<'a> {
             return Some(export_eq_type);
         }
 
-        use tsz_solver::PropertyInfo;
         let mut props: Vec<PropertyInfo> = Vec::new();
         for &(name, export_sym_id) in &ordered_exports {
             if self.should_skip_namespace_export_name(&exports_table, name, export_sym_id) {
@@ -215,25 +214,14 @@ impl<'a> CheckerState<'a> {
             };
             let prop_type = self.get_type_of_symbol(export_sym_id);
             let name_atom = self.ctx.types.intern_string(name);
-            props.push(PropertyInfo {
-                name: name_atom,
-                type_id: prop_type,
-                write_type: prop_type,
-                optional: false,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
+            props.push(type_analysis_boundary::namespace_export_property(
+                name_atom,
+                prop_type,
                 declaration_order,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+            ));
         }
         Self::normalize_namespace_export_declaration_order(&mut props);
-        let module_type = self.ctx.types.factory().object(props);
+        let module_type = type_analysis_boundary::namespace_object_type(self.ctx.types, props);
         self.ctx.namespace_module_names.insert(
             module_type,
             self.imported_namespace_display_module_name(module_name),
@@ -250,24 +238,15 @@ impl<'a> CheckerState<'a> {
             "default",
             Some(self.ctx.current_file_idx),
         )?;
-        use tsz_solver::PropertyInfo;
         let default_type = self.get_type_of_symbol(default_sym_id);
-        let module_type = self.ctx.types.factory().object(vec![PropertyInfo {
-            name: self.ctx.types.intern_string("default"),
-            type_id: default_type,
-            write_type: default_type,
-            optional: false,
-            readonly: false,
-            is_method: false,
-            is_class_prototype: false,
-            visibility: Visibility::Public,
-            parent_id: None,
-            declaration_order: 1,
-            is_string_named: false,
-            is_symbol_named: false,
-            single_quoted_name: false,
-            non_widening: false,
-        }]);
+        let module_type = type_analysis_boundary::namespace_object_type(
+            self.ctx.types,
+            vec![type_analysis_boundary::namespace_export_property(
+                self.ctx.types.intern_string("default"),
+                default_type,
+                1,
+            )],
+        );
         self.ctx.namespace_module_names.insert(
             module_type,
             self.imported_namespace_display_module_name(module_name),

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
@@ -5,7 +5,7 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{PropertyInfo, TypeId, Visibility};
+use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     pub(super) fn collect_direct_commonjs_assignment_exports(
@@ -412,16 +412,7 @@ impl<'a> CheckerState<'a> {
                 .or_else(|| self.commonjs_export_rhs_symbol_type(rhs_expr))
                 .unwrap_or_else(|| self.get_type_of_node(rhs_expr));
             ty = self.upgrade_commonjs_export_constructor_type(rhs_expr, ty);
-            ty = self.augment_commonjs_export_object_type_with_expandos(
-                target_file_idx,
-                expando_root,
-                ty,
-            );
-            ty = self.augment_commonjs_export_callable_type_with_expandos(
-                target_file_idx,
-                expando_root,
-                ty,
-            );
+            ty = self.augment_commonjs_export_type_with_expandos(target_file_idx, expando_root, ty);
             ty = self.widen_fresh_object_literal_properties_for_display(ty);
             return crate::query_boundaries::common::widen_freshness(self.ctx.types, ty);
         }
@@ -432,12 +423,7 @@ impl<'a> CheckerState<'a> {
                 .or_else(|| checker.commonjs_export_rhs_symbol_type(rhs_expr))
                 .unwrap_or_else(|| checker.get_type_of_node(rhs_expr));
             ty = checker.upgrade_commonjs_export_constructor_type(rhs_expr, ty);
-            ty = checker.augment_commonjs_export_object_type_with_expandos(
-                target_file_idx,
-                expando_root,
-                ty,
-            );
-            ty = checker.augment_commonjs_export_callable_type_with_expandos(
+            ty = checker.augment_commonjs_export_type_with_expandos(
                 target_file_idx,
                 expando_root,
                 ty,
@@ -632,197 +618,33 @@ impl<'a> CheckerState<'a> {
             .then_some(literal)
     }
 
-    fn augment_commonjs_export_object_type_with_expandos(
+    fn augment_commonjs_export_type_with_expandos(
         &mut self,
         target_file_idx: usize,
         expando_root: Option<&str>,
         base_type: TypeId,
     ) -> TypeId {
-        use rustc_hash::FxHashMap;
-        use tsz_solver::ObjectShape;
-
         let Some(root_name) = expando_root else {
             return base_type;
         };
-        let expando_props =
+        let expando_members =
             self.collect_commonjs_expando_property_types_for_root(target_file_idx, root_name);
-        if expando_props.is_empty() {
+        if expando_members.is_empty() {
             return base_type;
         }
 
-        let Some(shape) =
-            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, base_type)
-        else {
-            return base_type;
-        };
-
-        let mut properties: FxHashMap<tsz_common::interner::Atom, PropertyInfo> = shape
-            .properties
-            .iter()
-            .map(|prop| (prop.name, prop.clone()))
-            .collect();
-        let mut changed = false;
-
-        for (prop_name, prop_type) in expando_props {
-            let prop_type =
-                crate::query_boundaries::common::widen_literal_type(self.ctx.types, prop_type);
-            let prop_atom = self.ctx.types.intern_string(&prop_name);
-            if properties.contains_key(&prop_atom) {
-                continue;
-            }
-
-            properties.insert(
-                prop_atom,
-                PropertyInfo {
-                    name: prop_atom,
-                    type_id: prop_type,
-                    write_type: prop_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: None,
-                    declaration_order: properties.len() as u32,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                },
-            );
-            changed = true;
-        }
-
-        if !changed {
-            return base_type;
-        }
-
-        self.ctx.types.factory().object_with_index(ObjectShape {
-            flags: shape.flags,
-            properties: properties.into_values().collect(),
-            string_index: shape.string_index,
-            number_index: shape.number_index,
-            symbol_index: shape.symbol_index,
-            symbol: shape.symbol,
-        })
-    }
-
-    fn augment_commonjs_export_callable_type_with_expandos(
-        &mut self,
-        target_file_idx: usize,
-        expando_root: Option<&str>,
-        base_type: TypeId,
-    ) -> TypeId {
-        use rustc_hash::FxHashMap;
-        use tsz_solver::{CallableShape, PropertyInfo};
-
-        let Some(root_name) = expando_root else {
-            return base_type;
-        };
-        let expando_props =
-            self.collect_commonjs_expando_property_types_for_root(target_file_idx, root_name);
-        if expando_props.is_empty() {
-            return base_type;
-        }
-
-        let (mut callable_shape, mut property_count) = if let Some(shape) =
-            crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, base_type)
-        {
-            ((*shape).clone(), shape.properties.len())
-        } else if let Some(function_shape) =
-            crate::query_boundaries::type_computation::complex::function_shape_for_type(
-                self.ctx.types,
-                base_type,
-            )
-        {
-            let signature = tsz_solver::CallSignature {
-                type_params: function_shape.type_params.clone(),
-                params: function_shape.params.clone(),
-                this_type: function_shape.this_type,
-                return_type: function_shape.return_type,
-                type_predicate: function_shape.type_predicate,
-                is_method: function_shape.is_method,
-            };
-            (
-                CallableShape {
-                    call_signatures: if function_shape.is_constructor {
-                        Vec::new()
-                    } else {
-                        vec![signature.clone()]
-                    },
-                    construct_signatures: if function_shape.is_constructor {
-                        vec![signature]
-                    } else {
-                        Vec::new()
-                    },
-                    properties: Vec::new(),
-                    string_index: None,
-                    number_index: None,
-                    symbol: None,
-                    is_abstract: false,
-                },
-                0,
-            )
-        } else {
-            return base_type;
-        };
-
-        let mut properties: FxHashMap<tsz_common::interner::Atom, PropertyInfo> = callable_shape
-            .properties
-            .iter()
-            .map(|prop| (prop.name, prop.clone()))
-            .collect();
-        let mut changed = false;
-
-        for (prop_name, prop_type) in expando_props {
-            let prop_type =
-                crate::query_boundaries::common::widen_literal_type(self.ctx.types, prop_type);
-            let prop_atom = self.ctx.types.intern_string(&prop_name);
-            if let Some(existing) = properties.get_mut(&prop_atom) {
-                let existing_is_placeholder = existing.type_id.is_any_unknown_or_error();
-                if existing_is_placeholder && !matches!(prop_type, TypeId::ANY | TypeId::UNKNOWN) {
-                    existing.type_id = prop_type;
-                    existing.write_type = prop_type;
-                    changed = true;
-                }
-                continue;
-            }
-            properties.insert(
-                prop_atom,
-                PropertyInfo {
-                    name: prop_atom,
-                    type_id: prop_type,
-                    write_type: prop_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: None,
-                    declaration_order: property_count as u32,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                },
-            );
-            property_count += 1;
-            changed = true;
-        }
-
-        if !changed {
-            return base_type;
-        }
-
-        callable_shape.properties = properties.into_values().collect();
-        self.ctx.types.factory().callable(callable_shape)
+        crate::query_boundaries::js_exports::commonjs_export_type_with_expando_members(
+            self.ctx.types,
+            base_type,
+            &expando_members,
+        )
     }
 
     fn collect_commonjs_expando_property_types_for_root(
         &mut self,
         target_file_idx: usize,
         root_name: &str,
-    ) -> Vec<(String, TypeId)> {
+    ) -> Vec<crate::query_boundaries::js_exports::CommonJsExpandoMember> {
         use rustc_hash::FxHashMap;
 
         let target_arena = self.ctx.get_arena_for_file(target_file_idx as u32).clone();
@@ -841,7 +663,15 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        props.into_iter().collect()
+        props
+            .into_iter()
+            .map(
+                |(name, type_id)| crate::query_boundaries::js_exports::CommonJsExpandoMember {
+                    name,
+                    type_id,
+                },
+            )
+            .collect()
     }
 
     fn collect_commonjs_expando_property_types_from_node(

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::js_exports as js_exports_query;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde_json::Value as JsonValue;
@@ -7,7 +8,7 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{PropertyInfo, TypeId, Visibility};
+use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     pub(crate) fn current_source_file_has_esm_syntax(&self) -> bool {
@@ -328,108 +329,6 @@ impl<'a> CheckerState<'a> {
         })
     }
 
-    fn json_value_type(&mut self, value: &JsonValue) -> TypeId {
-        match value {
-            JsonValue::Null => TypeId::NULL,
-            JsonValue::Bool(_) => TypeId::BOOLEAN,
-            JsonValue::Number(_) => TypeId::NUMBER,
-            JsonValue::String(_) => TypeId::STRING,
-            JsonValue::Array(elements) => self.json_array_type(elements),
-            JsonValue::Object(entries) => self.json_object_type(entries, None),
-        }
-    }
-
-    fn json_array_type(&mut self, elements: &[JsonValue]) -> TypeId {
-        let object_property_order = Self::json_array_object_property_order(elements);
-        let element_types: Vec<TypeId> = elements
-            .iter()
-            .map(|element| match element {
-                JsonValue::Object(entries) if !object_property_order.is_empty() => {
-                    self.json_object_type(entries, Some(&object_property_order))
-                }
-                _ => self.json_value_type(element),
-            })
-            .collect();
-        let element_type = match element_types.as_slice() {
-            [] => TypeId::NEVER,
-            [single] => *single,
-            _ => self.ctx.types.factory().union(element_types),
-        };
-        self.ctx.types.factory().array(element_type)
-    }
-
-    fn json_array_object_property_order(elements: &[JsonValue]) -> Vec<String> {
-        let mut names = Vec::new();
-        for element in elements {
-            let JsonValue::Object(entries) = element else {
-                continue;
-            };
-            for name in entries.keys() {
-                if !names.iter().any(|existing| existing == name) {
-                    names.push(name.clone());
-                }
-            }
-        }
-        names
-    }
-
-    fn json_object_type(
-        &mut self,
-        entries: &serde_json::Map<String, JsonValue>,
-        complete_property_order: Option<&[String]>,
-    ) -> TypeId {
-        let mut props = Vec::with_capacity(entries.len());
-        let mut present_names = FxHashSet::default();
-        for (declaration_order, (name, entry_value)) in entries.iter().enumerate() {
-            let prop_type = self.json_value_type(entry_value);
-            present_names.insert(name.as_str());
-            props.push(PropertyInfo {
-                name: self.ctx.types.intern_string(name),
-                type_id: prop_type,
-                write_type: prop_type,
-                optional: false,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: (declaration_order + 1) as u32,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
-        }
-
-        if let Some(all_names) = complete_property_order {
-            let mut declaration_order = props.len() as u32 + 1;
-            for name in all_names {
-                if present_names.contains(name.as_str()) {
-                    continue;
-                }
-                props.push(PropertyInfo {
-                    name: self.ctx.types.intern_string(name),
-                    type_id: TypeId::UNDEFINED,
-                    write_type: TypeId::UNDEFINED,
-                    optional: true,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: None,
-                    declaration_order,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                });
-                declaration_order += 1;
-            }
-        }
-
-        self.ctx.types.factory().object(props)
-    }
-
     pub(crate) fn json_module_type_for_module(
         &mut self,
         module_name: &str,
@@ -454,11 +353,16 @@ impl<'a> CheckerState<'a> {
 
         let source_text = source_file.text.trim();
         if source_text.is_empty() {
-            return Some(self.ctx.types.factory().object(Vec::new()));
+            return Some(js_exports_query::commonjs_empty_namespace_type(
+                self.ctx.types,
+            ));
         }
 
         let parsed = serde_json::from_str::<JsonValue>(source_text).ok()?;
-        Some(self.json_value_type(&parsed))
+        Some(js_exports_query::json_module_value_type(
+            self.ctx.types,
+            &parsed,
+        ))
     }
 
     pub(crate) fn json_module_namespace_type_for_module(
@@ -468,54 +372,16 @@ impl<'a> CheckerState<'a> {
     ) -> Option<TypeId> {
         let json_type = self.json_module_type_for_module(module_name, source_file_idx)?;
         if !self.json_namespace_import_uses_default_export(source_file_idx) {
-            return Some(self.commonjs_json_namespace_type(json_type));
+            return Some(js_exports_query::commonjs_json_namespace_type(
+                self.ctx.types,
+                json_type,
+            ));
         }
 
-        let namespace_type = self.ctx.types.factory().object(vec![PropertyInfo {
-            name: self.ctx.types.intern_string("default"),
-            type_id: json_type,
-            write_type: json_type,
-            optional: false,
-            readonly: false,
-            is_method: false,
-            is_class_prototype: false,
-            visibility: Visibility::Public,
-            parent_id: None,
-            declaration_order: 0,
-            is_string_named: false,
-            is_symbol_named: false,
-            single_quoted_name: false,
-            non_widening: false,
-        }]);
-        Some(namespace_type)
-    }
-
-    fn commonjs_json_namespace_type(&mut self, json_type: TypeId) -> TypeId {
-        let default_atom = self.ctx.types.intern_string("default");
-        let Some(shape) =
-            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, json_type)
-        else {
-            return json_type;
-        };
-        if !shape
-            .properties
-            .iter()
-            .any(|property| property.name == default_atom)
-        {
-            return json_type;
-        }
-
-        let mut properties = shape.properties.clone();
-        for property in &mut properties {
-            if property.name == default_atom {
-                property.type_id = json_type;
-                property.write_type = json_type;
-                property.optional = false;
-                property.readonly = false;
-                property.declaration_order = 0;
-            }
-        }
-        self.ctx.types.factory().object(properties)
+        Some(js_exports_query::json_esm_namespace_type(
+            self.ctx.types,
+            json_type,
+        ))
     }
 
     fn json_namespace_import_uses_default_export(&self, source_file_idx: Option<usize>) -> bool {
@@ -589,7 +455,7 @@ impl<'a> CheckerState<'a> {
         preserve_js_extension: bool,
     ) -> TypeId {
         if self.current_source_file_has_esm_syntax() {
-            let empty_namespace = self.ctx.types.factory().object(Vec::new());
+            let empty_namespace = js_exports_query::commonjs_empty_namespace_type(self.ctx.types);
             self.ctx.namespace_module_names.insert(
                 empty_namespace,
                 self.current_file_commonjs_module_name(preserve_js_extension),
@@ -601,76 +467,30 @@ impl<'a> CheckerState<'a> {
         // re-scanning the AST with augment_namespace_props_with_commonjs_exports_for_file.
         let current_file_idx = self.ctx.current_file_idx;
         let surface = self.resolve_js_export_surface(current_file_idx);
-        let can_merge_named_exports = surface.direct_export_type.is_none_or(|direct_export_type| {
-            crate::query_boundaries::js_exports::commonjs_direct_export_supports_named_props(
+        let can_merge_named_exports =
+            js_exports_query::commonjs_export_surface_can_merge_named_exports(
                 self.ctx.types,
-                direct_export_type,
-            )
-        });
+                &surface,
+            );
 
         // Deep-scan the AST for export names that may be nested (in if-blocks, etc.)
         // and not captured by the surface's top-level + IIFE scan.
         let mut export_names = BTreeSet::new();
-        for source_file in &self.ctx.arena.source_files {
-            for &stmt_idx in &source_file.statements.nodes {
-                self.collect_current_file_commonjs_export_names(stmt_idx, &mut export_names);
+        if can_merge_named_exports {
+            for source_file in &self.ctx.arena.source_files {
+                for &stmt_idx in &source_file.statements.nodes {
+                    self.collect_current_file_commonjs_export_names(stmt_idx, &mut export_names);
+                }
             }
         }
 
-        // Start with the surface's typed named exports and any deep-scan names.
-        let mut props = if can_merge_named_exports {
-            surface.named_exports
-        } else {
-            Vec::new()
-        };
-
-        // Add ANY-typed entries for any deep-scan names not already in the surface
-        for name in &export_names {
-            if !can_merge_named_exports {
-                break;
-            }
-            let name_atom = self.ctx.types.intern_string(name);
-            if props.iter().any(|p| p.name == name_atom) {
-                continue;
-            }
-            props.push(PropertyInfo {
-                name: name_atom,
-                type_id: TypeId::ANY,
-                write_type: TypeId::ANY,
-                optional: false,
-                readonly: false,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: props.len() as u32,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
-        }
-
-        let has_named_props = !props.is_empty();
-        crate::query_boundaries::js_exports::JsExportSurface {
-            direct_export_type: surface.direct_export_type,
-            named_exports: props,
-            prototype_members: surface.prototype_members,
-            has_commonjs_exports: surface.has_commonjs_exports || has_named_props,
-            has_augmented_named_exports: surface.has_augmented_named_exports || has_named_props,
-        }
-        .to_type_id_with_display_name(
+        let display_name = self.current_file_commonjs_module_name(preserve_js_extension);
+        js_exports_query::current_file_commonjs_namespace_type(
             self,
-            Some(self.current_file_commonjs_module_name(preserve_js_extension)),
+            surface,
+            export_names,
+            display_name,
         )
-        .unwrap_or_else(|| {
-            let empty_namespace = self.ctx.types.factory().object(Vec::new());
-            self.ctx.namespace_module_names.insert(
-                empty_namespace,
-                self.current_file_commonjs_module_name(preserve_js_extension),
-            );
-            empty_namespace
-        })
     }
 
     fn collect_current_file_commonjs_export_names(

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
@@ -1,11 +1,11 @@
-use crate::query_boundaries::common::{callable_shape_for_type, function_shape_for_type};
+use crate::query_boundaries::common::function_shape_for_type;
 use crate::state::CheckerState;
 use rustc_hash::FxHashMap;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{ObjectShape, PropertyInfo, TypeId, Visibility};
+use tsz_solver::{PropertyInfo, TypeId};
 
 impl<'a> CheckerState<'a> {
     fn infer_descriptor_parameter_type_in_current_checker(
@@ -332,13 +332,7 @@ impl<'a> CheckerState<'a> {
                                 prop.initializer,
                                 None,
                             );
-                            value_type = Some(crate::query_boundaries::common::widen_type(
-                                self.ctx.types,
-                                crate::query_boundaries::common::widen_freshness(
-                                    self.ctx.types,
-                                    value,
-                                ),
-                            ));
+                            value_type = Some(value);
                         }
                         "writable" => {
                             writable_true = arena
@@ -386,21 +380,15 @@ impl<'a> CheckerState<'a> {
                     else {
                         continue;
                     };
-                    let contextual_method_type = (prop_name.as_str() == "set")
-                        .then_some(getter_type)
-                        .flatten();
+                    let contextual_method_type =
+                        crate::query_boundaries::js_exports::commonjs_define_property_setter_contextual_function_type(
+                            self.ctx.types,
+                            (prop_name.as_str() == "set").then_some(getter_type).flatten(),
+                        );
                     let method_type = self.infer_commonjs_descriptor_method_type(
                         target_file_idx,
                         element_idx,
-                        contextual_method_type.map(|ty| {
-                            self.ctx
-                                .types
-                                .factory()
-                                .function(tsz_solver::FunctionShape::new(
-                                    vec![tsz_solver::ParamInfo::unnamed(ty)],
-                                    TypeId::VOID,
-                                ))
-                        }),
+                        contextual_method_type,
                     );
                     let Some(shape) = function_shape_for_type(self.ctx.types, method_type) else {
                         continue;
@@ -462,88 +450,21 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let has_getter = getter_type.is_some();
-        let has_accessor_descriptor = has_getter || has_setter;
-        let has_data_descriptor = has_value || writable_true;
-
-        // tsc treats malformed or mixed descriptors as readonly any-typed
-        // properties: an empty `{}`, a mixed accessor+data shape (`get`+`value`),
-        // and a lone `writable: true` (no `value`, no accessor) all produce
-        // properties that exist for read access but reject writes with TS2540.
-        // Only a paired `value` + `writable: true` data descriptor or an explicit
-        // `set` accessor makes the property writable.
-        if (!has_accessor_descriptor && !has_data_descriptor)
-            || (has_accessor_descriptor && has_data_descriptor)
-            || (writable_true && !has_value && !has_accessor_descriptor)
-        {
-            return Some(PropertyInfo {
-                name: self.ctx.types.intern_string(name),
-                type_id: TypeId::ANY,
-                write_type: TypeId::ANY,
-                optional: false,
-                readonly: true,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
-        }
-
-        // Widen fresh literal types that flow from the inferred getter/setter
-        // bodies into the property's read/write type, mirroring tsc behavior.
-        // Without this, `Object.defineProperty(x, "p", { get() { return 21.75 }})`
-        // gives `x.p` the literal type `21.75` instead of `number`, and assigning
-        // anything else (even a JSDoc-cast `number`) fails TS2322.
-        let widen = |ty: TypeId| -> TypeId {
-            crate::query_boundaries::common::widen_type(
+        Some(
+            crate::query_boundaries::js_exports::commonjs_define_property_descriptor_property(
                 self.ctx.types,
-                crate::query_boundaries::common::widen_freshness(self.ctx.types, ty),
-            )
-        };
-        getter_type = getter_type.map(widen);
-        setter_type = setter_type.map(widen);
-
-        if has_setter && setter_type == Some(TypeId::ANY) && getter_type.is_some() {
-            setter_type = getter_type;
-        }
-
-        let writable = has_setter || (has_value && writable_true);
-        let precise_setter_type =
-            setter_type.filter(|&ty| ty != TypeId::ANY && ty != TypeId::UNKNOWN);
-        let read_type = value_type
-            .or(getter_type)
-            .or(setter_type)
-            .unwrap_or(TypeId::ANY);
-        let write_type = if writable {
-            precise_setter_type
-                .or(getter_type)
-                .or(value_type)
-                .unwrap_or(read_type)
-        } else {
-            read_type
-        };
-
-        Some(PropertyInfo {
-            name: self.ctx.types.intern_string(name),
-            type_id: read_type,
-            write_type,
-            optional: false,
-            readonly: !writable,
-            is_method: false,
-            is_class_prototype: false,
-            visibility: Visibility::Public,
-            parent_id: None,
-            declaration_order,
-            is_string_named: false,
-            is_symbol_named: false,
-            single_quoted_name: false,
-            non_widening: false,
-        })
+                name,
+                crate::query_boundaries::js_exports::CommonJsDefinePropertyDescriptorFacts {
+                    value_type,
+                    getter_type,
+                    setter_type,
+                    has_value,
+                    has_setter,
+                    writable_true,
+                },
+                declaration_order,
+            ),
+        )
     }
 
     pub(crate) fn augment_object_type_with_define_properties(
@@ -636,58 +557,11 @@ impl<'a> CheckerState<'a> {
             return base_type;
         }
 
-        let base_shape =
-            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, base_type)
-                .map(|shape| shape.as_ref().clone())
-                .or_else(|| {
-                    let widened =
-                        crate::query_boundaries::common::widen_freshness(self.ctx.types, base_type);
-                    crate::query_boundaries::common::object_shape_for_type(self.ctx.types, widened)
-                        .map(|shape| shape.as_ref().clone())
-                });
-        if let Some(shape) = base_shape {
-            let mut merged_props = shape.properties;
-            for prop in props {
-                if let Some(existing) = merged_props
-                    .iter_mut()
-                    .find(|existing| existing.name == prop.name)
-                {
-                    *existing = prop;
-                } else {
-                    merged_props.push(prop);
-                }
-            }
-
-            if shape.string_index.is_some()
-                || shape.number_index.is_some()
-                || shape.symbol_index.is_some()
-            {
-                return self.ctx.types.factory().object_with_index(ObjectShape {
-                    flags: shape.flags,
-                    properties: merged_props,
-                    string_index: shape.string_index,
-                    number_index: shape.number_index,
-                    symbol_index: shape.symbol_index,
-                    symbol: shape.symbol,
-                });
-            }
-
-            return self.ctx.types.factory().object_with_flags_and_symbol(
-                merged_props,
-                shape.flags,
-                shape.symbol,
-            );
-        }
-
-        let define_property_type = self.ctx.types.factory().object(props);
-        if base_type.is_unknown_or_error() {
-            define_property_type
-        } else {
-            self.ctx
-                .types
-                .factory()
-                .intersection2(base_type, define_property_type)
-        }
+        crate::query_boundaries::js_exports::commonjs_type_with_define_property_members(
+            self.ctx.types,
+            base_type,
+            props,
+        )
     }
 
     pub(super) fn upgrade_commonjs_export_constructor_type(
@@ -701,54 +575,13 @@ impl<'a> CheckerState<'a> {
             return rhs_type;
         };
 
-        if let Some(func) = function_shape_for_type(self.ctx.types, rhs_type) {
-            if func.is_constructor {
-                return rhs_type;
-            }
-
-            let call_sig = tsz_solver::CallSignature {
-                type_params: func.type_params.clone(),
-                params: func.params.clone(),
-                this_type: func.this_type,
-                return_type: func.return_type,
-                type_predicate: func.type_predicate,
-                is_method: func.is_method,
-            };
-            let construct_sig = tsz_solver::CallSignature {
-                return_type: instance_type,
-                ..call_sig.clone()
-            };
-            let symbol = self.resolve_identifier_symbol_without_tracking(rhs_expr);
-            return self
-                .ctx
-                .types
-                .factory()
-                .callable(tsz_solver::CallableShape {
-                    call_signatures: vec![call_sig],
-                    construct_signatures: vec![construct_sig],
-                    properties: Vec::new(),
-                    string_index: None,
-                    number_index: None,
-                    symbol,
-                    is_abstract: false,
-                });
-        }
-
-        let Some(shape) = callable_shape_for_type(self.ctx.types, rhs_type) else {
-            return rhs_type;
-        };
-        if !shape.construct_signatures.is_empty() || shape.call_signatures.is_empty() {
-            return rhs_type;
-        }
-
-        let mut new_shape = shape.as_ref().clone();
-        let mut construct_sig = new_shape.call_signatures[0].clone();
-        construct_sig.return_type = instance_type;
-        new_shape.construct_signatures.push(construct_sig);
-        if new_shape.symbol.is_none() {
-            new_shape.symbol = self.resolve_identifier_symbol_without_tracking(rhs_expr);
-        }
-        self.ctx.types.factory().callable(new_shape)
+        let symbol = self.resolve_identifier_symbol_without_tracking(rhs_expr);
+        crate::query_boundaries::js_exports::commonjs_export_constructor_type_with_instance(
+            self.ctx.types,
+            rhs_type,
+            instance_type,
+            symbol,
+        )
     }
 
     pub(crate) fn direct_commonjs_module_export_assignment_rhs(
@@ -896,22 +729,14 @@ impl<'a> CheckerState<'a> {
                     existing.readonly = false;
                     continue;
                 }
-                props.push(tsz_solver::PropertyInfo {
-                    name: name_atom,
-                    type_id: rhs_type,
-                    write_type: rhs_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: None,
-                    declaration_order: props.len() as u32 + 1,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                });
+                props.push(
+                    crate::query_boundaries::js_exports::commonjs_namespace_export_property(
+                        self.ctx.types,
+                        &name_text,
+                        rhs_type,
+                        props.len() as u32 + 1,
+                    ),
+                );
             }
         }
     }
@@ -1084,8 +909,6 @@ impl<'a> CheckerState<'a> {
         module_name: &str,
         source_file_idx: Option<usize>,
     ) -> Option<TypeId> {
-        let factory = self.ctx.types.factory();
-
         if let Some(json_type) = self.json_module_type_for_module(module_name, source_file_idx) {
             return Some(json_type);
         }
@@ -1181,7 +1004,11 @@ impl<'a> CheckerState<'a> {
                 && surface.has_commonjs_exports
             {
                 let display_name = self.imported_namespace_display_module_name(module_name);
-                return surface.to_type_id_with_display_name(self, Some(display_name));
+                return crate::query_boundaries::js_exports::commonjs_export_surface_type_with_display_name(
+                    self,
+                    surface,
+                    display_name,
+                );
             }
             let mut props: Vec<PropertyInfo> = if surface
                 .as_ref()
@@ -1218,23 +1045,14 @@ impl<'a> CheckerState<'a> {
                     } else {
                         props.len() as u32 + 2
                     };
-                    let name_atom = self.ctx.types.intern_string(name);
-                    props.push(PropertyInfo {
-                        name: name_atom,
-                        type_id: prop_type,
-                        write_type: prop_type,
-                        optional: false,
-                        readonly: false,
-                        is_method: false,
-                        is_class_prototype: false,
-                        visibility: Visibility::Public,
-                        parent_id: None,
-                        declaration_order,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                    props.push(
+                        crate::query_boundaries::js_exports::commonjs_namespace_export_property(
+                            self.ctx.types,
+                            name,
+                            prop_type,
+                            declaration_order,
+                        ),
+                    );
                 }
                 props
             };
@@ -1246,24 +1064,15 @@ impl<'a> CheckerState<'a> {
                         continue;
                     }
 
-                    props.push(PropertyInfo {
-                        name: name_atom,
-                        // Cross-file augmentation declarations may live in a different
-                        // arena; use `any` here to preserve namespace member visibility.
-                        type_id: TypeId::ANY,
-                        write_type: TypeId::ANY,
-                        optional: false,
-                        readonly: false,
-                        is_method: false,
-                        is_class_prototype: false,
-                        visibility: Visibility::Public,
-                        parent_id: None,
-                        declaration_order: 0,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                    // Cross-file augmentation declarations may live in a different
+                    // arena; use `any` here to preserve namespace member visibility.
+                    props.push(
+                        crate::query_boundaries::js_exports::commonjs_namespace_any_property(
+                            self.ctx.types,
+                            &aug_name,
+                            0,
+                        ),
+                    );
                 }
             }
 
@@ -1272,47 +1081,13 @@ impl<'a> CheckerState<'a> {
                 !(module_is_non_module_entity && self.ctx.allow_synthetic_default_imports());
             let display_module_name = (has_named_props && preserve_namespace_display)
                 .then(|| self.resolve_namespace_display_module_name(&exports_table, module_name));
-            let namespace_type = has_named_props.then(|| {
-                Self::normalize_namespace_export_declaration_order(&mut props);
-                let namespace_type = factory.object(props);
-                if let Some(display_module_name) = display_module_name.as_ref() {
-                    self.ctx
-                        .namespace_module_names
-                        .insert(namespace_type, display_module_name.clone());
-                }
-                namespace_type
-            });
-            if let Some(export_equals_type) = export_equals_type {
-                let result = if module_is_non_module_entity {
-                    if self.ctx.allow_synthetic_default_imports() {
-                        namespace_type.unwrap_or(export_equals_type)
-                    } else {
-                        export_equals_type
-                    }
-                } else {
-                    namespace_type
-                        .map(|namespace_type| {
-                            factory.intersection2(export_equals_type, namespace_type)
-                        })
-                        .unwrap_or(export_equals_type)
-                };
-                if let Some(display_module_name) = display_module_name {
-                    self.ctx
-                        .namespace_module_names
-                        .entry(result)
-                        .or_insert(display_module_name);
-                }
-                return Some(result);
-            }
-
-            if let Some(namespace_type) = namespace_type {
-                if module_is_non_module_entity {
-                    return Some(namespace_type);
-                }
-                return Some(namespace_type);
-            }
-
-            return None;
+            return crate::query_boundaries::js_exports::commonjs_imported_module_value_type(
+                self,
+                props,
+                export_equals_type,
+                module_is_non_module_entity,
+                display_module_name,
+            );
         }
 
         if let Some(direct_export_assignment_type) = direct_export_assignment_type {
@@ -1327,7 +1102,11 @@ impl<'a> CheckerState<'a> {
             && surface.has_commonjs_exports
         {
             let display_name = self.imported_namespace_display_module_name(module_name);
-            return surface.to_type_id_with_display_name(self, Some(display_name));
+            return crate::query_boundaries::js_exports::commonjs_export_surface_type_with_display_name(
+                self,
+                &surface,
+                display_name,
+            );
         }
 
         None

--- a/crates/tsz-checker/src/state/type_environment/formatting.rs
+++ b/crates/tsz-checker/src/state/type_environment/formatting.rs
@@ -3,6 +3,7 @@
 //! Extracted from `core.rs` to keep module size manageable.
 
 use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
@@ -404,7 +405,8 @@ impl<'a> CheckerState<'a> {
                 crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
             {
                 let anonymous = self.evaluate_function_shape_for_instantiation_display(&shape);
-                let anonymous_type = self.ctx.types.factory().function(anonymous);
+                let anonymous_type =
+                    diagnostic_query::function_type_from_shape(self.ctx.types, anonymous);
                 let mut structural_formatter = self.ctx.create_instantiation_display_formatter();
                 return structural_formatter.format(anonymous_type).into_owned();
             }
@@ -443,7 +445,8 @@ impl<'a> CheckerState<'a> {
                 && shape.construct_signatures.is_empty()
             {
                 let anonymous = self.evaluate_callable_shape_for_instantiation_display(&shape);
-                let anonymous_type = self.ctx.types.factory().callable(anonymous);
+                let anonymous_type =
+                    diagnostic_query::callable_type_from_shape(self.ctx.types, anonymous);
                 let mut structural_formatter = self.ctx.create_instantiation_display_formatter();
                 return structural_formatter.format(anonymous_type).into_owned();
             }
@@ -455,19 +458,8 @@ impl<'a> CheckerState<'a> {
                     .iter()
                     .map(|sig| self.evaluate_call_signature_for_instantiation_display(sig))
                     .collect();
-                let anonymous_type = self
-                    .ctx
-                    .types
-                    .factory()
-                    .callable(tsz_solver::CallableShape {
-                        call_signatures,
-                        construct_signatures: Vec::new(),
-                        properties: Vec::new(),
-                        string_index: None,
-                        number_index: None,
-                        symbol: None,
-                        is_abstract: false,
-                    });
+                let anonymous_type =
+                    diagnostic_query::call_only_callable_type(self.ctx.types, call_signatures);
                 let mut structural_formatter = self.ctx.create_instantiation_display_formatter();
                 return structural_formatter.format(anonymous_type).into_owned();
             }
@@ -607,19 +599,8 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
             && !shape.type_params.is_empty()
         {
-            let display_type = self
-                .ctx
-                .types
-                .factory()
-                .function(tsz_solver::FunctionShape {
-                    type_params: Vec::new(),
-                    params: shape.params.clone(),
-                    this_type: shape.this_type,
-                    return_type: shape.return_type,
-                    type_predicate: shape.type_predicate,
-                    is_constructor: shape.is_constructor,
-                    is_method: shape.is_method,
-                });
+            let display_type =
+                diagnostic_query::function_type_without_type_params(self.ctx.types, shape.as_ref());
             return self.format_type_diagnostic(display_type);
         }
 
@@ -633,19 +614,12 @@ impl<'a> CheckerState<'a> {
         {
             let sig = &shape.call_signatures[0];
             if !sig.type_params.is_empty() {
-                let display_type = self
-                    .ctx
-                    .types
-                    .factory()
-                    .function(tsz_solver::FunctionShape {
-                        type_params: Vec::new(),
-                        params: sig.params.clone(),
-                        this_type: sig.this_type,
-                        return_type: sig.return_type,
-                        type_predicate: sig.type_predicate,
-                        is_constructor: false,
-                        is_method: sig.is_method,
-                    });
+                let display_type =
+                    diagnostic_query::function_type_from_call_signature_without_type_params(
+                        self.ctx.types,
+                        sig,
+                        false,
+                    );
                 return self.format_type_diagnostic(display_type);
             }
         }
@@ -780,6 +754,6 @@ impl<'a> CheckerState<'a> {
             })
             .collect();
         new_props.sort_by_key(|p| p.name);
-        self.ctx.types.factory().object(new_props)
+        diagnostic_query::object_type_from_properties(self.ctx.types, new_props)
     }
 }

--- a/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
+++ b/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
@@ -3,6 +3,7 @@
 //! Handles `{ a, ...rest } = obj` and `[a, ...rest] = arr` patterns,
 //! computing the rest type by omitting named sibling properties.
 
+use crate::query_boundaries::binding_patterns as binding_construction;
 use crate::query_boundaries::state::checking as query;
 use crate::query_boundaries::type_checking_utilities;
 use crate::state::CheckerState;
@@ -118,18 +119,13 @@ impl<'a> CheckerState<'a> {
             if (!string_keys.is_empty() || !computed_key_type_ids.is_empty())
                 && let Some(omit_type) = omit_type
             {
-                let factory = self.ctx.types.factory();
-                let mut key_args: Vec<TypeId> = string_keys
-                    .iter()
-                    .map(|n| factory.literal_string(n))
-                    .collect();
-                key_args.extend_from_slice(&computed_key_type_ids);
-                let key_arg = if key_args.len() == 1 {
-                    key_args[0]
-                } else {
-                    factory.union(key_args)
-                };
-                return factory.application(omit_type, vec![parent_type, key_arg]);
+                return binding_construction::binding_rest_omit_application(
+                    self.ctx.types,
+                    omit_type,
+                    parent_type,
+                    &string_keys,
+                    &computed_key_type_ids,
+                );
             }
             return parent_type;
         }
@@ -149,7 +145,7 @@ impl<'a> CheckerState<'a> {
             return if rest_types.len() == 1 {
                 rest_types[0]
             } else {
-                self.ctx.types.factory().union(rest_types)
+                binding_construction::binding_pattern_member_union_type(self.ctx.types, rest_types)
             };
         }
 
@@ -322,7 +318,7 @@ impl<'a> CheckerState<'a> {
             return if !remaining_props.is_empty()
                 || query::is_object_like_type(self.ctx.types, type_id)
             {
-                self.ctx.types.factory().object(remaining_props)
+                binding_construction::binding_pattern_object_type(self.ctx.types, remaining_props)
             } else {
                 type_id
             };
@@ -332,12 +328,14 @@ impl<'a> CheckerState<'a> {
         // Rest results are structural copies, so they must not retain the
         // source type's nominal symbol (e.g. class identity).
         if shape.string_index.is_some() || shape.number_index.is_some() {
-            let mut rest_shape = shape.as_ref().clone();
-            rest_shape.properties = remaining_props;
-            rest_shape.symbol = None;
-            self.ctx.types.factory().object_with_index(rest_shape)
+            binding_construction::binding_rest_indexed_object_type(
+                self.ctx.types,
+                shape.as_ref().clone(),
+                remaining_props,
+            )
         } else {
-            self.ctx.types.factory().object_with_flags_and_symbol(
+            binding_construction::binding_rest_object_with_flags(
+                self.ctx.types,
                 remaining_props,
                 shape.flags,
                 None,
@@ -353,7 +351,7 @@ impl<'a> CheckerState<'a> {
         if query::array_element_type(self.ctx.types, tuple_member_type).is_some() {
             tuple_member_type
         } else {
-            self.ctx.types.factory().array(tuple_member_type)
+            binding_construction::binding_rest_array_type(self.ctx.types, tuple_member_type)
         }
     }
 
@@ -382,13 +380,13 @@ impl<'a> CheckerState<'a> {
             return if let Some(pos) = rest_pos {
                 self.rest_binding_array_type(elements[pos].type_id)
             } else {
-                self.ctx.types.factory().tuple(Vec::new())
+                binding_construction::binding_pattern_tuple_type(self.ctx.types, Vec::new())
             };
         }
-        self.ctx
-            .types
-            .factory()
-            .tuple(elements[rest_index..].to_vec())
+        binding_construction::binding_pattern_tuple_type(
+            self.ctx.types,
+            elements[rest_index..].to_vec(),
+        )
     }
 
     /// Compute the `...rest` binding type when the destructured source is a
@@ -430,7 +428,7 @@ impl<'a> CheckerState<'a> {
             return if slices.len() == 1 {
                 slices[0]
             } else {
-                self.ctx.types.factory().union(slices)
+                binding_construction::binding_pattern_member_union_type(self.ctx.types, slices)
             };
         }
         // All-array-like members distribute numeric indexed access; a
@@ -441,10 +439,10 @@ impl<'a> CheckerState<'a> {
         if saw_non_array_like {
             let iterated = self.for_of_element_type(parent_type, false);
             if iterated != TypeId::ANY && iterated != TypeId::ERROR {
-                return self.ctx.types.factory().array(iterated);
+                return binding_construction::binding_rest_array_type(self.ctx.types, iterated);
             }
         }
         let element_type = self.get_element_access_type(parent_type, TypeId::NUMBER, None);
-        self.ctx.types.factory().array(element_type)
+        binding_construction::binding_rest_array_type(self.ctx.types, element_type)
     }
 }

--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -1,6 +1,7 @@
 //! Destructuring pattern type resolution and validation.
 
 use crate::context::TypingRequest;
+use crate::query_boundaries::binding_patterns;
 use crate::query_boundaries::common as common_query;
 use crate::query_boundaries::flow as flow_boundary;
 use crate::query_boundaries::state::checking as query;
@@ -578,7 +579,11 @@ impl<'a> CheckerState<'a> {
                     .destructuring_relation_outcome(init_type, element_type)
                     .related
                 {
-                    element_type = self.ctx.types.factory().union2(element_type, init_type);
+                    element_type = binding_patterns::binding_pattern_initializer_union_type(
+                        self.ctx.types,
+                        element_type,
+                        init_type,
+                    );
                 }
             }
 
@@ -693,7 +698,6 @@ impl<'a> CheckerState<'a> {
                 }
                 let mut elem_types = Vec::new();
                 let mut saw_non_array_like = false;
-                let factory = self.ctx.types.factory();
                 for &member in &members {
                     let member = query::unwrap_readonly_deep(self.ctx.types, member);
                     if let Some(elem) = query::array_element_type(self.ctx.types, member) {
@@ -765,7 +769,7 @@ impl<'a> CheckerState<'a> {
                 return if elem_types.len() == 1 {
                     elem_types[0]
                 } else {
-                    factory.union(elem_types)
+                    binding_patterns::binding_pattern_member_union_type(self.ctx.types, elem_types)
                 };
             }
 
@@ -1331,8 +1335,10 @@ impl<'a> CheckerState<'a> {
                             }
                         }
                         if any_found && !non_empty_missing {
-                            let factory = self.ctx.types.factory();
-                            return factory.union(member_types);
+                            return binding_patterns::binding_pattern_member_union_type(
+                                self.ctx.types,
+                                member_types,
+                            );
                         }
                     }
 

--- a/crates/tsz-checker/src/state/variable_checking/destructuring/tail.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring/tail.rs
@@ -3,6 +3,7 @@
 //! Split out of the parent module to satisfy the source-file line cap.
 
 use super::*;
+use crate::query_boundaries::binding_patterns;
 
 impl<'a> CheckerState<'a> {
     pub(super) fn preserve_actual_lib_namespace_binding_parent_type(
@@ -96,7 +97,10 @@ impl<'a> CheckerState<'a> {
             } else if member_types.len() == 1 {
                 Some(member_types[0])
             } else {
-                Some(self.ctx.types.factory().union(member_types))
+                Some(binding_patterns::binding_pattern_member_union_type(
+                    self.ctx.types,
+                    member_types,
+                ))
             };
         }
 
@@ -163,7 +167,10 @@ impl<'a> CheckerState<'a> {
         } else if key_types.len() == 1 {
             Some(key_types[0])
         } else {
-            Some(self.ctx.types.factory().union(key_types))
+            Some(binding_patterns::binding_pattern_member_union_type(
+                self.ctx.types,
+                key_types,
+            ))
         }
     }
 
@@ -224,7 +231,8 @@ impl<'a> CheckerState<'a> {
                 request,
             );
             if key_types.len() > 1 {
-                key_type = self.ctx.types.factory().union(key_types);
+                key_type =
+                    binding_patterns::binding_pattern_member_union_type(self.ctx.types, key_types);
             } else {
                 key_type = effective_key;
             }
@@ -478,8 +486,6 @@ impl<'a> CheckerState<'a> {
         let pattern_data = self.ctx.arena.get_binding_pattern(pattern_node)?;
         let elem_indices: Vec<NodeIndex> = pattern_data.elements.nodes.clone();
         let pattern_kind = pattern_node.kind;
-        let factory = self.ctx.types.factory();
-
         if pattern_kind == syntax_kind_ext::ARRAY_BINDING_PATTERN {
             let mut tuple_elements = Vec::new();
             for &elem_idx in &elem_indices {
@@ -533,14 +539,14 @@ impl<'a> CheckerState<'a> {
                     }
                     _ => TypeId::ANY,
                 };
-                tuple_elements.push(tsz_solver::TupleElement {
-                    type_id: elem_type,
-                    optional: false,
-                    rest: false,
-                    name: None,
-                });
+                tuple_elements.push(binding_patterns::binding_pattern_tuple_element(
+                    elem_type, false, false,
+                ));
             }
-            Some(factory.tuple(tuple_elements))
+            Some(binding_patterns::binding_pattern_tuple_type(
+                self.ctx.types,
+                tuple_elements,
+            ))
         } else if pattern_kind == syntax_kind_ext::OBJECT_BINDING_PATTERN {
             // Collect all binding element names for intra-binding-pattern reference detection.
             // When a binding element's default references another binding in the same pattern
@@ -652,9 +658,14 @@ impl<'a> CheckerState<'a> {
                 };
 
                 let atom = self.ctx.types.intern_string(&name_str);
-                properties.push(tsz_solver::PropertyInfo::new(atom, prop_type));
+                properties.push(binding_patterns::binding_pattern_property(
+                    atom, prop_type, false,
+                ));
             }
-            Some(factory.object(properties))
+            Some(binding_patterns::binding_pattern_object_type(
+                self.ctx.types,
+                properties,
+            ))
         } else {
             None
         }

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -11,7 +11,7 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{CallSignature, CallableShape, IndexSignature, PropertyInfo, TypeId};
+use tsz_solver::{CallSignature, IndexSignature, PropertyInfo, TypeId};
 
 use super::can_skip_base_instantiation;
 
@@ -268,7 +268,6 @@ impl<'a> CheckerState<'a> {
         request: &TypingRequest,
         apply_module_augmentations: bool,
     ) -> TypeId {
-        let factory = self.ctx.types.factory();
         let is_abstract_class = self.has_abstract_modifier(&class.modifiers);
         let (mut class_type_params, mut type_param_updates) =
             self.push_type_parameters(&class.type_parameters);
@@ -421,13 +420,13 @@ impl<'a> CheckerState<'a> {
                         if !inst_prop_names.insert(name_atom) {
                             continue;
                         }
-                        inst_props.push(PropertyInfo {
-                            optional: prop.question_token,
-                            readonly: self.has_readonly_modifier(&prop.modifiers),
-                            visibility: self.get_member_visibility(&prop.modifiers, prop.name),
-                            parent_id: current_sym,
-                            ..PropertyInfo::new(name_atom, type_id)
-                        });
+                        inst_props.push(class_type::class_member_property(
+                            class_type::ClassMemberProperty::new(name_atom, type_id)
+                                .optional(prop.question_token)
+                                .readonly(self.has_readonly_modifier(&prop.modifiers))
+                                .visibility(self.get_member_visibility(&prop.modifiers, prop.name))
+                                .parent(current_sym),
+                        ));
                     }
                     k if k == syntax_kind_ext::CONSTRUCTOR => {
                         let Some(ctor) = self.ctx.arena.get_constructor(member_node) else {
@@ -460,13 +459,15 @@ impl<'a> CheckerState<'a> {
                             } else {
                                 TypeId::ANY
                             };
-                            inst_props.push(PropertyInfo {
-                                optional: param.question_token,
-                                readonly: self.has_readonly_modifier(&param.modifiers),
-                                visibility: self.get_visibility_from_modifiers(&param.modifiers),
-                                parent_id: current_sym,
-                                ..PropertyInfo::new(name_atom, type_id)
-                            });
+                            inst_props.push(class_type::class_member_property(
+                                class_type::ClassMemberProperty::new(name_atom, type_id)
+                                    .optional(param.question_token)
+                                    .readonly(self.has_readonly_modifier(&param.modifiers))
+                                    .visibility(
+                                        self.get_visibility_from_modifiers(&param.modifiers),
+                                    )
+                                    .parent(current_sym),
+                            ));
                         }
                     }
                     k if k == syntax_kind_ext::METHOD_DECLARATION => {
@@ -494,29 +495,25 @@ impl<'a> CheckerState<'a> {
                         );
                         let (return_type, type_predicate) = ret_pred;
                         self.pop_type_parameters(type_param_updates);
-                        let callable_type = factory.callable(CallableShape {
-                            call_signatures: vec![CallSignature {
+                        let callable_type = class_type::class_method_callable_type(
+                            self.ctx.types,
+                            vec![class_type::class_method_call_signature(
                                 type_params,
                                 params,
                                 this_type,
                                 return_type,
                                 type_predicate,
-                                is_method: true,
-                            }],
-                            construct_signatures: Vec::new(),
-                            properties: Vec::new(),
-                            string_index: None,
-                            number_index: None,
-                            symbol: None,
-                            is_abstract: false,
-                        });
-                        inst_props.push(PropertyInfo {
-                            optional: method.question_token,
-                            is_method: true,
-                            visibility: self.get_member_visibility(&method.modifiers, method.name),
-                            parent_id: current_sym,
-                            ..PropertyInfo::new(name_atom, callable_type)
-                        });
+                            )],
+                        );
+                        inst_props.push(class_type::class_member_property(
+                            class_type::ClassMemberProperty::new(name_atom, callable_type)
+                                .optional(method.question_token)
+                                .method(false)
+                                .visibility(
+                                    self.get_member_visibility(&method.modifiers, method.name),
+                                )
+                                .parent(current_sym),
+                        ));
                     }
                     _ => {}
                 }
@@ -524,8 +521,7 @@ impl<'a> CheckerState<'a> {
             if inst_props.is_empty() {
                 TypeId::ANY
             } else {
-                let factory = self.ctx.types.factory();
-                factory.object(inst_props)
+                class_type::class_member_object_type(self.ctx.types, inst_props)
             }
         };
 
@@ -538,16 +534,11 @@ impl<'a> CheckerState<'a> {
         // instance snapshot, so generic inference can match construct
         // constraints (`make<P>(x: { new(): { props: P } })` infers `P`) and
         // `return this` from static methods stays constructable (TS2351).
-        let patched_return_type = match rough_self_instance_ref {
-            Some(self_ref)
-                if rough_instance_return_type != TypeId::ANY
-                    && rough_instance_return_type != TypeId::ERROR =>
-            {
-                factory.intersection2(self_ref, rough_instance_return_type)
-            }
-            Some(self_ref) => self_ref,
-            None => rough_instance_return_type,
-        };
+        let patched_return_type = class_type::rough_class_instance_return_type(
+            self.ctx.types,
+            rough_self_instance_ref,
+            rough_instance_return_type,
+        );
         for sig in &mut rough_construct_signatures {
             sig.return_type = patched_return_type;
         }
@@ -640,13 +631,13 @@ impl<'a> CheckerState<'a> {
                                 accessors: &accessors,
                                 static_string_index: &static_string_index,
                                 static_number_index: &static_number_index,
-                                extra_property: Some(PropertyInfo {
-                                    optional: prop.question_token,
-                                    readonly,
-                                    visibility,
-                                    parent_id: current_sym,
-                                    ..PropertyInfo::new(name_atom, TypeId::ANY)
-                                }),
+                                extra_property: Some(class_type::class_member_property(
+                                    class_type::ClassMemberProperty::new(name_atom, TypeId::ANY)
+                                        .optional(prop.question_token)
+                                        .readonly(readonly)
+                                        .visibility(visibility)
+                                        .parent(current_sym),
+                                )),
                                 inherited_static_props: &inherited_static_props,
                                 all_static_member_names: &all_static_member_names,
                                 construct_signatures: &rough_construct_signatures,
@@ -752,13 +743,13 @@ impl<'a> CheckerState<'a> {
                                 accessors: &accessors,
                                 static_string_index: &static_string_index,
                                 static_number_index: &static_number_index,
-                                extra_property: Some(PropertyInfo {
-                                    optional: prop.question_token,
-                                    readonly,
-                                    visibility,
-                                    parent_id: current_sym,
-                                    ..PropertyInfo::new(name_atom, TypeId::ANY)
-                                }),
+                                extra_property: Some(class_type::class_member_property(
+                                    class_type::ClassMemberProperty::new(name_atom, TypeId::ANY)
+                                        .optional(prop.question_token)
+                                        .readonly(readonly)
+                                        .visibility(visibility)
+                                        .parent(current_sym),
+                                )),
                                 inherited_static_props: &inherited_static_props,
                                 all_static_member_names: &all_static_member_names,
                                 construct_signatures: &rough_construct_signatures,
@@ -822,13 +813,13 @@ impl<'a> CheckerState<'a> {
 
                     properties.insert(
                         name_atom,
-                        PropertyInfo {
-                            optional: prop.question_token,
-                            readonly,
-                            visibility,
-                            parent_id: current_sym,
-                            ..PropertyInfo::new(name_atom, type_id)
-                        },
+                        class_type::class_member_property(
+                            class_type::ClassMemberProperty::new(name_atom, type_id)
+                                .optional(prop.question_token)
+                                .readonly(readonly)
+                                .visibility(visibility)
+                                .parent(current_sym),
+                        ),
                     );
                 }
                 k if k == syntax_kind_ext::METHOD_DECLARATION => {
@@ -879,20 +870,15 @@ impl<'a> CheckerState<'a> {
                             self.ctx.symbol_types.remove(&sym_id);
                         }
                     }
-                    let callable_type = factory.callable(CallableShape {
-                        call_signatures: vec![signature.clone()],
-                        construct_signatures: Vec::new(),
-                        properties: Vec::new(),
-                        string_index: None,
-                        number_index: None,
-                        symbol: None,
-                        is_abstract: false,
-                    });
-                    let callable_or_undefined = if method.question_token {
-                        factory.union2(callable_type, TypeId::UNDEFINED)
-                    } else {
-                        callable_type
-                    };
+                    let callable_type = class_type::class_method_callable_type(
+                        self.ctx.types,
+                        vec![signature.clone()],
+                    );
+                    let callable_or_undefined = class_type::optional_class_member_type(
+                        self.ctx.types,
+                        callable_type,
+                        method.question_token,
+                    );
                     let Some(name) = self.get_property_name_resolved(method.name) else {
                         if self
                             .ctx
@@ -1073,12 +1059,9 @@ impl<'a> CheckerState<'a> {
                         .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
                         .map(|name_ident| self.ctx.types.intern_string(&name_ident.escaped_text));
 
-                    let idx_sig = IndexSignature {
-                        key_type,
-                        value_type,
-                        readonly,
-                        param_name,
-                    };
+                    let idx_sig = class_type::class_declared_index_signature(
+                        key_type, value_type, readonly, param_name,
+                    );
 
                     if is_valid_index_type {
                         if key_type == TypeId::NUMBER {
@@ -1105,14 +1088,13 @@ impl<'a> CheckerState<'a> {
             let readonly = accessor.getter.is_some() && accessor.setter.is_none();
             properties.insert(
                 name,
-                PropertyInfo {
-                    type_id: read_type,
-                    write_type,
-                    readonly,
-                    visibility: accessor.visibility,
-                    parent_id: current_sym,
-                    ..PropertyInfo::new(name, read_type)
-                },
+                class_type::class_member_property(
+                    class_type::ClassMemberProperty::new(name, read_type)
+                        .with_write_type(write_type)
+                        .readonly(readonly)
+                        .visibility(accessor.visibility)
+                        .parent(current_sym),
+                ),
             );
         }
 
@@ -1127,15 +1109,7 @@ impl<'a> CheckerState<'a> {
             if signatures.is_empty() {
                 continue;
             }
-            let type_id = factory.callable(CallableShape {
-                call_signatures: signatures,
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            });
+            let type_id = class_type::class_method_callable_type(self.ctx.types, signatures);
             // Cache the final method type for declaration emit so
             // the emitter can resolve return types for static methods.
             // Skip when overloads exist to avoid interfering with TS2394
@@ -1145,13 +1119,13 @@ impl<'a> CheckerState<'a> {
             }
             properties.insert(
                 name,
-                PropertyInfo {
-                    optional,
-                    is_method: true,
-                    visibility: method.visibility,
-                    parent_id: current_sym,
-                    ..PropertyInfo::new(name, type_id)
-                },
+                class_type::class_member_property(
+                    class_type::ClassMemberProperty::new(name, type_id)
+                        .optional(optional)
+                        .method(false)
+                        .visibility(method.visibility)
+                        .parent(current_sym),
+                ),
             );
         }
 
@@ -1229,21 +1203,20 @@ impl<'a> CheckerState<'a> {
                     let prototype_type = current_sym
                         .map(|sym_id| self.ctx.create_lazy_type_ref(sym_id))
                         .unwrap_or(TypeId::ANY);
-                    partial_ctor_props.push(PropertyInfo {
-                        parent_id: current_sym,
-                        ..PropertyInfo::new(prototype_name, prototype_type)
-                    });
+                    partial_ctor_props.push(class_type::class_member_property(
+                        class_type::ClassMemberProperty::new(prototype_name, prototype_type)
+                            .parent(current_sym),
+                    ));
                 }
 
-                let partial_ctor = factory.callable(CallableShape {
-                    call_signatures: Vec::new(),
-                    construct_signatures: rough_construct_signatures,
-                    properties: partial_ctor_props,
-                    string_index: static_string_index,
-                    number_index: static_number_index,
-                    symbol: current_sym,
-                    is_abstract: false,
-                });
+                let partial_ctor = class_type::partial_static_constructor_callable_type(
+                    self.ctx.types,
+                    current_sym,
+                    partial_ctor_props,
+                    &rough_construct_signatures,
+                    static_string_index,
+                    static_number_index,
+                );
                 self.ctx.symbol_types.insert(sym_id, partial_ctor);
 
                 // ── Partial INSTANCE type (for TYPE references like `Bar<any>`) ──
@@ -1275,16 +1248,17 @@ impl<'a> CheckerState<'a> {
                         continue;
                     };
                     let name_atom = self.ctx.types.intern_string(&name);
-                    inst_props.push(PropertyInfo {
-                        optional: prop.question_token,
-                        readonly: self.has_readonly_modifier(&prop.modifiers),
-                        visibility: self.get_member_visibility(&prop.modifiers, prop.name),
-                        parent_id: current_sym,
-                        ..PropertyInfo::new(name_atom, type_id)
-                    });
+                    inst_props.push(class_type::class_member_property(
+                        class_type::ClassMemberProperty::new(name_atom, type_id)
+                            .optional(prop.question_token)
+                            .readonly(self.has_readonly_modifier(&prop.modifiers))
+                            .visibility(self.get_member_visibility(&prop.modifiers, prop.name))
+                            .parent(current_sym),
+                    ));
                 }
                 if !inst_props.is_empty() {
-                    let partial_instance = factory.object(inst_props);
+                    let partial_instance =
+                        class_type::class_member_object_type(self.ctx.types, inst_props);
                     self.ctx
                         .symbol_instance_types
                         .insert(sym_id, partial_instance);
@@ -1347,10 +1321,10 @@ impl<'a> CheckerState<'a> {
         let prototype_name = self.ctx.types.intern_string("prototype");
         properties.insert(
             prototype_name,
-            PropertyInfo {
-                parent_id: current_sym,
-                ..PropertyInfo::new(prototype_name, prototype_type)
-            },
+            class_type::class_member_property(
+                class_type::ClassMemberProperty::new(prototype_name, prototype_type)
+                    .parent(current_sym),
+            ),
         );
 
         // Track base class constructor for inheritance

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -1,7 +1,9 @@
 //! Class constructor type resolution (static members, construct signatures, inheritance).
 
 use crate::context::TypingRequest;
-use crate::query_boundaries::class_type::{callable_shape_for_type, construct_signatures_for_type};
+use crate::query_boundaries::class_type::{
+    self, callable_shape_for_type, construct_signatures_for_type,
+};
 use crate::query_boundaries::common::{ContextualTypeContext, TypeSubstitution, instantiate_type};
 use crate::state::{CheckerState, MemberAccessLevel};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1846,25 +1848,25 @@ impl<'a> CheckerState<'a> {
                     construct_signatures = sigs;
                 } else {
                     // No base class or base class has no explicit constructor - use default
-                    construct_signatures.push(CallSignature {
-                        type_params: class_type_params,
-                        params: Vec::new(),
-                        this_type: None,
-                        return_type: instance_type,
-                        type_predicate: None,
-                        is_method: false,
-                    });
+                    construct_signatures.push(class_type::class_construct_signature(
+                        class_type_params,
+                        Vec::new(),
+                        None,
+                        instance_type,
+                        None,
+                        false,
+                    ));
                 }
             } else {
                 // No base class or base class has no explicit constructor - use default
-                construct_signatures.push(CallSignature {
-                    type_params: class_type_params,
-                    params: Vec::new(),
-                    this_type: None,
-                    return_type: instance_type,
-                    type_predicate: None,
-                    is_method: false,
-                });
+                construct_signatures.push(class_type::class_construct_signature(
+                    class_type_params,
+                    Vec::new(),
+                    None,
+                    instance_type,
+                    None,
+                    false,
+                ));
             }
         }
 
@@ -1879,27 +1881,29 @@ impl<'a> CheckerState<'a> {
         // tsc treats the constructor type as implicitly string-indexable to suppress TS7053.
         let effective_string_index = if let Some(mut static_index) = static_string_index {
             if has_static_late_bound_members {
-                static_index.value_type = factory.union2(static_index.value_type, instance_type);
+                static_index.value_type = class_type::merged_static_late_bound_index_value_type(
+                    self.ctx.types,
+                    static_index.value_type,
+                    instance_type,
+                );
             }
             Some(static_index)
         } else {
-            has_static_late_bound_members.then_some(IndexSignature {
-                key_type: TypeId::STRING,
-                value_type: TypeId::ANY,
-                readonly: false,
-                param_name: None,
-            })
+            has_static_late_bound_members.then_some(class_type::static_late_bound_index_signature(
+                TypeId::STRING,
+                TypeId::ANY,
+            ))
         };
 
-        let constructor_type = factory.callable(CallableShape {
-            call_signatures: Vec::new(),
-            construct_signatures,
+        let constructor_type = class_type::class_constructor_callable_type(
+            self.ctx.types,
+            class_symbol,
             properties,
-            string_index: effective_string_index,
-            number_index: static_number_index,
-            symbol: class_symbol,
-            is_abstract: is_abstract_class,
-        });
+            construct_signatures,
+            effective_string_index,
+            static_number_index,
+            is_abstract_class,
+        );
         // Track constructor accessibility
         if let Some(level) = constructor_access {
             match level {
@@ -1930,7 +1934,11 @@ impl<'a> CheckerState<'a> {
         // to T. This makes `T & ConstructorType <: T` succeed via the
         // intersection rule in the subtype checker.
         if let Some(base_tp) = base_type_param {
-            return factory.intersection2(base_tp, constructor_type);
+            return class_type::class_constructor_mixin_intersection(
+                self.ctx.types,
+                base_tp,
+                constructor_type,
+            );
         }
 
         constructor_type

--- a/crates/tsz-checker/src/types/class_type/constructor_parts/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor_parts/helpers.rs
@@ -1,5 +1,7 @@
 use crate::context::TypingRequest;
-use crate::query_boundaries::class_type::construct_signatures_for_type;
+use crate::query_boundaries::class_type::{
+    self as class_type_boundary, construct_signatures_for_type,
+};
 use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
@@ -7,10 +9,7 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{
-    CallSignature, CallableShape, IndexSignature, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
-    TypePredicate, Visibility,
-};
+use tsz_solver::{CallSignature, IndexSignature, PropertyInfo, TypeId, TypeParamInfo};
 
 use super::build_data::StaticMemberBuildData;
 
@@ -52,7 +51,7 @@ impl<'a> CheckerState<'a> {
                 created
             }
         };
-        self.ctx.types.factory().lazy(ctor_def)
+        class_type_boundary::class_constructor_companion_lazy_type(self.ctx.types, ctor_def)
     }
 
     /// Get the constructor type of a class declaration (static members,
@@ -99,11 +98,12 @@ impl<'a> CheckerState<'a> {
     ) {
         if let Some(existing) = target.as_mut() {
             if existing.value_type != incoming.value_type {
-                existing.value_type = self
-                    .ctx
-                    .types
-                    .factory()
-                    .union2(existing.value_type, incoming.value_type);
+                existing.value_type =
+                    class_type_boundary::merged_static_late_bound_index_value_type(
+                        self.ctx.types,
+                        existing.value_type,
+                        incoming.value_type,
+                    );
             }
             existing.readonly &= incoming.readonly;
         } else {
@@ -142,23 +142,13 @@ impl<'a> CheckerState<'a> {
         if wants_string {
             self.merge_static_late_bound_index_value(
                 static_string_index,
-                IndexSignature {
-                    key_type: TypeId::STRING,
-                    value_type,
-                    readonly: false,
-                    param_name: None,
-                },
+                class_type_boundary::static_late_bound_index_signature(TypeId::STRING, value_type),
             );
         }
         if wants_number {
             self.merge_static_late_bound_index_value(
                 static_number_index,
-                IndexSignature {
-                    key_type: TypeId::NUMBER,
-                    value_type,
-                    readonly: false,
-                    param_name: None,
-                },
+                class_type_boundary::static_late_bound_index_signature(TypeId::NUMBER, value_type),
             );
         }
     }
@@ -229,7 +219,6 @@ impl<'a> CheckerState<'a> {
             all_static_member_names,
             construct_signatures,
         } = data;
-        let factory = self.ctx.types.factory();
         let estimated_cap = properties.len()
             + methods.len()
             + accessors.len()
@@ -249,31 +238,15 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            let type_id = factory.callable(CallableShape {
-                call_signatures: signatures.clone(),
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            });
-            partial_ctor_props.push(PropertyInfo {
+            let type_id =
+                class_type_boundary::partial_static_method_type(self.ctx.types, signatures);
+            partial_ctor_props.push(class_type_boundary::partial_static_method_property(
                 name,
                 type_id,
-                write_type: type_id,
                 optional,
-                readonly: false,
-                is_method: true,
-                is_class_prototype: false,
-                visibility: method.visibility,
-                parent_id: current_sym,
-                declaration_order: 0,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+                method.visibility,
+                current_sym,
+            ));
         }
 
         for (&name, accessor) in accessors {
@@ -283,22 +256,14 @@ impl<'a> CheckerState<'a> {
             let read_type = accessor.getter.or(setter_type).unwrap_or(TypeId::UNKNOWN);
             let write_type = setter_type.or(accessor.getter).unwrap_or(read_type);
             let readonly = accessor.getter.is_some() && accessor.setter.is_none();
-            partial_ctor_props.push(PropertyInfo {
+            partial_ctor_props.push(class_type_boundary::partial_static_accessor_property(
                 name,
-                type_id: read_type,
+                read_type,
                 write_type,
-                optional: false,
                 readonly,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: accessor.visibility,
-                parent_id: current_sym,
-                declaration_order: 0,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+                accessor.visibility,
+                current_sym,
+            ));
         }
 
         if let Some(extra_property) = extra_property {
@@ -320,34 +285,21 @@ impl<'a> CheckerState<'a> {
         let final_names: FxHashSet<_> = partial_ctor_props.iter().map(|p| p.name).collect();
         for &name in all_static_member_names {
             if !final_names.contains(&name) {
-                partial_ctor_props.push(PropertyInfo {
+                partial_ctor_props.push(class_type_boundary::partial_static_placeholder_property(
                     name,
-                    type_id: TypeId::ANY,
-                    write_type: TypeId::ANY,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: current_sym,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                });
+                    current_sym,
+                ));
             }
         }
 
-        factory.callable(CallableShape {
-            call_signatures: Vec::new(),
-            construct_signatures: construct_signatures.to_vec(),
-            properties: partial_ctor_props,
-            string_index: *static_string_index,
-            number_index: *static_number_index,
-            symbol: current_sym,
-            is_abstract: false,
-        })
+        class_type_boundary::partial_static_constructor_callable_type(
+            self.ctx.types,
+            current_sym,
+            partial_ctor_props,
+            construct_signatures,
+            *static_string_index,
+            *static_number_index,
+        )
     }
 
     pub(super) fn remap_inherited_construct_signatures(
@@ -410,14 +362,14 @@ impl<'a> CheckerState<'a> {
                             instantiate_type(self.ctx.types, sig.return_type, subst)
                         })
                     };
-                    CallSignature {
+                    class_type_boundary::class_construct_signature(
                         type_params,
                         params,
                         this_type,
                         return_type,
-                        type_predicate: sig.type_predicate,
-                        is_method: sig.is_method,
-                    }
+                        sig.type_predicate,
+                        sig.is_method,
+                    )
                 })
                 .collect(),
         )
@@ -438,33 +390,41 @@ impl<'a> CheckerState<'a> {
         Some(
             signatures
                 .iter()
-                .map(|sig| CallSignature {
+                .map(|sig| {
                     // In inherited constructors, class type params live on the deriving class.
                     // Reusing base signature type_params can incorrectly shadow substitutions.
-                    type_params: class_type_params.to_vec(),
-                    params: sig
+                    let params = sig
                         .params
                         .iter()
-                        .map(|p| ParamInfo {
-                            name: p.name,
-                            type_id: instantiate_type(self.ctx.types, p.type_id, substitution),
-                            optional: p.optional,
-                            rest: p.rest,
+                        .map(|p| {
+                            class_type_boundary::class_construct_param(
+                                p.name,
+                                instantiate_type(self.ctx.types, p.type_id, substitution),
+                                p.optional,
+                                p.rest,
+                            )
                         })
-                        .collect(),
-                    this_type: sig
+                        .collect();
+                    let this_type = sig
                         .this_type
-                        .map(|t| instantiate_type(self.ctx.types, t, substitution)),
-                    return_type: instance_type,
-                    type_predicate: sig.type_predicate.as_ref().map(|pred| TypePredicate {
-                        asserts: pred.asserts,
-                        target: pred.target,
-                        type_id: pred
-                            .type_id
-                            .map(|t| instantiate_type(self.ctx.types, t, substitution)),
-                        parameter_index: pred.parameter_index,
-                    }),
-                    is_method: sig.is_method,
+                        .map(|t| instantiate_type(self.ctx.types, t, substitution));
+                    let type_predicate = sig.type_predicate.as_ref().map(|pred| {
+                        class_type_boundary::class_type_predicate(
+                            pred.asserts,
+                            pred.target,
+                            pred.type_id
+                                .map(|t| instantiate_type(self.ctx.types, t, substitution)),
+                            pred.parameter_index,
+                        )
+                    });
+                    class_type_boundary::class_construct_signature(
+                        class_type_params.to_vec(),
+                        params,
+                        this_type,
+                        instance_type,
+                        type_predicate,
+                        sig.is_method,
+                    )
                 })
                 .collect(),
         )
@@ -518,8 +478,6 @@ impl<'a> CheckerState<'a> {
             return Vec::new();
         };
         let mut updates = Vec::new();
-        let factory = self.ctx.types.factory();
-
         for &param_idx in &type_parameters.nodes {
             let Some(param_node) = self.ctx.arena.get(param_idx) else {
                 continue;
@@ -535,13 +493,10 @@ impl<'a> CheckerState<'a> {
             };
 
             let name = name_ident.escaped_text.clone();
-            let type_id = factory.type_param(tsz_solver::TypeParamInfo {
-                name: self.ctx.types.intern_string(&name),
-                constraint: None,
-                default: None,
-                is_const: false,
-                origin: tsz_solver::TypeParamOrigin::User,
-            });
+            let type_id = class_type_boundary::enclosing_function_type_param_type(
+                self.ctx.types,
+                self.ctx.types.intern_string(&name),
+            );
             if let Some(&sym_id) = self.ctx.binder.node_symbols.get(&param.name.0)
                 && let Some(def_id) = self.ctx.definition_store.find_def_by_symbol(sym_id.0)
             {

--- a/crates/tsz-checker/src/types/class_type/constructor_parts/rough_partial.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor_parts/rough_partial.rs
@@ -7,7 +7,9 @@
 //! window) observe the correct construct-signature arity instead of the
 //! default zero-parameter fallback.
 
-use crate::query_boundaries::class_type::construct_signatures_for_type;
+use crate::query_boundaries::class_type::{
+    self as class_type_boundary, construct_signatures_for_type,
+};
 use crate::state::CheckerState;
 use tsz_binder::SymbolId;
 use tsz_parser::parser::syntax_kind_ext;
@@ -30,9 +32,8 @@ impl<'a> CheckerState<'a> {
         class_type_params: &[TypeParamInfo],
     ) -> Option<TypeId> {
         let sym_id = current_sym?;
-        let factory = self.ctx.types.factory();
         let def_id = self.ctx.get_or_create_def_id(sym_id);
-        let lazy_ref = factory.lazy(def_id);
+        let lazy_ref = class_type_boundary::rough_self_instance_lazy_type(self.ctx.types, def_id);
         if class_type_params.is_empty() {
             Some(lazy_ref)
         } else {
@@ -47,7 +48,11 @@ impl<'a> CheckerState<'a> {
                         .unwrap_or(TypeId::ANY)
                 })
                 .collect();
-            Some(factory.application(lazy_ref, args))
+            Some(class_type_boundary::rough_self_instance_application_type(
+                self.ctx.types,
+                lazy_ref,
+                args,
+            ))
         }
     }
 
@@ -141,13 +146,15 @@ impl<'a> CheckerState<'a> {
                     return Some(
                         base_sigs
                             .iter()
-                            .map(|sig| CallSignature {
-                                type_params: class_type_params.to_vec(),
-                                params: sig.params.clone(),
-                                this_type: sig.this_type,
-                                return_type: rough_sig_return_type,
-                                type_predicate: sig.type_predicate,
-                                is_method: false,
+                            .map(|sig| {
+                                class_type_boundary::class_construct_signature(
+                                    class_type_params.to_vec(),
+                                    sig.params.clone(),
+                                    sig.this_type,
+                                    rough_sig_return_type,
+                                    sig.type_predicate,
+                                    false,
+                                )
                             })
                             .collect(),
                     );
@@ -158,14 +165,14 @@ impl<'a> CheckerState<'a> {
                 sigs = inherited;
             } else {
                 // Default construct signature (like the default constructor).
-                sigs.push(CallSignature {
-                    type_params: class_type_params.to_vec(),
-                    params: Vec::new(),
-                    this_type: None,
-                    return_type: rough_sig_return_type,
-                    type_predicate: None,
-                    is_method: false,
-                });
+                sigs.push(class_type_boundary::class_construct_signature(
+                    class_type_params.to_vec(),
+                    Vec::new(),
+                    None,
+                    rough_sig_return_type,
+                    None,
+                    false,
+                ));
             }
         }
         sigs

--- a/crates/tsz-checker/src/types/class_type/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/helpers.rs
@@ -1,6 +1,6 @@
 //! Helper routines for class instance type construction.
 
-use crate::query_boundaries::class_type::{callable_shape_for_type, object_shape_for_type};
+use crate::query_boundaries::class_type::{self, callable_shape_for_type, object_shape_for_type};
 use crate::query_boundaries::common::is_plain_object_type;
 use crate::state::CheckerState;
 use rustc_hash::FxHashMap;
@@ -8,8 +8,7 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{
-    CallSignature, CallableShape, IndexSignature, ObjectShape, TypeId, TypeParamInfo,
-    TypeParamOrigin, Visibility,
+    CallSignature, IndexSignature, TypeId, TypeParamInfo, TypeParamOrigin, Visibility,
 };
 
 /// Bookkeeping record for a single type parameter pushed into
@@ -311,8 +310,6 @@ impl<'a> CheckerState<'a> {
         instance_type: TypeId,
         interface_type: TypeId,
     ) -> TypeId {
-        let factory = self.ctx.types.factory();
-
         let mut properties = FxHashMap::default();
         let mut call_signatures = Vec::new();
         let mut construct_signatures = Vec::new();
@@ -366,34 +363,21 @@ impl<'a> CheckerState<'a> {
         merge_shape(instance_type, true);
         merge_shape(interface_type, false);
 
-        if result_is_callable {
-            return factory.callable(CallableShape {
+        class_type::merged_class_instance_interface_type(
+            self.ctx.types,
+            class_type::MergedClassInstanceInterfaceSurface::new(
+                result_is_callable,
                 call_signatures,
                 construct_signatures,
-                properties: properties.into_values().collect(),
+                properties.into_values().collect(),
                 string_index,
                 number_index,
                 symbol,
-                is_abstract: false,
-            });
-        }
-
-        let shape = ObjectShape {
-            properties: properties.into_values().collect(),
-            string_index,
-            number_index,
-            symbol,
-            ..ObjectShape::default()
-        };
-
-        if is_plain_object_type(self.ctx.types, instance_type)
-            && string_index.is_none()
-            && number_index.is_none()
-        {
-            factory.object(shape.properties)
-        } else {
-            factory.object_with_index(shape)
-        }
+                is_plain_object_type(self.ctx.types, instance_type)
+                    && string_index.is_none()
+                    && number_index.is_none(),
+            ),
+        )
     }
 
     pub(super) fn merge_union_index_signature(
@@ -403,11 +387,11 @@ impl<'a> CheckerState<'a> {
     ) {
         if let Some(existing) = target.as_mut() {
             if existing.value_type != incoming.value_type {
-                existing.value_type = self
-                    .ctx
-                    .types
-                    .factory()
-                    .union2(existing.value_type, incoming.value_type);
+                existing.value_type = class_type::merged_static_late_bound_index_value_type(
+                    self.ctx.types,
+                    existing.value_type,
+                    incoming.value_type,
+                );
             }
             existing.readonly &= incoming.readonly;
         } else {
@@ -441,23 +425,13 @@ impl<'a> CheckerState<'a> {
             if wants_string {
                 self.merge_union_index_signature(
                     string_index,
-                    IndexSignature {
-                        key_type: TypeId::STRING,
-                        value_type,
-                        readonly: false,
-                        param_name: None,
-                    },
+                    class_type::static_late_bound_index_signature(TypeId::STRING, value_type),
                 );
             }
             if wants_number {
                 self.merge_union_index_signature(
                     number_index,
-                    IndexSignature {
-                        key_type: TypeId::NUMBER,
-                        value_type,
-                        readonly: false,
-                        param_name: None,
-                    },
+                    class_type::static_late_bound_index_signature(TypeId::NUMBER, value_type),
                 );
             }
         }

--- a/crates/tsz-checker/src/types/class_type/instance.rs
+++ b/crates/tsz-checker/src/types/class_type/instance.rs
@@ -13,6 +13,7 @@
 
 use super::helpers::{AccessorAggregate, MethodAggregate};
 use crate::context::{EnclosingClassInfo, is_js_file_name};
+use crate::query_boundaries::class_type;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_binder::SymbolId;
@@ -20,10 +21,7 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{
-    CallSignature, CallableShape, IndexSignature, ObjectShape, PropertyInfo, TypeId, TypeParamInfo,
-    Visibility,
-};
+use tsz_solver::{IndexSignature, PropertyInfo, TypeId, TypeParamInfo, Visibility};
 
 /// Whether Phase 2 swapped in a temporary `enclosing_class` and, if so, the
 /// previous value to restore afterward.
@@ -175,7 +173,6 @@ impl<'a> CheckerState<'a> {
         class: &'b tsz_parser::parser::node::ClassData,
         b: &mut ClassInstanceBuilder<'b>,
     ) {
-        let factory = self.ctx.types.factory();
         let current_sym = b.current_sym;
         let member_count = b.member_count;
         {
@@ -244,22 +241,14 @@ impl<'a> CheckerState<'a> {
                         let is_readonly = self.has_readonly_modifier(&prop.modifiers)
                             || self.jsdoc_has_readonly_tag(member_idx);
                         let visibility = self.get_member_visibility(&prop.modifiers, prop.name);
-                        prescan_props.push(PropertyInfo {
-                            name: name_atom,
-                            type_id: declared_type,
-                            write_type: declared_type,
-                            optional: prop.question_token,
-                            readonly: is_readonly,
-                            is_method: false,
-                            is_class_prototype: false,
-                            visibility,
-                            parent_id: current_sym,
-                            declaration_order,
-                            is_string_named: false,
-                            is_symbol_named: false,
-                            single_quoted_name: false,
-                            non_widening: false,
-                        });
+                        prescan_props.push(class_type::class_member_property(
+                            class_type::ClassMemberProperty::new(name_atom, declared_type)
+                                .optional(prop.question_token)
+                                .readonly(is_readonly)
+                                .visibility(visibility)
+                                .parent(current_sym)
+                                .declaration_order(declaration_order),
+                        ));
                     }
                     k if k == syntax_kind_ext::METHOD_DECLARATION => {
                         let Some(method) = self.ctx.arena.get_method_decl(member_node) else {
@@ -283,46 +272,26 @@ impl<'a> CheckerState<'a> {
                                 self.push_type_parameters(&method.type_parameters);
                             let return_type = self.get_type_from_type_node(method.type_annotation);
                             self.pop_type_parameters(type_param_updates);
-                            self.ctx.types.factory().callable(CallableShape {
-                                call_signatures: vec![CallSignature {
+                            class_type::class_method_callable_type(
+                                self.ctx.types,
+                                vec![class_type::class_method_call_signature(
                                     type_params,
-                                    params: vec![tsz_solver::ParamInfo {
-                                        name: None,
-                                        type_id: TypeId::ANY,
-                                        optional: false,
-                                        rest: true,
-                                    }],
-                                    this_type: None,
+                                    vec![class_type::class_rest_any_param()],
+                                    None,
                                     return_type,
-                                    type_predicate: None,
-                                    is_method: true,
-                                }],
-                                construct_signatures: Vec::new(),
-                                properties: Vec::new(),
-                                string_index: None,
-                                number_index: None,
-                                symbol: None,
-                                is_abstract: false,
-                            })
+                                    None,
+                                )],
+                            )
                         } else {
                             TypeId::ANY
                         };
-                        prescan_props.push(PropertyInfo {
-                            name: name_atom,
-                            type_id: method_type,
-                            write_type: method_type,
-                            optional: false,
-                            readonly: false,
-                            is_method: true,
-                            is_class_prototype: false,
-                            visibility,
-                            parent_id: current_sym,
-                            declaration_order,
-                            is_string_named: false,
-                            is_symbol_named: false,
-                            single_quoted_name: false,
-                            non_widening: false,
-                        });
+                        prescan_props.push(class_type::class_member_property(
+                            class_type::ClassMemberProperty::new(name_atom, method_type)
+                                .method(false)
+                                .visibility(visibility)
+                                .parent(current_sym)
+                                .declaration_order(declaration_order),
+                        ));
                     }
                     k if k == syntax_kind_ext::GET_ACCESSOR
                         || k == syntax_kind_ext::SET_ACCESSOR =>
@@ -344,23 +313,15 @@ impl<'a> CheckerState<'a> {
                         } else {
                             TypeId::ANY
                         };
-                        prescan_props.push(PropertyInfo {
-                            name: name_atom,
-                            type_id: accessor_type,
-                            write_type: accessor_type,
-                            optional: false,
-                            readonly: k == syntax_kind_ext::GET_ACCESSOR,
-                            is_method: false,
-                            is_class_prototype: false,
-                            visibility: self
-                                .get_member_visibility(&accessor.modifiers, accessor.name),
-                            parent_id: current_sym,
-                            declaration_order,
-                            is_string_named: false,
-                            is_symbol_named: false,
-                            single_quoted_name: false,
-                            non_widening: false,
-                        });
+                        prescan_props.push(class_type::class_member_property(
+                            class_type::ClassMemberProperty::new(name_atom, accessor_type)
+                                .readonly(k == syntax_kind_ext::GET_ACCESSOR)
+                                .visibility(
+                                    self.get_member_visibility(&accessor.modifiers, accessor.name),
+                                )
+                                .parent(current_sym)
+                                .declaration_order(declaration_order),
+                        ));
                     }
                     k if k == syntax_kind_ext::CONSTRUCTOR => {
                         let Some(ctor) = self.ctx.arena.get_constructor(member_node) else {
@@ -390,22 +351,14 @@ impl<'a> CheckerState<'a> {
                                 TypeId::ANY
                             };
                             let visibility = self.get_visibility_from_modifiers(&param.modifiers);
-                            prescan_props.push(PropertyInfo {
-                                name: name_atom,
-                                type_id: declared_type,
-                                write_type: declared_type,
-                                optional: param.question_token,
-                                readonly: is_readonly,
-                                is_method: false,
-                                is_class_prototype: false,
-                                visibility,
-                                parent_id: current_sym,
-                                declaration_order: declaration_order + param_pos as u32 + 1,
-                                is_string_named: false,
-                                is_symbol_named: false,
-                                single_quoted_name: false,
-                                non_widening: false,
-                            });
+                            prescan_props.push(class_type::class_member_property(
+                                class_type::ClassMemberProperty::new(name_atom, declared_type)
+                                    .optional(param.question_token)
+                                    .readonly(is_readonly)
+                                    .visibility(visibility)
+                                    .parent(current_sym)
+                                    .declaration_order(declaration_order + param_pos as u32 + 1),
+                            ));
                         }
                     }
                     _ => {}
@@ -416,28 +369,18 @@ impl<'a> CheckerState<'a> {
                 self.inherited_prescan_this_base_type(class, needs_inherited_prescan_this);
 
             if !prescan_props.is_empty() || base_prescan_type.is_some() {
-                let own_prescan_type = if !prescan_props.is_empty() {
-                    Some(factory.object_with_index(ObjectShape {
-                        properties: prescan_props,
-                        symbol: current_sym,
-                        ..ObjectShape::default()
-                    }))
-                } else {
-                    None
-                };
-                let prescan_type = match (own_prescan_type, base_prescan_type) {
-                    (Some(own), Some(base)) => {
-                        // Intersection: derived-class own props take priority in lookup,
-                        // base props are reachable through the second member.
-                        self.ctx.types.factory().intersection(vec![own, base])
-                    }
-                    (Some(own), None) => own,
-                    (None, Some(base)) => base,
-                    (None, None) => unreachable!(
-                        "guarded by `!prescan_props.is_empty() || base_prescan_type.is_some()`: \
-                         at least one of own/base prescan types is present"
-                    ),
-                };
+                let prescan_type = class_type::class_member_partial_this_type(
+                    self.ctx.types,
+                    prescan_props,
+                    None,
+                    None,
+                    current_sym,
+                    base_prescan_type,
+                )
+                .expect(
+                    "guarded by `!prescan_props.is_empty() || base_prescan_type.is_some()`: \
+                     at least one of own/base prescan types is present",
+                );
                 self.ctx
                     .class_instance_type_cache
                     .borrow_mut()
@@ -477,7 +420,6 @@ impl<'a> CheckerState<'a> {
     ) where
         'a: 'b,
     {
-        let factory = self.ctx.types.factory();
         let current_sym = b.current_sym;
         // A derived class can only assign `this.<prop>` after `super()`, so
         // constructor-flow property inference must respect the same gate when
@@ -546,43 +488,28 @@ impl<'a> CheckerState<'a> {
                     let type_id = if let Some(declared_type) = declared_type {
                         declared_type
                     } else if prop.initializer.is_some() {
-                        let current_property_placeholder = PropertyInfo {
-                            name: name_atom,
-                            type_id: TypeId::ANY,
-                            write_type: TypeId::ANY,
-                            optional: prop.question_token,
-                            readonly: is_readonly,
-                            is_method: false,
-                            is_class_prototype: false,
-                            visibility,
-                            parent_id: current_sym,
-                            declaration_order,
-                            is_string_named: false,
-                            is_symbol_named,
-                            single_quoted_name: false,
-                            non_widening: false,
-                        };
+                        let current_property_placeholder = class_type::class_member_property(
+                            class_type::ClassMemberProperty::new(name_atom, TypeId::ANY)
+                                .optional(prop.question_token)
+                                .readonly(is_readonly)
+                                .visibility(visibility)
+                                .parent(current_sym)
+                                .declaration_order(declaration_order)
+                                .symbol_named(is_symbol_named),
+                        );
                         let mut partial_props: Vec<PropertyInfo> =
                             b.properties.values().cloned().collect();
                         if !partial_props.iter().any(|p| p.name == name_atom) {
                             partial_props.push(current_property_placeholder);
                         }
-                        let refreshed_this_type = if partial_props.is_empty() {
-                            b.prescan_this_type
-                        } else {
-                            let own_partial = factory.object_with_index(ObjectShape {
-                                properties: partial_props,
-                                string_index: b.string_index,
-                                number_index: b.number_index,
-                                symbol: current_sym,
-                                ..ObjectShape::default()
-                            });
-                            Some(if let Some(prescan) = b.prescan_this_type {
-                                factory.intersection(vec![own_partial, prescan])
-                            } else {
-                                own_partial
-                            })
-                        };
+                        let refreshed_this_type = class_type::class_member_partial_this_type(
+                            self.ctx.types,
+                            partial_props,
+                            b.string_index,
+                            b.number_index,
+                            current_sym,
+                            b.prescan_this_type,
+                        );
                         if let Some(partial_this) = refreshed_this_type {
                             self.ctx.this_type_stack.push(partial_this);
                             // Property initializers may already have been typed earlier
@@ -669,22 +596,15 @@ impl<'a> CheckerState<'a> {
 
                     b.properties.insert(
                         name_atom,
-                        PropertyInfo {
-                            name: name_atom,
-                            type_id,
-                            write_type: type_id,
-                            optional: prop.question_token,
-                            readonly: is_readonly,
-                            is_method: false,
-                            is_class_prototype: false,
-                            visibility,
-                            parent_id: current_sym,
-                            declaration_order,
-                            is_string_named: false,
-                            is_symbol_named,
-                            single_quoted_name: false,
-                            non_widening: false,
-                        },
+                        class_type::class_member_property(
+                            class_type::ClassMemberProperty::new(name_atom, type_id)
+                                .optional(prop.question_token)
+                                .readonly(is_readonly)
+                                .visibility(visibility)
+                                .parent(current_sym)
+                                .declaration_order(declaration_order)
+                                .symbol_named(is_symbol_named),
+                        ),
                     );
                 }
                 k if k == syntax_kind_ext::METHOD_DECLARATION => {
@@ -800,22 +720,14 @@ impl<'a> CheckerState<'a> {
                         let visibility = self.get_visibility_from_modifiers(&param.modifiers);
                         b.properties.insert(
                             name_atom,
-                            PropertyInfo {
-                                name: name_atom,
-                                type_id,
-                                write_type: type_id,
-                                optional: param.question_token,
-                                readonly: is_readonly,
-                                is_method: false,
-                                is_class_prototype: false,
-                                visibility,
-                                parent_id: current_sym,
-                                declaration_order: declaration_order + param_pos as u32 + 1,
-                                is_string_named: false,
-                                is_symbol_named: false,
-                                single_quoted_name: false,
-                                non_widening: false,
-                            },
+                            class_type::class_member_property(
+                                class_type::ClassMemberProperty::new(name_atom, type_id)
+                                    .optional(param.question_token)
+                                    .readonly(is_readonly)
+                                    .visibility(visibility)
+                                    .parent(current_sym)
+                                    .declaration_order(declaration_order + param_pos as u32 + 1),
+                            ),
                         );
                     }
 
@@ -899,12 +811,9 @@ impl<'a> CheckerState<'a> {
                         .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
                         .map(|name_ident| self.ctx.types.intern_string(&name_ident.escaped_text));
 
-                    let index = IndexSignature {
-                        key_type,
-                        value_type,
-                        readonly,
-                        param_name,
-                    };
+                    let index = class_type::class_declared_index_signature(
+                        key_type, value_type, readonly, param_name,
+                    );
 
                     if is_valid_index_type {
                         if key_type == TypeId::NUMBER {
@@ -979,7 +888,6 @@ impl<'a> CheckerState<'a> {
         class_idx: NodeIndex,
         b: &mut ClassInstanceBuilder<'b>,
     ) {
-        let factory = self.ctx.types.factory();
         let current_sym = b.current_sym;
         if !b.deferred_methods.is_empty() {
             let mut partial_method_props = b.properties.clone();
@@ -1065,73 +973,45 @@ impl<'a> CheckerState<'a> {
                         let (type_params, type_param_updates) =
                             self.push_type_parameters(&method.type_parameters);
                         self.pop_type_parameters(type_param_updates);
-                        let placeholder = factory.callable(CallableShape {
-                            call_signatures: vec![CallSignature {
+                        let placeholder = class_type::class_method_callable_type(
+                            self.ctx.types,
+                            vec![class_type::class_method_call_signature(
                                 type_params,
-                                params: vec![tsz_solver::ParamInfo {
-                                    name: None,
-                                    type_id: TypeId::ANY,
-                                    optional: false,
-                                    rest: true,
-                                }],
-                                this_type: None,
+                                vec![class_type::class_rest_any_param()],
+                                None,
                                 return_type,
-                                type_predicate: None,
-                                is_method: true,
-                            }],
-                            construct_signatures: Vec::new(),
-                            properties: Vec::new(),
-                            string_index: None,
-                            number_index: None,
-                            symbol: None,
-                            is_abstract: false,
-                        });
-                        partial_props.push(PropertyInfo {
-                            name: name_atom,
-                            type_id: placeholder,
-                            write_type: placeholder,
-                            optional: false,
-                            readonly: false,
-                            is_method: true,
-                            is_class_prototype: true,
-                            visibility: Visibility::Public,
-                            parent_id: current_sym,
-                            declaration_order: *declaration_order,
-                            is_string_named: false,
-                            is_symbol_named,
-                            single_quoted_name: false,
-                            non_widening: false,
-                        });
+                                None,
+                            )],
+                        );
+                        partial_props.push(class_type::class_member_property(
+                            class_type::ClassMemberProperty::new(name_atom, placeholder)
+                                .method(true)
+                                .parent(current_sym)
+                                .declaration_order(*declaration_order)
+                                .symbol_named(is_symbol_named),
+                        ));
                     }
                 }
             }
             for deferred in &b.deferred_accessors {
                 if partial_prop_names.insert(deferred.name_atom) {
-                    partial_props.push(PropertyInfo {
-                        name: deferred.name_atom,
-                        type_id: TypeId::ANY,
-                        write_type: TypeId::UNKNOWN,
-                        optional: false,
-                        readonly: false,
-                        is_method: false,
-                        is_class_prototype: true,
-                        visibility: deferred.visibility,
-                        parent_id: current_sym,
-                        declaration_order: deferred.declaration_order,
-                        is_string_named: false,
-                        is_symbol_named: deferred.is_symbol_named,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                    partial_props.push(class_type::class_member_property(
+                        class_type::ClassMemberProperty::new(deferred.name_atom, TypeId::ANY)
+                            .with_write_type(TypeId::UNKNOWN)
+                            .visibility(deferred.visibility)
+                            .parent(current_sym)
+                            .declaration_order(deferred.declaration_order)
+                            .symbol_named(deferred.is_symbol_named),
+                    ));
                 }
             }
-            let partial_type = factory.object_with_index(ObjectShape {
-                properties: partial_props,
-                string_index: partial_method_string_index,
-                number_index: partial_method_number_index,
-                symbol: current_sym,
-                ..ObjectShape::default()
-            });
+            let partial_type = class_type::class_member_object_with_indexes_type(
+                self.ctx.types,
+                partial_props,
+                partial_method_string_index,
+                partial_method_number_index,
+                current_sym,
+            );
             self.ctx.this_type_stack.push(partial_type);
 
             // Cache the partial instance type in the node-indexed cache only.
@@ -1179,14 +1059,13 @@ impl<'a> CheckerState<'a> {
                     let (params, this_type) =
                         self.extract_params_from_parameter_list(&method.parameters);
                     self.pop_type_parameters(type_param_updates);
-                    tsz_solver::CallSignature {
+                    class_type::class_method_call_signature(
                         type_params,
                         params,
                         this_type,
-                        return_type: TypeId::ANY,
-                        type_predicate: None,
-                        is_method: true,
-                    }
+                        TypeId::ANY,
+                        None,
+                    )
                 } else {
                     self.call_signature_from_method(method, member_idx)
                 };
@@ -1209,20 +1088,13 @@ impl<'a> CheckerState<'a> {
                         signature.return_type = self.ctx.types.this_type();
                     }
                 }
-                let callable_type = factory.callable(CallableShape {
-                    call_signatures: vec![signature.clone()],
-                    construct_signatures: Vec::new(),
-                    properties: Vec::new(),
-                    string_index: None,
-                    number_index: None,
-                    symbol: None,
-                    is_abstract: false,
-                });
-                let callable_or_undefined = if method.question_token {
-                    factory.union2(callable_type, TypeId::UNDEFINED)
-                } else {
-                    callable_type
-                };
+                let callable_type =
+                    class_type::class_method_callable_type(self.ctx.types, vec![signature.clone()]);
+                let callable_or_undefined = class_type::optional_class_member_type(
+                    self.ctx.types,
+                    callable_type,
+                    method.question_token,
+                );
                 let Some(name) = self.get_property_name_resolved(method.name) else {
                     if self
                         .ctx
@@ -1295,31 +1167,16 @@ impl<'a> CheckerState<'a> {
                 if signatures.is_empty() {
                     continue;
                 }
-                let type_id = self.ctx.types.factory().callable(CallableShape {
-                    call_signatures: signatures.clone(),
-                    construct_signatures: Vec::new(),
-                    properties: Vec::new(),
-                    string_index: None,
-                    number_index: None,
-                    symbol: None,
-                    is_abstract: false,
-                });
-                base_props.push(PropertyInfo {
-                    name,
-                    type_id,
-                    write_type: type_id,
-                    optional,
-                    readonly: false,
-                    is_method: true,
-                    is_class_prototype: true,
-                    visibility: method.visibility,
-                    parent_id: current_sym,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: method.is_symbol_named,
-                    single_quoted_name: false,
-                    non_widening: false,
-                });
+                let type_id =
+                    class_type::class_method_callable_type(self.ctx.types, signatures.clone());
+                base_props.push(class_type::class_member_property(
+                    class_type::ClassMemberProperty::new(name, type_id)
+                        .optional(optional)
+                        .method(true)
+                        .visibility(method.visibility)
+                        .parent(current_sym)
+                        .symbol_named(method.is_symbol_named),
+                ));
             }
             let deferred_accessors = std::mem::take(&mut b.deferred_accessors);
 
@@ -1355,30 +1212,21 @@ impl<'a> CheckerState<'a> {
                         .get(&ad.name_atom)
                         .and_then(|a| a.getter.or(a.setter))
                         .unwrap_or(TypeId::ANY);
-                    props.push(PropertyInfo {
-                        name: ad.name_atom,
-                        type_id: resolved,
-                        write_type: resolved,
-                        optional: false,
-                        readonly: false,
-                        is_method: false,
-                        is_class_prototype: true,
-                        visibility: ad.visibility,
-                        parent_id: current_sym,
-                        declaration_order: ad.declaration_order,
-                        is_string_named: false,
-                        is_symbol_named: ad.is_symbol_named,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                    props.push(class_type::class_member_property(
+                        class_type::ClassMemberProperty::new(ad.name_atom, resolved)
+                            .visibility(ad.visibility)
+                            .parent(current_sym)
+                            .declaration_order(ad.declaration_order)
+                            .symbol_named(ad.is_symbol_named),
+                    ));
                 }
-                let partial_type = self.ctx.types.factory().object_with_index(ObjectShape {
-                    properties: props,
-                    string_index: b.string_index,
-                    number_index: b.number_index,
-                    symbol: current_sym,
-                    ..ObjectShape::default()
-                });
+                let partial_type = class_type::class_member_object_with_indexes_type(
+                    self.ctx.types,
+                    props,
+                    b.string_index,
+                    b.number_index,
+                    current_sym,
+                );
                 if pushed_this {
                     self.ctx.this_type_stack.pop();
                 }
@@ -1510,7 +1358,6 @@ impl<'a> CheckerState<'a> {
         class_idx: NodeIndex,
         b: &mut ClassInstanceBuilder<'_>,
     ) {
-        let factory = self.ctx.types.factory();
         let current_sym = b.current_sym;
 
         // Convert accessors to properties
@@ -1527,22 +1374,15 @@ impl<'a> CheckerState<'a> {
             let readonly = accessor.getter.is_some() && accessor.setter.is_none();
             b.properties.insert(
                 name,
-                PropertyInfo {
-                    name,
-                    type_id: read_type,
-                    write_type,
-                    optional: false,
-                    readonly,
-                    is_method: false,
-                    is_class_prototype: true,
-                    visibility: accessor.visibility,
-                    parent_id: current_sym,
-                    declaration_order: accessor.declaration_order,
-                    is_string_named: false,
-                    is_symbol_named: accessor.is_symbol_named,
-                    single_quoted_name: false,
-                    non_widening: false,
-                },
+                class_type::class_member_property(
+                    class_type::ClassMemberProperty::new(name, read_type)
+                        .with_write_type(write_type)
+                        .readonly(readonly)
+                        .visibility(accessor.visibility)
+                        .parent(current_sym)
+                        .declaration_order(accessor.declaration_order)
+                        .symbol_named(accessor.is_symbol_named),
+                ),
             );
         }
 
@@ -1562,15 +1402,7 @@ impl<'a> CheckerState<'a> {
             if signatures.is_empty() {
                 continue;
             }
-            let type_id = factory.callable(CallableShape {
-                call_signatures: signatures,
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            });
+            let type_id = class_type::class_method_callable_type(self.ctx.types, signatures);
             // Note: we intentionally do NOT cache instance method types in
             // node_types here. Instance methods go through deferred processing
             // where the return type may be rewritten (e.g., `this` returns).
@@ -1578,22 +1410,15 @@ impl<'a> CheckerState<'a> {
             // when the type differs from what the emitter's fallback expects.
             b.properties.insert(
                 name,
-                PropertyInfo {
-                    name,
-                    type_id,
-                    write_type: type_id,
-                    optional,
-                    readonly: false,
-                    is_method: true,
-                    is_class_prototype: true,
-                    visibility: method.visibility,
-                    parent_id: current_sym,
-                    declaration_order: method.declaration_order,
-                    is_string_named: false,
-                    is_symbol_named: method.is_symbol_named,
-                    single_quoted_name: false,
-                    non_widening: false,
-                },
+                class_type::class_member_property(
+                    class_type::ClassMemberProperty::new(name, type_id)
+                        .optional(optional)
+                        .method(true)
+                        .visibility(method.visibility)
+                        .parent(current_sym)
+                        .declaration_order(method.declaration_order)
+                        .symbol_named(method.is_symbol_named),
+                ),
             );
         }
 
@@ -1605,22 +1430,12 @@ impl<'a> CheckerState<'a> {
                 format!("__private_brand_node_{}", class_idx.0)
             };
             let brand_atom = self.ctx.types.intern_string(&brand_name);
-            b.properties.entry(brand_atom).or_insert(PropertyInfo {
-                name: brand_atom,
-                type_id: TypeId::UNKNOWN,
-                write_type: TypeId::UNKNOWN,
-                optional: false,
-                readonly: true,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: 0,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+            b.properties
+                .entry(brand_atom)
+                .or_insert(class_type::class_member_property(
+                    class_type::ClassMemberProperty::new(brand_atom, TypeId::UNKNOWN)
+                        .readonly(true),
+                ));
         }
     }
 }

--- a/crates/tsz-checker/src/types/class_type/js_class_properties.rs
+++ b/crates/tsz-checker/src/types/class_type/js_class_properties.rs
@@ -2,6 +2,9 @@
 //! assignments that serve as implicit property declarations.
 
 use crate::context::speculation::DiagnosticSpeculationSnapshot;
+use crate::query_boundaries::checkers::class_properties::{
+    self as class_property_query, JsClassPropertyFact,
+};
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_binder::SymbolId;
@@ -9,10 +12,7 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{
-    CallSignature, CallableShape, ObjectShape, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
-    Visibility,
-};
+use tsz_solver::{PropertyInfo, TypeId, Visibility};
 
 /// Structural classification of an implicit-`any` constructor property, carried
 /// as a fact rather than re-derived from its rendered display string. The
@@ -149,16 +149,13 @@ impl CheckerState<'_> {
                         .get(&name)
                         .and_then(|s| self.resolve_jsdoc_reference(s));
                     template_types.entry(name).or_insert_with(|| {
-                        self.ctx
-                            .types
-                            .factory()
-                            .type_param(tsz_solver::TypeParamInfo {
-                                name: atom,
-                                constraint,
-                                default,
-                                is_const,
-                                origin: tsz_solver::TypeParamOrigin::User,
-                            })
+                        class_property_query::js_class_type_param_type(
+                            self.ctx.types,
+                            atom,
+                            constraint,
+                            default,
+                            is_const,
+                        )
                     });
                 }
                 return template_types;
@@ -220,16 +217,13 @@ impl CheckerState<'_> {
                     .get(&name)
                     .and_then(|s| self.resolve_jsdoc_reference(s));
                 function_template_types.entry(name).or_insert_with(|| {
-                    self.ctx
-                        .types
-                        .factory()
-                        .type_param(tsz_solver::TypeParamInfo {
-                            name: atom,
-                            constraint,
-                            default,
-                            is_const,
-                            origin: tsz_solver::TypeParamOrigin::User,
-                        })
+                    class_property_query::js_class_type_param_type(
+                        self.ctx.types,
+                        atom,
+                        constraint,
+                        default,
+                        is_const,
+                    )
                 });
             }
         }
@@ -444,14 +438,12 @@ impl CheckerState<'_> {
                             let constraint = constraint_strs
                                 .get(&name)
                                 .and_then(|s| self.resolve_jsdoc_reference(s));
-                            return Some(self.ctx.types.factory().type_param(
-                                tsz_solver::TypeParamInfo {
-                                    name: atom,
-                                    constraint,
-                                    default,
-                                    is_const,
-                                    origin: tsz_solver::TypeParamOrigin::User,
-                                },
+                            return Some(class_property_query::js_class_type_param_type(
+                                self.ctx.types,
+                                atom,
+                                constraint,
+                                default,
+                                is_const,
                             ));
                         }
                     }
@@ -524,13 +516,13 @@ impl CheckerState<'_> {
                         let constraint = constraint_strs
                             .get(&name)
                             .and_then(|s| self.resolve_jsdoc_reference(s));
-                        return Some(self.ctx.types.factory().type_param(TypeParamInfo {
-                            name: atom,
+                        return Some(class_property_query::js_class_type_param_type(
+                            self.ctx.types,
+                            atom,
                             constraint,
                             default,
                             is_const,
-                            origin: tsz_solver::TypeParamOrigin::User,
-                        }));
+                        ));
                     }
                 }
             }
@@ -664,7 +656,8 @@ impl CheckerState<'_> {
                     && crate::query_boundaries::common::array_element_type(self.ctx.types, rhs_type)
                         == Some(TypeId::NEVER)
                 {
-                    rhs_type = self.ctx.types.factory().array(TypeId::ANY);
+                    rhs_type =
+                        class_property_query::js_class_array_type(self.ctx.types, TypeId::ANY);
                     provisional_open = true;
                 }
                 if rhs_type == TypeId::NULL || rhs_type == TypeId::UNDEFINED {
@@ -743,7 +736,11 @@ impl CheckerState<'_> {
                         existing.type_id = type_id;
                         existing.write_type = type_id;
                     } else {
-                        let merged = self.ctx.types.factory().union2(existing.type_id, type_id);
+                        let merged = class_property_query::js_class_union_pair_type(
+                            self.ctx.types,
+                            existing.type_id,
+                            type_id,
+                        );
                         existing.type_id = merged;
                         existing.write_type = if provisional_open {
                             TypeId::ANY
@@ -759,7 +756,7 @@ impl CheckerState<'_> {
             constructor_collected_props.insert(name_atom);
             properties.insert(
                 name_atom,
-                PropertyInfo {
+                class_property_query::js_class_property_info(JsClassPropertyFact {
                     name: name_atom,
                     type_id,
                     write_type: if provisional_open {
@@ -769,16 +766,10 @@ impl CheckerState<'_> {
                     },
                     optional: false,
                     readonly: is_readonly,
-                    is_method: false,
-                    is_class_prototype: false,
                     visibility: Visibility::Public,
                     parent_id: parent_sym,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                },
+                    ..JsClassPropertyFact::new(name_atom, type_id)
+                }),
             );
         }
 
@@ -797,7 +788,8 @@ impl CheckerState<'_> {
 
             if let Some(property) = properties.get_mut(&name_atom) {
                 if implicit_kind == ImplicitAnyKind::AnyArray {
-                    let any_array = self.ctx.types.factory().array(TypeId::ANY);
+                    let any_array =
+                        class_property_query::js_class_array_type(self.ctx.types, TypeId::ANY);
                     let nullish_part = if property.type_id.is_nullable() {
                         Some(property.type_id)
                     } else {
@@ -814,12 +806,19 @@ impl CheckerState<'_> {
                             match nullish_members.as_slice() {
                                 [] => None,
                                 [single] => Some(*single),
-                                _ => Some(self.ctx.types.factory().union(nullish_members)),
+                                _ => Some(class_property_query::js_class_union_type(
+                                    self.ctx.types,
+                                    nullish_members,
+                                )),
                             }
                         })
                     };
                     if let Some(nullish_part) = nullish_part {
-                        property.type_id = self.ctx.types.factory().union2(any_array, nullish_part);
+                        property.type_id = class_property_query::js_class_union_pair_type(
+                            self.ctx.types,
+                            any_array,
+                            nullish_part,
+                        );
                     } else {
                         property.type_id = any_array;
                         property.write_type = any_array;
@@ -1158,7 +1157,6 @@ impl CheckerState<'_> {
         class_idx: NodeIndex,
         class: &tsz_parser::parser::node::ClassData,
     ) -> TypeId {
-        let factory = self.ctx.types.factory();
         let class_sym = self.ctx.binder.get_node_symbol(class_idx);
         let mut props: Vec<PropertyInfo> = Vec::new();
 
@@ -1201,22 +1199,18 @@ impl CheckerState<'_> {
                         TypeId::ANY
                     };
 
-                    props.push(PropertyInfo {
-                        name: name_atom,
-                        type_id,
-                        write_type: type_id,
-                        optional: prop.question_token,
-                        readonly: is_readonly,
-                        is_method: false,
-                        is_class_prototype: false,
-                        visibility,
-                        parent_id: class_sym,
-                        declaration_order: 0,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                    props.push(class_property_query::js_class_property_info(
+                        JsClassPropertyFact {
+                            name: name_atom,
+                            type_id,
+                            write_type: type_id,
+                            optional: prop.question_token,
+                            readonly: is_readonly,
+                            visibility,
+                            parent_id: class_sym,
+                            ..JsClassPropertyFact::new(name_atom, type_id)
+                        },
+                    ));
                 }
                 k if k == syntax_kind_ext::CONSTRUCTOR => {
                     let Some(ctor) = self.ctx.arena.get_constructor(member_node) else {
@@ -1250,22 +1244,18 @@ impl CheckerState<'_> {
                             TypeId::ANY
                         };
                         let visibility = self.get_visibility_from_modifiers(&param.modifiers);
-                        props.push(PropertyInfo {
-                            name: name_atom,
-                            type_id,
-                            write_type: type_id,
-                            optional: param.question_token,
-                            readonly: is_readonly,
-                            is_method: false,
-                            is_class_prototype: false,
-                            visibility,
-                            parent_id: class_sym,
-                            declaration_order: 0,
-                            is_string_named: false,
-                            is_symbol_named: false,
-                            single_quoted_name: false,
-                            non_widening: false,
-                        });
+                        props.push(class_property_query::js_class_property_info(
+                            JsClassPropertyFact {
+                                name: name_atom,
+                                type_id,
+                                write_type: type_id,
+                                optional: param.question_token,
+                                readonly: is_readonly,
+                                visibility,
+                                parent_id: class_sym,
+                                ..JsClassPropertyFact::new(name_atom, type_id)
+                            },
+                        ));
                     }
                 }
                 k if k == syntax_kind_ext::METHOD_DECLARATION => {
@@ -1280,43 +1270,21 @@ impl CheckerState<'_> {
                     };
                     let name_atom = self.ctx.types.intern_string(&name);
                     let visibility = self.get_member_visibility(&method.modifiers, method.name);
-                    let method_type = factory.callable(CallableShape {
-                        call_signatures: vec![CallSignature {
-                            type_params: Vec::new(),
-                            params: vec![ParamInfo {
-                                name: None,
-                                type_id: TypeId::ANY,
-                                optional: false,
-                                rest: true,
-                            }],
-                            this_type: None,
-                            return_type: TypeId::ANY,
-                            type_predicate: None,
+                    let method_type =
+                        class_property_query::js_class_method_callable_type(self.ctx.types);
+                    props.push(class_property_query::js_class_property_info(
+                        JsClassPropertyFact {
+                            name: name_atom,
+                            type_id: method_type,
+                            write_type: method_type,
+                            optional: method.question_token,
                             is_method: true,
-                        }],
-                        construct_signatures: Vec::new(),
-                        properties: Vec::new(),
-                        string_index: None,
-                        number_index: None,
-                        symbol: None,
-                        is_abstract: false,
-                    });
-                    props.push(PropertyInfo {
-                        name: name_atom,
-                        type_id: method_type,
-                        write_type: method_type,
-                        optional: method.question_token,
-                        readonly: false,
-                        is_method: true,
-                        is_class_prototype: true,
-                        visibility,
-                        parent_id: class_sym,
-                        declaration_order: 0,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                            is_class_prototype: true,
+                            visibility,
+                            parent_id: class_sym,
+                            ..JsClassPropertyFact::new(name_atom, method_type)
+                        },
+                    ));
                 }
                 k if matches!(
                     k,
@@ -1356,22 +1324,18 @@ impl CheckerState<'_> {
                     } else {
                         TypeId::ANY
                     };
-                    props.push(PropertyInfo {
-                        name: name_atom,
-                        type_id,
-                        write_type: TypeId::ANY,
-                        optional: false,
-                        readonly: false,
-                        is_method: false,
-                        is_class_prototype: true,
-                        visibility,
-                        parent_id: class_sym,
-                        declaration_order: 0,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                    props.push(class_property_query::js_class_property_info(
+                        JsClassPropertyFact {
+                            name: name_atom,
+                            type_id,
+                            write_type: TypeId::ANY,
+                            optional: false,
+                            is_class_prototype: true,
+                            visibility,
+                            parent_id: class_sym,
+                            ..JsClassPropertyFact::new(name_atom, type_id)
+                        },
+                    ));
                 }
                 _ => {}
             }
@@ -1486,11 +1450,8 @@ impl CheckerState<'_> {
             return TypeId::ERROR;
         }
 
-        let result = factory.object_with_index(ObjectShape {
-            properties: props,
-            symbol: class_sym,
-            ..ObjectShape::default()
-        });
+        let result =
+            class_property_query::js_class_instance_object_type(self.ctx.types, props, class_sym);
         // Cache the partial type so subsequent nested class expressions can use it
         self.ctx
             .class_instance_type_cache

--- a/crates/tsz-checker/src/types/computation/access_await.rs
+++ b/crates/tsz-checker/src/types/computation/access_await.rs
@@ -1,7 +1,7 @@
 //! Await expression type computation and Promise helper types.
 
 use crate::context::TypingRequest;
-use crate::query_boundaries::common as query;
+use crate::query_boundaries::checkers::promise as query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -95,11 +95,12 @@ impl<'a> CheckerState<'a> {
             {
                 let promise_like_t = self.get_promise_like_type(contextual);
                 let promise_t = self.get_promise_type(contextual);
-                let mut members = vec![contextual, promise_like_t];
-                if let Some(pt) = promise_t {
-                    members.push(pt);
-                }
-                let union_context = self.ctx.types.factory().union(members);
+                let union_context = query::await_contextual_operand_type(
+                    self.ctx.types,
+                    contextual,
+                    promise_like_t,
+                    promise_t,
+                );
                 request.read().contextual(union_context)
             } else {
                 request.read().contextual_opt(None)
@@ -211,7 +212,10 @@ impl<'a> CheckerState<'a> {
                     awaited
                 })
                 .collect();
-            return (self.ctx.types.factory().union(unwrapped), changed);
+            return (
+                query::awaited_union_type(self.ctx.types, unwrapped),
+                changed,
+            );
         }
         // Unwrap a single thenable layer. The fast path matches the
         // Application form (`Promise<T>` / `PromiseLike<T>`) without
@@ -282,7 +286,7 @@ impl<'a> CheckerState<'a> {
             // The factory dedups (`T | T` to `T`) and may collapse single-member
             // unions back to the bare type: exactly the semantics we want for
             // `Awaited<T | Promise<T>> = T`.
-            return self.ctx.types.factory().union(unwrapped);
+            return query::awaited_union_type(self.ctx.types, unwrapped);
         }
 
         // Distribute over top-level intersections: tsc reduces `Awaited<A & B>`
@@ -295,7 +299,7 @@ impl<'a> CheckerState<'a> {
                 .into_iter()
                 .map(|m| self.compute_awaited_type(m, depth + 1))
                 .collect();
-            return self.ctx.types.factory().intersection(unwrapped);
+            return query::awaited_intersection_type(self.ctx.types, unwrapped);
         }
 
         // Non-union: recursively unwrap nested Promise<...> applications.
@@ -396,10 +400,11 @@ impl<'a> CheckerState<'a> {
                 && promise_like_base != TypeId::UNKNOWN
             {
                 // Create PromiseLike<T> application
-                return self
-                    .ctx
-                    .types
-                    .application(promise_like_base, vec![type_arg]);
+                return query::promise_application_type(
+                    self.ctx.types,
+                    promise_like_base,
+                    type_arg,
+                );
             }
         }
 
@@ -422,7 +427,11 @@ impl<'a> CheckerState<'a> {
             && promise_base != TypeId::ERROR
             && promise_base != TypeId::UNKNOWN
         {
-            return Some(self.ctx.types.application(promise_base, vec![type_arg]));
+            return Some(query::promise_application_type(
+                self.ctx.types,
+                promise_base,
+                type_arg,
+            ));
         }
         None
     }

--- a/crates/tsz-checker/src/types/computation/binary_support.rs
+++ b/crates/tsz-checker/src/types/computation/binary_support.rs
@@ -6,6 +6,7 @@ use crate::context::TypingRequest;
 use crate::query_boundaries::type_computation::core::{
     WriteTargetLogicalOperator, WriteTargetLogicalResult,
 };
+use crate::query_boundaries::type_computation::expression_results as result_query;
 use crate::query_boundaries::type_computation::in_operator::{self, InOperatorRhsClassifier};
 use crate::state::CheckerState;
 use tsz_binder::symbol_flags;
@@ -192,7 +193,7 @@ impl CheckerState<'_> {
             .collect::<Vec<_>>();
 
         if changed {
-            self.ctx.types.factory().union_preserve_members(reduced)
+            result_query::literal_index_access_union(self.ctx.types, reduced)
         } else {
             type_id
         }
@@ -698,18 +699,7 @@ impl CheckerState<'_> {
         if unary.operator != SyntaxKind::TypeOfKeyword as u16 {
             return None;
         }
-        let factory = self.ctx.types.factory();
-        let members = vec![
-            factory.literal_string("string"),
-            factory.literal_string("number"),
-            factory.literal_string("bigint"),
-            factory.literal_string("boolean"),
-            factory.literal_string("symbol"),
-            factory.literal_string("undefined"),
-            factory.literal_string("object"),
-            factory.literal_string("function"),
-        ];
-        Some(factory.union(members))
+        Some(result_query::typeof_result_union(self.ctx.types))
     }
 
     /// Check if an identifier node's declared type overlaps with the given comparison type.

--- a/crates/tsz-checker/src/types/computation/call/callee_context.rs
+++ b/crates/tsz-checker/src/types/computation/call/callee_context.rs
@@ -1,4 +1,5 @@
 use crate::context::{TypingRequest, speculation::DiagnosticSpeculationSnapshot};
+use crate::query_boundaries::construct_signatures as signature_construction;
 use crate::state::CheckerState;
 use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
@@ -55,15 +56,13 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        Some(self.ctx.types.factory().function(FunctionShape {
-            type_params: fresh_signature.type_params,
-            params: fresh_signature.params,
-            this_type: fresh_signature.this_type,
-            return_type: fresh_signature.return_type,
-            type_predicate: fresh_signature.type_predicate,
-            is_constructor: false,
-            is_method: fresh_signature.is_method,
-        }))
+        Some(
+            signature_construction::function_type_from_call_signature_preserving_method(
+                self.ctx.types,
+                &fresh_signature,
+                false,
+            ),
+        )
     }
 
     pub(super) fn circular_identifier_callee_symbol(
@@ -163,15 +162,13 @@ impl<'a> CheckerState<'a> {
         let fresh_signature = self.call_signature_from_function(&func, initializer);
         diagnostics_before.rollback(&mut self.ctx.diagnostic_state());
 
-        Some(self.ctx.types.factory().function(FunctionShape {
-            type_params: fresh_signature.type_params,
-            params: fresh_signature.params,
-            this_type: fresh_signature.this_type,
-            return_type: fresh_signature.return_type,
-            type_predicate: fresh_signature.type_predicate,
-            is_constructor: false,
-            is_method: fresh_signature.is_method,
-        }))
+        Some(
+            signature_construction::function_type_from_call_signature_preserving_method(
+                self.ctx.types,
+                &fresh_signature,
+                false,
+            ),
+        )
     }
 
     pub(super) fn refresh_callee_shape_type_param_constraints(
@@ -259,11 +256,10 @@ impl<'a> CheckerState<'a> {
             .collect();
         snap.rollback(&mut self.ctx.diagnostic_state());
 
-        Some(
-            self.ctx
-                .types
-                .factory()
-                .function(FunctionShape::new(params, ctx_type)),
-        )
+        Some(signature_construction::function_type_from_parts(
+            self.ctx.types,
+            params,
+            ctx_type,
+        ))
     }
 }

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -279,13 +279,8 @@ impl<'a> CheckerState<'a> {
                     })
                     .unwrap_or_default();
                 let def_id = self.ctx.get_or_create_def_id(sym_id);
-                let factory = self.ctx.types.factory();
-                let lazy = factory.lazy(def_id);
-                let recursive_return_type = if type_args.is_empty() {
-                    lazy
-                } else {
-                    factory.application(lazy, type_args)
-                };
+                let recursive_return_type =
+                    call_checker::recursive_call_result_type(self.ctx.types, def_id, type_args);
 
                 if let Some(validation_callee_type) =
                     self.fresh_function_like_variable_call_type(sym_id)
@@ -376,13 +371,8 @@ impl<'a> CheckerState<'a> {
                     })
                     .unwrap_or_default();
                 let def_id = self.ctx.get_or_create_def_id(sym_id);
-                let factory = self.ctx.types.factory();
-                let lazy = factory.lazy(def_id);
-                let recursive_return_type = if type_args.is_empty() {
-                    lazy
-                } else {
-                    factory.application(lazy, type_args)
-                };
+                let recursive_return_type =
+                    call_checker::recursive_call_result_type(self.ctx.types, def_id, type_args);
 
                 if let Some(validation_callee_type) =
                     self.fresh_function_like_variable_call_type(sym_id)

--- a/crates/tsz-checker/src/types/computation/call_display.rs
+++ b/crates/tsz-checker/src/types/computation/call_display.rs
@@ -12,6 +12,7 @@ use crate::call_checker::CallableContext;
 use crate::context::TypingRequest;
 use crate::query_boundaries::checkers::call as call_checker;
 use crate::query_boundaries::common;
+use crate::query_boundaries::construct_signatures as signature_construction;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -83,8 +84,14 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        let source_fn = self.ctx.types.factory().function(normalize(source_shape));
-        let target_fn = self.ctx.types.factory().function(normalize(target_shape));
+        let source_fn = signature_construction::function_type_from_shape(
+            self.ctx.types,
+            normalize(source_shape),
+        );
+        let target_fn = signature_construction::function_type_from_shape(
+            self.ctx.types,
+            normalize(target_shape),
+        );
         self.call_arg_relation_outcome_with_env(source_fn, target_fn)
             .related
     }
@@ -242,11 +249,11 @@ impl<'a> CheckerState<'a> {
             };
             // Wrap contextual type as `() => ctx_type` so the function expression
             // resolver can use get_return_type() to extract the expected return type.
-            let wrapper_fn = self
-                .ctx
-                .types
-                .factory()
-                .function(FunctionShape::new(vec![], body_context_type));
+            let wrapper_fn = signature_construction::function_type_from_parts(
+                self.ctx.types,
+                vec![],
+                body_context_type,
+            );
             Some((wrapper_fn, ctx_type))
         } else {
             None

--- a/crates/tsz-checker/src/types/computation/call_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/call_helpers.rs
@@ -1,6 +1,7 @@
 //! Value declaration resolution, TDZ checking, and identifier type computation helpers.
 
 use crate::context::TypingRequest;
+use crate::query_boundaries::checkers::call as call_query;
 use crate::query_boundaries::common;
 use crate::state::CheckerState;
 use tsz_binder::{Symbol, SymbolId};
@@ -1387,7 +1388,7 @@ impl<'a> CheckerState<'a> {
                         });
 
                     let name_atom = self.ctx.types.intern_string(&name);
-                    properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+                    properties.push((name_atom, value_type));
                 }
             }
             // Shorthand property: { x }
@@ -1399,7 +1400,7 @@ impl<'a> CheckerState<'a> {
                 let name = ident.escaped_text.clone();
                 let value_type = self.get_type_of_node(shorthand.name);
                 let name_atom = self.ctx.types.intern_string(&name);
-                properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+                properties.push((name_atom, value_type));
             }
             // Methods with all params annotated are not context-sensitive
             else if elem_node.kind == syntax_kind_ext::METHOD_DECLARATION
@@ -1412,7 +1413,7 @@ impl<'a> CheckerState<'a> {
                 let value_type =
                     self.get_type_of_function_with_request(elem_idx, &TypingRequest::NONE);
                 let name_atom = self.ctx.types.intern_string(&name);
-                properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+                properties.push((name_atom, value_type));
             }
             // Accessors are always context-sensitive — skip them
         }
@@ -1421,14 +1422,13 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let object_type = self.ctx.types.factory().object_fresh(properties);
+        let object_type =
+            call_query::call_inference_partial_object_type(self.ctx.types, properties);
         if wrap_in_zero_arg_function {
-            Some(
-                self.ctx
-                    .types
-                    .factory()
-                    .function(tsz_solver::FunctionShape::new(Vec::new(), object_type)),
-            )
+            Some(call_query::call_inference_zero_arg_function_type(
+                self.ctx.types,
+                object_type,
+            ))
         } else {
             Some(object_type)
         }
@@ -1493,7 +1493,7 @@ impl<'a> CheckerState<'a> {
                     // of the partial type).
                     let value_type =
                         self.get_type_of_node_with_request(prop.initializer, &TypingRequest::NONE);
-                    properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+                    properties.push((name_atom, value_type));
                     continue;
                 }
 
@@ -1515,7 +1515,7 @@ impl<'a> CheckerState<'a> {
                 {
                     let value_type =
                         self.speculative_type_of_node(prop.initializer, &TypingRequest::NONE);
-                    properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+                    properties.push((name_atom, value_type));
                     continue;
                 }
 
@@ -1530,7 +1530,7 @@ impl<'a> CheckerState<'a> {
                         type_param_names,
                     )
                 {
-                    properties.push(tsz_solver::PropertyInfo::new(name_atom, nested_partial));
+                    properties.push((name_atom, nested_partial));
                     continue;
                 }
 
@@ -1548,7 +1548,7 @@ impl<'a> CheckerState<'a> {
                     mapped_id,
                     type_param_names,
                 ) {
-                    properties.push(tsz_solver::PropertyInfo::new(name_atom, nested_partial));
+                    properties.push((name_atom, nested_partial));
                     continue;
                 }
 
@@ -1596,7 +1596,7 @@ impl<'a> CheckerState<'a> {
                     continue;
                 }
 
-                properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+                properties.push((name_atom, value_type));
             }
             // Shorthand properties are never contextually sensitive
             else if elem_node.kind == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT
@@ -1607,7 +1607,7 @@ impl<'a> CheckerState<'a> {
                 let name = ident.escaped_text.clone();
                 let value_type = self.get_type_of_node(shorthand.name);
                 let name_atom = self.ctx.types.intern_string(&name);
-                properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+                properties.push((name_atom, value_type));
             }
             // Method declarations: check similarly to lambda properties
             else if elem_node.kind == syntax_kind_ext::METHOD_DECLARATION
@@ -1652,7 +1652,7 @@ impl<'a> CheckerState<'a> {
                 };
                 let value_type = self.speculative_type_of_function(elem_idx, &request);
 
-                properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+                properties.push((name_atom, value_type));
             }
         }
 
@@ -1660,7 +1660,10 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        Some(self.ctx.types.factory().object_fresh(properties))
+        Some(call_query::call_inference_partial_object_type(
+            self.ctx.types,
+            properties,
+        ))
     }
 
     fn inference_callable_context_for_property_target(
@@ -1800,7 +1803,7 @@ impl<'a> CheckerState<'a> {
                 let name_atom = self.ctx.types.intern_string(&name);
 
                 // Create a substitution mapping the mapped type's key param to this literal key
-                let key_literal = self.ctx.types.literal_string(&name);
+                let key_literal = call_query::call_inference_string_key_type(self.ctx.types, &name);
                 let subst = common::TypeSubstitution::single(type_param_name, key_literal);
 
                 // Instantiate the template with this key
@@ -1823,7 +1826,7 @@ impl<'a> CheckerState<'a> {
                         self.extract_non_sensitive_object_type(prop.initializer)
                     })
                 {
-                    properties.push(tsz_solver::PropertyInfo::new(name_atom, nested_partial));
+                    properties.push((name_atom, nested_partial));
                 }
             }
             // Handle method declarations - for mapped types, these typically aren't at this level
@@ -1844,7 +1847,7 @@ impl<'a> CheckerState<'a> {
 
                 // For thisless methods, compute the return type directly
                 let value_type = self.speculative_type_of_function(elem_idx, &TypingRequest::NONE);
-                properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
+                properties.push((name_atom, value_type));
             }
         }
 
@@ -1852,7 +1855,10 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        Some(self.ctx.types.factory().object_fresh(properties))
+        Some(call_query::call_inference_partial_object_type(
+            self.ctx.types,
+            properties,
+        ))
     }
 
     /// Like `extract_inference_contributing_object_type` but for array/tuple literals.
@@ -1894,12 +1900,7 @@ impl<'a> CheckerState<'a> {
             if !is_contextually_sensitive(self, elem_idx) {
                 // Non-sensitive: compute type without context
                 let value_type = self.get_type_of_node_with_request(elem_idx, &TypingRequest::NONE);
-                elements.push(tsz_solver::TupleElement {
-                    type_id: value_type,
-                    optional: false,
-                    rest: false,
-                    name: None,
-                });
+                elements.push(value_type);
                 any_contributed = true;
                 continue;
             }
@@ -1917,21 +1918,11 @@ impl<'a> CheckerState<'a> {
                     elem_idx,
                     &TypingRequest::with_contextual_type(target_elem_type),
                 );
-                elements.push(tsz_solver::TupleElement {
-                    type_id: value_type,
-                    optional: false,
-                    rest: false,
-                    name: None,
-                });
+                elements.push(value_type);
                 any_contributed = true;
             } else {
                 // Can't contribute — use ANY as placeholder
-                elements.push(tsz_solver::TupleElement {
-                    type_id: TypeId::ANY,
-                    optional: false,
-                    rest: false,
-                    name: None,
-                });
+                elements.push(TypeId::ANY);
             }
         }
 
@@ -1939,7 +1930,10 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        Some(self.ctx.types.factory().tuple(elements))
+        Some(call_query::call_inference_tuple_type(
+            self.ctx.types,
+            elements,
+        ))
     }
 
     /// Check if a type contains any of the specified type parameter names.

--- a/crates/tsz-checker/src/types/computation/call_inference.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference.rs
@@ -16,6 +16,7 @@ use crate::query_boundaries::common;
 use crate::query_boundaries::common::CallResult;
 use crate::query_boundaries::common::LiteralTypeKind;
 use crate::query_boundaries::common::{QueryDatabase, TypeDatabase};
+use crate::query_boundaries::construct_signatures as signature_construction;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
@@ -710,7 +711,7 @@ impl<'a> CheckerState<'a> {
             self.substitution_with_source_constraint_fallbacks(&source_fn, &substitution);
         let instantiated =
             instantiate_function_shape_with_substitution(self.ctx.types, &source_fn, &substitution);
-        self.ctx.types.factory().function(instantiated)
+        signature_construction::function_type_from_shape(self.ctx.types, instantiated)
     }
 
     pub(crate) fn instantiate_generic_function_argument_against_target_params(
@@ -786,7 +787,7 @@ impl<'a> CheckerState<'a> {
             self.substitution_with_source_constraint_fallbacks(&source_fn, &substitution);
         let instantiated =
             instantiate_function_shape_with_substitution(self.ctx.types, &source_fn, &substitution);
-        self.ctx.types.factory().function(instantiated)
+        signature_construction::function_type_from_shape(self.ctx.types, instantiated)
     }
 
     pub(crate) fn target_has_concrete_return_context_for_generic_refinement(
@@ -1077,14 +1078,14 @@ impl<'a> CheckerState<'a> {
                 &shape,
                 &binding_pattern_param_positions,
             );
-            self.ctx.types.factory().function(sanitized)
+            signature_construction::function_type_from_shape(self.ctx.types, sanitized)
         } else if let Some(shape) = common::callable_shape_for_type(self.ctx.types, arg_type) {
             let sanitized = common::sanitize_callable_shape_binding_pattern_params(
                 &shape,
                 &binding_pattern_param_positions,
                 TypeId::UNKNOWN,
             );
-            self.ctx.types.factory().callable(sanitized)
+            signature_construction::callable_type_from_shape(self.ctx.types, sanitized)
         } else {
             arg_type
         }

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1,6 +1,7 @@
 //! Call-result handling helpers shared by call expression computation.
 
 use crate::query_boundaries::assignability as assign_query;
+use crate::query_boundaries::checkers::call as call_checker;
 use crate::query_boundaries::common;
 use crate::query_boundaries::common::CallResult;
 use crate::query_boundaries::common::TypeResolver;
@@ -61,7 +62,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let param_union = self.ctx.types.factory().union(param_types);
+        let param_union = call_checker::call_result_correlated_union(self.ctx.types, param_types);
         if !self.call_arg_relation_outcome(actual, param_union).related {
             return None;
         }
@@ -70,7 +71,10 @@ impl<'a> CheckerState<'a> {
             .iter()
             .map(|signature| signature.return_type)
             .collect();
-        Some(self.ctx.types.factory().union(return_types))
+        Some(call_checker::call_result_correlated_union(
+            self.ctx.types,
+            return_types,
+        ))
     }
 
     fn finalize_call_return_like_success(
@@ -118,10 +122,7 @@ impl<'a> CheckerState<'a> {
             return_type
         };
         if is_optional_chain {
-            self.ctx
-                .types
-                .factory()
-                .union2(return_type, TypeId::UNDEFINED)
+            call_checker::call_result_optional_chain_return(self.ctx.types, return_type)
         } else {
             return_type
         }

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -7,7 +7,9 @@ use crate::call_checker::CallableContext;
 use crate::context::TypingRequest;
 use crate::query_boundaries::checkers::call as call_checker;
 use crate::query_boundaries::common::ContextualTypeContext;
-use crate::query_boundaries::construct_signatures::has_construct_overloads;
+use crate::query_boundaries::construct_signatures::{
+    function_type_from_shape, has_construct_overloads,
+};
 use crate::query_boundaries::type_computation::complex as query;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -889,16 +891,7 @@ impl<'a> CheckerState<'a> {
             // signatures. Without this, merged function+class declarations would use
             // the function's call signature parameters instead of the class constructor's
             // construct signature parameters for contextual typing of `new` arguments.
-            let factory = self.ctx.types.factory();
-            let func_type = factory.function(tsz_solver::FunctionShape {
-                params: shape.params.clone(),
-                return_type: shape.return_type,
-                this_type: shape.this_type,
-                type_params: shape.type_params.clone(),
-                type_predicate: shape.type_predicate,
-                is_constructor: true,
-                is_method: false,
-            });
+            let func_type = function_type_from_shape(self.ctx.types, shape.clone());
             ContextualTypeContext::with_expected_and_options(
                 self.ctx.types,
                 func_type,
@@ -1252,9 +1245,14 @@ impl<'a> CheckerState<'a> {
                                                 .types
                                                 .factory()
                                                 .union2(inner, promise_like_inner);
-                                            first_param.type_id =
-                                                self.ctx.types.function(resolve_shape);
-                                            Some(self.ctx.types.function(exec_shape))
+                                            first_param.type_id = function_type_from_shape(
+                                                self.ctx.types,
+                                                resolve_shape,
+                                            );
+                                            Some(function_type_from_shape(
+                                                self.ctx.types,
+                                                exec_shape,
+                                            ))
                                         } else {
                                             None
                                         }

--- a/crates/tsz-checker/src/types/computation/expression_guards.rs
+++ b/crates/tsz-checker/src/types/computation/expression_guards.rs
@@ -1,5 +1,6 @@
 //! Expression-shape helpers shared by computation diagnostics.
 
+use crate::query_boundaries::type_computation::expression_results as result_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -78,7 +79,7 @@ impl<'a> CheckerState<'a> {
         }
 
         if saw_promise_member && !non_promise_members.is_empty() {
-            self.ctx.types.factory().union(non_promise_members)
+            result_query::conditional_branch_union(self.ctx.types, non_promise_members)
         } else {
             contextual
         }

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -341,7 +341,9 @@ impl<'a> CheckerState<'a> {
             // Still type-check the operand for flow/node types.
             k if k == SyntaxKind::TypeOfKeyword as u16 => {
                 self.get_type_of_node(unary.operand);
-                self.ctx.types.factory().typeof_result_union()
+                crate::query_boundaries::type_computation::expression_results::typeof_result_union(
+                    self.ctx.types,
+                )
             }
             // Unary + and - return number unless contextual typing expects a numeric literal.
             // Note: tsc does NOT validate operand types for unary +/- in general.

--- a/crates/tsz-checker/src/types/computation/nullish_coalescing.rs
+++ b/crates/tsz-checker/src/types/computation/nullish_coalescing.rs
@@ -1,6 +1,7 @@
 //! Nullish-coalescing (`??`) diagnostic and result helpers.
 
 use super::binary_support::SyntacticNullishness;
+use crate::query_boundaries::type_computation::expression_results as result_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
@@ -56,7 +57,7 @@ impl<'a> CheckerState<'a> {
         // deliberately keeps `unknown` whole for flow `!= null` narrowing, so the
         // `??` result type substitutes the empty-object non-nullable form here.
         let non_nullish = if evaluated_left == TypeId::UNKNOWN {
-            self.ctx.types.factory().object(Vec::new())
+            result_query::empty_object_type(self.ctx.types)
         } else {
             non_nullish
         };
@@ -86,7 +87,7 @@ impl<'a> CheckerState<'a> {
             return right_type;
         }
 
-        self.ctx.types.factory().union2(non_nullish, right_type)
+        result_query::nullish_coalescing_union(self.ctx.types, non_nullish, right_type)
     }
 
     fn is_empty_object_literal_expression(&self, idx: NodeIndex) -> bool {

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -1,6 +1,7 @@
 //! Accessor element handling for object literal type computation.
 
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::query_boundaries::object_literal_context as object_context_query;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_common::interner::Atom;
@@ -154,26 +155,21 @@ impl<'a> CheckerState<'a> {
                     // Getter-only accessors are readonly in the object type
                     let is_getter_only = elem_node.kind == syntax_kind_ext::GET_ACCESSOR
                         && !setter_names.contains(&name_atom);
-                    this_props.push(PropertyInfo {
-                        name: name_atom,
-                        type_id: TypeId::ANY,
-                        write_type: TypeId::ANY,
-                        optional: false,
-                        readonly: is_getter_only,
-                        is_method: false,
-                        is_class_prototype: false,
-                        visibility: Visibility::Public,
-                        parent_id: None,
-                        declaration_order: 0,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                    this_props.push(object_context_query::synthetic_this_property(
+                        name_atom,
+                        TypeId::ANY,
+                        TypeId::ANY,
+                        is_getter_only,
+                        false,
+                        0,
+                    ));
                 }
                 self.ctx
                     .this_type_stack
-                    .push(self.ctx.types.factory().object(this_props));
+                    .push(object_context_query::synthetic_this_object(
+                        self.ctx.types,
+                        this_props,
+                    ));
                 pushed_synthetic_this = true;
             }
 

--- a/crates/tsz-checker/src/types/computation/object_literal/spread_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/spread_element.rs
@@ -7,6 +7,7 @@ use super::computation_support::{
 use crate::context::TypingRequest;
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use crate::query_boundaries::index_signature::IndexSignature;
+use crate::query_boundaries::type_computation::object_literals;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_common::interner::Atom;
@@ -425,11 +426,11 @@ impl<'a> CheckerState<'a> {
                                     self.ctx.types,
                                     resolved_spread,
                                 )
-                                .map(|value_type| IndexSignature {
-                                        key_type: TypeId::STRING,
+                                .map(|value_type| {
+                                    object_literals::spread_fallback_index_signature(
+                                        TypeId::STRING,
                                         value_type,
-                                        readonly: false,
-                                        param_name: None,
+                                    )
                                 });
                             if let Some(string_index) =
                                 crate::query_boundaries::index_signature::string_index_signature(
@@ -445,11 +446,11 @@ impl<'a> CheckerState<'a> {
                                     self.ctx.types,
                                     resolved_spread,
                                 )
-                                .map(|value_type| IndexSignature {
-                                        key_type: TypeId::NUMBER,
+                                .map(|value_type| {
+                                    object_literals::spread_fallback_index_signature(
+                                        TypeId::NUMBER,
                                         value_type,
-                                        readonly: false,
-                                        param_name: None,
+                                    )
                                 });
                             if let Some(number_index) =
                                 crate::query_boundaries::index_signature::number_index_signature(

--- a/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::object_literal_context as object_context_query;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_common::interner::Atom;
@@ -5,7 +6,7 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{CallSignature, CallableShape, TypeId, Visibility};
+use tsz_solver::{TypeId, Visibility};
 
 impl<'a> CheckerState<'a> {
     /// Whether an object-literal member, when its body is checked, binds the
@@ -709,22 +710,11 @@ impl<'a> CheckerState<'a> {
                             })
                         })
                         .collect();
-                    let placeholder = self.ctx.types.factory().callable(CallableShape {
-                        call_signatures: vec![CallSignature {
-                            type_params: Vec::new(),
-                            params,
-                            this_type: None,
-                            return_type: TypeId::VOID,
-                            type_predicate: None,
-                            is_method: true,
-                        }],
-                        construct_signatures: Vec::new(),
-                        properties: Vec::new(),
-                        string_index: None,
-                        number_index: None,
-                        symbol: None,
-                        is_abstract: false,
-                    });
+                    let placeholder = object_context_query::synthetic_this_method_callable(
+                        self.ctx.types,
+                        params,
+                        TypeId::VOID,
+                    );
                     self.pop_type_parameters(tp_updates);
                     placeholder
                 }
@@ -791,43 +781,23 @@ impl<'a> CheckerState<'a> {
                         )
                     });
 
-                self.ctx.types.factory().callable(CallableShape {
-                    call_signatures: vec![CallSignature {
-                        type_params: Vec::new(),
-                        params: other_params,
-                        this_type: None,
-                        return_type: other_return_type,
-                        type_predicate: None,
-                        is_method: true,
-                    }],
-                    construct_signatures: Vec::new(),
-                    properties: Vec::new(),
-                    string_index: None,
-                    number_index: None,
-                    symbol: None,
-                    is_abstract: false,
-                })
+                object_context_query::synthetic_this_method_callable(
+                    self.ctx.types,
+                    other_params,
+                    other_return_type,
+                )
             };
 
-            this_props.push(tsz_solver::PropertyInfo {
-                name: method_name_atom,
-                type_id: method_type,
-                write_type: method_type,
-                optional: false,
-                readonly: self.ctx.in_const_assertion,
-                is_method: true,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: decl_order,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+            this_props.push(object_context_query::synthetic_this_method_property(
+                method_name_atom,
+                method_type,
+                method_type,
+                self.ctx.in_const_assertion,
+                decl_order,
+            ));
         }
 
-        self.ctx.types.factory().object(this_props)
+        object_context_query::synthetic_this_object(self.ctx.types, this_props)
     }
 
     /// Build a synthetic `this` type for a function expression that is a property
@@ -923,40 +893,21 @@ impl<'a> CheckerState<'a> {
                     )
                 });
 
-            this_props.push(tsz_solver::PropertyInfo {
-                name: method_name_atom,
-                type_id: self.ctx.types.factory().callable(CallableShape {
-                    call_signatures: vec![CallSignature {
-                        type_params: Vec::new(),
-                        params: other_params,
-                        this_type: None,
-                        return_type: other_return_type,
-                        type_predicate: None,
-                        is_method: true,
-                    }],
-                    construct_signatures: Vec::new(),
-                    properties: Vec::new(),
-                    string_index: None,
-                    number_index: None,
-                    symbol: None,
-                    is_abstract: false,
-                }),
-                write_type: TypeId::ANY,
-                optional: false,
-                readonly: self.ctx.in_const_assertion,
-                is_method: true,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: decl_order,
-                is_string_named: false,
-                is_symbol_named: false,
-                single_quoted_name: false,
-                non_widening: false,
-            });
+            let method_type = object_context_query::synthetic_this_method_callable(
+                self.ctx.types,
+                other_params,
+                other_return_type,
+            );
+            this_props.push(object_context_query::synthetic_this_method_property(
+                method_name_atom,
+                method_type,
+                TypeId::ANY,
+                self.ctx.in_const_assertion,
+                decl_order,
+            ));
         }
 
-        self.ctx.types.factory().object(this_props)
+        object_context_query::synthetic_this_object(self.ctx.types, this_props)
     }
 
     /// Name of the variable binding an object literal initializes, if it is the

--- a/crates/tsz-checker/src/types/computation/object_literal_context.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_context.rs
@@ -16,6 +16,7 @@
 
 use crate::query_boundaries::checkers::call as call_checker;
 use crate::query_boundaries::common::{self, ContextualTypeContext, TypeSubstitution};
+use crate::query_boundaries::object_literal_context as object_context_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -51,7 +52,7 @@ impl<'a> CheckerState<'a> {
                 [] => TypeId::UNKNOWN,
                 [single] => *single,
                 _ if filtered.len() == members.len() => type_id,
-                _ => self.ctx.types.factory().intersection(filtered),
+                _ => object_context_query::contextual_intersection(self.ctx.types, filtered),
             };
         }
         if let Some(members) = common::union_members(self.ctx.types, type_id) {
@@ -72,7 +73,10 @@ impl<'a> CheckerState<'a> {
                 {
                     type_id
                 }
-                _ => self.ctx.types.factory().union_preserve_members(remapped),
+                _ => object_context_query::contextual_union_preserve_members(
+                    self.ctx.types,
+                    remapped,
+                ),
             };
         }
 
@@ -185,7 +189,10 @@ impl<'a> CheckerState<'a> {
         match candidates.as_slice() {
             [] => None,
             [single] => Some(*single),
-            _ => Some(self.ctx.types.factory().union_preserve_members(candidates)),
+            _ => Some(object_context_query::contextual_union_preserve_members(
+                self.ctx.types,
+                candidates,
+            )),
         }
     }
 
@@ -251,7 +258,10 @@ impl<'a> CheckerState<'a> {
         } else if candidates.len() == 1 {
             Some(candidates[0])
         } else {
-            Some(self.ctx.types.factory().union_preserve_members(candidates))
+            Some(object_context_query::contextual_union_preserve_members(
+                self.ctx.types,
+                candidates,
+            ))
         }
     }
 
@@ -445,12 +455,10 @@ impl<'a> CheckerState<'a> {
                     .iter()
                     .all(|&member| common::is_callable_type(self.ctx.types, member))
             {
-                return Some(
-                    self.ctx
-                        .types
-                        .factory()
-                        .union_preserve_members(callable_members),
-                );
+                return Some(object_context_query::contextual_union_preserve_members(
+                    self.ctx.types,
+                    callable_members,
+                ));
             }
             return None;
         }
@@ -463,7 +471,10 @@ impl<'a> CheckerState<'a> {
             return match callable_members.as_slice() {
                 [] => None,
                 [single] => Some(*single),
-                _ => Some(self.ctx.types.factory().intersection(callable_members)),
+                _ => Some(object_context_query::contextual_intersection(
+                    self.ctx.types,
+                    callable_members,
+                )),
             };
         }
 
@@ -506,12 +517,10 @@ impl<'a> CheckerState<'a> {
         match callable_members.len() {
             0 => None,
             1 => Some(callable_members[0]),
-            _ => Some(
-                self.ctx
-                    .types
-                    .factory()
-                    .union_preserve_members(callable_members),
-            ),
+            _ => Some(object_context_query::contextual_union_preserve_members(
+                self.ctx.types,
+                callable_members,
+            )),
         }
     }
 
@@ -879,12 +888,10 @@ impl<'a> CheckerState<'a> {
             if property_types.is_empty() {
                 has_unresolved_member.then_some(TypeId::ANY)
             } else {
-                Some(
-                    this.ctx
-                        .types
-                        .factory()
-                        .union_preserve_members(property_types),
-                )
+                Some(object_context_query::contextual_union_preserve_members(
+                    this.ctx.types,
+                    property_types,
+                ))
             }
         };
         let intersection_member_property_type = |this: &mut Self,
@@ -952,12 +959,10 @@ impl<'a> CheckerState<'a> {
             if property_types.is_empty() {
                 None
             } else {
-                Some(
-                    this.ctx
-                        .types
-                        .factory()
-                        .union_preserve_members(property_types),
-                )
+                Some(object_context_query::contextual_union_preserve_members(
+                    this.ctx.types,
+                    property_types,
+                ))
             }
         };
         let original_contextual_type = contextual_type;
@@ -1278,9 +1283,12 @@ impl<'a> CheckerState<'a> {
             .ok()
             .filter(|value| value.is_finite());
         let key_type = if let Some(value) = numeric_key {
-            self.ctx.types.literal_number(value)
+            object_context_query::mapped_contextual_property_number_key_type(self.ctx.types, value)
         } else {
-            common::create_string_literal_type(self.ctx.types, property_name)
+            object_context_query::mapped_contextual_property_string_key_type(
+                self.ctx.types,
+                property_name,
+            )
         };
 
         let constraint_resolved = self.resolve_lazy_type(constraint);
@@ -1836,10 +1844,10 @@ impl<'a> CheckerState<'a> {
         if matching_members.len() == 1 {
             matching_members[0]
         } else {
-            self.ctx
-                .types
-                .factory()
-                .union_preserve_members(matching_members)
+            object_context_query::contextual_union_preserve_members(
+                self.ctx.types,
+                matching_members,
+            )
         }
     }
 

--- a/crates/tsz-checker/src/types/computation/object_literal_support.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_support.rs
@@ -1,5 +1,6 @@
 use crate::context::TypingRequest;
 use crate::query_boundaries::common::TypeResolver;
+use crate::query_boundaries::type_computation::object_literals;
 use crate::state::CheckerState;
 use rustc_hash::FxHashMap;
 use tsz_common::interner::Atom;
@@ -38,19 +39,6 @@ pub(crate) struct ObjectLiteralFinalizeCtx {
     pub(crate) generic_spread_types: Vec<TypeId>,
     /// Whether all properties are context-sensitive (deferred freshness).
     pub(crate) all_properties_context_sensitive: bool,
-}
-
-fn order_preserving_union(
-    factory: tsz_solver::construction::TypeFactory<'_>,
-    mut members: Vec<TypeId>,
-) -> TypeId {
-    let mut seen = rustc_hash::FxHashSet::default();
-    members.retain(|id| *id != TypeId::NEVER && seen.insert(*id));
-    match members.as_slice() {
-        [] => TypeId::NEVER,
-        [only] => *only,
-        _ => factory.union_preserve_order(members),
-    }
 }
 
 impl<'a> CheckerState<'a> {
@@ -346,7 +334,7 @@ impl<'a> CheckerState<'a> {
             properties,
             display_type_overrides,
             display_parent_overrides,
-            mut string_index_types,
+            string_index_types,
             number_index_types,
             symbol_index_types,
             string_index_param_name,
@@ -377,15 +365,14 @@ impl<'a> CheckerState<'a> {
                 crate::query_boundaries::diagnostics::normalize_display_property_order(
                     &mut display_props,
                 );
-                let obj = self
-                    .ctx
-                    .types
-                    .factory()
-                    .object_preserve_declaration_order(branch_props);
-                self.ctx.types.store_display_properties(obj, display_props);
+                let obj = object_literals::spread_object_type(
+                    self.ctx.types,
+                    branch_props,
+                    display_props,
+                );
                 union_members.push(obj);
             }
-            self.ctx.types.factory().union(union_members)
+            object_literals::union_type(self.ctx.types, union_members)
         } else {
             let mut properties: Vec<PropertyInfo> = properties.into_values().collect();
             properties.sort_by_key(|p| p.declaration_order);
@@ -399,25 +386,11 @@ impl<'a> CheckerState<'a> {
                     crate::query_boundaries::diagnostics::normalize_display_property_order(
                         &mut display_props,
                     );
-                    let type_id = self
-                        .ctx
-                        .types
-                        .factory()
-                        .object_preserve_declaration_order(properties);
-                    self.ctx
-                        .types
-                        .store_display_properties(type_id, display_props);
-                    type_id
+                    object_literals::spread_object_type(self.ctx.types, properties, display_props)
                 } else {
-                    let type_id = if all_properties_context_sensitive {
-                        self.ctx
-                            .types
-                            .factory()
-                            .object_fresh_all_properties_context_sensitive(properties.clone())
-                    } else {
-                        self.ctx.types.factory().object_fresh(properties.clone())
-                    };
-                    if !display_type_overrides.is_empty() || !display_parent_overrides.is_empty() {
+                    let display_props = if !display_type_overrides.is_empty()
+                        || !display_parent_overrides.is_empty()
+                    {
                         let mut display_props: Vec<PropertyInfo> = properties
                             .iter()
                             .map(|prop| {
@@ -435,89 +408,20 @@ impl<'a> CheckerState<'a> {
                         crate::query_boundaries::diagnostics::normalize_display_property_order(
                             &mut display_props,
                         );
-                        self.ctx
-                            .types
-                            .store_display_properties(type_id, display_props);
-                    }
-                    type_id
+                        Some(display_props)
+                    } else {
+                        None
+                    };
+                    object_literals::fresh_object_type(
+                        self.ctx.types,
+                        properties,
+                        all_properties_context_sensitive,
+                        display_props,
+                    )
                 }
             } else {
-                use tsz_solver::{IndexSignature, ObjectShape};
-
-                if !string_index_types.is_empty() {
-                    let prop_types = properties.iter().map(|prop| prop.type_id);
-                    if self.ctx.in_const_assertion {
-                        string_index_types = prop_types.chain(string_index_types).collect();
-                    } else {
-                        string_index_types.extend(prop_types);
-                    }
-                }
-
-                let string_index = if !string_index_types.is_empty() {
-                    let value_type = if self.ctx.in_const_assertion {
-                        order_preserving_union(self.ctx.types.factory(), string_index_types)
-                    } else {
-                        self.ctx.types.factory().union(string_index_types)
-                    };
-                    Some(IndexSignature {
-                        key_type: TypeId::STRING,
-                        value_type,
-                        readonly: false,
-                        param_name: string_index_param_name,
-                    })
-                } else {
-                    None
-                };
-
-                let symbol_index = if !symbol_index_types.is_empty() {
-                    let value_type = if self.ctx.in_const_assertion {
-                        order_preserving_union(self.ctx.types.factory(), symbol_index_types)
-                    } else {
-                        self.ctx.types.factory().union(symbol_index_types)
-                    };
-                    Some(IndexSignature {
-                        key_type: TypeId::SYMBOL,
-                        value_type,
-                        readonly: false,
-                        param_name: None,
-                    })
-                } else {
-                    None
-                };
-
-                let number_index = if !number_index_types.is_empty() {
-                    let value_type = if self.ctx.in_const_assertion {
-                        order_preserving_union(self.ctx.types.factory(), number_index_types)
-                    } else {
-                        self.ctx.types.factory().union(number_index_types)
-                    };
-                    Some(IndexSignature {
-                        key_type: TypeId::NUMBER,
-                        value_type,
-                        readonly: false,
-                        param_name: number_index_param_name,
-                    })
-                } else {
-                    None
-                };
-
-                let mut shape = ObjectShape {
-                    properties,
-                    string_index,
-                    number_index,
-                    symbol_index,
-                    ..ObjectShape::default()
-                };
-                if !has_spread {
-                    shape.mark_fresh_literal();
-                    if all_properties_context_sensitive {
-                        shape.mark_all_properties_context_sensitive();
-                    }
-                }
-
                 let display_props = if has_spread {
-                    shape.mark_preserve_declaration_order();
-                    let mut display_props = shape.properties.clone();
+                    let mut display_props = properties.clone();
                     crate::query_boundaries::diagnostics::normalize_display_property_order(
                         &mut display_props,
                     );
@@ -525,20 +429,28 @@ impl<'a> CheckerState<'a> {
                 } else {
                     None
                 };
-                let type_id = self.ctx.types.factory().object_with_index(shape);
-                if let Some(display_props) = display_props {
-                    self.ctx
-                        .types
-                        .store_display_properties(type_id, display_props);
-                }
-                type_id
+                object_literals::indexed_object_type(
+                    self.ctx.types,
+                    object_literals::ObjectLiteralIndexedType {
+                        properties,
+                        string_index_types,
+                        number_index_types,
+                        symbol_index_types,
+                        string_index_param_name,
+                        number_index_param_name,
+                        in_const_assertion: self.ctx.in_const_assertion,
+                        has_spread,
+                        all_properties_context_sensitive,
+                        display_properties: display_props,
+                    },
+                )
             }
         };
 
         if !generic_spread_types.is_empty() {
             let mut members = generic_spread_types;
             members.push(object_type);
-            self.ctx.types.factory().intersection(members)
+            object_literals::intersection_type(self.ctx.types, members)
         } else {
             object_type
         }
@@ -572,17 +484,13 @@ impl<'a> CheckerState<'a> {
             let eval_constraint =
                 self.evaluate_mapped_constraint_with_resolution(mapped.constraint);
             let mapped_id = if eval_constraint != mapped.constraint {
-                let mapped_type = tsz_solver::MappedType {
-                    type_param: mapped.type_param,
-                    constraint: eval_constraint,
-                    name_type: mapped.name_type,
-                    template: mapped.template,
-                    readonly_modifier: mapped.readonly_modifier,
-                    optional_modifier: mapped.optional_modifier,
-                };
                 crate::query_boundaries::common::mapped_type_id(
                     self.ctx.types,
-                    self.ctx.types.factory().mapped(mapped_type),
+                    object_literals::mapped_type_with_constraint(
+                        self.ctx.types,
+                        mapped.as_ref(),
+                        eval_constraint,
+                    ),
                 )
                 .unwrap_or(mapped_id)
             } else {
@@ -604,21 +512,7 @@ impl<'a> CheckerState<'a> {
                                 mapped_id,
                                 prop_name.as_ref(),
                             )?;
-                        Some(PropertyInfo {
-                            name,
-                            type_id,
-                            optional: false,
-                            readonly: false,
-                            write_type: type_id,
-                            is_class_prototype: false,
-                            is_method: false,
-                            visibility: tsz_solver::Visibility::Public,
-                            parent_id: None,
-                            declaration_order: 0,
-                            is_string_named: false,
-                            is_symbol_named: false,
-                            single_quoted_name: false, non_widening: false,
-                        })
+                        Some(object_literals::mapped_spread_property(name, type_id))
                     })
                     .collect();
             }
@@ -745,17 +639,13 @@ impl<'a> CheckerState<'a> {
             let eval_constraint =
                 self.evaluate_mapped_constraint_with_resolution(mapped.constraint);
             let resolved_mapped_id = if eval_constraint != mapped.constraint {
-                let mapped_type = tsz_solver::MappedType {
-                    type_param: mapped.type_param,
-                    constraint: eval_constraint,
-                    name_type: mapped.name_type,
-                    template: mapped.template,
-                    readonly_modifier: mapped.readonly_modifier,
-                    optional_modifier: mapped.optional_modifier,
-                };
                 crate::query_boundaries::common::mapped_type_id(
                     self.ctx.types,
-                    self.ctx.types.factory().mapped(mapped_type),
+                    object_literals::mapped_type_with_constraint(
+                        self.ctx.types,
+                        mapped.as_ref(),
+                        eval_constraint,
+                    ),
                 )
                 .unwrap_or(mapped_id)
             } else {
@@ -777,11 +667,12 @@ impl<'a> CheckerState<'a> {
                             prop_name.as_ref(),
                         )
                     {
-                        properties.push(tsz_solver::PropertyInfo::new(name, prop_type_id));
+                        properties
+                            .push(object_literals::mapped_spread_property(name, prop_type_id));
                     }
                 }
                 if !properties.is_empty() {
-                    return self.ctx.types.factory().object(properties);
+                    return object_literals::mapped_spread_object_type(self.ctx.types, properties);
                 }
             }
         }

--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -9,6 +9,7 @@ use crate::context::TypingRequest;
 use crate::query_boundaries::checkers::call as call_checker;
 use crate::query_boundaries::common::ContextualTypeContext;
 use crate::query_boundaries::common::instantiate_type;
+use crate::query_boundaries::construct_signatures as signature_construction;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -224,12 +225,16 @@ impl<'a> CheckerState<'a> {
                 .or_else(|| {
                     call_checker::get_contextual_signature(self.ctx.types, call_target_type)
                 })
-                .map(|shape| self.ctx.types.factory().function(shape))
+                .map(|shape| {
+                    signature_construction::function_type_from_shape(self.ctx.types, shape)
+                })
                 .unwrap_or(call_target_type)
         } else {
             callee_shape
                 .as_ref()
-                .map(|shape| self.ctx.types.factory().function(shape.clone()))
+                .map(|shape| {
+                    signature_construction::function_type_from_shape(self.ctx.types, shape.clone())
+                })
                 .unwrap_or(callee_type_for_context)
         };
         let selected_callee_type = if tagged.type_arguments.is_some() {
@@ -292,19 +297,11 @@ impl<'a> CheckerState<'a> {
 
             if needs_two_pass {
                 // === Round 1: Collect non-contextual substitution types ===
-                let factory = self.ctx.types.factory();
-                let placeholder = {
-                    let fshape = tsz_solver::FunctionShape {
-                        params: vec![],
-                        return_type: TypeId::ANY,
-                        this_type: None,
-                        type_params: vec![],
-                        type_predicate: None,
-                        is_constructor: false,
-                        is_method: false,
-                    };
-                    factory.function(fshape)
-                };
+                let placeholder = signature_construction::function_type_from_parts(
+                    self.ctx.types,
+                    vec![],
+                    TypeId::ANY,
+                );
 
                 // Build argument types for Round 1: TemplateStringsArray + substitutions
                 // Use ANY as stand-in for TemplateStringsArray since it's a fixed

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -9,6 +9,7 @@ use crate::context::TypingRequest;
 use crate::context::speculation::DiagnosticSpeculationSnapshot;
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use crate::query_boundaries::common::ContextualTypeContext;
+use crate::query_boundaries::construct_signatures as signature_construction;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -230,7 +231,9 @@ impl<'a> CheckerState<'a> {
                     self.ctx.types,
                     evaluated_type,
                 )
-                .map(|shape| self.ctx.types.factory().function(shape))
+                .map(|shape| {
+                    signature_construction::function_type_from_shape(self.ctx.types, shape)
+                })
                 .unwrap_or(evaluated_type)
             } else {
                 evaluated_type
@@ -1515,17 +1518,11 @@ impl<'a> CheckerState<'a> {
             .expect("new_params cloned from non-empty shape.params")
             .type_id = evaluated_rest;
 
-        let new_shape = tsz_solver::FunctionShape {
-            type_params: shape.type_params.clone(),
-            params: new_params,
-            this_type: shape.this_type,
-            return_type: shape.return_type,
-            type_predicate: shape.type_predicate,
-            is_constructor: shape.is_constructor,
-            is_method: shape.is_method,
-        };
-
-        self.ctx.types.function(new_shape)
+        signature_construction::function_type_with_params_replaced(
+            self.ctx.types,
+            &shape,
+            new_params,
+        )
     }
 
     /// TS2366/TS2355/TS7030: Check that all code paths return a value when required.

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -9,6 +9,9 @@
 //! - Index signature handling
 //! - Type parameter instantiation for generic bases
 
+use crate::query_boundaries::{
+    construct_signatures as signature_boundary, type_construction as construction_boundary,
+};
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use crate::types_domain::type_node_helpers::type_node_includes_explicit_undefined;
@@ -20,7 +23,6 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::IndexSignature;
 use tsz_solver::TypeId;
-use tsz_solver::Visibility;
 
 // =============================================================================
 // Interface Type Resolution
@@ -238,10 +240,7 @@ impl<'a> CheckerState<'a> {
         use tsz_parser::parser::syntax_kind_ext::{
             CALL_SIGNATURE, CONSTRUCT_SIGNATURE, METHOD_SIGNATURE, PROPERTY_SIGNATURE,
         };
-        use tsz_solver::{
-            CallSignature as SolverCallSignature, CallableShape, IndexSignature, ObjectShape,
-            PropertyInfo,
-        };
+        use tsz_solver::{CallSignature as SolverCallSignature, IndexSignature, PropertyInfo};
         let factory = self.ctx.types.factory();
 
         let Some(node) = self.ctx.arena.get(idx) else {
@@ -443,22 +442,20 @@ impl<'a> CheckerState<'a> {
                         };
 
                         member_order += 1;
-                        properties.push(PropertyInfo {
-                            name: name_atom,
-                            type_id,
-                            write_type,
-                            optional: sig.question_token,
-                            readonly: self.has_readonly_modifier(&sig.modifiers),
-                            is_method: false,
-                            is_class_prototype: false,
-                            visibility: Visibility::Public,
-                            parent_id: None,
-                            declaration_order: member_order,
-                            is_string_named,
-                            is_symbol_named,
-                            single_quoted_name,
-                            non_widening: false,
-                        });
+                        properties.push(construction_boundary::declared_surface_property(
+                            construction_boundary::DeclaredSurfaceProperty {
+                                name: name_atom,
+                                type_id,
+                                write_type,
+                                optional: sig.question_token,
+                                readonly: self.has_readonly_modifier(&sig.modifiers),
+                                is_method: false,
+                                declaration_order: member_order,
+                                is_string_named,
+                                is_symbol_named,
+                                single_quoted_name,
+                            },
+                        ));
                     }
                 }
             } else if member_node.kind == METHOD_SIGNATURE {
@@ -638,12 +635,9 @@ impl<'a> CheckerState<'a> {
                     .get(param_data.name)
                     .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
                     .map(|name_ident| self.ctx.types.intern_string(&name_ident.escaped_text));
-                let info = IndexSignature {
-                    key_type,
-                    value_type,
-                    readonly,
-                    param_name,
-                };
+                let info = construction_boundary::declared_index_signature(
+                    key_type, value_type, readonly, param_name,
+                );
                 if is_valid_index_type {
                     if key_type == TypeId::NUMBER {
                         Self::merge_index_signature(&mut number_index, info);
@@ -674,44 +668,34 @@ impl<'a> CheckerState<'a> {
                     .into_iter()
                     .next()
                     .expect("single signature confirmed by len check");
-                factory.function(tsz_solver::FunctionShape {
-                    type_params: sig.type_params,
-                    params: sig.params,
-                    this_type: sig.this_type,
-                    return_type: sig.return_type,
-                    type_predicate: sig.type_predicate,
-                    is_constructor: false,
-                    is_method: true,
-                })
+                signature_boundary::declared_method_function_type(self.ctx.types, sig)
             } else {
                 // Multiple overloads: create a Callable type with all signatures
-                let shape = CallableShape {
-                    call_signatures: entry.signatures,
-                    construct_signatures: Vec::new(),
-                    properties: Vec::new(),
-                    string_index: None,
-                    number_index: None,
-                    symbol: None,
-                    is_abstract: false,
-                };
-                factory.callable(shape)
+                signature_boundary::declared_callable_surface_type(
+                    self.ctx.types,
+                    entry.signatures,
+                    Vec::new(),
+                    Vec::new(),
+                    None,
+                    None,
+                    None,
+                    false,
+                )
             };
-            properties.push(PropertyInfo {
-                name,
-                type_id,
-                write_type: type_id,
-                optional: entry.optional,
-                readonly: entry.readonly,
-                is_method: true,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: entry.declaration_order,
-                is_string_named: entry.is_string_named,
-                is_symbol_named: entry.is_symbol_named,
-                single_quoted_name: entry.single_quoted_name,
-                non_widening: false,
-            });
+            properties.push(construction_boundary::declared_surface_property(
+                construction_boundary::DeclaredSurfaceProperty {
+                    name,
+                    type_id,
+                    write_type: type_id,
+                    optional: entry.optional,
+                    readonly: entry.readonly,
+                    is_method: true,
+                    declaration_order: entry.declaration_order,
+                    is_string_named: entry.is_string_named,
+                    is_symbol_named: entry.is_symbol_named,
+                    single_quoted_name: entry.single_quoted_name,
+                },
+            ));
         }
 
         // Convert accessors to properties
@@ -728,48 +712,50 @@ impl<'a> CheckerState<'a> {
                 .or(accessor.getter)
                 .unwrap_or(read_type);
             let readonly = accessor.getter.is_some() && accessor.setter.is_none();
-            properties.push(PropertyInfo {
-                name,
-                type_id: read_type,
-                write_type,
-                optional: false,
-                readonly,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: accessor.declaration_order,
-                is_string_named: accessor.is_string_named,
-                is_symbol_named: accessor.is_symbol_named,
-                single_quoted_name: accessor.single_quoted_name,
-                non_widening: false,
-            });
+            properties.push(construction_boundary::declared_surface_property(
+                construction_boundary::DeclaredSurfaceProperty {
+                    name,
+                    type_id: read_type,
+                    write_type,
+                    optional: false,
+                    readonly,
+                    is_method: false,
+                    declaration_order: accessor.declaration_order,
+                    is_string_named: accessor.is_string_named,
+                    is_symbol_named: accessor.is_symbol_named,
+                    single_quoted_name: accessor.single_quoted_name,
+                },
+            ));
         }
 
         let result = if !call_signatures.is_empty() || !construct_signatures.is_empty() {
             // `CallableShape` keeps the single-slot index convention: a `symbol`
             // index rides in `string_index` (its `key_type` discriminates it).
-            let shape = CallableShape {
+            signature_boundary::declared_callable_surface_type(
+                self.ctx.types,
                 call_signatures,
                 construct_signatures,
                 properties,
-                string_index: string_index.or(symbol_index),
+                string_index.or(symbol_index),
                 number_index,
-                symbol: interface_symbol,
-                is_abstract: false,
-            };
-            factory.callable(shape)
+                interface_symbol,
+                false,
+            )
         } else if string_index.is_some() || number_index.is_some() || symbol_index.is_some() {
-            factory.object_with_index(ObjectShape {
+            construction_boundary::declared_object_with_indexes(
+                self.ctx.types,
                 properties,
                 string_index,
                 number_index,
                 symbol_index,
-                symbol: interface_symbol,
-                ..ObjectShape::default()
-            })
+                interface_symbol,
+            )
         } else if !properties.is_empty() {
-            factory.object_with_symbol(properties, interface_symbol)
+            construction_boundary::declared_object_with_symbol(
+                self.ctx.types,
+                properties,
+                interface_symbol,
+            )
         } else {
             TypeId::ANY
         };

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -6,13 +6,13 @@
 //! - Merging augmented members into the target interface/namespace type
 //! - Updating cached symbol types for self-referential augmentations
 
+use crate::query_boundaries::module_augmentation as module_augmentation_boundary;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use tsz_binder::{ModuleAugmentation, symbol_flags};
 use tsz_solver::TypeId;
-use tsz_solver::Visibility;
 
 impl<'a> CheckerState<'a> {
     fn module_augmentation_key_candidates(&self, module_spec: &str) -> Vec<String> {
@@ -656,8 +656,6 @@ impl<'a> CheckerState<'a> {
             METHOD_SIGNATURE, MODULE_BLOCK, MODULE_DECLARATION, PROPERTY_SIGNATURE,
             VARIABLE_STATEMENT,
         };
-        use tsz_solver::PropertyInfo;
-        use tsz_solver::TypeId;
 
         let augmentation_decls =
             self.get_module_augmentation_declarations(module_spec, interface_name);
@@ -766,22 +764,14 @@ impl<'a> CheckerState<'a> {
                         };
 
                         aug_member_order += 1;
-                        members.push(PropertyInfo {
-                            name: self.ctx.types.intern_string(&member_name),
+                        members.push(module_augmentation_boundary::augmentation_member_property(
+                            self.ctx.types.intern_string(&member_name),
                             type_id,
-                            write_type: type_id,
-                            optional: sig.question_token,
-                            readonly: self.has_readonly_modifier(&sig.modifiers),
-                            is_method: member_node.kind == METHOD_SIGNATURE,
-                            is_class_prototype: false,
-                            visibility: Visibility::Public,
-                            parent_id: None,
-                            declaration_order: aug_member_order,
-                            is_string_named: false,
-                            is_symbol_named: false,
-                            single_quoted_name: false,
-                            non_widening: false,
-                        });
+                            sig.question_token,
+                            self.has_readonly_modifier(&sig.modifiers),
+                            member_node.kind == METHOD_SIGNATURE,
+                            aug_member_order,
+                        ));
                     }
                 }
                 if let Some(updates) = interface_type_param_updates {
@@ -812,22 +802,14 @@ impl<'a> CheckerState<'a> {
                     };
 
                     aug_member_order += 1;
-                    members.push(PropertyInfo {
-                        name: self.ctx.types.intern_string(&member_name),
-                        type_id: TypeId::ANY,
-                        write_type: TypeId::ANY,
-                        optional: false,
-                        readonly: true,
-                        is_method: false,
-                        is_class_prototype: false,
-                        visibility: Visibility::Public,
-                        parent_id: None,
-                        declaration_order: aug_member_order,
-                        is_string_named: false,
-                        is_symbol_named: false,
-                        single_quoted_name: false,
-                        non_widening: false,
-                    });
+                    members.push(
+                        module_augmentation_boundary::augmentation_any_member_property(
+                            self.ctx.types.intern_string(&member_name),
+                            true,
+                            false,
+                            aug_member_order,
+                        ),
+                    );
                 }
                 continue;
             }
@@ -878,25 +860,14 @@ impl<'a> CheckerState<'a> {
                                                 TypeId::ANY
                                             };
 
-                                            members.push(PropertyInfo {
-                                                name: self
-                                                    .ctx
-                                                    .types
-                                                    .intern_string(&id_data.escaped_text),
-                                                type_id,
-                                                write_type: type_id,
-                                                optional: false,
-                                                readonly: false,
-                                                is_method: false,
-                                                is_class_prototype: false,
-                                                visibility: Visibility::Public,
-                                                parent_id: None,
-                                                declaration_order: 0,
-                                                is_string_named: false,
-                                                is_symbol_named: false,
-                                                single_quoted_name: false,
-                                                non_widening: false,
-                                            });
+                                            members.push(
+                                                module_augmentation_boundary::augmentation_value_member_property(
+                                                    self.ctx.types.intern_string(
+                                                        &id_data.escaped_text,
+                                                    ),
+                                                    type_id,
+                                                ),
+                                            );
                                         }
                                     } else if let Some(decl_node) = arena.get(decl_idx)
                                         && let Some(decl) =
@@ -912,25 +883,14 @@ impl<'a> CheckerState<'a> {
                                             TypeId::ANY
                                         };
 
-                                        members.push(PropertyInfo {
-                                            name: self
-                                                .ctx
-                                                .types
-                                                .intern_string(&id_data.escaped_text),
-                                            type_id,
-                                            write_type: type_id,
-                                            optional: false,
-                                            readonly: false,
-                                            is_method: false,
-                                            is_class_prototype: false,
-                                            visibility: Visibility::Public,
-                                            parent_id: None,
-                                            declaration_order: 0,
-                                            is_string_named: false,
-                                            is_symbol_named: false,
-                                            single_quoted_name: false,
-                                            non_widening: false,
-                                        });
+                                        members.push(
+                                            module_augmentation_boundary::augmentation_value_member_property(
+                                                self.ctx
+                                                    .types
+                                                    .intern_string(&id_data.escaped_text),
+                                                type_id,
+                                            ),
+                                        );
                                     }
                                 }
                             }
@@ -940,22 +900,11 @@ impl<'a> CheckerState<'a> {
                                 && let Some(name_node) = arena.get(func.name)
                                 && let Some(id_data) = arena.get_identifier(name_node)
                             {
-                                members.push(PropertyInfo {
-                                    name: self.ctx.types.intern_string(&id_data.escaped_text),
-                                    type_id: TypeId::ANY,
-                                    write_type: TypeId::ANY,
-                                    optional: false,
-                                    readonly: false,
-                                    is_method: true,
-                                    is_class_prototype: false,
-                                    visibility: Visibility::Public,
-                                    parent_id: None,
-                                    declaration_order: 0,
-                                    is_string_named: false,
-                                    is_symbol_named: false,
-                                    single_quoted_name: false,
-                                    non_widening: false,
-                                });
+                                members.push(
+                                    module_augmentation_boundary::augmentation_any_method_member_property(
+                                        self.ctx.types.intern_string(&id_data.escaped_text),
+                                    ),
+                                );
                             }
                         }
                         INTERFACE_DECLARATION => {
@@ -963,22 +912,11 @@ impl<'a> CheckerState<'a> {
                                 && let Some(name_node) = arena.get(iface.name)
                                 && let Some(id_data) = arena.get_identifier(name_node)
                             {
-                                members.push(PropertyInfo {
-                                    name: self.ctx.types.intern_string(&id_data.escaped_text),
-                                    type_id: TypeId::ANY,
-                                    write_type: TypeId::ANY,
-                                    optional: false,
-                                    readonly: false,
-                                    is_method: false,
-                                    is_class_prototype: false,
-                                    visibility: Visibility::Public,
-                                    parent_id: None,
-                                    declaration_order: 0,
-                                    is_string_named: false,
-                                    is_symbol_named: false,
-                                    single_quoted_name: false,
-                                    non_widening: false,
-                                });
+                                members.push(
+                                    module_augmentation_boundary::augmentation_any_value_member_property(
+                                        self.ctx.types.intern_string(&id_data.escaped_text),
+                                    ),
+                                );
                             }
                         }
                         EXPORT_DECLARATION => {
@@ -1017,25 +955,14 @@ impl<'a> CheckerState<'a> {
                                                 TypeId::ANY
                                             };
 
-                                            members.push(PropertyInfo {
-                                                name: self
-                                                    .ctx
-                                                    .types
-                                                    .intern_string(&id_data.escaped_text),
-                                                type_id,
-                                                write_type: type_id,
-                                                optional: false,
-                                                readonly: false,
-                                                is_method: false,
-                                                is_class_prototype: false,
-                                                visibility: Visibility::Public,
-                                                parent_id: None,
-                                                declaration_order: 0,
-                                                is_string_named: false,
-                                                is_symbol_named: false,
-                                                single_quoted_name: false,
-                                                non_widening: false,
-                                            });
+                                            members.push(
+                                                module_augmentation_boundary::augmentation_value_member_property(
+                                                    self.ctx.types.intern_string(
+                                                        &id_data.escaped_text,
+                                                    ),
+                                                    type_id,
+                                                ),
+                                            );
                                         }
                                     } else if let Some(decl_node) = arena.get(decl_idx)
                                         && let Some(decl) =
@@ -1051,25 +978,14 @@ impl<'a> CheckerState<'a> {
                                             TypeId::ANY
                                         };
 
-                                        members.push(PropertyInfo {
-                                            name: self
-                                                .ctx
-                                                .types
-                                                .intern_string(&id_data.escaped_text),
-                                            type_id,
-                                            write_type: type_id,
-                                            optional: false,
-                                            readonly: false,
-                                            is_method: false,
-                                            is_class_prototype: false,
-                                            visibility: Visibility::Public,
-                                            parent_id: None,
-                                            declaration_order: 0,
-                                            is_string_named: false,
-                                            is_symbol_named: false,
-                                            single_quoted_name: false,
-                                            non_widening: false,
-                                        });
+                                        members.push(
+                                            module_augmentation_boundary::augmentation_value_member_property(
+                                                self.ctx
+                                                    .types
+                                                    .intern_string(&id_data.escaped_text),
+                                                type_id,
+                                            ),
+                                        );
                                     }
                                 }
                             }
@@ -1136,7 +1052,13 @@ impl<'a> CheckerState<'a> {
         if type_args.is_empty() {
             Some(base_type)
         } else {
-            Some(self.ctx.types.factory().application(base_type, type_args))
+            Some(
+                module_augmentation_boundary::self_reference_application_type(
+                    self.ctx.types,
+                    base_type,
+                    type_args,
+                ),
+            )
         }
     }
 
@@ -1192,7 +1114,6 @@ impl<'a> CheckerState<'a> {
     ) -> tsz_solver::TypeId {
         use crate::query_boundaries::common::{AugmentationTargetKind, classify_for_augmentation};
         use crate::query_boundaries::state::type_resolution as query;
-        use tsz_solver::{CallableShape, ObjectShape};
 
         // Fast-path: avoids string allocations and hashset bookkeeping when
         // no augmentations are registered anywhere in the program.
@@ -1267,7 +1188,6 @@ impl<'a> CheckerState<'a> {
             }
             _ => None,
         };
-        let factory = self.ctx.types.factory();
 
         let result = match kind {
             AugmentationTargetKind::Object(shape_id) => {
@@ -1286,7 +1206,8 @@ impl<'a> CheckerState<'a> {
                 // object-level flags so the augmented type keeps its canonical
                 // declaration name (e.g. `Tool` rather than an expanded
                 // `{ ... }` literal) and stays a single interned identity.
-                let augmented = factory.object_with_flags_and_symbol(
+                let augmented = module_augmentation_boundary::augmented_object_type(
+                    self.ctx.types,
                     merged_properties,
                     base_shape.flags,
                     base_shape.symbol,
@@ -1320,14 +1241,15 @@ impl<'a> CheckerState<'a> {
                         .definition_store
                         .register_module_augmentation_symbol_def_if_enabled(symbol.0, def_id);
                 }
-                factory.object_with_index(ObjectShape {
-                    flags: base_shape.flags,
-                    properties: merged_properties,
-                    string_index: base_shape.string_index,
-                    number_index: base_shape.number_index,
-                    symbol_index: base_shape.symbol_index,
-                    symbol: base_shape.symbol,
-                })
+                module_augmentation_boundary::augmented_object_with_index_type(
+                    self.ctx.types,
+                    merged_properties,
+                    base_shape.flags,
+                    base_shape.string_index,
+                    base_shape.number_index,
+                    base_shape.symbol_index,
+                    base_shape.symbol,
+                )
             }
             AugmentationTargetKind::Callable(shape_id) => {
                 let base_shape = self.ctx.types.callable_shape(shape_id);
@@ -1359,28 +1281,28 @@ impl<'a> CheckerState<'a> {
                     }
                     properties
                 };
-                factory.callable(CallableShape {
-                    call_signatures: base_shape.call_signatures.clone(),
-                    construct_signatures: base_shape.construct_signatures.clone(),
+                module_augmentation_boundary::augmented_callable_type(
+                    self.ctx.types,
+                    base_shape.call_signatures.clone(),
+                    base_shape.construct_signatures.clone(),
                     properties,
-                    string_index: base_shape.string_index,
-                    number_index: base_shape.number_index,
                     // Preserve the callable's nominal identity and abstractness
                     // so the augmented class/namespace keeps its declaration name.
-                    symbol: base_shape.symbol,
-                    is_abstract: base_shape.is_abstract,
-                })
+                    base_shape.string_index,
+                    base_shape.number_index,
+                    base_shape.symbol,
+                    base_shape.is_abstract,
+                )
             }
             AugmentationTargetKind::Other => {
                 // For types that still can't be decomposed after evaluation (e.g.
                 // intrinsics, intersections), create an intersection of the base type
                 // and a new object with the augmentation members.
-                if !augmentation_members.is_empty() {
-                    let aug_object = factory.object(augmentation_members);
-                    factory.intersection2(base_type, aug_object)
-                } else {
-                    base_type
-                }
+                module_augmentation_boundary::other_target_with_augmentation_members(
+                    self.ctx.types,
+                    base_type,
+                    augmentation_members,
+                )
             }
         };
 

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -4,6 +4,7 @@
 //! checks, and const expando key resolution.
 
 use crate::FlowAnalyzer;
+use crate::query_boundaries::property_access as property_access_query;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use crate::symbols_domain::name_text::property_access_chain_text_in_arena;
@@ -1020,9 +1021,11 @@ impl<'a> CheckerState<'a> {
         let params = sig
             .params
             .iter()
-            .map(|param| tsz_solver::ParamInfo {
-                type_id: instantiate_type(self.ctx.types, param.type_id, &collapse_subst),
-                ..*param
+            .map(|param| {
+                property_access_query::strict_bind_call_apply_param_with_type(
+                    *param,
+                    instantiate_type(self.ctx.types, param.type_id, &collapse_subst),
+                )
             })
             .collect();
         let return_type = instantiate_type(self.ctx.types, sig.return_type, &collapse_subst);
@@ -1031,22 +1034,25 @@ impl<'a> CheckerState<'a> {
             .type_params
             .iter()
             .filter(|tp| !collapsed_names.contains(&tp.name))
-            .map(|tp| tsz_solver::TypeParamInfo {
-                constraint: tp
-                    .constraint
-                    .map(|c| instantiate_type(self.ctx.types, c, &collapse_subst)),
-                ..*tp
+            .map(|tp| {
+                property_access_query::strict_bind_call_apply_type_param_with_constraint(
+                    *tp,
+                    tp.constraint
+                        .map(|c| instantiate_type(self.ctx.types, c, &collapse_subst)),
+                )
             })
             .collect();
 
-        Some(tsz_solver::CallSignature {
-            type_params,
-            params,
-            this_type,
-            return_type,
-            type_predicate: sig.type_predicate,
-            is_method: sig.is_method,
-        })
+        Some(
+            property_access_query::strict_bind_call_apply_call_signature(
+                type_params,
+                params,
+                this_type,
+                return_type,
+                sig.type_predicate,
+                sig.is_method,
+            ),
+        )
     }
 
     pub(in crate::types_domain) fn strict_bind_call_apply_method_type(
@@ -1087,71 +1093,6 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        fn signature_to_call_signature(
-            shape: &tsz_solver::FunctionShape,
-        ) -> tsz_solver::CallSignature {
-            tsz_solver::CallSignature {
-                type_params: shape.type_params.clone(),
-                params: shape.params.clone(),
-                this_type: shape.this_type,
-                return_type: shape.return_type,
-                type_predicate: shape.type_predicate,
-                is_method: shape.is_method,
-            }
-        }
-
-        fn signature_params_as_tuple(
-            factory: tsz_solver::construction::TypeFactory<'_>,
-            params: &[tsz_solver::ParamInfo],
-        ) -> TypeId {
-            let tuple_elements: Vec<tsz_solver::TupleElement> = params
-                .iter()
-                .map(|param| tsz_solver::TupleElement {
-                    type_id: param.type_id,
-                    name: param.name,
-                    optional: param.optional && !param.rest,
-                    rest: param.rest,
-                })
-                .collect();
-            factory.tuple(tuple_elements)
-        }
-
-        fn bound_callable_return_type(
-            factory: tsz_solver::construction::TypeFactory<'_>,
-            sig: &tsz_solver::CallSignature,
-            remaining_params: Vec<tsz_solver::ParamInfo>,
-            is_constructor: bool,
-        ) -> TypeId {
-            if is_constructor {
-                return factory.callable(tsz_solver::CallableShape {
-                    call_signatures: Vec::new(),
-                    construct_signatures: vec![tsz_solver::CallSignature {
-                        type_params: sig.type_params.clone(),
-                        params: remaining_params,
-                        this_type: None,
-                        return_type: sig.return_type,
-                        type_predicate: None,
-                        is_method: false,
-                    }],
-                    properties: Vec::new(),
-                    string_index: None,
-                    number_index: None,
-                    symbol: None,
-                    is_abstract: false,
-                });
-            }
-
-            factory.function(tsz_solver::FunctionShape {
-                type_params: sig.type_params.clone(),
-                params: remaining_params,
-                this_type: None,
-                return_type: sig.return_type,
-                type_predicate: sig.type_predicate,
-                is_constructor: false,
-                is_method: false,
-            })
-        }
-
         let mut candidates = vec![object_type];
         if let Some(sym_id) = self.resolve_identifier_symbol(object_expr_idx) {
             let sym_type = self.get_type_of_symbol(sym_id);
@@ -1174,7 +1115,10 @@ impl<'a> CheckerState<'a> {
             if let Some(shape) =
                 crate::query_boundaries::property_access::function_shape(self.ctx.types, candidate)
             {
-                let sig = signature_to_call_signature(&shape);
+                let sig =
+                    property_access_query::strict_bind_call_apply_signature_from_function_shape(
+                        &shape,
+                    );
                 if !call_targets.contains(&sig) {
                     call_targets.push(sig);
                 }
@@ -1209,7 +1153,6 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let factory = self.ctx.types.factory();
         let mut method_signatures = Vec::new();
 
         // `tsc` parity: `.bind(thisArg)` on an overloaded function whose call
@@ -1230,28 +1173,26 @@ impl<'a> CheckerState<'a> {
             && construct_targets.is_empty()
             && call_targets.iter().all(|sig| sig.this_type.is_none())
         {
-            let full_receiver = factory.callable(tsz_solver::CallableShape {
-                call_signatures: call_targets.clone(),
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            });
-            method_signatures.push(tsz_solver::CallSignature {
-                type_params: Vec::new(),
-                params: vec![tsz_solver::ParamInfo {
-                    name: Some(self.ctx.types.intern_string("thisArg")),
-                    type_id: TypeId::ANY,
-                    optional: false,
-                    rest: false,
-                }],
-                this_type: None,
-                return_type: full_receiver,
-                type_predicate: None,
-                is_method: false,
-            });
+            let full_receiver =
+                property_access_query::strict_bind_call_apply_call_only_callable_type(
+                    self.ctx.types,
+                    call_targets.clone(),
+                );
+            method_signatures.push(
+                property_access_query::strict_bind_call_apply_call_signature(
+                    Vec::new(),
+                    vec![
+                        property_access_query::strict_bind_call_apply_this_arg_param(
+                            self.ctx.types,
+                            TypeId::ANY,
+                        ),
+                    ],
+                    None,
+                    full_receiver,
+                    None,
+                    false,
+                ),
+            );
         }
 
         for (sig, is_constructor) in call_targets
@@ -1261,61 +1202,56 @@ impl<'a> CheckerState<'a> {
         {
             match property_name {
                 "apply" => {
-                    let method_sig = tsz_solver::CallSignature {
-                        type_params: sig.type_params.clone(),
-                        params: vec![
-                            tsz_solver::ParamInfo {
-                                name: Some(self.ctx.types.intern_string("thisArg")),
-                                type_id: method_this_arg_type(
-                                    sig,
-                                    is_constructor,
-                                    receiver_this_type,
+                    let method_sig = property_access_query::strict_bind_call_apply_call_signature(
+                        sig.type_params.clone(),
+                        vec![
+                            property_access_query::strict_bind_call_apply_this_arg_param(
+                                self.ctx.types,
+                                method_this_arg_type(sig, is_constructor, receiver_this_type),
+                            ),
+                            property_access_query::strict_bind_call_apply_args_param(
+                                self.ctx.types,
+                                property_access_query::strict_bind_call_apply_params_tuple_type(
+                                    self.ctx.types,
+                                    &sig.params,
                                 ),
-                                optional: false,
-                                rest: false,
-                            },
-                            tsz_solver::ParamInfo {
-                                name: Some(self.ctx.types.intern_string("args")),
-                                type_id: signature_params_as_tuple(factory, &sig.params),
-                                optional: true,
-                                rest: false,
-                            },
+                            ),
                         ],
-                        this_type: None,
-                        return_type: if is_constructor {
+                        None,
+                        if is_constructor {
                             TypeId::VOID
                         } else {
                             sig.return_type
                         },
-                        type_predicate: None,
-                        is_method: false,
-                    };
+                        None,
+                        false,
+                    );
                     if !method_signatures.contains(&method_sig) {
                         method_signatures.push(method_sig);
                     }
                 }
                 "call" => {
                     let mut params = Vec::with_capacity(1 + sig.params.len());
-                    params.push(tsz_solver::ParamInfo {
-                        name: Some(self.ctx.types.intern_string("thisArg")),
-                        type_id: method_this_arg_type(sig, is_constructor, receiver_this_type),
-                        optional: false,
-                        rest: false,
-                    });
+                    params.push(
+                        property_access_query::strict_bind_call_apply_this_arg_param(
+                            self.ctx.types,
+                            method_this_arg_type(sig, is_constructor, receiver_this_type),
+                        ),
+                    );
                     params.extend(sig.params.clone());
 
-                    let method_sig = tsz_solver::CallSignature {
-                        type_params: sig.type_params.clone(),
+                    let method_sig = property_access_query::strict_bind_call_apply_call_signature(
+                        sig.type_params.clone(),
                         params,
-                        this_type: None,
-                        return_type: if is_constructor {
+                        None,
+                        if is_constructor {
                             TypeId::VOID
                         } else {
                             sig.return_type
                         },
-                        type_predicate: None,
-                        is_method: false,
-                    };
+                        None,
+                        false,
+                    );
                     if !method_signatures.contains(&method_sig) {
                         method_signatures.push(method_sig);
                     }
@@ -1327,62 +1263,61 @@ impl<'a> CheckerState<'a> {
                         let this_arg_type =
                             bind_this_arg_type(sig, is_constructor, receiver_this_type);
                         let mut params = Vec::with_capacity(1 + prefix_len);
-                        params.push(tsz_solver::ParamInfo {
-                            name: Some(self.ctx.types.intern_string("thisArg")),
-                            type_id: this_arg_type,
-                            optional: false,
-                            rest: false,
-                        });
+                        params.push(
+                            property_access_query::strict_bind_call_apply_this_arg_param(
+                                self.ctx.types,
+                                this_arg_type,
+                            ),
+                        );
                         params.extend(sig.params.iter().take(prefix_len).cloned());
 
                         let remaining_params =
                             sig.params.iter().skip(prefix_len).cloned().collect();
-                        let method_sig = tsz_solver::CallSignature {
-                            type_params: sig.type_params.clone(),
-                            params,
-                            this_type: None,
-                            return_type: bound_callable_return_type(
-                                factory,
-                                sig,
-                                remaining_params,
-                                is_constructor,
-                            ),
-                            type_predicate: None,
-                            is_method: false,
-                        };
+                        let method_sig =
+                            property_access_query::strict_bind_call_apply_call_signature(
+                                sig.type_params.clone(),
+                                params,
+                                None,
+                                property_access_query::strict_bind_call_apply_bound_return_type(
+                                    self.ctx.types,
+                                    sig,
+                                    remaining_params,
+                                    is_constructor,
+                                ),
+                                None,
+                                false,
+                            );
                         if !method_signatures.contains(&method_sig) {
                             method_signatures.push(method_sig);
                         }
 
                         if prefix_len == 0 && sig.this_type.is_some() && !is_constructor {
-                            let generic_this_param = tsz_solver::TypeParamInfo {
-                                name: self.ctx.types.intern_string("TThis"),
-                                constraint: Some(this_arg_type),
-                                default: None,
-                                is_const: false,
-                                origin: tsz_solver::TypeParamOrigin::User,
-                            };
-                            let generic_this_type = factory.type_param(generic_this_param);
-                            let generic_bind_sig = tsz_solver::CallSignature {
-                                type_params: std::iter::once(generic_this_param)
+                            let (generic_this_param, generic_this_type) =
+                                property_access_query::strict_bind_call_apply_generic_this_param(
+                                    self.ctx.types,
+                                    this_arg_type,
+                                );
+                            let generic_bind_sig =
+                                property_access_query::strict_bind_call_apply_call_signature(
+                                    std::iter::once(generic_this_param)
                                     .chain(sig.type_params.clone())
                                     .collect(),
-                                params: vec![tsz_solver::ParamInfo {
-                                    name: Some(self.ctx.types.intern_string("thisArg")),
-                                    type_id: generic_this_type,
-                                    optional: false,
-                                    rest: false,
-                                }],
-                                this_type: None,
-                                return_type: bound_callable_return_type(
-                                    factory,
+                                    vec![
+                                        property_access_query::strict_bind_call_apply_this_arg_param(
+                                            self.ctx.types,
+                                            generic_this_type,
+                                        ),
+                                    ],
+                                    None,
+                                    property_access_query::strict_bind_call_apply_bound_return_type(
+                                        self.ctx.types,
                                     sig,
                                     sig.params.clone(),
                                     is_constructor,
-                                ),
-                                type_predicate: None,
-                                is_method: false,
-                            };
+                                    ),
+                                    None,
+                                    false,
+                                );
                             if !method_signatures.contains(&generic_bind_sig) {
                                 method_signatures.push(generic_bind_sig);
                             }
@@ -1393,27 +1328,7 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        match method_signatures.len() {
-            0 => None,
-            1 => Some(factory.function(tsz_solver::FunctionShape {
-                type_params: method_signatures[0].type_params.clone(),
-                params: method_signatures[0].params.clone(),
-                this_type: None,
-                return_type: method_signatures[0].return_type,
-                type_predicate: method_signatures[0].type_predicate,
-                is_constructor: false,
-                is_method: false,
-            })),
-            _ => Some(factory.callable(tsz_solver::CallableShape {
-                call_signatures: method_signatures,
-                construct_signatures: Vec::new(),
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            })),
-        }
+        property_access_query::strict_bind_call_apply_method_type(self.ctx.types, method_signatures)
     }
 
     /// Report the module-compatibility error for `import.meta` when the

--- a/crates/tsz-checker/src/types/queries/binding.rs
+++ b/crates/tsz-checker/src/types/queries/binding.rs
@@ -1,4 +1,5 @@
 use crate::context::TypingRequest;
+use crate::query_boundaries::binding_patterns;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -26,8 +27,6 @@ impl<'a> CheckerState<'a> {
         let Some(pattern_node) = self.ctx.arena.get(pattern_idx) else {
             return TypeId::ANY;
         };
-
-        let factory = self.ctx.types.factory();
 
         if pattern_node.kind == syntax_kind_ext::OBJECT_BINDING_PATTERN {
             let Some(pattern_data) = self.ctx.arena.get_binding_pattern(pattern_node) else {
@@ -108,7 +107,11 @@ impl<'a> CheckerState<'a> {
                             .destructuring_relation_outcome(init_type, element_type)
                             .related
                         {
-                            element_type = self.ctx.types.factory().union2(element_type, init_type);
+                            element_type = binding_patterns::binding_pattern_initializer_union_type(
+                                self.ctx.types,
+                                element_type,
+                                init_type,
+                            );
                         }
                     } else if element_type == TypeId::ANY
                         && let Some(name_node) = self.ctx.arena.get(element_data.name)
@@ -125,9 +128,11 @@ impl<'a> CheckerState<'a> {
                     let is_optional =
                         element_data.initializer.is_some() || element_data.dot_dot_dot_token;
 
-                    let mut prop_info = tsz_solver::PropertyInfo::new(atom, element_type);
-                    prop_info.optional = is_optional;
-                    properties.push(prop_info);
+                    properties.push(binding_patterns::binding_pattern_property(
+                        atom,
+                        element_type,
+                        is_optional,
+                    ));
                 }
             }
             // An empty object binding pattern `{}` provides no structural constraints.
@@ -136,7 +141,7 @@ impl<'a> CheckerState<'a> {
             if properties.is_empty() {
                 return TypeId::ANY;
             }
-            return factory.object(properties);
+            return binding_patterns::binding_pattern_object_type(self.ctx.types, properties);
         } else if pattern_node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN {
             let Some(pattern_data) = self.ctx.arena.get_binding_pattern(pattern_node) else {
                 return TypeId::ANY;
@@ -150,12 +155,11 @@ impl<'a> CheckerState<'a> {
                 };
 
                 if element_node.kind == syntax_kind_ext::OMITTED_EXPRESSION {
-                    elements.push(tsz_solver::TupleElement {
-                        type_id: TypeId::ANY,
-                        optional: true,
-                        rest: false,
-                        name: None,
-                    });
+                    elements.push(binding_patterns::binding_pattern_tuple_element(
+                        TypeId::ANY,
+                        true,
+                        false,
+                    ));
                     continue;
                 }
 
@@ -192,7 +196,11 @@ impl<'a> CheckerState<'a> {
                             .destructuring_relation_outcome(init_type, element_type)
                             .related
                         {
-                            element_type = self.ctx.types.factory().union2(element_type, init_type);
+                            element_type = binding_patterns::binding_pattern_initializer_union_type(
+                                self.ctx.types,
+                                element_type,
+                                init_type,
+                            );
                         }
                     } else if element_type == TypeId::ANY
                         && let Some(name_node) = self.ctx.arena.get(element_data.name)
@@ -212,12 +220,11 @@ impl<'a> CheckerState<'a> {
                     // Only non-rest elements with a default initializer are optional.
                     let is_optional = element_data.initializer.is_some() && !is_rest;
 
-                    elements.push(tsz_solver::TupleElement {
-                        type_id: element_type,
-                        optional: is_optional,
-                        rest: is_rest,
-                        name: None,
-                    });
+                    elements.push(binding_patterns::binding_pattern_tuple_element(
+                        element_type,
+                        is_optional,
+                        is_rest,
+                    ));
                 }
             }
 
@@ -226,7 +233,7 @@ impl<'a> CheckerState<'a> {
             if elements.is_empty() {
                 return TypeId::ANY;
             }
-            return factory.tuple(elements);
+            return binding_patterns::binding_pattern_tuple_type(self.ctx.types, elements);
         }
         TypeId::ANY
     }

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -6,6 +6,7 @@
 //! `type_alias_checking.rs`.
 
 use crate::context::TypingRequest;
+use crate::query_boundaries::type_checking as query;
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
 use tsz_parser::parser::NodeIndex;
@@ -1419,7 +1420,7 @@ impl<'a> CheckerState<'a> {
                         }
                         let lit = self.ctx.arena.get_literal(node)?;
                         tsz_common::numeric::parse_numeric_literal_value(&lit.text)
-                            .map(|value| self.ctx.types.literal_number(value))
+                            .map(|value| query::type_checking_literal_number(self.ctx.types, value))
                     });
                 let source_type = literal_source.unwrap_or(default_value_type);
                 let source_for_display = literal_source

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -4,6 +4,7 @@
 //! Extracted from `core.rs` to keep module size manageable.
 
 use crate::context::TypingRequest;
+use crate::query_boundaries::type_checking as query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
@@ -141,7 +142,7 @@ impl<'a> CheckerState<'a> {
                     if let Some(pt) = promise_t {
                         members.push(pt);
                     }
-                    self.ctx.types.factory().union(members)
+                    query::type_checking_union(self.ctx.types, members)
                 } else {
                     contextual_expected_type
                 };
@@ -824,17 +825,7 @@ impl<'a> CheckerState<'a> {
         };
         let name = ident.escaped_text.clone();
         let atom = self.ctx.types.intern_string(&name);
-        let provisional_type_id = self
-            .ctx
-            .types
-            .factory()
-            .type_param(tsz_solver::TypeParamInfo {
-                name: atom,
-                constraint: None,
-                default: None,
-                is_const: false,
-                origin: tsz_solver::TypeParamOrigin::User,
-            });
+        let provisional_type_id = query::user_type_param(self.ctx.types, atom, None, None, false);
         let previous = self
             .ctx
             .type_parameter_scope
@@ -1090,17 +1081,8 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        let constrained_type_id = self
-            .ctx
-            .types
-            .factory()
-            .type_param(tsz_solver::TypeParamInfo {
-                name: atom,
-                constraint: Some(constraint_type),
-                default: None,
-                is_const: false,
-                origin: tsz_solver::TypeParamOrigin::User,
-            });
+        let constrained_type_id =
+            query::user_type_param(self.ctx.types, atom, Some(constraint_type), None, false);
         self.ctx
             .type_parameter_scope
             .insert(name.clone(), constrained_type_id);

--- a/crates/tsz-checker/src/types/type_checking/declarations.rs
+++ b/crates/tsz-checker/src/types/type_checking/declarations.rs
@@ -562,8 +562,6 @@ impl<'a> CheckerState<'a> {
         if let Some(members_vec) = query::union_members(self.ctx.types, callee_type_for_call) {
             let members = members_vec;
             let orig_members = query::union_members(self.ctx.types, callee_type_orig);
-            let factory = self.ctx.types.factory();
-
             let mut has_function = false;
             let mut new_members = Vec::new();
 
@@ -583,24 +581,10 @@ impl<'a> CheckerState<'a> {
 
                 if is_func {
                     has_function = true;
-                    // Replace Function member with a synthetic callable returning any
-                    // Use a simple function: (...args: any[]) => any
-                    let rest_param = tsz_solver::ParamInfo {
-                        name: Some(self.ctx.types.intern_string("args")),
-                        type_id: TypeId::ANY,
-                        optional: false,
-                        rest: true,
-                    };
-                    let func_shape = tsz_solver::FunctionShape {
-                        params: vec![rest_param],
-                        this_type: None,
-                        return_type: TypeId::ANY,
-                        type_params: vec![],
-                        type_predicate: None,
-                        is_constructor: false,
-                        is_method: false,
-                    };
-                    let func_type = factory.function(func_shape);
+                    let func_type = query::global_function_fallback_type(
+                        self.ctx.types,
+                        self.ctx.types.intern_string("args"),
+                    );
                     new_members.push(func_type);
                 } else {
                     new_members.push(member);
@@ -608,7 +592,7 @@ impl<'a> CheckerState<'a> {
             }
 
             if has_function {
-                return factory.union(new_members);
+                return query::type_checking_union(self.ctx.types, new_members);
             }
         }
 

--- a/crates/tsz-checker/src/types/type_checking/declarations_utils.rs
+++ b/crates/tsz-checker/src/types/type_checking/declarations_utils.rs
@@ -5,7 +5,7 @@ use crate::state::{CheckerState, ComputedKey, MAX_TREE_WALK_ITERATIONS, Property
 use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{TypeId, TypeParamInfo, TypeParamOrigin};
+use tsz_solver::TypeId;
 
 /// Per-position record for a declaration's type parameter list.
 ///
@@ -174,13 +174,9 @@ impl<'a> CheckerState<'a> {
 
         let mut updates = Vec::with_capacity(param_syntax.len());
         for &(name_node, _, _, ref name, name_atom, is_const) in &param_syntax {
-            let info = TypeParamInfo {
-                name: name_atom,
-                constraint: None,
-                default: None,
-                is_const,
-                origin: TypeParamOrigin::User,
-            };
+            let info = crate::query_boundaries::type_checking::user_type_param_info(
+                name_atom, None, None, is_const,
+            );
             let type_id = self.intern_type_param_for_decl(name_node, info);
             let previous = self.ctx.type_parameter_scope.insert(name.clone(), type_id);
             updates.push((name.clone(), previous, false));

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_followup.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_followup.rs
@@ -1,5 +1,6 @@
 //! Follow-up duplicate and merged declaration diagnostics.
 
+use crate::query_boundaries::type_checking as type_checking_query;
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
 use tsz_binder::symbol_flags;
@@ -453,18 +454,12 @@ impl<'a> CheckerState<'a> {
                                 TypeId::ANY
                             };
                             self.pop_type_parameters(tp_updates);
-                            self.ctx
-                                .types
-                                .factory()
-                                .function(tsz_solver::FunctionShape {
-                                    type_params,
-                                    params,
-                                    this_type: None,
-                                    return_type,
-                                    type_predicate: None,
-                                    is_constructor: false,
-                                    is_method: true,
-                                })
+                            type_checking_query::method_function_type(
+                                self.ctx.types,
+                                type_params,
+                                params,
+                                return_type,
+                            )
                         } else if sig.type_annotation.is_some() {
                             self.get_type_from_type_node(sig.type_annotation)
                         } else {

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::type_checking as type_checking_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -667,11 +668,11 @@ impl<'a> CheckerState<'a> {
             {
                 // Single-level `K[idx]`: the access base is itself a type
                 // parameter, so substitute its constraint and evaluate.
-                let constrained_access = self
-                    .ctx
-                    .types
-                    .factory()
-                    .index_access(base_constraint, access_index_type);
+                let constrained_access = type_checking_query::type_checking_index_access(
+                    self.ctx.types,
+                    base_constraint,
+                    access_index_type,
+                );
                 let evaluated_constrained_access =
                     self.evaluate_type_for_assignability(constrained_access);
                 if evaluated_constrained_access != TypeId::ERROR {
@@ -1196,10 +1197,11 @@ impl<'a> CheckerState<'a> {
                                 ..
                             } => type_id,
                             _ => self.evaluate_type_with_env(
-                                self.ctx
-                                    .types
-                                    .factory()
-                                    .index_access(constrained_base_type, nested_index_type),
+                                type_checking_query::type_checking_index_access(
+                                    self.ctx.types,
+                                    constrained_base_type,
+                                    nested_index_type,
+                                ),
                             ),
                         }
                     } else {
@@ -1212,10 +1214,11 @@ impl<'a> CheckerState<'a> {
                             sig.value_type
                         } else {
                             self.evaluate_type_with_env(
-                                self.ctx
-                                    .types
-                                    .factory()
-                                    .index_access(constrained_base_type, nested_index_type),
+                                type_checking_query::type_checking_index_access(
+                                    self.ctx.types,
+                                    constrained_base_type,
+                                    nested_index_type,
+                                ),
                             )
                         }
                     };
@@ -1673,7 +1676,11 @@ impl<'a> CheckerState<'a> {
                 if is_concrete {
                     let keyof_base = self.ctx.types.evaluate_keyof(eval_base);
                     let values_union = self.evaluate_type_with_env(
-                        self.ctx.types.factory().index_access(eval_base, keyof_base),
+                        crate::query_boundaries::type_checking::type_checking_index_access(
+                            self.ctx.types,
+                            eval_base,
+                            keyof_base,
+                        ),
                     );
                     if values_union != TypeId::ERROR
                         && values_union != TypeId::UNDEFINED

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/deferred_conditional_index.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/deferred_conditional_index.rs
@@ -2,6 +2,7 @@
 //! conditional type. Split out of `indexed_access.rs` to keep that file under
 //! the per-file LOC ceiling; behavior is unchanged.
 
+use crate::query_boundaries::indexed_access_key_space as key_space_query;
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
@@ -147,12 +148,11 @@ impl<'a> CheckerState<'a> {
         // The inner key drives `apparent = base_constraint[inner_index]`. Evaluate
         // it; an apparent type that is still deferred (e.g. the inner key was
         // itself generic) gives no concrete key space, so bail.
-        let apparent = self.evaluate_type_with_env(
-            self.ctx
-                .types
-                .factory()
-                .index_access(base_constraint, inner_index),
-        );
+        let apparent = self.evaluate_type_with_env(key_space_query::indexed_access_type(
+            self.ctx.types,
+            base_constraint,
+            inner_index,
+        ));
         if apparent == TypeId::ERROR
             || apparent == TypeId::ANY
             || q::is_index_access_type(self.ctx.types, apparent)

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/error_contagion.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/error_contagion.rs
@@ -283,7 +283,10 @@ impl CheckerState<'_> {
         // `keyof` over the union of the concrete branches already computes their
         // key-space intersection; use the checker resolver so named branches
         // contribute their resolved members.
-        let concrete_union = self.ctx.types.union(concrete);
+        let concrete_union = crate::query_boundaries::indexed_access_key_space::key_space_union(
+            self.ctx.types,
+            concrete,
+        );
         let keyof_concrete = self.indexed_access_keyof_with_env(concrete_union);
         if !self.indexed_access_key_space_is_resolved(keyof_concrete) {
             return None;

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::indexed_access_key_space as key_space_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -193,7 +194,7 @@ impl<'a> CheckerState<'a> {
     /// `evaluate_type_with_env` keeps the solver-owned `keyof` semantics while
     /// giving the evaluator the checker resolver environment.
     pub(super) fn indexed_access_keyof_with_env(&mut self, operand: TypeId) -> TypeId {
-        let keyof = self.ctx.types.factory().keyof(operand);
+        let keyof = key_space_query::keyof_type(self.ctx.types, operand);
         self.evaluate_type_with_env(keyof)
     }
 
@@ -874,20 +875,16 @@ impl<'a> CheckerState<'a> {
                         lit.value
                             .or_else(|| tsz_common::numeric::parse_numeric_literal_value(&lit.text))
                     })
-                    .map(|value| self.ctx.types.factory().literal_number(value))
+                    .map(|value| key_space_query::literal_number_key(self.ctx.types, value))
                     .unwrap_or_else(|| {
                         let atom = self.ctx.types.intern_string(&name);
-                        self.ctx.types.factory().literal_string_atom(atom)
+                        key_space_query::literal_string_key(self.ctx.types, atom)
                     });
                 key_types.push(key_type);
             }
         }
 
-        if key_types.is_empty() {
-            None
-        } else {
-            Some(self.ctx.types.factory().union(key_types))
-        }
+        key_space_query::literal_key_union(self.ctx.types, key_types)
     }
 
     pub(super) fn type_literal_ast_key_space_accepts_index(
@@ -1506,8 +1503,11 @@ impl<'a> CheckerState<'a> {
         }
 
         let key_space = self.indexed_access_keyof_with_env(constraint);
-        let values = self
-            .evaluate_type_with_env(self.ctx.types.factory().index_access(constraint, key_space));
+        let values = self.evaluate_type_with_env(key_space_query::indexed_access_type(
+            self.ctx.types,
+            constraint,
+            key_space,
+        ));
         if matches!(values, TypeId::ERROR | TypeId::UNDEFINED) {
             return false;
         }
@@ -1652,7 +1652,7 @@ impl<'a> CheckerState<'a> {
                     // constraint directly against `keyof B`. This path is rare; the
                     // large-union issue doesn't apply here since the constraint is not
                     // itself a computed keyof union.
-                    let keyof_current = self.ctx.types.factory().keyof(current_object);
+                    let keyof_current = key_space_query::keyof_type(self.ctx.types, current_object);
                     if self
                         .indexed_access_foreign_keyof_constraint_relation_outcome(
                             index_constraint,
@@ -1936,7 +1936,7 @@ impl<'a> CheckerState<'a> {
         if !has_plain_string_index {
             return false;
         }
-        let string_or_number = self.ctx.types.union2(TypeId::STRING, TypeId::NUMBER);
+        let string_or_number = key_space_query::string_or_number_key_space(self.ctx.types);
         if self
             .string_index_candidate_is_string_or_number_key(index_type_for_check, string_or_number)
         {

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -1,4 +1,5 @@
 use crate::query_boundaries::indexed_access_key_space as key_space_query;
+use crate::query_boundaries::type_checking as type_checking_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -1188,11 +1189,11 @@ impl<'a> CheckerState<'a> {
         }
 
         // The resolved value is the tuple's element-value union (`base[number]`).
-        let element_union = self
-            .ctx
-            .types
-            .factory()
-            .index_access(base_value, TypeId::NUMBER);
+        let element_union = type_checking_query::type_checking_index_access(
+            self.ctx.types,
+            base_value,
+            TypeId::NUMBER,
+        );
         let element_union = self.evaluate_type_with_env(element_union);
         if matches!(element_union, TypeId::ERROR | TypeId::UNDEFINED) {
             return None;

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -13,6 +13,7 @@
 mod type_query_flow;
 
 use super::alias_defid_visited_pool::with_alias_defid_visited;
+use crate::query_boundaries::type_checking as type_checking_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
@@ -213,7 +214,6 @@ impl<'a> CheckerState<'a> {
             self.check_type_parameters_for_missing_names(&alias.type_parameters);
         }
         if let Some(type_params) = &alias.type_parameters {
-            let factory = self.ctx.types.factory();
             for &param_idx in &type_params.nodes {
                 let Some(param_node) = self.ctx.arena.get(param_idx) else {
                     continue;
@@ -244,13 +244,13 @@ impl<'a> CheckerState<'a> {
                     None
                 };
                 let atom = self.ctx.types.intern_string(&ident.escaped_text);
-                let constrained_param = factory.type_param(tsz_solver::TypeParamInfo {
-                    name: atom,
+                let constrained_param = type_checking_query::user_type_param(
+                    self.ctx.types,
+                    atom,
                     constraint,
                     default,
-                    is_const: false,
-                    origin: tsz_solver::TypeParamOrigin::User,
-                });
+                    false,
+                );
                 self.ctx
                     .type_parameter_scope
                     .insert(ident.escaped_text.clone(), constrained_param);
@@ -1128,17 +1128,11 @@ impl<'a> CheckerState<'a> {
             .collect();
 
         // Phase 3: intern provisional `TypeParameter`s and install them in scope.
-        let factory = self.ctx.types.factory();
         let mut pushes: Vec<(String, Option<TypeId>)> = Vec::new();
         for (name, &constraint) in infer_names.iter().zip(infer_constraints.iter()) {
             let atom = self.ctx.types.intern_string(name);
-            let provisional = factory.type_param(tsz_solver::TypeParamInfo {
-                name: atom,
-                constraint,
-                default: None,
-                is_const: false,
-                origin: tsz_solver::TypeParamOrigin::User,
-            });
+            let provisional =
+                type_checking_query::user_type_param(self.ctx.types, atom, constraint, None, false);
             let previous = self
                 .ctx
                 .type_parameter_scope
@@ -1675,17 +1669,13 @@ impl<'a> CheckerState<'a> {
                                 constraint_type = resolved;
                             }
                         }
-                        let provisional =
-                            self.ctx
-                                .types
-                                .factory()
-                                .type_param(tsz_solver::TypeParamInfo {
-                                    name: atom,
-                                    constraint: Some(constraint_type),
-                                    default: None,
-                                    is_const: false,
-                                    origin: tsz_solver::TypeParamOrigin::User,
-                                });
+                        let provisional = type_checking_query::user_type_param(
+                            self.ctx.types,
+                            atom,
+                            Some(constraint_type),
+                            None,
+                            false,
+                        );
                         let previous = self
                             .ctx
                             .type_parameter_scope

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -4,6 +4,9 @@
 //! callable types with call/construct signatures.
 
 use super::type_node_helpers::type_node_includes_explicit_undefined;
+use crate::query_boundaries::{
+    construct_signatures as signature_boundary, type_construction as construction_boundary,
+};
 use crate::state::{CheckerState, ParamTypeResolutionMode};
 use crate::symbol_resolver::TypeSymbolResolution;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -12,7 +15,6 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
-use tsz_solver::Visibility;
 
 // =============================================================================
 // Type Literal Type Checking
@@ -1109,9 +1111,7 @@ impl<'a> CheckerState<'a> {
         use tsz_parser::parser::syntax_kind_ext::{
             CALL_SIGNATURE, CONSTRUCT_SIGNATURE, METHOD_SIGNATURE, PROPERTY_SIGNATURE,
         };
-        use tsz_solver::{
-            CallSignature, CallableShape, FunctionShape, IndexSignature, ObjectShape, PropertyInfo,
-        };
+        use tsz_solver::CallSignature;
         let factory = self.ctx.types.factory();
 
         let Some(node) = self.ctx.arena.get(idx) else {
@@ -1313,22 +1313,20 @@ impl<'a> CheckerState<'a> {
                                     type_id
                                 };
                             member_order += 1;
-                            properties.push(PropertyInfo {
-                                name: name_atom,
-                                type_id,
-                                write_type,
-                                optional: sig.question_token,
-                                readonly: self.has_readonly_modifier(&sig.modifiers),
-                                is_method: false,
-                                is_class_prototype: false,
-                                visibility: Visibility::Public,
-                                parent_id: None,
-                                declaration_order: member_order,
-                                is_string_named,
-                                is_symbol_named,
-                                single_quoted_name,
-                                non_widening: false,
-                            });
+                            properties.push(construction_boundary::declared_surface_property(
+                                construction_boundary::DeclaredSurfaceProperty {
+                                    name: name_atom,
+                                    type_id,
+                                    write_type,
+                                    optional: sig.question_token,
+                                    readonly: self.has_readonly_modifier(&sig.modifiers),
+                                    is_method: false,
+                                    declaration_order: member_order,
+                                    is_string_named,
+                                    is_symbol_named,
+                                    single_quoted_name,
+                                },
+                            ));
                         }
                     }
                     _ => {}
@@ -1438,12 +1436,9 @@ impl<'a> CheckerState<'a> {
                     .get(param_data.name)
                     .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
                     .map(|name_ident| self.ctx.types.intern_string(&name_ident.escaped_text));
-                let info = IndexSignature {
-                    key_type,
-                    value_type,
-                    readonly,
-                    param_name,
-                };
+                let info = construction_boundary::declared_index_signature(
+                    key_type, value_type, readonly, param_name,
+                );
                 if is_valid_index_type {
                     if key_type == TypeId::NUMBER {
                         if number_index.is_none() {
@@ -1618,22 +1613,20 @@ impl<'a> CheckerState<'a> {
             let (is_string_named, single_quoted_name) = primary_name_idx
                 .map(|name_idx| self.ctx.arena.string_property_name_flags(name_idx))
                 .unwrap_or((false, false));
-            properties.push(PropertyInfo {
-                name,
-                type_id: read_type,
-                write_type,
-                optional: false,
-                readonly,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: accessor.declaration_order,
-                is_string_named,
-                is_symbol_named,
-                single_quoted_name,
-                non_widening: false,
-            });
+            properties.push(construction_boundary::declared_surface_property(
+                construction_boundary::DeclaredSurfaceProperty {
+                    name,
+                    type_id: read_type,
+                    write_type,
+                    optional: false,
+                    readonly,
+                    is_method: false,
+                    declaration_order: accessor.declaration_order,
+                    is_string_named,
+                    is_symbol_named,
+                    single_quoted_name,
+                },
+            ));
         }
 
         // Merge overloaded method signatures into properties.
@@ -1649,101 +1642,82 @@ impl<'a> CheckerState<'a> {
                         .next()
                         .expect("sigs.len() == 1 guard ensures at least one element")
                         .signature;
-                    factory.function(FunctionShape {
-                        type_params: sig.type_params,
-                        params: sig.params,
-                        this_type: sig.this_type,
-                        return_type: sig.return_type,
-                        type_predicate: sig.type_predicate,
-                        is_constructor: false,
-                        is_method: true,
-                    })
+                    signature_boundary::declared_method_function_type(self.ctx.types, sig)
                 } else {
                     let merged_sigs: Vec<CallSignature> =
                         sigs.into_iter().map(|entry| entry.signature).collect();
-                    factory.callable(CallableShape {
-                        call_signatures: merged_sigs,
-                        construct_signatures: Vec::new(),
-                        properties: Vec::new(),
-                        string_index: None,
-                        number_index: None,
-                        symbol: None,
-                        is_abstract: false,
-                    })
+                    signature_boundary::declared_callable_surface_type(
+                        self.ctx.types,
+                        merged_sigs,
+                        Vec::new(),
+                        Vec::new(),
+                        None,
+                        None,
+                        None,
+                        false,
+                    )
                 };
-                properties.push(PropertyInfo {
-                    name: key.name,
-                    type_id: method_type,
-                    write_type: method_type,
-                    optional,
-                    readonly,
-                    is_method: true,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: None,
-                    declaration_order: key.decl_order,
-                    is_string_named: key.is_string_named,
-                    is_symbol_named,
-                    single_quoted_name: key.single_quoted_name,
-                    non_widening: false,
-                });
+                properties.push(construction_boundary::declared_surface_property(
+                    construction_boundary::DeclaredSurfaceProperty {
+                        name: key.name,
+                        type_id: method_type,
+                        write_type: method_type,
+                        optional,
+                        readonly,
+                        is_method: true,
+                        declaration_order: key.decl_order,
+                        is_string_named: key.is_string_named,
+                        is_symbol_named,
+                        single_quoted_name: key.single_quoted_name,
+                    },
+                ));
             }
         }
 
         if !call_signatures.is_empty() || !construct_signatures.is_empty() {
             // `CallableShape` keeps the single-slot index convention: a `symbol`
             // index rides in `string_index` (its `key_type` discriminates it).
-            let mut result = factory.callable(CallableShape {
+            let mut result = signature_boundary::declared_callable_surface_type(
+                self.ctx.types,
                 call_signatures,
                 construct_signatures,
                 properties,
-                string_index: string_index.or(symbol_index),
+                string_index.or(symbol_index),
                 number_index,
-                symbol: None,
-                is_abstract: has_abstract_construct_sig,
-            });
+                None,
+                has_abstract_construct_sig,
+            );
             for idx in extra_number_indices {
-                let member = factory.object_with_index(ObjectShape {
-                    number_index: Some(idx),
-                    ..ObjectShape::default()
-                });
-                result = self.ctx.types.intersect_types_raw2(result, member);
+                let member =
+                    construction_boundary::type_literal_number_index_member(self.ctx.types, idx);
+                result =
+                    construction_boundary::raw_intersection_pair(self.ctx.types, result, member);
             }
             return result;
         }
 
         if string_index.is_some() || number_index.is_some() || symbol_index.is_some() {
-            let mut shape = ObjectShape {
+            let mut result = construction_boundary::type_literal_object_with_indexes_and_late_bound(
+                self.ctx.types,
                 properties,
                 string_index,
                 number_index,
                 symbol_index,
-                ..ObjectShape::default()
-            };
-            if has_late_bound_members {
-                shape.mark_has_late_bound_members();
-            }
-            let mut result = factory.object_with_index(shape);
-            // Record the hand-written `{ ... }` annotation so the printer never
-            // repaints it with a utility-application display alias that shares
-            // this content-interned id.
-            self.ctx.types.mark_literal_object_annotation(result);
+                has_late_bound_members,
+            );
             for idx in extra_number_indices {
-                let member = factory.object_with_index(ObjectShape {
-                    number_index: Some(idx),
-                    ..ObjectShape::default()
-                });
-                result = self.ctx.types.intersect_types_raw2(result, member);
+                let member =
+                    construction_boundary::type_literal_number_index_member(self.ctx.types, idx);
+                result =
+                    construction_boundary::raw_intersection_pair(self.ctx.types, result, member);
             }
             return result;
         }
 
-        let result = if has_late_bound_members {
-            factory.object_with_late_bound_members(properties, None)
-        } else {
-            factory.object_with_symbol(properties, None)
-        };
-        self.ctx.types.mark_literal_object_annotation(result);
-        result
+        construction_boundary::type_literal_object_with_late_bound(
+            self.ctx.types,
+            properties,
+            has_late_bound_members,
+        )
     }
 }

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -6,6 +6,8 @@ use super::type_node_helpers::{
     type_node_includes_explicit_undefined,
 };
 use crate::context::{CheckerContext, TypeParameterScopeCacheKey};
+use crate::query_boundaries::construct_signatures as signature_construction;
+use crate::query_boundaries::type_construction;
 use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
@@ -350,7 +352,10 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 return TypeId::UNKNOWN; // Empty intersection is unknown
             }
 
-            return tsz_solver::utils::intersection_or_single(self.ctx.types, member_types);
+            return type_construction::type_node_intersection_or_single(
+                self.ctx.types,
+                member_types,
+            );
         }
 
         TypeId::ERROR
@@ -1180,9 +1185,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         use tsz_parser::parser::syntax_kind_ext::{
             CALL_SIGNATURE, CONSTRUCT_SIGNATURE, METHOD_SIGNATURE, PROPERTY_SIGNATURE,
         };
-        use tsz_solver::{
-            CallSignature, CallableShape, FunctionShape, IndexSignature, ObjectShape, PropertyInfo,
-        };
+        use tsz_solver::{CallSignature, IndexSignature, PropertyInfo};
 
         let Some(node) = self.ctx.arena.get(idx) else {
             return TypeId::ERROR;
@@ -1600,7 +1603,6 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         // Merge overloaded method signatures into properties.
         // Single-signature methods become Function types; multi-signature become Callable types.
         {
-            let factory = self.ctx.types.factory();
             for key in method_overload_order {
                 if let Some(sigs) = method_overloads.remove(&key.name) {
                     let optional = sigs.iter().all(|e| e.optional);
@@ -1612,27 +1614,14 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                             .next()
                             .expect("sigs.len() == 1 guard ensures at least one element")
                             .signature;
-                        factory.function(FunctionShape {
-                            type_params: sig.type_params,
-                            params: sig.params,
-                            this_type: sig.this_type,
-                            return_type: sig.return_type,
-                            type_predicate: sig.type_predicate,
-                            is_constructor: false,
-                            is_method: true,
-                        })
+                        signature_construction::method_function_type_from_call_signature(
+                            self.ctx.types,
+                            sig,
+                        )
                     } else {
                         let merged_sigs: Vec<CallSignature> =
                             sigs.into_iter().map(|e| e.signature).collect();
-                        factory.callable(CallableShape {
-                            call_signatures: merged_sigs,
-                            construct_signatures: Vec::new(),
-                            properties: Vec::new(),
-                            string_index: None,
-                            number_index: None,
-                            symbol: None,
-                            is_abstract: false,
-                        })
+                        signature_construction::call_only_callable_type(self.ctx.types, merged_sigs)
                     };
                     properties.push(PropertyInfo {
                         name: key.name,
@@ -1655,42 +1644,30 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         }
 
         if !call_signatures.is_empty() || !construct_signatures.is_empty() {
-            let factory = self.ctx.types.factory();
-
             // `CallableShape` keeps the single-slot index convention: a `symbol`
             // index rides in `string_index` (its `key_type` discriminates it).
-            return factory.callable(CallableShape {
+            return signature_construction::type_literal_callable_type(
+                self.ctx.types,
                 call_signatures,
                 construct_signatures,
                 properties,
-                string_index: string_index.or(symbol_index),
+                string_index.or(symbol_index),
                 number_index,
-                symbol: None,
-                is_abstract: false,
-            });
+            );
         }
 
         if string_index.is_some() || number_index.is_some() || symbol_index.is_some() {
-            let factory = self.ctx.types.factory();
-
-            let result = factory.object_with_index(ObjectShape {
+            let result = type_construction::type_literal_object_with_indexes(
+                self.ctx.types,
                 properties,
                 string_index,
                 number_index,
                 symbol_index,
-                ..ObjectShape::default()
-            });
-            // Record the hand-written `{ ... }` annotation so the printer never
-            // repaints it with a utility-application display alias that shares
-            // this content-interned id.
-            self.ctx.types.mark_literal_object_annotation(result);
+            );
             return result;
         }
 
-        let factory = self.ctx.types.factory();
-        let result = factory.object(properties);
-        self.ctx.types.mark_literal_object_annotation(result);
-        result
+        type_construction::type_literal_object(self.ctx.types, properties)
     }
 
     /// Resolve a type symbol from a node index.

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -17,6 +17,7 @@ use super::type_node_helpers::{
     is_typeof_global_this_type_node,
 };
 use super::unique_symbol_construction::unique_symbol_type_for_operator;
+use crate::query_boundaries::type_query_construction;
 use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
@@ -969,27 +970,18 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             .iter()
             .enumerate()
             .map(|(index, name)| {
-                let literal_type = self.ctx.types.literal_string(name);
-                tsz_solver::PropertyInfo {
-                    name: self.ctx.types.intern_string(name),
-                    type_id: literal_type,
-                    write_type: literal_type,
-                    optional: false,
-                    readonly: true,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: tsz_common::Visibility::Public,
-                    parent_id: None,
-                    declaration_order: index as u32,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                    non_widening: false,
-                }
+                let literal_type =
+                    type_query_construction::const_query_literal_string_type(self.ctx.types, name);
+                let name = self.ctx.types.intern_string(name);
+                type_query_construction::const_query_readonly_property(
+                    name,
+                    literal_type,
+                    index as u32,
+                )
             })
             .collect();
 
-        Some(self.ctx.types.factory().object(props))
+        Some(type_query_construction::const_query_array_to_enum_object_type(self.ctx.types, props))
     }
 
     fn array_to_enum_member_literal_type(
@@ -1000,7 +992,9 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         self.array_to_enum_literal_names(initializer)?
             .into_iter()
             .find(|name| name == property_name)
-            .map(|name| self.ctx.types.literal_string(&name))
+            .map(|name| {
+                type_query_construction::const_query_literal_string_type(self.ctx.types, &name)
+            })
     }
 
     fn array_to_enum_literal_names(&self, initializer: NodeIndex) -> Option<Vec<String>> {

--- a/crates/tsz-checker/src/types/type_node_merged_value_query.rs
+++ b/crates/tsz-checker/src/types/type_node_merged_value_query.rs
@@ -1,9 +1,10 @@
 //! Merged value/type-alias helpers for `typeof` type queries.
 
 use super::type_node::TypeNodeChecker;
+use crate::query_boundaries::type_query_construction;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{ObjectShape, PropertyInfo, TupleElement, TypeId};
+use tsz_solver::TypeId;
 
 impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     pub(crate) fn property_name_text(&self, name: tsz_parser::parser::NodeIndex) -> Option<String> {
@@ -30,15 +31,16 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             .arena
             .skip_parenthesized_and_assertions(initializer);
         let node = self.ctx.arena.get(initializer)?;
-        let factory = self.ctx.types.factory();
         match node.kind {
             k if k == SyntaxKind::StringLiteral as u16
                 || k == SyntaxKind::NoSubstitutionTemplateLiteral as u16 =>
             {
-                self.ctx
-                    .arena
-                    .get_literal(node)
-                    .map(|lit| factory.literal_string(&lit.text))
+                self.ctx.arena.get_literal(node).map(|lit| {
+                    type_query_construction::const_query_literal_string_type(
+                        self.ctx.types,
+                        &lit.text,
+                    )
+                })
             }
             k if k == SyntaxKind::NumericLiteral as u16 => self
                 .ctx
@@ -48,9 +50,15 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     lit.value
                         .or_else(|| tsz_common::numeric::parse_numeric_literal_value(&lit.text))
                 })
-                .map(|value| factory.literal_number(value)),
-            k if k == SyntaxKind::TrueKeyword as u16 => Some(factory.literal_boolean(true)),
-            k if k == SyntaxKind::FalseKeyword as u16 => Some(factory.literal_boolean(false)),
+                .map(|value| {
+                    type_query_construction::const_query_literal_number_type(self.ctx.types, value)
+                }),
+            k if k == SyntaxKind::TrueKeyword as u16 => Some(
+                type_query_construction::const_query_literal_boolean_type(self.ctx.types, true),
+            ),
+            k if k == SyntaxKind::FalseKeyword as u16 => Some(
+                type_query_construction::const_query_literal_boolean_type(self.ctx.types, false),
+            ),
             k if k == SyntaxKind::NullKeyword as u16 => Some(TypeId::NULL),
             k if k == SyntaxKind::UndefinedKeyword as u16 => Some(TypeId::UNDEFINED),
             _ => None,
@@ -97,17 +105,18 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             let prop = self.ctx.arena.get_property_assignment(element_node)?;
             let name = self.property_name_text(prop.name)?;
             let type_id = self.literal_type_from_const_member_initializer(prop.initializer)?;
-            let mut info = PropertyInfo::new(self.ctx.types.intern_string(&name), type_id);
-            info.write_type = type_id;
-            info.readonly = true;
-            info.declaration_order = props.len() as u32;
-            props.push(info);
+            let name = self.ctx.types.intern_string(&name);
+            props.push(type_query_construction::const_query_readonly_property(
+                name,
+                type_id,
+                props.len() as u32,
+            ));
         }
 
-        Some(self.ctx.types.factory().object_with_index(ObjectShape {
-            properties: props,
-            ..ObjectShape::default()
-        }))
+        Some(type_query_construction::const_query_object_literal_type(
+            self.ctx.types,
+            props,
+        ))
     }
 
     pub(crate) fn const_asserted_array_tuple_type_query(
@@ -174,14 +183,14 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 return None;
             }
             let element_type = self.literal_type_from_const_member_initializer(element)?;
-            elements.push(TupleElement {
-                type_id: element_type,
-                name: None,
-                optional: false,
-                rest: false,
-            });
+            elements.push(type_query_construction::const_query_tuple_element(
+                element_type,
+            ));
         }
 
-        Some(self.ctx.types.factory().tuple(elements))
+        Some(type_query_construction::const_query_tuple_type(
+            self.ctx.types,
+            elements,
+        ))
     }
 }

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -58,7 +58,12 @@
 //! - `class_partial_constructor_construction_boundary_scans`: class
 //!   constructor-part helpers route partial static-constructor solver
 //!   construction through `query_boundaries::class_type`.
+//! - `await_promise_construction_boundary_scans`: await checking routes
+//!   contextual promise operand and `Awaited<T>` join construction through
+//!   `query_boundaries::checkers::promise`.
 
+#[path = "arch_source_scans/await_promise_construction_boundary_scans.rs"]
+mod await_promise_construction_boundary_scans;
 #[path = "arch_source_scans/binding_pattern_construction_boundary_scans.rs"]
 mod binding_pattern_construction_boundary_scans;
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -61,6 +61,9 @@
 //! - `commonjs_json_export_surface_construction_boundary_scans`: JSON module
 //!   and current-file CommonJS namespace surfaces route solver construction
 //!   through `query_boundaries::js_exports`.
+//! - `commonjs_resolution_export_surface_construction_boundary_scans`: CommonJS
+//!   resolution routes descriptor, overlay, constructor, and imported module
+//!   value-surface construction through `query_boundaries::js_exports`.
 //! - `binding_pattern_construction_boundary_scans`: binding/destructuring
 //!   pattern callers route contextual tuple/object/property/union construction
 //!   through `query_boundaries::binding_patterns`.
@@ -108,6 +111,8 @@ mod class_partial_constructor_construction_boundary_scans;
 mod common_boundary_export_ratchets;
 #[path = "arch_source_scans/commonjs_json_export_surface_construction_boundary_scans.rs"]
 mod commonjs_json_export_surface_construction_boundary_scans;
+#[path = "arch_source_scans/commonjs_resolution_export_surface_construction_boundary_scans.rs"]
+mod commonjs_resolution_export_surface_construction_boundary_scans;
 #[path = "arch_source_scans/construction_boundary_signature_scans.rs"]
 mod construction_boundary_signature_scans;
 #[path = "arch_source_scans/cross_arena_delegation_scope_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -77,6 +77,9 @@
 //! - `class_partial_constructor_construction_boundary_scans`: class
 //!   constructor-part helpers route partial static-constructor solver
 //!   construction through `query_boundaries::class_type`.
+//! - `class_constructor_return_construction_boundary_scans`: class constructor
+//!   checking routes return/intersection/static-property construction through
+//!   `query_boundaries::checkers::constructor`.
 //! - `await_promise_construction_boundary_scans`: await checking routes
 //!   contextual promise operand and `Awaited<T>` join construction through
 //!   `query_boundaries::checkers::promise`.
@@ -104,6 +107,8 @@ mod binding_pattern_construction_boundary_scans;
 mod call_inference_construction_boundary_scans;
 #[path = "arch_source_scans/call_result_construction_boundary_scans.rs"]
 mod call_result_construction_boundary_scans;
+#[path = "arch_source_scans/class_constructor_return_construction_boundary_scans.rs"]
+mod class_constructor_return_construction_boundary_scans;
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
 #[path = "arch_source_scans/class_partial_constructor_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -55,11 +55,16 @@
 //! - `type_query_construction_boundary_scans`: const value/type-query callers
 //!   route literal/property/object/tuple construction through
 //!   `query_boundaries::type_query_construction`.
+//! - `class_partial_constructor_construction_boundary_scans`: class
+//!   constructor-part helpers route partial static-constructor solver
+//!   construction through `query_boundaries::class_type`.
 
 #[path = "arch_source_scans/binding_pattern_construction_boundary_scans.rs"]
 mod binding_pattern_construction_boundary_scans;
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
+#[path = "arch_source_scans/class_partial_constructor_construction_boundary_scans.rs"]
+mod class_partial_constructor_construction_boundary_scans;
 #[path = "arch_source_scans/common_boundary_export_ratchets.rs"]
 mod common_boundary_export_ratchets;
 #[path = "arch_source_scans/construction_boundary_signature_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -110,6 +110,9 @@
 //! - `object_literal_result_construction_boundary_scans`: object-literal
 //!   result construction routes final object/index/union/intersection/mapped
 //!   surfaces through `query_boundaries::type_computation::object_literals`.
+//! - `module_type_analysis_surface_construction_boundary_scans`: module and
+//!   namespace type-analysis surfaces route through
+//!   `query_boundaries::state::type_analysis`.
 //! - `yield_context_construction_boundary_scans`: yield dispatch routes
 //!   `yield*` contextual generator/array construction through
 //!   `query_boundaries::dispatch`.
@@ -168,6 +171,8 @@ mod jsdoc_construction_boundary_scans;
 mod jsx_construction_boundary_scans;
 #[path = "arch_source_scans/lazy_resolution_session_scans.rs"]
 mod lazy_resolution_session_scans;
+#[path = "arch_source_scans/module_type_analysis_surface_construction_boundary_scans.rs"]
+mod module_type_analysis_surface_construction_boundary_scans;
 #[path = "arch_source_scans/object_flags_boundary_scans.rs"]
 mod object_flags_boundary_scans;
 #[path = "arch_source_scans/object_literal_annotation_walker_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -74,6 +74,9 @@
 //! - `type_checking_surface_construction_boundary_scans`: type-checking
 //!   helpers route temporary type surfaces and user type-parameter
 //!   construction through `query_boundaries::type_checking`.
+//! - `type_node_fallback_construction_boundary_scans`: type-node resolution
+//!   routes intersection, callable/function, and object fallback construction
+//!   through construction query boundaries.
 //! - `class_partial_constructor_construction_boundary_scans`: class
 //!   constructor-part helpers route partial static-constructor solver
 //!   construction through `query_boundaries::class_type`.
@@ -172,6 +175,8 @@ mod strict_bind_call_apply_construction_boundary_scans;
 mod type_checking_surface_construction_boundary_scans;
 #[path = "arch_source_scans/type_guard_walk_state.rs"]
 mod type_guard_walk_state;
+#[path = "arch_source_scans/type_node_fallback_construction_boundary_scans.rs"]
+mod type_node_fallback_construction_boundary_scans;
 #[path = "arch_source_scans/type_query_construction_boundary_scans.rs"]
 mod type_query_construction_boundary_scans;
 #[path = "arch_source_scans/type_reference_depth_session_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -21,6 +21,9 @@
 //!   constructs signature-bearing solver types only through
 //!   `query_boundaries::construct_signatures`, never via inline shape
 //!   literals or direct interning calls.
+//! - `diagnostic_construction_boundary_scans`: diagnostic reporters route
+//!   display-only solver shape construction through
+//!   `query_boundaries::diagnostics`.
 //! - `class_instance_walk_state_scans`: class instance base traversal uses a
 //!   named checker-owned walk state instead of paired raw visited sets.
 //! - `cross_arena_delegation_scope_scans`: cross-arena delegation depth uses a
@@ -41,6 +44,8 @@ mod common_boundary_export_ratchets;
 mod construction_boundary_signature_scans;
 #[path = "arch_source_scans/cross_arena_delegation_scope_scans.rs"]
 mod cross_arena_delegation_scope_scans;
+#[path = "arch_source_scans/diagnostic_construction_boundary_scans.rs"]
+mod diagnostic_construction_boundary_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
 #[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -46,6 +46,9 @@
 //! - `declaration_export_construction_boundary_scans`: namespace/module
 //!   declaration checkers route export-surface construction through
 //!   `query_boundaries::declaration_exports`.
+//! - `import_attribute_construction_boundary_scans`: static and dynamic import
+//!   callers route import-attribute object construction through
+//!   `query_boundaries::import_attributes`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -61,6 +64,8 @@ mod declaration_export_construction_boundary_scans;
 mod diagnostic_construction_boundary_scans;
 #[path = "arch_source_scans/excess_property_construction_boundary_scans.rs"]
 mod excess_property_construction_boundary_scans;
+#[path = "arch_source_scans/import_attribute_construction_boundary_scans.rs"]
+mod import_attribute_construction_boundary_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
 #[path = "arch_source_scans/js_class_property_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -58,6 +58,9 @@
 //! - `import_attribute_construction_boundary_scans`: static and dynamic import
 //!   callers route import-attribute object construction through
 //!   `query_boundaries::import_attributes`.
+//! - `commonjs_json_export_surface_construction_boundary_scans`: JSON module
+//!   and current-file CommonJS namespace surfaces route solver construction
+//!   through `query_boundaries::js_exports`.
 //! - `binding_pattern_construction_boundary_scans`: binding/destructuring
 //!   pattern callers route contextual tuple/object/property/union construction
 //!   through `query_boundaries::binding_patterns`.
@@ -103,6 +106,8 @@ mod class_instance_walk_state_scans;
 mod class_partial_constructor_construction_boundary_scans;
 #[path = "arch_source_scans/common_boundary_export_ratchets.rs"]
 mod common_boundary_export_ratchets;
+#[path = "arch_source_scans/commonjs_json_export_surface_construction_boundary_scans.rs"]
+mod commonjs_json_export_surface_construction_boundary_scans;
 #[path = "arch_source_scans/construction_boundary_signature_scans.rs"]
 mod construction_boundary_signature_scans;
 #[path = "arch_source_scans/cross_arena_delegation_scope_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -24,6 +24,8 @@
 //! - `diagnostic_construction_boundary_scans`: diagnostic reporters route
 //!   display-only solver shape construction through
 //!   `query_boundaries::diagnostics`.
+//! - `excess_property_construction_boundary_scans`: excess-property checking
+//!   routes object shape construction through query boundaries.
 //! - `class_instance_walk_state_scans`: class instance base traversal uses a
 //!   named checker-owned walk state instead of paired raw visited sets.
 //! - `cross_arena_delegation_scope_scans`: cross-arena delegation depth uses a
@@ -46,6 +48,8 @@ mod construction_boundary_signature_scans;
 mod cross_arena_delegation_scope_scans;
 #[path = "arch_source_scans/diagnostic_construction_boundary_scans.rs"]
 mod diagnostic_construction_boundary_scans;
+#[path = "arch_source_scans/excess_property_construction_boundary_scans.rs"]
+mod excess_property_construction_boundary_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
 #[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -43,6 +43,9 @@
 //! - `strict_bind_call_apply_construction_boundary_scans`: property-access
 //!   helpers route strict bind/call/apply signature construction through
 //!   `query_boundaries::property_access`.
+//! - `declaration_export_construction_boundary_scans`: namespace/module
+//!   declaration checkers route export-surface construction through
+//!   `query_boundaries::declaration_exports`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -52,6 +55,8 @@ mod common_boundary_export_ratchets;
 mod construction_boundary_signature_scans;
 #[path = "arch_source_scans/cross_arena_delegation_scope_scans.rs"]
 mod cross_arena_delegation_scope_scans;
+#[path = "arch_source_scans/declaration_export_construction_boundary_scans.rs"]
+mod declaration_export_construction_boundary_scans;
 #[path = "arch_source_scans/diagnostic_construction_boundary_scans.rs"]
 mod diagnostic_construction_boundary_scans;
 #[path = "arch_source_scans/excess_property_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -46,6 +46,9 @@
 //! - `declaration_export_construction_boundary_scans`: namespace/module
 //!   declaration checkers route export-surface construction through
 //!   `query_boundaries::declaration_exports`.
+//! - `decorator_construction_boundary_scans`: class-member decorator
+//!   signature checking routes semantic helper-type construction through
+//!   `query_boundaries::checkers::decorators`.
 //! - `import_attribute_construction_boundary_scans`: static and dynamic import
 //!   callers route import-attribute object construction through
 //!   `query_boundaries::import_attributes`.
@@ -89,6 +92,8 @@ mod construction_boundary_signature_scans;
 mod cross_arena_delegation_scope_scans;
 #[path = "arch_source_scans/declaration_export_construction_boundary_scans.rs"]
 mod declaration_export_construction_boundary_scans;
+#[path = "arch_source_scans/decorator_construction_boundary_scans.rs"]
+mod decorator_construction_boundary_scans;
 #[path = "arch_source_scans/diagnostic_construction_boundary_scans.rs"]
 mod diagnostic_construction_boundary_scans;
 #[path = "arch_source_scans/excess_property_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -70,6 +70,9 @@
 //! - `expression_result_construction_boundary_scans`: expression computation
 //!   routes selected result-shape construction through
 //!   `query_boundaries::type_computation::expression_results`.
+//! - `object_literal_context_construction_boundary_scans`: object-literal
+//!   contextual typing routes union/intersection rebuilds through
+//!   `query_boundaries::object_literal_context`.
 //! - `yield_context_construction_boundary_scans`: yield dispatch routes
 //!   `yield*` contextual generator/array construction through
 //!   `query_boundaries::dispatch`.
@@ -116,6 +119,8 @@ mod lazy_resolution_session_scans;
 mod object_flags_boundary_scans;
 #[path = "arch_source_scans/object_literal_annotation_walker_scans.rs"]
 mod object_literal_annotation_walker_scans;
+#[path = "arch_source_scans/object_literal_context_construction_boundary_scans.rs"]
+mod object_literal_context_construction_boundary_scans;
 #[path = "arch_source_scans/relation_boundary_session_scans.rs"]
 mod relation_boundary_session_scans;
 #[path = "arch_source_scans/relation_routing_residual_arch_tests.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -37,6 +37,9 @@
 //!   solver shape construction through `query_boundaries::jsdoc_construction`.
 //! - `jsx_construction_boundary_scans`: JSX checker callers route object and
 //!   function shape construction through `query_boundaries::checkers::jsx`.
+//! - `js_class_property_construction_boundary_scans`: JS class-property
+//!   scanning routes type-parameter, array/union, property, callable, and object
+//!   construction through `query_boundaries::checkers::class_properties`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -52,6 +55,8 @@ mod diagnostic_construction_boundary_scans;
 mod excess_property_construction_boundary_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
+#[path = "arch_source_scans/js_class_property_construction_boundary_scans.rs"]
+mod js_class_property_construction_boundary_scans;
 #[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]
 mod jsdoc_construction_boundary_scans;
 #[path = "arch_source_scans/jsx_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -62,8 +62,9 @@
 //!   and current-file CommonJS namespace surfaces route solver construction
 //!   through `query_boundaries::js_exports`.
 //! - `commonjs_resolution_export_surface_construction_boundary_scans`: CommonJS
-//!   resolution routes descriptor, overlay, constructor, and imported module
-//!   value-surface construction through `query_boundaries::js_exports`.
+//!   resolution/collection routes descriptor, overlay, expando, constructor,
+//!   and imported module value-surface construction through
+//!   `query_boundaries::js_exports`.
 //! - `binding_pattern_construction_boundary_scans`: binding/destructuring
 //!   pattern callers route contextual tuple/object/property/union construction
 //!   through `query_boundaries::binding_patterns`.

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -116,6 +116,10 @@
 //! - `module_augmentation_surface_construction_boundary_scans`: module
 //!   augmentation member and augmented base surface construction routes through
 //!   `query_boundaries::module_augmentation`.
+//! - `interface_type_literal_surface_construction_boundary_scans`: interface
+//!   and type-literal own member surfaces route through
+//!   `query_boundaries::type_construction` and
+//!   `query_boundaries::construct_signatures`.
 //! - `yield_context_construction_boundary_scans`: yield dispatch routes
 //!   `yield*` contextual generator/array construction through
 //!   `query_boundaries::dispatch`.
@@ -166,6 +170,8 @@ mod import_attribute_construction_boundary_scans;
 mod index_signature_boundary_scans;
 #[path = "arch_source_scans/indexed_access_key_space_construction_boundary_scans.rs"]
 mod indexed_access_key_space_construction_boundary_scans;
+#[path = "arch_source_scans/interface_type_literal_surface_construction_boundary_scans.rs"]
+mod interface_type_literal_surface_construction_boundary_scans;
 #[path = "arch_source_scans/js_class_property_construction_boundary_scans.rs"]
 mod js_class_property_construction_boundary_scans;
 #[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -101,6 +101,9 @@
 //! - `object_literal_context_construction_boundary_scans`: object-literal
 //!   contextual typing routes union/intersection rebuilds through
 //!   `query_boundaries::object_literal_context`.
+//! - `object_literal_result_construction_boundary_scans`: object-literal
+//!   result construction routes final object/index/union/intersection/mapped
+//!   surfaces through `query_boundaries::type_computation::object_literals`.
 //! - `yield_context_construction_boundary_scans`: yield dispatch routes
 //!   `yield*` contextual generator/array construction through
 //!   `query_boundaries::dispatch`.
@@ -161,6 +164,8 @@ mod object_flags_boundary_scans;
 mod object_literal_annotation_walker_scans;
 #[path = "arch_source_scans/object_literal_context_construction_boundary_scans.rs"]
 mod object_literal_context_construction_boundary_scans;
+#[path = "arch_source_scans/object_literal_result_construction_boundary_scans.rs"]
+mod object_literal_result_construction_boundary_scans;
 #[path = "arch_source_scans/property_access_result_construction_boundary_scans.rs"]
 mod property_access_result_construction_boundary_scans;
 #[path = "arch_source_scans/relation_boundary_session_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -67,6 +67,9 @@
 //! - `expression_result_construction_boundary_scans`: expression computation
 //!   routes selected result-shape construction through
 //!   `query_boundaries::type_computation::expression_results`.
+//! - `yield_context_construction_boundary_scans`: yield dispatch routes
+//!   `yield*` contextual generator/array construction through
+//!   `query_boundaries::dispatch`.
 
 #[path = "arch_source_scans/await_promise_construction_boundary_scans.rs"]
 mod await_promise_construction_boundary_scans;
@@ -122,3 +125,5 @@ mod type_guard_walk_state;
 mod type_query_construction_boundary_scans;
 #[path = "arch_source_scans/type_reference_depth_session_scans.rs"]
 mod type_reference_depth_session_scans;
+#[path = "arch_source_scans/yield_context_construction_boundary_scans.rs"]
+mod yield_context_construction_boundary_scans;

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -28,6 +28,8 @@
 //! - `index_signature_boundary_scans`: production checker index-signature
 //!   queries go through `query_boundaries::index_signature` rather than
 //!   constructing the raw solver resolver at call sites.
+//! - `jsdoc_construction_boundary_scans`: JSDoc type-resolution callers route
+//!   solver shape construction through `query_boundaries::jsdoc_construction`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -39,6 +41,8 @@ mod construction_boundary_signature_scans;
 mod cross_arena_delegation_scope_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
+#[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]
+mod jsdoc_construction_boundary_scans;
 #[path = "arch_source_scans/lazy_resolution_session_scans.rs"]
 mod lazy_resolution_session_scans;
 #[path = "arch_source_scans/object_flags_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -64,6 +64,9 @@
 //! - `type_query_construction_boundary_scans`: const value/type-query callers
 //!   route literal/property/object/tuple construction through
 //!   `query_boundaries::type_query_construction`.
+//! - `type_checking_surface_construction_boundary_scans`: type-checking
+//!   helpers route temporary type surfaces and user type-parameter
+//!   construction through `query_boundaries::type_checking`.
 //! - `class_partial_constructor_construction_boundary_scans`: class
 //!   constructor-part helpers route partial static-constructor solver
 //!   construction through `query_boundaries::class_type`.
@@ -144,6 +147,8 @@ mod relation_routing_residual_arch_tests;
 mod spelling_suggestion_gateway_scans;
 #[path = "arch_source_scans/strict_bind_call_apply_construction_boundary_scans.rs"]
 mod strict_bind_call_apply_construction_boundary_scans;
+#[path = "arch_source_scans/type_checking_surface_construction_boundary_scans.rs"]
+mod type_checking_surface_construction_boundary_scans;
 #[path = "arch_source_scans/type_guard_walk_state.rs"]
 mod type_guard_walk_state;
 #[path = "arch_source_scans/type_query_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -80,6 +80,9 @@
 //! - `class_partial_constructor_construction_boundary_scans`: class
 //!   constructor-part helpers route partial static-constructor solver
 //!   construction through `query_boundaries::class_type`.
+//! - `class_surface_construction_boundary_scans`: class instance/interface and
+//!   final constructor surface construction routes through
+//!   `query_boundaries::class_type`.
 //! - `class_constructor_return_construction_boundary_scans`: class constructor
 //!   checking routes return/intersection/static-property construction through
 //!   `query_boundaries::checkers::constructor`.
@@ -122,6 +125,8 @@ mod class_constructor_return_construction_boundary_scans;
 mod class_instance_walk_state_scans;
 #[path = "arch_source_scans/class_partial_constructor_construction_boundary_scans.rs"]
 mod class_partial_constructor_construction_boundary_scans;
+#[path = "arch_source_scans/class_surface_construction_boundary_scans.rs"]
+mod class_surface_construction_boundary_scans;
 #[path = "arch_source_scans/common_boundary_export_ratchets.rs"]
 mod common_boundary_export_ratchets;
 #[path = "arch_source_scans/commonjs_json_export_surface_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -33,6 +33,9 @@
 //! - `index_signature_boundary_scans`: production checker index-signature
 //!   queries go through `query_boundaries::index_signature` rather than
 //!   constructing the raw solver resolver at call sites.
+//! - `indexed_access_key_space_construction_boundary_scans`: indexed-access
+//!   validation routes key-space/value-surface construction through
+//!   `query_boundaries::indexed_access_key_space`.
 //! - `jsdoc_construction_boundary_scans`: JSDoc type-resolution callers route
 //!   solver shape construction through `query_boundaries::jsdoc_construction`.
 //! - `jsx_construction_boundary_scans`: JSX checker callers route object and
@@ -115,6 +118,8 @@ mod expression_result_construction_boundary_scans;
 mod import_attribute_construction_boundary_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]
 mod index_signature_boundary_scans;
+#[path = "arch_source_scans/indexed_access_key_space_construction_boundary_scans.rs"]
+mod indexed_access_key_space_construction_boundary_scans;
 #[path = "arch_source_scans/js_class_property_construction_boundary_scans.rs"]
 mod js_class_property_construction_boundary_scans;
 #[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -83,6 +83,9 @@
 //! - `class_surface_construction_boundary_scans`: class instance/interface and
 //!   final constructor surface construction routes through
 //!   `query_boundaries::class_type`.
+//! - `class_member_surface_construction_boundary_scans`: class instance and
+//!   constructor member/in-progress surfaces route through
+//!   `query_boundaries::class_type`.
 //! - `class_constructor_return_construction_boundary_scans`: class constructor
 //!   checking routes return/intersection/static-property construction through
 //!   `query_boundaries::checkers::constructor`.
@@ -123,6 +126,8 @@ mod call_result_construction_boundary_scans;
 mod class_constructor_return_construction_boundary_scans;
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
+#[path = "arch_source_scans/class_member_surface_construction_boundary_scans.rs"]
+mod class_member_surface_construction_boundary_scans;
 #[path = "arch_source_scans/class_partial_constructor_construction_boundary_scans.rs"]
 mod class_partial_constructor_construction_boundary_scans;
 #[path = "arch_source_scans/class_surface_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -67,6 +67,9 @@
 //! - `call_inference_construction_boundary_scans`: call inference routes
 //!   partial object/function/tuple inference construction through
 //!   `query_boundaries::checkers::call`.
+//! - `call_result_construction_boundary_scans`: call result handling routes
+//!   correlated unions, optional-chain returns, and recursive fallback result
+//!   construction through `query_boundaries::checkers::call`.
 //! - `expression_result_construction_boundary_scans`: expression computation
 //!   routes selected result-shape construction through
 //!   `query_boundaries::type_computation::expression_results`.
@@ -83,6 +86,8 @@ mod await_promise_construction_boundary_scans;
 mod binding_pattern_construction_boundary_scans;
 #[path = "arch_source_scans/call_inference_construction_boundary_scans.rs"]
 mod call_inference_construction_boundary_scans;
+#[path = "arch_source_scans/call_result_construction_boundary_scans.rs"]
+mod call_result_construction_boundary_scans;
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
 #[path = "arch_source_scans/class_partial_constructor_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -89,6 +89,9 @@
 //! - `call_result_construction_boundary_scans`: call result handling routes
 //!   correlated unions, optional-chain returns, and recursive fallback result
 //!   construction through `query_boundaries::checkers::call`.
+//! - `excess_property_nested_target_construction_boundary_scans`: nested
+//!   excess-property target and annotation intersections route through
+//!   `query_boundaries::state::checking`.
 //! - `expression_result_construction_boundary_scans`: expression computation
 //!   routes selected result-shape construction through
 //!   `query_boundaries::type_computation::expression_results`.
@@ -131,6 +134,8 @@ mod decorator_construction_boundary_scans;
 mod diagnostic_construction_boundary_scans;
 #[path = "arch_source_scans/excess_property_construction_boundary_scans.rs"]
 mod excess_property_construction_boundary_scans;
+#[path = "arch_source_scans/excess_property_nested_target_construction_boundary_scans.rs"]
+mod excess_property_nested_target_construction_boundary_scans;
 #[path = "arch_source_scans/expression_result_construction_boundary_scans.rs"]
 mod expression_result_construction_boundary_scans;
 #[path = "arch_source_scans/import_attribute_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -64,6 +64,9 @@
 //! - `call_inference_construction_boundary_scans`: call inference routes
 //!   partial object/function/tuple inference construction through
 //!   `query_boundaries::checkers::call`.
+//! - `expression_result_construction_boundary_scans`: expression computation
+//!   routes selected result-shape construction through
+//!   `query_boundaries::type_computation::expression_results`.
 
 #[path = "arch_source_scans/await_promise_construction_boundary_scans.rs"]
 mod await_promise_construction_boundary_scans;
@@ -87,6 +90,8 @@ mod declaration_export_construction_boundary_scans;
 mod diagnostic_construction_boundary_scans;
 #[path = "arch_source_scans/excess_property_construction_boundary_scans.rs"]
 mod excess_property_construction_boundary_scans;
+#[path = "arch_source_scans/expression_result_construction_boundary_scans.rs"]
+mod expression_result_construction_boundary_scans;
 #[path = "arch_source_scans/import_attribute_construction_boundary_scans.rs"]
 mod import_attribute_construction_boundary_scans;
 #[path = "arch_source_scans/index_signature_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -30,6 +30,8 @@
 //!   constructing the raw solver resolver at call sites.
 //! - `jsdoc_construction_boundary_scans`: JSDoc type-resolution callers route
 //!   solver shape construction through `query_boundaries::jsdoc_construction`.
+//! - `jsx_construction_boundary_scans`: JSX checker callers route object and
+//!   function shape construction through `query_boundaries::checkers::jsx`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -43,6 +45,8 @@ mod cross_arena_delegation_scope_scans;
 mod index_signature_boundary_scans;
 #[path = "arch_source_scans/jsdoc_construction_boundary_scans.rs"]
 mod jsdoc_construction_boundary_scans;
+#[path = "arch_source_scans/jsx_construction_boundary_scans.rs"]
+mod jsx_construction_boundary_scans;
 #[path = "arch_source_scans/lazy_resolution_session_scans.rs"]
 mod lazy_resolution_session_scans;
 #[path = "arch_source_scans/object_flags_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -61,11 +61,16 @@
 //! - `await_promise_construction_boundary_scans`: await checking routes
 //!   contextual promise operand and `Awaited<T>` join construction through
 //!   `query_boundaries::checkers::promise`.
+//! - `call_inference_construction_boundary_scans`: call inference routes
+//!   partial object/function/tuple inference construction through
+//!   `query_boundaries::checkers::call`.
 
 #[path = "arch_source_scans/await_promise_construction_boundary_scans.rs"]
 mod await_promise_construction_boundary_scans;
 #[path = "arch_source_scans/binding_pattern_construction_boundary_scans.rs"]
 mod binding_pattern_construction_boundary_scans;
+#[path = "arch_source_scans/call_inference_construction_boundary_scans.rs"]
+mod call_inference_construction_boundary_scans;
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
 #[path = "arch_source_scans/class_partial_constructor_construction_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -113,6 +113,9 @@
 //! - `module_type_analysis_surface_construction_boundary_scans`: module and
 //!   namespace type-analysis surfaces route through
 //!   `query_boundaries::state::type_analysis`.
+//! - `module_augmentation_surface_construction_boundary_scans`: module
+//!   augmentation member and augmented base surface construction routes through
+//!   `query_boundaries::module_augmentation`.
 //! - `yield_context_construction_boundary_scans`: yield dispatch routes
 //!   `yield*` contextual generator/array construction through
 //!   `query_boundaries::dispatch`.
@@ -171,6 +174,8 @@ mod jsdoc_construction_boundary_scans;
 mod jsx_construction_boundary_scans;
 #[path = "arch_source_scans/lazy_resolution_session_scans.rs"]
 mod lazy_resolution_session_scans;
+#[path = "arch_source_scans/module_augmentation_surface_construction_boundary_scans.rs"]
+mod module_augmentation_surface_construction_boundary_scans;
 #[path = "arch_source_scans/module_type_analysis_surface_construction_boundary_scans.rs"]
 mod module_type_analysis_surface_construction_boundary_scans;
 #[path = "arch_source_scans/object_flags_boundary_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -40,6 +40,9 @@
 //! - `js_class_property_construction_boundary_scans`: JS class-property
 //!   scanning routes type-parameter, array/union, property, callable, and object
 //!   construction through `query_boundaries::checkers::class_properties`.
+//! - `strict_bind_call_apply_construction_boundary_scans`: property-access
+//!   helpers route strict bind/call/apply signature construction through
+//!   `query_boundaries::property_access`.
 
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
@@ -73,6 +76,8 @@ mod relation_boundary_session_scans;
 mod relation_routing_residual_arch_tests;
 #[path = "arch_source_scans/spelling_suggestion_gateway_scans.rs"]
 mod spelling_suggestion_gateway_scans;
+#[path = "arch_source_scans/strict_bind_call_apply_construction_boundary_scans.rs"]
+mod strict_bind_call_apply_construction_boundary_scans;
 #[path = "arch_source_scans/type_guard_walk_state.rs"]
 mod type_guard_walk_state;
 #[path = "arch_source_scans/type_reference_depth_session_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -43,6 +43,9 @@
 //! - `strict_bind_call_apply_construction_boundary_scans`: property-access
 //!   helpers route strict bind/call/apply signature construction through
 //!   `query_boundaries::property_access`.
+//! - `property_access_result_construction_boundary_scans`: property-access
+//!   environment resolution routes optional/union/intersection result
+//!   construction through `query_boundaries::property_access`.
 //! - `declaration_export_construction_boundary_scans`: namespace/module
 //!   declaration checkers route export-surface construction through
 //!   `query_boundaries::declaration_exports`.
@@ -126,6 +129,8 @@ mod object_flags_boundary_scans;
 mod object_literal_annotation_walker_scans;
 #[path = "arch_source_scans/object_literal_context_construction_boundary_scans.rs"]
 mod object_literal_context_construction_boundary_scans;
+#[path = "arch_source_scans/property_access_result_construction_boundary_scans.rs"]
+mod property_access_result_construction_boundary_scans;
 #[path = "arch_source_scans/relation_boundary_session_scans.rs"]
 mod relation_boundary_session_scans;
 #[path = "arch_source_scans/relation_routing_residual_arch_tests.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -49,7 +49,12 @@
 //! - `import_attribute_construction_boundary_scans`: static and dynamic import
 //!   callers route import-attribute object construction through
 //!   `query_boundaries::import_attributes`.
+//! - `binding_pattern_construction_boundary_scans`: binding/destructuring
+//!   pattern callers route contextual tuple/object/property/union construction
+//!   through `query_boundaries::binding_patterns`.
 
+#[path = "arch_source_scans/binding_pattern_construction_boundary_scans.rs"]
+mod binding_pattern_construction_boundary_scans;
 #[path = "arch_source_scans/class_instance_walk_state_scans.rs"]
 mod class_instance_walk_state_scans;
 #[path = "arch_source_scans/common_boundary_export_ratchets.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -52,6 +52,9 @@
 //! - `binding_pattern_construction_boundary_scans`: binding/destructuring
 //!   pattern callers route contextual tuple/object/property/union construction
 //!   through `query_boundaries::binding_patterns`.
+//! - `type_query_construction_boundary_scans`: const value/type-query callers
+//!   route literal/property/object/tuple construction through
+//!   `query_boundaries::type_query_construction`.
 
 #[path = "arch_source_scans/binding_pattern_construction_boundary_scans.rs"]
 mod binding_pattern_construction_boundary_scans;
@@ -95,5 +98,7 @@ mod spelling_suggestion_gateway_scans;
 mod strict_bind_call_apply_construction_boundary_scans;
 #[path = "arch_source_scans/type_guard_walk_state.rs"]
 mod type_guard_walk_state;
+#[path = "arch_source_scans/type_query_construction_boundary_scans.rs"]
+mod type_query_construction_boundary_scans;
 #[path = "arch_source_scans/type_reference_depth_session_scans.rs"]
 mod type_reference_depth_session_scans;

--- a/crates/tsz-checker/tests/arch_source_scans/await_promise_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/await_promise_construction_boundary_scans.rs
@@ -1,0 +1,151 @@
+//! Await/promise construction boundary scans.
+//!
+//! Await checking owns AST context, diagnostics, lib/global lookup, and
+//! recursion policy. Solver construction for contextual promise operands and
+//! distributed `Awaited<T>` joins belongs in
+//! `query_boundaries::checkers::promise`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const AWAIT_CHECKER: &str = "src/types/computation/access_await.rs";
+const PROMISE_CHECKER: &str = "src/checkers/promise_checker.rs";
+const PROMISE_BOUNDARY: &str = "src/query_boundaries/checkers/promise.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    scan_source_for_patterns(relative, &source, patterns, violations, 0);
+}
+
+fn scan_slice_for_patterns(
+    relative: &str,
+    start_marker: &str,
+    end_marker: &str,
+    patterns: &[&str],
+    violations: &mut Vec<String>,
+) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    let start = source
+        .find(start_marker)
+        .unwrap_or_else(|| panic!("failed to find start marker `{start_marker}` in {relative}"));
+    let after_start = &source[start..];
+    let end = after_start
+        .find(end_marker)
+        .unwrap_or_else(|| panic!("failed to find end marker `{end_marker}` in {relative}"));
+    let line_offset = source[..start].lines().count();
+    scan_source_for_patterns(
+        relative,
+        &after_start[..end],
+        patterns,
+        violations,
+        line_offset,
+    );
+}
+
+fn scan_source_for_patterns(
+    relative: &str,
+    source: &str,
+    patterns: &[&str],
+    violations: &mut Vec<String>,
+    line_offset: usize,
+) {
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_offset + line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn await_checker_routes_promise_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory().union(",
+        ".factory().intersection(",
+        ".types.union(",
+        ".types.intersection(",
+        ".types.application(",
+        ".application(",
+    ];
+
+    let mut violations = Vec::new();
+    scan_for_patterns(AWAIT_CHECKER, FORBIDDEN_PATTERNS, &mut violations);
+    assert!(
+        violations.is_empty(),
+        "await checking must route promise/await solver construction through \
+         query_boundaries::checkers::promise:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn promise_checker_routes_await_union_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[".factory().union("];
+
+    let mut violations = Vec::new();
+    scan_slice_for_patterns(
+        PROMISE_CHECKER,
+        "fn extract_awaited_type_from_valid_thenable(",
+        "/// Extract the first parameter type from a callable/function type,",
+        FORBIDDEN_PATTERNS,
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        PROMISE_CHECKER,
+        "pub fn unwrap_async_return_type_for_body(",
+        "/// If `type_id` is an `Awaited<X>` application,",
+        FORBIDDEN_PATTERNS,
+        &mut violations,
+    );
+    assert!(
+        violations.is_empty(),
+        "promise checking must route await/async union construction through \
+         query_boundaries::checkers::promise:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn promise_boundary_owns_await_construction_helpers() {
+    let source = fs::read_to_string(checker_path(PROMISE_BOUNDARY))
+        .expect("failed to read query_boundaries/checkers/promise.rs");
+
+    for helper in [
+        "promise_application_type",
+        "await_contextual_operand_type",
+        "awaited_union_type",
+        "awaited_intersection_type",
+        "thenable_callback_value_union",
+        "async_return_body_union",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::checkers::promise must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in ["db.application(", "db.union(", "db.intersection("] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::checkers::promise should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/binding_pattern_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/binding_pattern_construction_boundary_scans.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const BINDING_PATTERN_CALLERS: &[&str] = &[
+    "src/state/variable_checking/binding_rest.rs",
     "src/state/variable_checking/destructuring.rs",
     "src/state/variable_checking/destructuring/tail.rs",
     "src/types/queries/binding.rs",
@@ -19,21 +20,25 @@ fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
 }
 
+fn production_source_without_comments(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact(source: &str) -> String {
+    source.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
 fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
     let source = fs::read_to_string(checker_path(relative))
         .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
-    for (line_index, line) in source.lines().enumerate() {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("//") {
-            continue;
-        }
-        for pattern in patterns {
-            if line.contains(pattern) {
-                violations.push(format!(
-                    "{relative}:{} contains `{pattern}`",
-                    line_index + 1
-                ));
-            }
+    let compact_source = compact(&production_source_without_comments(&source));
+    for pattern in patterns {
+        if compact_source.contains(&compact(pattern)) {
+            violations.push(format!("{relative} contains `{pattern}`"));
         }
     }
 }
@@ -51,11 +56,20 @@ fn binding_pattern_callers_route_solver_construction_through_boundary() {
         ".factory().union(",
         ".factory().union2(",
         ".factory().object(",
+        ".factory().object_with_index(",
+        ".factory().object_with_flags_and_symbol(",
         ".factory().tuple(",
+        ".factory().array(",
+        ".factory().application(",
         "factory.union(",
         "factory.union2(",
         "factory.object(",
+        "factory.object_with_index(",
+        "factory.object_with_flags_and_symbol(",
         "factory.tuple(",
+        "factory.array(",
+        "factory.literal_string(",
+        "factory.application(",
         ".types.union(",
         ".types.union2(",
         ".types.object(",
@@ -88,6 +102,10 @@ fn binding_patterns_boundary_owns_binding_pattern_construction_helpers() {
         "binding_pattern_tuple_element",
         "binding_pattern_object_type",
         "binding_pattern_tuple_type",
+        "binding_rest_omit_application",
+        "binding_rest_indexed_object_type",
+        "binding_rest_object_with_flags",
+        "binding_rest_array_type",
     ] {
         assert!(
             defines_fn(&source, helper),
@@ -106,6 +124,11 @@ fn binding_patterns_boundary_owns_binding_pattern_construction_helpers() {
         "TupleElement {",
         "db.object(",
         "db.tuple(",
+        "db.literal_string(",
+        "db.application(",
+        "db.object_with_index(",
+        "db.object_with_flags_and_symbol(",
+        "db.array(",
     ] {
         assert!(
             source.contains(construction_pattern),

--- a/crates/tsz-checker/tests/arch_source_scans/binding_pattern_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/binding_pattern_construction_boundary_scans.rs
@@ -1,0 +1,115 @@
+//! Binding/destructuring construction boundary scans.
+//!
+//! Binding-pattern callers gather syntax, contextual typing, relation, and
+//! diagnostic facts. Solver tuple/object/property/union construction for those
+//! facts belongs in `query_boundaries::binding_patterns`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const BINDING_PATTERN_CALLERS: &[&str] = &[
+    "src/state/variable_checking/destructuring.rs",
+    "src/state/variable_checking/destructuring/tail.rs",
+    "src/types/queries/binding.rs",
+];
+const BINDING_PATTERN_BOUNDARY: &str = "src/query_boundaries/binding_patterns.rs";
+const COMMON_BOUNDARY: &str = "src/query_boundaries/common.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}(")) || source.contains(&format!("fn {name}<"))
+}
+
+#[test]
+fn binding_pattern_callers_route_solver_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        "PropertyInfo::new(",
+        "PropertyInfo {",
+        "TupleElement {",
+        ".factory().union(",
+        ".factory().union2(",
+        ".factory().object(",
+        ".factory().tuple(",
+        "factory.union(",
+        "factory.union2(",
+        "factory.object(",
+        "factory.tuple(",
+        ".types.union(",
+        ".types.union2(",
+        ".types.object(",
+        ".types.tuple(",
+    ];
+
+    let mut violations = Vec::new();
+    for caller in BINDING_PATTERN_CALLERS {
+        scan_for_patterns(caller, FORBIDDEN_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "binding/destructuring pattern callers must route solver construction \
+         through query_boundaries::binding_patterns:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn binding_patterns_boundary_owns_binding_pattern_construction_helpers() {
+    let source = fs::read_to_string(checker_path(BINDING_PATTERN_BOUNDARY))
+        .expect("failed to read query_boundaries/binding_patterns.rs");
+    let common =
+        fs::read_to_string(checker_path(COMMON_BOUNDARY)).expect("failed to read common.rs");
+
+    for helper in [
+        "binding_pattern_initializer_union_type",
+        "binding_pattern_member_union_type",
+        "binding_pattern_property",
+        "binding_pattern_tuple_element",
+        "binding_pattern_object_type",
+        "binding_pattern_tuple_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::binding_patterns must own `{helper}`"
+        );
+        assert!(
+            !defines_fn(&common, helper),
+            "query_boundaries::common must not define `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "db.union2(",
+        "db.union(",
+        "PropertyInfo::new(",
+        "TupleElement {",
+        "db.object(",
+        "db.tuple(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::binding_patterns should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/call_inference_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/call_inference_construction_boundary_scans.rs
@@ -1,0 +1,120 @@
+//! Call-inference construction boundary scans.
+//!
+//! Call inference gathers AST-derived contribution facts for partial
+//! object/function/tuple inference surfaces. Solver construction for those
+//! partial shapes belongs in `query_boundaries::checkers::call`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CALL_HELPERS: &str = "src/types/computation/call_helpers.rs";
+const CALL_BOUNDARY: &str = "src/query_boundaries/checkers/call.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_slice_for_patterns(
+    relative: &str,
+    start_marker: &str,
+    end_marker: &str,
+    patterns: &[&str],
+    violations: &mut Vec<String>,
+) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    let start = source
+        .find(start_marker)
+        .unwrap_or_else(|| panic!("failed to find start marker `{start_marker}` in {relative}"));
+    let after_start = &source[start..];
+    let end = after_start
+        .find(end_marker)
+        .unwrap_or_else(|| panic!("failed to find end marker `{end_marker}` in {relative}"));
+    let line_offset = source[..start].lines().count();
+
+    for (line_index, line) in after_start[..end].lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_offset + line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn call_inference_partial_construction_routes_through_call_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        "PropertyInfo::new(",
+        "PropertyInfo {",
+        "TupleElement {",
+        "FunctionShape::new(",
+        "FunctionShape {",
+        ".factory().object_fresh(",
+        ".factory().tuple(",
+        ".factory().function(",
+        ".types.literal_string(",
+        ".object_fresh(",
+        ".tuple(",
+        ".function(",
+        ".literal_string(",
+    ];
+
+    let mut violations = Vec::new();
+    scan_slice_for_patterns(
+        CALL_HELPERS,
+        "pub(crate) fn extract_non_sensitive_object_type(",
+        "/// Check if a type is an intersection containing an Application",
+        FORBIDDEN_PATTERNS,
+        &mut violations,
+    );
+    assert!(
+        violations.is_empty(),
+        "call inference must route partial object/function/tuple construction \
+         through query_boundaries::checkers::call:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn call_boundary_owns_call_inference_partial_construction_helpers() {
+    let source = fs::read_to_string(checker_path(CALL_BOUNDARY))
+        .expect("failed to read query_boundaries/checkers/call.rs");
+
+    for helper in [
+        "call_inference_partial_object_type",
+        "call_inference_zero_arg_function_type",
+        "call_inference_string_key_type",
+        "call_inference_tuple_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::checkers::call must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "PropertyInfo::new(",
+        "FunctionShape::new(",
+        "db.function(",
+        "db.literal_string(",
+        "TupleElement {",
+        "db.tuple(",
+        "db.object_fresh(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::checkers::call should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/call_result_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/call_result_construction_boundary_scans.rs
@@ -1,0 +1,130 @@
+//! Call-result construction boundary scans.
+//!
+//! Call checking owns callee/signature selection, argument diagnostics,
+//! optional-chain detection, and recursive fallback detection. Solver
+//! construction for the resulting call-result surfaces belongs in
+//! `query_boundaries::checkers::call`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CALL_RESULT: &str = "src/types/computation/call_result.rs";
+const CALL_INNER: &str = "src/types/computation/call/inner.rs";
+const CALL_BOUNDARY: &str = "src/query_boundaries/checkers/call.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_slice_for_patterns(
+    relative: &str,
+    start_marker: &str,
+    end_marker: &str,
+    patterns: &[&str],
+    violations: &mut Vec<String>,
+) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    let start = source
+        .find(start_marker)
+        .unwrap_or_else(|| panic!("failed to find start marker `{start_marker}` in {relative}"));
+    let after_start = &source[start..];
+    let end = after_start
+        .find(end_marker)
+        .unwrap_or_else(|| panic!("failed to find end marker `{end_marker}` in {relative}"));
+    let line_offset = source[..start].lines().count();
+
+    for (line_index, line) in after_start[..end].lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_offset + line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn call_result_construction_routes_through_call_boundary() {
+    let mut violations = Vec::new();
+
+    scan_slice_for_patterns(
+        CALL_RESULT,
+        "fn correlated_union_call_recovery_return(",
+        "fn finalize_call_return_like_success(",
+        &[
+            ".factory().union(",
+            ".factory().union2(",
+            ".types.union(",
+            ".types.union2(",
+        ],
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        CALL_RESULT,
+        "fn finalize_call_return_like_success(",
+        "fn return_application_uses_opaque_object_base(",
+        &[
+            ".factory().union(",
+            ".factory().union2(",
+            ".types.union(",
+            ".types.union2(",
+        ],
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        CALL_INNER,
+        "if callee_type == TypeId::ANY {",
+        "if callee_type == TypeId::ERROR\n            && let Some(recovered_type)",
+        &["factory.lazy(", "factory.application("],
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        CALL_INNER,
+        "if callee_type == TypeId::ERROR {",
+        "let check_excess_properties = false;",
+        &["factory.lazy(", "factory.application("],
+        &mut violations,
+    );
+
+    assert!(
+        violations.is_empty(),
+        "call result construction must route solver construction through \
+         query_boundaries::checkers::call:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn call_boundary_owns_call_result_construction_helpers() {
+    let source = fs::read_to_string(checker_path(CALL_BOUNDARY))
+        .expect("failed to read query_boundaries/checkers/call.rs");
+
+    for helper in [
+        "call_result_correlated_union",
+        "call_result_optional_chain_return",
+        "recursive_call_result_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::checkers::call must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in ["db.union(", "db.union2(", "db.lazy(", "db.application("] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::checkers::call should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/class_constructor_return_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/class_constructor_return_construction_boundary_scans.rs
@@ -1,0 +1,105 @@
+//! Class-constructor return construction boundary scans.
+//!
+//! `constructor_checker.rs` owns mixin detection, AST/control-flow facts,
+//! lazy resolution, and diagnostics. Solver construction for constructor
+//! return intersections, abstract-flag clearing, construct return rewrites,
+//! and static property merges belongs in `query_boundaries::checkers::constructor`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CONSTRUCTOR_CHECKER: &str = "src/classes/constructor_checker.rs";
+const CONSTRUCTOR_BOUNDARY: &str = "src/query_boundaries/checkers/constructor.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn production_source_without_comments(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact(source: &str) -> String {
+    source.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn class_constructor_return_construction_routes_through_boundary() {
+    let source = fs::read_to_string(checker_path(CONSTRUCTOR_CHECKER))
+        .expect("failed to read classes/constructor_checker.rs");
+    let source = production_source_without_comments(&source);
+    let compact_source = compact(&source);
+    let forbidden = [
+        "ConstructorReturnMergeKind",
+        "classify_for_constructor_return_merge(",
+        "tsz_solver::utils::intersection_or_single(",
+        "intersect_constructor_returns(",
+        ".factory().callable(",
+        ".factory().function(",
+        ".factory().intersection(",
+        ".factory().intersection2(",
+        "factory.callable(",
+        "factory.function(",
+        "factory.intersection(",
+        "factory.intersection2(",
+    ];
+
+    let mut violations = Vec::new();
+    for pattern in forbidden {
+        if source.contains(pattern) || compact_source.contains(&compact(pattern)) {
+            violations.push(pattern);
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "constructor_checker.rs must route constructor-return solver \
+         construction through query_boundaries::checkers::constructor, found: {}",
+        violations.join(", ")
+    );
+}
+
+#[test]
+fn constructor_boundary_owns_return_construction_helpers() {
+    let source = fs::read_to_string(checker_path(CONSTRUCTOR_BOUNDARY))
+        .expect("failed to read query_boundaries/checkers/constructor.rs");
+
+    for helper in [
+        "constructor_return_intersection_or_single",
+        "constructor_instance_intersection_or_single",
+        "mixin_returned_class_instance_type",
+        "mixin_return_type_with_base_constructor",
+        "constructor_type_without_abstract_flag",
+        "constructor_type_with_construct_return",
+        "constructor_type_with_base_instance_return",
+        "constructor_type_with_base_properties",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::checkers::constructor must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "tsz_solver::utils::intersection_or_single(",
+        "tsz_solver::type_queries::data::intersect_constructor_returns(",
+        "ConstructorReturnMergeKind",
+        "db.callable(",
+        "db.function(",
+        "db.intersection(",
+        "db.intersection2(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::checkers::constructor should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/class_member_surface_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/class_member_surface_construction_boundary_scans.rs
@@ -1,0 +1,126 @@
+//! Class member/in-progress surface construction boundary scans.
+//!
+//! Class instance and constructor builders own AST traversal, member ordering,
+//! cache-window publication, contextual typing, and late-bound detection. Raw
+//! solver construction for member properties, method callables, declared index
+//! signatures, partial `this`, rough instance snapshots, and temporary
+//! constructor/instance surfaces belongs in `query_boundaries::class_type`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CLASS_INSTANCE: &str = "src/types/class_type/instance.rs";
+const CLASS_CONSTRUCTOR: &str = "src/types/class_type/constructor.rs";
+const CLASS_TYPE_BOUNDARY: &str = "src/query_boundaries/class_type.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn production_source_without_comments(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact(source: &str) -> String {
+    source.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn scan_source_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    let source = production_source_without_comments(&source);
+    let compact_source = compact(&source);
+    for pattern in patterns {
+        if source.contains(pattern) || compact_source.contains(&compact(pattern)) {
+            violations.push(format!("{relative} contains `{pattern}`"));
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn class_member_surface_callers_route_solver_construction_through_boundary() {
+    let mut violations = Vec::new();
+    let patterns = [
+        "ParamInfo {",
+        "CallSignature {",
+        "CallableShape {",
+        "ObjectShape {",
+        "IndexSignature {",
+        "PropertyInfo {",
+        "PropertyInfo::new(",
+        "factory.callable(",
+        "factory.object(",
+        "factory.object_with_index(",
+        "factory.union2(",
+        "factory.intersection(",
+        "factory.intersection2(",
+    ];
+
+    scan_source_for_patterns(CLASS_INSTANCE, &patterns, &mut violations);
+    scan_source_for_patterns(CLASS_CONSTRUCTOR, &patterns, &mut violations);
+
+    assert!(
+        violations.is_empty(),
+        "class member and in-progress surface construction must route through \
+         query_boundaries::class_type:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn class_type_boundary_owns_class_member_surface_construction_helpers() {
+    let source = fs::read_to_string(checker_path(CLASS_TYPE_BOUNDARY))
+        .expect("failed to read query_boundaries/class_type.rs");
+
+    for helper in [
+        "class_member_property",
+        "class_method_callable_type",
+        "optional_class_member_type",
+        "class_rest_any_param",
+        "class_method_call_signature",
+        "class_declared_index_signature",
+        "class_member_object_type",
+        "class_member_object_with_indexes_type",
+        "class_member_partial_this_type",
+        "rough_class_instance_return_type",
+        "partial_static_constructor_callable_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::class_type must own `{helper}`"
+        );
+    }
+
+    assert!(
+        source.contains("struct ClassMemberProperty"),
+        "query_boundaries::class_type must own `ClassMemberProperty`"
+    );
+
+    for construction_pattern in [
+        "ParamInfo {",
+        "CallSignature {",
+        "CallableShape {",
+        "ObjectShape {",
+        "IndexSignature {",
+        "PropertyInfo {",
+        "db.callable(",
+        "db.object(",
+        "db.object_with_index(",
+        "db.union2(",
+        "db.intersection(",
+        "db.intersection2(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::class_type should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/class_partial_constructor_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/class_partial_constructor_construction_boundary_scans.rs
@@ -1,0 +1,130 @@
+//! Class partial-constructor construction boundary scans.
+//!
+//! Class-constructor helpers own AST traversal, declaration timing, publication
+//! windows, inheritance substitution, overload selection, and diagnostics.
+//! Solver construction for partial static constructor surfaces belongs in
+//! `query_boundaries::class_type`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CLASS_PARTIAL_CONSTRUCTOR_CALLERS: &[&str] = &[
+    "src/types/class_type/constructor_parts/helpers.rs",
+    "src/types/class_type/constructor_parts/rough_partial.rs",
+];
+const CLASS_TYPE_BOUNDARY: &str = "src/query_boundaries/class_type.rs";
+const COMMON_BOUNDARY: &str = "src/query_boundaries/common.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}(")) || source.contains(&format!("fn {name}<"))
+}
+
+#[test]
+fn class_partial_constructor_callers_route_solver_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        "IndexSignature {",
+        "CallableShape {",
+        "PropertyInfo {",
+        "ParamInfo {",
+        "TypePredicate {",
+        "CallSignature {",
+        "TypeParamInfo {",
+        ".factory().union2(",
+        ".factory().callable(",
+        ".factory().lazy(",
+        ".factory().application(",
+        ".factory().type_param(",
+        "factory.union2(",
+        "factory.callable(",
+        "factory.lazy(",
+        "factory.application(",
+        "factory.type_param(",
+    ];
+
+    let mut violations = Vec::new();
+    for caller in CLASS_PARTIAL_CONSTRUCTOR_CALLERS {
+        scan_for_patterns(caller, FORBIDDEN_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "class partial-constructor callers must route solver construction \
+         through query_boundaries::class_type:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn class_type_boundary_owns_partial_constructor_construction_helpers() {
+    let source = fs::read_to_string(checker_path(CLASS_TYPE_BOUNDARY))
+        .expect("failed to read query_boundaries/class_type.rs");
+    let common =
+        fs::read_to_string(checker_path(COMMON_BOUNDARY)).expect("failed to read common.rs");
+
+    for helper in [
+        "merged_static_late_bound_index_value_type",
+        "static_late_bound_index_signature",
+        "partial_static_method_type",
+        "partial_static_method_property",
+        "partial_static_accessor_property",
+        "partial_static_placeholder_property",
+        "partial_static_constructor_callable_type",
+        "class_constructor_companion_lazy_type",
+        "rough_self_instance_lazy_type",
+        "rough_self_instance_application_type",
+        "class_construct_param",
+        "class_type_predicate",
+        "class_construct_signature",
+        "enclosing_function_type_param_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::class_type must own `{helper}`"
+        );
+        assert!(
+            !defines_fn(&common, helper),
+            "query_boundaries::common must not define `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "db.union2(",
+        "IndexSignature {",
+        "db.callable(",
+        "CallableShape {",
+        "PropertyInfo {",
+        "db.lazy(",
+        "db.application(",
+        "ParamInfo {",
+        "TypePredicate {",
+        "CallSignature {",
+        "db.type_param(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::class_type should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/class_surface_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/class_surface_construction_boundary_scans.rs
@@ -1,0 +1,168 @@
+//! Class surface construction boundary scans.
+//!
+//! Class instance/constructor code owns AST collection, inheritance merging,
+//! late-bound-member discovery, and cache publication. Solver construction for
+//! merged instance/interface surfaces and final constructor surfaces belongs in
+//! `query_boundaries::class_type`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CLASS_HELPERS: &str = "src/types/class_type/helpers.rs";
+const CLASS_CONSTRUCTOR: &str = "src/types/class_type/constructor.rs";
+const CLASS_TYPE_BOUNDARY: &str = "src/query_boundaries/class_type.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn production_source_without_comments(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact(source: &str) -> String {
+    source.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn scan_slice_for_patterns(
+    relative: &str,
+    start_marker: &str,
+    end_marker: &str,
+    patterns: &[&str],
+    violations: &mut Vec<String>,
+) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    let start = source
+        .find(start_marker)
+        .unwrap_or_else(|| panic!("failed to find start marker `{start_marker}` in {relative}"));
+    let after_start = &source[start..];
+    let end = after_start
+        .find(end_marker)
+        .unwrap_or_else(|| panic!("failed to find end marker `{end_marker}` in {relative}"));
+    let line_offset = source[..start].lines().count();
+    scan_source_for_patterns(
+        relative,
+        &after_start[..end],
+        patterns,
+        line_offset,
+        violations,
+    );
+}
+
+fn scan_source_for_patterns(
+    relative: &str,
+    source: &str,
+    patterns: &[&str],
+    line_offset: usize,
+    violations: &mut Vec<String>,
+) {
+    let source = production_source_without_comments(source);
+    let compact_source = compact(&source);
+    for pattern in patterns {
+        if source.contains(pattern) || compact_source.contains(&compact(pattern)) {
+            violations.push(format!(
+                "{relative}:{} contains `{pattern}`",
+                line_offset + 1
+            ));
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn class_surface_callers_route_solver_construction_through_boundary() {
+    let mut violations = Vec::new();
+
+    scan_slice_for_patterns(
+        CLASS_HELPERS,
+        "pub(super) fn merge_class_instance_with_interface(",
+        "/// For JS classes without syntax-level type parameters",
+        &[
+            "CallableShape {",
+            "ObjectShape {",
+            "IndexSignature {",
+            "factory.callable(",
+            "factory.object(",
+            "factory.object_with_index(",
+            "factory.union2(",
+            ".factory().union2(",
+        ],
+        &mut violations,
+    );
+
+    scan_slice_for_patterns(
+        CLASS_CONSTRUCTOR,
+        "// Add default constructor if none exists",
+        "// Track constructor accessibility",
+        &[
+            "CallSignature {",
+            "IndexSignature {",
+            "CallableShape {",
+            "factory.callable(",
+            "factory.union2(",
+        ],
+        &mut violations,
+    );
+
+    scan_slice_for_patterns(
+        CLASS_CONSTRUCTOR,
+        "// Mixin pattern:",
+        "        constructor_type\n    }\n}",
+        &["factory.intersection2("],
+        &mut violations,
+    );
+
+    assert!(
+        violations.is_empty(),
+        "class surface callers must route solver construction through \
+         query_boundaries::class_type:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn class_type_boundary_owns_class_surface_construction_helpers() {
+    let source = fs::read_to_string(checker_path(CLASS_TYPE_BOUNDARY))
+        .expect("failed to read query_boundaries/class_type.rs");
+
+    for helper in [
+        "MergedClassInstanceInterfaceSurface",
+        "merged_class_instance_interface_type",
+        "class_constructor_callable_type",
+        "class_constructor_mixin_intersection",
+    ] {
+        if helper == "MergedClassInstanceInterfaceSurface" {
+            assert!(
+                source.contains("struct MergedClassInstanceInterfaceSurface"),
+                "query_boundaries::class_type must own `{helper}`"
+            );
+        } else {
+            assert!(
+                defines_fn(&source, helper),
+                "query_boundaries::class_type must own `{helper}`"
+            );
+        }
+    }
+
+    for construction_pattern in [
+        "db.callable(",
+        "CallableShape {",
+        "db.object(",
+        "db.object_with_index(",
+        "ObjectShape {",
+        "db.intersection2(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::class_type should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/commonjs_json_export_surface_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/commonjs_json_export_surface_construction_boundary_scans.rs
@@ -1,0 +1,110 @@
+//! CommonJS/JSON export-surface construction boundary scans.
+//!
+//! `exports_detection.rs` owns JSON parsing, module-mode decisions, and
+//! current-file CommonJS export-name discovery. Solver construction for the
+//! resulting JSON value and namespace surfaces belongs in
+//! `query_boundaries::js_exports`.
+
+use std::fs;
+use std::path::Path;
+
+const EXPORTS_DETECTION: &str = "src/state/type_analysis/computed_commonjs/exports_detection.rs";
+const JS_EXPORTS_BOUNDARY: &str = "src/query_boundaries/js_exports.rs";
+
+fn checker_path(relative: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn production_source_without_comments(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact(source: &str) -> String {
+    source.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn commonjs_json_export_surface_construction_routes_through_boundary() {
+    let source = fs::read_to_string(checker_path(EXPORTS_DETECTION))
+        .expect("failed to read computed_commonjs/exports_detection.rs");
+    let source = production_source_without_comments(&source);
+    let compact_source = compact(&source);
+    let forbidden = [
+        "PropertyInfo {",
+        "Visibility::Public",
+        ".factory().object(",
+        ".factory().array(",
+        ".factory().union(",
+        ".factory().union2(",
+        ".types.object(",
+        ".types.array(",
+        ".types.union(",
+        "fn json_value_type(",
+        "fn json_array_type(",
+        "fn json_object_type(",
+        "fn json_array_object_property_order(",
+        "JsExportSurface {",
+        ".to_type_id_with_display_name(",
+    ];
+
+    let mut violations = Vec::new();
+    for pattern in forbidden {
+        if source.contains(pattern) || compact_source.contains(&compact(pattern)) {
+            violations.push(pattern);
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "CommonJS/JSON export-surface construction must route through \
+         query_boundaries::js_exports, found: {}",
+        violations.join(", ")
+    );
+}
+
+#[test]
+fn js_exports_boundary_owns_commonjs_json_surface_helpers() {
+    let source = fs::read_to_string(checker_path(JS_EXPORTS_BOUNDARY))
+        .expect("failed to read query_boundaries/js_exports.rs");
+
+    for helper in [
+        "json_module_union",
+        "json_module_array_type",
+        "json_module_object_type",
+        "json_module_object_property",
+        "json_module_missing_property",
+        "json_module_value_type",
+        "json_esm_namespace_type",
+        "commonjs_json_namespace_type",
+        "commonjs_export_surface_can_merge_named_exports",
+        "current_file_commonjs_namespace_type",
+        "commonjs_namespace_any_property",
+        "commonjs_empty_namespace_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::js_exports must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "PropertyInfo {",
+        "db.union(",
+        "db.array(",
+        "db.object(",
+        "Visibility::Public",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::js_exports should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/commonjs_resolution_export_surface_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/commonjs_resolution_export_surface_construction_boundary_scans.rs
@@ -1,0 +1,109 @@
+//! CommonJS resolution export-surface construction boundary scans.
+//!
+//! `exports_resolution.rs` owns CommonJS AST recognition, symbol lookup, and
+//! module-resolution policy. Solver construction for descriptor properties,
+//! object overlays, callable constructor upgrades, and imported module value
+//! surfaces belongs in `query_boundaries::js_exports`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const EXPORTS_RESOLUTION: &str = "src/state/type_analysis/computed_commonjs/exports_resolution.rs";
+const JS_EXPORTS_BOUNDARY: &str = "src/query_boundaries/js_exports.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn production_source_without_comments(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact(source: &str) -> String {
+    source.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn commonjs_resolution_export_surface_construction_routes_through_boundary() {
+    let source = fs::read_to_string(checker_path(EXPORTS_RESOLUTION))
+        .expect("failed to read computed_commonjs/exports_resolution.rs");
+    let source = production_source_without_comments(&source);
+    let compact_source = compact(&source);
+    let forbidden = [
+        "PropertyInfo {",
+        "Visibility::Public",
+        "ObjectShape {",
+        "FunctionShape::new",
+        "CallSignature {",
+        "CallableShape {",
+        ".factory().function(",
+        ".factory().callable(",
+        ".factory().object",
+        ".factory().intersection2(",
+        ".types.object(",
+        ".types.intersection2(",
+        ".to_type_id_with_display_name(",
+    ];
+
+    let mut violations = Vec::new();
+    for pattern in forbidden {
+        if source.contains(pattern) || compact_source.contains(&compact(pattern)) {
+            violations.push(pattern);
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "CommonJS resolution export-surface construction must route through \
+         query_boundaries::js_exports, found: {}",
+        violations.join(", ")
+    );
+}
+
+#[test]
+fn js_exports_boundary_owns_commonjs_resolution_surface_helpers() {
+    let source = fs::read_to_string(checker_path(JS_EXPORTS_BOUNDARY))
+        .expect("failed to read query_boundaries/js_exports.rs");
+
+    for helper in [
+        "commonjs_namespace_export_property",
+        "commonjs_define_property_setter_contextual_function_type",
+        "commonjs_define_property_descriptor_property",
+        "commonjs_type_with_define_property_members",
+        "commonjs_export_constructor_type_with_instance",
+        "commonjs_export_surface_type_with_display_name",
+        "commonjs_imported_module_value_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::js_exports must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "PropertyInfo {",
+        "Visibility::Public",
+        "FunctionShape::new",
+        "CallSignature {",
+        "CallableShape {",
+        "ObjectShape {",
+        "db.function(",
+        "db.callable(",
+        "db.object(",
+        "db.object_with_index(",
+        "db.intersection2(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::js_exports should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/commonjs_resolution_export_surface_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/commonjs_resolution_export_surface_construction_boundary_scans.rs
@@ -1,14 +1,16 @@
 //! CommonJS resolution export-surface construction boundary scans.
 //!
-//! `exports_resolution.rs` owns CommonJS AST recognition, symbol lookup, and
-//! module-resolution policy. Solver construction for descriptor properties,
-//! object overlays, callable constructor upgrades, and imported module value
-//! surfaces belongs in `query_boundaries::js_exports`.
+//! `exports_resolution.rs` and `exports_collection.rs` own CommonJS AST
+//! recognition, symbol lookup, RHS inference, and module-resolution policy.
+//! Solver construction for descriptor properties, object overlays, expando
+//! members, callable constructor upgrades, and imported module value surfaces
+//! belongs in `query_boundaries::js_exports`.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 const EXPORTS_RESOLUTION: &str = "src/state/type_analysis/computed_commonjs/exports_resolution.rs";
+const EXPORTS_COLLECTION: &str = "src/state/type_analysis/computed_commonjs/exports_collection.rs";
 const JS_EXPORTS_BOUNDARY: &str = "src/query_boundaries/js_exports.rs";
 
 fn checker_path(relative: &str) -> PathBuf {
@@ -33,10 +35,6 @@ fn defines_fn(source: &str, name: &str) -> bool {
 
 #[test]
 fn commonjs_resolution_export_surface_construction_routes_through_boundary() {
-    let source = fs::read_to_string(checker_path(EXPORTS_RESOLUTION))
-        .expect("failed to read computed_commonjs/exports_resolution.rs");
-    let source = production_source_without_comments(&source);
-    let compact_source = compact(&source);
     let forbidden = [
         "PropertyInfo {",
         "Visibility::Public",
@@ -54,9 +52,16 @@ fn commonjs_resolution_export_surface_construction_routes_through_boundary() {
     ];
 
     let mut violations = Vec::new();
-    for pattern in forbidden {
-        if source.contains(pattern) || compact_source.contains(&compact(pattern)) {
-            violations.push(pattern);
+    for path in [EXPORTS_RESOLUTION, EXPORTS_COLLECTION] {
+        let source = fs::read_to_string(checker_path(path))
+            .unwrap_or_else(|err| panic!("failed to read {path}: {err}"));
+        let source = production_source_without_comments(&source);
+        let compact_source = compact(&source);
+
+        for pattern in forbidden {
+            if source.contains(pattern) || compact_source.contains(&compact(pattern)) {
+                violations.push(format!("{path} contains `{pattern}`"));
+            }
         }
     }
 
@@ -81,12 +86,21 @@ fn js_exports_boundary_owns_commonjs_resolution_surface_helpers() {
         "commonjs_export_constructor_type_with_instance",
         "commonjs_export_surface_type_with_display_name",
         "commonjs_imported_module_value_type",
+        "commonjs_expando_property",
+        "commonjs_export_type_with_expando_members",
+        "commonjs_export_object_type_with_expando_members",
+        "commonjs_export_callable_type_with_expando_members",
     ] {
         assert!(
             defines_fn(&source, helper),
             "query_boundaries::js_exports must own `{helper}`"
         );
     }
+
+    assert!(
+        source.contains("struct CommonJsExpandoMember"),
+        "query_boundaries::js_exports must own `CommonJsExpandoMember`"
+    );
 
     for construction_pattern in [
         "PropertyInfo {",

--- a/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
@@ -38,6 +38,11 @@ const CONTEXTUAL_FUNCTION_MATERIALIZATION_MODULES: &[&str] = &[
     "src/types/computation/tagged_template.rs",
     "src/types/function_type_helpers.rs",
 ];
+const CALL_CONTEXT_FUNCTION_SURFACE_MODULES: &[&str] = &[
+    "src/types/computation/call_inference.rs",
+    "src/types/computation/call/callee_context.rs",
+    "src/types/computation/complex.rs",
+];
 
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
@@ -158,6 +163,35 @@ fn contextual_function_materialization_routes_interning_through_boundary() {
     );
 }
 
+/// Call inference and callee/new-expression context helpers may assemble
+/// request shapes, but the interned function/callable surfaces must flow
+/// through `construct_signatures`.
+#[test]
+fn call_context_function_surfaces_route_interning_through_boundary() {
+    const PATTERNS: &[&str] = &[
+        ".factory().function(",
+        ".factory().callable(",
+        ".factory.function(",
+        ".factory.callable(",
+        ".types.function(",
+        ".types.callable(",
+        ".ctx.types.function(",
+        ".ctx.types.callable(",
+        "FunctionShape::new(",
+    ];
+
+    let mut violations = Vec::new();
+    for module in CALL_CONTEXT_FUNCTION_SURFACE_MODULES {
+        scan_for_patterns(module, PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "call context helpers must intern temporary function/callable types through \
+         query_boundaries::construct_signatures:\n{}",
+        violations.join("\n")
+    );
+}
+
 /// `CallSignature` literals are signature *data* assembly and belong to the
 /// designated builder module (`checkers/signature_builder.rs`) or the
 /// boundary itself; the other issue #13022 modules round-trip through
@@ -193,8 +227,10 @@ fn construct_signatures_boundary_owns_construction_helpers() {
         "function_type_from_parts",
         "function_type_with_params_replaced",
         "function_type_from_call_signature",
+        "function_type_from_call_signature_preserving_method",
         "call_only_callable_type",
         "construct_only_callable_type",
+        "callable_type_from_shape",
         "callable_with_signatures_replaced",
         "instantiated_callable_from_base",
         "map_function_shape_types",
@@ -210,6 +246,7 @@ fn construct_signatures_boundary_owns_construction_helpers() {
     for helper in [
         "call_only_callable_type",
         "construct_only_callable_type",
+        "callable_type_from_shape",
         "callable_with_signatures_replaced",
         "instantiated_callable_from_base",
         "map_function_shape_types",

--- a/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
@@ -33,6 +33,7 @@ const SIGNATURE_CONSTRUCTION_CLEAN_MODULES: &[&str] = &[
 
 /// The designated checker-side `CallSignature` data assembler.
 const SIGNATURE_DATA_BUILDER: &str = "src/checkers/signature_builder.rs";
+const CALL_DISPLAY_MODULE: &str = "src/types/computation/call_display.rs";
 
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
@@ -106,6 +107,29 @@ fn issue_13022_modules_do_not_build_type_shape_literals() {
     );
 }
 
+/// `call_display.rs` also builds temporary function surfaces for relation and
+/// contextual-return checks. Those function types are signature-bearing
+/// construction and must stay behind the same boundary, but the module still
+/// assembles read-only `CallSignature` data for display skeletons.
+#[test]
+fn call_display_routes_function_type_construction_through_boundary() {
+    const PATTERNS: &[&str] = &[
+        ".factory().function(",
+        ".factory.function(",
+        ".types.function(",
+        "FunctionShape::new(",
+    ];
+
+    let mut violations = Vec::new();
+    scan_for_patterns(CALL_DISPLAY_MODULE, PATTERNS, &mut violations);
+    assert!(
+        violations.is_empty(),
+        "call_display.rs must intern temporary function types through \
+         query_boundaries::construct_signatures:\n{}",
+        violations.join("\n")
+    );
+}
+
 /// `CallSignature` literals are signature *data* assembly and belong to the
 /// designated builder module (`checkers/signature_builder.rs`) or the
 /// boundary itself; the other issue #13022 modules round-trip through
@@ -138,6 +162,7 @@ fn construct_signatures_boundary_owns_construction_helpers() {
         "function_shape_from_call_signature",
         "call_signature_from_function_shape",
         "function_type_from_shape",
+        "function_type_from_parts",
         "function_type_from_call_signature",
         "call_only_callable_type",
         "construct_only_callable_type",

--- a/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
@@ -34,6 +34,10 @@ const SIGNATURE_CONSTRUCTION_CLEAN_MODULES: &[&str] = &[
 /// The designated checker-side `CallSignature` data assembler.
 const SIGNATURE_DATA_BUILDER: &str = "src/checkers/signature_builder.rs";
 const CALL_DISPLAY_MODULE: &str = "src/types/computation/call_display.rs";
+const CONTEXTUAL_FUNCTION_MATERIALIZATION_MODULES: &[&str] = &[
+    "src/types/computation/tagged_template.rs",
+    "src/types/function_type_helpers.rs",
+];
 
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
@@ -130,6 +134,30 @@ fn call_display_routes_function_type_construction_through_boundary() {
     );
 }
 
+/// Contextual typing helpers may assemble `FunctionShape` request data, but
+/// interned function types must flow through `construct_signatures`.
+#[test]
+fn contextual_function_materialization_routes_interning_through_boundary() {
+    const PATTERNS: &[&str] = &[
+        ".factory().function(",
+        ".factory.function(",
+        ".types.function(",
+        ".ctx.types.function(",
+        "FunctionShape::new(",
+    ];
+
+    let mut violations = Vec::new();
+    for module in CONTEXTUAL_FUNCTION_MATERIALIZATION_MODULES {
+        scan_for_patterns(module, PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "contextual function helpers must intern temporary function types through \
+         query_boundaries::construct_signatures:\n{}",
+        violations.join("\n")
+    );
+}
+
 /// `CallSignature` literals are signature *data* assembly and belong to the
 /// designated builder module (`checkers/signature_builder.rs`) or the
 /// boundary itself; the other issue #13022 modules round-trip through
@@ -163,6 +191,7 @@ fn construct_signatures_boundary_owns_construction_helpers() {
         "call_signature_from_function_shape",
         "function_type_from_shape",
         "function_type_from_parts",
+        "function_type_with_params_replaced",
         "function_type_from_call_signature",
         "call_only_callable_type",
         "construct_only_callable_type",

--- a/crates/tsz-checker/tests/arch_source_scans/declaration_export_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/declaration_export_construction_boundary_scans.rs
@@ -1,0 +1,121 @@
+//! Declaration export construction boundary scans.
+//!
+//! Namespace/module declaration checkers collect AST and binder facts. Solver
+//! property, object, callable, lazy-ref, intersection, and application
+//! construction for export surfaces belongs in
+//! `query_boundaries::declaration_exports`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DECLARATION_EXPORT_CALLERS: &[&str] = &[
+    "src/declarations/module_checker.rs",
+    "src/declarations/namespace_checker.rs",
+];
+const DECLARATION_EXPORT_BOUNDARY: &str = "src/query_boundaries/declaration_exports.rs";
+const COMMON_BOUNDARY: &str = "src/query_boundaries/common.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}(")) || source.contains(&format!("fn {name}<"))
+}
+
+#[test]
+fn declaration_export_callers_route_solver_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        "PropertyInfo {",
+        "PropertyInfo::new(",
+        "CallableShape {",
+        "CallableShape::default()",
+        ".factory().object(",
+        ".ctx.types.factory().object(",
+        "factory.object(",
+        ".object_with_symbol(",
+        ".factory().callable(",
+        ".callable(",
+        ".application(",
+        ".lazy(",
+        ".intersection2(",
+    ];
+
+    let mut violations = Vec::new();
+    for caller in DECLARATION_EXPORT_CALLERS {
+        scan_for_patterns(caller, FORBIDDEN_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "declaration export-surface callers must route solver construction \
+         through query_boundaries::declaration_exports:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn declaration_exports_boundary_owns_export_surface_construction_helpers() {
+    let source = fs::read_to_string(checker_path(DECLARATION_EXPORT_BOUNDARY))
+        .expect("failed to read query_boundaries/declaration_exports.rs");
+    let common =
+        fs::read_to_string(checker_path(COMMON_BOUNDARY)).expect("failed to read common.rs");
+
+    for helper in [
+        "declaration_export_property",
+        "declaration_lazy_export_type",
+        "module_export_augmented_type",
+        "dynamic_import_module_object_type",
+        "dynamic_import_promise_type",
+        "empty_namespace_object_type",
+        "namespace_object_placeholder_type",
+        "namespace_object_type",
+        "namespace_merged_constructor_callable_type",
+        "namespace_merged_function_callable_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::declaration_exports must own `{helper}`"
+        );
+        assert!(
+            !defines_fn(&common, helper),
+            "query_boundaries::common must not define `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "PropertyInfo {",
+        "Visibility::Public",
+        "db.lazy(",
+        "db.intersection2(",
+        "db.object(",
+        "db.object_with_flags_and_symbol(",
+        "db.application(",
+        "db.callable(",
+        "CallableShape {",
+        "ObjectFlags::empty()",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::declaration_exports should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/decorator_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/decorator_construction_boundary_scans.rs
@@ -1,0 +1,97 @@
+//! Class-member decorator construction boundary scans.
+//!
+//! Decorator signature checking owns AST/member-kind decisions, decorator ABI
+//! selection, diagnostics, and relation outcomes. Solver construction for the
+//! semantic helper types used by member decorators belongs in
+//! `query_boundaries::checkers::decorators`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DECORATOR_SIGNATURE_CHECKS: &str =
+    "src/state/state_checking_members/decorator_signature_checks.rs";
+const DECORATOR_BOUNDARY: &str = "src/query_boundaries/checkers/decorators.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn decorator_signature_checks_route_solver_construction_through_boundary() {
+    let mut violations = Vec::new();
+    scan_for_patterns(
+        DECORATOR_SIGNATURE_CHECKS,
+        &[
+            "create_lazy_type_ref(",
+            ".factory().application(",
+            ".factory().function(",
+            ".factory().union2(",
+            "tsz_solver::FunctionShape {",
+            "FunctionShape {",
+        ],
+        &mut violations,
+    );
+
+    assert!(
+        violations.is_empty(),
+        "decorator signature checks must route solver construction through \
+         query_boundaries::checkers::decorators:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn decorator_boundary_owns_construction_helpers() {
+    let source = fs::read_to_string(checker_path(DECORATOR_BOUNDARY))
+        .expect("failed to read query_boundaries/checkers/decorators.rs");
+
+    for helper in [
+        "decorator_global_type_ref",
+        "class_accessor_decorator_target_any",
+        "decorator_context_application",
+        "method_decorator_value_type",
+        "accessor_decorator_value_type",
+        "decorator_void_or_replacement_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::checkers::decorators must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "db.lazy(",
+        "db.application(",
+        "db.function(",
+        "FunctionShape {",
+        "db.union2(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::checkers::decorators should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -8,14 +8,22 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const DIAGNOSTICS_BOUNDARY: &str = "src/query_boundaries/diagnostics.rs";
-const DIAGNOSTIC_REPORTER_CONSTRUCTION_MODULES: &[&str] = &[
+const DIAGNOSTIC_CONSTRUCTION_MODULES: &[&str] = &[
     "src/error_reporter/core/type_display.rs",
     "src/error_reporter/core/excess_display.rs",
     "src/error_reporter/generics.rs",
+    "src/state/type_environment/formatting.rs",
 ];
 
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn is_allowed_shape_return_signature(trimmed: &str) -> bool {
+    matches!(
+        trimmed,
+        ") -> tsz_solver::FunctionShape {" | ") -> tsz_solver::CallableShape {"
+    )
 }
 
 fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
@@ -23,7 +31,7 @@ fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<Str
         .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
     for (line_index, line) in source.lines().enumerate() {
         let trimmed = line.trim_start();
-        if trimmed.starts_with("//") {
+        if trimmed.starts_with("//") || is_allowed_shape_return_signature(trimmed) {
             continue;
         }
         for pattern in patterns {
@@ -38,7 +46,7 @@ fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<Str
 }
 
 #[test]
-fn error_reporters_route_solver_shape_construction_through_diagnostics_boundary() {
+fn diagnostic_display_callers_route_solver_shape_construction_through_diagnostics_boundary() {
     const FORBIDDEN_PATTERNS: &[&str] = &[
         ".factory().object(",
         ".factory().object_with_index(",
@@ -61,13 +69,13 @@ fn error_reporters_route_solver_shape_construction_through_diagnostics_boundary(
     ];
 
     let mut violations = Vec::new();
-    for relative in DIAGNOSTIC_REPORTER_CONSTRUCTION_MODULES {
+    for relative in DIAGNOSTIC_CONSTRUCTION_MODULES {
         scan_for_patterns(relative, FORBIDDEN_PATTERNS, &mut violations);
     }
 
     assert!(
         violations.is_empty(),
-        "error_reporter modules must route diagnostic solver shape construction \
+        "diagnostic display callers must route solver shape construction \
          through query_boundaries::diagnostics:\n{}",
         violations.join("\n")
     );
@@ -85,6 +93,8 @@ fn diagnostics_boundary_owns_construction_helpers() {
         "function_type_with_params_replaced",
         "function_type_with_return_replaced",
         "function_type_with_params_and_return_replaced",
+        "function_type_without_type_params",
+        "function_type_from_call_signature_without_type_params",
         "callable_type_from_shape",
         "call_only_callable_type",
         "callable_type_with_signatures_replaced",

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -11,9 +11,13 @@ const DIAGNOSTICS_BOUNDARY: &str = "src/query_boundaries/diagnostics.rs";
 const DIAGNOSTIC_CONSTRUCTION_MODULES: &[&str] = &[
     "src/error_reporter/core/type_display.rs",
     "src/error_reporter/core/excess_display.rs",
+    "src/error_reporter/core/diagnostic_source/static_schema.rs",
     "src/error_reporter/generics.rs",
+    "src/error_reporter/properties.rs",
+    "src/error_reporter/call_errors/display_formatting_parameters.rs",
     "src/state/type_environment/formatting.rs",
 ];
+const DIAGNOSTIC_FUNCTION_CONSTRUCTION_MODULES: &[&str] = &["src/error_reporter/render_failure.rs"];
 
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
@@ -73,6 +77,17 @@ fn diagnostic_display_callers_route_solver_shape_construction_through_diagnostic
         scan_for_patterns(relative, FORBIDDEN_PATTERNS, &mut violations);
     }
 
+    const FUNCTION_FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory().function(",
+        ".factory.function(",
+        ".types.function(",
+        "FunctionShape {",
+        "FunctionShape::new(",
+    ];
+    for relative in DIAGNOSTIC_FUNCTION_CONSTRUCTION_MODULES {
+        scan_for_patterns(relative, FUNCTION_FORBIDDEN_PATTERNS, &mut violations);
+    }
+
     assert!(
         violations.is_empty(),
         "diagnostic display callers must route solver shape construction \
@@ -95,6 +110,7 @@ fn diagnostics_boundary_owns_construction_helpers() {
         "function_type_with_params_and_return_replaced",
         "function_type_without_type_params",
         "function_type_from_call_signature_without_type_params",
+        "function_type_from_call_signature",
         "callable_type_from_shape",
         "call_only_callable_type",
         "callable_type_with_signatures_replaced",

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -11,10 +11,13 @@ const DIAGNOSTICS_BOUNDARY: &str = "src/query_boundaries/diagnostics.rs";
 const DIAGNOSTIC_CONSTRUCTION_MODULES: &[&str] = &[
     "src/error_reporter/core/type_display.rs",
     "src/error_reporter/core/excess_display.rs",
+    "src/error_reporter/core/diagnostic_source.rs",
     "src/error_reporter/core/diagnostic_source/static_schema.rs",
     "src/error_reporter/generics.rs",
     "src/error_reporter/properties.rs",
+    "src/error_reporter/call_errors/display_formatting.rs",
     "src/error_reporter/call_errors/display_formatting_parameters.rs",
+    "src/error_reporter/call_errors/elaboration.rs",
     "src/state/type_environment/formatting.rs",
 ];
 const DIAGNOSTIC_FUNCTION_CONSTRUCTION_MODULES: &[&str] = &["src/error_reporter/render_failure.rs"];
@@ -104,6 +107,8 @@ fn diagnostics_boundary_owns_construction_helpers() {
         "object_type_from_properties",
         "object_type_from_shape",
         "object_type_preserving_display_properties",
+        "shallow_object_property_literals_widened_for_call_parameter_display",
+        "object_type_with_unknown_display_members",
         "function_type_from_shape",
         "function_type_with_params_replaced",
         "function_type_with_return_replaced",

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -13,10 +13,12 @@ const DIAGNOSTIC_CONSTRUCTION_MODULES: &[&str] = &[
     "src/error_reporter/core/excess_display.rs",
     "src/error_reporter/core/diagnostic_source.rs",
     "src/error_reporter/core/diagnostic_source/static_schema.rs",
+    "src/error_reporter/fingerprint_policy.rs",
     "src/error_reporter/generics.rs",
     "src/error_reporter/properties.rs",
     "src/error_reporter/call_errors/display_formatting.rs",
     "src/error_reporter/call_errors/display_formatting_parameters.rs",
+    "src/error_reporter/call_errors/error_emission.rs",
     "src/error_reporter/call_errors/elaboration.rs",
     "src/state/type_environment/formatting.rs",
 ];
@@ -33,12 +35,19 @@ fn is_allowed_shape_return_signature(trimmed: &str) -> bool {
     )
 }
 
+fn is_allowed_failure_reason_match(line: &str) -> bool {
+    line.contains("SubtypeFailureReason::MissingIndexSignature {")
+}
+
 fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
     let source = fs::read_to_string(checker_path(relative))
         .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
     for (line_index, line) in source.lines().enumerate() {
         let trimmed = line.trim_start();
-        if trimmed.starts_with("//") || is_allowed_shape_return_signature(trimmed) {
+        if trimmed.starts_with("//")
+            || is_allowed_shape_return_signature(trimmed)
+            || is_allowed_failure_reason_match(line)
+        {
             continue;
         }
         for pattern in patterns {
@@ -109,6 +118,8 @@ fn diagnostics_boundary_owns_construction_helpers() {
         "object_type_preserving_display_properties",
         "shallow_object_property_literals_widened_for_call_parameter_display",
         "object_type_with_unknown_display_members",
+        "mapped_property_mismatch_parameter_display_type",
+        "display_property_literals_widened_for_related_info",
         "function_type_from_shape",
         "function_type_with_params_replaced",
         "function_type_with_return_replaced",

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -23,6 +23,13 @@ const DIAGNOSTIC_CONSTRUCTION_MODULES: &[&str] = &[
     "src/state/type_environment/formatting.rs",
 ];
 const DIAGNOSTIC_FUNCTION_CONSTRUCTION_MODULES: &[&str] = &["src/error_reporter/render_failure.rs"];
+const DIAGNOSTIC_SOURCE_COLLECTION_MODULES: &[&str] = &[
+    "src/error_reporter/core/identifier_source_display.rs",
+    "src/error_reporter/core/diagnostic_source/contextual_index_display.rs",
+    "src/error_reporter/core/diagnostic_source/computed_index_source_display.rs",
+    "src/error_reporter/core/diagnostic_source/collection_source_display.rs",
+    "src/error_reporter/core/diagnostic_source/tuple_source_display.rs",
+];
 
 fn checker_path(relative: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
@@ -109,6 +116,32 @@ fn diagnostic_display_callers_route_solver_shape_construction_through_diagnostic
 }
 
 #[test]
+fn diagnostic_source_collection_routes_collection_construction_through_diagnostics_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory().union(",
+        ".factory().union_from_slice(",
+        ".factory.union(",
+        ".factory.union_from_slice(",
+        ".types.union(",
+        ".types.union_from_slice(",
+        ".types.array(",
+        ".types.readonly_type(",
+    ];
+
+    let mut violations = Vec::new();
+    for relative in DIAGNOSTIC_SOURCE_COLLECTION_MODULES {
+        scan_for_patterns(relative, FORBIDDEN_PATTERNS, &mut violations);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "diagnostic source collection display callers must route union/array \
+         construction through query_boundaries::diagnostics:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
 fn diagnostics_boundary_owns_construction_helpers() {
     let source = fs::read_to_string(checker_path(DIAGNOSTICS_BOUNDARY))
         .expect("failed to read query_boundaries/diagnostics.rs");
@@ -120,6 +153,9 @@ fn diagnostics_boundary_owns_construction_helpers() {
         "object_type_with_unknown_display_members",
         "mapped_property_mismatch_parameter_display_type",
         "display_property_literals_widened_for_related_info",
+        "source_display_union_type",
+        "source_display_union_type_from_slice",
+        "rebuilt_array_source_display_type",
         "function_type_from_shape",
         "function_type_with_params_replaced",
         "function_type_with_return_replaced",

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -1,8 +1,8 @@
 //! Diagnostic construction boundary scans.
 //!
 //! Reporter modules choose display policy and source locations. Interning
-//! diagnostic-only object/function/callable solver surfaces belongs in
-//! `query_boundaries::diagnostics`.
+//! diagnostic-only object/function/callable/compound solver surfaces belongs
+//! in `query_boundaries::diagnostics`.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -11,13 +11,21 @@ const DIAGNOSTICS_BOUNDARY: &str = "src/query_boundaries/diagnostics.rs";
 const DIAGNOSTIC_CONSTRUCTION_MODULES: &[&str] = &[
     "src/error_reporter/core/type_display.rs",
     "src/error_reporter/core/excess_display.rs",
+    "src/error_reporter/core_alias_display.rs",
+    "src/error_reporter/core_formatting.rs",
     "src/error_reporter/core/diagnostic_source.rs",
+    "src/error_reporter/core/diagnostic_source/assignment_formatting.rs",
+    "src/error_reporter/core/diagnostic_source/object_literal_targets.rs",
     "src/error_reporter/core/diagnostic_source/static_schema.rs",
+    "src/error_reporter/assignability_contextual_display.rs",
+    "src/error_reporter/assignability_helpers.rs",
     "src/error_reporter/fingerprint_policy.rs",
     "src/error_reporter/generics.rs",
+    "src/error_reporter/property_receiver_formatting.rs",
     "src/error_reporter/properties.rs",
     "src/error_reporter/call_errors/display_formatting.rs",
     "src/error_reporter/call_errors/display_formatting_parameters.rs",
+    "src/error_reporter/call_errors/elaboration_array_mismatch.rs",
     "src/error_reporter/call_errors/error_emission.rs",
     "src/error_reporter/call_errors/elaboration.rs",
     "src/state/type_environment/formatting.rs",
@@ -75,14 +83,42 @@ fn diagnostic_display_callers_route_solver_shape_construction_through_diagnostic
         ".factory().object_with_index(",
         ".factory().function(",
         ".factory().callable(",
+        ".factory().application(",
+        ".factory().union(",
+        ".factory().union_preserve_members(",
+        ".factory().intersection(",
+        ".factory().index_access(",
+        ".factory().array(",
+        ".factory().literal_string(",
+        ".factory().literal_string_atom(",
+        ".factory().literal_number(",
         ".factory.object(",
         ".factory.object_with_index(",
         ".factory.function(",
         ".factory.callable(",
+        ".factory.application(",
+        ".factory.union(",
+        ".factory.union_preserve_members(",
+        ".factory.intersection(",
+        ".factory.index_access(",
+        ".factory.array(",
+        ".factory.literal_string(",
+        ".factory.literal_string_atom(",
+        ".factory.literal_number(",
         ".types.object(",
         ".types.object_with_index(",
         ".types.function(",
         ".types.callable(",
+        ".types.array(",
+        ".types.union(",
+        ".types.union2(",
+        ".types.readonly_type(",
+        ".types.literal_string(",
+        ".types.literal_string_atom(",
+        ".types.literal_number(",
+        "PropertyInfo::new(",
+        "tsz_solver::utils::union_or_single(",
+        "tsz_solver::utils::intersection_or_single(",
         "FunctionShape {",
         "FunctionShape::new(",
         "CallableShape {",
@@ -109,7 +145,8 @@ fn diagnostic_display_callers_route_solver_shape_construction_through_diagnostic
 
     assert!(
         violations.is_empty(),
-        "diagnostic display callers must route solver shape construction \
+        "diagnostic display callers must route solver shape and compound \
+         construction \
          through query_boundaries::diagnostics:\n{}",
         violations.join("\n")
     );
@@ -156,6 +193,22 @@ fn diagnostics_boundary_owns_construction_helpers() {
         "source_display_union_type",
         "source_display_union_type_from_slice",
         "rebuilt_array_source_display_type",
+        "display_application_type",
+        "display_union_type",
+        "display_union_or_single_type",
+        "display_union_preserve_members_type",
+        "display_intersection_type",
+        "display_intersection_or_single_type",
+        "display_array_type",
+        "display_index_access_type",
+        "display_union_with_undefined",
+        "display_string_literal_type",
+        "display_string_literal_atom_type",
+        "display_number_literal_type",
+        "display_rest_parameter_type",
+        "display_property",
+        "mapped_display_property",
+        "static_schema_display_property_from_source",
         "function_type_from_shape",
         "function_type_with_params_replaced",
         "function_type_with_return_replaced",

--- a/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/diagnostic_construction_boundary_scans.rs
@@ -1,0 +1,97 @@
+//! Diagnostic construction boundary scans.
+//!
+//! Reporter modules choose display policy and source locations. Interning
+//! diagnostic-only object/function/callable solver surfaces belongs in
+//! `query_boundaries::diagnostics`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DIAGNOSTICS_BOUNDARY: &str = "src/query_boundaries/diagnostics.rs";
+const DIAGNOSTIC_REPORTER_CONSTRUCTION_MODULES: &[&str] = &[
+    "src/error_reporter/core/type_display.rs",
+    "src/error_reporter/core/excess_display.rs",
+    "src/error_reporter/generics.rs",
+];
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn error_reporters_route_solver_shape_construction_through_diagnostics_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory().object(",
+        ".factory().object_with_index(",
+        ".factory().function(",
+        ".factory().callable(",
+        ".factory.object(",
+        ".factory.object_with_index(",
+        ".factory.function(",
+        ".factory.callable(",
+        ".types.object(",
+        ".types.object_with_index(",
+        ".types.function(",
+        ".types.callable(",
+        "FunctionShape {",
+        "FunctionShape::new(",
+        "CallableShape {",
+        "ObjectShape {",
+        "IndexSignature {",
+        "ParamInfo::required(",
+    ];
+
+    let mut violations = Vec::new();
+    for relative in DIAGNOSTIC_REPORTER_CONSTRUCTION_MODULES {
+        scan_for_patterns(relative, FORBIDDEN_PATTERNS, &mut violations);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "error_reporter modules must route diagnostic solver shape construction \
+         through query_boundaries::diagnostics:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn diagnostics_boundary_owns_construction_helpers() {
+    let source = fs::read_to_string(checker_path(DIAGNOSTICS_BOUNDARY))
+        .expect("failed to read query_boundaries/diagnostics.rs");
+    for helper in [
+        "object_type_from_properties",
+        "object_type_from_shape",
+        "object_type_preserving_display_properties",
+        "function_type_from_shape",
+        "function_type_with_params_replaced",
+        "function_type_with_return_replaced",
+        "function_type_with_params_and_return_replaced",
+        "callable_type_from_shape",
+        "call_only_callable_type",
+        "callable_type_with_signatures_replaced",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::diagnostics must own `{helper}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/excess_property_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/excess_property_construction_boundary_scans.rs
@@ -1,12 +1,14 @@
 //! Excess-property construction boundary scans.
 //!
 //! State checking owns excess-property policy and source traversal. Solver
-//! object shape construction and interning belong behind query boundaries.
+//! object shape construction, target union construction, and interning belong
+//! behind query boundaries.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 const EXCESS_PROPERTY_TAIL: &str = "src/state/state_checking/property/excess_property_tail.rs";
+const EXCESS_PROPERTY_CORE: &str = "src/state/state_checking/property.rs";
 const STATE_CHECKING_BOUNDARY: &str = "src/query_boundaries/state/checking.rs";
 const INTERSECTION_DISPLAY_BOUNDARY: &str = "src/query_boundaries/intersection_display.rs";
 
@@ -18,6 +20,8 @@ fn checker_path(relative: &str) -> PathBuf {
 fn excess_property_tail_routes_object_construction_through_boundaries() {
     let source =
         fs::read_to_string(checker_path(EXCESS_PROPERTY_TAIL)).expect("failed to read source");
+    let core_source =
+        fs::read_to_string(checker_path(EXCESS_PROPERTY_CORE)).expect("failed to read source");
 
     for forbidden in [
         "tsz_solver::ObjectShape {",
@@ -33,11 +37,38 @@ fn excess_property_tail_routes_object_construction_through_boundaries() {
              boundaries, found `{forbidden}`"
         );
     }
+    for forbidden in [
+        "tsz_solver::utils::union_or_single(",
+        "tsz_solver::utils::union_or_single_literal_reduce(",
+    ] {
+        assert!(
+            !source.contains(forbidden) && !core_source.contains(forbidden),
+            "excess-property checking must route target union construction \
+             through query boundaries, found `{forbidden}`"
+        );
+    }
 
     assert!(
         source.contains("intersection_display::collected_properties_object_shape(")
             && source.contains("query::excess_property_any_object_type_from_names("),
         "excess_property_tail should call the intersection/display and state-checking boundaries"
+    );
+    assert!(
+        core_source.contains("query::excess_property_target_union("),
+        "property.rs should route nested excess-property target unions through the state-checking boundary"
+    );
+    assert!(
+        source
+            .matches("query::excess_property_display_target_union(")
+            .count()
+            >= 2,
+        "excess_property_tail should route annotation and discriminant display unions through the state-checking boundary"
+    );
+    assert!(
+        source.contains(
+            "return query::excess_property_target_union(self.ctx.types, matching_members);"
+        ),
+        "excess_property_tail should route discriminant-narrowed target unions through the state-checking boundary"
     );
 }
 
@@ -48,6 +79,16 @@ fn excess_property_boundaries_own_construction_helpers() {
     assert!(
         state_boundary.contains("fn excess_property_any_object_type_from_names("),
         "state checking boundary must own synthetic excess-property object construction"
+    );
+    assert!(
+        state_boundary.contains("fn excess_property_target_union(")
+            && state_boundary.contains("fn excess_property_display_target_union("),
+        "state checking boundary must own excess-property target union construction"
+    );
+    assert!(
+        state_boundary.contains("tsz_solver::utils::union_or_single(")
+            && state_boundary.contains("tsz_solver::utils::union_or_single_literal_reduce("),
+        "state checking boundary must own excess-property target union constructors"
     );
 
     let intersection_boundary = fs::read_to_string(checker_path(INTERSECTION_DISPLAY_BOUNDARY))

--- a/crates/tsz-checker/tests/arch_source_scans/excess_property_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/excess_property_construction_boundary_scans.rs
@@ -1,0 +1,59 @@
+//! Excess-property construction boundary scans.
+//!
+//! State checking owns excess-property policy and source traversal. Solver
+//! object shape construction and interning belong behind query boundaries.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const EXCESS_PROPERTY_TAIL: &str = "src/state/state_checking/property/excess_property_tail.rs";
+const STATE_CHECKING_BOUNDARY: &str = "src/query_boundaries/state/checking.rs";
+const INTERSECTION_DISPLAY_BOUNDARY: &str = "src/query_boundaries/intersection_display.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+#[test]
+fn excess_property_tail_routes_object_construction_through_boundaries() {
+    let source =
+        fs::read_to_string(checker_path(EXCESS_PROPERTY_TAIL)).expect("failed to read source");
+
+    for forbidden in [
+        "tsz_solver::ObjectShape {",
+        "ObjectShape::default()",
+        "tsz_solver::PropertyInfo {",
+        "PropertyInfo::new(",
+        ".factory().object(",
+        ".factory.object(",
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "excess_property_tail must route object construction through query \
+             boundaries, found `{forbidden}`"
+        );
+    }
+
+    assert!(
+        source.contains("intersection_display::collected_properties_object_shape(")
+            && source.contains("query::excess_property_any_object_type_from_names("),
+        "excess_property_tail should call the intersection/display and state-checking boundaries"
+    );
+}
+
+#[test]
+fn excess_property_boundaries_own_construction_helpers() {
+    let state_boundary = fs::read_to_string(checker_path(STATE_CHECKING_BOUNDARY))
+        .expect("failed to read state checking boundary");
+    assert!(
+        state_boundary.contains("fn excess_property_any_object_type_from_names("),
+        "state checking boundary must own synthetic excess-property object construction"
+    );
+
+    let intersection_boundary = fs::read_to_string(checker_path(INTERSECTION_DISPLAY_BOUNDARY))
+        .expect("failed to read intersection display boundary");
+    assert!(
+        intersection_boundary.contains("fn collected_properties_object_shape"),
+        "intersection display boundary must own collected-property object shape construction"
+    );
+}

--- a/crates/tsz-checker/tests/arch_source_scans/excess_property_nested_target_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/excess_property_nested_target_construction_boundary_scans.rs
@@ -1,0 +1,92 @@
+//! Excess-property nested target construction boundary scans.
+//!
+//! The property checker owns AST/source-order facts and diagnostic control flow.
+//! Construction for nested excess-property intersections, raw annotation
+//! intersections, and optional recursive nested-target unions belongs in
+//! `query_boundaries::state::checking`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const PROPERTY_CHECKER: &str = "src/state/state_checking/property.rs";
+const EXCESS_PROPERTY_TAIL: &str = "src/state/state_checking/property/excess_property_tail.rs";
+const STATE_CHECKING_BOUNDARY: &str = "src/query_boundaries/state/checking.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn production_source_without_comments(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact(source: &str) -> String {
+    source.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn excess_property_nested_target_construction_routes_through_boundary() {
+    let property_source = fs::read_to_string(checker_path(PROPERTY_CHECKER))
+        .expect("failed to read state_checking/property.rs");
+    let tail_source = fs::read_to_string(checker_path(EXCESS_PROPERTY_TAIL))
+        .expect("failed to read state_checking/property/excess_property_tail.rs");
+    let source = production_source_without_comments(&format!("{property_source}\n{tail_source}"));
+    let compact_source = compact(&source);
+    let forbidden = [
+        "tsz_solver::utils::intersection_or_single(",
+        ".intersect_types_raw2(",
+        "self.ctx.types.union(vec![",
+        ".ctx.types.union(vec![",
+        "raw_intersection_or_single(",
+    ];
+
+    let mut violations = Vec::new();
+    for pattern in forbidden {
+        if source.contains(pattern) || compact_source.contains(&compact(pattern)) {
+            violations.push(pattern);
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "property excess-checking must route nested target construction through \
+         query_boundaries::state::checking, found: {}",
+        violations.join(", ")
+    );
+}
+
+#[test]
+fn state_checking_boundary_owns_excess_property_nested_target_helpers() {
+    let source = fs::read_to_string(checker_path(STATE_CHECKING_BOUNDARY))
+        .expect("failed to read query_boundaries/state/checking.rs");
+
+    for helper in [
+        "excess_property_nested_target_intersection_or_single",
+        "excess_property_annotation_intersection_or_single",
+        "optional_excess_property_nested_target",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::state::checking must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "tsz_solver::utils::intersection_or_single(",
+        "db.intersect_types_raw2(",
+        "db.union(vec![target, TypeId::UNDEFINED])",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::state::checking should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/expression_result_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/expression_result_construction_boundary_scans.rs
@@ -1,0 +1,149 @@
+//! Expression result construction boundary scans.
+//!
+//! Expression computation owns AST classification, diagnostics, relation probes,
+//! and result-collapse policy. Solver construction for selected expression
+//! result surfaces belongs in `query_boundaries::type_computation::expression_results`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const NULLISH_COALESCING: &str = "src/types/computation/nullish_coalescing.rs";
+const EXPRESSION_GUARDS: &str = "src/types/computation/expression_guards.rs";
+const BINARY_SUPPORT: &str = "src/types/computation/binary_support.rs";
+const COMPUTATION_HELPERS: &str = "src/types/computation/helpers.rs";
+const RESULT_BOUNDARY: &str = "src/query_boundaries/type_computation/expression_results.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_file_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    scan_source_for_patterns(relative, &source, patterns, 0, violations);
+}
+
+fn scan_slice_for_patterns(
+    relative: &str,
+    start_marker: &str,
+    end_marker: &str,
+    patterns: &[&str],
+    violations: &mut Vec<String>,
+) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    let start = source
+        .find(start_marker)
+        .unwrap_or_else(|| panic!("failed to find start marker `{start_marker}` in {relative}"));
+    let after_start = &source[start..];
+    let end = after_start
+        .find(end_marker)
+        .unwrap_or_else(|| panic!("failed to find end marker `{end_marker}` in {relative}"));
+    let line_offset = source[..start].lines().count();
+    scan_source_for_patterns(
+        relative,
+        &after_start[..end],
+        patterns,
+        line_offset,
+        violations,
+    );
+}
+
+fn scan_source_for_patterns(
+    relative: &str,
+    source: &str,
+    patterns: &[&str],
+    line_offset: usize,
+    violations: &mut Vec<String>,
+) {
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_offset + line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn expression_result_callers_route_solver_construction_through_boundary() {
+    let mut violations = Vec::new();
+
+    scan_file_for_patterns(
+        NULLISH_COALESCING,
+        &[".factory().object(", ".factory().union2("],
+        &mut violations,
+    );
+    scan_file_for_patterns(EXPRESSION_GUARDS, &[".factory().union("], &mut violations);
+    scan_slice_for_patterns(
+        BINARY_SUPPORT,
+        "pub(crate) fn reduce_literal_index_access_property_types(",
+        "fn global_function_interface_type_for_instanceof(",
+        &[".factory().union_preserve_members("],
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        BINARY_SUPPORT,
+        "pub(super) fn typeof_result_type_if_typeof(",
+        "/// Check if an identifier node's declared type overlaps",
+        &[".literal_string(", ".factory().union("],
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        COMPUTATION_HELPERS,
+        "k if k == SyntaxKind::TypeOfKeyword as u16 =>",
+        "// Unary + and - return number",
+        &[".literal_string(", ".factory().union("],
+        &mut violations,
+    );
+
+    assert!(
+        violations.is_empty(),
+        "expression result callers must route solver construction through \
+         query_boundaries::type_computation::expression_results:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn expression_result_boundary_owns_result_construction_helpers() {
+    let source = fs::read_to_string(checker_path(RESULT_BOUNDARY))
+        .expect("failed to read query_boundaries/type_computation/expression_results.rs");
+
+    for helper in [
+        "empty_object_type",
+        "nullish_coalescing_union",
+        "conditional_branch_union",
+        "literal_index_access_union",
+        "typeof_result_union",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::type_computation::expression_results must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "db.object(",
+        "db.union2(",
+        "db.union(",
+        "db.union_preserve_members(",
+        "db.literal_string(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::type_computation::expression_results should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/import_attribute_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/import_attribute_construction_boundary_scans.rs
@@ -1,0 +1,102 @@
+//! Import attribute construction boundary scans.
+//!
+//! Static and dynamic import checkers gather syntax facts and issue grammar or
+//! assignability diagnostics. Solver property/object construction for
+//! `ImportAttributes` and `ImportCallOptions` belongs in
+//! `query_boundaries::import_attributes`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const IMPORT_ATTRIBUTE_CALLERS: &[&str] = &[
+    "src/declarations/import/declaration_attributes.rs",
+    "src/declarations/dynamic_import_checker.rs",
+];
+const IMPORT_ATTRIBUTE_BOUNDARY: &str = "src/query_boundaries/import_attributes.rs";
+const COMMON_BOUNDARY: &str = "src/query_boundaries/common.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}(")) || source.contains(&format!("fn {name}<"))
+}
+
+#[test]
+fn import_attribute_callers_route_solver_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        "PropertyInfo {",
+        "PropertyInfo::new(",
+        "PropertyInfo::opt(",
+        ".factory().object(",
+        ".factory().literal_string(",
+    ];
+
+    let mut violations = Vec::new();
+    for caller in IMPORT_ATTRIBUTE_CALLERS {
+        scan_for_patterns(caller, FORBIDDEN_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "import attribute/options callers must route solver construction \
+         through query_boundaries::import_attributes:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn import_attributes_boundary_owns_import_attribute_construction_helpers() {
+    let source = fs::read_to_string(checker_path(IMPORT_ATTRIBUTE_BOUNDARY))
+        .expect("failed to read query_boundaries/import_attributes.rs");
+    let common =
+        fs::read_to_string(checker_path(COMMON_BOUNDARY)).expect("failed to read common.rs");
+
+    for helper in [
+        "import_attribute_literal_string_type",
+        "import_attribute_property",
+        "optional_import_option_property",
+        "import_attribute_object_type",
+        "import_call_options_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::import_attributes must own `{helper}`"
+        );
+        assert!(
+            !defines_fn(&common, helper),
+            "query_boundaries::common must not define `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "db.literal_string(",
+        "PropertyInfo::new(",
+        "PropertyInfo::opt(",
+        "db.object(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::import_attributes should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/indexed_access_key_space_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/indexed_access_key_space_construction_boundary_scans.rs
@@ -1,0 +1,107 @@
+//! Indexed-access key-space construction boundary scans.
+//!
+//! Indexed-access validation owns AST/source selection, relation policy, and
+//! diagnostics. Solver construction for key spaces and indexed-access surfaces
+//! belongs in `query_boundaries::indexed_access_key_space`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const INDEXED_ACCESS_HELPERS: &str =
+    "src/types/type_checking/indexed_access/indexed_access_helpers.rs";
+const DEFERRED_CONDITIONAL_INDEX: &str =
+    "src/types/type_checking/indexed_access/deferred_conditional_index.rs";
+const ERROR_CONTAGION: &str = "src/types/type_checking/indexed_access/error_contagion.rs";
+const INDEXED_ACCESS_KEY_SPACE_BOUNDARY: &str = "src/query_boundaries/indexed_access_key_space.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn indexed_access_key_space_construction_routes_through_boundary() {
+    let forbidden = [
+        ".factory().keyof(",
+        ".factory().index_access(",
+        ".factory().literal_number(",
+        ".factory().literal_string_atom(",
+        ".factory().union(",
+        ".types.union(",
+        ".types.union2(",
+        "tsz_solver::utils::union_or_single(",
+    ];
+    let mut violations = Vec::new();
+
+    for file in [
+        INDEXED_ACCESS_HELPERS,
+        DEFERRED_CONDITIONAL_INDEX,
+        ERROR_CONTAGION,
+    ] {
+        scan_for_patterns(file, &forbidden, &mut violations);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "indexed-access key-space construction must route through \
+         query_boundaries::indexed_access_key_space:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn indexed_access_key_space_boundary_owns_construction_helpers() {
+    let source = fs::read_to_string(checker_path(INDEXED_ACCESS_KEY_SPACE_BOUNDARY))
+        .expect("failed to read query_boundaries/indexed_access_key_space.rs");
+
+    for helper in [
+        "keyof_type",
+        "indexed_access_type",
+        "literal_number_key",
+        "literal_string_key",
+        "literal_key_union",
+        "key_space_union",
+        "string_or_number_key_space",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::indexed_access_key_space must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "db.keyof(",
+        "db.index_access(",
+        "db.literal_number(",
+        "db.literal_string_atom(",
+        "db.union(",
+        "db.union2(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::indexed_access_key_space should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/interface_type_literal_surface_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/interface_type_literal_surface_construction_boundary_scans.rs
@@ -1,0 +1,164 @@
+//! Interface/type-literal own surface construction boundary scans.
+//!
+//! `get_type_of_interface` and `get_type_from_type_literal` own AST traversal,
+//! diagnostics, ordering, and member classification. Solver construction for
+//! declared properties, indexes, functions, callables, and object surfaces
+//! belongs in `query_boundaries::type_construction` or
+//! `query_boundaries::construct_signatures`.
+//!
+//! This scan intentionally excludes interface heritage/merge reconstruction in
+//! `interface_type.rs`; that is a separate, higher-risk surface.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const INTERFACE_TYPE: &str = "src/types/interface_type.rs";
+const TYPE_LITERAL_CHECKER: &str = "src/types/type_literal_checker.rs";
+const TYPE_CONSTRUCTION_BOUNDARY: &str = "src/query_boundaries/type_construction.rs";
+const CONSTRUCT_SIGNATURES_BOUNDARY: &str = "src/query_boundaries/construct_signatures.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn production_source_without_comments(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact(source: &str) -> String {
+    source.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn slice_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+    let start_idx = source
+        .find(start)
+        .unwrap_or_else(|| panic!("missing start marker `{start}`"));
+    let rest = &source[start_idx..];
+    let end_idx = rest
+        .find(end)
+        .unwrap_or_else(|| panic!("missing end marker `{end}`"));
+    &rest[..end_idx]
+}
+
+fn scan_source_for_patterns(source: &str, label: &str, patterns: &[&str]) -> Vec<String> {
+    let source = production_source_without_comments(source);
+    let compact_source = compact(&source);
+    patterns
+        .iter()
+        .filter(|pattern| source.contains(**pattern) || compact_source.contains(&compact(pattern)))
+        .map(|pattern| format!("{label} contains `{pattern}`"))
+        .collect()
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn interface_and_type_literal_own_surfaces_route_solver_construction_through_boundaries() {
+    let interface_source =
+        fs::read_to_string(checker_path(INTERFACE_TYPE)).expect("failed to read interface_type.rs");
+    let type_literal_source = fs::read_to_string(checker_path(TYPE_LITERAL_CHECKER))
+        .expect("failed to read type_literal_checker.rs");
+
+    let interface_surface = slice_between(
+        &interface_source,
+        "pub(crate) fn get_type_of_interface",
+        "pub(crate) fn merge_interface_heritage_types",
+    );
+    let type_literal_surface = slice_between(
+        &type_literal_source,
+        "pub(crate) fn get_type_from_type_literal",
+        "\n    }\n}",
+    );
+
+    let patterns = [
+        "PropertyInfo {",
+        "Visibility::Public",
+        "IndexSignature {",
+        "FunctionShape {",
+        "CallableShape {",
+        "ObjectShape {",
+        "factory.function(",
+        "factory.callable(",
+        "factory.object_with_index(",
+        "factory.object_with_symbol(",
+        "factory.object_with_late_bound_members(",
+        "intersect_types_raw2(",
+    ];
+
+    let mut violations =
+        scan_source_for_patterns(interface_surface, "get_type_of_interface", &patterns);
+    violations.extend(scan_source_for_patterns(
+        type_literal_surface,
+        "get_type_from_type_literal",
+        &patterns,
+    ));
+
+    assert!(
+        violations.is_empty(),
+        "interface/type-literal own surfaces must route solver construction \
+         through query boundaries:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn interface_and_type_literal_boundaries_own_surface_helpers() {
+    let type_construction = fs::read_to_string(checker_path(TYPE_CONSTRUCTION_BOUNDARY))
+        .expect("failed to read query_boundaries/type_construction.rs");
+    let construct_signatures = fs::read_to_string(checker_path(CONSTRUCT_SIGNATURES_BOUNDARY))
+        .expect("failed to read query_boundaries/construct_signatures.rs");
+
+    for helper in [
+        "declared_surface_property",
+        "declared_index_signature",
+        "declared_object_with_symbol",
+        "declared_object_with_indexes",
+        "type_literal_object_with_late_bound",
+        "type_literal_object_with_indexes_and_late_bound",
+        "type_literal_number_index_member",
+        "raw_intersection_pair",
+    ] {
+        assert!(
+            defines_fn(&type_construction, helper),
+            "query_boundaries::type_construction must own `{helper}`"
+        );
+    }
+
+    for helper in [
+        "declared_method_function_type",
+        "declared_callable_surface_type",
+    ] {
+        assert!(
+            defines_fn(&construct_signatures, helper),
+            "query_boundaries::construct_signatures must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "PropertyInfo {",
+        "Visibility::Public",
+        "IndexSignature {",
+        "ObjectShape {",
+        "db.object_with_flags_and_symbol(",
+        "db.object_with_index(",
+        "db.intersect_types_raw2(",
+    ] {
+        assert!(
+            type_construction.contains(construction_pattern),
+            "query_boundaries::type_construction should own `{construction_pattern}`"
+        );
+    }
+
+    for construction_pattern in ["FunctionShape {", "CallableShape {", "db.callable("] {
+        assert!(
+            construct_signatures.contains(construction_pattern),
+            "query_boundaries::construct_signatures should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/js_class_property_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/js_class_property_construction_boundary_scans.rs
@@ -1,0 +1,105 @@
+//! JS class-property construction boundary scans.
+//!
+//! JS class-property scanning gathers AST, JSDoc, modifier, and source-order
+//! facts. Solver type-parameter, array/union, property, callable, and object
+//! construction belongs in `query_boundaries::checkers::class_properties`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const JS_CLASS_PROPERTIES: &str = "src/types/class_type/js_class_properties.rs";
+const JS_CLASS_PROPERTY_BOUNDARY: &str = "src/query_boundaries/checkers/class_properties.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn js_class_property_scanner_routes_solver_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".array(",
+        ".type_param(",
+        ".union(",
+        ".union2(",
+        ".callable(",
+        ".object(",
+        ".object_with_index(",
+        "TypeParamInfo {",
+        "TypeParamInfo::simple(",
+        "TypeParamOrigin::User",
+        "PropertyInfo {",
+        "PropertyInfo::new(",
+        "ParamInfo {",
+        "ParamInfo::required(",
+        "CallSignature {",
+        "CallableShape {",
+        "CallableShape::default()",
+        "ObjectShape {",
+        "ObjectShape::default()",
+    ];
+
+    let mut violations = Vec::new();
+    scan_for_patterns(JS_CLASS_PROPERTIES, FORBIDDEN_PATTERNS, &mut violations);
+    assert!(
+        violations.is_empty(),
+        "JS class-property scanning must route solver shape construction \
+         through query_boundaries::checkers::class_properties:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn js_class_property_boundary_owns_construction_helpers_and_literals() {
+    let source = fs::read_to_string(checker_path(JS_CLASS_PROPERTY_BOUNDARY))
+        .expect("failed to read query_boundaries/checkers/class_properties.rs");
+
+    for helper in [
+        "js_class_type_param_info",
+        "js_class_type_param_type",
+        "js_class_array_type",
+        "js_class_union_type",
+        "js_class_union_pair_type",
+        "js_class_property_info",
+        "js_class_method_callable_type",
+        "js_class_instance_object_type",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::checkers::class_properties must own `{helper}`"
+        );
+    }
+
+    for shape_pattern in [
+        "TypeParamInfo {",
+        "TypeParamOrigin::User",
+        "PropertyInfo {",
+        "ParamInfo {",
+        "CallSignature {",
+        "CallableShape {",
+        "ObjectShape {",
+    ] {
+        assert!(
+            source.contains(shape_pattern),
+            "query_boundaries::checkers::class_properties should own `{shape_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
@@ -1,16 +1,19 @@
 //! JSDoc construction boundary scans.
 //!
 //! JSDoc resolution code parses source text and gathers facts. Raw solver
-//! `FunctionShape`, `ObjectShape`, and indexed-object construction belongs in
-//! `query_boundaries::jsdoc_construction`.
+//! `FunctionShape`, `ObjectShape`, indexed-object construction, and expression
+//! type construction belongs in `query_boundaries::jsdoc_construction`.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 const JSDOC_CONSTRUCTION_CALLERS: &[&str] = &[
+    "src/jsdoc/resolution/generic_typedef.rs",
     "src/jsdoc/resolution/type_construction.rs",
     "src/jsdoc/resolution/name_resolution.rs",
     "src/jsdoc/params_type_strings.rs",
+    "src/jsdoc/diagnostics_import_type_constraints.rs",
+    "src/jsdoc/lookup.rs",
 ];
 
 const JSDOC_CONSTRUCTION_BOUNDARY: &str = "src/query_boundaries/jsdoc_construction.rs";
@@ -48,6 +51,23 @@ fn jsdoc_callers_route_solver_shape_construction_through_boundary() {
         ".object(",
         ".object_with_index(",
         ".callable(",
+        ".array(",
+        ".union(",
+        ".union2(",
+        ".intersection(",
+        ".intersection2(",
+        ".application(",
+        ".tuple(",
+        ".index_access(",
+        ".keyof(",
+        ".mapped(",
+        ".conditional(",
+        ".type_param(",
+        "TupleElement {",
+        "MappedType {",
+        "ConditionalType {",
+        "TypeParamInfo {",
+        "TypeParamOrigin::User",
     ];
 
     let mut violations = Vec::new();
@@ -75,6 +95,20 @@ fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
         "jsdoc_object_type",
         "jsdoc_object_index_type",
         "jsdoc_function_type",
+        "jsdoc_array_type",
+        "jsdoc_union_type",
+        "jsdoc_union_pair_type",
+        "jsdoc_intersection_type",
+        "jsdoc_intersection_pair_type",
+        "jsdoc_application_type",
+        "jsdoc_index_access_type",
+        "jsdoc_keyof_type",
+        "jsdoc_type_param_info",
+        "jsdoc_type_param_type",
+        "jsdoc_tuple_type",
+        "jsdoc_tuple_element",
+        "jsdoc_mapped_type",
+        "jsdoc_conditional_type",
     ] {
         assert!(
             source.contains(&format!("fn {helper}(")),
@@ -86,7 +120,16 @@ fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
         );
     }
 
-    for shape_pattern in ["FunctionShape {", "ObjectShape {", "IndexSignature {"] {
+    for shape_pattern in [
+        "FunctionShape {",
+        "ObjectShape {",
+        "IndexSignature {",
+        "TupleElement {",
+        "MappedType {",
+        "ConditionalType {",
+        "TypeParamInfo {",
+        "TypeParamOrigin::User",
+    ] {
         assert!(
             source.contains(shape_pattern),
             "query_boundaries::jsdoc_construction should own `{shape_pattern}`"

--- a/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
@@ -1,0 +1,95 @@
+//! JSDoc construction boundary scans.
+//!
+//! JSDoc resolution code parses source text and gathers facts. Raw solver
+//! `FunctionShape`, `ObjectShape`, and indexed-object construction belongs in
+//! `query_boundaries::jsdoc_construction`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const JSDOC_CONSTRUCTION_CALLERS: &[&str] = &[
+    "src/jsdoc/resolution/type_construction.rs",
+    "src/jsdoc/resolution/name_resolution.rs",
+    "src/jsdoc/params_type_strings.rs",
+];
+
+const JSDOC_CONSTRUCTION_BOUNDARY: &str = "src/query_boundaries/jsdoc_construction.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn jsdoc_callers_route_solver_shape_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        "FunctionShape",
+        "ObjectShape",
+        "IndexSignature",
+        ".function(",
+        ".object(",
+        ".object_with_index(",
+        ".callable(",
+    ];
+
+    let mut violations = Vec::new();
+    for module in JSDOC_CONSTRUCTION_CALLERS {
+        scan_for_patterns(module, FORBIDDEN_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "JSDoc construction callers must route solver shape construction \
+         through query_boundaries::jsdoc_construction:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
+    let source = fs::read_to_string(checker_path(JSDOC_CONSTRUCTION_BOUNDARY))
+        .expect("failed to read query_boundaries/jsdoc_construction.rs");
+    let common = fs::read_to_string(checker_path("src/query_boundaries/common.rs"))
+        .expect("failed to read query_boundaries/common.rs");
+
+    for helper in [
+        "jsdoc_object_index_fact",
+        "jsdoc_empty_object_type",
+        "jsdoc_object_type",
+        "jsdoc_object_index_type",
+        "jsdoc_function_type",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::jsdoc_construction must own `{helper}`"
+        );
+        assert!(
+            !common.contains(&format!("fn {helper}(")),
+            "JSDoc construction helper `{helper}` must not drift into common.rs"
+        );
+    }
+
+    for shape_pattern in ["FunctionShape {", "ObjectShape {", "IndexSignature {"] {
+        assert!(
+            source.contains(shape_pattern),
+            "query_boundaries::jsdoc_construction should own `{shape_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
@@ -60,6 +60,16 @@ fn jsdoc_callers_route_solver_shape_construction_through_boundary() {
         ".tuple(",
         ".index_access(",
         ".keyof(",
+        "factory().lazy(",
+        ".lazy(",
+        "factory().readonly_type(",
+        ".readonly_type(",
+        "factory().literal_string(",
+        ".literal_string(",
+        "factory().literal_boolean(",
+        ".literal_boolean(",
+        "factory().literal_number(",
+        ".literal_number(",
         ".mapped(",
         ".conditional(",
         ".type_param(",
@@ -75,6 +85,7 @@ fn jsdoc_callers_route_solver_shape_construction_through_boundary() {
         "ParamInfo::unnamed(",
         "PropertyInfo::new(",
         "PropertyInfo {",
+        "TypePredicate {",
     ];
 
     let mut violations = Vec::new();
@@ -110,12 +121,18 @@ fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
         "jsdoc_application_type",
         "jsdoc_index_access_type",
         "jsdoc_keyof_type",
+        "jsdoc_lazy_type",
+        "jsdoc_readonly_type",
+        "jsdoc_literal_string_type",
+        "jsdoc_literal_boolean_type",
+        "jsdoc_literal_number_type",
         "jsdoc_type_param_info",
         "jsdoc_type_param_type",
         "jsdoc_tuple_type",
         "jsdoc_tuple_element",
         "jsdoc_param_info",
         "jsdoc_property_info",
+        "jsdoc_type_predicate",
         "jsdoc_mapped_type",
         "jsdoc_conditional_type",
     ] {
@@ -140,6 +157,7 @@ fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
         "TypeParamOrigin::User",
         "ParamInfo {",
         "PropertyInfo {",
+        "TypePredicate {",
     ] {
         assert!(
             source.contains(shape_pattern),

--- a/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsdoc_construction_boundary_scans.rs
@@ -68,6 +68,13 @@ fn jsdoc_callers_route_solver_shape_construction_through_boundary() {
         "ConditionalType {",
         "TypeParamInfo {",
         "TypeParamOrigin::User",
+        "ParamInfo {",
+        "ParamInfo::required(",
+        "ParamInfo::optional(",
+        "ParamInfo::rest(",
+        "ParamInfo::unnamed(",
+        "PropertyInfo::new(",
+        "PropertyInfo {",
     ];
 
     let mut violations = Vec::new();
@@ -107,6 +114,8 @@ fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
         "jsdoc_type_param_type",
         "jsdoc_tuple_type",
         "jsdoc_tuple_element",
+        "jsdoc_param_info",
+        "jsdoc_property_info",
         "jsdoc_mapped_type",
         "jsdoc_conditional_type",
     ] {
@@ -129,6 +138,8 @@ fn jsdoc_construction_boundary_owns_helpers_and_shape_literals() {
         "ConditionalType {",
         "TypeParamInfo {",
         "TypeParamOrigin::User",
+        "ParamInfo {",
+        "PropertyInfo {",
     ] {
         assert!(
             source.contains(shape_pattern),

--- a/crates/tsz-checker/tests/arch_source_scans/jsx_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsx_construction_boundary_scans.rs
@@ -1,13 +1,15 @@
 //! JSX construction boundary scans.
 //!
 //! JSX checker modules gather JSX syntax, prop, and callback facts. Interning
-//! object/function/callable solver types and rebuilding `FunctionShape`
-//! literals belongs in `query_boundaries::checkers::jsx`.
+//! object/function/callable and compound solver types, rebuilding
+//! `FunctionShape` literals, and creating synthetic solver properties belongs
+//! in `query_boundaries::checkers::jsx`.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 const JSX_CHECKER_ROOT: &str = "src/checkers/jsx";
+const JSX_ADDITIONAL_CONSTRUCTION_MODULES: &[&str] = &["src/dispatch/jsx.rs"];
 const JSX_CONSTRUCTION_BOUNDARY: &str = "src/query_boundaries/checkers/jsx.rs";
 
 fn checker_path(relative: &str) -> PathBuf {
@@ -56,25 +58,58 @@ fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<Str
 #[test]
 fn jsx_checkers_route_solver_shape_construction_through_boundary() {
     const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory()",
         ".factory().object(",
         ".factory().function(",
         ".factory().callable(",
+        ".factory().union(",
+        ".factory().union2(",
+        ".factory().intersection(",
+        ".factory().intersection2(",
+        ".factory().application(",
+        ".factory().index_access(",
+        ".factory().array(",
+        ".factory().tuple(",
         "factory().object(",
         "factory().function(",
         "factory().callable(",
+        "factory().union(",
+        "factory().union2(",
+        "factory().intersection(",
+        "factory().intersection2(",
+        "factory().application(",
+        "factory().index_access(",
+        "factory().array(",
+        "factory().tuple(",
         ".factory.object(",
         ".factory.function(",
         ".factory.callable(",
+        ".types.union(",
+        ".types.union2(",
+        ".types.intersection(",
+        ".types.intersection2(",
+        ".types.application(",
+        ".types.index_access(",
+        ".types.array(",
+        ".types.tuple(",
         "FunctionShape {",
         "FunctionShape::new(",
         "CallableShape {",
         "ObjectShape {",
         "ParamInfo::required(",
+        "PropertyInfo::new(",
+        "PropertyInfo {",
+        "TupleElement {",
     ];
 
     let root = checker_path(JSX_CHECKER_ROOT);
     let mut files = Vec::new();
     collect_rust_files(&root, &mut files);
+    files.extend(
+        JSX_ADDITIONAL_CONSTRUCTION_MODULES
+            .iter()
+            .map(|relative| checker_path(relative)),
+    );
     files.sort();
 
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -110,6 +145,17 @@ fn jsx_boundary_owns_construction_helpers() {
         "object_type_from_properties",
         "empty_props_object_type",
         "props_param_type_or_empty",
+        "property_info",
+        "property_info_with_write_type",
+        "union_type_from_members",
+        "union_type_from_pair",
+        "intersection_type_from_members",
+        "intersection_type_from_pair",
+        "array_type_from_element",
+        "tuple_type_from_elements",
+        "tuple_type_from_required_element_types",
+        "type_application_from_args",
+        "index_access_type",
         "function_type_from_shape",
         "function_type_from_parts",
         "single_required_param_function_type",

--- a/crates/tsz-checker/tests/arch_source_scans/jsx_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/jsx_construction_boundary_scans.rs
@@ -1,0 +1,128 @@
+//! JSX construction boundary scans.
+//!
+//! JSX checker modules gather JSX syntax, prop, and callback facts. Interning
+//! object/function/callable solver types and rebuilding `FunctionShape`
+//! literals belongs in `query_boundaries::checkers::jsx`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const JSX_CHECKER_ROOT: &str = "src/checkers/jsx";
+const JSX_CONSTRUCTION_BOUNDARY: &str = "src/query_boundaries/checkers/jsx.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn collect_rust_files(dir: &Path, files: &mut Vec<PathBuf>) {
+    for entry in
+        fs::read_dir(dir).unwrap_or_else(|err| panic!("failed to read {}: {err}", dir.display()))
+    {
+        let path = entry
+            .unwrap_or_else(|err| panic!("failed to read entry under {}: {err}", dir.display()))
+            .path();
+        if path.is_dir() {
+            collect_rust_files(&path, files);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            files.push(path);
+        }
+    }
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        // Return types and argument types may mention shape structs as
+        // read-only data. This scan guards construction, not type signatures.
+        if trimmed.contains("->") || trimmed.ends_with("&tsz_solver::FunctionShape,") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn jsx_checkers_route_solver_shape_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory().object(",
+        ".factory().function(",
+        ".factory().callable(",
+        "factory().object(",
+        "factory().function(",
+        "factory().callable(",
+        ".factory.object(",
+        ".factory.function(",
+        ".factory.callable(",
+        "FunctionShape {",
+        "FunctionShape::new(",
+        "CallableShape {",
+        "ObjectShape {",
+        "ParamInfo::required(",
+    ];
+
+    let root = checker_path(JSX_CHECKER_ROOT);
+    let mut files = Vec::new();
+    collect_rust_files(&root, &mut files);
+    files.sort();
+
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut violations = Vec::new();
+    for file in files {
+        let relative = file
+            .strip_prefix(manifest_dir)
+            .unwrap_or_else(|err| {
+                panic!(
+                    "failed to strip manifest dir {} from {}: {err}",
+                    manifest_dir.display(),
+                    file.display()
+                )
+            })
+            .to_str()
+            .expect("checker path is valid UTF-8");
+        scan_for_patterns(relative, FORBIDDEN_PATTERNS, &mut violations);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "JSX checker modules must route solver shape construction through \
+         query_boundaries::checkers::jsx:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn jsx_boundary_owns_construction_helpers() {
+    let source = fs::read_to_string(checker_path(JSX_CONSTRUCTION_BOUNDARY))
+        .expect("failed to read query_boundaries/checkers/jsx.rs");
+    for helper in [
+        "object_type_from_properties",
+        "empty_props_object_type",
+        "props_param_type_or_empty",
+        "function_type_from_shape",
+        "function_type_from_parts",
+        "single_required_param_function_type",
+        "function_type_with_mapped_component_types",
+        "function_type_without_this",
+        "construct_signature_function_shape",
+        "push_required_param",
+        "synthetic_single_param_function_shape",
+        "instantiate_function_shape_preserving_unresolved_params",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::checkers::jsx must own `{helper}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/module_augmentation_surface_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/module_augmentation_surface_construction_boundary_scans.rs
@@ -1,0 +1,115 @@
+//! Module augmentation surface construction boundary scans.
+//!
+//! `types/module_augmentation.rs` owns augmentation discovery, member merge
+//! policy, definition-store publication, and recursive prototype routing.
+//! Solver construction for augmented properties, application references,
+//! object/index/callable surfaces, and fallback intersections belongs in
+//! `query_boundaries::module_augmentation`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const MODULE_AUGMENTATION: &str = "src/types/module_augmentation.rs";
+const MODULE_AUGMENTATION_BOUNDARY: &str = "src/query_boundaries/module_augmentation.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn production_source_without_comments(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact(source: &str) -> String {
+    source.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn scan_source_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    let source = production_source_without_comments(&source);
+    let compact_source = compact(&source);
+    for pattern in patterns {
+        if source.contains(pattern) || compact_source.contains(&compact(pattern)) {
+            violations.push(format!("{relative} contains `{pattern}`"));
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn module_augmentation_surfaces_route_solver_construction_through_boundary() {
+    let mut violations = Vec::new();
+    let patterns = [
+        "PropertyInfo {",
+        "Visibility::Public",
+        "ObjectShape {",
+        "CallableShape {",
+        ".ctx.types.factory().application(",
+        "self.ctx.types.factory().application(",
+        ".factory().application(",
+        "factory.application(",
+        "factory.object(",
+        "factory.object_with",
+        "factory.object_with_index(",
+        "factory.callable(",
+        "factory.intersection2(",
+        ".types.object(",
+        ".types.intersection2(",
+    ];
+
+    scan_source_for_patterns(MODULE_AUGMENTATION, &patterns, &mut violations);
+
+    assert!(
+        violations.is_empty(),
+        "module augmentation surfaces must route solver construction through \
+         query_boundaries::module_augmentation:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn module_augmentation_boundary_owns_surface_helpers() {
+    let source = fs::read_to_string(checker_path(MODULE_AUGMENTATION_BOUNDARY))
+        .expect("failed to read query_boundaries/module_augmentation.rs");
+
+    for helper in [
+        "augmentation_member_property",
+        "augmentation_any_member_property",
+        "self_reference_application_type",
+        "augmented_object_type",
+        "augmented_object_with_index_type",
+        "augmented_callable_type",
+        "other_target_with_augmentation_members",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::module_augmentation must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "PropertyInfo {",
+        "Visibility::Public",
+        "ObjectShape {",
+        "CallableShape {",
+        "db.application(",
+        "db.object_with_flags_and_symbol(",
+        "db.object_with_index(",
+        "db.callable(",
+        "db.object(",
+        "db.intersection2(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::module_augmentation should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/module_type_analysis_surface_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/module_type_analysis_surface_construction_boundary_scans.rs
@@ -1,0 +1,113 @@
+//! Module/namespace type-analysis surface construction boundary scans.
+//!
+//! `computed/mod.rs` and `computed/type_alias_variable_alias.rs` own module
+//! resolution, export filtering, augmentation lookup, and display-name
+//! publication. Solver construction for namespace export properties, namespace
+//! object surfaces, and export-equals/namespace intersections belongs in
+//! `query_boundaries::state::type_analysis`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const COMPUTED_MOD: &str = "src/state/type_analysis/computed/mod.rs";
+const TYPE_ALIAS_VARIABLE_ALIAS: &str =
+    "src/state/type_analysis/computed/type_alias_variable_alias.rs";
+const TYPE_ALIAS_VARIABLE_ALIAS_HELPERS: &str =
+    "src/state/type_analysis/computed/type_alias_variable_alias/helpers.rs";
+const TYPE_ANALYSIS_BOUNDARY: &str = "src/query_boundaries/state/type_analysis.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn production_source_without_comments(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact(source: &str) -> String {
+    source.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn scan_source_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    let source = production_source_without_comments(&source);
+    let compact_source = compact(&source);
+    for pattern in patterns {
+        if source.contains(pattern) || compact_source.contains(&compact(pattern)) {
+            violations.push(format!("{relative} contains `{pattern}`"));
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn module_type_analysis_surfaces_route_solver_construction_through_boundary() {
+    let mut violations = Vec::new();
+    let patterns = [
+        "PropertyInfo {",
+        "Visibility::Public",
+        ".ctx.types.factory().object(",
+        "self.ctx.types.factory().object(",
+        ".ctx.types.factory().intersection2(",
+        "self.ctx.types.factory().intersection2(",
+        ".factory().object(",
+        ".factory().intersection2(",
+        ".types.object(",
+        ".types.intersection2(",
+        "factory.object(",
+        "factory.intersection2(",
+    ];
+
+    for path in [
+        COMPUTED_MOD,
+        TYPE_ALIAS_VARIABLE_ALIAS,
+        TYPE_ALIAS_VARIABLE_ALIAS_HELPERS,
+    ] {
+        scan_source_for_patterns(path, &patterns, &mut violations);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "module/namespace type-analysis surfaces must route solver construction \
+         through query_boundaries::state::type_analysis:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn state_type_analysis_boundary_owns_module_surface_helpers() {
+    let source = fs::read_to_string(checker_path(TYPE_ANALYSIS_BOUNDARY))
+        .expect("failed to read query_boundaries/state/type_analysis.rs");
+
+    for helper in [
+        "namespace_export_property",
+        "namespace_any_export_property",
+        "namespace_object_type",
+        "namespace_export_equals_intersection",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::state::type_analysis must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "PropertyInfo {",
+        "Visibility::Public",
+        "db.object(",
+        "db.intersection2(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::state::type_analysis should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/object_literal_context_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/object_literal_context_construction_boundary_scans.rs
@@ -1,0 +1,158 @@
+//! Object-literal contextual construction boundary scans.
+//!
+//! Object-literal contextual typing owns member selection, fallback policy,
+//! callable classification, and property lookup. Solver construction for
+//! contextual union/intersection rebuilds belongs in
+//! `query_boundaries::object_literal_context`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const OBJECT_LITERAL_CONTEXT: &str = "src/types/computation/object_literal_context.rs";
+const OBJECT_LITERAL_CONTEXT_BOUNDARY: &str = "src/query_boundaries/object_literal_context.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_slice_for_patterns(
+    relative: &str,
+    start_marker: &str,
+    end_marker: &str,
+    patterns: &[&str],
+    violations: &mut Vec<String>,
+) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    let start = source
+        .find(start_marker)
+        .unwrap_or_else(|| panic!("failed to find start marker `{start_marker}` in {relative}"));
+    let after_start = &source[start..];
+    let end = after_start
+        .find(end_marker)
+        .unwrap_or_else(|| panic!("failed to find end marker `{end_marker}` in {relative}"));
+    let line_offset = source[..start].lines().count();
+    scan_source_for_patterns(
+        relative,
+        &after_start[..end],
+        patterns,
+        line_offset,
+        violations,
+    );
+}
+
+fn scan_source_for_patterns(
+    relative: &str,
+    source: &str,
+    patterns: &[&str],
+    line_offset: usize,
+    violations: &mut Vec<String>,
+) {
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_offset + line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn object_literal_context_routes_contextual_rebuilds_through_boundary() {
+    let mut violations = Vec::new();
+    let forbidden = [
+        ".factory().union_preserve_members(",
+        ".factory().intersection(",
+        ".types.union_preserve_members(",
+        ".types.intersection(",
+        "factory.union_preserve_members(",
+        "factory.intersection(",
+    ];
+
+    scan_slice_for_patterns(
+        OBJECT_LITERAL_CONTEXT,
+        "pub(crate) fn strip_contextual_this_type_markers(",
+        "fn should_preserve_absent_contextual_property_type(",
+        &forbidden,
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        OBJECT_LITERAL_CONTEXT,
+        "pub(crate) fn precise_callable_context_type(",
+        "pub(crate) fn function_initializer_context_type(",
+        &forbidden,
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        OBJECT_LITERAL_CONTEXT,
+        "let union_member_property_type = |this: &mut Self,",
+        "let original_contextual_type = contextual_type;",
+        &forbidden,
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        OBJECT_LITERAL_CONTEXT,
+        "fn mapped_contextual_property_type(",
+        "fn contextual_union_reduces_to_member(",
+        &[
+            ".types.literal_number(",
+            "common::create_string_literal_type(",
+        ],
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        OBJECT_LITERAL_CONTEXT,
+        "pub(crate) fn narrow_contextual_union_via_object_literal_discriminants(",
+        "fn shorthand_const_literal_type(",
+        &forbidden,
+        &mut violations,
+    );
+
+    assert!(
+        violations.is_empty(),
+        "object literal contextual rebuilds must route solver construction through \
+         query_boundaries::object_literal_context:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn object_literal_context_boundary_owns_contextual_rebuild_helpers() {
+    let source = fs::read_to_string(checker_path(OBJECT_LITERAL_CONTEXT_BOUNDARY))
+        .expect("failed to read query_boundaries/object_literal_context.rs");
+
+    for helper in [
+        "contextual_union_preserve_members",
+        "contextual_intersection",
+        "mapped_contextual_property_number_key_type",
+        "mapped_contextual_property_string_key_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::object_literal_context must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "db.union_preserve_members(",
+        "db.intersection(",
+        "db.literal_number(",
+        "db.literal_string(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::object_literal_context should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/object_literal_context_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/object_literal_context_construction_boundary_scans.rs
@@ -1,14 +1,17 @@
 //! Object-literal contextual construction boundary scans.
 //!
 //! Object-literal contextual typing owns member selection, fallback policy,
-//! callable classification, and property lookup. Solver construction for
-//! contextual union/intersection rebuilds belongs in
+//! callable classification, property lookup, and synthetic `this` member
+//! discovery. Solver construction for contextual union/intersection rebuilds
+//! and synthetic receiver surfaces belongs in
 //! `query_boundaries::object_literal_context`.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 const OBJECT_LITERAL_CONTEXT: &str = "src/types/computation/object_literal_context.rs";
+const OBJECT_LITERAL_CIRCULARITY: &str = "src/types/computation/object_literal_circularity.rs";
+const OBJECT_LITERAL_ACCESSOR: &str = "src/types/computation/object_literal/accessor_element.rs";
 const OBJECT_LITERAL_CONTEXT_BOUNDARY: &str = "src/query_boundaries/object_literal_context.rs";
 
 fn checker_path(relative: &str) -> PathBuf {
@@ -118,6 +121,43 @@ fn object_literal_context_routes_contextual_rebuilds_through_boundary() {
         &forbidden,
         &mut violations,
     );
+    scan_slice_for_patterns(
+        OBJECT_LITERAL_CIRCULARITY,
+        "pub(super) fn build_object_literal_method_synthetic_this_type(",
+        "/// Build a synthetic `this` type for a function expression",
+        &[
+            ".factory().callable(",
+            ".factory().object(",
+            "CallableShape {",
+            "CallSignature {",
+            "tsz_solver::PropertyInfo {",
+        ],
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        OBJECT_LITERAL_CIRCULARITY,
+        "pub(super) fn build_object_literal_fn_property_synthetic_this_type(",
+        "/// Name of the variable binding",
+        &[
+            ".factory().callable(",
+            ".factory().object(",
+            "CallableShape {",
+            "CallSignature {",
+            "tsz_solver::PropertyInfo {",
+        ],
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        OBJECT_LITERAL_ACCESSOR,
+        "if marker_this_type.is_none() {",
+        "pushed_synthetic_this = true;",
+        &[
+            ".factory().object(",
+            "PropertyInfo {",
+            "tsz_solver::PropertyInfo {",
+        ],
+        &mut violations,
+    );
 
     assert!(
         violations.is_empty(),
@@ -137,6 +177,10 @@ fn object_literal_context_boundary_owns_contextual_rebuild_helpers() {
         "contextual_intersection",
         "mapped_contextual_property_number_key_type",
         "mapped_contextual_property_string_key_type",
+        "synthetic_this_method_callable",
+        "synthetic_this_method_property",
+        "synthetic_this_property",
+        "synthetic_this_object",
     ] {
         assert!(
             defines_fn(&source, helper),
@@ -149,6 +193,11 @@ fn object_literal_context_boundary_owns_contextual_rebuild_helpers() {
         "db.intersection(",
         "db.literal_number(",
         "db.literal_string(",
+        "db.callable(",
+        "db.object(",
+        "CallableShape {",
+        "CallSignature {",
+        "PropertyInfo {",
     ] {
         assert!(
             source.contains(construction_pattern),

--- a/crates/tsz-checker/tests/arch_source_scans/object_literal_result_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/object_literal_result_construction_boundary_scans.rs
@@ -1,0 +1,129 @@
+//! Object-literal result construction boundary scans.
+//!
+//! Object-literal computation owns AST traversal, property collection, spread
+//! policy, contextual typing, and display normalization. Final solver result
+//! surfaces for object literals and mapped-spread fallbacks belong in
+//! `query_boundaries::type_computation::object_literals`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const OBJECT_LITERAL_RESULT_CALLERS: &[&str] = &[
+    "src/types/computation/object_literal_support.rs",
+    "src/types/computation/object_literal/spread_element.rs",
+];
+const OBJECT_LITERAL_RESULT_BOUNDARY: &str =
+    "src/query_boundaries/type_computation/object_literals.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn production_source_without_comments(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact(source: &str) -> String {
+    source.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    let source = production_source_without_comments(&source);
+    let compact_source = compact(&source);
+    for pattern in patterns {
+        if source.contains(pattern) || compact_source.contains(&compact(pattern)) {
+            violations.push(format!("{relative} contains `{pattern}`"));
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn object_literal_result_callers_route_solver_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".factory().object(",
+        ".factory().object_fresh(",
+        ".factory().object_with_index(",
+        ".factory().union(",
+        ".factory().intersection(",
+        ".factory().mapped(",
+        "factory.union_preserve_order(",
+        "object_fresh_all_properties_context_sensitive(",
+        "object_preserve_declaration_order(",
+        "ObjectShape {",
+        "IndexSignature {",
+        "tsz_solver::MappedType {",
+        "PropertyInfo::new(",
+        "PropertyInfo {",
+        "store_display_properties(",
+    ];
+
+    let mut violations = Vec::new();
+    for caller in OBJECT_LITERAL_RESULT_CALLERS {
+        scan_for_patterns(caller, FORBIDDEN_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "object-literal result callers must route solver construction through \
+         query_boundaries::type_computation::object_literals:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn object_literal_result_boundary_owns_result_construction_helpers() {
+    let source = fs::read_to_string(checker_path(OBJECT_LITERAL_RESULT_BOUNDARY))
+        .expect("failed to read query_boundaries/type_computation/object_literals.rs");
+
+    assert!(
+        source.contains("struct ObjectLiteralIndexedType"),
+        "query_boundaries::type_computation::object_literals must own `ObjectLiteralIndexedType`"
+    );
+
+    for helper in [
+        "spread_object_type",
+        "fresh_object_type",
+        "indexed_object_type",
+        "spread_fallback_index_signature",
+        "union_type",
+        "intersection_type",
+        "mapped_type_with_constraint",
+        "mapped_spread_property",
+        "mapped_spread_object_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::type_computation::object_literals must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "db.object_with_flags_and_symbol(",
+        "db.store_display_properties(",
+        "ObjectFlags::FRESH_LITERAL",
+        "ObjectFlags::PRESERVE_DECLARATION_ORDER",
+        "ObjectShape {",
+        "IndexSignature {",
+        "db.union(",
+        "db.union_from_sorted_vec(",
+        "db.intersection(",
+        "db.mapped(",
+        "PropertyInfo::new(",
+        "db.object(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::type_computation::object_literals should own \
+             `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/property_access_result_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/property_access_result_construction_boundary_scans.rs
@@ -1,0 +1,127 @@
+//! Property-access result construction boundary scans.
+//!
+//! State checking owns receiver resolution, property lookup policy, and
+//! diagnostics. Solver construction for optional, union, and intersection
+//! property-access result surfaces belongs in `query_boundaries::property_access`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const PROPERTY_ACCESS_STATE: &str = "src/state/state_checking/property_access.rs";
+const PROPERTY_ACCESS_BOUNDARY: &str = "src/query_boundaries/property_access.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_slice_for_patterns(
+    relative: &str,
+    start_marker: &str,
+    end_marker: &str,
+    patterns: &[&str],
+    violations: &mut Vec<String>,
+) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    let start = source
+        .find(start_marker)
+        .unwrap_or_else(|| panic!("failed to find start marker `{start_marker}` in {relative}"));
+    let after_start = &source[start..];
+    let end = after_start
+        .find(end_marker)
+        .unwrap_or_else(|| panic!("failed to find end marker `{end_marker}` in {relative}"));
+    let line_offset = source[..start].lines().count();
+
+    for (line_index, line) in after_start[..end].lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_offset + line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn property_access_results_route_construction_through_boundary() {
+    let mut violations = Vec::new();
+    let forbidden = [
+        ".factory().union(",
+        ".factory().union2(",
+        ".factory().intersection(",
+        ".types.union(",
+        ".types.union2(",
+        ".types.intersection(",
+        "tsz_solver::utils::union_or_single(",
+        "tsz_solver::utils::intersection_or_single(",
+    ];
+
+    scan_slice_for_patterns(
+        PROPERTY_ACCESS_STATE,
+        "fn resolve_remapped_mapped_property_from_source_union(",
+        "pub(crate) fn computed_property_display_name(",
+        &forbidden,
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        PROPERTY_ACCESS_STATE,
+        "pub(crate) fn resolve_property_access_with_env_post_query(",
+        "fn resolve_mapped_constraint_for_property_access(",
+        &forbidden,
+        &mut violations,
+    );
+    scan_slice_for_patterns(
+        PROPERTY_ACCESS_STATE,
+        "fn resolve_mapped_property_with_env(",
+        "#[cfg(test)]",
+        &forbidden,
+        &mut violations,
+    );
+
+    assert!(
+        violations.is_empty(),
+        "property-access result construction must route through \
+         query_boundaries::property_access:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn property_access_boundary_owns_result_construction_helpers() {
+    let source = fs::read_to_string(checker_path(PROPERTY_ACCESS_BOUNDARY))
+        .expect("failed to read query_boundaries/property_access.rs");
+
+    for helper in [
+        "mapped_property_read_type",
+        "union_property_access_success",
+        "intersection_property_access_success",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::property_access must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "db.union2(",
+        "tsz_solver::utils::union_or_single(",
+        "tsz_solver::utils::intersection_or_single(",
+        "PropertyAccessResult::simple(",
+        "PropertyAccessResult::from_index(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::property_access should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/strict_bind_call_apply_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/strict_bind_call_apply_construction_boundary_scans.rs
@@ -1,0 +1,109 @@
+//! Strict bind/call/apply construction boundary scans.
+//!
+//! Property-access helpers own receiver lookup, `this` collapse, and method
+//! selection. Solver parameter, type-parameter, tuple, signature, function, and
+//! callable construction belongs in `query_boundaries::property_access`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const ACCESS_SEMANTICS: &str = "src/types/property_access_helpers/access_semantics.rs";
+const PROPERTY_ACCESS_BOUNDARY: &str = "src/query_boundaries/property_access.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+#[test]
+fn strict_bind_call_apply_routes_solver_construction_through_property_access_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        ".type_param(",
+        ".tuple(",
+        ".function(",
+        ".callable(",
+        "TypeParamInfo {",
+        "TypeParamOrigin::User",
+        "TupleElement {",
+        "ParamInfo {",
+        "CallSignature {",
+        "FunctionShape {",
+        "CallableShape {",
+        "FunctionShape::new(",
+        "CallableShape::default()",
+        "intern_string(\"thisArg\")",
+        "intern_string(\"args\")",
+        "intern_string(\"TThis\")",
+    ];
+
+    let mut violations = Vec::new();
+    scan_for_patterns(ACCESS_SEMANTICS, FORBIDDEN_PATTERNS, &mut violations);
+    assert!(
+        violations.is_empty(),
+        "strict bind/call/apply synthesis must route solver shape construction \
+         through query_boundaries::property_access:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn property_access_boundary_owns_strict_bind_call_apply_construction_helpers() {
+    let source = fs::read_to_string(checker_path(PROPERTY_ACCESS_BOUNDARY))
+        .expect("failed to read query_boundaries/property_access.rs");
+
+    for helper in [
+        "strict_bind_call_apply_param_with_type",
+        "strict_bind_call_apply_type_param_with_constraint",
+        "strict_bind_call_apply_call_signature",
+        "strict_bind_call_apply_signature_from_function_shape",
+        "strict_bind_call_apply_params_tuple_type",
+        "strict_bind_call_apply_bound_return_type",
+        "strict_bind_call_apply_call_only_callable_type",
+        "strict_bind_call_apply_this_arg_param",
+        "strict_bind_call_apply_args_param",
+        "strict_bind_call_apply_generic_this_param",
+        "strict_bind_call_apply_method_type",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::property_access must own `{helper}`"
+        );
+    }
+
+    for shape_pattern in [
+        "db.tuple(",
+        "db.function(",
+        "db.callable(",
+        "db.type_param(",
+        "TypeParamInfo {",
+        "TypeParamOrigin::User",
+        "TupleElement {",
+        "ParamInfo {",
+        "CallSignature {",
+        "FunctionShape {",
+        "CallableShape {",
+    ] {
+        assert!(
+            source.contains(shape_pattern),
+            "query_boundaries::property_access should own `{shape_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/type_checking_surface_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/type_checking_surface_construction_boundary_scans.rs
@@ -1,0 +1,157 @@
+//! Type-checking surface construction boundary scans.
+//!
+//! Type-checking modules own AST traversal, environment setup, relation
+//! requests, and diagnostics. Solver construction for type-checking helper
+//! surfaces belongs in `query_boundaries::type_checking`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const TYPE_CHECKING_ROOT: &str = "src/types/type_checking";
+const TYPE_CHECKING_BOUNDARY: &str = "src/query_boundaries/type_checking.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn collect_rs_files(relative: &str, files: &mut Vec<PathBuf>) {
+    let path = checker_path(relative);
+    let entries = fs::read_dir(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    for entry in entries {
+        let entry = entry.unwrap_or_else(|err| panic!("failed to read entry in {relative}: {err}"));
+        let path = entry.path();
+        if path.is_dir() {
+            let nested = path
+                .strip_prefix(Path::new(env!("CARGO_MANIFEST_DIR")))
+                .expect("path should be under checker manifest dir")
+                .to_string_lossy()
+                .into_owned();
+            collect_rs_files(&nested, files);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            files.push(path);
+        }
+    }
+}
+
+fn relative_path(path: &Path) -> String {
+    path.strip_prefix(Path::new(env!("CARGO_MANIFEST_DIR")))
+        .expect("path should be under checker manifest dir")
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn scan_file(path: &Path, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    let relative = relative_path(path);
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        if trimmed.contains("->") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+
+    let compact_source = source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .flat_map(|line| line.chars())
+        .filter(|ch| !ch.is_whitespace())
+        .collect::<String>();
+    for pattern in patterns {
+        let compact_pattern = pattern
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect::<String>();
+        if compact_source.contains(&compact_pattern) {
+            violations.push(format!(
+                "{relative} contains split or inline `{pattern}` construction"
+            ));
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn type_checking_surface_construction_routes_through_boundary() {
+    let forbidden = [
+        ".factory().function(",
+        ".factory().union(",
+        ".factory().type_param(",
+        ".factory().index_access(",
+        ".literal_number(",
+        ".types.union(",
+        ".types.union2(",
+        ".types.index_access(",
+        "FunctionShape {",
+        "ParamInfo {",
+        "TypeParamInfo {",
+        "TypeParamOrigin::User",
+    ];
+    let mut files = Vec::new();
+    let mut violations = Vec::new();
+    collect_rs_files(TYPE_CHECKING_ROOT, &mut files);
+
+    for file in files {
+        scan_file(&file, &forbidden, &mut violations);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "type-checking helper surface construction must route through \
+         query_boundaries::type_checking:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn type_checking_boundary_owns_surface_construction_helpers() {
+    let source = fs::read_to_string(checker_path(TYPE_CHECKING_BOUNDARY))
+        .expect("failed to read query_boundaries/type_checking.rs");
+
+    for helper in [
+        "type_checking_union",
+        "type_checking_index_access",
+        "type_checking_literal_number",
+        "user_type_param_info",
+        "user_type_param",
+        "param_info",
+        "global_function_fallback_type",
+        "method_function_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::type_checking must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "db.union(",
+        "db.index_access(",
+        "db.literal_number(",
+        "db.type_param(",
+        "db.function(",
+        "TypeParamInfo {",
+        "ParamInfo {",
+        "FunctionShape {",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::type_checking should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/type_node_fallback_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/type_node_fallback_construction_boundary_scans.rs
@@ -1,0 +1,97 @@
+//! Type-node fallback construction boundary scans.
+//!
+//! `types/type_node.rs` owns AST traversal and member-order facts. Synthetic
+//! solver surfaces for type-node intersections and type-literal function,
+//! callable, and object fallbacks belong behind construction query boundaries.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const TYPE_NODE: &str = "src/types/type_node.rs";
+const SIGNATURE_BOUNDARY: &str = "src/query_boundaries/construct_signatures.rs";
+const TYPE_CONSTRUCTION_BOUNDARY: &str = "src/query_boundaries/type_construction.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn production_source_without_comments(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact(source: &str) -> String {
+    source.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn type_node_fallback_construction_routes_through_boundaries() {
+    let source = fs::read_to_string(checker_path(TYPE_NODE)).expect("failed to read type_node.rs");
+    let source = production_source_without_comments(&source);
+    let compact_source = compact(&source);
+    let forbidden = [
+        "tsz_solver::utils::intersection_or_single(",
+        "factory.function(",
+        "factory.callable(",
+        "factory.object_with_index(",
+        "factory.object(",
+        ".factory().function(",
+        ".factory().callable(",
+        ".factory().object_with_index(",
+        ".factory().object(",
+        "mark_literal_object_annotation(",
+        "FunctionShape {",
+        "CallableShape {",
+        "ObjectShape {",
+    ];
+
+    let mut violations = Vec::new();
+    for pattern in forbidden {
+        if source.contains(pattern) || compact_source.contains(&compact(pattern)) {
+            violations.push(pattern);
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "type_node.rs must route synthetic intersection, callable/function, \
+         and object fallback construction through query boundaries, found: {}",
+        violations.join(", ")
+    );
+}
+
+#[test]
+fn type_node_fallback_boundaries_own_construction_helpers() {
+    let signatures = fs::read_to_string(checker_path(SIGNATURE_BOUNDARY))
+        .expect("failed to read query_boundaries/construct_signatures.rs");
+    for helper in [
+        "method_function_type_from_call_signature",
+        "call_only_callable_type",
+        "type_literal_callable_type",
+    ] {
+        assert!(
+            defines_fn(&signatures, helper),
+            "query_boundaries::construct_signatures must own `{helper}`"
+        );
+    }
+
+    let type_construction = fs::read_to_string(checker_path(TYPE_CONSTRUCTION_BOUNDARY))
+        .expect("failed to read query_boundaries/type_construction.rs");
+    for helper in [
+        "type_node_intersection_or_single",
+        "type_literal_object",
+        "type_literal_object_with_indexes",
+    ] {
+        assert!(
+            defines_fn(&type_construction, helper),
+            "query_boundaries::type_construction must own `{helper}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/type_query_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/type_query_construction_boundary_scans.rs
@@ -1,0 +1,119 @@
+//! Const value/type-query construction boundary scans.
+//!
+//! Type-node callers validate syntax, symbols, declarations, and fallback
+//! policy. Solver literal/property/object/tuple construction for accepted
+//! const query facts belongs in `query_boundaries::type_query_construction`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const TYPE_QUERY_CALLERS: &[&str] = &[
+    "src/types/type_node_merged_value_query.rs",
+    "src/types/type_node_advanced.rs",
+];
+const TYPE_QUERY_BOUNDARY: &str = "src/query_boundaries/type_query_construction.rs";
+const COMMON_BOUNDARY: &str = "src/query_boundaries/common.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}(")) || source.contains(&format!("fn {name}<"))
+}
+
+#[test]
+fn type_query_callers_route_const_construction_through_boundary() {
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        "PropertyInfo::new(",
+        "PropertyInfo {",
+        "ObjectShape {",
+        "TupleElement {",
+        ".factory().literal_string(",
+        ".factory().literal_number(",
+        ".factory().literal_boolean(",
+        ".factory().object(",
+        ".factory().object_with_index(",
+        ".factory().tuple(",
+        ".types.literal_string(",
+        ".types.literal_number(",
+        ".types.literal_boolean(",
+        ".types.object(",
+        ".types.tuple(",
+    ];
+
+    let mut violations = Vec::new();
+    for caller in TYPE_QUERY_CALLERS {
+        scan_for_patterns(caller, FORBIDDEN_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "const type-query callers must route solver construction through \
+         query_boundaries::type_query_construction:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn type_query_boundary_owns_const_query_construction_helpers() {
+    let source = fs::read_to_string(checker_path(TYPE_QUERY_BOUNDARY))
+        .expect("failed to read query_boundaries/type_query_construction.rs");
+    let common =
+        fs::read_to_string(checker_path(COMMON_BOUNDARY)).expect("failed to read common.rs");
+
+    for helper in [
+        "const_query_literal_string_type",
+        "const_query_literal_number_type",
+        "const_query_literal_boolean_type",
+        "const_query_readonly_property",
+        "const_query_object_literal_type",
+        "const_query_array_to_enum_object_type",
+        "const_query_tuple_element",
+        "const_query_tuple_type",
+    ] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::type_query_construction must own `{helper}`"
+        );
+        assert!(
+            !defines_fn(&common, helper),
+            "query_boundaries::common must not define `{helper}`"
+        );
+    }
+
+    for construction_pattern in [
+        "db.literal_string(",
+        "db.literal_number(",
+        "db.literal_boolean(",
+        "PropertyInfo {",
+        "ObjectShape {",
+        "db.object_with_index(",
+        "db.object(",
+        "TupleElement {",
+        "db.tuple(",
+    ] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::type_query_construction should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/arch_source_scans/yield_context_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/yield_context_construction_boundary_scans.rs
@@ -1,0 +1,115 @@
+//! `yield*` contextual construction boundary scans.
+//!
+//! Yield dispatch owns AST position, generator-name/lib lookup, diagnostics,
+//! and contextual-type selection. Solver construction for contextual
+//! `Generator<Y, R, N>` and array fallback surfaces belongs in
+//! `query_boundaries::dispatch`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const YIELD_DISPATCH: &str = "src/dispatch/yield_.rs";
+const DISPATCH_BOUNDARY: &str = "src/query_boundaries/dispatch.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}("))
+}
+
+#[test]
+fn yield_dispatch_routes_context_construction_through_boundary() {
+    let mut violations = Vec::new();
+    scan_for_patterns(
+        YIELD_DISPATCH,
+        &[
+            ".types.lazy(",
+            ".types.application(",
+            ".types.array(",
+            "types.lazy(",
+            "types.application(",
+            "types.array(",
+            "db.lazy(",
+            "db.application(",
+            "db.array(",
+            "factory.lazy(",
+            "factory.application(",
+            "factory.array(",
+            ".factory().lazy(",
+            ".factory().application(",
+            ".factory().array(",
+        ],
+        &mut violations,
+    );
+
+    assert!(
+        violations.is_empty(),
+        "`yield*` dispatch must route contextual solver construction through \
+         query_boundaries::dispatch:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn dispatch_boundary_keeps_yield_context_decisions_out_of_helpers() {
+    let mut violations = Vec::new();
+    scan_for_patterns(
+        DISPATCH_BOUNDARY,
+        &[
+            "ExpressionDispatcher",
+            "NodeIndex",
+            "syntax_kind_ext",
+            "get_global_type_with_libs(",
+            "find_enclosing_function(",
+        ],
+        &mut violations,
+    );
+
+    assert!(
+        violations.is_empty(),
+        "query_boundaries::dispatch yield helpers must not absorb checker AST/lib lookup \
+         responsibilities:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn dispatch_boundary_owns_yield_context_construction_helpers() {
+    let source = fs::read_to_string(checker_path(DISPATCH_BOUNDARY))
+        .expect("failed to read query_boundaries/dispatch.rs");
+
+    for helper in ["generator_context_application", "yield_star_array_context"] {
+        assert!(
+            defines_fn(&source, helper),
+            "query_boundaries::dispatch must own `{helper}`"
+        );
+    }
+
+    for construction_pattern in ["db.lazy(", "db.application(", "db.array("] {
+        assert!(
+            source.contains(construction_pattern),
+            "query_boundaries::dispatch should own `{construction_pattern}`"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/flow_boundary_contract_tests.rs
+++ b/crates/tsz-checker/tests/flow_boundary_contract_tests.rs
@@ -126,3 +126,38 @@ fn assignment_reduction_uses_flow_query_boundary() {
         "assignment member filtering belongs in query_boundaries::flow_analysis"
     );
 }
+
+#[test]
+fn assignment_fallback_shape_construction_uses_flow_query_boundary() {
+    let src = fs::read_to_string("src/flow/control_flow/assignment_fallback.rs")
+        .expect("failed to read src/flow/control_flow/assignment_fallback.rs");
+
+    for forbidden in [
+        ".factory().object(",
+        ".factory().callable(",
+        ".factory.object(",
+        ".factory.callable(",
+        "CallableShape {",
+        "CallableShape::default()",
+    ] {
+        assert!(
+            !src.contains(forbidden),
+            "assignment fallback must route solver shape construction through \
+             query_boundaries::flow_analysis, found `{forbidden}`"
+        );
+    }
+
+    assert!(
+        src.contains("flow_analysis::object_type_from_properties(")
+            && src.contains("flow_analysis::call_only_callable_type("),
+        "assignment fallback object/callable construction should route through flow_analysis"
+    );
+
+    let boundary = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read src/query_boundaries/flow_analysis.rs");
+    assert!(
+        boundary.contains("fn object_type_from_properties(")
+            && boundary.contains("fn call_only_callable_type("),
+        "flow_analysis must own assignment-fallback object/callable construction helpers"
+    );
+}

--- a/crates/tsz-checker/tests/property_access_boundaries.rs
+++ b/crates/tsz-checker/tests/property_access_boundaries.rs
@@ -1,9 +1,10 @@
 use super::*;
 use crate::query_boundaries::property_access::{
-    is_bigint_type, is_boolean_type, is_number_type, is_string_type, is_symbol_type,
+    intersection_property_access_success, is_bigint_type, is_boolean_type, is_number_type,
+    is_string_type, is_symbol_type, mapped_property_read_type, union_property_access_success,
 };
 use tsz_solver::construction::TypeInterner;
-use tsz_solver::{DefId, FunctionShape, ParamInfo, TupleElement};
+use tsz_solver::{DefId, FunctionShape, MappedModifier, ParamInfo, TupleElement};
 
 #[test]
 fn exposes_property_access_boundary_queries() {
@@ -195,6 +196,50 @@ fn tuple_element_union_and_array_element_type() {
     let arr = types.array(TypeId::NUMBER);
     assert_eq!(array_element_type(&types, arr), Some(TypeId::NUMBER));
     assert_eq!(array_element_type(&types, single), None);
+}
+
+#[test]
+fn property_access_result_construction_helpers() {
+    let types = TypeInterner::new();
+
+    assert_eq!(
+        mapped_property_read_type(&types, TypeId::STRING, None),
+        TypeId::STRING
+    );
+    assert_eq!(
+        mapped_property_read_type(&types, TypeId::STRING, Some(MappedModifier::Remove)),
+        TypeId::STRING
+    );
+    assert_eq!(
+        mapped_property_read_type(&types, TypeId::STRING, Some(MappedModifier::Add)),
+        types.union2(TypeId::STRING, TypeId::UNDEFINED)
+    );
+
+    assert!(union_property_access_success(&types, vec![]).is_none());
+    assert_eq!(
+        union_property_access_success(&types, vec![TypeId::STRING])
+            .and_then(|result| result.success_info()),
+        Some((TypeId::STRING, false))
+    );
+    let union_type = types.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    assert_eq!(
+        union_property_access_success(&types, vec![TypeId::STRING, TypeId::NUMBER])
+            .and_then(|result| result.success_info()),
+        Some((union_type, false))
+    );
+
+    assert!(intersection_property_access_success(&types, vec![], false).is_none());
+    assert_eq!(
+        intersection_property_access_success(&types, vec![TypeId::BOOLEAN], true)
+            .and_then(|result| result.success_info()),
+        Some((TypeId::BOOLEAN, true))
+    );
+    let intersection_type = types.intersection(vec![TypeId::STRING, TypeId::NUMBER]);
+    assert_eq!(
+        intersection_property_access_success(&types, vec![TypeId::STRING, TypeId::NUMBER], false)
+            .and_then(|result| result.success_info()),
+        Some((intersection_type, false))
+    );
 }
 
 #[test]

--- a/crates/tsz-checker/tests/spread_rest_tests.rs
+++ b/crates/tsz-checker/tests/spread_rest_tests.rs
@@ -884,6 +884,31 @@ function f(obj: Obj) {
 }
 
 #[test]
+fn test_object_rest_preserves_string_index_signature() {
+    let source = r#"
+interface Bag {
+    keep: number;
+    label: string;
+    [key: string]: string | number;
+}
+declare const bag: Bag;
+const { keep, ...rest } = bag;
+const value: string | number = rest["dynamic"];
+const wrong: boolean = rest["dynamic"];
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        has_diagnostic_where(&diagnostics, |d| {
+            d.code == 2322
+                && d.message_text.contains("string | number")
+                && d.message_text.contains("boolean")
+        }),
+        "Expected object-rest copy to preserve the string index signature, got diagnostics: {:?}",
+        diagnostic_code_messages(&diagnostics)
+    );
+}
+
+#[test]
 fn test_generic_rest_spread_preserves_type_parameter() {
     // When a generic function destructures `{ a, ...rest } = obj` where `obj: T`,
     // and returns `{ ...rest, b: a }`, the return type must preserve T's identity

--- a/crates/tsz-checker/tests/ts2322_literal_source_display_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_literal_source_display_tests.rs
@@ -191,3 +191,23 @@ var o: I = {
         "TS2322 should not expose expanded computed number key text, got: {ts2322:?}",
     );
 }
+
+#[test]
+fn ts2322_identifier_array_object_literal_source_display_unions_property_values() {
+    let diagnostics = diagnostic_messages(
+        r#"
+const rows = [{ name: "a" }, { name: 1 }];
+const out: { name: boolean }[] = rows;
+"#,
+    );
+
+    let ts2322 = diagnostics
+        .iter()
+        .find(|(code, _)| *code == 2322)
+        .expect("expected TS2322 for identifier array-object source display");
+
+    assert!(
+        ts2322.1.contains("Type '{ name: string | number; }[]'"),
+        "identifier array-object source should display unioned property values, got: {ts2322:?}",
+    );
+}

--- a/crates/tsz-checker/tests/ts2353_tests.rs
+++ b/crates/tsz-checker/tests/ts2353_tests.rs
@@ -436,6 +436,65 @@ v = { p: 1, q: 1, first: "ok", second: "error" }
 }
 
 #[test]
+fn nested_union_property_uses_all_member_targets_for_excess_check() {
+    let diags = get_diagnostics(
+        r#"
+type LeftPayload = { left: string };
+type RightPayload = { right: string };
+type Target = { box: LeftPayload } | { box: RightPayload };
+
+const ok: Target = { box: { right: "r" } };
+const bad: Target = { box: { right: "r", extra: 1 } };
+"#,
+    );
+    let ts2353: Vec<_> = diags.iter().filter(|d| d.0 == 2353).collect();
+    assert_eq!(
+        ts2353.len(),
+        1,
+        "expected only nested 'extra', got: {diags:?}"
+    );
+    assert!(ts2353[0].1.contains("'extra'"), "got: {ts2353:?}");
+    assert!(
+        !ts2353.iter().any(|d| d.1.contains("'right'")),
+        "right must be accepted: {diags:?}"
+    );
+    assert!(
+        !codes(&diags).contains(&2322),
+        "no aggregate TS2322 expected: {diags:?}"
+    );
+}
+
+#[test]
+fn discriminated_union_nested_property_uses_narrowed_target_for_excess() {
+    let diags = get_diagnostics(
+        r#"
+type AlphaPayload = { shared: number };
+type BetaPayload = { shared: number; betaOnly: number };
+type Alpha = { tag: "alpha"; payload: AlphaPayload };
+type Beta = { tag: "beta"; payload: BetaPayload };
+type Choice = Alpha | Beta;
+
+const bad: Choice = { tag: "alpha", payload: { shared: 1, betaOnly: 2 } };
+"#,
+    );
+    let ts2353: Vec<_> = diags.iter().filter(|d| d.0 == 2353).collect();
+    assert_eq!(
+        ts2353.len(),
+        1,
+        "expected narrowed nested excess, got: {diags:?}"
+    );
+    assert!(ts2353[0].1.contains("'betaOnly'"), "got: {ts2353:?}");
+    assert!(
+        ts2353[0].1.contains("'AlphaPayload'"),
+        "display should use narrowed target: {ts2353:?}"
+    );
+    assert!(
+        !ts2353[0].1.contains("BetaPayload"),
+        "must not use full union target: {ts2353:?}"
+    );
+}
+
+#[test]
 fn indirect_discriminant_variable_does_not_trigger_excess_property_narrowing() {
     let source = r#"
 type Blah =


### PR DESCRIPTION
Goal: fast

## Summary
- Add checker query-boundary helpers for declared property, index, object, callable, type-literal late-bound, and extra-number-index fallback construction.
- Route `get_type_of_interface` and `get_type_from_type_literal` own member surface construction through those helpers.
- Add an architecture scan that ratchets interface/type-literal own surfaces while explicitly leaving interface heritage/merge reconstruction for a later slice.

## Structural Rule
When interface and type-literal declarations collect their own member surfaces, `tsc` preserves declared property/index/accessor/method/callable shape metadata and member order. `tsz` keeps AST traversal, diagnostics, ordering, member classification, and type-node resolution in checker, while solver-facing property/index/object/function/callable/intersection construction routes through `query_boundaries::type_construction` and `query_boundaries::construct_signatures`.

## Owner Layer
Checker owns interface/type-literal syntax traversal, exact-optional write surfaces, accessor aggregation, overload grouping, index-signature diagnostics, late-bound-member detection, and final branch selection.

Query boundaries own construction of `PropertyInfo`, `IndexSignature`, `FunctionShape`, `CallableShape`, object surfaces, and the type-literal extra-number-index intersection fallback.

## Adjacent Matrix
- Interface own surfaces: property signatures, accessors, method overloads, index signatures, final callable/object-with-index/object-with-symbol branches.
- Type-literal own surfaces: property signatures, accessors, method overloads, index signatures, late-bound object branches, callable branches, and extra number-index fallback intersection.
- Boundary APIs use named declared-property inputs to avoid positional field drift.
- Scope note: this does not route later interface heritage/merge reconstruction in `interface_type.rs`; that remains a separate higher-risk slice.

## Local Note
The broader local lib filter without exclusion still inherits `split_accessor_variance_tests::type_literal_split_accessor_narrower_setter_rejected`; I verified it also fails with this branch's tracked diff reversed against the parent head, so it is not introduced here.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test arch_source_scans -E 'test(interface_and_type_literal)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test interface_call_signature_typeof_param_tests --test type_literal_method_overload_tests --test type_literal_overload_optionality_tests --test callable_interface_index_tests --test accessor_assignment_read_surface_tests --test object_literal_set_only_accessor_type_tests --test ts2314_in_type_literal_suppresses_ts2322_tests --test qualified_namespace_generic_substitution_tests --test array_generic_shorthand_canonical_tests --test symbol_index_signature_tests --test contextual_method_index_signature_tests --test construct_signature_boundary_matrix_tests --test new_generic_construct_signature_type_arg_display_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E '(test(type_literal) or test(interface_type) or test(interface_call)) and not test(type_literal_split_accessor_narrower_setter_rejected)'`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo clippy -p tsz-checker --lib --tests -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
