### PR TITLE
fix(checker): keep declaration-file bases on the symbol path in the cross-file interface hook

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/application.rs
+++ b/crates/tsz-checker/src/state/type_environment/application.rs
@@ -250,6 +250,19 @@ impl<'a> CheckerState<'a> {
         {
             return None;
         }
+        // A def in a declaration (`.d.ts`) file is ambient regardless of the
+        // `declare` keyword: react.d.ts's namespace-nested component interfaces
+        // (`Component`, `StatelessComponent`, `ComponentClass`) carry
+        // `is_declare = false`, so the guard above lets them through. But a
+        // declaration-file def does not suffer the per-file binder-id collision
+        // (#14344) this def-store route works around — the symbol route resolves
+        // it correctly — and instantiating it here mis-relates those library
+        // component types (a false `TS2322` on `tsxUnionTypeComponent1` and
+        // `reactReadonlyHOCAssignabilityReal`). Keep declaration-file bases on
+        // the symbol path.
+        if file_id.is_some_and(|file_id| self.file_idx_is_declaration_file(file_id)) {
+            return None;
+        }
         let ApplicationBaseBody {
             body_type,
             type_params,
@@ -263,6 +276,18 @@ impl<'a> CheckerState<'a> {
             args,
             application,
         ))
+    }
+
+    /// Whether the source file at `file_idx` is a TypeScript declaration file.
+    /// Reads the parser's structural `is_declaration_file` flag on the source
+    /// file (file kind), not a path/name string — a declaration-file def is
+    /// ambient regardless of the `declare` keyword.
+    fn file_idx_is_declaration_file(&self, file_idx: u32) -> bool {
+        self.ctx
+            .get_arena_for_file(file_idx)
+            .source_files
+            .first()
+            .is_some_and(|source_file| source_file.is_declaration_file)
     }
 
     /// Instantiate a generic interface/class body with its type parameters bound


### PR DESCRIPTION
Fixes the main conformance regression on `conformance/jsx/tsxUnionTypeComponent1.tsx` and `compiler/reactReadonlyHOCAssignabilityReal.tsx` introduced by #15358's cross-file interface instantiation hook.

Goal: hold

**Structural rule:** When a generic interface/class application's base def originates in a declaration (`.d.ts`) file, `tsc` treats it as ambient, and the per-file binder-id collision (#14344) the def-store route works around does not occur — the symbol route resolves it correctly. tsz now keeps declaration-file bases on the symbol path (owner: checker `instantiate_cross_file_interface_application`), via a structural `isDeclarationFile` check on the base def's source file (not a user-name check). Program `.ts` cross-file interfaces still route through the `DefinitionStore` (the #13212/#14344 fix). react.d.ts's namespace-nested component interfaces (`Component`/`StatelessComponent`/`ComponentClass`) carry `is_declare = false`, so the prior guard (declare-keyword only) let them through and the def-store instantiation mis-related them → false `TS2322`.

## Verification
- dist-fast conformance (against the primary checkout's TypeScript test-dir): `tsxUnionTypeComponent1.tsx` PASS and `reactReadonlyHOCAssignabilityReal.tsx` PASS (both false-positive `TS2322` gone; tsc compiles both clean).
- jsx family 211/211; `conformance/types/typeRelationships` 264/264 — no new regressions.
- Re-exported cross-file interface member access (`Box<T>` decl/barrel/main) still instantiates `T` correctly (only the intentional wrong-type assignment errors) — the #13212 preserve-set is intact.
- Causation confirmed by a disabled-hook build (both witnesses flip FAIL→PASS). `narrowingUnionToNeverAssigment.ts` is a SEPARATE fingerprint-only regression (codes match; still fails with the hook off) — routed separately, not addressed here.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
