### PR TITLE
ci: skip heavy jobs on pull_request (keep full suite on merge_group/main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   clippy:
     name: clippy
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -40,6 +41,7 @@ jobs:
 
   unit:
     name: unit
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -51,6 +53,7 @@ jobs:
 
   conformance:
     name: conformance-${{ matrix.shard }}
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
@@ -106,6 +109,7 @@ jobs:
 
   emit:
     name: emit-${{ matrix.shard }}
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
@@ -159,6 +163,7 @@ jobs:
 
   fourslash:
     name: fourslash-${{ matrix.shard }}
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
@@ -233,6 +238,7 @@ jobs:
       - name: Verify core CI jobs
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           python3 - <<'PY'
           import json
@@ -251,10 +257,18 @@ jobs:
               "fourslash-aggregate",
           }
 
+          # On pull_request the heavy jobs are intentionally skipped: the merge
+          # campaign validates PRs via local delta-verified trains, and the full
+          # suite still runs on merge_group / push-to-main / workflow_dispatch.
+          # So "skipped" counts as a pass ONLY for pull_request; a real failure or
+          # cancellation still fails, and every non-PR event stays strict.
+          allow_skipped = os.environ.get("EVENT_NAME") == "pull_request"
+          passing = {"success", "skipped"} if allow_skipped else {"success"}
+
           failures = []
           for name in sorted(required):
               result = needs.get(name, {}).get("result")
-              if result != "success":
+              if result not in passing:
                   failures.append(f"{name}: {result}")
 
           if failures:
@@ -263,5 +277,8 @@ jobs:
                   print(f"  - {failure}")
               sys.exit(1)
 
-          print("Clippy, unit, conformance, emit, and fourslash checks passed.")
+          if allow_skipped:
+              print("PR event: heavy jobs skipped by design; core gate passes.")
+          else:
+              print("Clippy, unit, conformance, emit, and fourslash checks passed.")
           PY


### PR DESCRIPTION
Make PR-event CI light. The active merge campaign validates every PR through **local delta-verified trains** (workspace build + whole-tree arch-guard + targeted nextest/conformance), so the heavy GitHub `pull_request` jobs are redundant — and their queued backlog burns Actions quota when runners/quota recover.

This gates the five heavy `ci.yml` jobs — `clippy`, `unit`, `conformance`, `emit`, `fourslash` — with `if: ${{ github.event_name != 'pull_request' }}`. Their three aggregate jobs (`conformance-aggregate` / `emit-aggregate` / `fourslash-aggregate`) already skip when their base skips (their `if` gates on `needs.<base>.result != 'skipped'`), so they auto-skip on PRs.

The FULL suite is unchanged on `merge_group`, push-to-`main`, and `workflow_dispatch` — main's own validation and the merge-queue gate stay intact for the endgame.

The required `ci-summary` ("CI Summary") job still RUNS on `pull_request` (`if: always()`) and now treats a **skipped** heavy job as a pass **only** for `pull_request` events. A real `failure`/`cancelled` still fails; every non-PR event stays strict (a `skipped` there fails), so `main` can never merge on skipped heavies.

Only `ci.yml` is `pull_request`-triggered in this repo — no other workflow (quality-tools, install-test, bench, etc. are schedule/dispatch/push only) and no cheap check (pr-body-gate is not a `ci.yml` job) is touched.

## Goal
Goal: hold

## Reversibility
Single revert restores full PR CI. When the campaign ends and quota recovers, `git revert` this PR (or drop the five `if:` lines + the `allow_skipped` branch in `ci-summary`) to re-enable heavy jobs on `pull_request`.

## Verification
- `actionlint .github/workflows/ci.yml` — clean (exit 0).
- YAML parses (`yaml.safe_load`); the embedded `ci-summary` python compiles (`py_compile`).
- `ci-summary` gate logic simulated across scenarios:
  - PR, all heavy skipped -> PASS (the goal)
  - PR, a job actually failed -> FAIL (real failures still fail)
  - merge_group / push, all success -> PASS (full suite gates main)
  - merge_group / push, a job skipped -> FAIL (strict; main can't merge on skipped heavies)
- Confirmed `ci.yml` is the only `pull_request`-triggered workflow (swept all `.github/workflows/*.yml`).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
