### PR TITLE
refactor(checker): route type queries through boundaries

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/substitution_constraint.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/substitution_constraint.rs
@@ -7,6 +7,7 @@
 //! `isTypeAssignableTo(typeArgument, constraint)`: the substitution relates
 //! through its intersection `base & constraint`.
 
+use crate::query_boundaries::checkers::generic::is_substitution_type;
 use crate::query_boundaries::common::TypeSubstitution;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
@@ -68,12 +69,7 @@ impl CheckerState<'_> {
         type_arg_subst: &TypeSubstitution,
         arg_idx: Option<NodeIndex>,
     ) -> bool {
-        if tsz_solver::type_queries::substitution_components(
-            self.ctx.types.as_type_database(),
-            type_arg,
-        )
-        .is_none()
-        {
+        if !is_substitution_type(self.ctx.types.as_type_database(), type_arg) {
             return false;
         }
 

--- a/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
@@ -8,7 +8,7 @@ use super::FlowAnalyzer;
 use crate::query_boundaries::flow_analysis::{
     PropertyAccessResult, TypeSubstitution, call_signatures_for_type,
     construct_signatures_for_type, contains_free_type_parameters, flow_call_signature,
-    flow_property, function_return_type, get_application_info, instantiate_type,
+    flow_property, function_return_type, get_application_info, get_lazy_def_id, instantiate_type,
     is_promise_like_type, literal_value, optional_flow_property, union_members_for_type,
     unwrap_promise_type_argument, widen_literal_to_primitive,
 };
@@ -738,7 +738,7 @@ impl<'a> FlowAnalyzer<'a> {
     /// flow narrowing (`narrow_assignment`, truthiness filtering) cannot reduce a
     /// union against it; callers must recover a concrete declared type instead.
     fn is_unresolved_lazy_type(&self, ty: TypeId) -> bool {
-        tsz_solver::type_queries::get_lazy_def_id(self.interner.as_type_database(), ty).is_some()
+        get_lazy_def_id(self.interner.as_type_database(), ty).is_some()
     }
 
     /// Resolve a declaration's declared type from its syntactic type annotation.

--- a/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
@@ -20,6 +20,11 @@ pub(crate) fn is_bare_named_type_parameter(db: &dyn TypeDatabase, type_id: TypeI
     tsz_solver::type_queries::is_bare_named_type_parameter(db, type_id)
 }
 
+/// Whether `type_id` is a solver substitution type.
+pub(crate) fn is_substitution_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::type_queries::substitution_components(db, type_id).is_some()
+}
+
 pub(crate) fn named_type_param_info(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/query_boundaries/state/type_resolution.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/type_resolution.rs
@@ -52,6 +52,26 @@ pub(crate) fn contains_type_parameters(db: &dyn TypeDatabase, type_id: TypeId) -
     tsz_solver::type_queries::contains_type_parameters_db(db, type_id)
 }
 
+pub(crate) fn substitution_base_or_self(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    tsz_solver::type_queries::substitution_base_or_self(db, type_id)
+}
+
+pub(crate) fn contains_conditional_through_aliases(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    resolve_lazy: &mut dyn FnMut(tsz_solver::def::DefId) -> Option<TypeId>,
+) -> bool {
+    tsz_solver::type_queries::contains_conditional_through_aliases(db, type_id, resolve_lazy)
+}
+
+pub(crate) fn object_property_names_cover(
+    db: &dyn TypeDatabase,
+    superset: TypeId,
+    subset: TypeId,
+) -> bool {
+    tsz_solver::type_queries::object_property_names_cover(db, superset, subset)
+}
+
 pub(crate) fn is_union_or_intersection(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::type_queries::is_union_type(db, type_id)
         || tsz_solver::type_queries::is_intersection_type(db, type_id)

--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -1458,21 +1458,21 @@ type Plain = { mon: number; tue: number };
 
         let schedule = resolve(&mut checker, "Schedule");
         assert!(
-            tsz_solver::type_queries::is_mapped_type(db, schedule),
+            crate::query_boundaries::state::checking::is_mapped_type(db, schedule),
             "concrete enum-key mapped alias must stay a Mapped type, got {}",
             checker.format_type(schedule),
         );
 
         let schedule_alias = resolve(&mut checker, "ScheduleAlias");
         assert!(
-            tsz_solver::type_queries::is_mapped_type(db, schedule_alias),
+            crate::query_boundaries::state::checking::is_mapped_type(db, schedule_alias),
             "wrapper alias of a concrete mapped type must preserve Mapped identity, got {}",
             checker.format_type(schedule_alias),
         );
 
         let plain = resolve(&mut checker, "Plain");
         assert!(
-            !tsz_solver::type_queries::is_mapped_type(db, plain),
+            !crate::query_boundaries::state::checking::is_mapped_type(db, plain),
             "plain object alias must not be a Mapped type (negative control), got {}",
             checker.format_type(plain),
         );

--- a/crates/tsz-checker/src/state/type_resolution/conditional_flow.rs
+++ b/crates/tsz-checker/src/state/type_resolution/conditional_flow.rs
@@ -7,6 +7,7 @@
 //! well-formed against dependent constraints.
 
 use crate::query_boundaries::common::{self as query_common, TypeSubstitution};
+use crate::query_boundaries::state::type_resolution as type_resolution_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
@@ -53,7 +54,7 @@ impl CheckerState<'_> {
         // Entries are `(type-param name, type-param id, accumulated extends)`.
         let mut naked: Vec<(tsz_common::interner::Atom, TypeId, TypeId)> = Vec::new();
 
-        let arg_actual = tsz_solver::type_queries::substitution_base_or_self(
+        let arg_actual = type_resolution_query::substitution_base_or_self(
             self.ctx.types.as_type_database(),
             type_arg,
         );
@@ -93,7 +94,7 @@ impl CheckerState<'_> {
                     // is the conditional's check operand (compared by actual type
                     // variable so a substitution on either side still matches).
                     let check_t = self.get_type_from_type_node(cond.check_type);
-                    let check_actual = tsz_solver::type_queries::substitution_base_or_self(
+                    let check_actual = type_resolution_query::substitution_base_or_self(
                         self.ctx.types.as_type_database(),
                         check_t,
                     );

--- a/crates/tsz-checker/src/state/type_resolution/heritage_publication.rs
+++ b/crates/tsz-checker/src/state/type_resolution/heritage_publication.rs
@@ -7,6 +7,7 @@
 //! guard predicates (published-body member coverage, program-file heritage
 //! provenance) and the import-alias `DefId` forwarding registration.
 
+use crate::query_boundaries::state::type_resolution as type_resolution_query;
 use crate::state::CheckerState;
 use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
@@ -127,7 +128,7 @@ impl<'a> CheckerState<'a> {
             let db = self.ctx.types.as_type_database();
             let def_store = &self.ctx.definition_store;
             let mut resolve_lazy = |d: tsz_solver::DefId| def_store.get_body(d);
-            tsz_solver::type_queries::contains_conditional_through_aliases(
+            type_resolution_query::contains_conditional_through_aliases(
                 db,
                 published,
                 &mut resolve_lazy,
@@ -175,7 +176,7 @@ impl<'a> CheckerState<'a> {
         published: TypeId,
         local: TypeId,
     ) -> bool {
-        tsz_solver::type_queries::object_property_names_cover(
+        type_resolution_query::object_property_names_cover(
             self.ctx.types.as_type_database(),
             published,
             local,


### PR DESCRIPTION
Goal: hold

## Summary
- add narrow domain wrappers for substitution, heritage-publication, and object-coverage queries
- route conditional-flow and assignment-flow type inspection through their existing boundaries
- make mapped-identity tests consume the state-checking query boundary
- restore the zero-tolerance inline type-query guard

Structural rule: checker orchestration asks its owning query boundary for semantic type facts; direct solver type-query calls remain confined to query-boundary modules.

Owner layer: checker query boundaries for generic checking, type resolution, state checking, and flow analysis.

Adjacent matrix: conditional true-branch substitutions and negative constraints, generic signature context instantiation, concrete mapped aliases and plain-object fallback, unresolved-lazy assignment flow, renamed binders, and nested wrappers.

## Verification
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --lib test_no_inline_type_queries_in_cleaned_modules --test-threads=2`
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --lib conditional_flow_substitution_ts2344_tests --test-threads=2`
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --lib concrete_enum_key_mapped_alias_preserves_mapped_identity --test-threads=2`
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --lib generic_signature_context_instantiation_tests --test-threads=2`
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo nextest run -p tsz-checker --test assignment_branch_merge_narrowing_tests --test-threads=2`
- `scripts/safe-run.sh --limit 16384 --interval 2 -- env CARGO_BUILD_JOBS=2 cargo clippy -p tsz-checker --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: max