### PR TITLE
ci(hold): add arch-size gate (arch_guard.py --size-only) on merge_group + push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,18 @@ jobs:
       - name: Aggregate fourslash results
         run: scripts/ci/github-suite.sh fourslash-aggregate
 
+  arch-size:
+    name: arch-size
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+      - name: Run architecture size guard (LOC caps + non-#8225 size ratchets)
+        run: python3 scripts/arch/arch_guard.py --size-only
+
   ci-summary:
     name: CI Summary
     needs:
@@ -231,6 +243,7 @@ jobs:
       - emit-aggregate
       - fourslash
       - fourslash-aggregate
+      - arch-size
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -255,6 +268,7 @@ jobs:
               "emit-aggregate",
               "fourslash",
               "fourslash-aggregate",
+              "arch-size",
           }
 
           # On pull_request the heavy jobs are intentionally skipped: the merge

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -112,6 +112,17 @@ def main() -> int:
         action="store_true",
         help="Print the CheckerContext lifetime manifest as a markdown table.",
     )
+    parser.add_argument(
+        "--size-only",
+        action="store_true",
+        help=(
+            "Run ONLY the physical-line-count checks (the per-crate LOC cap and "
+            "per-file size ratchets) and skip the #8225 quarantine and other "
+            "architecture-health metrics. Used by the CI size gate so a file "
+            "crossing its size ceiling fails without redding main on pre-existing "
+            "quarantine debt (which carries arch-owner-domain baselines)."
+        ),
+    )
     args = parser.parse_args()
 
     if args.checker_context_lifetime_table:
@@ -127,6 +138,55 @@ def main() -> int:
                 print(f"  {hit}")
             return 1
         print(checker_context_lifetime_markdown(struct_path, struct_name, manifest_path))
+        return 0
+
+    if args.size_only:
+        # CI size gate: run ONLY the physical-line-count checks (the per-crate
+        # LOC cap in LINE_LIMIT_CHECKS + the per-file size ratchets in
+        # FILE_LINE_LIMIT_CHECKS). This lets a merge_group/push CI job block a
+        # file crossing its size ceiling — the gap that let context/mod.rs land
+        # at 2030 lines with all jobs green — without failing on the #8225
+        # quarantine and other health metrics, whose baselines are arch-owner
+        # domain and are tracked/paid down separately.
+        size_failures = []
+        size_total = 0
+        for name, base, limit, *rest in LINE_LIMIT_CHECKS:
+            if not base.exists():
+                continue
+            exclude_files = rest[0] if rest else None
+            hits = scan_line_limits(base, limit, exclude_files)
+            size_total += len(hits)
+            if hits:
+                size_failures.append((name, hits))
+        for name, path, limit in FILE_LINE_LIMIT_CHECKS:
+            # The #8225 common-quarantine ratchets carry their own arch-owner
+            # green-campaign headroom policy and are tracked as debt separately;
+            # the campaign does not bump or pay them down. The CI size gate
+            # enforces the general per-file size ceilings, not the quarantine, so
+            # skip #8225 entries — the gate still blocks ordinary size growth (the
+            # per-crate LOC cap plus non-quarantine ratchets) and stays green on
+            # main instead of failing on pre-existing quarantine debt.
+            if "#8225" in name:
+                continue
+            hits = scan_file_line_limit(path, limit)
+            size_total += len(hits)
+            if hits:
+                size_failures.append((name, hits))
+
+        payload = build_json_payload(size_failures, size_total)
+        if args.json_report:
+            write_json_report(Path(args.json_report), payload)
+        if args.json:
+            print(json.dumps(payload, indent=2))
+            return 0 if not size_failures else 1
+        if size_failures:
+            print("ARCH GUARD FAILURES (size-only):")
+            for name, hits in size_failures:
+                print(f"- {name}:")
+                for hit in hits:
+                    print(f"  - {hit}")
+            return 1
+        print("Architecture size guardrails passed (size-only).")
         return 0
 
     failures = []


### PR DESCRIPTION
Adds a fast, cargo-free `arch-size` CI job that enforces the physical-line size ceilings on `merge_group` + `push` — closing the gap where the whole-tree arch guard ran in no CI workflow and no git hook, so a native-queue merge landed `context/mod.rs` at 2030 lines (over the hard 2000 cap) with every job green (fixed by #15641).

## What
- New `arch_guard.py --size-only` mode: runs ONLY the physical-line-count checks (`LINE_LIMIT_CHECKS` per-crate LOC caps + `FILE_LINE_LIMIT_CHECKS` per-file size ratchets), skipping the #8225 quarantine and other architecture-health metrics.
- New `arch-size` CI job runs `arch_guard.py --size-only`. Fast pure-script job (no cargo), `timeout-minutes: 5`, trivial quota cost.
- Gated `if: ${{ github.event_name != 'pull_request' }}` — runs on merge_group / push-to-main / workflow_dispatch, keeping PR CI light (per the campaign directive). Wired into the `CI Summary` `needs` and the same skipped-is-pass-on-PR logic as #15614 (skipped counts as pass ONLY on pull_request; a real failure still fails; every non-PR event stays strict).

## Scoping note (why `--size-only` skips #8225)
The `#8225` common-quarantine ratchets carry arch-owner green-campaign headroom and are **currently over baseline on main** (common.rs 1939/1925) — see the arch-debt tracking issue #15643. Those are arch-owner domain; the campaign will not bump or pay them down. So `--size-only` skips `#8225`-tagged size entries: the gate stays green on current main while still blocking any file crossing the general per-crate LOC cap or a non-quarantine per-file ratchet. Enforcing the `#8225` ceilings remains the full guard's job (unchanged) + issue #15643.

## Reversibility
Single commit; reverting it removes both the `arch-size` job and the `--size-only` flag. The full `arch_guard.py` behavior is unchanged.

## Verification
- `python3 scripts/arch/arch_guard.py --size-only` exits 0 on current main (639ac055a8).
- Positive test: a temporary 2001-line file under `crates/tsz-checker/src` makes `--size-only` exit 1 and flags it (probe confirmed, then removed).
- `--size-only --json` emits valid JSON and exits 0.
- Full guard (no flag) unchanged: still exits 1 and still reports the common.rs #8225 ratchet.
- ci.yml parses (YAML + the embedded ci-summary Python both parse); `arch-size` added to `needs` and the required set.

Goal: hold

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
