### PR TITLE
fix(checker): preserve nested JSX callback diagnostics

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
@@ -841,15 +841,23 @@ impl<'a> CheckerState<'a> {
                         self.evaluate_application_type(expected_context_type);
                     let expected_context_type = self.evaluate_type_with_env(expected_context_type);
                     // Pre-extract before &mut self calls to release the arena borrow.
-                    let value_node_fn_span = self
+                    let value_fn_spans = self
                         .ctx
                         .arena
                         .get(value_node_idx)
                         .filter(|n| n.is_function_expression_or_arrow())
-                        .map(|n| (n.pos, n.end));
+                        .map(|node| {
+                            let header_end = self
+                                .ctx
+                                .arena
+                                .get_function(node)
+                                .and_then(|function| self.ctx.arena.get(function.body))
+                                .map_or(node.end, |body| body.pos);
+                            (node.pos, header_end, node.end)
+                        });
 
-                    let mut function_param_diagnostic_span = None;
-                    let contextual_expected_type = if let Some(fn_span) = value_node_fn_span {
+                    let mut diagnostic_spans = None;
+                    let contextual_expected_type = if let Some(fn_spans) = value_fn_spans {
                         // Determine whether contextual typing applies to this arrow function.
                         // For union props (e.g. `(e: MouseEvent) => void | undefined`),
                         // extract callable members first — the raw union fails
@@ -904,15 +912,15 @@ impl<'a> CheckerState<'a> {
                             .implicit_any_checked_closures
                             .insert(value_node_idx);
                         self.invalidate_function_like_for_contextual_retry(value_node_idx);
-                        function_param_diagnostic_span = Some(fn_span);
+                        diagnostic_spans = Some(fn_spans);
                         refined
                     } else {
                         expected_context_type
                     };
                     // Set contextual type to preserve narrow literal types.
-                    let is_function_attr = function_param_diagnostic_span.is_some();
-                    let spec_snap = function_param_diagnostic_span
-                        .map(|_| DiagnosticSpeculationSnapshot::new(&self.ctx));
+                    let is_function_attr = diagnostic_spans.is_some();
+                    let spec_snap =
+                        diagnostic_spans.map(|_| DiagnosticSpeculationSnapshot::new(&self.ctx));
                     let actual_type = self.compute_type_of_node_with_request(
                         value_node_idx,
                         &opts
@@ -921,10 +929,21 @@ impl<'a> CheckerState<'a> {
                             .normal_origin()
                             .contextual(contextual_expected_type),
                     );
-                    if let (Some((start, end)), Some(snap)) =
-                        (function_param_diagnostic_span, spec_snap)
+                    if let (Some((start, header_end, function_end)), Some(snap)) =
+                        (diagnostic_spans, spec_snap)
                     {
+                        // Implicit-any diagnostics are transient only for the outer
+                        // function header. Nested callbacks in its body are independent
+                        // and must survive. TS2322 keeps the full-function boundary so
+                        // the later assignability check can re-anchor a contextual return
+                        // mismatch at the JSX attribute name.
                         snap.rollback_filtered(&mut self.ctx.diagnostic_state(), |diag| {
+                            let end =
+                                if diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE {
+                                    function_end
+                                } else {
+                                    header_end
+                                };
                             !(matches!(
                                 diag.code,
                                 7006 | 7019

--- a/crates/tsz-checker/tests/jsx_union_callback_context_tests.rs
+++ b/crates/tsz-checker/tests/jsx_union_callback_context_tests.rs
@@ -144,3 +144,69 @@ declare function Btn(props: DirectProps): JSX.Element;
         "direct callable prop should not emit TS2322, got: {diags:?}"
     );
 }
+
+#[test]
+fn jsx_contextual_retry_preserves_nested_callback_diagnostics() {
+    let source = format!(
+        r#"
+{JSX_PREAMBLE}
+interface Click {{ x: number; }}
+interface ButtonProps {{
+    onClick?: (event: Click) => void;
+}}
+declare function Button(props: ButtonProps): JSX.Element;
+declare const consumeAny: any;
+declare function consumeTyped(callback: (value: string) => void): void;
+
+<Button onClick={{({{ x: outerX }}) => {{
+    consumeAny((nested) => nested);
+    consumeAny(({{ destructured }}) => destructured);
+    consumeAny((...rest) => rest);
+    consumeTyped((typed) => typed.length);
+    void outerX;
+}}}} />;
+<Button onClick={{function (renamedOuter) {{
+    consumeAny((renamedNested) => renamedNested);
+    void renamedOuter.x;
+}}}} />;
+"#
+    );
+    let diags = jsx_diagnostics(&source);
+    let implicit_any_messages: Vec<_> = diags
+        .iter()
+        .filter(|(code, _)| *code == diagnostic_codes::PARAMETER_IMPLICITLY_HAS_AN_TYPE)
+        .map(|(_, message)| message.as_str())
+        .collect();
+
+    assert_eq!(
+        implicit_any_messages.len(),
+        2,
+        "only the two nested callbacks should emit TS7006, got: {diags:?}"
+    );
+    assert!(
+        implicit_any_messages
+            .iter()
+            .any(|message| message.contains("'nested'")),
+        "the nested arrow parameter should emit TS7006, got: {diags:?}"
+    );
+    assert!(
+        implicit_any_messages
+            .iter()
+            .any(|message| message.contains("'renamedNested'")),
+        "the nested function-expression parameter should emit TS7006, got: {diags:?}"
+    );
+    assert!(
+        diags.iter().any(|(code, message)| {
+            *code == diagnostic_codes::BINDING_ELEMENT_IMPLICITLY_HAS_AN_TYPE
+                && message.contains("'destructured'")
+        }),
+        "the nested destructured binding should emit TS7031, got: {diags:?}"
+    );
+    assert!(
+        diags.iter().any(|(code, message)| {
+            *code == diagnostic_codes::REST_PARAMETER_IMPLICITLY_HAS_AN_ANY_TYPE
+                && message.contains("'rest'")
+        }),
+        "the nested rest parameter should emit TS7019, got: {diags:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

## Summary

- Split JSX contextual-retry rollback into a header span for implicit-any diagnostics and the existing full-function span for TS2322 re-anchoring.
- Preserve TS7006, TS7031, and TS7019 emitted by nested callbacks in a JSX attribute body while keeping the outer callback contextually typed.
- Fall back to the full node end for malformed function bodies, preserving recovery behavior.
- Add an adjacent matrix covering arrow/function expressions, renamed binders, destructuring, rest parameters, optional callback unions, and a genuinely typed nested callback.

Structural rule: When a function-valued JSX attribute is contextually retried, transient implicit-any diagnostics belong only to the outer function header; diagnostics from nested functions in the body are independent and must survive.

Owner layer: checker JSX props diagnostic orchestration. The solver relation and TS2322 attribute-anchoring paths are unchanged.

Adjacent matrix: outer destructured and renamed parameters remain contextual; nested arrow, function-expression, destructured, and rest parameters retain the same TS7006/TS7031/TS7019 diagnostics as TypeScript.

Fallback: a missing/recovery body node uses the full function end, matching the prior malformed-node behavior.

## Verification

- TypeScript 6.0.0-dev.20260306 in-memory oracle: TS7006 nested, TS7031 destructured, TS7019 rest, TS7006 renamedNested; no outer or typed-nested implicit-any diagnostics.
- Upstream fragment oracle: exactly TS7006 for prev and no TS6133 for setCnt.
- `scripts/safe-run.sh --limit 75% -- cargo nextest run -p tsz-checker --test jsx_union_callback_context_tests --no-fail-fast` (5 passed)
- `scripts/safe-run.sh --limit 75% -- cargo nextest run -p tsz-checker --test jsx_component_attribute_tests part_01::test_jsx_fragment_factory_no_unused_locals_react16_fixture_checks_nested_callback_body`
- `scripts/safe-run.sh --limit 75% -- cargo nextest run -p tsz-checker --test jsx_component_attribute_tests --no-fail-fast` (220 passed, 5 pre-existing failures; clean main was 219 passed, 6 failures)
- `scripts/safe-run.sh --limit 75% -- cargo nextest run -p tsz-checker --no-fail-fast` (18,062 tests; canonical failures 113 -> 112; only the fragment fixture removed; zero additions)
- `scripts/safe-run.sh --limit 75% -- cargo clippy -p tsz-checker --all-targets`
- `git diff --check`

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5
Effort: max