### PR TITLE
fix(checker): TS2385 and TS2447 anchoring mechanisms (+3)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/arithmetic_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/arithmetic_ops.rs
@@ -107,6 +107,16 @@ impl<'a> CheckerState<'a> {
         let message = format!(
             "The '{op_str}' operator is not allowed for boolean types. Consider using '{suggestion}' instead."
         );
+        // tsc anchors TS2447 at the operator token.
+        if let Some((start, length)) = self.operator_token_span(node_idx, op_str) {
+            self.error_at_position(
+                start,
+                length,
+                &message,
+                diagnostic_codes::THE_OPERATOR_IS_NOT_ALLOWED_FOR_BOOLEAN_TYPES_CONSIDER_USING_INSTEAD,
+            );
+            return;
+        }
         self.error_at_node(
             node_idx,
             &message,

--- a/crates/tsz-checker/src/error_reporter/operator_errors.rs
+++ b/crates/tsz-checker/src/error_reporter/operator_errors.rs
@@ -24,6 +24,29 @@ pub(crate) enum InvocationSignatureKind {
 }
 
 impl<'a> CheckerState<'a> {
+    /// Span of the operator token inside a binary/compound-assignment
+    /// expression: tsc anchors TS2447 at the operator, not the whole
+    /// expression.
+    pub(crate) fn operator_token_span(
+        &self,
+        node_idx: NodeIndex,
+        op_str: &str,
+    ) -> Option<(u32, u32)> {
+        let node = self.ctx.arena.get(node_idx)?;
+        let bin = self.ctx.arena.get_binary_expr(node)?;
+        let left_end = self.ctx.arena.get(bin.left)?.end;
+        let right_pos = self.ctx.arena.get(bin.right)?.pos;
+        let text = self
+            .ctx
+            .arena
+            .source_files
+            .first()?
+            .text
+            .get(left_end as usize..right_pos as usize)?;
+        let off = text.find(op_str)? as u32;
+        Some((left_end + off, op_str.len() as u32))
+    }
+
     /// Report TS2351: "This expression is not constructable. Type 'X' has no construct signatures."
     /// This is for `new` expressions where the expression type has no construct signatures.
     pub fn error_not_constructable_at(&mut self, type_id: TypeId, idx: NodeIndex) {
@@ -946,6 +969,19 @@ impl<'a> CheckerState<'a> {
                 } else {
                     "!=="
                 };
+                // tsc anchors TS2447 at the operator token.
+                if let Some((start, length)) = self.operator_token_span(node_idx, op) {
+                    let message = format!(
+                        "The '{op}' operator is not allowed for boolean types. Consider using '{suggestion}' instead."
+                    );
+                    self.error_at_position(
+                        start,
+                        length,
+                        &message,
+                        diagnostic_codes::THE_OPERATOR_IS_NOT_ALLOWED_FOR_BOOLEAN_TYPES_CONSIDER_USING_INSTEAD,
+                    );
+                    return;
+                }
                 self.emit_render_request(
                     node_idx,
                     DiagnosticRenderRequest::simple_msg(

--- a/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
@@ -1091,23 +1091,31 @@ impl<'a> CheckerState<'a> {
             }
             let decl_modifier = get_access_modifier(self.ctx.arena, decl_idx);
             if decl_modifier != impl_modifier {
-                // TSC anchors TS2385 at the start of the overload declaration (including modifiers),
-                // not at the declaration name. Our constructor nodes start at the `constructor`
-                // keyword, so we need to extend the span back to the first modifier.
-                if let Some(decl_node) = self.ctx.arena.get(decl_idx) {
+                // tsc 7.0.2 anchors TS2385 at the overload's NAME token for
+                // methods, but at the declaration start (modifiers included)
+                // for constructors.
+                if let Some(node) = self.ctx.arena.get(decl_idx)
+                    && node.kind == syntax_kind_ext::CONSTRUCTOR
+                {
                     let start = self
                         .ctx
                         .arena
-                        .get_declaration_modifiers(decl_node)
+                        .get_declaration_modifiers(node)
                         .and_then(|mods| mods.nodes.first().copied())
                         .and_then(|first_mod| self.ctx.arena.get(first_mod))
-                        .map_or(decl_node.pos, |mod_node| mod_node.pos);
-                    let length = decl_node.end.saturating_sub(start);
+                        .map_or(node.pos, |mod_node| mod_node.pos);
                     self.error(
                         start,
-                        length,
+                        node.end.saturating_sub(start),
                         diagnostic_messages::OVERLOAD_SIGNATURES_MUST_ALL_BE_PUBLIC_PRIVATE_OR_PROTECTED.to_string(),
                         diagnostic_codes::OVERLOAD_SIGNATURES_MUST_ALL_BE_PUBLIC_PRIVATE_OR_PROTECTED,
+                    );
+                } else {
+                    let anchor = self.get_declaration_name_node(decl_idx).unwrap_or(decl_idx);
+                    self.error_at_node_msg(
+                        anchor,
+                        diagnostic_codes::OVERLOAD_SIGNATURES_MUST_ALL_BE_PUBLIC_PRIVATE_OR_PROTECTED,
+                        &[],
                     );
                 }
             }
@@ -1213,109 +1221,9 @@ impl<'a> CheckerState<'a> {
         // TS2385: static method overloads still need the implementation-vs-overload
         // agreement check here. Instance methods get their canonical TS2385s from the
         // duplicate-identifier pass, and re-emitting them here duplicates diagnostics.
-        let impl_is_static = self
-            .ctx
-            .arena
-            .get(impl_node_idx)
-            .and_then(|node| self.ctx.arena.get_method_decl(node))
-            .and_then(|method| method.modifiers.as_ref())
-            .is_some_and(|mods| {
-                self.ctx
-                    .arena
-                    .has_modifier_ref(Some(mods), SyntaxKind::StaticKeyword)
-            });
-        if impl_is_static {
-            let get_access = |idx: NodeIndex| -> u8 {
-                let Some(node) = self.ctx.arena.get(idx) else {
-                    return 0;
-                };
-                let modifiers = match node.kind {
-                    k if k == syntax_kind_ext::METHOD_DECLARATION => self
-                        .ctx
-                        .arena
-                        .get_method_decl(node)
-                        .and_then(|m| m.modifiers.as_ref()),
-                    k if k == syntax_kind_ext::METHOD_SIGNATURE => self
-                        .ctx
-                        .arena
-                        .get_signature(node)
-                        .and_then(|s| s.modifiers.as_ref()),
-                    _ => None,
-                };
-                let Some(mods) = modifiers else {
-                    return 0;
-                };
-                if self
-                    .ctx
-                    .arena
-                    .has_modifier_ref(Some(mods), SyntaxKind::PrivateKeyword)
-                {
-                    1
-                } else if self
-                    .ctx
-                    .arena
-                    .has_modifier_ref(Some(mods), SyntaxKind::ProtectedKeyword)
-                {
-                    2
-                } else {
-                    0
-                }
-            };
-
-            let impl_access = get_access(impl_node_idx);
-            for &decl_idx in &overload_decls {
-                if decl_idx == impl_node_idx {
-                    continue;
-                }
-                let decl_is_static = self
-                    .ctx
-                    .arena
-                    .get(decl_idx)
-                    .and_then(|node| match node.kind {
-                        k if k == syntax_kind_ext::METHOD_DECLARATION => self
-                            .ctx
-                            .arena
-                            .get_method_decl(node)
-                            .and_then(|method| method.modifiers.as_ref()),
-                        k if k == syntax_kind_ext::METHOD_SIGNATURE => self
-                            .ctx
-                            .arena
-                            .get_signature(node)
-                            .and_then(|sig| sig.modifiers.as_ref()),
-                        _ => None,
-                    })
-                    .is_some_and(|mods| {
-                        self.ctx
-                            .arena
-                            .has_modifier_ref(Some(mods), SyntaxKind::StaticKeyword)
-                    });
-                if decl_is_static != impl_is_static {
-                    continue;
-                }
-                if get_access(decl_idx) != impl_access {
-                    let error_node = self
-                        .ctx
-                        .arena
-                        .get(decl_idx)
-                        .and_then(|n| match n.kind {
-                            k if k == syntax_kind_ext::METHOD_DECLARATION => {
-                                self.ctx.arena.get_method_decl(n).map(|m| m.name)
-                            }
-                            k if k == syntax_kind_ext::METHOD_SIGNATURE => {
-                                self.ctx.arena.get_signature(n).map(|s| s.name)
-                            }
-                            _ => None,
-                        })
-                        .unwrap_or(decl_idx);
-                    self.error_at_node(
-                        error_node,
-                        diagnostic_messages::OVERLOAD_SIGNATURES_MUST_ALL_BE_PUBLIC_PRIVATE_OR_PROTECTED,
-                        diagnostic_codes::OVERLOAD_SIGNATURES_MUST_ALL_BE_PUBLIC_PRIVATE_OR_PROTECTED,
-                    );
-                }
-            }
-        }
-
+        // Mixed-visibility TS2385 is owned by the duplicate-identifiers pass
+        // (one name-anchored diagnostic per deviating overload); the old
+        // static-only re-emit here duplicated it.
         // TS2386: Check optionality consistency
         let get_optional = |idx: NodeIndex| -> bool {
             let Some(node) = self.ctx.arena.get(idx) else {

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -31,6 +31,25 @@ pub(super) enum DuplicateDeclarationOrigin {
 }
 
 impl<'a> CheckerState<'a> {
+    /// TS2385 anchor: the overload's NAME token for methods, but the
+    /// declaration start including modifiers for constructors
+    /// (classConstructorOverloadsAccessibility anchors `private constructor`
+    /// at the modifier).
+    fn ts2385_anchor_span(&self, decl_idx: NodeIndex) -> Option<(u32, u32)> {
+        let node = self.ctx.arena.get(decl_idx)?;
+        if node.kind == tsz_parser::parser::syntax_kind_ext::CONSTRUCTOR {
+            let start = self
+                .ctx
+                .arena
+                .get_declaration_modifiers(node)
+                .and_then(|mods| mods.nodes.first().copied())
+                .and_then(|first_mod| self.ctx.arena.get(first_mod))
+                .map_or(node.pos, |mod_node| mod_node.pos);
+            return Some((start, node.end.saturating_sub(start)));
+        }
+        None
+    }
+
     /// Check for duplicate identifiers (TS2300, TS2451, TS2392).
     /// Reports when variables, functions, classes, or other declarations
     /// have conflicting names within the same scope.
@@ -491,22 +510,23 @@ impl<'a> CheckerState<'a> {
                 if has_mismatch {
                     for &(decl_idx, access) in &access_infos {
                         if access != ref_access {
-                            // TSC anchors TS2385 at the start of the overload declaration
-                            // (including modifiers), not at the declaration name.
-                            if let Some(decl_node) = self.ctx.arena.get(decl_idx) {
-                                let start = self
-                                    .ctx
-                                    .arena
-                                    .get_declaration_modifiers(decl_node)
-                                    .and_then(|mods| mods.nodes.first().copied())
-                                    .and_then(|first_mod| self.ctx.arena.get(first_mod))
-                                    .map_or(decl_node.pos, |mod_node| mod_node.pos);
-                                let length = decl_node.end.saturating_sub(start);
+                            // tsc 7.0.2 anchors TS2385 at the overload's NAME
+                            // token for methods, but at the declaration start
+                            // (modifiers included) for constructors.
+                            if let Some((start, length)) = self.ts2385_anchor_span(decl_idx) {
                                 self.error(
                                     start,
                                     length,
                                     diagnostic_messages::OVERLOAD_SIGNATURES_MUST_ALL_BE_PUBLIC_PRIVATE_OR_PROTECTED.to_string(),
                                     diagnostic_codes::OVERLOAD_SIGNATURES_MUST_ALL_BE_PUBLIC_PRIVATE_OR_PROTECTED,
+                                );
+                            } else {
+                                let anchor =
+                                    self.get_declaration_name_node(decl_idx).unwrap_or(decl_idx);
+                                self.error_at_node_msg(
+                                    anchor,
+                                    diagnostic_codes::OVERLOAD_SIGNATURES_MUST_ALL_BE_PUBLIC_PRIVATE_OR_PROTECTED,
+                                    &[],
                                 );
                             }
                         }


### PR DESCRIPTION
Goal: green

Two anchor mechanisms from the Wave-3 queue. Conformance 11,135 → **11,138 (+3; +119/-0 on the day)**.

Structural rules (checker):
1. TS2385 ("Overload signatures must all be public, private or protected") anchors at the overload's NAME token for methods, but at the declaration start including modifiers for constructors (`private constructor` flags the modifier) — verified across both witnesses; exactly one diagnostic per deviating overload (the static-path re-emit that duplicated the duplicate-identifiers pass is deleted, and the modifier-start method anchoring corrected in both emitters).
2. TS2447 ("The '&' operator is not allowed for boolean types…") anchors at the operator token for plain `&`/`|`/`^` and compound `&=`/`|=`/`^=` forms, via a shared operator-token span helper (source scan between the operand nodes).

## Verification
Conformance FULL: 11,138/12,043, +119/-0 vs snapshot today; witnesses classConstructorOverloadsAccessibility, memberFunctionsWithPublicPrivateOverloads, arithmeticOperatorWithInvalidOperands flip; clippy-clean touched crates.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max