### PR TITLE
refactor(checker): route display reduction through boundary

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -1728,7 +1728,11 @@ impl<'a> CheckerState<'a> {
         }
         let deep_reduced = {
             let env = self.ctx.type_env.borrow();
-            tsz_solver::deep_reduce_for_display(self.ctx.types, &*env, evaluated)
+            crate::query_boundaries::diagnostics::deep_reduce_for_display(
+                self.ctx.types,
+                &*env,
+                evaluated,
+            )
         };
         if deep_reduced != evaluated && deep_reduced != target {
             return self.find_string_literal_spelling_suggestion(source, deep_reduced);


### PR DESCRIPTION
Goal: hold

## Summary
- route TS2820 deep display reduction through the existing diagnostics query boundary
- preserve the existing solver operation and diagnostic behavior
- restore the zero-tolerance checker boundary guard

Structural rule: when checker diagnostic rendering needs a deeply reduced display type, the error reporter asks the diagnostics query boundary; only that boundary reaches the solver display reducer.

Owner layer: checker diagnostic query boundary.

Adjacent matrix: conditional/template-infer near miss, renamed binders, and far-miss fallback.

## Verification
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --lib test_no_inline_solver_function_calls_in_checker_modules --test-threads=2`
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --test ts2322_tests ts2820_template_infer --test-threads=2`
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo clippy -p tsz-checker --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: max