### PR TITLE
test(checker): recognize deferred bridge write owner

### DIFF
--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
@@ -667,13 +667,16 @@ fn test_def_symbol_bridge_writes_route_through_dual_env_helper() {
     let mut files = Vec::new();
     collect_checker_rs_files(Path::new("src"), &mut files);
 
-    let helper_path = Path::new("src/context/def_mapping.rs");
+    let helper_paths = [
+        Path::new("src/context/def_mapping.rs"),
+        Path::new("src/context/deferred_flow_env_write.rs"),
+    ];
     let method = "register_def_symbol_mapping";
     let needle = format!(".{method}(");
     let mut offenders = Vec::new();
 
     for path in files {
-        if path == helper_path {
+        if helper_paths.contains(&path.as_path()) {
             continue;
         }
         let source = fs::read_to_string(&path).unwrap_or_default();


### PR DESCRIPTION
Goal: hold

## Summary

- Update the dual-environment DefId/SymbolId bridge ratchet after the context-owned leaf replay moved from `def_mapping.rs` into `deferred_flow_env_write.rs`.
- Structural rule: callers must route bridge publication through `CheckerContext`; raw single-environment mutation is permitted only in the context authority and its deferred leaf apply operation.
- No production behavior changes and no new allowlist outside the owning context boundary.

## Verification

- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --lib test_def_symbol_bridge_writes_route_through_dual_env_helper --test-threads=2`: 1 passed.
- Source audit: all `DeferredFlowEnvWrite::RegisterDefSymbolMapping` construction remains in `context/def_mapping.rs`; the only raw `register_def_symbol_mapping` replay is the owning leaf in `context/deferred_flow_env_write.rs`.
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo clippy -p tsz-checker --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- Disk guard remained healthy at 163 GiB free; hot caches preserved.

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5
Effort: max