### PR TITLE
refactor(checker): route fixture replacements through reporter

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -986,7 +986,12 @@ impl CheckerState<'_> {
         });
         self.ctx.rebuild_emitted_diagnostics_from_current();
         for replacement in replacements {
-            self.ctx.push_diagnostic(replacement);
+            self.push_error_at(
+                replacement.start,
+                replacement.length,
+                replacement.message_text,
+                replacement.code,
+            );
         }
     }
 


### PR DESCRIPTION
Goal: hold

## Summary

- Route the source-file conditional-types compatibility shim through the existing `error_reporter::push_error_at` front door.
- Structural rule: source-file checking may own replacement selection and source spans, but diagnostic construction, deduplication, and emission belong to the error reporter.
- Preserve the exact replacement start, length, message, code, error category, current file, and the existing dedup-state rebuild sequence.
- No diagnostic oracle or compiler semantic behavior changes.

## Verification

- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --lib test_no_push_diagnostic_outside_error_reporter --test-threads=2`: 1 passed.
- Source audit: no production `push_diagnostic` call remains outside `error_reporter/` and the context method definition.
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo clippy -p tsz-checker --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- Verification stayed under a 16 GiB process-tree cap with two build/test workers.

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5
Effort: max