### PR TITLE
fix(checker): resolution-mode import attribute rule + TS1454 (+2)

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/core/helpers.rs
@@ -103,19 +103,11 @@ impl<'a> CheckerState<'a> {
         attributes_idx: NodeIndex,
         declaration_is_type_only: bool,
     ) -> bool {
-        if self.get_resolution_mode_override(attributes_idx).is_none() {
-            return false;
-        }
-
-        if self
-            .ctx
-            .capabilities
-            .feature_available(FeatureGate::ImportAttributes)
-        {
-            return true;
-        }
-
-        self.ctx.capabilities.module == ModuleKind::Node16
+        // tsc treats a `resolution-mode` attribute as effective only when the
+        // declaration is exclusively type-only AND the attributes contain
+        // exactly one valid resolution-mode entry — uniformly across module
+        // modes (getResolutionModeOverride + isExclusivelyTypeOnlyImportOrExport).
+        self.get_resolution_mode_override(attributes_idx).is_some()
             && declaration_is_type_only
             && self.has_only_valid_resolution_mode_attribute(attributes_idx)
     }

--- a/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
@@ -173,7 +173,27 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // Step 6: type-only declarations cannot carry attributes.
+        // Step 6: a valid `resolution-mode` override on a NON-type-only
+        // declaration gets tsc's dedicated TS1454 at the attribute name
+        // ("`resolution-mode` can only be set for type-only imports.").
+        if !declaration_is_type_only
+            && self.get_resolution_mode_override(attributes_idx).is_some()
+            && attrs_data.elements.nodes.len() == 1
+        {
+            if let Some(&elem_idx) = attrs_data.elements.nodes.first()
+                && let Some(elem_node) = self.ctx.arena.get(elem_idx)
+                && let Some(attr) = self.ctx.arena.get_import_attribute_data(elem_node)
+            {
+                self.error_at_node(
+                    attr.name,
+                    diagnostic_messages::RESOLUTION_MODE_CAN_ONLY_BE_SET_FOR_TYPE_ONLY_IMPORTS,
+                    diagnostic_codes::RESOLUTION_MODE_CAN_ONLY_BE_SET_FOR_TYPE_ONLY_IMPORTS,
+                );
+                return;
+            }
+        }
+
+        // Step 7: type-only declarations cannot carry attributes.
         if declaration_is_type_only {
             self.report_import_attribute_grammar_error(
                 node_pos,


### PR DESCRIPTION
Goal: green

One mechanism from the Wave-3 queue. Conformance 11,148 → **11,150 (+2; +131/-0 on the day)**.

Structural rule (checker/imports): tsc treats a `resolution-mode` import attribute as effective — suppressing TS2823/TS2856/TS2857 and overriding module resolution — only when the declaration is exclusively type-only AND the attributes contain exactly one valid `resolution-mode` entry, uniformly across module modes. tsz's predicate returned true for any attribute set whenever import attributes were feature-available (and had a Node16-only fallback). A valid override on a non-type-only declaration now emits tsc's dedicated TS1454 "`resolution-mode` can only be set for type-only imports." at the attribute name.

## Verification
Conformance FULL: 11,150/12,043, +131/-0 vs snapshot today; witness nodeModulesImportAttributesModeDeclarationEmitErrors + sibling flip (per-module-mode matrix oracle-verified with tsc 7.0.2). tsz-checker at the 21-row pool, tsz-core 3,228/3,228.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max