### PR TITLE
test(checker): salvage uncovered numeric-string witnesses from #15675

### DIFF
--- a/crates/tsz-checker/tests/js_number_string_semantics_tests.rs
+++ b/crates/tsz-checker/tests/js_number_string_semantics_tests.rs
@@ -321,3 +321,70 @@ const exact: 1e21 = rust;
         "the Rust Display spelling must widen to number, not the literal"
     );
 }
+
+// === Salvaged witnesses from superseded #15675 (tsc-verified 2026-07-11) ===
+
+/// tsc: a numeric-declared property is addressable by its canonical
+/// `Number::toString` string name (`{ 1e21: string }` has key `"1e+21"`).
+#[test]
+fn indexed_access_type_with_canonical_string_key_resolves() {
+    assert!(
+        no_errors(
+            r#"
+type Rec = { 1e21: string };
+type Val = Rec["1e+21"];
+const v: Val = "ok";
+"#
+        ),
+        "Rec[\"1e+21\"] must resolve the property declared as `1e21`"
+    );
+}
+
+/// Negative control: the raw source spelling is NOT the property's name;
+/// tsc reports TS2339 for `Rec["1e21"]`.
+#[test]
+fn indexed_access_type_rejects_source_spelling_string_key() {
+    assert!(
+        codes(
+            r#"
+type Rec = { 1e21: string };
+type Val = Rec["1e21"];
+"#
+        )
+        .contains(&2339),
+        "source spelling \"1e21\" must miss the canonical \"1e+21\" property"
+    );
+}
+
+/// tsc: boolean and bigint template captures coerce like their literal
+/// grammar — `is:${B}` captures `true`; `${G}n` captures `7n`.
+#[test]
+fn call_inference_coerces_boolean_and_bigint_captures() {
+    assert!(
+        no_errors(
+            r#"
+declare function flag<B extends boolean>(s: `is:${B}`): B;
+const yes: true = flag("is:true");
+declare function big<G extends bigint>(s: `${G}n`): G;
+const g: 7n = big("7n");
+"#
+        ),
+        "boolean/bigint template captures must infer their literal types"
+    );
+}
+
+/// tsc: enum member values flow through template literal types via the same
+/// `Number::toString` owner (`Scale.Big = 1e21` → `"1e+21"`).
+#[test]
+fn template_over_enum_member_with_exotic_value() {
+    assert!(
+        no_errors(
+            r#"
+enum Scale { Big = 1e21 }
+type S = `${Scale.Big}`;
+const s: S = "1e+21";
+"#
+        ),
+        "`${{Scale.Big}}` must evaluate through Number::toString"
+    );
+}


### PR DESCRIPTION
Goal: hold

Coverage completion for the numeric-literal→string owner (#15678, merged): a cross-check of superseded #15675's 18-test matrix found four scenarios with no witness in the merged suite. All four verified against tsc and passing on main:

1. Canonical string-key indexed access resolves: `{ 1e21: string }["1e+21"]`.
2. Source-spelling string key misses (TS2339 negative): `Rec["1e21"]`.
3. Boolean + bigint template-capture coercion — the merged `coerce_captured_template_segment` boolean/bigint branches previously had zero end-to-end coverage.
4. Enum member values through template literal types: `` `${Scale.Big}` `` → `"1e+21"`.

Test-only; 25/25 green in js_number_string_semantics_tests on main.

## Verification
- cargo nextest run -p tsz-checker --test js_number_string_semantics_tests → 25/25.
- Each fixture executed against the pinned-era tsc before assertion.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max