### PR TITLE
refactor(checker): split context/mod.rs under the 2000-LOC cap (arch-guard main repair)

### DIFF
--- a/crates/tsz-checker/src/context/analysis_state_types.rs
+++ b/crates/tsz-checker/src/context/analysis_state_types.rs
@@ -1,0 +1,110 @@
+//! In-progress analysis-state value types for `CheckerContext`.
+//!
+//! Deferred implicit-any diagnostics, circular return-site tracking, the
+//! inferred-return-type memo key, and object-literal initializer tracking.
+//! Extracted from `context/mod.rs` to hold it under the 2000-LOC checker cap;
+//! re-exported from the module root (`pub use analysis_state_types::*`) so call
+//! sites are unchanged.
+
+use super::PendingImplicitAnyKind;
+use rustc_hash::FxHashMap;
+use tsz_binder::SymbolId;
+use tsz_common::interner::Atom;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::{PropertyInfo, TypeId};
+
+/// Deferred implicit-any diagnostic state for a variable declaration.
+#[derive(Clone, Copy, Debug)]
+pub struct PendingImplicitAnyVar {
+    /// Declaration name node used for the TS7034 anchor.
+    pub name_node: NodeIndex,
+    /// Which deferred implicit-any behavior applies to this declaration.
+    pub kind: PendingImplicitAnyKind,
+}
+
+/// Closure/function-expression circular return-site state for the active file.
+///
+/// `sites` are deferred functions whose return expressions read a variable
+/// symbol still being resolved; they centralize TS7022/TS7023/TS7024 emission
+/// and suppress downstream relation noise. `lazy` is the subset whose
+/// self-reference is benign (no contextual return type and no recursive callee
+/// self-invocation): those sites still widen the variable to `any`, but their
+/// diagnostic is suppressed to match `tsc`, which resolves such deferred
+/// references on demand without an error (#10675).
+#[derive(Clone, Debug, Default)]
+pub struct PendingCircularReturnSites {
+    pub sites: FxHashMap<SymbolId, Vec<NodeIndex>>,
+    pub lazy: FxHashMap<SymbolId, Vec<NodeIndex>>,
+}
+
+impl PendingCircularReturnSites {
+    pub fn clear(&mut self) {
+        self.sites.clear();
+        self.lazy.clear();
+    }
+}
+
+/// Identity key for the inferred-body-return-type memo (`resolvedReturnType`
+/// analog). Captures every ambient input that determines the result of pure
+/// return-type inference for a given function/arrow/method body, so a cache hit
+/// is byte-identical to recomputing the inference:
+///
+/// - `function_node`: the function/arrow/method/accessor node being inferred.
+/// - `return_context`: the unwrapped contextual return type fed to inference
+///   (`None` for context-free inference). Different contextual types can drive
+///   different inferred results (e.g. `const` type-parameter context), so they
+///   are distinct keys.
+/// - `in_const_assertion` / `preserve_literal_types`: literal-preservation modes
+///   that change widening of inferred literal returns.
+/// - `this_type`: the active contextual `this` type. A method/function body that
+///   returns or references `this` (e.g. `foo() { return this; }`, or a
+///   `this`-polymorphic predicate) infers a `this`-dependent return type, so the
+///   same node inferred under different `this` bindings must not collide.
+/// - `scope_fingerprint`: a stable hash of the active `type_parameter_scope`
+///   bindings, so a generic body inferred under one ambient type-parameter
+///   binding is never reused under a different binding.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct InferredReturnTypeKey {
+    pub function_node: NodeIndex,
+    pub return_context: Option<TypeId>,
+    pub in_const_assertion: bool,
+    pub preserve_literal_types: bool,
+    pub this_type: Option<TypeId>,
+    pub scope_fingerprint: u64,
+}
+
+/// In-progress object literal initializer for a variable declaration.
+///
+/// TypeScript allows later property initializers to reference earlier properties
+/// through the variable being initialized, e.g.
+/// `const keys = { all: ["x"] as const, list: () => [...keys.all] }`.
+/// The full variable type is not available while the object literal is being
+/// checked, so this stack exposes only properties that have already been
+/// processed for the exact active literal.
+#[derive(Clone, Debug)]
+pub struct PartialObjectLiteralInitializer {
+    pub variable_symbol: SymbolId,
+    pub object_literal: NodeIndex,
+    pub properties: FxHashMap<Atom, PropertyInfo>,
+}
+
+impl PartialObjectLiteralInitializer {
+    #[must_use]
+    pub fn new(variable_symbol: SymbolId, object_literal: NodeIndex) -> Self {
+        Self {
+            variable_symbol,
+            object_literal,
+            properties: FxHashMap::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ObjectLiteralTracking {
+    /// Raw object-literal property diagnostic target, keyed by property element for TS2322/TS2345 display recovery.
+    pub property_diag_targets: FxHashMap<NodeIndex, TypeId>,
+    /// Contextual target type for an object literal, keyed by literal node for per-property diagnostic recovery.
+    pub contextual_targets: FxHashMap<NodeIndex, TypeId>,
+    /// Stack of in-progress object literal variable initializers.
+    pub partial_initializers: Vec<PartialObjectLiteralInitializer>,
+}

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -4,6 +4,7 @@
 //! This separates state from logic, allowing specialized checkers (expressions, statements)
 //! to borrow the context mutably.
 mod aliases;
+mod analysis_state_types;
 mod cache_statistics;
 mod caches;
 mod canonical_app_key;
@@ -75,6 +76,7 @@ use crate::control_flow::FlowGraph;
 use crate::diagnostics::Diagnostic;
 use crate::query_boundaries::common::{QueryDatabase, TypeEnvironment};
 pub use aliases::*;
+pub use analysis_state_types::*;
 pub(crate) use diagnostic_indices::DiagnosticIndices;
 pub use request_cache::{RequestCacheCounters, RequestCacheKey};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -87,8 +89,8 @@ pub use symbol_file_targets::SymbolFileTargetsOverlay;
 use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
 use tsz_solver::def::{DefId, DefinitionStore};
-use tsz_solver::{PropertyInfo, TypeId};
 pub use type_parameter_scope_cache_key::TypeParameterScopeCacheKey;
 pub use typing_request::{ContextualOrigin, FlowIntent, TypingRequest};
 // Re-export context-facing types used by downstream crates.
@@ -228,102 +230,6 @@ impl CheckerContext<'_> {
         self.generator_yield_operand_types
             .push(GeneratorYieldContribution { type_id, widenable });
     }
-}
-
-/// Deferred implicit-any diagnostic state for a variable declaration.
-#[derive(Clone, Copy, Debug)]
-pub struct PendingImplicitAnyVar {
-    /// Declaration name node used for the TS7034 anchor.
-    pub name_node: NodeIndex,
-    /// Which deferred implicit-any behavior applies to this declaration.
-    pub kind: PendingImplicitAnyKind,
-}
-
-/// Closure/function-expression circular return-site state for the active file.
-///
-/// `sites` are deferred functions whose return expressions read a variable
-/// symbol still being resolved; they centralize TS7022/TS7023/TS7024 emission
-/// and suppress downstream relation noise. `lazy` is the subset whose
-/// self-reference is benign (no contextual return type and no recursive callee
-/// self-invocation): those sites still widen the variable to `any`, but their
-/// diagnostic is suppressed to match `tsc`, which resolves such deferred
-/// references on demand without an error (#10675).
-#[derive(Clone, Debug, Default)]
-pub struct PendingCircularReturnSites {
-    pub sites: FxHashMap<SymbolId, Vec<NodeIndex>>,
-    pub lazy: FxHashMap<SymbolId, Vec<NodeIndex>>,
-}
-
-impl PendingCircularReturnSites {
-    pub fn clear(&mut self) {
-        self.sites.clear();
-        self.lazy.clear();
-    }
-}
-
-/// Identity key for the inferred-body-return-type memo (`resolvedReturnType`
-/// analog). Captures every ambient input that determines the result of pure
-/// return-type inference for a given function/arrow/method body, so a cache hit
-/// is byte-identical to recomputing the inference:
-///
-/// - `function_node`: the function/arrow/method/accessor node being inferred.
-/// - `return_context`: the unwrapped contextual return type fed to inference
-///   (`None` for context-free inference). Different contextual types can drive
-///   different inferred results (e.g. `const` type-parameter context), so they
-///   are distinct keys.
-/// - `in_const_assertion` / `preserve_literal_types`: literal-preservation modes
-///   that change widening of inferred literal returns.
-/// - `this_type`: the active contextual `this` type. A method/function body that
-///   returns or references `this` (e.g. `foo() { return this; }`, or a
-///   `this`-polymorphic predicate) infers a `this`-dependent return type, so the
-///   same node inferred under different `this` bindings must not collide.
-/// - `scope_fingerprint`: a stable hash of the active `type_parameter_scope`
-///   bindings, so a generic body inferred under one ambient type-parameter
-///   binding is never reused under a different binding.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub struct InferredReturnTypeKey {
-    pub function_node: NodeIndex,
-    pub return_context: Option<TypeId>,
-    pub in_const_assertion: bool,
-    pub preserve_literal_types: bool,
-    pub this_type: Option<TypeId>,
-    pub scope_fingerprint: u64,
-}
-
-/// In-progress object literal initializer for a variable declaration.
-///
-/// TypeScript allows later property initializers to reference earlier properties
-/// through the variable being initialized, e.g.
-/// `const keys = { all: ["x"] as const, list: () => [...keys.all] }`.
-/// The full variable type is not available while the object literal is being
-/// checked, so this stack exposes only properties that have already been
-/// processed for the exact active literal.
-#[derive(Clone, Debug)]
-pub struct PartialObjectLiteralInitializer {
-    pub variable_symbol: SymbolId,
-    pub object_literal: NodeIndex,
-    pub properties: FxHashMap<Atom, PropertyInfo>,
-}
-
-impl PartialObjectLiteralInitializer {
-    #[must_use]
-    pub fn new(variable_symbol: SymbolId, object_literal: NodeIndex) -> Self {
-        Self {
-            variable_symbol,
-            object_literal,
-            properties: FxHashMap::default(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct ObjectLiteralTracking {
-    /// Raw object-literal property diagnostic target, keyed by property element for TS2322/TS2345 display recovery.
-    pub property_diag_targets: FxHashMap<NodeIndex, TypeId>,
-    /// Contextual target type for an object literal, keyed by literal node for per-property diagnostic recovery.
-    pub contextual_targets: FxHashMap<NodeIndex, TypeId>,
-    /// Stack of in-progress object literal variable initializers.
-    pub partial_initializers: Vec<PartialObjectLiteralInitializer>,
 }
 
 /// Persistent cache for type checking results across LSP queries.


### PR DESCRIPTION
Standalone split-only PR: `crates/tsz-checker/src/context/mod.rs` reached 2030 physical lines on main (over the tsz-checker/src hard 2000-LOC cap). This holds it back under the cap with pure code motion.

## Structural rule
When a file in `crates/tsz-checker/src` exceeds 2000 physical lines, the arch guard's "Checker boundary: src files must stay under 2000 LOC" check fails. Extract a coherent cluster to a sibling/child module rather than bumping any ceiling.

## What moved
The in-progress analysis-state value types move to a new child module `context/analysis_state_types.rs` (re-exported from the module root):
- `PendingImplicitAnyVar`, `PendingCircularReturnSites` (+ `clear`), `InferredReturnTypeKey`, `PartialObjectLiteralInitializer` (+ `new`), `ObjectLiteralTracking`.

Pure code motion:
- All are `pub` structs/enums with `pub` fields, so no visibility widening is needed.
- The child imports `super::PendingImplicitAnyKind` (the paired enum stays in `mod.rs`, referenced by other modules alongside it).
- `mod.rs` re-exports via `pub use analysis_state_types::*;` (matching the existing `pub use aliases::*;` convention), so every `crate::context::*` call site is unchanged.
- `mod.rs` drops its now-unused `PropertyInfo` import (the moved cluster was its only consumer).

No ceiling/ratchet edits. No behavior change. `CheckerContext` field types and its `impl` blocks are untouched.

context/mod.rs: 2030 -> 1936. New child module: 110 lines. Both under the cap.

## Note for arch-health (surfaced to the team)
This 2030-line file passed GREEN main CI because the whole-tree LOC arch guard (`scripts/arch/arch_guard.py`) is not wired into any GitHub Actions workflow (nor the git hooks) — it runs only as manual/verification-time tooling; the GCP-backed CI that used to run it was removed in #15343/#15375. So a native-queue merge lands a >2000 file with all CI jobs green. (Unrelated to #15614, which never touched an arch job.)

## Verification
- Lane-B `cargo check -p tsz-checker --tests` -> Finished, 0 errors, 0 warnings (independent clean target; --tests covers the checker integration test files that reference these context types).
- `scripts/arch/arch_guard.py` no longer reports `context/mod.rs` under the 2000-LOC check.
- Both files confirmed under 2000 physical lines post-rustfmt (mod.rs 1936, child 110).

Goal: hold

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
