### PR TITLE
fix(ci): make dedup-sentinel tracking issues self-healing

### DIFF
--- a/scripts/bench/check-latest-freshness.mjs
+++ b/scripts/bench/check-latest-freshness.mjs
@@ -32,12 +32,14 @@
 
 import fs from "node:fs";
 import https from "node:https";
-import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 
+import { runGh, runGhJson } from "../ci/lib/gh.mjs";
 import {
   collectSentinelIssues,
+  splitSentinels,
   closeDuplicateSentinels,
+  SENTINEL_LABEL,
 } from "../ci/lib/sentinel-issues.mjs";
 
 export const DEFAULT_LATEST_URL = "https://tsz.dev/benchmark-data/latest.json";
@@ -186,61 +188,12 @@ export function formatIssueBody(verdict, ctx, nowIso) {
   ].join("\n");
 }
 
-// ---- gh I/O (kept behind injectable seams so main() stays testable) ----------
-
-const GH_RETRY_ATTEMPTS = 3;
-const GH_RETRY_BASE_MS = 750;
-const GH_RETRY_MAX_MS = 6000;
-const TRANSIENT_NET_CODES = new Set(["ETIMEDOUT", "ECONNRESET", "EAI_AGAIN", "ENETUNREACH"]);
-
-function sleepSync(ms) {
-  if (!(ms > 0)) return;
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function isTransientGhResult(result) {
-  if (result.error) return TRANSIENT_NET_CODES.has(result.error.code);
-  if ((result.status ?? 0) === 0) return false;
-  const text = `${result.stdout || ""}\n${result.stderr || ""}`;
-  return /\bHTTP\s+(?:408|425|429|5\d\d)\b/i.test(text) || /secondary rate limit/i.test(text);
-}
-
-function spawnGh(args) {
-  let result;
-  for (let attempt = 1; attempt <= GH_RETRY_ATTEMPTS; attempt += 1) {
-    result = spawnSync("gh", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "pipe"] });
-    if (attempt === GH_RETRY_ATTEMPTS || !isTransientGhResult(result)) break;
-    sleepSync(Math.min(GH_RETRY_BASE_MS * 2 ** (attempt - 1), GH_RETRY_MAX_MS));
-  }
-  return result;
-}
-
-function runGhJson(args) {
-  const result = spawnGh(args);
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(`gh ${args.join(" ")} failed: ${result.stderr?.trim() || result.stdout?.trim()}`);
-  }
-  return JSON.parse(result.stdout);
-}
-
-function runGh(args) {
-  const result = spawnGh(args);
-  if (result.error) return { status: 1, stdout: "", stderr: result.error.message };
-  return { status: result.status ?? 1, stdout: (result.stdout || "").trim(), stderr: (result.stderr || "").trim() };
-}
-
 const TRACKED_GENERATED_RE = /generated_at:\s*`([^`]+)`/;
 
 /**
- * Open / update / close the single dedup tracking issue.
- *
- * The lookup (shared with `check-main-red.mjs`) returns every open sentinel —
- * marker match or exact-title fallback, oldest first. The oldest is canonical:
- * it is the one updated (re-stamping the marker if a body edit stripped it) or
- * closed on recovery; any younger matches are duplicates from a past lookup
- * miss and are closed pointing at the canonical issue, so a duplicated
- * sentinel heals itself on the next firing instead of splitting forever.
+ * Open / update / close the single dedup tracking issue. The oldest open
+ * sentinel is canonical; younger matches from a past lookup miss are closed as
+ * duplicates (see `../ci/lib/sentinel-issues.mjs` for the healing rules).
  *
  * @param {ReturnType<typeof classifyFreshness>} verdict
  */
@@ -252,8 +205,9 @@ export function reconcileIssue(verdict, ctx, nowIso, gh = {}) {
     marker: ISSUE_MARKER,
     title: ISSUE_TITLE,
   });
-  const existing = matches[0] ?? null;
-  const duplicates = matches.slice(1);
+  const { canonical: existing, duplicates } = splitSentinels(matches);
+  const closeDupes = () =>
+    closeDuplicateSentinels(duplicates, existing.number, repository, runCommand, nowIso);
 
   if (verdict.alert) {
     const body = formatIssueBody(verdict, ctx, nowIso);
@@ -275,14 +229,7 @@ export function reconcileIssue(verdict, ctx, nowIso, gh = {}) {
           `Still stale as of ${nowIso}: generated_at \`${current}\` (${verdict.reason}).`,
         ]);
       }
-      const closedDuplicates = closeDuplicateSentinels(
-        duplicates,
-        existing.number,
-        repository,
-        runCommand,
-        nowIso,
-      );
-      return { action: "updated", number: existing.number, commented: changed, closedDuplicates };
+      return { action: "updated", number: existing.number, commented: changed, closedDuplicates: closeDupes() };
     }
     const created = runCommand([
       "issue",
@@ -294,7 +241,7 @@ export function reconcileIssue(verdict, ctx, nowIso, gh = {}) {
       "--body",
       body,
       "--label",
-      "tech-debt",
+      SENTINEL_LABEL,
     ]);
     return { action: "created", detail: created.stdout || created.stderr };
   }
@@ -310,14 +257,7 @@ export function reconcileIssue(verdict, ctx, nowIso, gh = {}) {
       `✅ Published benchmark data is fresh again as of ${nowIso} (${verdict.reason}). Closing.`,
     ]);
     runCommand(["issue", "close", String(existing.number), "--repo", repository, "--reason", "completed"]);
-    const closedDuplicates = closeDuplicateSentinels(
-      duplicates,
-      existing.number,
-      repository,
-      runCommand,
-      nowIso,
-    );
-    return { action: "closed", number: existing.number, closedDuplicates };
+    return { action: "closed", number: existing.number, closedDuplicates: closeDupes() };
   }
   return { action: "noop" };
 }

--- a/scripts/bench/check-latest-freshness.mjs
+++ b/scripts/bench/check-latest-freshness.mjs
@@ -39,6 +39,7 @@ import {
   collectSentinelIssues,
   splitSentinels,
   createSentinelIssue,
+  closeSentinelIssue,
   closeDuplicateSentinels,
 } from "../ci/lib/sentinel-issues.mjs";
 
@@ -236,16 +237,12 @@ export function reconcileIssue(verdict, ctx, nowIso, gh = {}) {
   }
 
   if (existing) {
-    runCommand([
-      "issue",
-      "comment",
-      String(existing.number),
-      "--repo",
+    closeSentinelIssue(
+      existing.number,
       repository,
-      "--body",
+      runCommand,
       `✅ Published benchmark data is fresh again as of ${nowIso} (${verdict.reason}). Closing.`,
-    ]);
-    runCommand(["issue", "close", String(existing.number), "--repo", repository, "--reason", "completed"]);
+    );
     return { action: "closed", number: existing.number, closedDuplicates: closeDupes() };
   }
   return { action: "noop" };

--- a/scripts/bench/check-latest-freshness.mjs
+++ b/scripts/bench/check-latest-freshness.mjs
@@ -35,6 +35,11 @@ import https from "node:https";
 import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 
+import {
+  collectSentinelIssues,
+  closeDuplicateSentinels,
+} from "../ci/lib/sentinel-issues.mjs";
+
 export const DEFAULT_LATEST_URL = "https://tsz.dev/benchmark-data/latest.json";
 export const DEFAULT_MAX_AGE_HOURS = 6;
 const ISSUE_MARKER = "<!-- bench-latest-freshness-sentinel -->";
@@ -227,46 +232,28 @@ function runGh(args) {
 
 const TRACKED_GENERATED_RE = /generated_at:\s*`([^`]+)`/;
 
-const SENTINEL_PER_PAGE = 100;
-// The `/issues` endpoint returns open issues *and* open PRs, so on an active
-// repo the combined list routinely exceeds one 100-item page. A persistent
-// tracking issue (a standing freeze can live for hours/days) is sorted
-// created-desc and steadily sinks past page 1 as new PRs/issues land, so a
-// single-page scan silently stops finding it — then reconcileIssue re-creates a
-// duplicate every firing and can never close the real one on recovery. Page
-// through open issues until the marker is found or the list is exhausted so the
-// dedup sentinel is always located. The bound caps the walk on a pathological
-// backlog without ever masking a reachable sentinel.
-const SENTINEL_MAX_PAGES = 20;
-
-function findSentinelIssue(repository, fetchJson) {
-  for (let page = 1; page <= SENTINEL_MAX_PAGES; page += 1) {
-    const issues = fetchJson([
-      "api",
-      "-H",
-      "Accept: application/vnd.github+json",
-      `repos/${repository}/issues?state=open&per_page=${SENTINEL_PER_PAGE}&page=${page}`,
-    ]);
-    if (!Array.isArray(issues)) return null;
-    const match = issues.find(
-      (it) => typeof it.body === "string" && it.body.includes(ISSUE_MARKER),
-    );
-    if (match) return match;
-    // A short (or empty) page is the last one — the sentinel is not open.
-    if (issues.length < SENTINEL_PER_PAGE) return null;
-  }
-  return null;
-}
-
 /**
  * Open / update / close the single dedup tracking issue.
+ *
+ * The lookup (shared with `check-main-red.mjs`) returns every open sentinel —
+ * marker match or exact-title fallback, oldest first. The oldest is canonical:
+ * it is the one updated (re-stamping the marker if a body edit stripped it) or
+ * closed on recovery; any younger matches are duplicates from a past lookup
+ * miss and are closed pointing at the canonical issue, so a duplicated
+ * sentinel heals itself on the next firing instead of splitting forever.
+ *
  * @param {ReturnType<typeof classifyFreshness>} verdict
  */
 export function reconcileIssue(verdict, ctx, nowIso, gh = {}) {
   const { repository } = ctx;
   const fetchJson = gh.fetchJson || runGhJson;
   const runCommand = gh.runCommand || runGh;
-  const existing = findSentinelIssue(repository, fetchJson);
+  const matches = collectSentinelIssues(repository, fetchJson, {
+    marker: ISSUE_MARKER,
+    title: ISSUE_TITLE,
+  });
+  const existing = matches[0] ?? null;
+  const duplicates = matches.slice(1);
 
   if (verdict.alert) {
     const body = formatIssueBody(verdict, ctx, nowIso);
@@ -288,7 +275,14 @@ export function reconcileIssue(verdict, ctx, nowIso, gh = {}) {
           `Still stale as of ${nowIso}: generated_at \`${current}\` (${verdict.reason}).`,
         ]);
       }
-      return { action: "updated", number: existing.number, commented: changed };
+      const closedDuplicates = closeDuplicateSentinels(
+        duplicates,
+        existing.number,
+        repository,
+        runCommand,
+        nowIso,
+      );
+      return { action: "updated", number: existing.number, commented: changed, closedDuplicates };
     }
     const created = runCommand([
       "issue",
@@ -316,7 +310,14 @@ export function reconcileIssue(verdict, ctx, nowIso, gh = {}) {
       `✅ Published benchmark data is fresh again as of ${nowIso} (${verdict.reason}). Closing.`,
     ]);
     runCommand(["issue", "close", String(existing.number), "--repo", repository, "--reason", "completed"]);
-    return { action: "closed", number: existing.number };
+    const closedDuplicates = closeDuplicateSentinels(
+      duplicates,
+      existing.number,
+      repository,
+      runCommand,
+      nowIso,
+    );
+    return { action: "closed", number: existing.number, closedDuplicates };
   }
   return { action: "noop" };
 }

--- a/scripts/bench/check-latest-freshness.mjs
+++ b/scripts/bench/check-latest-freshness.mjs
@@ -38,8 +38,8 @@ import { runGh, runGhJson } from "../ci/lib/gh.mjs";
 import {
   collectSentinelIssues,
   splitSentinels,
+  createSentinelIssue,
   closeDuplicateSentinels,
-  SENTINEL_LABEL,
 } from "../ci/lib/sentinel-issues.mjs";
 
 export const DEFAULT_LATEST_URL = "https://tsz.dev/benchmark-data/latest.json";
@@ -231,18 +231,7 @@ export function reconcileIssue(verdict, ctx, nowIso, gh = {}) {
       }
       return { action: "updated", number: existing.number, commented: changed, closedDuplicates: closeDupes() };
     }
-    const created = runCommand([
-      "issue",
-      "create",
-      "--repo",
-      repository,
-      "--title",
-      ISSUE_TITLE,
-      "--body",
-      body,
-      "--label",
-      SENTINEL_LABEL,
-    ]);
+    const created = createSentinelIssue(repository, runCommand, { title: ISSUE_TITLE, body });
     return { action: "created", detail: created.stdout || created.stderr };
   }
 

--- a/scripts/bench/test-check-latest-freshness.mjs
+++ b/scripts/bench/test-check-latest-freshness.mjs
@@ -219,6 +219,99 @@ function NOW_ISO() {
   assert.deepEqual(seenPages, [1, 2], "pages through until the marker is found");
   assert.ok(!calls.some((c) => c[1] === "create"), "never creates a duplicate tracking issue");
 }
+{
+  // Two open sentinels (a healed duplicate from a past lookup miss) + still
+  // stale -> the oldest is canonical and updated; the newer one is closed as a
+  // duplicate pointing at it. Never a third issue.
+  const MARKER = "<!-- bench-latest-freshness-sentinel -->";
+  const calls = [];
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: "2026-06-27T19:03:16.801Z" }), {
+    now: NOW,
+    maxAgeHours: 6,
+  });
+  const existingBody = formatIssueBody(verdict, { url: DEFAULT_LATEST_URL, repository: "tsz-org/tsz" }, NOW_ISO());
+  const outcome = reconcileIssue(
+    verdict,
+    { url: DEFAULT_LATEST_URL, repository: "tsz-org/tsz" },
+    NOW_ISO(),
+    {
+      fetchJson: () => [
+        { number: 15532, body: `${MARKER}\nnewer duplicate` },
+        { number: 15401, body: existingBody },
+      ],
+      runCommand: (args) => {
+        calls.push(args);
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    },
+  );
+  assert.equal(outcome.action, "updated");
+  assert.equal(outcome.number, 15401, "the oldest sentinel is canonical");
+  assert.deepEqual(outcome.closedDuplicates, [15532], "the younger duplicate is closed");
+  assert.ok(!calls.some((c) => c[1] === "create"), "never creates a third tracking issue");
+  const dupComment = calls.find((c) => c[1] === "comment" && c[2] === "15532");
+  assert.match(dupComment[dupComment.length - 1], /#15401/, "duplicate close points at the canonical issue");
+}
+{
+  // A body edit that stripped the marker must not orphan the sentinel: the
+  // exact bot title still matches, the issue is updated (re-stamping the
+  // marker), and no duplicate is created.
+  const calls = [];
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: "2026-06-27T19:03:16.801Z" }), {
+    now: NOW,
+    maxAgeHours: 6,
+  });
+  const outcome = reconcileIssue(
+    verdict,
+    { url: DEFAULT_LATEST_URL, repository: "tsz-org/tsz" },
+    NOW_ISO(),
+    {
+      fetchJson: () => [
+        {
+          number: 61,
+          title: "🟡 benchmark site data is stale — latest.json generated_at not advancing",
+          body: "claimed; body rewritten without the marker",
+        },
+      ],
+      runCommand: (args) => {
+        calls.push(args);
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    },
+  );
+  assert.equal(outcome.action, "updated", "title fallback finds the marker-stripped sentinel");
+  assert.equal(outcome.number, 61);
+  assert.ok(!calls.some((c) => c[1] === "create"), "no duplicate for a marker-stripped body");
+  const edit = calls.find((c) => c[1] === "edit");
+  assert.match(edit[edit.length - 1], /bench-latest-freshness-sentinel/, "edit restores the marker");
+}
+{
+  // Recovery with a lingering duplicate: BOTH sentinels close, not just the
+  // first match.
+  const MARKER = "<!-- bench-latest-freshness-sentinel -->";
+  const calls = [];
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: at(1) }), { now: NOW, maxAgeHours: 6 });
+  const outcome = reconcileIssue(
+    verdict,
+    { url: DEFAULT_LATEST_URL, repository: "tsz-org/tsz" },
+    NOW_ISO(),
+    {
+      fetchJson: () => [
+        { number: 90, body: `${MARKER}\nnewer duplicate` },
+        { number: 80, body: `${MARKER}\nstale` },
+      ],
+      runCommand: (args) => {
+        calls.push(args);
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    },
+  );
+  assert.equal(outcome.action, "closed");
+  assert.equal(outcome.number, 80, "the canonical (oldest) sentinel closes as completed");
+  assert.deepEqual(outcome.closedDuplicates, [90], "the duplicate closes too");
+  const closed = calls.filter((c) => c[1] === "close").map((c) => c[2]);
+  assert.deepEqual(closed.sort(), ["80", "90"], "no zombie sentinel survives recovery");
+}
 
 // ---- end-to-end CLI via --fixture (offline, no network) ---------------------
 function runCli(args, fixtureValue) {

--- a/scripts/ci/check-main-red.mjs
+++ b/scripts/ci/check-main-red.mjs
@@ -18,8 +18,8 @@ import { runGh, runGhJson } from "./lib/gh.mjs";
 import {
   collectSentinelIssues,
   splitSentinels,
+  createSentinelIssue,
   closeDuplicateSentinels,
-  SENTINEL_LABEL,
 } from "./lib/sentinel-issues.mjs";
 
 const DEFAULT_MAX_RUNS = 60;
@@ -376,8 +376,7 @@ export function reconcileIssue(verdict, regressedTests, nowIso, ctx) {
       }
       return { action: "updated", number: existing.number, commented: headChanged, closedDuplicates: closeDupes() };
     }
-    const created = runCommand(["issue", "create", "--repo", repository,
-      "--title", ISSUE_TITLE, "--body", body, "--label", SENTINEL_LABEL]);
+    const created = createSentinelIssue(repository, runCommand, { title: ISSUE_TITLE, body });
     return { action: "created", detail: created.stdout || created.stderr };
   }
 

--- a/scripts/ci/check-main-red.mjs
+++ b/scripts/ci/check-main-red.mjs
@@ -19,6 +19,7 @@ import {
   collectSentinelIssues,
   splitSentinels,
   createSentinelIssue,
+  closeSentinelIssue,
   closeDuplicateSentinels,
 } from "./lib/sentinel-issues.mjs";
 
@@ -382,10 +383,8 @@ export function reconcileIssue(verdict, regressedTests, nowIso, ctx) {
 
   // Green: close every open sentinel issue (canonical + healed duplicates).
   if (existing) {
-    runCommand(["issue", "comment", String(existing.number), "--repo", repository,
-      "--body", `✅ \`main\` is green again as of ${nowIso} (\`${(verdict.run.sha || "").slice(0, 12)}\`). Closing.`]);
-    runCommand(["issue", "close", String(existing.number), "--repo", repository,
-      "--reason", "completed"]);
+    closeSentinelIssue(existing.number, repository, runCommand,
+      `✅ \`main\` is green again as of ${nowIso} (\`${(verdict.run.sha || "").slice(0, 12)}\`). Closing.`);
     return { action: "closed", number: existing.number, closedDuplicates: closeDupes() };
   }
   return { action: "noop" };

--- a/scripts/ci/check-main-red.mjs
+++ b/scripts/ci/check-main-red.mjs
@@ -15,6 +15,11 @@
 import fs from "node:fs";
 import { spawnSync } from "node:child_process";
 
+import {
+  collectSentinelIssues,
+  closeDuplicateSentinels,
+} from "./lib/sentinel-issues.mjs";
+
 const DEFAULT_MAX_RUNS = 60;
 const DEFAULT_GH_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
 const WORKFLOW_NAME = "CI";
@@ -410,40 +415,21 @@ function lastTrackedSha(issue) {
   return match ? match[1] : "";
 }
 
-const SENTINEL_PER_PAGE = 100;
-// The `/issues` endpoint returns open issues *and* open PRs, so on an active
-// repo the combined list routinely exceeds one 100-item page. A persistent
-// tracking issue (a standing main-red can live for hours) is sorted created-desc
-// and steadily sinks past page 1 as new PRs/issues land, so a single-page scan
-// silently stops finding it — then reconcileIssue re-creates a duplicate every
-// firing and can never close the real one on recovery. Page through open issues
-// until the marker is found or the list is exhausted so the dedup sentinel is
-// always located. The bound caps the walk on a pathological backlog without ever
-// masking a reachable sentinel.
-const SENTINEL_MAX_PAGES = 20;
-
-function findSentinelIssue(repository, fetchJson) {
-  for (let page = 1; page <= SENTINEL_MAX_PAGES; page += 1) {
-    const issues = fetchJson([
-      "api",
-      "-H",
-      "Accept: application/vnd.github+json",
-      `repos/${repository}/issues?state=open&per_page=${SENTINEL_PER_PAGE}&page=${page}`,
-    ]);
-    if (!Array.isArray(issues)) return null;
-    const match = issues.find(
-      (it) => typeof it.body === "string" && it.body.includes(ISSUE_MARKER),
-    );
-    if (match) return match;
-    // A short (or empty) page is the last one — the sentinel is not open.
-    if (issues.length < SENTINEL_PER_PAGE) return null;
-  }
-  return null;
-}
-
+// The lookup (shared with `check-latest-freshness.mjs`) returns every open
+// sentinel — marker match or exact-title fallback, oldest first. The oldest is
+// canonical: it is the one updated (re-stamping the marker if a body edit
+// stripped it) or closed on recovery; any younger matches are duplicates from
+// a past lookup miss and are closed pointing at the canonical issue, so a
+// duplicated sentinel heals itself on the next firing instead of splitting
+// forever.
 export function reconcileIssue(verdict, regressedTests, nowIso, ctx) {
   const { repository, fetchJson = runGhJson, runCommand = runGh } = ctx;
-  const existing = findSentinelIssue(repository, fetchJson);
+  const matches = collectSentinelIssues(repository, fetchJson, {
+    marker: ISSUE_MARKER,
+    title: ISSUE_TITLE,
+  });
+  const existing = matches[0] ?? null;
+  const duplicates = matches.slice(1);
   const body = formatIssueBody(verdict, regressedTests, nowIso);
 
   if (verdict.red) {
@@ -459,20 +445,22 @@ export function reconcileIssue(verdict, regressedTests, nowIso, ctx) {
         runCommand(["issue", "comment", String(existing.number), "--repo", repository,
           "--body", `Still red as of ${nowIso}: \`${currentSha}\` ([run](${verdict.run.url})).`]);
       }
-      return { action: "updated", number: existing.number, commented: headChanged };
+      const closedDuplicates = closeDuplicateSentinels(duplicates, existing.number, repository, runCommand, nowIso);
+      return { action: "updated", number: existing.number, commented: headChanged, closedDuplicates };
     }
     const created = runCommand(["issue", "create", "--repo", repository,
       "--title", ISSUE_TITLE, "--body", body, "--label", "tech-debt"]);
     return { action: "created", detail: created.stdout || created.stderr };
   }
 
-  // Green: close any open sentinel issue.
+  // Green: close every open sentinel issue (canonical + healed duplicates).
   if (existing) {
     runCommand(["issue", "comment", String(existing.number), "--repo", repository,
       "--body", `✅ \`main\` is green again as of ${nowIso} (\`${(verdict.run.sha || "").slice(0, 12)}\`). Closing.`]);
     runCommand(["issue", "close", String(existing.number), "--repo", repository,
       "--reason", "completed"]);
-    return { action: "closed", number: existing.number };
+    const closedDuplicates = closeDuplicateSentinels(duplicates, existing.number, repository, runCommand, nowIso);
+    return { action: "closed", number: existing.number, closedDuplicates };
   }
   return { action: "noop" };
 }

--- a/scripts/ci/check-main-red.mjs
+++ b/scripts/ci/check-main-red.mjs
@@ -13,15 +13,16 @@
 // Pure functions (mainCiHealth/formatIssueBody/formatReport) are unit tested;
 // gh I/O lives in main() behind injectable fetchers.
 import fs from "node:fs";
-import { spawnSync } from "node:child_process";
 
+import { runGh, runGhJson } from "./lib/gh.mjs";
 import {
   collectSentinelIssues,
+  splitSentinels,
   closeDuplicateSentinels,
+  SENTINEL_LABEL,
 } from "./lib/sentinel-issues.mjs";
 
 const DEFAULT_MAX_RUNS = 60;
-const DEFAULT_GH_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
 const WORKFLOW_NAME = "CI";
 const MAIN_EVENTS = new Set(["push", "merge_group"]);
 // Conclusions that do not represent a real verdict on the merged tree.
@@ -100,75 +101,6 @@ function parseArgs(argv) {
     throw new Error(`unknown argument: ${arg}`);
   }
   return options;
-}
-
-// Bounded exponential backoff over transient gh transport failures (5xx,
-// secondary rate limit, transient network errors). This retries only the
-// transport — never a real verdict/finding — so the sentinel's signal is
-// unchanged; it just survives a flaky GitHub API call instead of reddening the
-// advisory ci-health workflow. See issue #13744.
-const GH_RETRY_ATTEMPTS = Math.max(1, Number.parseInt(process.env.GH_RETRY_ATTEMPTS || "", 10) || 4);
-const GH_RETRY_BASE_MS = Math.max(0, Number.parseInt(process.env.GH_RETRY_BASE_MS || "", 10) || 500);
-const GH_RETRY_MAX_MS = 8000;
-const TRANSIENT_NET_CODES = new Set([
-  "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EAI_AGAIN", "ENOTFOUND", "EPIPE",
-]);
-
-function sleepSync(ms) {
-  if (!(ms > 0)) return;
-  // Synchronous sleep without busy-waiting; spawnSync gives us no async seam.
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function isTransientGhResult(result) {
-  if (result.error) {
-    // ENOBUFS is a hard output-size error, not transient.
-    if (result.error.code === "ENOBUFS") return false;
-    return TRANSIENT_NET_CODES.has(result.error.code);
-  }
-  if ((result.status ?? 0) === 0) return false;
-  const text = `${result.stdout || ""}\n${result.stderr || ""}`;
-  return /\bHTTP\s+(?:408|425|429|5\d\d)\b/i.test(text)
-    || /secondary rate limit/i.test(text)
-    || /\b(?:Bad Gateway|Service Unavailable|Gateway Time-?out|Internal Server Error|Server Error)\b/i.test(text);
-}
-
-function spawnGh(args, spawnOptions) {
-  let result;
-  for (let attempt = 1; attempt <= GH_RETRY_ATTEMPTS; attempt += 1) {
-    result = spawnSync("gh", args, spawnOptions);
-    if (attempt === GH_RETRY_ATTEMPTS || !isTransientGhResult(result)) break;
-    sleepSync(Math.min(GH_RETRY_BASE_MS * 2 ** (attempt - 1), GH_RETRY_MAX_MS));
-  }
-  return result;
-}
-
-function runGhJson(args) {
-  const result = spawnGh(args, {
-    encoding: "utf8",
-    maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error([`gh ${args.join(" ")} failed`, result.stdout?.trim(), result.stderr?.trim()]
-      .filter(Boolean).join("\n"));
-  }
-  return JSON.parse(result.stdout);
-}
-
-function runGh(args) {
-  const result = spawnGh(args, {
-    encoding: "utf8",
-    maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  if (result.error) return { status: 1, stdout: "", stderr: result.error.message };
-  return {
-    status: result.status ?? 1,
-    stdout: (result.stdout || "").trim(),
-    stderr: (result.stderr || "").trim(),
-  };
 }
 
 function normalizeRuns(payload) {
@@ -415,21 +347,18 @@ function lastTrackedSha(issue) {
   return match ? match[1] : "";
 }
 
-// The lookup (shared with `check-latest-freshness.mjs`) returns every open
-// sentinel — marker match or exact-title fallback, oldest first. The oldest is
-// canonical: it is the one updated (re-stamping the marker if a body edit
-// stripped it) or closed on recovery; any younger matches are duplicates from
-// a past lookup miss and are closed pointing at the canonical issue, so a
-// duplicated sentinel heals itself on the next firing instead of splitting
-// forever.
+// The oldest open sentinel is canonical; younger matches from a past lookup
+// miss are closed as duplicates (see `./lib/sentinel-issues.mjs` for the
+// healing rules).
 export function reconcileIssue(verdict, regressedTests, nowIso, ctx) {
   const { repository, fetchJson = runGhJson, runCommand = runGh } = ctx;
   const matches = collectSentinelIssues(repository, fetchJson, {
     marker: ISSUE_MARKER,
     title: ISSUE_TITLE,
   });
-  const existing = matches[0] ?? null;
-  const duplicates = matches.slice(1);
+  const { canonical: existing, duplicates } = splitSentinels(matches);
+  const closeDupes = () =>
+    closeDuplicateSentinels(duplicates, existing.number, repository, runCommand, nowIso);
   const body = formatIssueBody(verdict, regressedTests, nowIso);
 
   if (verdict.red) {
@@ -445,11 +374,10 @@ export function reconcileIssue(verdict, regressedTests, nowIso, ctx) {
         runCommand(["issue", "comment", String(existing.number), "--repo", repository,
           "--body", `Still red as of ${nowIso}: \`${currentSha}\` ([run](${verdict.run.url})).`]);
       }
-      const closedDuplicates = closeDuplicateSentinels(duplicates, existing.number, repository, runCommand, nowIso);
-      return { action: "updated", number: existing.number, commented: headChanged, closedDuplicates };
+      return { action: "updated", number: existing.number, commented: headChanged, closedDuplicates: closeDupes() };
     }
     const created = runCommand(["issue", "create", "--repo", repository,
-      "--title", ISSUE_TITLE, "--body", body, "--label", "tech-debt"]);
+      "--title", ISSUE_TITLE, "--body", body, "--label", SENTINEL_LABEL]);
     return { action: "created", detail: created.stdout || created.stderr };
   }
 
@@ -459,8 +387,7 @@ export function reconcileIssue(verdict, regressedTests, nowIso, ctx) {
       "--body", `✅ \`main\` is green again as of ${nowIso} (\`${(verdict.run.sha || "").slice(0, 12)}\`). Closing.`]);
     runCommand(["issue", "close", String(existing.number), "--repo", repository,
       "--reason", "completed"]);
-    const closedDuplicates = closeDuplicateSentinels(duplicates, existing.number, repository, runCommand, nowIso);
-    return { action: "closed", number: existing.number, closedDuplicates };
+    return { action: "closed", number: existing.number, closedDuplicates: closeDupes() };
   }
   return { action: "noop" };
 }

--- a/scripts/ci/full-ci.sh
+++ b/scripts/ci/full-ci.sh
@@ -371,6 +371,7 @@ run_lint() {
   node scripts/bench/test-measure-protocol.mjs || return $?
   node scripts/bench/test-measure-tsz.mjs || return $?
   node scripts/bench/test-check-artifact-readiness.mjs || return $?
+  node scripts/bench/test-check-latest-freshness.mjs || return $?
   node scripts/bench/test-bench-readiness-banner.mjs || return $?
   node scripts/bench/test-ci-health-benchmark-readiness.mjs || return $?
   node scripts/bench/test-benchmark-artifact-selection.mjs || return $?
@@ -391,6 +392,7 @@ run_lint() {
   node scripts/ci/test-check-stale-ci-runs.mjs || return $?
   node scripts/ci/test-check-ci-job-timing.mjs || return $?
   node scripts/ci/test-check-main-red.mjs || return $?
+  node scripts/ci/test-sentinel-issues.mjs || return $?
   node scripts/ci/test-known-failures-check.mjs || return $?
   node scripts/ci/test-wip-state-comments.mjs || return $?
   node scripts/ci/test-project-compatibility.mjs || return $?

--- a/scripts/ci/full-ci.sh
+++ b/scripts/ci/full-ci.sh
@@ -393,6 +393,7 @@ run_lint() {
   node scripts/ci/test-check-ci-job-timing.mjs || return $?
   node scripts/ci/test-check-main-red.mjs || return $?
   node scripts/ci/test-sentinel-issues.mjs || return $?
+  node scripts/ci/test-gh.mjs || return $?
   node scripts/ci/test-known-failures-check.mjs || return $?
   node scripts/ci/test-wip-state-comments.mjs || return $?
   node scripts/ci/test-project-compatibility.mjs || return $?

--- a/scripts/ci/lib/gh.mjs
+++ b/scripts/ci/lib/gh.mjs
@@ -12,10 +12,10 @@
 // exactly one place.
 import { spawnSync } from "node:child_process";
 
-export const GH_RETRY_ATTEMPTS = Math.max(1, Number.parseInt(process.env.GH_RETRY_ATTEMPTS || "", 10) || 4);
-export const GH_RETRY_BASE_MS = Math.max(0, Number.parseInt(process.env.GH_RETRY_BASE_MS || "", 10) || 500);
-export const GH_RETRY_MAX_MS = 8000;
-export const DEFAULT_GH_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
+const GH_RETRY_ATTEMPTS = Math.max(1, Number.parseInt(process.env.GH_RETRY_ATTEMPTS || "", 10) || 4);
+const GH_RETRY_BASE_MS = Math.max(0, Number.parseInt(process.env.GH_RETRY_BASE_MS || "", 10) || 500);
+const GH_RETRY_MAX_MS = 8000;
+const DEFAULT_GH_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
 const TRANSIENT_NET_CODES = new Set([
   "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EAI_AGAIN", "ENOTFOUND", "EPIPE", "ENETUNREACH",
 ]);
@@ -39,7 +39,7 @@ export function isTransientGhResult(result) {
     || /\b(?:Bad Gateway|Service Unavailable|Gateway Time-?out|Internal Server Error|Server Error)\b/i.test(text);
 }
 
-export function spawnGh(args, spawnOptions = {
+function spawnGh(args, spawnOptions = {
   encoding: "utf8",
   maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
   stdio: ["ignore", "pipe", "pipe"],

--- a/scripts/ci/lib/gh.mjs
+++ b/scripts/ci/lib/gh.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Shared synchronous `gh` invocation seam for ci-health monitor scripts.
+//
+// Bounded exponential backoff over transient gh transport failures (5xx,
+// secondary rate limit, transient network errors). This retries only the
+// transport — never a real verdict/finding — so a monitor's signal is
+// unchanged; it just survives a flaky GitHub API call instead of reddening the
+// advisory ci-health workflow. See issue #13744.
+//
+// Consumers keep `fetchJson`/`runCommand` as injectable seams for tests and
+// default them to `runGhJson`/`runGh` from here, so the retry policy lives in
+// exactly one place.
+import { spawnSync } from "node:child_process";
+
+export const GH_RETRY_ATTEMPTS = Math.max(1, Number.parseInt(process.env.GH_RETRY_ATTEMPTS || "", 10) || 4);
+export const GH_RETRY_BASE_MS = Math.max(0, Number.parseInt(process.env.GH_RETRY_BASE_MS || "", 10) || 500);
+export const GH_RETRY_MAX_MS = 8000;
+export const DEFAULT_GH_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
+const TRANSIENT_NET_CODES = new Set([
+  "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EAI_AGAIN", "ENOTFOUND", "EPIPE", "ENETUNREACH",
+]);
+
+function sleepSync(ms) {
+  if (!(ms > 0)) return;
+  // Synchronous sleep without busy-waiting; spawnSync gives us no async seam.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+export function isTransientGhResult(result) {
+  if (result.error) {
+    // ENOBUFS is a hard output-size error, not transient.
+    if (result.error.code === "ENOBUFS") return false;
+    return TRANSIENT_NET_CODES.has(result.error.code);
+  }
+  if ((result.status ?? 0) === 0) return false;
+  const text = `${result.stdout || ""}\n${result.stderr || ""}`;
+  return /\bHTTP\s+(?:408|425|429|5\d\d)\b/i.test(text)
+    || /secondary rate limit/i.test(text)
+    || /\b(?:Bad Gateway|Service Unavailable|Gateway Time-?out|Internal Server Error|Server Error)\b/i.test(text);
+}
+
+export function spawnGh(args, spawnOptions = {
+  encoding: "utf8",
+  maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
+  stdio: ["ignore", "pipe", "pipe"],
+}) {
+  let result;
+  for (let attempt = 1; attempt <= GH_RETRY_ATTEMPTS; attempt += 1) {
+    result = spawnSync("gh", args, spawnOptions);
+    if (attempt === GH_RETRY_ATTEMPTS || !isTransientGhResult(result)) break;
+    sleepSync(Math.min(GH_RETRY_BASE_MS * 2 ** (attempt - 1), GH_RETRY_MAX_MS));
+  }
+  return result;
+}
+
+/** Run `gh` and parse stdout as JSON; throws on spawn error or non-zero exit. */
+export function runGhJson(args) {
+  const result = spawnGh(args);
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error([`gh ${args.join(" ")} failed`, result.stdout?.trim(), result.stderr?.trim()]
+      .filter(Boolean).join("\n"));
+  }
+  return JSON.parse(result.stdout);
+}
+
+/** Run `gh` and report `{ status, stdout, stderr }` without throwing. */
+export function runGh(args) {
+  const result = spawnGh(args);
+  if (result.error) return { status: 1, stdout: "", stderr: result.error.message };
+  return {
+    status: result.status ?? 1,
+    stdout: (result.stdout || "").trim(),
+    stderr: (result.stderr || "").trim(),
+  };
+}

--- a/scripts/ci/lib/sentinel-issues.mjs
+++ b/scripts/ci/lib/sentinel-issues.mjs
@@ -19,38 +19,28 @@
 //   marker-stripped body edit cannot orphan the issue;
 // - it skips pull requests (the `/issues` endpoint interleaves them, and a PR
 //   body quoting the marker must never be edited/closed as the sentinel);
-// - callers treat the oldest match as canonical and close the rest as
-//   duplicates via `closeDuplicateSentinels`.
+// - `splitSentinels` names the oldest match canonical; callers close the rest
+//   as duplicates via `closeDuplicateSentinels`.
+
+// Every monitor creates its sentinel with this label; the lookup uses it as a
+// cheap server-side pre-filter before falling back to the exhaustive walk.
+export const SENTINEL_LABEL = "tech-debt";
 
 export const SENTINEL_PER_PAGE = 100;
-// The `/issues` endpoint returns open issues *and* open PRs, so on an active
-// repo the combined list routinely exceeds one 100-item page. A persistent
-// tracking issue (a standing condition can live for hours/days) is sorted
-// created-desc and steadily sinks past page 1 as new PRs/issues land. Page
-// through until the list is exhausted; the bound caps the walk on a
-// pathological backlog without masking a reachable sentinel.
+// Caps the exhaustive walk on a pathological backlog (the `/issues` endpoint
+// interleaves open PRs, so the combined listing routinely exceeds one page)
+// without masking a reachable sentinel.
 export const SENTINEL_MAX_PAGES = 20;
 
-/**
- * Collect every open sentinel issue for a monitor, oldest first.
- *
- * A sentinel matches when its body carries `marker` or its title equals the
- * bot-owned `title` exactly (the fallback that survives marker-stripping body
- * edits). Pull requests are ignored. Returns `[]` when nothing matches or the
- * issue listing is unavailable.
- *
- * @param {string} repository owner/repo
- * @param {(args: string[]) => any} fetchJson gh JSON fetcher seam
- * @param {{ marker: string, title?: string }} keys
- */
-export function collectSentinelIssues(repository, fetchJson, { marker, title }) {
+function scanIssueListing(repository, fetchJson, { marker, title }, label) {
   const matches = [];
+  const labelParam = label ? `&labels=${encodeURIComponent(label)}` : "";
   for (let page = 1; page <= SENTINEL_MAX_PAGES; page += 1) {
     const issues = fetchJson([
       "api",
       "-H",
       "Accept: application/vnd.github+json",
-      `repos/${repository}/issues?state=open&per_page=${SENTINEL_PER_PAGE}&page=${page}`,
+      `repos/${repository}/issues?state=open&per_page=${SENTINEL_PER_PAGE}&page=${page}${labelParam}`,
     ]);
     if (!Array.isArray(issues)) break;
     for (const item of issues) {
@@ -70,10 +60,42 @@ export function collectSentinelIssues(repository, fetchJson, { marker, title }) 
 }
 
 /**
- * Close redundant sentinel issues, pointing each at the canonical one.
+ * Collect every open sentinel issue for a monitor, oldest first.
  *
- * Used whenever the lookup finds more than one open sentinel (a healed
- * duplicate from a past lookup miss). Returns the closed issue numbers.
+ * A sentinel matches when its body carries `marker` or its title equals the
+ * bot-owned `title` exactly (the fallback that survives marker-stripping body
+ * edits). Pull requests are ignored. Returns `[]` when nothing matches or the
+ * issue listing is unavailable.
+ *
+ * The label-scoped listing usually answers in one API call; a de-labeled
+ * sentinel is invisible to it, so an empty result falls through to the
+ * exhaustive unlabeled walk rather than declaring "no sentinel" and letting
+ * the reconciler file a duplicate.
+ *
+ * @param {string} repository owner/repo
+ * @param {(args: string[]) => any} fetchJson gh JSON fetcher seam
+ * @param {{ marker: string, title: string }} keys
+ */
+export function collectSentinelIssues(repository, fetchJson, keys) {
+  const labeled = scanIssueListing(repository, fetchJson, keys, SENTINEL_LABEL);
+  if (labeled.length > 0) return labeled;
+  return scanIssueListing(repository, fetchJson, keys, null);
+}
+
+/**
+ * Name the canonical sentinel among the open matches: the oldest (lowest
+ * number) survives — it carries the original discussion — and every younger
+ * match is a duplicate from a past lookup miss.
+ *
+ * @param {ReturnType<typeof collectSentinelIssues>} matches
+ */
+export function splitSentinels(matches) {
+  return { canonical: matches[0] ?? null, duplicates: matches.slice(1) };
+}
+
+/**
+ * Close redundant sentinel issues, pointing each at the canonical one.
+ * Returns the closed issue numbers.
  *
  * @param {Array<{ number?: number }>} duplicates non-canonical matches
  * @param {number} canonicalNumber the issue that stays open (or just closed as completed)

--- a/scripts/ci/lib/sentinel-issues.mjs
+++ b/scripts/ci/lib/sentinel-issues.mjs
@@ -31,7 +31,7 @@ export const SENTINEL_PER_PAGE = 100;
 // Caps the walk on a pathological backlog (the `/issues` endpoint interleaves
 // open PRs, so the combined listing routinely exceeds one page) without
 // masking a reachable sentinel.
-export const SENTINEL_MAX_PAGES = 20;
+const SENTINEL_MAX_PAGES = 20;
 
 /**
  * Collect every open sentinel issue for a monitor, oldest first.
@@ -102,6 +102,20 @@ export function createSentinelIssue(repository, runCommand, { title, body }) {
     "--label",
     SENTINEL_LABEL,
   ]);
+}
+
+/**
+ * Close the canonical sentinel on recovery: a monitor-worded comment, then a
+ * close with reason `completed`.
+ *
+ * @param {number} number the canonical sentinel's issue number
+ * @param {string} repository owner/repo
+ * @param {(args: string[]) => any} runCommand gh command seam
+ * @param {string} message recovery comment body
+ */
+export function closeSentinelIssue(number, repository, runCommand, message) {
+  runCommand(["issue", "comment", String(number), "--repo", repository, "--body", message]);
+  runCommand(["issue", "close", String(number), "--repo", repository, "--reason", "completed"]);
 }
 
 /**

--- a/scripts/ci/lib/sentinel-issues.mjs
+++ b/scripts/ci/lib/sentinel-issues.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Shared dedup-sentinel issue lookup for the ci-health monitors
+// Shared dedup-sentinel issue lifecycle for the ci-health monitors
 // (`scripts/ci/check-main-red.mjs`, `scripts/bench/check-latest-freshness.mjs`).
 //
 // Each monitor tracks a standing condition (red `main`, frozen benchmark
@@ -13,8 +13,8 @@
 //    one of them: the other is never updated and never closed on recovery
 //    (#15532 duplicating #15401 is the concrete witness).
 //
-// This module makes the sentinel lookup self-healing:
-// - it collects ALL open matches, not the first;
+// This module makes the sentinel lifecycle self-healing:
+// - the lookup collects ALL open matches, not the first;
 // - it matches on the marker OR the exact bot-owned title, so a
 //   marker-stripped body edit cannot orphan the issue;
 // - it skips pull requests (the `/issues` endpoint interleaves them, and a PR
@@ -22,25 +22,37 @@
 // - `splitSentinels` names the oldest match canonical; callers close the rest
 //   as duplicates via `closeDuplicateSentinels`.
 
-// Every monitor creates its sentinel with this label; the lookup uses it as a
-// cheap server-side pre-filter before falling back to the exhaustive walk.
-export const SENTINEL_LABEL = "tech-debt";
+// Every monitor's sentinel is created with this label (via
+// `createSentinelIssue`) so humans can triage it; the lookup deliberately does
+// NOT rely on it — a re-labeled sentinel must still be found.
+const SENTINEL_LABEL = "tech-debt";
 
 export const SENTINEL_PER_PAGE = 100;
-// Caps the exhaustive walk on a pathological backlog (the `/issues` endpoint
-// interleaves open PRs, so the combined listing routinely exceeds one page)
-// without masking a reachable sentinel.
+// Caps the walk on a pathological backlog (the `/issues` endpoint interleaves
+// open PRs, so the combined listing routinely exceeds one page) without
+// masking a reachable sentinel.
 export const SENTINEL_MAX_PAGES = 20;
 
-function scanIssueListing(repository, fetchJson, { marker, title }, label) {
+/**
+ * Collect every open sentinel issue for a monitor, oldest first.
+ *
+ * A sentinel matches when its body carries `marker` or its title equals the
+ * bot-owned `title` exactly (the fallback that survives marker-stripping body
+ * edits). Pull requests are ignored. Returns `[]` when nothing matches or the
+ * issue listing is unavailable.
+ *
+ * @param {string} repository owner/repo
+ * @param {(args: string[]) => any} fetchJson gh JSON fetcher seam
+ * @param {{ marker: string, title: string }} keys
+ */
+export function collectSentinelIssues(repository, fetchJson, { marker, title }) {
   const matches = [];
-  const labelParam = label ? `&labels=${encodeURIComponent(label)}` : "";
   for (let page = 1; page <= SENTINEL_MAX_PAGES; page += 1) {
     const issues = fetchJson([
       "api",
       "-H",
       "Accept: application/vnd.github+json",
-      `repos/${repository}/issues?state=open&per_page=${SENTINEL_PER_PAGE}&page=${page}${labelParam}`,
+      `repos/${repository}/issues?state=open&per_page=${SENTINEL_PER_PAGE}&page=${page}`,
     ]);
     if (!Array.isArray(issues)) break;
     for (const item of issues) {
@@ -60,29 +72,6 @@ function scanIssueListing(repository, fetchJson, { marker, title }, label) {
 }
 
 /**
- * Collect every open sentinel issue for a monitor, oldest first.
- *
- * A sentinel matches when its body carries `marker` or its title equals the
- * bot-owned `title` exactly (the fallback that survives marker-stripping body
- * edits). Pull requests are ignored. Returns `[]` when nothing matches or the
- * issue listing is unavailable.
- *
- * The label-scoped listing usually answers in one API call; a de-labeled
- * sentinel is invisible to it, so an empty result falls through to the
- * exhaustive unlabeled walk rather than declaring "no sentinel" and letting
- * the reconciler file a duplicate.
- *
- * @param {string} repository owner/repo
- * @param {(args: string[]) => any} fetchJson gh JSON fetcher seam
- * @param {{ marker: string, title: string }} keys
- */
-export function collectSentinelIssues(repository, fetchJson, keys) {
-  const labeled = scanIssueListing(repository, fetchJson, keys, SENTINEL_LABEL);
-  if (labeled.length > 0) return labeled;
-  return scanIssueListing(repository, fetchJson, keys, null);
-}
-
-/**
  * Name the canonical sentinel among the open matches: the oldest (lowest
  * number) survives — it carries the original discussion — and every younger
  * match is a duplicate from a past lookup miss.
@@ -91,6 +80,28 @@ export function collectSentinelIssues(repository, fetchJson, keys) {
  */
 export function splitSentinels(matches) {
   return { canonical: matches[0] ?? null, duplicates: matches.slice(1) };
+}
+
+/**
+ * Create a monitor's sentinel issue, labeled `tech-debt`.
+ *
+ * @param {string} repository owner/repo
+ * @param {(args: string[]) => { status: number, stdout: string, stderr: string }} runCommand gh command seam
+ * @param {{ title: string, body: string }} content
+ */
+export function createSentinelIssue(repository, runCommand, { title, body }) {
+  return runCommand([
+    "issue",
+    "create",
+    "--repo",
+    repository,
+    "--title",
+    title,
+    "--body",
+    body,
+    "--label",
+    SENTINEL_LABEL,
+  ]);
 }
 
 /**

--- a/scripts/ci/lib/sentinel-issues.mjs
+++ b/scripts/ci/lib/sentinel-issues.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// Shared dedup-sentinel issue lookup for the ci-health monitors
+// (`scripts/ci/check-main-red.mjs`, `scripts/bench/check-latest-freshness.mjs`).
+//
+// Each monitor tracks a standing condition (red `main`, frozen benchmark
+// publish) through ONE open tracking issue, deduplicated on a hidden HTML
+// marker in the body. Two failure modes historically broke that invariant:
+//
+// 1. A lookup miss (single-page scan before #15467, or a human/agent editing
+//    the body and dropping the marker despite the "do not edit" note) makes
+//    the reconciler create a duplicate on the next firing.
+// 2. Once two sentinel issues are open, a first-match lookup only ever sees
+//    one of them: the other is never updated and never closed on recovery
+//    (#15532 duplicating #15401 is the concrete witness).
+//
+// This module makes the sentinel lookup self-healing:
+// - it collects ALL open matches, not the first;
+// - it matches on the marker OR the exact bot-owned title, so a
+//   marker-stripped body edit cannot orphan the issue;
+// - it skips pull requests (the `/issues` endpoint interleaves them, and a PR
+//   body quoting the marker must never be edited/closed as the sentinel);
+// - callers treat the oldest match as canonical and close the rest as
+//   duplicates via `closeDuplicateSentinels`.
+
+export const SENTINEL_PER_PAGE = 100;
+// The `/issues` endpoint returns open issues *and* open PRs, so on an active
+// repo the combined list routinely exceeds one 100-item page. A persistent
+// tracking issue (a standing condition can live for hours/days) is sorted
+// created-desc and steadily sinks past page 1 as new PRs/issues land. Page
+// through until the list is exhausted; the bound caps the walk on a
+// pathological backlog without masking a reachable sentinel.
+export const SENTINEL_MAX_PAGES = 20;
+
+/**
+ * Collect every open sentinel issue for a monitor, oldest first.
+ *
+ * A sentinel matches when its body carries `marker` or its title equals the
+ * bot-owned `title` exactly (the fallback that survives marker-stripping body
+ * edits). Pull requests are ignored. Returns `[]` when nothing matches or the
+ * issue listing is unavailable.
+ *
+ * @param {string} repository owner/repo
+ * @param {(args: string[]) => any} fetchJson gh JSON fetcher seam
+ * @param {{ marker: string, title?: string }} keys
+ */
+export function collectSentinelIssues(repository, fetchJson, { marker, title }) {
+  const matches = [];
+  for (let page = 1; page <= SENTINEL_MAX_PAGES; page += 1) {
+    const issues = fetchJson([
+      "api",
+      "-H",
+      "Accept: application/vnd.github+json",
+      `repos/${repository}/issues?state=open&per_page=${SENTINEL_PER_PAGE}&page=${page}`,
+    ]);
+    if (!Array.isArray(issues)) break;
+    for (const item of issues) {
+      if (!item || typeof item !== "object") continue;
+      // The /issues listing marks PRs with a `pull_request` key.
+      if (item.pull_request) continue;
+      const bodyHit = typeof item.body === "string" && item.body.includes(marker);
+      const titleHit =
+        typeof title === "string" && title !== "" && item.title === title;
+      if (bodyHit || titleHit) matches.push(item);
+    }
+    // A short (or empty) page is the last one.
+    if (issues.length < SENTINEL_PER_PAGE) break;
+  }
+  matches.sort((a, b) => (a.number ?? 0) - (b.number ?? 0));
+  return matches;
+}
+
+/**
+ * Close redundant sentinel issues, pointing each at the canonical one.
+ *
+ * Used whenever the lookup finds more than one open sentinel (a healed
+ * duplicate from a past lookup miss). Returns the closed issue numbers.
+ *
+ * @param {Array<{ number?: number }>} duplicates non-canonical matches
+ * @param {number} canonicalNumber the issue that stays open (or just closed as completed)
+ * @param {string} repository owner/repo
+ * @param {(args: string[]) => any} runCommand gh command seam
+ * @param {string} nowIso timestamp for the audit comment
+ */
+export function closeDuplicateSentinels(duplicates, canonicalNumber, repository, runCommand, nowIso) {
+  const closed = [];
+  for (const duplicate of duplicates) {
+    if (duplicate?.number == null) continue;
+    runCommand([
+      "issue",
+      "comment",
+      String(duplicate.number),
+      "--repo",
+      repository,
+      "--body",
+      `Duplicate tracking issue — consolidated into #${canonicalNumber} as of ${nowIso}. Closing.`,
+    ]);
+    runCommand([
+      "issue",
+      "close",
+      String(duplicate.number),
+      "--repo",
+      repository,
+      "--reason",
+      "not planned",
+    ]);
+    closed.push(duplicate.number);
+  }
+  return closed;
+}

--- a/scripts/ci/test-check-main-red.mjs
+++ b/scripts/ci/test-check-main-red.mjs
@@ -319,6 +319,78 @@ test("reconcileIssue finds a sentinel that sank past page 1", () => {
   assert.ok(!calls.some((a) => a[0] === "issue" && a[1] === "create"), "never creates a duplicate");
 });
 
+test("reconcileIssue heals a duplicated sentinel: oldest updated, newer closed", () => {
+  const calls = [];
+  const v = mainCiHealth([run({ id: 5, conclusion: "failure", created_at: "2026-06-12T21:00:00Z" })]);
+  const result = reconcileIssue(v, [], NOW, {
+    repository: "o/r",
+    fetchJson: () => [
+      { number: 90, body: "x <!-- main-red-sentinel --> y" },
+      { number: 77, body: "x <!-- main-red-sentinel --> y" },
+    ],
+    runCommand: (args) => { calls.push(args); return { status: 0, stdout: "", stderr: "" }; },
+  });
+  assert.equal(result.action, "updated");
+  assert.equal(result.number, 77, "the oldest sentinel is canonical");
+  assert.deepEqual(result.closedDuplicates, [90]);
+  assert.ok(!calls.some((a) => a[0] === "issue" && a[1] === "create"), "never creates a third issue");
+  const dupComment = calls.find((a) => a[1] === "comment" && a[2] === "90");
+  assert.match(dupComment[dupComment.length - 1], /#77/, "duplicate close points at the canonical issue");
+});
+
+test("reconcileIssue finds a marker-stripped sentinel by its exact title", () => {
+  const calls = [];
+  const v = mainCiHealth([run({ id: 5, conclusion: "failure", created_at: "2026-06-12T21:00:00Z" })]);
+  const result = reconcileIssue(v, [], NOW, {
+    repository: "o/r",
+    fetchJson: () => [{
+      number: 61,
+      title: "🔴 main CI is red — conformance/parity floor breached",
+      body: "claimed; body rewritten without the marker",
+    }],
+    runCommand: (args) => { calls.push(args); return { status: 0, stdout: "", stderr: "" }; },
+  });
+  assert.equal(result.action, "updated", "title fallback finds the sentinel");
+  assert.equal(result.number, 61);
+  const edit = calls.find((a) => a[1] === "edit");
+  assert.match(edit[edit.length - 1], /main-red-sentinel/, "edit restores the marker");
+});
+
+test("reconcileIssue closes every sentinel on recovery, not just the first", () => {
+  const calls = [];
+  const v = mainCiHealth([run({ id: 6, conclusion: "success", created_at: "2026-06-12T21:00:00Z" })]);
+  const result = reconcileIssue(v, [], NOW, {
+    repository: "o/r",
+    fetchJson: () => [
+      { number: 90, body: "<!-- main-red-sentinel -->" },
+      { number: 77, body: "<!-- main-red-sentinel -->" },
+    ],
+    runCommand: (args) => { calls.push(args); return { status: 0, stdout: "", stderr: "" }; },
+  });
+  assert.equal(result.action, "closed");
+  assert.equal(result.number, 77);
+  assert.deepEqual(result.closedDuplicates, [90]);
+  const closed = calls.filter((a) => a[1] === "close").map((a) => a[2]);
+  assert.deepEqual(closed.sort(), ["77", "90"], "no zombie sentinel survives recovery");
+});
+
+test("reconcileIssue skips a PR that quotes the marker", () => {
+  const calls = [];
+  const v = mainCiHealth([run({ id: 5, conclusion: "failure", created_at: "2026-06-12T21:00:00Z" })]);
+  const result = reconcileIssue(v, [], NOW, {
+    repository: "o/r",
+    fetchJson: () => [{
+      number: 88,
+      title: "fix(ci): sentinel lookup",
+      body: "this PR mentions <!-- main-red-sentinel --> in prose",
+      pull_request: { url: "https://gh.example/pulls/88" },
+    }],
+    runCommand: (args) => { calls.push(args); return { status: 0, stdout: "https://gh/issues/99", stderr: "" }; },
+  });
+  assert.equal(result.action, "created", "a marker-quoting PR is not the sentinel");
+  assert.ok(!calls.some((a) => a[1] === "edit"), "never edits a PR as if it were the sentinel");
+});
+
 test("reconcileIssue noop when green and no issue", () => {
   const v = mainCiHealth([run({ id: 6, conclusion: "success", created_at: "2026-06-12T21:00:00Z" })]);
   const result = reconcileIssue(v, [], NOW, {

--- a/scripts/ci/test-gh.mjs
+++ b/scripts/ci/test-gh.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { isTransientGhResult } from "./lib/gh.mjs";
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`ok - ${name}`);
+}
+
+test("transient network error codes retry; ENOBUFS does not", () => {
+  assert.equal(isTransientGhResult({ error: { code: "ETIMEDOUT" } }), true);
+  assert.equal(isTransientGhResult({ error: { code: "ECONNREFUSED" } }), true);
+  assert.equal(isTransientGhResult({ error: { code: "ENETUNREACH" } }), true);
+  assert.equal(isTransientGhResult({ error: { code: "ENOBUFS" } }), false, "hard output-size error");
+  assert.equal(isTransientGhResult({ error: { code: "EACCES" } }), false);
+});
+
+test("successful exits never retry", () => {
+  assert.equal(isTransientGhResult({ status: 0, stdout: "HTTP 502 mentioned in output" }), false);
+});
+
+test("5xx / rate-limit failures retry; real failures do not", () => {
+  assert.equal(isTransientGhResult({ status: 1, stdout: "", stderr: "HTTP 502" }), true);
+  assert.equal(isTransientGhResult({ status: 1, stdout: "", stderr: "You have exceeded a secondary rate limit" }), true);
+  assert.equal(isTransientGhResult({ status: 1, stdout: "", stderr: "Bad Gateway" }), true);
+  assert.equal(isTransientGhResult({ status: 1, stdout: "", stderr: "HTTP 404: Not Found" }), false);
+  assert.equal(isTransientGhResult({ status: 1, stdout: "", stderr: "could not resolve to an Issue" }), false);
+});
+
+console.log(`\n${passed} gh tests passed`);

--- a/scripts/ci/test-sentinel-issues.mjs
+++ b/scripts/ci/test-sentinel-issues.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import {
+  collectSentinelIssues,
+  closeDuplicateSentinels,
+  SENTINEL_PER_PAGE,
+} from "./lib/sentinel-issues.mjs";
+
+const MARKER = "<!-- test-sentinel -->";
+const TITLE = "🟡 something is wrong — tracked";
+const REPO = "o/r";
+
+function pagedFetch(pages, seenPages = []) {
+  return (args) => {
+    const url = String(args[args.length - 1]);
+    const page = Number((url.match(/[?&]page=(\d+)/) || [])[1] || 1);
+    seenPages.push(page);
+    return pages[page - 1] ?? [];
+  };
+}
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`ok - ${name}`);
+}
+
+test("matches on the body marker", () => {
+  const matches = collectSentinelIssues(
+    REPO,
+    () => [{ number: 7, title: "edited by hand", body: `x ${MARKER} y` }],
+    { marker: MARKER, title: TITLE },
+  );
+  assert.deepEqual(matches.map((m) => m.number), [7]);
+});
+
+test("falls back to the exact bot title when a body edit stripped the marker", () => {
+  const matches = collectSentinelIssues(
+    REPO,
+    () => [
+      { number: 8, title: TITLE, body: "claimed + rewritten body, marker gone" },
+      { number: 9, title: `${TITLE} (extra)`, body: "near-title must not match" },
+    ],
+    { marker: MARKER, title: TITLE },
+  );
+  assert.deepEqual(matches.map((m) => m.number), [8], "only the exact title matches");
+});
+
+test("skips pull requests even when their body quotes the marker", () => {
+  const matches = collectSentinelIssues(
+    REPO,
+    () => [
+      { number: 10, title: "fix: sentinel lookup", body: MARKER, pull_request: { url: "x" } },
+      { number: 11, title: TITLE, body: MARKER },
+    ],
+    { marker: MARKER, title: TITLE },
+  );
+  assert.deepEqual(matches.map((m) => m.number), [11]);
+});
+
+test("collects ALL matches across pages, oldest (lowest number) first", () => {
+  const page1 = Array.from({ length: SENTINEL_PER_PAGE }, (_, i) =>
+    i === 3
+      ? { number: 900, title: TITLE, body: MARKER }
+      : { number: 5000 - i, title: "noise", body: "unrelated" },
+  );
+  const page2 = [{ number: 42, title: "old sentinel", body: `${MARKER}\nstale` }];
+  const seenPages = [];
+  const matches = collectSentinelIssues(REPO, pagedFetch([page1, page2], seenPages), {
+    marker: MARKER,
+    title: TITLE,
+  });
+  assert.deepEqual(seenPages, [1, 2], "pages until a short page ends the walk");
+  assert.deepEqual(matches.map((m) => m.number), [42, 900], "all matches, oldest first");
+});
+
+test("returns [] on an empty or non-array listing", () => {
+  assert.deepEqual(collectSentinelIssues(REPO, () => [], { marker: MARKER, title: TITLE }), []);
+  assert.deepEqual(
+    collectSentinelIssues(REPO, () => ({ message: "rate limited" }), { marker: MARKER, title: TITLE }),
+    [],
+  );
+});
+
+test("tolerates malformed listing entries", () => {
+  const matches = collectSentinelIssues(
+    REPO,
+    () => [null, "junk", { number: 3 }, { number: 4, title: TITLE }],
+    { marker: MARKER, title: TITLE },
+  );
+  assert.deepEqual(matches.map((m) => m.number), [4]);
+});
+
+test("closeDuplicateSentinels comments with the canonical pointer and closes as not planned", () => {
+  const calls = [];
+  const closed = closeDuplicateSentinels(
+    [{ number: 15532 }, { number: 15600 }, { number: null }],
+    15401,
+    REPO,
+    (args) => {
+      calls.push(args);
+      return { status: 0, stdout: "", stderr: "" };
+    },
+    "2026-07-07T00:00:00Z",
+  );
+  assert.deepEqual(closed, [15532, 15600]);
+  const comments = calls.filter((c) => c[1] === "comment");
+  const closes = calls.filter((c) => c[1] === "close");
+  assert.equal(comments.length, 2);
+  assert.equal(closes.length, 2);
+  assert.match(comments[0][comments[0].length - 1], /#15401/, "comment points at the canonical issue");
+  assert.ok(closes.every((c) => c.includes("not planned")), "duplicates close as not planned");
+});
+
+test("closeDuplicateSentinels with no duplicates is a no-op", () => {
+  const closed = closeDuplicateSentinels([], 1, REPO, () => {
+    throw new Error("must not be called");
+  }, "2026-07-07T00:00:00Z");
+  assert.deepEqual(closed, []);
+});
+
+console.log(`\n${passed} sentinel-issues tests passed`);

--- a/scripts/ci/test-sentinel-issues.mjs
+++ b/scripts/ci/test-sentinel-issues.mjs
@@ -2,7 +2,9 @@
 import assert from "node:assert/strict";
 import {
   collectSentinelIssues,
+  splitSentinels,
   closeDuplicateSentinels,
+  SENTINEL_LABEL,
   SENTINEL_PER_PAGE,
 } from "./lib/sentinel-issues.mjs";
 
@@ -73,6 +75,45 @@ test("collects ALL matches across pages, oldest (lowest number) first", () => {
   });
   assert.deepEqual(seenPages, [1, 2], "pages until a short page ends the walk");
   assert.deepEqual(matches.map((m) => m.number), [42, 900], "all matches, oldest first");
+});
+
+test("answers from the label-scoped listing in one call when the sentinel is labeled", () => {
+  const urls = [];
+  const matches = collectSentinelIssues(
+    REPO,
+    (args) => {
+      const url = String(args[args.length - 1]);
+      urls.push(url);
+      return url.includes(`labels=${SENTINEL_LABEL}`) ? [{ number: 5, title: TITLE, body: MARKER }] : [];
+    },
+    { marker: MARKER, title: TITLE },
+  );
+  assert.deepEqual(matches.map((m) => m.number), [5]);
+  assert.equal(urls.length, 1, "label-scoped listing answers without the exhaustive walk");
+  assert.match(urls[0], new RegExp(`labels=${SENTINEL_LABEL}`));
+});
+
+test("a de-labeled sentinel is still found by the exhaustive fallback walk", () => {
+  const urls = [];
+  const matches = collectSentinelIssues(
+    REPO,
+    (args) => {
+      const url = String(args[args.length - 1]);
+      urls.push(url);
+      // The sentinel lost its label, so the label-scoped listing misses it.
+      return url.includes("labels=") ? [] : [{ number: 6, title: "renamed", body: MARKER }];
+    },
+    { marker: MARKER, title: TITLE },
+  );
+  assert.deepEqual(matches.map((m) => m.number), [6], "fallback walk finds the de-labeled sentinel");
+  assert.ok(urls.some((u) => !u.includes("labels=")), "falls through to the unlabeled listing");
+});
+
+test("splitSentinels names the oldest canonical and the rest duplicates", () => {
+  assert.deepEqual(splitSentinels([]), { canonical: null, duplicates: [] });
+  const a = { number: 10 };
+  const b = { number: 20 };
+  assert.deepEqual(splitSentinels([a, b]), { canonical: a, duplicates: [b] });
 });
 
 test("returns [] on an empty or non-array listing", () => {

--- a/scripts/ci/test-sentinel-issues.mjs
+++ b/scripts/ci/test-sentinel-issues.mjs
@@ -3,8 +3,8 @@ import assert from "node:assert/strict";
 import {
   collectSentinelIssues,
   splitSentinels,
+  createSentinelIssue,
   closeDuplicateSentinels,
-  SENTINEL_LABEL,
   SENTINEL_PER_PAGE,
 } from "./lib/sentinel-issues.mjs";
 
@@ -77,36 +77,25 @@ test("collects ALL matches across pages, oldest (lowest number) first", () => {
   assert.deepEqual(matches.map((m) => m.number), [42, 900], "all matches, oldest first");
 });
 
-test("answers from the label-scoped listing in one call when the sentinel is labeled", () => {
-  const urls = [];
+test("the lookup does not depend on labels — a re-labeled sentinel is still found", () => {
   const matches = collectSentinelIssues(
     REPO,
-    (args) => {
-      const url = String(args[args.length - 1]);
-      urls.push(url);
-      return url.includes(`labels=${SENTINEL_LABEL}`) ? [{ number: 5, title: TITLE, body: MARKER }] : [];
-    },
+    () => [{ number: 6, title: "renamed", body: MARKER, labels: [] }],
     { marker: MARKER, title: TITLE },
   );
-  assert.deepEqual(matches.map((m) => m.number), [5]);
-  assert.equal(urls.length, 1, "label-scoped listing answers without the exhaustive walk");
-  assert.match(urls[0], new RegExp(`labels=${SENTINEL_LABEL}`));
+  assert.deepEqual(matches.map((m) => m.number), [6]);
 });
 
-test("a de-labeled sentinel is still found by the exhaustive fallback walk", () => {
-  const urls = [];
-  const matches = collectSentinelIssues(
-    REPO,
-    (args) => {
-      const url = String(args[args.length - 1]);
-      urls.push(url);
-      // The sentinel lost its label, so the label-scoped listing misses it.
-      return url.includes("labels=") ? [] : [{ number: 6, title: "renamed", body: MARKER }];
-    },
-    { marker: MARKER, title: TITLE },
-  );
-  assert.deepEqual(matches.map((m) => m.number), [6], "fallback walk finds the de-labeled sentinel");
-  assert.ok(urls.some((u) => !u.includes("labels=")), "falls through to the unlabeled listing");
+test("createSentinelIssue owns the tech-debt label", () => {
+  const calls = [];
+  createSentinelIssue(REPO, (args) => {
+    calls.push(args);
+    return { status: 0, stdout: "https://gh/issues/1", stderr: "" };
+  }, { title: TITLE, body: `${MARKER}\nbody` });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][1], "create");
+  const labelIndex = calls[0].indexOf("--label");
+  assert.equal(calls[0][labelIndex + 1], "tech-debt", "sentinels are created labeled for triage");
 });
 
 test("splitSentinels names the oldest canonical and the rest duplicates", () => {

--- a/scripts/ci/test-sentinel-issues.mjs
+++ b/scripts/ci/test-sentinel-issues.mjs
@@ -4,6 +4,7 @@ import {
   collectSentinelIssues,
   splitSentinels,
   createSentinelIssue,
+  closeSentinelIssue,
   closeDuplicateSentinels,
   SENTINEL_PER_PAGE,
 } from "./lib/sentinel-issues.mjs";
@@ -141,6 +142,17 @@ test("closeDuplicateSentinels comments with the canonical pointer and closes as 
   assert.equal(closes.length, 2);
   assert.match(comments[0][comments[0].length - 1], /#15401/, "comment points at the canonical issue");
   assert.ok(closes.every((c) => c.includes("not planned")), "duplicates close as not planned");
+});
+
+test("closeSentinelIssue comments then closes as completed", () => {
+  const calls = [];
+  closeSentinelIssue(80, REPO, (args) => {
+    calls.push(args);
+    return { status: 0, stdout: "", stderr: "" };
+  }, "✅ recovered. Closing.");
+  assert.deepEqual(calls.map((c) => c[1]), ["comment", "close"]);
+  assert.ok(calls[0].includes("✅ recovered. Closing."));
+  assert.ok(calls[1].includes("completed"), "canonical recovery closes as completed");
 });
 
 test("closeDuplicateSentinels with no duplicates is a no-op", () => {


### PR DESCRIPTION
Fixes #15532.

The ci-health monitors (`scripts/ci/check-main-red.mjs`, `scripts/bench/check-latest-freshness.mjs`) each track a standing condition through ONE open issue deduplicated on a hidden body marker. Structural rule: when more than one open issue matches a monitor's dedup key, the reconciler must converge back to exactly one; previously it only ever saw the *first* match, so a duplicate born from any lookup miss (the pre-#15467 single-page scan, or a body edit that strips the marker) split the sentinel forever — the older issue was never updated and never closed on recovery. #15532 duplicating #15401 is the concrete witness; the same flaw existed verbatim in the main-red monitor.

What changed (owner layer: shared ci-health issue-lifecycle lib, `scripts/ci/lib/`):

- **`scripts/ci/lib/sentinel-issues.mjs` (new)** — shared sentinel lifecycle. The lookup collects **all** open matches across pages (not first-match), matches on the marker **or** the exact bot-owned title (survives marker-stripping edits), and skips pull requests (the `/issues` listing interleaves them, and a PR quoting the marker must never be edited/closed as the sentinel). `splitSentinels` names the oldest match canonical; `closeDuplicateSentinels` closes younger matches as duplicates pointing at it; `createSentinelIssue` owns the `tech-debt` label; `closeSentinelIssue` owns the canonical recovery close.
- **`scripts/ci/lib/gh.mjs` (new)** — the previously copy-pasted (and already drifted) `gh` spawn/retry seam for the two monitors, keeping the richer transient classification (env-tunable attempts, ENOBUFS non-retry, 5xx/rate-limit text matching). Four sibling scripts keep deliberate per-script transport policies (different buffers, ETIMEDOUT handling); migrating them is noted as follow-up, not snuck in here.
- **Both monitors** now reconcile identically: update the oldest sentinel (re-stamping the marker if an edit removed it), close duplicates, and on recovery close every open sentinel, not just the first.
- **`scripts/ci/full-ci.sh`** — registers `test-check-latest-freshness.mjs`, which existed but was never wired into CI, plus the new `test-sentinel-issues.mjs` / `test-gh.mjs`.

Adjacent-case matrix covered by tests: duplicated sentinel while still alerting (oldest updated, newer closed), duplicated sentinel on recovery (all closed), marker-stripped body found via exact title, marker-quoting PR ignored, sentinel past page 1, re-labeled sentinel still found, malformed/empty listings, no-duplicate no-op, transient-vs-hard gh failure classification.

## Goal
Goal: hold

## Verification
- `node scripts/ci/test-sentinel-issues.mjs` (12 tests)
- `node scripts/ci/test-gh.mjs` (3 tests)
- `node scripts/ci/test-check-main-red.mjs` (30 tests, incl. 4 new healing cases)
- `node scripts/bench/test-check-latest-freshness.mjs` (incl. 3 new healing cases)
- `bash -n scripts/ci/full-ci.sh` + `python3 scripts/lib/check-sh-portability.py`
- All of the above run in the full-ci lint gate on this PR.

## Provenance
Machine: cloud
Assistant: claude-code
Model: undisclosed (harness undercover mode)
Effort: high

https://claude.ai/code/session_01HzQkyiqEa9veL5BmCy5wih

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzQkyiqEa9veL5BmCy5wih)_