### PR TITLE
chore(release): bump try-tsz publish version to 0.1.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-binder"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-checker"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "dashmap",
  "rustc-hash",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-cli"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "clap",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-common"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-core"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-emitter"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lowering"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "indexmap",
  "rustc-hash",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lsp"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "globset",
  "json5",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-parser"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-scanner"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "serde",
  "tsz-common",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-solver"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "bitflags",
  "dashmap",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-wasm"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-website"
-version = "0.1.47"
+version = "0.1.48"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/.target"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.47"
+version = "0.1.48"
 edition = "2024"
 repository = "https://github.com/tsz-org/tsz"
 homepage = "https://github.com/tsz-org/tsz"
@@ -16,16 +16,16 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal workspace crates
-tsz = { path = "crates/tsz-core", version = "0.1.47", package = "tsz-core" }
-tsz-common = { path = "crates/tsz-common", version = "0.1.47" }
-tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.47" }
-tsz-parser = { path = "crates/tsz-parser", version = "0.1.47" }
-tsz-binder = { path = "crates/tsz-binder", version = "0.1.47" }
-tsz-solver = { path = "crates/tsz-solver", version = "0.1.47" }
-tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.47" }
-tsz-checker = { path = "crates/tsz-checker", version = "0.1.47" }
-tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.47", default-features = false }
-tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.47" }
+tsz = { path = "crates/tsz-core", version = "0.1.48", package = "tsz-core" }
+tsz-common = { path = "crates/tsz-common", version = "0.1.48" }
+tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.48" }
+tsz-parser = { path = "crates/tsz-parser", version = "0.1.48" }
+tsz-binder = { path = "crates/tsz-binder", version = "0.1.48" }
+tsz-solver = { path = "crates/tsz-solver", version = "0.1.48" }
+tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.48" }
+tsz-checker = { path = "crates/tsz-checker", version = "0.1.48" }
+tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.48", default-features = false }
+tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.48" }
 
 # External dependencies (shared versions)
 anyhow = "1.0"


### PR DESCRIPTION
Daily automated release PR.

## Goal
Goal: hold

## Invariant
Daily automated release of `try-tsz` to npm. Bumps the workspace
version from `0.1.47` to `0.1.48` and lets the merge queue
land it. The follow-up `tag-on-merge` job in `daily-release.yml`
tags the merge commit and dispatches `release.yml` plus
`npm-publish.yml`.

Commits accumulated since `v0.1.47`: 2.

## Scope
Mechanical version bump only:
- `Cargo.toml`: `workspace.package.version` plus every `tsz-*`
  pin in `[workspace.dependencies]` move `0.1.47` → `0.1.48`.
- `Cargo.lock`: each `tsz-*` workspace crate's `version` line
  moves `0.1.47` → `0.1.48`. Replacements are structurally
  paired to the preceding `name = "tsz-*"` line; a paired-count
  mismatch fails the workflow.

No semantic, build, or script changes.

## Verification
- Cargo.toml occurrence count of `0.1.47` before vs. `0.1.48`
  after must match (enforced by the workflow).
- Cargo.lock replacements are paired with their `name = "tsz-*"`
  header (Python pairing script in the workflow).

## Coordination Notes
- On merge, `daily-release.yml`'s `tag-on-merge` job pushes
  `v0.1.48` and dispatches `release.yml` and `npm-publish.yml`.
- To skip a day's release, close this PR; the next scheduled run
  opens a new one with the next patch.

## Provenance
Machine: cloud
Assistant: bot
Model: github-actions
Effort: low