### PR TITLE
fix(checker,core): twelve oracle-verified conformance mechanisms (+26)

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
@@ -13,17 +13,10 @@ impl<'a> CheckerState<'a> {
         display_target: &str,
         provided_attrs: &[(String, TypeId)],
     ) {
-        let mut ordered_attrs: Vec<(String, TypeId)> = Vec::with_capacity(provided_attrs.len());
-        if let Some((_, children_type)) = provided_attrs.iter().find(|(name, _)| name == "children")
-        {
-            ordered_attrs.push(("children".to_string(), *children_type));
-        }
-        ordered_attrs.extend(
-            provided_attrs
-                .iter()
-                .filter(|(name, _)| name != "children")
-                .cloned(),
-        );
+        // tsc displays explicit attributes in source order with 'children'
+        // appended last (the synthesis pipeline already pushes it last); do
+        // not reorder.
+        let ordered_attrs: Vec<(String, TypeId)> = provided_attrs.to_vec();
 
         let properties: Vec<tsz_solver::PropertyInfo> = ordered_attrs
             .iter()

--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -1407,11 +1407,20 @@ impl<'a> CheckerState<'a> {
                         .rest_parameter_relation_outcome(init_type, readonly_any_array)
                         .related
                     {
-                        self.error_at_node(
-                            param_idx,
-                            "A rest parameter must be of an array type.",
-                            diagnostic_codes::A_REST_PARAMETER_MUST_BE_OF_AN_ARRAY_TYPE,
-                        );
+                        // Anchor at the parameter start (the `...` token) like
+                        // the annotated branches; error_at_node would
+                        // normalize to the name node.
+                        if let Some(pn) = self.ctx.arena.get(param_idx)
+                            && let Some(name_node) = self.ctx.arena.get(param.name)
+                        {
+                            let length = name_node.end.saturating_sub(pn.pos);
+                            self.error_at_position(
+                                pn.pos,
+                                length,
+                                "A rest parameter must be of an array type.",
+                                diagnostic_codes::A_REST_PARAMETER_MUST_BE_OF_AN_ARRAY_TYPE,
+                            );
+                        }
                     }
                 }
             }

--- a/crates/tsz-checker/src/declarations/declarations.rs
+++ b/crates/tsz-checker/src/declarations/declarations.rs
@@ -114,12 +114,25 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
             return;
         };
 
-        // Check if this is a const declaration by checking the parent's flags
-        let is_const = (parent_node.flags & node_flags::CONST as u16) != 0;
+        // TS1155's message parameter follows the declaration kind:
+        // `await using` (Const|Using), `using`, or `const`.
+        let kind_flags = u32::from(parent_node.flags);
+        let ts1155_kind = if kind_flags & node_flags::AWAIT_USING == node_flags::AWAIT_USING {
+            Some("await using")
+        } else if kind_flags & node_flags::USING != 0 {
+            Some("using")
+        } else if kind_flags & node_flags::CONST != 0 {
+            Some("const")
+        } else {
+            None
+        };
 
-        // TS1155: 'const' declarations must be initialized
+        // TS1155: '<kind>' declarations must be initialized
         // Skip when file has real syntax errors — the parse error is sufficient.
-        if is_const && decl_data.initializer.is_none() && !self.ctx.has_real_syntax_errors {
+        if let Some(kind_name) = ts1155_kind
+            && decl_data.initializer.is_none()
+            && !self.ctx.has_real_syntax_errors
+        {
             // Skip for destructuring patterns - they get TS1182 from the parser
             if let Some(name_node) = self.ctx.arena.get(decl_data.name) {
                 if name_node.kind == syntax_kind_ext::OBJECT_BINDING_PATTERN
@@ -147,7 +160,7 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
                     self.ctx.error(
                         decl_node.pos,
                         decl_node.end - decl_node.pos,
-                        "'const' declarations must be initialized.".to_string(),
+                        format!("'{kind_name}' declarations must be initialized."),
                         1155,
                     );
                 }

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1331,8 +1331,6 @@ impl<'a> CheckerState<'a> {
         use tsz_binder::symbol_flags;
         use tsz_parser::parser::syntax_kind_ext;
 
-        let mut reported_cycle_symbols = rustc_hash::FxHashSet::default();
-
         let is_js_file = self.ctx.is_js_file();
 
         // Collect ALIAS symbols only from scope tables, not from the full symbol arena.
@@ -1358,10 +1356,6 @@ impl<'a> CheckerState<'a> {
                 Some(s) => s,
                 None => continue,
             };
-
-            if reported_cycle_symbols.contains(&sym_id) {
-                continue;
-            }
 
             // In JS files, `import x = require(...)` is TS-only syntax (TS8002).
             // tsc skips semantic analysis for such statements — skip circular check.
@@ -1636,28 +1630,12 @@ impl<'a> CheckerState<'a> {
             }
 
             if cycle_detected {
-                // For cross-file cycles, use max SymbolId heuristic to deduplicate:
-                // only report the cycle from the file containing the highest SymbolId.
-                // For same-file cycles, report on the first symbol encountered (no dedup needed).
-                let this_file_idx = self.ctx.current_file_idx;
-                let is_cross_file = visited.iter().any(|key| key.0 != this_file_idx);
-                if is_cross_file {
-                    let max_sym_in_cycle = visited_sym_ids
-                        .iter()
-                        .max_by_key(|s| s.0)
-                        .copied()
-                        .unwrap_or(sym_id);
-                    if sym_id != max_sym_in_cycle {
-                        continue;
-                    }
-                }
-
-                for key in &visited {
-                    if key.0 == this_file_idx {
-                        reported_cycle_symbols.insert(tsz_binder::SymbolId(key.1 as u32));
-                    }
-                }
-
+                // tsc 7.0.2 reports TS2303 once at EVERY alias declaration
+                // participating in the cycle (each file flags its own
+                // specifier; both specifiers within one file too), so there
+                // is no cross-file dedup and no blanket same-file
+                // suppression — each per-symbol iteration reports its own
+                // alias at its own anchor.
                 let Some(decl_idx) = sym.primary_declaration() else {
                     continue;
                 };

--- a/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
@@ -15,9 +15,9 @@ impl<'a> CheckerState<'a> {
         property_name: tsz_common::interner::Atom,
         target: TypeId,
     ) -> String {
-        if let Some(display) = self.enum_mapped_property_name_for_display(property_name, target) {
-            return display;
-        }
+        // tsc 7.0.2 renders enum-derived mapped keys as the bare literal
+        // value ('0', 'sa'), never as a qualified '[E.A]'; only symbol keys
+        // keep their bracketed display.
         if let Some(display) = self.symbol_keyed_property_name_for_display(property_name, target) {
             return display;
         }

--- a/crates/tsz-checker/src/state/state_checking/directive.rs
+++ b/crates/tsz-checker/src/state/state_checking/directive.rs
@@ -140,18 +140,11 @@ impl<'a> CheckerState<'a> {
                     .unwrap_or_else(|| Path::new(""))
                     .join(&forward_slash_path);
 
-                // Render the resolved path the way tsc does for this driver
-                // mode. Explicit-file checks supply `current_directory` and use
-                // cwd-relative display; project/config checks leave it unset
-                // and keep resolved paths. Absolute reference literals always
-                // stay absolute.
-                let current_directory = if reference_path_is_absolute(&forward_slash_path) {
-                    None
-                } else {
-                    self.ctx.current_directory.as_deref()
-                };
-                let display_path = display_reference_path(&resolved, current_directory);
-                let message = format_message("File '{0}' not found.", &[&display_path]);
+                // tsc 7.0.2 prints the directive text exactly as written in
+                // BOTH explicit-file and project modes; the resolved path is
+                // used only for the existence probe.
+                let _ = &resolved;
+                let message = format_message("File '{0}' not found.", &[reference_path.as_str()]);
                 self.emit_error_at(pos, length, &message, diagnostic_codes::FILE_NOT_FOUND);
             }
         }

--- a/crates/tsz-checker/src/state/state_checking_members/class_member_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/class_member_checks.rs
@@ -413,56 +413,18 @@ impl CheckerState<'_> {
                     }
                 }
 
-                // All properties: only report subsequent declarations
-                for &idx in info.indices.iter().skip(1) {
+                // All properties: tsc's binder (declareSymbol) reports
+                // TS2300 at EVERY declaration site, the first included.
+                for &idx in info.indices.iter() {
                     self.report_duplicate_class_member_ts2300(idx);
                 }
             } else if property_count > 0 && method_count > 0 {
-                let mut first_member_type: Option<(TypeId, String)> = None;
-                for (&idx, &is_property) in info.indices.iter().zip(info.is_property.iter()) {
-                    if first_member_type.is_none() {
-                        first_member_type = if is_property {
-                            self.get_class_property_declared_type_info(idx)
-                                .map(|(name, _name_node, type_id)| (type_id, name))
-                        } else {
-                            self.get_class_method_type_info(idx)
-                                .map(|(name, _name_node, type_id)| (type_id, name))
-                        }
-                        .filter(|(type_id, _)| !self.type_contains_error(*type_id));
-                        continue;
-                    }
-
-                    if !is_property {
-                        continue;
-                    }
-
-                    let Some((name, name_node, current_type)) =
-                        self.get_class_property_declared_type_info(idx)
-                    else {
-                        continue;
-                    };
-                    let Some((first_type, _first_name)) = first_member_type.as_ref() else {
-                        continue;
-                    };
-                    if self.type_contains_error(current_type) || *first_type == current_type {
-                        continue;
-                    }
-
-                    let display_name = self.get_member_name_display_text(name_node).unwrap_or(name);
-                    let first_type_str = self.format_type(*first_type);
-                    let current_type_str = self.format_type(current_type);
-                    self.error_at_node_msg(
-                        name_node,
-                        diagnostic_codes::SUBSEQUENT_PROPERTY_DECLARATIONS_MUST_HAVE_THE_SAME_TYPE_PROPERTY_MUST_BE_OF_TYP,
-                        &[&display_name, &first_type_str, &current_type_str],
-                    );
-                }
-
-                // Mixed properties and methods: check if first is property
-                let first_is_property = info.is_property.first().copied().unwrap_or(false);
-                let skip_count = usize::from(!first_is_property);
-
-                for &idx in info.indices.iter().skip(skip_count) {
+                // Mixed property/method duplicates: tsc 7.0.2 reports TS2300
+                // at EVERY declaration (either order) and no TS2717 — the
+                // subsequent-declaration type rule only applies between
+                // PROPERTY declarations (oracle: `class { m(){} m: number }`
+                // gets 2x TS2300 and nothing else).
+                for &idx in info.indices.iter() {
                     self.report_duplicate_class_member_ts2300(idx);
                 }
             } else if method_impl_count > 1 {

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -145,9 +145,13 @@ impl<'a> CheckerState<'a> {
         }
 
         // Error 1183: An implementation cannot be declared in ambient contexts
-        // Check if function has 'declare' modifier but also has a body
-        // Point error at the body (opening brace) to match tsc
-        if func.body.is_some() && self.has_declare_modifier(&func.modifiers) {
+        // Fires for an own `declare` modifier AND for ambient-by-containment
+        // (a body inside `declare namespace`/`declare module`); anchored at
+        // the body's opening brace like tsc.
+        if func.body.is_some()
+            && (self.has_declare_modifier(&func.modifiers)
+                || self.ctx.is_ambient_declaration(func_idx))
+        {
             use crate::diagnostics::diagnostic_codes;
             self.error_at_node(
                 func.body,

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -834,8 +834,14 @@ impl<'a> CheckerState<'a> {
             // quote style for string-literal property names in TS2411 diagnostics.
             let diag_prop_name = if let Some(name_node) = self.ctx.arena.get(name_idx) {
                 if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+                    // The node range runs one token past the `]` (a trailing
+                    // `(`, `:`, `=` leaks in); truncate at the closing bracket
+                    // so the printed name is exactly the bracketed text.
                     self.node_text(name_idx)
-                        .map(|text| text.trim_end_matches(':').to_string())
+                        .map(|text| match text.rfind(']') {
+                            Some(end) => text[..=end].to_string(),
+                            None => text.trim_end_matches(':').to_string(),
+                        })
                         .unwrap_or_else(|| prop_name.clone())
                 } else if name_node.kind == tsz_scanner::SyntaxKind::StringLiteral as u16 {
                     self.node_text(name_idx)

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -343,8 +343,22 @@ impl<'a> CheckerState<'a> {
                 && let Some(parent_node) = self.ctx.arena.get(ext.parent)
             {
                 use tsz_parser::parser::node_flags;
-                let is_const = (parent_node.flags & node_flags::CONST as u16) != 0;
-                if is_const && var_decl.initializer.is_none() {
+                // TS1155's message parameter follows the declaration kind:
+                // `await using` (Const|Using), `using`, or `const`.
+                let kind_flags = u32::from(parent_node.flags);
+                let ts1155_kind = if kind_flags & node_flags::AWAIT_USING == node_flags::AWAIT_USING
+                {
+                    Some("await using")
+                } else if kind_flags & node_flags::USING != 0 {
+                    Some("using")
+                } else if kind_flags & node_flags::CONST != 0 {
+                    Some("const")
+                } else {
+                    None
+                };
+                if let Some(kind_name) = ts1155_kind
+                    && var_decl.initializer.is_none()
+                {
                     // Skip for destructuring patterns - they get TS1182 from the parser
                     let is_binding_pattern =
                         if let Some(name_node) = self.ctx.arena.get(var_decl.name) {
@@ -369,7 +383,7 @@ impl<'a> CheckerState<'a> {
                         self.ctx.error(
                             node.pos,
                             node.end - node.pos,
-                            "'const' declarations must be initialized.".to_string(),
+                            format!("'{kind_name}' declarations must be initialized."),
                             1155,
                         );
                     }

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -1682,12 +1682,13 @@ impl<'a> CheckerState<'a> {
         Some(self.get_syntactic_class_name_or_anonymous(class_idx))
     }
 
-    /// Return the class's syntactic name, or `"(anonymous)"` if the class
-    /// expression has no name. Unlike `get_bound_class_name_from_decl`, this
-    /// does NOT fall back to an enclosing `VariableDeclaration` name — tsc
-    /// uses this stricter form for TS18013 messages.
+    /// Return the class's name for TS18013-style messages: the syntactic
+    /// name, else the enclosing `VariableDeclaration` binding name (tsc
+    /// names `const C = class {…}` as 'C' via the class symbol), else the
+    /// exact tsc placeholder `"(Anonymous class)"`.
     fn get_syntactic_class_name_or_anonymous(&self, class_idx: NodeIndex) -> String {
-        self.ctx
+        let syntactic = self
+            .ctx
             .arena
             .get(class_idx)
             .and_then(|node| self.ctx.arena.get_class(node))
@@ -1697,8 +1698,24 @@ impl<'a> CheckerState<'a> {
                     .get(class.name)
                     .and_then(|n| self.ctx.arena.get_identifier(n))
                     .map(|ident| ident.escaped_text.clone())
-            })
-            .unwrap_or_else(|| "(anonymous)".to_string())
+            });
+        if let Some(name) = syntactic {
+            return name;
+        }
+        if let Some(ext) = self.ctx.arena.get_extended(class_idx)
+            && let Some(parent_node) = self.ctx.arena.get(ext.parent)
+            && parent_node.kind == tsz_parser::parser::syntax_kind_ext::VARIABLE_DECLARATION
+            && let Some(var_decl) = self.ctx.arena.get_variable_declaration(parent_node)
+            && let Some(name) = self
+                .ctx
+                .arena
+                .get(var_decl.name)
+                .and_then(|n| self.ctx.arena.get_identifier(n))
+                .map(|ident| ident.escaped_text.clone())
+        {
+            return name;
+        }
+        "(Anonymous class)".to_string()
     }
 
     pub(crate) fn get_private_identifier_declaring_class_name(

--- a/crates/tsz-core/src/config/parse.rs
+++ b/crates/tsz-core/src/config/parse.rs
@@ -416,9 +416,16 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                         "nodenext" => "NodeNext",
                         _ => &mod_normalized,
                     };
+                    // There is no node18/node20 moduleResolution: the required
+                    // resolution arg is 'Node16' for every node1x module kind
+                    // and 'NodeNext' for nodenext.
+                    let required_resolution = match mod_normalized.as_str() {
+                        "nodenext" => "NodeNext",
+                        _ => "Node16",
+                    };
                     let msg = format_message(
                         diagnostic_messages::OPTION_MODULERESOLUTION_MUST_BE_SET_TO_OR_LEFT_UNSPECIFIED_WHEN_OPTION_MODULE_IS,
-                        &[mod_display, mod_display],
+                        &[required_resolution, mod_display],
                     );
                     diagnostics.push(Diagnostic::error(
                         file_path,


### PR DESCRIPTION
Goal: green

Twelve fingerprint/code mechanisms from the 84-item Wave-3 triage queue, each adjudicated by executing tsc 7.0.2. Conformance 11,102 → **11,128 (+26 on this branch; +109/-0 on the day, zero regressions at every step)**.

## Structural rules (owner in parens)
1. TS2300 duplicate class members report at EVERY declaration, first included; mixed property/method duplicates emit no TS2717 (checker/members).
2. TS1183 fires for ambient-by-containment function bodies (declare namespace/module), anchored at the body brace (checker/members).
3. TS2411 computed-name display truncates at the closing bracket — the node range leaks the following token (checker/members).
4. JSX excess-children display keeps source attribute order, children last (checker/jsx).
5. TS2303 import/export alias cycles report once at every participating alias — cross-file max-SymbolId dedup and same-file suppression deleted (checker/modules).
6. TS6053 prints the reference-path directive text as written in both driver modes (checker/directives).
7. TS1155's message parameter follows the declaration kind: 'await using' | 'using' | 'const', both emission sites (checker/variables).
8. TS5109 names the required resolution (Node16 for node16/18/20, NodeNext for nodenext) instead of echoing the module kind (tsz-core/config).
9. Enum-derived mapped keys in missing-property names render as bare literal values, never '[E.A]' (checker/error_reporter).
10. TS18013 names variable-bound class expressions via the binding and uses tsc's exact '(Anonymous class)' placeholder (checker/queries).
11. TS2370 for un-annotated initialized rest params anchors at the rest token (checker/parameters).
12. TS1053 anchors at the rest token (landed same-day in #15739; listed for the family).

## Verification
- Conformance FULL after every batch: 11,128/12,043, +109/-0 vs snapshot on the day.
- Witnesses per mechanism (autoAccessor11, duplicatePropertyNames, ambientErrors, computedPropertyNames36, checkJsxChildrenProperty15, circular1, ReferenceResolution/outputdir_multifolder/relative-nested-ref, awaitUsingDeclarations.8, and adjacents) each verified.
- clippy -D warnings clean on touched crates; binder names varied in probes; no user-name/file-name literals drive logic.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max