### PR TITLE
test(checker): load ReadonlyArray lib for TS2542 oracle

### DIFF
--- a/crates/tsz-checker/tests/ts2542_readonly_index_coemission_tests.rs
+++ b/crates/tsz-checker/tests/ts2542_readonly_index_coemission_tests.rs
@@ -4,7 +4,8 @@
 //! element-access assignment, TS2542 still fires for the readonly write, but the
 //! element type is also checked so TS2322 co-emits for mismatched values.
 
-use tsz_checker::test_utils::check_source_codes;
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{check_source_codes, check_source_with_libs, load_lib_files};
 
 fn codes(source: &str) -> Vec<u32> {
     check_source_codes(source)
@@ -16,6 +17,15 @@ fn codes(source: &str) -> Vec<u32> {
 fn has_both(source: &str, a: u32, b: u32) -> bool {
     let codes = codes(source);
     codes.contains(&a) && codes.contains(&b)
+}
+
+fn es5_codes(source: &str) -> Vec<u32> {
+    let libs = load_lib_files(&["es5.d.ts"]);
+    assert!(!libs.is_empty(), "expected es5.d.ts to load");
+    check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs)
+        .into_iter()
+        .map(|diag| diag.code)
+        .collect()
 }
 
 #[test]
@@ -82,9 +92,23 @@ fn readonly_array_generic_index_write_wrong_type_emits_2322_and_2542() {
 declare const arr: ReadonlyArray<number>;
 arr[0] = "hello";
 "#;
+    let codes = es5_codes(source);
     assert!(
-        has_both(source, 2322, 2542),
-        "ReadonlyArray<number> wrong-type write must emit TS2322 and TS2542"
+        codes.contains(&2322) && codes.contains(&2542),
+        "ReadonlyArray<number> wrong-type write must emit TS2322 and TS2542, got: {codes:?}"
+    );
+}
+
+#[test]
+fn readonly_array_generic_without_lib_does_not_synthesize_write_diagnostics() {
+    let source = r#"
+declare const arr: ReadonlyArray<number>;
+arr[0] = "hello";
+"#;
+    let codes = codes(source);
+    assert!(
+        !codes.contains(&2322) && !codes.contains(&2542),
+        "an unresolved ReadonlyArray must not synthesize write diagnostics, got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Goal: hold

## Summary
- run the generic ReadonlyArray TS2542 witness with the faithful es5.d.ts definition
- retain the structural co-emission rule: a wrong-typed readonly index write reports both TS2322 and TS2542
- add an unresolved-name control proving the checker does not synthesize either write diagnostic without the library definition

Owner layer: checker test harness and library loading; compiler semantics are unchanged.

Adjacent matrix: mutable and readonly arrays, number and string elements, same-type writes, aliases, readonly tuples, named readonly properties, and the no-lib fallback.

## Verification
- TypeScript 6.0.3 oracle: no-lib emits missing-global/name diagnostics but no TS2322 or TS2542; es5 emits TS2322 and TS2542
- cargo nextest run -p tsz-checker --test ts2542_readonly_index_coemission_tests (9 passed)
- clean baseline: 18,070 run; 17,963 passed; 107 raw failures; 15 skipped; 98 canonical failures
- post-change: 18,072 run; 17,967 passed; 105 raw failures; 15 skipped; 97 canonical failures
- full failure-set diff: only ts2542_readonly_index_coemission_tests::readonly_array_generic_index_write_wrong_type_emits_2322_and_2542 removed; zero added
- cargo fmt --all -- --check
- cargo clippy -p tsz-checker --all-targets

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: max