### PR TITLE
fix(checker): normalize inferred async returns through Awaited

### DIFF
--- a/crates/tsz-checker/src/types/function_type/tests.rs
+++ b/crates/tsz-checker/src/types/function_type/tests.rs
@@ -197,8 +197,12 @@ fn resolved_conditional_target_still_reduces_to_branch() {
     );
 }
 
-/// Minimal Promise definition so async tests can resolve Promise<T>.
-const PROMISE_DEF: &str = "interface Promise<T> { then<U>(cb: (val: T) => U): Promise<U>; }";
+/// Minimal Promise definitions so async tests can resolve promise-like values
+/// without loading the default libraries.
+const PROMISE_DEF: &str = r#"
+interface Promise<T> { then<U>(cb: (val: T) => U): Promise<U>; }
+interface PromiseLike<T> { then<U>(cb: (val: T) => U): PromiseLike<U>; }
+"#;
 
 fn async_diagnostics(body: &str) -> Vec<u32> {
     diagnostics_for_source(&format!("{PROMISE_DEF}\n{body}"))
@@ -297,6 +301,90 @@ fn async_inferred_return_union_with_promise() {
     assert!(
         !diags.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
         "async returning Promise in union context should not double-wrap: {diags:?}"
+    );
+}
+
+#[test]
+fn async_inferred_return_recursively_awaits_nested_promise() {
+    let diags = async_diagnostics(
+        "declare function load<Payload>(): Promise<Promise<Payload>>;
+         const cb: () => Promise<boolean> = async () => load<boolean>();",
+    );
+    assert!(
+        !diags.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "nested Promise layers should flatten before the inferred return is wrapped: {diags:?}"
+    );
+}
+
+#[test]
+fn async_inferred_return_awaits_promiselike_with_renamed_binder() {
+    let diags = async_diagnostics(
+        "declare function load<Item>(): PromiseLike<Item>;
+         const cb: () => Promise<number> = async () => load<number>();",
+    );
+    assert!(
+        !diags.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "PromiseLike payloads should use the same awaited return path across binder names: {diags:?}"
+    );
+}
+
+#[test]
+fn async_inferred_return_distributes_awaited_union() {
+    let diags = async_diagnostics(
+        "declare const pick: boolean;
+         declare function load<Value>(): PromiseLike<Value>;
+         const cb: () => Promise<number> = async () => pick ? 1 : load<number>();",
+    );
+    assert!(
+        !diags.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "mixed value/PromiseLike unions should be awaited member-wise before wrapping: {diags:?}"
+    );
+}
+
+#[test]
+fn async_inferred_return_awaits_alias_wrapped_promiselike() {
+    let diags = async_diagnostics(
+        "type Later<Payload> = PromiseLike<Payload>;
+         declare function load<Result>(): Later<Result>;
+         const cb: () => Promise<string> = async () => load<string>();",
+    );
+    assert!(
+        !diags.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "alias-wrapped PromiseLike values should resolve through the awaited query: {diags:?}"
+    );
+}
+
+#[test]
+fn async_inferred_return_preserves_non_thenable_generic_application() {
+    let diags = async_diagnostics(
+        "interface Box<Payload> { value: Payload; }
+         declare function make<Item>(): Box<Item>;
+         const cb: () => Promise<Box<string>> = async () => make<string>();",
+    );
+    assert!(
+        !diags.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "non-thenable generic applications should be wrapped without structural evaluation: {diags:?}"
+    );
+}
+
+#[test]
+fn async_inferred_return_keeps_bare_constrained_parameter() {
+    let diags = async_diagnostics(
+        "const keep = async <P extends PromiseLike<number>>(value: P) => value;
+         const check: <Q extends PromiseLike<number>>(value: Q) => Promise<Q> = keep;",
+    );
+    assert!(
+        !diags.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "a bare constrained parameter should stay Promise<P>, not unwrap its constraint: {diags:?}"
+    );
+}
+
+#[test]
+fn async_inferred_return_still_reports_incompatible_payload() {
+    let diags = async_diagnostics("const cb: () => Promise<string> = async () => 42;");
+    assert!(
+        diags.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "canonical Promise wrapping must not suppress a genuine payload mismatch: {diags:?}"
     );
 }
 

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -1034,26 +1034,21 @@ impl<'a> CheckerState<'a> {
         Some(widened)
     }
 
-    fn wrap_unannotated_async_return_type(&mut self, mut return_type: TypeId) -> TypeId {
-        let had_promise_wrapper = if let Some(inner) = self.unwrap_promise_type(return_type) {
-            return_type = inner;
-            true
-        } else {
-            false
-        };
-        if !had_promise_wrapper
-            && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, return_type)
+    fn wrap_unannotated_async_return_type(&mut self, return_type: TypeId) -> TypeId {
+        let mut awaited_type = self.compute_awaited_type(return_type, 0);
+        let had_awaitable_layer = awaited_type != return_type;
+        if !had_awaitable_layer
+            && !crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, awaited_type)
         {
-            return_type = self.widen_literal_type(return_type);
+            awaited_type = self.widen_literal_type(awaited_type);
         }
-        let promise_base = self
-            .ctx
-            .lib_promise_type_ref()
-            .unwrap_or(TypeId::PROMISE_BASE);
+        if let Some(promise_type) = self.get_promise_type(awaited_type) {
+            return promise_type;
+        }
         return_type_construction::function_return_application(
             self.ctx.types,
-            promise_base,
-            vec![return_type],
+            TypeId::PROMISE_BASE,
+            vec![awaited_type],
         )
     }
 


### PR DESCRIPTION
Unannotated async functions now compute the recursive awaited value of their
inferred body result and construct the return through the canonical in-scope
`Promise`, instead of unwrapping one layer and falling back immediately to the
synthetic Promise base.

Goal: hold

## Structural rule

When an unannotated, non-generator async function has inferred body result `R`,
`tsc` recursively computes `Awaited<R>`—distributing unions and unwrapping
valid `Promise`, `PromiseLike`, alias, nested, and structural-thenable layers—
then exposes the canonical global `Promise<Awaited<R>>`. Non-thenable generic
applications and bare constrained type parameters remain unchanged. Explicit
return annotations stay on their existing path.

This was verified with `tsc 6.0.0-dev.20260306`; the positive matrix is clean
and the incompatible `Promise<number>` to `Promise<string>` control emits
`TS2322`.

## Owner layer

- `types/function_type_helpers.rs` owns function-signature orchestration,
  literal widening, and the final wrapper.
- Existing solver-backed `compute_awaited_type` and `get_promise_type` own the
  semantic Awaited fold and canonical Promise construction.

No user name, file name, rendered diagnostic text, or fixture source drives the
decision.

## Adjacent-case matrix

- plain values and one-layer Promise returns;
- nested `Promise<Promise<T>>`;
- `PromiseLike<T>` with renamed binders;
- `T | PromiseLike<T>` distribution;
- alias-wrapped thenables;
- non-thenable generic `Box<T>` fallback;
- bare `P extends PromiseLike<number>` remains `Promise<P>`;
- incompatible payload still emits `TS2322`.

The separate contextual-call display failure in
`async_return_widening_tests::async_arrow_returning_promise_expression_preserves_inner`
does not enter this function (verified with `rdbg`) and remains outside this
single-invariant slice.

## Verification

- `tsc --strict --noEmit` / compiler-API oracle on the adjacent matrix.
- `cargo nextest run -p tsz-checker --lib async_inferred_return` — direct
  harness readback: 11 passed, 0 failed.
- `cargo nextest run -p tsz-checker --test no_lib_async_promise_tests --test awaited_generic_application_fold_tests --test async_return_promise_identity_tests` — passed.
- Full base: 18,061 run, 17,938 passed, 123 raw failures / 113 canonical.
- Full head: 18,068 run, 17,949 passed, 119 raw failures / 109 canonical.
- Canonical set diff: exactly the four `async_inferred_return_*` failures
  removed; newly failing set empty.
- `cargo clippy -p tsz-checker --all-targets` — passed.
- `python3 scripts/arch/arch_guard.py --size-only` — passed.

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5
Effort: max
