### PR TITLE
fix(checker): TS1015/TS1016 for member signatures (+1)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -892,6 +892,16 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
+        // TS1015/TS1016 also run for method signatures of interfaces and
+        // type literals (tsc runs parameter grammar for every function-like
+        // signature).
+        if node.kind == syntax_kind_ext::METHOD_SIGNATURE
+            && let Some(sig) = self.ctx.arena.get_signature(node)
+            && let Some(params) = &sig.parameters
+        {
+            self.check_parameter_ordering(params, Some(member_idx));
+        }
+
         // Check call signatures and construct signatures for parameter properties
         if node.kind == syntax_kind_ext::CALL_SIGNATURE
             || node.kind == syntax_kind_ext::CONSTRUCT_SIGNATURE
@@ -906,6 +916,10 @@ impl<'a> CheckerState<'a> {
                     self.check_parameter_properties(&params.nodes);
                     // TS2371: Parameter initializers not allowed in call/construct signatures
                     self.check_non_impl_parameter_initializers(&params.nodes, false, false);
+                    // TS1015/TS1016: parameter grammar runs for every
+                    // function-like signature, call/construct signatures of
+                    // interfaces and type literals included.
+                    self.check_parameter_ordering(params, Some(member_idx));
                     for (pi, &param_idx) in params.nodes.iter().enumerate() {
                         if let Some(param_node) = self.ctx.arena.get(param_idx)
                             && let Some(param) = self.ctx.arena.get_parameter(param_node)

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -1393,6 +1393,9 @@ impl<'a> CheckerState<'a> {
             }
             // Method shorthand: { foo() {} }
             else if let Some(method) = self.ctx.arena.get_method_decl(elem_node) {
+                // TS1015/TS1016: parameter grammar runs for object-literal
+                // methods like any other function-like signature.
+                self.check_parameter_ordering(&method.parameters, Some(elem_idx));
                 // Always type-check computed property name expressions for methods,
                 // even when the identifier can be resolved as a literal name.
                 // E.g., `{ [e]() {} }` needs TS2304 for undeclared `e`.


### PR DESCRIPTION
Goal: green

One mechanism from the Wave-3 queue. Conformance 11,139 → **11,140 (+1; +121/-0 on the day)**.

Structural rule (checker/parameters): tsc runs the TS1015 (question mark + initializer) and TS1016 (required after optional) parameter grammar checks for EVERY function-like signature — interface and type-literal call/construct/method signatures and object-literal methods included — anchored at the parameter name. tsz only ran them for declarations, class members, and function expressions. Wired via the existing member-signature check pass (call/construct + method-signature arms) and the object-literal method processing loop.

## Verification
Conformance FULL: 11,140/12,043, +121/-0 vs snapshot today; the witness covers interface call sig, interface method sig, type-literal call+method sigs, and object-literal method/function-property/arrow shapes, each oracle-verified with tsc 7.0.2.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max