### PR TITLE
chore(ci): baseline the CI-divergent jsx_component_attribute test (reconcile r2)

### DIFF
--- a/scripts/ci/known-failures.txt
+++ b/scripts/ci/known-failures.txt
@@ -12,7 +12,7 @@
 # this list may only shrink; a deliberate re-reconcile must bump the marker's
 # `r<N>` generation in the same diff (`--update --bump-generation`), which is
 # what scripts/ci/check-known-failures-growth.py accepts as authorization.
-# baseline-status: reconciled r1
+# baseline-status: reconciled r2
 tsz-checker::arbitrary_ext_decl_module_resolution_tests::html_arbitrary_ext_decl_renamed_extension_still_resolves
 tsz-checker::arbitrary_ext_decl_module_resolution_tests::html_arbitrary_ext_decl_resolves_under_user_form
 tsz-checker::arbitrary_ext_decl_module_resolution_tests::nested_arbitrary_ext_decl_resolves_with_directory_prefix
@@ -60,6 +60,7 @@ tsz-checker::issue_9692_function_candidate_inference::callback_parameter_functio
 tsz-checker::jsdoc_cross_file_typedef_tests::jsdoc_class_self_param_uses_instance_type_across_commonjs_file
 tsz-checker::jsx_component_attribute_tests::part_00::cross_file_react_class_empty_attrs_reports_missing_props_not_whole_target_ts2322
 tsz-checker::jsx_component_attribute_tests::part_00::test_cross_file_react_class_generic_props_emit_errors
+tsz-checker::jsx_component_attribute_tests::part_03::jsx_react_class_tuple_children_prefer_declared_tuple_over_injected_react_node
 tsz-checker::jsx_component_attribute_tests::part_03::test_generic_jsx_function_attr_error_anchors_at_attribute_not_body
 tsz-checker::kysely_callback_context_tests::kysely_schemable_identifier_factory_preserves_nested_imported_literal_kind
 tsz-checker::lib_global_namespace_shadowing_tests::module_local_interface_regexp_does_not_augment_lib_constructor_return


### PR DESCRIPTION
Unblocks the red `unit` job on main (`cd06fe9`, [run 29059968769](https://github.com/tsz-org/tsz/actions/runs/29059968769)) — the first strict run of the #15646 known-failures gate correctly caught one failure absent from the r1 baseline.

Goal: hold

## What

Adds one entry to `scripts/ci/known-failures.txt` and bumps the reconcile generation r1 → r2 (the gate's in-artifact escape for reviewed growth):

- `tsz-checker::jsx_component_attribute_tests::part_03::jsx_react_class_tuple_children_prefer_declared_tuple_over_injected_react_node`

## Why baseline instead of fix

This test passes on the reconcile box (isolation 3/3 at 0.012s — not a timeout —, full-binary run, and the full 21-report suite) but fails on ubuntu-latest inside the same batch shape, while three of its siblings fail identically in both environments (already baselined at r1). That is an environment/co-tenancy-sensitive failure family in the checker's JSX contextual-typing tests — pre-existing debt the previously masked unit job could never surface, not a regression introduced by the gate. Root cause is tracked in #15685; if another sibling surfaces, that issue owns the real fix (the gate going red again on it would be correct behavior).

The 9 shrink notices in the same CI run (baselined tests that pass on ubuntu-latest but fail on the reconcile box) are intentionally kept: the baseline covers the superset of environments/populations, and shrink notices are non-blocking by design.

## Verification

- `python3 scripts/ci/check-known-failures-growth.py --base-ref origin/main` — growth of exactly 1 entry authorized by the r1→r2 bump; integrity (sorted/unique/canonical) passes
- `scripts/ci/check-unit-gate-contracts.sh` — green
- Local characterization runs documented in #15685 (3× isolation pass, full-binary runs at `--test-threads 4` and `2` failing only the three already-baselined siblings)

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude (id withheld by harness policy)
Effort: high

https://claude.ai/code/session_016cr91fP7VYChBYN8xrstx8

---
_Generated by [Claude Code](https://claude.ai/code/session_016cr91fP7VYChBYN8xrstx8)_