### PR TITLE
fix(checker): preserve literal-union assignment source against a never target

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -70,6 +70,17 @@ impl<'a> CheckerState<'a> {
         if generalized == source {
             return source;
         }
+        // tsc preserves a literal / literal-union source verbatim against a
+        // `never` target: the exhaustiveness and narrowed-to-`never` surface
+        // reports the residual literal union (`Type '"d" | "c"' is not
+        // assignable to type 'never'`), not its widened base (`string`). `never`
+        // is not singleton-capable, so the general gate below would otherwise
+        // widen it. This is the one non-singleton-capable target where tsc keeps
+        // the literal source, so it is handled explicitly rather than through
+        // `relation_target_could_hold_singleton`.
+        if target == TypeId::NEVER {
+            return source;
+        }
         if crate::query_boundaries::diagnostics::relation_target_could_hold_singleton(
             self.ctx.types,
             &self.ctx,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1299,6 +1299,9 @@ mod namespace_property_mismatch_boundary_arch_tests;
 #[path = "tests/narrowed_union_source_display_tests.rs"]
 mod narrowed_union_source_display_tests;
 #[cfg(test)]
+#[path = "tests/narrowing_union_source_display_tests.rs"]
+mod narrowing_union_source_display_tests;
+#[cfg(test)]
 #[path = "tests/nested_tuple_literal_source_display_tests.rs"]
 mod nested_tuple_literal_source_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/narrowing_union_source_display_tests.rs
+++ b/crates/tsz-checker/src/tests/narrowing_union_source_display_tests.rs
@@ -1,0 +1,113 @@
+//! Regression tests for narrowingUnionToNeverAssigment.ts: a literal-union
+//! assignment SOURCE must display its literal members verbatim in the TS2322
+//! message, not its widened primitive base.
+//!
+//! Structural rule: when a non-fresh literal union (declared annotation, named
+//! alias, or flow-narrowed residue) is the assignability source, tsc renders
+//! the union spelling (`"c" | "d"`). tsz must not widen a non-fresh union
+//! source to its primitive base (`string`) for display. Target-position unions
+//! already render correctly; only the source side was widening.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322_messages(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+#[test]
+fn declared_string_literal_union_source_keeps_union_display() {
+    let messages = ts2322_messages(
+        r#"
+declare const w: "c" | "d";
+const y: never = w;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains(r#"Type '"c" | "d"' is not assignable to type 'never'"#)),
+        "declared string-literal union source must render verbatim, got: {messages:?}"
+    );
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.contains("Type 'string' is not assignable to type 'never'")),
+        "source union must not widen to 'string', got: {messages:?}"
+    );
+}
+
+#[test]
+fn declared_number_literal_union_source_keeps_union_display() {
+    let messages = ts2322_messages(
+        r#"
+declare const w: 1 | 2;
+const y: never = w;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Type '1 | 2' is not assignable to type 'never'")),
+        "declared number-literal union source must render verbatim, got: {messages:?}"
+    );
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.contains("Type 'number' is not assignable to type 'never'")),
+        "source union must not widen to 'number', got: {messages:?}"
+    );
+}
+
+#[test]
+fn flow_narrowed_union_source_keeps_union_display() {
+    // The original witness: `x` is narrowed to `"c" | "d"` in the else branch.
+    let messages = ts2322_messages(
+        r#"
+type Variants = "a" | "b" | "c" | "d";
+function fx1(x: Variants) {
+    if (x === "a" || x === "b") {
+    } else {
+        const y: never = x;
+    }
+}
+"#,
+    );
+    // tsc renders the flow-narrowed residual union verbatim (member order
+    // follows the narrowing, e.g. `"d" | "c"`), never its widened base.
+    assert!(
+        messages.iter().any(|m| {
+            m.ends_with("is not assignable to type 'never'.")
+                && m.contains(r#""c""#)
+                && m.contains(r#""d""#)
+        }),
+        "flow-narrowed union source must render its literal members, got: {messages:?}"
+    );
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.contains("Type 'string' is not assignable to type 'never'")),
+        "flow-narrowed union source must not widen to 'string', got: {messages:?}"
+    );
+}
+
+#[test]
+fn literal_union_target_position_still_renders_verbatim() {
+    // Guard: the union in TARGET position already renders correctly; the source
+    // fix must not disturb it.
+    let messages = ts2322_messages(
+        r#"
+declare const s: string;
+const z: "c" | "d" = s;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains(r#"is not assignable to type '"c" | "d"'"#)),
+        "target-position union must render verbatim, got: {messages:?}"
+    );
+}


### PR DESCRIPTION
Restores `narrowingUnionToNeverAssigment.ts` to parity with `tsc` (fingerprint-only TS2322 regression at the current tip; official run 28986080558 flagged it).

## Problem
`tsc` renders a non-fresh literal / literal-union assignment source verbatim against a `never` target — `Type '"d" | "c"' is not assignable to type 'never'` — not its widened primitive base `string`. The literal-source generalization added in #15626/#15628 widens the top-level source via `getBaseTypeOfLiteralType` whenever the target is not singleton-capable. `never` is not singleton-capable, so it over-widened the residual union `"d" | "c"` -> `string` on the exhaustiveness / narrowed-to-`never` surface: correct code and count, wrong source display.

## Structural rule
When the assignability source is a non-fresh literal or literal-union and the target is `never`, `tsc` renders the source verbatim; `tsz` now does this through `generalize_nested_relation_source_for_display` (checker `error_reporter`/`render_failure`), which returns the source unchanged for a `never` target instead of applying the `getBaseTypeOfLiteralType` generalization that `relation_target_could_hold_singleton` (false for `never`) would otherwise trigger. `never` is the one non-singleton-capable target where `tsc` keeps the literal source, so it is handled explicitly.

## Owner layer
Checker `error_reporter` (`render_failure`) — display only. No relation, inference, or narrowing change.

## Adjacent matrix
- declared string union `"c" | "d"` -> `never`: preserved.
- declared numeric union `1 | 2` -> `never`: preserved (`1 | 2`, not `number`).
- flow-narrowed residual union (the witness, `"d" | "c"`) -> `never`: preserved.
- literal-sensitive target (`"z"`) and the #15628 targets (boolean / string / number / `"w" | "z"` / enum member): unchanged (widen or preserve exactly as before).

Goal: hold

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Conformance filter (debug `tsz` + `tsz-conformance` against `tsc-cache-full.json`): `narrowingUnionToNever` 1/1 PASS (was fingerprint-only FAIL). No regressions across the affected families: never 9/9, exhaustiv 4/4, narrowing 29/29, discriminat 16/16, switchStatement 3/3, controlFlow 94/94, assignmentCompat 128/128.
- Unit: new `tests/narrowing_union_source_display_tests.rs` (4/4) covering declared string/number unions, the flow-narrowed witness, and the literal-sensitive-target control; existing `narrowed_union_source_display_tests` 7/7 pass. The one local `higher_order_regeneralization` failure is pre-existing (unrelated inference test), confirmed by reverting this change.
- CI ready-review runs the full conformance suite.