### PR TITLE
test(checker): align recursive diagnostic count oracle

### DIFF
--- a/crates/tsz-checker/tests/recursive_type_references_tests.rs
+++ b/crates/tsz-checker/tests/recursive_type_references_tests.rs
@@ -305,8 +305,18 @@ let s: string = 1;
         .collect();
     assert_eq!(
         number_to_string.len(),
-        1,
-        "Expected unrelated TS2322 messages to survive recursive rewrite filtering: {diagnostics:?}"
+        2,
+        "Expected both unrelated TS2322 messages to survive recursive rewrite filtering: {diagnostics:?}"
+    );
+
+    let spans: HashSet<_> = number_to_string
+        .iter()
+        .map(|diag| (diag.start, diag.length))
+        .collect();
+    assert_eq!(
+        spans,
+        HashSet::from([(382, 1), (418, 1)]),
+        "Expected the matching TS2322 messages at the flat1 call and unrelated assignment: {diagnostics:?}"
     );
 }
 


### PR DESCRIPTION
Goal: hold

## Summary

- Align the recursive-array diagnostic preservation test with the pinned TypeScript 6.0.3 oracle.
- Structural rule: recursive-alias diagnostic deduplication may remove duplicate emissions at the same source location, but it must preserve identical TS2322 messages originating at distinct source spans.
- The witness has two legitimate `Type number is not assignable to type string` diagnostics: one inside the `flat1` call and one at the unrelated assignment. The test now requires both exact spans, preventing either accidental suppression or duplicate-at-one-span false positives.
- This is a stale-oracle correction; checker and solver behavior are unchanged.

## Verification

- Pinned TypeScript 6.0.3 oracle: two matching TS2322 diagnostics at starts 382 and 418, each length 1.
- `cargo nextest run -p tsz-checker --test recursive_type_references_tests`: 9 passed, 0 failed.
- Clean current-main baseline: 18,071 tests; 17,966 passed; 105 raw failures; 15 skipped; 97 canonical failures.
- Full post-change checker run: 18,071 tests; 17,967 passed; 104 raw failures; 15 skipped; 96 canonical failures.
- Canonical failure-set diff: removed only `recursive_type_references_tests::recursive_array_rewrite_preserves_unrelated_same_message_diagnostics`; added none.
- `cargo fmt --all -- --check`
- `cargo clippy -p tsz-checker --all-targets`
- `git diff --check`

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5
Effort: max