### PR TITLE
perf(checker): skip diagnostic presentation work in contexts whose diagnostics never surface

### DIFF
--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -882,10 +882,13 @@ impl<'a> CheckerContext<'a> {
         ctx.definition_store = Arc::clone(&parent.definition_store);
         ctx.share_owner_symbol_type_results = parent.share_owner_symbol_type_results;
 
-        // A child of a discarded-diagnostics checker is itself discarded: the
-        // whole delegation subtree's diagnostics are dropped at teardown, so
-        // none of its descendants should pay for diagnostic presentation.
-        ctx.diagnostics_discarded = parent.diagnostics_discarded;
+        // Every `with_parent_cache` child is a transient delegation checker:
+        // the parent consumes only the delegated symbol's type, and no
+        // construction site merges the child's diagnostics back — they are
+        // dropped at teardown. Mark the whole delegation subtree discarded so
+        // none of it pays for diagnostic presentation work (failure
+        // elaboration, type display, spelling-suggestion candidate scans).
+        ctx.diagnostics_discarded = true;
 
         ctx
     }

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -1176,16 +1176,19 @@ pub struct CheckerContext<'a> {
     pub diagnostics: Vec<Diagnostic>,
     /// Whether this context's `diagnostics` are never surfaced to the user.
     ///
-    /// Set for transient cross-arena delegation child checkers (the parent
-    /// consumes only the delegated symbol's type and drops the child's
-    /// diagnostics at teardown) and inherited by their descendants via
-    /// [`Self::with_parent_cache`]. When set, the expensive diagnostic
-    /// *presentation* work — solver failure-reason elaboration
-    /// (`explain_failure`), diagnostic type formatting, and related-info
-    /// chains — is skipped; diagnostics are still recorded with the correct
-    /// code and span so child-internal counting/dedup predicates keep
-    /// working. This flag must never change which checks run or what types
-    /// are computed.
+    /// Set by [`Self::with_parent_cache`] for every transient cross-arena
+    /// delegation child checker (the parent consumes only the delegated
+    /// symbol's type and drops the child's diagnostics at teardown — no
+    /// construction site merges them back), and by the driver's skipLibCheck
+    /// declaration-preparation pass, which likewise drops its checker
+    /// diagnostics. When set, the expensive diagnostic *presentation* work —
+    /// solver failure-reason elaboration (`explain_failure`), diagnostic type
+    /// formatting, related-info chains, and spelling-suggestion candidate
+    /// scans — is skipped; diagnostics routed through
+    /// [`Self::error`](crate::context::CheckerContext) are still recorded
+    /// with the correct code and span so context-internal counting/dedup
+    /// predicates keep working. This flag must never change which checks run
+    /// or what types are computed.
     pub diagnostics_discarded: bool,
     pub(crate) diagnostic_indices: DiagnosticIndices,
     /// Call-expression nodes that resolved to TS2769 during the current

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -1184,10 +1184,12 @@ pub struct CheckerContext<'a> {
     /// diagnostics. When set, the expensive diagnostic *presentation* work —
     /// solver failure-reason elaboration (`explain_failure`), diagnostic type
     /// formatting, related-info chains, and spelling-suggestion candidate
-    /// scans — is skipped; diagnostics routed through `CheckerContext::error`
-    /// are still recorded with the correct code and span so context-internal
-    /// counting/dedup predicates keep working. This flag must never change
-    /// which checks run or what types are computed.
+    /// scans — is skipped. Diagnostics routed through
+    /// `CheckerContext::error` are still recorded with the correct code and
+    /// span, so counting/dedup predicates over that family keep working;
+    /// diagnostics routed through `CheckerContext::push_diagnostic` are
+    /// dropped wholesale (before the dedup-key insert). This flag must never
+    /// change which checks run or what types are computed.
     pub diagnostics_discarded: bool,
     pub(crate) diagnostic_indices: DiagnosticIndices,
     /// Call-expression nodes that resolved to TS2769 during the current

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -1184,11 +1184,10 @@ pub struct CheckerContext<'a> {
     /// diagnostics. When set, the expensive diagnostic *presentation* work —
     /// solver failure-reason elaboration (`explain_failure`), diagnostic type
     /// formatting, related-info chains, and spelling-suggestion candidate
-    /// scans — is skipped; diagnostics routed through
-    /// [`Self::error`](crate::context::CheckerContext) are still recorded
-    /// with the correct code and span so context-internal counting/dedup
-    /// predicates keep working. This flag must never change which checks run
-    /// or what types are computed.
+    /// scans — is skipped; diagnostics routed through `CheckerContext::error`
+    /// are still recorded with the correct code and span so context-internal
+    /// counting/dedup predicates keep working. This flag must never change
+    /// which checks run or what types are computed.
     pub diagnostics_discarded: bool,
     pub(crate) diagnostic_indices: DiagnosticIndices,
     /// Call-expression nodes that resolved to TS2769 during the current

--- a/crates/tsz-checker/src/error_reporter/emitters.rs
+++ b/crates/tsz-checker/src/error_reporter/emitters.rs
@@ -9,6 +9,21 @@ use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 
 impl<'a> CheckerState<'a> {
+    /// Whether a diagnostic anchored at `idx` can be emitted from this
+    /// checker.
+    ///
+    /// Every node-anchored emitter below (`error_at_node` and friends) is
+    /// span-gated: it silently drops the diagnostic when `idx` is not
+    /// addressable in the current arena — the case for nodes from another
+    /// arena reached through demand-driven lowering, whose diagnostics
+    /// belong to the owning file's own check. Pre-flight gates that want to
+    /// skip diagnostic-presentation work (message building, spelling
+    /// suggestion scans) for such nodes must use this predicate so they
+    /// cannot drift from the emitters' actual drop rule.
+    pub(crate) fn can_emit_diagnostic_at(&self, idx: NodeIndex) -> bool {
+        self.get_node_span(idx).is_some()
+    }
+
     /// Report an error at a specific node.
     ///
     /// The span is normalized via `normalized_anchor_span` so that, for

--- a/crates/tsz-checker/src/error_reporter/emitters.rs
+++ b/crates/tsz-checker/src/error_reporter/emitters.rs
@@ -12,8 +12,8 @@ impl<'a> CheckerState<'a> {
     /// Whether a diagnostic anchored at `idx` can be emitted from this
     /// checker.
     ///
-    /// Every node-anchored emitter below (`error_at_node` and friends) is
-    /// span-gated: it silently drops the diagnostic when `idx` is not
+    /// The node-anchored emitters below (`error_at_node` and friends) are
+    /// span-gated: they silently drop the diagnostic when `idx` is not
     /// addressable in the current arena — the case for nodes from another
     /// arena reached through demand-driven lowering, whose diagnostics
     /// belong to the owning file's own check. Pre-flight gates that want to

--- a/crates/tsz-checker/src/error_reporter/name_resolution.rs
+++ b/crates/tsz-checker/src/error_reporter/name_resolution.rs
@@ -1162,13 +1162,11 @@ impl<'a> CheckerState<'a> {
     /// the previous eager `collect_spelling_suggestions`, so cap behavior and
     /// the resulting diagnostics are unchanged.
     pub(crate) fn suggestion_scan_eligible(&self, name: &str, idx: NodeIndex) -> bool {
-        // A failure site that is not addressable in this checker's arena
-        // (demand-driven lowering of another arena's declarations, or a
-        // missing node) can never emit a diagnostic here — every emitter is
-        // span-gated on `idx`. Skip both the scan and the cap-counter charge:
-        // tsc's `suggestionCount` only ever advances for failures it reports,
-        // and it never reports these.
-        if self.get_node_span(idx).is_none() {
+        // A failure site whose diagnostic can never be emitted from this
+        // checker (node not addressable in the current arena) must skip both
+        // the scan and the cap-counter charge: tsc's `suggestionCount` only
+        // ever advances for failures it reports, and it never reports these.
+        if !self.can_emit_diagnostic_at(idx) {
             return false;
         }
 

--- a/crates/tsz-checker/src/error_reporter/name_resolution.rs
+++ b/crates/tsz-checker/src/error_reporter/name_resolution.rs
@@ -1237,6 +1237,13 @@ impl<'a> CheckerState<'a> {
     /// (it does not re-apply the suppression predicates or touch the cap
     /// counter), and only when a diagnostic is actually being emitted.
     pub(crate) fn scan_similar_identifiers(&self, name: &str, idx: NodeIndex) -> Vec<String> {
+        // Bail before the meaning-detection parent walk: a discarded context
+        // returns no candidates regardless of meaning (the same gate inside
+        // `scan_similar_identifiers_for_meaning` covers direct callers).
+        if self.ctx.diagnostics_discarded {
+            return Vec::new();
+        }
+
         // Determine spelling suggestion meaning based on context.
         // In type positions (type annotations, implements clauses, type references),
         // only suggest TYPE-meaning symbols. In value positions, suggest VALUE symbols.

--- a/crates/tsz-checker/src/error_reporter/name_resolution.rs
+++ b/crates/tsz-checker/src/error_reporter/name_resolution.rs
@@ -1162,6 +1162,16 @@ impl<'a> CheckerState<'a> {
     /// the previous eager `collect_spelling_suggestions`, so cap behavior and
     /// the resulting diagnostics are unchanged.
     pub(crate) fn suggestion_scan_eligible(&self, name: &str, idx: NodeIndex) -> bool {
+        // A failure site that is not addressable in this checker's arena
+        // (demand-driven lowering of another arena's declarations, or a
+        // missing node) can never emit a diagnostic here — every emitter is
+        // span-gated on `idx`. Skip both the scan and the cap-counter charge:
+        // tsc's `suggestionCount` only ever advances for failures it reports,
+        // and it never reports these.
+        if self.get_node_span(idx).is_none() {
+            return false;
+        }
+
         // Keep TS2304 for accessibility modifier keywords recovered as identifiers.
         // tsc does not emit TS2552 suggestions (e.g. "private" -> "print") in these cases.
         let is_accessibility_modifier_name = matches!(name, "public" | "private" | "protected");
@@ -1286,12 +1296,14 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         meaning: u32,
     ) -> Vec<String> {
-        // Name-resolution failures inside built-in libs are often encountered by
-        // transient cross-arena child checkers whose diagnostics are discarded;
-        // their spelling suggestions are pure presentation work. Keep the scan
-        // for retained diagnostics, because `tsc` can still surface observable
-        // lib diagnostics such as the Temporal/Intl TS2552 baseline.
-        if self.ctx.diagnostics_discarded && self.node_is_in_builtin_lib_file(idx) {
+        // A discarded-diagnostics context (transient cross-arena child
+        // checkers, the driver's skipLibCheck declaration-preparation pass)
+        // never surfaces any diagnostic, so the full-symbol-universe
+        // Levenshtein scan below is pure presentation work for it — skip it
+        // for every node. Retained-diagnostics contexts always scan, because
+        // `tsc` can still surface observable lib diagnostics such as the
+        // Temporal/Intl TS2552 baseline.
+        if self.ctx.diagnostics_discarded {
             return Vec::new();
         }
         // Memoize per (reference site, meaning): the same unresolved reference is

--- a/crates/tsz-checker/src/error_reporter/suggestions.rs
+++ b/crates/tsz-checker/src/error_reporter/suggestions.rs
@@ -46,6 +46,12 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
+        // A discarded-diagnostics context never surfaces the diagnostic this
+        // suggestion would decorate; skip the property-universe scan.
+        if self.ctx.diagnostics_discarded {
+            return None;
+        }
+
         let evaluated_type = self.evaluate_type_for_assignability(type_id);
         let property_names = self.collect_accessible_type_property_names(type_id, evaluated_type);
         if property_names.is_empty() {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -511,6 +511,9 @@ mod stability_validation_tests;
 #[path = "../tests/string_literal_arithmetic_tests.rs"]
 mod string_literal_arithmetic_tests;
 #[cfg(test)]
+#[path = "tests/suggestion_scan_discarded_tests.rs"]
+mod suggestion_scan_discarded_tests;
+#[cfg(test)]
 #[path = "../tests/symbol_resolver_stability_tests.rs"]
 mod symbol_resolver_stability_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/name_resolution.rs
+++ b/crates/tsz-checker/src/query_boundaries/name_resolution.rs
@@ -700,16 +700,14 @@ impl<'a> CheckerState<'a> {
         failure: &ResolutionFailure,
     ) {
         // Every arm below anchors its diagnostic at `request.idx` through the
-        // span-gated emitters (`error_at_node` and friends), which silently
-        // drop the diagnostic when the node is not addressable in this
-        // checker's arena. That happens when demand-driven lowering resolves
-        // names inside declarations from another arena (e.g. lib interface
-        // bodies materialized on behalf of user code): the failure produces
-        // an error type, but the diagnostic belongs to the owning file's own
-        // check. Bail out before building messages or running the
-        // full-symbol-universe spelling-suggestion scan for a diagnostic that
-        // is structurally guaranteed to be dropped at emission.
-        if self.get_node_span(request.idx).is_none() {
+        // span-gated emitters, so an unaddressable node (demand-driven
+        // lowering of another arena's declarations — e.g. lib interface
+        // bodies materialized on behalf of user code) is structurally
+        // guaranteed to be dropped at emission. Bail out before building
+        // messages or running the full-symbol-universe spelling-suggestion
+        // scan for it; the failure still produces an error type, and the
+        // diagnostic belongs to the owning file's own check.
+        if !self.can_emit_diagnostic_at(request.idx) {
             return;
         }
 

--- a/crates/tsz-checker/src/query_boundaries/name_resolution.rs
+++ b/crates/tsz-checker/src/query_boundaries/name_resolution.rs
@@ -699,6 +699,20 @@ impl<'a> CheckerState<'a> {
         request: &NameResolutionRequest<'_>,
         failure: &ResolutionFailure,
     ) {
+        // Every arm below anchors its diagnostic at `request.idx` through the
+        // span-gated emitters (`error_at_node` and friends), which silently
+        // drop the diagnostic when the node is not addressable in this
+        // checker's arena. That happens when demand-driven lowering resolves
+        // names inside declarations from another arena (e.g. lib interface
+        // bodies materialized on behalf of user code): the failure produces
+        // an error type, but the diagnostic belongs to the owning file's own
+        // check. Bail out before building messages or running the
+        // full-symbol-universe spelling-suggestion scan for a diagnostic that
+        // is structurally guaranteed to be dropped at emission.
+        if self.get_node_span(request.idx).is_none() {
+            return;
+        }
+
         // Suppress TS2304/TS2552 entirely for identifiers inside enum computed
         // property names. tsc only emits TS1164 for these and doesn't resolve
         // the expressions.

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -896,11 +896,6 @@ impl CheckerState<'_> {
                 self, // Share parent's cache to fix Cache Isolation Bug
                 tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaSymbol,
             ));
-            // The parent consumes only the delegated symbol's type; the
-            // child's diagnostics are dropped at teardown. Skip diagnostic
-            // presentation work (failure elaboration, type formatting) in
-            // this subtree.
-            checker.ctx.diagnostics_discarded = true;
             // Copy lib contexts for global symbol resolution (Array, Promise, etc.)
             checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
             // Copy all cross-file state: arenas, binders, all 6 global indices,
@@ -1332,8 +1327,6 @@ impl CheckerState<'_> {
             self,
             tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaClass,
         ));
-        // Transient delegation child: diagnostics are discarded at teardown.
-        checker.ctx.diagnostics_discarded = true;
         checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
         checker.ctx.current_file_idx = query_file_idx
             .or(delegate_file_idx)
@@ -1565,8 +1558,6 @@ impl CheckerState<'_> {
             self,
             tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaInterface,
         ));
-        // Transient delegation child: diagnostics are discarded at teardown.
-        checker.ctx.diagnostics_discarded = true;
         checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
         checker.ctx.copy_cross_file_state_from(&self.ctx);
         self.ctx.copy_symbol_file_targets_to_attributed(
@@ -1795,8 +1786,6 @@ impl CheckerState<'_> {
             self,
             tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaOther,
         ));
-        // Transient delegation child: diagnostics are discarded at teardown.
-        checker.ctx.diagnostics_discarded = true;
         checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
         checker.ctx.copy_cross_file_state_from(&self.ctx);
         self.ctx.copy_symbol_file_targets_to_attributed(

--- a/crates/tsz-checker/src/state/type_resolution/cross_file_constructors.rs
+++ b/crates/tsz-checker/src/state/type_resolution/cross_file_constructors.rs
@@ -47,8 +47,6 @@ impl<'a> CheckerState<'a> {
             self,
             CheckerCreationReason::DelegateCrossArenaOther,
         ));
-        // Transient delegation child: diagnostics are discarded at teardown.
-        checker.ctx.diagnostics_discarded = true;
         checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
         checker.ctx.copy_cross_file_state_from(&self.ctx);
         self.ctx.copy_symbol_file_targets_to_attributed(

--- a/crates/tsz-checker/src/tests/suggestion_scan_discarded_tests.rs
+++ b/crates/tsz-checker/src/tests/suggestion_scan_discarded_tests.rs
@@ -1,0 +1,86 @@
+//! Discarded-diagnostics contexts must skip spelling-suggestion candidate
+//! scans (issue #13250, Fast workstream B).
+//!
+//! When `CheckerContext::diagnostics_discarded` is set (transient cross-arena
+//! delegation children, the driver's skipLibCheck declaration-preparation
+//! pass), no diagnostic from the context ever surfaces, so the
+//! full-symbol-universe Levenshtein scan behind "did you mean" suggestions is
+//! pure presentation work. The scan gate must:
+//!
+//! - return no candidates for ANY node while the flag is set (previously only
+//!   nodes inside built-in `lib.*.d.ts` files were gated), and
+//! - keep producing candidates in retained-diagnostics contexts, where the
+//!   suggestion decides the surfaced diagnostic (TS2552/TS2551 vs plain
+//!   TS2304/TS2339).
+//!
+//! The retained-context lib behavior (e.g. `Arrray` -> `Array` TS2552) is
+//! covered by `tests/lib_type_spelling_suggestions_tests.rs`.
+
+use crate::context::CheckerOptions;
+use crate::state::CheckerState;
+use tsz_binder::BinderState;
+use tsz_parser::ParserState;
+use tsz_solver::TypeInterner;
+
+/// Run `f` against a checked source file, with `diagnostics_discarded` set
+/// before the check when requested. `f` receives the checker and the
+/// source-file root node, which sits in the top-level scope and therefore
+/// sees every top-level binding as a suggestion candidate.
+fn with_checked_state<R>(
+    source: &str,
+    discarded: bool,
+    f: impl FnOnce(&CheckerState<'_>, tsz_parser::NodeIndex) -> R,
+) -> R {
+    let mut parser = ParserState::new("main.ts".to_string(), source.to_string());
+    let source_file = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), source_file);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "main.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker.ctx.diagnostics_discarded = discarded;
+    checker.check_source_file(source_file);
+    f(&checker, source_file)
+}
+
+const TYPO_SOURCE: &str = "const whole = 1;\nlet x = wole;\n";
+
+#[test]
+fn retained_context_scans_candidates_for_user_node() {
+    with_checked_state(TYPO_SOURCE, false, |checker, root| {
+        let suggestions = checker.scan_similar_identifiers_for_meaning(
+            "wole",
+            root,
+            tsz_binder::symbol_flags::VALUE,
+        );
+        assert_eq!(
+            suggestions,
+            vec!["whole".to_string()],
+            "retained-diagnostics contexts must keep producing suggestions"
+        );
+    });
+}
+
+#[test]
+fn discarded_context_skips_scan_for_user_node() {
+    with_checked_state(TYPO_SOURCE, true, |checker, root| {
+        let suggestions = checker.scan_similar_identifiers_for_meaning(
+            "wole",
+            root,
+            tsz_binder::symbol_flags::VALUE,
+        );
+        assert!(
+            suggestions.is_empty(),
+            "discarded-diagnostics contexts must not run the candidate scan \
+             even for nodes outside built-in lib files, got: {suggestions:?}"
+        );
+    });
+}

--- a/crates/tsz-checker/src/tests/suggestion_scan_discarded_tests.rs
+++ b/crates/tsz-checker/src/tests/suggestion_scan_discarded_tests.rs
@@ -17,10 +17,10 @@
 //! covered by `tests/lib_type_spelling_suggestions_tests.rs`.
 
 use crate::context::CheckerOptions;
+use crate::query_boundaries::common::TypeInterner;
 use crate::state::CheckerState;
 use tsz_binder::BinderState;
 use tsz_parser::ParserState;
-use tsz_solver::TypeInterner;
 
 /// Run `f` against a checked source file, with `diagnostics_discarded` set
 /// before the check when requested. `f` receives the checker and the

--- a/crates/tsz-checker/src/types/module_augmentation_value.rs
+++ b/crates/tsz-checker/src/types/module_augmentation_value.rs
@@ -64,8 +64,6 @@ impl<'a> CheckerState<'a> {
             self,
             CheckerCreationReason::ModuleAugmentationValue,
         ));
-        // Transient delegation child: diagnostics are discarded at teardown.
-        checker.ctx.diagnostics_discarded = true;
         checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
         checker.ctx.copy_cross_file_state_from(&self.ctx);
         self.ctx.copy_symbol_file_targets_to_attributed(

--- a/crates/tsz-cli/src/driver/check_file.rs
+++ b/crates/tsz-cli/src/driver/check_file.rs
@@ -289,8 +289,6 @@ fn run_check_on_existing_checker<'a>(
         tsz_common::perf_counters::record_interner_working_set_for_file();
         checker.ctx.diagnostics.clear();
         if let Some(start) = check_start {
-            // Diagnostic count 0: nothing from this pass is surfaced, and the
-            // buffer only ever held the discard-mode subset anyway.
             tsz_common::perf_counters::record_slow_check_file_timing(
                 &file.file_name,
                 start.elapsed().as_nanos() as u64,

--- a/crates/tsz-cli/src/driver/check_file.rs
+++ b/crates/tsz-cli/src/driver/check_file.rs
@@ -273,27 +273,25 @@ fn run_check_on_existing_checker<'a>(
     if skip_lib_check && is_declaration_file(&file.file_name) {
         let check_start = tsz_common::perf_counters::enabled_fast().then(std::time::Instant::now);
         tsz::checker::reset_stack_overflow_flag();
+        // This pass exists only to populate shared caches (lib symbol types,
+        // heritage, cross-file state); every checker diagnostic it produces
+        // is dropped before returning. Declare the discard up front so the
+        // checker skips diagnostic presentation work entirely — failure
+        // elaboration, type display, and spelling-suggestion candidate scans
+        // — instead of formatting diagnostics that are thrown away below.
+        // The flag is restored for session-reuse callers that check a user
+        // file on this same `CheckerState` next.
+        let diagnostics_previously_discarded = checker.ctx.diagnostics_discarded;
+        checker.ctx.diagnostics_discarded = true;
         checker.check_source_file(file.source_file);
+        checker.ctx.diagnostics_discarded = diagnostics_previously_discarded;
         tsz_common::perf_counters::record_interner_working_set_for_file();
-        let mut checker_diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
-        let effective_options = ResolvedCompilerOptions {
-            check_js,
-            explicit_check_js_false,
-            ..ResolvedCompilerOptions::default()
-        };
-        post_process_checker_diagnostics(
-            &mut checker_diagnostics,
-            file,
-            &effective_options,
-            program_has_real_syntax_errors,
-            program_has_unsupported_js_root,
-            program_context.has_deprecation_diagnostics,
-        );
+        let discarded_diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
         if let Some(start) = check_start {
             tsz_common::perf_counters::record_slow_check_file_timing(
                 &file.file_name,
                 start.elapsed().as_nanos() as u64,
-                checker_diagnostics.len() as u64,
+                discarded_diagnostics.len() as u64,
             );
         }
         return file_diagnostics;

--- a/crates/tsz-cli/src/driver/check_file.rs
+++ b/crates/tsz-cli/src/driver/check_file.rs
@@ -279,19 +279,22 @@ fn run_check_on_existing_checker<'a>(
         // checker skips diagnostic presentation work entirely — failure
         // elaboration, type display, and spelling-suggestion candidate scans
         // — instead of formatting diagnostics that are thrown away below.
-        // The flag is restored for session-reuse callers that check a user
-        // file on this same `CheckerState` next.
-        let diagnostics_previously_discarded = checker.ctx.diagnostics_discarded;
+        // The flag is cleared again for session-reuse callers that check a
+        // user file on this same `CheckerState` next (`reset_for_next_file`
+        // does not touch it); top-level per-file checkers always arrive here
+        // with the flag off.
         checker.ctx.diagnostics_discarded = true;
         checker.check_source_file(file.source_file);
-        checker.ctx.diagnostics_discarded = diagnostics_previously_discarded;
+        checker.ctx.diagnostics_discarded = false;
         tsz_common::perf_counters::record_interner_working_set_for_file();
-        let discarded_diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
+        checker.ctx.diagnostics.clear();
         if let Some(start) = check_start {
+            // Diagnostic count 0: nothing from this pass is surfaced, and the
+            // buffer only ever held the discard-mode subset anyway.
             tsz_common::perf_counters::record_slow_check_file_timing(
                 &file.file_name,
                 start.elapsed().as_nanos() as u64,
-                discarded_diagnostics.len() as u64,
+                0,
             );
         }
         return file_diagnostics;

--- a/crates/tsz-cli/tests/skip_lib_check_declaration_diagnostics_tests.rs
+++ b/crates/tsz-cli/tests/skip_lib_check_declaration_diagnostics_tests.rs
@@ -52,7 +52,7 @@ fn run_tsz(files: &[(&str, &str)], skip_lib_check: bool) -> String {
     std::fs::write(
         dir.path().join("tsconfig.json"),
         format!(
-            r#"{{ "compilerOptions": {{ "noEmit": true, "strict": true, "target": "esnext", "module": "esnext", "moduleResolution": "bundler", "skipLibCheck": {skip_lib_check} }} }}"#
+            r#"{{ "compilerOptions": {{ "noEmit": true, "strict": true, "target": "esnext", "module": "esnext", "lib": ["esnext"], "moduleResolution": "bundler", "skipLibCheck": {skip_lib_check} }} }}"#
         ),
     )
     .expect("write tsconfig.json");

--- a/crates/tsz-cli/tests/skip_lib_check_declaration_diagnostics_tests.rs
+++ b/crates/tsz-cli/tests/skip_lib_check_declaration_diagnostics_tests.rs
@@ -1,0 +1,131 @@
+//! `skipLibCheck` declaration-preparation pass diagnostic equivalence
+//! (issue #13250, Fast workstream B).
+//!
+//! With `skipLibCheck: true` the driver still runs the checker over each
+//! declaration file to populate shared caches, but every checker diagnostic
+//! from that pass is dropped. The pass now runs with
+//! `diagnostics_discarded` set so the checker skips diagnostic presentation
+//! work (spelling-suggestion candidate scans, failure elaboration) instead of
+//! formatting diagnostics destined for the bin. These tests pin the
+//! observable contract around that change:
+//!
+//! * `skipLibCheck: true` — semantic errors inside a local `.d.ts` stay
+//!   unreported, while errors in regular `.ts` files (including suggestion
+//!   diagnostics) are unaffected.
+//! * `skipLibCheck: false` — the same `.d.ts` errors surface, with the
+//!   "did you mean" suggestion machinery still intact.
+//!
+//! Binder names are varied between the two configurations so nothing keys on
+//! identifier text.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+/// Run `tsz -p tsconfig.json` over `files` with the given `skipLibCheck`
+/// setting, returning combined stdout+stderr.
+fn run_tsz(files: &[(&str, &str)], skip_lib_check: bool) -> String {
+    let Some(tsz_bin) = find_tsz_binary() else {
+        return String::from("__SKIP__");
+    };
+    let dir = tempfile::tempdir().expect("temp dir");
+    for (name, contents) in files {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dir");
+        }
+        std::fs::write(path, contents).expect("write file");
+    }
+    std::fs::write(
+        dir.path().join("tsconfig.json"),
+        format!(
+            r#"{{ "compilerOptions": {{ "noEmit": true, "strict": true, "target": "esnext", "module": "esnext", "moduleResolution": "bundler", "skipLibCheck": {skip_lib_check} }} }}"#
+        ),
+    )
+    .expect("write tsconfig.json");
+
+    let output = Command::new(tsz_bin)
+        .args(["-p", "tsconfig.json", "--pretty", "false"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run tsz");
+
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    combined
+}
+
+/// With `skipLibCheck: true`, a semantic error inside a local `.d.ts`
+/// (an unresolved type name that would produce TS2552/TS2304) must stay
+/// unreported, and user-file diagnostics — including spelling suggestions —
+/// must be unaffected by the discarded-diagnostics preparation pass.
+#[test]
+fn skip_lib_check_drops_declaration_diagnostics_keeps_user_diagnostics() {
+    let out = run_tsz(
+        &[
+            (
+                "shapes.d.ts",
+                "declare interface WideShape { edge: number }\ndeclare const fallback: WideShap;\n",
+            ),
+            (
+                "main.ts",
+                "const rounded = 1;\nexport const r = roundd;\n",
+            ),
+        ],
+        true,
+    );
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("WideShap'"),
+        "declaration-file diagnostics must be dropped under skipLibCheck, got:\n{out}"
+    );
+    assert!(
+        !out.contains("shapes.d.ts"),
+        "no diagnostic may anchor into the skipped declaration file, got:\n{out}"
+    );
+    assert!(
+        out.contains("2552") && out.contains("rounded"),
+        "user-file typo must still produce a TS2552 suggestion, got:\n{out}"
+    );
+}
+
+/// With `skipLibCheck: false`, the same shape of `.d.ts` error must surface,
+/// with the suggestion machinery intact — proving the discarded-diagnostics
+/// gate does not leak into retained-diagnostics checking of declaration
+/// files.
+#[test]
+fn checked_declaration_files_keep_suggestion_diagnostics() {
+    let out = run_tsz(
+        &[
+            (
+                "geometry.d.ts",
+                "declare interface NarrowBox { side: number }\ndeclare const primary: NarrowBo;\n",
+            ),
+            ("entry.ts", "export const ok: number = 1;\n"),
+        ],
+        false,
+    );
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        out.contains("2552") && out.contains("NarrowBox"),
+        "without skipLibCheck the declaration-file typo must surface as TS2552 \
+         with a suggestion, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Fast-goal slice under the #13250 master tracker (claimed there with WIP + provenance comment; the open workstream sub-issues are WIP-claimed elsewhere, so this carves an unclaimed slice from the same retrospective's "stop doing work tsc never does" family).

## Structural rule

When a checker context's diagnostics are structurally guaranteed never to surface — transient cross-arena delegation children whose parent consumes only the delegated symbol's type, the driver's skipLibCheck declaration-preparation pass whose checker diagnostics were dropped on the floor after `check_source_file`, and name-resolution failures anchored at nodes not addressable in the current checker's arena (every emitter is span-gated and silently drops them) — `tsc` never pays for diagnostic *presentation* there at all (`getSpellingSuggestion` and error elaboration only run for reported diagnostics, and `suggestionCount` only advances for failures it reports). tsz now does the same through the existing `diagnostics_discarded` mode flag plus a named `can_emit_diagnostic_at` addressability predicate.

## Owner layer

- `CheckerContext::with_parent_cache` (constructors.rs) now owns `diagnostics_discarded = true` for every delegation child — no construction site merges child diagnostics back (verified across all ~28 sites); the six scattered per-site sets are deleted.
- Driver `run_check_on_existing_checker` (check_file.rs) declares the skipLibCheck prep pass discarded up front instead of formatting-then-dropping, and drops the dead `post_process_checker_diagnostics` call.
- Error reporter: `scan_similar_identifiers`/`scan_similar_identifiers_for_meaning` and `find_similar_property` bail under the flag; `suggestion_scan_eligible` and the `report_name_resolution_failure` gateway bail via `can_emit_diagnostic_at` (emitters.rs), the single named owner of the span-gated emitters' drop rule. The cap counter no longer charges for unaddressable failure sites, matching tsc's `suggestionCount`.

## Witness and measurements (this box: 4-core cloud VM, plain release build)

- Callgrind attribution on the ts-toolbelt row (zero-diagnostic compile) showed 9.5% of all instructions in 4 full-symbol-universe Levenshtein scans (~43k candidates each, 173k `consider_identifier_suggestion` calls) for `Intl` names (`UnicodeBCP47LocaleIdentifier`, `Locale`, `LocaleOptions`) that fail cross-arena resolution inside a lib-context delegation child while lowering lib interface bodies.
- A 3-line `Intl.DisplayNames`/`Intl.Locale` repro ran 11 such scans.
- After: repro runs **0** `consider_identifier_suggestion` calls (gdb breakpoint count); ts-toolbelt total instructions **6.86G → 6.21G (−9.5%)**; wall **1.76–1.99s → 1.45–1.52s** across 3 runs; exit code and diagnostics unchanged (exit 0, zero diagnostics, byte-identical empty output).
- The deeper divergence — cross-arena resolution failing for lib-namespace-local names at all (types degrade to error internally) — is the #15396/#13806 materialize-or-defer family and is intentionally untouched: this PR only removes the dead presentation work, it does not change any resolution outcome.

## Adjacent-case matrix

- Identifier suggestions, value and type position: discarded context returns no candidates for any node (unit tests, renamed binders `whole`/`wole`); retained context still suggests.
- Property suggestions (TS2551 path): gated by the same flag before type evaluation.
- Lib TS2552 retention without skipLibCheck: CLI test proves a local `.d.ts` typo still surfaces TS2552 with suggestion when `skipLibCheck: false` (`NarrowBox` binder), and existing `lib_type_spelling_suggestions_tests` (5/5 pass) pin `Arrray → Array` etc.
- skipLibCheck drop-equivalence: CLI test proves `.d.ts` diagnostics stay unreported while user-file TS2552 suggestions are unaffected (`WideShape`/`rounded` binders).
- Fallback: unaddressable-node failures still produce error types; only the doomed diagnostic construction is skipped, and every `report_name_resolution_failure` arm was verified to anchor at `request.idx` through span-gated emitters.

## Goal
Goal: fast

## Verification
- `cargo nextest run -p tsz-checker -E 'test(suggestion_scan_discarded) or test(lib_type_spelling) or test(spurious_suggestion) or test(private_field_no_spelling)'` — pass (2 new + 5 + adjacent).
- `cargo nextest run -p tsz-cli -E 'test(skip_lib_check) or test(cannot_find_name_value_suggestion)'` — 6 pass; `skip_lib_check_skips_default_lib_recheck_after_global_merge` exceeds the 60s nextest budget **on this dev-profile 4-core box at base too** (A/B: base 140.9s vs branch 152.9s, both pass with a longer budget) — pre-existing box limitation, not a regression; ready-review CI owns the authoritative run.
- Before/after callgrind + wall + gdb scan counts on the pinned ts-toolbelt fixture (`b8a49285`) and the Intl repro, as above.
- `/simplify` ×3 (12 review agents total) applied: shared `can_emit_diagnostic_at` predicate, driver flag set/clear simplification, test lib-set pinning, discard-bail hoist, and `diagnostics_discarded` doc accuracy (including the `push_diagnostic` wholesale-drop caveat, verified non-observable).
- Follow-ups noted, not in scope: `find_similar_property` node-addressability gate asymmetry; dead placeholder dedup-key work in `render_failure.rs` discarded branch; `module_exports_for_module` 3.2M-call repeated lookup family (next candidate from the same callgrind profile).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_011fb5NHXDth2oVpTsnujmSc)_