### PR TITLE
fix(checker,solver,parser): class UnionReduction.Subtype, TS1013 assignment form, JSX TS2769 anchor + attr display order

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -978,6 +978,7 @@ impl<'a> CheckerState<'a> {
         // TS1186: Check for rest elements with initializers in destructuring assignments.
         if is_destructuring {
             self.check_rest_element_initializer(left_idx);
+            self.check_rest_element_trailing_comma(left_idx);
         }
 
         // tsc suppresses TS2322 alongside TS2540 (readonly named property writes)
@@ -1662,6 +1663,84 @@ impl<'a> CheckerState<'a> {
                     diagnostic_codes::A_REST_ELEMENT_MUST_BE_LAST_IN_A_DESTRUCTURING_PATTERN,
                     &[],
                 );
+            }
+        }
+    }
+
+    /// TS1013: A rest element in a destructuring *assignment* target may not
+    /// be followed by a trailing comma (`([...c,] = a)`, `({...d,} = {})`).
+    ///
+    /// The parser owns the binding-pattern form (`let [...e,] = x`);
+    /// assignment targets parse as plain array/object literals — where a
+    /// trailing comma is legal expression syntax — so the pattern-context rule
+    /// is only enforceable here, and it applies at every nesting level
+    /// (`[x, [...a,]] = y` errors on the inner pattern). Anchored at the comma
+    /// token with a 1-char span, matching tsc.
+    fn check_rest_element_trailing_comma(&mut self, left_idx: NodeIndex) {
+        let Some(left_node) = self.ctx.arena.get(left_idx) else {
+            return;
+        };
+        let rest_kind = if left_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
+            syntax_kind_ext::SPREAD_ELEMENT
+        } else if left_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            syntax_kind_ext::SPREAD_ASSIGNMENT
+        } else {
+            return;
+        };
+        let Some(lit) = self.ctx.arena.get_literal_expr(left_node) else {
+            return;
+        };
+        let elements: Vec<NodeIndex> = lit.elements.nodes.clone();
+        if lit.elements.has_trailing_comma
+            && let Some(&last_idx) = elements.last()
+            && let Some(last_node) = self.ctx.arena.get(last_idx)
+            && last_node.kind == rest_kind
+        {
+            // The trailing comma is the last `,` before the closing
+            // bracket/brace. Scan backwards from the closer: the rest
+            // element's own `end` can swallow the separator token, and the
+            // element may contain interior commas (`[...[a, b],] = x`), so
+            // `rfind` over the element-to-closer window is the only anchor
+            // that always lands on the separator.
+            let comma_pos = self
+                .ctx
+                .arena
+                .source_files
+                .first()
+                .and_then(|sf| sf.text.get(last_node.pos as usize..left_node.end as usize))
+                .and_then(|text| text.rfind(','))
+                .map_or(last_node.end, |off| last_node.pos + off as u32);
+            self.error_at_position(
+                comma_pos,
+                1,
+                diagnostic_messages::A_REST_PARAMETER_OR_BINDING_PATTERN_MAY_NOT_HAVE_A_TRAILING_COMMA,
+                diagnostic_codes::A_REST_PARAMETER_OR_BINDING_PATTERN_MAY_NOT_HAVE_A_TRAILING_COMMA,
+            );
+        }
+        // Recurse into nested destructuring targets: array elements, object
+        // property values, rest operands, and `= default` left sides.
+        for element_idx in elements {
+            let Some(element_node) = self.ctx.arena.get(element_idx) else {
+                continue;
+            };
+            if element_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                || element_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+            {
+                self.check_rest_element_trailing_comma(element_idx);
+            } else if element_node.kind == syntax_kind_ext::SPREAD_ELEMENT
+                || element_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT
+            {
+                if let Some(spread) = self.ctx.arena.get_spread(element_node) {
+                    self.check_rest_element_trailing_comma(spread.expression);
+                }
+            } else if element_node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT {
+                if let Some(prop) = self.ctx.arena.get_property_assignment(element_node) {
+                    self.check_rest_element_trailing_comma(prop.initializer);
+                }
+            } else if let Some(bin) = self.ctx.arena.get_binary_expr(element_node) {
+                if bin.operator_token == SyntaxKind::EqualsToken as u16 {
+                    self.check_rest_element_trailing_comma(bin.left);
+                }
             }
         }
     }

--- a/crates/tsz-checker/src/checkers/jsx/overloads.rs
+++ b/crates/tsz-checker/src/checkers/jsx/overloads.rs
@@ -104,8 +104,7 @@ impl<'a> CheckerState<'a> {
 
         // Try each overload
         let has_any_attrs = !attrs_info.attrs.is_empty() || attrs_info.has_spread;
-        let mut shared_explicit_anchor_name: Option<String> = None;
-        let mut all_overload_failures_share_explicit_anchor = true;
+        let mut last_explicit_anchor_name: Option<String> = None;
         let mut considered_overload_failures: usize = 0;
 
         // When an `any`-typed spread exists, any non-0-param overload matches.
@@ -184,44 +183,38 @@ impl<'a> CheckerState<'a> {
             }
 
             considered_overload_failures += 1;
-            if let Some(overload_anchor_name) =
-                self.jsx_overload_explicit_failure_attr(&attrs_info, props_resolved)
-            {
-                if let Some(shared_name) = shared_explicit_anchor_name.as_deref() {
-                    if shared_name != overload_anchor_name.as_str() {
-                        all_overload_failures_share_explicit_anchor = false;
-                    }
-                } else {
-                    shared_explicit_anchor_name = Some(overload_anchor_name);
-                }
-            } else {
-                all_overload_failures_share_explicit_anchor = false;
-            }
+            // tsc's candidateForArgumentError is overwritten by each failing
+            // candidate, so the reported anchor follows the LAST considered
+            // overload — including clearing a previous overload's attribute
+            // anchor when the last failure has no explicit attribute (pure
+            // arity/children failures fall back to the tag name).
+            last_explicit_anchor_name =
+                self.jsx_overload_explicit_failure_attr(&attrs_info, props_resolved);
         }
 
         // No overload matched — roll back speculative diagnostics and emit TS2769.
-        // tsc often anchors at the tag name, but when every non-0-param overload
-        // fails on the same explicit attribute, anchor that attribute instead.
+        // Anchor at the failing explicit attribute of the LAST considered
+        // overload (tsc's last-candidate-wins reporting); tag name only when
+        // that failure has no explicit attribute anchor.
         snap.rollback(&mut self.ctx.speculation_state());
-        let anchor_idx =
-            if considered_overload_failures > 0 && all_overload_failures_share_explicit_anchor {
-                shared_explicit_anchor_name
-                    .as_deref()
-                    .and_then(|shared_name| {
-                        attrs_info
-                            .attrs
-                            .iter()
-                            .find(|a| {
-                                !a.from_spread
-                                    && a.name_node_idx.is_some()
-                                    && a.name.as_str() == shared_name
-                            })
-                            .and_then(|a| a.name_node_idx)
-                    })
-                    .unwrap_or(tag_name_idx)
-            } else {
-                tag_name_idx
-            };
+        let anchor_idx = if considered_overload_failures > 0 {
+            last_explicit_anchor_name
+                .as_deref()
+                .and_then(|anchor_name| {
+                    attrs_info
+                        .attrs
+                        .iter()
+                        .find(|a| {
+                            !a.from_spread
+                                && a.name_node_idx.is_some()
+                                && a.name.as_str() == anchor_name
+                        })
+                        .and_then(|a| a.name_node_idx)
+                })
+                .unwrap_or(tag_name_idx)
+        } else {
+            tag_name_idx
+        };
 
         // TS2786: skipped for React aliases (cycle-detection false positives).
         if !skip_return_check {

--- a/crates/tsz-checker/src/checkers/jsx/props/synthesized_display.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/synthesized_display.rs
@@ -32,11 +32,11 @@ impl<'a> CheckerState<'a> {
         format!("{display_name}: {type_str}")
     }
 
-    /// Walks the attributes once and produces a formatted object-type string with
-    /// explicit (non-spread) attrs first (in source order), then spread-derived
-    /// props that aren't shadowed by an explicit attr (in spread source order).
-    /// This matches tsc's display for elements like `<X {...{p: v}} q />` where
-    /// the printed source type is `{ q: true; p: v; }`.
+    /// Walks the attributes once and produces a formatted object-type string
+    /// merging spread properties and named attributes in source order with
+    /// first-occurrence slots: `<X {...{p: v}} q />` prints `{ p: v; q: true; }`,
+    /// and a duplicate name keeps its first slot while taking the last writer's
+    /// type (tsc 7.0.2 overwrite semantics).
     pub(super) fn format_jsx_attrs_synthesized_source_for_excess(
         &mut self,
         attributes_idx: NodeIndex,
@@ -46,8 +46,7 @@ impl<'a> CheckerState<'a> {
         let attrs_node = self.ctx.arena.get(attributes_idx)?;
         let attrs = self.ctx.arena.get_jsx_attributes(attrs_node)?;
 
-        let mut explicit: Vec<(String, TypeId)> = Vec::new();
-        let mut spread_props: Vec<(String, TypeId)> = Vec::new();
+        let mut props: Vec<(String, TypeId)> = Vec::new();
 
         for &attr_idx in &attrs.properties.nodes {
             let Some(attr_node) = self.ctx.arena.get(attr_idx) else {
@@ -74,10 +73,10 @@ impl<'a> CheckerState<'a> {
                     self.compute_jsx_attr_value_type_without_context(attr_data.initializer)
                 };
 
-                if let Some(existing) = explicit.iter_mut().find(|(n, _)| n == &attr_name) {
+                if let Some(existing) = props.iter_mut().find(|(n, _)| n == &attr_name) {
                     existing.1 = attr_value_type;
                 } else {
-                    explicit.push((attr_name, attr_value_type));
+                    props.push((attr_name, attr_value_type));
                 }
             } else if attr_node.kind == syntax_kind_ext::JSX_SPREAD_ATTRIBUTE {
                 let Some(spread_data) = self.ctx.arena.get_jsx_spread_attribute(attr_node) else {
@@ -106,36 +105,24 @@ impl<'a> CheckerState<'a> {
                         if name == "key" || name == "ref" {
                             continue;
                         }
-                        if let Some(existing) = spread_props.iter_mut().find(|(n, _)| *n == name) {
+                        if let Some(existing) = props.iter_mut().find(|(n, _)| *n == name) {
                             existing.1 = prop.type_id;
                         } else {
-                            spread_props.push((name, prop.type_id));
+                            props.push((name, prop.type_id));
                         }
                     }
                 }
             }
         }
 
-        if explicit.is_empty() && spread_props.is_empty() {
+        if props.is_empty() {
             return None;
         }
 
-        let explicit_names: rustc_hash::FxHashSet<String> =
-            explicit.iter().map(|(n, _)| n.clone()).collect();
-        let mut fragments: Vec<String> = Vec::with_capacity(explicit.len() + spread_props.len());
-        for (name, type_id) in &explicit {
-            fragments.push(self.format_jsx_synthesized_prop_fragment(name, *type_id));
-        }
-        for (name, type_id) in &spread_props {
-            if explicit_names.contains(name) {
-                continue;
-            }
-            fragments.push(self.format_jsx_synthesized_prop_fragment(name, *type_id));
-        }
-
-        if fragments.is_empty() {
-            return None;
-        }
+        let fragments: Vec<String> = props
+            .iter()
+            .map(|(name, type_id)| self.format_jsx_synthesized_prop_fragment(name, *type_id))
+            .collect();
         Some(format!("{{ {}; }}", fragments.join("; ")))
     }
 

--- a/crates/tsz-checker/src/declarations/import/core/helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/core/helpers.rs
@@ -1,7 +1,6 @@
 //! Resolution mode helpers, module-not-found diagnostics, and export helpers.
 
 use crate::diagnostics::format_message;
-use crate::query_boundaries::capabilities::FeatureGate;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::symbol_flags;

--- a/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
@@ -145,6 +145,18 @@ pub(crate) fn compute_conditional_expression_type_with_resolver<R: TypeResolver>
     )
 }
 
+/// tsc `UnionReduction.Subtype` over an already-constructed union, scoped to
+/// class-reference members with tsc's heritage-derivation guard
+/// (`isTypeDerivedFrom`): `Base | Derived` collapses to `Base` at
+/// Subtype-reduction sites while unrelated same-shape classes coexist.
+pub(crate) fn reduce_class_subtype_union_members<R: TypeResolver>(
+    db: &dyn TypeDatabase,
+    resolver: &R,
+    union: TypeId,
+) -> TypeId {
+    tsz_solver::operations::expression_ops::reduce_class_subtype_union_members(db, resolver, union)
+}
+
 /// Merge a single object-spread property contribution through the solver-owned
 /// AST-independent spread merge rule.
 pub(crate) fn merge_object_spread_property(

--- a/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
@@ -1183,7 +1183,6 @@ impl<'a> CheckerState<'a> {
     /// Re-emitting it here duplicates diagnostics for class methods.
     pub(crate) fn check_overload_modifier_agreement(&mut self, impl_node_idx: NodeIndex) {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-        use tsz_scanner::SyntaxKind;
 
         let Some(impl_sym_id) = self.ctx.binder.get_node_symbol(impl_node_idx) else {
             return;

--- a/crates/tsz-checker/src/tests/jsx_excess_attr_with_spread_display_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_excess_attr_with_spread_display_tests.rs
@@ -133,8 +133,10 @@ const _x = <F {...{x: 5, y: "2"}} Z="hi" />;
         "synthesized source-type display must include the spread's y: \"2\"; got: {synthesized:?}"
     );
 
-    // The explicit attribute Z="hi" still leads the synthesized literal —
-    // tsc emits explicit attrs (in source order) before spread-derived props.
+    // tsc 7.0.2 merges spread properties and named attributes in source
+    // order with first-occurrence slots, so the spread's props lead and the
+    // later explicit attribute Z trails: `{ x: number; y: "2"; Z: string; }`
+    // (oracle: `<F {...{x: 5, y: "2"}} Z="hi" />`).
     let z_pos = synthesized
         .find("Z: string")
         .expect("Z: string must be in the synthesized literal");
@@ -145,8 +147,8 @@ const _x = <F {...{x: 5, y: "2"}} Z="hi" />;
         .find("y: \"2\"")
         .expect("y: \"2\" must be in the synthesized literal");
     assert!(
-        z_pos < x_pos && z_pos < y_pos,
-        "Explicit attribute Z must precede spread-derived props; got: {synthesized:?}"
+        x_pos < y_pos && y_pos < z_pos,
+        "Spread-derived props must precede the later explicit attribute Z; got: {synthesized:?}"
     );
 }
 

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -1319,6 +1319,16 @@ impl<'a> CheckerState<'a> {
         // subtrees (#14530).
         let widen_expr = return_types.iter().find_map(|c| c.widen_expr);
         let union = factory.union(return_types.iter().map(|c| c.type_id).collect());
+        // tsc computes this union with `UnionReduction.Subtype`, so
+        // `if (c) return new Base(); return new Derived();` infers `Base`. The
+        // plain constructor keeps `Lazy` class refs deferred; run the
+        // class-scoped, heritage-guarded reduction with the checker resolver.
+        let union =
+            crate::query_boundaries::type_computation::core::reduce_class_subtype_union_members(
+                self.ctx.types,
+                &self.ctx,
+                union,
+            );
         if let Some(expr_idx) = widen_expr
             && crate::query_boundaries::common::is_literal_type(self.ctx.types, union)
         {

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -1458,6 +1458,7 @@ impl ParserState {
         let mut elements = Vec::new();
         let mut emit_semicolon_expected_at_close_bracket = false;
         let mut recovered_empty_array_end = None;
+        let mut has_trailing_comma = false;
         while !self.is_token(SyntaxKind::CloseBracketToken)
             && !self.is_token(SyntaxKind::EndOfFileToken)
         {
@@ -1507,7 +1508,16 @@ impl ParserState {
                 elements.push(elem);
             }
 
-            if !self.parse_optional(SyntaxKind::CommaToken) {
+            if self.parse_optional(SyntaxKind::CommaToken) {
+                // A separator followed directly by the closer is a trailing
+                // comma; the checker needs this for the TS1013 rest-element
+                // rule on destructuring assignment targets (`[...c,] = a`).
+                if self.is_token(SyntaxKind::CloseBracketToken)
+                    || self.is_token(SyntaxKind::EndOfFileToken)
+                {
+                    has_trailing_comma = true;
+                }
+            } else {
                 if self.is_token(SyntaxKind::SemicolonToken) {
                     let saved_token = self.current_token;
                     let saved_state = self.scanner.save_state();
@@ -1635,7 +1645,11 @@ impl ParserState {
             start_pos,
             end_pos,
             LiteralExprData {
-                elements: Self::make_node_list(elements),
+                elements: {
+                    let mut list = Self::make_node_list(elements);
+                    list.has_trailing_comma = has_trailing_comma;
+                    list
+                },
                 multi_line: false,
             },
         )

--- a/crates/tsz-parser/src/parser/state_expressions_literals_object.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_object.rs
@@ -30,6 +30,7 @@ impl ParserState {
         self.parse_expected(SyntaxKind::OpenBraceToken);
 
         let mut properties = Vec::new();
+        let mut has_trailing_comma = false;
         while !self.is_token(SyntaxKind::CloseBraceToken) {
             if !self.is_object_literal_element_start()
                 && !self.is_token(SyntaxKind::SemicolonToken)
@@ -53,7 +54,16 @@ impl ParserState {
                 break;
             }
 
-            if !self.parse_optional(SyntaxKind::CommaToken) {
+            if self.parse_optional(SyntaxKind::CommaToken) {
+                // A separator followed directly by the closer is a trailing
+                // comma; the checker needs this for the TS1013 rest-element
+                // rule on destructuring assignment targets (`({...d,} = x)`).
+                if self.is_token(SyntaxKind::CloseBraceToken)
+                    || self.is_token(SyntaxKind::EndOfFileToken)
+                {
+                    has_trailing_comma = true;
+                }
+            } else {
                 if self.suppress_object_literal_comma_once && self.is_property_start() {
                     self.suppress_object_literal_comma_once = false;
                     continue;
@@ -112,7 +122,11 @@ impl ParserState {
             start_pos,
             end_pos,
             LiteralExprData {
-                elements: Self::make_node_list(properties),
+                elements: {
+                    let mut list = Self::make_node_list(properties);
+                    list.has_trailing_comma = has_trailing_comma;
+                    list
+                },
                 multi_line: false,
             },
         )

--- a/crates/tsz-solver/src/operations/expression_ops.rs
+++ b/crates/tsz-solver/src/operations/expression_ops.rs
@@ -78,7 +78,11 @@ pub fn compute_conditional_expression_type_with_resolver<R: TypeResolver>(
         {
             return reduced;
         }
-        return interner.union2(true_type, false_type);
+        let union = interner.union2(true_type, false_type);
+        if let Some(res) = resolver {
+            return reduce_class_subtype_union_members(interner, res, union);
+        }
+        return union;
     }
     if condition == TypeId::NEVER {
         // never ? A : B -> never (unreachable)
@@ -137,7 +141,15 @@ pub fn compute_conditional_expression_type_with_resolver<R: TypeResolver>(
         return reduced;
     }
 
-    interner.union2(true_type, false_type)
+    let union = interner.union2(true_type, false_type);
+    if let Some(res) = resolver {
+        // `true ? new Base() : new Derived()` — the class-scoped slice of
+        // UnionReduction.Subtype (heritage-guarded), which the broad
+        // reduction above could not take without regressing
+        // `unionTypeReduction2`.
+        return reduce_class_subtype_union_members(interner, res, union);
+    }
+    union
 }
 
 /// Drop an empty array literal branch (`Array<never>` or the empty tuple `[]`)
@@ -1026,19 +1038,31 @@ pub fn compute_best_common_type_cached<R: TypeResolver>(
     // and SubtypeChecker<NoopResolver> are different types.
     if let Some(res) = resolver {
         let mut checker = SubtypeChecker::with_resolver(interner, res);
+        // tsc's removeSubtypes class guard, applied to the tournament: one
+        // class reference only counts as a subtype of another for BCT
+        // purposes when it genuinely derives from it. Without this,
+        // `[new A(), new B()]` for unrelated same-shape classes crowns one of
+        // them BCT winner where tsc keeps `(A | B)[]`.
+        let mut related = |checker: &mut SubtypeChecker<_>, source: TypeId, target: TypeId| {
+            if let (Some(src_def), Some(tgt_def)) = (
+                class_ref_def(interner, res, source),
+                class_ref_def(interner, res, target),
+            ) && !class_derives_from(interner, res, source, src_def, target, tgt_def)
+            {
+                return false;
+            }
+            checker.guard.reset();
+            checker.is_subtype_of(source, target)
+        };
         // Pass 1: Tournament to find potential best candidate
         let mut best = widened[0];
         for &candidate in &widened[1..] {
-            checker.guard.reset();
-            if checker.is_subtype_of(best, candidate) {
+            if related(&mut checker, best, candidate) {
                 best = candidate;
             }
         }
         // Pass 2: Verify the winner is supertype of all
-        let is_supertype = widened.iter().all(|&ty| {
-            checker.guard.reset();
-            checker.is_subtype_of(ty, best)
-        });
+        let is_supertype = widened.iter().all(|&ty| related(&mut checker, ty, best));
         if is_supertype {
             return best;
         }
@@ -1139,6 +1163,162 @@ fn nominal_hierarchy_for_bct<R: TypeResolver>(
     (!hierarchy.is_empty()).then_some(hierarchy)
 }
 
+/// Identify a *class reference* union member: a `Lazy` ref whose def is a
+/// class, a generic instantiation (`Application`) whose head is a class, or a
+/// materialized class instance type registered with the resolver. This is the
+/// tsz equivalent of tsc's `getObjectFlags(getTargetType(type)) & ObjectFlags.Class`
+/// test inside `removeSubtypes`.
+fn class_ref_def<R: TypeResolver>(
+    interner: &dyn TypeDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> Option<crate::def::DefId> {
+    let lazy_class = |ty: TypeId| match interner.lookup(ty) {
+        Some(TypeData::Lazy(def_id)) => {
+            (resolver.get_def_kind(def_id) == Some(crate::def::DefKind::Class)).then_some(def_id)
+        }
+        _ => None,
+    };
+    match interner.lookup(type_id) {
+        Some(TypeData::Lazy(_)) => lazy_class(type_id),
+        Some(TypeData::Application(app_id)) => lazy_class(interner.type_application(app_id).base),
+        _ => resolver.class_def_for_instance_type(type_id),
+    }
+}
+
+/// tsc's `isTypeDerivedFrom` for two *class references*: does `source` extend
+/// `target` through its heritage chain?
+///
+/// Tries the instance-`TypeId` chain first (`get_base_type`, which covers
+/// materialized instance types and non-generic `Lazy` refs), then the `DefId`
+/// `extends` chain. The def-level hit deliberately ignores the target's type
+/// arguments — tsc's `isTypeDerivedFrom` compares against
+/// `getTargetType(target)` (argument-erased), and the strict-subtype half of
+/// the removal conjunction is what rejects `GD extends GB<string>` against a
+/// `GB<number>` sibling.
+fn class_derives_from<R: TypeResolver>(
+    interner: &dyn TypeDatabase,
+    resolver: &R,
+    source: TypeId,
+    source_def: crate::def::DefId,
+    target: TypeId,
+    target_def: crate::def::DefId,
+) -> bool {
+    if nominally_extends_or_is(interner, source, target, resolver) {
+        return true;
+    }
+    let mut current = source_def;
+    for _ in 0..32 {
+        let Some(parent) = resolver.get_class_extends(current) else {
+            return false;
+        };
+        if parent == target_def {
+            return true;
+        }
+        if parent == current {
+            return false;
+        }
+        current = parent;
+    }
+    false
+}
+
+/// tsc `UnionReduction.Subtype` (checker.ts `removeSubtypes`) over an
+/// already-constructed union, for member pairs the interner's shallow engine
+/// treats as inert.
+///
+/// The default union constructor skips subtype reduction whenever a member is
+/// `TypeData::Lazy` (class instance refs stay deferred), so `Base | Derived`
+/// survives at tsc's Subtype-reduction sites (return-type-from-body unions,
+/// conditional expressions). This entry point re-runs the pairwise sweep with
+/// the resolver-backed `SubtypeChecker`, restricted to *class-reference
+/// sources*: a source member is dropped when it is a subtype of a sibling AND
+/// — when the sibling is itself a class reference — the source really derives
+/// from it (tsc's `isTypeDerivedFrom` guard), so unrelated same-shape classes
+/// coexist while `Derived extends Base` collapses to `Base`. Non-class
+/// sources (interfaces, object literals, primitives) are left untouched: the
+/// full-sweep variant historically picked the wrong constituent for
+/// structurally-related call-signature unions (`unionTypeReduction2`).
+///
+/// Plain union type annotations (`var x: Base | Derived`) never route here;
+/// only explicit Subtype-reduction call sites do — tsc's plain `getUnionType`
+/// does not subtype-reduce either.
+pub fn reduce_class_subtype_union_members<R: TypeResolver>(
+    interner: &dyn TypeDatabase,
+    resolver: &R,
+    union: TypeId,
+) -> TypeId {
+    let Some(TypeData::Union(list_id)) = interner.lookup(union) else {
+        return union;
+    };
+    let members: Vec<TypeId> = interner.type_list(list_id).to_vec();
+    let len = members.len();
+    // Mirror tsc's removeSubtypes pairwise-iteration cap.
+    if (len as u64) * (len as u64 - 1) >= 1_000_000 {
+        return union;
+    }
+    let class_defs: Vec<Option<crate::def::DefId>> = members
+        .iter()
+        .map(|&m| class_ref_def(interner, resolver, m))
+        .collect();
+    tracing::trace!(
+        ?members,
+        ?class_defs,
+        member_data = ?members.iter().map(|&m| interner.lookup(m)).collect::<Vec<_>>(),
+        "reduce_class_subtype_union_members: entry"
+    );
+    if class_defs.iter().all(Option::is_none) {
+        return union;
+    }
+    let mut keep = vec![true; len];
+    let mut removed = false;
+    let mut checker = SubtypeChecker::with_resolver(interner, resolver);
+    for i in 0..len {
+        if class_defs[i].is_none() {
+            continue;
+        }
+        for j in 0..len {
+            if i == j || !keep[j] {
+                continue;
+            }
+            // Class-vs-class removal requires genuine heritage derivation,
+            // not mere structural subtyping (tsc's isTypeDerivedFrom guard).
+            if let (Some(src_def), Some(tgt_def)) = (class_defs[i], class_defs[j])
+                && !class_derives_from(interner, resolver, members[i], src_def, members[j], tgt_def)
+            {
+                tracing::trace!(
+                    src = ?members[i], tgt = ?members[j], ?src_def, ?tgt_def,
+                    "reduce_class_subtype_union_members: derivation guard blocked"
+                );
+                continue;
+            }
+            checker.guard.reset();
+            let subtype = checker.is_subtype_of(members[i], members[j]);
+            tracing::trace!(
+                src = ?members[i], tgt = ?members[j],
+                src_data = ?interner.lookup(members[i]), tgt_data = ?interner.lookup(members[j]),
+                src_class = ?class_defs[i], tgt_class = ?class_defs[j], subtype,
+                "reduce_class_subtype_union_members: pair"
+            );
+            if subtype {
+                keep[i] = false;
+                removed = true;
+                break;
+            }
+        }
+    }
+    if !removed {
+        return union;
+    }
+    let kept: Vec<TypeId> = members
+        .iter()
+        .zip(keep.iter())
+        .filter(|&(_, &k)| k)
+        .map(|(&t, _)| t)
+        .collect();
+    interner.union(kept)
+}
+
 fn nominally_extends_or_is<R: TypeResolver>(
     interner: &dyn TypeDatabase,
     source: TypeId,
@@ -1218,6 +1398,10 @@ fn remove_subtypes_for_bct<R: TypeResolver>(
 
     let result: Arc<[TypeId]> = if let Some(res) = resolver {
         let mut keep = vec![true; len];
+        let class_defs: Vec<Option<crate::def::DefId>> = types
+            .iter()
+            .map(|&t| class_ref_def(interner, res, t))
+            .collect();
         let mut checker = SubtypeChecker::with_resolver(interner, res);
         for i in 0..len {
             if !keep[i] {
@@ -1225,6 +1409,16 @@ fn remove_subtypes_for_bct<R: TypeResolver>(
             }
             for j in 0..len {
                 if i == j || !keep[j] {
+                    continue;
+                }
+                // tsc's removeSubtypes class guard: when BOTH sides are class
+                // references, structural subtyping alone must not drop a
+                // member — removal additionally requires heritage derivation
+                // (isTypeDerivedFrom), so unrelated same-shape classes keep
+                // producing `(A | B)[]` from `[new A(), new B()]`.
+                if let (Some(src_def), Some(tgt_def)) = (class_defs[i], class_defs[j])
+                    && !class_derives_from(interner, res, types[i], src_def, types[j], tgt_def)
+                {
                     continue;
                 }
                 checker.guard.reset();


### PR DESCRIPTION
Goal: green

Four oracle-adjudicated tsc 7.0.2 parity mechanisms from the Wave-3 queue, +7 conformance flips, 0 regressions.

## Structural rules

1. **Class UnionReduction.Subtype** — When a union is built at tsc's `UnionReduction.Subtype` sites (block-body return unions, conditional expressions), tsc drops a class-reference member that is a strict subtype of a sibling AND genuinely derives from it (`isTypeDerivedFrom`, argument-erased target); tsz does X through the new solver entry `operations::expression_ops::reduce_class_subtype_union_members`, consumed by the checker via `query_boundaries::type_computation::core`. The same heritage guard now gates `remove_subtypes_for_bct` and the BCT tournament, fixing a pre-existing FP where `[new A(), new B()]` for unrelated same-shape classes collapsed to `B[]` instead of `(A | B)[]`. Scoped to class-reference sources: the historical broad sweep regressed `unionTypeReduction2` (interface call-signature unions).
2. **TS1013 assignment form** — When a rest element in a destructuring *assignment* target has a trailing comma, tsc emits TS1013 anchored at the comma, at every nesting level; tsz does X through `check_rest_element_trailing_comma` in the assignment checker, fed by new `has_trailing_comma` tracking in the array/object literal parsers (binding patterns already had the parser-side check; rvalue literals/call args stay legal).
3. **JSX TS2769 anchor** — When no JSX component overload matches, tsc anchors TS2769 at the failing attribute of the LAST considered overload (`candidateForArgumentError` overwritten per candidate); tsz does X through last-failure-wins in `checkers/jsx/overloads.rs` (tag-name fallback when the last failure has no explicit-attribute anchor).
4. **JSX attrs display order** — When synthesizing the JSX attributes source type for TS2322 display with spreads present, tsc 7.0.2 merges spread properties and named attributes in source order with first-occurrence slots (last-writer type); tsz does X through one ordered walk in `props/synthesized_display.rs`. The old explicit-first order was TS6 behavior; the unit test encoding it was re-adjudicated against the 7.0.2 oracle and updated.

## Adjacent matrix (oracle-verified, scratchpad repros)

- Subtype-reduction: public/private hierarchies, 3-level chains, class-implements-interface, generic base instantiations (`GD extends GB<string>` vs `GB<string>` Application member), mixed literal+class unions, unrelated same-shape classes (must both survive), annotations `var x: Base | Derived` (must survive — default union constructor untouched), generator yield unions, array literals.
- TS1013: array/object assignment forms, parenthesized/bare, nested patterns (`[x, [...a,]]`, `{ p: [...a,] }`), rest holding a pattern with interior commas (`[...[x, y],]` — `rfind` anchor), non-rest trailing commas legal, rvalue spread + call-args trailing commas legal.
- JSX: shared-anchor single-attribute case unchanged; spread-before-attr and attr-before-spread orders; duplicate name keeps first slot with last-writer type.

## Conformance flips (+7)

functionImplementations, trailingCommasInBindingPatterns, contextuallyTypedStringLiteralsInJsxAttributes02, tsxStatelessFunctionComponentOverload4/5, tsxSpreadAttributesResolution2/14.

## Verification

- Full conformance: `scripts/conformance/conformance.sh run` → 11,159/12,043 (main 11,152; plus-list diff vs main-built binary: +7 / −0)
- `cargo nextest run -p tsz-parser --lib` → 1,490/1,490
- `cargo nextest run -p tsz-solver --lib` → 7,434/7,434
- `cargo nextest run -p tsz-checker --lib` → exactly the pre-existing 21-row pool (arch boundary gate + JSX display test both green; the two failures my WIP introduced were fixed by rerouting through `query_boundaries` and re-adjudicating the TS6-stale expectation)
- `cargo nextest run -p tsz-core --lib` → 3,228/3,228 (one run flaked on `parallel::core::…zod_issue_data_cross_file_spread`, 8 subsequent runs clean — scheduling-sensitive test, unrelated)
- Full emit: JS 11,563/11,563; DTS 1,372 at floor, 0 new failures

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max