### PR TITLE
fix(solver): route numeric-literal→string through a single ECMAScript Number::toString owner; SameValueZero literal identity; template-capture inference coercion

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2431,3 +2431,6 @@ path = "tests/readonly_alias_display_14826_tests.rs"
 [[test]]
 name = "interface_extends_generic_mapped_base_no_ts2430_tests"
 path = "tests/interface_extends_generic_mapped_base_no_ts2430_tests.rs"
+[[test]]
+name = "js_number_string_canonicalization_tests"
+path = "tests/js_number_string_canonicalization_tests.rs"

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1147,9 +1147,13 @@ impl<'a> CheckerState<'a> {
             && node.kind == SyntaxKind::NumericLiteral as u16
             && let Some(lit) = self.ctx.arena.get_literal(node)
         {
-            let property_name = &lit.text;
+            // tsc looks the property up by the *value's* canonical string
+            // (`Number::toString`), not the source spelling: `o[1e21]` reads
+            // the property named `"1e+21"`.
+            let property_name =
+                crate::types_domain::type_node_helpers::literal_index_property_name(node, lit);
             let resolved_type = self.resolve_type_for_property_access(object_type_for_access);
-            let result = self.resolve_property_access_with_env(resolved_type, property_name);
+            let result = self.resolve_property_access_with_env(resolved_type, &property_name);
             if let PropertyAccessResult::Success {
                 type_id,
                 write_type,

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -297,7 +297,9 @@ impl<'a> CheckerState<'a> {
                 {
                     return Some(match lit {
                         tsz_solver::LiteralValue::String(s) => self.ctx.types.resolve_atom(s),
-                        tsz_solver::LiteralValue::Number(n) => n.0.to_string(),
+                        tsz_solver::LiteralValue::Number(n) => {
+                            tsz_solver::utils::js_number_to_string(n.0).into_owned()
+                        }
                         tsz_solver::LiteralValue::Boolean(b) => b.to_string(),
                         tsz_solver::LiteralValue::BigInt(b) => self.ctx.types.resolve_atom(b),
                     });

--- a/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
@@ -467,18 +467,28 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         }
     }
 
-    /// Collect the string-literal keys named by an indexed-access index type.
-    /// Returns one entry per string-literal union member (or the single literal),
-    /// so union-key access (`I["x" | "y"]`) is validated the same way as a single
-    /// literal regardless of where the indexed access appears syntactically.
+    /// Collect the literal keys named by an indexed-access index type.
+    /// Returns one entry per string- or number-literal union member (or the
+    /// single literal), so union-key access (`I["x" | "y"]`) is validated the
+    /// same way as a single literal regardless of where the indexed access
+    /// appears syntactically. Number-literal keys use the value's canonical
+    /// `Number::toString` name (`1e21` names the property `"1e+21"`).
     fn literal_index_keys(&self, index_type: TypeId, index_node: NodeIndex) -> Vec<String> {
-        use crate::query_boundaries::common::{string_literal_value, union_members};
+        use crate::query_boundaries::common::{
+            number_literal_value, string_literal_value, union_members,
+        };
         let members =
             union_members(self.ctx.types, index_type).unwrap_or_else(|| vec![index_type].into());
         let keys: Vec<String> = members
             .iter()
-            .filter_map(|&member| string_literal_value(self.ctx.types, member))
-            .map(|atom| self.ctx.types.resolve_atom(atom))
+            .filter_map(|&member| {
+                string_literal_value(self.ctx.types, member)
+                    .map(|atom| self.ctx.types.resolve_atom(atom))
+                    .or_else(|| {
+                        number_literal_value(self.ctx.types, member)
+                            .map(|value| tsz_solver::utils::js_number_to_string(value).into_owned())
+                    })
+            })
             .collect();
         if keys.is_empty() {
             get_string_literal_from_type_index(self.ctx.arena, index_node)

--- a/crates/tsz-checker/src/types/type_node_helpers.rs
+++ b/crates/tsz-checker/src/types/type_node_helpers.rs
@@ -12,8 +12,11 @@ use crate::query_boundaries::indexed_access_key_space;
 use crate::query_boundaries::signature_building as signature_building_boundary;
 use crate::query_boundaries::type_construction;
 
-/// Extract the string literal text from a type-level index (e.g., `'y'` from `T['y']`).
-/// In type position, the index is a `LiteralType` node wrapping a string literal.
+/// Extract the property name from a type-level literal index (e.g., `'y'`
+/// from `T['y']`). In type position, the index is a `LiteralType` node
+/// wrapping the literal. A numeric literal index names the property spelled
+/// by the value's `Number::toString` (`1e21` names `"1e+21"`), not its
+/// source text.
 pub(crate) fn get_string_literal_from_type_index(
     arena: &tsz_parser::parser::NodeArena,
     idx: NodeIndex,
@@ -21,15 +24,29 @@ pub(crate) fn get_string_literal_from_type_index(
     let node = arena.get(idx)?;
     // Try direct literal first (for expression-like contexts)
     if let Some(lit) = arena.get_literal(node) {
-        return Some(lit.text.to_string());
+        return Some(literal_index_property_name(node, lit));
     }
     // In type position, the index is a LiteralType wrapping an inner literal
     if let Some(lit_type) = arena.get_literal_type(node) {
         let inner = arena.get(lit_type.literal)?;
         let lit = arena.get_literal(inner)?;
-        return Some(lit.text.to_string());
+        return Some(literal_index_property_name(inner, lit));
     }
     None
+}
+
+/// Canonical property name named by a literal index node, shared by the
+/// type-position (`T[1e21]`) and value-position (`o[1e21]`) lookup paths.
+pub(crate) fn literal_index_property_name(
+    node: &tsz_parser::parser::node::Node,
+    lit: &tsz_parser::parser::node::LiteralData,
+) -> String {
+    if node.kind == SyntaxKind::NumericLiteral as u16
+        && let Some(canonical) = tsz_solver::utils::canonicalize_numeric_name(&lit.text)
+    {
+        return canonical;
+    }
+    lit.text.to_string()
 }
 
 /// Check if a type node is `typeof globalThis`, possibly wrapped in parentheses.

--- a/crates/tsz-checker/tests/js_number_string_canonicalization_tests.rs
+++ b/crates/tsz-checker/tests/js_number_string_canonicalization_tests.rs
@@ -1,0 +1,239 @@
+//! Numeric-literal → string conversion must use ECMAScript `Number::toString`.
+//!
+//! Structural rule: whenever a numeric literal type is converted to its string
+//! form — template literal type evaluation, indexed-access/element-access key
+//! canonicalization, property-name derivation — tsc produces the value's
+//! `Number::toString(10)` text (`1e21` → `"1e+21"`, `1e-7` → `"1e-7"`,
+//! `-0` → `"0"`), never the source spelling or a formatter that diverges on
+//! the exponential thresholds. Number literal types themselves are keyed by
+//! `SameValueZero`, so `-0` and `0` are one type. Template-literal inference
+//! that captures a segment for a number-constrained type variable infers the
+//! numeric literal when the segment round-trips through `Number::toString`.
+//!
+//! Binder names are varied across cases so the rules stay structural.
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn assert_clean(source: &str) {
+    let codes = check_source_codes(source);
+    assert!(codes.is_empty(), "expected no diagnostics, got {codes:?}");
+}
+
+fn assert_codes(source: &str, expected: &[u32]) {
+    let codes = check_source_codes(source);
+    assert_eq!(codes, expected, "diagnostic codes mismatch");
+}
+
+// ── Template literal type evaluation ────────────────────────────────────────
+
+#[test]
+fn template_literal_large_magnitude_uses_exponential_form() {
+    assert_clean(
+        r#"
+type Big = `${1e21}`;
+const big: Big = "1e+21";
+type Huge = `${1.5e22}`;
+const huge: Huge = "1.5e+22";
+"#,
+    );
+}
+
+#[test]
+fn template_literal_small_magnitude_uses_exponential_form() {
+    assert_clean(
+        r#"
+type Tiny = `${1e-7}`;
+const tiny: Tiny = "1e-7";
+type Fine = `${0.000001}`;
+const fine: Fine = "0.000001";
+"#,
+    );
+}
+
+#[test]
+fn template_literal_negative_zero_prints_as_zero() {
+    assert_clean(
+        r#"
+type Zed = `${-0}`;
+const zed: Zed = "0";
+"#,
+    );
+}
+
+#[test]
+fn template_literal_positional_21_digit_integer() {
+    assert_clean(
+        r#"
+type Wide = `${1e20}`;
+const wide: Wide = "100000000000000000000";
+"#,
+    );
+}
+
+#[test]
+fn template_literal_rejects_source_spelling_of_exponential_number() {
+    // Negative case: the source spelling "1e21" is NOT the canonical string.
+    assert_codes(
+        r#"
+type Big = `${1e21}`;
+const bad: Big = "1e21";
+"#,
+        &[2322],
+    );
+}
+
+#[test]
+fn template_literal_exotic_number_inside_generic_alias() {
+    // Alias/wrapper + generic instantiation form of the same rule.
+    assert_clean(
+        r#"
+type Tag<N extends number> = `v${N}`;
+type Wrapped = Tag<1e21>;
+const w: Wrapped = "v1e+21";
+"#,
+    );
+}
+
+// ── Indexed access / element access key canonicalization ───────────────────
+
+#[test]
+fn indexed_access_type_with_exponential_numeric_key() {
+    assert_clean(
+        r#"
+type Rec = { 1e21: string };
+type Val = Rec[1e21];
+const v: Val = "ok";
+"#,
+    );
+}
+
+#[test]
+fn indexed_access_type_with_canonical_string_key() {
+    assert_clean(
+        r#"
+type Rec = { 1e21: string };
+type Val = Rec["1e+21"];
+const v: Val = "ok";
+"#,
+    );
+}
+
+#[test]
+fn indexed_access_type_rejects_source_spelling_string_key() {
+    // The property's canonical name is "1e+21"; the raw spelling misses.
+    assert_codes(
+        r#"
+type Rec = { 1e21: string };
+type Val = Rec["1e21"];
+"#,
+        &[2339],
+    );
+}
+
+#[test]
+fn element_access_with_exponential_numeric_key() {
+    assert_clean(
+        r#"
+declare const box: { 1e21: string };
+const v: string = box[1e21];
+const w: string = box["1e+21"];
+"#,
+    );
+}
+
+#[test]
+fn element_access_with_small_exponential_numeric_key() {
+    assert_clean(
+        r#"
+declare const bag: { 1e-7: number };
+const n: number = bag[1e-7];
+const m: number = bag["1e-7"];
+"#,
+    );
+}
+
+// ── SameValueZero literal identity ──────────────────────────────────────────
+
+#[test]
+fn negative_zero_and_zero_are_one_literal_type() {
+    assert_clean(
+        r#"
+type NegZero = -0;
+const a: NegZero = 0;
+const b: 0 = -0 as const;
+let c = -0 as -0;
+const d: 0 = c;
+"#,
+    );
+}
+
+#[test]
+fn negative_zero_still_rejects_other_numbers() {
+    assert_codes(
+        r#"
+const bad: -0 = 1;
+"#,
+        &[2322],
+    );
+}
+
+// ── Template-literal inference capture coercion ─────────────────────────────
+
+#[test]
+fn call_inference_coerces_numeric_capture_for_number_constraint() {
+    assert_clean(
+        r#"
+declare function fromPx<W extends number>(s: `${W}px`): W;
+const forty: 42 = fromPx("42px");
+const half: 1.5 = fromPx("1.5px");
+"#,
+    );
+}
+
+#[test]
+fn call_inference_keeps_string_capture_for_string_constraint() {
+    assert_clean(
+        r#"
+declare function tail<S extends string>(s: `x-${S}`): S;
+const t: "42" = tail("x-42");
+"#,
+    );
+}
+
+#[test]
+fn call_inference_widens_non_round_trip_numeric_capture() {
+    // "042" parses to 42 but does not round-trip, so tsc infers `number`,
+    // which cannot satisfy the literal check.
+    assert_codes(
+        r#"
+declare function fromPx<W extends number>(s: `${W}px`): W;
+const bad: 42 = fromPx("042px");
+"#,
+        &[2322],
+    );
+}
+
+#[test]
+fn call_inference_coerces_boolean_and_bigint_captures() {
+    assert_clean(
+        r#"
+declare function flag<B extends boolean>(s: `is:${B}`): B;
+const yes: true = flag("is:true");
+declare function big<G extends bigint>(s: `${G}n`): G;
+const g: 7n = big("7n");
+"#,
+    );
+}
+
+// ── Enum member values through templates ────────────────────────────────────
+
+#[test]
+fn template_over_enum_member_with_exotic_value() {
+    assert_clean(
+        r#"
+enum Scale { Big = 1e21 }
+type S = `${Scale.Big}`;
+const s: S = "1e+21";
+"#,
+    );
+}

--- a/crates/tsz-common/src/primitives/numeric.rs
+++ b/crates/tsz-common/src/primitives/numeric.rs
@@ -1,4 +1,65 @@
-//! Utilities for parsing numeric literals.
+//! Utilities for parsing and formatting numeric literals.
+
+use std::borrow::Cow;
+
+/// ECMAScript `Number::toString(10)`
+/// (<https://tc39.es/ecma262/#sec-numeric-types-number-tostring>).
+///
+/// This is the single workspace-wide owner for converting a JavaScript number
+/// to its runtime string form. Every semantic or emit decision that needs a
+/// number's string representation (template literal type evaluation, numeric
+/// property-key canonicalization, enum value emit, declaration-file literal
+/// text) must route through it — raw `f64::to_string()`/`format!` diverge from
+/// JavaScript on the exponential-notation thresholds (`1e21` → `"1e+21"`,
+/// `1e-7` → `"1e-7"`) and on negative zero (`-0` → `"0"`).
+///
+/// Rust's shortest-roundtrip formatter produces the same digits as the spec's
+/// shortest-`s` requirement; the remaining work is the positional/exponential
+/// switch (exponential when the magnitude is `>= 1e21` or `< 1e-6`) and the
+/// `e+`/`e-` exponent sign JavaScript always includes.
+///
+/// Returns `Cow::Borrowed` for static special cases (`NaN`, `0`, infinities)
+/// and `Cow::Owned` for dynamically formatted numbers.
+#[must_use]
+pub fn js_number_to_string(value: f64) -> Cow<'static, str> {
+    if value.is_nan() {
+        return Cow::Borrowed("NaN");
+    }
+    if value == 0.0 {
+        // Matches JavaScript `String(-0) === "0"`.
+        return Cow::Borrowed("0");
+    }
+    if value.is_infinite() {
+        return if value.is_sign_negative() {
+            Cow::Borrowed("-Infinity")
+        } else {
+            Cow::Borrowed("Infinity")
+        };
+    }
+
+    let abs = value.abs();
+    if !(1e-6..1e21).contains(&abs) {
+        // Rust `{:e}` produces the shortest mantissa but bare exponents
+        // (`1e21`, `1.5e-7`); JavaScript prints an explicit exponent sign and
+        // no leading zeros (`1e+21`, `1.5e-7`).
+        let mut formatted = format!("{value:e}");
+        if let Some(split) = formatted.find('e') {
+            let (mantissa, exp) = formatted.split_at(split);
+            let exp_digits = exp.strip_prefix('e').unwrap_or("");
+            let (sign, digits) = if let Some(digits) = exp_digits.strip_prefix('-') {
+                ('-', digits)
+            } else {
+                ('+', exp_digits)
+            };
+            let trimmed = digits.trim_start_matches('0');
+            let digits = if trimmed.is_empty() { "0" } else { trimmed };
+            formatted = format!("{mantissa}e{sign}{digits}");
+        }
+        return Cow::Owned(formatted);
+    }
+
+    Cow::Owned(value.to_string())
+}
 
 /// Parse a numeric literal text representation into a f64 value.
 /// Supports standard floating point literals as well as 0x, 0b, and 0o prefixes.
@@ -220,6 +281,51 @@ mod tests {
         assert_eq!(to_int32(3_000_000_000.0), -1_294_967_296);
         assert_eq!(to_int32(4_294_967_296.0), 0);
         assert_eq!(to_int32(f64::NAN), 0);
+    }
+
+    #[test]
+    fn js_number_to_string_matches_ecmascript_special_values() {
+        assert_eq!(js_number_to_string(f64::NAN), "NaN");
+        assert_eq!(js_number_to_string(f64::INFINITY), "Infinity");
+        assert_eq!(js_number_to_string(f64::NEG_INFINITY), "-Infinity");
+        assert_eq!(js_number_to_string(0.0), "0");
+        // SameValueZero: JavaScript `String(-0)` is `"0"`, not `"-0"`.
+        assert_eq!(js_number_to_string(-0.0), "0");
+    }
+
+    #[test]
+    fn js_number_to_string_positional_range() {
+        assert_eq!(js_number_to_string(1.0), "1");
+        assert_eq!(js_number_to_string(-3.5), "-3.5");
+        assert_eq!(js_number_to_string(42.0), "42");
+        // Smallest positional magnitude: JS `String(1e-6)` is `"0.000001"`.
+        assert_eq!(js_number_to_string(1e-6), "0.000001");
+        // Largest positional magnitudes: 21-digit integers stay positional.
+        assert_eq!(js_number_to_string(1e20), "100000000000000000000");
+        assert_eq!(
+            js_number_to_string(123456789123456790000.0),
+            "123456789123456800000"
+        );
+    }
+
+    #[test]
+    fn js_number_to_string_exponential_range() {
+        // JS switches to exponential at 1e21 and below 1e-6, always with an
+        // explicit exponent sign.
+        assert_eq!(js_number_to_string(1e21), "1e+21");
+        assert_eq!(js_number_to_string(-1e21), "-1e+21");
+        assert_eq!(js_number_to_string(1.5e22), "1.5e+22");
+        assert_eq!(js_number_to_string(1e-7), "1e-7");
+        assert_eq!(js_number_to_string(-1.5e-7), "-1.5e-7");
+        assert_eq!(
+            js_number_to_string(5.462437423415177e244),
+            "5.462437423415177e+244"
+        );
+        // Shortest round-trip digits, same as V8.
+        assert_eq!(
+            js_number_to_string(1.2345678912345678e53),
+            "1.2345678912345678e+53"
+        );
     }
 
     #[test]

--- a/crates/tsz-emitter/src/text_utils/mod.rs
+++ b/crates/tsz-emitter/src/text_utils/mod.rs
@@ -6,55 +6,13 @@
 
 /// Format an f64 value the way JavaScript's `Number.toString()` would.
 ///
-/// Handles `NaN`, `+/-Infinity`, and the scientific-notation threshold
-/// (magnitudes >= 1e21 or < 1e-6). Uses Rust's shortest-roundtrip formatter
-/// which matches JS `Number.prototype.toString()` for the normal range.
+/// Delegates to the workspace-wide ECMAScript `Number::toString(10)` owner in
+/// `tsz_common`; see [`tsz_common::numeric::js_number_to_string`]. (A previous
+/// local implementation switched to scientific notation one decimal digit too
+/// early, emitting `1e+20` where JavaScript prints
+/// `100000000000000000000`.)
 pub(crate) fn format_js_number(value: f64) -> String {
-    if value.is_nan() {
-        return "NaN".to_string();
-    }
-    if value.is_infinite() {
-        return if value.is_sign_positive() {
-            "Infinity".to_string()
-        } else {
-            "-Infinity".to_string()
-        };
-    }
-    let abs = value.abs();
-    if abs != 0.0 && abs < 1e-6 {
-        return format_js_scientific(value);
-    }
-    let s = value.to_string();
-    let abs_s = s.strip_prefix('-').unwrap_or(&s);
-    let needs_scientific = if let Some(dot_pos) = abs_s.find('.') {
-        dot_pos >= 21
-    } else {
-        abs_s.len() >= 21
-    };
-    if needs_scientific {
-        format_js_scientific(value)
-    } else {
-        s
-    }
-}
-
-/// Format a number in JavaScript-style scientific notation (e.g., `1.2345678912345678e+53`).
-fn format_js_scientific(n: f64) -> String {
-    let neg = n < 0.0;
-    let abs_n = n.abs();
-    let s = format!("{abs_n:e}");
-    let result = if let Some(pos) = s.find('e') {
-        let (mantissa, exp_part) = s.split_at(pos);
-        let exp_str = &exp_part[1..];
-        if exp_str.starts_with('-') {
-            format!("{mantissa}e{exp_str}")
-        } else {
-            format!("{mantissa}e+{exp_str}")
-        }
-    } else {
-        s
-    };
-    if neg { format!("-{result}") } else { result }
+    tsz_common::numeric::js_number_to_string(value).into_owned()
 }
 
 #[cfg(test)]
@@ -84,6 +42,19 @@ mod tests {
     fn floats() {
         assert_eq!(format_js_number(3.15), "3.15");
         assert_eq!(format_js_number(-0.5), "-0.5");
+    }
+
+    #[test]
+    fn positional_up_to_21_digits() {
+        // JavaScript stays positional below 1e21; the old local formatter
+        // switched to scientific one digit early.
+        assert_eq!(format_js_number(1e20), "100000000000000000000");
+        assert_eq!(format_js_number(-1e20), "-100000000000000000000");
+    }
+
+    #[test]
+    fn negative_zero_prints_as_zero() {
+        assert_eq!(format_js_number(-0.0), "0");
     }
 
     #[test]

--- a/crates/tsz-emitter/src/transforms/enum_es5.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5.rs
@@ -1070,8 +1070,8 @@ impl<'a> EnumES5Transformer<'a> {
             if val == val.floor() && val.is_finite() && val.abs() < (i64::MAX as f64) {
                 return IRNode::NumericLiteral((val as i64).to_string().into());
             }
-            // Otherwise emit as float
-            return IRNode::NumericLiteral(format!("{val}").into());
+            // Otherwise emit through `Number::toString` like tsc.
+            return IRNode::NumericLiteral(crate::text_utils::format_js_number(val).into());
         }
         if node.kind == SyntaxKind::BigIntLiteral as u16 {
             // BigInt literal names like `0n` are emitted as-is (no quotes)
@@ -1139,8 +1139,9 @@ impl<'a> EnumES5Transformer<'a> {
                 }
             }
         } else {
-            // Format with enough precision to round-trip
-            let s = format!("{val}");
+            // tsc emits the evaluated value through `Number::toString`
+            // (`1e21` → `1e+21`, `1e-7` → `1e-7`), not the source text.
+            let s = crate::text_utils::format_js_number(val);
             IRNode::NumericLiteral(s.into())
         }
     }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_template_match.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_template_match.rs
@@ -50,93 +50,6 @@ struct TemplateStringCaptureKey {
 }
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
-    fn parse_template_number_capture(&self, captured: &str) -> Option<TypeId> {
-        let value = if let Some(digits) = captured.strip_prefix("0x") {
-            u64::from_str_radix(digits, 16).ok().map(|n| n as f64)?
-        } else if let Some(digits) = captured.strip_prefix("0X") {
-            u64::from_str_radix(digits, 16).ok().map(|n| n as f64)?
-        } else if let Some(digits) = captured.strip_prefix("0o") {
-            u64::from_str_radix(digits, 8).ok().map(|n| n as f64)?
-        } else if let Some(digits) = captured.strip_prefix("0O") {
-            u64::from_str_radix(digits, 8).ok().map(|n| n as f64)?
-        } else if let Some(digits) = captured.strip_prefix("0b") {
-            u64::from_str_radix(digits, 2).ok().map(|n| n as f64)?
-        } else if let Some(digits) = captured.strip_prefix("0B") {
-            u64::from_str_radix(digits, 2).ok().map(|n| n as f64)?
-        } else {
-            captured.parse::<f64>().ok()?
-        };
-
-        if !value.is_finite() {
-            return None;
-        }
-
-        let literal = self.interner().literal_number(value);
-        let round_trips = match value {
-            v if v.fract() == 0.0 && v.abs() < 1e15 => (v as i64).to_string() == captured,
-            v => format!("{v}") == captured,
-        };
-        Some(if round_trips { literal } else { TypeId::NUMBER })
-    }
-
-    fn parse_template_bigint_capture(&self, captured: &str) -> Option<TypeId> {
-        let (negative, digits) = captured
-            .strip_prefix('-')
-            .map_or((false, captured), |rest| (true, rest));
-        if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_digit()) {
-            return None;
-        }
-
-        Some(self.interner().literal_bigint_with_sign(negative, digits))
-    }
-
-    /// Non-string primitive coercions of a captured template segment.
-    ///
-    /// A captured `infer` segment is always a raw string. When the placeholder
-    /// carries an `extends` constraint that admits a non-string primitive, tsc
-    /// re-interprets the segment as that primitive (`"2"` -> the `2` literal,
-    /// `"true"` -> `true`, etc.). The candidates are constraint-agnostic — the
-    /// caller decides which one satisfies the constraint via a structural
-    /// subtype check — so this covers intrinsic, literal, and union-of-literal
-    /// constraints uniformly, e.g. `extends number`, `extends 5`, `extends
-    /// 0 | 1`, or `extends bigint`.
-    fn template_capture_coercions(&self, captured: &str) -> [Option<TypeId>; 5] {
-        [
-            self.parse_template_number_capture(captured),
-            self.parse_template_bigint_capture(captured),
-            match captured {
-                "true" => Some(self.interner().literal_boolean(true)),
-                "false" => Some(self.interner().literal_boolean(false)),
-                _ => None,
-            },
-            (captured == "null").then_some(TypeId::NULL),
-            (captured == "undefined").then_some(TypeId::UNDEFINED),
-        ]
-    }
-
-    fn template_capture_for_constraint(
-        &self,
-        captured: &str,
-        captured_type: TypeId,
-        constraint: TypeId,
-        checker: &mut SubtypeChecker<'_, R>,
-    ) -> Option<TypeId> {
-        if checker.is_subtype_of(captured_type, constraint) {
-            return Some(captured_type);
-        }
-
-        // The captured segment did not satisfy the constraint as a string.
-        // Re-interpret it as each non-string primitive and accept the first
-        // coercion the constraint admits. Matching on the *coerced value*
-        // rather than the constraint's shape keeps the rule structural:
-        // numeric/bigint/boolean/null/undefined literals, their intrinsics,
-        // and any union of them are all handled by the same subtype probe.
-        self.template_capture_coercions(captured)
-            .into_iter()
-            .flatten()
-            .find(|&candidate| checker.is_subtype_of(candidate, constraint))
-    }
-
     /// Match a template literal string against a pattern.
     pub(crate) fn match_template_literal_string(
         &self,
@@ -305,8 +218,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         let captured = &source[start..end];
         let captured_type = self.interner().literal_string(captured);
-        let result =
-            self.template_capture_for_constraint(captured, captured_type, constraint, checker);
+        let result = crate::evaluation::template_capture::capture_for_constraint(
+            self.interner(),
+            checker,
+            captured,
+            captured_type,
+            constraint,
+        );
         scratch.constrained_captures.insert(key, result);
         result
     }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/template_literal.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/template_literal.rs
@@ -293,45 +293,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     fn literal_template_string(&self, lit: LiteralValue) -> Option<String> {
         match lit {
             LiteralValue::String(atom) => Some(self.interner().resolve_atom_ref(atom).to_string()),
-            LiteralValue::Number(n) => {
-                // Convert number to string matching JavaScript's Number::toString(10).
-                // ECMAScript spec: use scientific notation if |x| < 10^-6 or |x| >= 10^21.
-                let n_val = n.0;
-                let abs_val = n_val.abs();
-
-                tracing::trace!(
-                    number = n_val,
-                    abs_val = abs_val,
-                    "extract_literal_strings: converting number to string"
-                );
-
-                if n_val == 0.0 {
-                    Some("0".to_string())
-                } else if !(1e-6..1e21).contains(&abs_val) {
-                    // Use scientific notation (Rust adds sign for negative exponents, but not positive).
-                    let mut s = format!("{n_val:e}");
-                    // Rust outputs "1e-7" for 1e-7 (good) but "1e21" instead of "1e+21" for 1e21.
-                    // We need to add "+" to positive exponents.
-                    if s.contains("e") && !s.contains("e-") && !s.contains("e+") {
-                        let parts: Vec<&str> = s.split('e').collect();
-                        if parts.len() == 2 {
-                            s = format!("{}e+{}", parts[0], parts[1]);
-                        }
-                    }
-                    tracing::trace!(result = %s, "extract_literal_strings: scientific notation");
-                    Some(s)
-                } else if n_val.fract() == 0.0 && abs_val < 1e15 {
-                    // Integer-like number - avoid scientific notation.
-                    let s = (n_val as i64).to_string();
-                    tracing::trace!(result = %s, "extract_literal_strings: integer-like");
-                    Some(s)
-                } else {
-                    // Fixed-point notation.
-                    let s = format!("{n_val}");
-                    tracing::trace!(result = %s, "extract_literal_strings: fixed-point");
-                    Some(s)
-                }
-            }
+            LiteralValue::Number(n) => Some(crate::utils::js_number_to_string(n.0).into_owned()),
             LiteralValue::Boolean(b) => Some(if b { "true" } else { "false" }.to_string()),
             LiteralValue::BigInt(atom) => {
                 // BigInt literals are stored without the 'n' suffix.

--- a/crates/tsz-solver/src/evaluation/mod.rs
+++ b/crates/tsz-solver/src/evaluation/mod.rs
@@ -8,3 +8,4 @@ pub(crate) mod recursive_growth;
 pub mod request;
 pub mod result;
 pub mod session;
+pub(crate) mod template_capture;

--- a/crates/tsz-solver/src/evaluation/template_capture.rs
+++ b/crates/tsz-solver/src/evaluation/template_capture.rs
@@ -1,0 +1,114 @@
+//! Coercion of captured template-literal segments to non-string primitives.
+//!
+//! A segment captured out of a template literal string is always raw text.
+//! When the capture target (an `infer` placeholder or an inference type
+//! variable) carries a constraint that admits a non-string primitive, tsc
+//! re-interprets the text as that primitive: `"2"` becomes the `2` number
+//! literal for `T extends number`, `"true"` the `true` literal for
+//! `T extends boolean`, and so on (`inferToTemplateLiteralType` in
+//! `checker.ts`). Both the conditional-type `infer` path and call-site type
+//! parameter inference share this rule, so it lives here as the single owner.
+
+use crate::caches::db::TypeDatabase;
+use crate::relations::subtype::{SubtypeChecker, TypeResolver};
+use crate::types::TypeId;
+
+/// Re-interpret a captured segment as a number literal type.
+///
+/// Returns the number literal when the text round-trips through ECMAScript
+/// `Number::toString` (tsc's `isValidNumberString(text, roundTripOnly:
+/// true)`), the `number` intrinsic when the text parses but does not
+/// round-trip (e.g. `"0x10"`, `"1e21"`), and `None` when it does not parse.
+///
+/// The radix parsing here deliberately does NOT reuse
+/// `tsz_common::numeric::parse_numeric_literal_value`: that helper implements
+/// the numeric *literal* grammar (numeric separators allowed), while a
+/// captured segment is a runtime string coerced with `Number(string)`
+/// semantics (`"1_0"` is `NaN`, hex/octal/binary strings are allowed).
+fn parse_number_capture(db: &dyn TypeDatabase, captured: &str) -> Option<TypeId> {
+    let value = if let Some(digits) = captured
+        .strip_prefix("0x")
+        .or_else(|| captured.strip_prefix("0X"))
+    {
+        u64::from_str_radix(digits, 16).ok().map(|n| n as f64)?
+    } else if let Some(digits) = captured
+        .strip_prefix("0o")
+        .or_else(|| captured.strip_prefix("0O"))
+    {
+        u64::from_str_radix(digits, 8).ok().map(|n| n as f64)?
+    } else if let Some(digits) = captured
+        .strip_prefix("0b")
+        .or_else(|| captured.strip_prefix("0B"))
+    {
+        u64::from_str_radix(digits, 2).ok().map(|n| n as f64)?
+    } else {
+        captured.parse::<f64>().ok()?
+    };
+
+    if !value.is_finite() {
+        return None;
+    }
+
+    let round_trips = crate::utils::js_number_to_string(value) == captured;
+    Some(if round_trips {
+        db.literal_number(value)
+    } else {
+        TypeId::NUMBER
+    })
+}
+
+/// Re-interpret a captured segment as a bigint literal type (digits with an
+/// optional sign, no `n` suffix in the captured text).
+fn parse_bigint_capture(db: &dyn TypeDatabase, captured: &str) -> Option<TypeId> {
+    let (negative, digits) = captured
+        .strip_prefix('-')
+        .map_or((false, captured), |rest| (true, rest));
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+
+    Some(db.literal_bigint_with_sign(negative, digits))
+}
+
+/// Non-string primitive coercions of a captured template segment.
+///
+/// The candidates are constraint-agnostic — the caller decides which one
+/// satisfies the constraint via a structural subtype probe — so this covers
+/// intrinsic, literal, and union-of-literal constraints uniformly, e.g.
+/// `extends number`, `extends 5`, `extends 0 | 1`, or `extends bigint`.
+fn capture_coercions(db: &dyn TypeDatabase, captured: &str) -> [Option<TypeId>; 5] {
+    [
+        parse_number_capture(db, captured),
+        parse_bigint_capture(db, captured),
+        match captured {
+            "true" => Some(db.literal_boolean(true)),
+            "false" => Some(db.literal_boolean(false)),
+            _ => None,
+        },
+        (captured == "null").then_some(TypeId::NULL),
+        (captured == "undefined").then_some(TypeId::UNDEFINED),
+    ]
+}
+
+/// Pick the capture interpretation admitted by `constraint`.
+///
+/// The captured segment is used as-is (a string literal type) when it already
+/// satisfies the constraint; otherwise the first non-string coercion the
+/// constraint admits wins. Returns `None` when nothing satisfies the
+/// constraint.
+pub(crate) fn capture_for_constraint<R: TypeResolver>(
+    db: &dyn TypeDatabase,
+    checker: &mut SubtypeChecker<'_, R>,
+    captured: &str,
+    captured_type: TypeId,
+    constraint: TypeId,
+) -> Option<TypeId> {
+    if checker.is_subtype_of(captured_type, constraint) {
+        return Some(captured_type);
+    }
+
+    capture_coercions(db, captured)
+        .into_iter()
+        .flatten()
+        .find(|&candidate| checker.is_subtype_of(candidate, constraint))
+}

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -1774,10 +1774,29 @@ impl<'a> InferenceContext<'a> {
         if let Some(source_str) = self.extract_string_literal(source)
             && let Some(captures) = self.match_template_pattern(&source_str, &spans)
         {
-            // Convert captured strings to literal types and add as candidates
+            // Convert captured strings to literal types and add as candidates.
+            // When the type variable's declared constraint admits a non-string
+            // primitive, tsc re-interprets the captured text as that primitive
+            // (`"42"` -> the `42` literal for `T extends number`); the shared
+            // capture-coercion owner applies the same rule as `infer` patterns.
+            let mut checker = (!self.declared_constraints.is_empty())
+                .then(|| crate::relations::subtype::SubtypeChecker::new(self.interner));
             for (infer_var, captured_string) in captures {
                 let literal_type = self.interner.literal_string(&captured_string);
-                self.add_candidate(infer_var, literal_type, priority);
+                let candidate = checker
+                    .as_mut()
+                    .zip(self.declared_constraints.get(&infer_var))
+                    .and_then(|(checker, &constraint)| {
+                        crate::evaluation::template_capture::capture_for_constraint(
+                            self.interner,
+                            checker,
+                            &captured_string,
+                            literal_type,
+                            constraint,
+                        )
+                    })
+                    .unwrap_or(literal_type);
+                self.add_candidate(infer_var, candidate, priority);
             }
         }
 

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -41,8 +41,20 @@ impl TypeInterner {
         self.intern(TypeData::Literal(LiteralValue::String(atom)))
     }
 
-    /// Intern a literal number type
+    /// Intern a literal number type.
+    ///
+    /// Number literal types are keyed by `SameValueZero`, matching tsc's
+    /// `numberLiteralTypes` map: `-0` interns as the same type as `0`, and
+    /// every `NaN` bit pattern interns as one canonical `NaN` type. The
+    /// interner hashes raw `f64` bits, so canonicalization must happen here.
     pub fn literal_number(&self, value: f64) -> TypeId {
+        let value = if value == 0.0 {
+            0.0
+        } else if value.is_nan() {
+            f64::NAN
+        } else {
+            value
+        };
         self.intern(TypeData::Literal(LiteralValue::Number(OrderedFloat(value))))
     }
 

--- a/crates/tsz-solver/src/intern/template.rs
+++ b/crates/tsz-solver/src/intern/template.rs
@@ -144,8 +144,9 @@ impl TypeInterner {
                 }
                 Some(TypeData::Literal(LiteralValue::Boolean(b))) => Some(b.to_string()),
                 Some(TypeData::Literal(LiteralValue::Number(n))) => {
-                    // TypeScript stringifies numbers in templates (e.g., 1 -> "1", 1.5 -> "1.5")
-                    Some(format!("{}", n.0))
+                    // TypeScript stringifies numbers in templates with
+                    // `Number::toString` semantics (1e21 -> "1e+21", -0 -> "0").
+                    Some(crate::utils::js_number_to_string(n.0).into_owned())
                 }
                 Some(TypeData::Literal(LiteralValue::BigInt(atom))) => {
                     // BigInts in templates are stringified (e.g., 100n -> "100")
@@ -158,7 +159,9 @@ impl TypeInterner {
                     Some(TypeData::Literal(LiteralValue::String(atom))) => {
                         Some(self.resolve_atom_ref(atom).to_string())
                     }
-                    Some(TypeData::Literal(LiteralValue::Number(n))) => Some(format!("{}", n.0)),
+                    Some(TypeData::Literal(LiteralValue::Number(n))) => {
+                        Some(crate::utils::js_number_to_string(n.0).into_owned())
+                    }
                     _ => None,
                 },
                 _ => None,
@@ -365,7 +368,9 @@ impl TypeInterner {
                                 let s = self.resolve_atom_ref(atom);
                                 (!s.is_empty()).then(|| s.to_string())
                             }
-                            LiteralValue::Number(n) => Some(format!("{}", n.0)),
+                            LiteralValue::Number(n) => {
+                                Some(crate::utils::js_number_to_string(n.0).into_owned())
+                            }
                             LiteralValue::Boolean(b) => Some(b.to_string()),
                             LiteralValue::BigInt(_) => {
                                 if let Some(text) = pending_text.take()

--- a/crates/tsz-solver/src/relations/subtype/rules/literals.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/literals.rs
@@ -1045,28 +1045,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 // Helper functions for template literal matching
 // =============================================================================
 
-/// Format a number for template literal string coercion.
-/// Follows JavaScript's number-to-string conversion rules.
+/// Format a number for template literal string coercion with ECMAScript
+/// `Number::toString` semantics. (A previous local implementation trimmed
+/// trailing zeros off large integers, turning `1e21` into `"1"`.)
 pub(crate) fn format_number_for_template(num: f64) -> String {
-    if num.is_nan() {
-        return "NaN".to_string();
-    }
-    if num.is_infinite() {
-        return if num.is_sign_positive() {
-            "Infinity".to_string()
-        } else {
-            "-Infinity".to_string()
-        };
-    }
-    // Use JavaScript-like formatting (no trailing .0 for integers)
-    if num.fract() == 0.0 && num.abs() < 1e15 {
-        format!("{num:.0}")
-    } else {
-        // Use default Rust formatting which is close enough for most cases
-        let s = format!("{num}");
-        // Remove unnecessary trailing zeros after decimal point
-        s.trim_end_matches('0').trim_end_matches('.').to_string()
-    }
+    crate::utils::js_number_to_string(num).into_owned()
 }
 
 /// Find the length of a valid number at the start of a string.

--- a/crates/tsz-solver/src/type_queries/extended.rs
+++ b/crates/tsz-solver/src/type_queries/extended.rs
@@ -587,13 +587,15 @@ pub fn stringify_literal_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option<
             Some(db.resolve_atom_ref(atom).to_string())
         }
         Some(TypeData::Literal(crate::types::LiteralValue::Boolean(b))) => Some(b.to_string()),
-        Some(TypeData::Literal(crate::types::LiteralValue::Number(n))) => Some(format!("{}", n.0)),
+        Some(TypeData::Literal(crate::types::LiteralValue::Number(n))) => {
+            Some(crate::utils::js_number_to_string(n.0).into_owned())
+        }
         Some(TypeData::Enum(_, structural_type)) => match db.lookup(structural_type) {
             Some(TypeData::Literal(crate::types::LiteralValue::String(atom))) => {
                 Some(db.resolve_atom_ref(atom).to_string())
             }
             Some(TypeData::Literal(crate::types::LiteralValue::Number(n))) => {
-                Some(format!("{}", n.0))
+                Some(crate::utils::js_number_to_string(n.0).into_owned())
             }
             _ => None,
         },

--- a/crates/tsz-solver/src/utils/mod.rs
+++ b/crates/tsz-solver/src/utils/mod.rs
@@ -3,8 +3,6 @@
 //! This module contains common utilities used across multiple solver components
 //! to avoid code duplication.
 
-use std::borrow::Cow;
-
 use crate::caches::db::TypeDatabase;
 use crate::types::{ObjectShapeId, ParamInfo, PropertyInfo, PropertyLookup, TupleElement, TypeId};
 use crate::visitor::{array_element_type, readonly_inner_type, tuple_list_id};
@@ -188,51 +186,10 @@ pub fn canonicalize_numeric_name(name: &str) -> Option<String> {
 
 /// Converts a JavaScript number to its string representation.
 ///
-/// This matches JavaScript's `Number.prototype.toString()` behavior for proper
-/// numeric literal name checking.
-///
-/// Returns `Cow::Borrowed` for static special cases (NaN, 0, Infinity) and
-/// `Cow::Owned` for dynamically formatted numbers.
-pub fn js_number_to_string(value: f64) -> Cow<'static, str> {
-    if value.is_nan() {
-        return Cow::Borrowed("NaN");
-    }
-    if value == 0.0 {
-        return Cow::Borrowed("0");
-    }
-    if value.is_infinite() {
-        return if value.is_sign_negative() {
-            Cow::Borrowed("-Infinity")
-        } else {
-            Cow::Borrowed("Infinity")
-        };
-    }
-
-    let abs = value.abs();
-    if !(1e-6..1e21).contains(&abs) {
-        let mut formatted = format!("{value:e}");
-        if let Some(split) = formatted.find('e') {
-            let (mantissa, exp) = formatted.split_at(split);
-            let exp_digits = exp.strip_prefix('e').unwrap_or("");
-            let (sign, digits) = if let Some(digits) = exp_digits.strip_prefix('-') {
-                ('-', digits)
-            } else {
-                ('+', exp_digits)
-            };
-            let trimmed = digits.trim_start_matches('0');
-            let digits = if trimmed.is_empty() { "0" } else { trimmed };
-            formatted = format!("{mantissa}e{sign}{digits}");
-        }
-        return Cow::Owned(formatted);
-    }
-
-    let formatted = value.to_string();
-    if formatted == "-0" {
-        Cow::Borrowed("0")
-    } else {
-        Cow::Owned(formatted)
-    }
-}
+/// Re-export of the workspace-wide ECMAScript `Number::toString(10)` owner so
+/// solver-internal callers keep a local path; see
+/// [`tsz_common::numeric::js_number_to_string`] for the contract.
+pub use tsz_common::numeric::js_number_to_string;
 
 /// Reduces a vector of types to a union, single type, or NEVER.
 ///

--- a/crates/tsz-solver/tests/utils_tests.rs
+++ b/crates/tsz-solver/tests/utils_tests.rs
@@ -321,3 +321,17 @@ fn is_numeric_property_name_via_interner_round_trip() {
         "non-canonical numeric forms (e.g. '01') must not classify as numeric property names"
     );
 }
+
+/// Number literal types are keyed by `SameValueZero`, matching tsc's
+/// `numberLiteralTypes` map: `-0` interns as `0`, and every NaN bit pattern
+/// interns as one canonical NaN literal type.
+#[test]
+fn literal_number_interning_uses_same_value_zero() {
+    let interner = TypeInterner::new();
+    assert_eq!(interner.literal_number(0.0), interner.literal_number(-0.0));
+    assert_eq!(
+        interner.literal_number(f64::NAN),
+        interner.literal_number(-f64::NAN),
+    );
+    assert_ne!(interner.literal_number(0.0), interner.literal_number(1.0));
+}


### PR DESCRIPTION
Fixes #15668. Found by differential testing against tsc 6.0.2 (all open bug issues were WIP-claimed; conformance and emit snapshots are at zero, so this parity family was hunted fresh).

Structural rule: when a numeric literal type is converted to string form — template literal type evaluation, indexed-access/element-access key derivation, property-name canonicalization, enum value emit, DTS literal text — tsc produces ECMAScript `Number::toString(10)` output (`1e21` → `"1e+21"`, `1e-7` → `"1e-7"`, `1e20` → `"100000000000000000000"`, `-0` → `"0"`); tsz does X through the single `tsz_common::numeric::js_number_to_string` owner (solver re-exports it; emitter `text_utils::format_js_number` delegates to it). When two numeric literals are SameValueZero-equal, tsc interns one literal type (its `numberLiteralTypes` map is keyed by a JS `Map`); tsz does X through canonicalization in the solver's `literal_number` constructor. When template-literal inference captures a segment for a type variable whose constraint admits a non-string primitive and the segment round-trips, tsc infers the coerced literal; tsz does X through the shared `evaluation::template_capture` module used by both `infer` patterns and call-site inference.

Witnesses fixed (tsc 6.0.2 clean or matching; tsz previously diverged on each):

- ``type N = `${1e21}` `` produced `"1000000000000000000000"` (raw Rust `Display` in `intern/template.rs` ×3, `type_queries/extended.rs` ×2); `${1e-7}` produced `"0.0000001"`, `${-0}` produced `"-0"`.
- `format_number_for_template` (7th duplicate) trimmed trailing zeros: `1e21` formatted as `"1"`.
- `O[1e21]` (type position) and `o[1e21]` (expression position) looked the property up by source spelling and emitted false TS2339/TS7053; both now share `literal_index_property_name`, and `literal_index_keys` also validates number-literal union keys like tsc.
- `const a: -0 = 0` emitted the absurd `Type '0' is not assignable to type '0'`.
- ``declare function parse<W extends number>(s: `${W}px`): W; parse("42px")`` inferred `number` instead of `42` (with bigint/boolean/round-trip-negative adjacents).
- JS enum emit printed `E[E["C"] = 1000000000000000000000]` / `= 0.0000001` (raw `Display` in `enum_es5.rs::format_float_literal`); DTS emit printed `1e+20` for `1e20` (off-by-one scientific threshold in the emitter's local `format_js_number`).

Owner layers: conversion in `tsz-common` (beside the other ECMAScript abstract ops `to_uint32`/`to_int32`); literal identity in the solver interner constructor (the only production `LiteralValue::Number` interning site); capture coercion in the solver evaluation/inference boundary; checker consumes via `tsz_solver::utils` and the shared `literal_index_property_name` helper; emitter consumes via `text_utils`. No formatted-diagnostic-string predicates, no user-name literals; tests vary binder names and include negative/fallback cases (source-spelling string keys still miss, `042px` still widens to `number`, `-0` still rejects `1`).

Adjacent-case matrix in `crates/tsz-checker/tests/js_number_string_canonicalization_tests.rs` (18 tests): alias/generic wrapper (`Tag<1e21>`), enum member value through templates, canonical vs source-spelling string keys, positional/exponential boundary values (`1e20`, `1e-6`, `0.000001`), positive and negative forms.

Three pre-existing failures on clean main reproduce identically before/after (solver `literal_mask_preserves_object_vs_literal_reduction`, emitter `generator_object_literal_prefix_before_yield_omits_source_trailing_comma`, checker `quickinfo_return_position_conformance_shape_keeps_only_expected_missing_property`) — attributed under #15338, untouched by this change.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --test js_number_string_canonicalization_tests` (18/18 new adjacent-matrix tests)
- `cargo nextest run -p tsz-common` (563/563, includes new `js_number_to_string` boundary tests)
- `cargo nextest run -p tsz-solver -E 'test(template) or test(literal) or test(keyof) or test(number) or test(utils)'` (1408 pass; 1 pre-existing main failure)
- `cargo nextest run -p tsz-emitter -E 'test(enum) or test(number) or test(literal) or test(numeric)'` (637 pass; 1 pre-existing main failure)
- `cargo clippy -p tsz-common -p tsz-solver -p tsz-checker -p tsz-emitter --no-deps` clean
- Differential harness: 14-file edge-case corpus + 9 minimal witnesses vs tsc 6.0.2 — all picked-family witnesses now match on diagnostic codes; JS and DTS enum emit byte-identical to tsc for `enum { A = -0, B = 1e20, C = 1e21, D = 1e-7 }`
- Ready-review CI owns the broad conformance/emit/fourslash suites

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high