### PR TITLE
fix(checker): cap array-literal element drill-in for rest-tuple targets (#15458)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -242,6 +242,9 @@ path = "tests/tuple_call_argument_elaboration_tests.rs"
 name = "array_source_tuple_target_elaboration_tests"
 path = "tests/array_source_tuple_target_elaboration_tests.rs"
 [[test]]
+name = "array_literal_rest_tuple_drill_cap_tests"
+path = "tests/array_literal_rest_tuple_drill_cap_tests.rs"
+[[test]]
 name = "arrow_conditional_body_return_elaboration_tests"
 path = "tests/arrow_conditional_body_return_elaboration_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -85,15 +85,15 @@ impl<'a> CheckerState<'a> {
                 target_element,
                 ..
             }) => {
-                // For variadic-rest tuples with trailing fixed elements, only
-                // report element-level errors for the leading fixed section.
-                // A failure at index >= leading_fixed_count means the mismatch
-                // is in the variadic or trailing section — those can't be mapped
-                // to source element positions reliably, so defer to tuple-level.
+                // For rest-tuple targets, only report element-level errors for
+                // the leading fixed section. A failure at index >=
+                // leading_fixed_count is rest-covered or trailing — tsc defers
+                // those to the whole-tuple relation (`Type at position(s) … in
+                // source …` anchored at the argument), so defer to tuple-level.
                 if let Some(target_elements) =
                     crate::query_boundaries::common::tuple_elements(self.ctx.types, target_type)
                     && let Some(n_leading) =
-                        crate::query_boundaries::common::tuple_leading_fixed_count_before_trailing(
+                        crate::query_boundaries::common::tuple_leading_fixed_drill_cap(
                             &target_elements,
                         )
                     && index >= n_leading

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -1139,8 +1139,9 @@ impl<'a> CheckerState<'a> {
 
         // tsc's `elaborateElementwise` reports an unelaborated element mismatch
         // with the *source tuple's* element type
-        // (`getTypeOfPropertyOfType(source, `${i}`)`), not a context-free
-        // retype of the element expression. Recover that tuple once; element
+        // (`getIndexedAccessTypeOrUndefined(source, getNumberLiteralType(i))`,
+        // which reduces to the fixed slot's type), not a context-free retype
+        // of the element expression. Recover that tuple once; element
         // index i maps to slot i only when the literal is hole/spread-free
         // (equal lengths, all fixed slots — checked per element below).
         let source_tuple_elements = crate::query_boundaries::common::tuple_elements(

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -1368,12 +1368,14 @@ impl<'a> CheckerState<'a> {
                     continue;
                 }
 
-                // For a nested array literal the context-free retype is an
-                // open array, which mis-classifies the sub-reason (arity
-                // family instead of the positional chain), so use the source
-                // tuple's slot type recovered above. Only a fixed slot maps
-                // back to this element position (a rest slot from a source
-                // spread would hand the relation the whole array type).
+                // For a nested (possibly parenthesized) array literal the
+                // context-free retype is an open array, which mis-classifies
+                // the sub-reason (arity family instead of the positional
+                // chain), so use the source tuple's slot type recovered above.
+                // tsc applies the slot-type rule to *every* reported element;
+                // gating on array literals is conservative staging — other
+                // element kinds keep the display baselines tuned to
+                // `elem_type` until their parity witnesses surface.
                 let elem_is_array_literal = self
                     .ctx
                     .arena

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -1125,15 +1125,16 @@ impl<'a> CheckerState<'a> {
             && tuple_target_elements.is_some();
         let mut saw_elision = false;
 
-        // For variadic-rest tuples with trailing fixed elements (e.g., [number, ...string[], number]),
-        // element positions can only be reliably matched against the leading fixed section.
-        // Trailing fixed elements cannot be mapped without knowing the total source length, and
-        // variadic-section positions are ambiguous when trailing elements shift the mapping.
-        // Limit elaboration to the leading fixed count; tsc emits element-level only for leading
-        // fixed failures and falls back to a tuple-level error for variadic/trailing mismatches.
+        // For rest-tuple targets (e.g. `[number, ...string[]]` or
+        // `[number, ...string[], number]`), element positions can only be
+        // reliably matched against the leading fixed section. Rest-covered and
+        // trailing fixed positions have no fixed source index, so tsc emits
+        // element-level errors only for leading fixed failures and falls back
+        // to the whole-tuple relation (`Type at position(s) … in source …`)
+        // for the rest. Cap element drill-in to the leading fixed count.
         let max_elaborate_index: Option<usize> =
             tuple_target_elements.as_deref().and_then(|elements| {
-                crate::query_boundaries::common::tuple_leading_fixed_count_before_trailing(elements)
+                crate::query_boundaries::common::tuple_leading_fixed_drill_cap(elements)
             });
 
         let mut elaborated = false;

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -1383,7 +1383,7 @@ impl<'a> CheckerState<'a> {
                     source_tuple_elements
                         .as_deref()
                         .and_then(|elements| elements.get(index))
-                        .filter(|element| !element.rest && !element.optional)
+                        .filter(|element| element.is_required())
                         .map(|element| element.type_id)
                         .filter(|&source_element| !source_element.is_any_unknown_or_error())
                         .unwrap_or(elem_type)

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -1137,6 +1137,18 @@ impl<'a> CheckerState<'a> {
                 crate::query_boundaries::common::tuple_leading_fixed_drill_cap(elements)
             });
 
+        // tsc's `elaborateElementwise` reports an unelaborated element mismatch
+        // with the *source tuple's* element type
+        // (`getTypeOfPropertyOfType(source, `${i}`)`), not a context-free
+        // retype of the element expression. Recover that tuple once; element
+        // index i maps to slot i only when the literal is hole/spread-free
+        // (equal lengths, all fixed slots — checked per element below).
+        let source_tuple_elements = crate::query_boundaries::common::tuple_elements(
+            self.ctx.types,
+            self.get_type_of_node(arg_idx),
+        )
+        .filter(|elements| elements.len() == arr.elements.nodes.len());
+
         let mut elaborated = false;
 
         for (index, &elem_idx) in arr.elements.nodes.iter().enumerate() {
@@ -1356,28 +1368,28 @@ impl<'a> CheckerState<'a> {
                     continue;
                 }
 
-                // tsc's `elaborateElementwise` reports an unelaborated element
-                // mismatch with the *source tuple's* element type
-                // (`getTypeOfPropertyOfType(source, `${i}`)`), not a
-                // context-free retype of the element expression. For a nested
-                // array literal the context-free type is an open array, which
-                // mis-classifies the sub-reason (arity family instead of the
-                // positional chain), so recover the element type from the
-                // outer literal's computed tuple type. Only a hole/spread-free
-                // literal maps element index i to tuple slot i.
-                let relation_elem_type =
-                    if elem_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
-                        crate::query_boundaries::common::tuple_elements(
-                            self.ctx.types,
-                            self.get_type_of_node(arg_idx),
-                        )
-                        .filter(|elements| elements.len() == arr.elements.nodes.len())
-                        .and_then(|elements| elements.get(index).map(|element| element.type_id))
+                // For a nested array literal the context-free retype is an
+                // open array, which mis-classifies the sub-reason (arity
+                // family instead of the positional chain), so use the source
+                // tuple's slot type recovered above. Only a fixed slot maps
+                // back to this element position (a rest slot from a source
+                // spread would hand the relation the whole array type).
+                let elem_is_array_literal = self
+                    .ctx
+                    .arena
+                    .get(self.ctx.arena.skip_parenthesized(elem_idx))
+                    .is_some_and(|node| node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION);
+                let relation_elem_type = if elem_is_array_literal {
+                    source_tuple_elements
+                        .as_deref()
+                        .and_then(|elements| elements.get(index))
+                        .filter(|element| !element.rest && !element.optional)
+                        .map(|element| element.type_id)
                         .filter(|&source_element| !source_element.is_any_unknown_or_error())
                         .unwrap_or(elem_type)
-                    } else {
-                        elem_type
-                    };
+                } else {
+                    elem_type
+                };
                 tracing::debug!(
                     "try_elaborate_array_literal_elements: elem_type = {:?}, target_element_type = {:?}, file = {}",
                     elem_type,

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -1356,6 +1356,28 @@ impl<'a> CheckerState<'a> {
                     continue;
                 }
 
+                // tsc's `elaborateElementwise` reports an unelaborated element
+                // mismatch with the *source tuple's* element type
+                // (`getTypeOfPropertyOfType(source, `${i}`)`), not a
+                // context-free retype of the element expression. For a nested
+                // array literal the context-free type is an open array, which
+                // mis-classifies the sub-reason (arity family instead of the
+                // positional chain), so recover the element type from the
+                // outer literal's computed tuple type. Only a hole/spread-free
+                // literal maps element index i to tuple slot i.
+                let relation_elem_type =
+                    if elem_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
+                        crate::query_boundaries::common::tuple_elements(
+                            self.ctx.types,
+                            self.get_type_of_node(arg_idx),
+                        )
+                        .filter(|elements| elements.len() == arr.elements.nodes.len())
+                        .and_then(|elements| elements.get(index).map(|element| element.type_id))
+                        .filter(|&source_element| !source_element.is_any_unknown_or_error())
+                        .unwrap_or(elem_type)
+                    } else {
+                        elem_type
+                    };
                 tracing::debug!(
                     "try_elaborate_array_literal_elements: elem_type = {:?}, target_element_type = {:?}, file = {}",
                     elem_type,
@@ -1364,13 +1386,13 @@ impl<'a> CheckerState<'a> {
                 );
                 if widen_source_display {
                     self.error_type_not_assignable_at_with_widened_source_display(
-                        elem_type,
+                        relation_elem_type,
                         display_target_element_type,
                         elem_idx,
                     );
                 } else {
                     self.error_type_not_assignable_at_with_anchor(
-                        elem_type,
+                        relation_elem_type,
                         display_target_element_type,
                         elem_idx,
                     );

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -222,7 +222,7 @@ impl<'a> CheckerState<'a> {
             return display;
         }
 
-        if let Some(expr_idx) = self.assignment_source_expression(anchor_idx)
+        if let Some(expr_idx) = self.tuple_display_source_expression(anchor_idx)
             && let Some(display) =
                 self.array_literal_tuple_source_type_display(expr_idx, source, target)
         {
@@ -325,7 +325,7 @@ impl<'a> CheckerState<'a> {
             return self.format_assignability_type_for_message(widened, target);
         }
 
-        if let Some(expr_idx) = self.assignment_source_expression(anchor_idx)
+        if let Some(expr_idx) = self.tuple_display_source_expression(anchor_idx)
             && let Some(display) =
                 self.array_literal_tuple_source_type_display(expr_idx, source, target)
         {
@@ -546,7 +546,7 @@ impl<'a> CheckerState<'a> {
                 return display;
             }
         }
-        if let Some(expr_idx) = self.assignment_source_expression(anchor_idx) {
+        if let Some(expr_idx) = self.tuple_display_source_expression(anchor_idx) {
             if let Some(display) = self.type_assertion_mapped_alias_source_display(expr_idx) {
                 return display;
             }

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/tuple_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/tuple_source_display.rs
@@ -5,6 +5,41 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// Expression whose syntax backs an array-literal tuple source display.
+    ///
+    /// Element-level elaboration anchors a diagnostic on the mismatching
+    /// element itself. When that anchor is an array literal nested inside
+    /// another array literal, the anchor's own elements are what pair with the
+    /// (element-level) target type; walking up to the enclosing assignment RHS
+    /// would pair the *outer* literal with the inner target slot and
+    /// mis-render the source (e.g. `[(string | number)[]]` instead of
+    /// `[number, string]`). Ordinary assignment diagnostics anchor on a
+    /// non-expression node (the binder name) or on the RHS itself, so they
+    /// keep the enclosing-assignment walk.
+    pub(in crate::error_reporter) fn tuple_display_source_expression(
+        &self,
+        anchor_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let expr_idx = self.ctx.arena.skip_parenthesized(anchor_idx);
+        let is_array_literal = |idx: NodeIndex| {
+            self.ctx
+                .arena
+                .get(self.ctx.arena.skip_parenthesized(idx))
+                .is_some_and(|node| node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION)
+        };
+        if is_array_literal(expr_idx)
+            && self
+                .ctx
+                .arena
+                .get_extended(expr_idx)
+                .map(|ext| ext.parent)
+                .is_some_and(|parent| parent.is_some() && is_array_literal(parent))
+        {
+            return Some(expr_idx);
+        }
+        self.assignment_source_expression(anchor_idx)
+    }
+
     pub(crate) fn array_literal_tuple_source_type_display(
         &mut self,
         expr_idx: NodeIndex,

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/tuple_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/tuple_source_display.rs
@@ -15,7 +15,9 @@ impl<'a> CheckerState<'a> {
     /// instead of `[number, string]`). Ordinary assignment diagnostics anchor
     /// on a non-expression node (the binder name — rejected by
     /// `direct_diagnostic_source_expression`) or on the RHS itself, so they
-    /// keep the enclosing-assignment walk.
+    /// keep the enclosing-assignment walk. Callers may feed the selected
+    /// expression to non-tuple displays too (annotation text, literal
+    /// display); the preference applies to any array-literal anchor.
     pub(in crate::error_reporter) fn tuple_display_source_expression(
         &self,
         anchor_idx: NodeIndex,

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/tuple_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/tuple_source_display.rs
@@ -8,36 +8,27 @@ impl<'a> CheckerState<'a> {
     /// Expression whose syntax backs an array-literal tuple source display.
     ///
     /// Element-level elaboration anchors a diagnostic on the mismatching
-    /// element itself. When that anchor is an array literal nested inside
-    /// another array literal, the anchor's own elements are what pair with the
-    /// (element-level) target type; walking up to the enclosing assignment RHS
-    /// would pair the *outer* literal with the inner target slot and
-    /// mis-render the source (e.g. `[(string | number)[]]` instead of
-    /// `[number, string]`). Ordinary assignment diagnostics anchor on a
-    /// non-expression node (the binder name) or on the RHS itself, so they
+    /// element itself. When that anchor is an array literal, its own elements
+    /// are what pair with the (element-level) target type; walking up to the
+    /// enclosing assignment RHS would pair the *outer* literal with the inner
+    /// target slot and mis-render the source (e.g. `[(string | number)[]]`
+    /// instead of `[number, string]`). Ordinary assignment diagnostics anchor
+    /// on a non-expression node (the binder name — rejected by
+    /// `direct_diagnostic_source_expression`) or on the RHS itself, so they
     /// keep the enclosing-assignment walk.
     pub(in crate::error_reporter) fn tuple_display_source_expression(
         &self,
         anchor_idx: NodeIndex,
     ) -> Option<NodeIndex> {
-        let expr_idx = self.ctx.arena.skip_parenthesized(anchor_idx);
-        let is_array_literal = |idx: NodeIndex| {
-            self.ctx
-                .arena
-                .get(self.ctx.arena.skip_parenthesized(idx))
-                .is_some_and(|node| node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION)
-        };
-        if is_array_literal(expr_idx)
-            && self
-                .ctx
-                .arena
-                .get_extended(expr_idx)
-                .map(|ext| ext.parent)
-                .is_some_and(|parent| parent.is_some() && is_array_literal(parent))
-        {
-            return Some(expr_idx);
-        }
-        self.assignment_source_expression(anchor_idx)
+        self.direct_diagnostic_source_expression(anchor_idx)
+            .map(|expr_idx| self.ctx.arena.skip_parenthesized(expr_idx))
+            .filter(|&expr_idx| {
+                self.ctx
+                    .arena
+                    .get(expr_idx)
+                    .is_some_and(|node| node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION)
+            })
+            .or_else(|| self.assignment_source_expression(anchor_idx))
     }
 
     pub(crate) fn array_literal_tuple_source_type_display(

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1474,7 +1474,7 @@ pub(crate) fn tuple_leading_fixed_drill_cap(
     // elements before interning, so a `rest` marker here is always a genuine
     // variable-length rest.
     let first_rest_pos = elements.iter().position(|e| e.rest)?;
-    if elements.len() == 1 {
+    if elements.iter().all(|e| e.rest) {
         return None;
     }
     Some(first_rest_pos)

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1442,23 +1442,39 @@ pub(crate) fn get_fixed_tuple_length(db: &dyn TypeDatabase, type_id: TypeId) -> 
     tsz_solver::type_queries::get_fixed_tuple_length(db, type_id)
 }
 
-/// Returns the number of leading fixed (non-rest) elements before the first rest element,
-/// when the tuple has trailing fixed elements after the rest. Returns `None` if the tuple
-/// has no rest element or no trailing fixed elements after the rest.
+/// Upper bound (exclusive) on the source element indices that array-literal /
+/// argument elaboration may report per-element against a tuple *target* that
+/// contains a rest element.
 ///
-/// For `[number, ...string[], number]`: returns `Some(1)` (1 leading fixed before rest).
-/// For `[...string[], number]`: returns `Some(0)` (0 leading fixed before rest).
-/// For `[number, ...string[]]`: returns `None` (no trailing fixed after rest).
+/// tsc's `generateLimitedTupleElements` skips any source element whose index
+/// has no *fixed* slot in the tuple-like target (`isTupleLikeType(target) &&
+/// !getPropertyOfType(target, `${i}`)`), so only the leading fixed prefix
+/// (required or optional slots) before the first rest element is ever drilled
+/// into at the element level. Positions covered by the rest element — and any
+/// trailing fixed elements, whose position depends on the source length — fall
+/// back to the whole-tuple relation, which renders the
+/// `Type at position(s) i[ through j] in source …` chain.
+///
+/// Returns `Some(leading_fixed_count)` when the target tuple pairs a rest
+/// element with at least one fixed element, capping element drill-in to that
+/// prefix. Returns `None` when there is no rest element (a closed tuple —
+/// every position is a fixed slot and drills in) or when the tuple is a lone
+/// rest element (`[...T[]]`, which tsc normalizes to the array `T[]` — not
+/// tuple-like, so every element drills in).
+///
+/// For `[number, ...string[]]`: returns `Some(1)`.
+/// For `[number, ...string[], number]`: returns `Some(1)`.
+/// For `[...string[], number]`: returns `Some(0)`.
+/// For `[...string[]]`: returns `None` (array-like — drill every element).
 /// For `[number, string]`: returns `None` (no rest element).
-pub(crate) fn tuple_leading_fixed_count_before_trailing(
+pub(crate) fn tuple_leading_fixed_drill_cap(
     elements: &[tsz_solver::TupleElement],
 ) -> Option<usize> {
+    // Fixed-length tuple spreads (`[a, ...[b, c]]`) are flattened into fixed
+    // elements before interning, so a `rest` marker here is always a genuine
+    // variable-length rest.
     let first_rest_pos = elements.iter().position(|e| e.rest)?;
-    let n_trailing = elements[first_rest_pos..]
-        .iter()
-        .filter(|e| !e.rest)
-        .count();
-    if n_trailing == 0 {
+    if elements.len() == 1 {
         return None;
     }
     Some(first_rest_pos)

--- a/crates/tsz-checker/tests/arch_source_scans/common_boundary_export_ratchets.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/common_boundary_export_ratchets.rs
@@ -250,7 +250,7 @@ const ALLOWED_COMMON_PUB_CRATE_FNS: &[&str] = &[
     "substitute_this_type",
     "substitute_this_type_at_return_position",
     "tuple_elements",
-    "tuple_leading_fixed_count_before_trailing",
+    "tuple_leading_fixed_drill_cap",
     "tuple_list_id",
     "type_application",
     "type_contains_string_literal",

--- a/crates/tsz-checker/tests/array_literal_rest_tuple_drill_cap_tests.rs
+++ b/crates/tsz-checker/tests/array_literal_rest_tuple_drill_cap_tests.rs
@@ -1,0 +1,297 @@
+//! A fresh **array literal** assigned to a **tuple target with a rest element**
+//! must match `tsc`'s element-drill-in cap.
+//!
+//! `tsc`'s `generateLimitedTupleElements` skips any source element whose index
+//! has no *fixed* slot in the tuple-like target (`isTupleLikeType(target) &&
+//! !getPropertyOfType(target, `${i}`)`). So only the **leading fixed prefix**
+//! (required or optional slots) before the first rest element is ever reported
+//! at the element level; any source element covered by the rest element falls
+//! back to the whole-tuple relation, which renders the `Type at position(s)
+//! i[ through j] in source is not compatible with type at position k in
+//! target.` chain anchored at the initializer (or, for a call argument, at the
+//! argument under `TS2345`).
+//!
+//! `tsz` previously capped element drill-in only when the target tuple had
+//! *trailing* fixed elements after the rest, so `[number, ...boolean[]]` (rest
+//! last) wrongly drilled into the rest-covered source element — wrong anchor,
+//! no positional chain, and one range-frame split into N leaf errors. The cap
+//! now applies whenever the target pairs a rest element with any fixed
+//! element. The rule is structural: it depends only on the tuple shape, so the
+//! cases vary binder names, element types, wrappers (readonly), aliases,
+//! generic instantiations, and both elaboration entry points.
+//!
+//! Differential-verified against `tsc 6.0.2` (`--noEmit --strict`).
+
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn with_code(source: &str, code: u32) -> Vec<Diagnostic> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code == code)
+        .collect()
+}
+
+fn related_lines(diagnostic: &Diagnostic) -> Vec<String> {
+    diagnostic
+        .related_information
+        .iter()
+        .map(|related| related.message_text.clone())
+        .collect()
+}
+
+fn has_related(diagnostic: &Diagnostic, expected: &str) -> bool {
+    diagnostic
+        .related_information
+        .iter()
+        .any(|related| related.message_text == expected)
+}
+
+/// Assert the source produces exactly one diagnostic with `code` and return it.
+fn single(source: &str, code: u32) -> Diagnostic {
+    let diagnostics = with_code(source, code);
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one TS{code}, got {diagnostics:#?}"
+    );
+    diagnostics.into_iter().next().unwrap()
+}
+
+/// Assert the source produces exactly one TS2322 whose headline is `expected` —
+/// the per-element leaf drilled at the mismatching slot (no whole-tuple chain).
+fn assert_single_leaf(source: &str, expected: &str) {
+    let diagnostic = single(source, 2322);
+    assert_eq!(diagnostic.message_text, expected);
+}
+
+/// Assert the source produces exactly one TS2322 carrying the whole-tuple
+/// positional frame `expected_frame` in its related information.
+fn assert_single_chain(source: &str, expected_frame: &str) {
+    let diagnostic = single(source, 2322);
+    assert!(
+        has_related(&diagnostic, expected_frame),
+        "missing the whole-tuple position frame; related = {:#?}",
+        related_lines(&diagnostic)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Rest-covered failure only -> one whole-tuple relation chain, not a leaf.
+// ---------------------------------------------------------------------------
+
+/// A single rest-covered element mismatch reports the whole-tuple relation at
+/// the initializer with the `Type at position 1 …` frame, not a bare element
+/// leaf.
+#[test]
+fn rest_covered_single_failure_reports_whole_tuple_chain() {
+    for source in [
+        "const bad: [number, ...boolean[]] = [1, \"no\"];",
+        // Renamed binder + different element types: same structural reason.
+        "const other: [string, ...number[]] = [\"lead\", true];",
+    ] {
+        assert_single_chain(
+            source,
+            "Type at position 1 in source is not compatible with type at position 1 in target.",
+        );
+    }
+}
+
+/// Several consecutive rest-covered failures collapse into a single
+/// `Type at positions i through j …` range frame, not one leaf per element.
+#[test]
+fn rest_covered_multiple_failures_report_position_range() {
+    assert_single_chain(
+        "const bad: [number, ...boolean[]] = [1, \"a\", \"b\"];",
+        "Type at positions 1 through 2 in source is not compatible with type at position 1 in target.",
+    );
+}
+
+/// A rest-covered failure past a longer passing fixed prefix still defers to
+/// the whole-tuple relation (the frame indexes the rest element's slot).
+#[test]
+fn rest_covered_failure_after_two_passing_fixed_slots_chains() {
+    assert_single_chain(
+        "const bad: [number, string, ...boolean[]] = [1, \"s\", \"no\"];",
+        "Type at position 2 in source is not compatible with type at position 2 in target.",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Target wrappers and indirections resolve to the same tuple shape: the cap
+// must apply through `readonly`, aliases, and generic instantiations.
+// ---------------------------------------------------------------------------
+
+/// A `readonly` rest-tuple target chains exactly like the mutable one.
+#[test]
+fn readonly_rest_tuple_target_reports_whole_tuple_chain() {
+    assert_single_chain(
+        "const bad: readonly [number, ...boolean[]] = [1, \"no\"];",
+        "Type at position 1 in source is not compatible with type at position 1 in target.",
+    );
+}
+
+/// An aliased rest-tuple target chains: the cap sees the resolved tuple shape,
+/// not the alias node.
+#[test]
+fn alias_rest_tuple_target_reports_whole_tuple_chain() {
+    assert_single_chain(
+        "type Row = [number, ...boolean[]];\nconst bad: Row = [1, \"no\"];",
+        "Type at position 1 in source is not compatible with type at position 1 in target.",
+    );
+}
+
+/// A generic alias instantiated to a rest tuple chains: the cap applies to the
+/// instantiated shape.
+#[test]
+fn generic_alias_instantiation_reports_whole_tuple_chain() {
+    assert_single_chain(
+        "type Wrap<T> = [number, ...T[]];\nconst bad: Wrap<boolean> = [1, \"no\"];",
+        "Type at position 1 in source is not compatible with type at position 1 in target.",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Optional fixed slots are fixed slots: they count toward the drill prefix and
+// keep drilling; only rest-covered positions defer.
+// ---------------------------------------------------------------------------
+
+/// A mismatch at an optional fixed slot ahead of the rest element still drills
+/// into that element (`tsc` has a fixed property for the optional index).
+#[test]
+fn optional_fixed_slot_mismatch_drills() {
+    assert_single_leaf(
+        "const bad: [number, string?, ...boolean[]] = [1, 2, true];",
+        "Type 'number' is not assignable to type 'string'.",
+    );
+}
+
+/// With the optional fixed slot passing, a rest-covered failure after it
+/// defers to the whole-tuple relation.
+#[test]
+fn rest_covered_failure_after_optional_fixed_slot_chains() {
+    assert_single_chain(
+        "const bad: [number, string?, ...boolean[]] = [1, \"x\", \"no\"];",
+        "Type at position 2 in source is not compatible with type at position 2 in target.",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Entry points: the same cap governs the variable-initializer and the
+// call-argument elaborators, and it recurses into nested array literals.
+// ---------------------------------------------------------------------------
+
+/// A call argument with a rest-covered mismatch reports the `TS2345` header
+/// with the whole-tuple frame, not a drilled element leaf.
+#[test]
+fn call_argument_rest_covered_failure_reports_ts2345_chain() {
+    let diagnostic = single(
+        "function take(row: [number, ...boolean[]]) {}\ntake([1, \"no\"]);",
+        2345,
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type at position 1 in source is not compatible with type at position 1 in target."
+        ),
+        "missing the whole-tuple position frame; related = {:#?}",
+        related_lines(&diagnostic)
+    );
+}
+
+/// A nested array literal drills through the (closed) outer tuple slot, then
+/// the inner rest-tuple failure renders the whole-tuple chain for the inner
+/// relation.
+#[test]
+fn nested_array_literal_inner_rest_tuple_chains() {
+    assert_single_chain(
+        "const bad: [[number, ...boolean[]]] = [[1, \"no\"]];",
+        "Type at position 1 in source is not compatible with type at position 1 in target.",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mixed failures: the leading fixed prefix still drills; rest-covered elements
+// are dropped (tsc reports only the fixed-prefix leaves).
+// ---------------------------------------------------------------------------
+
+/// When a leading-fixed element fails, `tsc` drills into it and drops the
+/// rest-covered failure entirely (element elaboration reported an error, so
+/// the whole-tuple fallback never fires). Exactly one leaf, at the fixed slot.
+#[test]
+fn fixed_prefix_failure_drills_and_drops_rest_covered() {
+    assert_single_leaf(
+        "const bad: [string, ...boolean[]] = [1, \"no\"];",
+        "Type 'number' is not assignable to type 'string'.",
+    );
+}
+
+/// A fixed-prefix failure that is *not* at position 0 still drills in at its
+/// true slot, and the trailing rest-covered element is dropped.
+#[test]
+fn fixed_prefix_failure_after_passing_slot_drills() {
+    assert_single_leaf(
+        "const bad: [number, boolean, ...string[]] = [1, \"no\", \"ok\"];",
+        "Type 'string' is not assignable to type 'boolean'.",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Array-like and closed targets keep drilling into each element (unchanged):
+// a lone-rest `[...T[]]` normalizes to an array, a plain array target indexes
+// at every position, and a closed tuple makes every position a fixed slot.
+// ---------------------------------------------------------------------------
+
+/// A lone-rest tuple `[...T[]]` is array-like, so `tsc` reports each element
+/// individually — the cap must not intercept it.
+#[test]
+fn lone_rest_tuple_still_drills_into_element() {
+    assert_single_leaf(
+        "const bad: [...boolean[]] = [\"no\"];",
+        "Type 'string' is not assignable to type 'boolean'.",
+    );
+}
+
+/// A plain array target keeps per-element drill-in.
+#[test]
+fn plain_array_target_still_drills_into_element() {
+    assert_single_leaf(
+        "const bad: boolean[] = [true, \"no\"];",
+        "Type 'string' is not assignable to type 'boolean'.",
+    );
+}
+
+/// A closed (rest-free) tuple keeps its per-element leaf — the cap only
+/// applies when a rest element is present.
+#[test]
+fn closed_tuple_still_drills_into_element() {
+    assert_single_leaf(
+        "const bad: [number, boolean] = [1, \"no\"];",
+        "Type 'string' is not assignable to type 'boolean'.",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Middle-rest and trailing-fixed shapes: the pre-existing cap behavior, kept
+// as regression guards (these were already correct before the generalization).
+// ---------------------------------------------------------------------------
+
+/// A middle-rest tuple (trailing fixed after the rest) defers rest-span
+/// failures to the whole-tuple relation.
+#[test]
+fn middle_rest_with_trailing_fixed_chains() {
+    assert_single_chain(
+        "const bad: [number, ...boolean[], string] = [1, \"no\", \"s\"];",
+        "Type at position 1 in source is not compatible with type at position 1 in target.",
+    );
+}
+
+/// Zero leading fixed elements with a trailing fixed element caps drill-in at
+/// index 0: everything defers to the whole-tuple relation.
+#[test]
+fn zero_leading_fixed_with_trailing_fixed_chains() {
+    assert_single_chain(
+        "const bad: [...boolean[], string] = [\"no\", \"s\"];",
+        "Type at position 0 in source is not compatible with type at position 0 in target.",
+    );
+}

--- a/crates/tsz-checker/tests/array_literal_rest_tuple_drill_cap_tests.rs
+++ b/crates/tsz-checker/tests/array_literal_rest_tuple_drill_cap_tests.rs
@@ -65,15 +65,21 @@ fn assert_single_leaf(source: &str, expected: &str) {
     assert_eq!(diagnostic.message_text, expected);
 }
 
-/// Assert the source produces exactly one TS2322 carrying the whole-tuple
-/// positional frame `expected_frame` in its related information.
-fn assert_single_chain(source: &str, expected_frame: &str) {
-    let diagnostic = single(source, 2322);
+/// Assert the source produces exactly one diagnostic with `code` carrying the
+/// whole-tuple positional frame `expected_frame` in its related information.
+fn assert_single_chain_with_code(source: &str, code: u32, expected_frame: &str) {
+    let diagnostic = single(source, code);
     assert!(
         has_related(&diagnostic, expected_frame),
         "missing the whole-tuple position frame; related = {:#?}",
         related_lines(&diagnostic)
     );
+}
+
+/// Assert the source produces exactly one TS2322 carrying the whole-tuple
+/// positional frame `expected_frame` in its related information.
+fn assert_single_chain(source: &str, expected_frame: &str) {
+    assert_single_chain_with_code(source, 2322, expected_frame);
 }
 
 // ---------------------------------------------------------------------------
@@ -185,17 +191,10 @@ fn rest_covered_failure_after_optional_fixed_slot_chains() {
 /// with the whole-tuple frame, not a drilled element leaf.
 #[test]
 fn call_argument_rest_covered_failure_reports_ts2345_chain() {
-    let diagnostic = single(
+    assert_single_chain_with_code(
         "function take(row: [number, ...boolean[]]) {}\ntake([1, \"no\"]);",
         2345,
-    );
-    assert!(
-        has_related(
-            &diagnostic,
-            "Type at position 1 in source is not compatible with type at position 1 in target."
-        ),
-        "missing the whole-tuple position frame; related = {:#?}",
-        related_lines(&diagnostic)
+        "Type at position 1 in source is not compatible with type at position 1 in target.",
     );
 }
 
@@ -206,6 +205,17 @@ fn call_argument_rest_covered_failure_reports_ts2345_chain() {
 fn nested_array_literal_inner_rest_tuple_chains() {
     assert_single_chain(
         "const bad: [[number, ...boolean[]]] = [[1, \"no\"]];",
+        "Type at position 1 in source is not compatible with type at position 1 in target.",
+    );
+}
+
+/// A parenthesized nested array literal takes the same path: the element gate
+/// and the display anchor both see through parens, so the inner rest-tuple
+/// failure still renders the whole-tuple chain.
+#[test]
+fn parenthesized_nested_array_literal_inner_rest_tuple_chains() {
+    assert_single_chain(
+        "const bad: [[number, ...boolean[]]] = [([1, \"no\"])];",
         "Type at position 1 in source is not compatible with type at position 1 in target.",
     );
 }


### PR DESCRIPTION
Closes #15458. Supersedes #15459 (same structural rule; that PR has been merge-conflicted with `main` since #15617 landed in the same elaboration path — this reimplements on current `main` and broadens the fix).

When a fresh **array literal** is assigned to a **tuple target that carries a
rest element**, `tsc` only drills into source elements that map to a *fixed*
slot in the target (`generateLimitedTupleElements` skips any index with no
fixed property: `isTupleLikeType(target) &amp;&amp; !getPropertyOfType(target, "i")`).
Rest-covered positions fall back to the whole-tuple relation — `Type at
position(s) i[ through j] in source is not compatible with type at position k
in target.` — anchored at the initializer (or the argument, under `TS2345`).

**Structural rule:** when a fresh array literal targets a tuple that pairs a
rest element with any fixed element, tsc reports element-level errors only for
the leading fixed prefix (required or optional slots) and defers rest-covered
mismatches to the whole-tuple relation; tsz now does the same through the
checker's shared elaboration drill-in cap
(`query_boundaries::common::tuple_leading_fixed_drill_cap`). Previously
`tuple_leading_fixed_count_before_trailing` only capped when the tuple had
*trailing* fixed elements after the rest, so `[number, ...boolean[]]` (rest
last) drilled into rest-covered elements — wrong anchor, no positional chain,
and one range-frame split into N leaf errors.

Three interlocking checker-side changes (owner layer: diagnostic elaboration
and display; assignability decisions and resolved types unchanged):

1. **Drill-in cap** — generalized to cap whenever a rest element pairs with any
   fixed element; an all-rest tuple (`[...T[]]`, array-like in tsc after tuple
   normalization) stays per-element. Both elaboration entry points — variable
   initializer (`elaboration_object_properties.rs`) and call argument
   (`elaboration_array_mismatch.rs`) — share the helper.
2. **Source slot type for unelaborated elements** — mirroring tsc's
   `elaborateElementwise` (`getIndexedAccessTypeOrUndefined(source, i)`), an
   unelaborated nested array-literal element now reports with the source
   tuple's fixed slot type instead of a context-free retype (which is an open
   array and mis-classified the sub-reason as the arity family).
3. **Display anchor for drilled elements** — the tuple source display derived
   its backing expression by walking to the enclosing assignment RHS even when
   the diagnostic anchors a drilled element that is itself an array literal,
   pairing the outer literal's syntax with the inner target slot. It now
   prefers the direct anchor expression via the established
   `direct_diagnostic_source_expression().or_else(assignment_source_expression)`
   chain, filtered to array-literal anchors.

Divergence matrix fixed (differential vs `tsc 6.0.2`, `--noEmit --strict`):

| witness | tsc | tsz before | tsz after |
|---|---|---|---|
| `[number, ...boolean[]] = [1, "no"]` | whole-tuple chain `@init` | leaf `@elem` | whole-tuple chain |
| `[number, ...boolean[]] = [1, "a", "b"]` | one `positions 1 through 2` frame | two leaves | one range frame |
| `[string, ...boolean[]] = [1, "no"]` | one fixed-slot leaf | two leaves | one fixed-slot leaf |
| `readonly [number, ...boolean[]] = [1, "no"]` | chain | leaf | chain |
| `[number, string?, ...boolean[]] = [1, "x", "no"]` | chain (`position 2`) | leaf | chain |
| alias / generic alias (`Row`, `Wrap&lt;boolean&gt;`) targets | chain | leaf | chain |
| `f([1, "no"])` with `f(x: [number, ...boolean[]])` | TS2345 + chain | drilled TS2322 leaf | TS2345 + chain |
| nested `[[number, ...boolean[]]] = [[1, "no"]]` | inner chain, source `[number, string]` | inner leaf | inner chain, source `[number, string]` |
| parenthesized nested `= [([1, "no"])]` | inner chain | inner leaf | inner chain |

Adjacent negative controls unchanged: fixed-prefix failures still drill
(including optional fixed slots, which count toward the prefix); closed
tuples, lone-rest `[...boolean[]]`, and plain `boolean[]` targets still drill
per-element; middle-rest and trailing-fixed shapes keep their pre-existing
chains; renamed-binder variants verified (rule is structural, not
name-driven).

Residuals surfaced by the sweep, all pre-existing families out of scope here:
alias-name retention in chain headlines (`R15`/`W16&lt;boolean&gt;`) is #15368's
`aliasSymbol` family (reproduces for variable sources on `main`); the fresh
literal leaf in TS2345 chains (`'"no"'` where tsc widens to `'string'`) is
filed as #15626 with a `main` repro on an already-capped shape.

## Goal
Goal: hold

## Verification
- New suite `crates/tsz-checker/tests/array_literal_rest_tuple_drill_cap_tests.rs`
  (18 cases: rest-covered chain/range, readonly/alias/generic-instantiated
  targets, optional-prefix drill + rest-covered chain, call-argument TS2345
  chain, nested + parenthesized-nested literals, mixed fixed+rest,
  lone-rest/array/closed negative controls, middle-rest and trailing-fixed
  regression guards) — 18/18 green.
- Regression batch green (95 tests): `array_source_tuple_target_elaboration_tests`,
  `tuple_call_argument_elaboration_tests`, `tuple_arity_elaboration_tests`,
  `tuple_element_mismatch_tests`, `readonly_tuple_source_display_tests`,
  `union_tuple_source_display_tests`, `contextual_tuple_tests`,
  `variadic_tuple_rest_aggregate_display_tests`, `spread_rest_diagnostics_tests`,
  plus the wider display/contextual/elaboration batch
  (`destructuring_spread_rest_tuple_source_display_tests`,
  `assertion_source_literal_display_tests`, `literal_widening_display_tests`,
  `keyof_source_display_tests`, `conditional_alias_source_display_tests`,
  `array_declaration_display_summary_tests`, `tuple_variadic_position_elaboration_tests`,
  `tuple_argument_mismatch_elaboration_tests`, `arch_source_scans`).
- 4 pre-existing local failures (3 `arch_source_scans` ratchets +
  `literal_widening_display_tests::ts2559_call_argument_literal_member_widens`)
  confirmed identical on clean `origin/main` (#15338 territory).
- `cargo clippy -p tsz-checker --tests` clean.
- Differential sweep vs `tsc 6.0.2` (`--noEmit --strict`) across the 18-case
  witness matrix plus nested/paren probes: parity on every drill-cap witness;
  only the pre-existing #15368/#15626 display families remain.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

https://claude.ai/code/session_01WvxJXGfLJqWzj7FGdJPfvc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvxJXGfLJqWzj7FGdJPfvc)_