### PR TITLE
fix(checker,solver): close the remaining literal-source generalization gaps (#15628)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -727,6 +727,9 @@ path = "tests/tuple_arity_elaboration_tests.rs"
 name = "tuple_variadic_position_elaboration_tests"
 path = "tests/tuple_variadic_position_elaboration_tests.rs"
 [[test]]
+name = "relation_leaf_literal_generalization_tests"
+path = "tests/relation_leaf_literal_generalization_tests.rs"
+[[test]]
 name = "conditional_alias_source_display_tests"
 path = "tests/conditional_alias_source_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -231,14 +231,13 @@ impl<'a> CheckerState<'a> {
         // `sip(g)` with `g: EG.A` against `boolean` renders `EG`, while a
         // literal/template/enum parameter preserves `EG.A`.
         if self.should_widen_enum_member_assignment_source(arg_type, param_type) {
+            // The gate already proved the widening makes progress. Plain
+            // structural render: the `CallArgument` role would repaint the
+            // display from the argument expression's declared annotation
+            // (`EG.A`), undoing the widening.
             let widened = self.widen_enum_member_type(arg_type);
-            if widened != arg_type {
-                // Plain structural render: the `CallArgument` role would
-                // repaint the display from the argument expression's declared
-                // annotation (`EG.A`), undoing the widening.
-                arg_str = self.format_type_for_assignability_message(widened);
-                arg_display_type = Some(widened);
-            }
+            arg_str = self.format_type_for_assignability_message(widened);
+            arg_display_type = Some(widened);
         }
         // Widen a fresh boolean-literal array source (`true[]`/`false[]`) to
         // `boolean[]` against a `boolean` parameter. The decision is structural;

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -1059,9 +1059,16 @@ impl<'a> CheckerState<'a> {
             return;
         };
         let mut related = Vec::new();
-        let mut formatter = self.ctx.create_type_formatter();
         let span =
             tsz_solver::SourceSpan::new(self.ctx.file_name.as_str(), anchor.start, anchor.length);
+        // Generalize every candidate failure's literal source up front: the
+        // generalization needs `&mut self`, which cannot run while the
+        // formatter below borrows the checker context.
+        let generalized_pendings: Vec<tsz_solver::PendingDiagnostic> = failures
+            .iter()
+            .map(|failure| self.overload_failure_generalized_pending(failure, &span))
+            .collect();
+        let mut formatter = self.ctx.create_type_formatter();
 
         tracing::debug!("File name: {}", self.ctx.file_name);
 
@@ -1095,7 +1102,9 @@ impl<'a> CheckerState<'a> {
 
         let related_policy = if wrap_overloads {
             let total = failures.len();
-            for (ordinal, failure) in failures.iter().enumerate() {
+            for (ordinal, (failure, pending)) in
+                failures.iter().zip(&generalized_pendings).enumerate()
+            {
                 let signature = failure
                     .overload_signature
                     .expect("wrap_overloads requires every failure to carry a signature");
@@ -1117,8 +1126,7 @@ impl<'a> CheckerState<'a> {
                     diagnostic_codes::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
                     0,
                 ));
-                let pending = self.overload_failure_generalized_pending(failure, &span);
-                let diag = formatter.render(&pending);
+                let diag = formatter.render(pending);
                 let diag_span = diag.span.as_ref().unwrap_or(&span);
                 // The candidate's applicability error nests one level under its
                 // TS2772 header; any deeper chain it carries nests below that.
@@ -1134,9 +1142,8 @@ impl<'a> CheckerState<'a> {
             }
             RelatedInformationPolicy::OVERLOAD_CHAINS
         } else {
-            for failure in failures {
-                let pending = self.overload_failure_generalized_pending(failure, &span);
-                let diag = formatter.render(&pending);
+            for pending in &generalized_pendings {
+                let diag = formatter.render(pending);
                 if let Some(diag_span) = diag.span.as_ref() {
                     related.push(related_line(diag_span, diag.message, diag.code, 0));
                 }
@@ -1164,7 +1171,7 @@ impl<'a> CheckerState<'a> {
     /// raw literal source, so without this the overload elaboration diverges
     /// from tsc (and from the single-overload TS2345 display).
     fn overload_failure_generalized_pending(
-        &self,
+        &mut self,
         failure: &tsz_solver::PendingDiagnostic,
         span: &tsz_solver::SourceSpan,
     ) -> tsz_solver::PendingDiagnostic {
@@ -1179,12 +1186,7 @@ impl<'a> CheckerState<'a> {
             ) = (pending.args.first(), pending.args.get(1))
         {
             let (source, target) = (*source, *target);
-            let display_source =
-                crate::query_boundaries::diagnostics::generalized_literal_source_for_display(
-                    self.ctx.types,
-                    source,
-                    target,
-                );
+            let display_source = self.generalize_nested_relation_source_for_display(source, target);
             if display_source != source {
                 pending.args[0] = tsz_solver::DiagnosticArg::Type(display_source);
             }

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -230,12 +230,10 @@ impl<'a> CheckerState<'a> {
         // `reportRelationError`), mirroring the TS2322 assignment surface:
         // `sip(g)` with `g: EG.A` against `boolean` renders `EG`, while a
         // literal/template/enum parameter preserves `EG.A`.
-        if self.should_widen_enum_member_assignment_source(arg_type, param_type) {
-            // The gate already proved the widening makes progress. Plain
-            // structural render: the `CallArgument` role would repaint the
-            // display from the argument expression's declared annotation
+        if let Some(widened) = self.widened_enum_member_assignment_source(arg_type, param_type) {
+            // Plain structural render: the `CallArgument` role would repaint
+            // the display from the argument expression's declared annotation
             // (`EG.A`), undoing the widening.
-            let widened = self.widen_enum_member_type(arg_type);
             arg_str = self.format_type_for_assignability_message(widened);
             arg_display_type = Some(widened);
         }

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -225,6 +225,21 @@ impl<'a> CheckerState<'a> {
         // produced from `arg_type` (overrides render their own types and
         // carry no literal annotations to widen).
         let mut arg_display_type = Some(arg_type);
+        // An enum-member argument generalizes to its parent enum when the
+        // parameter could not hold a top-level singleton type (tsc
+        // `reportRelationError`), mirroring the TS2322 assignment surface:
+        // `sip(g)` with `g: EG.A` against `boolean` renders `EG`, while a
+        // literal/template/enum parameter preserves `EG.A`.
+        if self.should_widen_enum_member_assignment_source(arg_type, param_type) {
+            let widened = self.widen_enum_member_type(arg_type);
+            if widened != arg_type {
+                // Plain structural render: the `CallArgument` role would
+                // repaint the display from the argument expression's declared
+                // annotation (`EG.A`), undoing the widening.
+                arg_str = self.format_type_for_assignability_message(widened);
+                arg_display_type = Some(widened);
+            }
+        }
         // Widen a fresh boolean-literal array source (`true[]`/`false[]`) to
         // `boolean[]` against a `boolean` parameter. The decision is structural;
         // the output string is plain rendering (no rendered-text decision, §25).

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -1102,10 +1102,10 @@ impl<'a> CheckerState<'a> {
 
         let related_policy = if wrap_overloads {
             let total = failures.len();
-            for (ordinal, (failure, pending)) in
-                failures.iter().zip(&generalized_pendings).enumerate()
-            {
-                let signature = failure
+            // The pendings are struct-update clones of the failures, so they
+            // carry the same `overload_signature`.
+            for (ordinal, pending) in generalized_pendings.iter().enumerate() {
+                let signature = pending
                     .overload_signature
                     .expect("wrap_overloads requires every failure to carry a signature");
                 // signatureToString colon form (`(x: number): number`); fall

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1438,12 +1438,37 @@ impl<'a> CheckerState<'a> {
                 .type_list(list)
                 .iter()
                 .copied()
-                .any(|member| self.is_literal_sensitive_assignment_target_inner(member));
+                .any(|member| {
+                    // tsc stores `boolean` inside a union as `true | false`, whose
+                    // members are singletons, so a `string | boolean` target keeps
+                    // a literal source (`5` stays `5`).
+                    member == TypeId::BOOLEAN
+                        || self.is_literal_sensitive_assignment_target_inner(member)
+                });
+        }
+        // Deferred instantiable targets (`Cfg[K]`, `Cond<T>`, alias/enum refs)
+        // answer through their constraints, mirroring tsc's
+        // `typeCouldHaveTopLevelSingletonTypes` -> `getConstraintOfType`.
+        if crate::query_boundaries::diagnostics::is_deferred_instantiable_display_target(
+            self.ctx.types,
+            target,
+        ) {
+            return crate::query_boundaries::diagnostics::relation_target_could_hold_singleton(
+                self.ctx.types,
+                &self.ctx,
+                target,
+            );
         }
         target == TypeId::NEVER
     }
 
-    fn should_widen_enum_member_assignment_source(
+    /// Whether an enum-member assignment source widens to its parent enum in
+    /// the top-level display, mirroring tsc's `reportRelationError` gate: the
+    /// member generalizes exactly when the target could not hold a top-level
+    /// singleton type. A literal, template-literal, enum, or singleton-capable
+    /// union/instantiable target preserves the member spelling (`EM.X`); a
+    /// primitive or all-primitive union/intersection target widens it (`EM`).
+    pub(in crate::error_reporter) fn should_widen_enum_member_assignment_source(
         &mut self,
         source: TypeId,
         target: TypeId,
@@ -1454,10 +1479,11 @@ impl<'a> CheckerState<'a> {
         }
 
         let target = self.evaluate_type_for_assignability(target);
-        crate::query_boundaries::common::enum_def_id(self.ctx.types, target).is_none()
-            && crate::query_boundaries::common::union_members(self.ctx.types, target).is_none()
-            && crate::query_boundaries::common::intersection_members(self.ctx.types, target)
-                .is_none()
+        !crate::query_boundaries::diagnostics::relation_target_could_hold_singleton(
+            self.ctx.types,
+            &self.ctx,
+            target,
+        )
     }
 
     pub(in crate::error_reporter) fn unresolved_unused_renaming_property_in_type_query(

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1488,17 +1488,6 @@ impl<'a> CheckerState<'a> {
         .then_some(widened_source)
     }
 
-    /// Boolean form of [`Self::widened_enum_member_assignment_source`] for the
-    /// pre-existing display sites that widen separately.
-    pub(in crate::error_reporter) fn should_widen_enum_member_assignment_source(
-        &mut self,
-        source: TypeId,
-        target: TypeId,
-    ) -> bool {
-        self.widened_enum_member_assignment_source(source, target)
-            .is_some()
-    }
-
     pub(in crate::error_reporter) fn unresolved_unused_renaming_property_in_type_query(
         &self,
         name: &str,

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1462,28 +1462,41 @@ impl<'a> CheckerState<'a> {
         target == TypeId::NEVER
     }
 
-    /// Whether an enum-member assignment source widens to its parent enum in
-    /// the top-level display, mirroring tsc's `reportRelationError` gate: the
-    /// member generalizes exactly when the target could not hold a top-level
-    /// singleton type. A literal, template-literal, enum, or singleton-capable
-    /// union/instantiable target preserves the member spelling (`EM.X`); a
-    /// primitive or all-primitive union/intersection target widens it (`EM`).
+    /// The parent-enum display type of an enum-member assignment source when
+    /// the top-level display widens it, mirroring tsc's `reportRelationError`
+    /// gate: the member generalizes exactly when the target could not hold a
+    /// top-level singleton type. A literal, template-literal, enum, or
+    /// singleton-capable union/instantiable target preserves the member
+    /// spelling (`EM.X`, returns `None`); a primitive or all-primitive
+    /// union/intersection target widens it (`Some(EM)`).
+    pub(in crate::error_reporter) fn widened_enum_member_assignment_source(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> Option<TypeId> {
+        let widened_source = self.widen_enum_member_type(source);
+        if widened_source == source {
+            return None;
+        }
+
+        let target = self.evaluate_type_for_assignability(target);
+        (!crate::query_boundaries::diagnostics::relation_target_could_hold_singleton(
+            self.ctx.types,
+            &self.ctx,
+            target,
+        ))
+        .then_some(widened_source)
+    }
+
+    /// Boolean form of [`Self::widened_enum_member_assignment_source`] for the
+    /// pre-existing display sites that widen separately.
     pub(in crate::error_reporter) fn should_widen_enum_member_assignment_source(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> bool {
-        let widened_source = self.widen_enum_member_type(source);
-        if widened_source == source {
-            return false;
-        }
-
-        let target = self.evaluate_type_for_assignability(target);
-        !crate::query_boundaries::diagnostics::relation_target_could_hold_singleton(
-            self.ctx.types,
-            &self.ctx,
-            target,
-        )
+        self.widened_enum_member_assignment_source(source, target)
+            .is_some()
     }
 
     pub(in crate::error_reporter) fn unresolved_unused_renaming_property_in_type_query(

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -471,12 +471,9 @@ impl<'a> CheckerState<'a> {
                     }
                     return self.format_declared_annotation_for_diagnostic(&annotation_text);
                 }
-                let display_type =
-                    if self.should_widen_enum_member_assignment_source(expr_display_type, target) {
-                        self.widen_enum_member_type(expr_display_type)
-                    } else {
-                        expr_display_type
-                    };
+                let display_type = self
+                    .widened_enum_member_assignment_source(expr_display_type, target)
+                    .unwrap_or(expr_display_type);
                 let display_type = self.widen_function_like_display_type(display_type);
                 let display_type = if self.is_literal_sensitive_assignment_target(target)
                     || preserve_literal_surface
@@ -665,11 +662,8 @@ impl<'a> CheckerState<'a> {
                 } else {
                     self.widen_type_for_display(expr_display_type)
                 };
-                if self.should_widen_enum_member_assignment_source(widened_expr_type, target) {
-                    self.widen_enum_member_type(widened_expr_type)
-                } else {
-                    widened_expr_type
-                }
+                self.widened_enum_member_assignment_source(widened_expr_type, target)
+                    .unwrap_or(widened_expr_type)
             } else {
                 self.widen_type_for_display(source)
             };
@@ -1635,12 +1629,9 @@ impl<'a> CheckerState<'a> {
                 } else {
                     self.widen_type_for_display(expr_type)
                 };
-                let display_type =
-                    if self.should_widen_enum_member_assignment_source(widened_expr_type, target) {
-                        self.widen_enum_member_type(widened_expr_type)
-                    } else {
-                        widened_expr_type
-                    };
+                let display_type = self
+                    .widened_enum_member_assignment_source(widened_expr_type, target)
+                    .unwrap_or(widened_expr_type);
                 let display_type = self.widen_function_like_display_type(display_type);
                 if let Some(display) =
                     self.new_expression_nominal_source_display(expr_idx, display_type)
@@ -1683,11 +1674,8 @@ impl<'a> CheckerState<'a> {
                 } else {
                     self.widen_type_for_display(expr_type)
                 };
-                if self.should_widen_enum_member_assignment_source(widened_expr_type, target) {
-                    self.widen_enum_member_type(widened_expr_type)
-                } else {
-                    widened_expr_type
-                }
+                self.widened_enum_member_assignment_source(widened_expr_type, target)
+                    .unwrap_or(widened_expr_type)
             } else {
                 self.widen_type_for_display(source)
             };

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/wrapper_provenance.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/wrapper_provenance.rs
@@ -220,11 +220,9 @@ impl<'a> CheckerState<'a> {
         } else {
             self.widen_type_for_display(expr_display_type)
         };
-        let display_type = if self.should_widen_enum_member_assignment_source(widened, target) {
-            self.widen_enum_member_type(widened)
-        } else {
-            widened
-        };
+        let display_type = self
+            .widened_enum_member_assignment_source(widened, target)
+            .unwrap_or(widened);
 
         Some(self.widen_function_like_display_type(display_type))
     }

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -1407,7 +1407,7 @@ impl<'a> CheckerState<'a> {
         // alias/interface refs never reach the enum naming.
         let enum_data_def = crate::query_boundaries::common::enum_def_id(self.ctx.types, ty);
         let def_id = enum_data_def
-            .or_else(|| crate::query_boundaries::common::enum_or_lazy_def_id(self.ctx.types, ty))?;
+            .or_else(|| crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty))?;
         // Parent-edge path first: it covers member defs whose binder symbol is
         // not wired (`def_to_symbol_id_with_fallback` fails and the bare
         // member name would leak), and it encodes tsc's single-member

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -271,14 +271,10 @@ impl<'a> CheckerState<'a> {
             // binder symbol carries `ENUM_MEMBER`; the alias-name fallthrough
             // below would leak the bare member name (`X`). Route it through
             // the enum naming so it renders qualified (`E.X`) — or as the
-            // bare enum name for a single-member enum (tsc identity).
-            if def
-                .symbol_id
-                .map(tsz_binder::SymbolId)
-                .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
-                .is_some_and(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER))
-                && let Some(name) = self.format_qualified_enum_name_for_message(ty)
-            {
+            // bare enum name for a single-member enum (tsc identity). The
+            // helper answers `None` for every non-enum lazy ref, so no extra
+            // gate is needed here.
+            if let Some(name) = self.format_qualified_enum_name_for_message(ty) {
                 return name;
             }
             if let Some(body) = def.body {
@@ -1412,28 +1408,21 @@ impl<'a> CheckerState<'a> {
         let enum_data_def = crate::query_boundaries::common::enum_def_id(self.ctx.types, ty);
         let def_id = enum_data_def
             .or_else(|| crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty))?;
-        // Definition-store parent edge first: it covers member defs whose
-        // binder symbol is not wired (`def_to_symbol_id_with_fallback` fails
-        // and the bare member name would leak), and it encodes tsc's
-        // single-member identity — a single-member enum's member type IS the
-        // enum type and renders as the bare enum name.
+        // Parent-edge path first: it covers member defs whose binder symbol is
+        // not wired (`def_to_symbol_id_with_fallback` fails and the bare
+        // member name would leak), and it encodes tsc's single-member
+        // identity — a single-member enum's member type IS the enum type and
+        // renders as the bare enum name. The environment lookup already falls
+        // back to the shared definition store; the resolver's symbol-based
+        // lookup covers canonicalized twins of the decl-site def that neither
+        // map saw.
         if let Some(parent_id) = self
             .ctx
-            .definition_store
-            .get_enum_parent(def_id)
+            .type_env
+            .try_borrow()
+            .ok()
+            .and_then(|env| env.get_enum_parent(def_id))
             .or_else(|| {
-                // The per-file environment map covers member defs the shared
-                // store never saw (the widening paths already read it).
-                self.ctx
-                    .type_env
-                    .try_borrow()
-                    .ok()
-                    .and_then(|env| env.get_enum_parent(def_id))
-            })
-            .or_else(|| {
-                // Relation-level member refs can carry a canonicalized twin of
-                // the decl-site def that the shared parent map never saw; the
-                // resolver's symbol-based lookup covers those.
                 tsz_solver::resolver::TypeResolver::get_enum_parent_def_id(&self.ctx, def_id)
             })
             && let Some(parent) = self.ctx.definition_store.get(parent_id)
@@ -1447,16 +1436,7 @@ impl<'a> CheckerState<'a> {
                 return Some(format!("{parent_name}.{member_name}"));
             }
         }
-        let sym_id = self
-            .ctx
-            .def_to_symbol_id_with_fallback(def_id)
-            .or_else(|| {
-                self.ctx
-                    .definition_store
-                    .get(def_id)
-                    .and_then(|def| def.symbol_id)
-                    .map(tsz_binder::SymbolId)
-            })?;
+        let sym_id = self.ctx.def_to_symbol_id_with_fallback(def_id)?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
         if symbol.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER) {
             let parent = self.ctx.binder.get_symbol(symbol.parent)?;

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -267,6 +267,20 @@ impl<'a> CheckerState<'a> {
             && def.kind == tsz_solver::def::DefKind::TypeAlias
             && def.type_params.is_empty()
         {
+            // A type-position `E.X` reference is stabilized as a def whose
+            // binder symbol carries `ENUM_MEMBER`; the alias-name fallthrough
+            // below would leak the bare member name (`X`). Route it through
+            // the enum naming so it renders qualified (`E.X`) — or as the
+            // bare enum name for a single-member enum (tsc identity).
+            if def
+                .symbol_id
+                .map(tsz_binder::SymbolId)
+                .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
+                .is_some_and(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER))
+                && let Some(name) = self.format_qualified_enum_name_for_message(ty)
+            {
+                return name;
+            }
             if let Some(body) = def.body {
                 if crate::query_boundaries::common::is_type_query_type(self.ctx.types, body)
                     || self.type_alias_definition_body_is_type_query(&def)
@@ -1390,12 +1404,77 @@ impl<'a> CheckerState<'a> {
     }
 
     pub(super) fn format_qualified_enum_name_for_message(&mut self, ty: TypeId) -> Option<String> {
-        let def_id = crate::query_boundaries::common::enum_def_id(self.ctx.types, ty)?;
-        let sym_id = self.ctx.def_to_symbol_id_with_fallback(def_id)?;
+        // Accept both the evaluated `Enum` data and a still-deferred
+        // `Lazy(DefId)` member ref (a type-position `E.X` annotation is
+        // stabilized as a def whose binder symbol carries `ENUM_MEMBER`).
+        // The lazy form is gated on the enum symbol flags below so ordinary
+        // alias/interface refs never reach the enum naming.
+        let enum_data_def = crate::query_boundaries::common::enum_def_id(self.ctx.types, ty);
+        let def_id = enum_data_def
+            .or_else(|| crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty))?;
+        // Definition-store parent edge first: it covers member defs whose
+        // binder symbol is not wired (`def_to_symbol_id_with_fallback` fails
+        // and the bare member name would leak), and it encodes tsc's
+        // single-member identity — a single-member enum's member type IS the
+        // enum type and renders as the bare enum name.
+        if let Some(parent_id) = self
+            .ctx
+            .definition_store
+            .get_enum_parent(def_id)
+            .or_else(|| {
+                // The per-file environment map covers member defs the shared
+                // store never saw (the widening paths already read it).
+                self.ctx
+                    .type_env
+                    .try_borrow()
+                    .ok()
+                    .and_then(|env| env.get_enum_parent(def_id))
+            })
+            .or_else(|| {
+                // Relation-level member refs can carry a canonicalized twin of
+                // the decl-site def that the shared parent map never saw; the
+                // resolver's symbol-based lookup covers those.
+                tsz_solver::resolver::TypeResolver::get_enum_parent_def_id(&self.ctx, def_id)
+            })
+            && let Some(parent) = self.ctx.definition_store.get(parent_id)
+        {
+            let parent_name = self.ctx.types.resolve_atom_ref(parent.name).to_string();
+            if parent.enum_members.len() == 1 {
+                return Some(parent_name);
+            }
+            if let Some(def) = self.ctx.definition_store.get(def_id) {
+                let member_name = self.ctx.types.resolve_atom_ref(def.name);
+                return Some(format!("{parent_name}.{member_name}"));
+            }
+        }
+        let sym_id = self
+            .ctx
+            .def_to_symbol_id_with_fallback(def_id)
+            .or_else(|| {
+                self.ctx
+                    .definition_store
+                    .get(def_id)
+                    .and_then(|def| def.symbol_id)
+                    .map(tsz_binder::SymbolId)
+            })?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
         if symbol.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER) {
             let parent = self.ctx.binder.get_symbol(symbol.parent)?;
+            // tsc single-member identity: the lone member's type IS the enum
+            // type, so it displays as the bare enum name.
+            if parent
+                .exports
+                .as_ref()
+                .is_some_and(|members| members.len() == 1)
+            {
+                return Some(parent.escaped_name.clone());
+            }
             return Some(format!("{}.{}", parent.escaped_name, symbol.escaped_name));
+        }
+        // A lazy ref that is not an enum member (interface/alias/namespace)
+        // must not be renamed by the enum machinery.
+        if enum_data_def.is_none() && !symbol.has_any_flags(tsz_binder::symbol_flags::ENUM) {
+            return None;
         }
         let mut parts = vec![symbol.escaped_name.clone()];
         let decl_idx = symbol.primary_declaration()?;

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -1407,7 +1407,7 @@ impl<'a> CheckerState<'a> {
         // alias/interface refs never reach the enum naming.
         let enum_data_def = crate::query_boundaries::common::enum_def_id(self.ctx.types, ty);
         let def_id = enum_data_def
-            .or_else(|| crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty))?;
+            .or_else(|| crate::query_boundaries::common::enum_or_lazy_def_id(self.ctx.types, ty))?;
         // Parent-edge path first: it covers member defs whose binder symbol is
         // not wired (`def_to_symbol_id_with_fallback` fails and the bare
         // member name would leak), and it encodes tsc's single-member

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -311,6 +311,27 @@ impl<'a> CheckerState<'a> {
         Some((start_loc.start, end_loc.end.saturating_sub(start_loc.start)))
     }
 
+    /// Generalize the literal source (tsc `reportRelationError`, via
+    /// `generalize_nested_relation_source_for_display`) and produce the
+    /// finalized `(source, target)` display pair with the `DefaultDiagnostic`
+    /// role — the shared shape of the hand-rolled TS2345 related-info arms
+    /// below. The finalizer receives the generalized source so same-name
+    /// disambiguation sees the pair actually rendered.
+    fn generalized_default_role_pair_display(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> (String, String) {
+        let display_source = self.generalize_nested_relation_source_for_display(source, target);
+        let source_str = self.format_type_for_diagnostic_role(
+            display_source,
+            DiagnosticTypeDisplayRole::DefaultDiagnostic,
+        );
+        let target_str = self
+            .format_type_for_diagnostic_role(target, DiagnosticTypeDisplayRole::DefaultDiagnostic);
+        self.finalize_pair_display_for_diagnostic(display_source, target, source_str, target_str)
+    }
+
     pub(crate) fn related_from_failure_reason(
         &mut self,
         reason: &tsz_solver::SubtypeFailureReason,
@@ -512,26 +533,9 @@ impl<'a> CheckerState<'a> {
                 } else {
                     *target_property_type
                 };
-                // Nested relation leaf: generalize a literal source to its base
-                // type when the target has no singleton capacity (tsc
-                // `reportRelationError`), matching the TS2322 chain renderers.
-                let display_property_type = self.generalize_nested_relation_source_for_display(
+                let (source_str, target_str) = self.generalized_default_role_pair_display(
                     *source_property_type,
                     target_property_type,
-                );
-                let source_str = self.format_type_for_diagnostic_role(
-                    display_property_type,
-                    DiagnosticTypeDisplayRole::DefaultDiagnostic,
-                );
-                let target_str = self.format_type_for_diagnostic_role(
-                    target_property_type,
-                    DiagnosticTypeDisplayRole::DefaultDiagnostic,
-                );
-                let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                    display_property_type,
-                    target_property_type,
-                    source_str,
-                    target_str,
                 );
 
                 let mut items = vec![
@@ -613,25 +617,8 @@ impl<'a> CheckerState<'a> {
                 target_return,
                 nested_reason,
             } => {
-                // Nested relation leaf: generalize a literal return source to
-                // its base type when the target has no singleton capacity (tsc
-                // `reportRelationError`).
-                let display_return = self
-                    .generalize_nested_relation_source_for_display(*source_return, *target_return);
-                let source_str = self.format_type_for_diagnostic_role(
-                    display_return,
-                    DiagnosticTypeDisplayRole::DefaultDiagnostic,
-                );
-                let target_str = self.format_type_for_diagnostic_role(
-                    *target_return,
-                    DiagnosticTypeDisplayRole::DefaultDiagnostic,
-                );
-                let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                    display_return,
-                    *target_return,
-                    source_str,
-                    target_str,
-                );
+                let (source_str, target_str) =
+                    self.generalized_default_role_pair_display(*source_return, *target_return);
                 // tsc's elaboration shape for TS2345 function-return-type
                 // mismatches goes straight from the top-level message into
                 // the inner mismatch line:

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -512,8 +512,15 @@ impl<'a> CheckerState<'a> {
                 } else {
                     *target_property_type
                 };
-                let source_str = self.format_type_for_diagnostic_role(
+                // Nested relation leaf: generalize a literal source to its base
+                // type when the target has no singleton capacity (tsc
+                // `reportRelationError`), matching the TS2322 chain renderers.
+                let display_property_type = self.generalize_nested_relation_source_for_display(
                     *source_property_type,
+                    target_property_type,
+                );
+                let source_str = self.format_type_for_diagnostic_role(
+                    display_property_type,
                     DiagnosticTypeDisplayRole::DefaultDiagnostic,
                 );
                 let target_str = self.format_type_for_diagnostic_role(
@@ -521,7 +528,7 @@ impl<'a> CheckerState<'a> {
                     DiagnosticTypeDisplayRole::DefaultDiagnostic,
                 );
                 let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                    *source_property_type,
+                    display_property_type,
                     target_property_type,
                     source_str,
                     target_str,
@@ -606,8 +613,13 @@ impl<'a> CheckerState<'a> {
                 target_return,
                 nested_reason,
             } => {
+                // Nested relation leaf: generalize a literal return source to
+                // its base type when the target has no singleton capacity (tsc
+                // `reportRelationError`).
+                let display_return = self
+                    .generalize_nested_relation_source_for_display(*source_return, *target_return);
                 let source_str = self.format_type_for_diagnostic_role(
-                    *source_return,
+                    display_return,
                     DiagnosticTypeDisplayRole::DefaultDiagnostic,
                 );
                 let target_str = self.format_type_for_diagnostic_role(
@@ -615,7 +627,7 @@ impl<'a> CheckerState<'a> {
                     DiagnosticTypeDisplayRole::DefaultDiagnostic,
                 );
                 let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                    *source_return,
+                    display_return,
                     *target_return,
                     source_str,
                     target_str,

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -48,12 +48,11 @@ impl<'a> CheckerState<'a> {
     /// (`"no"` vs `"yes"`, literal-union targets, singleton-constrained type
     /// parameters).
     ///
-    /// tsc applies this in every relation-error report. tsz's top-level
-    /// assignability messages already generalize through their display roles,
-    /// so this entry serves the nested chain leaves — property / array-element
-    /// / tuple-position / return frames — and the TS2769 overload elaboration
-    /// (`overload_failure_generalized_pending`), which previously leaked the
-    /// raw literal source (#15626).
+    /// tsc applies this in every relation-error report. This entry serves the
+    /// nested chain leaves — property / array-element / tuple-position /
+    /// return frames — the TS2769 overload elaboration
+    /// (`overload_failure_generalized_pending`), and the top-level
+    /// union-of-literals surface in `render_type_mismatch` (#15626, #15628).
     ///
     /// An all-unit union source maps member-wise through the same bases
     /// (tsc `getBaseTypeOfLiteralTypeUnion`): `"x" | "y"` -> `string`,
@@ -63,6 +62,13 @@ impl<'a> CheckerState<'a> {
         source: TypeId,
         target: TypeId,
     ) -> TypeId {
+        // Source side first: it is a cheap shape check for the overwhelmingly
+        // common non-literal sources, while the target gate may need
+        // resolver-backed constraint evaluation for deferred targets.
+        let generalized = self.relation_literal_source_base_for_display(source);
+        if generalized == source {
+            return source;
+        }
         if crate::query_boundaries::diagnostics::relation_target_could_hold_singleton(
             self.ctx.types,
             &self.ctx,
@@ -70,7 +76,7 @@ impl<'a> CheckerState<'a> {
         ) {
             return source;
         }
-        self.relation_literal_source_base_for_display(source)
+        generalized
     }
 
     /// tsc's `getBaseTypeOfLiteralType` over the checker environment: a scalar
@@ -101,11 +107,8 @@ impl<'a> CheckerState<'a> {
                 .iter()
                 .map(|&member| self.relation_literal_source_base_for_display(member))
                 .collect();
-            if mapped.iter().zip(members.iter()).any(|(a, b)| a != b) {
-                return crate::query_boundaries::diagnostics::union_of_generalized_literal_members(
-                    self.ctx.types,
-                    mapped,
-                );
+            if mapped != members {
+                return crate::query_boundaries::flow_analysis::union_types(self.ctx.types, mapped);
             }
         }
         source

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -57,8 +57,8 @@ impl<'a> CheckerState<'a> {
     ///
     /// The top-level assignment surface keeps its own, older enum-member
     /// policy (`should_widen_enum_member_assignment_source`) with a different
-    /// target gate; migrating it onto this tsc-shaped gate is tracked
-    /// follow-up work, not silently changed here.
+    /// target gate; migrating it onto this tsc-shaped gate is tracked as
+    /// follow-up in #15628, not silently changed here.
     pub(in crate::error_reporter) fn generalize_nested_relation_source_for_display(
         &mut self,
         source: TypeId,

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -40,6 +40,48 @@ pub(in crate::error_reporter) struct RenderContext {
 }
 
 impl<'a> CheckerState<'a> {
+    /// Apply tsc's `reportRelationError` literal-source generalization to a
+    /// nested relation line's source type: a literal source is displayed as
+    /// its base type (`"no"` -> `string`, `true` -> `boolean`, `E.X` -> `E`)
+    /// when the target could not hold a top-level singleton type, and
+    /// preserved when the literal-vs-literal comparison stays meaningful
+    /// (`"no"` vs `"yes"`, literal-union targets, singleton-constrained type
+    /// parameters).
+    ///
+    /// tsc applies this in every relation-error report. tsz's top-level
+    /// assignability messages already generalize through their display roles
+    /// (and the TS2769 overload elaboration through
+    /// `overload_failure_generalized_pending`), so this entry serves the
+    /// nested chain leaves — property / array-element / tuple-position frames
+    /// — which previously leaked the raw literal source (#15626).
+    pub(in crate::error_reporter) fn generalize_nested_relation_source_for_display(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> TypeId {
+        let generalized =
+            crate::query_boundaries::diagnostics::generalized_literal_source_for_display(
+                self.ctx.types,
+                source,
+                target,
+            );
+        if generalized != source {
+            return generalized;
+        }
+        // Enum members widen to their parent enum (tsc's
+        // `getBaseTypeOfLiteralType` EnumLike branch). The parent lookup needs
+        // the checker's enum environment, so it sits outside the pure query.
+        if self.is_enum_member_type_for_widening(source)
+            && !crate::query_boundaries::diagnostics::relation_target_could_hold_singleton(
+                self.ctx.types,
+                target,
+            )
+        {
+            return self.widen_enum_member_type(source);
+        }
+        source
+    }
+
     /// Resolve the parameter name at `param_index` in the first call
     /// signature of `callable_ty` (if any). Used to render TS2328
     /// "Types of parameters '_' and '_' are incompatible." messages.
@@ -1634,7 +1676,12 @@ impl<'a> CheckerState<'a> {
                 // structural formatter instead so the rendered type matches the
                 // solver's `source` TypeId.
                 let source_str = if depth > 0 {
-                    self.format_type_for_assignability_message(source)
+                    // Nested relation leaf: generalize a literal source to its
+                    // base type when the target has no singleton capacity
+                    // (tsc `reportRelationError`).
+                    let display_source =
+                        self.generalize_nested_relation_source_for_display(source, target);
+                    self.format_type_for_assignability_message(display_source)
                 } else {
                     self.format_type_for_diagnostic_role(
                         source,

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -49,11 +49,16 @@ impl<'a> CheckerState<'a> {
     /// parameters).
     ///
     /// tsc applies this in every relation-error report. tsz's top-level
-    /// assignability messages already generalize through their display roles
-    /// (and the TS2769 overload elaboration through
-    /// `overload_failure_generalized_pending`), so this entry serves the
-    /// nested chain leaves — property / array-element / tuple-position frames
-    /// — which previously leaked the raw literal source (#15626).
+    /// assignability messages already generalize through their display roles,
+    /// so this entry serves the nested chain leaves — property / array-element
+    /// / tuple-position / return frames — and the TS2769 overload elaboration
+    /// (`overload_failure_generalized_pending`), which previously leaked the
+    /// raw literal source (#15626).
+    ///
+    /// The top-level assignment surface keeps its own, older enum-member
+    /// policy (`should_widen_enum_member_assignment_source`) with a different
+    /// target gate; migrating it onto this tsc-shaped gate is tracked
+    /// follow-up work, not silently changed here.
     pub(in crate::error_reporter) fn generalize_nested_relation_source_for_display(
         &mut self,
         source: TypeId,

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -55,34 +55,58 @@ impl<'a> CheckerState<'a> {
     /// (`overload_failure_generalized_pending`), which previously leaked the
     /// raw literal source (#15626).
     ///
-    /// The top-level assignment surface keeps its own, older enum-member
-    /// policy (`should_widen_enum_member_assignment_source`) with a different
-    /// target gate; migrating it onto this tsc-shaped gate is tracked as
-    /// follow-up in #15628, not silently changed here.
+    /// An all-unit union source maps member-wise through the same bases
+    /// (tsc `getBaseTypeOfLiteralTypeUnion`): `"x" | "y"` -> `string`,
+    /// `true | 1` -> `number | boolean` (#15628).
     pub(in crate::error_reporter) fn generalize_nested_relation_source_for_display(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> TypeId {
-        let generalized =
-            crate::query_boundaries::diagnostics::generalized_literal_source_for_display(
-                self.ctx.types,
-                source,
-                target,
-            );
+        if crate::query_boundaries::diagnostics::relation_target_could_hold_singleton(
+            self.ctx.types,
+            &self.ctx,
+            target,
+        ) {
+            return source;
+        }
+        self.relation_literal_source_base_for_display(source)
+    }
+
+    /// tsc's `getBaseTypeOfLiteralType` over the checker environment: a scalar
+    /// literal widens to its primitive base, an enum member (including a
+    /// still-deferred `Lazy` member ref) to its parent enum, and an all-unit
+    /// union maps member-wise (`getBaseTypeOfLiteralTypeUnion`). Every other
+    /// type is returned unchanged. The target gate is the caller's job.
+    fn relation_literal_source_base_for_display(&mut self, source: TypeId) -> TypeId {
+        let generalized = crate::query_boundaries::diagnostics::literal_base_type_for_display(
+            self.ctx.types,
+            source,
+        );
         if generalized != source {
             return generalized;
         }
         // Enum members widen to their parent enum (tsc's
         // `getBaseTypeOfLiteralType` EnumLike branch). The parent lookup needs
         // the checker's enum environment, so it sits outside the pure query.
-        if self.is_enum_member_type_for_widening(source)
-            && !crate::query_boundaries::diagnostics::relation_target_could_hold_singleton(
-                self.ctx.types,
-                target,
-            )
-        {
+        if self.is_enum_member_type_for_widening(source) {
             return self.widen_enum_member_type(source);
+        }
+        if crate::query_boundaries::common::is_unit_type(self.ctx.types, source)
+            && let Some(members) =
+                crate::query_boundaries::common::union_members(self.ctx.types, source)
+        {
+            let members: Vec<TypeId> = members.iter().copied().collect();
+            let mapped: Vec<TypeId> = members
+                .iter()
+                .map(|&member| self.relation_literal_source_base_for_display(member))
+                .collect();
+            if mapped.iter().zip(members.iter()).any(|(a, b)| a != b) {
+                return crate::query_boundaries::diagnostics::union_of_generalized_literal_members(
+                    self.ctx.types,
+                    mapped,
+                );
+            }
         }
         source
     }
@@ -1696,6 +1720,7 @@ impl<'a> CheckerState<'a> {
                         },
                     )
                 };
+                let mut source_str = source_str;
                 let mut target_str = self.format_assignability_type_for_message(target, source);
                 if let Some(display) = self
                     .object_literal_property_literal_union_alias_target_display(
@@ -1705,6 +1730,13 @@ impl<'a> CheckerState<'a> {
                     )
                 {
                     target_str = display;
+                }
+                if depth > 0 {
+                    // Same-named nominal pairs at nested leaves disambiguate
+                    // like the top level (tsc `getTypeNamesForErrorDisplay`).
+                    (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
+                        source, target, source_str, target_str,
+                    );
                 }
                 let message = format_message(
                     diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -94,9 +94,11 @@ impl<'a> CheckerState<'a> {
         }
         // Enum members widen to their parent enum (tsc's
         // `getBaseTypeOfLiteralType` EnumLike branch). The parent lookup needs
-        // the checker's enum environment, so it sits outside the pure query.
-        if self.is_enum_member_type_for_widening(source) {
-            return self.widen_enum_member_type(source);
+        // the checker's enum environment, so it sits outside the pure query;
+        // the widen is a no-op for non-members.
+        let enum_widened = self.widen_enum_member_type(source);
+        if enum_widened != source {
+            return enum_widened;
         }
         if crate::query_boundaries::common::is_unit_type(self.ctx.types, source)
             && let Some(members) =
@@ -1707,7 +1709,7 @@ impl<'a> CheckerState<'a> {
                 // instead of the mismatched property type).  Use the plain
                 // structural formatter instead so the rendered type matches the
                 // solver's `source` TypeId.
-                let source_str = if depth > 0 {
+                let mut source_str = if depth > 0 {
                     // Nested relation leaf: generalize a literal source to its
                     // base type when the target has no singleton capacity
                     // (tsc `reportRelationError`).
@@ -1723,7 +1725,6 @@ impl<'a> CheckerState<'a> {
                         },
                     )
                 };
-                let mut source_str = source_str;
                 let mut target_str = self.format_assignability_type_for_message(target, source);
                 if let Some(display) = self
                     .object_literal_property_literal_union_alias_target_display(

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -268,21 +268,6 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// Shared core of the two leaf-message helpers: generalize the literal
-    /// source ([`Self::generalize_nested_relation_source_for_display`]) and
-    /// format both sides. Returns the generalized source id so callers that
-    /// disambiguate the pair pass the type actually rendered.
-    fn generalized_leaf_pair(
-        &mut self,
-        source: TypeId,
-        target: TypeId,
-    ) -> (TypeId, String, String) {
-        let display_source = self.generalize_nested_relation_source_for_display(source, target);
-        let source_str = self.format_type_diagnostic(display_source);
-        let target_str = self.format_type_diagnostic(target);
-        (display_source, source_str, target_str)
-    }
-
     pub(super) fn render_property_type_mismatch(
         &mut self,
         reason: &tsz_solver::SubtypeFailureReason,
@@ -1792,8 +1777,13 @@ impl<'a> CheckerState<'a> {
         source_element: TypeId,
         target_element: TypeId,
     ) -> String {
-        let (display_source, source_str, target_str) =
-            self.generalized_leaf_pair(source_element, target_element);
+        // Generalize the literal source (tsc `reportRelationError`), format
+        // both sides, and disambiguate same-named nominal pairs like the top
+        // level does — the disambiguator gets the type actually rendered.
+        let display_source =
+            self.generalize_nested_relation_source_for_display(source_element, target_element);
+        let source_str = self.format_type_diagnostic(display_source);
+        let target_str = self.format_type_diagnostic(target_element);
         let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
             display_source,
             target_element,

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -268,16 +268,30 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// Format the plain `Type 'S' is not assignable to type 'T'.` leaf line
-    /// for a nested relation pair, applying the literal-source generalization
-    /// ([`Self::generalize_nested_relation_source_for_display`]) before
-    /// rendering. Unlike [`Self::element_mismatch_message`] this variant skips
-    /// the same-name pair disambiguation, preserving the exact output of the
-    /// leaf sites it factored out.
-    fn generalized_leaf_mismatch_message(&mut self, source: TypeId, target: TypeId) -> String {
+    /// Shared core of the two leaf-message helpers: generalize the literal
+    /// source ([`Self::generalize_nested_relation_source_for_display`]) and
+    /// format both sides. Returns the generalized source id so callers that
+    /// disambiguate the pair pass the type actually rendered.
+    fn generalized_leaf_pair(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> (TypeId, String, String) {
         let display_source = self.generalize_nested_relation_source_for_display(source, target);
         let source_str = self.format_type_diagnostic(display_source);
         let target_str = self.format_type_diagnostic(target);
+        (display_source, source_str, target_str)
+    }
+
+    /// Format the plain `Type 'S' is not assignable to type 'T'.` leaf line
+    /// for a nested relation pair. Unlike [`Self::element_mismatch_message`]
+    /// this variant skips the same-name pair disambiguation, preserving the
+    /// exact output of the leaf sites it factored out — whether tsc
+    /// disambiguates same-named nominal pairs at these particular leaves is
+    /// unverified; converging the two helpers needs a tsc witness first
+    /// (#15628).
+    fn generalized_leaf_mismatch_message(&mut self, source: TypeId, target: TypeId) -> String {
+        let (_, source_str, target_str) = self.generalized_leaf_pair(source, target);
         format_message(
             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             &[&source_str, &target_str],
@@ -673,24 +687,12 @@ impl<'a> CheckerState<'a> {
                 self.render_failure_reason(inner, source_return, target_return, idx, leaf_depth);
             Self::push_rebased_subdiagnostic(diag, sub, leaf_depth, leaf_depth);
         } else {
-            let display_return =
-                self.generalize_nested_relation_source_for_display(source_return, target_return);
-            let source_str = self.format_type_diagnostic(display_return);
-            let target_str = self.format_type_diagnostic(target_return);
-            let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                display_return,
-                target_return,
-                source_str,
-                target_str,
-            );
+            let message = self.element_mismatch_message(source_return, target_return);
             let (start, length) = (diag.start, diag.length);
             diag.push_elaboration_in_span(
                 start,
                 length,
-                format_message(
-                    diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                    &[&source_str, &target_str],
-                ),
+                message,
                 diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 leaf_depth,
             );
@@ -1787,12 +1789,10 @@ impl<'a> CheckerState<'a> {
         source_element: TypeId,
         target_element: TypeId,
     ) -> String {
-        let source_element =
-            self.generalize_nested_relation_source_for_display(source_element, target_element);
-        let source_str = self.format_type_diagnostic(source_element);
-        let target_str = self.format_type_diagnostic(target_element);
+        let (display_source, source_str, target_str) =
+            self.generalized_leaf_pair(source_element, target_element);
         let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-            source_element,
+            display_source,
             target_element,
             source_str,
             target_str,

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -259,20 +259,29 @@ impl<'a> CheckerState<'a> {
             let leaf_diag = self.render_failure_reason(leaf, s, t, idx, depth);
             Self::push_nested_chain(diag, leaf_diag, depth);
         } else {
-            let display_src =
-                self.generalize_nested_relation_source_for_display(leaf_src, leaf_tgt);
-            let s = self.format_type_diagnostic(display_src);
-            let t = self.format_type_diagnostic(leaf_tgt);
-            let message = format_message(
-                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                &[&s, &t],
-            );
+            let message = self.generalized_leaf_mismatch_message(leaf_src, leaf_tgt);
             diag.push_elaboration(
                 message,
                 diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 depth,
             );
         }
+    }
+
+    /// Format the plain `Type 'S' is not assignable to type 'T'.` leaf line
+    /// for a nested relation pair, applying the literal-source generalization
+    /// ([`Self::generalize_nested_relation_source_for_display`]) before
+    /// rendering. Unlike [`Self::element_mismatch_message`] this variant skips
+    /// the same-name pair disambiguation, preserving the exact output of the
+    /// leaf sites it factored out.
+    fn generalized_leaf_mismatch_message(&mut self, source: TypeId, target: TypeId) -> String {
+        let display_source = self.generalize_nested_relation_source_for_display(source, target);
+        let source_str = self.format_type_diagnostic(display_source);
+        let target_str = self.format_type_diagnostic(target);
+        format_message(
+            diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[&source_str, &target_str],
+        )
     }
 
     pub(super) fn render_property_type_mismatch(
@@ -669,7 +678,7 @@ impl<'a> CheckerState<'a> {
             let source_str = self.format_type_diagnostic(display_return);
             let target_str = self.format_type_diagnostic(target_return);
             let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
-                source_return,
+                display_return,
                 target_return,
                 source_str,
                 target_str,
@@ -856,16 +865,8 @@ impl<'a> CheckerState<'a> {
         nested_reason: Option<&tsz_solver::SubtypeFailureReason>,
     ) -> Diagnostic {
         let depth = ctx.depth;
-        let element_message = {
-            let display_element =
-                self.generalize_nested_relation_source_for_display(source_element, target_element);
-            let source_str = self.format_type_diagnostic(display_element);
-            let target_str = self.format_type_diagnostic(target_element);
-            format_message(
-                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                &[&source_str, &target_str],
-            )
-        };
+        let element_message =
+            self.generalized_leaf_mismatch_message(source_element, target_element);
         let needs_header = nested_reason.is_some_and(Self::tuple_element_nested_needs_header);
 
         // Deeper levels (`depth > 0`) whose element self-heads: the nested
@@ -1560,14 +1561,7 @@ impl<'a> CheckerState<'a> {
                 self.render_failure_reason(nested, nested_source, nested_target, idx, depth + 1);
             Self::push_nested_chain(diag, nested_diag, depth + 1);
         } else {
-            let display_element =
-                self.generalize_nested_relation_source_for_display(source_element, target_element);
-            let source_str = self.format_type_diagnostic(display_element);
-            let target_str = self.format_type_diagnostic(target_element);
-            let message = format_message(
-                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                &[&source_str, &target_str],
-            );
+            let message = self.generalized_leaf_mismatch_message(source_element, target_element);
             diag.push_elaboration(
                 message,
                 diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -259,7 +259,9 @@ impl<'a> CheckerState<'a> {
             let leaf_diag = self.render_failure_reason(leaf, s, t, idx, depth);
             Self::push_nested_chain(diag, leaf_diag, depth);
         } else {
-            let s = self.format_type_diagnostic(leaf_src);
+            let display_src =
+                self.generalize_nested_relation_source_for_display(leaf_src, leaf_tgt);
+            let s = self.format_type_diagnostic(display_src);
             let t = self.format_type_diagnostic(leaf_tgt);
             let message = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
@@ -662,7 +664,9 @@ impl<'a> CheckerState<'a> {
                 self.render_failure_reason(inner, source_return, target_return, idx, leaf_depth);
             Self::push_rebased_subdiagnostic(diag, sub, leaf_depth, leaf_depth);
         } else {
-            let source_str = self.format_type_diagnostic(source_return);
+            let display_return =
+                self.generalize_nested_relation_source_for_display(source_return, target_return);
+            let source_str = self.format_type_diagnostic(display_return);
             let target_str = self.format_type_diagnostic(target_return);
             let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
                 source_return,
@@ -853,7 +857,9 @@ impl<'a> CheckerState<'a> {
     ) -> Diagnostic {
         let depth = ctx.depth;
         let element_message = {
-            let source_str = self.format_type_diagnostic(source_element);
+            let display_element =
+                self.generalize_nested_relation_source_for_display(source_element, target_element);
+            let source_str = self.format_type_diagnostic(display_element);
             let target_str = self.format_type_diagnostic(target_element);
             format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
@@ -1554,7 +1560,9 @@ impl<'a> CheckerState<'a> {
                 self.render_failure_reason(nested, nested_source, nested_target, idx, depth + 1);
             Self::push_nested_chain(diag, nested_diag, depth + 1);
         } else {
-            let source_str = self.format_type_diagnostic(source_element);
+            let display_element =
+                self.generalize_nested_relation_source_for_display(source_element, target_element);
+            let source_str = self.format_type_diagnostic(display_element);
             let target_str = self.format_type_diagnostic(target_element);
             let message = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
@@ -1785,6 +1793,8 @@ impl<'a> CheckerState<'a> {
         source_element: TypeId,
         target_element: TypeId,
     ) -> String {
+        let source_element =
+            self.generalize_nested_relation_source_for_display(source_element, target_element);
         let source_str = self.format_type_diagnostic(source_element);
         let target_str = self.format_type_diagnostic(target_element);
         let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -259,7 +259,7 @@ impl<'a> CheckerState<'a> {
             let leaf_diag = self.render_failure_reason(leaf, s, t, idx, depth);
             Self::push_nested_chain(diag, leaf_diag, depth);
         } else {
-            let message = self.generalized_leaf_mismatch_message(leaf_src, leaf_tgt);
+            let message = self.element_mismatch_message(leaf_src, leaf_tgt);
             diag.push_elaboration(
                 message,
                 diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
@@ -281,21 +281,6 @@ impl<'a> CheckerState<'a> {
         let source_str = self.format_type_diagnostic(display_source);
         let target_str = self.format_type_diagnostic(target);
         (display_source, source_str, target_str)
-    }
-
-    /// Format the plain `Type 'S' is not assignable to type 'T'.` leaf line
-    /// for a nested relation pair. Unlike [`Self::element_mismatch_message`]
-    /// this variant skips the same-name pair disambiguation, preserving the
-    /// exact output of the leaf sites it factored out — whether tsc
-    /// disambiguates same-named nominal pairs at these particular leaves is
-    /// unverified; converging the two helpers needs a tsc witness first
-    /// (#15628).
-    fn generalized_leaf_mismatch_message(&mut self, source: TypeId, target: TypeId) -> String {
-        let (_, source_str, target_str) = self.generalized_leaf_pair(source, target);
-        format_message(
-            diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-            &[&source_str, &target_str],
-        )
     }
 
     pub(super) fn render_property_type_mismatch(
@@ -867,8 +852,7 @@ impl<'a> CheckerState<'a> {
         nested_reason: Option<&tsz_solver::SubtypeFailureReason>,
     ) -> Diagnostic {
         let depth = ctx.depth;
-        let element_message =
-            self.generalized_leaf_mismatch_message(source_element, target_element);
+        let element_message = self.element_mismatch_message(source_element, target_element);
         let needs_header = nested_reason.is_some_and(Self::tuple_element_nested_needs_header);
 
         // Deeper levels (`depth > 0`) whose element self-heads: the nested
@@ -1193,7 +1177,11 @@ impl<'a> CheckerState<'a> {
         let mut diag = if depth == 0 {
             self.render_type_mismatch(ctx)
         } else {
-            let source_str = self.format_type_diagnostic(source_type);
+            // Nested union line: generalize an all-unit union source to its
+            // base (tsc `reportRelationError` / `getBaseTypeOfLiteralTypeUnion`).
+            let display_source =
+                self.generalize_nested_relation_source_for_display(source_type, target_type);
+            let source_str = self.format_type_diagnostic(display_source);
             let base = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&source_str, &target_str],
@@ -1218,7 +1206,9 @@ impl<'a> CheckerState<'a> {
         let header_depth = if depth == 0 { 0 } else { depth + 1 };
         let drill_depth = header_depth + 1;
 
-        let member_str = self.format_type_diagnostic(member_type);
+        let display_member =
+            self.generalize_nested_relation_source_for_display(member_type, target_type);
+        let member_str = self.format_type_diagnostic(display_member);
         diag.push_elaboration_in_span(
             ctx.start,
             ctx.length,
@@ -1316,7 +1306,12 @@ impl<'a> CheckerState<'a> {
         let mut diag = if depth == 0 {
             self.render_type_mismatch(ctx)
         } else {
-            let source_str = self.format_type_diagnostic(source_type);
+            // Nested relation line: generalize a literal / all-unit-union
+            // source to its base when the target has no singleton capacity
+            // (tsc `reportRelationError`).
+            let display_source =
+                self.generalize_nested_relation_source_for_display(source_type, target_type);
+            let source_str = self.format_type_diagnostic(display_source);
             let target_str = self.format_type_diagnostic(target_type);
             let base = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
@@ -1343,8 +1338,12 @@ impl<'a> CheckerState<'a> {
                 // Plain leaf relation (e.g. `undefined` vs `number`): render
                 // the child source/target structurally so the displayed
                 // source is the failing branch/member, not the enclosing
-                // assignment's RHS expression.
-                let source_str = self.format_type_diagnostic(nested_source);
+                // assignment's RHS expression. The leaf generalizes the same
+                // way as the outer line (tsc runs `reportRelationError` on
+                // every relation line).
+                let display_source = self
+                    .generalize_nested_relation_source_for_display(nested_source, nested_target);
+                let source_str = self.format_type_diagnostic(display_source);
                 let target_str = self.format_type_diagnostic(nested_target);
                 diag.push_elaboration_in_span(
                     start,
@@ -1479,8 +1478,12 @@ impl<'a> CheckerState<'a> {
 
         // Otherwise emit the constituent frame `Type 'S' is not assignable to
         // type 'Ci'.` (structural display, so the constituent — not the merged
-        // intersection — is named) one level beneath the headline.
-        let frame_source = self.format_type_diagnostic(source_type);
+        // intersection — is named) one level beneath the headline. The frame is
+        // a nested relation line, so its literal source generalizes against
+        // the constituent (tsc `reportRelationError`).
+        let display_source =
+            self.generalize_nested_relation_source_for_display(source_type, constituent_type);
+        let frame_source = self.format_type_diagnostic(display_source);
         let frame_target = self.format_type_diagnostic(constituent_type);
         let frame_message = format_message(
             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
@@ -1563,7 +1566,7 @@ impl<'a> CheckerState<'a> {
                 self.render_failure_reason(nested, nested_source, nested_target, idx, depth + 1);
             Self::push_nested_chain(diag, nested_diag, depth + 1);
         } else {
-            let message = self.generalized_leaf_mismatch_message(source_element, target_element);
+            let message = self.element_mismatch_message(source_element, target_element);
             diag.push_elaboration(
                 message,
                 diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -60,7 +60,14 @@ impl<'a> CheckerState<'a> {
                 display
             }
         } else {
-            self.format_nested_assignment_source_type_for_diagnostic(source, target, idx)
+            // Nested relation leaf: generalize a literal source to its base
+            // type when the target has no singleton capacity (tsc
+            // `reportRelationError`). When the source generalizes, the
+            // anchor-expression display path inside no longer applies (the
+            // anchor's type is the raw literal), so the plain structural
+            // formatter renders the widened form.
+            let display_source = self.generalize_nested_relation_source_for_display(source, target);
+            self.format_nested_assignment_source_type_for_diagnostic(display_source, target, idx)
         };
         let mut target_str = if depth == 0 {
             self.format_top_level_assignability_message_types_at(source, target, idx)

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -79,6 +79,14 @@ impl<'a> CheckerState<'a> {
         } else {
             self.format_assignability_type_for_message(target, source)
         };
+        if depth > 0 {
+            // tsc runs `getTypeNamesForErrorDisplay` on every relation line, so
+            // a same-named nominal pair at a nested leaf disambiguates the same
+            // way the top level does (`NA.Crate` vs `NB.Crate`, not
+            // `Crate` vs `Crate`).
+            (source_str, target_str) =
+                self.finalize_pair_display_for_diagnostic(source, target, source_str, target_str);
+        }
         if depth == 0 {
             let source_enum_symbol = self.enum_symbol_from_enumish_type(source);
             let target_enum_symbol = self.enum_symbol_from_enumish_type(target);
@@ -500,6 +508,17 @@ impl<'a> CheckerState<'a> {
             &target_str,
         ) {
             source_str = restored;
+        }
+        // An all-unit union source generalizes member-wise to its base when
+        // the target has no singleton capacity (tsc `reportRelationError` ->
+        // `getBaseTypeOfLiteralTypeUnion`): `"x" | "y"` vs `boolean` renders
+        // `string`. Scalar literal sources are already handled by the display
+        // pipeline above; this covers only the union form it preserves.
+        if crate::query_boundaries::common::union_members(self.ctx.types, source).is_some() {
+            let display_source = self.generalize_nested_relation_source_for_display(source, target);
+            if display_source != source {
+                source_str = self.format_type_for_assignability_message(display_source);
+            }
         }
         let base = format_message(
             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,

--- a/crates/tsz-checker/src/query_boundaries/assignability_alias_display.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability_alias_display.rs
@@ -170,12 +170,12 @@ pub(crate) fn has_optional_parameter_undefined_surface(
 }
 
 pub(crate) fn is_literal_for_alias_display(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    // `literal_value` first: the boolean literals `true`/`false` are intrinsic
-    // `TypeId`s that the shared union predicate's intrinsic fast-path skips,
-    // but they are literal sources for display purposes (tsc widens a declared
-    // `true` to `boolean` against a non-literal target; repainting it with the
-    // annotation text would undo that).
-    common::literal_value(db, type_id).is_some()
+    // Unit-literal check first: the boolean literals `true`/`false` are
+    // intrinsic `TypeId`s that the shared union predicate's intrinsic
+    // fast-path skips, but they are literal sources for display purposes (tsc
+    // widens a declared `true` to `boolean` against a non-literal target;
+    // repainting it with the annotation text would undo that).
+    is_unit_literal_type(db, type_id)
         || tsz_solver::type_queries::is_literal_or_literal_union_type(db, type_id)
         || common::is_template_literal_type(db, type_id)
 }

--- a/crates/tsz-checker/src/query_boundaries/assignability_alias_display.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability_alias_display.rs
@@ -170,7 +170,13 @@ pub(crate) fn has_optional_parameter_undefined_surface(
 }
 
 pub(crate) fn is_literal_for_alias_display(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    tsz_solver::type_queries::is_literal_or_literal_union_type(db, type_id)
+    // `literal_value` first: the boolean literals `true`/`false` are intrinsic
+    // `TypeId`s that the shared union predicate's intrinsic fast-path skips,
+    // but they are literal sources for display purposes (tsc widens a declared
+    // `true` to `boolean` against a non-literal target; repainting it with the
+    // annotation text would undo that).
+    common::literal_value(db, type_id).is_some()
+        || tsz_solver::type_queries::is_literal_or_literal_union_type(db, type_id)
         || common::is_template_literal_type(db, type_id)
 }
 

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -679,6 +679,19 @@ pub(crate) fn enum_def_id(
     tsz_solver::type_queries::get_enum_def_id(db, type_id)
 }
 
+/// Get the def id behind an enum-member reference in either of its two
+/// representations: the evaluated `Enum` member data, or the still-deferred
+/// `Lazy(DefId)` semantic ref a type-position `E.X` annotation stabilizes to.
+/// Callers must still verify the def is an enum member (parent-edge or
+/// `ENUM_MEMBER` symbol flags) — a plain alias/interface ref also matches the
+/// lazy arm.
+pub(crate) fn enum_or_lazy_def_id(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<tsz_solver::def::DefId> {
+    enum_def_id(db, type_id).or_else(|| lazy_def_id(db, type_id))
+}
+
 /// Check whether a mapped type has a `readonly` modifier applied.
 pub(crate) fn is_mapped_type_with_readonly_modifier(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -649,32 +649,67 @@ pub(crate) fn widen_argument_type_for_display(db: &dyn TypeDatabase, type_id: Ty
     tsz_solver::operations::widening::widen_argument_type_for_display(db, type_id)
 }
 
-/// Generalize a fresh literal assignment/argument `source` to its base type for
-/// diagnostic display, mirroring tsc's `reportRelationError`: a literal source
-/// is widened to its base (`true` -> `boolean`, `1` -> `number`) when the
-/// `target` could not hold a top-level singleton type, and preserved otherwise
-/// (`true` vs `1`, `"a"` vs `"b"`). Non-literal sources are returned unchanged.
-pub(crate) fn generalized_literal_source_for_display(
-    db: &dyn TypeDatabase,
-    source: TypeId,
-    target: TypeId,
-) -> TypeId {
-    if tsz_solver::type_queries::is_literal_type(db, source)
-        && !tsz_solver::type_queries::type_could_have_top_level_singleton_types(db, target)
-    {
+/// Widen a scalar literal relation source to its base type for diagnostic
+/// display (tsc `getBaseTypeOfLiteralType` on the non-enum arms): `"no"` ->
+/// `string`, `1` -> `number`, `true` -> `boolean`, `1n` -> `bigint`. Non-literal
+/// types (including enum members, whose parent lookup needs the checker's enum
+/// environment) are returned unchanged.
+pub(crate) fn literal_base_type_for_display(db: &dyn TypeDatabase, source: TypeId) -> TypeId {
+    if tsz_solver::type_queries::is_literal_type(db, source) {
         tsz_solver::operations::widening::widen_type(db, source)
     } else {
         source
     }
 }
 
+/// Union of the member-wise generalized bases of an all-unit union source
+/// (tsc `getBaseTypeOfLiteralTypeUnion`): the caller maps each member through
+/// its base (`literal_base_type_for_display` / enum-member widening) and this
+/// boundary interns the reduced union (`"x" | "y"` -> `string`,
+/// `true | 1` -> `number | boolean`).
+pub(crate) fn union_of_generalized_literal_members(
+    db: &dyn TypeDatabase,
+    members: Vec<TypeId>,
+) -> TypeId {
+    db.union(members)
+}
+
+/// Whether `target` is one of the deferred instantiable/semantic-ref forms
+/// (`IndexAccess`, `Conditional`, `Substitution`, `Application`, `Lazy`) whose
+/// literal-sensitivity answer requires constraint computation or resolver
+/// evaluation ([`relation_target_could_hold_singleton`]) rather than direct
+/// shape inspection.
+pub(crate) fn is_deferred_instantiable_display_target(
+    db: &dyn TypeDatabase,
+    target: TypeId,
+) -> bool {
+    if target.is_intrinsic() {
+        return false;
+    }
+    matches!(
+        db.lookup(target),
+        Some(
+            tsz_solver::TypeData::IndexAccess(_, _)
+                | tsz_solver::TypeData::Conditional(_)
+                | tsz_solver::TypeData::Substitution { .. }
+                | tsz_solver::TypeData::Application(_)
+                | tsz_solver::TypeData::Lazy(_)
+        )
+    )
+}
+
 /// Whether a relation target could hold a top-level singleton (unit) type —
-/// tsc's `typeCouldHaveTopLevelSingletonTypes`. Exposed for display decisions
-/// that need the target gate separately from
-/// [`generalized_literal_source_for_display`] (e.g. enum-member sources whose
-/// base-enum widening needs the checker's enum environment).
-pub(crate) fn relation_target_could_hold_singleton(db: &dyn TypeDatabase, target: TypeId) -> bool {
-    tsz_solver::type_queries::type_could_have_top_level_singleton_types(db, target)
+/// tsc's `typeCouldHaveTopLevelSingletonTypes`. Resolver-aware so deferred
+/// semantic refs (`Cfg[K]`, `Cond<T>`, enum/alias references) answer through
+/// their constraints the way tsc's `getConstraintOfType` does.
+pub(crate) fn relation_target_could_hold_singleton<R: tsz_solver::resolver::TypeResolver>(
+    db: &dyn TypeDatabase,
+    resolver: &R,
+    target: TypeId,
+) -> bool {
+    tsz_solver::type_queries::type_could_have_top_level_singleton_types_resolved(
+        db, resolver, target,
+    )
 }
 
 /// Apparent type of an element-access receiver for the implicit-any index

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -668,6 +668,15 @@ pub(crate) fn generalized_literal_source_for_display(
     }
 }
 
+/// Whether a relation target could hold a top-level singleton (unit) type —
+/// tsc's `typeCouldHaveTopLevelSingletonTypes`. Exposed for display decisions
+/// that need the target gate separately from
+/// [`generalized_literal_source_for_display`] (e.g. enum-member sources whose
+/// base-enum widening needs the checker's enum environment).
+pub(crate) fn relation_target_could_hold_singleton(db: &dyn TypeDatabase, target: TypeId) -> bool {
+    tsz_solver::type_queries::type_could_have_top_level_singleton_types(db, target)
+}
+
 /// Apparent type of an element-access receiver for the implicit-any index
 /// diagnostic (`TS7053`). `tsc` renders `typeToString(getApparentType(objectType))`,
 /// so the `object` intrinsic prints as its apparent type `{}` and a bare

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -662,40 +662,16 @@ pub(crate) fn literal_base_type_for_display(db: &dyn TypeDatabase, source: TypeI
     }
 }
 
-/// Union of the member-wise generalized bases of an all-unit union source
-/// (tsc `getBaseTypeOfLiteralTypeUnion`): the caller maps each member through
-/// its base (`literal_base_type_for_display` / enum-member widening) and this
-/// boundary interns the reduced union (`"x" | "y"` -> `string`,
-/// `true | 1` -> `number | boolean`).
-pub(crate) fn union_of_generalized_literal_members(
-    db: &dyn TypeDatabase,
-    members: Vec<TypeId>,
-) -> TypeId {
-    db.union(members)
-}
-
 /// Whether `target` is one of the deferred instantiable/semantic-ref forms
-/// (`IndexAccess`, `Conditional`, `Substitution`, `Application`, `Lazy`) whose
-/// literal-sensitivity answer requires constraint computation or resolver
-/// evaluation ([`relation_target_could_hold_singleton`]) rather than direct
-/// shape inspection.
+/// whose literal-sensitivity answer requires constraint computation or
+/// resolver evaluation ([`relation_target_could_hold_singleton`]) rather than
+/// direct shape inspection. The variant list is owned by the solver next to
+/// the predicate itself so the two cannot drift.
 pub(crate) fn is_deferred_instantiable_display_target(
     db: &dyn TypeDatabase,
     target: TypeId,
 ) -> bool {
-    if target.is_intrinsic() {
-        return false;
-    }
-    matches!(
-        db.lookup(target),
-        Some(
-            tsz_solver::TypeData::IndexAccess(_, _)
-                | tsz_solver::TypeData::Conditional(_)
-                | tsz_solver::TypeData::Substitution { .. }
-                | tsz_solver::TypeData::Application(_)
-                | tsz_solver::TypeData::Lazy(_)
-        )
-    )
+    tsz_solver::type_queries::singleton_capacity_needs_constraint(db, target)
 }
 
 /// Whether a relation target could hold a top-level singleton (unit) type —

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -540,8 +540,13 @@ impl<'a> CheckerState<'a> {
     /// literal types (e.g., `2` stays `2`, not `number`). This is used in operator
     /// error messages where tsc preserves literal types but widens enum members.
     pub(crate) fn widen_enum_member_type(&mut self, type_id: TypeId) -> TypeId {
-        // Check if this is an enum member type that should widen to parent enum
+        // Check if this is an enum member type that should widen to parent
+        // enum. A member reference can still be the deferred `Lazy(DefId)`
+        // semantic ref (e.g. an object-property annotation `{ a: E.X }`), so
+        // fall back to the lazy def id when the ref has not been evaluated to
+        // its `Enum` data yet.
         if let Some(def_id) = crate::query_boundaries::common::enum_def_id(self.ctx.types, type_id)
+            .or_else(|| crate::query_boundaries::common::lazy_def_id(self.ctx.types, type_id))
         {
             let parent_def_id = self
                 .ctx
@@ -574,7 +579,10 @@ impl<'a> CheckerState<'a> {
     /// Enum member types (e.g., `Colors.Red`) should widen to the parent enum type
     /// when assigned to mutable bindings, even if they're not "fresh" literals.
     pub(crate) fn is_enum_member_type_for_widening(&self, type_id: TypeId) -> bool {
+        // Like `widen_enum_member_type`, accept both the evaluated `Enum`
+        // member data and the deferred `Lazy(DefId)` member ref.
         if let Some(def_id) = crate::query_boundaries::common::enum_def_id(self.ctx.types, type_id)
+            .or_else(|| crate::query_boundaries::common::lazy_def_id(self.ctx.types, type_id))
         {
             // Check if this DefId has a parent (meaning it's a member, not the enum itself)
             return self

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -541,12 +541,10 @@ impl<'a> CheckerState<'a> {
     /// error messages where tsc preserves literal types but widens enum members.
     pub(crate) fn widen_enum_member_type(&mut self, type_id: TypeId) -> TypeId {
         // Check if this is an enum member type that should widen to parent
-        // enum. A member reference can still be the deferred `Lazy(DefId)`
-        // semantic ref (e.g. an object-property annotation `{ a: E.X }`), so
-        // fall back to the lazy def id when the ref has not been evaluated to
-        // its `Enum` data yet.
-        if let Some(def_id) = crate::query_boundaries::common::enum_def_id(self.ctx.types, type_id)
-            .or_else(|| crate::query_boundaries::common::lazy_def_id(self.ctx.types, type_id))
+        // enum; `enum_or_lazy_def_id` accepts both the evaluated member data
+        // and the deferred `Lazy(DefId)` ref an annotation stabilizes to.
+        if let Some(def_id) =
+            crate::query_boundaries::common::enum_or_lazy_def_id(self.ctx.types, type_id)
         {
             let parent_def_id = self
                 .ctx
@@ -581,8 +579,8 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn is_enum_member_type_for_widening(&self, type_id: TypeId) -> bool {
         // Like `widen_enum_member_type`, accept both the evaluated `Enum`
         // member data and the deferred `Lazy(DefId)` member ref.
-        if let Some(def_id) = crate::query_boundaries::common::enum_def_id(self.ctx.types, type_id)
-            .or_else(|| crate::query_boundaries::common::lazy_def_id(self.ctx.types, type_id))
+        if let Some(def_id) =
+            crate::query_boundaries::common::enum_or_lazy_def_id(self.ctx.types, type_id)
         {
             // Check if this DefId has a parent (meaning it's a member, not the enum itself)
             return self

--- a/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
+++ b/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
@@ -290,3 +290,318 @@ const port: { spin: () => boolean } = gadget;
     assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
     assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
 }
+
+// ── #15628: union-of-literals sources (tsc `getBaseTypeOfLiteralTypeUnion`) ──
+
+/// An all-unit union property source generalizes member-wise: the union line
+/// renders the reduced base (`"x" | "y"` -> `string`).
+#[test]
+fn union_of_string_literals_property_line_generalizes() {
+    let source = r#"
+declare const carton: { a: "x" | "y" };
+const sinkC: { a: boolean } = carton;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(
+        diag,
+        "Type '\"x\" | \"y\"' is not assignable to type 'boolean'.",
+    );
+}
+
+/// Mixed-base unit union maps each member through its base and re-unions
+/// (`true | 1` -> `number | boolean`).
+#[test]
+fn mixed_literal_union_property_line_generalizes_to_base_union() {
+    let source = r#"
+declare const blend: { e: true | 1 };
+const sinkE: { e: string } = blend;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(
+        diag,
+        "Type 'number | boolean' is not assignable to type 'string'.",
+    );
+}
+
+/// Preservation gate: a literal-union target keeps the literal-union source.
+#[test]
+fn union_of_literals_preserved_against_literal_union_target() {
+    let source = r#"
+declare const duo2: { d: "x" | "y" };
+const sinkD: { d: "w" | "z" } = duo2;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(
+        diag,
+        "Type '\"x\" | \"y\"' is not assignable to type '\"w\" | \"z\"'.",
+    );
+}
+
+/// Top-level all-unit union source generalizes too (tsc runs the same
+/// `reportRelationError` at every relation line).
+#[test]
+fn top_level_union_of_literals_generalizes() {
+    let source = r#"
+declare const pick2: "x" | "y";
+const bool2: boolean = pick2;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert!(
+        diag.message_text == "Type 'string' is not assignable to type 'boolean'.",
+        "top-level union line must generalize; got: {}",
+        diag.message_text
+    );
+}
+
+// ── #15628: top-level boolean-literal sources ──
+
+/// A declared boolean-literal source widens to `boolean` against a
+/// non-singleton target; string/number literal sources already widened.
+#[test]
+fn top_level_boolean_literal_source_generalizes() {
+    let source = r#"
+declare const flag1: true;
+const s1: string = flag1;
+declare const flag2: false;
+const n2: number = flag2;
+"#;
+    let diags = check_strict(source);
+    let texts: Vec<&str> = diags.iter().map(|d| d.message_text.as_str()).collect();
+    assert!(
+        texts.contains(&"Type 'boolean' is not assignable to type 'string'."),
+        "true must widen to boolean; got: {texts:?}"
+    );
+    assert!(
+        texts.contains(&"Type 'boolean' is not assignable to type 'number'."),
+        "false must widen to boolean; got: {texts:?}"
+    );
+}
+
+/// Preservation gate: a boolean-literal target keeps the boolean literal.
+#[test]
+fn top_level_boolean_literal_preserved_against_literal_target() {
+    let source = r#"
+declare const flag3: true;
+const f3: false = flag3;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_eq!(
+        diag.message_text,
+        "Type 'true' is not assignable to type 'false'."
+    );
+}
+
+// ── #15628: enum members at property leaves and the tsc-shaped top-level gate ──
+
+/// Enum-member property leaves generalize to the parent enum against a
+/// primitive target (previously leaked the bare member name).
+#[test]
+fn enum_member_property_leaf_widens_to_parent_enum() {
+    let source = r#"
+enum Bulk { One = 1, Two = 2 }
+declare const crate1: { a: Bulk.One };
+const sinkA: { a: string } = crate1;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type 'Bulk' is not assignable to type 'string'.");
+    assert_no_related(diag, "Type 'One' is not assignable to type 'string'.");
+}
+
+/// Preservation gate: an enum-member target is singleton-capable, so the
+/// source member keeps its qualified spelling at the leaf.
+#[test]
+fn enum_member_property_leaf_preserved_against_enum_member_target() {
+    let source = r#"
+enum Left { A = 1, B = 2 }
+enum Right { C = 5, D = 6 }
+declare const holder: { a: Left.A };
+const sinkR: { a: Right.C } = holder;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type 'Left.A' is not assignable to type 'Right.C'.");
+    assert_no_related(diag, "Type 'A' is not assignable to type 'C'.");
+}
+
+/// tsc-shaped top-level gate: a literal target preserves the enum member
+/// (the older gate widened whenever the target was not enum/union/intersection).
+#[test]
+fn top_level_enum_member_preserved_against_literal_target() {
+    let source = r#"
+enum Gauge { Lo = 1, Hi = 2 }
+declare const g1: Gauge.Lo;
+const z1: "z" = g1;
+declare const g2: Gauge.Lo;
+const t1: `x${string}` = g2;
+declare const g3: Gauge.Lo;
+const b1: true = g3;
+"#;
+    let diags = check_strict(source);
+    let texts: Vec<&str> = diags.iter().map(|d| d.message_text.as_str()).collect();
+    assert!(
+        texts.contains(&"Type 'Gauge.Lo' is not assignable to type '\"z\"'."),
+        "literal target preserves the member; got: {texts:?}"
+    );
+    assert!(
+        texts.contains(&"Type 'Gauge.Lo' is not assignable to type '`x${string}`'."),
+        "template-literal target preserves the member; got: {texts:?}"
+    );
+    assert!(
+        texts.contains(&"Type 'Gauge.Lo' is not assignable to type 'true'."),
+        "boolean-literal target preserves the member; got: {texts:?}"
+    );
+}
+
+/// TS2345 call-argument surface uses the same gate: an enum-member argument
+/// widens to the parent enum against a primitive parameter and keeps its
+/// spelling against a literal parameter.
+#[test]
+fn call_argument_enum_member_uses_singleton_gate() {
+    let source = r#"
+enum Cargo { A = 1, B = 2 }
+declare const load: Cargo.A;
+declare function sipX(x: boolean): void;
+sipX(load);
+declare const load2: Cargo.A;
+declare function pinX(x: "z"): void;
+pinX(load2);
+"#;
+    let diags = check_strict(source);
+    let texts: Vec<&str> = diags.iter().map(|d| d.message_text.as_str()).collect();
+    assert!(
+        texts.contains(
+            &"Argument of type 'Cargo' is not assignable to parameter of type 'boolean'."
+        ),
+        "primitive parameter widens the member; got: {texts:?}"
+    );
+    assert!(
+        texts.contains(
+            &"Argument of type 'Cargo.A' is not assignable to parameter of type '\"z\"'."
+        ),
+        "literal parameter preserves the member; got: {texts:?}"
+    );
+}
+
+/// A single-member enum's member type IS the enum type in tsc, so it renders
+/// as the bare enum name at every surface.
+#[test]
+fn single_member_enum_member_displays_as_enum_name() {
+    let source = r#"
+enum Solo { Only = 1 }
+enum Pair { L = 1, R = 2 }
+declare const s0: Solo.Only;
+const sp: Pair.L = s0;
+declare const s1: { a: Solo.Only };
+const so: { a: string } = s1;
+"#;
+    let diags = check_strict(source);
+    let texts: Vec<String> = diags
+        .iter()
+        .flat_map(|d| {
+            std::iter::once(d.message_text.clone())
+                .chain(d.related_information.iter().map(|r| r.message_text.clone()))
+        })
+        .collect();
+    assert!(
+        texts
+            .iter()
+            .any(|t| t == "Type 'Solo' is not assignable to type 'Pair.L'."),
+        "single-member enum renders as the enum name; got: {texts:?}"
+    );
+    // The relation LEAF also renders the identity form. (The *object property
+    // display* `{ a: Solo.Only; }` still shows the annotation spelling — that
+    // provenance path is a separate display owner, tracked in #15628's
+    // remaining notes.)
+    assert!(
+        texts
+            .iter()
+            .any(|t| t == "Type 'Solo' is not assignable to type 'string'."),
+        "the lone member's leaf renders the enum name; got: {texts:?}"
+    );
+}
+
+/// tsc gate detail: `boolean` inside a union target flattens to `true | false`
+/// (both units), so the union preserves a literal source.
+#[test]
+fn boolean_in_union_target_preserves_literal_source() {
+    let source = r#"
+declare const five2: 5;
+const mix1: string | boolean = five2;
+declare const five3: 5;
+const mix2: string | symbol = five3;
+"#;
+    let diags = check_strict(source);
+    let texts: Vec<&str> = diags.iter().map(|d| d.message_text.as_str()).collect();
+    assert!(
+        texts.contains(&"Type '5' is not assignable to type 'string | boolean'."),
+        "boolean member makes the union singleton-capable; got: {texts:?}"
+    );
+    assert!(
+        texts.contains(&"Type 'number' is not assignable to type 'string | symbol'."),
+        "no singleton capacity without the boolean member; got: {texts:?}"
+    );
+}
+
+// ── #15628: deferred instantiable targets answer through their constraints ──
+
+/// A deferred conditional-alias target whose default constraint contains
+/// units preserves the literal source; an all-primitive constraint widens it.
+#[test]
+fn deferred_conditional_target_answers_through_constraint() {
+    let source = r#"
+type PickU<T> = T extends string ? "a" | "b" : number;
+type PickP<T> = T extends string ? string : number;
+function scope<T>(x: T) {
+  const u: PickU<T> = "no" as const;
+  const p: PickP<T> = "no" as const;
+}
+"#;
+    let diags = check_strict(source);
+    let texts: Vec<&str> = diags.iter().map(|d| d.message_text.as_str()).collect();
+    assert!(
+        texts.contains(&"Type '\"no\"' is not assignable to type 'PickU<T>'."),
+        "unit-bearing constraint preserves the literal; got: {texts:?}"
+    );
+    assert!(
+        texts.contains(&"Type 'string' is not assignable to type 'PickP<T>'."),
+        "all-primitive constraint widens the literal; got: {texts:?}"
+    );
+}
+
+/// An indexed-access target in a generic body answers through the evaluated
+/// key-space union: unit-bearing property types preserve, primitives widen.
+#[test]
+fn deferred_indexed_access_target_answers_through_constraint() {
+    let source = r#"
+interface KnobsU { mode: "on" | "off"; size: number }
+interface KnobsP { mode: string; size: number }
+declare const feedU: { p: "no" };
+function genU<K extends keyof KnobsU>(k: K) {
+  const q: { p: KnobsU[K] } = feedU;
+}
+function genP<K extends keyof KnobsP>(k: K) {
+  const q2: { p: KnobsP[K] } = feedU;
+}
+"#;
+    let diags = check_strict(source);
+    let leaves: Vec<&str> = diags
+        .iter()
+        .flat_map(|d| d.related_information.iter())
+        .map(|r| r.message_text.as_str())
+        .collect();
+    assert!(
+        leaves.contains(&"Type '\"no\"' is not assignable to type 'KnobsU[K]'."),
+        "unit-bearing key space preserves the literal; got: {leaves:?}"
+    );
+    assert!(
+        leaves.contains(&"Type 'string' is not assignable to type 'KnobsP[K]'."),
+        "all-primitive key space widens the literal; got: {leaves:?}"
+    );
+}

--- a/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
+++ b/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
@@ -1,0 +1,301 @@
+//! Literal-source generalization at nested relation leaves (`tsc`'s
+//! `reportRelationError`), issue #15626.
+//!
+//! When the failing source of a nested `Type 'S' is not assignable to type
+//! 'T'.` relation line is a literal type and the target could not hold a
+//! top-level singleton type, `tsc` displays the literal's base type
+//! (`"no"` -> `string`, `true` -> `boolean`, `E.X` -> `E`). When the target is
+//! singleton-capable (a literal, a literal union, a template literal, or a
+//! type parameter constrained to one of those), the literal is preserved so
+//! the literal-vs-literal comparison stays meaningful.
+//!
+//! The rule is a property of relation-error display, not of expression
+//! freshness: a *variable* whose declared tuple element is `"no"` renders the
+//! same generalized leaf as a fresh array-literal argument. Cases below cover
+//! the tuple positional chain (both TS2345 call-argument and TS2322
+//! initializer entry points), property chains, array element chains, return
+//! leaves, and the preservation gates. Binder names vary across cases so the
+//! behavior is proven structural.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_common::diagnostics::Diagnostic;
+
+fn check_strict(source: &str) -> Vec<Diagnostic> {
+    let options = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..Default::default()
+    };
+    tsz_checker::test_utils::check_source(source, "test.ts", options)
+}
+
+fn one(diags: &[Diagnostic], code: u32) -> &Diagnostic {
+    let matches: Vec<&Diagnostic> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one TS{code}, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    matches[0]
+}
+
+fn assert_has_related(diag: &Diagnostic, expected: &str) {
+    assert!(
+        diag.related_information
+            .iter()
+            .any(|r| r.message_text == expected),
+        "expected related line {expected:?}; related: {:?}",
+        diag.related_information
+            .iter()
+            .map(|r| &r.message_text)
+            .collect::<Vec<_>>()
+    );
+}
+
+fn assert_no_related(diag: &Diagnostic, unexpected: &str) {
+    assert!(
+        diag.related_information
+            .iter()
+            .all(|r| r.message_text != unexpected),
+        "unexpected related line {unexpected:?}; related: {:?}",
+        diag.related_information
+            .iter()
+            .map(|r| &r.message_text)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The #15626 repro: a fresh array-literal call argument against a middle-rest
+/// tuple parameter renders the widened element in the positional-chain leaf.
+#[test]
+fn call_argument_middle_rest_tuple_chain_leaf_widens_fresh_literal() {
+    let source = r#"
+function grab(items: [number, ...boolean[], string]) {}
+grab([1, "no", "s"]);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(
+        diag,
+        "Type at position 1 in source is not compatible with type at position 1 in target.",
+    );
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}
+
+/// Initializer entry point (already correct before the fix): the same chain
+/// leaf renders the widened element.
+#[test]
+fn initializer_middle_rest_tuple_chain_leaf_widens_fresh_literal() {
+    let source = r#"
+const slots: [number, ...boolean[], string] = [1, "no", "s"];
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}
+
+/// The generalization is a relation-display rule, not a freshness rule: a
+/// variable whose *declared* tuple element is the literal renders the same
+/// generalized leaf (verified against `tsc 6.0.2`).
+#[test]
+fn declared_tuple_variable_source_chain_leaf_also_generalizes() {
+    let source = r#"
+declare const packed: [number, "no", string];
+function feed(cells: [number, ...boolean[], string]) {}
+feed(packed);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}
+
+/// Multi-element span aligned to a middle rest slot: the plural positional
+/// line keeps its shape and the leaf generalizes.
+#[test]
+fn variadic_span_chain_leaf_generalizes() {
+    let source = r#"
+function quilt(zz: [string, ...number[], boolean]) {}
+quilt(["a", "b", "c", true]);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(
+        diag,
+        "Type at positions 1 through 2 in source is not compatible with type at position 1 in target.",
+    );
+    assert_has_related(diag, "Type 'string' is not assignable to type 'number'.");
+}
+
+/// Preservation gate: a literal-typed rest slot is singleton-capable, so the
+/// source literal survives in the leaf.
+#[test]
+fn literal_rest_slot_preserves_source_literal() {
+    let source = r#"
+declare const duo: [number, "no"];
+function pin(x: [number, ..."yes"[]]) {}
+pin(duo);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(diag, "Type '\"no\"' is not assignable to type '\"yes\"'.");
+    assert_no_related(diag, "Type 'string' is not assignable to type '\"yes\"'.");
+}
+
+/// Property-chain leaf (TS2322): a declared string-literal property widens
+/// against a non-singleton target property.
+#[test]
+fn property_chain_leaf_generalizes_string_literal() {
+    let source = r#"
+declare const wrap: { flag: "no" };
+const sink: { flag: boolean } = wrap;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}
+
+/// Property-chain leaf (TS2345 hand-rolled related-info arm): same rule on the
+/// call-argument surface, including through a type-parameter target whose
+/// constraint is a plain primitive.
+#[test]
+fn call_argument_property_leaf_generalizes_through_primitive_constraint() {
+    let source = r#"
+function lodge<W extends boolean>(x: { knob: W }) {}
+declare const dial: { knob: "no" };
+lodge(dial);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+}
+
+/// Preservation gate: a type parameter constrained to a literal union is
+/// singleton-capable, so the source literal survives.
+#[test]
+fn singleton_constrained_type_parameter_preserves_literal() {
+    let source = r#"
+function tune<Q extends "aa" | "bb">(x: { pitch: Q }) {}
+declare const chord: { pitch: "no" };
+tune(chord);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(
+        diag,
+        "Type '\"no\"' is not assignable to type '\"aa\" | \"bb\"'.",
+    );
+}
+
+/// Collapsed dotted property chain (`a.b`) leaf generalizes a number literal.
+#[test]
+fn dotted_property_chain_leaf_generalizes_number_literal() {
+    let source = r#"
+declare const deep: { a: { b: 5 } };
+const basin: { a: { b: string } } = deep;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type 'number' is not assignable to type 'string'.");
+    assert_no_related(diag, "Type '5' is not assignable to type 'string'.");
+}
+
+/// Array element chain leaf generalizes.
+#[test]
+fn array_element_chain_leaf_generalizes() {
+    let source = r#"
+declare const noes: "no"[];
+const bools: boolean[] = noes;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}
+
+/// Boolean and bigint literal property leaves generalize to their bases.
+#[test]
+fn boolean_and_bigint_literal_property_leaves_generalize() {
+    let source = r#"
+declare const lit: { on: true };
+const strung: { on: string } = lit;
+declare const big: { n: 1n };
+const booled: { n: boolean } = big;
+"#;
+    let diags = check_strict(source);
+    let texts: Vec<&str> = diags
+        .iter()
+        .flat_map(|d| d.related_information.iter())
+        .map(|r| r.message_text.as_str())
+        .collect();
+    assert!(
+        texts.contains(&"Type 'boolean' is not assignable to type 'string'."),
+        "boolean literal leaf must widen; related: {texts:?}"
+    );
+    assert!(
+        texts.contains(&"Type 'bigint' is not assignable to type 'boolean'."),
+        "bigint literal leaf must widen; related: {texts:?}"
+    );
+}
+
+/// Preservation gate: a union target containing a same-base literal is
+/// singleton-capable, so the number literal survives.
+#[test]
+fn union_target_with_singleton_preserves_number_literal() {
+    let source = r#"
+declare const five: { a: 5 };
+const mixed: { a: 6 | string } = five;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type '5' is not assignable to type 'string | 6'.");
+}
+
+/// Enum members generalize to their parent enum in the positional-chain leaf
+/// (tsc `getBaseTypeOfLiteralType` EnumLike branch).
+#[test]
+fn enum_member_tuple_chain_leaf_widens_to_parent_enum() {
+    let source = r#"
+enum Gear { Low = 1 }
+declare const kit: [number, Gear.Low, string];
+function stow(x: [number, ...string[], string]) {}
+stow(kit);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(diag, "Type 'Gear' is not assignable to type 'string'.");
+}
+
+/// Callback return leaf under TS2345 generalizes the literal return type.
+#[test]
+fn callback_return_leaf_generalizes() {
+    let source = r#"
+declare function pump(cb: () => boolean): void;
+declare const feedCb: () => "no";
+pump(feedCb);
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2345);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}
+
+/// Member-return frame (`The types returned by 'm()' ...`) leaf generalizes.
+#[test]
+fn member_return_frame_leaf_generalizes() {
+    let source = r#"
+declare const gadget: { spin: () => "no" };
+const port: { spin: () => boolean } = gadget;
+"#;
+    let diags = check_strict(source);
+    let diag = one(&diags, 2322);
+    assert_has_related(diag, "Type 'string' is not assignable to type 'boolean'.");
+    assert_no_related(diag, "Type '\"no\"' is not assignable to type 'boolean'.");
+}

--- a/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
+++ b/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
@@ -515,15 +515,17 @@ const so: { a: string } = s1;
             .any(|t| t == "Type 'Solo' is not assignable to type 'Pair.L'."),
         "single-member enum renders as the enum name; got: {texts:?}"
     );
-    // The relation LEAF also renders the identity form. (The *object property
-    // display* `{ a: Solo.Only; }` still shows the annotation spelling — that
-    // provenance path is a separate display owner, tracked in #15628's
-    // remaining notes.)
+    // The relation leaf and the object property display both render the
+    // identity form — `Solo.Only` never appears.
     assert!(
         texts
             .iter()
             .any(|t| t == "Type 'Solo' is not assignable to type 'string'."),
         "the lone member's leaf renders the enum name; got: {texts:?}"
+    );
+    assert!(
+        !texts.iter().any(|t| t.contains("Solo.Only")),
+        "the lone member never renders qualified; got: {texts:?}"
     );
 }
 

--- a/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
+++ b/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
@@ -17,17 +17,8 @@
 //! leaves, and the preservation gates. Binder names vary across cases so the
 //! behavior is proven structural.
 
-use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source_strict as check_strict;
 use tsz_common::diagnostics::Diagnostic;
-
-fn check_strict(source: &str) -> Vec<Diagnostic> {
-    let options = CheckerOptions {
-        strict: true,
-        strict_null_checks: true,
-        ..Default::default()
-    };
-    tsz_checker::test_utils::check_source(source, "test.ts", options)
-}
 
 fn one(diags: &[Diagnostic], code: u32) -> &Diagnostic {
     let matches: Vec<&Diagnostic> = diags.iter().filter(|d| d.code == code).collect();

--- a/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
@@ -225,6 +225,62 @@ impl<'a> TypeFormatter<'a> {
         None
     }
 
+    /// Display for an enum *member* semantic ref (`TypeData::Enum` member data
+    /// or a still-deferred `Lazy(DefId)` member ref), mirroring tsc:
+    ///
+    /// - a single-member enum's member type IS the declared enum type in tsc,
+    ///   so it renders as the bare enum name (`E`, never `E.A`);
+    /// - a multi-member enum's member renders qualified (`E.A`).
+    ///
+    /// Returns `None` when `def_id` is not a registered enum member (no
+    /// parent-enum edge) or no `def_store` is wired.
+    pub(super) fn format_enum_member_ref(&mut self, def_id: crate::def::DefId) -> Option<String> {
+        let def_store = self.def_store?;
+        if let Some(parent_id) = def_store.get_enum_parent(def_id)
+            && let Some(parent) = def_store.get(parent_id)
+        {
+            if parent.enum_members.len() == 1 {
+                if let Some(sym_raw) = parent.symbol_id
+                    && let Some(name) = self.format_symbol_name(SymbolId(sym_raw))
+                {
+                    return Some(name);
+                }
+                return Some(self.format_def_name(&parent));
+            }
+            let def = def_store.get(def_id)?;
+            if let Some(sym_raw) = def.symbol_id
+                && let Some(name) = self.format_symbol_name(SymbolId(sym_raw))
+            {
+                return Some(name);
+            }
+            return Some(format!(
+                "{}.{}",
+                self.format_def_name(&parent),
+                self.format_def_name(&def)
+            ));
+        }
+        // No parent edge in the store (a type-position `E.X` ref stabilized as
+        // its own def): identify the member through its binder symbol instead.
+        let def = def_store.get(def_id)?;
+        let sym = self.symbol_arena?.get(SymbolId(def.symbol_id?))?;
+        if !sym.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER) {
+            return None;
+        }
+        let parent_sym = self.symbol_arena?.get(sym.parent)?;
+        // tsc single-member identity: the lone member's type IS the enum type.
+        if parent_sym
+            .exports
+            .as_ref()
+            .is_some_and(|members| members.len() == 1)
+        {
+            return Some(parent_sym.escaped_name.clone());
+        }
+        Some(format!(
+            "{}.{}",
+            parent_sym.escaped_name, sym.escaped_name
+        ))
+    }
+
     pub(super) fn format_symbol_name(&mut self, sym_id: SymbolId) -> Option<String> {
         let arena = self.symbol_arena?;
         let sym = arena.get(sym_id)?;

--- a/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
@@ -275,10 +275,9 @@ impl<'a> TypeFormatter<'a> {
         {
             return Some(parent_sym.escaped_name.clone());
         }
-        Some(format!(
-            "{}.{}",
-            parent_sym.escaped_name, sym.escaped_name
-        ))
+        // Qualified `E.X` via the shared symbol-name walk (keeps the
+        // file-module guard and multi-level parent handling in one place).
+        self.format_symbol_name(SymbolId(def.symbol_id?))
     }
 
     pub(super) fn format_symbol_name(&mut self, sym_id: SymbolId) -> Option<String> {

--- a/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
@@ -262,11 +262,13 @@ impl<'a> TypeFormatter<'a> {
         // No parent edge in the store (a type-position `E.X` ref stabilized as
         // its own def): identify the member through its binder symbol instead.
         let def = def_store.get(def_id)?;
-        let sym = self.symbol_arena?.get(SymbolId(def.symbol_id?))?;
+        let sym_id = SymbolId(def.symbol_id?);
+        let arena = self.symbol_arena?;
+        let sym = arena.get(sym_id)?;
         if !sym.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER) {
             return None;
         }
-        let parent_sym = self.symbol_arena?.get(sym.parent)?;
+        let parent_sym = arena.get(sym.parent)?;
         // tsc single-member identity: the lone member's type IS the enum type.
         if parent_sym
             .exports
@@ -277,7 +279,7 @@ impl<'a> TypeFormatter<'a> {
         }
         // Qualified `E.X` via the shared symbol-name walk (keeps the
         // file-module guard and multi-level parent handling in one place).
-        self.format_symbol_name(SymbolId(def.symbol_id?))
+        self.format_symbol_name(sym_id)
     }
 
     pub(super) fn format_symbol_name(&mut self, sym_id: SymbolId) -> Option<String> {

--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -211,6 +211,13 @@ impl<'a> TypeFormatter<'a> {
                 {
                     return self.format(body);
                 }
+                // A still-deferred enum *member* ref (e.g. an object-property
+                // annotation `{ a: E.X }` keeps the member as `Lazy(DefId)`)
+                // renders like the evaluated `Enum` member data: qualified
+                // `E.X`, or the bare enum name for a single-member enum.
+                if let Some(name) = self.format_enum_member_ref(*def_id) {
+                    return name.into();
+                }
                 self.format_def_id_with_type_params(*def_id, "Lazy").into()
             }
             TypeData::Recursive(idx) => format!("Recursive({idx})").into(),
@@ -848,11 +855,18 @@ impl<'a> TypeFormatter<'a> {
                 format!("{}<{}>", kind_name, self.format(*type_arg)).into()
             }
             TypeData::Enum(def_id, _member_type) => {
-                // Enum members should be qualified with their parent enum name
-                // (e.g., `Foo.A` not just `A`). Try the symbol arena first, which
-                // walks the parent chain and qualifies enum members correctly.
-                // Use the definition's stored symbol_id (not the raw def_id) to
-                // find the correct binder symbol.
+                // Enum members render through the shared member-ref display:
+                // qualified with the parent enum (`Foo.A`), except that a
+                // single-member enum's member type IS the enum type in tsc and
+                // renders as the bare enum name (`Foo`).
+                if let Some(name) = self.format_enum_member_ref(*def_id) {
+                    return name.into();
+                }
+                // Not a registered member (the enum type itself, or no parent
+                // edge yet): try the symbol arena, which walks the parent chain
+                // and qualifies enum members correctly. Use the definition's
+                // stored symbol_id (not the raw def_id) to find the correct
+                // binder symbol.
                 if let Some(def_store) = self.def_store
                     && let Some(def) = def_store.get(*def_id)
                     && let Some(sym_raw) = def.symbol_id

--- a/crates/tsz-solver/src/type_queries/flow.rs
+++ b/crates/tsz-solver/src/type_queries/flow.rs
@@ -729,6 +729,9 @@ fn type_could_have_top_level_singleton_types_inner(
     type_id: TypeId,
     depth: u32,
 ) -> bool {
+    // Fuel exhaustion answers "no singleton capacity", failing toward
+    // *generalizing* a literal source in the diagnostic — the direction that
+    // loses precision rather than inventing a literal-vs-literal contrast.
     if depth > 16 {
         return false;
     }

--- a/crates/tsz-solver/src/type_queries/flow.rs
+++ b/crates/tsz-solver/src/type_queries/flow.rs
@@ -744,12 +744,41 @@ pub fn type_could_have_top_level_singleton_types_resolved<R: TypeResolver>(
     type_could_have_top_level_singleton_types_inner(db, resolver, type_id, 0)
 }
 
+/// Whether `type_id` is one of the deferred instantiable/semantic-ref forms
+/// whose singleton-capacity answer requires constraint computation or resolver
+/// evaluation ([`type_could_have_top_level_singleton_types_resolved`]) rather
+/// than direct shape inspection. Owned here, next to the predicate's match
+/// arms, so the variant list cannot drift from the predicate.
+pub fn singleton_capacity_needs_constraint(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if type_id.is_intrinsic() {
+        return false;
+    }
+    matches!(
+        db.lookup(type_id),
+        Some(
+            TypeData::IndexAccess(_, _)
+                | TypeData::Conditional(_)
+                | TypeData::Substitution { .. }
+                | TypeData::Application(_)
+                | TypeData::Lazy(_)
+        )
+    )
+}
+
 fn type_could_have_top_level_singleton_types_inner<R: TypeResolver>(
     db: &dyn TypeDatabase,
     resolver: &R,
     type_id: TypeId,
     depth: u32,
 ) -> bool {
+    // A computed constraint answers for its type only when it made progress
+    // and did not collapse to the error sentinel; otherwise fall back toward
+    // "no singleton capacity" (the caller's `is_unit_type` arm).
+    let recurse_if_progress = |constraint: TypeId, depth: u32| {
+        constraint != type_id
+            && constraint != TypeId::ERROR
+            && type_could_have_top_level_singleton_types_inner(db, resolver, constraint, depth + 1)
+    };
     // Fuel exhaustion answers "no singleton capacity", failing toward
     // *generalizing* a literal source in the diagnostic — the direction that
     // loses precision rather than inventing a literal-vs-literal contrast.
@@ -790,61 +819,54 @@ fn type_could_have_top_level_singleton_types_inner<R: TypeResolver>(
         // Remaining `Instantiable` forms answer through their computed
         // constraint (tsc `getConstraintOfType`); no progress falls back to
         // the unit check, i.e. "no singleton capacity".
-        Some(TypeData::Substitution { .. }) => {
-            let constraint = crate::type_queries::get_base_constraint_of_type(db, type_id);
-            constraint != type_id
-                && type_could_have_top_level_singleton_types_inner(
-                    db,
-                    resolver,
-                    constraint,
-                    depth + 1,
-                )
-        }
+        Some(TypeData::Substitution { .. }) => recurse_if_progress(
+            crate::type_queries::get_base_constraint_of_type(db, type_id),
+            depth,
+        ),
         Some(TypeData::IndexAccess(_, _)) => {
             // Reduce contained type parameters to their constraints, then
             // evaluate the access (tsc `getConstraintOfIndexedAccess`):
             // `Cfg[K]` with `K extends keyof Cfg` answers through the union
-            // of `Cfg`'s property types.
+            // of `Cfg`'s property types. (This reduces the *index*'s type
+            // parameters too, unlike `reduce_index_access_to_base_constraint`,
+            // which only reduces the object side for the comparability
+            // relation.)
             let substituted = instantiate_type_params_to_constraints_uncached(db, type_id);
-            let constraint = evaluate_type_with_resolver(db, resolver, substituted);
-            constraint != type_id
-                && constraint != TypeId::ERROR
-                && type_could_have_top_level_singleton_types_inner(
-                    db,
-                    resolver,
-                    constraint,
-                    depth + 1,
-                )
+            recurse_if_progress(
+                evaluate_type_with_resolver(db, resolver, substituted),
+                depth,
+            )
         }
         Some(TypeData::Conditional(_)) => {
             // tsc `getDefaultConstraintOfConditionalType`: the union of the
             // (inferred) true branch and the false branch.
             match crate::type_queries::get_conditional_default_constraint(db, type_id) {
-                Some(constraint) if constraint != type_id => {
-                    type_could_have_top_level_singleton_types_inner(
-                        db,
-                        resolver,
-                        constraint,
-                        depth + 1,
-                    )
-                }
-                _ => is_unit_type(db, type_id),
+                Some(constraint) => recurse_if_progress(constraint, depth),
+                None => is_unit_type(db, type_id),
             }
         }
-        Some(TypeData::Lazy(_) | TypeData::Application(_)) => {
-            // A still-deferred semantic ref (alias/enum/interface reference or
-            // generic alias application). tsc holds the evaluated type here;
-            // resolve it and re-ask. An enum reference evaluates to its union
-            // of enum-literal members, which has singleton capacity.
-            let evaluated = evaluate_type_with_resolver(db, resolver, type_id);
-            evaluated != type_id
-                && evaluated != TypeId::ERROR
-                && type_could_have_top_level_singleton_types_inner(
-                    db,
-                    resolver,
-                    evaluated,
-                    depth + 1,
-                )
+        Some(TypeData::Lazy(def_id)) => {
+            // A still-deferred semantic ref. Structural def kinds
+            // (interface/class/function/...) can never evaluate to a unit
+            // type, so answer without the evaluator; enums (union of
+            // enum-literal members), type aliases, and unknown kinds resolve
+            // and re-ask.
+            match resolver.get_def_kind(def_id) {
+                Some(
+                    crate::def::DefKind::Interface
+                    | crate::def::DefKind::Class
+                    | crate::def::DefKind::ClassConstructor
+                    | crate::def::DefKind::Namespace
+                    | crate::def::DefKind::Function
+                    | crate::def::DefKind::Variable,
+                ) => false,
+                _ => recurse_if_progress(evaluate_type_with_resolver(db, resolver, type_id), depth),
+            }
+        }
+        Some(TypeData::Application(_)) => {
+            // A deferred generic alias application (`Cond<T>`): tsc holds the
+            // evaluated type here, so resolve it and re-ask.
+            recurse_if_progress(evaluate_type_with_resolver(db, resolver, type_id), depth)
         }
         _ => is_unit_type(db, type_id),
     }

--- a/crates/tsz-solver/src/type_queries/flow.rs
+++ b/crates/tsz-solver/src/type_queries/flow.rs
@@ -12,7 +12,11 @@ pub(super) use comparability::types_are_comparable_for_assertion_inner;
 pub use comparability::{types_are_comparable, types_are_comparable_for_assertion};
 
 use crate::construction::TypeDatabase;
-use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
+use crate::def::resolver::{NoopResolver, TypeResolver};
+use crate::evaluation::evaluate::evaluate_type_with_resolver;
+use crate::instantiation::instantiate::{
+    TypeSubstitution, instantiate_type, instantiate_type_params_to_constraints_uncached,
+};
 use crate::type_queries::{
     StringLiteralKeyKind, classify_for_string_literal_keys, get_string_literal_value,
     get_union_members, is_invokable_type,
@@ -721,11 +725,28 @@ pub fn is_unit_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
 /// hold a singleton (a literal/union-of-literals target makes the literal vs
 /// literal mismatch meaningful) and widened to its base otherwise.
 pub fn type_could_have_top_level_singleton_types(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    type_could_have_top_level_singleton_types_inner(db, type_id, 0)
+    type_could_have_top_level_singleton_types_inner(db, &NoopResolver, type_id, 0)
 }
 
-fn type_could_have_top_level_singleton_types_inner(
+/// [`type_could_have_top_level_singleton_types`] with a resolver, so deferred
+/// semantic refs answer through their constraints the way tsc's
+/// `getConstraintOfType` does for every `Instantiable` type: an indexed access
+/// `Cfg[K]` or conditional `Cond<T>` target whose constraint contains a unit
+/// type preserves a literal source, while one whose constraint is all
+/// primitives generalizes it. `Lazy`/`Application` refs are resolver-evaluated
+/// first — in tsc they are already evaluated types, so this restores the same
+/// answer surface.
+pub fn type_could_have_top_level_singleton_types_resolved<R: TypeResolver>(
     db: &dyn TypeDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> bool {
+    type_could_have_top_level_singleton_types_inner(db, resolver, type_id, 0)
+}
+
+fn type_could_have_top_level_singleton_types_inner<R: TypeResolver>(
+    db: &dyn TypeDatabase,
+    resolver: &R,
     type_id: TypeId,
     depth: u32,
 ) -> bool {
@@ -739,20 +760,92 @@ fn type_could_have_top_level_singleton_types_inner(
         return false;
     }
     match db.lookup(type_id) {
-        Some(TypeData::Union(list_id) | TypeData::Intersection(list_id)) => db
-            .type_list(list_id)
-            .iter()
-            .any(|&member| type_could_have_top_level_singleton_types_inner(db, member, depth + 1)),
+        Some(TypeData::Union(list_id) | TypeData::Intersection(list_id)) => {
+            db.type_list(list_id).iter().any(|&member| {
+                // tsc stores `boolean` inside a union as its two literal
+                // members (`true | false`), so a union containing `boolean`
+                // has top-level singleton capacity there. tsz may keep the
+                // `boolean` intrinsic as the member; treat it as the
+                // `true | false` pair it denotes rather than re-applying the
+                // top-level `TypeFlags.Boolean` carve-out.
+                member == TypeId::BOOLEAN
+                    || type_could_have_top_level_singleton_types_inner(
+                        db,
+                        resolver,
+                        member,
+                        depth + 1,
+                    )
+            })
+        }
         Some(TypeData::TemplateLiteral(_)) => true,
         // tsc's `Instantiable` branch: a type parameter (or `infer` binder)
         // answers through its constraint when it has one — a target `T extends
         // "a" | "b"` can hold a singleton, `T extends string` cannot.
         Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => match info.constraint {
             Some(constraint) if constraint != type_id => {
-                type_could_have_top_level_singleton_types_inner(db, constraint, depth + 1)
+                type_could_have_top_level_singleton_types_inner(db, resolver, constraint, depth + 1)
             }
             _ => is_unit_type(db, type_id),
         },
+        // Remaining `Instantiable` forms answer through their computed
+        // constraint (tsc `getConstraintOfType`); no progress falls back to
+        // the unit check, i.e. "no singleton capacity".
+        Some(TypeData::Substitution { .. }) => {
+            let constraint = crate::type_queries::get_base_constraint_of_type(db, type_id);
+            constraint != type_id
+                && type_could_have_top_level_singleton_types_inner(
+                    db,
+                    resolver,
+                    constraint,
+                    depth + 1,
+                )
+        }
+        Some(TypeData::IndexAccess(_, _)) => {
+            // Reduce contained type parameters to their constraints, then
+            // evaluate the access (tsc `getConstraintOfIndexedAccess`):
+            // `Cfg[K]` with `K extends keyof Cfg` answers through the union
+            // of `Cfg`'s property types.
+            let substituted = instantiate_type_params_to_constraints_uncached(db, type_id);
+            let constraint = evaluate_type_with_resolver(db, resolver, substituted);
+            constraint != type_id
+                && constraint != TypeId::ERROR
+                && type_could_have_top_level_singleton_types_inner(
+                    db,
+                    resolver,
+                    constraint,
+                    depth + 1,
+                )
+        }
+        Some(TypeData::Conditional(_)) => {
+            // tsc `getDefaultConstraintOfConditionalType`: the union of the
+            // (inferred) true branch and the false branch.
+            match crate::type_queries::get_conditional_default_constraint(db, type_id) {
+                Some(constraint) if constraint != type_id => {
+                    type_could_have_top_level_singleton_types_inner(
+                        db,
+                        resolver,
+                        constraint,
+                        depth + 1,
+                    )
+                }
+                _ => is_unit_type(db, type_id),
+            }
+        }
+        Some(TypeData::Lazy(_) | TypeData::Application(_)) => {
+            // A still-deferred semantic ref (alias/enum/interface reference or
+            // generic alias application). tsc holds the evaluated type here;
+            // resolve it and re-ask. An enum reference evaluates to its union
+            // of enum-literal members, which has singleton capacity.
+            let evaluated = evaluate_type_with_resolver(db, resolver, type_id);
+            evaluated != type_id
+                && evaluated != TypeId::ERROR
+                && type_could_have_top_level_singleton_types_inner(
+                    db,
+                    resolver,
+                    evaluated,
+                    depth + 1,
+                )
+        }
         _ => is_unit_type(db, type_id),
     }
 }
@@ -1136,6 +1229,60 @@ mod tests {
         assert!(type_could_have_top_level_singleton_types(
             &interner,
             mixed_union
+        ));
+    }
+
+    #[test]
+    fn singleton_predicate_boolean_union_member_counts_as_singleton() {
+        let interner = TypeInterner::new();
+        // tsc stores `boolean` in a union as `true | false` (unit members), so
+        // `string | boolean` has singleton capacity even though a bare
+        // `boolean` target does not. Build the member list explicitly so the
+        // interner's union normalization cannot pre-flatten the intrinsic
+        // away and mask the member-level rule.
+        let with_boolean = interner.union(vec![TypeId::STRING, TypeId::BOOLEAN]);
+        assert!(type_could_have_top_level_singleton_types(
+            &interner,
+            with_boolean
+        ));
+        assert!(!type_could_have_top_level_singleton_types(
+            &interner,
+            TypeId::BOOLEAN
+        ));
+    }
+
+    #[test]
+    fn singleton_predicate_conditional_answers_through_default_constraint() {
+        let interner = TypeInterner::new();
+        let check = interner.type_param(crate::types::TypeParamInfo::simple(
+            interner.intern_string("T"),
+        ));
+        // `T extends string ? "a" | "b" : number` — default constraint
+        // contains units -> singleton-capable.
+        let unit_branch = interner.union(vec![
+            interner.literal_string("a"),
+            interner.literal_string("b"),
+        ]);
+        let cond_unit = interner.conditional(crate::types::ConditionalType {
+            check_type: check,
+            extends_type: TypeId::STRING,
+            true_type: unit_branch,
+            false_type: TypeId::NUMBER,
+            is_distributive: true,
+        });
+        assert!(type_could_have_top_level_singleton_types(
+            &interner, cond_unit
+        ));
+        // `T extends string ? string : number` — all-primitive constraint.
+        let cond_prim = interner.conditional(crate::types::ConditionalType {
+            check_type: check,
+            extends_type: TypeId::STRING,
+            true_type: TypeId::STRING,
+            false_type: TypeId::NUMBER,
+            is_distributive: true,
+        });
+        assert!(!type_could_have_top_level_singleton_types(
+            &interner, cond_prim
         ));
     }
 

--- a/crates/tsz-solver/src/type_queries/flow.rs
+++ b/crates/tsz-solver/src/type_queries/flow.rs
@@ -721,6 +721,17 @@ pub fn is_unit_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
 /// hold a singleton (a literal/union-of-literals target makes the literal vs
 /// literal mismatch meaningful) and widened to its base otherwise.
 pub fn type_could_have_top_level_singleton_types(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    type_could_have_top_level_singleton_types_inner(db, type_id, 0)
+}
+
+fn type_could_have_top_level_singleton_types_inner(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    depth: u32,
+) -> bool {
+    if depth > 16 {
+        return false;
+    }
     if type_id == TypeId::BOOLEAN {
         return false;
     }
@@ -728,8 +739,17 @@ pub fn type_could_have_top_level_singleton_types(db: &dyn TypeDatabase, type_id:
         Some(TypeData::Union(list_id) | TypeData::Intersection(list_id)) => db
             .type_list(list_id)
             .iter()
-            .any(|&member| type_could_have_top_level_singleton_types(db, member)),
+            .any(|&member| type_could_have_top_level_singleton_types_inner(db, member, depth + 1)),
         Some(TypeData::TemplateLiteral(_)) => true,
+        // tsc's `Instantiable` branch: a type parameter (or `infer` binder)
+        // answers through its constraint when it has one — a target `T extends
+        // "a" | "b"` can hold a singleton, `T extends string` cannot.
+        Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => match info.constraint {
+            Some(constraint) if constraint != type_id => {
+                type_could_have_top_level_singleton_types_inner(db, constraint, depth + 1)
+            }
+            _ => is_unit_type(db, type_id),
+        },
         _ => is_unit_type(db, type_id),
     }
 }


### PR DESCRIPTION
Closes #15628.

> **Stacked on #15630** (the #15626 fix): this branch contains #15630's three commits until it lands; the last four commits are this PR's own work. I will rebase onto `main` once #15630 merges so the diff shrinks to this PR's changes.

**Structural rule:** when any relation line's failing source is a literal type — a scalar literal, an enum member, or an all-unit union — and the target could not hold a top-level singleton type, tsc displays the source's base (`reportRelationError` → `getBaseTypeOfLiteralType` / `getBaseTypeOfLiteralTypeUnion`: `"x" | "y"` → `string`, `true` → `boolean`, `E.X` → `E`); tsz does the same through the checker's shared `generalize_nested_relation_source_for_display` wrapper backed by the solver's resolver-aware `type_could_have_top_level_singleton_types_resolved` via the `query_boundaries/diagnostics` gateway. Singleton capacity answers through constraints for every instantiable form (tsc `getConstraintOfType`): type-parameter/infer constraints, indexed accesses (`Cfg[K]` via params-to-constraints + evaluation), conditionals (default constraint), substitutions, and resolver-evaluated `Lazy`/`Application` refs; a `boolean` union member counts as the `true | false` unit pair tsc stores.

Per witness gap from #15628 (all verified against `tsc 6.0.2 --noEmit --strict --pretty false`):

1. **Union-of-literals sources** generalize member-wise at nested lines (union header, union-member drill, parent/child and intersection-constituent frames) and at the top level (`"x" | "y"` vs `boolean` renders `string`; `true | 1` vs `string` renders `number | boolean`); literal-union targets preserve.
2. **Enum-member property leaves** stop leaking the bare member name: widen to the parent enum against primitive targets (`EM`), render qualified when preserved (`EM.X`). Root cause was a type-position `E.X` ref stabilized as a `TypeAlias`-kinded def whose name-fallthrough printed `X`; the display paths now identify members through the def-store/env parent edge and the `ENUM_MEMBER` symbol flags. tsc's single-member identity (the lone member's type IS the enum type) renders the bare enum name at every relation surface and in object-property displays (`{ a: E2; }`).
3. **Top-level boolean-literal sources** widen (`true` vs `string` renders `boolean`); boolean-literal targets preserve. The blind spot was the alias-display repaint guard whose literal predicate skipped the intrinsic `true`/`false` `TypeId`s.
4. **The older top-level enum gate** (`should_widen_enum_member_assignment_source`'s target-is-not-enum/union/intersection test) is replaced by the tsc-shaped singleton gate: literal/template-literal/enum-member targets now preserve `EM.X`; primitive and all-primitive-union targets widen. The TS2345 call-argument surface uses the same gate (`Argument of type 'EG' …` vs `boolean`; preserved vs `"z"`).
5. **Deferred instantiable targets** answer through their constraints: `CondU<T>` with a unit-bearing branch preserves `"no"` where `CondP<T>` widens to `string`; `KnobsU[K]` vs `KnobsP[K]` likewise at property leaves; `5` vs `string | boolean` preserves while `5` vs `string | symbol` widens.
6. **Leaf disambiguation fork resolved:** the tsc witness (namespace-qualified same-named classes) shows nested leaves run the same pair display as the top level, so `generalized_leaf_mismatch_message` was deleted, its callers converged on `element_mismatch_message`, and the plain-leaf renderers finalize same-named nominal pairs at depth > 0.

**Owner layers:** solver owns the singleton-capacity predicate, its instantiable-constraint arms, and the deferred-form classifier (`singleton_capacity_needs_constraint`, co-located with the predicate); the printer owns enum-member ref naming (`format_enum_member_ref`); the checker's `error_reporter` consumes both through `query_boundaries/diagnostics` and keeps only the env-backed enum-parent lookups. No rendered-string predicates and no user-name literals drive any decision.

**Adjacent-case matrix** (binder names varied throughout): string/number/boolean/bigint literals and enum members; scalar and all-unit-union sources (same-base, mixed-base, boolean-bearing); numeric and string enums, single- and multi-member enums, deferred `Lazy` member refs and evaluated member data; TS2322 initializer, TS2345 call-argument, tuple positional-chain, property/dotted-chain, array-element, member-return, union-header/member, and intersection-constituent surfaces; preservation gates — literal targets, literal-union targets, template-literal targets, enum/enum-member targets, boolean-literal targets, singleton-constrained type parameters, boolean-in-union targets, unit-bearing indexed-access/conditional constraints.

**Known remaining sub-gaps** (display-only, separate owners): the duplicated identical leaf line tsc emits under a generalized tuple positional chain (tsz emits one); the preserve-case union member drill line tsc emits under a literal-union vs literal-union line; deferred-but-concrete target display (`Cfg["size"]`/`Cond<string>` where tsc shows the evaluated form); tsc's extra `'never'` constraint-instantiation lines under generic-body leaves; nested private-property leaves (the `Types have separate declarations of a private property` elaboration line is missing); union member *selection/order* differences rooted in interner union ordering. Follow-up refactors deliberately not taken here: registration-side fix for member refs stabilized as `TypeAlias` defs; folding the checker's `is_literal_sensitive_assignment_target_inner` (NoInfer/unique-symbol/never arms) wholesale into the solver predicate; unifying the enum naming between printer and checker once the parent-edge lookup is canonicalized.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --test relation_leaf_literal_generalization_tests` — 29 cases (the 15 from #15630 plus 14 new: union-of-literals at nested/top-level with preservation gates, top-level boolean literals both directions, enum property leaves widen/preserve, the tsc-shaped top-level enum gate incl. template-literal/boolean-literal targets, TS2345 argument gate both directions, single-member identity, boolean-in-union targets, deferred conditional/indexed-access constraints both directions), green.
- Solver unit tests: `singleton_predicate_*` (5, incl. new boolean-union-member and conditional-default-constraint cases), green.
- Regression batch green: `tuple_call_argument_elaboration_tests`, `tuple_variadic_position_elaboration_tests`, `tuple_argument_mismatch_elaboration_tests`, `tuple_element_mismatch_tests`, `tuple_arity_elaboration_tests`, `union_source_structural_elaboration_tests`, `array_source_tuple_target_elaboration_tests`, `variadic_tuple_rest_aggregate_display_tests`, `property_chain_elaboration_collapse_tests`, `readonly_tuple_source_display_tests`, `union_tuple_source_display_tests`, `satisfies_elaboration_chain_tests`, `deep_partial_optional_leaf_elaboration_tests`, `enum_nominality_tests`, `overload_literal_source_generalization_tests` (lib), plus a ~60-suite sweep over `display|widen|literal_|assignab|ts2322|ts2345|overload|fingerprint|enum_` test targets — only 2 failures, both reproduced identically on the base commit (`async_return_widening_tests::async_arrow_returning_promise_expression_preserves_inner`, `conditional_application_display_tests::deferred_generic_conditional_keeps_branch_union`; #15338-family local debt).
- Full witness differential (`gap1`–`gap6b` from the issue plus multi-member-enum and call-arg matrices) re-run against `tsc 6.0.2`: every targeted line now byte-matches tsc; remaining deltas are the catalogued sub-gaps above.
- `cargo clippy -p tsz-checker -p tsz-solver` clean (deny-warnings profile).
- Efficiency audit: the resolver-backed predicate and the new evaluation arms are reachable only from `error_reporter` display code; no hot semantic path (relations/narrowing/inference) gains work. Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

https://claude.ai/code/session_01JP4up6cVEe9Rqgo9DnYQ1p

---
_Generated by [Claude Code](https://claude.ai/code/session_01JP4up6cVEe9Rqgo9DnYQ1p)_