### PR TITLE
fix(checker): freshness- and context-gated literal widening for inferred generator yield types (#15631)

### DIFF
--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -200,6 +200,36 @@ pub enum PendingImplicitAnyKind {
     EvolvingArray,
 }
 
+/// One `yield` operand's contribution to an unannotated generator's inferred
+/// yield type.
+///
+/// `tsc` widens the aggregated yield type only when it is a single literal that
+/// is *fresh* (`getWidenedLiteralType` inside
+/// `getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded`). tsz does not
+/// carry freshness on types, so each collection site records whether its
+/// operand expression was a widenable (fresh) literal contribution; the
+/// aggregation site widens the collapsed literal union only when every
+/// contribution agreed.
+#[derive(Clone, Copy, Debug)]
+pub struct GeneratorYieldContribution {
+    /// The yielded value type (element type for `yield*`).
+    pub type_id: TypeId,
+    /// Whether the operand was a fresh literal expression (or fresh enum-member
+    /// access) with no `const`-assertion pinning — i.e. `tsc` would widen it.
+    pub widenable: bool,
+}
+
+impl CheckerContext<'_> {
+    /// Record one `yield` operand's contribution to the enclosing unannotated
+    /// generator's inferred yield type. Pass `widenable: false` for delegated
+    /// (`yield*`) element types — they come from another iterator's declared
+    /// type, never a fresh literal.
+    pub fn push_generator_yield_contribution(&mut self, type_id: TypeId, widenable: bool) {
+        self.generator_yield_operand_types
+            .push(GeneratorYieldContribution { type_id, widenable });
+    }
+}
+
 /// Deferred implicit-any diagnostic state for a variable declaration.
 #[derive(Clone, Copy, Debug)]
 pub struct PendingImplicitAnyVar {
@@ -1523,7 +1553,7 @@ pub struct CheckerContext<'a> {
     pub generator_next_type_stack: Vec<Option<TypeId>>,
     /// Collected yield operand types during body check for unannotated generators.
     /// After body check, the union determines the inferred yield type for TS7055/TS7025 vs TS7057.
-    pub generator_yield_operand_types: Vec<TypeId>,
+    pub generator_yield_operand_types: Vec<GeneratorYieldContribution>,
     /// Whether TS7057 was emitted for any yield in the current generator.
     /// When true, TS7055 is suppressed (tsc emits one or the other, not both).
     pub generator_had_ts7057: bool,

--- a/crates/tsz-checker/src/dispatch/yield_.rs
+++ b/crates/tsz-checker/src/dispatch/yield_.rs
@@ -456,7 +456,9 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     // generator yield type must come from actual body yields, not context
                     // (see function_type.rs comment on final_generator_yield_type).
                     if async_info.is_some() {
-                        self.checker.ctx.generator_yield_operand_types.push(element);
+                        self.checker
+                            .ctx
+                            .push_generator_yield_contribution(element, false);
                         // When yield* delegates to an async iterable with `any` element
                         // type, suppress TS7055 at the function level (see sync path).
                         if element == TypeId::ANY {
@@ -506,8 +508,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                         };
                         self.checker
                             .ctx
-                            .generator_yield_operand_types
-                            .push(effective_yield_type);
+                            .push_generator_yield_contribution(effective_yield_type, false);
                         // When yield* delegates to an iterable with `any` element type
                         // (e.g. `any[]`), suppress TS7055 at the function level.
                         // tsc considers the `any` yield type to be "explained" by
@@ -543,10 +544,12 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     .get(yield_expr.expression)
                     .is_some_and(|n| n.kind == syntax_kind_ext::YIELD_EXPRESSION);
             if !operand_is_yield {
+                let widenable = self
+                    .checker
+                    .yield_contribution_is_widenable(yield_expr.expression, yielded_type);
                 self.checker
                     .ctx
-                    .generator_yield_operand_types
-                    .push(yielded_type);
+                    .push_generator_yield_contribution(yielded_type, widenable);
             }
             // When the yield operand is an explicit type assertion (`<any>expr`
             // or `expr as any`) that produces `any`, the resulting yield type is

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -277,6 +277,9 @@ mod generator_union_return_type_tests;
 #[path = "tests/generator_yield_identity_tests.rs"]
 mod generator_yield_identity_tests;
 #[cfg(test)]
+#[path = "tests/generator_yield_literal_widening_tests.rs"]
+mod generator_yield_literal_widening_tests;
+#[cfg(test)]
 #[path = "tests/generic_call_non_fresh_object_widening_tests.rs"]
 mod generic_call_non_fresh_object_widening_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -1123,13 +1123,10 @@ impl<'a> CheckerState<'a> {
         func_idx: NodeIndex,
         func: &tsz_parser::parser::node::FunctionData,
     ) {
-        let yield_types = std::mem::take(&mut self.ctx.generator_yield_operand_types);
-
-        let inferred_yield = if yield_types.is_empty() {
-            TypeId::NEVER // No yields -> never
-        } else {
-            self.ctx.types.factory().union(yield_types)
-        };
+        // Literal widening is irrelevant here — only the `any` outcome matters
+        // for TS7055, and literal→base widening never produces `any`. The real
+        // widening policy lives in `check_generator_body_return`.
+        let (_, inferred_yield) = self.take_generator_yield_union();
 
         let widened = self.widen_literal_type(inferred_yield);
         // When strictNullChecks is off, tsc widens null/undefined yield types

--- a/crates/tsz-checker/src/tests/generator_yield_literal_widening_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_yield_literal_widening_tests.rs
@@ -1,0 +1,297 @@
+//! Regression tests for freshness- and context-gated literal widening of an
+//! unannotated generator's inferred yield type.
+//!
+//! `tsc` widens the aggregated yield type only when it collapses to a single
+//! *fresh* literal that the contextual yield type does not pin
+//! (`getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded`):
+//! - `function* () { yield 1; }` infers `Generator<number, ...>`;
+//! - `yield 1 as const` and references to annotated bindings stay literal;
+//! - `yield 1; yield 2` keeps the `1 | 2` literal union;
+//! - a contextual `Generator<1 | 2, ...>` pins `yield 1` to `1`;
+//! - a non-literal contextual yield type (e.g. `T | undefined` from a generic
+//!   callback signature) still widens — generatorTypeCheck63;
+//! - a fresh enum-member access widens to its parent enum.
+//!
+//! `yield*` delegation still collapses the inferred yield type to `any`
+//! (declarations bail in `infer_generator_declaration_yield_type`; expressions
+//! lose the generator shape entirely); that family is tracked separately.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_diagnostics(source: &str) -> Vec<(u32, String)> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| (diagnostic.code, diagnostic.message_text))
+    .collect()
+}
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    strict_diagnostics(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+#[test]
+fn bare_literal_yield_widens_to_base_type() {
+    // `Generator<number, ...>` is not assignable to `Generator<1, ...>`, so the
+    // TS2345 proves the fresh literal was widened.
+    let codes = strict_codes(
+        r#"
+export {};
+declare function wantsOne(producer: Generator<1, void, unknown>): void;
+function* counts() { yield 1; }
+wantsOne(counts());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "fresh `yield 1` must widen to number, rejecting Generator<1, ...>; got: {codes:?}"
+    );
+}
+
+#[test]
+fn const_asserted_yield_keeps_literal() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare function wantsOne(producer: Generator<1, void, unknown>): void;
+function* pinned() { yield 1 as const; }
+wantsOne(pinned());
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "`yield 1 as const` must keep the literal 1; got: {codes:?}"
+    );
+}
+
+#[test]
+fn annotated_const_reference_yield_keeps_literal() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare function wantsTag(producer: Generator<"start", void, unknown>): void;
+const marker: "start" = "start";
+function* labels() { yield marker; }
+wantsTag(labels());
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "a reference to an annotated literal binding is non-fresh and must not widen; got: {codes:?}"
+    );
+}
+
+#[test]
+fn unannotated_const_reference_yield_widens() {
+    // `const flag = 1` is a widening literal binding in tsc; copying it through
+    // `yield` still widens.
+    let codes = strict_codes(
+        r#"
+export {};
+declare function wantsOne(producer: Generator<1, void, unknown>): void;
+const flag = 1;
+function* flags() { yield flag; }
+wantsOne(flags());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "fresh-by-reference const must widen like a bare literal; got: {codes:?}"
+    );
+}
+
+#[test]
+fn multi_literal_yields_keep_literal_union() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare function wantsDigits(producer: Generator<1 | 2, void, unknown>): void;
+function* digits() { yield 1; yield 2; }
+wantsDigits(digits());
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "`yield 1; yield 2` must keep the 1 | 2 literal union; got: {codes:?}"
+    );
+}
+
+#[test]
+fn mixed_fresh_and_const_asserted_same_literal_keeps_literal() {
+    // One contribution is pinned by `as const`, so the collapsed literal must
+    // not widen even though the other contribution is fresh (tsc keeps `1`).
+    let codes = strict_codes(
+        r#"
+export {};
+declare function wantsOne(producer: Generator<1, void, unknown>): void;
+function* ones() { yield 1; yield 1 as const; }
+wantsOne(ones());
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "a const-asserted contribution must pin the collapsed literal; got: {codes:?}"
+    );
+}
+
+#[test]
+fn contextual_literal_yield_type_pins_literal() {
+    // The contextual `Generator<1 | 2, ...>` admits the literal, so `yield 1`
+    // stays `1` and the assignment is clean.
+    let codes = strict_codes(
+        r#"
+export {};
+const steps: () => Generator<1 | 2, void, unknown> = function* () { yield 1; };
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "a literal contextual yield type must pin the fresh literal; got: {codes:?}"
+    );
+}
+
+#[test]
+fn non_literal_contextual_yield_type_still_widens() {
+    // generatorTypeCheck63 witness: the contextual yield type
+    // `Cargo | undefined` is not literal-like, so the fresh `yield 1` widens and
+    // the whole-argument TS2345 renders `Generator<number, Cargo, any>`.
+    let diagnostics = strict_diagnostics(
+        r#"
+export {};
+interface Cargo { weight: number; }
+declare function pipeline<T extends Cargo>(
+    step: (a: T) => IterableIterator<T | undefined, void>,
+): (a: T) => IterableIterator<T | undefined, void>;
+const move: (a: Cargo) => IterableIterator<Cargo | undefined, void> =
+    pipeline(function* (state: Cargo) {
+        yield 1;
+        return state;
+    });
+"#,
+    );
+    let ts2345 = diagnostics
+        .iter()
+        .find(|(code, _)| *code == 2345)
+        .map(|(_, message)| message.clone())
+        .unwrap_or_default();
+    assert!(
+        ts2345.contains("Generator<number, Cargo, any>"),
+        "fresh literal must widen under a non-literal contextual yield type; got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn enum_member_yield_widens_to_parent_enum() {
+    // If the fresh enum-member access widened correctly, the inferred yield
+    // type is the parent enum, which is not assignable to the single member.
+    let codes = strict_codes(
+        r#"
+export {};
+enum Phase { Start, End }
+declare function wantsStart(producer: Generator<Phase.Start, void, unknown>): void;
+function* phases() { yield Phase.Start; }
+wantsStart(phases());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "a fresh enum-member yield must widen to the parent enum; got: {codes:?}"
+    );
+}
+
+#[test]
+fn enum_member_yield_assignable_to_parent_enum() {
+    let codes = strict_codes(
+        r#"
+export {};
+enum Phase { Start, End }
+declare function wantsPhase(producer: Generator<Phase, void, unknown>): void;
+function* phases() { yield Phase.Start; }
+wantsPhase(phases());
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "the widened enum yield type must remain assignable to the parent enum; got: {codes:?}"
+    );
+}
+
+#[test]
+fn async_generator_const_asserted_yield_keeps_literal() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare function wantsOne(producer: AsyncGenerator<1, void, unknown>): void;
+async function* pinned() { yield 1 as const; }
+wantsOne(pinned());
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "async generator `yield 1 as const` must keep the literal; got: {codes:?}"
+    );
+}
+
+#[test]
+fn conditional_with_identical_literal_branches_widens() {
+    // tsc 6.0.3: `yield flip ? 1 : 1` collapses to the single fresh literal 1
+    // and widens to number (unlike the return path's conditional carve-out).
+    let codes = strict_codes(
+        r#"
+export {};
+declare const flip: boolean;
+declare function wantsOne(producer: Generator<1, void, unknown>): void;
+function* coins() { yield flip ? 1 : 1; }
+wantsOne(coins());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "identical-branch conditional yield must widen to number; got: {codes:?}"
+    );
+}
+
+#[test]
+fn conditional_with_distinct_literal_branches_keeps_union() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const flip: boolean;
+declare function wantsDigits(producer: Generator<1 | 2, void, unknown>): void;
+function* coins() { yield flip ? 1 : 2; }
+wantsDigits(coins());
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "distinct-branch conditional yield must keep the 1 | 2 union; got: {codes:?}"
+    );
+}
+
+#[test]
+fn boolean_literal_yield_widens_to_boolean() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare function wantsTrue(producer: Generator<true, void, unknown>): void;
+function* toggles() { yield true; }
+wantsTrue(toggles());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "fresh `yield true` must widen to boolean; got: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -272,6 +272,24 @@ impl<'a> CheckerState<'a> {
         (None, None, None, false)
     }
 
+    /// Drain the collected `yield` contributions of the just-checked generator
+    /// body and collapse them to the unwidened inferred yield type (`never`
+    /// when the body has no yields). Shared by the yield-type aggregation here
+    /// and the TS7055 implicit-any check in `function_declaration_checks.rs` so
+    /// the two sites cannot drift on how contributions collapse.
+    pub(crate) fn take_generator_yield_union(
+        &mut self,
+    ) -> (Vec<crate::context::GeneratorYieldContribution>, TypeId) {
+        let contributions = std::mem::take(&mut self.ctx.generator_yield_operand_types);
+        let inferred = if contributions.is_empty() {
+            TypeId::NEVER
+        } else {
+            let types: Vec<TypeId> = contributions.iter().map(|c| c.type_id).collect();
+            self.ctx.types.factory().union(types)
+        };
+        (contributions, inferred)
+    }
+
     pub(crate) fn check_generator_body_return(
         &mut self,
         ctx: GeneratorBodyReturnCheckCtx<'_>,
@@ -297,25 +315,37 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let yield_types = std::mem::take(&mut self.ctx.generator_yield_operand_types);
-        let inferred_yield = if yield_types.is_empty() {
-            TypeId::NEVER
+        let (yield_contributions, inferred_yield) = self.take_generator_yield_union();
+        // tsc's `getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded` +
+        // `getWidenedType(getUnionType(...))`: widen only a union collapsed to a
+        // single *fresh* literal (or enum member) that the contextual yield
+        // type does not itself admit. A non-literal contextual yield type does
+        // NOT suppress widening — with a `(a: T) => IterableIterator<T |
+        // undefined, void>` contextual signature, `yield 1` still widens to
+        // `number` (generatorTypeCheck63). Per-contribution freshness policy
+        // lives in `yield_contribution_is_widenable`. The blanket
+        // `widen_literal_type` is safe here (unlike the return path, which
+        // needs `widen_return_contribution_preserving_const`): only unit
+        // literals reach the widener, never object-literal shapes with
+        // per-property `as const`.
+        let is_widenable_literal =
+            crate::query_boundaries::common::is_literal_type(self.ctx.types, inferred_yield)
+                || self.is_enum_member_type_for_widening(inferred_yield);
+        // Term order matters: `is_widenable_literal` is the cheap, selective
+        // gate (an empty contribution set collapses to `never` and fails it);
+        // the contribution scan runs only for a collapsed unit literal; and the
+        // contextual gate runs last because it resolves lazy types in the
+        // environment — evaluating it for every generator perturbs in-flight
+        // inference state on speculative re-checks.
+        let widened = if is_widenable_literal
+            && yield_contributions.iter().all(|c| c.widenable)
+            && !ctx.early_yield_type.is_some_and(|ctx_yield| {
+                self.contextual_type_allows_literal(ctx_yield, inferred_yield)
+            }) {
+            let widened_literal = self.widen_literal_type(inferred_yield);
+            self.widen_enum_member_type(widened_literal)
         } else {
-            self.ctx.types.factory().union(yield_types)
-        };
-        // tsc computes the inferred yield type as `getWidenedType(getUnionType(...))`:
-        // a single literal is widened (`yield 1` -> `number`), but a multi-member
-        // literal union is preserved (`yield 1; yield 2` -> `1 | 2`) because a union
-        // is not itself a widenable literal. Mirror that by widening only when the
-        // reduced union is a single literal type — the same gate the regular
-        // return-type inference uses in `return_type.rs`. (The yield operands reach
-        // here unwidened for bare literals, so the union keeps its members.)
-        let widened = if ctx.early_yield_type.is_some()
-            || !crate::query_boundaries::common::is_literal_type(self.ctx.types, inferred_yield)
-        {
             inferred_yield
-        } else {
-            self.widen_literal_type(inferred_yield)
         };
         let final_yield = if !self.ctx.strict_null_checks()
             && crate::query_boundaries::common::is_only_null_or_undefined(self.ctx.types, widened)

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -534,6 +534,33 @@ impl<'a> CheckerState<'a> {
         type_id
     }
 
+    /// Whether a single `yield` operand contribution would be widened by the
+    /// generator yield-type aggregation in `check_generator_body_return` — the
+    /// yield-path sibling of [`Self::return_contribution_is_widenable`].
+    ///
+    /// Deliberate differences from the return predicate: the contextual gate is
+    /// applied at the aggregation site against the contextual *yield* type
+    /// (`contextual_type_allows_literal`, tsc `isLiteralOfContextualType`), not
+    /// per contribution; and there is no conditional-expression carve-out —
+    /// tsc widens `yield cond ? 1 : 1` to `number` (the branches collapse to a
+    /// single fresh literal), which `is_fresh_literal_expression`'s
+    /// either-branch-fresh rule reproduces. The cheap type-shape check runs
+    /// first so the AST freshness walk is skipped for the common non-literal
+    /// operand.
+    pub(crate) fn yield_contribution_is_widenable(
+        &mut self,
+        expr_idx: NodeIndex,
+        type_id: TypeId,
+    ) -> bool {
+        if expr_idx.is_none() || self.ctx.preserve_literal_types {
+            return false;
+        }
+        if crate::query_boundaries::common::is_literal_type(self.ctx.types, type_id) {
+            return self.is_fresh_literal_expression(expr_idx);
+        }
+        self.is_enum_member_type_for_widening(type_id)
+    }
+
     /// Whether a single return-expression contribution would be widened by
     /// `maybe_widen_return_contribution` — i.e. it is a fresh literal expression
     /// with none of the per-expression carve-outs (contextual return type,

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -198,8 +198,23 @@
 # both relative and package JSDoc import-types resolve like tsc. Covered by
 # jsdoc_import_type_specifier_collection_tests.
 
+# generatorTypeCheck63.ts: RESOLVED. The first TS2345 rendered the argument as
+# `(state: State) => Generator<1, State, any>` where tsc widens the yielded
+# fresh literal to `Generator<number, State, any>`. Root cause: the
+# unannotated-generator yield-type gate suppressed literal widening whenever
+# ANY contextual yield type existed and widened freshness-blind. It now mirrors
+# tsc's getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded: each yield
+# contribution records AST-derived freshness at the collection site, and the
+# aggregation widens a collapsed literal union only when every contribution is
+# fresh and the contextual yield type does not itself admit the literal
+# (contextual_type_allows_literal). `yield 1 as const`, annotated-binding
+# references, and multi-literal unions stay literal; fresh enum-member yields
+# widen to the parent enum. Covered by generator_yield_literal_widening_tests
+# (12 cases) and verified 1/1 by the conformance runner against the pinned
+# 6.0.3 cache. See #15631; the sibling yield*-delegation inference gap is
+# tracked in #15632.
+
 # PR #15375 run 28571773361 at b675fbc17d recovered the core PR CI aggregate
 # and found these exact current-main rows still failing. Keep them listed as
 # path-based runway so the aggregate rejects any new unlisted conformance drift.
 TypeScript/tests/cases/compiler/recursiveConditionalTypes.ts
-TypeScript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts


### PR DESCRIPTION
Fixes #15631. Pays down the `generatorTypeCheck63.ts` row of
`scripts/conformance/conformance-accepted-regressions.txt`, leaving
`recursiveConditionalTypes.ts` as the single live entry.

**Structural rule:** when inferring an unannotated generator's yield type from
its body, tsc unions the `yield` operand types and widens only a union
collapsed to a single *fresh* literal (or fresh enum-member access) that the
contextual yield type does not itself admit
(`getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded` +
`getWidenedType(getUnionType(...))`); tsz does X through the checker's
return-type-from-body machinery — per-contribution AST-derived freshness is
recorded at the collection site (`dispatch/yield_.rs`,
`yield_contribution_is_widenable` — the yield sibling of
`return_contribution_is_widenable` in `return_type.rs`), and the aggregation
gate in `check_generator_body_return` applies the contextual pin through
`contextual_type_allows_literal` (tsc `isLiteralOfContextualType`).

Previously the gate (a) suppressed widening whenever *any* contextual yield
type existed — so with generatorTypeCheck63's
`(a: T) => IterableIterator<T | undefined, void>` contextual signature,
`yield 1` stayed `1` and the whole-argument TS2345 rendered
`Generator<1, State, any>` where tsc renders `Generator<number, State, any>` —
and (b) widened freshness-blind, so `yield 1 as const` and annotated-binding
references over-widened while `yield E.A` never reached its parent enum.

Adjacent-case matrix (verified against tsc 6.0.3 via declaration-emit A/B):

| Case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `yield 1` (no context) | `number` | `number` | `number` |
| `yield 1 as const` | `1` | `number` | `1` |
| `yield "a" as const` | `"a"` | `string` | `"a"` |
| `const c: 1 = 1; yield c` | `1` | `number` | `1` |
| `declare const d: 1; yield d` | `1` | `number` | `1` |
| `const f = 1; yield f` (fresh-by-ref) | `number` | `number` | `number` |
| `yield 1; yield 2` | `1 \| 2` | `1 \| 2` | `1 \| 2` |
| `yield 1; yield 1 as const` | `1` | `number` | `1` |
| `yield E.A` | `E` | `E.A` | `E` |
| `yield flip ? 1 : 1` | `number` | `number` | `number` |
| `yield flip ? 1 : 2` | `1 \| 2` | `1 \| 2` | `1 \| 2` |
| async `yield 1 as const` | `1` | `number` | `1` |
| contextual `Generator<1 \| 2>` | `1` | `1` | `1` |
| contextual `IterableIterator<T \| undefined, void>` (gen63) | `number` | `1` | `number` |

Negative/fallback behavior unchanged: non-literal unions, object/array
operands, bare `yield;` (non-strict `undefined` → `any`), and the
TS7055/TS7057 interplay; both aggregation sites now share
`take_generator_yield_union` so the TS7055 path cannot drift. `yield*`
contributions are never fresh; the sibling `yield*`-delegation inference gap
(collapses to `any`) is a distinct owner tracked in #15632 — removing the
declaration bail alone was tested and does not fix it.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --lib -E 'test(generator_yield_literal_widening)'` — 14/14 new tests (renamed binders, positive + negative directions per case).
- `cargo nextest run -p tsz-checker --lib` A/B vs pristine HEAD (stash/pop): identical pre-existing failure set, no new failures.
- Conformance runner against the pinned tsc 6.0.3 cache: `--filter generatorTypeCheck63` → PASS 1/1; full `conformance/es6/yieldExpressions` + `conformance/generators` corpus families → 114/114.
- Declaration-emit differential (matrix above) byte-identical to tsc 6.0.3 modulo two pre-existing, separately-tracked families (DTS retention of non-exported `declare enum`; union display order).
- `cargo fmt` / `cargo clippy -p tsz-checker --lib` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01KiFpkeyuBttQS41S8jiFr1)_