### PR TITLE
fix(checker,solver): nest the relation reason chain under each TS2772 overload candidate (#15387)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -53,7 +53,14 @@ impl<'a> CheckerState<'a> {
                 return source;
             };
 
-            let first_arg_type = self.get_type_of_node(first_arg);
+            // Display recovery must only *read* already-computed node types.
+            // Forcing a fresh computation here can re-enter checking of an
+            // expression whose enclosing chain is still mid-resolution (e.g.
+            // rendering a nested call's overload failure), typing a callback
+            // without its contextual type and leaking its diagnostics.
+            let Some(first_arg_type) = self.ctx.node_types.get(&first_arg.0).copied() else {
+                return source;
+            };
             if matches!(first_arg_type, TypeId::ERROR | TypeId::UNKNOWN) {
                 return source;
             }

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -1081,12 +1081,20 @@ impl<'a> CheckerState<'a> {
 
         // Per-candidate relation reason chains (#15387), computed before the
         // type formatter takes its borrow of the checker context (failure
-        // analysis needs `&mut self`).
+        // analysis needs `&mut self`). The chain anchors at the candidate's
+        // failing *argument* node — exactly like the single-signature TS2345
+        // path — never at the call node: the renderer's display probes climb
+        // from their anchor to enclosing initializers and would type the
+        // surrounding expression mid-flight.
         let candidate_chains: Vec<Vec<DiagnosticRelatedInformation>> = if wrap_overloads {
             failures
                 .iter()
                 .map(|failure| {
-                    self.overload_candidate_reason_chain(failure, anchor.node_idx, &span)
+                    self.overload_failure_argument_node(idx, failure)
+                        .map(|arg_idx| {
+                            self.overload_candidate_reason_chain(failure, arg_idx, &span)
+                        })
+                        .unwrap_or_default()
                 })
                 .collect()
         } else {
@@ -1192,6 +1200,27 @@ impl<'a> CheckerState<'a> {
     /// cross-location pointers. Candidates whose pending diagnostic already
     /// carries a related payload keep it (the caller renders it); arity and
     /// `this` failures carry no chain, matching tsc.
+    /// The argument node one overload candidate's failure describes: the
+    /// logical argument containing the failure's span, or the sole argument
+    /// when the failure carries no span (solver-resolved candidates).
+    fn overload_failure_argument_node(
+        &self,
+        idx: NodeIndex,
+        failure: &tsz_solver::PendingDiagnostic,
+    ) -> Option<NodeIndex> {
+        let arg_nodes = self.logical_call_argument_nodes(idx)?;
+        let Some(span) = failure.span.as_ref() else {
+            return match arg_nodes.as_slice() {
+                [only] => Some(*only),
+                _ => None,
+            };
+        };
+        arg_nodes.into_iter().find(|&arg_idx| {
+            self.get_source_location(arg_idx)
+                .is_some_and(|loc| span.start >= loc.start && span.start < loc.end)
+        })
+    }
+
     fn overload_candidate_reason_chain(
         &mut self,
         failure: &tsz_solver::PendingDiagnostic,

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -897,15 +897,11 @@ impl<'a> CheckerState<'a> {
             let mut first_name = None;
             let mut all_same = true;
             for failure in &argument_failures {
-                let Some(tsz_solver::DiagnosticArg::Type(arg_type)) = failure.args.first() else {
+                let Some((arg_type, param_type)) = failure.type_pair() else {
                     all_same = false;
                     break;
                 };
-                let Some(tsz_solver::DiagnosticArg::Type(param_type)) = failure.args.get(1) else {
-                    all_same = false;
-                    break;
-                };
-                let analysis = self.analyze_assignability_failure(*arg_type, *param_type);
+                let analysis = self.analyze_assignability_failure(arg_type, param_type);
                 let Some(tsz_solver::SubtypeFailureReason::ExcessProperty {
                     property_name, ..
                 }) = analysis.failure_reason
@@ -937,9 +933,15 @@ impl<'a> CheckerState<'a> {
         let argument_anchor_is_callback = raw_argument_anchor
             .is_some_and(|anchor_idx| self.is_callback_expression_argument(anchor_idx));
         let callback_overloads_are_callable_only = argument_failures.iter().all(|failure| {
-            matches!(failure.args.get(1), Some(tsz_solver::DiagnosticArg::Type(param_ty))
-                if crate::query_boundaries::common::function_shape_for_type(self.ctx.types, *param_ty).is_some()
-                    || crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, *param_ty).is_some())
+            failure.type_pair().is_some_and(|(_, param_ty)| {
+                crate::query_boundaries::common::function_shape_for_type(self.ctx.types, param_ty)
+                    .is_some()
+                    || crate::query_boundaries::common::callable_shape_for_type(
+                        self.ctx.types,
+                        param_ty,
+                    )
+                    .is_some()
+            })
         });
         let callback_argument_has_prior_diagnostics =
             raw_argument_anchor.is_some_and(|anchor_idx| {
@@ -1058,26 +1060,10 @@ impl<'a> CheckerState<'a> {
         else {
             return;
         };
-        let mut related = Vec::new();
-        let mut formatter = self.ctx.create_type_formatter();
         let span =
             tsz_solver::SourceSpan::new(self.ctx.file_name.as_str(), anchor.start, anchor.length);
 
         tracing::debug!("File name: {}", self.ctx.file_name);
-
-        // One elaboration line at `span_of` with the given message/code/depth.
-        let related_line =
-            |span_of: &tsz_solver::SourceSpan, message_text: String, code: u32, depth: u8| {
-                DiagnosticRelatedInformation {
-                    file: span_of.file.to_string(),
-                    start: span_of.start,
-                    length: span_of.length,
-                    message_text,
-                    category: DiagnosticCategory::Message,
-                    code,
-                    depth,
-                }
-            };
 
         // tsc reports a no-overload-match as one `Overload N of M, '<signature>',
         // gave the following error.` (TS2772) chain per candidate — in
@@ -1093,9 +1079,40 @@ impl<'a> CheckerState<'a> {
                 .iter()
                 .all(|failure| failure.overload_signature.is_some());
 
+        // Per-candidate relation reason chains (#15387), computed before the
+        // type formatter takes its borrow of the checker context (failure
+        // analysis needs `&mut self`).
+        let candidate_chains: Vec<Vec<DiagnosticRelatedInformation>> = if wrap_overloads {
+            failures
+                .iter()
+                .map(|failure| {
+                    self.overload_candidate_reason_chain(failure, anchor.node_idx, &span)
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        let mut related = Vec::new();
+        let mut formatter = self.ctx.create_type_formatter();
+
+        // One elaboration line at `span_of` with the given message/code/depth.
+        let related_line =
+            |span_of: &tsz_solver::SourceSpan, message_text: String, code: u32, depth: u8| {
+                DiagnosticRelatedInformation {
+                    file: span_of.file.to_string(),
+                    start: span_of.start,
+                    length: span_of.length,
+                    message_text,
+                    category: DiagnosticCategory::Message,
+                    code,
+                    depth,
+                }
+            };
+
         let related_policy = if wrap_overloads {
             let total = failures.len();
-            for (ordinal, failure) in failures.iter().enumerate() {
+            for (ordinal, (failure, chain)) in failures.iter().zip(candidate_chains).enumerate() {
                 let signature = failure
                     .overload_signature
                     .expect("wrap_overloads requires every failure to carry a signature");
@@ -1131,6 +1148,11 @@ impl<'a> CheckerState<'a> {
                         nested.depth.saturating_add(2),
                     ));
                 }
+                // The reason chain nests under the applicability error.
+                for mut line in chain {
+                    line.depth = line.depth.saturating_add(2);
+                    related.push(line);
+                }
             }
             RelatedInformationPolicy::OVERLOAD_CHAINS
         } else {
@@ -1156,6 +1178,47 @@ impl<'a> CheckerState<'a> {
         );
     }
 
+    /// Build the relation failure-reason elaboration chain for one overload
+    /// candidate's argument mismatch (#15387).
+    ///
+    /// tsc nests the same reason chain under each candidate's `TS2772` header
+    /// that the single-signature path renders under a plain `TS2345`
+    /// (`getSignatureApplicabilityError` reuses
+    /// `checkTypeRelatedToAndOptionallyElaborate`). Reuse the shared
+    /// relation → reason → diagnostic gateway (`analyze_assignability_failure`,
+    /// whose captured pass is memoized) and the single elaboration owner
+    /// (`related_from_failure_reason`), then re-anchor every line onto the
+    /// shared `TS2769` span: chain lines are message-chain text, not
+    /// cross-location pointers. Candidates whose pending diagnostic already
+    /// carries a related payload keep it (the caller renders it); arity and
+    /// `this` failures carry no chain, matching tsc.
+    fn overload_candidate_reason_chain(
+        &mut self,
+        failure: &tsz_solver::PendingDiagnostic,
+        anchor_idx: NodeIndex,
+        span: &tsz_solver::SourceSpan,
+    ) -> Vec<DiagnosticRelatedInformation> {
+        if !failure.related.is_empty()
+            || failure.code
+                != diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+        {
+            return Vec::new();
+        }
+        let Some((source, target)) = failure.type_pair() else {
+            return Vec::new();
+        };
+        let Some(reason) = self
+            .analyze_assignability_failure(source, target)
+            .failure_reason
+        else {
+            return Vec::new();
+        };
+        let chain = self
+            .related_from_failure_reason(&reason, source, target, anchor_idx)
+            .unwrap_or_default();
+        Self::reanchor_chain_lines(chain, span.start, span.length)
+    }
+
     /// Build the per-overload failure diagnostic anchored at the shared
     /// `TS2769` span, applying tsc's `reportRelationError` source
     /// generalization: a fresh literal source (`true`, `1`) is widened to its
@@ -1173,12 +1236,8 @@ impl<'a> CheckerState<'a> {
             ..failure.clone()
         };
         if pending.code == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
-            && let (
-                Some(tsz_solver::DiagnosticArg::Type(source)),
-                Some(tsz_solver::DiagnosticArg::Type(target)),
-            ) = (pending.args.first(), pending.args.get(1))
+            && let Some((source, target)) = pending.type_pair()
         {
-            let (source, target) = (*source, *target);
             let display_source =
                 crate::query_boundaries::diagnostics::generalized_literal_source_for_display(
                     self.ctx.types,

--- a/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
@@ -296,9 +296,8 @@ impl<'a> CheckerState<'a> {
             {
                 return false;
             }
-            let expected_type = match failure.args.as_slice() {
-                [_, tsz_solver::DiagnosticArg::Type(expected_type)] => *expected_type,
-                _ => return false,
+            let Some((_, expected_type)) = failure.type_pair() else {
+                return false;
             };
             if matches!(expected_type, TypeId::ERROR | TypeId::UNKNOWN) {
                 continue;

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -837,8 +837,24 @@ impl<'a> CheckerState<'a> {
         start: u32,
         length: u32,
     ) -> Vec<DiagnosticRelatedInformation> {
-        self.render_failure_reason(reason, source, target, anchor_idx, 0)
-            .related_information
+        Self::reanchor_chain_lines(
+            self.render_failure_reason(reason, source, target, anchor_idx, 0)
+                .related_information,
+            start,
+            length,
+        )
+    }
+
+    /// Re-anchor elaboration chain lines onto a primary diagnostic surface:
+    /// category reset to `Message`, anchor rewritten to (`start`, `length`).
+    /// Chain lines are message-chain text, not cross-location pointers, so
+    /// they always carry the primary diagnostic's position.
+    pub(crate) fn reanchor_chain_lines(
+        lines: Vec<DiagnosticRelatedInformation>,
+        start: u32,
+        length: u32,
+    ) -> Vec<DiagnosticRelatedInformation> {
+        lines
             .into_iter()
             .map(|mut rel| {
                 rel.category = DiagnosticCategory::Message;

--- a/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
@@ -479,6 +479,41 @@ pair(t);
     );
 }
 
+/// Chain rendering must not perturb checking of the enclosing expression:
+/// rendering a nested call's overload failure runs display recovery, which
+/// may only *read* already-computed node types. Forcing a fresh computation
+/// re-entered the still-unresolved outer `.map(...)` call and typed its
+/// callback without a contextual type, leaking a spurious `TS7006`
+/// (regressed `arrayConcatMap.ts` in conformance).
+#[test]
+fn chain_rendering_does_not_leak_diagnostics_into_enclosing_call() {
+    let diags = check_source_diagnostics(
+        r#"
+interface Out {
+    pick(cb: (value: string) => void): Out;
+}
+declare function make(items: { tag: number }[]): Out;
+declare function make(items: { tag: string }[]): Out;
+declare const seed: { other: boolean }[];
+var r = make(seed).pick(v => {});
+"#,
+    );
+
+    assert!(
+        !diags.iter().any(|d| d.code == 7006),
+        "chain rendering must not leak TS7006 into the enclosing call, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2769),
+        "the nested no-overload-match itself must still report, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
 /// More than three failing candidates keep tsc's distinct top-level shape:
 /// tsz leaves them as the flat fallback (no `TS2772` wrappers), and the
 /// top-level `TS2769` is unchanged.

--- a/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
@@ -251,6 +251,234 @@ f(true);
     );
 }
 
+/// The `(depth, message)` pairs of the chain, for tests that assert shape
+/// and text but not per-line codes.
+fn chain_lines(source: &str) -> Vec<(u8, String)> {
+    overload_chain(source)
+        .into_iter()
+        .map(|(depth, _, message)| (depth, message))
+        .collect()
+}
+
+/// Borrowing view of a chain for comparison against literal expectations.
+fn as_pairs(chain: &[(u8, String)]) -> Vec<(u8, &str)> {
+    chain.iter().map(|(d, m)| (*d, m.as_str())).collect()
+}
+
+/// The messages of every chain line at exactly `depth`.
+fn lines_at_depth(chain: &[(u8, String)], depth: u8) -> Vec<&str> {
+    chain
+        .iter()
+        .filter(|(d, _)| *d == depth)
+        .map(|(_, m)| m.as_str())
+        .collect()
+}
+
+/// The witness from #15387: a callback parameter incompatibility nests the
+/// full relation reason chain under each candidate's `TS2772` header — the
+/// `Types of parameters 'a' and 'x' are incompatible.` frame and the
+/// contravariant leaf — exactly as the single-signature `TS2345` path
+/// renders them (differential-verified against tsc 6.0.2).
+#[test]
+fn callback_parameter_mismatch_nests_reason_chain_per_candidate() {
+    let chain = chain_lines(
+        r#"
+declare function each(cb: (x: string) => void): void;
+declare function each(cb: (x: number, i: number) => void): void;
+each((a: boolean) => {});
+"#,
+    );
+
+    assert_eq!(
+        as_pairs(&chain),
+        vec![
+            (
+                0,
+                "Overload 1 of 2, '(cb: (x: string) => void): void', gave the following error."
+            ),
+            (
+                1,
+                "Argument of type '(a: boolean) => void' is not assignable to parameter of type '(x: string) => void'."
+            ),
+            (2, "Types of parameters 'a' and 'x' are incompatible."),
+            (3, "Type 'string' is not assignable to type 'boolean'."),
+            (
+                0,
+                "Overload 2 of 2, '(cb: (x: number, i: number) => void): void', gave the following error."
+            ),
+            (
+                1,
+                "Argument of type '(a: boolean) => void' is not assignable to parameter of type '(x: number, i: number) => void'."
+            ),
+            (2, "Types of parameters 'a' and 'x' are incompatible."),
+            (3, "Type 'number' is not assignable to type 'boolean'."),
+        ],
+        "expected the full per-candidate reason chain under each TS2772 header"
+    );
+}
+
+/// A missing-property failure nests its `Property 'p' is missing …` line
+/// under each candidate, and the two candidates keep their distinct leaves
+/// (dedupe is off under `OVERLOAD_CHAINS`).
+#[test]
+fn missing_property_reason_chain_nests_under_each_header() {
+    let chain = chain_lines(
+        r#"
+declare function take(o: { alpha: string }): void;
+declare function take(o: { beta: number }): void;
+declare const arg: { gamma: boolean };
+take(arg);
+"#,
+    );
+
+    assert_eq!(
+        lines_at_depth(&chain, 2),
+        vec![
+            "Property 'alpha' is missing in type '{ gamma: boolean; }' but required in type '{ alpha: string; }'.",
+            "Property 'beta' is missing in type '{ gamma: boolean; }' but required in type '{ beta: number; }'.",
+        ],
+        "expected one missing-property leaf under each header, got: {chain:?}"
+    );
+}
+
+/// Constructor (`new`) overload candidates nest the same reason chains as
+/// call overloads.
+#[test]
+fn constructor_overloads_nest_reason_chains() {
+    let chain = chain_lines(
+        r#"
+declare class Widget {
+    constructor(cb: (x: string) => void);
+    constructor(cb: (x: number) => void);
+}
+new Widget((a: boolean) => {});
+"#,
+    );
+
+    let depth2plus: Vec<(u8, &str)> = as_pairs(&chain)
+        .into_iter()
+        .filter(|(depth, _)| *depth >= 2)
+        .collect();
+    assert_eq!(
+        depth2plus,
+        vec![
+            (2, "Types of parameters 'a' and 'x' are incompatible."),
+            (3, "Type 'string' is not assignable to type 'boolean'."),
+            (2, "Types of parameters 'a' and 'x' are incompatible."),
+            (3, "Type 'number' is not assignable to type 'boolean'."),
+        ],
+        "expected reason chains under both constructor candidates, got: {chain:?}"
+    );
+}
+
+/// Overloaded *call signatures on an interface* resolve through the solver's
+/// callable path; its candidate failures now carry their declared signature
+/// too, so the set wraps and chains identically to declared function
+/// overloads.
+#[test]
+fn callable_interface_overloads_wrap_and_chain() {
+    let chain = chain_lines(
+        r#"
+interface Callable {
+    (cb: (x: string) => void): void;
+    (cb: (x: number, i: number) => void): void;
+}
+declare const invoke: Callable;
+invoke((a: boolean) => {});
+"#,
+    );
+
+    assert_eq!(
+        lines_at_depth(&chain, 0),
+        vec![
+            "Overload 1 of 2, '(cb: (x: string) => void): void', gave the following error.",
+            "Overload 2 of 2, '(cb: (x: number, i: number) => void): void', gave the following error.",
+        ],
+        "expected TS2772 headers on the callable-interface path, got: {chain:?}"
+    );
+    assert!(
+        chain
+            .iter()
+            .any(|(depth, m)| *depth == 2
+                && m == "Types of parameters 'a' and 'x' are incompatible."),
+        "expected the parameter-incompatibility frame on the callable-interface path, got: {chain:?}"
+    );
+}
+
+/// A scalar leaf mismatch has no deeper elaboration in tsc; the wrapped
+/// candidates must not grow synthetic chain lines below depth 1.
+#[test]
+fn scalar_leaf_candidates_carry_no_extra_chain() {
+    let chain = chain_lines(
+        r#"
+declare function s(x: string): void;
+declare function s(x: number): void;
+s(true);
+"#,
+    );
+
+    assert!(
+        chain.iter().all(|(depth, _)| *depth <= 1),
+        "scalar leaf candidates must not carry a reason chain, got: {chain:?}"
+    );
+}
+
+/// Anti-hardcoding: the chain is structural — renaming the callee, callback
+/// parameters, and target parameters only changes the rendered names.
+#[test]
+fn reason_chain_is_independent_of_binder_names() {
+    let chain = chain_lines(
+        r#"
+declare function visit(handler: (item: string) => void): void;
+declare function visit(handler: (entry: number, pos: number) => void): void;
+visit((row: boolean) => {});
+"#,
+    );
+
+    assert!(
+        chain.iter().any(|(depth, m)| *depth == 2
+            && m == "Types of parameters 'row' and 'item' are incompatible."),
+        "expected the renamed-binder parameter frame, got: {chain:?}"
+    );
+    assert!(
+        chain
+            .iter()
+            .any(|(depth, m)| *depth == 3
+                && m == "Type 'string' is not assignable to type 'boolean'."),
+        "expected the contravariant leaf under the renamed frame, got: {chain:?}"
+    );
+}
+
+/// Tuple-argument candidates drill to the offending position under each
+/// header, mirroring the single-signature TS2345 positional chain.
+#[test]
+fn tuple_argument_candidates_nest_positional_chains() {
+    let chain = chain_lines(
+        r#"
+declare function pair(a: [string, number]): void;
+declare function pair(a: [number, string]): void;
+declare const t: [boolean, boolean];
+pair(t);
+"#,
+    );
+
+    assert_eq!(
+        lines_at_depth(&chain, 2),
+        vec![
+            "Type at position 0 in source is not compatible with type at position 0 in target.",
+            "Type at position 0 in source is not compatible with type at position 0 in target.",
+        ],
+        "expected a positional disambiguator under each header, got: {chain:?}"
+    );
+    assert!(
+        chain
+            .iter()
+            .any(|(depth, m)| *depth == 3
+                && m == "Type 'boolean' is not assignable to type 'string'."),
+        "expected the position-0 leaf under the first header, got: {chain:?}"
+    );
+}
+
 /// More than three failing candidates keep tsc's distinct top-level shape:
 /// tsz leaves them as the flat fallback (no `TS2772` wrappers), and the
 /// top-level `TS2769` is unchanged.

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -595,6 +595,18 @@ impl PendingDiagnostic {
         self
     }
 
+    /// The `(source, target)` pair of a two-type diagnostic (e.g. `TS2345`
+    /// argument-not-assignable), when the first two message args are types.
+    /// Owns the positional arg encoding so consumers do not.
+    pub fn type_pair(&self) -> Option<(TypeId, TypeId)> {
+        match (self.args.first(), self.args.get(1)) {
+            (Some(DiagnosticArg::Type(source)), Some(DiagnosticArg::Type(target))) => {
+                Some((*source, *target))
+            }
+            _ => None,
+        }
+    }
+
     /// Attach a source span to this diagnostic.
     pub fn with_span(mut self, span: SourceSpan) -> Self {
         self.span = Some(span);

--- a/crates/tsz-solver/src/operations/constructors.rs
+++ b/crates/tsz-solver/src/operations/constructors.rs
@@ -199,7 +199,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         crate::diagnostics::PendingDiagnosticBuilder::argument_not_assignable(
                             actual, expected,
                         )
-                        .with_overload_signature(self.interner.function(func.clone())),
+                        .with_overload_signature(self.interner.function(func)),
                     );
                 }
                 CallResult::ArgumentCountMismatch {
@@ -221,7 +221,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             max,
                             actual,
                         )
-                        .with_overload_signature(self.interner.function(func.clone())),
+                        .with_overload_signature(self.interner.function(func)),
                     );
                 }
                 // Track this-type mismatches for TS2345 optimization (tsc reports TS2345 not TS2769
@@ -243,7 +243,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             expected_this,
                             actual_this,
                         )
-                        .with_overload_signature(self.interner.function(func.clone())),
+                        .with_overload_signature(self.interner.function(func)),
                     );
                 }
                 _ => {

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -1615,7 +1615,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     failures.push(
                         crate::diagnostics::PendingDiagnosticBuilder::argument_not_assignable(
                             actual, expected,
-                        ),
+                        )
+                        .with_overload_signature(self.interner.function(func)),
                     );
                 }
                 CallResult::ArgumentCountMismatch {
@@ -1636,7 +1637,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             expected_min,
                             max,
                             actual,
-                        ),
+                        )
+                        .with_overload_signature(self.interner.function(func)),
                     );
                 }
                 // Track this-type mismatches for TS2345 optimization (tsc reports TS2345 not TS2769
@@ -1657,7 +1659,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         crate::diagnostics::PendingDiagnosticBuilder::this_type_mismatch(
                             expected_this,
                             actual_this,
-                        ),
+                        )
+                        .with_overload_signature(self.interner.function(func)),
                     );
                 }
                 _ => {


### PR DESCRIPTION
Closes #15387.

**Structural rule:** when a call matches no overload and a candidate's argument mismatch has an elaborable relation failure reason, tsc nests the full reason chain under that candidate's TS2772 header (`getSignatureApplicabilityError` reuses the same `checkTypeRelatedToAndOptionallyElaborate` chain as the single-signature path); tsz does this through the checker error reporter, which routes each wrapped candidate through the same shared relation → reason → diagnostic gateway the single-signature TS2345 path uses (`analyze_assignability_failure`, memoized per #13243, → `related_from_failure_reason`), nesting the chain depth-shifted (+2) under the TS2772 header.

Before, `each((a: boolean) => {})` against two overloads printed two flat "Argument of type … is not assignable" lines under TS2769 with no sub-chain, while the identical single-signature call printed the full `Types of parameters 'a' and 'x' are incompatible.` + leaf chain. After, each TS2772 header carries the same chain — byte-identical to `tsc` 6.0.2 on every differential below.

**Owner layer:**
- Checker error reporter (`error_no_overload_matches_at` + new `overload_candidate_reason_chain` in `error_emission.rs`): chain synthesis at emission time — the construction sites are speculative (candidate failures are discarded when a later candidate resolves) and the solver cannot run checker display roles, so emission is the structurally correct point; it also keeps the overload path symmetric with the single-signature TS2345 path, which likewise analyzes at emission. The chain anchors at the candidate's failing *argument* node (matching the single-signature path), with a conservative no-chain fallback when it cannot be identified.
- Solver (`call_resolution.rs`): the callable path (`resolve_callable_call`) now tags each candidate failure with its declared signature via `with_overload_signature`, exactly as `constructors.rs` already did — the missing fourth leg named in the issue. Interface-callable overload sets now wrap + chain like declared function overloads.
- Solver (`diagnostics/core.rs`): new `PendingDiagnostic::type_pair()` owns the positional `(source, target)` arg encoding; four checker sites that open-coded the positional match now use it.
- Checker (`fingerprint_policy.rs`): the re-anchor transform (category → Message, span → primary surface) is extracted into `reanchor_chain_lines`, shared by `reanchored_container_related` and the new chain builder.
- Both solver overload loops move `func` into the interner instead of cloning (six clone elisions; failure arms only, the success path never interns).

**Merge-queue regression fixed in-flight:** the first queue run regressed `arrayConcatMap.ts` (spurious TS7006). Root cause (backtraced to the deciding frame): chain rendering runs `recover_unknown_array_source_type_for_display`, which *forced* `get_type_of_node` on the first argument of the enclosing assignment-source call while that call was still mid-resolution — typing the outer `.map` callback without its contextual type and leaking its implicit-any diagnostic. Display recovery now only *reads* already-computed node types (cached `node_types` lookup, skip when absent). Committed rendering paths are unaffected (their argument types are always cached by the time TS2322 display runs); the mid-flight case is precisely where computing was unsafe. Pinned by `chain_rendering_does_not_leak_diagnostics_into_enclosing_call`, which fails without the helper fix.

No formatted-string predicates, no binder-name checks: the chain appears iff the shared gateway produces a failure reason. Chain computation runs only on the error path for the 2–3-candidate wrapped case, and `analyze_assignability_failure` replays the memoized relation capture, so no relation re-runs. Dedupe stays off and declaration order preserved under `RelatedInformationPolicy::OVERLOAD_CHAINS`, so sibling chains with identical leaves round-trip (no #15388 interaction).

**Adjacent matrix** (13-fixture CLI differential vs `tsc` 6.0.2, byte-identical; pinned as unit tests with renamed binders):
- callback parameter incompatibility → `Types of parameters …` + contravariant leaf under each header (the issue witness)
- missing-property leaf per candidate, distinct leaves preserved (dedupe-off)
- tuple argument → positional disambiguator + leaf per candidate
- deep chain: callback whose parameter object mismatches (4-level nesting)
- `new` overloads (constructor candidates chain identically)
- interface-callable overloads (solver path — previously flat, now wrapped + chained)
- negative/fallback: scalar leaf candidates gain no synthetic chain lines (tsc has none); single failing signature stays plain TS2345; >3 candidates keep the flat fallback; mixed arity+type sets still collapse per tsc; union-parameter single-candidate control unchanged
- no diagnostic leakage from chain rendering into the enclosing expression (the arrayConcatMap family)

Known residual (pre-existing, unchanged): the candidate *head* line for fresh object-literal excess-property failures renders TS2345 where tsc renders TS2353 (`lit({ z: 3 })` family) — a head-line-selection defect, not the reason-chain payload; no chain lines are added there on either side.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --lib` — failure set byte-identical to `main`'s local baseline (74 pre-existing failures while CI is reduced, #15338; zero new, zero fixed), including 15/15 `overload_elaboration_tests` (8 new).
- `cargo nextest run -p tsz-solver --lib` — 4 failures, all reproduced on clean `main` (narrowing/normalize/evaluation, unrelated).
- Ten overload-related integration targets (`ts2769_anchor_disagreeing_overloads_tests`, `jsx_multi_construct_overload_tests`, `jsx_overload_anchor_literal_attr_tests`, `overload_argument_flow_narrowing_visibility_tests`, `overload_constraint_fallback_applicability_tests`, `string_iterable_overload_matching_tests`, `speculation_rollback_tests`, `contextual_return_value_arg_pinned_tests`, `cross_file_lib_generic_heritage_tests`, `thisless_functions_not_context_sensitive_tests`) — 95/96; the 1 failure fails identically on clean `main`.
- 13-fixture CLI differential vs `tsc` 6.0.2: byte-identical (see adjacent matrix), re-run after the TS7006 fix.
- `arrayConcatMap.ts` local repro: diagnostics restored to exactly TS2769 + TS2339 (the merge-queue regression), with the reason chains rendering.
- `cargo clippy -p tsz-checker -p tsz-solver --profile ci-lint --lib` clean; `cargo fmt --check` clean.
- Broad conformance / emit / fourslash gates owned by exact-head ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: max

https://claude.ai/code/session_015ZBNHkyapw3VyGdt7w68wK