### PR TITLE
test(checker): follow split class member checks

### DIFF
--- a/crates/tsz-checker/tests/member_access_architecture_boundary_tests.rs
+++ b/crates/tsz-checker/tests/member_access_architecture_boundary_tests.rs
@@ -2,18 +2,18 @@ use std::fs;
 
 #[test]
 fn member_access_uses_centralized_mutual_assignability_gateway() {
-    // After the member_access.rs split, duplicate-property type consistency
-    // checks live in interface_checks.rs.
-    let source = fs::read_to_string("src/state/state_checking_members/interface_checks.rs")
-        .expect("failed to read src/state/state_checking_members/interface_checks.rs");
+    // After the member-checking splits, accessor/property type consistency
+    // checks live in class_member_checks.rs.
+    let source = fs::read_to_string("src/state/state_checking_members/class_member_checks.rs")
+        .expect("failed to read src/state/state_checking_members/class_member_checks.rs");
 
     assert!(
         !source.contains("&& self.is_assignable_to(current_type, *first_type)")
             && !source.contains("&& self.is_assignable_to(current_type, first_type)"),
-        "interface_checks should route bidirectional relation checks through are_mutually_assignable",
+        "class_member_checks should route bidirectional relation checks through are_mutually_assignable",
     );
     assert!(
         source.contains("are_mutually_assignable(first_type, current_type)"),
-        "interface_checks should use are_mutually_assignable for duplicate-property type consistency checks",
+        "class_member_checks should use are_mutually_assignable for duplicate-property type consistency checks",
     );
 }


### PR DESCRIPTION
Goal: hold

## Summary

- Repoint the mutual-assignability architecture scan after class duplicate-member checking moved from `interface_checks.rs` into `class_member_checks.rs`.
- Structural rule: class-member checking owns the TS2717 location, while bidirectional type comparability routes through `are_mutually_assignable` and the typed relation/query-boundary gateway.
- No production behavior changes.

## Verification

- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --lib member_access_uses_centralized_mutual_assignability_gateway --test-threads=2`: 1 passed.
- Source audit: `class_member_checks.rs` contains the centralized `are_mutually_assignable(first_type, current_type)` call and no direct paired `is_assignable_to` decision.
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo clippy -p tsz-checker --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- Verification stayed under a 16 GiB process-tree cap with two build/test workers.

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5
Effort: max