### PR TITLE
fix(cli): tslib helper diagnostics once per program (+1)

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils/tslib_helpers.rs
+++ b/crates/tsz-cli/src/driver/check_utils/tslib_helpers.rs
@@ -195,6 +195,9 @@ fn emit_tslib_helper_diagnostics(
 ) -> Vec<Diagnostic> {
     let mut result = Vec::new();
     let tslib_exports = program.module_exports.get(tslib_key);
+    // Program-wide once-per-helper accumulator (tsc's
+    // requestedExternalEmitHelpers): first requesting site reports.
+    let mut reported_helpers: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
     for file in &program.files {
         if file.file_name == tslib_key || is_ts_declaration_file(Path::new(&file.file_name)) {
             continue;
@@ -218,6 +221,7 @@ fn emit_tslib_helper_diagnostics(
                         helper_parameter_count_for_symbol(program, sym_id).unwrap_or(usize::MAX);
                     if let Some(required_parameter_count) = helper.required_parameter_count
                         && actual_parameter_count < required_parameter_count
+                        && reported_helpers.insert(helper.name)
                     {
                         let message = tsz_common::diagnostics::format_message(
                             tsz_common::diagnostics::diagnostic_messages::THIS_SYNTAX_REQUIRES_AN_IMPORTED_HELPER_NAMED_WITH_PARAMETERS_WHICH_IS_NOT_COMPA,
@@ -237,16 +241,18 @@ fn emit_tslib_helper_diagnostics(
                     }
                 }
                 None => {
-                    result.push(Diagnostic::error(
-                        file.file_name.clone(),
-                        helper.start,
-                        helper.length,
-                        format!(
-                            "This syntax requires an imported helper named '{}' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.",
-                            helper.name
-                        ),
-                        2343,
-                    ));
+                    if reported_helpers.insert(helper.name) {
+                        result.push(Diagnostic::error(
+                            file.file_name.clone(),
+                            helper.start,
+                            helper.length,
+                            format!(
+                                "This syntax requires an imported helper named '{}' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.",
+                                helper.name
+                            ),
+                            2343,
+                        ));
+                    }
                 }
             }
         }
@@ -289,6 +295,10 @@ fn emit_tslib_helper_diagnostics_from_counts(
     file_is_esm_map: &rustc_hash::FxHashMap<String, bool>,
 ) -> Vec<Diagnostic> {
     let mut result = Vec::new();
+    // tsc's checkExternalEmitHelpers accumulates requested helpers program-wide
+    // (requestedExternalEmitHelpers): each missing/incompatible helper is
+    // reported ONCE at its first requesting site in program order.
+    let mut reported_helpers: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
     for file in &program.files {
         if is_ts_declaration_file(Path::new(&file.file_name)) {
             continue;
@@ -309,6 +319,7 @@ fn emit_tslib_helper_diagnostics_from_counts(
                 Some(&actual_parameter_count) => {
                     if let Some(required_parameter_count) = helper.required_parameter_count
                         && actual_parameter_count < required_parameter_count
+                        && reported_helpers.insert(helper.name)
                     {
                         let message = tsz_common::diagnostics::format_message(
                             tsz_common::diagnostics::diagnostic_messages::THIS_SYNTAX_REQUIRES_AN_IMPORTED_HELPER_NAMED_WITH_PARAMETERS_WHICH_IS_NOT_COMPA,
@@ -328,16 +339,18 @@ fn emit_tslib_helper_diagnostics_from_counts(
                     }
                 }
                 None => {
-                    result.push(Diagnostic::error(
-                        file.file_name.clone(),
-                        helper.start,
-                        helper.length,
-                        format!(
-                            "This syntax requires an imported helper named '{}' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.",
-                            helper.name
-                        ),
-                        2343,
-                    ));
+                    if reported_helpers.insert(helper.name) {
+                        result.push(Diagnostic::error(
+                            file.file_name.clone(),
+                            helper.start,
+                            helper.length,
+                            format!(
+                                "This syntax requires an imported helper named '{}' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.",
+                                helper.name
+                            ),
+                            2343,
+                        ));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Goal: green

One mechanism from the Wave-3 queue. Conformance 11,138 → **11,139 (+1; +120/-0 on the day)**.

Structural rule (cli/driver): tsc's `checkExternalEmitHelpers` accumulates requested emit helpers program-wide, so a helper that is missing from tslib (TS2343) or parameter-incompatible reports exactly ONCE at its first requesting site in program order; tsz reported per file per site. Both emission paths (exports-based and counts-based) now share a per-program reported-helpers set covering both arms.

## Verification
Conformance FULL: 11,139/12,043, +120/-0 vs snapshot today; witness nodeModulesAllowJsImportHelpersCollisions3 (two files requesting the same missing helper) flips; oracle-verified with tsc 7.0.2.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max