### PR TITLE
fix(checker): keep error-typed returns in inferred return type (class-transformer FP)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1469,6 +1469,10 @@ path = "tests/ts2538_tparam_resolved_to_any_tests.rs"
 name = "import_attributes_resolution_mode_tests"
 path = "tests/import_attributes_resolution_mode_tests.rs"
 [[test]]
+name = "inferred_return_error_and_self_call_tests"
+path = "tests/inferred_return_error_and_self_call_tests.rs"
+
+[[test]]
 name = "imported_companion_value_type_tests"
 path = "tests/imported_companion_value_type_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -349,6 +349,9 @@ mod index_signature_symbol_keyspace_tests;
 #[path = "../tests/indexed_access_alias_application_relation_tests.rs"]
 mod indexed_access_alias_application_relation_tests;
 #[cfg(test)]
+#[path = "../tests/inferred_return_error_and_self_call_tests.rs"]
+mod inferred_return_error_and_self_call_tests;
+#[cfg(test)]
 #[path = "tests/inferred_return_object_array_widening_tests.rs"]
 mod inferred_return_object_array_widening_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -922,7 +922,15 @@ impl<'a> CheckerState<'a> {
         }) {
             self.ctx.preserve_literal_types = false;
         }
-        let result = self.infer_return_type_from_body_inner(body_idx, return_context);
+        // The enclosing function's own symbol, used to skip *direct* recursive
+        // self-calls (`return self(...)`) during return aggregation — matching
+        // tsc's `checkAndAggregateReturnExpressionTypes`, which drops such a
+        // return rather than folding its (circular) type into the union. This is
+        // the ONLY return form tsc omits; genuine error-typed returns (e.g.
+        // `return unresolvedName`) are kept and make the union collapse to
+        // `error`/`any`, exactly as tsc's contagious `errorType` does.
+        let self_sym = self.enclosing_function_self_symbol(function_idx);
+        let result = self.infer_return_type_from_body_inner(body_idx, return_context, self_sym);
         self.ctx.preserve_literal_types = prev_preserve_literals;
         self.ctx.preserve_logical_operand_literals = prev_preserve_logical;
 
@@ -1148,6 +1156,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         body_idx: NodeIndex,
         return_context: Option<TypeId>,
+        self_sym: Option<tsz_binder::SymbolId>,
     ) -> TypeId {
         let factory = self.ctx.types.factory();
         if body_idx.is_none() {
@@ -1174,6 +1183,7 @@ impl<'a> CheckerState<'a> {
                     &mut return_types,
                     &mut saw_empty,
                     return_context,
+                    self_sym,
                 );
             }
         }
@@ -1275,17 +1285,15 @@ impl<'a> CheckerState<'a> {
             });
         }
 
-        // Filter out ERROR types from return type inference when there are
-        // non-ERROR alternatives. This handles recursive self-referencing functions
-        // like `const fn1 = () => { if (...) return fn1(); return 0; }`.
-        // The recursive call resolves to ERROR during type computation (circular
-        // reference), but the base case `return 0` provides a concrete `number` type.
-        // tsc filters out circular contributions and infers the return type from
-        // non-circular branches only, so `fn1` gets return type `number`.
-        let has_non_error = return_types.iter().any(|c| c.type_id != TypeId::ERROR);
-        if has_non_error {
-            return_types.retain(|c| c.type_id != TypeId::ERROR);
-        }
+        // NOTE: error-typed contributions are intentionally NOT filtered here.
+        // tsc keeps a genuine error-typed return (e.g. `return unresolvedName`,
+        // whose `errorType` carries the `Any` flag) and lets `getUnionType`
+        // collapse the whole union to `errorType`/`any`. The only return form tsc
+        // omits is a *direct* recursive self-call (`return self(...)`), which
+        // `collect_return_types_in_statement` already skips via `self_sym` — so a
+        // recursive `const fn1 = () => { if (c) return fn1(); return 0; }` still
+        // infers `number` from its base case, while `function g() { return global; }`
+        // (unresolved `global`) infers `any`, matching tsc.
 
         // Union the contributions and apply the remaining primitive-collapse
         // widen (tsc's `getWidenedType(getUnionType(...))`). Fresh object/array
@@ -1474,6 +1482,96 @@ impl<'a> CheckerState<'a> {
         return_type
     }
 
+    /// The symbol a *direct* recursive self-reference resolves to for the
+    /// function at `function_idx`. For a named function / method / accessor this
+    /// is the declaration's own symbol. For an anonymous arrow / function
+    /// expression bound to a variable (`const fn1 = () => ...`), the recursive
+    /// name `fn1` resolves to the *variable*, not the function node, so the
+    /// enclosing variable-declaration symbol is used instead (climbing through
+    /// transparent expression wrappers). Returns `None` when no stable
+    /// self-reference name exists (e.g. an arrow passed inline as an argument).
+    fn enclosing_function_self_symbol(
+        &self,
+        function_idx: NodeIndex,
+    ) -> Option<tsz_binder::SymbolId> {
+        let node = self.ctx.arena.get(function_idx)?;
+        if !matches!(
+            node.kind,
+            syntax_kind_ext::ARROW_FUNCTION | syntax_kind_ext::FUNCTION_EXPRESSION
+        ) {
+            // Named function declaration / method / accessor: the node carries
+            // its own binding symbol, which the recursive call resolves to.
+            return self.ctx.binder.get_node_symbol(function_idx);
+        }
+
+        // Anonymous function expression / arrow: walk out through transparent
+        // wrappers to the binding site and use its symbol.
+        let mut current = function_idx;
+        loop {
+            let Some(ext) = self.ctx.arena.get_extended(current) else {
+                break;
+            };
+            let parent_idx = ext.parent;
+            if parent_idx.is_none() {
+                break;
+            }
+            let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
+                break;
+            };
+            match parent_node.kind {
+                syntax_kind_ext::PARENTHESIZED_EXPRESSION
+                | syntax_kind_ext::NON_NULL_EXPRESSION
+                | syntax_kind_ext::AS_EXPRESSION
+                | syntax_kind_ext::TYPE_ASSERTION
+                | syntax_kind_ext::SATISFIES_EXPRESSION => {
+                    current = parent_idx;
+                }
+                syntax_kind_ext::VARIABLE_DECLARATION | syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                    return self.ctx.binder.get_node_symbol(parent_idx);
+                }
+                _ => break,
+            }
+        }
+        // Fall back to a named function expression's own symbol (e.g.
+        // `const f = function g() { return g(); }`, self-referenced via `g`).
+        self.ctx.binder.get_node_symbol(function_idx)
+    }
+
+    /// Whether `expr_idx` is a *direct* recursive call to the enclosing
+    /// function — `return self(...)` where the callee is a bare identifier that
+    /// resolves to `self_sym`. Mirrors tsc's
+    /// `checkAndAggregateReturnExpressionTypes`, which omits such a return (a
+    /// `CallExpression` whose `expression` is an `Identifier` bound to the
+    /// function's own symbol) from the aggregated return type.
+    ///
+    /// Only the *callee-is-a-bare-identifier* shape counts: a wrapped self-call
+    /// (`return [self][0]()`, `return (0, self)()`) is NOT direct, so — like tsc
+    /// — its circular type is aggregated and collapses the union to `any`.
+    fn return_expression_is_direct_self_call(
+        &self,
+        expr_idx: NodeIndex,
+        self_sym: tsz_binder::SymbolId,
+    ) -> bool {
+        let expr_idx = self.ctx.arena.skip_parenthesized(expr_idx);
+        let Some(node) = self.ctx.arena.get(expr_idx) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return false;
+        }
+        let Some(call) = self.ctx.arena.get_call_expr(node) else {
+            return false;
+        };
+        let callee = call.expression;
+        let Some(callee_node) = self.ctx.arena.get(callee) else {
+            return false;
+        };
+        if callee_node.kind != SyntaxKind::Identifier as u16 {
+            return false;
+        }
+        self.resolve_identifier_symbol(callee) == Some(self_sym)
+    }
+
     /// Collect return types from a statement and its nested statements.
     ///
     /// This function recursively walks through statements, collecting the types
@@ -1490,6 +1588,7 @@ impl<'a> CheckerState<'a> {
         return_types: &mut Vec<ReturnContribution>,
         saw_empty: &mut bool,
         return_context: Option<TypeId>,
+        self_sym: Option<tsz_binder::SymbolId>,
     ) {
         let Some(node) = self.ctx.arena.get(stmt_idx) else {
             return;
@@ -1500,6 +1599,13 @@ impl<'a> CheckerState<'a> {
                 if let Some(return_data) = self.ctx.arena.get_return_statement(node) {
                     if return_data.expression.is_none() {
                         *saw_empty = true;
+                    } else if self_sym.is_some_and(|sym| {
+                        self.return_expression_is_direct_self_call(return_data.expression, sym)
+                    }) {
+                        // A direct recursive self-call (`return self(...)`) is
+                        // omitted from the aggregate, mirroring tsc. Its circular
+                        // provisional type must not poison the union; the base
+                        // cases decide the inferred return type.
                     } else {
                         // Keep block-body inference mostly raw, but allow concrete
                         // contextual return types to shape literals and other
@@ -1578,6 +1684,7 @@ impl<'a> CheckerState<'a> {
                             return_types,
                             saw_empty,
                             return_context,
+                            self_sym,
                         );
                     }
                 }
@@ -1598,6 +1705,7 @@ impl<'a> CheckerState<'a> {
                         return_types,
                         saw_empty,
                         return_context,
+                        self_sym,
                     );
                     if if_data.else_statement.is_some() {
                         self.collect_return_types_in_statement(
@@ -1605,6 +1713,7 @@ impl<'a> CheckerState<'a> {
                             return_types,
                             saw_empty,
                             return_context,
+                            self_sym,
                         );
                     }
                 }
@@ -1624,6 +1733,7 @@ impl<'a> CheckerState<'a> {
                                     return_types,
                                     saw_empty,
                                     return_context,
+                                    self_sym,
                                 );
                             }
                         }
@@ -1637,6 +1747,7 @@ impl<'a> CheckerState<'a> {
                         return_types,
                         saw_empty,
                         return_context,
+                        self_sym,
                     );
                     if try_data.catch_clause.is_some() {
                         self.collect_return_types_in_statement(
@@ -1644,6 +1755,7 @@ impl<'a> CheckerState<'a> {
                             return_types,
                             saw_empty,
                             return_context,
+                            self_sym,
                         );
                     }
                     if try_data.finally_block.is_some() {
@@ -1652,6 +1764,7 @@ impl<'a> CheckerState<'a> {
                             return_types,
                             saw_empty,
                             return_context,
+                            self_sym,
                         );
                     }
                 }
@@ -1663,6 +1776,7 @@ impl<'a> CheckerState<'a> {
                         return_types,
                         saw_empty,
                         return_context,
+                        self_sym,
                     );
                 }
             }
@@ -1675,6 +1789,7 @@ impl<'a> CheckerState<'a> {
                         return_types,
                         saw_empty,
                         return_context,
+                        self_sym,
                     );
                 }
             }
@@ -1685,6 +1800,7 @@ impl<'a> CheckerState<'a> {
                         return_types,
                         saw_empty,
                         return_context,
+                        self_sym,
                     );
                 }
             }
@@ -1695,6 +1811,7 @@ impl<'a> CheckerState<'a> {
                         return_types,
                         saw_empty,
                         return_context,
+                        self_sym,
                     );
                 }
             }

--- a/crates/tsz-checker/tests/inferred_return_error_and_self_call_tests.rs
+++ b/crates/tsz-checker/tests/inferred_return_error_and_self_call_tests.rs
@@ -12,8 +12,8 @@
 //! flagging downstream property accesses (TS2339). See the class-transformer
 //! `getGlobal()` false-positive cluster.
 
-use crate::context::CheckerOptions;
-use crate::test_utils::check_source;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
 
 fn check_strict(source: &str) -> Vec<u32> {
     let options = CheckerOptions {

--- a/crates/tsz-checker/tests/inferred_return_error_and_self_call_tests.rs
+++ b/crates/tsz-checker/tests/inferred_return_error_and_self_call_tests.rs
@@ -1,0 +1,151 @@
+//! Inferred return type aggregation for error-typed and recursive self-call
+//! returns.
+//!
+//! tsc's `checkAndAggregateReturnExpressionTypes` keeps a genuine error-typed
+//! return (an unresolved name's `errorType` carries the `Any` flag) and lets
+//! `getUnionType` collapse the whole union to `error`/`any`; the ONLY return
+//! form it omits is a *direct* recursive self-call (`return self(...)`), whose
+//! circular provisional type must not poison the aggregate. tsz previously
+//! blanket-dropped every error-typed contribution, which turned
+//! `function g() { if (c) return globalThis; return global; }` (unresolved
+//! `global`) into `typeof globalThis | undefined` instead of `any`, spuriously
+//! flagging downstream property accesses (TS2339). See the class-transformer
+//! `getGlobal()` false-positive cluster.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn check_strict(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        strict_null_checks: true,
+        no_implicit_any: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.ts", options)
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+/// A function whose body mixes a concrete return with a genuine error-typed
+/// return (here `obj.nonExistentProp`, whose result is the `error` type) infers
+/// `any`, matching tsc's contagious `errorType`. The real error (TS2339 on the
+/// bad property access) is still reported, but assigning the *result* to an
+/// incompatible annotation does NOT report TS2322 — proving the inferred return
+/// is `any`, not `{ z: 1 } | undefined`. Before this fix, the error-typed
+/// contribution was blanket-dropped and the assignment reported a spurious
+/// TS2322.
+#[test]
+fn error_typed_return_collapses_inferred_return_to_any() {
+    let source = r#"
+declare const cond: boolean;
+declare const obj: { a: number };
+function pick() {
+  if (cond) return { z: 1 };
+  return obj.nonExistentProp;
+}
+const s: string = pick();
+"#;
+    let codes = check_strict(source);
+    assert!(
+        codes.contains(&2339),
+        "the genuine bad property access must still report TS2339; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2322),
+        "the error-typed return must collapse the inferred return to any, so \
+         `string = pick()` reports NO TS2322; got: {codes:?}"
+    );
+}
+
+/// Renamed-binder variant: the rule is structural, not tied to any identifier.
+#[test]
+fn error_typed_return_collapses_inferred_return_to_any_renamed() {
+    let source = r#"
+declare const flag: boolean;
+declare const source: { count: number };
+function resolveEnv() {
+  if (flag) return { kind: "node" };
+  return source.missingMember;
+}
+const env: number = resolveEnv();
+"#;
+    let codes = check_strict(source);
+    assert!(
+        codes.contains(&2339),
+        "the genuine bad property access must still report TS2339; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2322),
+        "the error-typed return must collapse the inferred return to any; got: {codes:?}"
+    );
+}
+
+/// A *direct* recursive self-call (`return countdown()`) is omitted from the
+/// aggregate — matching tsc — so a `const` arrow still infers its base-case
+/// type (`number`). Assigning it to `string` therefore reports TS2322; if the
+/// self-call poisoned the union, the result would be `any` and no error would
+/// fire.
+#[test]
+fn direct_self_call_const_arrow_keeps_base_case_type() {
+    let source = r#"
+declare const cond: boolean;
+const countdown = () => {
+  if (cond) return countdown();
+  return 0;
+};
+const label: string = countdown();
+"#;
+    let codes = check_strict(source);
+    assert!(
+        codes.contains(&2322),
+        "recursive const arrow must infer its base-case type (number), so \
+         `string = countdown()` reports TS2322; got: {codes:?}"
+    );
+}
+
+/// Same for a named function declaration self-call: the base case wins.
+#[test]
+fn direct_self_call_function_declaration_keeps_base_case_type() {
+    let source = r#"
+declare const cond: boolean;
+function walk() {
+  if (cond) return walk();
+  return "leaf";
+}
+const size: number = walk();
+"#;
+    let codes = check_strict(source);
+    assert!(
+        codes.contains(&2322),
+        "recursive function declaration must infer its base-case type (string), \
+         so `number = walk()` reports TS2322; got: {codes:?}"
+    );
+}
+
+/// A *wrapped* self-call (`return [bounce][0]()`) is NOT a direct self-call, so
+/// — like tsc — its circular type is aggregated and the function degrades to the
+/// implicit-`any` circular return (TS7023), rather than adopting the base case.
+/// The assignment to `string` therefore does NOT report TS2322.
+#[test]
+fn wrapped_self_call_is_not_skipped() {
+    let source = r#"
+declare const cond: boolean;
+function bounce() {
+  if (cond) return [bounce][0]();
+  return 0;
+}
+const t: string = bounce();
+"#;
+    let codes = check_strict(source);
+    assert!(
+        codes.contains(&7023),
+        "a wrapped self-call must still report the circular implicit-any return \
+         (TS7023); got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2322),
+        "a wrapped self-call degrades to any, so no TS2322 fires on the \
+         assignment; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary

Fixes the class-transformer canary false-positive cluster: 6 tsz-only diagnostics
(TS2339 `Property … does not exist on type 'typeof globalThis | undefined'` across
`storage.ts`, `TransformOperationExecutor.ts`, and `get-global.util.spect.ts`) where
`tsc` reports nothing. Root cause is inferred-return-type aggregation.

## Structural rule

When a function body has no return-type annotation, `tsc`'s
`checkAndAggregateReturnExpressionTypes` aggregates every return expression's type and
lets `getUnionType` collapse the union. A genuine **error-typed** return (an unresolved
name, whose `errorType` carries the `Any` flag) makes the whole union `error`/`any`. The
**only** return form `tsc` omits is a **direct recursive self-call** (`return self(...)`),
whose circular provisional type must not poison the aggregate.

tsz owned this in the checker (`infer_return_type_from_body` →
`infer_return_type_from_body_inner`), but blanket-dropped **every** `TypeId::ERROR`
contribution whenever a non-error alternative existed. So class-transformer's

```ts
export function getGlobal() {
  if (typeof globalThis !== 'undefined') return globalThis;
  if (typeof global !== 'undefined') return global; // `global` unresolved -> error type
  ...
}
```

inferred `typeof globalThis | undefined` instead of `any`, and every downstream
`globalScope.foo` / `getGlobal().Buffer` was flagged TS2339. `tsc` infers `any` (the
`return global` error type collapses the union), so it reports nothing.

## Owner layer

Checker — `crates/tsz-checker/src/types/utilities/return_type.rs`. Replaces the blunt
ERROR filter with tsc's rule:
- `enclosing_function_self_symbol` resolves the function's self-reference symbol (its own
  node symbol for named functions/methods; the enclosing variable-declaration symbol for
  arrows / function expressions bound to a `const`/`let`/property).
- `return_expression_is_direct_self_call` matches tsc's shape: a `CallExpression` whose
  callee is a bare `Identifier` bound to that symbol.
- Direct self-calls are skipped during aggregation (threaded `self_sym`); genuine
  error-typed returns are kept, so the union collapses to `error`/`any` via the existing
  contagious-error union normalizer.

## Adjacent-case matrix (verified against vendored `tsc` 6.0.3)

| case | tsc | tsz after |
| --- | --- | --- |
| `getGlobal()` (error return + concrete) | `any`, no error | matches |
| `const fn1 = () => { if(c) return fn1(); return 0 }` | `number` | `number` |
| `let fn1 = …` / `function fn1() {…}` recursion | `number`/base | matches |
| wrapped self-call `return [fn1][0]()` | circular `any` (TS7023) | matches |
| async `return unresolvedName` | `Promise<any>` | matches |
| mutual recursion `f↔g` | TS2322 agree | TS2322 agree |

## Verification

- Minimal repro: `getGlobal().Buffer` FP gone; recursion base-case types preserved.
- class-transformer row (`tsconfig.tsz-guard.json`, vendored tsc 6.0.3 oracle):
  tsz-only diagnostic delta **6 → 0**; tsc-only delta unchanged (5), so no previously
  shared diagnostic was suppressed.
- superjson row: tsz-only delta **15 → 15** (neutral; its FPs are a separate
  generic-Map type-guard narrowing bug, out of scope).
- New unit tests `crates/tsz-checker/tests/inferred_return_error_and_self_call_tests.rs`
  (5 tests, incl. a renamed-binder variant and positive/negative self-call controls); 3
  fail when the fix is reverted (flip confirmed).
- `cargo nextest run -p tsz-checker --lib` over return/recursion/circular/implicit-any
  families: 1029 pass; the only 5 failures are pre-existing (fail identically on
  `origin/main`, tracked in `docs/plan/handoff/`).
- `cargo clippy -p tsz-checker`: clean.

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max
