### PR TITLE
fix(checker): freshness-gate enum-member widening and target the enum instance type (#15445, #15444)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1306,6 +1306,9 @@ path = "tests/enum_member_cache_tests.rs"
 name = "enum_merge_tests"
 path = "tests/enum_merge_tests.rs"
 [[test]]
+name = "enum_member_widening_freshness_tests"
+path = "tests/enum_member_widening_freshness_tests.rs"
+[[test]]
 name = "const_enum_merge_ts2567_tests"
 path = "tests/const_enum_merge_ts2567_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -678,12 +678,10 @@ impl<'a> CheckerState<'a> {
                         if !self.is_const_variable_declaration(resolved_value_decl)
                             && !self.is_const_assertion_initializer(var_decl.initializer)
                         {
-                            let widened_type =
-                                if self.is_fresh_literal_expression(var_decl.initializer) {
-                                    self.widen_initializer_type_for_mutable_binding(inferred_type)
-                                } else {
-                                    inferred_type
-                                };
+                            let widened_type = self.widen_mutable_binding_observation(
+                                var_decl.initializer,
+                                inferred_type,
+                            );
                             // Route null/undefined widening through the flow observation boundary.
                             let final_type = flow_boundary::widen_null_undefined_to_any(
                                 self.ctx.types,

--- a/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
@@ -56,8 +56,8 @@ impl<'a> CheckerState<'a> {
         let Some(symbol) = self.checker_symbol(sym_id) else {
             return type_id;
         };
-        if symbol.flags & tsz_binder::symbol_flags::ENUM == 0
-            || (symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER) != 0
+        if !symbol.has_any_flags(tsz_binder::symbol_flags::ENUM)
+            || symbol.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER)
         {
             return type_id;
         }

--- a/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
@@ -32,6 +32,53 @@ impl<'a> CheckerState<'a> {
         })
     }
 
+    /// Enum-namespace conversion gated on the queried *entity symbol*.
+    ///
+    /// A value reference denotes the static enum object (`typeof E`) only when
+    /// the referenced entity (after alias resolution) *is* the enum symbol. A
+    /// variable whose type merely is the enum instance type keeps it:
+    /// `let stage = Phase.Init; typeof stage` is `Phase`, not `typeof Phase`.
+    /// The type-based [`Self::get_enum_namespace_type_for_value`] cannot make
+    /// that distinction — both entities observe the same instance `TypeId`.
+    pub(crate) fn enum_namespace_type_for_value_symbol(
+        &mut self,
+        queried_sym: tsz_binder::SymbolId,
+        type_id: TypeId,
+    ) -> TypeId {
+        use crate::symbols_domain::alias_cycle::AliasCycleTracker;
+        let mut sym_id = queried_sym;
+        if let Some(symbol) = self.checker_symbol(sym_id)
+            && symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
+            && let Some(resolved) = self.resolve_alias_symbol(sym_id, &mut AliasCycleTracker::new())
+        {
+            sym_id = resolved;
+        }
+        let Some(symbol) = self.checker_symbol(sym_id) else {
+            return type_id;
+        };
+        if symbol.flags & tsz_binder::symbol_flags::ENUM == 0
+            || (symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER) != 0
+        {
+            return type_id;
+        }
+        self.get_enum_namespace_type_for_value(type_id)
+    }
+
+    /// [`Self::enum_namespace_type_for_value_symbol`] keyed by a `typeof`
+    /// query's entity name; falls back to the type-based conversion when the
+    /// entity does not resolve to a symbol (e.g. global-like chains resolved
+    /// purely through property access).
+    fn enum_namespace_type_for_type_query_entity(
+        &mut self,
+        expr_name: NodeIndex,
+        type_id: TypeId,
+    ) -> TypeId {
+        match self.resolve_qualified_symbol(expr_name) {
+            Some(sym_id) => self.enum_namespace_type_for_value_symbol(sym_id, type_id),
+            None => self.get_enum_namespace_type_for_value(type_id),
+        }
+    }
+
     /// Build the deferred `typeof` representation of a value entity name as a
     /// chain of indexed accesses over a base `TypeQuery`.
     ///
@@ -289,7 +336,8 @@ impl<'a> CheckerState<'a> {
                                 "type_query qualified: resolved merged ns+interface via binder"
                             );
                             if member_type != TypeId::ERROR {
-                                return self.get_enum_namespace_type_for_value(member_type);
+                                return self
+                                    .enum_namespace_type_for_value_symbol(sym_id, member_type);
                             }
                         }
                     }
@@ -333,7 +381,10 @@ impl<'a> CheckerState<'a> {
                                 left_idx, &prop_name, right_idx,
                             )
                         {
-                            let resolved = self.get_enum_namespace_type_for_value(global_like_type);
+                            let resolved = self.enum_namespace_type_for_type_query_entity(
+                                type_query.expr_name,
+                                global_like_type,
+                            );
                             return if use_flow_sensitive_query {
                                 self.apply_flow_narrowing(type_query.expr_name, resolved)
                             } else {
@@ -380,8 +431,10 @@ impl<'a> CheckerState<'a> {
                                     // property result so that `typeof k.foo` where
                                     // `foo: typeof I` yields the resolved value type.
                                     let property_type = self.resolve_type_query_type(type_id);
-                                    let resolved =
-                                        self.get_enum_namespace_type_for_value(property_type);
+                                    let resolved = self.enum_namespace_type_for_type_query_entity(
+                                        type_query.expr_name,
+                                        property_type,
+                                    );
                                     let resolved = self.apply_type_query_instantiation_arguments(
                                         resolved,
                                         &type_argument_nodes,
@@ -421,7 +474,8 @@ impl<'a> CheckerState<'a> {
                         let member_type = self.get_type_of_symbol(sym_id);
                         trace!(sym_id = ?sym_id, member_type = ?member_type, "type_query qualified: resolved via binder exports");
                         if member_type != TypeId::ERROR {
-                            let member_type = self.get_enum_namespace_type_for_value(member_type);
+                            let member_type =
+                                self.enum_namespace_type_for_value_symbol(sym_id, member_type);
                             return self.apply_type_query_instantiation_arguments(
                                 member_type,
                                 &type_argument_nodes,
@@ -480,7 +534,10 @@ impl<'a> CheckerState<'a> {
                     let expr_type = query_expr_type(self, use_flow_sensitive_query);
                     let is_lazy = lazy_def_id(self.ctx.types, expr_type).is_some();
                     if expr_type != TypeId::ANY && expr_type != TypeId::ERROR && !is_lazy {
-                        let expr_type = self.get_enum_namespace_type_for_value(expr_type);
+                        let expr_type = self.enum_namespace_type_for_type_query_entity(
+                            type_query.expr_name,
+                            expr_type,
+                        );
                         return self.apply_type_query_instantiation_arguments(
                             expr_type,
                             &type_argument_nodes,
@@ -518,7 +575,10 @@ impl<'a> CheckerState<'a> {
                     && let Some(declared_type) =
                         self.declared_value_type_for_type_query_symbol(tsz_binder::SymbolId(sym_id))
                 {
-                    return self.get_enum_namespace_type_for_value(declared_type);
+                    return self.enum_namespace_type_for_value_symbol(
+                        tsz_binder::SymbolId(sym_id),
+                        declared_type,
+                    );
                 }
                 if use_flow_sensitive_query {
                     let flow_resolved = query_expr_type(self, true);
@@ -528,7 +588,10 @@ impl<'a> CheckerState<'a> {
                         && !flow_is_lazy
                         && !is_self_referential
                     {
-                        let flow_resolved = self.get_enum_namespace_type_for_value(flow_resolved);
+                        let flow_resolved = self.enum_namespace_type_for_value_symbol(
+                            tsz_binder::SymbolId(sym_id),
+                            flow_resolved,
+                        );
                         trace!(flow_resolved = ?flow_resolved, "=> returning flow-resolved type directly");
                         return flow_resolved;
                     }
@@ -539,7 +602,10 @@ impl<'a> CheckerState<'a> {
                     && !resolved_is_lazy
                     && !is_self_referential
                 {
-                    let resolved = self.get_enum_namespace_type_for_value(resolved);
+                    let resolved = self.enum_namespace_type_for_value_symbol(
+                        tsz_binder::SymbolId(sym_id),
+                        resolved,
+                    );
                     // Fall back to symbol type when flow result is unavailable.
                     trace!("=> returning symbol-resolved type directly");
                     return resolved;

--- a/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
@@ -65,15 +65,15 @@ impl<'a> CheckerState<'a> {
     }
 
     /// [`Self::enum_namespace_type_for_value_symbol`] keyed by a `typeof`
-    /// query's entity name; falls back to the type-based conversion when the
-    /// entity does not resolve to a symbol (e.g. global-like chains resolved
-    /// purely through property access).
-    fn enum_namespace_type_for_type_query_entity(
+    /// query's pre-resolved entity symbol; falls back to the type-based
+    /// conversion when the entity did not resolve to a symbol (e.g.
+    /// global-like chains resolved purely through property access).
+    fn enum_namespace_type_for_resolved_entity(
         &mut self,
-        expr_name: NodeIndex,
+        entity_sym: Option<tsz_binder::SymbolId>,
         type_id: TypeId,
     ) -> TypeId {
-        match self.resolve_qualified_symbol(expr_name) {
+        match entity_sym {
             Some(sym_id) => self.enum_namespace_type_for_value_symbol(sym_id, type_id),
             None => self.get_enum_namespace_type_for_value(type_id),
         }
@@ -313,6 +313,11 @@ impl<'a> CheckerState<'a> {
                     // whose deferral does not depend on member-materialization order.
                     let mut deferred_value_member_access: Option<TypeId> = None;
 
+                    // Resolve the qualified entity once; the merged-ns probe, the
+                    // enum-namespace gates below, and the binder-exports fallback
+                    // all key off the same resolution.
+                    let qualified_sym = self.resolve_qualified_symbol(type_query.expr_name);
+
                     // For merged namespace+interface symbols (e.g., `typeof M2.Point`
                     // where Point is both a namespace and an interface), resolve via
                     // the binder's export tables FIRST. Property access on the parent
@@ -320,7 +325,7 @@ impl<'a> CheckerState<'a> {
                     // path which can return the interface type instead of the namespace
                     // value type. Direct symbol resolution via get_type_of_symbol returns
                     // the correct value-position type.
-                    if let Some(sym_id) = self.resolve_qualified_symbol(type_query.expr_name) {
+                    if let Some(sym_id) = qualified_sym {
                         let sym_flags = self.ctx.binder.get_symbol(sym_id).map_or(0, |s| s.flags);
                         let is_merged_ns_interface = (sym_flags
                             & (tsz_binder::symbol_flags::NAMESPACE_MODULE
@@ -381,8 +386,8 @@ impl<'a> CheckerState<'a> {
                                 left_idx, &prop_name, right_idx,
                             )
                         {
-                            let resolved = self.enum_namespace_type_for_type_query_entity(
-                                type_query.expr_name,
+                            let resolved = self.enum_namespace_type_for_resolved_entity(
+                                qualified_sym,
                                 global_like_type,
                             );
                             return if use_flow_sensitive_query {
@@ -431,8 +436,8 @@ impl<'a> CheckerState<'a> {
                                     // property result so that `typeof k.foo` where
                                     // `foo: typeof I` yields the resolved value type.
                                     let property_type = self.resolve_type_query_type(type_id);
-                                    let resolved = self.enum_namespace_type_for_type_query_entity(
-                                        type_query.expr_name,
+                                    let resolved = self.enum_namespace_type_for_resolved_entity(
+                                        qualified_sym,
                                         property_type,
                                     );
                                     let resolved = self.apply_type_query_instantiation_arguments(
@@ -470,7 +475,7 @@ impl<'a> CheckerState<'a> {
                         }
                     }
                     // Fall back: resolve via binder symbol exports for namespace members
-                    if let Some(sym_id) = self.resolve_qualified_symbol(type_query.expr_name) {
+                    if let Some(sym_id) = qualified_sym {
                         let member_type = self.get_type_of_symbol(sym_id);
                         trace!(sym_id = ?sym_id, member_type = ?member_type, "type_query qualified: resolved via binder exports");
                         if member_type != TypeId::ERROR {
@@ -534,10 +539,9 @@ impl<'a> CheckerState<'a> {
                     let expr_type = query_expr_type(self, use_flow_sensitive_query);
                     let is_lazy = lazy_def_id(self.ctx.types, expr_type).is_some();
                     if expr_type != TypeId::ANY && expr_type != TypeId::ERROR && !is_lazy {
-                        let expr_type = self.enum_namespace_type_for_type_query_entity(
-                            type_query.expr_name,
-                            expr_type,
-                        );
+                        let entity_sym = self.resolve_qualified_symbol(type_query.expr_name);
+                        let expr_type =
+                            self.enum_namespace_type_for_resolved_entity(entity_sym, expr_type);
                         return self.apply_type_query_instantiation_arguments(
                             expr_type,
                             &type_argument_nodes,

--- a/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
+++ b/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
@@ -938,15 +938,11 @@ impl<'a> CheckerState<'a> {
                 return (init_type, jsdoc_declared_type);
             }
             // Only widen when the initializer is a "fresh" literal expression
-            // (direct literal in source code). Types from variable references,
-            // narrowing, or computed expressions are "non-fresh" and NOT widened.
-            // EXCEPTION: Enum member types are always widened for mutable bindings.
-            let is_enum_member = self.is_enum_member_type_for_widening(init_type);
-            let widened = if is_enum_member || self.is_fresh_literal_expression(facts.initializer) {
-                self.widen_initializer_type_for_mutable_binding(init_type)
-            } else {
-                init_type
-            };
+            // (direct literal or enum-member access in source code). Types
+            // from variable references, narrowing, or computed expressions
+            // are "non-fresh" and NOT widened — including annotated consts
+            // holding an enum-member type.
+            let widened = self.widen_mutable_binding_observation(facts.initializer, init_type);
             // Route null/undefined widening through the flow observation boundary.
             let final_type = flow_boundary::widen_null_undefined_to_any(
                 self.ctx.types,

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -1003,11 +1003,8 @@ impl<'a> CheckerState<'a> {
             // expressions are "non-fresh" and should NOT be widened.
             // For const bindings, preserve literal types (unless in array/object context)
             if !self.is_const_variable_declaration(idx) {
-                let widened = if self.is_fresh_literal_expression(var_decl.initializer) {
-                    self.widen_initializer_type_for_mutable_binding(init_type)
-                } else {
-                    init_type
-                };
+                let widened =
+                    self.widen_mutable_binding_observation(var_decl.initializer, init_type);
                 // Route null/undefined widening through the flow observation boundary.
                 return flow_boundary::widen_null_undefined_to_any(
                     self.ctx.types,

--- a/crates/tsz-checker/src/types/computation/identifier/resolved.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/resolved.rs
@@ -1395,8 +1395,9 @@ impl CheckerState<'_> {
                 // above applies. This matters across re-export hops
                 // (`export { E } from "..."`), where the local symbol is an
                 // alias rather than the enum itself. No-op for aliases that
-                // resolve to non-enum targets.
-                self.get_enum_namespace_type_for_value(base)
+                // resolve to non-enum targets — including imported *variables*
+                // whose type is the enum instance type, which must keep it.
+                self.enum_namespace_type_for_value_symbol(sym_id, base)
             } else {
                 base
             }

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -860,13 +860,10 @@ impl<'a> CheckerState<'a> {
                                 }
                             }
                         }
-                        // Only widen when the initializer is a "fresh" literal expression
-                        let is_enum_member = self.is_enum_member_type_for_widening(init_type);
-                        if is_enum_member || self.is_fresh_literal_expression(param.initializer) {
-                            self.widen_initializer_type_for_mutable_binding(init_type)
-                        } else {
-                            init_type
-                        }
+                        // Only widen when the initializer is a "fresh" literal
+                        // or enum-member expression; non-fresh sources keep
+                        // their literal/member type.
+                        self.widen_mutable_binding_observation(param.initializer, init_type)
                     } else {
                         inferred_type
                     };

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -330,7 +330,7 @@ impl<'a> CheckerState<'a> {
         // per-property `as const`.
         let is_widenable_literal =
             crate::query_boundaries::common::is_literal_type(self.ctx.types, inferred_yield)
-                || self.is_enum_member_type_for_widening(inferred_yield);
+                || self.is_enum_member_like_type(inferred_yield);
         // Term order matters: `is_widenable_literal` is the cheap, selective
         // gate (an empty contribution set collapses to `never` and fails it);
         // the contribution scan runs only for a collapsed unit literal; and the

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -500,31 +500,10 @@ impl<'a> CheckerState<'a> {
     /// initializers (`let x = E.A`) to the parent enum type (`E`), not the
     /// specific member.
     pub(crate) fn widen_initializer_type_for_mutable_binding(&mut self, type_id: TypeId) -> TypeId {
-        // Check if this is an enum member type that should widen to parent enum
-        if let Some(def_id) = crate::query_boundaries::common::enum_def_id(self.ctx.types, type_id)
-        {
-            // Check if this DefId is an enum member (has a parent enum)
-            let parent_def_id = self
-                .ctx
-                .type_env
-                .try_borrow()
-                .ok()
-                .and_then(|env| env.get_enum_parent(def_id));
-
-            if let Some(parent_def_id) = parent_def_id {
-                // This is an enum member - widen to parent enum type
-                if let Some(parent_sym_id) = self.ctx.def_to_symbol_id(parent_def_id) {
-                    return self.get_type_of_symbol(parent_sym_id);
-                }
-            }
-        }
-
-        // Fallback: check via symbol flags (legacy path)
-        if let Some(sym_id) = self.ctx.resolve_type_to_symbol_id(type_id)
-            && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-            && symbol.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER)
-        {
-            return self.get_type_of_symbol(symbol.parent);
+        // An enum member widens to the parent enum's instance type (`E`),
+        // never the enum's static object shape (`typeof E`).
+        if let Some(parent_type) = self.enum_member_parent_instance_type(type_id) {
+            return parent_type;
         }
         // Use the mutable-binding widening entry so fresh array/object members
         // nested inside a top-level union widen too. tsc collapses a conditional
@@ -540,29 +519,10 @@ impl<'a> CheckerState<'a> {
     /// literal types (e.g., `2` stays `2`, not `number`). This is used in operator
     /// error messages where tsc preserves literal types but widens enum members.
     pub(crate) fn widen_enum_member_type(&mut self, type_id: TypeId) -> TypeId {
-        // Check if this is an enum member type that should widen to parent enum
-        if let Some(def_id) = crate::query_boundaries::common::enum_def_id(self.ctx.types, type_id)
-        {
-            let parent_def_id = self
-                .ctx
-                .type_env
-                .try_borrow()
-                .ok()
-                .and_then(|env| env.get_enum_parent(def_id));
-
-            if let Some(parent_def_id) = parent_def_id
-                && let Some(parent_sym_id) = self.ctx.def_to_symbol_id(parent_def_id)
-            {
-                return self.get_type_of_symbol(parent_sym_id);
-            }
-        }
-
-        // Fallback: check via symbol flags (legacy path)
-        if let Some(sym_id) = self.ctx.resolve_type_to_symbol_id(type_id)
-            && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-            && symbol.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER)
-        {
-            return self.get_type_of_symbol(symbol.parent);
+        // An enum member widens to the parent enum's instance type (`E`),
+        // never the enum's static object shape (`typeof E`).
+        if let Some(parent_type) = self.enum_member_parent_instance_type(type_id) {
+            return parent_type;
         }
 
         // Do NOT widen literal types - return as-is
@@ -584,125 +544,6 @@ impl<'a> CheckerState<'a> {
                 .ok()
                 .is_some_and(|env| env.get_enum_parent(def_id).is_some());
         }
-        false
-    }
-
-    /// Check if an expression produces a "fresh" literal type that should be widened.
-    ///
-    /// In TypeScript, literal types created from literal expressions are "fresh" and get
-    /// widened when assigned to mutable bindings (let/var). Literal types from other
-    /// sources (variable references, type annotations, narrowing) are "non-fresh" and
-    /// should NOT be widened.
-    ///
-    /// An identifier referring to an unannotated `const` declaration whose initializer
-    /// is itself a fresh literal expression is also treated as fresh: tsc tracks
-    /// such bindings as widening literal types and widens them when copied into a
-    /// mutable binding.
-    ///
-    /// ## Examples:
-    /// ```typescript
-    /// let x = "foo";          // "foo" is fresh → widened to string
-    /// let a: "foo" = "foo";
-    /// let y = a;              // a's type is non-fresh → y: "foo" (not widened)
-    /// let z = a || "bar";     // result from || is non-fresh → z: "foo" (not widened)
-    ///
-    /// const tag = "start";    // unannotated const literal → widening literal type
-    /// let m = tag;            // tag is fresh-by-reference → widened to string
-    /// ```
-    pub(crate) fn is_fresh_literal_expression(&self, idx: NodeIndex) -> bool {
-        self.is_fresh_literal_expression_inner(idx, 0)
-    }
-
-    fn is_fresh_literal_expression_inner(&self, idx: NodeIndex, depth: u8) -> bool {
-        use tsz_parser::parser::syntax_kind_ext;
-        use tsz_scanner::SyntaxKind;
-
-        // Cycle / runaway-recursion guard. Identifier-following can in principle
-        // reach itself through pathological forward references like
-        // `const a = a;`. Bound the chain so the structural recursion always
-        // terminates.
-        const MAX_FRESH_LITERAL_DEPTH: u8 = 16;
-        if depth > MAX_FRESH_LITERAL_DEPTH {
-            return false;
-        }
-
-        let Some(node) = self.ctx.arena.get(idx) else {
-            return false;
-        };
-
-        let kind = node.kind;
-
-        // Direct literal tokens are always fresh
-        if kind == SyntaxKind::StringLiteral as u16
-            || kind == SyntaxKind::NumericLiteral as u16
-            || kind == SyntaxKind::BigIntLiteral as u16
-            || kind == SyntaxKind::TrueKeyword as u16
-            || kind == SyntaxKind::FalseKeyword as u16
-            || kind == SyntaxKind::NullKeyword as u16
-            || kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
-        {
-            return true;
-        }
-
-        // Parenthesized expressions inherit freshness from inner expression
-        if kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
-            && let Some(paren) = self.ctx.arena.get_parenthesized(node)
-        {
-            return self.is_fresh_literal_expression_inner(paren.expression, depth + 1);
-        }
-
-        // Prefix unary (+/-) on numeric/bigint literals are fresh
-        if kind == syntax_kind_ext::PREFIX_UNARY_EXPRESSION
-            && let Some(prefix) = self.ctx.arena.get_unary_expr(node)
-        {
-            let op = prefix.operator;
-            if op == SyntaxKind::PlusToken as u16 || op == SyntaxKind::MinusToken as u16 {
-                return self.is_fresh_literal_expression_inner(prefix.operand, depth + 1);
-            }
-        }
-
-        // Conditional expressions: fresh if either branch produces a fresh type.
-        // E.g., `cond ? true : undefined` has a fresh `true` branch, so the
-        // result type `true | undefined` should be widened to `boolean | undefined`.
-        if kind == syntax_kind_ext::CONDITIONAL_EXPRESSION
-            && let Some(cond) = self.ctx.arena.get_conditional_expr(node)
-        {
-            return self.is_fresh_literal_expression_inner(cond.when_true, depth + 1)
-                || self.is_fresh_literal_expression_inner(cond.when_false, depth + 1);
-        }
-
-        // Object and array literals need widening (property types get widened)
-        if kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
-            || kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
-        {
-            return true;
-        }
-
-        // Template expressions (with substitutions) produce string, which doesn't need widening
-        // but we mark them fresh for consistency
-        if kind == syntax_kind_ext::TEMPLATE_EXPRESSION {
-            return true;
-        }
-
-        // Identifier referencing an unannotated `const` declaration whose
-        // initializer is itself a fresh literal expression. tsc tracks these
-        // bindings as widening literal types, so copying them into a `let`/`var`
-        // binding must still widen.
-        if kind == SyntaxKind::Identifier as u16
-            && let Some(sym_id) = self.resolve_identifier_symbol_without_tracking(idx)
-            && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-            && let Some(decl_idx) = symbol.primary_declaration()
-            && self.ctx.arena.is_const_variable_declaration(decl_idx)
-            && let Some(decl_node) = self.ctx.arena.get(decl_idx)
-            && let Some(var_decl) = self.ctx.arena.get_variable_declaration(decl_node)
-            && var_decl.type_annotation.is_none()
-            && var_decl.initializer.is_some()
-        {
-            return self.is_fresh_literal_expression_inner(var_decl.initializer, depth + 1);
-        }
-
-        // Everything else (identifiers, call expressions, binary expressions, etc.)
-        // produces non-fresh types that should NOT be widened
         false
     }
 

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -520,13 +520,10 @@ impl<'a> CheckerState<'a> {
     /// error messages where tsc preserves literal types but widens enum members.
     pub(crate) fn widen_enum_member_type(&mut self, type_id: TypeId) -> TypeId {
         // An enum member widens to the parent enum's instance type (`E`),
-        // never the enum's static object shape (`typeof E`).
-        if let Some(parent_type) = self.enum_member_parent_instance_type(type_id) {
-            return parent_type;
-        }
-
-        // Do NOT widen literal types - return as-is
-        type_id
+        // never the enum's static object shape (`typeof E`). Literal types
+        // are NOT widened — non-enum input passes through unchanged.
+        self.enum_member_parent_instance_type(type_id)
+            .unwrap_or(type_id)
     }
 
     /// Check if a type is an enum member type (not the parent enum type).

--- a/crates/tsz-checker/src/types/utilities/fresh_literal.rs
+++ b/crates/tsz-checker/src/types/utilities/fresh_literal.rs
@@ -46,11 +46,42 @@ impl<'a> CheckerState<'a> {
         expr_idx: NodeIndex,
         init_type: TypeId,
     ) -> TypeId {
-        if self.is_fresh_literal_expression(expr_idx) {
+        if self.is_fresh_widening_source(expr_idx, init_type) {
             self.widen_initializer_type_for_mutable_binding(init_type)
         } else {
             init_type
         }
+    }
+
+    /// Freshness of an initializer/contribution expression, with the
+    /// enum-member-access arm enabled only when the observed type is
+    /// enum-member shaped.
+    ///
+    /// The enum arm resolves symbols (a scope-chain walk), so it must not run
+    /// for ordinary property reads like `let x = obj.prop`; the cheap type
+    /// gate keeps the non-enum common case on the zero-cost AST fall-through.
+    pub(crate) fn is_fresh_widening_source(&self, expr_idx: NodeIndex, init_type: TypeId) -> bool {
+        self.is_fresh_literal_expression_inner(
+            expr_idx,
+            0,
+            self.is_enum_member_like_type(init_type),
+        )
+    }
+
+    /// Cheap shape test with the same detection breadth as
+    /// [`Self::enum_member_parent_instance_type`]: a def-backed
+    /// `Enum(member_def, _)` or a symbol-backed identity carrying the
+    /// `ENUM_MEMBER` flag (the shape some resolution orders observe before the
+    /// member's def-backed type is interned). Tag reads and map lookups only —
+    /// no symbol scope walk, no type computation.
+    fn is_enum_member_like_type(&self, type_id: TypeId) -> bool {
+        if self.is_enum_member_type_for_widening(type_id) {
+            return true;
+        }
+        self.ctx
+            .resolve_type_to_symbol_id(type_id)
+            .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
+            .is_some_and(|symbol| symbol.has_any_flags(symbol_flags::ENUM_MEMBER))
     }
 
     /// The parent enum's instance type for an enum-*member* type, or `None`
@@ -157,10 +188,19 @@ impl<'a> CheckerState<'a> {
     /// let n = c;              // c's type is non-fresh → n: E.A (not widened)
     /// ```
     pub(crate) fn is_fresh_literal_expression(&self, idx: NodeIndex) -> bool {
-        self.is_fresh_literal_expression_inner(idx, 0)
+        self.is_fresh_literal_expression_inner(idx, 0, false)
     }
 
-    fn is_fresh_literal_expression_inner(&self, idx: NodeIndex, depth: u8) -> bool {
+    /// `enum_member_arm` enables the enum-member-access case; callers turn it
+    /// on only when the observed type is enum-member shaped (see
+    /// [`Self::is_fresh_widening_source`]), keeping symbol resolution off the
+    /// common property-read path.
+    fn is_fresh_literal_expression_inner(
+        &self,
+        idx: NodeIndex,
+        depth: u8,
+        enum_member_arm: bool,
+    ) -> bool {
         if depth > MAX_FRESH_LITERAL_DEPTH {
             return false;
         }
@@ -187,7 +227,11 @@ impl<'a> CheckerState<'a> {
         if kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
             && let Some(paren) = self.ctx.arena.get_parenthesized(node)
         {
-            return self.is_fresh_literal_expression_inner(paren.expression, depth + 1);
+            return self.is_fresh_literal_expression_inner(
+                paren.expression,
+                depth + 1,
+                enum_member_arm,
+            );
         }
 
         // Prefix unary (+/-) on numeric/bigint literals are fresh
@@ -196,7 +240,11 @@ impl<'a> CheckerState<'a> {
         {
             let op = prefix.operator;
             if op == SyntaxKind::PlusToken as u16 || op == SyntaxKind::MinusToken as u16 {
-                return self.is_fresh_literal_expression_inner(prefix.operand, depth + 1);
+                return self.is_fresh_literal_expression_inner(
+                    prefix.operand,
+                    depth + 1,
+                    enum_member_arm,
+                );
             }
         }
 
@@ -206,8 +254,15 @@ impl<'a> CheckerState<'a> {
         if kind == syntax_kind_ext::CONDITIONAL_EXPRESSION
             && let Some(cond) = self.ctx.arena.get_conditional_expr(node)
         {
-            return self.is_fresh_literal_expression_inner(cond.when_true, depth + 1)
-                || self.is_fresh_literal_expression_inner(cond.when_false, depth + 1);
+            return self.is_fresh_literal_expression_inner(
+                cond.when_true,
+                depth + 1,
+                enum_member_arm,
+            ) || self.is_fresh_literal_expression_inner(
+                cond.when_false,
+                depth + 1,
+                enum_member_arm,
+            );
         }
 
         // Object and array literals need widening (property types get widened)
@@ -227,8 +282,9 @@ impl<'a> CheckerState<'a> {
         // a primitive literal token mints a fresh primitive literal. Property
         // reads whose base is not the enum object (`o.p` where `p: E.A`)
         // resolve to `None` here and stay non-fresh.
-        if (kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-            || kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
+        if enum_member_arm
+            && (kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                || kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
             && self.enum_member_access_symbol(idx, depth).is_some()
         {
             return true;
@@ -248,7 +304,11 @@ impl<'a> CheckerState<'a> {
             && var_decl.type_annotation.is_none()
             && var_decl.initializer.is_some()
         {
-            return self.is_fresh_literal_expression_inner(var_decl.initializer, depth + 1);
+            return self.is_fresh_literal_expression_inner(
+                var_decl.initializer,
+                depth + 1,
+                enum_member_arm,
+            );
         }
 
         // Everything else (identifiers, call expressions, binary expressions, etc.)

--- a/crates/tsz-checker/src/types/utilities/fresh_literal.rs
+++ b/crates/tsz-checker/src/types/utilities/fresh_literal.rs
@@ -33,6 +33,19 @@ use tsz_solver::TypeId;
 /// recursive walk in this module carries a depth and stops here.
 const MAX_FRESH_LITERAL_DEPTH: u8 = 16;
 
+/// Lazily-evaluated state of the enum-member-access arm of the freshness
+/// walk. The arm's shape test only matters when the walk actually reaches a
+/// property/element access, so `Lazy` defers it to that single consumption
+/// point — `let x = 1` or `return f()` never pay it.
+enum EnumMemberArm {
+    /// Arm disabled: plain literal freshness (no type observation available).
+    Off,
+    /// Arm enabled iff the observed type turns out enum-member shaped.
+    Lazy(TypeId),
+    /// Shape already computed (memo, or supplied by the caller).
+    Known(bool),
+}
+
 impl<'a> CheckerState<'a> {
     /// Widen a mutable-binding-like observation of `init_type` inferred from
     /// the initializer expression `expr_idx`.
@@ -58,13 +71,26 @@ impl<'a> CheckerState<'a> {
     /// enum-member shaped.
     ///
     /// The enum arm resolves symbols (a scope-chain walk), so it must not run
-    /// for ordinary property reads like `let x = obj.prop`; the cheap type
-    /// gate keeps the non-enum common case on the zero-cost AST fall-through.
+    /// for ordinary property reads like `let x = obj.prop`. The shape test is
+    /// evaluated lazily at the arm itself, so initializers the walk decides
+    /// without reaching a property/element access (`let x = 1`, `let x = f()`)
+    /// pay no type-shape work at all.
     pub(crate) fn is_fresh_widening_source(&self, expr_idx: NodeIndex, init_type: TypeId) -> bool {
+        self.is_fresh_literal_expression_inner(expr_idx, 0, &mut EnumMemberArm::Lazy(init_type))
+    }
+
+    /// [`Self::is_fresh_widening_source`] with the enum-member shape already
+    /// computed by the caller — avoids re-deriving it when a predicate gate
+    /// (e.g. the yield-contribution gate) needed the same answer first.
+    pub(crate) fn is_fresh_widening_source_with_enum_arm(
+        &self,
+        expr_idx: NodeIndex,
+        enum_member_like: bool,
+    ) -> bool {
         self.is_fresh_literal_expression_inner(
             expr_idx,
             0,
-            self.is_enum_member_like_type(init_type),
+            &mut EnumMemberArm::Known(enum_member_like),
         )
     }
 
@@ -74,7 +100,7 @@ impl<'a> CheckerState<'a> {
     /// `ENUM_MEMBER` flag (the shape some resolution orders observe before the
     /// member's def-backed type is interned). Tag reads and map lookups only —
     /// no symbol scope walk, no type computation.
-    fn is_enum_member_like_type(&self, type_id: TypeId) -> bool {
+    pub(crate) fn is_enum_member_like_type(&self, type_id: TypeId) -> bool {
         if self.is_enum_member_type_for_widening(type_id) {
             return true;
         }
@@ -188,7 +214,7 @@ impl<'a> CheckerState<'a> {
     /// let n = c;              // c's type is non-fresh → n: E.A (not widened)
     /// ```
     pub(crate) fn is_fresh_literal_expression(&self, idx: NodeIndex) -> bool {
-        self.is_fresh_literal_expression_inner(idx, 0, false)
+        self.is_fresh_literal_expression_inner(idx, 0, &mut EnumMemberArm::Off)
     }
 
     /// `enum_member_arm` enables the enum-member-access case; callers turn it
@@ -199,7 +225,7 @@ impl<'a> CheckerState<'a> {
         &self,
         idx: NodeIndex,
         depth: u8,
-        enum_member_arm: bool,
+        enum_member_arm: &mut EnumMemberArm,
     ) -> bool {
         if depth > MAX_FRESH_LITERAL_DEPTH {
             return false;
@@ -282,10 +308,10 @@ impl<'a> CheckerState<'a> {
         // a primitive literal token mints a fresh primitive literal. Property
         // reads whose base is not the enum object (`o.p` where `p: E.A`)
         // resolve to `None` here and stay non-fresh.
-        if enum_member_arm
-            && (kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-                || kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
-            && self.enum_member_access_symbol(idx, depth).is_some()
+        if (kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            || kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
+            && self.enum_member_arm_enabled(enum_member_arm)
+            && self.is_direct_enum_member_access(idx, depth)
         {
             return true;
         }
@@ -316,10 +342,29 @@ impl<'a> CheckerState<'a> {
         false
     }
 
-    /// The enum-*member* symbol denoted by a direct member access expression
-    /// (`E.A`, `Ns.E.A`, `E["A"]`), or `None` when the access does not read a
-    /// member off the enum object itself.
-    fn enum_member_access_symbol(&self, idx: NodeIndex, depth: u8) -> Option<SymbolId> {
+    /// Resolve (and memoize) whether the enum-member-access arm is enabled
+    /// for this walk. `Lazy` computes the shape test on first consultation so
+    /// walks that never reach an access expression never pay it.
+    fn enum_member_arm_enabled(&self, arm: &mut EnumMemberArm) -> bool {
+        match *arm {
+            EnumMemberArm::Off => false,
+            EnumMemberArm::Known(enabled) => enabled,
+            EnumMemberArm::Lazy(type_id) => {
+                let enabled = self.is_enum_member_like_type(type_id);
+                *arm = EnumMemberArm::Known(enabled);
+                enabled
+            }
+        }
+    }
+
+    /// Whether `idx` is a direct member access on an enum object (`E.A`,
+    /// `Ns.E.A`, `E["A"]`) — the accesses that mint a fresh enum literal.
+    /// Property reads whose base is not the enum object (`o.p`) are not.
+    fn is_direct_enum_member_access(&self, idx: NodeIndex, depth: u8) -> bool {
+        self.direct_enum_member_access(idx, depth).is_some()
+    }
+
+    fn direct_enum_member_access(&self, idx: NodeIndex, depth: u8) -> Option<()> {
         let node = self.ctx.arena.get(idx)?;
         let access = self.ctx.arena.get_access_expr(node)?;
         if access.question_dot_token {
@@ -352,7 +397,7 @@ impl<'a> CheckerState<'a> {
         let member_symbol = self.checker_symbol(member_sym_id)?;
         member_symbol
             .has_any_flags(symbol_flags::ENUM_MEMBER)
-            .then_some(member_sym_id)
+            .then_some(())
     }
 
     /// Resolve an entity-shaped value expression (identifier or dotted chain,

--- a/crates/tsz-checker/src/types/utilities/fresh_literal.rs
+++ b/crates/tsz-checker/src/types/utilities/fresh_literal.rs
@@ -1,0 +1,374 @@
+//! Literal-freshness boundary for widening observation points.
+//!
+//! Owns the two halves of enum-member/literal widening policy at mutable
+//! observation points (mutable bindings, parameter defaults, inferred return
+//! and yield contributions):
+//!
+//! - **When to widen** ([`CheckerState::is_fresh_literal_expression`]): only
+//!   *fresh* initializer expressions widen. Fresh means a direct literal, a
+//!   direct enum-member access, or a chain of parentheses/conditional
+//!   branches/unannotated `const` references ending in one — mirroring tsc's
+//!   fresh vs regular literal types and `getWidenedLiteralTypeForInitializer`.
+//!   Annotated `const` references, property reads, and call results are
+//!   non-fresh and keep their literal/member type.
+//! - **What enum members widen to**
+//!   ([`CheckerState::enum_member_parent_instance_type`]): the parent enum's
+//!   *instance* type `E` (`Enum(def, union-of-member-literals)`), never the
+//!   enum's static object/namespace value shape (`typeof E`). The enum
+//!   symbol's cached value meaning is resolution-order dependent, so the
+//!   result is normalized against the definition store instead of trusting
+//!   `get_type_of_symbol` alone.
+
+use crate::state::CheckerState;
+use crate::symbols_domain::alias_cycle::AliasCycleTracker;
+use tsz_binder::{SymbolId, symbol_flags};
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+use tsz_solver::TypeId;
+
+/// Bound for freshness chains (`const a = b; const b = ...`) and entity
+/// resolution walks. Identifier-following can in principle reach itself
+/// through pathological forward references like `const a = a;`, so every
+/// recursive walk in this module carries a depth and stops here.
+const MAX_FRESH_LITERAL_DEPTH: u8 = 16;
+
+impl<'a> CheckerState<'a> {
+    /// Widen a mutable-binding-like observation of `init_type` inferred from
+    /// the initializer expression `expr_idx`.
+    ///
+    /// This is the single freshness-gated entry for `let`/`var` initializers
+    /// and parameter defaults: fresh initializers widen (literals to their
+    /// primitive base, enum members to the parent enum instance type),
+    /// non-fresh initializers keep their type.
+    pub(crate) fn widen_mutable_binding_observation(
+        &mut self,
+        expr_idx: NodeIndex,
+        init_type: TypeId,
+    ) -> TypeId {
+        if self.is_fresh_literal_expression(expr_idx) {
+            self.widen_initializer_type_for_mutable_binding(init_type)
+        } else {
+            init_type
+        }
+    }
+
+    /// The parent enum's instance type for an enum-*member* type, or `None`
+    /// when `type_id` is not an enum member.
+    ///
+    /// The instance type is `Enum(parent_def, union-of-member-literals)` — the
+    /// type a `: E` annotation denotes — not the enum's static object value
+    /// shape (`typeof E`). `get_type_of_symbol` on the enum symbol can return
+    /// either depending on which position resolved the enum first, so the
+    /// result is normalized against the definition store's registered
+    /// structural body.
+    pub(crate) fn enum_member_parent_instance_type(&mut self, type_id: TypeId) -> Option<TypeId> {
+        // Def-backed member identity: `Enum(member_def, literal)`.
+        if let Some(member_def) =
+            crate::query_boundaries::common::enum_def_id(self.ctx.types, type_id)
+        {
+            // The parent edge only exists for member defs; the parent enum
+            // type itself resolves to `None` here and is returned unchanged
+            // by the widening callers.
+            let parent_def = self
+                .ctx
+                .type_env
+                .try_borrow()
+                .ok()
+                .and_then(|env| env.get_enum_parent(member_def))?;
+            let parent_sym = self.ctx.def_to_symbol_id_with_fallback(parent_def)?;
+            return Some(self.enum_instance_type_for_enum_symbol(parent_sym, parent_def));
+        }
+
+        // Legacy identity: the member is only reachable through the symbol
+        // table (no `DefId` on the type).
+        let sym_id = self.ctx.resolve_type_to_symbol_id(type_id)?;
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        if !symbol.has_any_flags(symbol_flags::ENUM_MEMBER) {
+            return None;
+        }
+        let parent_sym = symbol.parent;
+        let parent_def = self.ctx.definition_store.find_def_by_symbol(parent_sym.0);
+        Some(match parent_def {
+            Some(parent_def) => self.enum_instance_type_for_enum_symbol(parent_sym, parent_def),
+            // No definition mapping to normalize against; the symbol's type
+            // is the only available meaning.
+            None => self.get_type_of_symbol(parent_sym),
+        })
+    }
+
+    /// The enum instance type (`Enum(enum_def, member-union)`) for an enum
+    /// symbol, independent of whether the symbol's cached value meaning is the
+    /// instance type or the static namespace object.
+    fn enum_instance_type_for_enum_symbol(
+        &mut self,
+        enum_sym: SymbolId,
+        enum_def: tsz_solver::def::DefId,
+    ) -> TypeId {
+        // Forces the enum declaration's type computation on first touch,
+        // which also registers the structural member union as the def body.
+        let symbol_type = self.get_type_of_symbol(enum_sym);
+        if crate::query_boundaries::common::enum_def_id(self.ctx.types, symbol_type)
+            == Some(enum_def)
+        {
+            return symbol_type;
+        }
+        // The cached value meaning is the namespace object (`typeof E`);
+        // rebuild the instance type from the registered structural body.
+        if let Some(body) = self.ctx.definition_store.get_body(enum_def) {
+            if crate::query_boundaries::common::enum_def_id(self.ctx.types, body) == Some(enum_def)
+            {
+                return body;
+            }
+            return self.ctx.types.factory().enum_type(enum_def, body);
+        }
+        symbol_type
+    }
+
+    /// Check if an expression produces a "fresh" literal type that should be widened.
+    ///
+    /// In TypeScript, literal types created from literal expressions are "fresh" and get
+    /// widened when assigned to mutable bindings (let/var). Literal types from other
+    /// sources (variable references, type annotations, narrowing) are "non-fresh" and
+    /// should NOT be widened.
+    ///
+    /// A direct enum-member access (`E.A`, `Ns.E.A`, `E["A"]`) mints a fresh
+    /// enum literal exactly like a primitive literal token; a property read of
+    /// an enum-member-typed property on an ordinary object (`o.p`) does not.
+    ///
+    /// An identifier referring to an unannotated `const` declaration whose
+    /// initializer is itself a fresh literal expression is also treated as fresh: tsc
+    /// tracks such bindings as widening literal types and widens them when copied into a
+    /// mutable binding.
+    ///
+    /// ## Examples:
+    /// ```typescript
+    /// let x = "foo";          // "foo" is fresh → widened to string
+    /// let a: "foo" = "foo";
+    /// let y = a;              // a's type is non-fresh → y: "foo" (not widened)
+    /// let z = a || "bar";     // result from || is non-fresh → z: "foo" (not widened)
+    ///
+    /// const tag = "start";    // unannotated const literal → widening literal type
+    /// let m = tag;            // tag is fresh-by-reference → widened to string
+    ///
+    /// enum E { A, B }
+    /// let e = E.A;            // E.A is fresh → widened to E
+    /// const c: E.A = E.A;
+    /// let n = c;              // c's type is non-fresh → n: E.A (not widened)
+    /// ```
+    pub(crate) fn is_fresh_literal_expression(&self, idx: NodeIndex) -> bool {
+        self.is_fresh_literal_expression_inner(idx, 0)
+    }
+
+    fn is_fresh_literal_expression_inner(&self, idx: NodeIndex, depth: u8) -> bool {
+        if depth > MAX_FRESH_LITERAL_DEPTH {
+            return false;
+        }
+
+        let Some(node) = self.ctx.arena.get(idx) else {
+            return false;
+        };
+
+        let kind = node.kind;
+
+        // Direct literal tokens are always fresh
+        if kind == SyntaxKind::StringLiteral as u16
+            || kind == SyntaxKind::NumericLiteral as u16
+            || kind == SyntaxKind::BigIntLiteral as u16
+            || kind == SyntaxKind::TrueKeyword as u16
+            || kind == SyntaxKind::FalseKeyword as u16
+            || kind == SyntaxKind::NullKeyword as u16
+            || kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+        {
+            return true;
+        }
+
+        // Parenthesized expressions inherit freshness from inner expression
+        if kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+            && let Some(paren) = self.ctx.arena.get_parenthesized(node)
+        {
+            return self.is_fresh_literal_expression_inner(paren.expression, depth + 1);
+        }
+
+        // Prefix unary (+/-) on numeric/bigint literals are fresh
+        if kind == syntax_kind_ext::PREFIX_UNARY_EXPRESSION
+            && let Some(prefix) = self.ctx.arena.get_unary_expr(node)
+        {
+            let op = prefix.operator;
+            if op == SyntaxKind::PlusToken as u16 || op == SyntaxKind::MinusToken as u16 {
+                return self.is_fresh_literal_expression_inner(prefix.operand, depth + 1);
+            }
+        }
+
+        // Conditional expressions: fresh if either branch produces a fresh type.
+        // E.g., `cond ? true : undefined` has a fresh `true` branch, so the
+        // result type `true | undefined` should be widened to `boolean | undefined`.
+        if kind == syntax_kind_ext::CONDITIONAL_EXPRESSION
+            && let Some(cond) = self.ctx.arena.get_conditional_expr(node)
+        {
+            return self.is_fresh_literal_expression_inner(cond.when_true, depth + 1)
+                || self.is_fresh_literal_expression_inner(cond.when_false, depth + 1);
+        }
+
+        // Object and array literals need widening (property types get widened)
+        if kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+            || kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+        {
+            return true;
+        }
+
+        // Template expressions (with substitutions) produce string, which doesn't need widening
+        // but we mark them fresh for consistency
+        if kind == syntax_kind_ext::TEMPLATE_EXPRESSION {
+            return true;
+        }
+
+        // A direct enum-member access mints a fresh enum literal, exactly as
+        // a primitive literal token mints a fresh primitive literal. Property
+        // reads whose base is not the enum object (`o.p` where `p: E.A`)
+        // resolve to `None` here and stay non-fresh.
+        if (kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            || kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
+            && self.enum_member_access_symbol(idx, depth).is_some()
+        {
+            return true;
+        }
+
+        // Identifier referencing an unannotated `const` declaration whose
+        // initializer is itself a fresh literal expression. tsc tracks these
+        // bindings as widening literal types, so copying them into a `let`/`var`
+        // binding must still widen.
+        if kind == SyntaxKind::Identifier as u16
+            && let Some(sym_id) = self.resolve_identifier_symbol_without_tracking(idx)
+            && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
+            && let Some(decl_idx) = symbol.primary_declaration()
+            && self.ctx.arena.is_const_variable_declaration(decl_idx)
+            && let Some(decl_node) = self.ctx.arena.get(decl_idx)
+            && let Some(var_decl) = self.ctx.arena.get_variable_declaration(decl_node)
+            && var_decl.type_annotation.is_none()
+            && var_decl.initializer.is_some()
+        {
+            return self.is_fresh_literal_expression_inner(var_decl.initializer, depth + 1);
+        }
+
+        // Everything else (identifiers, call expressions, binary expressions, etc.)
+        // produces non-fresh types that should NOT be widened
+        false
+    }
+
+    /// The enum-*member* symbol denoted by a direct member access expression
+    /// (`E.A`, `Ns.E.A`, `E["A"]`), or `None` when the access does not read a
+    /// member off the enum object itself.
+    fn enum_member_access_symbol(&self, idx: NodeIndex, depth: u8) -> Option<SymbolId> {
+        let node = self.ctx.arena.get(idx)?;
+        let access = self.ctx.arena.get_access_expr(node)?;
+        if access.question_dot_token {
+            return None;
+        }
+        let member_name: &str = {
+            let name_node = self.ctx.arena.get(access.name_or_argument)?;
+            if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+                self.ctx
+                    .arena
+                    .get_identifier(name_node)?
+                    .escaped_text
+                    .as_str()
+            } else if name_node.kind == SyntaxKind::StringLiteral as u16
+                || name_node.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+            {
+                self.ctx.arena.get_literal(name_node)?.text.as_str()
+            } else {
+                return None;
+            }
+        };
+        let enum_sym_id = self.value_entity_symbol(access.expression, depth + 1)?;
+        let enum_symbol = self.checker_symbol(enum_sym_id)?;
+        if !enum_symbol.has_any_flags(symbol_flags::ENUM)
+            || enum_symbol.has_any_flags(symbol_flags::ENUM_MEMBER)
+        {
+            return None;
+        }
+        let member_sym_id = enum_symbol.exports.as_ref()?.get(member_name)?;
+        let member_symbol = self.checker_symbol(member_sym_id)?;
+        member_symbol
+            .has_any_flags(symbol_flags::ENUM_MEMBER)
+            .then_some(member_sym_id)
+    }
+
+    /// Resolve an entity-shaped value expression (identifier or dotted chain,
+    /// possibly parenthesized) to the symbol it denotes, following import
+    /// aliases and unannotated `const` value bindings — the same freshness
+    /// transparency the identifier arm of
+    /// [`Self::is_fresh_literal_expression`] gives literal initializers.
+    fn value_entity_symbol(&self, idx: NodeIndex, depth: u8) -> Option<SymbolId> {
+        if depth > MAX_FRESH_LITERAL_DEPTH {
+            return None;
+        }
+        let node = self.ctx.arena.get(idx)?;
+        let kind = node.kind;
+        if kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION {
+            let paren = self.ctx.arena.get_parenthesized(node)?;
+            return self.value_entity_symbol(paren.expression, depth + 1);
+        }
+        if kind == SyntaxKind::Identifier as u16 {
+            let sym_id = self.resolve_identifier_symbol_without_tracking(idx)?;
+            return self.value_entity_target(sym_id, depth);
+        }
+        if kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            let access = self.ctx.arena.get_access_expr(node)?;
+            if access.question_dot_token {
+                return None;
+            }
+            let container_sym = self.value_entity_symbol(access.expression, depth + 1)?;
+            let name_node = self.ctx.arena.get(access.name_or_argument)?;
+            let name = self
+                .ctx
+                .arena
+                .get_identifier(name_node)?
+                .escaped_text
+                .as_str();
+            let member_sym = self
+                .checker_symbol(container_sym)?
+                .exports
+                .as_ref()?
+                .get(name)?;
+            return self.value_entity_target(member_sym, depth);
+        }
+        None
+    }
+
+    /// Follow one resolution step for [`Self::value_entity_symbol`]: import
+    /// aliases resolve to their target, and an unannotated `const` bound to
+    /// another entity (`const e = E`) is transparent.
+    fn value_entity_target(&self, sym_id: SymbolId, depth: u8) -> Option<SymbolId> {
+        if depth > MAX_FRESH_LITERAL_DEPTH {
+            return None;
+        }
+        let symbol = self.checker_symbol(sym_id)?;
+        if symbol.has_any_flags(symbol_flags::ALIAS) {
+            let resolved = self.resolve_alias_symbol(sym_id, &mut AliasCycleTracker::new())?;
+            if resolved != sym_id {
+                return self.value_entity_target(resolved, depth + 1);
+            }
+        }
+        if let Some(decl_idx) = symbol.primary_declaration()
+            && self.ctx.arena.is_const_variable_declaration(decl_idx)
+            && let Some(decl_node) = self.ctx.arena.get(decl_idx)
+            && let Some(var_decl) = self.ctx.arena.get_variable_declaration(decl_node)
+            && var_decl.type_annotation.is_none()
+            && var_decl.initializer.is_some()
+            && let Some(target) = self.value_entity_symbol(var_decl.initializer, depth + 1)
+        {
+            return Some(target);
+        }
+        Some(sym_id)
+    }
+
+    /// A symbol view that works for both same-file and cross-file symbols.
+    pub(crate) fn checker_symbol(&self, sym_id: SymbolId) -> Option<&tsz_binder::Symbol> {
+        self.ctx
+            .binder
+            .get_symbol(sym_id)
+            .or_else(|| self.get_cross_file_symbol(sym_id))
+    }
+}

--- a/crates/tsz-checker/src/types/utilities/mod.rs
+++ b/crates/tsz-checker/src/types/utilities/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod cycle_guard;
 pub(crate) mod element_indexable;
 pub(crate) mod enum_utils;
 pub(crate) mod enum_utils_readonly;
+pub(crate) mod fresh_literal;
 pub(crate) mod heritage_walk_state;
 pub(crate) mod overlap_relation_helpers;
 pub(crate) mod return_type;

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -555,9 +555,10 @@ impl<'a> CheckerState<'a> {
         if expr_idx.is_none() || self.ctx.preserve_literal_types {
             return false;
         }
-        (crate::query_boundaries::common::is_literal_type(self.ctx.types, type_id)
-            || self.is_enum_member_type_for_widening(type_id))
-            && self.is_fresh_widening_source(expr_idx, type_id)
+        let enum_member_like = self.is_enum_member_like_type(type_id);
+        (enum_member_like
+            || crate::query_boundaries::common::is_literal_type(self.ctx.types, type_id))
+            && self.is_fresh_widening_source_with_enum_arm(expr_idx, enum_member_like)
     }
 
     /// Whether a single return-expression contribution would be widened by

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -555,12 +555,9 @@ impl<'a> CheckerState<'a> {
         if expr_idx.is_none() || self.ctx.preserve_literal_types {
             return false;
         }
-        if crate::query_boundaries::common::is_literal_type(self.ctx.types, type_id)
-            || self.is_enum_member_type_for_widening(type_id)
-        {
-            return self.is_fresh_literal_expression(expr_idx);
-        }
-        false
+        (crate::query_boundaries::common::is_literal_type(self.ctx.types, type_id)
+            || self.is_enum_member_type_for_widening(type_id))
+            && self.is_fresh_widening_source(expr_idx, type_id)
     }
 
     /// Whether a single return-expression contribution would be widened by
@@ -601,12 +598,12 @@ impl<'a> CheckerState<'a> {
         // A direct enum-member access (`return E.A`) is a fresh enum literal in
         // tsc: `getReturnTypeFromBody` widens it to the parent enum (`E`),
         // exactly as a fresh primitive literal widens to its base (`return "x"`
-        // → `string`). The freshness walk owns that arm, so a non-fresh
-        // enum-member source (`const c: E.A = E.A; return c;`) keeps the member
-        // type. The widen itself runs through `widen_enum_member_type` at each
-        // widenable site, since the primitive literal widener leaves
-        // `TypeData::Enum` untouched.
-        self.is_fresh_literal_expression(expr_idx)
+        // → `string`). The freshness walk owns that arm (enabled only for
+        // enum-member-shaped contributions), so a non-fresh enum-member source
+        // (`const c: E.A = E.A; return c;`) keeps the member type. The widen
+        // itself runs through `widen_enum_member_type` at each widenable site,
+        // since the primitive literal widener leaves `TypeData::Enum` untouched.
+        self.is_fresh_widening_source(expr_idx, type_id)
     }
 
     /// Widen a fresh return-expression contribution while preserving literal

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -555,10 +555,12 @@ impl<'a> CheckerState<'a> {
         if expr_idx.is_none() || self.ctx.preserve_literal_types {
             return false;
         }
-        if crate::query_boundaries::common::is_literal_type(self.ctx.types, type_id) {
+        if crate::query_boundaries::common::is_literal_type(self.ctx.types, type_id)
+            || self.is_enum_member_type_for_widening(type_id)
+        {
             return self.is_fresh_literal_expression(expr_idx);
         }
-        self.is_enum_member_type_for_widening(type_id)
+        false
     }
 
     /// Whether a single return-expression contribution would be widened by
@@ -596,15 +598,15 @@ impl<'a> CheckerState<'a> {
         }) {
             return false;
         }
-        // An enum-member access (`return E.A`) is a fresh enum literal in tsc:
-        // `getReturnTypeFromBody` widens it to the parent enum (`E`), exactly as
-        // a fresh primitive literal widens to its base (`return "x"` → `string`).
-        // The carve-outs above (a pinning contextual return, `preserve_literal_types`,
-        // an `as const` assertion, a conditional deferred to union collapse) already
-        // returned, so enum members observe the same preservation rules. The widen
-        // itself runs through `widen_enum_member_type` at each widenable site,
-        // since the primitive literal widener leaves `TypeData::Enum` untouched.
-        self.is_fresh_literal_expression(expr_idx) || self.is_enum_member_type_for_widening(type_id)
+        // A direct enum-member access (`return E.A`) is a fresh enum literal in
+        // tsc: `getReturnTypeFromBody` widens it to the parent enum (`E`),
+        // exactly as a fresh primitive literal widens to its base (`return "x"`
+        // → `string`). The freshness walk owns that arm, so a non-fresh
+        // enum-member source (`const c: E.A = E.A; return c;`) keeps the member
+        // type. The widen itself runs through `widen_enum_member_type` at each
+        // widenable site, since the primitive literal widener leaves
+        // `TypeData::Enum` untouched.
+        self.is_fresh_literal_expression(expr_idx)
     }
 
     /// Widen a fresh return-expression contribution while preserving literal

--- a/crates/tsz-checker/tests/enum_member_widening_freshness_tests.rs
+++ b/crates/tsz-checker/tests/enum_member_widening_freshness_tests.rs
@@ -1,0 +1,332 @@
+//! Freshness-gated enum-member widening at mutable observation points.
+//!
+//! Structural rule: when an observation point widens an enum-member-typed
+//! initializer (mutable binding, parameter default, inferred return), the
+//! widening applies only when the initializer expression is *fresh* — a direct
+//! enum-member access or a chain of parentheses/conditional branches/
+//! unannotated `const` references ending in one — and the widening target is
+//! the enum *instance* type `E`, never the enum's static object type
+//! (`typeof E`). Non-fresh enum-member sources (annotated consts, property
+//! reads) keep the member type. Mirrors tsc's fresh/regular enum literal
+//! types and `getWidenedLiteralTypeForInitializer`.
+//!
+//! Regression tests for #15445 (false-negative: annotated enum-member const
+//! references over-widened) and #15444 (false-positive: `typeof` of an
+//! enum-initialized binding observed the enum object type).
+
+use tsz_checker::test_utils::check_source_codes as get_error_codes;
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+// ---------------------------------------------------------------------------
+// Fresh sources widen to the enum type (must keep working).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn direct_member_access_widens_to_enum() {
+    let codes = get_error_codes(
+        r#"
+enum E { A, B }
+let x = E.A;
+x = E.B;
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "fresh member access must widen `x` to `E`, got: {codes:?}"
+    );
+}
+
+#[test]
+fn conditional_over_members_widens_to_enum() {
+    let codes = get_error_codes(
+        r#"
+enum Dir { Up, Down }
+declare const cond: boolean;
+let d = cond ? Dir.Up : Dir.Down;
+d = Dir.Up;
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "fresh conditional branches must widen `d` to `Dir`, got: {codes:?}"
+    );
+}
+
+#[test]
+fn unannotated_const_chain_stays_fresh() {
+    let codes = get_error_codes(
+        r#"
+enum E { A, B }
+const u = E.A;
+let x = u;
+x = E.B;
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "unannotated const chain keeps freshness; `x` must widen to `E`, got: {codes:?}"
+    );
+}
+
+#[test]
+fn element_access_member_is_fresh() {
+    let codes = get_error_codes(
+        r#"
+enum E { A, B }
+let x = E["A"];
+x = E.B;
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "element access of a member is a fresh enum literal, got: {codes:?}"
+    );
+}
+
+#[test]
+fn member_access_through_const_enum_object_alias_is_fresh() {
+    let codes = get_error_codes(
+        r#"
+enum E { A, B }
+const alias = E;
+let x = alias.A;
+x = E.B;
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "member access through an unannotated const enum-object alias stays fresh, got: {codes:?}"
+    );
+}
+
+#[test]
+fn parameter_default_member_widens_to_enum() {
+    let codes = get_error_codes(
+        r#"
+enum E { A, B }
+function g(p = E.A) {
+    p = E.B;
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "fresh parameter default must widen `p` to `E`, got: {codes:?}"
+    );
+}
+
+#[test]
+fn fresh_return_widens_to_enum() {
+    let codes = get_error_codes(
+        r#"
+enum E { A, B }
+function h() { return E.A; }
+declare function wantsE(x: E): void;
+wantsE(h());
+const back: E = h();
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "fresh member return must widen the inferred return type to `E`, got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Non-fresh sources keep the member type (#15445).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn annotated_const_reference_keeps_member_type() {
+    let codes = get_error_codes(
+        r#"
+enum E { A, B }
+const c: E.A = E.A;
+let x = c;
+x = E.B;
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2322),
+        1,
+        "annotated const reference is non-fresh; `x: E.A` must reject `E.B`, got: {codes:?}"
+    );
+}
+
+#[test]
+fn annotated_const_reference_keeps_member_type_string_enum() {
+    let codes = get_error_codes(
+        r#"
+enum S { On = "on", Off = "off" }
+const sc: S.On = S.On;
+let x = sc;
+x = S.Off;
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2322),
+        1,
+        "string-enum annotated const reference must keep `S.On`, got: {codes:?}"
+    );
+}
+
+#[test]
+fn property_read_keeps_member_type() {
+    let codes = get_error_codes(
+        r#"
+enum E { A, B }
+declare const o: { p: E.A };
+let x = o.p;
+x = E.B;
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2322),
+        1,
+        "property read is non-fresh; `x: E.A` must reject `E.B`, got: {codes:?}"
+    );
+}
+
+#[test]
+fn non_fresh_return_keeps_member_type() {
+    let codes = get_error_codes(
+        r#"
+enum E { A, B }
+function h() { const c: E.A = E.A; return c; }
+const back: E.A = h();
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "non-fresh member return must keep `E.A` so the annotated read-back succeeds, got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Widening target: enum type `E`, never `typeof E` (#15444).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn typeof_of_widened_binding_is_enum_type() {
+    let codes = get_error_codes(
+        r#"
+enum Phase { Init, Run }
+let stage = Phase.Init;
+declare function expectStage(value: typeof stage): void;
+expectStage(Phase.Run);
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "`typeof stage` must observe the widened enum type `Phase`, got: {codes:?}"
+    );
+}
+
+#[test]
+fn typeof_of_widened_binding_in_annotation_is_enum_type() {
+    let codes = get_error_codes(
+        r#"
+enum Phase { Init, Run }
+let stage = Phase.Init;
+const x: typeof stage = Phase.Run;
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "`typeof stage` annotation must admit other members of `Phase`, got: {codes:?}"
+    );
+}
+
+#[test]
+fn typeof_of_namespace_nested_binding_is_enum_type() {
+    let codes = get_error_codes(
+        r#"
+enum Phase { Init, Run }
+namespace N {
+    export let inner = Phase.Init;
+}
+declare function wantsInner(v: typeof N.inner): void;
+wantsInner(Phase.Run);
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "`typeof N.inner` must observe the widened enum type `Phase`, got: {codes:?}"
+    );
+}
+
+#[test]
+fn typeof_of_enum_itself_stays_object_type() {
+    let codes = get_error_codes(
+        r#"
+enum Phase { Init, Run }
+declare function wantsObj(o: typeof Phase): void;
+wantsObj(Phase);
+wantsObj(Phase.Run);
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2345),
+        1,
+        "`typeof Phase` stays the enum object type: `Phase` ok, `Phase.Run` rejected, got: {codes:?}"
+    );
+}
+
+#[test]
+fn keyof_typeof_enum_still_enumerates_member_names() {
+    let codes = get_error_codes(
+        r#"
+enum Phase { Init, Run }
+type Names = keyof typeof Phase;
+const ok: Names = "Init";
+const bad: Names = "Nope";
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2322),
+        1,
+        "`keyof typeof Phase` keeps enumerating member names, got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Direct assignment across members keeps compiling after the target fix.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn direct_reassignment_across_members_allowed() {
+    let codes = get_error_codes(
+        r#"
+enum Signal { Go, Stop }
+let current = Signal.Go;
+current = Signal.Stop;
+declare function wantsSignal(s: Signal): void;
+wantsSignal(current);
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "widened binding must accept every member and satisfy `Signal` positions, got: {codes:?}"
+    );
+}
+
+#[test]
+fn widened_binding_rejects_other_enum_and_raw_string() {
+    let codes = get_error_codes(
+        r#"
+enum A { X }
+enum B { Y }
+let a = A.X;
+a = B.Y;
+a = "nope";
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2322),
+        2,
+        "widened `A` binding must reject another enum and raw strings, got: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/tests/enum_member_widening_freshness_tests.rs
+++ b/crates/tsz-checker/tests/enum_member_widening_freshness_tests.rs
@@ -31,11 +31,13 @@ fn direct_member_access_widens_to_enum() {
 enum E { A, B }
 let x = E.A;
 x = E.B;
+declare function wantsE(v: E): void;
+wantsE(x);
 "#,
     );
     assert!(
         codes.is_empty(),
-        "fresh member access must widen `x` to `E`, got: {codes:?}"
+        "fresh member access must widen `x` to `E` and satisfy `E` positions, got: {codes:?}"
     );
 }
 
@@ -295,23 +297,6 @@ const bad: Names = "Nope";
 // ---------------------------------------------------------------------------
 // Direct assignment across members keeps compiling after the target fix.
 // ---------------------------------------------------------------------------
-
-#[test]
-fn direct_reassignment_across_members_allowed() {
-    let codes = get_error_codes(
-        r#"
-enum Signal { Go, Stop }
-let current = Signal.Go;
-current = Signal.Stop;
-declare function wantsSignal(s: Signal): void;
-wantsSignal(current);
-"#,
-    );
-    assert!(
-        codes.is_empty(),
-        "widened binding must accept every member and satisfy `Signal` positions, got: {codes:?}"
-    );
-}
 
 #[test]
 fn widened_binding_rejects_other_enum_and_raw_string() {


### PR DESCRIPTION
Fixes #15445. Fixes #15444.

## Structural rule

When an observation point widens an enum-member-typed initializer (mutable binding, parameter default, inferred return/yield contribution), `tsc` widens **only when the initializer expression is fresh** — a direct enum-member access (`E.A`, `Ns.E.A`, `E["A"]`) or a chain of parentheses / conditional branches / unannotated `const` references ending in one — and the widening target is the **enum instance type `E`** (`Enum(def, union-of-member-literals)`), never the enum's static object type (`typeof E`). Non-fresh enum-member sources (annotated consts, property reads, call results) keep the member type. tsz owns this through the checker's literal-freshness boundary (`types/utilities/fresh_literal.rs`), mirroring tsc's fresh/regular enum literal duality and `getWidenedLiteralTypeForInitializer` + `getBaseTypeOfEnumLikeType`.

Additionally, a `typeof` query's enum-namespace conversion applies **only when the queried entity (after alias resolution) is the enum symbol itself**: `let stage = Phase.Init; typeof stage` observes the widened `Phase`, while `typeof Phase` stays the object type. The old conversion was type-keyed (any type whose backing symbol is an enum), so a *variable* of enum type was indistinguishable from the enum itself.

## Owner layer

Checker widening policy (`crates/tsz-checker/src/types/utilities/fresh_literal.rs`, new boundary module) plus the `typeof`-query entity gating in `state/type_analysis/core_type_query.rs`.

- `is_fresh_literal_expression` moves from `types/utilities/core.rs` into the boundary and gains the enum-member-access arm (symbol-resolved, no name literals; the arm's shape test is lazily evaluated and memoized per walk, so non-enum initializers pay nothing).
- `widen_mutable_binding_observation` is the single freshness-gated entry shared by all four mutable-binding observation paths (`state/variable_checking/initializer_policy.rs`, param defaults in `types/function_type.rs`, `types/computation/helpers.rs`, `state/type_analysis/computed/type_alias_variable_alias.rs`); the first two previously carried an unconditional type-based enum bypass.
- `enum_member_parent_instance_type` replaces the two duplicated `get_type_of_symbol(parent)` arms in `widen_initializer_type_for_mutable_binding` / `widen_enum_member_type`. `get_type_of_symbol` on an enum symbol is resolution-order dependent (instance type vs cached namespace object), so the result is normalized against the definition store's registered structural body.
- Return/yield widening predicates (`types/utilities/return_type.rs`) drop the unconditional `is_enum_member_type_for_widening` arm; one shared shape predicate (`is_enum_member_like_type`) feeds the gates, computed once per contribution.
- `typeof`-query sites (`core_type_query.rs`, `types/computation/identifier/resolved.rs`) route through `enum_namespace_type_for_value_symbol`, gated on the queried/aliased symbol's enum flags; the qualified-name arm resolves the entity once and threads it; sites without a resolvable entity symbol keep the type-based fallback.

## Adjacent-case matrix

Covered in `crates/tsz-checker/tests/enum_member_widening_freshness_tests.rs` (17 tests):

- Fresh, must widen (positive): `let x = E.A` (and satisfying `E` positions); conditional over members; unannotated-const chain (`const u = E.A; let x = u`); element access (`E["A"]`); member access through unannotated const enum-object alias (`const a = E; let x = a.A`); parameter default (`function g(p = E.A)`); fresh return (`return E.A` → `E`).
- Non-fresh, must keep member type (negative — #15445): annotated const reference (numeric and string enums); property read (`o.p` where `p: E.A`); non-fresh return (`const c: E.A = E.A; return c` stays `E.A`).
- Widening target / `typeof` observation (#15444): `typeof stage` in parameter and annotation positions admits other members; namespace-nested binding (`typeof N.inner`); `typeof Phase` itself stays the object type (`Phase.Run` rejected); `keyof typeof Phase` still enumerates member names.
- Compatibility floor: widened binding rejects other enums and raw strings; renamed binders throughout.

## Simplify rounds

Three `/simplify` review rounds (reuse / simplification / efficiency / altitude agents) ran before review. Applied: lazy evaluation of the enum-member freshness arm (`EnumMemberArm` memo — literal/call initializers pay zero type-shape work; the symbol walk runs only for enum-member-shaped access expressions), one shared shape predicate (`is_enum_member_like_type`) across the yield/return/aggregate gates, all four mutable-binding paths routed through `widen_mutable_binding_observation`, the two previously duplicated enum-widening arms collapsed onto `enum_member_parent_instance_type`, and the qualified `typeof` entity resolved once per query. Noted follow-ups (out of scope): make the enum symbol's instance-type query order-independent so read-site normalization collapses; fold class-property initializer widening into the same boundary (pre-existing gap); move `checker_symbol` to a symbols-domain module.

## Goal
Goal: hold

## Verification

- `cargo nextest run -p tsz-checker --test enum_member_widening_freshness_tests` — 17/17 pass.
- Enum suites: `enum_recursion_tests enum_nominality_tests enum_equality_narrowing_tests enum_indexed_access_tests enum_keyof_excludes_number_tests enum_member_cache_tests enum_merge_tests const_enum_merge_ts2567_tests enum_literal_comparison_overlap_tests ts2403_enum_object_redeclaration_tests ts2450_const_enum_tests enum_discriminant_excess_property_tests jsdoc_enum_member_assignability_tests` — 254/254 pass.
- Widening/display suites: `freshness_stripping_tests literal_widening_display_tests literal_source_widening_position_parity_tests return_literal_union_widening_tests return_type_literal_union_widening_tests generator_return_type_widening_tests async_return_widening_tests block_body_callback_literal_widening_tests operator_literal_annotation_widen_tests typeof_object_literal_widened_display_tests global_augmentation_const_enum_rebind_tests ts2567_augmentation_enum_cross_arena_decl_tests ts2322_pair_disambiguation_widening_tests generic_call_primitive_widening_display_tests ts2344_widen_literal_arg_display_tests const_assertion_tests conditional_branch_array_literal_widening_tests generic_callback_local_literal_widening_tests` — pass except 4 failures (`async_arrow_returning_promise_expression_preserves_inner`, `ts2559_call_argument_literal_member_widens`, `type_alias_annotation_does_not_show_raw_alias_name{,_renamed}`) verified pre-existing on `main` via stash-rerun (the #15338 local-failure family).
- `cargo clippy -p tsz-checker --lib` clean.
- Ready-review CI owns conformance/emit/fourslash floors.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: max

https://claude.ai/code/session_01J9Njcp6CMRFvrsA14FxLge