### PR TITLE
fix(checker): preserve imported generator yield types

### DIFF
--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -652,7 +652,12 @@ impl<'a> CheckerState<'a> {
     /// Returns ANY as fallback if the protocol cannot be resolved.
     fn resolve_iterator_element_type(&mut self, type_id: TypeId) -> TypeId {
         // Try solver-level iterator resolution first (handles Application types correctly)
-        if let Some(yield_type) = iterator_info_yield_type(self.ctx.types, type_id, false) {
+        // `ANY` is also the solver's unresolved-iterator sentinel. Let the
+        // environment-aware property chain distinguish that from an explicit
+        // `Generator<any>` yield, mirroring the async iterator path above.
+        if let Some(yield_type) = iterator_info_yield_type(self.ctx.types, type_id, false)
+            && yield_type != TypeId::ANY
+        {
             return yield_type;
         }
 

--- a/crates/tsz-checker/tests/imported_generator_iterable_tests.rs
+++ b/crates/tsz-checker/tests/imported_generator_iterable_tests.rs
@@ -1,55 +1,42 @@
 use tsz_checker::context::CheckerOptions;
-use tsz_common::common::ModuleKind;
+use tsz_checker::test_utils::{check_multi_file_with_libs, load_lib_files};
+use tsz_common::common::{ModuleKind, ScriptTarget};
 
-fn compile_entry_file(files: &[(&str, &str)], entry_file: &str) -> Vec<(u32, String)> {
-    tsz_checker::test_utils::check_multi_file(
-        files,
-        entry_file,
-        CheckerOptions {
-            module: ModuleKind::CommonJS,
-            strict: true,
-            strict_null_checks: true,
-            ..CheckerOptions::default()
-        },
-    )
-    .into_iter()
-    .filter(|diag| diag.code != 2318)
-    .map(|diag| (diag.code, diag.message_text))
-    .collect()
-}
-
-#[test]
-fn imported_generator_return_type_is_iterable_in_for_of() {
-    let globals = r#"
-interface SymbolConstructor {
-    readonly iterator: unique symbol;
-}
-declare var Symbol: SymbolConstructor;
-
-interface IteratorResult<T, TReturn = any> {
-    done?: boolean;
-    value: T | TReturn;
-}
-
-interface Iterator<T = unknown, TReturn = any, TNext = unknown> {
-    next(...args: [] | [TNext]): IteratorResult<T, TReturn>;
-}
-
-interface Iterable<T> {
-    [Symbol.iterator](): Iterator<T>;
-}
-
-interface Generator<T = unknown, TReturn = any, TNext = unknown>
-    extends Iterator<T, TReturn, TNext>, Iterable<T> {}
-"#;
-
-    let generator = r#"
+const GENERATOR_MODULE: &str = r#"
 export function* generatorExport(): Generator<number> {
     yield 1;
     yield 2;
 }
 "#;
 
+fn compile_entry_file(files: &[(&str, &str)], entry_file: &str) -> Vec<(u32, String)> {
+    let libs = load_lib_files(&[
+        "es5.d.ts",
+        "es2015.symbol.d.ts",
+        "es2015.iterable.d.ts",
+        "es2015.generator.d.ts",
+    ]);
+    assert_eq!(libs.len(), 4, "expected all Generator dependencies to load");
+
+    check_multi_file_with_libs(
+        files,
+        entry_file,
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            target: ScriptTarget::ES2015,
+            strict: true,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diag| (diag.code, diag.message_text))
+    .collect()
+}
+
+#[test]
+fn imported_generator_return_type_is_iterable_in_for_of() {
     let consumer = r#"
 import { generatorExport } from "./generator";
 
@@ -60,19 +47,98 @@ for (const n of generatorExport()) {
 
     let diagnostics = compile_entry_file(
         &[
-            ("globals.d.ts", globals),
-            ("generator.ts", generator),
+            ("generator.ts", GENERATOR_MODULE),
             ("consumer.ts", consumer),
         ],
         "consumer.ts",
     );
 
-    let ts2488 = diagnostics
-        .iter()
-        .filter(|(code, _)| *code == 2488)
-        .collect::<Vec<_>>();
     assert!(
-        ts2488.is_empty(),
-        "imported Generator<T> return type should be iterable in for-of; got TS2488 {ts2488:?}. All diagnostics: {diagnostics:#?}",
+        diagnostics.is_empty(),
+        "imported Generator<number> should be iterable in for-of, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn imported_generator_for_of_preserves_number_yield_type() {
+    let consumer = r#"
+import { generatorExport } from "./generator";
+
+for (const n of generatorExport()) {
+    const _s: string = n;
+}
+"#;
+
+    let diagnostics = compile_entry_file(
+        &[
+            ("generator.ts", GENERATOR_MODULE),
+            ("consumer.ts", consumer),
+        ],
+        "consumer.ts",
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![(
+            2322,
+            "Type 'number' is not assignable to type 'string'.".to_string()
+        )],
+        "the imported Generator element must remain number"
+    );
+}
+
+#[test]
+fn imported_generator_for_of_preserves_explicit_any_yield_type() {
+    let generator = r#"
+export function* generatorExport(): Generator<any> {
+    yield 1;
+}
+"#;
+    let consumer = r#"
+import { generatorExport } from "./generator";
+
+for (const value of generatorExport()) {
+    const _s: string = value;
+}
+"#;
+
+    let diagnostics = compile_entry_file(
+        &[("generator.ts", generator), ("consumer.ts", consumer)],
+        "consumer.ts",
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "an explicit Generator<any> yield must remain any, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn imported_generator_for_of_preserves_unknown_yield_type() {
+    let generator = r#"
+export function* generatorExport(): Generator<unknown> {
+    yield 1;
+}
+"#;
+    let consumer = r#"
+import { generatorExport } from "./generator";
+
+for (const value of generatorExport()) {
+    const _s: string = value;
+}
+"#;
+
+    let diagnostics = compile_entry_file(
+        &[("generator.ts", generator), ("consumer.ts", consumer)],
+        "consumer.ts",
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![(
+            2322,
+            "Type 'unknown' is not assignable to type 'string'.".to_string()
+        )],
+        "the imported Generator element must remain unknown"
     );
 }


### PR DESCRIPTION
Goal: hold

## Summary
- replace the hand-written Generator surrogate with the four minimal standard-library files
- treat solver ANY from synchronous iterator-info as inconclusive and fall through to the existing environment-aware protocol walk
- prove imported Generator<number>, Generator<any>, and Generator<unknown> retain their yield semantics

Structural rule: when synchronous iterator-info returns a concrete yield type, use it; when it returns ANY, run the environment-aware Symbol.iterator -> next -> IteratorResult chain, which distinguishes an unresolved sentinel from an explicit any yield.

Owner layer: checker iterator orchestration. Solver/query boundaries remain the fast semantic query; the checker owns the cross-arena environment fallback and diagnostic-facing loop-variable type.

Adjacent matrix: imported number positive and mismatch, explicit any permissiveness, and unknown rejection. The harness uses actual es5/symbol/iterable/generator declarations and no diagnostic filtering.

## Verification
- TypeScript 6.0.3 oracle: imported Generator<number> iterates as number; assigning to string emits exact TS2322; Generator<any> stays clean; Generator<unknown> emits exact TS2322
- cargo nextest run -p tsz-checker --lib imported_generator_iterable_tests (4 passed)
- clean baseline: 18,070 run; 17,963 passed; 107 raw failures; 15 skipped; 98 canonical failures
- post-change: 18,073 run; 17,967 passed; 106 raw failures; 15 skipped; 97 canonical failures
- full failure-set diff: only imported_generator_iterable_tests::imported_generator_return_type_is_iterable_in_for_of removed; zero added
- cargo fmt --all -- --check
- cargo clippy -p tsz-checker --all-targets

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: max