### PR TITLE
fix(checker): pair TS2722 with the TS18048-family companion for declaration-inferred call initializers

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -475,6 +475,9 @@ mod override_intersection_display_tests;
 #[path = "tests/private_field_no_spelling_suggestion_tests.rs"]
 mod private_field_no_spelling_suggestion_tests;
 #[cfg(test)]
+#[path = "../tests/quick_type_nullish_callee_companion_tests.rs"]
+mod quick_type_nullish_callee_companion_tests;
+#[cfg(test)]
 #[path = "tests/readonly_assignment_no_flow_narrow_tests.rs"]
 mod readonly_assignment_no_flow_narrow_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/types/computation/call_quick_type_nullish.rs
+++ b/crates/tsz-checker/src/types/computation/call_quick_type_nullish.rs
@@ -24,13 +24,7 @@ impl CheckerState<'_> {
         callee_expr: NodeIndex,
         cause: TypeId,
     ) {
-        let call_is_chain = self
-            .ctx
-            .arena
-            .get(call_idx)
-            .is_some_and(tsz_parser::parser::node::Node::is_optional_chain)
-            || super::access::is_optional_chain(self.ctx.arena, callee_expr);
-        if call_is_chain {
+        if super::access::is_optional_chain(self.ctx.arena, call_idx) {
             return;
         }
         if !self.call_result_infers_declaration_type(call_idx) {
@@ -44,6 +38,14 @@ impl CheckerState<'_> {
     /// variable declaration, property declaration, or parameter without a
     /// type annotation, or the default of a binding element (which never
     /// carries its own annotation).
+    ///
+    /// tsc's gate also excludes `super(...)`, `import(...)`, `require(...)`,
+    /// and `Symbol()` calls and skips JSDoc type assertions. Those arms are
+    /// deliberately omitted: this predicate only runs after TS2721/TS2722/
+    /// TS2723 fired for the callee, and none of those callee forms can be
+    /// possibly-nullish (`super`/`import` are keywords, `require`/`Symbol`
+    /// resolve to non-nullish globals), while JSDoc assertions only occur in
+    /// JS files where `strictNullChecks` call diagnostics take other paths.
     fn call_result_infers_declaration_type(&self, call_idx: NodeIndex) -> bool {
         let arena = self.ctx.arena;
         let mut cur = call_idx;

--- a/crates/tsz-checker/src/types/computation/call_quick_type_nullish.rs
+++ b/crates/tsz-checker/src/types/computation/call_quick_type_nullish.rs
@@ -1,0 +1,89 @@
+//! Nullish-callee companion diagnostics for declaration-inferred call results.
+//!
+//! When a variable-like declaration infers its type from a call-expression
+//! initializer, tsc computes that type through `getQuickTypeOfExpression`,
+//! which re-checks the callee with `checkNonNullExpression`. For a
+//! possibly-nullish callee that re-check reports the
+//! `reportObjectPossiblyNullOrUndefinedError` family (TS18047/TS18048/TS18049
+//! for entity names, TS2531/TS2532/TS2533 otherwise) in addition to the
+//! TS2721/TS2722/TS2723 that call resolution reports. Optional-chain calls
+//! take the chain arm of the quick path, which never re-checks the callee, so
+//! they only get the invoke-family diagnostic.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
+use tsz_solver::TypeId;
+
+impl CheckerState<'_> {
+    /// Emit the possibly-nullish companion for a callee that already produced
+    /// TS2721/TS2722/TS2723, when the call's type flows into a variable-like
+    /// declaration's inferred type (tsc's quick-type path).
+    pub(crate) fn report_nullish_callee_declaration_companion(
+        &mut self,
+        call_idx: NodeIndex,
+        callee_expr: NodeIndex,
+        cause: TypeId,
+    ) {
+        let call_is_chain = self
+            .ctx
+            .arena
+            .get(call_idx)
+            .is_some_and(tsz_parser::parser::node::Node::is_optional_chain)
+            || super::access::is_optional_chain(self.ctx.arena, callee_expr);
+        if call_is_chain {
+            return;
+        }
+        if !self.call_result_infers_declaration_type(call_idx) {
+            return;
+        }
+        self.report_possibly_nullish_expression(callee_expr, cause);
+    }
+
+    /// Whether tsc's `getQuickTypeOfExpression` runs for this call: the call,
+    /// reachable through parentheses and `await`, is the initializer of a
+    /// variable declaration, property declaration, or parameter without a
+    /// type annotation, or the default of a binding element (which never
+    /// carries its own annotation).
+    fn call_result_infers_declaration_type(&self, call_idx: NodeIndex) -> bool {
+        let arena = self.ctx.arena;
+        let mut cur = call_idx;
+        // Bounded walk to guard against malformed parent links.
+        for _ in 0..100 {
+            let Some(parent_idx) = arena.parent_of(cur) else {
+                return false;
+            };
+            let Some(parent) = arena.get(parent_idx) else {
+                return false;
+            };
+            match parent.kind {
+                k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+                    || k == syntax_kind_ext::AWAIT_EXPRESSION =>
+                {
+                    cur = parent_idx;
+                }
+                k if k == syntax_kind_ext::VARIABLE_DECLARATION => {
+                    return arena.get_variable_declaration(parent).is_some_and(|decl| {
+                        decl.initializer == cur && decl.type_annotation.is_none()
+                    });
+                }
+                k if k == syntax_kind_ext::PROPERTY_DECLARATION => {
+                    return arena.get_property_decl(parent).is_some_and(|decl| {
+                        decl.initializer == cur && decl.type_annotation.is_none()
+                    });
+                }
+                k if k == syntax_kind_ext::PARAMETER => {
+                    return arena.get_parameter(parent).is_some_and(|param| {
+                        param.initializer == cur && param.type_annotation.is_none()
+                    });
+                }
+                k if k == syntax_kind_ext::BINDING_ELEMENT => {
+                    return arena
+                        .get_binding_element(parent)
+                        .is_some_and(|element| element.initializer == cur);
+                }
+                _ => return false,
+            }
+        }
+        false
+    }
+}

--- a/crates/tsz-checker/src/types/computation/call_quick_type_nullish.rs
+++ b/crates/tsz-checker/src/types/computation/call_quick_type_nullish.rs
@@ -8,7 +8,9 @@
 //! for entity names, TS2531/TS2532/TS2533 otherwise) in addition to the
 //! TS2721/TS2722/TS2723 that call resolution reports. Optional-chain calls
 //! take the chain arm of the quick path, which never re-checks the callee, so
-//! they only get the invoke-family diagnostic.
+//! they never get the companion (a direct `?.()` also suppresses the
+//! invoke-family diagnostic upstream; only inherited-chain forms like
+//! `a?.b.c()` reach this guard with one already emitted).
 
 use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -935,6 +935,11 @@ impl<'a> CheckerState<'a> {
                     let (_non_nullish, nullish_cause) = self.split_nullish_type(callee_type);
                     if let Some(cause) = nullish_cause {
                         self.error_cannot_invoke_possibly_nullish_at(cause, callee_expr);
+                        self.report_nullish_callee_declaration_companion(
+                            call_idx,
+                            callee_expr,
+                            cause,
+                        );
                     } else if !self.is_in_decorator_expression(callee_expr) {
                         // Don't emit TS2349 for calls inside decorators - decorators
                         // are resolved at runtime and should not be checked for callability.

--- a/crates/tsz-checker/src/types/computation/mod.rs
+++ b/crates/tsz-checker/src/types/computation/mod.rs
@@ -36,6 +36,7 @@ pub(crate) mod call_display;
 pub(crate) mod call_finalize;
 pub(crate) mod call_helpers;
 pub(crate) mod call_inference;
+pub(crate) mod call_quick_type_nullish;
 pub(crate) mod call_result;
 mod call_result_signatures;
 pub(crate) mod class_member_annotation_circularity;

--- a/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
+++ b/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
@@ -292,8 +292,10 @@ impl<'a> CheckerState<'a> {
                 .then(|| "this".to_string())
             })
             // tsc falls back to the anonymous `Object is possibly ...` form
-            // when the rendered entity name reaches 100 UTF-16 units.
-            .filter(|name| name.encode_utf16().count() < 100);
+            // when the rendered entity name reaches 100 UTF-16 units. A name
+            // never has more UTF-16 units than UTF-8 bytes, so short byte
+            // lengths skip the exact count.
+            .filter(|name| name.len() < 100 || name.encode_utf16().count() < 100);
 
         let (code, message): (u32, String) = if let Some(ref name) = name {
             if cause == TypeId::NULL {

--- a/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
+++ b/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
@@ -97,8 +97,6 @@ impl<'a> CheckerState<'a> {
             return factory.union2(base_type, TypeId::UNDEFINED);
         }
 
-        use crate::diagnostics::diagnostic_codes;
-
         if cause == TypeId::ERROR || cause == TypeId::ANY || cause == TypeId::UNKNOWN {
             return property_type.unwrap_or(TypeId::ERROR);
         }
@@ -177,31 +175,7 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        let is_literal_nullish = if let Some(expr_node) = self.ctx.arena.get(expression) {
-            expr_node.kind == SyntaxKind::NullKeyword as u16
-                || (expr_node.kind == SyntaxKind::Identifier as u16
-                    && self
-                        .ctx
-                        .arena
-                        .get_identifier(expr_node)
-                        .is_some_and(|ident| ident.escaped_text == "undefined"))
-        } else {
-            false
-        };
-
-        if is_literal_nullish {
-            let value_name = if cause == TypeId::NULL {
-                "null"
-            } else if cause == TypeId::UNDEFINED {
-                "undefined"
-            } else {
-                "null | undefined"
-            };
-            self.error_at_node_msg(
-                expression,
-                diagnostic_codes::THE_VALUE_CANNOT_BE_USED_HERE,
-                &[value_name],
-            );
+        if self.report_literal_nullish_value_error(expression, cause) {
             return self.finalize_property_access_result(
                 idx,
                 property_type.unwrap_or(TypeId::ERROR),
@@ -230,12 +204,96 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        let name = self.expression_text(expression).or_else(|| {
-            (self.is_this_expression(expression)
-                && (self.enclosing_function_has_explicit_this_parameter(expression)
-                    || self.enclosing_function_has_contextual_this_type(expression)))
-            .then(|| "this".to_string())
-        });
+        self.report_named_possibly_nullish_expression(expression, cause);
+
+        self.finalize_property_access_result(
+            idx,
+            property_type.unwrap_or(TypeId::ERROR),
+            skip_flow_narrowing,
+            false,
+        )
+    }
+
+    /// Report a possibly-nullish `expression` the way tsc's
+    /// `reportObjectPossiblyNullOrUndefinedError` does: a literal `null` or
+    /// `undefined` reports TS18050, entity names report the
+    /// TS18047/TS18048/TS18049 family, and everything else reports the
+    /// `Object is possibly ...` TS2531/TS2532/TS2533 family.
+    pub(crate) fn report_possibly_nullish_expression(
+        &mut self,
+        expression: NodeIndex,
+        cause: TypeId,
+    ) {
+        if !self.report_literal_nullish_value_error(expression, cause) {
+            self.report_named_possibly_nullish_expression(expression, cause);
+        }
+    }
+
+    /// Mirror the literal arm of tsc's
+    /// `reportObjectPossiblyNullOrUndefinedError`: a `null` keyword or an
+    /// `undefined` identifier reports TS18050 `The value '{0}' cannot be used
+    /// here.` instead of a possibly-nullish message. Returns whether the
+    /// diagnostic was emitted.
+    pub(crate) fn report_literal_nullish_value_error(
+        &mut self,
+        expression: NodeIndex,
+        cause: TypeId,
+    ) -> bool {
+        use crate::diagnostics::diagnostic_codes;
+
+        let is_literal_nullish = if let Some(expr_node) = self.ctx.arena.get(expression) {
+            expr_node.kind == SyntaxKind::NullKeyword as u16
+                || (expr_node.kind == SyntaxKind::Identifier as u16
+                    && self
+                        .ctx
+                        .arena
+                        .get_identifier(expr_node)
+                        .is_some_and(|ident| ident.escaped_text == "undefined"))
+        } else {
+            false
+        };
+        if !is_literal_nullish {
+            return false;
+        }
+
+        let value_name = if cause == TypeId::NULL {
+            "null"
+        } else if cause == TypeId::UNDEFINED {
+            "undefined"
+        } else {
+            "null | undefined"
+        };
+        self.error_at_node_msg(
+            expression,
+            diagnostic_codes::THE_VALUE_CANNOT_BE_USED_HERE,
+            &[value_name],
+        );
+        true
+    }
+
+    /// Mirror the naming arms of tsc's
+    /// `reportObjectPossiblyNullOrUndefinedError`: entity-name expressions
+    /// shorter than 100 characters report `'{0}' is possibly ...`
+    /// (TS18047/TS18048/TS18049); other expressions report the anonymous
+    /// `Object is possibly ...` forms (TS2531/TS2532/TS2533).
+    pub(crate) fn report_named_possibly_nullish_expression(
+        &mut self,
+        expression: NodeIndex,
+        cause: TypeId,
+    ) {
+        use crate::diagnostics::diagnostic_codes;
+
+        let name = self
+            .expression_text(expression)
+            .or_else(|| {
+                (self.is_this_expression(expression)
+                    && (self.enclosing_function_has_explicit_this_parameter(expression)
+                        || self.enclosing_function_has_contextual_this_type(expression)))
+                .then(|| "this".to_string())
+            })
+            // tsc falls back to the anonymous `Object is possibly ...` form
+            // when the rendered entity name reaches 100 UTF-16 units.
+            .filter(|name| name.encode_utf16().count() < 100);
 
         let (code, message): (u32, String) = if let Some(ref name) = name {
             if cause == TypeId::NULL {
@@ -272,13 +330,6 @@ impl<'a> CheckerState<'a> {
         };
 
         self.error_at_node(expression, &message, code);
-
-        self.finalize_property_access_result(
-            idx,
-            property_type.unwrap_or(TypeId::ERROR),
-            skip_flow_narrowing,
-            false,
-        )
     }
 
     fn explicit_variable_annotation_type_for_nullish_receiver(

--- a/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
+++ b/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
@@ -1,4 +1,8 @@
-//! Diagnostics for property access on possibly nullish receivers.
+//! Diagnostics for property access on possibly nullish receivers, plus the
+//! shared possibly-nullish expression reporter (tsc's
+//! `reportObjectPossiblyNullOrUndefinedError`) also consumed by the
+//! declaration-inferred call-callee companion in
+//! `computation::call_quick_type_nullish`.
 
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;

--- a/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
+++ b/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
@@ -276,8 +276,9 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Mirror the naming arms of tsc's
-    /// `reportObjectPossiblyNullOrUndefinedError`: entity-name expressions
-    /// shorter than 100 characters report `'{0}' is possibly ...`
+    /// `reportObjectPossiblyNullOrUndefinedError`: nameable expressions
+    /// (entity names, plus the `this` receiver fallback) shorter than 100
+    /// UTF-16 units report `'{0}' is possibly ...`
     /// (TS18047/TS18048/TS18049); other expressions report the anonymous
     /// `Object is possibly ...` forms (TS2531/TS2532/TS2533).
     pub(crate) fn report_named_possibly_nullish_expression(

--- a/crates/tsz-checker/tests/quick_type_nullish_callee_companion_tests.rs
+++ b/crates/tsz-checker/tests/quick_type_nullish_callee_companion_tests.rs
@@ -40,6 +40,15 @@ fn assert_invoke_only(source: &str, context: &str) {
     );
 }
 
+/// Assert neither the invoke-family TS2722 nor the TS18048 companion fired.
+fn assert_neither_fires(source: &str, context: &str) {
+    let codes = check_source_strict_codes(source);
+    assert!(
+        !codes.contains(&2722) && !codes.contains(&18048),
+        "{context}: expected neither TS2722 nor TS18048; got: {codes:?}"
+    );
+}
+
 // =========================================================================
 // Companion fires: variable declarations
 // =========================================================================
@@ -409,21 +418,17 @@ fn enum_member_initializer_reports_invoke_only() {
 
 #[test]
 fn optional_call_chain_reports_nothing() {
-    let codes =
-        check_source_strict_codes("declare const o: { f?: () => number };\nconst r = o.f?.();\n");
-    assert!(
-        !codes.contains(&2722) && !codes.contains(&18048),
-        "`?.()` guards the callee; got: {codes:?}"
+    assert_neither_fires(
+        "declare const o: { f?: () => number };\nconst r = o.f?.();\n",
+        "`?.()` guards the callee",
     );
 }
 
 #[test]
 fn non_null_asserted_callee_reports_nothing() {
-    let codes =
-        check_source_strict_codes("declare const o: { f?: () => number };\nconst r = o.f!();\n");
-    assert!(
-        !codes.contains(&2722) && !codes.contains(&18048),
-        "`!` removes the nullish callee slice; got: {codes:?}"
+    assert_neither_fires(
+        "declare const o: { f?: () => number };\nconst r = o.f!();\n",
+        "`!` removes the nullish callee slice",
     );
 }
 
@@ -433,25 +438,20 @@ fn non_null_asserted_callee_reports_nothing() {
 
 #[test]
 fn required_member_call_reports_nothing() {
-    let codes =
-        check_source_strict_codes("declare const o: { f: () => number };\nconst r = o.f();\n");
-    assert!(
-        !codes.contains(&2722) && !codes.contains(&18048),
-        "required members must not gain optionality; got: {codes:?}"
+    assert_neither_fires(
+        "declare const o: { f: () => number };\nconst r = o.f();\n",
+        "required members must not gain optionality",
     );
 }
 
 #[test]
 fn identity_key_remap_keeps_required_member_required() {
-    let codes = check_source_strict_codes(
+    assert_neither_fires(
         "type Model = { save: () => number };\n\
          type Same<T> = { [P in keyof T as P]: T[P] };\n\
          declare const store: Same<Model>;\n\
          const value = store.save();\n",
-    );
-    assert!(
-        !codes.contains(&2722) && !codes.contains(&18048),
-        "remapped required members must not gain optionality; got: {codes:?}"
+        "remapped required members must not gain optionality",
     );
 }
 

--- a/crates/tsz-checker/tests/quick_type_nullish_callee_companion_tests.rs
+++ b/crates/tsz-checker/tests/quick_type_nullish_callee_companion_tests.rs
@@ -1,0 +1,533 @@
+//! Tests for the possibly-nullish callee companion diagnostic on
+//! declaration-inferred call initializers.
+//!
+//! Structural rule: when a variable-like declaration (variable declaration,
+//! property declaration, parameter, or binding-element default) infers its
+//! type from a call-expression initializer, tsc computes that type through
+//! `getQuickTypeOfExpression`, which re-checks the callee with
+//! `checkNonNullExpression`. A possibly-nullish callee therefore reports the
+//! `reportObjectPossiblyNullOrUndefinedError` family (TS18047/TS18048/TS18049
+//! for entity names, TS2531/TS2532/TS2533 otherwise) in addition to
+//! TS2721/TS2722/TS2723 from call resolution. Optional-chain calls, annotated
+//! declarations, assignments, arguments, returns, and bare statements do not
+//! run the callee re-check and only report the invoke-family diagnostic.
+//!
+//! Fixes issue #15677.
+
+use crate::test_utils::{check_source_strict_codes, check_source_strict_messages};
+
+// =========================================================================
+// Companion fires: variable declarations
+// =========================================================================
+
+#[test]
+fn const_from_optional_method_call_emits_invoke_and_companion() {
+    let messages = check_source_strict_messages(
+        "declare const obj: { run?: () => void };\nconst out = obj.run();\n",
+    );
+    assert!(
+        messages.iter().any(|(code, _)| *code == 2722),
+        "expected TS2722; got: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|(code, msg)| *code == 18048 && msg == "'obj.run' is possibly 'undefined'."),
+        "expected TS18048 companion naming the callee; got: {messages:?}"
+    );
+}
+
+#[test]
+fn issue_witness_key_remapped_homomorphic_mapped_type_getter() {
+    // Direct witness from issue #15677: optional member produced by an
+    // `as`-remapped homomorphic mapped type keeps its optionality, and the
+    // declaration-inferred call reports both TS2722 and TS18048.
+    let messages = check_source_strict_messages(
+        "type Src = { a?: number; b: string };\n\
+         type Getters<T> = { [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K] };\n\
+         declare const g: Getters<Src>;\n\
+         const x = g.getA();\n",
+    );
+    assert!(
+        messages.iter().any(|(code, _)| *code == 2722),
+        "expected TS2722; got: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|(code, msg)| *code == 18048 && msg == "'g.getA' is possibly 'undefined'."),
+        "expected TS18048 companion; got: {messages:?}"
+    );
+}
+
+#[test]
+fn identity_key_remap_without_intrinsic_keeps_optionality_pairing() {
+    let messages = check_source_strict_messages(
+        "type Model = { load?: () => number };\n\
+         type Same<T> = { [P in keyof T as P]: T[P] };\n\
+         declare const store: Same<Model>;\n\
+         const value = store.load();\n",
+    );
+    assert!(
+        messages.iter().any(|(code, _)| *code == 2722),
+        "expected TS2722; got: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|(code, msg)| *code == 18048 && msg == "'store.load' is possibly 'undefined'."),
+        "expected TS18048 companion; got: {messages:?}"
+    );
+}
+
+#[test]
+fn null_callee_emits_ts2721_and_ts18047() {
+    let messages = check_source_strict_messages(
+        "declare const box: { open: (() => void) | null };\nconst r = box.open();\n",
+    );
+    assert!(
+        messages.iter().any(|(code, _)| *code == 2721),
+        "expected TS2721; got: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|(code, msg)| *code == 18047 && msg == "'box.open' is possibly 'null'."),
+        "expected TS18047 companion; got: {messages:?}"
+    );
+}
+
+#[test]
+fn null_or_undefined_callee_emits_ts2723_and_ts18049() {
+    let messages = check_source_strict_messages(
+        "declare const cfg: { init: (() => void) | null | undefined };\nconst r = cfg.init();\n",
+    );
+    assert!(
+        messages.iter().any(|(code, _)| *code == 2723),
+        "expected TS2723; got: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|(code, msg)| *code == 18049
+                && msg == "'cfg.init' is possibly 'null' or 'undefined'."),
+        "expected TS18049 companion; got: {messages:?}"
+    );
+}
+
+#[test]
+fn bare_identifier_callee_names_identifier_in_companion() {
+    let messages = check_source_strict_messages(
+        "declare const handler: (() => void) | undefined;\nconst r = handler();\n",
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|(code, msg)| *code == 18048 && msg == "'handler' is possibly 'undefined'."),
+        "expected TS18048 naming the identifier; got: {messages:?}"
+    );
+}
+
+#[test]
+fn var_declaration_gets_companion() {
+    let codes =
+        check_source_strict_codes("declare const o: { f?: () => number };\nvar w = o.f();\n");
+    assert!(
+        codes.contains(&2722) && codes.contains(&18048),
+        "var declarations infer through the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn overloaded_optional_callee_still_gets_companion() {
+    // The callee re-check runs before signature counting, so overloads
+    // (multiple non-generic signatures) still pair the diagnostics.
+    let codes = check_source_strict_codes(
+        "declare const o: { f?: { (): number; (s: string): string } };\nconst r = o.f();\n",
+    );
+    assert!(
+        codes.contains(&2722) && codes.contains(&18048),
+        "expected both TS2722 and TS18048 for overloaded callee; got: {codes:?}"
+    );
+}
+
+#[test]
+fn generic_optional_callee_still_gets_companion() {
+    let codes = check_source_strict_codes(
+        "declare const o: { pick?: <T>(x?: T) => T };\nconst r = o.pick();\n",
+    );
+    assert!(
+        codes.contains(&2722) && codes.contains(&18048),
+        "expected both TS2722 and TS18048 for generic callee; got: {codes:?}"
+    );
+}
+
+// =========================================================================
+// Companion fires: other variable-like declarations
+// =========================================================================
+
+#[test]
+fn class_property_initializer_gets_companion() {
+    let codes = check_source_strict_codes(
+        "declare const src: { get?: () => number };\nclass Holder { slot = src.get(); }\n",
+    );
+    assert!(
+        codes.contains(&2722) && codes.contains(&18048),
+        "property declarations infer through the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn static_class_property_initializer_gets_companion() {
+    let codes = check_source_strict_codes(
+        "declare const src: { get?: () => number };\nclass Holder { static slot = src.get(); }\n",
+    );
+    assert!(
+        codes.contains(&2722) && codes.contains(&18048),
+        "static property declarations infer through the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn parameter_default_gets_companion() {
+    let codes = check_source_strict_codes(
+        "declare const env: { port?: () => number };\nfunction serve(p = env.port()) {}\n",
+    );
+    assert!(
+        codes.contains(&2722) && codes.contains(&18048),
+        "parameter defaults infer through the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn binding_element_default_gets_companion_even_when_pattern_is_annotated() {
+    let codes = check_source_strict_codes(
+        "declare const o: { f?: () => number };\nconst { n = o.f() }: { n?: number } = {};\n",
+    );
+    assert!(
+        codes.contains(&2722) && codes.contains(&18048),
+        "binding-element defaults always take the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn destructuring_from_call_initializer_gets_companion() {
+    let codes = check_source_strict_codes(
+        "declare const o: { f?: () => { p: number } };\nconst { p } = o.f();\n",
+    );
+    assert!(
+        codes.contains(&2722) && codes.contains(&18048),
+        "binding-pattern declarations infer through the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_loop_initializer_declaration_gets_companion() {
+    let codes = check_source_strict_codes(
+        "declare const o: { g?: () => number };\nfor (const n = o.g(); ;) { break; }\n",
+    );
+    assert!(
+        codes.contains(&2722) && codes.contains(&18048),
+        "for-init declarations infer through the quick-type path; got: {codes:?}"
+    );
+}
+
+// =========================================================================
+// Companion fires: wrappers and non-entity-name callees
+// =========================================================================
+
+#[test]
+fn parenthesized_initializer_still_gets_companion() {
+    let codes =
+        check_source_strict_codes("declare const o: { f?: () => number };\nconst r = ((o.f()));\n");
+    assert!(
+        codes.contains(&2722) && codes.contains(&18048),
+        "parentheses are skipped by the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn parenthesized_callee_gets_object_variant_companion() {
+    let messages = check_source_strict_messages(
+        "declare const o: { f?: () => number };\nconst r = (o.f)();\n",
+    );
+    assert!(
+        messages.iter().any(|(code, _)| *code == 2722),
+        "expected TS2722; got: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|(code, msg)| *code == 2532 && msg == "Object is possibly 'undefined'."),
+        "parenthesized callees are not entity names, so tsc reports TS2532; got: {messages:?}"
+    );
+}
+
+#[test]
+fn element_access_callee_gets_object_variant_companion() {
+    let messages = check_source_strict_messages(
+        "declare const o: { [k: string]: (() => void) | undefined };\nconst r = o[\"f\"]();\n",
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|(code, msg)| *code == 2532 && msg == "Object is possibly 'undefined'."),
+        "element-access callees are not entity names, so tsc reports TS2532; got: {messages:?}"
+    );
+}
+
+#[test]
+fn this_property_callee_gets_object_variant_companion() {
+    let messages = check_source_strict_messages(
+        "class W {\n  job?: () => number;\n  go() { const r = this.job(); }\n}\n",
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|(code, msg)| *code == 2532 && msg == "Object is possibly 'undefined'."),
+        "`this.x` is not an entity name, so tsc reports TS2532; got: {messages:?}"
+    );
+}
+
+#[test]
+fn entity_name_of_100_utf16_units_falls_back_to_object_variant() {
+    // `receiver.` (9 units) + 91-unit member = 100 units: tsc switches to the
+    // anonymous `Object is possibly 'undefined'.` form at 100.
+    let member = "m".repeat(91);
+    let source = format!(
+        "declare const receiver: {{ {member}?: () => number }};\nconst r = receiver.{member}();\n"
+    );
+    let messages = check_source_strict_messages(&source);
+    assert!(
+        messages
+            .iter()
+            .any(|(code, msg)| *code == 2532 && msg == "Object is possibly 'undefined'."),
+        "names at 100 UTF-16 units use the Object form; got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|(code, _)| *code == 18048),
+        "no named TS18048 at 100 UTF-16 units; got: {messages:?}"
+    );
+}
+
+#[test]
+fn entity_name_of_99_utf16_units_keeps_named_variant() {
+    let member = "m".repeat(90);
+    let source = format!(
+        "declare const receiver: {{ {member}?: () => number }};\nconst r = receiver.{member}();\n"
+    );
+    let codes = check_source_strict_codes(&source);
+    assert!(
+        codes.contains(&18048) && !codes.contains(&2532),
+        "names below 100 UTF-16 units keep the named TS18048 form; got: {codes:?}"
+    );
+}
+
+// =========================================================================
+// Companion does NOT fire: non-inferring contexts
+// =========================================================================
+
+#[test]
+fn bare_statement_call_reports_invoke_only() {
+    let codes = check_source_strict_codes("declare const o: { f?: () => void };\no.f();\n");
+    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
+    assert!(
+        !codes.contains(&18048) && !codes.contains(&2532),
+        "statement calls do not take the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn annotated_variable_reports_invoke_only() {
+    let codes =
+        check_source_strict_codes("declare const o: { f?: () => void };\nconst r: void = o.f();\n");
+    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
+    assert!(
+        !codes.contains(&18048),
+        "annotated declarations do not take the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn annotated_class_property_reports_invoke_only() {
+    let codes = check_source_strict_codes(
+        "declare const o: { f?: () => number };\nclass H { p: number | undefined = o.f(); }\n",
+    );
+    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
+    assert!(
+        !codes.contains(&18048),
+        "annotated properties do not take the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn annotated_parameter_default_reports_invoke_only() {
+    let codes = check_source_strict_codes(
+        "declare const o: { f?: () => number };\nfunction u(p: number | undefined = o.f()) {}\n",
+    );
+    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
+    assert!(
+        !codes.contains(&18048),
+        "annotated parameters do not take the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn assignment_reports_invoke_only() {
+    let codes =
+        check_source_strict_codes("declare const o: { f?: () => number };\nlet t;\nt = o.f();\n");
+    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
+    assert!(
+        !codes.contains(&18048),
+        "assignments do not take the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn argument_position_reports_invoke_only() {
+    let codes = check_source_strict_codes(
+        "declare const o: { f?: () => number };\ndeclare function sink(v: unknown): void;\nsink(o.f());\n",
+    );
+    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
+    assert!(
+        !codes.contains(&18048),
+        "call arguments do not take the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn return_position_reports_invoke_only() {
+    let codes = check_source_strict_codes(
+        "declare const o: { f?: () => number };\nfunction relay() { return o.f(); }\n",
+    );
+    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
+    assert!(
+        !codes.contains(&18048),
+        "return expressions do not take the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn as_assertion_initializer_reports_invoke_only() {
+    let codes = check_source_strict_codes(
+        "declare const o: { f?: () => number };\nconst r = o.f() as unknown;\n",
+    );
+    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
+    assert!(
+        !codes.contains(&18048),
+        "assertion initializers short-circuit the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn satisfies_initializer_reports_invoke_only() {
+    let codes = check_source_strict_codes(
+        "declare const o: { f?: () => number };\nconst r = o.f() satisfies unknown;\n",
+    );
+    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
+    assert!(
+        !codes.contains(&18048),
+        "satisfies initializers do not take the quick-type path; got: {codes:?}"
+    );
+}
+
+#[test]
+fn enum_member_initializer_reports_invoke_only() {
+    let codes =
+        check_source_strict_codes("declare const o: { f?: () => number };\nenum E { A = o.f() }\n");
+    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
+    assert!(
+        !codes.contains(&18048),
+        "enum members are not variable-like declarations; got: {codes:?}"
+    );
+}
+
+// =========================================================================
+// Companion does NOT fire: optional chains and non-null assertions
+// =========================================================================
+
+#[test]
+fn optional_call_chain_reports_nothing() {
+    let codes =
+        check_source_strict_codes("declare const o: { f?: () => number };\nconst r = o.f?.();\n");
+    assert!(
+        !codes.contains(&2722) && !codes.contains(&18048),
+        "`?.()` guards the callee; got: {codes:?}"
+    );
+}
+
+#[test]
+fn non_null_asserted_callee_reports_nothing() {
+    let codes =
+        check_source_strict_codes("declare const o: { f?: () => number };\nconst r = o.f!();\n");
+    assert!(
+        !codes.contains(&2722) && !codes.contains(&18048),
+        "`!` removes the nullish callee slice; got: {codes:?}"
+    );
+}
+
+// =========================================================================
+// Negative optionality case: required members stay required
+// =========================================================================
+
+#[test]
+fn required_member_call_reports_nothing() {
+    let codes =
+        check_source_strict_codes("declare const o: { f: () => number };\nconst r = o.f();\n");
+    assert!(
+        !codes.contains(&2722) && !codes.contains(&18048),
+        "required members must not gain optionality; got: {codes:?}"
+    );
+}
+
+#[test]
+fn identity_key_remap_keeps_required_member_required() {
+    let codes = check_source_strict_codes(
+        "type Model = { save: () => number };\n\
+         type Same<T> = { [P in keyof T as P]: T[P] };\n\
+         declare const store: Same<Model>;\n\
+         const value = store.save();\n",
+    );
+    assert!(
+        !codes.contains(&2722) && !codes.contains(&18048),
+        "remapped required members must not gain optionality; got: {codes:?}"
+    );
+}
+
+// =========================================================================
+// Property-access reporter parity: 100-unit entity-name fallback
+// =========================================================================
+
+#[test]
+fn property_access_on_long_named_receiver_uses_object_variant() {
+    // The same reporter serves possibly-nullish property accesses; receivers
+    // whose rendered name reaches 100 UTF-16 units use the Object form.
+    let receiver = "r".repeat(100);
+    let source = format!(
+        "declare const {receiver}: {{ p: number }} | undefined;\nconst v = {receiver}.p;\n"
+    );
+    let messages = check_source_strict_messages(&source);
+    assert!(
+        messages
+            .iter()
+            .any(|(code, msg)| *code == 2532 && msg == "Object is possibly 'undefined'."),
+        "receiver names at 100 UTF-16 units use the Object form; got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|(code, _)| *code == 18048),
+        "no named TS18048 at 100 UTF-16 units; got: {messages:?}"
+    );
+}
+
+#[test]
+fn property_access_on_short_named_receiver_keeps_named_variant() {
+    let messages = check_source_strict_messages(
+        "declare const conn: { p: number } | undefined;\nconst v = conn.p;\n",
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|(code, msg)| *code == 18048 && msg == "'conn' is possibly 'undefined'."),
+        "short receiver names keep the named TS18048 form; got: {messages:?}"
+    );
+}

--- a/crates/tsz-checker/tests/quick_type_nullish_callee_companion_tests.rs
+++ b/crates/tsz-checker/tests/quick_type_nullish_callee_companion_tests.rs
@@ -49,24 +49,38 @@ fn assert_neither_fires(source: &str, context: &str) {
     );
 }
 
+/// Assert the invoke-family diagnostic fired together with a companion of
+/// the given code and exact message.
+fn assert_invoke_and_companion_message(
+    source: &str,
+    invoke_code: u32,
+    companion_code: u32,
+    expected_msg: &str,
+) {
+    let messages = check_source_strict_messages(source);
+    assert!(
+        messages.iter().any(|(code, _)| *code == invoke_code),
+        "expected TS{invoke_code}; got: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|(code, msg)| *code == companion_code && msg == expected_msg),
+        "expected TS{companion_code} companion {expected_msg:?}; got: {messages:?}"
+    );
+}
+
 // =========================================================================
 // Companion fires: variable declarations
 // =========================================================================
 
 #[test]
 fn const_from_optional_method_call_emits_invoke_and_companion() {
-    let messages = check_source_strict_messages(
+    assert_invoke_and_companion_message(
         "declare const obj: { run?: () => void };\nconst out = obj.run();\n",
-    );
-    assert!(
-        messages.iter().any(|(code, _)| *code == 2722),
-        "expected TS2722; got: {messages:?}"
-    );
-    assert!(
-        messages
-            .iter()
-            .any(|(code, msg)| *code == 18048 && msg == "'obj.run' is possibly 'undefined'."),
-        "expected TS18048 companion naming the callee; got: {messages:?}"
+        2722,
+        18048,
+        "'obj.run' is possibly 'undefined'.",
     );
 }
 
@@ -75,76 +89,47 @@ fn issue_witness_key_remapped_homomorphic_mapped_type_getter() {
     // Direct witness from issue #15677: optional member produced by an
     // `as`-remapped homomorphic mapped type keeps its optionality, and the
     // declaration-inferred call reports both TS2722 and TS18048.
-    let messages = check_source_strict_messages(
+    assert_invoke_and_companion_message(
         "type Src = { a?: number; b: string };\n\
          type Getters<T> = { [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K] };\n\
          declare const g: Getters<Src>;\n\
          const x = g.getA();\n",
-    );
-    assert!(
-        messages.iter().any(|(code, _)| *code == 2722),
-        "expected TS2722; got: {messages:?}"
-    );
-    assert!(
-        messages
-            .iter()
-            .any(|(code, msg)| *code == 18048 && msg == "'g.getA' is possibly 'undefined'."),
-        "expected TS18048 companion; got: {messages:?}"
+        2722,
+        18048,
+        "'g.getA' is possibly 'undefined'.",
     );
 }
 
 #[test]
 fn identity_key_remap_without_intrinsic_keeps_optionality_pairing() {
-    let messages = check_source_strict_messages(
+    assert_invoke_and_companion_message(
         "type Model = { load?: () => number };\n\
          type Same<T> = { [P in keyof T as P]: T[P] };\n\
          declare const store: Same<Model>;\n\
          const value = store.load();\n",
-    );
-    assert!(
-        messages.iter().any(|(code, _)| *code == 2722),
-        "expected TS2722; got: {messages:?}"
-    );
-    assert!(
-        messages
-            .iter()
-            .any(|(code, msg)| *code == 18048 && msg == "'store.load' is possibly 'undefined'."),
-        "expected TS18048 companion; got: {messages:?}"
+        2722,
+        18048,
+        "'store.load' is possibly 'undefined'.",
     );
 }
 
 #[test]
 fn null_callee_emits_ts2721_and_ts18047() {
-    let messages = check_source_strict_messages(
+    assert_invoke_and_companion_message(
         "declare const box: { open: (() => void) | null };\nconst r = box.open();\n",
-    );
-    assert!(
-        messages.iter().any(|(code, _)| *code == 2721),
-        "expected TS2721; got: {messages:?}"
-    );
-    assert!(
-        messages
-            .iter()
-            .any(|(code, msg)| *code == 18047 && msg == "'box.open' is possibly 'null'."),
-        "expected TS18047 companion; got: {messages:?}"
+        2721,
+        18047,
+        "'box.open' is possibly 'null'.",
     );
 }
 
 #[test]
 fn null_or_undefined_callee_emits_ts2723_and_ts18049() {
-    let messages = check_source_strict_messages(
+    assert_invoke_and_companion_message(
         "declare const cfg: { init: (() => void) | null | undefined };\nconst r = cfg.init();\n",
-    );
-    assert!(
-        messages.iter().any(|(code, _)| *code == 2723),
-        "expected TS2723; got: {messages:?}"
-    );
-    assert!(
-        messages
-            .iter()
-            .any(|(code, msg)| *code == 18049
-                && msg == "'cfg.init' is possibly 'null' or 'undefined'."),
-        "expected TS18049 companion; got: {messages:?}"
+        2723,
+        18049,
+        "'cfg.init' is possibly 'null' or 'undefined'.",
     );
 }
 
@@ -253,18 +238,12 @@ fn parenthesized_initializer_still_gets_companion() {
 
 #[test]
 fn parenthesized_callee_gets_object_variant_companion() {
-    let messages = check_source_strict_messages(
+    // Parenthesized callees are not entity names, so tsc reports TS2532.
+    assert_invoke_and_companion_message(
         "declare const o: { f?: () => number };\nconst r = (o.f)();\n",
-    );
-    assert!(
-        messages.iter().any(|(code, _)| *code == 2722),
-        "expected TS2722; got: {messages:?}"
-    );
-    assert!(
-        messages
-            .iter()
-            .any(|(code, msg)| *code == 2532 && msg == "Object is possibly 'undefined'."),
-        "parenthesized callees are not entity names, so tsc reports TS2532; got: {messages:?}"
+        2722,
+        2532,
+        "Object is possibly 'undefined'.",
     );
 }
 

--- a/crates/tsz-checker/tests/quick_type_nullish_callee_companion_tests.rs
+++ b/crates/tsz-checker/tests/quick_type_nullish_callee_companion_tests.rs
@@ -16,6 +16,30 @@
 
 use crate::test_utils::{check_source_strict_codes, check_source_strict_messages};
 
+/// Assert the declaration-inferred quick-type path fired: TS2722 plus the
+/// TS18048 companion.
+fn assert_companion_fires(source: &str, context: &str) {
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.contains(&2722) && codes.contains(&18048),
+        "{context}: expected TS2722 + TS18048; got: {codes:?}"
+    );
+}
+
+/// Assert the call reported only the invoke-family TS2722 with no
+/// quick-type companion.
+fn assert_invoke_only(source: &str, context: &str) {
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.contains(&2722),
+        "{context}: expected TS2722; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&18048),
+        "{context}: unexpected TS18048 companion; got: {codes:?}"
+    );
+}
+
 // =========================================================================
 // Companion fires: variable declarations
 // =========================================================================
@@ -130,11 +154,9 @@ fn bare_identifier_callee_names_identifier_in_companion() {
 
 #[test]
 fn var_declaration_gets_companion() {
-    let codes =
-        check_source_strict_codes("declare const o: { f?: () => number };\nvar w = o.f();\n");
-    assert!(
-        codes.contains(&2722) && codes.contains(&18048),
-        "var declarations infer through the quick-type path; got: {codes:?}"
+    assert_companion_fires(
+        "declare const o: { f?: () => number };\nvar w = o.f();\n",
+        "var declarations infer through the quick-type path",
     );
 }
 
@@ -142,23 +164,17 @@ fn var_declaration_gets_companion() {
 fn overloaded_optional_callee_still_gets_companion() {
     // The callee re-check runs before signature counting, so overloads
     // (multiple non-generic signatures) still pair the diagnostics.
-    let codes = check_source_strict_codes(
+    assert_companion_fires(
         "declare const o: { f?: { (): number; (s: string): string } };\nconst r = o.f();\n",
-    );
-    assert!(
-        codes.contains(&2722) && codes.contains(&18048),
-        "expected both TS2722 and TS18048 for overloaded callee; got: {codes:?}"
+        "overloaded callee",
     );
 }
 
 #[test]
 fn generic_optional_callee_still_gets_companion() {
-    let codes = check_source_strict_codes(
+    assert_companion_fires(
         "declare const o: { pick?: <T>(x?: T) => T };\nconst r = o.pick();\n",
-    );
-    assert!(
-        codes.contains(&2722) && codes.contains(&18048),
-        "expected both TS2722 and TS18048 for generic callee; got: {codes:?}"
+        "generic callee",
     );
 }
 
@@ -168,67 +184,49 @@ fn generic_optional_callee_still_gets_companion() {
 
 #[test]
 fn class_property_initializer_gets_companion() {
-    let codes = check_source_strict_codes(
+    assert_companion_fires(
         "declare const src: { get?: () => number };\nclass Holder { slot = src.get(); }\n",
-    );
-    assert!(
-        codes.contains(&2722) && codes.contains(&18048),
-        "property declarations infer through the quick-type path; got: {codes:?}"
+        "property declarations infer through the quick-type path",
     );
 }
 
 #[test]
 fn static_class_property_initializer_gets_companion() {
-    let codes = check_source_strict_codes(
+    assert_companion_fires(
         "declare const src: { get?: () => number };\nclass Holder { static slot = src.get(); }\n",
-    );
-    assert!(
-        codes.contains(&2722) && codes.contains(&18048),
-        "static property declarations infer through the quick-type path; got: {codes:?}"
+        "static property declarations infer through the quick-type path",
     );
 }
 
 #[test]
 fn parameter_default_gets_companion() {
-    let codes = check_source_strict_codes(
+    assert_companion_fires(
         "declare const env: { port?: () => number };\nfunction serve(p = env.port()) {}\n",
-    );
-    assert!(
-        codes.contains(&2722) && codes.contains(&18048),
-        "parameter defaults infer through the quick-type path; got: {codes:?}"
+        "parameter defaults infer through the quick-type path",
     );
 }
 
 #[test]
 fn binding_element_default_gets_companion_even_when_pattern_is_annotated() {
-    let codes = check_source_strict_codes(
+    assert_companion_fires(
         "declare const o: { f?: () => number };\nconst { n = o.f() }: { n?: number } = {};\n",
-    );
-    assert!(
-        codes.contains(&2722) && codes.contains(&18048),
-        "binding-element defaults always take the quick-type path; got: {codes:?}"
+        "binding-element defaults always take the quick-type path",
     );
 }
 
 #[test]
 fn destructuring_from_call_initializer_gets_companion() {
-    let codes = check_source_strict_codes(
+    assert_companion_fires(
         "declare const o: { f?: () => { p: number } };\nconst { p } = o.f();\n",
-    );
-    assert!(
-        codes.contains(&2722) && codes.contains(&18048),
-        "binding-pattern declarations infer through the quick-type path; got: {codes:?}"
+        "binding-pattern declarations infer through the quick-type path",
     );
 }
 
 #[test]
 fn for_loop_initializer_declaration_gets_companion() {
-    let codes = check_source_strict_codes(
+    assert_companion_fires(
         "declare const o: { g?: () => number };\nfor (const n = o.g(); ;) { break; }\n",
-    );
-    assert!(
-        codes.contains(&2722) && codes.contains(&18048),
-        "for-init declarations infer through the quick-type path; got: {codes:?}"
+        "for-init declarations infer through the quick-type path",
     );
 }
 
@@ -238,11 +236,9 @@ fn for_loop_initializer_declaration_gets_companion() {
 
 #[test]
 fn parenthesized_initializer_still_gets_companion() {
-    let codes =
-        check_source_strict_codes("declare const o: { f?: () => number };\nconst r = ((o.f()));\n");
-    assert!(
-        codes.contains(&2722) && codes.contains(&18048),
-        "parentheses are skipped by the quick-type path; got: {codes:?}"
+    assert_companion_fires(
+        "declare const o: { f?: () => number };\nconst r = ((o.f()));\n",
+        "parentheses are skipped by the quick-type path",
     );
 }
 
@@ -329,116 +325,81 @@ fn entity_name_of_99_utf16_units_keeps_named_variant() {
 
 #[test]
 fn bare_statement_call_reports_invoke_only() {
-    let codes = check_source_strict_codes("declare const o: { f?: () => void };\no.f();\n");
-    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
-    assert!(
-        !codes.contains(&18048) && !codes.contains(&2532),
-        "statement calls do not take the quick-type path; got: {codes:?}"
+    assert_invoke_only(
+        "declare const o: { f?: () => void };\no.f();\n",
+        "statement calls do not take the quick-type path",
     );
 }
 
 #[test]
 fn annotated_variable_reports_invoke_only() {
-    let codes =
-        check_source_strict_codes("declare const o: { f?: () => void };\nconst r: void = o.f();\n");
-    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
-    assert!(
-        !codes.contains(&18048),
-        "annotated declarations do not take the quick-type path; got: {codes:?}"
+    assert_invoke_only(
+        "declare const o: { f?: () => void };\nconst r: void = o.f();\n",
+        "annotated declarations do not take the quick-type path",
     );
 }
 
 #[test]
 fn annotated_class_property_reports_invoke_only() {
-    let codes = check_source_strict_codes(
+    assert_invoke_only(
         "declare const o: { f?: () => number };\nclass H { p: number | undefined = o.f(); }\n",
-    );
-    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
-    assert!(
-        !codes.contains(&18048),
-        "annotated properties do not take the quick-type path; got: {codes:?}"
+        "annotated properties do not take the quick-type path",
     );
 }
 
 #[test]
 fn annotated_parameter_default_reports_invoke_only() {
-    let codes = check_source_strict_codes(
+    assert_invoke_only(
         "declare const o: { f?: () => number };\nfunction u(p: number | undefined = o.f()) {}\n",
-    );
-    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
-    assert!(
-        !codes.contains(&18048),
-        "annotated parameters do not take the quick-type path; got: {codes:?}"
+        "annotated parameters do not take the quick-type path",
     );
 }
 
 #[test]
 fn assignment_reports_invoke_only() {
-    let codes =
-        check_source_strict_codes("declare const o: { f?: () => number };\nlet t;\nt = o.f();\n");
-    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
-    assert!(
-        !codes.contains(&18048),
-        "assignments do not take the quick-type path; got: {codes:?}"
+    assert_invoke_only(
+        "declare const o: { f?: () => number };\nlet t;\nt = o.f();\n",
+        "assignments do not take the quick-type path",
     );
 }
 
 #[test]
 fn argument_position_reports_invoke_only() {
-    let codes = check_source_strict_codes(
+    assert_invoke_only(
         "declare const o: { f?: () => number };\ndeclare function sink(v: unknown): void;\nsink(o.f());\n",
-    );
-    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
-    assert!(
-        !codes.contains(&18048),
-        "call arguments do not take the quick-type path; got: {codes:?}"
+        "call arguments do not take the quick-type path",
     );
 }
 
 #[test]
 fn return_position_reports_invoke_only() {
-    let codes = check_source_strict_codes(
+    assert_invoke_only(
         "declare const o: { f?: () => number };\nfunction relay() { return o.f(); }\n",
-    );
-    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
-    assert!(
-        !codes.contains(&18048),
-        "return expressions do not take the quick-type path; got: {codes:?}"
+        "return expressions do not take the quick-type path",
     );
 }
 
 #[test]
 fn as_assertion_initializer_reports_invoke_only() {
-    let codes = check_source_strict_codes(
+    assert_invoke_only(
         "declare const o: { f?: () => number };\nconst r = o.f() as unknown;\n",
-    );
-    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
-    assert!(
-        !codes.contains(&18048),
-        "assertion initializers short-circuit the quick-type path; got: {codes:?}"
+        "assertion initializers short-circuit the quick-type path",
     );
 }
 
 #[test]
 fn satisfies_initializer_reports_invoke_only() {
-    let codes = check_source_strict_codes(
+    assert_invoke_only(
         "declare const o: { f?: () => number };\nconst r = o.f() satisfies unknown;\n",
-    );
-    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
-    assert!(
-        !codes.contains(&18048),
-        "satisfies initializers do not take the quick-type path; got: {codes:?}"
+        "satisfies initializers do not take the quick-type path",
     );
 }
 
 #[test]
 fn enum_member_initializer_reports_invoke_only() {
-    let codes =
-        check_source_strict_codes("declare const o: { f?: () => number };\nenum E { A = o.f() }\n");
-    assert!(codes.contains(&2722), "expected TS2722; got: {codes:?}");
-    assert!(
-        !codes.contains(&18048),
-        "enum members are not variable-like declarations; got: {codes:?}"
+    assert_invoke_only(
+        "declare const o: { f?: () => number };\nenum E { A = o.f() }\n",
+        "enum members are not variable-like declarations",
     );
 }
 


### PR DESCRIPTION
Calling a possibly-nullish member as a declaration initializer emitted only TS2722 in tsz; tsc pairs it with a TS18048-family companion. Witness from #15677: `const x = g.getA();` over a key-remapped homomorphic mapped type — tsc reports TS2722 + TS18048, tsz reported TS2722 only.

Structural rule: when a variable-like declaration (variable declaration, property declaration, parameter default, or binding-element default) infers its type from a call-expression initializer, tsc computes that type through `getQuickTypeOfExpression`, which re-checks the callee with `checkNonNullExpression`; a possibly-nullish callee therefore reports the entity-name TS18047/TS18048/TS18049 (or anonymous TS2531/TS2532/TS2533) companion in addition to the TS2721/TS2722/TS2723 from call resolution. tsz does this through the checker: the companion is emitted at the single TS2721/22/23 emission site (`handle_call_result` in `types/computation/call_result.rs`), gated by a syntactic quick-type-position walk (`types/computation/call_quick_type_nullish.rs`), reusing the shared possibly-nullish expression reporter extracted from the property-access path (`types/property_access_type/nullish_access.rs`). Optional-chain calls take tsc's chain arm of the quick path and never get the companion. The shared reporter also picks up tsc's 100-UTF16-unit entity-name fallback (names at or over the cap use the anonymous `Object is possibly ...` form) on both the callee-companion and property-access paths.

Owner layer: checker (diagnostics + AST orchestration). No solver changes; the mapped-type optionality itself was already correct.

Adjacent-case matrix (40-case differential vs `tsc` 6.0.2 under `--strict`, binder names varied):
- Companion fires: `const`/`let`/`var`, class properties (incl. `static`), parameter defaults, binding-element defaults (even under an annotated pattern), binding-pattern initializers, `for`-init declarations, `await`- and paren-wrapped initializers, overloaded and generic callees, `null` (TS2721+TS18047) and `null | undefined` (TS2723+TS18049) causes, bare-identifier callees.
- Anonymous variant: parenthesized callees, element-access callees, `this.x` callees, ≥100-UTF16-unit entity names → TS2532.
- Companion absent (negative cases): bare statement calls, annotated declarations/properties/parameters, assignments, argument/return positions, `as`/`satisfies` initializers, enum member initializers, optional-chain calls, non-null-asserted callees, and required members (no diagnostics at all — no optionality invented).

The wider #15677 variant (`readonly a?` + `--target es2022` flags dropping TS2722 entirely) did not reproduce on current main — tsz emits TS2722 there; only the missing companion remained. Filed #15682 for the pre-existing adjacent divergence discovered while building the matrix (`o?.f()` strips the callee's inherent optionality — different owning operation: chain optional-marker tracking).

Fixes #15677

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --lib quick_type_nullish_callee_companion` — 37 tests covering the issue witness and the adjacent matrix above, all passing
- Full `tsz-checker` lib suite before/after the change: identical failure sets (41 pre-existing failures on base commit cd06fe9, zero new), 8073 tests run
- 40-case differential fixture sweep vs `tsc` 6.0.2 `--strict --noEmit`: tsz output matches tsc on every case except pre-existing #15682
- `cargo clippy -p tsz-checker --lib` and `cargo fmt --check` clean

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rkw9gBVqGcU5Fabb4L6fpQ)_