### PR TITLE
test(checker): align assignability cache ownership ratchet

### DIFF
--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
@@ -452,8 +452,8 @@ fn test_array_helpers_avoid_direct_typekey_interning() {
         "assignability_checker infer-shape cacheability checks should route through query_boundaries::assignability"
     );
     assert!(
-        assignability_checker_src.contains("is_relation_cacheable("),
-        "assignability_checker should use query_boundaries::assignability::is_relation_cacheable for relation-cache gating"
+        !assignability_checker_src.contains("is_relation_cacheable("),
+        "assignability_checker should delegate relation-cache policy to boundary-owned cached_* helpers"
     );
 
     let mut state_type_environment_src = fs::read_to_string("src/state/type_environment/mod.rs")
@@ -488,8 +488,8 @@ fn test_array_helpers_avoid_direct_typekey_interning() {
         "state_type_environment relation precondition setup should route through ensure_relation_input_ready"
     );
     assert!(
-        state_type_environment_src.contains("collect_type_queries("),
-        "state_type_environment should use solver collect_type_queries visitor helper for type-query symbol preconditions"
+        state_type_environment_src.contains("collect_type_queries_cached("),
+        "state_type_environment should use the context-memoized solver type-query collector for symbol preconditions"
     );
     assert!(
         state_type_environment_src.contains("resolve_lazy_def_for_type_env("),


### PR DESCRIPTION
Goal: hold

## Summary

- Align the architecture ratchet with the current assignability cache boundary.
- Structural rule: checker assignability orchestration delegates cacheability, lookup, relation execution, and insertion to `query_boundaries::assignability`; it must not call `is_relation_cacheable` directly.
- Update the same logical-module guard for the context-memoized `collect_type_queries_cached` path introduced by the type-query readiness cache.
- No compiler behavior or production code changes.

## Verification

- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --lib test_array_helpers_avoid_direct_typekey_interning --test-threads=2`: 1 passed.
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --lib architecture_contract_tests_src::part_00 --test-threads=2`: target passed; 26 passed overall, with only the two independent pre-existing architecture failures (`test_def_symbol_bridge_writes_route_through_dual_env_helper` and `test_no_push_diagnostic_outside_error_reporter`) remaining.
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo clippy -p tsz-checker --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- Disk guard after verification: 163 GiB free; 1.3 GiB hot `.target` cache preserved.

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5
Effort: max