### PR TITLE
fix(solver): infer contextual return through alias-union applications

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -179,6 +179,9 @@ path = "tests/inference_placeholder_determinism_tests.rs"
 name = "context_sensitive_callback_inference_tests"
 path = "tests/context_sensitive_callback_inference_tests.rs"
 [[test]]
+name = "contextual_alias_union_return_inference_tests"
+path = "tests/contextual_alias_union_return_inference_tests.rs"
+[[test]]
 name = "type_only_import_reexport_tests"
 path = "tests/type_only_import_reexport_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/contextual_alias_union_return_inference_tests.rs
+++ b/crates/tsz-checker/tests/contextual_alias_union_return_inference_tests.rs
@@ -1,0 +1,264 @@
+//! Contextual return-type inference through a type-alias application whose body
+//! is a union.
+//!
+//! When a generic call (`x.then(cb)`) is contextually typed by a declared return
+//! type that is a type-alias application (`Parse<Output>` where
+//! `Parse<T> = Sync<T> | Async<T>` and `Async<T> = Thenable<Sync<T>>`), tsc
+//! relates the signature return against the *reduced apparent type* of the
+//! contextual type. The union arm that reuses the call's generic base
+//! (`Thenable<Sync<T>>`) must seed the tracked return type parameter
+//! (`then`'s `R1`); otherwise it collapses to `never` and a non-thenable
+//! callback body is spuriously rejected against `PromiseLike<never>`
+//! (canary false-positive on the zod / neverthrow rows).
+//!
+//! The harness loads no standard library, so each case declares a local
+//! `Thenable` interface carrying a `then` signature shaped like `PromiseLike`.
+
+use tsz_checker::test_utils::{check_source_diagnostics, diagnostic_code_message_refs};
+
+/// A `then` signature shaped like the lib's `PromiseLike.then`, plus the
+/// `Sync`/`Async`/`Parse` alias family. `$name` renames every binder so the
+/// assertions cannot depend on identifier text.
+macro_rules! thenable_prelude {
+    ($th:literal, $sync:literal, $async:literal, $parse:literal, $ok:literal, $bad:literal, $r1:literal, $r2:literal) => {
+        concat!(
+            "interface ",
+            $th,
+            "<T> {\n",
+            "  then<",
+            $r1,
+            " = T, ",
+            $r2,
+            " = never>(\n",
+            "    onfulfilled?: ((value: T) => ",
+            $r1,
+            " | ",
+            $th,
+            "<",
+            $r1,
+            ">) | null,\n",
+            "    onrejected?: ((reason: any) => ",
+            $r2,
+            " | ",
+            $th,
+            "<",
+            $r2,
+            ">) | null\n",
+            "  ): ",
+            $th,
+            "<",
+            $r1,
+            " | ",
+            $r2,
+            ">;\n",
+            "}\n",
+            "type ",
+            $bad,
+            " = { valid: false };\n",
+            "declare const ",
+            $bad,
+            ": ",
+            $bad,
+            ";\n",
+            "type ",
+            $ok,
+            "<T> = { valid: true; value: T };\n",
+            "type ",
+            $sync,
+            "<T> = ",
+            $ok,
+            "<T> | ",
+            $bad,
+            ";\n",
+            "type ",
+            $async,
+            "<T> = ",
+            $th,
+            "<",
+            $sync,
+            "<T>>;\n",
+            "type ",
+            $parse,
+            "<T> = ",
+            $sync,
+            "<T> | ",
+            $async,
+            "<T>;\n",
+        )
+    };
+}
+
+fn assert_no_codes(source: &str, codes: &[u32], context: &str) {
+    let diagnostics = check_source_diagnostics(source);
+    let offending: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| codes.contains(&d.code))
+        .collect();
+    assert!(
+        offending.is_empty(),
+        "{context}: expected none of {codes:?}, got {:#?}",
+        diagnostic_code_message_refs(&diagnostics),
+    );
+}
+
+/// The dossier witness: `Output = T["_output"]` is a deferred indexed access,
+/// so `Parse<Output>` stays an unreduced alias application at the point of
+/// contextual inference. The `Async<Output>` arm (an alias wrapping the
+/// thenable) must still seed `then`'s `R1`, keeping the callback body's
+/// non-thenable return assignable.
+#[test]
+fn alias_union_return_with_deferred_indexed_access_is_clean() {
+    let source = concat!(
+        thenable_prelude!(
+            "Thenable", "Sync", "Async", "Parse", "OK", "INVALID", "R1", "R2"
+        ),
+        "class Base<Output> {\n",
+        "  _output!: Output;\n",
+        "  run(): Thenable<Sync<Output>> { return null as any; }\n",
+        "}\n",
+        "type AnyBase = Base<any>;\n",
+        "class Eff<T extends AnyBase, Output = T[\"_output\"]> extends Base<Output> {\n",
+        "  schema!: T;\n",
+        "  go(): Parse<Output> {\n",
+        "    return this.schema.run().then((val) => INVALID);\n",
+        "  }\n",
+        "}\n",
+    );
+    assert_no_codes(
+        source,
+        &[2741, 2345, 2322],
+        "deferred indexed-access alias union return",
+    );
+}
+
+/// Renamed-binder variant of the witness: identical structure, every alias /
+/// type parameter / property renamed. Guards against any identifier-string
+/// dependence in the fix.
+#[test]
+fn alias_union_return_renamed_binders_is_clean() {
+    let source = concat!(
+        thenable_prelude!(
+            "Deferred", "Good", "Later", "Outcome", "Hit", "Miss", "First", "Second"
+        ),
+        "class Node<Payload> {\n",
+        "  _payload!: Payload;\n",
+        "  eval(): Deferred<Good<Payload>> { return null as any; }\n",
+        "}\n",
+        "type AnyNode = Node<any>;\n",
+        "class Wrap<N extends AnyNode, Payload = N[\"_payload\"]> extends Node<Payload> {\n",
+        "  inner!: N;\n",
+        "  go(): Outcome<Payload> {\n",
+        "    return this.inner.eval().then((v) => Miss);\n",
+        "  }\n",
+        "}\n",
+    );
+    assert_no_codes(
+        source,
+        &[2741, 2345, 2322],
+        "renamed-binder alias union return",
+    );
+}
+
+/// Control: `Output` is a direct class type parameter (not a deferred indexed
+/// access). Already clean on `main`; must stay clean.
+#[test]
+fn alias_union_return_direct_output_param_is_clean() {
+    let source = concat!(
+        thenable_prelude!(
+            "Thenable", "Sync", "Async", "Parse", "OK", "INVALID", "R1", "R2"
+        ),
+        "class Base<Output> {\n",
+        "  run(): Thenable<Sync<Output>> { return null as any; }\n",
+        "}\n",
+        "class Eff<Output> extends Base<Output> {\n",
+        "  schema!: Base<Output>;\n",
+        "  go(): Parse<Output> {\n",
+        "    return this.schema.run().then((val) => INVALID);\n",
+        "  }\n",
+        "}\n",
+    );
+    assert_no_codes(source, &[2741, 2345, 2322], "direct output-param control");
+}
+
+/// Control: the return type is written as an inline union rather than an alias
+/// application, so no alias expansion is required. Must stay clean.
+#[test]
+fn inline_union_return_is_clean() {
+    let source = concat!(
+        thenable_prelude!(
+            "Thenable", "Sync", "Async", "Parse", "OK", "INVALID", "R1", "R2"
+        ),
+        "class Base<Output> {\n",
+        "  _output!: Output;\n",
+        "  run(): Thenable<Sync<Output>> { return null as any; }\n",
+        "}\n",
+        "type AnyBase = Base<any>;\n",
+        "class Eff<T extends AnyBase, Output = T[\"_output\"]> {\n",
+        "  schema!: T;\n",
+        "  go(): Sync<Output> | Thenable<Sync<Output>> {\n",
+        "    return this.schema.run().then((val) => INVALID);\n",
+        "  }\n",
+        "}\n",
+    );
+    assert_no_codes(source, &[2741, 2345, 2322], "inline union return control");
+}
+
+/// Control: the return type is a single (non-union) thenable application, so
+/// there is no union to decompose. Must stay clean.
+#[test]
+fn non_union_thenable_return_is_clean() {
+    let source = concat!(
+        thenable_prelude!(
+            "Thenable", "Sync", "Async", "Parse", "OK", "INVALID", "R1", "R2"
+        ),
+        "class Base<Output> {\n",
+        "  _output!: Output;\n",
+        "  run(): Thenable<Sync<Output>> { return null as any; }\n",
+        "}\n",
+        "type AnyBase = Base<any>;\n",
+        "class Eff<T extends AnyBase, Output = T[\"_output\"]> extends Base<Output> {\n",
+        "  schema!: T;\n",
+        "  go(): Thenable<Sync<Output>> {\n",
+        "    return this.schema.run().then((val) => INVALID);\n",
+        "  }\n",
+        "}\n",
+    );
+    assert_no_codes(
+        source,
+        &[2741, 2345, 2322],
+        "non-union thenable return control",
+    );
+}
+
+/// Convergence guard: the contextual return alias is self-referential
+/// (`Rec<T> = Sync<T> | Thenable<Rec<T>>`). Arm expansion must terminate (it is
+/// bounded) and type-checking must complete without hanging.
+#[test]
+fn self_referential_alias_union_return_terminates() {
+    let source = concat!(
+        "interface Thenable<T> {\n",
+        "  then<R1 = T, R2 = never>(\n",
+        "    onfulfilled?: ((value: T) => R1 | Thenable<R1>) | null\n",
+        "  ): Thenable<R1 | R2>;\n",
+        "}\n",
+        "type INVALID = { valid: false };\n",
+        "declare const INVALID: INVALID;\n",
+        "type OK<T> = { valid: true; value: T };\n",
+        "type Sync<T> = OK<T> | INVALID;\n",
+        "type Rec<T> = Sync<T> | Thenable<Rec<T>>;\n",
+        "class Base<Output> {\n",
+        "  _output!: Output;\n",
+        "  run(): Thenable<Sync<Output>> { return null as any; }\n",
+        "}\n",
+        "type AnyBase = Base<any>;\n",
+        "class Eff<T extends AnyBase, Output = T[\"_output\"]> extends Base<Output> {\n",
+        "  schema!: T;\n",
+        "  go(): Rec<Output> {\n",
+        "    return this.schema.run().then((val) => INVALID);\n",
+        "  }\n",
+        "}\n",
+    );
+    // Only asserting termination + no panic here; the self-referential arm is a
+    // convergence stress case, not a parity witness.
+    let _ = check_source_diagnostics(source);
+}

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -669,10 +669,11 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 }
                 _ => None,
             };
-            if let Some((cand_base, cand_args)) = app {
-                if cand_base == base && cand_args.len() == arity {
-                    return Some(cand_args);
-                }
+            if let Some((cand_base, cand_args)) = app
+                && cand_base == base
+                && cand_args.len() == arity
+            {
+                return Some(cand_args);
             }
             match self.checker.expand_type_alias_application(candidate) {
                 Some(next) if next != candidate => candidate = next,

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -500,6 +500,55 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             }
         }
 
+        // Contextual (target) type is a type-alias application whose body is a
+        // union — e.g. a declared return type
+        // `ParseReturnType<T> = Sync<T> | Async<T>`. tsc relates the
+        // placeholder-bearing signature return against the *reduced apparent
+        // type* of the contextual type, so an arm that shares the source's
+        // generic base (here the `Promise<...>` arm) must constrain the
+        // source's type arguments. `expand_type_alias_application` substitutes
+        // an alias body one level without deep-reducing its members, keeping
+        // that arm an Application so its type argument (which carries the
+        // tracked return placeholder) stays visible; a deep `evaluate_type`
+        // would collapse the arm to a bare object shape and lose the argument.
+        // Arms may themselves be alias wrappers of the source's generic (e.g.
+        // `AsyncParseReturnType<T> = Promise<Sync<T>>`), so expand each arm a
+        // bounded number of levels until its base matches the source. Without
+        // this the tracked return placeholder (`TResult1`) never receives a
+        // candidate and collapses to `never`, spuriously rejecting a
+        // non-thenable callback body against `PromiseLike<never>`.
+        if !constrained_structurally
+            && let Some(TypeData::Application(s_app_id)) = self.interner.lookup(source_ty)
+            && matches!(
+                self.interner.lookup(target_ty),
+                Some(TypeData::Application(_))
+            )
+            && let Some(expanded_target) = self.checker.expand_type_alias_application(target_ty)
+            && let Some(arms) = crate::type_queries::get_union_members(
+                self.interner.as_type_database(),
+                expanded_target,
+            )
+        {
+            let s_app = self.interner.type_application(s_app_id);
+            let s_base = s_app.base;
+            let s_args: Vec<TypeId> = s_app.args.to_vec();
+            for arm in arms.iter() {
+                if let Some(arm_args) = self.same_base_application_args(*arm, s_base, s_args.len())
+                {
+                    constrained_structurally = true;
+                    for (s_arg, arm_arg) in s_args.iter().zip(arm_args.iter()) {
+                        // Covariant return position: the contextual arm's type
+                        // argument is a candidate (lower bound) for the return
+                        // placeholder, so drive it as the source and the
+                        // placeholder-bearing return arg as the target. A union of
+                        // return placeholders (`TResult1 | TResult2`) is decomposed
+                        // on the target side, seeding each with the arm argument.
+                        self.constrain_types(infer_ctx, var_map, *arm_arg, *s_arg, priority);
+                    }
+                }
+            }
+        }
+
         let raw_functions = Self::get_source_signature_for_target(
             self.interner.as_type_database(),
             source_ty,
@@ -597,6 +646,40 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         }
 
         constrained_structurally
+    }
+
+    /// Resolve `ty` to the type arguments of an application whose base is
+    /// `base` and whose arity is `arity`, expanding wrapping type aliases a
+    /// bounded number of levels. Used by the contextual-return union matcher to
+    /// recognise a union arm that reuses the source's generic base directly
+    /// (`Promise<Sync<T>>`) or through an alias (`Async<T> = Promise<Sync<T>>`).
+    fn same_base_application_args(
+        &mut self,
+        ty: TypeId,
+        base: TypeId,
+        arity: usize,
+    ) -> Option<Vec<TypeId>> {
+        const MAX_ARM_ALIAS_EXPANSIONS: usize = 4;
+        let mut candidate = ty;
+        for _ in 0..MAX_ARM_ALIAS_EXPANSIONS {
+            let app = match self.interner.lookup(candidate) {
+                Some(TypeData::Application(app_id)) => {
+                    let app = self.interner.type_application(app_id);
+                    Some((app.base, app.args.to_vec()))
+                }
+                _ => None,
+            };
+            if let Some((cand_base, cand_args)) = app {
+                if cand_base == base && cand_args.len() == arity {
+                    return Some(cand_args);
+                }
+            }
+            match self.checker.expand_type_alias_application(candidate) {
+                Some(next) if next != candidate => candidate = next,
+                _ => return None,
+            }
+        }
+        None
     }
 
     pub(super) fn collect_placeholder_vars_in_type(


### PR DESCRIPTION
Goal: green

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max

## Summary

Fixes the flagship canary false-positive cluster on the **zod** row: five
`PromiseLike<never>` witnesses (`TS2741` / `TS2345` / `TS2322`) at
`src/types.ts` lines 1997, 2140, 3164, 3225, 3252.

### Structural rule

When a generic call's contextual (return) type is a **type-alias application
whose body is a union** — e.g. a declared return type
`ParseReturnType<T> = SyncParseReturnType<T> | AsyncParseReturnType<T>` where an
arm reuses the call's own generic base (`AsyncParseReturnType<T> =
Promise<SyncParseReturnType<T>>`) — `tsc` relates the placeholder-bearing
signature return against the *reduced apparent type* of the contextual type
(`getReducedApparentType`). The union arm that shares the source's generic base
(the `Promise<…>` arm) seeds the call's tracked return type parameter
(`Promise.then`'s `TResult1`).

tsz's `constrain_return_context_structure` only matched **same-base**
applications. `Promise<TResult1 | TResult2>` (the signature return) and
`ParseReturnType<Output>` (the contextual type) have different bases, and the
contextual alias stays unreduced when its argument is a deferred indexed access
(`Output = T["_output"]`). So the arm was never seen, `TResult1` received no
candidate and collapsed to `never`, and the non-thenable callback body
(`(val) => INVALID`) was rejected against `PromiseLike<never>`.

### Fix (owner: solver)

`crates/tsz-solver/src/operations/generic_call/inference_helpers.rs`,
`constrain_return_context_structure`: when the same-base match does not fire and
the contextual target is an alias application, expand it one level into its
union body (`expand_type_alias_application`, which substitutes without
deep-reducing members so `Promise<…>` keeps its `Application` shape). For each
arm, resolve it — through bounded alias unwrapping, since an arm may itself be an
alias of the source's generic — to an application sharing the source's base, then
seed the return placeholders from the arm's type argument as a covariant
lower-bound candidate.

The match is purely structural (base `TypeId` identity + solver alias
expansion); no identifier/alias/file-name strings and no printer output drive
the decision.

## Verification

Machine-built debug `tsz` CLI and `cargo nextest`.

**zod fixture** (`tsconfig.tsz-guard.json`), vs `origin/main` baseline:

| | main | this PR |
|---|---|---|
| total `error TS` | 11 | 6 |
| `PromiseLike<never>` witness sites (1997/2140/3164/3225/3252) | 5 | 0 |
| new errors introduced | — | 0 |

**neverthrow fixture**: unchanged (1 pre-existing unrelated `TS2339` before and
after; the `PromiseLike<never>` cluster was not present on `main` in this
snapshot).

**Minimal repro + necessity controls** (dossier), built debug CLI, `--strict`:
- `repro_never.ts` (deferred indexed-access alias-union return): TS2741 →
  **clean** (matches `tsc`).
- `control_direct_output_CLEAN.ts`, `control_inline_union_CLEAN.ts`,
  `control_nonunion_return_CLEAN.ts`: **stay clean**.

**New unit tests**
(`crates/tsz-checker/tests/contextual_alias_union_return_inference_tests.rs`, 6
tests, all pass): deferred-indexed-access witness, renamed-binder variant, the
three necessity controls, and a self-referential-alias convergence guard. The
witness test **flips** — without the fix it fails with
`Property 'then' is missing in type 'INVALID' but required in type 'Thenable<never>'`.

**Regression**: `cargo nextest run -p tsz-solver --lib` — 7434 passed, 0 failed.
Targeted `tsz-checker` contextual/return-context/generic-call families pass.
Broad conformance/emit/fourslash deferred to ready-review CI.
