### PR TITLE
fix(parser): terminate recovery on EOF-truncated generic declarations

### DIFF
--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -1252,10 +1252,16 @@ impl ParserState {
     /// (`;` or `,`). Callers should skip their own body lookup in this case to
     /// avoid emitting a redundant `'{' expected.` past the actual terminator.
     pub(crate) fn recover_from_missing_method_open_paren(&mut self) -> bool {
+        // `EndOfFileToken` must terminate the scan: a malformed member whose
+        // body/`(` never arrives (e.g. `class A { f<` truncated at EOF) leaves
+        // no `{`/`;`/`,`/`}` ahead, and `next_token` idles on EOF, so omitting
+        // it here spins forever. tsc's member `parseList` treats EOF as a list
+        // terminator; mirror that so recovery always makes progress.
         while !(self.is_token(SyntaxKind::OpenBraceToken)
             || self.is_token(SyntaxKind::SemicolonToken)
             || self.is_token(SyntaxKind::CommaToken)
-            || self.is_token(SyntaxKind::CloseBraceToken))
+            || self.is_token(SyntaxKind::CloseBraceToken)
+            || self.is_token(SyntaxKind::EndOfFileToken))
         {
             self.next_token();
         }

--- a/crates/tsz-parser/src/parser/state_type_parameters.rs
+++ b/crates/tsz-parser/src/parser/state_type_parameters.rs
@@ -39,6 +39,10 @@ impl ParserState {
         }
 
         while !self.is_greater_than_or_compound() && !self.is_token(SyntaxKind::EndOfFileToken) {
+            // tsc's `parseDelimitedList` records the element start so it can
+            // force progress when an element parses nothing (see the
+            // no-progress guard below). Mirror that here.
+            let element_start = self.token_pos();
             let param = self.parse_type_parameter();
             params.push(param);
 
@@ -86,10 +90,23 @@ impl ParserState {
             // `const`/variance modifier — all of which sort at or above
             // `Identifier`). Otherwise break and let `parse_expected_greater_than`
             // and the enclosing parser recover, mirroring tsc's `isListElement`
-            // gate. This also guarantees loop progress: every `continue` is
-            // followed by a `parse_type_parameter` that consumes the name token.
+            // gate.
             if !self.is_identifier_or_keyword() {
                 break;
+            }
+
+            // Guaranteed progress: the token above can *start* a type parameter,
+            // yet `parse_type_parameter` consumed nothing — this happens for a
+            // reserved word such as `class`/`function` that sorts at or above
+            // `Identifier` (so it is not broken out here) but which
+            // `parse_identifier` reports on without consuming. Force one token
+            // forward so the list cannot spin forever, mirroring tsc's
+            // `parseDelimitedList` no-progress `nextToken()` (`if (startPos ===
+            // scanner.getTokenFullStart()) nextToken()`). Truncated generics
+            // like `interface A<` followed by further declarations would
+            // otherwise wedge the parser here.
+            if self.token_pos() == element_start {
+                self.next_token();
             }
         }
 

--- a/crates/tsz-parser/tests/parser_improvement_class_member_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_class_member_recovery_tests.rs
@@ -701,3 +701,73 @@ fn method_missing_body_still_emits_or_expected_not_brace_only() {
         "method recovery must not switch to the accessor-only `'{{' expected`"
     );
 }
+
+// Regression: a truncated generic declaration must never wedge the parser.
+//
+// Every construct below opens a type-parameter list (or a method whose `(`
+// never arrives) and hits EOF before it closes. Two recovery paths have to make
+// forward progress on each iteration for parsing to terminate:
+//   * `recover_from_missing_method_open_paren` must treat `EndOfFileToken` as a
+//     stop token — otherwise `next_token` idles on EOF forever (`class A { f<`).
+//   * the `parse_type_parameters` delimited-list loop must force one token
+//     forward when an element parses nothing (a reserved word like `class`
+//     sorts at or above `Identifier`, so it is not broken out, yet
+//     `parse_identifier` reports on it without consuming) — mirroring tsc's
+//     `parseDelimitedList` no-progress `nextToken()`.
+//
+// Witnessed by fourslash `completionListAtIdentifierDefinitionLocations_Generics`,
+// which hung past the 60s worker watchdog before both guards existed. In these
+// tests `parse_source` *returning at all* is the guard; a reintroduced loop
+// hangs the test.
+#[test]
+fn truncated_generic_declarations_terminate() {
+    // Marker-stripped body of the fourslash regression fixture.
+    let source = "interface A<\nclass A<\nclass B<T, \nclass A{\n     f<\nfunction A<\n";
+    let (parser, root) = parse_source(source);
+    let source_file = parser.get_arena().get_source_file_at(root).unwrap();
+    assert!(
+        !source_file.statements.nodes.is_empty(),
+        "truncated generics should still yield recovered top-level statements"
+    );
+    assert!(
+        !parser.get_diagnostics().is_empty(),
+        "truncated generics must report parse diagnostics"
+    );
+}
+
+#[test]
+fn truncated_generic_declarations_terminate_renamed_binders() {
+    // Same shape, distinct binder names: the fix is structural, not name-keyed.
+    let source = "interface Outer<\nclass Widget<\nclass Bag<Elem, \nclass Holder{\n     handle<\nfunction make<\n";
+    let (parser, root) = parse_source(source);
+    let source_file = parser.get_arena().get_source_file_at(root).unwrap();
+    assert!(!source_file.statements.nodes.is_empty());
+    assert!(!parser.get_diagnostics().is_empty());
+}
+
+#[test]
+fn truncated_class_method_type_parameters_terminate() {
+    // A class method whose type-parameter list and `(` never arrive before the
+    // stop token. Covers EOF, a following newline, and a closing `}`.
+    for source in [
+        "class A{f<",
+        "class A {\n    f<\n",
+        "class A {\n    f<\n}\n",
+    ] {
+        let (parser, root) = parse_source(source);
+        let source_file = parser.get_arena().get_source_file_at(root).unwrap();
+        assert!(
+            !source_file.statements.nodes.is_empty(),
+            "class with a truncated method should recover a class statement: {source:?}"
+        );
+    }
+}
+
+#[test]
+fn truncated_object_literal_method_type_parameters_terminate() {
+    // The same `(`-recovery path is shared by object-literal members.
+    let (parser, root) = parse_source("const o = { f<");
+    let source_file = parser.get_arena().get_source_file_at(root).unwrap();
+    assert!(!source_file.statements.nodes.is_empty());
+    assert!(!parser.get_diagnostics().is_empty());
+}

--- a/scripts/fourslash/skip_if_failing.txt
+++ b/scripts/fourslash/skip_if_failing.txt
@@ -1,3 +1,2 @@
 codeFixClassImplementInterfaceNoTruncation
 codeFixClassImplementInterfaceNoTruncationProperties
-completionListAtIdentifierDefinitionLocations_Generics


### PR DESCRIPTION
Goal: hold

Two independent non-terminating parser recovery loops on generic declarations that open `<` and hit EOF before closing — the root cause of the `completionListAtIdentifierDefinitionLocations_Generics` fourslash hang (skipped since #15375 as "runner-killing"; memory ballooned to ~20 GB):

1. `recover_from_missing_method_open_paren` (parser/state.rs) scanned for `{`/`;`/`,`/`}` but not `EndOfFileToken` — `class A{f<` at EOF idles forever.
2. `parse_type_parameters` delimited-list loop (parser/state_type_parameters.rs) re-enters `parse_type_parameter` on a reserved word that passes the `is_identifier_or_keyword` gate but is reported (TS1359) WITHOUT consuming — zero progress, infinite loop.

Structural rule: when a generic declaration or class/object method is truncated before its list closes, tsc's `parseList`/`parseDelimitedList` still terminates (EOF is a list terminator; a no-progress element forces one `nextToken`); tsz now terminates through the same parser recovery ownership.

Fix: added `EndOfFileToken` to the recovery stop set; added tsc's `parseDelimitedList` no-progress guard (capture token position before the element, force one `next_token` when nothing was consumed), placed after the existing `is_identifier_or_keyword` break so it never swallows an enclosing terminator. Both guards only change behavior for inputs that previously never terminated.

Unskips `completionListAtIdentifierDefinitionLocations_Generics` (scripts/fourslash/skip_if_failing.txt 3 → 2 entries).

Follow-up (pre-existing, was masked by the hang): tsc emits TS1139 and reparses `class`/`function` as declarations; tsz emits TS1359/TS1005 at these recovery points — parity candidate in `parse_type_parameter` name handling.

## Verification
- CLI + tsz-server terminate in ~0.5s on the full harness content and a renamed-binder variant (previously infinite / ~20 GB RSS).
- Faithful tsz-server `completionInfo` driver at all 5 markers: entries `[0,0,0,0,0]` (the test's expected empty completions).
- `cargo nextest run -p tsz-parser`: 1488 passed, 0 failed, including 4 new regression tests (parser_improvement_class_member_recovery_tests.rs).
- `cargo clippy -p tsz-parser`: clean.
- Full suite: merge-queue `merge_group` CI.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max