### PR TITLE
fix(checker): report missing qualified typeof members

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
@@ -428,8 +428,20 @@ impl<'a> CheckerState<'a> {
                             );
                         }
                     }
-                    // Namespace resolution did not apply: resolve the value member
-                    // lazily through the deferred indexed access recorded above.
+                    // A namespace/class/enum has a complete binder-owned value
+                    // surface. If its export/static lookup missed, report that
+                    // name-resolution failure now instead of hiding it behind an
+                    // unresolved indexed access. Ordinary value objects are not
+                    // namespace-like, so they keep the materialization-order-safe
+                    // deferred path below.
+                    if deferred_value_member_access.is_some()
+                        && self.report_type_query_missing_member(type_query.expr_name)
+                    {
+                        return TypeId::ERROR;
+                    }
+
+                    // Namespace resolution did not apply: resolve an ordinary value
+                    // member lazily through the deferred indexed access recorded above.
                     if let Some(deferred) = deferred_value_member_access {
                         let resolved = self.apply_type_query_instantiation_arguments(
                             deferred,

--- a/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
@@ -1130,9 +1130,10 @@ impl<'a> CheckerState<'a> {
         }
 
         if from_typeof && left_symbol.import_module().is_none() {
-            let left_text = self
-                .entity_name_text(qn.left)
-                .unwrap_or_else(|| left_symbol.escaped_name.clone());
+            // `tsc` displays the resolved value symbol here, not the source
+            // spelling of its qualification. Thus `typeof Outer.Inner.Missing`
+            // and an import-equals alias to `Outer.Inner` both name `Inner`.
+            let left_text = left_symbol.escaped_name.clone();
             let Some(right_node) = self.ctx.arena.get(qn.right) else {
                 return false;
             };

--- a/crates/tsz-checker/tests/namespace_qualified_diagnostic_tests.rs
+++ b/crates/tsz-checker/tests/namespace_qualified_diagnostic_tests.rs
@@ -39,6 +39,150 @@ let useIt: T;
 }
 
 #[test]
+fn typeof_missing_namespace_value_member_rule_is_name_agnostic_and_nested() {
+    let source = r#"
+namespace Cabinet {
+    export const present = 1;
+}
+namespace Outer {
+    export namespace Inner {
+        export const present = 1;
+    }
+}
+import Alias = Outer.Inner;
+
+type Renamed = typeof Cabinet.Absent;
+type Nested = typeof Outer.Inner.Missing;
+type Aliased = typeof Alias.Gone;
+"#;
+    let diags = get_diagnostics(source);
+
+    assert_eq!(
+        diags,
+        vec![
+            (
+                2339,
+                "Property 'Absent' does not exist on type 'typeof Cabinet'.".to_string(),
+            ),
+            (
+                2339,
+                "Property 'Missing' does not exist on type 'typeof Inner'.".to_string(),
+            ),
+            (
+                2339,
+                "Property 'Gone' does not exist on type 'typeof Inner'.".to_string(),
+            ),
+        ],
+        "renamed, nested, and aliased namespace value misses should use TS2339"
+    );
+}
+
+#[test]
+fn typeof_non_exported_namespace_value_member_reports_ts2339() {
+    let source = r#"
+namespace Ns {
+    const hidden = 1;
+    export const visible = 2;
+}
+
+type Hidden = typeof Ns.hidden;
+"#;
+    let diags = get_diagnostics(source);
+
+    assert_eq!(
+        diags,
+        vec![(
+            2339,
+            "Property 'hidden' does not exist on type 'typeof Ns'.".to_string(),
+        )],
+        "non-exported namespace values should not become deferred members"
+    );
+}
+
+#[test]
+fn typeof_missing_namespace_value_member_under_type_operators_reports_ts2339() {
+    let source = r#"
+namespace Catalog {
+    export const present = 1;
+}
+namespace Registry {
+    export const available = 2;
+}
+
+type Keys = keyof typeof Catalog.Absent;
+type Flags = { [K in keyof typeof Registry.Missing]: boolean };
+"#;
+    let diags = get_diagnostics(source);
+
+    assert_eq!(
+        diags,
+        vec![
+            (
+                2339,
+                "Property 'Absent' does not exist on type 'typeof Catalog'.".to_string(),
+            ),
+            (
+                2339,
+                "Property 'Missing' does not exist on type 'typeof Registry'.".to_string(),
+            ),
+        ],
+        "type operators must not hide missing namespace value members behind deferral"
+    );
+}
+
+#[test]
+fn typeof_existing_namespace_value_members_stay_clean() {
+    let source = r#"
+namespace Ns {
+    export const value = 1;
+    export namespace Nested {
+        export const leaf = 2;
+    }
+}
+
+type Value = typeof Ns.value;
+type Leaf = typeof Ns.Nested.leaf;
+"#;
+    let diags = get_diagnostics(source);
+
+    assert!(
+        diags.is_empty(),
+        "exported namespace value members should continue to resolve, got: {diags:?}"
+    );
+}
+
+#[test]
+fn typeof_missing_class_and_enum_value_members_report_ts2339() {
+    let source = r#"
+class Container {
+    static present = 1;
+}
+enum Choice {
+    Present,
+}
+
+type ClassMiss = typeof Container.Absent;
+type EnumMiss = typeof Choice.Missing;
+"#;
+    let diags = get_diagnostics(source);
+
+    assert_eq!(
+        diags,
+        vec![
+            (
+                2339,
+                "Property 'Absent' does not exist on type 'typeof Container'.".to_string(),
+            ),
+            (
+                2339,
+                "Property 'Missing' does not exist on type 'typeof Choice'.".to_string(),
+            ),
+        ],
+        "class and enum value surfaces should report missing static members"
+    );
+}
+
+#[test]
 fn plain_missing_namespace_type_member_still_reports_ts2694() {
     let source = r#"
 namespace Ns {


### PR DESCRIPTION
Goal: hold

## Summary

- restore checker-owned TS2339 reporting when a namespace/class/enum value member lookup misses before qualified `typeof` falls back to a deferred indexed access;
- keep ordinary value-object member resolution lazy, preserving evaluation-order-safe `typeof a.b` behavior;
- render nested and import-equals-qualified misses from the resolved value symbol, matching `tsc`'s `typeof Inner` display;
- cover renamed, nested, aliased, hidden, type-operator, class/enum, exported-positive, and type-space fallback cases.

## Structural rule

When a qualified value query `typeof N.M` has a namespace-like left symbol whose complete binder-owned export/static surface does not contain `M`, `tsc` reports TS2339 at `M`. The checker owns that name-resolution diagnostic before handing ordinary value-object misses to the solver-backed deferred indexed-access path. Nested and aliased queries display the resolved value symbol, not the source qualification.

Owner layer: checker type-query/name-resolution boundary. Ordinary value-object semantics remain in deferred indexed access; no solver type-shape logic or rendered-text predicate was added.

Adjacent matrix: top-level and renamed namespaces, nested namespaces, import-equals aliases, non-exported members, `keyof`/mapped operands, exported members, class/enum static surfaces, plain type-space TS2694, and import-equals TS2694/TS2724 fallback.

Fallback: non-namespace variables continue returning the deferred `(typeof value)["member"]` form, and exported/re-exported/static members continue through the existing successful resolution paths.

## Verification

- TypeScript `6.0.0-dev.20260306` oracle: local/renamed/nested/hidden/class/enum misses emit TS2339; exported members are clean; plain type-space misses emit TS2694.
- `cargo nextest run -p tsz-checker --test namespace_qualified_diagnostic_tests` (22 passed)
- `cargo nextest run -p tsz-checker --test qualified_typeof_member_deferred_tests` (9 passed)
- Clean-main full checker baseline at `043c3e10`: 18,068 run; 17,959 passed; 109 failed; 15 skipped; 99 canonical failure identities.
- Post-change full checker run: 18,073 run; 17,965 passed; 108 failed; 15 skipped; 98 canonical failure identities.
- Canonical failure-set diff: only `namespace_qualified_diagnostic_tests::typeof_missing_namespace_value_member_reports_ts2339` removed; zero new identities.
- `cargo fmt --all -- --check`
- `cargo clippy -p tsz-checker --all-targets`

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5
Effort: max
