### PR TITLE
fix(checker): clear tsz-checker clippy (too-many-arguments via struct literal + masked doc-markdown)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/class_type.rs
+++ b/crates/tsz-checker/src/query_boundaries/class_type.rs
@@ -85,41 +85,15 @@ pub(crate) const fn static_late_bound_index_signature(
 }
 
 pub(crate) struct MergedClassInstanceInterfaceSurface {
-    result_is_callable: bool,
-    call_signatures: Vec<CallSignature>,
-    construct_signatures: Vec<CallSignature>,
-    properties: Vec<PropertyInfo>,
-    string_index: Option<IndexSignature>,
-    number_index: Option<IndexSignature>,
-    symbol_index: Option<IndexSignature>,
-    symbol: Option<SymbolId>,
-    plain_object_without_indexes: bool,
-}
-
-impl MergedClassInstanceInterfaceSurface {
-    pub(crate) const fn new(
-        result_is_callable: bool,
-        call_signatures: Vec<CallSignature>,
-        construct_signatures: Vec<CallSignature>,
-        properties: Vec<PropertyInfo>,
-        string_index: Option<IndexSignature>,
-        number_index: Option<IndexSignature>,
-        symbol_index: Option<IndexSignature>,
-        symbol: Option<SymbolId>,
-        plain_object_without_indexes: bool,
-    ) -> Self {
-        Self {
-            result_is_callable,
-            call_signatures,
-            construct_signatures,
-            properties,
-            string_index,
-            number_index,
-            symbol_index,
-            symbol,
-            plain_object_without_indexes,
-        }
-    }
+    pub(crate) result_is_callable: bool,
+    pub(crate) call_signatures: Vec<CallSignature>,
+    pub(crate) construct_signatures: Vec<CallSignature>,
+    pub(crate) properties: Vec<PropertyInfo>,
+    pub(crate) string_index: Option<IndexSignature>,
+    pub(crate) number_index: Option<IndexSignature>,
+    pub(crate) symbol_index: Option<IndexSignature>,
+    pub(crate) symbol: Option<SymbolId>,
+    pub(crate) plain_object_without_indexes: bool,
 }
 
 pub(crate) fn merged_class_instance_interface_type(

--- a/crates/tsz-checker/src/types/class_type/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/helpers.rs
@@ -369,20 +369,20 @@ impl<'a> CheckerState<'a> {
 
         class_type::merged_class_instance_interface_type(
             self.ctx.types,
-            class_type::MergedClassInstanceInterfaceSurface::new(
+            class_type::MergedClassInstanceInterfaceSurface {
                 result_is_callable,
                 call_signatures,
                 construct_signatures,
-                properties.into_values().collect(),
+                properties: properties.into_values().collect(),
                 string_index,
                 number_index,
                 symbol_index,
                 symbol,
-                is_plain_object_type(self.ctx.types, instance_type)
+                plain_object_without_indexes: is_plain_object_type(self.ctx.types, instance_type)
                     && string_index.is_none()
                     && number_index.is_none()
                     && symbol_index.is_none(),
-            ),
+            },
         )
     }
 

--- a/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
+++ b/crates/tsz-checker/tests/relation_leaf_literal_generalization_tests.rs
@@ -250,7 +250,7 @@ const mixed: { a: 6 | string } = five;
 }
 
 /// Enum members generalize to their parent enum in the positional-chain leaf
-/// (tsc `getBaseTypeOfLiteralType` EnumLike branch).
+/// (tsc `getBaseTypeOfLiteralType` `EnumLike` branch).
 #[test]
 fn enum_member_tuple_chain_leaf_widens_to_parent_enum() {
     let source = r#"


### PR DESCRIPTION
Clears the last clippy failure on tsz-checker (external integrate-round4 content, tip d0bee040): `too_many_arguments (9/8)` on `MergedClassInstanceInterfaceSurface::new`.

## Fix
`MergedClassInstanceInterfaceSurface` already IS a parameter bundle — it is passed whole to `merged_class_instance_interface_type(db, surface)` and destructured there. So a 9-arg field-by-field `new()` is redundant with struct-literal construction. Make the fields `pub(crate)` and build the struct with a literal at its single call site (`types/class_type/helpers.rs`), then delete `new()`. A struct literal is not a function, so the lint no longer applies — no `#[allow]`, no synthetic sub-struct. (`Option<IndexSignature>` is `Copy`, so the literal's field shorthand and the `plain_object_without_indexes` reuse of `*_index.is_none()` are fine — same pattern the original call already relied on.)

## Second, masked warning
Clearing the lib error let clippy reach the test targets and surface a `doc_markdown` warning that was hidden behind it: a CamelCase identifier missing backticks in `relation_leaf_literal_generalization_tests.rs:253`, from the same external content, also denied under CI `-D warnings`. Backticked it.

## Verification
- `cargo clippy -p tsz-checker --all-targets` -> 0 errors / 0 warnings (independent clean Lane-B target).
- `arch_guard.py --size-only` still exits 0 (class_type.rs shrank from deleting `new`; no ratchet touched).
- Behavior-neutral: pure constructor-to-literal refactor + a doc-comment backtick.

Goal: hold

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
