### PR TITLE
fix(checker,solver): gate object-literal drill-in through tsc's union best-match and render the union checkTypes property chain (#15403)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -326,6 +326,9 @@ path = "tests/generic_multi_prop_object_literal_tests.rs"
 name = "issue_9757_reduce_accumulator_context_tests"
 path = "tests/issue_9757_reduce_accumulator_context_tests.rs"
 [[test]]
+name = "object_literal_union_best_match_elaboration_tests"
+path = "tests/object_literal_union_best_match_elaboration_tests.rs"
+[[test]]
 name = "abstract_constructor_argument_tests"
 path = "tests/abstract_constructor_argument_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -981,6 +981,57 @@ impl<'a> CheckerState<'a> {
         Some(display_type)
     }
 
+    /// Whether a resolved union member carries `prop_name` for drill-in
+    /// purposes — a named property or an applicable index signature (tsc's
+    /// `getIndexedAccessTypeOrUndefined` on the member).
+    pub(crate) fn union_member_has_property_for_drill_in(
+        &mut self,
+        member: TypeId,
+        prop_name: &str,
+    ) -> bool {
+        if member.is_nullish() {
+            return false;
+        }
+        if matches!(
+            self.resolve_property_access_with_env(member, prop_name),
+            tsz_solver::operations::property::PropertyAccessResult::Success { .. }
+        ) {
+            return true;
+        }
+        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, member).is_some_and(
+            |shape| {
+                shape.string_index_signature().is_some()
+                    || (tsz_solver::utils::is_numeric_literal_name(prop_name)
+                        && shape.number_index.is_some())
+            },
+        )
+    }
+
+    /// The resolved member list of `target` when it is a (multi-member)
+    /// union, for the drill-in gate. Resolves the target and each member
+    /// through lazy aliases so classification sees structural members.
+    fn drill_in_union_view(&mut self, target: TypeId) -> Option<Vec<TypeId>> {
+        let resolved = self.resolve_lazy_type(target);
+        let members = crate::query_boundaries::common::union_members(self.ctx.types, resolved)?;
+        if members.len() < 2 {
+            return None;
+        }
+        Some(
+            members
+                .iter()
+                .map(|&member| self.resolve_lazy_type(member))
+                .collect(),
+        )
+    }
+
+    /// tsc `findBestTypeForObjectLiteral` over a drill-in union view: the
+    /// first non-array-like member in relation order, when the union carries
+    /// an array-like member.
+    pub(crate) fn drill_in_best_union_member(&mut self, target: TypeId) -> Option<TypeId> {
+        let members = self.drill_in_union_view(target)?;
+        crate::query_boundaries::common::first_non_array_like_union_member(self.ctx.types, &members)
+    }
+
     pub(in crate::error_reporter) fn object_literal_target_property_type(
         &mut self,
         target_type: TypeId,
@@ -990,6 +1041,41 @@ impl<'a> CheckerState<'a> {
         let resolved_target = self.resolve_type_for_property_access(target_type);
         let evaluated_target = self.judge_evaluate(resolved_target);
         let contextual_target = self.evaluate_contextual_type(target_type);
+
+        // Union drill-in gate (tsc `getBestMatchIndexedAccessTypeOrUndefined`
+        // -> `findBestTypeForObjectLiteral`, issue #15403): when the target is
+        // a union whose property is NOT present on every member, the drill-in
+        // target resolves through the best-matching member only. With an
+        // array-like member in the union, the best match for an
+        // object-literal source is the first non-array-like member in tsc's
+        // relation order — which may be a primitive without the property, in
+        // which case the property is skipped (no drill-in) and the caller
+        // reports the outer relation error with the union per-property chain.
+        let union_view = [
+            contextual_target,
+            evaluated_target,
+            resolved_target,
+            target_type,
+        ]
+        .into_iter()
+        .find_map(|candidate| self.drill_in_union_view(candidate));
+        if let Some(members) = union_view
+            && !members
+                .iter()
+                .all(|&member| self.union_member_has_property_for_drill_in(member, prop_name))
+            && let Some(best) = crate::query_boundaries::common::first_non_array_like_union_member(
+                self.ctx.types,
+                &members,
+            )
+        {
+            if best.is_nullish() {
+                // A nullish best member carries no properties: skip the
+                // drill-in entirely (tsc elaborates nothing for it).
+                return None;
+            }
+            return self.object_literal_target_property_type(best, prop_name_idx, prop_name);
+        }
+
         let mut contextual_property_type = None;
         let mut env_property_type = None;
         let mut mapped_property_display_type = None;

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -40,6 +40,15 @@ impl<'a> CheckerState<'a> {
         let overall_target_is_union =
             crate::query_boundaries::common::union_members(self.ctx.types, param_type).is_some();
 
+        // tsc's drill-in gate operates on the ORIGINAL union — nullish members
+        // included, since `findBestTypeForObjectLiteral` can pick `null` as the
+        // best member — so compute it before the nullish-wrapper split below
+        // (issue #15403). `Some(best)` only when the union carries an
+        // array-like member; the loop then skips any property the best member
+        // does not carry, leaving the outer relation error to report tsc's
+        // union per-property chain.
+        let drill_gate_best_member = self.drill_in_best_union_member(param_type);
+
         // Normalize optional/nullish wrappers (e.g., `{...} | undefined`).
         let mut effective_param_type = if let (Some(non_nullish), Some(_nullish_cause)) =
             self.split_nullish_type(param_type)
@@ -113,7 +122,16 @@ impl<'a> CheckerState<'a> {
         // → `string`) does not produce a spurious mismatch against a `'name'`
         // target — the false positive a prior up-front bail tried to avoid.
         let diagnostics_before_epc = self.ctx.diagnostics.len();
-        self.check_object_literal_excess_properties(source_type, effective_param_type, arg_idx);
+        // When the drill-in gate is active (union target with an array-like
+        // member), the excess pass must see the RAW union — its per-property
+        // index-value check gates on the same best member, and the nullish
+        // members the wrapper split strips can be that best member.
+        let excess_check_target = if drill_gate_best_member.is_some() {
+            param_type
+        } else {
+            effective_param_type
+        };
+        self.check_object_literal_excess_properties(source_type, excess_check_target, arg_idx);
         // `check_object_literal_excess_properties` can trigger a contextual-type
         // refresh that retains/drops earlier implicit-any diagnostics (see
         // object_literal_support.rs). `recent_diagnostics` clamps its start, so
@@ -272,6 +290,20 @@ impl<'a> CheckerState<'a> {
                 }
                 None => continue,
             };
+            if !narrowed_by_discriminant
+                && let Some(best) = drill_gate_best_member
+                && !self.union_member_has_property_for_drill_in(best, &prop_name)
+            {
+                // The union's best-matching member (first non-array-like)
+                // does not carry this property: tsc skips the drill-in and
+                // reports the outer relation error instead.
+                continue;
+            }
+            // A did-you-mean-to-call hint applies only to property-assignment
+            // VALUES — methods and shorthand properties carry no inner
+            // expression in tsc's object-literal iterator, and both have
+            // their own syntax kinds.
+            let did_you_mean_candidate = elem_node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT;
             let Some((target_prop_type, target_prop_type_for_diagnostic)) = self
                 .object_literal_target_property_type(
                     effective_param_type,
@@ -520,6 +552,23 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get(prop_value_idx)
                     .is_some_and(|n| n.kind == syntax_kind_ext::METHOD_DECLARATION);
+                // tsc `elaborateDidYouMeanToCallOrConstruct`: a property-assignment
+                // value whose call-signature return type is assignable to the
+                // target property type anchors the TS2322 at the VALUE expression
+                // with a `Did you mean to call this expression?` hint. Methods and
+                // shorthand properties carry no inner expression in tsc's
+                // object-literal iterator, so they keep the property-name anchor.
+                if did_you_mean_candidate
+                    && self.emit_did_you_mean_to_call_property_value_error(
+                        source_prop_type_for_diagnostic,
+                        target_for_diag,
+                        target_prop_type,
+                        prop_value_idx,
+                    )
+                {
+                    elaborated = true;
+                    continue;
+                }
                 if is_method {
                     self.error_type_not_assignable_at_with_anchor(
                         source_prop_type_for_diagnostic,
@@ -692,6 +741,21 @@ impl<'a> CheckerState<'a> {
                 .call_arg_relation_outcome(source_prop_type, target_prop_type)
                 .related;
             if !prop_assignable {
+                // tsc's `elaborateError` runs `elaborateDidYouMeanToCallOrConstruct`
+                // before any node-kind elaboration: a property-assignment value of
+                // ANY expression kind whose call/construct return type is
+                // assignable anchors the TS2322 at the value with the hint.
+                if did_you_mean_candidate
+                    && self.emit_did_you_mean_to_call_property_value_error(
+                        source_prop_type,
+                        target_prop_type_for_diagnostic,
+                        target_prop_type,
+                        prop_value_idx,
+                    )
+                {
+                    elaborated = true;
+                    continue;
+                }
                 if self.try_elaborate_assignment_source_error(prop_value_idx, target_prop_type) {
                     elaborated = true;
                     continue;
@@ -883,6 +947,82 @@ impl<'a> CheckerState<'a> {
         }
 
         elaborated
+    }
+
+    /// tsc `elaborateDidYouMeanToCallOrConstruct` for object-literal property
+    /// values: when the value's call-signature return type (not `any`/`never`)
+    /// is assignable to the target property type, the TS2322 anchors at the
+    /// value expression with a `Did you mean to call this expression?` hint.
+    /// Emits and reports `true` on that shape; emits nothing otherwise.
+    fn emit_did_you_mean_to_call_property_value_error(
+        &mut self,
+        source_display: TypeId,
+        target_display: TypeId,
+        target_prop_type: TypeId,
+        prop_value_idx: NodeIndex,
+    ) -> bool {
+        // tsc checks construct signatures before call signatures: any
+        // construct signature's (non-`any`, non-`never`) return type
+        // assignable to the target wins; the call side inspects the first
+        // call signature (`first_callable_return_type`).
+        let return_relates = |this: &mut Self, return_type: TypeId| {
+            return_type != TypeId::ANY
+                && return_type != TypeId::NEVER
+                && this
+                    .call_arg_relation_outcome(return_type, target_prop_type)
+                    .related
+        };
+        let resolved_source = self.resolve_lazy_type(source_display);
+        let construct_hit = crate::query_boundaries::common::get_construct_signatures(
+            self.ctx.types,
+            resolved_source,
+        )
+        .is_some_and(|sigs| sigs.iter().any(|sig| return_relates(self, sig.return_type)));
+        let (hint_message, hint_code) = if construct_hit {
+            (
+                diagnostic_messages::DID_YOU_MEAN_TO_USE_NEW_WITH_THIS_EXPRESSION,
+                diagnostic_codes::DID_YOU_MEAN_TO_USE_NEW_WITH_THIS_EXPRESSION,
+            )
+        } else {
+            let call_hit = self
+                .first_callable_return_type(resolved_source)
+                .is_some_and(|return_type| return_relates(self, return_type));
+            if !call_hit {
+                return false;
+            }
+            (
+                diagnostic_messages::DID_YOU_MEAN_TO_CALL_THIS_EXPRESSION,
+                diagnostic_codes::DID_YOU_MEAN_TO_CALL_THIS_EXPRESSION,
+            )
+        };
+        let anchor_idx =
+            self.resolve_diagnostic_anchor_node(prop_value_idx, DiagnosticAnchorKind::Exact);
+        let Some(anchor) = self.resolve_diagnostic_anchor(anchor_idx, DiagnosticAnchorKind::Exact)
+        else {
+            return false;
+        };
+        let src_str = self.format_type_for_assignability_message(source_display);
+        let tgt_str = self.format_type_for_assignability_message(target_display);
+        let message = format_message(
+            diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[&src_str, &tgt_str],
+        );
+        let related = vec![crate::diagnostics::DiagnosticRelatedInformation {
+            category: tsz_common::diagnostics::DiagnosticCategory::Message,
+            code: hint_code,
+            file: self.ctx.file_name.clone(),
+            start: anchor.start,
+            length: anchor.length,
+            message_text: hint_message.to_string(),
+            depth: 0,
+        }];
+        self.error_at_node_with_related(
+            anchor_idx,
+            &message,
+            diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            related,
+        );
+        true
     }
 
     fn object_literal_numeric_members_assign_to_mapped_target(

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -1328,7 +1328,20 @@ impl<'a> CheckerState<'a> {
         other: TypeId,
     ) -> Option<TypeId> {
         match self.nullish_stripped_members(ty, other)?.as_slice() {
-            [only] => Some(*only),
+            [only] => {
+                // tsc's nullable-target reduction counts the FLAT normalized
+                // union — `Json | undefined` is seven members to `isRelatedTo`,
+                // not two — so a sole survivor that itself resolves to a
+                // multi-member union keeps the original union display
+                // (`Json | undefined`), never the collapsed alias.
+                let resolved = self.resolve_lazy_type(*only);
+                if crate::query_boundaries::common::union_members(self.ctx.types, resolved)
+                    .is_some_and(|members| members.len() >= 2)
+                {
+                    return None;
+                }
+                Some(*only)
+            }
             _ => None,
         }
     }

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -875,9 +875,10 @@ impl<'a> CheckerState<'a> {
     /// *deeper or differently shaped* than a single property leaf — nested
     /// property chains (dotted-path collapse), tuple positions, array/index
     /// drill, and missing-property frames. Returns `false` for self-heading
-    /// leaves (scalar/literal/intrinsic mismatches) and for union/conditional
-    /// members, which the surrounding arm already surfaces via
-    /// [`Self::union_member_related_line`]; those keep their established shape.
+    /// leaves (scalar/literal/intrinsic mismatches) and for union-source/
+    /// conditional-branch members, which the surrounding arm already surfaces
+    /// via [`Self::union_member_related_line`]; those keep their established
+    /// shape.
     const fn property_nested_reason_needs_full_drill(
         reason: &tsz_solver::SubtypeFailureReason,
     ) -> bool {
@@ -896,11 +897,19 @@ impl<'a> CheckerState<'a> {
                 | R::IndexSignatureMismatch { .. }
                 | R::ReturnTypeMismatch { .. }
                 | R::ParameterTypeMismatch { .. }
+                // The union checkTypes chain (issue #15403) frames a nested
+                // fresh-literal relation (`Type '{…}' is not assignable to
+                // type 'M | undefined'.` + its own property drill) or a
+                // nested excess-property line; both are deeper than the
+                // hand-rolled pair.
+                | R::UnionTargetMismatch { .. }
+                | R::ExcessProperty { .. }
         )
         // Scalar/intrinsic/literal leaves self-head with the same
         // `Type 'sp' … 'tp'.` line the hand-rolled pair already emits, and
-        // union/conditional members are handled by the surrounding arm's
-        // `union_member_related_line`; those stay on the hand-rolled path.
+        // union-source/conditional-branch members are handled by the
+        // surrounding arm's `union_member_related_line`; those stay on the
+        // hand-rolled path.
     }
 
     /// Build the child-relation elaboration line (`Type 'C' is not assignable

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -176,6 +176,12 @@ impl<'a> CheckerState<'a> {
                 target_value_type,
                 ..
             } => (*source_value_type, *target_value_type),
+            // An excess property carries the member it is excess AGAINST; its
+            // message must name that member (`'q' does not exist in type 'B'`),
+            // not the parent-supplied union.
+            tsz_solver::SubtypeFailureReason::ExcessProperty { target_type, .. } => {
+                (fallback_source, *target_type)
+            }
             _ => (fallback_source, fallback_target),
         }
     }
@@ -503,6 +509,19 @@ impl<'a> CheckerState<'a> {
                     Self::push_nested_chain(&mut diag, nested_diag, depth + 1);
                 }
             }
+            // tsc anchors a chain that terminates in a NESTED literal's excess
+            // property at that property's name (`reportParentSkippedError`
+            // rebinds `errorNode` to the offending property declaration).
+            if let Some((path, excess_prop)) = Self::terminal_excess_property_of(reason)
+                && let Some(expr_idx) = self
+                    .direct_diagnostic_source_expression(idx)
+                    .or_else(|| self.assignment_source_expression(idx))
+                && let Some((excess_start, excess_length)) =
+                    self.excess_property_anchor_along_path(expr_idx, &path, excess_prop)
+            {
+                diag.start = excess_start;
+                diag.length = excess_length;
+            }
             return diag;
         }
 
@@ -527,6 +546,35 @@ impl<'a> CheckerState<'a> {
             Self::push_nested_chain(&mut diag, nested_diag, depth + 1);
         }
         diag
+    }
+
+    /// The property path to (and name of) the excess property an elaboration
+    /// chain terminates in, if any: walks `PropertyTypeMismatch` /
+    /// `UnionTargetMismatch` links to the leaf, collecting the property names
+    /// along the way, and reports the leaf's `ExcessProperty` name.
+    fn terminal_excess_property_of(
+        reason: &tsz_solver::SubtypeFailureReason,
+    ) -> Option<(Vec<tsz_common::interner::Atom>, tsz_common::interner::Atom)> {
+        match reason {
+            tsz_solver::SubtypeFailureReason::ExcessProperty { property_name, .. } => {
+                Some((Vec::new(), *property_name))
+            }
+            tsz_solver::SubtypeFailureReason::PropertyTypeMismatch {
+                property_name,
+                nested_reason,
+                ..
+            } => {
+                let (mut path, excess) = nested_reason
+                    .as_deref()
+                    .and_then(Self::terminal_excess_property_of)?;
+                path.insert(0, *property_name);
+                Some((path, excess))
+            }
+            tsz_solver::SubtypeFailureReason::UnionTargetMismatch { nested_reason, .. } => {
+                Self::terminal_excess_property_of(nested_reason)
+            }
+            _ => None,
+        }
     }
 
     /// Render a member whose two call signatures differ only in their RETURN

--- a/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
@@ -672,6 +672,41 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// The span of the excess property that terminates a union `checkTypes`
+    /// chain, located by walking the SOURCE literal along the chain's
+    /// recorded property path (`{ z: { q: 1 } }` with path `["z"]` and excess
+    /// `q` anchors at the nested `q` — tsc's `reportParentSkippedError`
+    /// rebinding, issue #15403). Following the recorded path (rather than
+    /// scanning for the name) keeps same-named properties in sibling values
+    /// unambiguous.
+    pub(crate) fn excess_property_anchor_along_path(
+        &self,
+        expr_idx: NodeIndex,
+        path: &[tsz_common::interner::Atom],
+        excess_property: tsz_common::interner::Atom,
+    ) -> Option<(u32, u32)> {
+        use tsz_parser::parser::syntax_kind_ext;
+        let mut current = self.ctx.arena.skip_parenthesized(expr_idx);
+        for &segment in path {
+            let node = self.ctx.arena.get(current)?;
+            if node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+                return None;
+            }
+            let literal = self.ctx.arena.get_literal_expr(node)?;
+            let value = literal.elements.nodes.iter().find_map(|&elem_idx| {
+                let elem_node = self.ctx.arena.get(elem_idx)?;
+                if elem_node.kind != syntax_kind_ext::PROPERTY_ASSIGNMENT {
+                    return None;
+                }
+                let prop = self.ctx.arena.get_property_assignment(elem_node)?;
+                self.property_name_matches_atom(prop.name, segment)
+                    .then_some(prop.initializer)
+            })?;
+            current = self.ctx.arena.skip_parenthesized(value);
+        }
+        self.excess_property_name_span_in_literal(current, excess_property)
+    }
+
     pub(super) fn excess_property_name_span_in_literal(
         &self,
         literal_idx: NodeIndex,

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1712,6 +1712,17 @@ pub(crate) fn is_primitive_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool 
     tsz_solver::visitor::is_primitive_type(db, type_id)
 }
 
+/// tsc `findBestTypeForObjectLiteral`: the first non-array-like member of a
+/// union (in tsc's relation order) when the union contains an array-like
+/// member; `None` when the rule does not apply. Used to gate object-literal
+/// property drill-in against union targets (issue #15403).
+pub(crate) fn first_non_array_like_union_member(
+    db: &dyn TypeDatabase,
+    members: &[TypeId],
+) -> Option<TypeId> {
+    tsz_solver::visitor::first_non_array_like_union_member(db, members)
+}
+
 pub(crate) fn is_literal_type_through_type_constraints(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -330,11 +330,28 @@ impl<'a> CheckerState<'a> {
                 .map(|(_, shape)| shape.clone())
                 .collect::<Vec<_>>();
 
+            // Classify members from the ORIGINAL declared union — nullish
+            // members included, since tsc's `findBestTypeForObjectLiteral`
+            // can pick `null` as the best member. The `target` reaching this
+            // check can be nullish-stripped/pruned, so fall back to the
+            // literal's tracked contextual target when `target` is not a
+            // union view.
+            let tracked_contextual_target = self
+                .ctx
+                .object_literal_tracking
+                .contextual_targets
+                .get(&object_literal_idx)
+                .copied();
+            let best_union_member = [Some(target), tracked_contextual_target]
+                .into_iter()
+                .flatten()
+                .find_map(|candidate| self.drill_in_best_union_member(candidate));
             if self.try_union_index_signature_value_check(
                 source_props,
                 idx,
                 &target_shapes,
                 explicit_property_names.as_ref(),
+                best_union_member,
             ) {
                 return;
             }
@@ -796,6 +813,7 @@ impl<'a> CheckerState<'a> {
                     idx,
                     std::slice::from_ref(&target_shape),
                     explicit_property_names.as_ref(),
+                    None,
                 ) {
                     return;
                 }

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     pub(super) fn try_union_index_signature_value_check(
@@ -11,6 +12,7 @@ impl<'a> CheckerState<'a> {
         obj_literal_idx: NodeIndex,
         union_shapes: &[std::sync::Arc<tsz_solver::ObjectShape>],
         explicit_property_names: Option<&HashSet<Atom>>,
+        best_union_member: Option<TypeId>,
     ) -> bool {
         let diag_count_before = self.ctx.diagnostics.len();
 
@@ -36,6 +38,19 @@ impl<'a> CheckerState<'a> {
             }
 
             let prop_name = self.ctx.types.resolve_atom(source_prop.name);
+
+            // tsc drills a union-target property through the best-matching
+            // member only (`getBestMatchIndexedAccessTypeOrUndefined`). When
+            // the union carries an array-like member, that is the first
+            // non-array-like member (`findBestTypeForObjectLiteral`); a
+            // property it does not carry is never checked at the property
+            // level — the outer relation error reports tsc's union
+            // per-property chain instead (issue #15403).
+            if let Some(best) = best_union_member
+                && !self.union_member_has_property_for_drill_in(best, &prop_name)
+            {
+                continue;
+            }
             let is_numeric_name = tsz_solver::utils::is_numeric_literal_name(&prop_name);
             let mut applicable_index_value_types = Vec::new();
             let mut accepted_by_index = false;

--- a/crates/tsz-checker/tests/object_literal_union_best_match_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/object_literal_union_best_match_elaboration_tests.rs
@@ -1,0 +1,403 @@
+//! Union-target object-literal elaboration: the best-match drill-in gate and
+//! the union per-property (`checkTypes`) chain (issue #15403).
+//!
+//! Structural rule: when a fresh object literal fails against a union target
+//! that contains an array-like member and the union's best-matching member
+//! (tsc `findBestTypeForObjectLiteral`: the first non-array-like member in
+//! relation order) does not carry a failing property, tsc does NOT drill into
+//! the property. It reports the outer TS2322/TS2345/TS1360 at the assignment
+//! anchor with the `hasExcessProperties` checkTypes chain: `Types of property
+//! 'x' are incompatible.` against the union of per-member property-or-index
+//! types (members lacking the property contribute `undefined`). Unions without
+//! an array-like member keep drilling in (control), and a drilled
+//! function-valued property whose return type fits the target anchors at the
+//! VALUE expression with a `Did you mean to call this expression?` hint
+//! (tsc `elaborateDidYouMeanToCallOrConstruct`).
+
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn diagnostics(source: &str) -> Vec<Diagnostic> {
+    check_source_diagnostics(source)
+}
+
+fn offset_of(source: &str, needle: &str) -> u32 {
+    u32::try_from(source.find(needle).expect("needle present")).expect("offset fits")
+}
+
+/// The single diagnostic with `code`, panicking (with context) otherwise.
+fn sole_diagnostic(diags: &[Diagnostic], code: u32) -> &Diagnostic {
+    let mut matching = diags.iter().filter(|diag| diag.code == code);
+    let first = matching
+        .next()
+        .unwrap_or_else(|| panic!("expected a TS{code}; got {diags:?}"));
+    assert!(
+        matching.next().is_none(),
+        "expected exactly one TS{code}; got {diags:?}"
+    );
+    first
+}
+
+fn chain_messages(diag: &Diagnostic) -> Vec<String> {
+    diag.related_information
+        .iter()
+        .map(|info| info.message_text.clone())
+        .collect()
+}
+
+const JSONISH: &str =
+    "type Wire = string | number | boolean | null | Wire[] | { [slot: string]: Wire };\n";
+
+#[test]
+fn var_init_reports_outer_with_union_property_chain() {
+    let source = format!("{JSONISH}const payload: Wire = {{ fetch: () => 1 }};\n");
+    let diags = diagnostics(&source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(
+        diag.start,
+        offset_of(&source, "payload"),
+        "outer TS2322 anchors at the declaration name; got {diags:?}"
+    );
+    assert_eq!(
+        diag.message_text,
+        "Type '{ fetch: () => number; }' is not assignable to type 'Wire'."
+    );
+    assert_eq!(
+        chain_messages(diag),
+        vec![
+            "Types of property 'fetch' are incompatible.".to_string(),
+            "Type '() => number' is not assignable to type 'Wire | undefined'.".to_string(),
+        ],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn nested_literal_recurses_through_the_check_types_chain() {
+    let source = format!("{JSONISH}let sink: Wire;\nsink = {{ outer: {{ inner: () => 1 }} }};\n");
+    let diags = diagnostics(&source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(diag.start, offset_of(&source, "sink ="));
+    assert_eq!(
+        chain_messages(diag),
+        vec![
+            "Types of property 'outer' are incompatible.".to_string(),
+            "Type '{ inner: () => number; }' is not assignable to type 'Wire | undefined'."
+                .to_string(),
+            "Types of property 'inner' are incompatible.".to_string(),
+            "Type '() => number' is not assignable to type 'Wire | undefined'.".to_string(),
+        ],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn call_argument_reports_ts2345_with_full_chain() {
+    let source = format!(
+        "{JSONISH}declare function send(w: Wire): void;\nsend({{ outer: {{ inner: () => 1 }} }});\n"
+    );
+    let diags = diagnostics(&source);
+    let diag = sole_diagnostic(&diags, 2345);
+    assert_eq!(
+        chain_messages(diag),
+        vec![
+            "Types of property 'outer' are incompatible.".to_string(),
+            "Type '{ inner: () => number; }' is not assignable to type 'Wire | undefined'."
+                .to_string(),
+            "Types of property 'inner' are incompatible.".to_string(),
+            "Type '() => number' is not assignable to type 'Wire | undefined'.".to_string(),
+        ],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn return_statement_reports_outer_with_chain() {
+    let source = format!("{JSONISH}function make(): Wire {{\n  return {{ leaf: () => 1 }};\n}}\n");
+    let diags = diagnostics(&source);
+    let diag = sole_diagnostic(&diags, 2322);
+    // tsc anchors a failing return statement at the `return` keyword.
+    assert_eq!(diag.start, offset_of(&source, "return {"));
+    assert_eq!(
+        chain_messages(diag),
+        vec![
+            "Types of property 'leaf' are incompatible.".to_string(),
+            "Type '() => number' is not assignable to type 'Wire | undefined'.".to_string(),
+        ],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn satisfies_reports_ts1360_with_chain() {
+    let source = format!("{JSONISH}const checked = {{ leaf: () => 1 }} satisfies Wire;\n");
+    let diags = diagnostics(&source);
+    let diag = sole_diagnostic(&diags, 1360);
+    assert_eq!(
+        chain_messages(diag),
+        vec![
+            "Types of property 'leaf' are incompatible.".to_string(),
+            "Type '() => number' is not assignable to type 'Wire | undefined'.".to_string(),
+        ],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn index_member_chain_reduces_two_member_union_target() {
+    // Per-property union `Rec | undefined` reduces to `Rec` for a
+    // definitely-non-nullable source (tsc `isRelatedTo` nullable reduction).
+    let source = "interface Rec { tag: string }\n\
+         type Bag = string | Rec[] | { [key: string]: Rec };\n\
+         const wrong: Bag = { item: true };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(
+        chain_messages(diag),
+        vec![
+            "Types of property 'item' are incompatible.".to_string(),
+            "Type 'boolean' is not assignable to type 'Rec'.".to_string(),
+        ],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn nullish_source_keeps_the_undefined_arm() {
+    let source = "interface Rec { tag: string }\n\
+         type Bag = string | Rec[] | { [key: string]: Rec };\n\
+         const wrong: Bag = { item: null };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(
+        chain_messages(diag),
+        vec![
+            "Types of property 'item' are incompatible.".to_string(),
+            "Type 'null' is not assignable to type 'Rec | undefined'.".to_string(),
+        ],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn named_property_member_contributes_its_declared_type() {
+    let source = "interface Rec { tag: string }\n\
+         type Bag = string | Rec[] | { item: number };\n\
+         const wrong: Bag = { item: true };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(
+        chain_messages(diag),
+        vec![
+            "Types of property 'item' are incompatible.".to_string(),
+            "Type 'boolean' is not assignable to type 'number'.".to_string(),
+        ],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn three_member_property_union_with_two_nullish_arms_reduces() {
+    let source = "interface Rec { tag: string }\n\
+         type Bag = string | Rec[] | { [key: string]: Rec | null };\n\
+         const wrong: Bag = { item: true };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(
+        chain_messages(diag),
+        vec![
+            "Types of property 'item' are incompatible.".to_string(),
+            "Type 'boolean' is not assignable to type 'Rec'.".to_string(),
+        ],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn all_properties_passing_elaborates_against_best_member() {
+    // `undefined` satisfies the per-property union, so the fallback elaborates
+    // against the best member — the first non-array-like member (`string`).
+    let source = "interface Rec { tag: string }\n\
+         type Bag = string | Rec[] | { [key: string]: Rec };\n\
+         const wrong: Bag = { item: undefined };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(
+        chain_messages(diag),
+        vec!["Type '{ item: undefined; }' is not assignable to type 'string'.".to_string()],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn nullish_union_member_is_the_best_match_when_it_sorts_first() {
+    let source = "interface Rec { tag: string }\n\
+         type Bag = null | Rec[] | { [key: string]: Rec };\n\
+         const wrong: Bag = { item: undefined };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(
+        chain_messages(diag),
+        vec!["Type '{ item: undefined; }' is not assignable to type 'null'.".to_string()],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn declaration_order_of_union_members_does_not_change_the_best_match() {
+    // Written with the index member first: tsc's relation order still picks
+    // the primitive member as the best match.
+    let source = "interface Rec { tag: string }\n\
+         type Bag = { [key: string]: Rec } | string | Rec[];\n\
+         const wrong: Bag = { item: undefined };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(
+        chain_messages(diag),
+        vec!["Type '{ item: undefined; }' is not assignable to type 'string'.".to_string()],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn nested_excess_property_wins_and_anchors_at_the_nested_property() {
+    let source = "interface Rec { tag: string }\n\
+         type Bag = string | Rec[] | { [key: string]: Rec };\n\
+         const wrong: Bag = { item: { bogus: 1 } };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(
+        diag.start,
+        offset_of(source, "bogus"),
+        "chain terminating in a nested excess property anchors at that property; got {diags:?}"
+    );
+    assert_eq!(
+        chain_messages(diag),
+        vec![
+            "Types of property 'item' are incompatible.".to_string(),
+            "Object literal may only specify known properties, and 'bogus' does not exist in type 'Rec'.".to_string(),
+        ],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn nested_excess_property_outranks_a_sibling_property_mismatch() {
+    let source = "interface Rec { tag: string }\n\
+         type Bag = string | Rec[] | { [key: string]: Rec };\n\
+         const wrong: Bag = { item: { tag: 1, bogus: 2 } };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(diag.start, offset_of(source, "bogus"), "got {diags:?}");
+    assert_eq!(
+        chain_messages(diag),
+        vec![
+            "Types of property 'item' are incompatible.".to_string(),
+            "Object literal may only specify known properties, and 'bogus' does not exist in type 'Rec'.".to_string(),
+        ],
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn union_without_array_like_member_still_drills_into_the_property() {
+    let source = "interface Rec { tag: string }\n\
+         type Bag = number | { [key: string]: Rec };\n\
+         const wrong: Bag = { item: true };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(
+        diag.start,
+        offset_of(source, "item: true"),
+        "no array-like member: keep the inner property drill; got {diags:?}"
+    );
+    assert_eq!(
+        diag.message_text,
+        "Type 'boolean' is not assignable to type 'Rec'."
+    );
+}
+
+#[test]
+fn array_member_union_whose_object_member_has_the_property_drills() {
+    let source = "type Pair = number[] | { first: number };\n\
+         const wrong: Pair = { first: \"s\" };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(
+        diag.start,
+        offset_of(source, "first: \"s\""),
+        "best member carries the property: keep the drill; got {diags:?}"
+    );
+    assert_eq!(
+        diag.message_text,
+        "Type 'string' is not assignable to type 'number'."
+    );
+}
+
+#[test]
+fn tuple_and_readonly_array_members_count_as_array_like() {
+    for union in [
+        "[number] | { first: number }",
+        "readonly string[] | { first: number }",
+    ] {
+        let source = format!("type Pair = {union};\nconst wrong: Pair = {{ first: \"s\" }};\n");
+        let diags = diagnostics(&source);
+        let diag = sole_diagnostic(&diags, 2322);
+        assert_eq!(
+            diag.start,
+            offset_of(&source, "first: \"s\""),
+            "best member `{{ first: number }}` still drills for `{union}`; got {diags:?}"
+        );
+    }
+}
+
+#[test]
+fn did_you_mean_to_call_anchors_at_the_value_expression() {
+    let source = "const holder: { count: number } = { count: () => 1 };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(
+        diag.start,
+        offset_of(source, "() => 1"),
+        "function-valued property with a fitting return anchors at the value; got {diags:?}"
+    );
+    assert!(
+        diag.related_information
+            .iter()
+            .any(|info| info.message_text == "Did you mean to call this expression?"),
+        "expected the call hint; got {diags:?}"
+    );
+}
+
+#[test]
+fn did_you_mean_to_call_applies_to_identifier_values() {
+    let source = "declare function supply(): number;\n\
+         const holder: { count: number } = { count: supply };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(diag.start, offset_of(source, "supply }"), "got {diags:?}");
+    assert!(
+        diag.related_information
+            .iter()
+            .any(|info| info.message_text == "Did you mean to call this expression?"),
+        "expected the call hint; got {diags:?}"
+    );
+}
+
+#[test]
+fn mismatching_return_type_keeps_the_property_name_anchor() {
+    let source = "const holder: { count: number } = { count: () => \"s\" };\n";
+    let diags = diagnostics(source);
+    let diag = sole_diagnostic(&diags, 2322);
+    assert_eq!(
+        diag.start,
+        offset_of(source, "count: () => \"s\""),
+        "return type does not fit: anchor stays at the property name; got {diags:?}"
+    );
+    assert!(
+        diag.related_information
+            .iter()
+            .all(|info| info.message_text != "Did you mean to call this expression?"),
+        "no call hint for a non-fitting return; got {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -63,6 +63,23 @@ fn reorder_union_members_nullish_first(members: &[TypeId]) -> Vec<TypeId> {
     ordered
 }
 
+/// Outcome of the fresh-object-literal union `checkTypes` pass
+/// (tsc `hasExcessProperties`, issue #15403).
+enum FreshLiteralUnionCheck {
+    /// A present, target-known source property failed the per-member
+    /// property-type union relation; the carried reason is the
+    /// `Types of property 'x' are incompatible.` chain.
+    FailingProperty(SubtypeFailureReason),
+    /// Every present source property is known in the target union and passes
+    /// its per-member property-type relation, so the failure elaborates
+    /// against the best-matching member instead.
+    AllPropertiesPass,
+    /// The pass does not apply: non-fresh source, no object shape, or the
+    /// first problematic property is unknown in every member (an excess
+    /// property, owned by the excess-property machinery).
+    NotApplicable,
+}
+
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Array element type, transparently peeling a single `readonly` array
     /// wrapper (`readonly T[]` / `ReadonlyArray<T>`).
@@ -985,6 +1002,40 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
 
         if union_list_id(self.interner, resolved_target).is_some() {
+            // Fresh object-literal source vs union target: tsc's
+            // `hasExcessProperties` checkTypes pass runs before any
+            // best-member selection (`typeRelatedToSomeType`), relating each
+            // present source property against the union of per-member
+            // property-or-index types and reporting the first failing one as
+            // `Types of property 'x' are incompatible.` with the inner
+            // relation nested (issue #15403). When every property passes, the
+            // relation error elaborates against the best-matching member —
+            // for an object-literal source vs a union containing an
+            // array-like member, the first non-array-like member in tsc's
+            // relation order (`findBestTypeForObjectLiteral`).
+            match self.explain_fresh_literal_union_check_types(resolved_source, target) {
+                FreshLiteralUnionCheck::FailingProperty(reason) => return Some(reason),
+                FreshLiteralUnionCheck::AllPropertiesPass => {
+                    if let Some(best) =
+                        self.first_non_array_like_union_member_in_relation_order(resolved_target)
+                    {
+                        let nested = self
+                            .explain_failure_guarded(resolved_source, best)
+                            .unwrap_or(SubtypeFailureReason::TypeMismatch {
+                                source_type: source,
+                                target_type: best,
+                            });
+                        return Some(SubtypeFailureReason::UnionTargetMismatch {
+                            source_type: source,
+                            target_type: target,
+                            member_type: best,
+                            nested_reason: Box::new(nested),
+                        });
+                    }
+                }
+                FreshLiteralUnionCheck::NotApplicable => {}
+            }
+
             // Prefer the original target's union members so member display keeps
             // user-facing aliases (e.g. an identity mapped type `Mapped<B>` that
             // structurally simplifies to `B` in `resolved_target` must still
@@ -2022,5 +2073,390 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
 
         None
+    }
+
+    /// tsc `hasExcessProperties` union `checkTypes` pass (issue #15403).
+    ///
+    /// For a FRESH object-literal source failing against a union target, tsc
+    /// relates each present source property against the union of per-member
+    /// property-or-index types (`getTypeOfPropertyInTypes`): a member with a
+    /// named property contributes that property's type, a member whose index
+    /// signature applies contributes the index value type, and every other
+    /// member contributes `undefined`. The first failing property reports
+    /// `Types of property 'x' are incompatible.` with the inner relation
+    /// nested. Properties unknown in every member are excess properties and
+    /// belong to the excess-property machinery, so the pass defers to it.
+    fn explain_fresh_literal_union_check_types(
+        &mut self,
+        resolved_source: TypeId,
+        target: TypeId,
+    ) -> FreshLiteralUnionCheck {
+        use crate::relations::freshness::is_fresh_object_type;
+
+        if !is_fresh_object_type(self.interner, resolved_source) {
+            return FreshLiteralUnionCheck::NotApplicable;
+        }
+        let Some(shape_id) = object_shape_id(self.interner, resolved_source)
+            .or_else(|| object_with_index_shape_id(self.interner, resolved_source))
+        else {
+            return FreshLiteralUnionCheck::NotApplicable;
+        };
+        let Some(check_members) = self.flattened_resolved_union_members(target) else {
+            return FreshLiteralUnionCheck::NotApplicable;
+        };
+
+        let shape = self.interner.object_shape(shape_id);
+        let mut per_member = Vec::with_capacity(check_members.len());
+        for prop in shape.properties.iter() {
+            let name_str = self.interner.resolve_atom_ref(prop.name);
+            per_member.clear();
+            let mut known = false;
+            for &member in &check_members {
+                match self.member_property_or_index_type(member, prop.name, name_str.as_ref()) {
+                    Some(member_prop_type) => {
+                        known = true;
+                        per_member.push(member_prop_type);
+                    }
+                    None => per_member.push(TypeId::UNDEFINED),
+                }
+            }
+            if !known {
+                // A property unknown in every member is an excess property;
+                // tsc reports the excess error before any property-type
+                // chain, so the whole pass defers to the excess machinery.
+                return FreshLiteralUnionCheck::NotApplicable;
+            }
+            let prop_union = self.interner.union_from_slice(&per_member);
+            if self.check_subtype(prop.type_id, prop_union).is_true() {
+                continue;
+            }
+            // tsc's reported property type is post-widening (`() => 1`
+            // contextually kept alive in tsz renders as tsc's `() => number`);
+            // the relation above already ran on the raw type.
+            let display_prop_type = self.widen_check_types_property_display(prop.type_id);
+            let nested = self.check_types_inner_reason(display_prop_type, prop_union);
+            return FreshLiteralUnionCheck::FailingProperty(
+                SubtypeFailureReason::PropertyTypeMismatch {
+                    property_name: prop.name,
+                    source_property_type: display_prop_type,
+                    target_property_type: prop_union,
+                    nested_reason: Some(Box::new(nested)),
+                },
+            );
+        }
+        FreshLiteralUnionCheck::AllPropertiesPass
+    }
+
+    /// Widen a fresh-literal property type for the reported `checkTypes`
+    /// reason: scalar literals to their primitives and a function's literal
+    /// return to its primitive (`() => 1` renders as tsc's `() => number` —
+    /// tsc's mutable-location widening has already generalized the property
+    /// type by the time its relation reports it). Display-only; the relation
+    /// verdict runs on the raw type.
+    fn widen_check_types_property_display(&self, ty: TypeId) -> TypeId {
+        let widened = crate::operations::widening::widen_literal_type(self.interner, ty);
+        if widened != ty {
+            return widened;
+        }
+        let return_type = crate::type_queries::get_function_return_type(self.interner, ty);
+        if return_type != TypeId::ERROR {
+            let widened_return =
+                crate::operations::widening::widen_literal_type(self.interner, return_type);
+            if widened_return == return_type {
+                return ty;
+            }
+            return crate::type_queries::replace_function_return_type(
+                self.interner,
+                ty,
+                widened_return,
+            );
+        }
+        // A nested object-literal property displays its own property types
+        // one level deep (`{ inner: () => 1 }` renders as tsc's
+        // `{ inner: () => number; }`); deeper levels re-widen at their own
+        // recursion step.
+        if let Some(shape_id) = object_shape_id(self.interner, ty)
+            .or_else(|| object_with_index_shape_id(self.interner, ty))
+        {
+            let shape = self.interner.object_shape(shape_id);
+            let mut changed = false;
+            let new_props: Vec<crate::types::PropertyInfo> = shape
+                .properties
+                .iter()
+                .map(|prop| {
+                    let widened_type = self.widen_check_types_property_display(prop.type_id);
+                    changed |= widened_type != prop.type_id;
+                    let mut widened_prop = prop.clone();
+                    widened_prop.type_id = widened_type;
+                    widened_prop
+                })
+                .collect();
+            if !changed {
+                return ty;
+            }
+            return crate::operations::widening::rebuild_object_with_shape_metadata(
+                self.interner,
+                ty,
+                &shape,
+                new_props,
+            );
+        }
+        ty
+    }
+
+    /// The inner relation reason beneath a `Types of property 'x' are
+    /// incompatible.` line of the union `checkTypes` pass.
+    ///
+    /// Mirrors tsc's inner `isRelatedTo(sourcePropType, propUnion)` error
+    /// reporting: a definitely-non-nullable source against a union of one
+    /// non-nullish member plus one or two nullish members is related (and
+    /// displayed) against the non-nullish member alone (tsc `isRelatedTo`'s
+    /// nullable-target reduction); a fresh object-literal source recurses
+    /// through the checkTypes pass itself; anything else is the plain
+    /// `Type 'S' is not assignable to type 'U'.` leaf.
+    fn check_types_inner_reason(
+        &mut self,
+        source_prop: TypeId,
+        prop_union: TypeId,
+    ) -> SubtypeFailureReason {
+        let leaf = |target: TypeId| SubtypeFailureReason::TypeMismatch {
+            source_type: source_prop,
+            target_type: target,
+        };
+        let Some(flat) = self.flattened_resolved_union_members(prop_union) else {
+            return leaf(prop_union);
+        };
+
+        let mut sole_non_nullish = None;
+        let mut non_nullish_count = 0usize;
+        for &member in &flat {
+            if !member.is_nullish() {
+                non_nullish_count += 1;
+                sole_non_nullish = Some(member);
+            }
+        }
+        let nullish_count = flat.len() - non_nullish_count;
+        if let Some(reduced) = sole_non_nullish
+            && non_nullish_count == 1
+            && (1..=2).contains(&nullish_count)
+            && self.is_definitely_non_nullable(source_prop)
+        {
+            return self.reduced_member_inner_reason(source_prop, reduced);
+        }
+
+        let resolved_prop = self.resolve_lazy_type(source_prop);
+        if let FreshLiteralUnionCheck::FailingProperty(inner) =
+            self.explain_fresh_literal_union_check_types(resolved_prop, prop_union)
+        {
+            return Self::framed_inner_reason(source_prop, prop_union, inner);
+        }
+
+        leaf(prop_union)
+    }
+
+    /// The inner reason for the reduced relation `S` vs the union's sole
+    /// non-nullish member (tsc `isRelatedTo`'s nullable-target reduction).
+    ///
+    /// tsc's inner `isRelatedTo(S, reduced)` runs `hasExcessProperties`
+    /// before any structural property check, so for a fresh object-literal
+    /// source the first source property unknown in the reduced member wins —
+    /// even over a present-property type mismatch (no elaboration pass runs
+    /// inside a nested relation).
+    fn reduced_member_inner_reason(
+        &mut self,
+        source_prop: TypeId,
+        reduced: TypeId,
+    ) -> SubtypeFailureReason {
+        if let Some(excess) = self.first_excess_property_against_member(source_prop, reduced) {
+            return SubtypeFailureReason::ExcessProperty {
+                property_name: excess,
+                target_type: reduced,
+            };
+        }
+        let Some(inner) = self.explain_failure_guarded(source_prop, reduced) else {
+            return SubtypeFailureReason::TypeMismatch {
+                source_type: source_prop,
+                target_type: reduced,
+            };
+        };
+        if Self::reason_carries_own_headline(&inner) {
+            inner
+        } else {
+            Self::framed_inner_reason(source_prop, reduced, inner)
+        }
+    }
+
+    /// Frame `inner` beneath its own `Type 'S' is not assignable to type
+    /// 'T'.` line (rendered via the `UnionTargetMismatch` parent-with-child
+    /// shape; the member field carries the same target — there is no separate
+    /// member to name).
+    fn framed_inner_reason(
+        source: TypeId,
+        target: TypeId,
+        inner: SubtypeFailureReason,
+    ) -> SubtypeFailureReason {
+        SubtypeFailureReason::UnionTargetMismatch {
+            source_type: source,
+            target_type: target,
+            member_type: target,
+            nested_reason: Box::new(inner),
+        }
+    }
+
+    /// `true` when the rendered form of `reason` already begins with its own
+    /// full first line (a `Type 'S' is not assignable ...`, missing-property,
+    /// or excess-property message), so no extra relation frame is needed
+    /// above it.
+    const fn reason_carries_own_headline(reason: &SubtypeFailureReason) -> bool {
+        matches!(
+            reason,
+            SubtypeFailureReason::TypeMismatch { .. }
+                | SubtypeFailureReason::IntrinsicTypeMismatch { .. }
+                | SubtypeFailureReason::LiteralTypeMismatch { .. }
+                | SubtypeFailureReason::MissingProperty { .. }
+                | SubtypeFailureReason::MissingProperties { .. }
+                | SubtypeFailureReason::ExcessProperty { .. }
+                | SubtypeFailureReason::UnionTargetMismatch { .. }
+                | SubtypeFailureReason::NoUnionMemberMatches { .. }
+        )
+    }
+
+    /// The union member list of `ty` after resolving lazy aliases, with one
+    /// level of nested-union flattening — the member list tsc's normalized
+    /// union carries (`Json | undefined` is the seven flat members, not a
+    /// nested alias pair).
+    fn flattened_resolved_union_members(&self, ty: TypeId) -> Option<Vec<TypeId>> {
+        let resolved = self.resolve_lazy_type(ty);
+        let list_id = union_list_id(self.interner, resolved)?;
+        let members = self.interner.type_list(list_id);
+        let mut flat = Vec::with_capacity(members.len());
+        let mut seen = rustc_hash::FxHashSet::default();
+        for &member in members.iter() {
+            let resolved_member = self.resolve_lazy_type(member);
+            if let Some(sub_id) = union_list_id(self.interner, resolved_member) {
+                let sub_members: Vec<TypeId> = self.interner.type_list(sub_id).to_vec();
+                flat.extend(
+                    sub_members
+                        .into_iter()
+                        .map(|sub| self.resolve_lazy_type(sub))
+                        .filter(|&sub| seen.insert(sub)),
+                );
+            } else if seen.insert(resolved_member) {
+                flat.push(resolved_member);
+            }
+        }
+        Some(flat)
+    }
+
+    /// Per-member contribution to the union `checkTypes` property type
+    /// (tsc `getTypeOfPropertyInTypes`): the named property's type (optional
+    /// properties gain `| undefined` under strict null checks, matching the
+    /// optional property symbol's type), else the applicable index
+    /// signature's value type, else `None` (the property is not known on
+    /// this member and it contributes `undefined`).
+    fn member_property_or_index_type(
+        &self,
+        member: TypeId,
+        prop_name: tsz_common::interner::Atom,
+        name_str: &str,
+    ) -> Option<TypeId> {
+        let resolved = self.resolve_lazy_type(member);
+        let shape_id = object_shape_id(self.interner, resolved)
+            .or_else(|| object_with_index_shape_id(self.interner, resolved))?;
+        let shape = self.interner.object_shape(shape_id);
+        if let Some(prop) =
+            utils::lookup_property(self.interner, &shape.properties, Some(shape_id), prop_name)
+        {
+            return Some(self.optional_property_type(prop));
+        }
+        if utils::is_numeric_literal_name(name_str)
+            && let Some(number_index) = shape.number_index.as_ref()
+        {
+            return Some(number_index.value_type);
+        }
+        shape
+            .string_index
+            .as_ref()
+            .map(|string_index| string_index.value_type)
+    }
+
+    /// First source property that is excess against a single reduced target
+    /// member: a fresh object-literal source property named nowhere in the
+    /// member's shape and not accepted by an applicable index signature.
+    /// Mirrors the per-property excess pass tsc's `hasExcessProperties` runs
+    /// ahead of structural property checks. `None` when the member is not a
+    /// plain object shape (primitives and arrays route through other reasons).
+    fn first_excess_property_against_member(
+        &self,
+        source: TypeId,
+        member: TypeId,
+    ) -> Option<tsz_common::interner::Atom> {
+        let resolved_source = self.resolve_lazy_type(source);
+        if !crate::relations::freshness::is_fresh_object_type(self.interner, resolved_source) {
+            return None;
+        }
+        let source_shape_id = object_shape_id(self.interner, resolved_source)
+            .or_else(|| object_with_index_shape_id(self.interner, resolved_source))?;
+        let resolved_member = self.resolve_lazy_type(member);
+        object_shape_id(self.interner, resolved_member)
+            .or_else(|| object_with_index_shape_id(self.interner, resolved_member))?;
+        let source_shape = self.interner.object_shape(source_shape_id);
+        source_shape
+            .properties
+            .iter()
+            .find(|prop| {
+                // Excess iff the member carries the property neither as a
+                // named member nor through an applicable index signature.
+                self.member_property_or_index_type(
+                    resolved_member,
+                    prop.name,
+                    self.interner.resolve_atom_ref(prop.name).as_ref(),
+                )
+                .is_none()
+            })
+            .map(|prop| prop.name)
+    }
+
+    /// `true` for definitely-non-nullable sources (tsc
+    /// `TypeFlags.DefinitelyNonNullable`): concrete value types that can
+    /// never hold `null`/`undefined`. Nullish types, `void`, `any`/`unknown`,
+    /// type parameters, and unions carrying a nullish member are excluded.
+    fn is_definitely_non_nullable(&self, ty: TypeId) -> bool {
+        let resolved = self.resolve_lazy_type(ty);
+        if resolved.is_nullish()
+            || resolved == TypeId::VOID
+            || resolved.is_any_or_unknown()
+            || resolved.is_never()
+            || is_type_parameter(self.interner, resolved)
+        {
+            return false;
+        }
+        if let Some(list_id) = union_list_id(self.interner, resolved) {
+            return self
+                .interner
+                .type_list(list_id)
+                .iter()
+                .all(|&m| self.is_definitely_non_nullable(m));
+        }
+        true
+    }
+
+    /// tsc `findBestTypeForObjectLiteral`: the best-matching member of a
+    /// union target containing an array-like member — the first
+    /// non-array-like member in tsc's relation order. Members are lazily
+    /// resolved before classification so aliased array members participate.
+    /// (Callers have already established the fresh object-literal source.)
+    fn first_non_array_like_union_member_in_relation_order(
+        &self,
+        resolved_target: TypeId,
+    ) -> Option<TypeId> {
+        let list_id = union_list_id(self.interner, resolved_target)?;
+        let members: Vec<TypeId> = self
+            .interner
+            .type_list(list_id)
+            .iter()
+            .map(|&m| self.resolve_lazy_type(m))
+            .collect();
+        crate::visitor::first_non_array_like_union_member(self.interner, &members)
     }
 }

--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -584,6 +584,61 @@ pub fn is_generic_application(types: &dyn TypeDatabase, type_id: TypeId) -> bool
     matches!(types.lookup(type_id), Some(TypeData::Application(_)))
 }
 
+/// tsc `isArrayLikeType` for union best-member selection: arrays, readonly
+/// arrays, and tuples, resolving `readonly` wrappers, applications, and
+/// substitution/constraint indirection through
+/// [`crate::type_queries::classify_array_like`]. Callers resolve lazy
+/// aliases before asking.
+fn is_array_like_for_union_best_match(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    use crate::type_queries::extended::{ArrayLikeKind, classify_array_like};
+    match classify_array_like(types, type_id) {
+        ArrayLikeKind::Array(_) | ArrayLikeKind::Tuple => true,
+        ArrayLikeKind::Readonly(inner) => matches!(
+            classify_array_like(types, inner),
+            ArrayLikeKind::Array(_) | ArrayLikeKind::Tuple
+        ),
+        ArrayLikeKind::Union(_) | ArrayLikeKind::Intersection(_) | ArrayLikeKind::Other => false,
+    }
+}
+
+/// tsc `findBestTypeForObjectLiteral`: for an object-literal source failing
+/// against a union that contains an array-like member, the best-matching
+/// member is the first non-array-like member in tsc's relation order.
+///
+/// tsc iterates `union.types` in ascending type-id order: `undefined`/`null`
+/// first, then the remaining intrinsics and literal types (interned before
+/// any user object type in practice), then object-like members in stored
+/// order. Returns `None` when no member is array-like (the rule does not
+/// apply) or every member is array-like.
+pub fn first_non_array_like_union_member(
+    types: &dyn TypeDatabase,
+    members: &[TypeId],
+) -> Option<TypeId> {
+    let relation_rank = |m: TypeId| match m {
+        TypeId::UNDEFINED => 0,
+        TypeId::NULL => 1,
+        _ if is_intrinsic_or_literal_type(types, m) => 2,
+        _ => 3,
+    };
+    let mut saw_array_like = false;
+    let mut best: Option<(u32, TypeId)> = None;
+    for &member in members {
+        if is_array_like_for_union_best_match(types, member) {
+            saw_array_like = true;
+        } else {
+            let rank = relation_rank(member);
+            // Strictly-less keeps the FIRST member of the minimal rank.
+            if best.is_none_or(|(best_rank, _)| rank < best_rank) {
+                best = Some((rank, member));
+            }
+        }
+    }
+    if !saw_array_like {
+        return None;
+    }
+    best.map(|(_, member)| member)
+}
+
 mod content;
 
 pub use content::{


### PR DESCRIPTION
Fixes #15403.

## Goal
Goal: hold

## Structural rule

When a fresh object literal fails against a union target that contains an array-like member, tsc's object-literal elaboration (`elaborateElementwise` → `getBestMatchIndexedAccessTypeOrUndefined` → `findBestTypeForObjectLiteral`) resolves each property through the union's best-matching member only — the first non-array-like member in relation order (`undefined`/`null`, then intrinsics/literals, then object members). When that member does not carry the property, tsc does **not** drill in; it reports the outer TS2322/TS2345/TS1360 at the assignment anchor with the `hasExcessProperties` checkTypes chain: `Types of property 'x' are incompatible.` against the union of per-member property-or-index types (`getTypeOfPropertyInTypes` — members lacking the property contribute `undefined`), recursing through nested fresh literals. tsz now does the same through the solver explain pass (chain construction) and a checker-side drill-in gate (elaboration + index-signature sink), with the outer diagnostic routed through the existing relation → reason → diagnostic gateway.

Owner layers:

- **Solver** (`relations/subtype/explain.rs`): the fresh-literal union checkTypes pass (`explain_fresh_literal_union_check_types`), the per-member property-or-index union, tsc's nullable-target reduction for the inner relation (2/3-member unions with one non-nullish member reduce for definitely-non-nullable sources), the nested excess-property precedence (`hasExcessProperties` runs before structural property checks inside a nested relation), and the `findBestTypeForObjectLiteral` fallback when every property passes. `visitor_predicates.rs` owns the shared best-member selection (`first_non_array_like_union_member`, reusing `classify_array_like`).
- **Checker** (orchestration/anchors): the drill-in gate at the elaboration entry points and the union index-signature value sink (`drill_in_best_union_member` / `union_member_has_property_for_drill_in`), the `Did you mean to call this expression?` / `Did you mean to use 'new' with this expression?` value-expression anchor (tsc `elaborateDidYouMeanToCallOrConstruct`, related info 6212/6213), the nested-excess anchor relocation along the reason chain's recorded property path, and the display rule that a sole nullish-strip survivor which itself resolves to a multi-member union keeps the full union display (`Json | undefined`, never collapsed to `Json`).

## Adjacent-case matrix (differential vs tsc 6.0.2, byte-exact)

| case | position | result |
|---|---|---|
| `{ a: () => 1 }` vs recursive `Json` union | var init | outer + `Json \| undefined` chain |
| `{ outer: { inner: () => 1 } }` vs `Json` | var init, assignment, call arg (TS2345), return, satisfies (TS1360) | outer + 4-line recursive chain |
| index member `{ [k: string]: B }`, sources `true`/`Symbol()`/`null`/`undefined` | var init | chain targets `B` / `B` / `B \| undefined` / best-match `string` fallback |
| named member `{ z: number }`, optional member `{ z?: number }`, index `B \| null` | var init | chain targets `number` / `number` / `B` (3-member reduction) |
| `null`-first unions (`null \| B[] \| {index}`) | var init | best-match `null` line, no drill |
| member order permuted (`{index} \| string \| B[]`) | var init | best-match `string` (relation order, not declaration order) |
| nested excess `{ z: { q: 1 } }`, also with sibling mismatch | var init | excess line wins, diagnostic anchored at nested `q` |
| controls: `number[] \| {a}`, `[number] \| {a}`, `readonly string[] \| {a}`, `number \| {index}` | var init | keep drilling in (unchanged) |
| `{ a: () => 1 }` vs `{ a: number }`, identifier and function values | var init | anchored at value expression + 6212 hint; negative control keeps name anchor |

Known adjacent gaps (unchanged, tracked in #15403's follow-up section): non-fresh sources vs these unions, and one display-order corner where a contextual retype renders a nested literal's properties in canonical rather than declaration order.

## Verification

- New suite `crates/tsz-checker/tests/object_literal_union_best_match_elaboration_tests.rs` (20 tests: full matrix, renamed binders, positive/negative controls, anchors).
- `cargo nextest run -p tsz-solver`: only the 3 pre-existing failures already tracked in #15338 (verified identical on a clean tree).
- `cargo nextest run -p tsz-checker --lib -E 'test(elaborat) or test(excess) or test(union) or test(object_literal)'` (1038 tests): only 3 failures, each reproduced identically at `origin/main` (pre-existing #15338 family). The full checker suite exceeds this runner's memory/disk; ready-review CI owns it.
- Differential runs vs `tsc` 6.0.2 across the matrix above: byte-exact including anchors.
- `cargo clippy -p tsz-solver -p tsz-checker` and `cargo fmt --check`: clean.
- Conformance/emit/fourslash parity floors: ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

https://claude.ai/code/session_01FV6gbXhA9KPK1F6gDkszj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01FV6gbXhA9KPK1F6gDkszj6)_