### PR TITLE
fix(checker): import.meta codes, super anchor, any-index resolution (+2)

### DIFF
--- a/crates/tsz-checker/src/classes/super_checker.rs
+++ b/crates/tsz-checker/src/classes/super_checker.rs
@@ -2,6 +2,7 @@
 
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 
 // =============================================================================
@@ -279,6 +280,43 @@ impl<'a> CheckerState<'a> {
         }
 
         false
+    }
+
+    /// Whether `idx` is the source-first `super(...)` call inside its
+    /// enclosing constructor (tsc's `findFirstSuperCall` anchor).
+    fn is_first_super_call_in_constructor(&self, idx: NodeIndex) -> bool {
+        let Some(ctor_idx) = self.enclosing_constructor_node(idx) else {
+            return true;
+        };
+        let Some(my_pos) = self.ctx.arena.get(idx).map(|n| n.pos) else {
+            return true;
+        };
+        let mut stack = vec![ctor_idx];
+        let mut first_pos = u32::MAX;
+        while let Some(cur) = stack.pop() {
+            if let Some(node) = self.ctx.arena.get(cur) {
+                if node.kind == tsz_parser::parser::syntax_kind_ext::CALL_EXPRESSION
+                    && let Some(call) = self.ctx.arena.get_call_expr(node)
+                    && self
+                        .ctx
+                        .arena
+                        .get(call.expression)
+                        .is_some_and(|e| e.kind == tsz_scanner::SyntaxKind::SuperKeyword as u16)
+                {
+                    first_pos = first_pos.min(node.pos);
+                }
+                // Nested functions/classes get their own super analysis.
+                if cur != ctor_idx
+                    && (node.is_function_expression_or_arrow()
+                        || node.kind == tsz_parser::parser::syntax_kind_ext::CLASS_EXPRESSION
+                        || node.kind == tsz_parser::parser::syntax_kind_ext::FUNCTION_DECLARATION)
+                {
+                    continue;
+                }
+            }
+            stack.extend(self.ctx.arena.get_children(cur));
+        }
+        first_pos == u32::MAX || my_pos <= first_pos
     }
 
     fn is_super_call_root_level_statement_in_constructor(&self, idx: NodeIndex) -> bool {
@@ -974,8 +1012,14 @@ impl<'a> CheckerState<'a> {
             let diagnostic_node = self.enclosing_constructor_node(idx).unwrap_or(idx);
 
             if !self.is_super_call_root_level_statement_in_constructor(idx) {
+                // tsc anchors at the FIRST super call in the body and emits
+                // exactly once per constructor
+                // (checkConstructorDeclaration: error(findFirstSuperCall(...))).
+                if !self.is_first_super_call_in_constructor(idx) {
+                    return;
+                }
                 self.error_at_node(
-                    diagnostic_node,
+                    idx,
                     diagnostic_messages::A_SUPER_CALL_MUST_BE_A_ROOT_LEVEL_STATEMENT_WITHIN_A_CONSTRUCTOR_OF_A_DERIVED_CL,
                     diagnostic_codes::A_SUPER_CALL_MUST_BE_A_ROOT_LEVEL_STATEMENT_WITHIN_A_CONSTRUCTOR_OF_A_DERIVED_CL,
                 );

--- a/crates/tsz-checker/src/tests/noUIA_any_index_emits_ts2322_tests.rs
+++ b/crates/tsz-checker/src/tests/noUIA_any_index_emits_ts2322_tests.rs
@@ -56,7 +56,10 @@ const e: boolean = strMap[null as any];
 }
 
 #[test]
-fn non_nuia_read_with_any_index_keeps_any_and_does_not_emit_ts2322() {
+fn non_nuia_read_with_any_index_resolves_index_signature_and_emits_ts2322() {
+    // tsc 7.0.2 resolves an any-typed index through applicable index infos in
+    // ALL modes (findApplicableIndexInfo), so the access is `boolean` and the
+    // string annotation mismatches — oracle-verified.
     let source = r#"
 declare const strMap: { [s: string]: boolean };
 const e: string = strMap[null as any];
@@ -64,8 +67,8 @@ const e: string = strMap[null as any];
     let diags = diags_for_strict(source);
     let codes = diagnostic_codes(&diags);
     assert!(
-        !codes.contains(&2322),
-        "Non-NUIA value access with any-typed index must keep the any fallback. Got: {codes:?}",
+        codes.contains(&2322),
+        "Any-typed index resolves through the string index signature (boolean -> string mismatch). Got: {codes:?}",
     );
 }
 

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1281,10 +1281,11 @@ impl<'a> CheckerState<'a> {
             use_index_signature_check = false;
         }
 
-        // Under NUIA, value-level `any` indexes use the receiver index signature.
+        // Value-level `any` indexes resolve through applicable index infos in
+        // ALL modes (tsc findApplicableIndexInfo: numeric preferred, string
+        // fallback), not just under noUncheckedIndexedAccess.
         if result_type.is_none()
             && index_type == TypeId::ANY
-            && self.ctx.compiler_options.no_unchecked_indexed_access
             && let Some(any_result) = self.ctx.types.resolve_any_index_access(
                 object_type_for_access,
                 self.ctx.compiler_options.no_unchecked_indexed_access,

--- a/crates/tsz-checker/src/types/property_access_type/helpers.rs
+++ b/crates/tsz-checker/src/types/property_access_type/helpers.rs
@@ -59,8 +59,12 @@ impl<'a> CheckerState<'a> {
             .and_then(|n| self.ctx.arena.get_identifier(n))
             .is_some_and(|ident| ident.escaped_text == "meta");
 
+        // tsc emits the module-support diagnostic (TS1343/TS1470) for EVERY
+        // `import.<name>` meta-property, invalid names included
+        // ('import.metal' gets it alongside TS17012).
+        self.check_import_meta_module_support(idx);
+
         if is_meta {
-            self.check_import_meta_module_support(idx);
             // import.meta resolves to the global `ImportMeta` interface
             // (declared in lib.es2020.full.d.ts). Returning that type
             // enables TS2339 on unknown properties (`import.meta.blah`)


### PR DESCRIPTION
Goal: green

Three mechanisms from the Wave-3 queue. Conformance 11,150 → **11,152 (+2; +133/-0 on the day)**.

Structural rules (checker):
1. The `--module` support diagnostic for `import.meta` (TS1343 / node-CJS TS1470) fires for EVERY `import.<name>` meta-property including invalid names (`import.metal` gets it alongside TS17012); tsz only checked valid `meta` accesses. importMeta family 3/3.
2. TS2401 ("A 'super' call must be a root-level statement…") anchors once per constructor at the FIRST `super(...)` call in the body (tsc's `findFirstSuperCall`), replacing the constructor-keyword anchor; a first-call gate keeps it single per constructor.
3. An `any`-typed element access resolves through applicable index infos in ALL modes (tsc `findApplicableIndexInfo`: numeric index preferred, string fallback, plain `any` only with no signatures), not just under `noUncheckedIndexedAccess`. The unit test asserting the old any-fallback was oracle-disproven (tsc 7.0.2 emits the boolean→string TS2322) and rewritten.

## Verification
Conformance FULL: 11,152/12,043, +133/-0 vs snapshot today. tsz-checker at the 21-row pool (the one drift test updated with oracle proof), tsz-core 3,228/3,228, tsz-solver 7,434/7,434. Witnesses: importMeta, derivedClassSuperStatementPosition (4 span pairs), propertyAccess family, each oracle-verified.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max