### PR TITLE
refactor(checker): route solver imports through boundaries

### DIFF
--- a/crates/tsz-checker/src/context/canonical_app_key.rs
+++ b/crates/tsz-checker/src/context/canonical_app_key.rs
@@ -1,7 +1,7 @@
 //! Canonical key for the `type_resolution_visiting` cycle guard.
 
+use crate::query_boundaries::common::TypeDatabase;
 use tsz_solver::TypeId;
-use tsz_solver::construction::TypeDatabase;
 use tsz_solver::def::{DefId, DefinitionStore};
 
 use crate::query_boundaries::state::type_environment as query;

--- a/crates/tsz-checker/src/context/def_mapping_flow_mirror.rs
+++ b/crates/tsz-checker/src/context/def_mapping_flow_mirror.rs
@@ -2,9 +2,9 @@
 
 use crate::context::CheckerContext;
 use crate::context::deferred_flow_env_write::DeferredFlowEnvWrite;
+use crate::query_boundaries::common::TypeEnvironment;
 use tsz_solver::TypeId;
 use tsz_solver::def::DefId;
-use tsz_solver::relations::subtype::TypeEnvironment;
 
 impl CheckerContext<'_> {
     /// Mirror a definition body into the flow-analyzer env (`type_environment`)

--- a/crates/tsz-checker/src/context/env_eval_cache.rs
+++ b/crates/tsz-checker/src/context/env_eval_cache.rs
@@ -1,5 +1,6 @@
 use rustc_hash::{FxHashMap, FxHashSet};
-use tsz_solver::{DefId, TypeId};
+use tsz_solver::TypeId;
+use tsz_solver::def::DefId;
 
 use super::{AssignabilityEvalStamp, CheckerContext, EnvEvalCacheEntry};
 
@@ -388,14 +389,11 @@ impl<'a> CheckerContext<'a> {
     /// interned type structure, so the reachable lazy-`DefId` set is cached per
     /// `type_id` and reused across the many hot callers that re-query the same
     /// (lib-heavy) types. Returns an `Rc` slice for cheap clone-on-hit.
-    pub(crate) fn collect_lazy_def_ids_cached(
-        &self,
-        type_id: TypeId,
-    ) -> std::rc::Rc<[tsz_solver::DefId]> {
+    pub(crate) fn collect_lazy_def_ids_cached(&self, type_id: TypeId) -> std::rc::Rc<[DefId]> {
         if let Some(cached) = self.lazy_def_ids_cache.borrow().get(&type_id) {
             return std::rc::Rc::clone(cached);
         }
-        let collected: std::rc::Rc<[tsz_solver::DefId]> =
+        let collected: std::rc::Rc<[DefId]> =
             crate::query_boundaries::common::collect_lazy_def_ids(self.types, type_id).into();
         self.lazy_def_ids_cache
             .borrow_mut()
@@ -427,7 +425,7 @@ impl<'a> CheckerContext<'a> {
         collected
     }
 
-    fn type_mentions_def(&self, type_id: TypeId, def_id: tsz_solver::DefId) -> bool {
+    fn type_mentions_def(&self, type_id: TypeId, def_id: DefId) -> bool {
         self.collect_lazy_def_ids_cached(type_id).contains(&def_id)
     }
 
@@ -610,7 +608,7 @@ impl<'a> CheckerContext<'a> {
         removed + normalization_removed
     }
 
-    pub(crate) fn clear_type_evaluation_caches_for_def(&self, def_id: tsz_solver::DefId) {
+    pub(crate) fn clear_type_evaluation_caches_for_def(&self, def_id: DefId) {
         self.env_eval_cache.borrow_mut().invalidate_for_def(def_id);
         self.flow_shared
             .narrowing_cache

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -4,6 +4,7 @@
 //! checks, and const expando key resolution.
 
 use crate::FlowAnalyzer;
+use crate::query_boundaries::common::TypeResolver;
 use crate::query_boundaries::property_access as property_access_query;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -538,8 +539,6 @@ impl<'a> CheckerState<'a> {
         use crate::query_boundaries::definition_identity::lazy_def_id;
         use crate::query_boundaries::property_access::type_has_property;
         use crate::query_boundaries::type_checking_utilities::application_base;
-        use tsz_solver::relations::subtype::TypeResolver;
-
         if type_has_property(self.ctx.types, type_id, prop_atom) {
             return true;
         }

--- a/crates/tsz-checker/src/types/queries/lib_scoped_heritage.rs
+++ b/crates/tsz-checker/src/types/queries/lib_scoped_heritage.rs
@@ -7,11 +7,12 @@
 //! `IteratorConstructor` can inherit an abstract construct signature without
 //! polluting the global namespace with the helper class declaration.
 
+use crate::query_boundaries::signature_building::user_type_param_info;
 use crate::state::CheckerState;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::{NodeArena, NodeIndex};
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{CallSignature, CallableShape, TypeId, TypeParamInfo, TypeParamOrigin};
+use tsz_solver::{CallSignature, CallableShape, TypeId, TypeParamInfo};
 
 use super::lib_resolution::{
     keyword_name_to_type_id, keyword_syntax_to_type_id, resolve_scope_chain,
@@ -159,13 +160,12 @@ impl<'a> CheckerState<'a> {
                             .get_identifier_text(param.constraint)
                             .and_then(keyword_name_to_type_id)
                     });
-                Some(TypeParamInfo {
-                    name: name_atom,
+                Some(user_type_param_info(
+                    name_atom,
                     constraint,
                     default,
-                    is_const: arena.has_modifier(&param.modifiers, SyntaxKind::ConstKeyword),
-                    origin: TypeParamOrigin::User,
-                })
+                    arena.has_modifier(&param.modifiers, SyntaxKind::ConstKeyword),
+                ))
             })
             .collect()
     }

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -1,11 +1,11 @@
 use crate::query_boundaries::indexed_access_key_space as key_space_query;
+use crate::query_boundaries::property_access::PropertyAccessResult;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_TYPE;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
-use tsz_solver::operations::property::PropertyAccessResult;
 
 /// Check if a property with the given name is private or protected on the given type.
 /// Delegates to the solver's type query via `query_boundaries`.


### PR DESCRIPTION
Goal: hold

## Summary
- replace six direct solver imports with existing checker query-boundary exports
- construct scoped-lib user type-parameter metadata through the signature-building boundary
- preserve property, environment, database, definition, and cache behavior

Structural rule: checker modules consume solver traits, result records, and construction records through query boundaries; only boundary modules name the underlying solver ownership paths.

Owner layer: checker query boundaries.

Adjacent matrix: property access resolution, indexed-access result matching, scoped-lib heritage type parameters, flow environment mirroring, canonical application keys, and environment-evaluation dependency indexing.

## Verification
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --lib test_solver_imports_go_through_query_boundaries --test-threads=2`
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo clippy -p tsz-checker --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: max