### PR TITLE
fix(checker): classify unique-symbol computed keys as late-bound across re-exports

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
+++ b/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
@@ -400,9 +400,24 @@ impl<'a> CheckerState<'a> {
             self.ctx.types,
             expr_type,
         ) {
-            Some(ResolvedComputedName::string(
-                self.ctx.types.resolve_atom_ref(name).to_string(),
-            ))
+            // A `unique symbol` value type surfaces here as its binding-identity
+            // key (`__unique_<id>`), which `literal_property_name` reports
+            // alongside genuine string/number literal keys. That is a symbol-named
+            // (late-bound) member, not a string-literal key — the distinction a
+            // string const whose *value* spells `"__unique_1"` must NOT share.
+            // Read the value type's unique-symbol identity to classify: a unique
+            // symbol is `is_symbol`, a literal-typed const is not.
+            if crate::query_boundaries::common::unique_symbol_ref(self.ctx.types, expr_type)
+                .is_some()
+            {
+                Some(ResolvedComputedName::symbol(
+                    self.ctx.types.resolve_atom_ref(name).to_string(),
+                ))
+            } else {
+                Some(ResolvedComputedName::string(
+                    self.ctx.types.resolve_atom_ref(name).to_string(),
+                ))
+            }
         } else if let Some(name) =
             self.symbol_valued_binding_property_name(computed.expression, expr_type)
         {

--- a/crates/tsz-checker/tests/ts2344_keyof_bare_tparam_defer_tests.rs
+++ b/crates/tsz-checker/tests/ts2344_keyof_bare_tparam_defer_tests.rs
@@ -384,6 +384,74 @@ fakeKey;
 }
 
 #[test]
+fn test_reexported_symbol_key_member_indexed_on_generic_interface() {
+    // A `Symbol.for(...)` const (unique-symbol identity) is re-exported through a
+    // barrel of a LOCAL import binding (`import { s } from './origin'; export { s
+    // };`). An interface declares a `[s]()` member keyed by the symbol reached via
+    // the re-export, and a generic indexed-access type `Iface<T>[s]` indexes it
+    // with the same symbol reached DIRECTLY from the origin. tsc accepts this: `s`
+    // is a valid symbol member key of the generic interface. The member's value
+    // type surfaces as its binding-identity key (`__unique_<id>`) through
+    // `literal_property_name`; classifying that as a string key (not a late-bound
+    // symbol) drops it from the object's symbol key space, so the symbol index no
+    // longer matches — a false TS2536. Binder names deliberately differ from the
+    // ts-pattern witness (`brand`/`Wrapper`) so the fix cannot be name-coupled.
+    let diagnostics = check_multi_file_with_libs(
+        &[
+            (
+                "./src/origin.ts",
+                r#"
+export const brand = Symbol.for("brand");
+export type brand = typeof brand;
+"#,
+            ),
+            (
+                "./src/barrel.ts",
+                r#"
+import { brand } from "./origin";
+export { brand };
+import { Wrapper } from "./iface";
+export type Unwrap<T> = ReturnType<Wrapper<T>[brand]>;
+"#,
+            ),
+            (
+                "./src/iface.ts",
+                r#"
+import { brand } from "./barrel";
+export interface Wrapper<T> {
+  [brand](): T;
+}
+"#,
+            ),
+            (
+                "./src/main.ts",
+                r#"
+import type { Unwrap } from "./barrel";
+
+declare const value: Unwrap<number>;
+const check: number = value;
+check;
+"#,
+            ),
+        ],
+        "./src/main.ts",
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            strict: true,
+            target: ScriptTarget::ES2022,
+            ..CheckerOptions::default()
+        },
+        &[],
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "a re-exported symbol member indexed on a generic interface must stay a \
+         late-bound symbol key (no false TS2536): {diagnostics:#?}"
+    );
+}
+
+#[test]
 fn test_mapped_literal_unique_prefix_keys_stay_string_keys() {
     let diagnostics = compile_and_get_diagnostic_codes_with_options(
         r#"


### PR DESCRIPTION
Goal: green

Fixes the ts-pattern canary/guard row TS2536 false positive that appeared after today's merges. The row was GREEN this morning and went YELLOW; the `tsconfig.tsz-guard.json` `--noEmit` compile (what `project-compile-guard.sh` runs) is clean again with this change.

## Structural rule

When an interface computed member `[s]()` is keyed by a `unique symbol` binding (a `Symbol.for(...)`/`Symbol()` const) reached through a **re-export of a local import binding** (`import { s } from './origin'; export { s };`), tsc late-binds the member as a symbol-named key, so indexing the generic interface by that same symbol (`Iface<T>[s]`) is valid. tsz must key it the same way — through the checker's computed-property late-bound set.

## Root cause

Introduced by #15709 (computed-key symbol provenance). That PR replaced the late-bound-set string-prefix heuristic (`name.starts_with("__unique_")`) with a resolved provenance flag (`ResolvedComputedName.is_symbol`) so a string const whose *value* spells `"__unique_1"` is not wrongly late-bound. But one resolution branch mis-labels a genuine symbol:

In `resolve_local_computed_property_name`, the value-position leg reads the key via `query_boundaries::type_computation::access::literal_property_name(types, expr_type)`. For a `unique symbol` value type this returns the binding-identity key `__unique_<id>` — *alongside* genuine string/number literal keys — and the branch wrapped it as `ResolvedComputedName::string` (`is_symbol = false`). The member was then dropped from the late-bound set (`precompute_symbol_named_computed_property_names_in_arenas`), so the interface member became a plain string key. The `unique symbol` index no longer matched the object's key space → false TS2536.

(The member has *two* resolutions in the whole-project compile: a cross-arena symbol branch → `__unique_909`/`is_symbol=true`, and this local literal-key branch → `__unique_543`/`is_symbol=false`. The false one is what the lowering consumed.)

## Fix

Owner layer: checker (computed-property-name resolution). In the `literal_property_name` branch, classify by the value type's unique-symbol identity: if `unique_symbol_ref(expr_type)` is `Some`, the key is a late-bound symbol member (`ResolvedComputedName::symbol`); otherwise it stays a string key. A literal-typed const whose text merely spells `"__unique_1"` has no `unique_symbol_ref`, so #15709's distinction is preserved.

## Adjacent cases / matrix

- Re-exported `Symbol.for` symbol member indexed on a generic interface → clean (new test, distinct binder names `brand`/`Wrapper`).
- String const `"__unique_41"` used as a cross-file computed key → stays a string key (#15709 test still green).
- Same-file `realKey: unique symbol` member → late-bound (#15709 test still green).
- Well-known `[Symbol.X]` members → `unique_symbol_ref` is `None` → unaffected (still not binding-identity-flagged).

## Verification

- `tsz --noEmit -p ../tsz-canary-fixtures/ts-pattern/tsconfig.tsz-guard.json` → 0 diagnostics (was 1× TS2536 at patterns.ts:104). `tsc` on the same config → 0.
- Minimal 3-file repro (origin → barrel re-export of local import → interface, generic indexed access) → clean under tsz and tsc.
- `cargo nextest run -p tsz-checker --test ts2344_keyof_bare_tparam_defer_tests` → 15/15 pass (14 existing incl. #15709's provenance cases + 1 new regression test).
- `cargo check -p tsz-checker` → clean.

## The second reported FP (TS2394) is not in the canary compile path

The canary/compile-guard compiles ts-pattern with `tsz --noEmit -p tsconfig.tsz-guard.json` (`project-compile-guard.sh check_project`, invoked by `project-compile-canary-aggregate.sh run_canary_projects`). Under that config the row is now 0 diagnostics (verified), matching `tsc`.

`patterns.ts(673,17) TS2394 (overload not compatible with implementation)` only surfaces under `declaration: true` (the project's own `tsconfig.json`), which also surfaces a long-standing `TS4023` at `patterns.ts:805` ("cannot be named"). Neither appears under `--noEmit`. Because the row was reported GREEN this morning and TS4023 is a pre-existing declaration-emit limitation, the canary is not compiling with `declaration: true` — so TS2394 is a declaration-mode-only artifact outside the canary's `--noEmit` path, not the row's YELLOW cause.

I verified TS2394 is NOT caused by #15680 (reverting its `subtype_of_conditional_target` change in `conditionals.rs` and rebuilding leaves TS2394 unchanged). Isolating it in the deeply-recursive `Chainable`/`SelectP` overload graph needs separate declaration-mode investigation; it is intentionally out of scope for this checker-only fix and does not gate the green canary row. Tracked in #15726.

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max
