### PR TITLE
test(checker): load Function lib for DeepReadonly oracle

### DIFF
--- a/crates/tsz-checker/tests/ts2540_readonly_tests.rs
+++ b/crates/tsz-checker/tests/ts2540_readonly_tests.rs
@@ -2,7 +2,10 @@
 //!
 //! Verifies that assigning to readonly properties emits TS2540.
 
-use tsz_checker::test_utils::{check_source_code_messages, check_source_codes};
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{
+    check_source_code_messages, check_source_codes, check_source_with_libs, load_lib_files,
+};
 
 fn has_error_with_code(source: &str, code: u32) -> bool {
     check_source_codes(source).contains(&code)
@@ -629,17 +632,32 @@ declare const drn: DRN;
 
 #[test]
 fn test_deep_readonly_function_branch_all_levels_error() {
+    let libs = load_lib_files(&["es5.d.ts"]);
+    assert!(!libs.is_empty(), "expected es5.d.ts to load");
+
     for (expr, label) in [
         ("drn.a = { b: { c: 1 } };", "level 1 (drn.a)"),
         ("drn.a.b = { c: 1 };", "level 2 (drn.a.b)"),
         ("drn.a.b.c = 5;", "level 3 (drn.a.b.c)"),
     ] {
         let source = format!("{DEEP_READONLY_PREAMBLE}\n{expr}");
+        let diagnostics =
+            check_source_with_libs(&source, "test.ts", CheckerOptions::default(), &libs);
         assert!(
-            has_error_with_code(&source, 2540),
-            "Should emit TS2540 at {label}"
+            diagnostics.iter().any(|diag| diag.code == 2540),
+            "Should emit TS2540 at {label}, got: {diagnostics:?}"
         );
     }
+}
+
+#[test]
+fn test_deep_readonly_function_branch_without_lib_does_not_synthesize_readonly_error() {
+    let source = format!("{DEEP_READONLY_PREAMBLE}\ndrn.a.b.c = 5;");
+    let codes = check_source_codes(&source);
+    assert!(
+        !codes.contains(&2540),
+        "an unresolved Function must not synthesize TS2540, got: {codes:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Goal: hold

## Summary
- evaluate the DeepReadonly Function branch with the faithful es5.d.ts global definition
- preserve unresolved-name deferral: without the library, the checker must not fabricate readonly writes
- keep the correction in the checker test harness; compiler semantics are unchanged

Structural rule: when Function is the standard library type, non-callable object branches recurse through the readonly mapped type; when Function is unresolved, conditional evaluation defers instead of choosing a branch.

Owner layer: checker test harness and library loading.

Adjacent matrix: three nested readonly levels, the mapped type without the Function branch, mutable nested properties, and the unresolved no-lib fallback.

## Verification
- TypeScript 6.0.3 oracle: es5.d.ts yields exactly one TS2540 for each of the a, b, and c writes; no-lib yields missing-global/name diagnostics and zero TS2540
- cargo nextest run -p tsz-checker --test ts2540_readonly_tests (43 passed)
- clean baseline: 18,070 run; 17,963 passed; 107 raw failures; 15 skipped; 98 canonical failures
- post-change: 18,072 run; 17,967 passed; 105 raw failures; 15 skipped; 97 canonical failures
- full failure-set diff: only ts2540_readonly_tests::test_deep_readonly_function_branch_all_levels_error removed; zero added
- cargo fmt --all -- --check
- cargo clippy -p tsz-checker --all-targets

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: max