### PR TITLE
fix(checker): object-literal this typing gated on noImplicitThis (+2)

### DIFF
--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -150,7 +150,10 @@ impl<'a> CheckerState<'a> {
             // lightweight synthetic receiver so property access checks (TS2339)
             // run during accessor body checking.
             let mut pushed_synthetic_this = false;
-            if marker_this_type.is_none() {
+            // Gated like tsc's getContextualThisParameterType: object-literal
+            // `this` typing needs noImplicitThis (or a JS file); otherwise
+            // `this` in an accessor body is plain `any`.
+            if marker_this_type.is_none() && (self.ctx.no_implicit_this() || self.is_js_file()) {
                 let mut this_props: Vec<PropertyInfo> = properties.values().cloned().collect();
                 // Splice in members declared after this accessor so that
                 // `this.<laterMember>` resolves like the complete object literal.

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -562,7 +562,11 @@ impl<'a> CheckerState<'a> {
                         // `this` to its declared type (tsc `getThisTypeOfSignature`, #14843),
                         // so neither gets the synthetic push.
                         let mut pushed_prop_fn_this = false;
+                        // Gated like tsc's getContextualThisParameterType:
+                        // object-literal `this` typing needs noImplicitThis
+                        // (or a JS file); otherwise `this` is plain `any`.
                         if initializer_is_function_expression
+                            && (self.ctx.no_implicit_this() || self.is_js_file())
                             && marker_this_type.is_none()
                             && self.current_this_type().is_none()
                             && !self.function_like_has_explicit_this_parameter(prop.initializer)
@@ -1473,6 +1477,13 @@ impl<'a> CheckerState<'a> {
                             );
                             ctx_helper.get_this_type()
                         });
+                        // tsc's containing-object-literal `this` typing is
+                        // gated on `noImplicitThis || isInJSFile`
+                        // (getContextualThisParameterType): with the gate off,
+                        // `this` in an object-literal method is plain `any`.
+                        // A contextual-signature this-PARAMETER stays ungated.
+                        let object_literal_this_enabled =
+                            self.ctx.no_implicit_this() || self.is_js_file();
                         if let Some(mut method_this) = method_ctx_this {
                             if crate::query_boundaries::common::contains_type_parameters(
                                 self.ctx.types,
@@ -1485,6 +1496,8 @@ impl<'a> CheckerState<'a> {
                             }
                             self.ctx.this_type_stack.push(method_this);
                             pushed_contextual_this = true;
+                        } else if !object_literal_this_enabled {
+                            // No push: `this` resolves to `any` downstream.
                         } else if let Some(receiver_this_type) = contextual_receiver_this_type {
                             self.ctx.this_type_stack.push(receiver_this_type);
                             pushed_contextual_this = true;


### PR DESCRIPTION
Goal: green

The non-strict `this` leniency mechanism from the Wave-3 queue. Conformance 11,146 → **11,148 (+2; +129/-0 on the day)**.

Structural rule (checker/object-literals): tsc's `getContextualThisParameterType` types `this` from the containing object literal only when `noImplicitThis || isInJSFile`; with the gate off, `this` inside an object-literal method, accessor body, or function-expression property is plain `any`. tsz pushed the literal's own (or contextual) `this` type unconditionally and then over-emitted TS2339 on members the literal lacks. All three push arms (method, fn-property, accessor) are now gated; a contextual-signature this-PARAMETER stays ungated, matching tsc.

Adjacent matrix (oracle-verified): non-strict `.ts` `{m(){this.q}}` clean; same with `--noImplicitThis` keeps TS2339; JS files keep the literal `this` typing; explicit `this` parameters unaffected.

## Verification
Conformance FULL: 11,148/12,043, +129/-0 vs snapshot today. Full battery: tsz-checker at the tracked 21-row pre-existing pool, tsz-core 3,228/3,228, tsz-solver 7,434/7,434, emit JS 100% + DTS at floor.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max