### PR TITLE
fix(checker): keep inherent callee/member nullishness in optional-chain continuations

### DIFF
--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -261,3 +261,4 @@ emitted_ts2454_errors = { lifetime = "SpeculationScoped", capability = "Speculat
 emitted_ts2411_for_iface_prop = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
 type_resolution_fuel = { lifetime = "FileLocalReset", capability = "RelationSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 type_param_node_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "node-keyed TypeId cache for class/method/interface type params lacking DefId registration; ensures push_type_parameters convergence within a file session" }
+optional_chain_marker_only_nodes = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "per-node set of optional-chain marker-only positions computed while checking the active file; reset at file-session boundary" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -295,6 +295,7 @@ impl<'a> CheckerContext<'a> {
             ),
             symbol_flow_confirmed: RefCell::new(crate::context::CowCache::default()),
             daa_error_nodes: crate::context::CowCache::default(),
+            optional_chain_marker_only_nodes: FxHashSet::default(),
             deferred_ts2454_errors: Vec::new(),
             flow_narrowed_nodes: crate::context::CowCache::new(
                 FxHashSet::with_capacity_and_hasher(256, Default::default()),

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -162,6 +162,7 @@ impl<'a> CheckerContext<'a> {
         self.class_instance_type_to_decl.clear();
         self.flow_narrowed_nodes.clear();
         self.daa_error_nodes.clear();
+        self.optional_chain_marker_only_nodes.clear();
         self.deferred_ts2454_errors.clear();
         self.type_only_nodes.clear();
         self.closures_with_contextual_this_type.clear();

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -877,6 +877,17 @@ pub struct CheckerContext<'a> {
     /// otherwise the declared type gets overridden with the narrowed type.
     pub daa_error_nodes: CowCache<FxHashSet<u32>>,
 
+    /// Optional-chain nodes whose computed type's `undefined` member exists
+    /// only because the chain can short-circuit — the equivalent of tsc's
+    /// optional-type marker (`addOptionalTypeMarker`). Chain continuations
+    /// (`o?.f()`, `o?.f.g`, `o?.f["g"]`) remove `undefined` from the receiver
+    /// or callee only for nodes recorded here, so a member's own inherent
+    /// `undefined`/`null` still drives the possibly-nullish diagnostics
+    /// (TS18047/TS18048/TS2721/TS2722). Entries are overwritten whenever the
+    /// producing access is recomputed, so stale speculative results
+    /// self-correct.
+    pub optional_chain_marker_only_nodes: FxHashSet<u32>,
+
     /// Deferred TS2454 diagnostics that survive speculative rollback.
     /// `check_flow_usage` can run inside speculative call-checker contexts
     /// (generic inference, overload probing) that truncate diagnostics on

--- a/crates/tsz-checker/src/flow/control_flow/references.rs
+++ b/crates/tsz-checker/src/flow/control_flow/references.rs
@@ -256,9 +256,8 @@ impl<'a> FlowAnalyzer<'a> {
             ) else {
                 return false;
             };
-            if access_a.question_dot_token || access_b.question_dot_token {
-                return false;
-            }
+            // `?.` does not change the reference identity (see
+            // `property_reference`).
             return self.is_matching_reference(access_a.expression, access_b.expression)
                 && self
                     .is_matching_reference(access_a.name_or_argument, access_b.name_or_argument);
@@ -544,11 +543,12 @@ impl<'a> FlowAnalyzer<'a> {
             return self.property_reference(assertion.expression);
         }
 
+        // `?.` accesses form the same reference as their non-optional
+        // spelling: tsc's `isMatchingReference` keys on the accessed property
+        // name and ignores `questionDotToken`, so `if (a.b) { a?.b }` and
+        // `if (a?.b) { a.b }` both narrow.
         if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
             let access = self.arena.get_access_expr(node)?;
-            if access.question_dot_token {
-                return None;
-            }
             let ident = self.arena.get_identifier_at(access.name_or_argument)?;
             let name = self.interner.intern_string(&ident.escaped_text);
             return Some((access.expression, name));
@@ -556,9 +556,6 @@ impl<'a> FlowAnalyzer<'a> {
 
         if node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
             let access = self.arena.get_access_expr(node)?;
-            if access.question_dot_token {
-                return None;
-            }
             let name = self.literal_atom_from_node_or_type(access.name_or_argument);
             tracing::trace!(
                 ?idx,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1392,6 +1392,9 @@ mod object_spread_optional_merge_tests;
 #[path = "tests/operator_chain_overload_resolution_tests.rs"]
 mod operator_chain_overload_resolution_tests;
 #[cfg(test)]
+#[path = "tests/optional_chain_inherent_nullish_tests.rs"]
+mod optional_chain_inherent_nullish_tests;
+#[cfg(test)]
 #[path = "tests/optional_key_extraction_tests.rs"]
 mod optional_key_extraction_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -9,8 +9,8 @@ pub(crate) use tsz_solver::computation::CompatChecker;
 pub(crate) use tsz_solver::construction::TypeInterner;
 pub(crate) use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 pub(crate) use tsz_solver::narrowing::{
-    CachedPropertyType, NarrowingCache, NarrowingContext, OptionalPropertyChainKey, TypeGuard,
-    TypeofKind,
+    CachedChainType, CachedPropertyType, NarrowingCache, NarrowingContext,
+    OptionalPropertyChainKey, TypeGuard, TypeofKind,
 };
 pub(crate) use tsz_solver::objects::IndexSignatureResolver;
 pub(crate) use tsz_solver::operations::property::PropertyAccessResult;

--- a/crates/tsz-checker/src/tests/optional_chain_inherent_nullish_tests.rs
+++ b/crates/tsz-checker/src/tests/optional_chain_inherent_nullish_tests.rs
@@ -1,0 +1,278 @@
+//! Chain-introduced vs inherent nullishness in optional chains (#15682).
+//!
+//! Structural rule: when a call or member access continues an optional chain
+//! but the `?.` token does not directly guard the consumed value (`o?.f()` as
+//! opposed to `o.f?.()`), tsc strips only the optionality introduced by the
+//! chain short-circuit (the optional-type marker in
+//! `getOptionalExpressionType` / `removeOptionalTypeMarker`) and then runs the
+//! normal possibly-nullish checks, so a member whose own type includes
+//! `undefined`/`null` still reports TS2721/TS2722 (calls) or TS18047/TS18048
+//! (member accesses). tsz mirrors this through the per-node optional-chain
+//! marker recorded by the chain producers and consumed by
+//! `remove_optional_chain_marker`.
+
+use tsz_common::options::checker::CheckerOptions;
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    crate::test_utils::check_source(source, "test.ts", opts())
+        .iter()
+        .map(|diag| diag.code)
+        .collect()
+}
+
+const CANNOT_INVOKE_POSSIBLY_NULL: u32 = 2721;
+const CANNOT_INVOKE_POSSIBLY_UNDEFINED: u32 = 2722;
+const IS_POSSIBLY_UNDEFINED: u32 = 18048;
+const OBJECT_IS_POSSIBLY_UNDEFINED: u32 = 2532;
+
+// ---------------------------------------------------------------------------
+// Reported repro: `box?.fn()` where `fn` itself is optional keeps the
+// member's inherent `undefined` and reports TS2722.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn chain_call_with_inherent_optional_member_reports_ts2722() {
+    let diags = codes(
+        r#"
+declare const bag: { pick?: () => void } | undefined;
+const out = bag?.pick();
+"#,
+    );
+    assert_eq!(
+        diags,
+        vec![CANNOT_INVOKE_POSSIBLY_UNDEFINED],
+        "o?.f() with f?: must report TS2722 like tsc; got {diags:?}"
+    );
+}
+
+#[test]
+fn chain_call_with_null_member_reports_ts2721() {
+    let diags = codes(
+        r#"
+declare const crate_: { open: (() => void) | null } | undefined;
+const out = crate_?.open();
+"#,
+    );
+    assert_eq!(
+        diags,
+        vec![CANNOT_INVOKE_POSSIBLY_NULL],
+        "o?.f() with f: T | null must report TS2721 like tsc; got {diags:?}"
+    );
+}
+
+#[test]
+fn chain_call_with_entirely_undefined_member_reports_ts2722() {
+    let diags = codes(
+        r#"
+declare const husk: { start: undefined } | undefined;
+const out = husk?.start();
+"#,
+    );
+    assert_eq!(
+        diags,
+        vec![CANNOT_INVOKE_POSSIBLY_UNDEFINED],
+        "o?.f() with f: undefined must report TS2722 like tsc; got {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative / fallback cases: `?.` directly guarding the invoked value, or a
+// required member, stay silent.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn direct_optional_call_on_optional_member_is_clean() {
+    let diags = codes(
+        r#"
+declare const kiosk: { vend?: () => void } | undefined;
+kiosk?.vend?.();
+declare const stall: { vend?: () => void };
+stall.vend?.();
+declare const fnv: (() => void) | undefined;
+fnv?.();
+"#,
+    );
+    assert_eq!(
+        diags,
+        Vec::<u32>::new(),
+        "?.() guards the callee: {diags:?}"
+    );
+}
+
+#[test]
+fn chain_call_with_required_member_is_clean_and_returns_undefined_union() {
+    let diags = codes(
+        r#"
+declare const cart: { total: () => number } | undefined;
+const t: number | undefined = cart?.total();
+"#,
+    );
+    assert_eq!(diags, Vec::<u32>::new(), "required member: {diags:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Alias/wrapper/nesting variants: the inherent optionality can sit deeper in
+// the chain, come from an element access, or come from a chained call result.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_chain_call_with_inherent_optional_leaf_reports_ts2722() {
+    let diags = codes(
+        r#"
+declare const shelf: { row: { grab?: () => void } } | undefined;
+shelf?.row.grab();
+"#,
+    );
+    assert_eq!(diags, vec![CANNOT_INVOKE_POSSIBLY_UNDEFINED], "{diags:?}");
+}
+
+#[test]
+fn element_access_chain_call_with_inherent_optional_member_reports_ts2722() {
+    let diags = codes(
+        r#"
+declare const drawer: { ["knob"]?: () => void } | undefined;
+drawer?.["knob"]();
+"#,
+    );
+    assert_eq!(diags, vec![CANNOT_INVOKE_POSSIBLY_UNDEFINED], "{diags:?}");
+}
+
+#[test]
+fn chain_member_read_with_inherent_optional_receiver_reports_ts18048() {
+    let diags = codes(
+        r#"
+declare const attic: { box?: { lid: string } } | undefined;
+const lid = attic?.box.lid;
+"#,
+    );
+    assert_eq!(
+        diags,
+        vec![IS_POSSIBLY_UNDEFINED],
+        "o?.f.g with f?: must report TS18048 like tsc; got {diags:?}"
+    );
+}
+
+#[test]
+fn chain_element_read_with_inherent_optional_receiver_reports_ts18048() {
+    let diags = codes(
+        r#"
+declare const vault: { bin?: { [slot: string]: number } } | undefined;
+const coin = vault?.bin["gold"];
+"#,
+    );
+    assert_eq!(diags, vec![IS_POSSIBLY_UNDEFINED], "{diags:?}");
+}
+
+#[test]
+fn chained_call_result_with_inherent_optional_member_reports_ts2532() {
+    let diags = codes(
+        r#"
+declare const forge: { cast?: () => ({ heat?: number } | undefined) } | undefined;
+const heat = forge?.cast?.().heat;
+"#,
+    );
+    assert_eq!(
+        diags,
+        vec![OBJECT_IS_POSSIBLY_UNDEFINED],
+        "call-result continuation keeps the return type's inherent undefined; got {diags:?}"
+    );
+}
+
+#[test]
+fn middle_inherent_optionality_reports_ts18048_not_ts2722() {
+    let diags = codes(
+        r#"
+declare const yard: { gate?: { open: () => void } } | undefined;
+yard?.gate.open();
+"#,
+    );
+    assert_eq!(
+        diags,
+        vec![IS_POSSIBLY_UNDEFINED],
+        "the receiver's inherent undefined reports TS18048 and the call stays clean; got {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Guards: a narrowed chain must not report — the marker model may not
+// resurrect nullishness that control flow already removed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn guarded_chain_call_is_clean() {
+    let diags = codes(
+        r#"
+declare const relay: { send?: () => void } | undefined;
+if (relay?.send) {
+  relay.send();
+  relay?.send();
+}
+declare const modem: { dial?: () => void } | undefined;
+if (modem !== undefined && modem.dial !== undefined) {
+  modem?.dial();
+}
+"#,
+    );
+    assert_eq!(diags, Vec::<u32>::new(), "guarded chain calls: {diags:?}");
+}
+
+#[test]
+fn guarded_chain_member_reads_are_clean() {
+    let diags = codes(
+        r#"
+declare const nest: { egg?: { crack: () => void } } | undefined;
+if (nest?.egg) {
+  nest?.egg.crack();
+}
+declare const hive: { comb?: { [cell: string]: number } } | undefined;
+if (hive?.comb) {
+  const honey = hive?.comb["a1"];
+}
+"#,
+    );
+    assert_eq!(diags, Vec::<u32>::new(), "guarded continuations: {diags:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Repeated identical chains share type-level caches; the marker must replay
+// per node so the second occurrence behaves like the first.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repeated_chain_calls_report_per_occurrence() {
+    let diags = codes(
+        r#"
+declare const pump: { prime?: () => number } | undefined;
+const first = pump?.prime();
+const second = pump?.prime();
+"#,
+    );
+    assert_eq!(
+        diags,
+        vec![
+            CANNOT_INVOKE_POSSIBLY_UNDEFINED,
+            CANNOT_INVOKE_POSSIBLY_UNDEFINED
+        ],
+        "cache-hit occurrences must keep the marker bit; got {diags:?}"
+    );
+}
+
+#[test]
+fn repeated_clean_chain_calls_stay_clean() {
+    let diags = codes(
+        r#"
+declare const meter: { read: () => number } | undefined;
+const a = meter?.read();
+const b = meter?.read();
+"#,
+    );
+    assert_eq!(diags, Vec::<u32>::new(), "{diags:?}");
+}

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1837,34 +1837,25 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        if let Some(cause) = nullish_cause {
-            if access.question_dot_token {
-                // The `| undefined` below is the chain short-circuit marker;
-                // track whether the element type itself already carried
-                // `undefined` so chain continuations can strip only the marker.
-                self.record_optional_chain_marker(idx, result_type);
-                result_type = self
-                    .ctx
-                    .types
-                    .factory()
-                    .union2(result_type, TypeId::UNDEFINED);
-            } else if !report_no_index {
-                self.report_possibly_nullish_object(access.expression, cause);
-            }
-        } else if access.question_dot_token {
-            // No short-circuit possible: any `undefined` in the result is
-            // inherent. Clear a stale marker bit from a prior recomputation.
-            self.set_optional_chain_marker_only(idx, false);
+        if access.question_dot_token {
+            // The added `| undefined` is the chain short-circuit marker; the
+            // helper tracks whether the element type itself already carried
+            // `undefined` so chain continuations can strip only the marker.
+            result_type = self
+                .union_optional_chain_undefined(idx, result_type, nullish_cause.is_some())
+                .0;
+        } else if let Some(cause) = nullish_cause
+            && !report_no_index
+        {
+            self.report_possibly_nullish_object(access.expression, cause);
         }
 
         // The chain can short-circuit at the `?.`; add back the `| undefined`
         // that was stripped when resolving the element access.
         if is_chain_continuation {
-            self.record_optional_chain_marker(idx, result_type);
-            result_type = crate::query_boundaries::optional_chain::add_undefined_if_missing(
-                self.ctx.types,
-                result_type,
-            );
+            result_type = self
+                .union_optional_chain_undefined(idx, result_type, true)
+                .0;
         }
 
         let result_type = if skip_flow_narrowing {

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -188,16 +188,29 @@ impl<'a> CheckerState<'a> {
             )
         };
 
-        // Strip nullish from the object type when this element access continues
-        // an optional chain (e.g., the `["c"]` in `o?.b["c"]`). Track whether
-        // stripping occurred so we can add `| undefined` back to the result.
-        let (object_type, is_chain_continuation) =
-            if !access.question_dot_token && is_optional_chain(self.ctx.arena, access.expression) {
-                let (non_nullish, stripped) = self.split_nullish_type(object_type);
-                (non_nullish.unwrap_or(object_type), stripped.is_some())
-            } else {
-                (object_type, false)
-            };
+        // Remove the chain-introduced `undefined` marker from the object type
+        // when this element access continues an optional chain (e.g., the
+        // `["c"]` in `o?.b["c"]`), mirroring tsc's `removeOptionalTypeMarker`:
+        // when `b` itself is optional, its own `undefined` survives and the
+        // normal possibly-nullish path reports TS18048. Track whether the
+        // receiver could be nullish at this link so we can add `| undefined`
+        // back to the result.
+        let (object_type, is_chain_continuation) = if !access.question_dot_token
+            && is_optional_chain(self.ctx.arena, access.expression)
+        {
+            let non_optional = self.remove_optional_chain_marker(access.expression, object_type);
+            let had_marker = non_optional != object_type;
+            // Honor guards (`if (o?.f) o?.f["g"]`) before diagnosing:
+            // tsc's receiver is the flow-narrowed reference.
+            let narrowed =
+                self.flow_narrow_optional_chain_remainder(access.expression, non_optional);
+            // The chain can short-circuit when the marker was present or
+            // the receiver can still be nullish after narrowing.
+            let still_nullish = self.split_nullish_type(narrowed).1.is_some();
+            (narrowed, had_marker || still_nullish)
+        } else {
+            (object_type, false)
+        };
         let object_type = if !skip_flow_narrowing
             && self
                 .resolve_identifier_symbol(access.expression)
@@ -1826,6 +1839,10 @@ impl<'a> CheckerState<'a> {
 
         if let Some(cause) = nullish_cause {
             if access.question_dot_token {
+                // The `| undefined` below is the chain short-circuit marker;
+                // track whether the element type itself already carried
+                // `undefined` so chain continuations can strip only the marker.
+                self.record_optional_chain_marker(idx, result_type);
                 result_type = self
                     .ctx
                     .types
@@ -1834,11 +1851,16 @@ impl<'a> CheckerState<'a> {
             } else if !report_no_index {
                 self.report_possibly_nullish_object(access.expression, cause);
             }
+        } else if access.question_dot_token {
+            // No short-circuit possible: any `undefined` in the result is
+            // inherent. Clear a stale marker bit from a prior recomputation.
+            self.set_optional_chain_marker_only(idx, false);
         }
 
         // The chain can short-circuit at the `?.`; add back the `| undefined`
         // that was stripped when resolving the element access.
         if is_chain_continuation {
+            self.record_optional_chain_marker(idx, result_type);
             result_type = crate::query_boundaries::optional_chain::add_undefined_if_missing(
                 self.ctx.types,
                 result_type,

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -465,32 +465,64 @@ impl<'a> CheckerState<'a> {
         // A call is in an optional chain when it uses `?.()` directly, or when
         // the callee expression continues an earlier optional chain such as
         // `o?.a.b()`.
-        let callee_is_optional_chain = node.is_optional_chain()
-            || crate::types_domain::computation::access::is_optional_chain(
-                self.ctx.arena,
-                call.expression,
-            );
+        let callee_expr_is_chain = crate::types_domain::computation::access::is_optional_chain(
+            self.ctx.arena,
+            call.expression,
+        );
+        let callee_is_optional_chain = node.is_optional_chain() || callee_expr_is_chain;
         if callee_is_optional_chain {
             // Evaluate the callee type to resolve Application/Lazy types before
             // splitting nullish members. Without this, `Transform1<T>` stays as an
             // unevaluated Application and split_nullish_type can't see its union members.
             let callee_for_split = self.evaluate_type_with_env(callee_type);
-            let (non_nullish, cause) = self.split_nullish_type(callee_for_split);
-            nullish_cause = cause;
-            let Some(non_nullish) = non_nullish else {
-                // The callee is entirely nullish (`null`, `undefined`, or
-                // `null | undefined`). The chain short-circuits to `undefined`,
-                // but tsc still computes the non-nullish slice as `never`, which
-                // has no call signatures, and reports TS2349 — unless a property
-                // access on a `never` receiver already emitted the companion
-                // TS2339. Mirror that so `fn?.()` where `fn: undefined` is not
-                // silently accepted.
-                if !self.never_callee_has_companion_property_diagnostic(call.expression) {
-                    self.error_not_callable_at(TypeId::NEVER, call.expression);
+            if call.question_dot_token || !callee_expr_is_chain {
+                // The `?.` guards the invoked value itself (`f?.()`,
+                // `o.m?.()`, `o?.f?.()`): strip all of its nullishness,
+                // mirroring tsc's chain-root `getNonNullableType`.
+                let (non_nullish, cause) = self.split_nullish_type(callee_for_split);
+                nullish_cause = cause;
+                let Some(non_nullish) = non_nullish else {
+                    // The callee is entirely nullish (`null`, `undefined`, or
+                    // `null | undefined`). The chain short-circuits to `undefined`,
+                    // but tsc still computes the non-nullish slice as `never`, which
+                    // has no call signatures, and reports TS2349 — unless a property
+                    // access on a `never` receiver already emitted the companion
+                    // TS2339. Mirror that so `fn?.()` where `fn: undefined` is not
+                    // silently accepted.
+                    if !self.never_callee_has_companion_property_diagnostic(call.expression) {
+                        self.error_not_callable_at(TypeId::NEVER, call.expression);
+                    }
+                    return TypeId::UNDEFINED;
+                };
+                callee_type = non_nullish;
+            } else {
+                // The call continues a chain without its own `?.` (`o?.f()`):
+                // tsc's `getOptionalExpressionType` removes only the
+                // chain-introduced `undefined` here, so a callee whose own type
+                // includes `undefined`/`null` still fails resolution and
+                // reports TS2721/TS2722/TS2723 through the normal
+                // possibly-nullish path.
+                let non_optional =
+                    self.remove_optional_chain_marker(call.expression, callee_for_split);
+                if non_optional != callee_for_split {
+                    // The chain can short-circuit: the call result gains the
+                    // `| undefined` marker.
+                    nullish_cause = Some(TypeId::UNDEFINED);
                 }
-                return TypeId::UNDEFINED;
-            };
-            callee_type = non_nullish;
+                let (non_nullish, _) = self.split_nullish_type(non_optional);
+                if non_nullish.is_none()
+                    && self.never_callee_has_companion_property_diagnostic(call.expression)
+                {
+                    // The callee access already reported TS2339 on an
+                    // entirely-nullish receiver (`o?.f()` with `o: undefined`);
+                    // tsc's callee is errorType there and the call stays silent.
+                    return TypeId::UNDEFINED;
+                }
+                // Honor guards (`if (o?.f) o?.f()`) before diagnosing: tsc's
+                // callee is the flow-narrowed reference.
+                callee_type =
+                    self.flow_narrow_optional_chain_remainder(call.expression, non_optional);
+            }
             if callee_type == TypeId::ANY {
                 return TypeId::ANY;
             }

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -129,7 +129,8 @@ impl<'a> CheckerState<'a> {
             self.record_optional_chain_marker(call_idx, return_type);
             call_checker::call_result_optional_chain_return(self.ctx.types, return_type)
         } else {
-            self.set_optional_chain_marker_only(call_idx, false);
+            // No clear needed: only the chain arm above ever records a bit
+            // for a call node, so a non-chain call was never inserted.
             return_type
         }
     }

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -80,6 +80,7 @@ impl<'a> CheckerState<'a> {
     fn finalize_call_return_like_success(
         &mut self,
         callee_expr: NodeIndex,
+        call_idx: NodeIndex,
         callee_type: TypeId,
         arg_types: &[TypeId],
         return_type: TypeId,
@@ -122,8 +123,13 @@ impl<'a> CheckerState<'a> {
             return_type
         };
         if is_optional_chain {
+            // The `| undefined` added below is the chain short-circuit marker;
+            // track whether the return type itself already carried `undefined`
+            // so outer chain continuations can strip only the marker.
+            self.record_optional_chain_marker(call_idx, return_type);
             call_checker::call_result_optional_chain_return(self.ctx.types, return_type)
         } else {
+            self.set_optional_chain_marker_only(call_idx, false);
             return_type
         }
     }
@@ -880,6 +886,7 @@ impl<'a> CheckerState<'a> {
                 self.report_polymorphic_this_indexed_conditional_arg(callee_type, args, arg_types);
                 self.finalize_call_return_like_success(
                     callee_expr,
+                    call_idx,
                     callee_type,
                     arg_types,
                     return_type,
@@ -1002,6 +1009,7 @@ impl<'a> CheckerState<'a> {
                 {
                     self.finalize_call_return_like_success(
                         callee_expr,
+                        call_idx,
                         callee_type,
                         arg_types,
                         return_type,

--- a/crates/tsz-checker/src/types/property_access_type/helpers.rs
+++ b/crates/tsz-checker/src/types/property_access_type/helpers.rs
@@ -1554,19 +1554,8 @@ impl<'a> CheckerState<'a> {
         let obj_type = self.get_type_of_node(access.expression);
         let obj_eval = self.evaluate_application_type(obj_type);
         let (_, nullish) = self.split_nullish_type(obj_eval);
-        if nullish.is_some() {
-            // The `| undefined` below is the chain short-circuit marker; track
-            // whether the member itself already carried `undefined` so outer
-            // chain continuations can strip only the marker.
-            self.record_optional_chain_marker(idx, result);
-            crate::query_boundaries::optional_chain::add_undefined_if_missing(
-                self.ctx.types,
-                result,
-            )
-        } else {
-            self.set_optional_chain_marker_only(idx, false);
-            result
-        }
+        self.union_optional_chain_undefined(idx, result, nullish.is_some())
+            .0
     }
 
     pub(crate) fn missing_typescript_lib_dom_global_alias(&self, idx: NodeIndex) -> Option<String> {

--- a/crates/tsz-checker/src/types/property_access_type/helpers.rs
+++ b/crates/tsz-checker/src/types/property_access_type/helpers.rs
@@ -1555,11 +1555,16 @@ impl<'a> CheckerState<'a> {
         let obj_eval = self.evaluate_application_type(obj_type);
         let (_, nullish) = self.split_nullish_type(obj_eval);
         if nullish.is_some() {
+            // The `| undefined` below is the chain short-circuit marker; track
+            // whether the member itself already carried `undefined` so outer
+            // chain continuations can strip only the marker.
+            self.record_optional_chain_marker(idx, result);
             crate::query_boundaries::optional_chain::add_undefined_if_missing(
                 self.ctx.types,
                 result,
             )
         } else {
+            self.set_optional_chain_marker_only(idx, false);
             result
         }
     }

--- a/crates/tsz-checker/src/types/property_access_type/mod.rs
+++ b/crates/tsz-checker/src/types/property_access_type/mod.rs
@@ -14,6 +14,7 @@ mod optional_fast_path;
 mod partial_initializer;
 mod receiver_eval;
 mod resolve;
+mod this_receiver_class_type;
 mod value_import;
 
 #[cfg(test)]

--- a/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
+++ b/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
@@ -54,8 +54,6 @@ impl<'a> CheckerState<'a> {
         } = site;
         use crate::query_boundaries::common::PropertyAccessResult;
 
-        let factory = self.ctx.types.factory();
-
         if receiver_has_daa_error {
             return self.finalize_property_access_result(
                 idx,
@@ -98,11 +96,10 @@ impl<'a> CheckerState<'a> {
                 self.error_property_not_exist_at(property_name, TypeId::NEVER, name_or_argument);
             }
             let base_type = property_type.unwrap_or(TypeId::UNKNOWN);
-            // The `| undefined` below is the chain short-circuit marker; track
-            // whether the member itself already carried `undefined` so chain
-            // continuations can strip only the marker.
-            self.record_optional_chain_marker(idx, base_type);
-            return factory.union2(base_type, TypeId::UNDEFINED);
+            // The added `| undefined` is the chain short-circuit marker; the
+            // helper tracks whether the member itself already carried
+            // `undefined` so chain continuations can strip only the marker.
+            return self.union_optional_chain_undefined(idx, base_type, true).0;
         }
 
         if cause == TypeId::ERROR || cause == TypeId::ANY || cause == TypeId::UNKNOWN {

--- a/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
+++ b/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
@@ -98,6 +98,10 @@ impl<'a> CheckerState<'a> {
                 self.error_property_not_exist_at(property_name, TypeId::NEVER, name_or_argument);
             }
             let base_type = property_type.unwrap_or(TypeId::UNKNOWN);
+            // The `| undefined` below is the chain short-circuit marker; track
+            // whether the member itself already carried `undefined` so chain
+            // continuations can strip only the marker.
+            self.record_optional_chain_marker(idx, base_type);
             return factory.union2(base_type, TypeId::UNDEFINED);
         }
 

--- a/crates/tsz-checker/src/types/property_access_type/optional_fast_path.rs
+++ b/crates/tsz-checker/src/types/property_access_type/optional_fast_path.rs
@@ -65,16 +65,21 @@ impl<'a> CheckerState<'a> {
         // Only used when flow narrowing is skipped (skip_result_flow_for_result),
         // which guarantees the result is context-independent.
         let cache_generation = TypeResolver::resolver_generation(&self.ctx);
-        if skip_result_flow_for_result
-            && let Some(cached) = self
+        if skip_result_flow_for_result {
+            let cached = self
                 .ctx
                 .flow_shared
                 .narrowing_cache
                 .optional_chain_cache
                 .borrow()
-                .get(&(object_type, prop_atom), cache_generation)
-        {
-            return Some(cached);
+                .get(&(object_type, prop_atom), cache_generation);
+            if let Some(cached) = cached {
+                // The cache is keyed by type, not node: replay the marker bit
+                // for this node so chain continuations still know whether the
+                // result's `undefined` is chain-introduced only.
+                self.set_optional_chain_marker_only(idx, cached.undefined_is_marker_only);
+                return Some(cached.type_id);
+            }
         }
 
         let (non_nullish_base, base_nullish) = self.split_nullish_type(object_type);
@@ -129,19 +134,31 @@ impl<'a> CheckerState<'a> {
                 property_name,
                 entry.type_id,
             );
-            if base_nullish.is_some() {
+            let marker_only = if base_nullish.is_some() {
+                let marker_only = self.record_optional_chain_marker(idx, result_type);
                 result_type = crate::query_boundaries::optional_chain::add_undefined_if_missing(
                     self.ctx.types,
                     result_type,
                 );
-            }
+                marker_only
+            } else {
+                self.set_optional_chain_marker_only(idx, false);
+                false
+            };
             if skip_result_flow_for_result {
                 self.ctx
                     .flow_shared
                     .narrowing_cache
                     .optional_chain_cache
                     .borrow_mut()
-                    .insert((object_type, prop_atom), resolver_generation, result_type);
+                    .insert(
+                        (object_type, prop_atom),
+                        resolver_generation,
+                        crate::query_boundaries::common::CachedChainType {
+                            type_id: result_type,
+                            undefined_is_marker_only: marker_only,
+                        },
+                    );
             }
             return Some(self.finalize_property_access_result(
                 idx,
@@ -213,19 +230,28 @@ impl<'a> CheckerState<'a> {
                         )),
                     );
                 let mut result_type = effective_write_result(refined_type_id, write_type);
-                if base_nullish.is_some() {
+                let marker_only = if base_nullish.is_some() {
+                    let marker_only = self.record_optional_chain_marker(idx, result_type);
                     result_type = crate::query_boundaries::optional_chain::add_undefined_if_missing(
                         self.ctx.types,
                         result_type,
                     );
-                }
+                    marker_only
+                } else {
+                    self.set_optional_chain_marker_only(idx, false);
+                    false
+                };
+                let cached_chain = crate::query_boundaries::common::CachedChainType {
+                    type_id: result_type,
+                    undefined_is_marker_only: marker_only,
+                };
                 if skip_result_flow_for_result {
                     self.ctx
                         .flow_shared
                         .narrowing_cache
                         .optional_chain_cache
                         .borrow_mut()
-                        .insert((object_type, prop_atom), resolver_generation, result_type);
+                        .insert((object_type, prop_atom), resolver_generation, cached_chain);
                 }
                 if let Some(key) = optional_property_chain_cache_key {
                     self.ctx
@@ -233,7 +259,7 @@ impl<'a> CheckerState<'a> {
                         .narrowing_cache
                         .optional_property_chain_cache
                         .borrow_mut()
-                        .insert(key.clone(), resolver_generation, result_type);
+                        .insert(key.clone(), resolver_generation, cached_chain);
                 }
                 Some(self.finalize_property_access_result(
                     idx,
@@ -255,10 +281,13 @@ impl<'a> CheckerState<'a> {
                     );
                 let mut result_type = property_type.unwrap_or(TypeId::ERROR);
                 if base_nullish.is_some() {
+                    self.record_optional_chain_marker(idx, result_type);
                     result_type = crate::query_boundaries::optional_chain::add_undefined_if_missing(
                         self.ctx.types,
                         result_type,
                     );
+                } else {
+                    self.set_optional_chain_marker_only(idx, false);
                 }
                 Some(self.finalize_property_access_result(
                     idx,

--- a/crates/tsz-checker/src/types/property_access_type/optional_fast_path.rs
+++ b/crates/tsz-checker/src/types/property_access_type/optional_fast_path.rs
@@ -128,23 +128,14 @@ impl<'a> CheckerState<'a> {
             .borrow()
             .get(&cache_key(resolved_base, prop_atom), resolver_generation);
         if let Some(Some(entry)) = cached_property_type {
-            let mut result_type = self.refine_expando_property_read_type(
+            let result_type = self.refine_expando_property_read_type(
                 idx,
                 expression,
                 property_name,
                 entry.type_id,
             );
-            let marker_only = if base_nullish.is_some() {
-                let marker_only = self.record_optional_chain_marker(idx, result_type);
-                result_type = crate::query_boundaries::optional_chain::add_undefined_if_missing(
-                    self.ctx.types,
-                    result_type,
-                );
-                marker_only
-            } else {
-                self.set_optional_chain_marker_only(idx, false);
-                false
-            };
+            let (result_type, marker_only) =
+                self.union_optional_chain_undefined(idx, result_type, base_nullish.is_some());
             if skip_result_flow_for_result {
                 self.ctx
                     .flow_shared
@@ -154,10 +145,10 @@ impl<'a> CheckerState<'a> {
                     .insert(
                         (object_type, prop_atom),
                         resolver_generation,
-                        crate::query_boundaries::common::CachedChainType {
-                            type_id: result_type,
-                            undefined_is_marker_only: marker_only,
-                        },
+                        crate::query_boundaries::common::CachedChainType::new(
+                            result_type,
+                            marker_only,
+                        ),
                     );
             }
             return Some(self.finalize_property_access_result(
@@ -229,22 +220,11 @@ impl<'a> CheckerState<'a> {
                             from_index_signature,
                         )),
                     );
-                let mut result_type = effective_write_result(refined_type_id, write_type);
-                let marker_only = if base_nullish.is_some() {
-                    let marker_only = self.record_optional_chain_marker(idx, result_type);
-                    result_type = crate::query_boundaries::optional_chain::add_undefined_if_missing(
-                        self.ctx.types,
-                        result_type,
-                    );
-                    marker_only
-                } else {
-                    self.set_optional_chain_marker_only(idx, false);
-                    false
-                };
-                let cached_chain = crate::query_boundaries::common::CachedChainType {
-                    type_id: result_type,
-                    undefined_is_marker_only: marker_only,
-                };
+                let result_type = effective_write_result(refined_type_id, write_type);
+                let (result_type, marker_only) =
+                    self.union_optional_chain_undefined(idx, result_type, base_nullish.is_some());
+                let cached_chain =
+                    crate::query_boundaries::common::CachedChainType::new(result_type, marker_only);
                 if skip_result_flow_for_result {
                     self.ctx
                         .flow_shared
@@ -279,16 +259,11 @@ impl<'a> CheckerState<'a> {
                         resolver_generation,
                         property_type.map(CachedPropertyType::explicit),
                     );
-                let mut result_type = property_type.unwrap_or(TypeId::ERROR);
-                if base_nullish.is_some() {
-                    self.record_optional_chain_marker(idx, result_type);
-                    result_type = crate::query_boundaries::optional_chain::add_undefined_if_missing(
-                        self.ctx.types,
-                        result_type,
-                    );
-                } else {
-                    self.set_optional_chain_marker_only(idx, false);
-                }
+                let (result_type, _) = self.union_optional_chain_undefined(
+                    idx,
+                    property_type.unwrap_or(TypeId::ERROR),
+                    base_nullish.is_some(),
+                );
                 Some(self.finalize_property_access_result(
                     idx,
                     result_type,

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -636,65 +636,16 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // When `this` has been deliberately typed as `any` (e.g. TS2683 was
-        // emitted because the `this` expression is in a nested regular
-        // function without its own `this` binding), don't override back to
-        // the enclosing class type — property access on `any` must succeed
-        // without a TS2339 cascade.
-        let this_has_own_fresh_binding = self
-            .ctx
-            .arena
-            .get(access.expression)
-            .is_some_and(|node| node.kind == SyntaxKind::ThisKeyword as u16)
-            && self.is_this_in_nested_function_without_own_this_binding(access.expression);
-        if self
-            .ctx
-            .arena
-            .get(access.expression)
-            .is_some_and(|node| node.kind == SyntaxKind::ThisKeyword as u16)
-            && !this_has_own_fresh_binding
-            && object_type != TypeId::ANY
-            && let Some(class_info) = self.ctx.enclosing_class.as_ref()
-            && crate::query_boundaries::common::object_shape_for_type(self.ctx.types, object_type)
-                .is_none()
-        {
-            // In static context, `this` refers to the constructor type (typeof ClassName).
-            // In instance context, `this` refers to the instance type (ClassName).
-            let is_static_context = self.is_in_static_class_member_context(idx);
-            let class_this_type = if is_static_context {
-                // Get the constructor type for static context
-                let class_idx = class_info.class_idx;
-                self.ctx
-                    .arena
-                    .get(class_idx)
-                    .and_then(|node| self.ctx.arena.get_class(node))
-                    .map(|class| self.get_class_constructor_type(class_idx, class))
-            } else {
-                // Use cached instance type for instance context
-                class_info.cached_instance_this_type
-            };
-            if let Some(class_this_type) = class_this_type
-                && crate::query_boundaries::common::object_shape_for_type(
-                    self.ctx.types,
-                    class_this_type,
-                )
-                .is_some()
-            {
-                // When `this` has been narrowed by flow analysis (e.g., via a
-                // `this is DatafulFoo<T>` type predicate), the narrowed type is
-                // an intersection that lacks a direct object shape. Do NOT
-                // override it with the class instance type — that would discard
-                // the narrowing and cause false TS2532/TS2339 diagnostics on
-                // properties that differ between the original class and the
-                // predicate target interface.
-                let was_narrowed_by_flow =
-                    object_type != class_this_type && original_object_type != class_this_type;
-                if !was_narrowed_by_flow {
-                    object_type = class_this_type;
-                    display_object_type = class_this_type;
-                }
-            }
-        }
+        // When the receiver is a bare `this` whose flow type lost its object
+        // shape, fall back to the enclosing class's instance/constructor type
+        // (see `apply_this_receiver_class_type_override`).
+        (object_type, display_object_type) = self.apply_this_receiver_class_type_override(
+            idx,
+            access.expression,
+            object_type,
+            original_object_type,
+            display_object_type,
+        );
 
         if name_node.kind == SyntaxKind::PrivateIdentifier as u16 {
             return self.get_type_of_private_property_access(

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -67,14 +67,19 @@ impl<'a> CheckerState<'a> {
             self.optional_property_chain_cache_key(idx, request);
         let optional_property_chain_cache_generation = TypeResolver::resolver_generation(&self.ctx);
         if let Some(key) = optional_property_chain_cache_key.as_ref() {
-            let cache = self
+            let cached = self
                 .ctx
                 .flow_shared
                 .narrowing_cache
                 .optional_property_chain_cache
-                .borrow();
-            if let Some(cached) = cache.get(key, optional_property_chain_cache_generation) {
-                return cached;
+                .borrow()
+                .get(key, optional_property_chain_cache_generation);
+            if let Some(cached) = cached {
+                // The cache is keyed by root type and path, not node: replay
+                // the marker bit for this node so chain continuations still
+                // know whether the result's `undefined` is chain-introduced.
+                self.set_optional_chain_marker_only(idx, cached.undefined_is_marker_only);
+                return cached.type_id;
             }
         }
 
@@ -469,16 +474,21 @@ impl<'a> CheckerState<'a> {
 
         // Handle optional chain continuations: for `o?.b.c`, when processing `.c`,
         // the object type from `o?.b` includes `undefined` from the optional chain.
-        // But `.c` should only be reached when `o` is defined, so we strip nullish
-        // types. Only do this when this access is NOT itself an optional chain
-        // (`question_dot_token` is false) but is part of one (parent has `?.`).
+        // Remove only that chain-introduced marker (tsc's
+        // `removeOptionalTypeMarker`): when `b` itself is optional, its own
+        // `undefined` survives and the normal possibly-nullish path reports
+        // TS18048 exactly like tsc. Only do this when this access is NOT itself
+        // an optional chain (`question_dot_token` is false) but is part of one
+        // (parent has `?.`).
         object_type = if !access.question_dot_token
             && crate::types_domain::computation::access::is_optional_chain(
                 self.ctx.arena,
                 access.expression,
             ) {
-            let (non_nullish, _) = self.split_nullish_type(object_type);
-            non_nullish.unwrap_or(object_type)
+            let non_optional = self.remove_optional_chain_marker(access.expression, object_type);
+            // Honor guards (`if (o?.f) o?.f.g`) before diagnosing: tsc's
+            // receiver is the flow-narrowed reference.
+            self.flow_narrow_optional_chain_remainder(access.expression, non_optional)
         } else {
             object_type
         };

--- a/crates/tsz-checker/src/types/property_access_type/this_receiver_class_type.rs
+++ b/crates/tsz-checker/src/types/property_access_type/this_receiver_class_type.rs
@@ -1,0 +1,86 @@
+//! When a property access reads through a bare `this` receiver, the flow type
+//! of `this` may lack a direct object shape (e.g. it resolved to a bare type
+//! parameter or an index-access remnant). tsc falls back to the enclosing
+//! class's instance/constructor type in that case so member lookup still
+//! succeeds. This module owns that fallback, extracted from
+//! `get_type_of_property_access_inner` to keep `resolve.rs` cohesive.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_scanner::SyntaxKind;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Override `object_type`/`display_object_type` with the enclosing class's
+    /// `this` type when the receiver is a bare `this` whose current type has no
+    /// object shape. Returns the (possibly overridden) pair
+    /// `(object_type, display_object_type)`.
+    pub(crate) fn apply_this_receiver_class_type_override(
+        &mut self,
+        idx: NodeIndex,
+        access_expression: NodeIndex,
+        object_type: TypeId,
+        original_object_type: TypeId,
+        display_object_type: TypeId,
+    ) -> (TypeId, TypeId) {
+        // When `this` has been deliberately typed as `any` (e.g. TS2683 was
+        // emitted because the `this` expression is in a nested regular
+        // function without its own `this` binding), don't override back to
+        // the enclosing class type — property access on `any` must succeed
+        // without a TS2339 cascade.
+        let this_has_own_fresh_binding = self
+            .ctx
+            .arena
+            .get(access_expression)
+            .is_some_and(|node| node.kind == SyntaxKind::ThisKeyword as u16)
+            && self.is_this_in_nested_function_without_own_this_binding(access_expression);
+        if self
+            .ctx
+            .arena
+            .get(access_expression)
+            .is_some_and(|node| node.kind == SyntaxKind::ThisKeyword as u16)
+            && !this_has_own_fresh_binding
+            && object_type != TypeId::ANY
+            && let Some(class_info) = self.ctx.enclosing_class.as_ref()
+            && crate::query_boundaries::common::object_shape_for_type(self.ctx.types, object_type)
+                .is_none()
+        {
+            // In static context, `this` refers to the constructor type (typeof ClassName).
+            // In instance context, `this` refers to the instance type (ClassName).
+            let is_static_context = self.is_in_static_class_member_context(idx);
+            let class_this_type = if is_static_context {
+                // Get the constructor type for static context
+                let class_idx = class_info.class_idx;
+                self.ctx
+                    .arena
+                    .get(class_idx)
+                    .and_then(|node| self.ctx.arena.get_class(node))
+                    .map(|class| self.get_class_constructor_type(class_idx, class))
+            } else {
+                // Use cached instance type for instance context
+                class_info.cached_instance_this_type
+            };
+            if let Some(class_this_type) = class_this_type
+                && crate::query_boundaries::common::object_shape_for_type(
+                    self.ctx.types,
+                    class_this_type,
+                )
+                .is_some()
+            {
+                // When `this` has been narrowed by flow analysis (e.g., via a
+                // `this is DatafulFoo<T>` type predicate), the narrowed type is
+                // an intersection that lacks a direct object shape. Do NOT
+                // override it with the class instance type — that would discard
+                // the narrowing and cause false TS2532/TS2339 diagnostics on
+                // properties that differ between the original class and the
+                // predicate target interface.
+                let was_narrowed_by_flow =
+                    object_type != class_this_type && original_object_type != class_this_type;
+                if !was_narrowed_by_flow {
+                    return (class_this_type, class_this_type);
+                }
+            }
+        }
+        (object_type, display_object_type)
+    }
+}

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -1410,12 +1410,38 @@ impl<'a> CheckerState<'a> {
 
     /// Set or clear the marker-only bit for an optional-chain node. Producers
     /// call this on every recomputation so speculative or stale entries
-    /// self-correct.
+    /// self-correct. The emptiness fast-path keeps clears free for programs
+    /// without optional chains.
     pub(crate) fn set_optional_chain_marker_only(&mut self, idx: NodeIndex, marker_only: bool) {
         if marker_only {
             self.ctx.optional_chain_marker_only_nodes.insert(idx.0);
-        } else {
+        } else if !self.ctx.optional_chain_marker_only_nodes.is_empty() {
             self.ctx.optional_chain_marker_only_nodes.remove(&idx.0);
+        }
+    }
+
+    /// Union the chain short-circuit `undefined` into an optional-chain result
+    /// and record the marker bit for `idx`; clears the bit when the chain
+    /// cannot short-circuit. Returns the result type and whether its
+    /// `undefined` is marker-only.
+    pub(crate) fn union_optional_chain_undefined(
+        &mut self,
+        idx: NodeIndex,
+        type_id: TypeId,
+        chain_can_short_circuit: bool,
+    ) -> (TypeId, bool) {
+        if chain_can_short_circuit {
+            let marker_only = self.record_optional_chain_marker(idx, type_id);
+            (
+                crate::query_boundaries::optional_chain::add_undefined_if_missing(
+                    self.ctx.types,
+                    type_id,
+                ),
+                marker_only,
+            )
+        } else {
+            self.set_optional_chain_marker_only(idx, false);
+            (type_id, false)
         }
     }
 
@@ -1430,7 +1456,7 @@ impl<'a> CheckerState<'a> {
         type_id: TypeId,
     ) -> TypeId {
         if self.ctx.optional_chain_marker_only_nodes.contains(&expr.0) {
-            tsz_solver::narrowing::remove_undefined(self.ctx.types.as_type_database(), type_id)
+            crate::query_boundaries::common::remove_undefined(self.ctx.types, type_id)
         } else {
             type_id
         }

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -1394,18 +1394,12 @@ impl<'a> CheckerState<'a> {
     /// contains `undefined`, that `undefined` is inherent and must survive
     /// marker removal. Mirrors tsc's `addOptionalTypeMarker`, which keeps the
     /// chain-introduced `undefined` distinguishable from a member's own.
-    /// Returns the recorded marker-only bit.
-    pub(crate) fn record_optional_chain_marker(
-        &mut self,
-        idx: NodeIndex,
-        pre_marker: TypeId,
-    ) -> bool {
+    pub(crate) fn record_optional_chain_marker(&mut self, idx: NodeIndex, pre_marker: TypeId) {
         let inherent = crate::query_boundaries::common::type_contains_undefined(
             self.ctx.types.as_type_database(),
             pre_marker,
         );
         self.set_optional_chain_marker_only(idx, !inherent);
-        !inherent
     }
 
     /// Set or clear the marker-only bit for an optional-chain node. Producers

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -1388,6 +1388,76 @@ impl<'a> CheckerState<'a> {
         split
     }
 
+    /// Record whether `idx`'s optional-chain result type owes its `undefined`
+    /// member solely to chain short-circuiting. `pre_marker` is the result
+    /// type before the chain's `| undefined` was unioned in; when it already
+    /// contains `undefined`, that `undefined` is inherent and must survive
+    /// marker removal. Mirrors tsc's `addOptionalTypeMarker`, which keeps the
+    /// chain-introduced `undefined` distinguishable from a member's own.
+    /// Returns the recorded marker-only bit.
+    pub(crate) fn record_optional_chain_marker(
+        &mut self,
+        idx: NodeIndex,
+        pre_marker: TypeId,
+    ) -> bool {
+        let inherent = crate::query_boundaries::common::type_contains_undefined(
+            self.ctx.types.as_type_database(),
+            pre_marker,
+        );
+        self.set_optional_chain_marker_only(idx, !inherent);
+        !inherent
+    }
+
+    /// Set or clear the marker-only bit for an optional-chain node. Producers
+    /// call this on every recomputation so speculative or stale entries
+    /// self-correct.
+    pub(crate) fn set_optional_chain_marker_only(&mut self, idx: NodeIndex, marker_only: bool) {
+        if marker_only {
+            self.ctx.optional_chain_marker_only_nodes.insert(idx.0);
+        } else {
+            self.ctx.optional_chain_marker_only_nodes.remove(&idx.0);
+        }
+    }
+
+    /// tsc `removeOptionalTypeMarker`: strip `undefined` from a chain node's
+    /// type only when it was introduced by the chain short-circuit. Inherent
+    /// nullishness (an optional member's own `undefined`, or `null`) stays,
+    /// so the normal possibly-nullish checks (TS18047/TS18048/TS2721/TS2722)
+    /// still fire on chain continuations like `o?.f()` and `o?.f.g`.
+    pub(crate) fn remove_optional_chain_marker(
+        &mut self,
+        expr: NodeIndex,
+        type_id: TypeId,
+    ) -> TypeId {
+        if self.ctx.optional_chain_marker_only_nodes.contains(&expr.0) {
+            tsz_solver::narrowing::remove_undefined(self.ctx.types.as_type_database(), type_id)
+        } else {
+            type_id
+        }
+    }
+
+    /// Flow-narrow the remainder of an optional-chain node's type on the cold
+    /// (possibly-nullish) path. `apply_flow_narrowing` skips `?.` access nodes
+    /// as a hot-path optimization, so a guard like `if (o?.f) o?.f()` has not
+    /// been applied to the chain node's type when a continuation consumes it.
+    /// Returns the type unchanged unless it still carries nullish members, so
+    /// successful marker-only chains pay no flow-analysis cost.
+    pub(crate) fn flow_narrow_optional_chain_remainder(
+        &mut self,
+        expr: NodeIndex,
+        type_id: TypeId,
+    ) -> TypeId {
+        let (_, nullish) = self.split_nullish_type(type_id);
+        if nullish.is_none() {
+            return type_id;
+        }
+        let Some(flow_node) = self.flow_node_for_reference_usage(expr) else {
+            return type_id;
+        };
+        self.flow_analyzer_for_property_reads()
+            .get_flow_type(expr, type_id, flow_node)
+    }
+
     /// Check if a node is a literal `null` keyword or an identifier named `undefined`.
     /// Used to distinguish `null.foo` / `undefined.bar` from `x.foo` where `x: null`.
     pub(crate) fn is_literal_null_or_undefined_node(&self, idx: NodeIndex) -> bool {

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -1431,14 +1431,15 @@ impl<'a> CheckerState<'a> {
         chain_can_short_circuit: bool,
     ) -> (TypeId, bool) {
         if chain_can_short_circuit {
-            let marker_only = self.record_optional_chain_marker(idx, type_id);
-            (
-                crate::query_boundaries::optional_chain::add_undefined_if_missing(
-                    self.ctx.types,
-                    type_id,
-                ),
-                marker_only,
-            )
+            let result = crate::query_boundaries::optional_chain::add_undefined_if_missing(
+                self.ctx.types,
+                type_id,
+            );
+            // `undefined` was newly added exactly when the member lacked its
+            // own `undefined` — the marker-only case.
+            let marker_only = result != type_id;
+            self.set_optional_chain_marker_only(idx, marker_only);
+            (result, marker_only)
         } else {
             self.set_optional_chain_marker_only(idx, false);
             (type_id, false)

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1276,6 +1276,13 @@ pub(super) const fn is_real_syntax_error(code: u32) -> bool {
         | 1438 // Interface must be given a name (recovery creates invalid expression statements)
         | 1442 // Identifier or expression expected (TS-only construct in JS)
         | 1477 // Member must have an initializer
+        // TS18030 is emitted by tsc's parser (`parseErrorAtRange` on a private
+        // identifier in an optional chain), so it belongs to the syntactic
+        // phase: tsc reports it and then skips the whole program's semantic
+        // diagnostics. Without this entry a chain continuation such as
+        // `o?.a.#b` would still surface the receiver's possibly-nullish
+        // TS2532/TS18048, which tsc suppresses.
+        | 18030 // An optional chain cannot contain private identifiers
     )
 }
 

--- a/crates/tsz-cli/src/driver/tests_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/tests_diagnostics.rs
@@ -303,6 +303,105 @@ fn js_only_syntactic_error_suppresses_semantic_diagnostics_program_wide() {
     }
 }
 
+/// Regression test for `conformance/.../privateIdentifierChain.1.ts`.
+///
+/// A private identifier in an optional chain (`o?.a.#b`) is a parser grammar
+/// error (`TS18030`, emitted by `parseErrorAtRange`). Because tsc surfaces it
+/// in the syntactic phase, `emitFilesAndReportErrors` then skips
+/// `getSemanticDiagnostics` for the whole program. So the receiver's own
+/// possibly-nullish diagnostics (`TS2532`/`TS18048`) — and any unrelated
+/// semantic error in another file — must be suppressed, while `TS18030`
+/// itself survives.
+#[test]
+fn private_identifier_chain_grammar_error_suppresses_semantic_diagnostics_program_wide() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let base = dir.path();
+
+    // `this?.a.#b`: `a?` is optional so the receiver `this?.a` is possibly
+    // undefined; without the syntactic gate the checker would emit TS2532.
+    fs::write(
+        base.join("a.ts"),
+        "class A {\n    a?: A;\n    #b?: A;\n    m() {\n        this?.a.#b;\n    }\n}\n",
+    )
+    .expect("write a.ts");
+    // An unrelated semantic error in a second file proves the gate is
+    // program-wide, not just file-local.
+    fs::write(base.join("b.ts"), "let n: number = \"s\";\n").expect("write b.ts");
+    fs::write(
+        base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "strict": true,
+            "target": "esnext",
+            "useDefineForClassFields": false,
+            "noEmit": true
+          },
+          "files": ["a.ts", "b.ts"]
+        }"#,
+    )
+    .expect("write tsconfig");
+
+    let args = CliArgs::try_parse_from(["tsz", "--project", "tsconfig.json"]).expect("parse args");
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+
+    assert!(
+        codes.contains(&18030),
+        "Expected TS18030 for the private identifier in an optional chain, got: {:?}",
+        result.diagnostics,
+    );
+    for &suppressed in &[2532_u32, 18048, 2322] {
+        assert!(
+            !codes.contains(&suppressed),
+            "TS{suppressed} must be suppressed program-wide when a TS18030 grammar error exists; got: {:?}",
+            result.diagnostics,
+        );
+    }
+}
+
+/// Control for the gate above: with a *public* member continuation
+/// (`this?.a.b`) there is no grammar error, so the receiver's possibly-nullish
+/// `TS2532` must still be reported. Guards against over-suppression.
+#[test]
+fn public_optional_chain_continuation_keeps_possibly_nullish_diagnostic() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let base = dir.path();
+
+    fs::write(
+        base.join("a.ts"),
+        "class A {\n    a?: A;\n    b?: A;\n    m() {\n        this?.a.b;\n    }\n}\n",
+    )
+    .expect("write a.ts");
+    fs::write(
+        base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "strict": true,
+            "target": "esnext",
+            "useDefineForClassFields": false,
+            "noEmit": true
+          },
+          "files": ["a.ts"]
+        }"#,
+    )
+    .expect("write tsconfig");
+
+    let args = CliArgs::try_parse_from(["tsz", "--project", "tsconfig.json"]).expect("parse args");
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+
+    assert!(
+        codes.contains(&2532),
+        "Expected TS2532 for the possibly-undefined receiver `this?.a`, got: {:?}",
+        result.diagnostics,
+    );
+    assert!(
+        !codes.contains(&18030),
+        "No private identifier here, so TS18030 must not appear, got: {:?}",
+        result.diagnostics,
+    );
+}
+
 /// Regression test for `conformance/salsa/plainJSGrammarErrors.ts`.
 ///
 /// When a JavaScript file emits a TS-only-syntactic diagnostic (e.g. `TS8009`

--- a/crates/tsz-parser/src/parser/node.rs
+++ b/crates/tsz-parser/src/parser/node.rs
@@ -270,6 +270,12 @@ pub struct CallExprData {
     pub expression: NodeIndex,
     pub type_arguments: Option<NodeList>,
     pub arguments: Option<NodeList>,
+    /// `true` when the call itself is written with `?.` before its argument
+    /// list (`f?.()`, `o.m?.<T>()`), mirroring tsc's `questionDotToken` on
+    /// `CallChain`. A call that merely continues a chain (`o?.f()`) carries
+    /// the `OPTIONAL_CHAIN` node flag but leaves this `false`; the distinction
+    /// decides whether `?.` guards the invoked value itself.
+    pub question_dot_token: bool,
 }
 
 /// Data for property/element access

--- a/crates/tsz-parser/src/parser/state_expressions_call_member.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_call_member.rs
@@ -191,6 +191,7 @@ impl ParserState {
                         CallExprData {
                             expression: expr,
                             type_arguments: None,
+                            question_dot_token: false,
                             arguments: Some(arguments),
                         },
                     );
@@ -237,6 +238,7 @@ impl ParserState {
                                 CallExprData {
                                     expression: expr,
                                     type_arguments: Some(type_args),
+                                    question_dot_token: true,
                                     arguments: Some(arguments),
                                 },
                             );
@@ -277,6 +279,7 @@ impl ParserState {
                             CallExprData {
                                 expression: expr,
                                 type_arguments: Some(type_args),
+                                question_dot_token: true,
                                 arguments: Some(Self::make_node_list(Vec::new())),
                             },
                         );
@@ -319,6 +322,7 @@ impl ParserState {
                             CallExprData {
                                 expression: expr,
                                 type_arguments: None,
+                                question_dot_token: true,
                                 arguments: Some(arguments),
                             },
                         );
@@ -435,6 +439,7 @@ impl ParserState {
                                 CallExprData {
                                     expression: expr,
                                     type_arguments: Some(type_args),
+                                    question_dot_token: false,
                                     arguments: Some(arguments),
                                 },
                             );
@@ -488,6 +493,7 @@ impl ParserState {
                                 CallExprData {
                                     expression: expr,
                                     type_arguments: Some(type_args),
+                                    question_dot_token: false,
                                     arguments: Some(arguments),
                                 },
                             );

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -1059,6 +1059,7 @@ impl ParserState {
                 expression: import_node,
                 type_arguments: import_call_type_arguments,
                 arguments: Some(arguments),
+                question_dot_token: false,
             },
         )
     }
@@ -1729,6 +1730,7 @@ impl ParserState {
                 expression,
                 type_arguments,
                 arguments,
+                question_dot_token: false,
             },
         )
     }

--- a/crates/tsz-parser/src/parser/state_statements_class_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_declarations.rs
@@ -1280,6 +1280,7 @@ impl ParserState {
                             expression: expr,
                             type_arguments: Some(Self::make_node_list(type_args)),
                             arguments: Some(args),
+                            question_dot_token: false,
                         },
                     ))
                 } else {
@@ -1305,6 +1306,7 @@ impl ParserState {
                         expression: expr,
                         type_arguments: None,
                         arguments: Some(args),
+                        question_dot_token: false,
                     },
                 ))
             }

--- a/crates/tsz-solver/src/narrowing/cache.rs
+++ b/crates/tsz-solver/src/narrowing/cache.rs
@@ -12,8 +12,19 @@ type DiscriminantIndex = FxHashMap<(TypeId, Atom), Arc<DiscriminantMembers>>;
 type PropertyCacheKey = (TypeId, Atom);
 type NarrowedPropertyCache = GenerationMemo<PropertyCacheKey, Option<CachedPropertyType>>;
 type RequiredPropertyCache = GenerationMemo<PropertyCacheKey, bool>;
-type OptionalChainCache = GenerationMemo<PropertyCacheKey, TypeId>;
-type OptionalPropertyChainCache = GenerationMemo<OptionalPropertyChainKey, TypeId>;
+type OptionalChainCache = GenerationMemo<PropertyCacheKey, CachedChainType>;
+type OptionalPropertyChainCache = GenerationMemo<OptionalPropertyChainKey, CachedChainType>;
+
+/// Final optional-chain read result plus whether its `undefined` member exists
+/// only because the chain can short-circuit (the equivalent of tsc's
+/// optional-type marker). Chain continuations remove `undefined` from the
+/// receiver only when `undefined_is_marker_only` is set, so a member's own
+/// `undefined` still drives the possibly-nullish diagnostics.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CachedChainType {
+    pub type_id: TypeId,
+    pub undefined_is_marker_only: bool,
+}
 
 /// Cache key for a successful identifier-rooted optional property chain.
 ///

--- a/crates/tsz-solver/src/narrowing/cache.rs
+++ b/crates/tsz-solver/src/narrowing/cache.rs
@@ -26,6 +26,16 @@ pub struct CachedChainType {
     pub undefined_is_marker_only: bool,
 }
 
+impl CachedChainType {
+    #[must_use]
+    pub const fn new(type_id: TypeId, undefined_is_marker_only: bool) -> Self {
+        Self {
+            type_id,
+            undefined_is_marker_only,
+        }
+    }
+}
+
 /// Cache key for a successful identifier-rooted optional property chain.
 ///
 /// The root is semantic (`TypeId`), while the path uses interned property

--- a/crates/tsz-solver/src/narrowing/cache/cache_visibility_tests.rs
+++ b/crates/tsz-solver/src/narrowing/cache/cache_visibility_tests.rs
@@ -48,18 +48,12 @@ fn narrowing_cache_statistics_report_entries_and_size() {
     cache.optional_chain_cache.borrow_mut().insert(
         (TypeId::STRING, prop),
         7,
-        CachedChainType {
-            type_id: TypeId::BOOLEAN,
-            undefined_is_marker_only: false,
-        },
+        CachedChainType::new(TypeId::BOOLEAN, false),
     );
     cache.optional_property_chain_cache.borrow_mut().insert(
         chain_key,
         7,
-        CachedChainType {
-            type_id: TypeId::BOOLEAN,
-            undefined_is_marker_only: false,
-        },
+        CachedChainType::new(TypeId::BOOLEAN, false),
     );
     cache
         .contextual_resolve_cache
@@ -127,18 +121,12 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
         cache.optional_chain_cache.borrow_mut().insert(
             property_key,
             generation,
-            CachedChainType {
-                type_id: TypeId::BOOLEAN,
-                undefined_is_marker_only: false,
-            },
+            CachedChainType::new(TypeId::BOOLEAN, false),
         );
         cache.optional_property_chain_cache.borrow_mut().insert(
             chain_key.clone(),
             generation,
-            CachedChainType {
-                type_id: TypeId::NUMBER,
-                undefined_is_marker_only: false,
-            },
+            CachedChainType::new(TypeId::NUMBER, false),
         );
         cache.narrow_type_cache.borrow_mut().insert(
             request_key.clone(),
@@ -209,10 +197,7 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
     );
     assert_eq!(
         cache.optional_chain_cache.borrow().get(&property_key, 7),
-        Some(CachedChainType {
-            type_id: TypeId::BOOLEAN,
-            undefined_is_marker_only: false,
-        })
+        Some(CachedChainType::new(TypeId::BOOLEAN, false))
     );
     assert_eq!(
         cache
@@ -226,10 +211,7 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
             .optional_property_chain_cache
             .borrow()
             .get(&chain_key, 7),
-        Some(CachedChainType {
-            type_id: TypeId::NUMBER,
-            undefined_is_marker_only: false,
-        })
+        Some(CachedChainType::new(TypeId::NUMBER, false))
     );
     assert_eq!(cache.narrow_type_cache.borrow().get(&request_key, 1), None);
     assert_eq!(
@@ -254,26 +236,17 @@ fn optional_chain_caches_serve_only_matching_resolver_generation() {
     cache.optional_chain_cache.borrow_mut().insert(
         property_key,
         3,
-        CachedChainType {
-            type_id: TypeId::BOOLEAN,
-            undefined_is_marker_only: false,
-        },
+        CachedChainType::new(TypeId::BOOLEAN, false),
     );
     cache.optional_property_chain_cache.borrow_mut().insert(
         chain_key.clone(),
         3,
-        CachedChainType {
-            type_id: TypeId::NUMBER,
-            undefined_is_marker_only: false,
-        },
+        CachedChainType::new(TypeId::NUMBER, false),
     );
 
     assert_eq!(
         cache.optional_chain_cache.borrow().get(&property_key, 3),
-        Some(CachedChainType {
-            type_id: TypeId::BOOLEAN,
-            undefined_is_marker_only: false,
-        })
+        Some(CachedChainType::new(TypeId::BOOLEAN, false))
     );
     assert_eq!(
         cache.optional_chain_cache.borrow().get(&property_key, 4),
@@ -284,10 +257,7 @@ fn optional_chain_caches_serve_only_matching_resolver_generation() {
             .optional_property_chain_cache
             .borrow()
             .get(&chain_key, 3),
-        Some(CachedChainType {
-            type_id: TypeId::NUMBER,
-            undefined_is_marker_only: false,
-        })
+        Some(CachedChainType::new(TypeId::NUMBER, false))
     );
     assert_eq!(
         cache

--- a/crates/tsz-solver/src/narrowing/cache/cache_visibility_tests.rs
+++ b/crates/tsz-solver/src/narrowing/cache/cache_visibility_tests.rs
@@ -45,14 +45,22 @@ fn narrowing_cache_statistics_report_entries_and_size() {
         .contains_type_parameters_cache
         .borrow_mut()
         .insert(TypeId::STRING, false);
-    cache
-        .optional_chain_cache
-        .borrow_mut()
-        .insert((TypeId::STRING, prop), 7, TypeId::BOOLEAN);
-    cache
-        .optional_property_chain_cache
-        .borrow_mut()
-        .insert(chain_key, 7, TypeId::BOOLEAN);
+    cache.optional_chain_cache.borrow_mut().insert(
+        (TypeId::STRING, prop),
+        7,
+        CachedChainType {
+            type_id: TypeId::BOOLEAN,
+            undefined_is_marker_only: false,
+        },
+    );
+    cache.optional_property_chain_cache.borrow_mut().insert(
+        chain_key,
+        7,
+        CachedChainType {
+            type_id: TypeId::BOOLEAN,
+            undefined_is_marker_only: false,
+        },
+    );
     cache
         .contextual_resolve_cache
         .borrow_mut()
@@ -116,14 +124,21 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
             .required_property_cache
             .borrow_mut()
             .insert(property_key, generation, true);
-        cache
-            .optional_chain_cache
-            .borrow_mut()
-            .insert(property_key, generation, TypeId::BOOLEAN);
+        cache.optional_chain_cache.borrow_mut().insert(
+            property_key,
+            generation,
+            CachedChainType {
+                type_id: TypeId::BOOLEAN,
+                undefined_is_marker_only: false,
+            },
+        );
         cache.optional_property_chain_cache.borrow_mut().insert(
             chain_key.clone(),
             generation,
-            TypeId::NUMBER,
+            CachedChainType {
+                type_id: TypeId::NUMBER,
+                undefined_is_marker_only: false,
+            },
         );
         cache.narrow_type_cache.borrow_mut().insert(
             request_key.clone(),
@@ -194,7 +209,10 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
     );
     assert_eq!(
         cache.optional_chain_cache.borrow().get(&property_key, 7),
-        Some(TypeId::BOOLEAN)
+        Some(CachedChainType {
+            type_id: TypeId::BOOLEAN,
+            undefined_is_marker_only: false,
+        })
     );
     assert_eq!(
         cache
@@ -208,7 +226,10 @@ fn generation_stamped_narrowing_caches_bound_retained_generations() {
             .optional_property_chain_cache
             .borrow()
             .get(&chain_key, 7),
-        Some(TypeId::NUMBER)
+        Some(CachedChainType {
+            type_id: TypeId::NUMBER,
+            undefined_is_marker_only: false,
+        })
     );
     assert_eq!(cache.narrow_type_cache.borrow().get(&request_key, 1), None);
     assert_eq!(
@@ -230,18 +251,29 @@ fn optional_chain_caches_serve_only_matching_resolver_generation() {
     };
     let cache = NarrowingCache::new();
 
-    cache
-        .optional_chain_cache
-        .borrow_mut()
-        .insert(property_key, 3, TypeId::BOOLEAN);
-    cache
-        .optional_property_chain_cache
-        .borrow_mut()
-        .insert(chain_key.clone(), 3, TypeId::NUMBER);
+    cache.optional_chain_cache.borrow_mut().insert(
+        property_key,
+        3,
+        CachedChainType {
+            type_id: TypeId::BOOLEAN,
+            undefined_is_marker_only: false,
+        },
+    );
+    cache.optional_property_chain_cache.borrow_mut().insert(
+        chain_key.clone(),
+        3,
+        CachedChainType {
+            type_id: TypeId::NUMBER,
+            undefined_is_marker_only: false,
+        },
+    );
 
     assert_eq!(
         cache.optional_chain_cache.borrow().get(&property_key, 3),
-        Some(TypeId::BOOLEAN)
+        Some(CachedChainType {
+            type_id: TypeId::BOOLEAN,
+            undefined_is_marker_only: false,
+        })
     );
     assert_eq!(
         cache.optional_chain_cache.borrow().get(&property_key, 4),
@@ -252,7 +284,10 @@ fn optional_chain_caches_serve_only_matching_resolver_generation() {
             .optional_property_chain_cache
             .borrow()
             .get(&chain_key, 3),
-        Some(TypeId::NUMBER)
+        Some(CachedChainType {
+            type_id: TypeId::NUMBER,
+            undefined_is_marker_only: false,
+        })
     );
     assert_eq!(
         cache

--- a/crates/tsz-solver/src/narrowing/mod.rs
+++ b/crates/tsz-solver/src/narrowing/mod.rs
@@ -48,7 +48,9 @@ pub use utils::{
 // Re-export public items from compound narrowing
 pub use self::compound::NullishFilter;
 
-pub use self::cache::{CachedPropertyType, NarrowingCache, OptionalPropertyChainKey};
+pub use self::cache::{
+    CachedChainType, CachedPropertyType, NarrowingCache, OptionalPropertyChainKey,
+};
 
 pub use self::guard::{GuardSense, TypeGuard, TypeofKind};
 

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -94,9 +94,9 @@ active campaigns.
   test out of the shard failure set.
 - Output-surgery audit stays at zero unallowlisted calls and zero allowlist
   entries.
-- CheckerContext field-count guard is ratcheted at `252` fields after adding
-  `type_position_resolution_cache` (a per-file memo of type-position identifier
-  resolution; #13987). Future work should reduce this through capability
+- CheckerContext field-count guard is ratcheted at `254` fields after adding
+  `optional_chain_marker_only_nodes` (per-node optional-chain marker positions
+  for tsc's optional-type-marker semantics; #15691). Future work should reduce this through capability
   extraction rather than silently adding checker-global state.
 
 ## How To Pick Work

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1213,7 +1213,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        253,
+        254,
     ),
 ]
 


### PR DESCRIPTION
Fixes #15682.

Structural rule: when a call or member access continues an optional chain but the `?.` token does not directly guard the consumed value (`o?.f()` as opposed to `o.f?.()`), tsc strips only the chain-introduced `undefined` (the optional-type marker in `getOptionalExpressionType` / `removeOptionalTypeMarker`) and then runs the normal possibly-nullish checks; tsz does X through a per-node optional-chain marker recorded by the chain producers (checker) and consumed by `remove_optional_chain_marker` at the three continuation consumers (call callee, property access, element access). A member whose own type includes `undefined`/`null` now reports TS2721/TS2722/TS2723 (calls) and TS18047/TS18048/TS2532 (member/element reads) exactly like tsc; tsz previously split off all nullish members at once and silently accepted the whole family.

## What

- **Parser**: `CallExprData` gains `question_dot_token`, mirroring tsc's `questionDotToken` on `CallChain`. Before this, `o?.f()` and `o?.f?.()` were indistinguishable in the AST (the emitter even back-scans source text to recover the token; unifying that is left as follow-up).
- **Checker (owner layer)**: chain producers record whether the node's `undefined` is chain-introduced only (`union_optional_chain_undefined`); the two type-keyed chain caches (`optional_chain_cache`, `optional_property_chain_cache`) store the bit and replay it per node on hits so repeated identical chains keep per-occurrence diagnostics.
- **Flow references**: `property_reference` no longer refuses `?.` accesses, so `if (o.f) o?.f()` and `if (o?.f) o.f()` match the same reference (tsc's `isMatchingReference` ignores the token).
- **Cold-path narrowing**: when inherent nullishness survives marker removal, the continuation consults flow narrowing before diagnosing (`flow_narrow_optional_chain_remainder`); the `apply_flow_narrowing` hot-path skip for `?.` nodes is untouched, so clean marker-only chains pay no flow cost.

## Adjacent matrix (all verified against tsc 6.0.2, strict and non-strict)

- `o?.f()` with `f?:` → TS2722; with `f: T | null` → TS2721; with `f: undefined` → TS2722; required `f` → clean with `ret | undefined`.
- `o.f?.()`, `o?.f?.()`, `fn?.()` → clean (the `?.` guards the callee).
- `o?.f.g()` (leaf inherent) → TS2722; `o?.f.g()` (middle inherent) → TS18048 only; `o?.f.g` → TS18048 `'o.f'`; `o?.f["g"]` → TS18048; `o?.f?.().x` → TS2532.
- Guards: `if (o?.f) { o.f(); o?.f(); }`, `if (o !== undefined && o.f !== undefined) o?.f();`, guarded property/element continuations → clean.
- Entirely-nullish receiver `o10?.f()` (`o10: undefined`) → TS2339 only (companion suppression preserved).
- Repeated identical chains (cache hits) report per occurrence; renamed binders throughout.

Known pre-existing divergences left alone (not introduced here): element access on `never` reports TS2339 where tsc reports TS2349, and the *result type* of a guarded chain read (`const t = o?.f` inside `if (o?.f)`) is not flow-narrowed because of the `apply_flow_narrowing` `?.` skip. A solver-intrinsic marker type (tsc's `optionalType`) would let the marker ride the type itself instead of a checker-side node set; that is the deeper design but a large solver blast radius (union interning, relations, display), noted as follow-up.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --lib -E 'test(optional_chain_inherent_nullish)'` — 15 new tests, all pass (reported repro, adjacent matrix, guards, cache-replay cases).
- `cargo nextest run -p tsz-checker --lib -E 'test(optional) or test(chain) or test(nullish) or test(narrow) or test(2722) or test(18048) or test(2532)'` — 1022 tests, 3 failures all reproduced on the base commit (pre-existing).
- `cargo nextest run -p tsz-parser` — 1484 pass; `cargo nextest run -p tsz-solver` — 3 failures, all pre-existing on base.
- Differential matrices vs tsc 6.0.2 (44 cases across 4 files, strict + non-strict): byte-identical diagnostics except the two pre-existing divergences noted above.
- `cargo clippy -p tsz-parser -p tsz-solver -p tsz-checker --all-targets` clean; ready-review CI owns conformance/emit/fourslash.
- `/simplify` ×3 applied (shared producer helper, cache constructor, query-boundary routing, hot-path clear removed).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude (id withheld by harness policy)
Effort: high

https://claude.ai/code/session_014YTG8VCtFkAq55MQQovV9D

---
_Generated by [Claude Code](https://claude.ai/code/session_014YTG8VCtFkAq55MQQovV9D)_