### PR TITLE
fix(checker): drill sparse-tuple elision mismatch to the offending element (#15612)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -919,7 +919,7 @@ impl<'a> CheckerState<'a> {
         annotation.is_some().then_some(annotation)
     }
 
-    fn error_type_not_assignable_at_with_raw_display_types(
+    pub(crate) fn error_type_not_assignable_at_with_raw_display_types(
         &mut self,
         source_for_display: TypeId,
         target_for_display: TypeId,

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -1108,6 +1108,23 @@ impl<'a> CheckerState<'a> {
         let tuple_target_elements =
             crate::query_boundaries::common::tuple_elements(self.ctx.types, effective_param_type);
 
+        // tsc's `checkArrayLiteral` carries a cumulative `hasOmittedExpression`
+        // flag: once an elision precedes a present element, `elaborateArrayLiteral`
+        // compares that element's *widened, `| undefined`-unioned* source type
+        // (`addOptionality(widen(type), /*isProperty*/ true, true)`) against the
+        // target slot (issue #15612). tsz models the hole as absence (`never?`)
+        // rather than a distinct `missingType`, so the source tuple keeps the bare
+        // element type and the whole-tuple relation reports a coarse message. Only
+        // failing assignments reach this elaborator, so recovering the widening
+        // here — for a present element after an elision, in a tuple context, under
+        // `exactOptionalPropertyTypes` — drills to `T | undefined` vs the required
+        // target slot without perturbing the (already-correct) assignability
+        // decision. The optional-target case never fails the relation, so it never
+        // reaches this path and stays green.
+        let elision_widening_applies = self.ctx.compiler_options.exact_optional_property_types
+            && tuple_target_elements.is_some();
+        let mut saw_elision = false;
+
         // For variadic-rest tuples with trailing fixed elements (e.g., [number, ...string[], number]),
         // element positions can only be reliably matched against the leading fixed section.
         // Trailing fixed elements cannot be mapped without knowing the total source length, and
@@ -1128,6 +1145,10 @@ impl<'a> CheckerState<'a> {
                 break;
             }
             let Some(elem_node) = self.ctx.arena.get(elem_idx) else {
+                // Elided slot (a "hole"): tsc's `elaborateArrayLiteral` skips it
+                // (no expression to anchor) but records that later present
+                // elements are now optional-with-`| undefined` (issue #15612).
+                saw_elision = true;
                 continue;
             };
 
@@ -1193,6 +1214,45 @@ impl<'a> CheckerState<'a> {
             } else {
                 target_element_type
             };
+
+            // Present element following an elision under `exactOptionalPropertyTypes`
+            // in a tuple context: widen its type and union `undefined`, mirroring
+            // tsc's `addOptionality(widen(type), /*isProperty*/ true, true)`
+            // (issue #15612). When that `T | undefined` is exactly what the target
+            // slot rejects — a *required* target element — report it at this
+            // element. An optional target slot would make the whole assignment
+            // succeed, so this elaborator never runs for it.
+            if elision_widening_applies
+                && saw_elision
+                && elem_node.kind != syntax_kind_ext::SPREAD_ELEMENT
+            {
+                let widened = crate::query_boundaries::common::widen_literal_type(
+                    self.ctx.types,
+                    self.elaboration_source_expression_type(elem_idx),
+                );
+                let src_elem_type = self.ctx.types.union2(widened, TypeId::UNDEFINED);
+                if src_elem_type != target_element_type
+                    && target_element_type != TypeId::ERROR
+                    && target_element_type != TypeId::ANY
+                    && !self
+                        .call_arg_relation_outcome(src_elem_type, target_element_type)
+                        .related
+                {
+                    // Render the widened source (`T | undefined`) and the target
+                    // slot verbatim, anchored at the element. The role-based
+                    // emitters re-derive an `AssignmentSource` from the enclosing
+                    // assignment's RHS (surfacing the whole source tuple), which
+                    // would defeat the per-element drill; the raw emitter keeps
+                    // the element types.
+                    self.error_type_not_assignable_at_with_raw_display_types(
+                        src_elem_type,
+                        display_target_element_type,
+                        elem_idx,
+                    );
+                    elaborated = true;
+                    continue;
+                }
+            }
 
             let elem_type = self.elaboration_source_expression_type(elem_idx);
             let contextual_request =

--- a/crates/tsz-checker/src/tests/call_elaboration_mutual_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_elaboration_mutual_relation_routing_arch_tests.rs
@@ -174,7 +174,7 @@ fn call_elaboration_object_array_helpers_use_relation_outcome_boundary() {
 
     assert_eq!(
         helpers.matches("call_arg_relation_outcome(").count(),
-        5,
+        6,
         "object/array call elaboration helper probes should route through call_arg_relation_outcome"
     );
     assert_eq!(

--- a/crates/tsz-checker/tests/optional_tuple_element_undefined_assignability_tests.rs
+++ b/crates/tsz-checker/tests/optional_tuple_element_undefined_assignability_tests.rs
@@ -227,6 +227,102 @@ const t2: [number, string?, boolean?] = [1, "ok", undefined];
     );
 }
 
+/// Issue #15612: a present element following an elision (a "hole") in a
+/// sparse array literal is, under `exactOptionalPropertyTypes`, widened and
+/// unioned with `undefined` — target-independently — mirroring tsc's
+/// cumulative `hasOmittedExpression` model in `checkArrayLiteral`. Against a
+/// *required* target slot the relation therefore drills into that element's
+/// position and reports `Type 'boolean | undefined' is not assignable to type
+/// 'boolean'`, matching the oracle, instead of a whole-tuple message.
+#[test]
+fn mid_hole_present_element_widens_with_undefined_against_required_slot() {
+    let source = r#"
+function f(t: [number, string, boolean]) {
+    t = [42, , true];
+}
+"#;
+    let diags = check_exact_optional(source);
+    let ts2322: Vec<_> = diags
+        .iter()
+        .filter(|diag| diag.code == 2322)
+        .map(|diag| diag.message_text.as_str())
+        .collect();
+    assert!(
+        ts2322
+            .iter()
+            .any(|msg| msg
+                .contains("Type 'boolean | undefined' is not assignable to type 'boolean'")),
+        "mid-hole element must surface `boolean | undefined` vs `boolean` at its own position; got: {ts2322:#?}"
+    );
+}
+
+/// Anti-hardcoding (§25): the after-hole widening is structural, not tied to
+/// the `boolean`/index-2 shape. A leading hole before a `string` element
+/// against a required `string` slot surfaces `string | undefined` too.
+#[test]
+fn leading_hole_present_element_widens_with_undefined() {
+    let source = r#"
+function f(t: [string, string]) {
+    t = [, "b"];
+}
+"#;
+    let diags = check_exact_optional(source);
+    let ts2322: Vec<_> = diags
+        .iter()
+        .filter(|diag| diag.code == 2322)
+        .map(|diag| diag.message_text.as_str())
+        .collect();
+    assert!(
+        ts2322
+            .iter()
+            .any(|msg| msg.contains("Type 'string | undefined' is not assignable to type 'string'")),
+        "leading-hole element must surface `string | undefined` vs `string`; got: {ts2322:#?}"
+    );
+}
+
+/// Anti-hardcoding (§25): the source model is target-independent, so a tuple
+/// *alias* target behaves identically to the inline tuple — the after-hole
+/// element still drills to `boolean | undefined` vs the alias's `boolean` slot.
+#[test]
+fn mid_hole_present_element_widens_against_alias_tuple_target() {
+    let source = r#"
+type Triple = [number, string, boolean];
+function f(t: Triple) {
+    t = [42, , true];
+}
+"#;
+    let diags = check_exact_optional(source);
+    let ts2322: Vec<_> = diags
+        .iter()
+        .filter(|diag| diag.code == 2322)
+        .map(|diag| diag.message_text.as_str())
+        .collect();
+    assert!(
+        ts2322
+            .iter()
+            .any(|msg| msg
+                .contains("Type 'boolean | undefined' is not assignable to type 'boolean'")),
+        "alias tuple target must still drill to `boolean | undefined` vs `boolean`; got: {ts2322:#?}"
+    );
+}
+
+/// Positive companion: against an *optional* target slot the after-hole
+/// `| undefined` is absorbed, so the mid-hole literal must stay assignable and
+/// emit no TS2322 — the divergence is required-target-only (issue #15612).
+#[test]
+fn mid_hole_present_element_stays_green_against_optional_slot() {
+    let source = r#"
+function f(t: [number, string?, boolean?]) {
+    t = [42, , true];
+}
+"#;
+    let diags = check_exact_optional(source);
+    assert!(
+        !diags.iter().any(|diag| diag.code == 2322),
+        "mid-hole literal into an all-optional tail must stay assignable; got: {diags:#?}"
+    );
+}
+
 #[test]
 fn exact_optional_tuple_elisions_remain_absence_not_undefined() {
     let source = r#"


### PR DESCRIPTION
Fixes #15612.

When a sparse array literal (`[42, , true]`) is assigned to a tuple under `exactOptionalPropertyTypes`, `tsc`'s `checkArrayLiteral` carries a cumulative `hasOmittedExpression` flag: once an elision precedes a present element, that element's source type becomes `addOptionality(widen(type), /*isProperty*/ true, true)` = `widened | undefined`. Against a **required** target slot, `elaborateArrayLiteral` drills to that element and reports `Type 'boolean | undefined' is not assignable to type 'boolean'`; against an **optional** slot the relation succeeds and nothing is reported.

`tsz` already made the correct assignability **decision** (TS2322 for a required target, none for an optional target) but rendered a coarse whole-tuple message for the required case:

| target | before | after (matches `tsc`) |
|---|---|---|
| `[number, string, boolean]` (required) | `Type '[number, never?, true]' is not assignable to type '[number, string, boolean]'` | `Type 'boolean \| undefined' is not assignable to type 'boolean'` |
| `[number, string?, boolean?]` (optional) | *(0 diagnostics)* | *(0 diagnostics)* — unchanged |

`tsz` models a hole as absence (`never?`) rather than a distinct `missingType`, so unioning real `undefined` into the source tuple (the naive fix) regresses the optional-target case — a present `undefined` is not assignable to an optional slot under EOPT. The fix therefore lives purely in the array-literal element **elaborator**, which only runs on already-failing assignments: for a present element following an elision, in a tuple context, under EOPT, it recomputes `widen(elem) | undefined` and — when that is exactly what a required target slot rejects — reports it verbatim at the element via the raw-display emitter (the role-based emitters would re-derive the whole source tuple from the enclosing assignment RHS and defeat the drill). The optional-target relation succeeds, so this path never runs for it and it stays green. No assignability-decision change.

Structural rule: when a present array-literal element follows an elision in a tuple context under `exactOptionalPropertyTypes` and its widened `T | undefined` is not assignable to the aligned **required** target slot, `tsc` reports the mismatch at that element; `tsz` now does the same through the array-literal element elaborator (`crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs`).

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --test optional_tuple_element_undefined_assignability_tests` — 13 pass, including new adjacency cases: required-slot drill (`boolean | undefined` vs `boolean`), leading-hole drill (`string | undefined` vs `string`), alias tuple target, and the optional-target case staying green (name-independent, positive + negative).
- `cargo nextest run -p tsz-checker --lib elaborat tuple` — 517 pass; the 4 remaining failures are pre-existing in this environment (missing lib types: `PropertyKey`/`Symbol`) and fail identically on the base commit.
- Updated the `call_elaboration_object_array_helpers_use_relation_outcome_boundary` arch guard count (5→6) for the one added `call_arg_relation_outcome` probe, which correctly routes through the relation-outcome boundary.
- `cargo clippy -p tsz-checker --lib` clean.
- Deciding frame confirmed with `rdbg` (rust-debugger): source tuple built `[number, never?, true]`, elaborator re-derives `boolean | undefined` at the after-hole element and anchors the drilled message.
- Ready-review CI owns the broad conformance/emit suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_015UKvxkUCMz5BFwp8H4UX3U)_