### PR TITLE
docs(agents): add rust-debugger (rdbg) repo skill with tsz diagnostic-sink recipe

### DIFF
--- a/.agents/skills/rust-debugger/REFERENCE.md
+++ b/.agents/skills/rust-debugger/REFERENCE.md
@@ -1,0 +1,129 @@
+# rdbg full reference
+
+Expanded command reference for the `rust-debugger` skill (upstream:
+<https://github.com/mohsen1/rust-debugger-skill>). Read on demand; the triage
+and tsz-specific recipe live in `SKILL.md`.
+
+## Start a session
+
+```
+rdbg where parse_config                            # find where to break
+rdbg launch --cargo . --bin app --break src/config.rs:88 -- --threads 4
+rdbg launch --cargo . --lib --break src/lib.rs:42 -- my_test        # a #[test] in the library
+rdbg launch --cargo . --test mytest --break tests/mytest.rs:12 -- some_case  # tests/mytest.rs
+rdbg launch --bin-path target/debug/app --break src/main.rs:11   # skip the build
+```
+
+Pick the target by where the test lives: `--lib` for a `#[test]` inside the
+library (`#[cfg(test)] mod tests` in `src/` — the common case), `--test <name>`
+only for an integration test file `tests/<name>.rs`. In both, the words after
+`--` are the test-name filter, so exactly the test you name runs.
+
+Add `--panic` to also stop where any panic is raised, or `--break-fn <name>`.
+
+To watch a value evolve without stepping, `trace` instead of `launch` — it runs
+through every hit and returns a table in one call:
+
+```
+rdbg trace --cargo . --bin app --break src/x.rs:42 --capture i,sum --max 30
+rdbg trace --cargo . --lib --break src/lib.rs:42 --capture a,b -- my_test
+```
+
+## Breakpoints
+
+Set or change these any time, including while paused.
+
+```
+rdbg break src/x.rs:42                # line
+rdbg break src/x.rs:42 --if "i == 5"  # conditional (simple comparisons)
+rdbg break src/x.rs:42 --hit 3        # on the 3rd hit
+rdbg break src/x.rs:42 --log "i={i}"  # logpoint (print, don't stop)
+rdbg break --fn my_crate::do_thing    # entering a function
+rdbg break --panic                    # where a Rust panic is raised
+rdbg watch cfg.threads                # when a value changes
+rdbg breaks                           # list with ids; break-rm/break-on/break-off <id>
+```
+
+## Run and step
+
+```
+rdbg continue
+rdbg continue --until 'sum >= 100'    # keep resuming until a condition holds
+rdbg step over | in | out | insn
+rdbg until src/x.rs:99                # run to a line
+rdbg pause                            # interrupt a running program
+rdbg restart
+```
+
+`continue --until '<path> <op> <value>'` (ops `== != < <= > >=`) re-checks the
+condition at each breakpoint stop itself — one call instead of a continue/eval
+loop per iteration, and it works where lldb conditional breakpoints don't fire.
+Needs an active breakpoint to stop at; ends at the first stop where the
+condition holds, or reports that the program exited.
+
+## Read and change state
+
+```
+rdbg vars                             # locals with real Rust values
+rdbg eval items[0].qty sum            # one or more variable paths (not method calls)
+rdbg set cfg.threads = 8 --then continue   # change a value and resume
+rdbg set cfg.threads = 8              # change a value
+rdbg watch-expr add total             # re-shown at every stop
+rdbg bt                               # backtrace
+rdbg list                             # source around the current line
+rdbg state                            # stop + locals + watches together
+```
+
+## Threads and frames
+
+```
+rdbg threads
+rdbg thread <id>
+rdbg frame <n> | up | down            # vars/eval follow the selected frame
+```
+
+## Navigate
+
+```
+rdbg where <Name>
+rdbg def | hover | refs <file> <line> <col>
+```
+
+`rdbg stop` ends the session; `rdbg down` stops the daemon.
+
+## Batching and machine-readable output
+
+- `rdbg do '<cmd>; <cmd>; ...'` runs several subcommands in one call; the batch
+  stops at the first error or program exit.
+- Stops list only the top-frame locals that changed since the previous stop
+  (`~ sum: u32 = 6 (was 3)`); `rdbg vars --full` forces the complete deep dump.
+- Pass `--json` anywhere in the args for one compact JSON line per command with
+  a `status` field (`ok | user_error | target_error | build_error |
+  debug_adapter_error | timeout | no_session`).
+
+## Common loops
+
+- **Wrong value.** Break where it is computed, `vars` and `eval` to see the
+  real inputs, `step` to watch it go wrong, `set` to test a fix without
+  recompiling.
+- **Value goes wrong at some iteration.** Break in the loop, then
+  `continue --until 'sum > 100'` to jump straight to the first stop where the
+  condition holds instead of continue/eval-ing by hand.
+- **Panic.** `rdbg debug --cargo . --lib --panic -- <test>` (or
+  `--bin`/`--test`) runs to the panic and returns the message, the first *user*
+  frame with its arguments and locals, and a backtrace in one call. (Or
+  `launch … --panic`, then `bt`/`up` to your frame, to keep poking around.)
+- **Unexpected mutation.** `watch <var>`, then `continue` to stop the moment it
+  changes.
+- **Failing test.** `--lib … -- <test_name>` for a `#[test]` in the library,
+  `--test <name> … -- <test_name>` for `tests/<name>.rs`; break at the
+  assertion or inside the code under test.
+
+## Notes
+
+- `eval`, `set`, and conditions take variable paths and simple comparisons, not
+  arbitrary Rust expressions. `codelldb` on `PATH` lifts this (the installer
+  sets it up); Rust *method* calls still can't be evaluated — break inside
+  instead.
+- Debug the debug build; a `--release` binary has little to inspect.
+- One paused process per project; `rdbg down` (or 30 minutes idle) releases it.

--- a/.agents/skills/rust-debugger/SKILL.md
+++ b/.agents/skills/rust-debugger/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: rust-debugger
+description: Debug a Rust program or failing test with rdbg — set breakpoints (line, function, conditional, hit-count, panic, or watchpoint), run and step, read locals as real Rust values, change a variable mid-run, and jump to definition/hover/references via rust-analyzer. In tsz, reach for it on a runtime question reading hasn't localized — above all a wrong or extra (false-positive) diagnostic, where you break the diagnostic sinks and backtrace to the deciding frame instead of grepping emit sites. Skip it for missing-diagnostic bugs (nothing fires to break on) and small localized bugs a quick read already pins down.
+---
+
+# rust-debugger
+
+`rdbg` debugs from the command line: one paused process per project; breakpoints
+and state carry across calls. Needs a debug build (the default `cargo build`).
+Run `rdbg` with no arguments for the full command list; `REFERENCE.md` beside
+this file adds examples. Install:
+`curl -fsSL https://azimi.me/rust-debugger-skill/install.sh | sh` (also sets up
+codelldb), plus `rust-analyzer` on `PATH`.
+
+## When to reach for it (and when not)
+
+Read first. Every `launch` rebuilds the target, so a wasted debugging detour is
+expensive. Launch only for a **runtime question at a place you can name**:
+- a **wrong** value where you need the real inputs/flow that produced it;
+- an unexpected branch, type, or state that reading can't pin down;
+- a **panic** — `rdbg debug --panic` lands on the culprit frame in one call;
+- testing a fix live with `set --then continue` before editing + rebuilding.
+
+Don't launch when a quick read already points at the fix; when the output is
+**missing** (nothing fires to break on — finding the absent check is a reading
+task); or to iterate on a candidate fix — re-run the narrowed test instead.
+
+Stay cheap: one session with several breakpoints, or one `trace`, beats
+re-launching. If 2–3 probes haven't localized it, go back to reading.
+
+Fix once, don't churn: after ~2–3 edit→test cycles you're guessing — break at
+the failing assertion and compare actual vs expected values, or `set` the
+suspect value and `continue` to validate the hypothesis without editing.
+
+## tsz: wrong or extra diagnostics (the main use here)
+
+tsz diagnostics funnel through a few sinks: `CheckerState::error`,
+`CheckerContext::push_diagnostic` (`context/diagnostic_push.rs`), and
+`emit_render_request`. For a **wrong** or **extra** (false-positive)
+diagnostic, break the sinks and trace the emit *backward* to the deciding
+code instead of grepping emit sites:
+
+```
+rdbg launch --cargo crates/tsz-checker --test <stem> --break-fn error --break-fn push_diagnostic -- <test_fn>
+rdbg eval code                         # `code` at an error stop; `diag.code` at push_diagnostic
+rdbg continue --until 'code == <code>' # ONLY if the current stop isn't already the emit
+rdbg bt                                # walk back to the deciding frame
+rdbg frame <n> ; rdbg vars             # the types/flags that produced it
+```
+
+`<stem>` is `crates/tsz-checker/tests/<stem>.rs`; words after `--` filter to
+the failing `#[test]` name. Check the current stop's `code` before
+`continue --until` — it resumes first and tests only later stops.
+
+- Unhit sinks are reported at exit (`bound, 0 hits` = wrong path, try the
+  next sink; `NOT BOUND` = bad name). Qualified names (`Type::method`) don't
+  bind — use the base name, or `--break <file>:<line>` inside the function.
+- A **missing** diagnostic has nothing to trace. Read to find where the check
+  should fire; only then break there to see why its condition is false.
+- The same pattern works a layer down: break a `tsz-solver` relation or
+  evaluation function to see the actual `TypeId`s and flags at the decision.
+- vs `tsz-tracing`: `TSZ_LOG` traces show the breadth of what solver/checker
+  did; rdbg answers a pointed question with concrete values and lets you
+  mutate state to test a hypothesis.
+- `rdbg down` when finished; `.rdbg/` is gitignored; use rdbg instead of
+  temporary `dbg!`/`println!` (forbidden here anyway).
+
+## Targets and sessions
+
+```
+rdbg launch --cargo <dir> --bin app --break src/x.rs:88 -- --threads 4
+rdbg launch --cargo <dir> --lib --break src/lib.rs:42 -- my_test     # #[test] in src/
+rdbg launch --cargo <dir> --test t --break tests/t.rs:12 -- case     # tests/t.rs
+rdbg trace --cargo <dir> --lib --break src/lib.rs:42 --capture a,b -- my_test
+```
+
+`--lib` for a `#[test]` inside the library (the common case); `--test <name>`
+only for an integration test file `tests/<name>.rs`. Add `--panic` to also stop
+where a panic is raised, or `--break-fn <name>` for a function breakpoint.
+`trace` runs through every hit and returns a table in one call — use it to
+watch a value evolve without stepping.
+
+## Command crib
+
+```
+rdbg break src/x.rs:42 [--if "i == 5" | --hit 3 | --log "i={i}"]
+rdbg break --fn crate::f | --panic ; rdbg watch var ; rdbg breaks
+rdbg continue [--until 'sum >= 100']  # condition re-checked at each stop
+rdbg step over|in|out ; rdbg until src/x.rs:99 ; rdbg restart
+rdbg vars ; rdbg eval a.b c ; rdbg set a.b = 8 [--then continue]
+rdbg bt ; rdbg frame <n>|up|down ; rdbg list ; rdbg state
+rdbg where <Name> ; rdbg def|hover|refs <file> <line> <col>
+rdbg stop ; rdbg down                 # end session; stop the daemon
+```
+
+## Notes
+
+- `eval`/`set`/conditions take variable paths and simple comparisons; codelldb
+  adds comparison/arithmetic/field eval. Rust method calls can't run — break
+  inside instead.
+- Panicking test, one call: `rdbg debug --cargo <dir> --lib --panic -- <test>`
+  returns the message, first user frame with args and locals, and a backtrace.
+- Debug the debug build; `--release` has little to inspect. `rdbg down` (or 30
+  minutes idle) releases the paused process.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -124,6 +124,8 @@ Use repo-local skills under `.agents/skills/` when the task matches:
 - `tsz-conformance`: diagnostic conformance and accepted-regression drift.
 - `tsz-emit`: JS/DTS emit.
 - `tsz-tracing`: tracing-driven debugging.
+- `rust-debugger`: live rdbg breakpoint debugging; for wrong/extra diagnostics
+  break the diagnostic sinks and backtrace to the deciding frame.
 - `tsz-performance-engineering`: perf/cache/residency.
 - `tsz-project-bench`: project corpus and benchmark rows.
 - `tsz-iteration-audit`: workflow, guardrail, context debt.

--- a/.claude/skills/rust-debugger/REFERENCE.md
+++ b/.claude/skills/rust-debugger/REFERENCE.md
@@ -1,0 +1,129 @@
+# rdbg full reference
+
+Expanded command reference for the `rust-debugger` skill (upstream:
+<https://github.com/mohsen1/rust-debugger-skill>). Read on demand; the triage
+and tsz-specific recipe live in `SKILL.md`.
+
+## Start a session
+
+```
+rdbg where parse_config                            # find where to break
+rdbg launch --cargo . --bin app --break src/config.rs:88 -- --threads 4
+rdbg launch --cargo . --lib --break src/lib.rs:42 -- my_test        # a #[test] in the library
+rdbg launch --cargo . --test mytest --break tests/mytest.rs:12 -- some_case  # tests/mytest.rs
+rdbg launch --bin-path target/debug/app --break src/main.rs:11   # skip the build
+```
+
+Pick the target by where the test lives: `--lib` for a `#[test]` inside the
+library (`#[cfg(test)] mod tests` in `src/` — the common case), `--test <name>`
+only for an integration test file `tests/<name>.rs`. In both, the words after
+`--` are the test-name filter, so exactly the test you name runs.
+
+Add `--panic` to also stop where any panic is raised, or `--break-fn <name>`.
+
+To watch a value evolve without stepping, `trace` instead of `launch` — it runs
+through every hit and returns a table in one call:
+
+```
+rdbg trace --cargo . --bin app --break src/x.rs:42 --capture i,sum --max 30
+rdbg trace --cargo . --lib --break src/lib.rs:42 --capture a,b -- my_test
+```
+
+## Breakpoints
+
+Set or change these any time, including while paused.
+
+```
+rdbg break src/x.rs:42                # line
+rdbg break src/x.rs:42 --if "i == 5"  # conditional (simple comparisons)
+rdbg break src/x.rs:42 --hit 3        # on the 3rd hit
+rdbg break src/x.rs:42 --log "i={i}"  # logpoint (print, don't stop)
+rdbg break --fn my_crate::do_thing    # entering a function
+rdbg break --panic                    # where a Rust panic is raised
+rdbg watch cfg.threads                # when a value changes
+rdbg breaks                           # list with ids; break-rm/break-on/break-off <id>
+```
+
+## Run and step
+
+```
+rdbg continue
+rdbg continue --until 'sum >= 100'    # keep resuming until a condition holds
+rdbg step over | in | out | insn
+rdbg until src/x.rs:99                # run to a line
+rdbg pause                            # interrupt a running program
+rdbg restart
+```
+
+`continue --until '<path> <op> <value>'` (ops `== != < <= > >=`) re-checks the
+condition at each breakpoint stop itself — one call instead of a continue/eval
+loop per iteration, and it works where lldb conditional breakpoints don't fire.
+Needs an active breakpoint to stop at; ends at the first stop where the
+condition holds, or reports that the program exited.
+
+## Read and change state
+
+```
+rdbg vars                             # locals with real Rust values
+rdbg eval items[0].qty sum            # one or more variable paths (not method calls)
+rdbg set cfg.threads = 8 --then continue   # change a value and resume
+rdbg set cfg.threads = 8              # change a value
+rdbg watch-expr add total             # re-shown at every stop
+rdbg bt                               # backtrace
+rdbg list                             # source around the current line
+rdbg state                            # stop + locals + watches together
+```
+
+## Threads and frames
+
+```
+rdbg threads
+rdbg thread <id>
+rdbg frame <n> | up | down            # vars/eval follow the selected frame
+```
+
+## Navigate
+
+```
+rdbg where <Name>
+rdbg def | hover | refs <file> <line> <col>
+```
+
+`rdbg stop` ends the session; `rdbg down` stops the daemon.
+
+## Batching and machine-readable output
+
+- `rdbg do '<cmd>; <cmd>; ...'` runs several subcommands in one call; the batch
+  stops at the first error or program exit.
+- Stops list only the top-frame locals that changed since the previous stop
+  (`~ sum: u32 = 6 (was 3)`); `rdbg vars --full` forces the complete deep dump.
+- Pass `--json` anywhere in the args for one compact JSON line per command with
+  a `status` field (`ok | user_error | target_error | build_error |
+  debug_adapter_error | timeout | no_session`).
+
+## Common loops
+
+- **Wrong value.** Break where it is computed, `vars` and `eval` to see the
+  real inputs, `step` to watch it go wrong, `set` to test a fix without
+  recompiling.
+- **Value goes wrong at some iteration.** Break in the loop, then
+  `continue --until 'sum > 100'` to jump straight to the first stop where the
+  condition holds instead of continue/eval-ing by hand.
+- **Panic.** `rdbg debug --cargo . --lib --panic -- <test>` (or
+  `--bin`/`--test`) runs to the panic and returns the message, the first *user*
+  frame with its arguments and locals, and a backtrace in one call. (Or
+  `launch … --panic`, then `bt`/`up` to your frame, to keep poking around.)
+- **Unexpected mutation.** `watch <var>`, then `continue` to stop the moment it
+  changes.
+- **Failing test.** `--lib … -- <test_name>` for a `#[test]` in the library,
+  `--test <name> … -- <test_name>` for `tests/<name>.rs`; break at the
+  assertion or inside the code under test.
+
+## Notes
+
+- `eval`, `set`, and conditions take variable paths and simple comparisons, not
+  arbitrary Rust expressions. `codelldb` on `PATH` lifts this (the installer
+  sets it up); Rust *method* calls still can't be evaluated — break inside
+  instead.
+- Debug the debug build; a `--release` binary has little to inspect.
+- One paused process per project; `rdbg down` (or 30 minutes idle) releases it.

--- a/.claude/skills/rust-debugger/SKILL.md
+++ b/.claude/skills/rust-debugger/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: rust-debugger
+description: Debug a Rust program or failing test with rdbg — set breakpoints (line, function, conditional, hit-count, panic, or watchpoint), run and step, read locals as real Rust values, change a variable mid-run, and jump to definition/hover/references via rust-analyzer. In tsz, reach for it on a runtime question reading hasn't localized — above all a wrong or extra (false-positive) diagnostic, where you break the diagnostic sinks and backtrace to the deciding frame instead of grepping emit sites. Skip it for missing-diagnostic bugs (nothing fires to break on) and small localized bugs a quick read already pins down.
+---
+
+# rust-debugger
+
+`rdbg` debugs from the command line: one paused process per project; breakpoints
+and state carry across calls. Needs a debug build (the default `cargo build`).
+Run `rdbg` with no arguments for the full command list; `REFERENCE.md` beside
+this file adds examples. Install:
+`curl -fsSL https://azimi.me/rust-debugger-skill/install.sh | sh` (also sets up
+codelldb), plus `rust-analyzer` on `PATH`.
+
+## When to reach for it (and when not)
+
+Read first. Every `launch` rebuilds the target, so a wasted debugging detour is
+expensive. Launch only for a **runtime question at a place you can name**:
+- a **wrong** value where you need the real inputs/flow that produced it;
+- an unexpected branch, type, or state that reading can't pin down;
+- a **panic** — `rdbg debug --panic` lands on the culprit frame in one call;
+- testing a fix live with `set --then continue` before editing + rebuilding.
+
+Don't launch when a quick read already points at the fix; when the output is
+**missing** (nothing fires to break on — finding the absent check is a reading
+task); or to iterate on a candidate fix — re-run the narrowed test instead.
+
+Stay cheap: one session with several breakpoints, or one `trace`, beats
+re-launching. If 2–3 probes haven't localized it, go back to reading.
+
+Fix once, don't churn: after ~2–3 edit→test cycles you're guessing — break at
+the failing assertion and compare actual vs expected values, or `set` the
+suspect value and `continue` to validate the hypothesis without editing.
+
+## tsz: wrong or extra diagnostics (the main use here)
+
+tsz diagnostics funnel through a few sinks: `CheckerState::error`,
+`CheckerContext::push_diagnostic` (`context/diagnostic_push.rs`), and
+`emit_render_request`. For a **wrong** or **extra** (false-positive)
+diagnostic, break the sinks and trace the emit *backward* to the deciding
+code instead of grepping emit sites:
+
+```
+rdbg launch --cargo crates/tsz-checker --test <stem> --break-fn error --break-fn push_diagnostic -- <test_fn>
+rdbg eval code                         # `code` at an error stop; `diag.code` at push_diagnostic
+rdbg continue --until 'code == <code>' # ONLY if the current stop isn't already the emit
+rdbg bt                                # walk back to the deciding frame
+rdbg frame <n> ; rdbg vars             # the types/flags that produced it
+```
+
+`<stem>` is `crates/tsz-checker/tests/<stem>.rs`; words after `--` filter to
+the failing `#[test]` name. Check the current stop's `code` before
+`continue --until` — it resumes first and tests only later stops.
+
+- Unhit sinks are reported at exit (`bound, 0 hits` = wrong path, try the
+  next sink; `NOT BOUND` = bad name). Qualified names (`Type::method`) don't
+  bind — use the base name, or `--break <file>:<line>` inside the function.
+- A **missing** diagnostic has nothing to trace. Read to find where the check
+  should fire; only then break there to see why its condition is false.
+- The same pattern works a layer down: break a `tsz-solver` relation or
+  evaluation function to see the actual `TypeId`s and flags at the decision.
+- vs `tsz-tracing`: `TSZ_LOG` traces show the breadth of what solver/checker
+  did; rdbg answers a pointed question with concrete values and lets you
+  mutate state to test a hypothesis.
+- `rdbg down` when finished; `.rdbg/` is gitignored; use rdbg instead of
+  temporary `dbg!`/`println!` (forbidden here anyway).
+
+## Targets and sessions
+
+```
+rdbg launch --cargo <dir> --bin app --break src/x.rs:88 -- --threads 4
+rdbg launch --cargo <dir> --lib --break src/lib.rs:42 -- my_test     # #[test] in src/
+rdbg launch --cargo <dir> --test t --break tests/t.rs:12 -- case     # tests/t.rs
+rdbg trace --cargo <dir> --lib --break src/lib.rs:42 --capture a,b -- my_test
+```
+
+`--lib` for a `#[test]` inside the library (the common case); `--test <name>`
+only for an integration test file `tests/<name>.rs`. Add `--panic` to also stop
+where a panic is raised, or `--break-fn <name>` for a function breakpoint.
+`trace` runs through every hit and returns a table in one call — use it to
+watch a value evolve without stepping.
+
+## Command crib
+
+```
+rdbg break src/x.rs:42 [--if "i == 5" | --hit 3 | --log "i={i}"]
+rdbg break --fn crate::f | --panic ; rdbg watch var ; rdbg breaks
+rdbg continue [--until 'sum >= 100']  # condition re-checked at each stop
+rdbg step over|in|out ; rdbg until src/x.rs:99 ; rdbg restart
+rdbg vars ; rdbg eval a.b c ; rdbg set a.b = 8 [--then continue]
+rdbg bt ; rdbg frame <n>|up|down ; rdbg list ; rdbg state
+rdbg where <Name> ; rdbg def|hover|refs <file> <line> <col>
+rdbg stop ; rdbg down                 # end session; stop the daemon
+```
+
+## Notes
+
+- `eval`/`set`/conditions take variable paths and simple comparisons; codelldb
+  adds comparison/arithmetic/field eval. Rust method calls can't run — break
+  inside instead.
+- Panicking test, one call: `rdbg debug --cargo <dir> --lib --panic -- <test>`
+  returns the message, first user frame with args and locals, and a backtrace.
+- Debug the debug build; `--release` has little to inspect. `rdbg down` (or 30
+  minutes idle) releases the paused process.

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ crates/tsz-website/data/*
 .local-target-main/
 __pycache__
 dist/
+
+# rdbg (rust-debugger-skill) per-project daemon state
+.rdbg/


### PR DESCRIPTION
Installs the [rust-debugger skill](https://github.com/mohsen1/rust-debugger-skill) (rdbg 0.4.0) as a repo skill, adapted to tsz: agents get live breakpoint debugging — read actual runtime values instead of adding `println!`/`dbg!` (which the agent contract forbids anyway).

The tsz-specific part is the fingerprint-trace recipe for wrong/extra (false-positive) diagnostics: break the diagnostic sinks and backtrace to the deciding frame instead of grepping emit sites. Upstream benchmarks on real tsz bugs measured −49%/−70% agent token cost on wrong-display and FP-diagnostic fixes (identical fix rate), and +91% on a missing-diagnostic bug — hence the skill's triage explicitly routes missing-diagnostic bugs to reading, not launching.

The recipe was verified live against this checkout and corrected from upstream's notes: the sink family is `CheckerState::error` (not only `push_diagnostic` — that bound but never fired for TS2416), qualified fn names don't bind in lldb, and `continue --until` resumes before testing, so the skill says to eval the current stop's `code` first. One launch + `bt` on `overload_with_wrong_return_type_still_emits_ts2416` landed on `check_overloaded_method_compat` (`class_checker.rs:1427`) — the exact deciding frame.

What's in the diff:
- `.agents/skills/rust-debugger/` + identical `.claude/skills/rust-debugger/` copy (repo convention): `SKILL.md` (triage + tsz recipe + command crib, within the 120-line/900-word skill budget) and `REFERENCE.md` (full command reference, read on demand).
- `.claude/CLAUDE.md`: one pointer line in the repo-skills list (`AGENTS.md` symlinks to it).
- `.gitignore`: `.rdbg/` (per-project daemon state).

No compiler code is touched.

## Goal
Goal: green

## Verification
- `python3 scripts/agents/llm-context-audit.py` → `llm_context_audit_status=pass` (skill within 120-line/900-word budget)
- Live smoke on this checkout: `rdbg launch --cargo crates/tsz-checker --test abstract_method_overload_ts2416_tests --break-fn error -- overload_with_wrong_return_type_still_emits_ts2416` stopped at `CheckerState::error` with `code = 2416`; `rdbg bt` walked to `check_overloaded_method_compat`; `rdbg frame 2; rdbg vars` inspected the deciding frame; `rdbg down` cleaned up
- Negative path verified: `--break-fn push_diagnostic` and `emit_render_request` report `bound, 0 hits` for this family (the skill documents the fallback order)

## Provenance
Machine: Mac.home
Assistant: claude-code
Model: claude-fable-5
Effort: high