### PR TITLE
test(checker): align member reassignment flow oracle

### DIFF
--- a/crates/tsz-checker/src/tests/member_assignment_narrowing_join_tests.rs
+++ b/crates/tsz-checker/src/tests/member_assignment_narrowing_join_tests.rs
@@ -11,8 +11,9 @@
 //! guard's narrowing is preserved. Owner layer: checker flow narrowing
 //! (`flow/control_flow/core/flow_traversal.rs`).
 //!
-//! Negatives: a *direct* reassignment of `m` itself (`m = undefined`,
-//! `m = maybe`) is a real definition and still un-narrows `m`.
+//! A direct reassignment follows the right-hand side's current flow type. It
+//! un-narrows `m` only when that type still includes `undefined`; an annotated
+//! local initialized from the narrowed `m` remains flow-narrowed to `M`.
 
 use crate::context::CheckerOptions;
 use crate::test_utils::{check_with_options, diagnostic_count};
@@ -114,11 +115,23 @@ fn direct_reassign_undefined_after_join_keeps_ts18048() {
 
 #[test]
 fn direct_reassign_maybe_after_join_keeps_ts18048() {
-    let diags = check("if (m) { if (cond) {} let maybe: M | undefined = m; m = maybe; m.id; }");
+    let diags = check(
+        "if (m) { if (cond) {} let maybe: M | undefined = cond ? m : undefined; m = maybe; m.id; }",
+    );
     assert_eq!(
         diagnostic_count(&diags, 18048),
         1,
-        "reassigning m to a possibly-undefined value after the guard must still report TS18048: {diags:?}"
+        "reassigning m from a flow type that includes undefined must still report TS18048: {diags:?}"
+    );
+}
+
+#[test]
+fn direct_reassign_flow_narrowed_alias_after_join_stays_clean() {
+    let diags = check("if (m) { if (cond) {} let maybe: M | undefined = m; m = maybe; m.id; }");
+    assert_eq!(
+        diagnostic_count(&diags, 18048),
+        0,
+        "an annotated alias initialized from narrowed m has current flow type M: {diags:?}"
     );
 }
 


### PR DESCRIPTION
Goal: hold

## Summary

- Align the direct member reassignment regression with the pinned TypeScript 6.0.3 oracle.
- Structural rule: when a narrowed variable is copied into an annotated union local, flow analysis uses the initializer current type; assigning that alias back remains narrowed. A conditional RHS that can still produce undefined remains the negative case.
- Owner layer remains checker flow narrowing; this is a stale-oracle correction with an adjacent positive and negative matrix and no compiler behavior change.

## Verification

- Pinned TypeScript 6.0.3 oracle: the original flow-narrowed alias witness is clean; the conditional possibly-undefined witness emits TS18048.
- `cargo nextest run -p tsz-checker --lib member_assignment_narrowing_join_tests`: 11 passed, 0 failed.
- Clean current-main baseline: 18,071 tests; 17,966 passed; 105 raw failures; 15 skipped; 97 canonical failures.
- Full post-change checker run: 18,072 tests; 17,968 passed; 104 raw failures; 15 skipped; 96 canonical failures.
- Canonical failure-set diff: removed only `member_assignment_narrowing_join_tests::direct_reassign_maybe_after_join_keeps_ts18048`; added none.
- `cargo fmt --all -- --check`
- `cargo clippy -p tsz-checker --all-targets`
- `git diff --check`

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5
Effort: max