### PR TITLE
test(checker): isolate arbitrary extension resolution

### DIFF
--- a/crates/tsz-checker/tests/arbitrary_ext_decl_module_resolution_tests.rs
+++ b/crates/tsz-checker/tests/arbitrary_ext_decl_module_resolution_tests.rs
@@ -73,7 +73,7 @@ declare const value: number;
 export = value;
 "#;
     let consumer = r#"
-import value from "./component.html";
+import value = require("./component.html");
 const n: number = value;
 "#;
     let codes = diagnostic_codes(
@@ -98,7 +98,7 @@ declare const config: { url: string };
 export = config;
 "#;
     let consumer = r#"
-import config from "./Button.svelte";
+import config = require("./Button.svelte");
 const u: string = config.url;
 "#;
     let codes = diagnostic_codes(
@@ -124,7 +124,7 @@ declare const config: { title: string };
 export = config;
 "#;
     let consumer = r#"
-import config from "./widgets/Card.svelte";
+import config = require("./widgets/Card.svelte");
 const t: string = config.title;
 "#;
     let codes = diagnostic_codes(


### PR DESCRIPTION
Goal: hold

## Summary

- Change the three arbitrary-extension `export =` witnesses from ES default imports to canonical TypeScript import assignments.
- Keep the HTML, renamed Svelte, and nested-directory variants focused on user-form `.d.<ext>.ts` resolution.
- Leave checker module resolution and interop policy unchanged.

Structural rule: When a checker test runs with synthetic default imports disabled, an `export =` declaration must be consumed with `import = require` if the intended invariant is module resolution rather than TS1259 interop diagnostics.

Owner layer: checker integration-test witnesses only. No parser, binder, checker, solver, resolver, or emitter behavior changes.

Adjacent matrix: HTML, renamed extension, and nested-directory export-equals shapes now use the interop-neutral form; named and default export cases remain unchanged and pass in the same target.

Fallback: TS1259 coverage remains in the dedicated export-equals interop test suite.

## Verification

- TypeScript 6.0.0-dev.20260306 oracle with `allowSyntheticDefaultImports: false`: default import emits TS1259; `import = require` is clean for HTML, renamed Svelte, and nested Svelte declarations.
- `scripts/safe-run.sh --limit 75% -- cargo nextest run -p tsz-checker --test arbitrary_ext_decl_module_resolution_tests --no-fail-fast` (12 passed)
- `scripts/safe-run.sh --limit 75% -- cargo nextest run -p tsz-checker --no-fail-fast` (18,061 tests; canonical failures 113 -> 110; exactly the three arbitrary-extension witnesses removed; zero additions)
- `scripts/safe-run.sh --limit 75% -- cargo clippy -p tsz-checker --all-targets`
- `git diff --check`

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5
Effort: max