### PR TITLE
fix(checker): model strict .call/.apply/.bind on overloaded receivers by the last overload only (#15635)

### DIFF
--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -1196,17 +1196,13 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // For `.call`/`.apply`, `tsc` fixes the rest-arg tuple from the
-        // target's original signature, collapsing type parameters whose
-        // constraint references the `this`-type parameter (e.g. `K extends
-        // keyof T` -> `never`). `.bind` defers the rest-arg check to the bound
-        // function's later invocation, so it keeps the un-collapsed target.
-        if matches!(property_name, "call" | "apply") {
-            for sig in &mut call_targets {
-                if let Some(collapsed) = self.collapse_this_dependent_type_params(sig) {
-                    *sig = collapsed;
-                }
-            }
+        // `tsc` resolves `.call`/`.apply`/`.bind` on a value with call
+        // signatures through the lib `CallableFunction` members;
+        // `NewableFunction` only applies when the receiver has construct
+        // signatures and no call signatures, so construct signatures never
+        // contribute method candidates alongside call signatures.
+        if !call_targets.is_empty() {
+            construct_targets.clear();
         }
 
         let factory = self.ctx.types.factory();
@@ -1227,7 +1223,6 @@ impl<'a> CheckerState<'a> {
         // ...)` calls still fall through to the per-signature overloads below.
         if property_name == "bind"
             && call_targets.len() > 1
-            && construct_targets.is_empty()
             && call_targets.iter().all(|sig| sig.this_type.is_none())
         {
             let full_receiver = factory.callable(tsz_solver::CallableShape {
@@ -1252,6 +1247,38 @@ impl<'a> CheckerState<'a> {
                 type_predicate: None,
                 is_method: false,
             });
+        }
+
+        // `CallableFunction`/`NewableFunction` expose ONE generic method
+        // signature per operation, and `tsc`'s signature-list inference
+        // aligns source and target signatures from the end, so an overloaded
+        // receiver is modeled by its LAST overload only (the documented
+        // `strictBindCallApply` caveat). Synthesizing one candidate per
+        // receiver overload instead reports TS2769 where `tsc` reports a
+        // single TS2345 against the last overload's parameters, and silently
+        // accepts arguments that only match earlier overloads. The
+        // `.bind(thisArg)` identity method above is the one exception
+        // (`OmitThisParameter<T> = T`), which is why it is synthesized from
+        // the full set before this truncation. The alignment rule itself is
+        // owned by the solver (`constrain_matching_signatures` in
+        // `tsz_solver::operations::constraints::signatures`); this synthesis
+        // emulates its single-target outcome.
+        call_targets.drain(..call_targets.len().saturating_sub(1));
+        construct_targets.drain(..construct_targets.len().saturating_sub(1));
+
+        // For `.call`/`.apply`, `tsc` fixes the rest-arg tuple from the
+        // target's original signature, collapsing type parameters whose
+        // constraint references the `this`-type parameter (e.g. `K extends
+        // keyof T` -> `never`). `.bind` defers the rest-arg check to the bound
+        // function's later invocation, so it keeps the un-collapsed target.
+        // (Runs after the truncation so only the surviving signature pays for
+        // the collapse.)
+        if matches!(property_name, "call" | "apply") {
+            for sig in &mut call_targets {
+                if let Some(collapsed) = self.collapse_this_dependent_type_params(sig) {
+                    *sig = collapsed;
+                }
+            }
         }
 
         for (sig, is_constructor) in call_targets

--- a/crates/tsz-core/tests/strict_bind_call_apply_tests.rs
+++ b/crates/tsz-core/tests/strict_bind_call_apply_tests.rs
@@ -5,7 +5,10 @@ use crate::parser::ParserState;
 use crate::test_fixtures::{merge_shared_lib_symbols, setup_lib_contexts};
 use tsz_solver::construction::TypeInterner;
 
-fn check_source_with_libs(source: &str) -> Vec<crate::checker::diagnostics::Diagnostic> {
+fn check_source_with_options(
+    source: &str,
+    options: CheckerOptions,
+) -> Vec<crate::checker::diagnostics::Diagnostic> {
     let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
     let root = parser.parse_source_file();
 
@@ -19,11 +22,15 @@ fn check_source_with_libs(source: &str) -> Vec<crate::checker::diagnostics::Diag
         &binder,
         &types,
         "test.ts".to_string(),
-        CheckerOptions::default(),
+        options,
     );
     setup_lib_contexts(&mut checker);
     checker.check_source_file(root);
     checker.ctx.diagnostics.clone()
+}
+
+fn check_source_with_libs(source: &str) -> Vec<crate::checker::diagnostics::Diagnostic> {
+    check_source_with_options(source, CheckerOptions::default())
 }
 
 #[test]
@@ -180,6 +187,373 @@ f.bind(o);
     assert!(
         !diagnostics.iter().any(|diag| diag.code == 2345),
         "bind must not collapse at the bind site, got: {diagnostics:?}"
+    );
+}
+
+// --- Overloaded receivers (issue #15635) ---------------------------------
+//
+// Structural rule: `tsc` resolves `.call`/`.apply`/`.bind` under
+// `strictBindCallApply` against the single generic method signature of the
+// lib `CallableFunction`/`NewableFunction` type, and its signature-list
+// inference aligns source and target signatures from the end — an overloaded
+// receiver is therefore modeled by its LAST overload only (the documented
+// strictBindCallApply caveat). An argument mismatch surfaces as one plain
+// TS2345 against the last overload's instantiated parameter, never as a
+// synthesized TS2769 expansion of the receiver's own overload set.
+// All behaviors below are differentially verified against tsc 6.0.2.
+
+/// The issue #15635 witness (with a lib-independent mismatch argument): a
+/// `.call` on an overloaded function reports a single TS2345 against the last
+/// overload's parameter, anchored at the argument — not TS2769.
+#[test]
+fn strict_call_on_overloaded_function_reports_single_ts2345_from_last_overload() {
+    let source = r#"
+interface Ctx { tag: string }
+declare function m(this: Ctx, a: string): void;
+declare function m(this: Ctx, a: number): void;
+declare const flag: boolean;
+m.call({ tag: "x" }, flag);
+"#;
+    let diagnostics = check_source_with_libs(source);
+    assert!(
+        !diagnostics.iter().any(|diag| diag.code == 2769),
+        "overloaded `.call` must not expand the receiver overload set into \
+         TS2769, got: {diagnostics:?}"
+    );
+    let ts2345: Vec<_> = diagnostics
+        .iter()
+        .filter(|diag| diag.code == 2345)
+        .collect();
+    assert_eq!(
+        ts2345.len(),
+        1,
+        "expected exactly one TS2345, got: {diagnostics:?}"
+    );
+    let diag = ts2345[0];
+    assert!(
+        diag.message_text.contains("'number'"),
+        "the error must name the LAST overload's parameter type, got: {diag:?}"
+    );
+    let arg_start = source.rfind("flag").expect("argument position") as u32;
+    assert_eq!(
+        diag.start, arg_start,
+        "TS2345 should anchor at the mismatching argument, got: {diag:?}"
+    );
+}
+
+/// The documented tsc caveat: an argument that matches only an EARLIER
+/// overload still fails, because only the last overload is modeled.
+#[test]
+fn strict_call_overloaded_receiver_rejects_earlier_overload_argument() {
+    let diagnostics = check_source_with_libs(
+        r#"
+interface Ctx { tag: string }
+declare function m(this: Ctx, a: string): void;
+declare function m(this: Ctx, a: number): void;
+m.call({ tag: "x" }, "str");
+"#,
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diag| diag.code == 2345 && diag.message_text.contains("'number'")),
+        "argument matching only the first overload must be rejected against \
+         the last overload's parameter, got: {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|diag| diag.code == 2769),
+        "no TS2769 expansion, got: {diagnostics:?}"
+    );
+}
+
+/// Control: an argument matching the last overload is accepted.
+#[test]
+fn strict_call_overloaded_receiver_accepts_last_overload_argument() {
+    let diagnostics = check_source_with_libs(
+        r#"
+interface Ctx { tag: string }
+declare function m(this: Ctx, a: string): void;
+declare function m(this: Ctx, a: number): void;
+m.call({ tag: "x" }, 42);
+"#,
+    );
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|diag| matches!(diag.code, 2345 | 2769 | 2322)),
+        "argument matching the last overload must be accepted, got: {diagnostics:?}"
+    );
+}
+
+/// Renamed binders with the overload order REVERSED: the reported parameter
+/// tracks the last declaration (`string` here), proving the rule is
+/// "last overload", not "first" and not keyed to any type or name.
+#[test]
+fn strict_call_last_overload_rule_is_order_and_name_agnostic() {
+    let diagnostics = check_source_with_libs(
+        r#"
+interface Env { id: number }
+declare function pick(this: Env, x: boolean): void;
+declare function pick(this: Env, x: string): void;
+declare const n: number;
+pick.call({ id: 1 }, n);
+"#,
+    );
+    let ts2345: Vec<_> = diagnostics
+        .iter()
+        .filter(|diag| diag.code == 2345)
+        .collect();
+    assert_eq!(
+        ts2345.len(),
+        1,
+        "expected exactly one TS2345, got: {diagnostics:?}"
+    );
+    assert!(
+        ts2345[0].message_text.contains("'string'"),
+        "the LAST declared overload's parameter must be reported, got: {:?}",
+        ts2345[0]
+    );
+    assert!(!diagnostics.iter().any(|diag| diag.code == 2769));
+}
+
+/// The `thisArg` parameter also comes from the last overload.
+#[test]
+fn strict_call_this_arg_comes_from_last_overload() {
+    let diagnostics = check_source_with_libs(
+        r#"
+declare function k(this: { a: string }, x: string): void;
+declare function k(this: { b: number }, x: number): void;
+declare const wrongThis: { a: string };
+k.call(wrongThis, 42);
+"#,
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diag| diag.code == 2345 && diag.message_text.contains("{ b: number; }")),
+        "thisArg must be checked against the LAST overload's this type, \
+         got: {diagnostics:?}"
+    );
+    assert!(!diagnostics.iter().any(|diag| diag.code == 2769));
+}
+
+/// `.apply` on an overloaded receiver: the tuple/element mismatch is against
+/// the last overload's parameter list, with no TS2769 expansion; a tuple
+/// matching the last overload is accepted.
+#[test]
+fn strict_apply_on_overloaded_function_uses_last_overload() {
+    let bad = check_source_with_libs(
+        r#"
+interface Ctx { tag: string }
+declare function m(this: Ctx, a: string): void;
+declare function m(this: Ctx, a: number): void;
+declare const flag: boolean;
+m.apply({ tag: "x" }, [flag]);
+"#,
+    );
+    assert!(
+        !bad.iter().any(|diag| diag.code == 2769),
+        "overloaded `.apply` must not expand into TS2769, got: {bad:?}"
+    );
+    assert!(
+        bad.iter()
+            .any(|diag| matches!(diag.code, 2345 | 2322) && diag.message_text.contains("'number'")),
+        "the args tuple must be checked against the last overload, got: {bad:?}"
+    );
+
+    let good = check_source_with_libs(
+        r#"
+interface Ctx { tag: string }
+declare function m(this: Ctx, a: string): void;
+declare function m(this: Ctx, a: number): void;
+m.apply({ tag: "x" }, [42]);
+"#,
+    );
+    assert!(
+        !good
+            .iter()
+            .any(|diag| matches!(diag.code, 2345 | 2769 | 2322)),
+        "args tuple matching the last overload must be accepted, got: {good:?}"
+    );
+}
+
+/// `.bind` partial application on an overloaded receiver sees only the last
+/// overload: a prefix argument that matches only the first overload fails,
+/// one matching the last overload binds cleanly and stays callable.
+#[test]
+fn strict_bind_partial_application_uses_last_overload() {
+    let bad = check_source_with_libs(
+        r#"
+interface Ctx { tag: string }
+declare function m(this: Ctx, a: string): void;
+declare function m(this: Ctx, a: number): void;
+m.bind({ tag: "x" }, "str");
+"#,
+    );
+    assert!(
+        bad.iter().any(|diag| matches!(diag.code, 2345 | 2769)),
+        "bind prefix argument matching only the first overload must be \
+         rejected, got: {bad:?}"
+    );
+
+    let good = check_source_with_libs(
+        r#"
+interface Ctx { tag: string }
+declare function m(this: Ctx, a: string): void;
+declare function m(this: Ctx, a: number): void;
+const bound = m.bind({ tag: "x" }, 42);
+bound();
+"#,
+    );
+    assert!(
+        !good
+            .iter()
+            .any(|diag| matches!(diag.code, 2345 | 2769 | 2322 | 2554)),
+        "bind prefix argument matching the last overload must be accepted \
+         and the bound function callable, got: {good:?}"
+    );
+}
+
+/// Overloaded class constructors go through the `NewableFunction` model with
+/// the same last-overload rule.
+#[test]
+fn strict_call_on_overloaded_constructor_uses_last_construct_signature() {
+    let bad = check_source_with_libs(
+        r#"
+class Box {
+  constructor(v: string);
+  constructor(v: number);
+  constructor(v: unknown) {}
+}
+declare const s: string;
+Box.call(new Box(1), s);
+"#,
+    );
+    assert!(
+        !bad.iter().any(|diag| diag.code == 2769),
+        "overloaded constructor `.call` must not expand into TS2769, got: {bad:?}"
+    );
+    assert!(
+        bad.iter()
+            .any(|diag| diag.code == 2345 && diag.message_text.contains("'number'")),
+        "the argument must be checked against the LAST construct signature, \
+         got: {bad:?}"
+    );
+
+    let good = check_source_with_libs(
+        r#"
+class Box {
+  constructor(v: string);
+  constructor(v: number);
+  constructor(v: unknown) {}
+}
+Box.call(new Box(1), 42);
+"#,
+    );
+    assert!(
+        !good
+            .iter()
+            .any(|diag| matches!(diag.code, 2345 | 2769 | 2322)),
+        "argument matching the last construct signature must be accepted, \
+         got: {good:?}"
+    );
+}
+
+/// A hybrid receiver with both call and construct signatures resolves
+/// `.call` through `CallableFunction` — construct signatures contribute no
+/// method candidates (tsc: call signatures shadow `NewableFunction`).
+#[test]
+fn strict_call_on_hybrid_receiver_uses_call_signatures_only() {
+    let bad = check_source_with_libs(
+        r#"
+interface Hybrid {
+  (a: string): void;
+  new (a: number): object;
+}
+declare const h: Hybrid;
+h.call(undefined, 42);
+"#,
+    );
+    assert!(
+        bad.iter()
+            .any(|diag| diag.code == 2345 && diag.message_text.contains("'string'")),
+        "hybrid `.call` must check against the CALL signature, got: {bad:?}"
+    );
+    assert!(!bad.iter().any(|diag| diag.code == 2769));
+
+    let good = check_source_with_libs(
+        r#"
+interface Hybrid {
+  (a: string): void;
+  new (a: number): object;
+}
+declare const h: Hybrid;
+h.call(undefined, "ok");
+"#,
+    );
+    assert!(
+        !good
+            .iter()
+            .any(|diag| matches!(diag.code, 2345 | 2769 | 2322)),
+        "hybrid `.call` matching the call signature must be accepted, got: {good:?}"
+    );
+}
+
+/// Overloaded methods on an interface receiver follow the same rule.
+#[test]
+fn strict_call_on_overloaded_interface_method_uses_last_overload() {
+    let diagnostics = check_source_with_libs(
+        r#"
+interface Ops {
+  run(this: Ops, a: string): void;
+  run(this: Ops, a: number): void;
+}
+declare const ops: Ops;
+declare const flag2: boolean;
+ops.run.call(ops, flag2);
+"#,
+    );
+    let ts2345: Vec<_> = diagnostics
+        .iter()
+        .filter(|diag| diag.code == 2345)
+        .collect();
+    assert_eq!(
+        ts2345.len(),
+        1,
+        "expected exactly one TS2345, got: {diagnostics:?}"
+    );
+    assert!(
+        ts2345[0].message_text.contains("'number'"),
+        "interface method `.call` must use the last overload, got: {:?}",
+        ts2345[0]
+    );
+    assert!(!diagnostics.iter().any(|diag| diag.code == 2769));
+}
+
+/// With `strictBindCallApply: false` the loose `Function.call` fallback
+/// applies and no argument checking happens at all.
+#[test]
+fn loose_call_on_overloaded_function_is_unchecked() {
+    let diagnostics = check_source_with_options(
+        r#"
+interface Ctx { tag: string }
+declare function m(this: Ctx, a: string): void;
+declare function m(this: Ctx, a: number): void;
+declare const flag: boolean;
+m.call({ tag: "x" }, flag);
+"#,
+        CheckerOptions {
+            strict: false,
+            strict_function_types: false,
+            strict_bind_call_apply: false,
+            ..CheckerOptions::default()
+        },
+    );
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|diag| matches!(diag.code, 2345 | 2769 | 2322)),
+        "with strictBindCallApply off the call must be unchecked, got: {diagnostics:?}"
     );
 }
 


### PR DESCRIPTION
Fixes #15635.

## Structural rule

When `strictBindCallApply` resolves `f.call(...)`/`f.apply(...)`/`f.bind(...)` on an overloaded target, `tsc` types the call through the single generic `CallableFunction`/`NewableFunction` method signature, and its signature-list inference aligns source and target signatures **from the end** — so only the target's **last** overload is modeled (the documented strictBindCallApply caveat). An argument mismatch therefore surfaces as one plain TS2345 against the last overload's instantiated parameter. tsz does this through the checker's strict bind/call/apply method synthesis (`strict_bind_call_apply_method_type` in `crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs`), which previously expanded the target's own overload set into one synthesized method candidate per overload, reporting a fabricated `TS2769: No overload matches this call` — and silently *accepting* arguments that only match earlier overloads (a false negative tsc rejects).

Two related sub-rules, both differentially verified against tsc 6.0.2:

1. **Member owner**: `tsc` resolves `.call`/`.apply`/`.bind` from `CallableFunction` whenever the receiver has call signatures; `NewableFunction` only applies to receivers with construct signatures and *no* call signatures. tsz previously let a hybrid receiver's construct signatures contribute extra method candidates alongside its call signatures.
2. **The `.bind(thisArg)` identity exception**: for a no-`this` overloaded receiver, `OmitThisParameter&lt;T&gt; = T` preserves the full overload set (the immer `produceWithPatches.bind(immer)` case). That path keeps synthesizing from the full set; the last-overload truncation happens after it.

The signature-alignment rule itself is owned by the solver (`constrain_matching_signatures`); the synthesis now carries a pointer comment naming it as the authoritative owner for a future consolidation onto the real generic lib signatures.

## Adjacent-case matrix (tsz output byte-identical to `tsc 6.0.2 --noEmit --strict --pretty false` on every row)

| Case | Behavior |
| --- | --- |
| `.call` arg mismatching every overload (issue witness) | single TS2345 vs last overload's param, anchored at the arg |
| `.call` arg matching only an **earlier** overload | still TS2345 (tsc caveat; tsz previously accepted — false negative) |
| `.call` arg matching the last overload | clean |
| overload order reversed + renamed binders | reported param tracks the *last* declaration |
| `thisArg` mismatch | TS2345 vs last overload's `this` type, with elaboration |
| `.apply` tuple element mismatch | element-level TS2322 vs last overload |
| `.bind` partial application | last overload only; matching prefix stays callable |
| `.bind(thisArg)` on no-`this` overloaded receiver | identity, full overload set preserved (immer case) |
| `.bind(thisArg)` on `this`-typed overloaded receiver | bound function = last overload, `this` stripped |
| overloaded class constructors (`NewableFunction`) | last construct signature |
| hybrid call+construct receiver | call signatures win; construct signatures contribute nothing |
| overloaded generic target | last overload, inference intact |
| rest-param / optional-param overloads | arity and element checks track the last overload |
| non-overloaded target | unchanged |
| `strictBindCallApply: false` | unchanged loose `Function` fallback, unchecked |

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-core strict_bind_call_apply` — 20/20 (11 new matrix tests + 9 pre-existing: this-dependent collapse, TS2769 anchors, apply tuple display).
- `cargo nextest run -p tsz-checker --lib bind_overloaded` — 4/4 (immer identity-bind regression suite).
- Differential runs of seven witness files against `tsc 6.0.2` — byte-identical output (including elaboration lines) on every matrix row above.
- `cargo clippy -p tsz-checker` clean; the 10 pre-existing local `tsz-checker --lib` failures in the call/overload filter reproduce identically on a clean `main` tree (stash-verified; #15338 territory) and are untouched by this change.
- Ready-review CI owns the conformance/emit/fourslash parity floors.

## Provenance
Machine: cloud
Assistant: claude-code
Model: undisclosed (harness undercover mode)
Effort: high

https://claude.ai/code/session_01FaPEoUEbFG6bcqjTwfi4TX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaPEoUEbFG6bcqjTwfi4TX)_