### PR TITLE
fix(checker): decorator failure anchoring family (+7)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -265,7 +265,7 @@ impl<'a> CheckerState<'a> {
                         // value. Save the expression type and validate it after the
                         // class value side has been refreshed; doing it here can see a
                         // provisional/re-entrant constructor shape and miss TS1238.
-                        experimental_class_decorators.push((decorator.expression, decorator_type));
+                        experimental_class_decorators.push((mod_idx, decorator_type));
                     } else {
                         // ES decorators: tsc anchors TS1238 at the whole decorator
                         // (including `@`) when the factory requires too many args, but
@@ -1044,14 +1044,30 @@ impl<'a> CheckerState<'a> {
             let _ = self.get_type_of_symbol(sym_id);
         }
 
-        for (decorator_expression, decorator_type) in experimental_class_decorators {
-            // Experimental decorators: tsc anchors TS1238 at the expression (after @).
-            self.check_class_decorator_call_signature(
-                decorator_expression,
-                decorator_type,
-                stmt_idx,
-                class,
-            );
+        for (decorator_node, decorator_type) in experimental_class_decorators {
+            // tsc 7.0.2 anchors TS1238 at the decorator's EXPRESSION for bare
+            // entities (`@CtorDtor` flags col 2) but at the whole DECORATOR
+            // spanning the `@` when the expression is itself a call
+            // (`@dec()` flags col 1) — mirroring call-node arity anchoring.
+            let anchor = self
+                .ctx
+                .arena
+                .get(decorator_node)
+                .and_then(|n| self.ctx.arena.get_decorator(n))
+                .map(|d| {
+                    let expr_is_call = self
+                        .ctx
+                        .arena
+                        .get(d.expression)
+                        .is_some_and(|e| e.kind == syntax_kind_ext::CALL_EXPRESSION);
+                    if expr_is_call {
+                        decorator_node
+                    } else {
+                        d.expression
+                    }
+                })
+                .unwrap_or(decorator_node);
+            self.check_class_decorator_call_signature(anchor, decorator_type, stmt_idx, class);
         }
     }
 

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -17,6 +17,41 @@ const fn decorator_type_is_unchecked(t: TypeId) -> bool {
 }
 
 impl<'a> CheckerState<'a> {
+    /// tsc anchors member/parameter decorator failures (TS1239/TS1240/TS1241)
+    /// at the decorator's EXPRESSION (one column after the `@`) for
+    /// type-mismatch and extra-argument failures, but at the whole DECORATOR
+    /// (spanning the `@`) when the failure is missing required arguments —
+    /// mirroring call-expression arity anchoring (decoratorOnClassProperty6
+    /// vs 7).
+    fn decorator_expression_anchor(&self, decorator_node: NodeIndex) -> NodeIndex {
+        self.ctx
+            .arena
+            .get(decorator_node)
+            .and_then(|n| self.ctx.arena.get_decorator(n))
+            .map(|d| d.expression)
+            .filter(|e| e.is_some())
+            .unwrap_or(decorator_node)
+    }
+
+    fn decorator_failure_anchor(
+        &self,
+        decorator_node: NodeIndex,
+        resolved: TypeId,
+        provided_args: usize,
+    ) -> NodeIndex {
+        // "Too few arguments" = every declared signature demands more
+        // parameters than the decorator protocol provides at this position.
+        let too_few_args = Self::decorator_signature_param_counts(self.ctx.types, resolved)
+            .is_some_and(|counts| {
+                !counts.is_empty() && counts.iter().all(|&count| count > provided_args)
+            });
+        if too_few_args {
+            decorator_node
+        } else {
+            self.decorator_expression_anchor(decorator_node)
+        }
+    }
+
     /// TS1240 for ES class-member decorators (TC39 stage 3).
     ///
     /// The runtime calling convention for the first argument varies by member kind:
@@ -76,7 +111,7 @@ impl<'a> CheckerState<'a> {
 
         if !matches!(result, CallResult::Success(_)) {
             self.error_at_node(
-                decorator_node,
+                self.decorator_failure_anchor(decorator_node, resolved, args.len()),
                 diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
             );
@@ -313,11 +348,11 @@ impl<'a> CheckerState<'a> {
             actual_this_type,
         );
 
-        let return_type = match result {
-            CallResult::Success(return_type) => Some(return_type),
+        let return_type = match &result {
+            CallResult::Success(return_type) => Some(*return_type),
             _ => {
                 self.error_at_node(
-                    decorator_node,
+                    self.decorator_failure_anchor(decorator_node, resolved, arg_types.len()),
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_METHOD_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_METHOD_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 );
@@ -673,7 +708,7 @@ impl<'a> CheckerState<'a> {
             CallResult::Success(return_type) => Some(return_type),
             _ => {
                 self.error_at_node(
-                    decorator_node,
+                    self.decorator_failure_anchor(decorator_node, resolved, arg_types.len()),
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 );
@@ -803,7 +838,7 @@ impl<'a> CheckerState<'a> {
 
         if !matches!(result, CallResult::Success(_)) {
             self.error_at_node(
-                decorator_node,
+                self.decorator_failure_anchor(decorator_node, resolved, 3),
                 diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PARAMETER_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PARAMETER_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
             );


### PR DESCRIPTION
Goal: green

The decorator anchor family from the Wave-3 mechanism queue. Conformance 11,128 → **11,135 (+7; +116/-0 on the day)**.

Structural rule (checker/decorators): tsc 7.0.2 anchors decorator signature-resolution failures like call-expression errors — member decorators (TS1239/TS1240/TS1241, both ES and legacy paths) at the decorator's EXPRESSION for type-mismatch/extra-argument failures, but at the whole DECORATOR spanning the `@` when every declared signature demands more parameters than the protocol provides at that position (too-few-arguments); class TS1238 anchors at the expression for bare entities (`@CtorDtor` flags col+1) and at the `@` when the decorator expression is itself a call (`@dec()`).

The too-few predicate is structural (declared per-signature parameter counts vs the protocol's argument count for that position), not a CallResult sniff — the resolve adapter does not surface arity distinctly on these paths.

Witnesses (each oracle-verified with tsc 7.0.2): decoratorOnClass8, decoratorOnClassMethod10, decoratorOnClassProperty6+7, decoratorOnClassConstructor2, decoratorOnClassConstructorParameter1, constructableDecoratorOnClass01, decoratorCallGeneric. decoratorOnClassProperty11 remains failing pre-existing (TS1329 factory-hint selection, a distinct queued mechanism).

## Verification
Conformance FULL: 11,135/12,043, +116/-0 vs snapshot today; decorator family 129+/137.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max