### PR TITLE
style(checker): while-let binding walk (clippy fix for #15730)

### DIFF
--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -1507,10 +1507,7 @@ impl<'a> CheckerState<'a> {
         // Anonymous function expression / arrow: walk out through transparent
         // wrappers to the binding site and use its symbol.
         let mut current = function_idx;
-        loop {
-            let Some(ext) = self.ctx.arena.get_extended(current) else {
-                break;
-            };
+        while let Some(ext) = self.ctx.arena.get_extended(current) {
             let parent_idx = ext.parent;
             if parent_idx.is_none() {
                 break;


### PR DESCRIPTION
Goal: hold

Un-blocks main clippy: #15730's binding-site walk used `loop { let Some(..) else break }`, denied as clippy::while_let_loop on CI (local cached clippy missed it). Pure style rewrite; behavior unchanged.

## Verification
- cargo clippy --profile ci-lint -p tsz-checker -- -D warnings: clean (fresh, not cached).
- inferred_return_error_and_self_call_tests: 5/5.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max