### PR TITLE
fix(checker): skip TS2344 type-arg validation in diagnostics-discarding delegates (react16 JSX timeout)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1376,6 +1376,9 @@ path = "tests/ts2344_infer_conditional_constraint.rs"
 name = "ts2344_generic_ref_scoped_param_concrete_constraint"
 path = "tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs"
 [[test]]
+name = "ts2344_consumed_lib_delegate_gate_tests"
+path = "tests/ts2344_consumed_lib_delegate_gate_tests.rs"
+[[test]]
 name = "ts2344_any_key_mapped_constraint_tests"
 path = "tests/ts2344_any_key_mapped_constraint_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -859,6 +859,23 @@ impl<'a> CheckerState<'a> {
         type_args_list: &tsz_parser::parser::NodeList,
         type_ref_idx: NodeIndex,
     ) -> bool {
+        // TS2344 type-argument constraint validation belongs to a file's own
+        // check pass, not to consumption-time type resolution. When a type
+        // reference is lowered inside a transient cross-arena delegate checker
+        // (`delegate_for_arena`, e.g. `AliasResolution` lowering a consumed
+        // `.d.ts` alias body), that delegate has `diagnostics_discarded` set and
+        // every diagnostic it produces is dropped at `push_diagnostic`. Running
+        // the validation there is therefore pure waste — it emits nothing — yet
+        // it is the walk that re-enters the mutually generic React alias family
+        // (`ReactElement`/`JSXElementConstructor`/`Component`) and drives a
+        // super-linear blowup on faithful lib fixtures. Skipping it is
+        // behaviour-neutral (the discarded diagnostics never existed) and matches
+        // `tsc`, which validates such references only while checking the file
+        // that owns them: a `.d.ts` checked as a program root runs in the
+        // primary (non-discarding) checker and still reports TS2344.
+        if self.ctx.diagnostics_discarded {
+            return false;
+        }
         use tsz_binder::symbol_flags;
         let mut sym_id = sym_id;
         let syntax_base_name = self

--- a/crates/tsz-checker/tests/ts2344_consumed_lib_delegate_gate_tests.rs
+++ b/crates/tsz-checker/tests/ts2344_consumed_lib_delegate_gate_tests.rs
@@ -1,0 +1,86 @@
+//! Negative controls for the consumed-`.d.ts` TS2344 delegate gate.
+//!
+//! `validate_type_reference_type_arguments` is skipped when the checker's
+//! diagnostics are discarded — i.e. inside a transient cross-arena delegate
+//! (`delegate_for_arena`) that lowers a consumed lib alias body. That skip
+//! removes a super-linear re-validation blowup on faithful React libs while
+//! staying diagnostic-neutral (the delegate's diagnostics were dropped at
+//! `push_diagnostic` anyway). These tests pin the behaviour the skip must NOT
+//! change: TS2344 still fires for a constraint violation written in a checked
+//! file, whether that file is a user `.ts` referencing a consumed-lib generic
+//! or a `.d.ts` that is itself the checked program root.
+
+use std::sync::Arc;
+
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source_with_libs_code_messages;
+
+/// A consumed lib that declares a generic alias with a `string` constraint.
+/// Loaded as a `LibFile` (a consumed `.d.ts`), so lowering its `Box` body runs
+/// in a diagnostics-discarding delegate — exactly the context the fix gates.
+fn constrained_generic_lib() -> Vec<Arc<LibFile>> {
+    vec![Arc::new(LibFile::from_source(
+        "constrained.d.ts".to_string(),
+        "type Box<T extends string> = T;\n".to_string(),
+    ))]
+}
+
+fn ts2344_count(diags: &[(u32, String)]) -> usize {
+    diags.iter().filter(|(code, _)| *code == 2344).count()
+}
+
+#[test]
+fn user_reference_to_consumed_lib_generic_reports_ts2344() {
+    // The violation is written in the checked USER file; it is validated by the
+    // primary (non-discarding) checker, so the delegate gate must not suppress
+    // it. `number` does not satisfy `Box`'s `string` constraint.
+    let diags = check_source_with_libs_code_messages(
+        "type Bad = Box<number>;\n",
+        "file.ts",
+        CheckerOptions::default(),
+        &constrained_generic_lib(),
+    );
+    assert_eq!(
+        ts2344_count(&diags),
+        1,
+        "user reference to a consumed-lib generic with a bad type arg must still report TS2344, got: {diags:?}"
+    );
+}
+
+#[test]
+fn user_reference_to_consumed_lib_generic_satisfying_arg_is_clean() {
+    // Positive control: a satisfying argument must not report TS2344, ensuring
+    // the assertion above measures a real constraint check rather than an
+    // unconditional error.
+    let diags = check_source_with_libs_code_messages(
+        "type Ok = Box<\"literal\">;\n",
+        "file.ts",
+        CheckerOptions::default(),
+        &constrained_generic_lib(),
+    );
+    assert_eq!(
+        ts2344_count(&diags),
+        0,
+        "a satisfying type argument to a consumed-lib generic must not report TS2344, got: {diags:?}"
+    );
+}
+
+#[test]
+fn checked_declaration_file_root_reports_ts2344() {
+    // A `.d.ts` that is the checked program root runs in the primary checker
+    // (diagnostics NOT discarded), so the delegate gate must not suppress its
+    // own constraint violations. This distinguishes "consumed `.d.ts`" (gated)
+    // from "checked `.d.ts` root" (still validated).
+    let diags = check_source_with_libs_code_messages(
+        "type Box<T extends string> = T;\ntype Bad = Box<number>;\n",
+        "root.d.ts",
+        CheckerOptions::default(),
+        &[],
+    );
+    assert_eq!(
+        ts2344_count(&diags),
+        1,
+        "a constraint violation in a checked .d.ts root must still report TS2344, got: {diags:?}"
+    );
+}


### PR DESCRIPTION
## Summary

`tsz-checker::jsx_component_attribute_tests::part_01::test_jsx_intrinsic_union_react16_fixture_accepts_shared_attributes` (and its sibling `jsx_import_side_effects_non_extant_no_false_intrinsic_missing_props`) time out on Linux CI (`RUST_MIN_STACK=16777216` from `scripts/ci/full-ci.sh`) while passing on the faster macOS runner. The failure is a nextest 60s **timeout**, not a wrong diagnostic.

Root cause is a super-linear re-validation of type-argument constraints while lowering faithful React 16 lib types. `validate_type_reference_type_arguments` (TS2344) is coupled into type *lowering*: consuming a generic declared in a consumed `.d.ts` re-validates that lib's own mutually-generic alias bodies (`ReactElement` / `JSXElementConstructor` / `Component`) on every lowering. The re-entry (`compute_type_of_symbol_type_alias_variable_alias` <-> `validate_type_reference_type_arguments` <-> `explicit_alias_type_parameter_constraint_satisfies_arg_constraint` <-> the constraint relation) is bounded only by the physical-stack breaker in `checkers/mod.rs`, so its cost is a function of `RUST_MIN_STACK` and CPU speed — ~22s at 16MB on a fast Mac, over 60s on a slower Linux host. (It surfaced after #15663 switched the fixture to full faithful libs and #15685 removed its silent-skip.)

## Structural rule

When a type reference is lowered inside a transient cross-arena delegate checker (`delegate_for_arena`, e.g. `AliasResolution` lowering a consumed `.d.ts` alias body), `tsc` does not run TS2344 type-argument constraint validation — validation belongs to the check pass of the file that *owns* the reference. tsz does this through the generic checker: such delegates carry `diagnostics_discarded = true`, and every diagnostic they push is already dropped at `push_diagnostic`. Gate the validation on `!diagnostics_discarded`.

This is **behaviour-neutral** — the delegate's diagnostics never surfaced — and tsc-aligned: a `.d.ts` checked as a *program root* runs in the primary (non-discarding) checker and still reports TS2344.

- Owner layer: checker (`crates/tsz-checker/src/checkers/generic_checker/mod.rs`).
- Adjacent matrix (`tests/ts2344_consumed_lib_delegate_gate_tests.rs`): user `.ts` reference to a consumed-lib generic with a bad arg -> TS2344 still fires; satisfying arg -> clean; constraint violation in a checked `.d.ts` root -> TS2344 still fires.
- Performance: the two faithful-React intrinsic tests drop from ~22s/15s to ~2s at 16MB `RUST_MIN_STACK`; the constraint-validation recursion is gone from the profile (0 `validate_type_reference_type_arguments` / `explicit_alias` frames), leaving only legitimate lowering/evaluation of the React types.

Goal: hold

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max

## Verification

- `RUST_MIN_STACK=16777216 cargo nextest run -p tsz-checker --test jsx_component_attribute_tests` — 227/227 pass; suite 2.27s (was timing out); the two react16 tests ~2.0s each.
- `cargo nextest run -p tsz-checker --test ts2344_consumed_lib_delegate_gate_tests` — 3/3 pass (user-file TS2344 fires, satisfying arg clean, checked `.d.ts` root TS2344 fires).
- TS2344 families green: `ts2344_infer_result_application_constraint_tests`, `ts2344_keyof_bare_tparam_defer_tests`, `ts2344_generic_ref_scoped_param_concrete_constraint`, `sibling_defaulted_conditional_constraint_tests`, `type_argument_inference_constraints_fingerprint_tests` — 48/48 pass.
- Broad cross-file/lib/module-augmentation/constraint batch (11 suites): 110 pass; only the 3 pre-existing `cross_file_generic_interface_mapped_filter_tests` entries already in `scripts/ci/known-failures.txt` fail (unchanged by this PR).
- Filtered conformance run locally (`scripts/conformance/conformance.sh run --filter`), all against the pinned tsc 6.0.3 cache, 100% pass with 0 crashes / 0 timeouts / 0 regressions: `jsx` 298/298, `genericCall` 50/50, `typeArgument` 43/43, `react` 16/16, `constraint` 12/12, `libTypeScript` 4/4, `genericCallWithConstraints` 2/2, `typeParameterConstraint` 2/2.
- Full CI adjudicates broad conformance/emit/fourslash.
