### PR TITLE
test(checker): align split-accessor variance oracle

### DIFF
--- a/crates/tsz-checker/src/tests/split_accessor_variance_tests.rs
+++ b/crates/tsz-checker/src/tests/split_accessor_variance_tests.rs
@@ -4,9 +4,10 @@
 //! types.  The solver tracks a distinct write type per property.  These tests
 //! verify:
 //!
-//! 1. **Variance** — write-position assignments into a split-accessor type are
-//!    checked against the *setter* parameter type (contravariant), not the
-//!    getter return type.
+//! 1. **Writes** — assigning through a split-accessor property is checked
+//!    against the setter parameter type, while normal structural compatibility
+//!    compares the readable getter type and does not reject differing setter
+//!    widths.
 //! 2. **Display** — nested property-mismatch diagnostics report the actual
 //!    mismatched property type, not the outer expression's type.
 //! 3. **Readonly** — getter-only type-literal/interface properties are readonly.
@@ -114,18 +115,24 @@ obj.y = true;
     );
 }
 
-/// Assigning a type-literal with a mismatched setter parameter to a target
-/// that requires a wider setter should fail (contravariant write position).
+/// In normal TypeScript compatibility mode, differing setter widths do not
+/// affect structural assignment when the readable getter types agree. This is
+/// symmetric: both the wider and narrower setter shapes remain compatible.
 #[test]
-fn type_literal_split_accessor_narrower_setter_rejected() {
-    assert_has_2322(
+fn type_literal_split_accessor_setter_width_does_not_affect_assignability() {
+    let codes = check_source_codes(
         "
 type Wide  = { get z(): string; set z(v: string | number) };
 type Narrow = { get z(): string; set z(v: string) };
 declare let wide: Wide;
 declare let narrow: Narrow;
 wide = narrow;
+narrow = wide;
 ",
+    );
+    assert!(
+        codes.is_empty(),
+        "matching getter types should be compatible in both directions, got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Goal: hold

## Summary

- correct the stale split-accessor structural-assignability expectation to match `tsc`;
- assert both assignment directions are clean when getter types agree, even when setter widths differ;
- preserve write-site setter checking, getter-mismatch negatives, readonly checks, and diagnostic-display coverage.

## Structural rule

In normal TypeScript compatibility mode, structural assignment of split-accessor properties compares the readable getter type; differing setter parameter widths do not make otherwise matching property shapes incompatible. Assigning through the property is still checked against the setter parameter type. TSZ's production solver already implements this rule; this PR corrects only the stale unit oracle.

Owner layer: test contract only. No checker or solver behavior changes.

Adjacent matrix: wide-to-narrow and narrow-to-wide setter shapes are clean; a boolean write to a `string | number` setter still emits TS2322; getter type mismatches still emit TS2322; interface writes and getter-only readonly behavior remain covered.

## Verification

- TypeScript 6.0.3 oracle: both `Wide = Narrow` and `Narrow = Wide` are clean when getter types are `string`.
- `cargo nextest run -p tsz-checker --lib split_accessor_variance_tests` (8 passed)
- Clean-main full checker baseline at `7e772312`: 18,070 run; 17,963 passed; 107 failed; 15 skipped; 98 canonical failure identities.
- Post-change full checker run: 18,070 run; 17,964 passed; 106 failed; 15 skipped; 97 canonical failure identities.
- Canonical failure-set diff: only `split_accessor_variance_tests::type_literal_split_accessor_narrower_setter_rejected` removed; zero new identities.
- `cargo fmt --all -- --check`
- `cargo clippy -p tsz-checker --all-targets`

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5
Effort: max
