### PR TITLE
fix(checker): collapse 4+ overload argument-error candidates to TS2770 and exclude arity failures from the TS2772 chain (#15371)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -757,6 +757,10 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Report "No overload matches this call" with related overload failures.
+    ///
+    /// Contract: `failures` carries exactly one entry per failed overload
+    /// candidate, in declaration order — the `Overload {i} of {N}` total
+    /// renders its length.
     pub fn error_no_overload_matches_at(
         &mut self,
         idx: NodeIndex,
@@ -1083,7 +1087,6 @@ impl<'a> CheckerState<'a> {
         let every_candidate_signed = chain_candidates
             .iter()
             .all(|failure| failure.overload_signature.is_some());
-        #[derive(PartialEq, Eq)]
         enum ChainShape {
             /// Fewer than 2 argument-error candidates, or a candidate without
             /// a declared signature: historical flat rendering.
@@ -1094,11 +1097,14 @@ impl<'a> CheckerState<'a> {
             /// the last candidate.
             LastOverload,
         }
-        let shape = match chain_candidates.len() {
-            _ if !every_candidate_signed => ChainShape::Flat,
-            0 | 1 => ChainShape::Flat,
-            2 | 3 => ChainShape::PerOverload,
-            _ => ChainShape::LastOverload,
+        let shape = if !every_candidate_signed {
+            ChainShape::Flat
+        } else {
+            match chain_candidates.len() {
+                0 | 1 => ChainShape::Flat,
+                2 | 3 => ChainShape::PerOverload,
+                _ => ChainShape::LastOverload,
+            }
         };
         let wrapped_candidates: &[&tsz_solver::PendingDiagnostic] = match shape {
             ChainShape::Flat => &[],
@@ -1139,7 +1145,7 @@ impl<'a> CheckerState<'a> {
                 }
             };
 
-        let related_policy = if shape == ChainShape::Flat {
+        let related_policy = if matches!(shape, ChainShape::Flat) {
             for failure in failures {
                 let pending = self.overload_failure_generalized_pending(failure, &span);
                 let diag = formatter.render(&pending);
@@ -1152,7 +1158,7 @@ impl<'a> CheckerState<'a> {
             for (ordinal, (failure, chain)) in
                 wrapped_candidates.iter().zip(candidate_chains).enumerate()
             {
-                let (header_message, header_code) = if shape == ChainShape::LastOverload {
+                let (header_message, header_code) = if matches!(shape, ChainShape::LastOverload) {
                     (
                         diagnostic_messages::THE_LAST_OVERLOAD_GAVE_THE_FOLLOWING_ERROR.to_string(),
                         diagnostic_codes::THE_LAST_OVERLOAD_GAVE_THE_FOLLOWING_ERROR,

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -844,13 +844,9 @@ impl<'a> CheckerState<'a> {
         } else {
             None
         };
-        let remaining_failures_are_count_mismatches = remaining_failures.iter().all(|failure| {
-            matches!(
-                failure.code,
-                diagnostic_codes::EXPECTED_ARGUMENTS_BUT_GOT
-                    | diagnostic_codes::EXPECTED_AT_LEAST_ARGUMENTS_BUT_GOT
-            )
-        });
+        let remaining_failures_are_count_mismatches = remaining_failures
+            .iter()
+            .all(|failure| failure.is_arity_failure());
         let all_failures_are_argument_mismatches = !failures.is_empty()
             && failures.iter().all(|failure| {
                 failure.code
@@ -1079,13 +1075,7 @@ impl<'a> CheckerState<'a> {
         // sets) keep the historical flat rendering.
         let chain_candidates: Vec<&tsz_solver::PendingDiagnostic> = failures
             .iter()
-            .filter(|failure| {
-                !matches!(
-                    failure.code,
-                    diagnostic_codes::EXPECTED_ARGUMENTS_BUT_GOT
-                        | diagnostic_codes::EXPECTED_AT_LEAST_ARGUMENTS_BUT_GOT
-                )
-            })
+            .filter(|failure| !failure.is_arity_failure())
             .collect();
         let wrap_overloads = chain_candidates.len() >= 2
             && chain_candidates
@@ -1135,7 +1125,7 @@ impl<'a> CheckerState<'a> {
 
         let related_policy = if wrap_overloads {
             // `{N}` counts every failed overload, arity failures included.
-            let total = failures.len();
+            let total = failures.len().to_string();
             for (ordinal, (failure, chain)) in
                 wrapped_candidates.iter().zip(candidate_chains).enumerate()
             {
@@ -1156,11 +1146,7 @@ impl<'a> CheckerState<'a> {
                     (
                         format_message(
                             diagnostic_messages::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
-                            &[
-                                &(ordinal + 1).to_string(),
-                                &total.to_string(),
-                                &signature_display,
-                            ],
+                            &[&(ordinal + 1).to_string(), &total, &signature_display],
                         ),
                         diagnostic_codes::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
                     )

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -1065,19 +1065,40 @@ impl<'a> CheckerState<'a> {
 
         tracing::debug!("File name: {}", self.ctx.file_name);
 
-        // tsc reports a no-overload-match as one `Overload N of M, '<signature>',
-        // gave the following error.` (TS2772) chain per candidate — in
-        // declaration order — when 2 or 3 candidates reached argument checking
-        // (`resolveCall`). A single candidate collapses to a plain TS2345 (no
-        // TS2769 at all, handled upstream), and >3 candidates use tsc's distinct
-        // "last overload" shape, left as the historical flat rendering. Each
-        // candidate failure carries its declared signature; a 2-3 set whose
-        // failures all have one wraps, otherwise we fall back to the flat list
-        // (e.g. callback-body sets whose failures carry no signature).
-        let wrap_overloads = matches!(failures.len(), 2 | 3)
-            && failures
+        // tsc's `resolveCall` partitions the failed candidates: overloads that
+        // matched arity but failed argument checks (`candidatesForArgumentError`)
+        // are elaborated, while arity failures never appear in the chain yet
+        // still count toward the `{N}` of `Overload {i} of {N}`. Two or three
+        // argument-error candidates each get a TS2772 header in declaration
+        // order (`{i}` is the candidate's 1-based position among the
+        // argument-error candidates); four or more collapse to a single
+        // `The last overload gave the following error.` (TS2770) header
+        // wrapping only the last candidate. A lone argument-error candidate
+        // collapses to a plain TS2345 upstream (no TS2769 at all). Candidate
+        // sets whose failures carry no declared signature (e.g. callback-body
+        // sets) keep the historical flat rendering.
+        let chain_candidates: Vec<&tsz_solver::PendingDiagnostic> = failures
+            .iter()
+            .filter(|failure| {
+                !matches!(
+                    failure.code,
+                    diagnostic_codes::EXPECTED_ARGUMENTS_BUT_GOT
+                        | diagnostic_codes::EXPECTED_AT_LEAST_ARGUMENTS_BUT_GOT
+                )
+            })
+            .collect();
+        let wrap_overloads = chain_candidates.len() >= 2
+            && chain_candidates
                 .iter()
                 .all(|failure| failure.overload_signature.is_some());
+        let collapse_to_last_overload = wrap_overloads && chain_candidates.len() > 3;
+        let wrapped_candidates: &[&tsz_solver::PendingDiagnostic] = if !wrap_overloads {
+            &[]
+        } else if collapse_to_last_overload {
+            &chain_candidates[chain_candidates.len() - 1..]
+        } else {
+            &chain_candidates
+        };
 
         // Per-candidate relation reason chains (#15387), computed before the
         // type formatter takes its borrow of the checker context (failure
@@ -1086,20 +1107,14 @@ impl<'a> CheckerState<'a> {
         // path — never at the call node: the renderer's display probes climb
         // from their anchor to enclosing initializers and would type the
         // surrounding expression mid-flight.
-        let candidate_chains: Vec<Vec<DiagnosticRelatedInformation>> = if wrap_overloads {
-            failures
-                .iter()
-                .map(|failure| {
-                    self.overload_failure_argument_node(idx, failure)
-                        .map(|arg_idx| {
-                            self.overload_candidate_reason_chain(failure, arg_idx, &span)
-                        })
-                        .unwrap_or_default()
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let candidate_chains: Vec<Vec<DiagnosticRelatedInformation>> = wrapped_candidates
+            .iter()
+            .map(|failure| {
+                self.overload_failure_argument_node(idx, failure)
+                    .map(|arg_idx| self.overload_candidate_reason_chain(failure, arg_idx, &span))
+                    .unwrap_or_default()
+            })
+            .collect();
 
         let mut related = Vec::new();
         let mut formatter = self.ctx.create_type_formatter();
@@ -1119,29 +1134,38 @@ impl<'a> CheckerState<'a> {
             };
 
         let related_policy = if wrap_overloads {
+            // `{N}` counts every failed overload, arity failures included.
             let total = failures.len();
-            for (ordinal, (failure, chain)) in failures.iter().zip(candidate_chains).enumerate() {
-                let signature = failure
-                    .overload_signature
-                    .expect("wrap_overloads requires every failure to carry a signature");
-                // signatureToString colon form (`(x: number): number`); fall
-                // back to the plain render only if the type is not a signature.
-                let signature_display = formatter
-                    .format_overload_signature(signature)
-                    .unwrap_or_else(|| formatter.format(signature).into_owned());
-                related.push(related_line(
-                    &span,
-                    format_message(
-                        diagnostic_messages::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
-                        &[
-                            &(ordinal + 1).to_string(),
-                            &total.to_string(),
-                            &signature_display,
-                        ],
-                    ),
-                    diagnostic_codes::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
-                    0,
-                ));
+            for (ordinal, (failure, chain)) in
+                wrapped_candidates.iter().zip(candidate_chains).enumerate()
+            {
+                let (header_message, header_code) = if collapse_to_last_overload {
+                    (
+                        diagnostic_messages::THE_LAST_OVERLOAD_GAVE_THE_FOLLOWING_ERROR.to_string(),
+                        diagnostic_codes::THE_LAST_OVERLOAD_GAVE_THE_FOLLOWING_ERROR,
+                    )
+                } else {
+                    let signature = failure
+                        .overload_signature
+                        .expect("wrap_overloads requires every candidate to carry a signature");
+                    // signatureToString colon form (`(x: number): number`); fall
+                    // back to the plain render only if the type is not a signature.
+                    let signature_display = formatter
+                        .format_overload_signature(signature)
+                        .unwrap_or_else(|| formatter.format(signature).into_owned());
+                    (
+                        format_message(
+                            diagnostic_messages::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
+                            &[
+                                &(ordinal + 1).to_string(),
+                                &total.to_string(),
+                                &signature_display,
+                            ],
+                        ),
+                        diagnostic_codes::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
+                    )
+                };
+                related.push(related_line(&span, header_message, header_code, 0));
                 let pending = self.overload_failure_generalized_pending(failure, &span);
                 let diag = formatter.render(&pending);
                 let diag_span = diag.span.as_ref().unwrap_or(&span);

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -1077,17 +1077,33 @@ impl<'a> CheckerState<'a> {
             .iter()
             .filter(|failure| !failure.is_arity_failure())
             .collect();
-        let wrap_overloads = chain_candidates.len() >= 2
-            && chain_candidates
-                .iter()
-                .all(|failure| failure.overload_signature.is_some());
-        let collapse_to_last_overload = wrap_overloads && chain_candidates.len() > 3;
-        let wrapped_candidates: &[&tsz_solver::PendingDiagnostic] = if !wrap_overloads {
-            &[]
-        } else if collapse_to_last_overload {
-            &chain_candidates[chain_candidates.len() - 1..]
-        } else {
-            &chain_candidates
+        // Signature presence is the provenance proxy for "one failure per
+        // candidate from real overload resolution" (callback-body sets carry
+        // none and stay flat), so it gates both wrapped shapes.
+        let every_candidate_signed = chain_candidates
+            .iter()
+            .all(|failure| failure.overload_signature.is_some());
+        #[derive(PartialEq, Eq)]
+        enum ChainShape {
+            /// Fewer than 2 argument-error candidates, or a candidate without
+            /// a declared signature: historical flat rendering.
+            Flat,
+            /// 2-3 argument-error candidates: one `TS2772` header each.
+            PerOverload,
+            /// 4+ argument-error candidates: one `TS2770` header wrapping only
+            /// the last candidate.
+            LastOverload,
+        }
+        let shape = match chain_candidates.len() {
+            _ if !every_candidate_signed => ChainShape::Flat,
+            0 | 1 => ChainShape::Flat,
+            2 | 3 => ChainShape::PerOverload,
+            _ => ChainShape::LastOverload,
+        };
+        let wrapped_candidates: &[&tsz_solver::PendingDiagnostic] = match shape {
+            ChainShape::Flat => &[],
+            ChainShape::PerOverload => &chain_candidates,
+            ChainShape::LastOverload => &chain_candidates[chain_candidates.len() - 1..],
         };
 
         // Per-candidate relation reason chains (#15387), computed before the
@@ -1123,13 +1139,20 @@ impl<'a> CheckerState<'a> {
                 }
             };
 
-        let related_policy = if wrap_overloads {
-            // `{N}` counts every failed overload, arity failures included.
-            let total = failures.len().to_string();
+        let related_policy = if shape == ChainShape::Flat {
+            for failure in failures {
+                let pending = self.overload_failure_generalized_pending(failure, &span);
+                let diag = formatter.render(&pending);
+                if let Some(diag_span) = diag.span.as_ref() {
+                    related.push(related_line(diag_span, diag.message, diag.code, 0));
+                }
+            }
+            RelatedInformationPolicy::OVERLOAD_FAILURES
+        } else {
             for (ordinal, (failure, chain)) in
                 wrapped_candidates.iter().zip(candidate_chains).enumerate()
             {
-                let (header_message, header_code) = if collapse_to_last_overload {
+                let (header_message, header_code) = if shape == ChainShape::LastOverload {
                     (
                         diagnostic_messages::THE_LAST_OVERLOAD_GAVE_THE_FOLLOWING_ERROR.to_string(),
                         diagnostic_codes::THE_LAST_OVERLOAD_GAVE_THE_FOLLOWING_ERROR,
@@ -1137,7 +1160,7 @@ impl<'a> CheckerState<'a> {
                 } else {
                     let signature = failure
                         .overload_signature
-                        .expect("wrap_overloads requires every candidate to carry a signature");
+                        .expect("wrapped shapes require every candidate to carry a signature");
                     // signatureToString colon form (`(x: number): number`); fall
                     // back to the plain render only if the type is not a signature.
                     let signature_display = formatter
@@ -1146,7 +1169,13 @@ impl<'a> CheckerState<'a> {
                     (
                         format_message(
                             diagnostic_messages::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
-                            &[&(ordinal + 1).to_string(), &total, &signature_display],
+                            &[
+                                &(ordinal + 1).to_string(),
+                                // `{N}` counts every failed overload, arity
+                                // failures included.
+                                &failures.len().to_string(),
+                                &signature_display,
+                            ],
                         ),
                         diagnostic_codes::OVERLOAD_OF_GAVE_THE_FOLLOWING_ERROR,
                     )
@@ -1173,15 +1202,6 @@ impl<'a> CheckerState<'a> {
                 }
             }
             RelatedInformationPolicy::OVERLOAD_CHAINS
-        } else {
-            for failure in failures {
-                let pending = self.overload_failure_generalized_pending(failure, &span);
-                let diag = formatter.render(&pending);
-                if let Some(diag_span) = diag.span.as_ref() {
-                    related.push(related_line(diag_span, diag.message, diag.code, 0));
-                }
-            }
-            RelatedInformationPolicy::OVERLOAD_FAILURES
         };
 
         self.emit_render_request_at_anchor(

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -71,8 +71,10 @@ impl RelatedInformationPolicy {
         preserve_order: false,
     };
 
-    /// Flat overload-failure list (1 or >3 candidates, or callback-body sets):
-    /// one related line per failure, deduped and sorted as before.
+    /// Flat overload-failure list (fewer than 2 argument-error candidates, or
+    /// candidate sets whose failures carry no declared signature, e.g.
+    /// callback-body sets): one related line per failure, deduped and sorted
+    /// as before.
     pub(crate) const OVERLOAD_FAILURES: Self = Self {
         include_primary: false,
         dedupe: true,
@@ -80,10 +82,12 @@ impl RelatedInformationPolicy {
         preserve_order: false,
     };
 
-    /// Per-overload `TS2772` elaboration (the 2-3 candidate case): each
-    /// candidate contributes a depth-0 `Overload N of M, '...', gave the
-    /// following error.` header immediately followed by its applicability
-    /// error at depth 1+. Insertion order is declaration order and must be
+    /// Per-overload elaboration for 2+ argument-error candidates: with 2 or 3,
+    /// each candidate contributes a depth-0 `Overload N of M, '...', gave the
+    /// following error.` (`TS2772`) header immediately followed by its
+    /// applicability error at depth 1+; with four or more, a single `The last
+    /// overload gave the following error.` (`TS2770`) header wraps only the
+    /// last candidate. Insertion order is declaration order and must be
     /// preserved; dedupe is off so two overloads that fail identically still
     /// each keep their own nested body under their distinct header.
     pub(crate) const OVERLOAD_CHAINS: Self = Self {

--- a/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
@@ -1,18 +1,22 @@
-//! Regression tests for tsc's per-overload `TS2772` elaboration under a
-//! `TS2769` ("No overload matches this call.") diagnostic.
+//! Regression tests for tsc's per-overload `TS2772`/`TS2770` elaboration under
+//! a `TS2769` ("No overload matches this call.") diagnostic.
 //!
-//! When a call matches no overload and 2 or 3 candidate signatures reached
-//! argument checking, tsc wraps each candidate's applicability error in a
-//! `Overload {n} of {total}, '{signature}', gave the following error.` chain
-//! node (`TS2772`) — in declaration order, with the applicability error nested
-//! one level deeper. A single failing candidate collapses to a plain `TS2345`
-//! (no `TS2769`), and `>3` candidates use tsc's distinct "last overload" shape,
-//! left as the flat fallback here.
+//! When a call matches no overload, tsc elaborates the candidates that matched
+//! arity but failed argument checks (`candidatesForArgumentError`): 2 or 3
+//! such candidates each get an `Overload {i} of {N}, '{signature}', gave the
+//! following error.` chain node (`TS2772`) — in declaration order, with the
+//! applicability error nested one level deeper — and four or more collapse to
+//! a single `The last overload gave the following error.` node (`TS2770`)
+//! wrapping only the last candidate. `{i}` is the candidate's 1-based position
+//! among the argument-error candidates while `{N}` counts every overload;
+//! arity-failing overloads never appear in the chain but still count toward
+//! `{N}`. A single argument-error candidate collapses to a plain `TS2345`
+//! (no `TS2769`).
 //!
-//! Before the fix tsz defined the `TS2772` string but never emitted it: it
-//! flattened every candidate's argument error directly under `TS2769` and, due
-//! to the related-info `(file, start, depth, message)` sort, rendered them out
-//! of declaration order.
+//! Before the fix tsz defined the `TS2772`/`TS2770` strings but never emitted
+//! them: it flattened every candidate's argument error directly under `TS2769`
+//! and, due to the related-info `(file, start, depth, message)` sort, rendered
+//! them out of declaration order.
 //!
 //! See `crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs`
 //! (`error_no_overload_matches_at`) and
@@ -514,34 +518,246 @@ var r = make(seed).pick(v => {});
     );
 }
 
-/// More than three failing candidates keep tsc's distinct top-level shape:
-/// tsz leaves them as the flat fallback (no `TS2772` wrappers), and the
-/// top-level `TS2769` is unchanged.
+/// Four or more argument-error candidates collapse to a single `TS2770`
+/// header wrapping only the *last* candidate's error — no `TS2772` headers,
+/// no lines from the earlier candidates (differential-verified against
+/// tsc 6.0.2).
 #[test]
-fn more_than_three_overloads_stay_flat() {
-    let diags = check_source_diagnostics(
+fn four_or_more_overloads_collapse_to_last_overload_header() {
+    let chain = overload_chain(
         r#"
 declare function f(x: number): number;
 declare function f(x: string): string;
-declare function f(x: boolean): boolean;
-declare function f(x: symbol): symbol;
-f({});
+declare function f(x: boolean[]): boolean;
+declare function f(x: object): symbol;
+f(Symbol());
 "#,
     );
 
-    let ts2769: Vec<_> = diags.iter().filter(|d| d.code == 2769).collect();
     assert_eq!(
-        ts2769.len(),
-        1,
-        "expected the top-level TS2769 to be unchanged"
+        chain,
+        vec![
+            (
+                0,
+                2770,
+                "The last overload gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                "Argument of type 'symbol' is not assignable to parameter of type 'object'."
+                    .to_string()
+            ),
+        ],
+        "expected a single TS2770 chain holding only the last candidate's error"
+    );
+}
+
+/// An arity-failing overload interleaved among argument-error candidates is
+/// excluded from the chain but still counts toward `{N}`: `{i}` numbers the
+/// argument-error candidates, so the third declaration renders as
+/// `Overload 2 of 3` and the arity error line disappears entirely
+/// (differential-verified against tsc 6.0.2).
+#[test]
+fn arity_failing_overload_is_excluded_from_chain_but_counted_in_total() {
+    let chain = overload_chain(
+        r#"
+declare function g(a: string): void;
+declare function g(a: number, b: number): void;
+declare function g(a: boolean): void;
+g(Symbol());
+"#,
+    );
+
+    assert_eq!(
+        chain,
+        vec![
+            (
+                0,
+                2772,
+                "Overload 1 of 3, '(a: string): void', gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                "Argument of type 'symbol' is not assignable to parameter of type 'string'."
+                    .to_string()
+            ),
+            (
+                0,
+                2772,
+                "Overload 2 of 3, '(a: boolean): void', gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                "Argument of type 'symbol' is not assignable to parameter of type 'boolean'."
+                    .to_string()
+            ),
+        ],
+        "expected the arity candidate dropped from the chain yet counted in {{N}}"
+    );
+}
+
+/// The `TS2770` collapse keys on the *argument-error* candidate count, not the
+/// raw failure count: four argument-error candidates plus an interleaved
+/// arity failure still collapse, and the last *argument-error* candidate in
+/// declaration order is the one shown.
+#[test]
+fn four_argument_error_candidates_plus_arity_still_collapse() {
+    let chain = overload_chain(
+        r#"
+declare function r(a: string): void;
+declare function r(a: number, b: number): void;
+declare function r(a: boolean): void;
+declare function r(a: object): void;
+declare function r(a: number[]): void;
+r(Symbol());
+"#,
+    );
+
+    assert_eq!(
+        chain,
+        vec![
+            (
+                0,
+                2770,
+                "The last overload gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                "Argument of type 'symbol' is not assignable to parameter of type 'number[]'."
+                    .to_string()
+            ),
+        ],
+        "expected the TS2770 collapse keyed on argument-error candidates"
+    );
+}
+
+/// The collapsed last candidate keeps its relation reason chain nested under
+/// its applicability error, exactly as a `TS2772`-wrapped candidate does
+/// (differential-verified against tsc 6.0.2).
+#[test]
+fn last_overload_collapse_nests_reason_chain() {
+    let chain = chain_lines(
+        r#"
+declare function q(cb: (x: string) => void): void;
+declare function q(cb: (x: number) => void): void;
+declare function q(cb: (x: boolean) => void): void;
+declare function q(cb: (x: object) => void): void;
+q((x: symbol) => {});
+"#,
+    );
+
+    assert_eq!(
+        as_pairs(&chain),
+        vec![
+            (0, "The last overload gave the following error."),
+            (
+                1,
+                "Argument of type '(x: symbol) => void' is not assignable to parameter of type '(x: object) => void'."
+            ),
+            (2, "Types of parameters 'x' and 'x' are incompatible."),
+            (3, "Type 'object' is not assignable to type 'symbol'."),
+        ],
+        "expected the last candidate's reason chain under the TS2770 header"
+    );
+}
+
+/// Constructor (`new`) overload sets collapse through the same policy.
+#[test]
+fn constructor_overloads_collapse_to_last_overload_header() {
+    let chain = overload_chain(
+        r#"
+interface Maker {
+    new (a: string): object;
+    new (a: number): object;
+    new (a: boolean[]): object;
+    new (a: object): object;
+}
+declare const Maker: Maker;
+new Maker(Symbol());
+"#,
+    );
+
+    assert_eq!(
+        lines_at_depth_with_codes(&chain, 0),
+        vec![(2770, "The last overload gave the following error.")],
+        "expected the constructor set to collapse to one TS2770 header, got: {chain:?}"
+    );
+    assert_eq!(
+        lines_at_depth_with_codes(&chain, 1),
+        vec![(
+            2345,
+            "Argument of type 'symbol' is not assignable to parameter of type 'object'."
+        )],
+        "expected only the last constructor candidate's error, got: {chain:?}"
+    );
+}
+
+/// A lone argument-error candidate among arity-failing overloads still
+/// collapses to a plain `TS2345` (tsc reports the single applicability error
+/// directly, with no `TS2769` head), regardless of how many overloads failed
+/// on arity.
+#[test]
+fn lone_argument_error_candidate_with_arity_failures_stays_plain_ts2345() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function p(a: string): void;
+declare function p(a: number, b: number): void;
+declare function p(a: boolean, b: boolean, c: boolean): void;
+p(Symbol());
+"#,
+    );
+
+    assert!(
+        diags.iter().any(|d| d.code == 2345),
+        "expected a plain TS2345, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
     );
     assert!(
-        !ts2769[0].related_information.iter().any(|r| r.code == 2772),
-        "the >3-candidate case must not emit TS2772 wrappers, got: {:?}",
-        ts2769[0]
-            .related_information
-            .iter()
-            .map(|r| (r.code, &r.message_text))
-            .collect::<Vec<_>>()
+        !diags.iter().any(|d| d.code == 2769),
+        "a lone argument-error candidate must not produce TS2769, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
     );
+}
+
+/// Anti-hardcoding: the collapse and the arity exclusion are structural —
+/// renaming the callee and every binder changes nothing but the rendered
+/// signature text.
+#[test]
+fn collapse_and_exclusion_are_independent_of_binder_names() {
+    let chain = overload_chain(
+        r#"
+declare function visitNode(entry: string): void;
+declare function visitNode(entry: number, extra: number): void;
+declare function visitNode(entry: boolean): void;
+visitNode(Symbol());
+"#,
+    );
+
+    assert_eq!(
+        lines_at_depth_with_codes(&chain, 0),
+        vec![
+            (
+                2772,
+                "Overload 1 of 3, '(entry: string): void', gave the following error."
+            ),
+            (
+                2772,
+                "Overload 2 of 3, '(entry: boolean): void', gave the following error."
+            ),
+        ],
+        "expected renamed binders to change only the signature text, got: {chain:?}"
+    );
+}
+
+/// The `(code, message)` pairs of every chain line at exactly `depth`.
+fn lines_at_depth_with_codes(chain: &[(u8, u32, String)], depth: u8) -> Vec<(u32, &str)> {
+    chain
+        .iter()
+        .filter(|(d, _, _)| *d == depth)
+        .map(|(_, code, m)| (*code, m.as_str()))
+        .collect()
 }

--- a/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
@@ -269,12 +269,6 @@ fn as_pairs(chain: &[(u8, String)]) -> Vec<(u8, &str)> {
     chain.iter().map(|(d, m)| (*d, m.as_str())).collect()
 }
 
-/// Borrowing view of a full `(depth, code, message)` chain for comparison
-/// against literal expectations.
-fn as_triples(chain: &[(u8, u32, String)]) -> Vec<(u8, u32, &str)> {
-    chain.iter().map(|(d, c, m)| (*d, *c, m.as_str())).collect()
-}
-
 /// The messages of every chain line at exactly `depth`.
 fn lines_at_depth(chain: &[(u8, String)], depth: u8) -> Vec<&str> {
     chain
@@ -524,13 +518,37 @@ var r = make(seed).pick(v => {});
     );
 }
 
-/// Four or more argument-error candidates collapse to a single `TS2770`
-/// header wrapping only the *last* candidate's error — no `TS2772` headers,
-/// no lines from the earlier candidates (differential-verified against
+/// Assert the `TS2770` collapse shape: exactly one header line plus the last
+/// candidate's `TS2345` naming `last_param_ty` — no `TS2772` headers, no
+/// lines from the earlier candidates (differential-verified against
 /// tsc 6.0.2).
+fn assert_last_overload_collapse(source: &str, last_param_ty: &str) {
+    let chain = overload_chain(source);
+    assert_eq!(
+        chain,
+        vec![
+            (
+                0,
+                2770,
+                "The last overload gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                format!(
+                    "Argument of type 'symbol' is not assignable to parameter of type '{last_param_ty}'."
+                )
+            ),
+        ],
+        "expected a single TS2770 chain holding only the last candidate's error"
+    );
+}
+
+/// Four or more argument-error candidates collapse to a single `TS2770`
+/// header wrapping only the *last* candidate's error.
 #[test]
 fn four_or_more_overloads_collapse_to_last_overload_header() {
-    let chain = overload_chain(
+    assert_last_overload_collapse(
         r#"
 declare function f(x: number): number;
 declare function f(x: string): string;
@@ -539,19 +557,7 @@ declare function f(x: object): symbol;
 declare const sym: symbol;
 f(sym);
 "#,
-    );
-
-    assert_eq!(
-        as_triples(&chain),
-        vec![
-            (0, 2770, "The last overload gave the following error."),
-            (
-                1,
-                2345,
-                "Argument of type 'symbol' is not assignable to parameter of type 'object'."
-            ),
-        ],
-        "expected a single TS2770 chain holding only the last candidate's error"
+        "object",
     );
 }
 
@@ -622,7 +628,7 @@ fn collapse_and_exclusion_are_independent_of_binder_names() {
 /// declaration order is the one shown.
 #[test]
 fn four_argument_error_candidates_plus_arity_still_collapse() {
-    let chain = overload_chain(
+    assert_last_overload_collapse(
         r#"
 declare function r(a: string): void;
 declare function r(a: number, b: number): void;
@@ -632,19 +638,7 @@ declare function r(a: number[]): void;
 declare const sym: symbol;
 r(sym);
 "#,
-    );
-
-    assert_eq!(
-        as_triples(&chain),
-        vec![
-            (0, 2770, "The last overload gave the following error."),
-            (
-                1,
-                2345,
-                "Argument of type 'symbol' is not assignable to parameter of type 'number[]'."
-            ),
-        ],
-        "expected the TS2770 collapse keyed on argument-error candidates"
+        "number[]",
     );
 }
 
@@ -681,7 +675,7 @@ q((x: symbol) => {});
 /// Constructor (`new`) overload sets collapse through the same policy.
 #[test]
 fn constructor_overloads_collapse_to_last_overload_header() {
-    let chain = overload_chain(
+    assert_last_overload_collapse(
         r#"
 interface Maker {
     new (a: string): object;
@@ -693,19 +687,7 @@ declare const Maker: Maker;
 declare const sym: symbol;
 new Maker(sym);
 "#,
-    );
-
-    assert_eq!(
-        as_triples(&chain),
-        vec![
-            (0, 2770, "The last overload gave the following error."),
-            (
-                1,
-                2345,
-                "Argument of type 'symbol' is not assignable to parameter of type 'object'."
-            ),
-        ],
-        "expected the constructor set to collapse to only the last candidate's error"
+        "object",
     );
 }
 

--- a/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
@@ -530,7 +530,8 @@ declare function f(x: number): number;
 declare function f(x: string): string;
 declare function f(x: boolean[]): boolean;
 declare function f(x: object): symbol;
-f(Symbol());
+declare const sym: symbol;
+f(sym);
 "#,
     );
 
@@ -565,7 +566,8 @@ fn arity_failing_overload_is_excluded_from_chain_but_counted_in_total() {
 declare function g(a: string): void;
 declare function g(a: number, b: number): void;
 declare function g(a: boolean): void;
-g(Symbol());
+declare const sym: symbol;
+g(sym);
 "#,
     );
 
@@ -612,7 +614,8 @@ declare function r(a: number, b: number): void;
 declare function r(a: boolean): void;
 declare function r(a: object): void;
 declare function r(a: number[]): void;
-r(Symbol());
+declare const sym: symbol;
+r(sym);
 "#,
     );
 
@@ -677,7 +680,8 @@ interface Maker {
     new (a: object): object;
 }
 declare const Maker: Maker;
-new Maker(Symbol());
+declare const sym: symbol;
+new Maker(sym);
 "#,
     );
 
@@ -707,7 +711,8 @@ fn lone_argument_error_candidate_with_arity_failures_stays_plain_ts2345() {
 declare function p(a: string): void;
 declare function p(a: number, b: number): void;
 declare function p(a: boolean, b: boolean, c: boolean): void;
-p(Symbol());
+declare const sym: symbol;
+p(sym);
 "#,
     );
 
@@ -733,7 +738,8 @@ fn collapse_and_exclusion_are_independent_of_binder_names() {
 declare function visitNode(entry: string): void;
 declare function visitNode(entry: number, extra: number): void;
 declare function visitNode(entry: boolean): void;
-visitNode(Symbol());
+declare const sym: symbol;
+visitNode(sym);
 "#,
     );
 

--- a/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
@@ -269,6 +269,12 @@ fn as_pairs(chain: &[(u8, String)]) -> Vec<(u8, &str)> {
     chain.iter().map(|(d, m)| (*d, m.as_str())).collect()
 }
 
+/// Borrowing view of a full `(depth, code, message)` chain for comparison
+/// against literal expectations.
+fn as_triples(chain: &[(u8, u32, String)]) -> Vec<(u8, u32, &str)> {
+    chain.iter().map(|(d, c, m)| (*d, *c, m.as_str())).collect()
+}
+
 /// The messages of every chain line at exactly `depth`.
 fn lines_at_depth(chain: &[(u8, String)], depth: u8) -> Vec<&str> {
     chain
@@ -536,40 +542,35 @@ f(sym);
     );
 
     assert_eq!(
-        chain,
+        as_triples(&chain),
         vec![
-            (
-                0,
-                2770,
-                "The last overload gave the following error.".to_string()
-            ),
+            (0, 2770, "The last overload gave the following error."),
             (
                 1,
                 2345,
                 "Argument of type 'symbol' is not assignable to parameter of type 'object'."
-                    .to_string()
             ),
         ],
         "expected a single TS2770 chain holding only the last candidate's error"
     );
 }
 
-/// An arity-failing overload interleaved among argument-error candidates is
-/// excluded from the chain but still counts toward `{N}`: `{i}` numbers the
-/// argument-error candidates, so the third declaration renders as
-/// `Overload 2 of 3` and the arity error line disappears entirely
-/// (differential-verified against tsc 6.0.2).
-#[test]
-fn arity_failing_overload_is_excluded_from_chain_but_counted_in_total() {
-    let chain = overload_chain(
+/// Shared scenario for the arity-exclusion rule: a `string`/arity/`boolean`
+/// overload triple called with a `symbol` argument. The arity candidate is
+/// excluded from the chain but still counts toward `{N}`, so the third
+/// declaration renders as `Overload 2 of 3` and the arity error line
+/// disappears entirely (differential-verified against tsc 6.0.2). Invoked
+/// with two distinct binder-name sets so the rule is proven structural.
+fn assert_arity_exclusion_chain(callee: &str, param: &str, extra: &str) {
+    let chain = overload_chain(&format!(
         r#"
-declare function g(a: string): void;
-declare function g(a: number, b: number): void;
-declare function g(a: boolean): void;
+declare function {callee}({param}: string): void;
+declare function {callee}({param}: number, {extra}: number): void;
+declare function {callee}({param}: boolean): void;
 declare const sym: symbol;
-g(sym);
-"#,
-    );
+{callee}(sym);
+"#
+    ));
 
     assert_eq!(
         chain,
@@ -577,7 +578,7 @@ g(sym);
             (
                 0,
                 2772,
-                "Overload 1 of 3, '(a: string): void', gave the following error.".to_string()
+                format!("Overload 1 of 3, '({param}: string): void', gave the following error.")
             ),
             (
                 1,
@@ -588,7 +589,7 @@ g(sym);
             (
                 0,
                 2772,
-                "Overload 2 of 3, '(a: boolean): void', gave the following error.".to_string()
+                format!("Overload 2 of 3, '({param}: boolean): void', gave the following error.")
             ),
             (
                 1,
@@ -599,6 +600,20 @@ g(sym);
         ],
         "expected the arity candidate dropped from the chain yet counted in {{N}}"
     );
+}
+
+/// An arity-failing overload interleaved among argument-error candidates is
+/// excluded from the chain but still counts toward `{N}`.
+#[test]
+fn arity_failing_overload_is_excluded_from_chain_but_counted_in_total() {
+    assert_arity_exclusion_chain("g", "a", "b");
+}
+
+/// Anti-hardcoding: the exclusion and numbering are structural — renaming the
+/// callee and every binder changes nothing but the rendered signature text.
+#[test]
+fn collapse_and_exclusion_are_independent_of_binder_names() {
+    assert_arity_exclusion_chain("visitNode", "entry", "extra");
 }
 
 /// The `TS2770` collapse keys on the *argument-error* candidate count, not the
@@ -620,18 +635,13 @@ r(sym);
     );
 
     assert_eq!(
-        chain,
+        as_triples(&chain),
         vec![
-            (
-                0,
-                2770,
-                "The last overload gave the following error.".to_string()
-            ),
+            (0, 2770, "The last overload gave the following error."),
             (
                 1,
                 2345,
                 "Argument of type 'symbol' is not assignable to parameter of type 'number[]'."
-                    .to_string()
             ),
         ],
         "expected the TS2770 collapse keyed on argument-error candidates"
@@ -686,18 +696,13 @@ new Maker(sym);
     );
 
     assert_eq!(
-        chain,
+        as_triples(&chain),
         vec![
-            (
-                0,
-                2770,
-                "The last overload gave the following error.".to_string()
-            ),
+            (0, 2770, "The last overload gave the following error."),
             (
                 1,
                 2345,
                 "Argument of type 'symbol' is not assignable to parameter of type 'object'."
-                    .to_string()
             ),
         ],
         "expected the constructor set to collapse to only the last candidate's error"
@@ -729,50 +734,5 @@ p(sym);
         !diags.iter().any(|d| d.code == 2769),
         "a lone argument-error candidate must not produce TS2769, got: {:?}",
         diags.iter().map(|d| d.code).collect::<Vec<_>>()
-    );
-}
-
-/// Anti-hardcoding: the collapse and the arity exclusion are structural —
-/// renaming the callee and every binder changes nothing but the rendered
-/// signature text.
-#[test]
-fn collapse_and_exclusion_are_independent_of_binder_names() {
-    let chain = overload_chain(
-        r#"
-declare function visitNode(entry: string): void;
-declare function visitNode(entry: number, extra: number): void;
-declare function visitNode(entry: boolean): void;
-declare const sym: symbol;
-visitNode(sym);
-"#,
-    );
-
-    assert_eq!(
-        chain,
-        vec![
-            (
-                0,
-                2772,
-                "Overload 1 of 3, '(entry: string): void', gave the following error.".to_string()
-            ),
-            (
-                1,
-                2345,
-                "Argument of type 'symbol' is not assignable to parameter of type 'string'."
-                    .to_string()
-            ),
-            (
-                0,
-                2772,
-                "Overload 2 of 3, '(entry: boolean): void', gave the following error.".to_string()
-            ),
-            (
-                1,
-                2345,
-                "Argument of type 'symbol' is not assignable to parameter of type 'boolean'."
-                    .to_string()
-            ),
-        ],
-        "expected renamed binders to change only the signature text"
     );
 }

--- a/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
@@ -686,17 +686,21 @@ new Maker(sym);
     );
 
     assert_eq!(
-        lines_at_depth_with_codes(&chain, 0),
-        vec![(2770, "The last overload gave the following error.")],
-        "expected the constructor set to collapse to one TS2770 header, got: {chain:?}"
-    );
-    assert_eq!(
-        lines_at_depth_with_codes(&chain, 1),
-        vec![(
-            2345,
-            "Argument of type 'symbol' is not assignable to parameter of type 'object'."
-        )],
-        "expected only the last constructor candidate's error, got: {chain:?}"
+        chain,
+        vec![
+            (
+                0,
+                2770,
+                "The last overload gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                "Argument of type 'symbol' is not assignable to parameter of type 'object'."
+                    .to_string()
+            ),
+        ],
+        "expected the constructor set to collapse to only the last candidate's error"
     );
 }
 
@@ -744,26 +748,31 @@ visitNode(sym);
     );
 
     assert_eq!(
-        lines_at_depth_with_codes(&chain, 0),
+        chain,
         vec![
             (
+                0,
                 2772,
-                "Overload 1 of 3, '(entry: string): void', gave the following error."
+                "Overload 1 of 3, '(entry: string): void', gave the following error.".to_string()
             ),
             (
+                1,
+                2345,
+                "Argument of type 'symbol' is not assignable to parameter of type 'string'."
+                    .to_string()
+            ),
+            (
+                0,
                 2772,
-                "Overload 2 of 3, '(entry: boolean): void', gave the following error."
+                "Overload 2 of 3, '(entry: boolean): void', gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                "Argument of type 'symbol' is not assignable to parameter of type 'boolean'."
+                    .to_string()
             ),
         ],
-        "expected renamed binders to change only the signature text, got: {chain:?}"
+        "expected renamed binders to change only the signature text"
     );
-}
-
-/// The `(code, message)` pairs of every chain line at exactly `depth`.
-fn lines_at_depth_with_codes(chain: &[(u8, u32, String)], depth: u8) -> Vec<(u32, &str)> {
-    chain
-        .iter()
-        .filter(|(d, _, _)| *d == depth)
-        .map(|(_, code, m)| (*code, m.as_str()))
-        .collect()
 }

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -596,11 +596,10 @@ impl PendingDiagnostic {
     }
 
     /// Whether this diagnostic reports an argument-arity failure
-    /// (`TS2554`/`TS2555`). Within a `NoOverloadMatch` failure set these are
-    /// tsc's arity-failing candidates (`resolveCall` keeps them out of
-    /// `candidatesForArgumentError`): never elaborated in the per-overload
-    /// chain, yet still counted toward the `Overload {i} of {N}` total. Owned
-    /// here so the code set stays beside the builders that assign it.
+    /// (`TS2554`/`TS2555`), tsc's `candidatesForArgumentError` exclusion.
+    /// Owned here so the code set stays beside the builders that assign it;
+    /// the rendering policy it feeds lives in the checker's
+    /// `error_no_overload_matches_at`.
     pub const fn is_arity_failure(&self) -> bool {
         matches!(
             self.code,

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -595,6 +595,19 @@ impl PendingDiagnostic {
         self
     }
 
+    /// Whether this diagnostic reports an argument-arity failure
+    /// (`TS2554`/`TS2555`). Within a `NoOverloadMatch` failure set these are
+    /// tsc's arity-failing candidates (`resolveCall` keeps them out of
+    /// `candidatesForArgumentError`): never elaborated in the per-overload
+    /// chain, yet still counted toward the `Overload {i} of {N}` total. Owned
+    /// here so the code set stays beside the builders that assign it.
+    pub const fn is_arity_failure(&self) -> bool {
+        matches!(
+            self.code,
+            codes::ARG_COUNT_MISMATCH | codes::ARG_COUNT_AT_LEAST_MISMATCH
+        )
+    }
+
     /// The `(source, target)` pair of a two-type diagnostic (e.g. `TS2345`
     /// argument-not-assignable), when the first two message args are types.
     /// Owns the positional arg encoding so consumers do not.
@@ -757,6 +770,7 @@ pub mod codes {
     pub use dc::CANNOT_FIND_NAME_DO_YOU_NEED_TO_INSTALL_TYPE_DEFINITIONS_FOR_BUN_TRY_NPM_I_SAVE_2 as CANNOT_FIND_NAME_BUN;
     pub use dc::CANNOT_FIND_NAME_DO_YOU_NEED_TO_INSTALL_TYPE_DEFINITIONS_FOR_NODE_TRY_NPM_I_SAVE_2 as CANNOT_FIND_NAME_NODE;
     pub use dc::EXPECTED_ARGUMENTS_BUT_GOT as ARG_COUNT_MISMATCH;
+    pub use dc::EXPECTED_AT_LEAST_ARGUMENTS_BUT_GOT as ARG_COUNT_AT_LEAST_MISMATCH;
     pub use dc::PROPERTY_DOES_NOT_EXIST_ON_TYPE as PROPERTY_NOT_EXIST;
     pub use dc::PROPERTY_DOES_NOT_EXIST_ON_TYPE_DID_YOU_MEAN as PROPERTY_NOT_EXIST_DID_YOU_MEAN;
     pub use dc::THE_THIS_CONTEXT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_METHODS_THIS_OF_TYPE as THIS_TYPE_MISMATCH;


### PR DESCRIPTION
Closes #15371 (the residual scope after #15370 and #15625).

Structural rule: when a call matches no overload, tsc (`resolveCall`) elaborates only the candidates that matched arity but failed argument checks (`candidatesForArgumentError`) — 2 or 3 such candidates each get an `Overload {i} of {N}, '<signature>', gave the following error.` (TS2772) header in declaration order, where `{i}` is the candidate's 1-based position **among the argument-error candidates** and `{N}` counts **every** overload; four or more collapse to a single `The last overload gave the following error.` (TS2770) header wrapping only the last candidate; arity-failing overloads never appear in the chain yet still count toward `{N}`; a lone argument-error candidate collapses to a plain TS2345. tsz does this through the checker's error reporter (`error_no_overload_matches_at` in `crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs`), with the arity classification owned by the solver (`PendingDiagnostic::is_arity_failure`, beside the builders that assign TS2554/TS2555).

Before: tsz gated the TS2772 wrap on the **raw failure count** being exactly 2 or 3, so an interleaved arity failure consumed a header and shifted the `{i}` numbering (`Overload 2 of 3, '(a: number, b: number): void' … Expected 2 arguments, but got 1.` where tsc shows nothing), and 4+ argument-error candidates fell back to the flat, alphabetically-sorted list with no TS2770.

Owner layer: checker error reporter (diagnostic display shape); solver owns the arity-failure classification. No semantic operation changes; no top-level diagnostic code changes.

Adjacent-case matrix, all byte-identical to `tsc 6.0.2 --noEmit --strict --pretty false` (17/17 differential cases):
- 4 / 5+ candidates → TS2770 + last candidate only (calls, constructor `new` on interface, tagged templates, generic overload sets)
- 4 argument-error candidates + interleaved arity failure → still TS2770, last **argument-error** candidate shown
- 2–3 argument-error candidates + interleaved arity failure(s) → arity candidates dropped from the chain, `{i}` renumbered among argument-error candidates, `{N}` = total overloads (`Overload 2 of 3` / `Overload 3 of 5`)
- TS2770 body keeps the nested relation reason chain (callback parameter contravariance leaf)
- lone argument-error candidate + any number of arity failures → plain TS2345, no TS2769 (unchanged, now pinned by a test)
- all-arity sets (TS2554/TS2575) and 2–3 clean wraps unchanged; renamed-binder anti-hardcoding variants for both new behaviors
- fallback: candidate sets whose failures carry no declared signature (callback-body sets) keep the historical flat rendering

Found and filed separately during differential verification: #15635 (strictBindCallApply `.call(...)` overload expansion — a different owning operation, upstream of chain rendering).

Residual (documented on #15371): tsc's TS2771 `The last overload is declared here.` related-location info is not emitted — tsz's CLI pipeline does not yet carry location-related info for any family (TS2728/TS6500 are likewise absent in pretty mode); plain-mode output, the parity surface, matches tsc exactly. A deeper follow-up could thread structured candidate-kind metadata through the `NoOverloadMatch` payload instead of classifying by diagnostic code; `is_arity_failure` keeps that classification single-owner in the meantime.

## Goal
Goal: hold

## Verification
- Differential matrix vs `tsc 6.0.2` (`--noEmit --strict --pretty false`): 17/17 byte-identical, covering the adjacent cases above
- `cargo nextest run -p tsz-checker --lib -E 'test(overload)'`: 264 passed; the only 2 failures (`overload_two_pass_any_source_tests::reduce_like_any_seed_selects_generic_candidate`, `union_multi_overload_unified_sig_tests::union_single_plus_multi_overload_no_match_emits_ts2349`) fail identically on pristine `origin/main` in the same container (verified by reverting the diff and rerunning)
- Full `cargo nextest run -p tsz-checker --lib`: failure set identical to pristine `origin/main` baseline (74 pre-existing environment-dependent failures either way; zero regressions, +6 new tests passing)
- `cargo clippy -p tsz-checker --lib` and `-p tsz-solver --lib`: clean
- Conformance/emit/fourslash: ready-review CI (chain lines are indented continuations; the conformance harness parses top-level codes only, which this change never alters)

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

https://claude.ai/code/session_01S1QUf828PorARKpZc4V2iB

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1QUf828PorARKpZc4V2iB)_