### PR TITLE
fix(checker): generalize literal sources at nested relation leaves (#15626)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -727,6 +727,9 @@ path = "tests/tuple_arity_elaboration_tests.rs"
 name = "tuple_variadic_position_elaboration_tests"
 path = "tests/tuple_variadic_position_elaboration_tests.rs"
 [[test]]
+name = "relation_leaf_literal_generalization_tests"
+path = "tests/relation_leaf_literal_generalization_tests.rs"
+[[test]]
 name = "conditional_alias_source_display_tests"
 path = "tests/conditional_alias_source_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -1059,9 +1059,16 @@ impl<'a> CheckerState<'a> {
             return;
         };
         let mut related = Vec::new();
-        let mut formatter = self.ctx.create_type_formatter();
         let span =
             tsz_solver::SourceSpan::new(self.ctx.file_name.as_str(), anchor.start, anchor.length);
+        // Generalize every candidate failure's literal source up front: the
+        // generalization needs `&mut self`, which cannot run while the
+        // formatter below borrows the checker context.
+        let generalized_pendings: Vec<tsz_solver::PendingDiagnostic> = failures
+            .iter()
+            .map(|failure| self.overload_failure_generalized_pending(failure, &span))
+            .collect();
+        let mut formatter = self.ctx.create_type_formatter();
 
         tracing::debug!("File name: {}", self.ctx.file_name);
 
@@ -1095,7 +1102,9 @@ impl<'a> CheckerState<'a> {
 
         let related_policy = if wrap_overloads {
             let total = failures.len();
-            for (ordinal, failure) in failures.iter().enumerate() {
+            for (ordinal, (failure, pending)) in
+                failures.iter().zip(&generalized_pendings).enumerate()
+            {
                 let signature = failure
                     .overload_signature
                     .expect("wrap_overloads requires every failure to carry a signature");
@@ -1117,8 +1126,7 @@ impl<'a> CheckerState<'a> {
                     diagnostic_codes::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
                     0,
                 ));
-                let pending = self.overload_failure_generalized_pending(failure, &span);
-                let diag = formatter.render(&pending);
+                let diag = formatter.render(pending);
                 let diag_span = diag.span.as_ref().unwrap_or(&span);
                 // The candidate's applicability error nests one level under its
                 // TS2772 header; any deeper chain it carries nests below that.
@@ -1134,9 +1142,8 @@ impl<'a> CheckerState<'a> {
             }
             RelatedInformationPolicy::OVERLOAD_CHAINS
         } else {
-            for failure in failures {
-                let pending = self.overload_failure_generalized_pending(failure, &span);
-                let diag = formatter.render(&pending);
+            for pending in &generalized_pendings {
+                let diag = formatter.render(pending);
                 if let Some(diag_span) = diag.span.as_ref() {
                     related.push(related_line(diag_span, diag.message, diag.code, 0));
                 }
@@ -1164,7 +1171,7 @@ impl<'a> CheckerState<'a> {
     /// raw literal source, so without this the overload elaboration diverges
     /// from tsc (and from the single-overload TS2345 display).
     fn overload_failure_generalized_pending(
-        &self,
+        &mut self,
         failure: &tsz_solver::PendingDiagnostic,
         span: &tsz_solver::SourceSpan,
     ) -> tsz_solver::PendingDiagnostic {
@@ -1179,12 +1186,7 @@ impl<'a> CheckerState<'a> {
             ) = (pending.args.first(), pending.args.get(1))
         {
             let (source, target) = (*source, *target);
-            let display_source =
-                crate::query_boundaries::diagnostics::generalized_literal_source_for_display(
-                    self.ctx.types,
-                    source,
-                    target,
-                );
+            let display_source = self.generalize_nested_relation_source_for_display(source, target);
             if display_source != source {
                 pending.args[0] = tsz_solver::DiagnosticArg::Type(display_source);
             }

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -1102,10 +1102,10 @@ impl<'a> CheckerState<'a> {
 
         let related_policy = if wrap_overloads {
             let total = failures.len();
-            for (ordinal, (failure, pending)) in
-                failures.iter().zip(&generalized_pendings).enumerate()
-            {
-                let signature = failure
+            // The pendings are struct-update clones of the failures, so they
+            // carry the same `overload_signature`.
+            for (ordinal, pending) in generalized_pendings.iter().enumerate() {
+                let signature = pending
                     .overload_signature
                     .expect("wrap_overloads requires every failure to carry a signature");
                 // signatureToString colon form (`(x: number): number`); fall

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -311,6 +311,27 @@ impl<'a> CheckerState<'a> {
         Some((start_loc.start, end_loc.end.saturating_sub(start_loc.start)))
     }
 
+    /// Generalize the literal source (tsc `reportRelationError`, via
+    /// `generalize_nested_relation_source_for_display`) and produce the
+    /// finalized `(source, target)` display pair with the `DefaultDiagnostic`
+    /// role — the shared shape of the hand-rolled TS2345 related-info arms
+    /// below. The finalizer receives the generalized source so same-name
+    /// disambiguation sees the pair actually rendered.
+    fn generalized_default_role_pair_display(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> (String, String) {
+        let display_source = self.generalize_nested_relation_source_for_display(source, target);
+        let source_str = self.format_type_for_diagnostic_role(
+            display_source,
+            DiagnosticTypeDisplayRole::DefaultDiagnostic,
+        );
+        let target_str = self
+            .format_type_for_diagnostic_role(target, DiagnosticTypeDisplayRole::DefaultDiagnostic);
+        self.finalize_pair_display_for_diagnostic(display_source, target, source_str, target_str)
+    }
+
     pub(crate) fn related_from_failure_reason(
         &mut self,
         reason: &tsz_solver::SubtypeFailureReason,
@@ -512,26 +533,9 @@ impl<'a> CheckerState<'a> {
                 } else {
                     *target_property_type
                 };
-                // Nested relation leaf: generalize a literal source to its base
-                // type when the target has no singleton capacity (tsc
-                // `reportRelationError`), matching the TS2322 chain renderers.
-                let display_property_type = self.generalize_nested_relation_source_for_display(
+                let (source_str, target_str) = self.generalized_default_role_pair_display(
                     *source_property_type,
                     target_property_type,
-                );
-                let source_str = self.format_type_for_diagnostic_role(
-                    display_property_type,
-                    DiagnosticTypeDisplayRole::DefaultDiagnostic,
-                );
-                let target_str = self.format_type_for_diagnostic_role(
-                    target_property_type,
-                    DiagnosticTypeDisplayRole::DefaultDiagnostic,
-                );
-                let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                    display_property_type,
-                    target_property_type,
-                    source_str,
-                    target_str,
                 );
 
                 let mut items = vec![
@@ -613,25 +617,8 @@ impl<'a> CheckerState<'a> {
                 target_return,
                 nested_reason,
             } => {
-                // Nested relation leaf: generalize a literal return source to
-                // its base type when the target has no singleton capacity (tsc
-                // `reportRelationError`).
-                let display_return = self
-                    .generalize_nested_relation_source_for_display(*source_return, *target_return);
-                let source_str = self.format_type_for_diagnostic_role(
-                    display_return,
-                    DiagnosticTypeDisplayRole::DefaultDiagnostic,
-                );
-                let target_str = self.format_type_for_diagnostic_role(
-                    *target_return,
-                    DiagnosticTypeDisplayRole::DefaultDiagnostic,
-                );
-                let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                    display_return,
-                    *target_return,
-                    source_str,
-                    target_str,
-                );
+                let (source_str, target_str) =
+                    self.generalized_default_role_pair_display(*source_return, *target_return);
                 // tsc's elaboration shape for TS2345 function-return-type
                 // mismatches goes straight from the top-level message into
                 // the inner mismatch line:

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -512,8 +512,15 @@ impl<'a> CheckerState<'a> {
                 } else {
                     *target_property_type
                 };
-                let source_str = self.format_type_for_diagnostic_role(
+                // Nested relation leaf: generalize a literal source to its base
+                // type when the target has no singleton capacity (tsc
+                // `reportRelationError`), matching the TS2322 chain renderers.
+                let display_property_type = self.generalize_nested_relation_source_for_display(
                     *source_property_type,
+                    target_property_type,
+                );
+                let source_str = self.format_type_for_diagnostic_role(
+                    display_property_type,
                     DiagnosticTypeDisplayRole::DefaultDiagnostic,
                 );
                 let target_str = self.format_type_for_diagnostic_role(
@@ -521,7 +528,7 @@ impl<'a> CheckerState<'a> {
                     DiagnosticTypeDisplayRole::DefaultDiagnostic,
                 );
                 let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                    *source_property_type,
+                    display_property_type,
                     target_property_type,
                     source_str,
                     target_str,
@@ -606,8 +613,13 @@ impl<'a> CheckerState<'a> {
                 target_return,
                 nested_reason,
             } => {
+                // Nested relation leaf: generalize a literal return source to
+                // its base type when the target has no singleton capacity (tsc
+                // `reportRelationError`).
+                let display_return = self
+                    .generalize_nested_relation_source_for_display(*source_return, *target_return);
                 let source_str = self.format_type_for_diagnostic_role(
-                    *source_return,
+                    display_return,
                     DiagnosticTypeDisplayRole::DefaultDiagnostic,
                 );
                 let target_str = self.format_type_for_diagnostic_role(
@@ -615,7 +627,7 @@ impl<'a> CheckerState<'a> {
                     DiagnosticTypeDisplayRole::DefaultDiagnostic,
                 );
                 let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                    *source_return,
+                    display_return,
                     *target_return,
                     source_str,
                     target_str,

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -57,8 +57,8 @@ impl<'a> CheckerState<'a> {
     ///
     /// The top-level assignment surface keeps its own, older enum-member
     /// policy (`should_widen_enum_member_assignment_source`) with a different
-    /// target gate; migrating it onto this tsc-shaped gate is tracked
-    /// follow-up work, not silently changed here.
+    /// target gate; migrating it onto this tsc-shaped gate is tracked as
+    /// follow-up in #15628, not silently changed here.
     pub(in crate::error_reporter) fn generalize_nested_relation_source_for_display(
         &mut self,
         source: TypeId,

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -40,6 +40,48 @@ pub(in crate::error_reporter) struct RenderContext {
 }
 
 impl<'a> CheckerState<'a> {
+    /// Apply tsc's `reportRelationError` literal-source generalization to a
+    /// nested relation line's source type: a literal source is displayed as
+    /// its base type (`"no"` -> `string`, `true` -> `boolean`, `E.X` -> `E`)
+    /// when the target could not hold a top-level singleton type, and
+    /// preserved when the literal-vs-literal comparison stays meaningful
+    /// (`"no"` vs `"yes"`, literal-union targets, singleton-constrained type
+    /// parameters).
+    ///
+    /// tsc applies this in every relation-error report. tsz's top-level
+    /// assignability messages already generalize through their display roles
+    /// (and the TS2769 overload elaboration through
+    /// `overload_failure_generalized_pending`), so this entry serves the
+    /// nested chain leaves — property / array-element / tuple-position frames
+    /// — which previously leaked the raw literal source (#15626).
+    pub(in crate::error_reporter) fn generalize_nested_relation_source_for_display(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> TypeId {
+        let generalized =
+            crate::query_boundaries::diagnostics::generalized_literal_source_for_display(
+                self.ctx.types,
+                source,
+                target,
+            );
+        if generalized != source {
+            return generalized;
+        }
+        // Enum members widen to their parent enum (tsc's
+        // `getBaseTypeOfLiteralType` EnumLike branch). The parent lookup needs
+        // the checker's enum environment, so it sits outside the pure query.
+        if self.is_enum_member_type_for_widening(source)
+            && !crate::query_boundaries::diagnostics::relation_target_could_hold_singleton(
+                self.ctx.types,
+                target,
+            )
+        {
+            return self.widen_enum_member_type(source);
+        }
+        source
+    }
+
     /// Resolve the parameter name at `param_index` in the first call
     /// signature of `callable_ty` (if any). Used to render TS2328
     /// "Types of parameters '_' and '_' are incompatible." messages.
@@ -1634,7 +1676,12 @@ impl<'a> CheckerState<'a> {
                 // structural formatter instead so the rendered type matches the
                 // solver's `source` TypeId.
                 let source_str = if depth > 0 {
-                    self.format_type_for_assignability_message(source)
+                    // Nested relation leaf: generalize a literal source to its
+                    // base type when the target has no singleton capacity
+                    // (tsc `reportRelationError`).
+                    let display_source =
+                        self.generalize_nested_relation_source_for_display(source, target);
+                    self.format_type_for_assignability_message(display_source)
                 } else {
                     self.format_type_for_diagnostic_role(
                         source,

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -49,11 +49,16 @@ impl<'a> CheckerState<'a> {
     /// parameters).
     ///
     /// tsc applies this in every relation-error report. tsz's top-level
-    /// assignability messages already generalize through their display roles
-    /// (and the TS2769 overload elaboration through
-    /// `overload_failure_generalized_pending`), so this entry serves the
-    /// nested chain leaves — property / array-element / tuple-position frames
-    /// — which previously leaked the raw literal source (#15626).
+    /// assignability messages already generalize through their display roles,
+    /// so this entry serves the nested chain leaves — property / array-element
+    /// / tuple-position / return frames — and the TS2769 overload elaboration
+    /// (`overload_failure_generalized_pending`), which previously leaked the
+    /// raw literal source (#15626).
+    ///
+    /// The top-level assignment surface keeps its own, older enum-member
+    /// policy (`should_widen_enum_member_assignment_source`) with a different
+    /// target gate; migrating it onto this tsc-shaped gate is tracked
+    /// follow-up work, not silently changed here.
     pub(in crate::error_reporter) fn generalize_nested_relation_source_for_display(
         &mut self,
         source: TypeId,

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -268,16 +268,30 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// Format the plain `Type 'S' is not assignable to type 'T'.` leaf line
-    /// for a nested relation pair, applying the literal-source generalization
-    /// ([`Self::generalize_nested_relation_source_for_display`]) before
-    /// rendering. Unlike [`Self::element_mismatch_message`] this variant skips
-    /// the same-name pair disambiguation, preserving the exact output of the
-    /// leaf sites it factored out.
-    fn generalized_leaf_mismatch_message(&mut self, source: TypeId, target: TypeId) -> String {
+    /// Shared core of the two leaf-message helpers: generalize the literal
+    /// source ([`Self::generalize_nested_relation_source_for_display`]) and
+    /// format both sides. Returns the generalized source id so callers that
+    /// disambiguate the pair pass the type actually rendered.
+    fn generalized_leaf_pair(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> (TypeId, String, String) {
         let display_source = self.generalize_nested_relation_source_for_display(source, target);
         let source_str = self.format_type_diagnostic(display_source);
         let target_str = self.format_type_diagnostic(target);
+        (display_source, source_str, target_str)
+    }
+
+    /// Format the plain `Type 'S' is not assignable to type 'T'.` leaf line
+    /// for a nested relation pair. Unlike [`Self::element_mismatch_message`]
+    /// this variant skips the same-name pair disambiguation, preserving the
+    /// exact output of the leaf sites it factored out — whether tsc
+    /// disambiguates same-named nominal pairs at these particular leaves is
+    /// unverified; converging the two helpers needs a tsc witness first
+    /// (#15628).
+    fn generalized_leaf_mismatch_message(&mut self, source: TypeId, target: TypeId) -> String {
+        let (_, source_str, target_str) = self.generalized_leaf_pair(source, target);
         format_message(
             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             &[&source_str, &target_str],
@@ -673,24 +687,12 @@ impl<'a> CheckerState<'a> {
                 self.render_failure_reason(inner, source_return, target_return, idx, leaf_depth);
             Self::push_rebased_subdiagnostic(diag, sub, leaf_depth, leaf_depth);
         } else {
-            let display_return =
-                self.generalize_nested_relation_source_for_display(source_return, target_return);
-            let source_str = self.format_type_diagnostic(display_return);
-            let target_str = self.format_type_diagnostic(target_return);
-            let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                display_return,
-                target_return,
-                source_str,
-                target_str,
-            );
+            let message = self.element_mismatch_message(source_return, target_return);
             let (start, length) = (diag.start, diag.length);
             diag.push_elaboration_in_span(
                 start,
                 length,
-                format_message(
-                    diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                    &[&source_str, &target_str],
-                ),
+                message,
                 diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 leaf_depth,
             );
@@ -1787,12 +1789,10 @@ impl<'a> CheckerState<'a> {
         source_element: TypeId,
         target_element: TypeId,
     ) -> String {
-        let source_element =
-            self.generalize_nested_relation_source_for_display(source_element, target_element);
-        let source_str = self.format_type_diagnostic(source_element);
-        let target_str = self.format_type_diagnostic(target_element);
+        let (display_source, source_str, target_str) =
+            self.generalized_leaf_pair(source_element, target_element);
         let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-            source_element,
+            display_source,
             target_element,
             source_str,
             target_str,

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -259,20 +259,29 @@ impl<'a> CheckerState<'a> {
             let leaf_diag = self.render_failure_reason(leaf, s, t, idx, depth);
             Self::push_nested_chain(diag, leaf_diag, depth);
         } else {
-            let display_src =
-                self.generalize_nested_relation_source_for_display(leaf_src, leaf_tgt);
-            let s = self.format_type_diagnostic(display_src);
-            let t = self.format_type_diagnostic(leaf_tgt);
-            let message = format_message(
-                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                &[&s, &t],
-            );
+            let message = self.generalized_leaf_mismatch_message(leaf_src, leaf_tgt);
             diag.push_elaboration(
                 message,
                 diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 depth,
             );
         }
+    }
+
+    /// Format the plain `Type 'S' is not assignable to type 'T'.` leaf line
+    /// for a nested relation pair, applying the literal-source generalization
+    /// ([`Self::generalize_nested_relation_source_for_display`]) before
+    /// rendering. Unlike [`Self::element_mismatch_message`] this variant skips
+    /// the same-name pair disambiguation, preserving the exact output of the
+    /// leaf sites it factored out.
+    fn generalized_leaf_mismatch_message(&mut self, source: TypeId, target: TypeId) -> String {
+        let display_source = self.generalize_nested_relation_source_for_display(source, target);
+        let source_str = self.format_type_diagnostic(display_source);
+        let target_str = self.format_type_diagnostic(target);
+        format_message(
+            diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[&source_str, &target_str],
+        )
     }
 
     pub(super) fn render_property_type_mismatch(
@@ -669,7 +678,7 @@ impl<'a> CheckerState<'a> {
             let source_str = self.format_type_diagnostic(display_return);
             let target_str = self.format_type_diagnostic(target_return);
             let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                source_return,
+                display_return,
                 target_return,
                 source_str,
                 target_str,
@@ -856,16 +865,8 @@ impl<'a> CheckerState<'a> {
         nested_reason: Option<&tsz_solver::SubtypeFailureReason>,
     ) -> Diagnostic {
         let depth = ctx.depth;
-        let element_message = {
-            let display_element =
-                self.generalize_nested_relation_source_for_display(source_element, target_element);
-            let source_str = self.format_type_diagnostic(display_element);
-            let target_str = self.format_type_diagnostic(target_element);
-            format_message(
-                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                &[&source_str, &target_str],
-            )
-        };
+        let element_message =
+            self.generalized_leaf_mismatch_message(source_element, target_element);
         let needs_header = nested_reason.is_some_and(Self::tuple_element_nested_needs_header);
 
         // Deeper levels (`depth > 0`) whose element self-heads: the nested
@@ -1560,14 +1561,7 @@ impl<'a> CheckerState<'a> {
                 self.render_failure_reason(nested, nested_source, nested_target, idx, depth + 1);
             Self::push_nested_chain(diag, nested_diag, depth + 1);
         } else {
-            let display_element =
-                self.generalize_nested_relation_source_for_display(source_element, target_element);
-            let source_str = self.format_type_diagnostic(display_element);
-            let target_str = self.format_type_diagnostic(target_element);
-            let message = format_message(
-                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                &[&source_str, &target_str],
-            );
+            let message = self.generalized_leaf_mismatch_message(source_element, target_element);
             diag.push_elaboration(
                 message,
                 diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -259,7 +259,9 @@ impl<'a> CheckerState<'a> {
             let leaf_diag = self.render_failure_reason(leaf, s, t, idx, depth);
             Self::push_nested_chain(diag, leaf_diag, depth);
         } else {
-            let s = self.format_type_diagnostic(leaf_src);
+            let display_src =
+                self.generalize_nested_relation_source_for_display(leaf_src, leaf_tgt);
+            let s = self.format_type_diagnostic(display_src);
             let t = self.format_type_diagnostic(leaf_tgt);
             let message = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
@@ -662,7 +664,9 @@ impl<'a> CheckerState<'a> {
                 self.render_failure_reason(inner, source_return, target_return, idx, leaf_depth);
             Self::push_rebased_subdiagnostic(diag, sub, leaf_depth, leaf_depth);
         } else {
-            let source_str = self.format_type_diagnostic(source_return);
+            let display_return =
+                self.generalize_nested_relation_source_for_display(source_return, target_return);
+            let source_str = self.format_type_diagnostic(display_return);
             let target_str = self.format_type_diagnostic(target_return);
             let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
                 source_return,
@@ -853,7 +857,9 @@ impl<'a> CheckerState<'a> {
     ) -> Diagnostic {
         let depth = ctx.depth;
         let element_message = {
-            let source_str = self.format_type_diagnostic(source_element);
+            let display_element =
+                self.generalize_nested_relation_source_for_display(source_element, target_element);
+            let source_str = self.format_type_diagnostic(display_element);
             let target_str = self.format_type_diagnostic(target_element);
             format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
@@ -1554,7 +1560,9 @@ impl<'a> CheckerState<'a> {
                 self.render_failure_reason(nested, nested_source, nested_target, idx, depth + 1);
             Self::push_nested_chain(diag, nested_diag, depth + 1);
         } else {
-            let source_str = self.format_type_diagnostic(source_element);
+            let display_element =
+                self.generalize_nested_relation_source_for_display(source_element, target_element);
+            let source_str = self.format_type_diagnostic(display_element);
             let target_str = self.format_type_diagnostic(target_element);
             let message = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
@@ -1785,6 +1793,8 @@ impl<'a> CheckerState<'a> {
         source_element: TypeId,
         target_element: TypeId,
     ) -> String {
+        let source_element =
+            self.generalize_nested_relation_source_for_display(source_element, target_element);
         let source_str = self.format_type_diagnostic(source_element);
         let target_str = self.format_type_diagnostic(target_element);
         let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -60,7 +60,14 @@ impl<'a> CheckerState<'a> {
                 display
             }
         } else {
-            self.format_nested_assignment_source_type_for_diagnostic(source, target, idx)
+            // Nested relation leaf: generalize a literal source to its base
+            // type when the target has no singleton capacity (tsc
+            // `reportRelationError`). When the source generalizes, the
+            // anchor-expression display path inside no longer applies (the
+            // anchor's type is the raw literal), so the plain structural
+            // formatter renders the widened form.
+            let display_source = self.generalize_nested_relation_source_for_display(source, target);
+            self.format_nested_assignment_source_type_for_diagnostic(display_source, target, idx)
         };
         let mut target_str = if depth == 0 {
             self.format_top_level_assignability_message_types_at(source, target, idx)

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -668,6 +668,15 @@ pub(crate) fn generalized_literal_source_for_display(
     }
 }
 
+/// Whether a relation target could hold a top-level singleton (unit) type —
+/// tsc's `typeCouldHaveTopLevelSingletonTypes`. Exposed for display decisions
+/// that need the target gate separately from
+/// [`generalized_literal_source_for_display`] (e.g. enum-member sources whose
+/// base-enum widening needs the checker's enum environment).
+pub(crate) fn relation_target_could_hold_singleton(db: &dyn TypeDatabase, target: TypeId) -> bool {
+    tsz_solver::type_queries::type_could_have_top_level_singleton_types(db, target)
+}
+
 /// Apparent type of an element-access receiver for the implicit-any index
 /// diagnostic (`TS7053`). `tsc` renders `typeToString(getApparentType(objectType))`,
 /// so the `object` intrinsic prints as its apparent type `{}` and a bare

--- a/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
+++ b/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
@@ -1,0 +1,301 @@
+//! Literal-source generalization at nested relation leaves (`tsc`'s
+//! `reportRelationError`), issue #15626.
+//!
+//! When the failing source of a nested `Type 'S' is not assignable to type
+//! 'T'.` relation line is a literal type and the target could not hold a
+//! top-level singleton type, `tsc` displays the literal's base type
+//! (`"no"` -> `string`, `true` -> `boolean`, `E.X` -> `E`). When the target is
+//! singleton-capable (a literal, a literal union, a template literal, or a
+//! type parameter constrained to one of those), the literal is preserved so
+//! the literal-vs-literal comparison stays meaningful.
+//!
+//! The rule is a property of relation-error display, not of expression
+//! freshness: a *variable* whose declared tuple element is `"no"` renders the
+//! same generalized leaf as a fresh array-literal argument. Cases below cover
+//! the tuple positional chain (both TS2345 call-argument and TS2322
+//! initializer entry points), property chains, array element chains, return
+//! leaves, and the preservation gates. Binder names vary across cases so the
+//! behavior is proven structural.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_common::diagnostics::Diagnostic;
+
+fn check_strict(source: &str) -> Vec<Diagnostic> {
+    let options = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..Default::default()
+    };
+    tsz_checker::test_utils::check_source(source, "test.ts", options)
+}
+
+fn one(diags: &[Diagnostic], code: u32) -> &Diagnostic {
+    let matches: Vec<&Diagnostic> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one TS{code}, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    matches[0]
+}
+
+fn assert_has_related(diag: &Diagnostic, expected: &str) {
+    assert!(
+        diag.related_information
+            .iter()
+            .any(|r| r.message_text == expected),
+        "expected related line {expected:?}; related: {:?}",
+        diag.related_information
+            .iter()
+            .map(|r| &r.message_text)
+            .collect::<Vec<_>>()
+    );
+}
+
+fn assert_no_related(diag: &Diagnostic, unexpected: &str) {
+    assert!(
+        diag.related_information
+            .iter()
+            .all(|r| r.message_text != unexpected),
+        "unexpected related line {unexpected:?}; related: {:?}",
+        diag.related_information
+            .iter()
+            .map(|r| &r.message_text)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The #15626 repro: a fresh array-literal call argument against a middle-rest
+/// tuple parameter renders the widened element in the positional-chain leaf.
+#[test]
+fn call_argument_middle_rest_tuple_chain_leaf_widens_fresh_literal() {
+    let source = r#"
+function grab(items: [number, ...boolean[], string]) {}
+grab([1, "no", "s"]);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(
+        diag,
+        "Type at position 1 in source is not compatible with type at position 1 in target.",
+    );
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}
+
+/// Initializer entry point (already correct before the fix): the same chain
+/// leaf renders the widened element.
+#[test]
+fn initializer_middle_rest_tuple_chain_leaf_widens_fresh_literal() {
+    let source = r#"
+const slots: [number, ...boolean[], string] = [1, "no", "s"];
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}
+
+/// The generalization is a relation-display rule, not a freshness rule: a
+/// variable whose *declared* tuple element is the literal renders the same
+/// generalized leaf (verified against `tsc 6.0.2`).
+#[test]
+fn declared_tuple_variable_source_chain_leaf_also_generalizes() {
+    let source = r#"
+declare const packed: [number, "no", string];
+function feed(cells: [number, ...boolean[], string]) {}
+feed(packed);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}
+
+/// Multi-element span aligned to a middle rest slot: the plural positional
+/// line keeps its shape and the leaf generalizes.
+#[test]
+fn variadic_span_chain_leaf_generalizes() {
+    let source = r#"
+function quilt(zz: [string, ...number[], boolean]) {}
+quilt(["a", "b", "c", true]);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(
+        diag,
+        "Type at positions 1 through 2 in source is not compatible with type at position 1 in target.",
+    );
+    assert_has_related(diag, "Type 'string' is not assignable to type 'number'.");
+}
+
+/// Preservation gate: a literal-typed rest slot is singleton-capable, so the
+/// source literal survives in the leaf.
+#[test]
+fn literal_rest_slot_preserves_source_literal() {
+    let source = r#"
+declare const duo: [number, "no"];
+function pin(x: [number, ..."yes"[]]) {}
+pin(duo);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(diag, "Type '\"no\"' is not assignable to type '\"yes\"'.");
+    assert_no_related(diag, "Type 'string' is not assignable to type '\"yes\"'.");
+}
+
+/// Property-chain leaf (TS2322): a declared string-literal property widens
+/// against a non-singleton target property.
+#[test]
+fn property_chain_leaf_generalizes_string_literal() {
+    let source = r#"
+declare const wrap: { flag: "no" };
+const sink: { flag: boolean } = wrap;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}
+
+/// Property-chain leaf (TS2345 hand-rolled related-info arm): same rule on the
+/// call-argument surface, including through a type-parameter target whose
+/// constraint is a plain primitive.
+#[test]
+fn call_argument_property_leaf_generalizes_through_primitive_constraint() {
+    let source = r#"
+function lodge<W extends boolean>(x: { knob: W }) {}
+declare const dial: { knob: "no" };
+lodge(dial);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+}
+
+/// Preservation gate: a type parameter constrained to a literal union is
+/// singleton-capable, so the source literal survives.
+#[test]
+fn singleton_constrained_type_parameter_preserves_literal() {
+    let source = r#"
+function tune<Q extends "aa" | "bb">(x: { pitch: Q }) {}
+declare const chord: { pitch: "no" };
+tune(chord);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(
+        diag,
+        "Type '\"no\"' is not assignable to type '\"aa\" | \"bb\"'.",
+    );
+}
+
+/// Collapsed dotted property chain (`a.b`) leaf generalizes a number literal.
+#[test]
+fn dotted_property_chain_leaf_generalizes_number_literal() {
+    let source = r#"
+declare const deep: { a: { b: 5 } };
+const basin: { a: { b: string } } = deep;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type 'number' is not assignable to type 'string'.");
+    assert_no_related(diag, "Type '5' is not assignable to type 'string'.");
+}
+
+/// Array element chain leaf generalizes.
+#[test]
+fn array_element_chain_leaf_generalizes() {
+    let source = r#"
+declare const noes: "no"[];
+const bools: boolean[] = noes;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}
+
+/// Boolean and bigint literal property leaves generalize to their bases.
+#[test]
+fn boolean_and_bigint_literal_property_leaves_generalize() {
+    let source = r#"
+declare const lit: { on: true };
+const strung: { on: string } = lit;
+declare const big: { n: 1n };
+const booled: { n: boolean } = big;
+"#;
+    let diags = check_strict(source);
+    let texts: Vec<&str> = diags
+        .iter()
+        .flat_map(|d| d.related_information.iter())
+        .map(|r| r.message_text.as_str())
+        .collect();
+    assert!(
+        texts.contains(&"Type 'boolean' is not assignable to type 'string'."),
+        "boolean literal leaf must widen; related: {texts:?}"
+    );
+    assert!(
+        texts.contains(&"Type 'bigint' is not assignable to type 'boolean'."),
+        "bigint literal leaf must widen; related: {texts:?}"
+    );
+}
+
+/// Preservation gate: a union target containing a same-base literal is
+/// singleton-capable, so the number literal survives.
+#[test]
+fn union_target_with_singleton_preserves_number_literal() {
+    let source = r#"
+declare const five: { a: 5 };
+const mixed: { a: 6 | string } = five;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type '5' is not assignable to type 'string | 6'.");
+}
+
+/// Enum members generalize to their parent enum in the positional-chain leaf
+/// (tsc `getBaseTypeOfLiteralType` EnumLike branch).
+#[test]
+fn enum_member_tuple_chain_leaf_widens_to_parent_enum() {
+    let source = r#"
+enum Gear { Low = 1 }
+declare const kit: [number, Gear.Low, string];
+function stow(x: [number, ...string[], string]) {}
+stow(kit);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(diag, "Type 'Gear' is not assignable to type 'string'.");
+}
+
+/// Callback return leaf under TS2345 generalizes the literal return type.
+#[test]
+fn callback_return_leaf_generalizes() {
+    let source = r#"
+declare function pump(cb: () => boolean): void;
+declare const feedCb: () => "no";
+pump(feedCb);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}
+
+/// Member-return frame (`The types returned by 'm()' ...`) leaf generalizes.
+#[test]
+fn member_return_frame_leaf_generalizes() {
+    let source = r#"
+declare const gadget: { spin: () => "no" };
+const port: { spin: () => boolean } = gadget;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}

--- a/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
+++ b/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
@@ -17,17 +17,8 @@
 //! leaves, and the preservation gates. Binder names vary across cases so the
 //! behavior is proven structural.
 
-use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source_strict as check_strict;
 use tsz_common::diagnostics::Diagnostic;
-
-fn check_strict(source: &str) -> Vec<Diagnostic> {
-    let options = CheckerOptions {
-        strict: true,
-        strict_null_checks: true,
-        ..Default::default()
-    };
-    tsz_checker::test_utils::check_source(source, "test.ts", options)
-}
 
 fn one(diags: &[Diagnostic], code: u32) -> &Diagnostic {
     let matches: Vec<&Diagnostic> = diags.iter().filter(|d| d.code == code).collect();

--- a/crates/tsz-solver/src/type_queries/flow.rs
+++ b/crates/tsz-solver/src/type_queries/flow.rs
@@ -729,6 +729,9 @@ fn type_could_have_top_level_singleton_types_inner(
     type_id: TypeId,
     depth: u32,
 ) -> bool {
+    // Fuel exhaustion answers "no singleton capacity", failing toward
+    // *generalizing* a literal source in the diagnostic — the direction that
+    // loses precision rather than inventing a literal-vs-literal contrast.
     if depth > 16 {
         return false;
     }

--- a/crates/tsz-solver/src/type_queries/flow.rs
+++ b/crates/tsz-solver/src/type_queries/flow.rs
@@ -721,6 +721,17 @@ pub fn is_unit_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
 /// hold a singleton (a literal/union-of-literals target makes the literal vs
 /// literal mismatch meaningful) and widened to its base otherwise.
 pub fn type_could_have_top_level_singleton_types(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    type_could_have_top_level_singleton_types_inner(db, type_id, 0)
+}
+
+fn type_could_have_top_level_singleton_types_inner(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    depth: u32,
+) -> bool {
+    if depth > 16 {
+        return false;
+    }
     if type_id == TypeId::BOOLEAN {
         return false;
     }
@@ -728,8 +739,17 @@ pub fn type_could_have_top_level_singleton_types(db: &dyn TypeDatabase, type_id:
         Some(TypeData::Union(list_id) | TypeData::Intersection(list_id)) => db
             .type_list(list_id)
             .iter()
-            .any(|&member| type_could_have_top_level_singleton_types(db, member)),
+            .any(|&member| type_could_have_top_level_singleton_types_inner(db, member, depth + 1)),
         Some(TypeData::TemplateLiteral(_)) => true,
+        // tsc's `Instantiable` branch: a type parameter (or `infer` binder)
+        // answers through its constraint when it has one — a target `T extends
+        // "a" | "b"` can hold a singleton, `T extends string` cannot.
+        Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => match info.constraint {
+            Some(constraint) if constraint != type_id => {
+                type_could_have_top_level_singleton_types_inner(db, constraint, depth + 1)
+            }
+            _ => is_unit_type(db, type_id),
+        },
         _ => is_unit_type(db, type_id),
     }
 }


### PR DESCRIPTION
Closes #15626.

**Structural rule:** when the failing source of a `Type 'S' is not assignable to type 'T'.` relation line is a literal type and the target could not hold a top-level singleton type, tsc displays the literal's base type (`reportRelationError` → `getBaseTypeOfLiteralType`: `"no"` → `string`, `true` → `boolean`, `E.X` → `E`); tsz does the same through the checker's relation-reason renderers, backed by the solver queries `is_literal_type` / `type_could_have_top_level_singleton_types` via the `query_boundaries/diagnostics` gateway. When the target is singleton-capable (a literal, literal union, template literal, or a type parameter constrained to one of those), the literal is preserved.

The #15626 repro was the TS2345 tuple positional-chain leaf (`g([1, "no", "s"])` against `[number, ...boolean[], string]` rendered `'"no"'` where tsc renders `'string'`), but differential sweeps against `tsc 6.0.2` showed the same leak on **every** nested relation leaf — property chains, dotted `a.b` collapses, array-element chains, member/callback return frames, and via a plain *variable* source (`declare const t: [number, "no", string]` leaks the same way), proving the rule is relation-display policy, not array-literal freshness. The fix therefore routes all of these through one shared policy point:

- `generalize_nested_relation_source_for_display` (checker, `render_failure.rs`) — composes the existing `generalized_literal_source_for_display` query with the checker-env-backed enum-member widening; every touched leaf renderer and the TS2769 overload elaboration call it, so all surfaces render the same generalization.
- Solver `type_could_have_top_level_singleton_types` gains tsc's `Instantiable` branch: a type parameter (or `infer` binder) answers through its constraint, so `T extends boolean` generalizes while `T extends "aa" | "bb"` preserves the literal.
- Leaf formatting rituals are shared: `generalized_leaf_pair` / `element_mismatch_message` / `generalized_leaf_mismatch_message` (TS2322 chains) and `generalized_default_role_pair_display` (hand-rolled TS2345 related-info arms).

**Adjacent-case matrix** (all verified against `tsc 6.0.2 --noEmit --strict`, binder names varied): middle-rest / rest-last / multi-element-span tuple chains on both TS2345 and TS2322 entry points; fresh array-literal and declared-variable sources; string/number/boolean/bigint literals and enum members; negative gates — literal target slots, literal-union targets, singleton-constrained type parameters, union targets containing a same-base literal all preserve the source literal.

**Known remaining gaps** are catalogued with witnesses in #15628 (union-of-literals mid-lines, an enum property-leaf path that bypasses these renderers, top-level boolean-literal sources, the older top-level enum gate) — display-only, deliberately out of scope here.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --test relation_leaf_literal_generalization_tests` — 15 new cases (repro, both entry points, variable sources, enum/boolean/bigint, preservation gates), green.
- Regression batch green: `tuple_call_argument_elaboration_tests`, `tuple_variadic_position_elaboration_tests`, `tuple_argument_mismatch_elaboration_tests`, `tuple_element_mismatch_tests`, `tuple_arity_elaboration_tests`, `union_source_structural_elaboration_tests`, `array_source_tuple_target_elaboration_tests`, `variadic_tuple_rest_aggregate_display_tests`, `property_chain_elaboration_collapse_tests`, `readonly_tuple_source_display_tests`, `union_tuple_source_display_tests`, union/intersection missing-property elaboration suites, `satisfies_elaboration_chain_tests`, `deep_partial_optional_leaf_elaboration_tests`.
- Lib suites around the touched arms green: `overload_literal_source_generalization_tests`, `function_parameter_mismatch_elaboration`, `ts2322_readonly_array_element_elaboration`, fingerprint/render-request suites; solver `singleton_predicate_*` unit tests green.
- `cargo clippy -p tsz-checker -p tsz-solver` clean.
- Local pre-existing failures confirmed identical with the change stashed and on the base commit (5 `optional_property_required_elaboration_tests`, 2 lib display tests, 2 overload lib tests, 2 architecture-contract ratchets — tracked under #15338-family debt).
- Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

https://claude.ai/code/session_012BF2d24uQwFBQ238DM3mjB

---
_Generated by [Claude Code](https://claude.ai/code/session_012BF2d24uQwFBQ238DM3mjB)_