### PR TITLE
fix(solver,core,checker): boolean union display rank, TS-extension import resolution, TS1329 legacy property hint

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -673,6 +673,7 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn check_legacy_property_decorator_call_signature(
         &mut self,
         decorator_node: NodeIndex,
+        decorator_expr: NodeIndex,
         decorator_type: TypeId,
         is_auto_accessor: bool,
         actual_this_type: Option<TypeId>,
@@ -690,6 +691,12 @@ impl<'a> CheckerState<'a> {
         let Some(resolved) = self.prepare_decorator_callee(resolved) else {
             return;
         };
+
+        // A zero-parameter decorator function is a factory used uncalled:
+        // tsc reports only the TS1329 call-it-first hint, not TS1240/TS1271.
+        if self.decorator_has_zero_arg_factory_shape(decorator_expr, resolved, decorator_node) {
+            return;
+        }
 
         let arg_types: &[TypeId] = if is_auto_accessor {
             &[TypeId::ANY, TypeId::STRING, TypeId::ANY]

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -1679,6 +1679,7 @@ impl<'a> CheckerState<'a> {
                 {
                     self.check_legacy_property_decorator_call_signature(
                         modifier_idx,
+                        decorator.expression,
                         decorator_type,
                         self.has_accessor_modifier_ref(Some(modifiers)),
                         actual_this_type,

--- a/crates/tsz-core/src/module_resolver/file_probing.rs
+++ b/crates/tsz-core/src/module_resolver/file_probing.rs
@@ -98,6 +98,37 @@ impl ModuleResolver {
                 return Some(resolved);
             }
 
+            // A relative specifier naming a TS implementation extension
+            // (`./tsx.ts`, `./plain.tsx`, `./mts1.mts`) resolves like tsc's
+            // allowImportingTsExtensions probing: when the exact file is
+            // missing, strip the extension and try the mode candidate list
+            // ('./tsx.ts' -> tsx.tsx, './dts.ts' -> dts.d.ts, './js1.ts' ->
+            // js1.js under allowJs). `.mts`/`.cts` specifiers stay within
+            // their module-format pair.
+            let ts_impl_fallback: Option<&[&str]> = match extension {
+                "ts" | "tsx" => Some(self.extension_candidates_for_package_type(package_type)),
+                "mts" => Some(if self.allow_js {
+                    &["d.mts", "mjs"]
+                } else {
+                    &["d.mts"]
+                }),
+                "cts" => Some(if self.allow_js {
+                    &["d.cts", "cjs"]
+                } else {
+                    &["d.cts"]
+                }),
+                _ => None,
+            };
+            if let Some(fallback_extensions) = ts_impl_fallback {
+                for ext in fallback_extensions {
+                    if let Some(resolved) =
+                        try_file_with_suffixes_and_extension(&base, ext, suffixes)
+                    {
+                        return Some(resolved);
+                    }
+                }
+            }
+
             return None;
         }
 

--- a/crates/tsz-solver/src/diagnostics/format/compound/union_display.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/union_display.rs
@@ -269,7 +269,13 @@ impl<'a> TypeFormatter<'a> {
             TypeId::STRING => Some(32),
             TypeId::NUMBER => Some(64),
             TypeId::BIGINT => Some(128),
-            TypeId::BOOLEAN => Some(256),
+            // In tsc 7's diagnostic display, `boolean` in a union sorts at its
+            // literal pair's slot — internally it is the `true | false` union
+            // whose members carry `BooleanLiteral` flags — so string/number/
+            // bigint literals precede it (oracle: '"defaulPath" | boolean',
+            // '"a" | 1n | boolean'). Bare `true`/`false` intrinsics share the
+            // same bucket as `TypeData::Literal(Boolean)`.
+            TypeId::BOOLEAN | TypeId::BOOLEAN_TRUE | TypeId::BOOLEAN_FALSE => Some(1 << 13),
             TypeId::SYMBOL => Some(512),
             // The non-primitive `object` sorts after primitives/literals/enums
             // but BEFORE type parameters and the undefined/null tail


### PR DESCRIPTION
Goal: green

Three oracle-adjudicated tsc 7.0.2 parity mechanisms from the Wave-3 queue, +3 conformance flips, 0 regressions.

## Structural rules

1. **Boolean union display rank** — When a diagnostic renders a union containing `boolean`, tsc 7 sorts it at its literal pair's TypeFlags slot (internally `true | false`, `BooleanLiteral` = 1<<13), so string/number/bigint literals precede it (`"defaulPath" | boolean`, `"a" | 1n`); tsz does X through `union_member_primitive_rank` in the solver's diagnostic formatter (`union_display.rs`), which ranked `BOOLEAN` at the primitive slot 256. Bare `true`/`false` intrinsic TypeIds join the same bucket. The DTS printer rank tables are a separately-calibrated surface (baselines at floor) and are deliberately untouched.
2. **TS-extension import resolution** — When a relative specifier names a TS implementation extension (`./tsx.ts`, `./plain.tsx`, `./mts1.mts`) and the exact file is missing, tsc strips the extension and probes the full mode candidate list (`./tsx.ts` → `tsx.tsx`, `./dts.ts` → `dts.d.ts`, `./js1.ts` → `js1.js` under allowJs); tsz does X in `try_file_inner` (`module_resolver/file_probing.rs`) after the exact-extension probe, with `.mts`/`.cts` restricted to their module-format pair (`d.mts`/`mjs`, `d.cts`/`cjs`).
3. **TS1329 legacy property factory hint** — When a legacy (`experimentalDecorators`) property decorator expression's every call signature takes zero parameters, tsc reports only the TS1329 "accepts too few arguments… Did you mean to call it first" hint anchored at `@`, not TS1240+TS1271; tsz does X by consulting the existing `decorator_has_zero_arg_factory_shape` helper (already wired on the ES member paths) from `check_legacy_property_decorator_call_signature`.

## Adjacent matrix (oracle-verified)

- Union rank: 28-case diagnostic matrix (scratchpad/w3-rank/m.ts, m2.ts) covering literal-vs-primitive for every kind, enum members, templates, `object`, classes/interfaces/arrays/functions, unique symbol, null/undefined tail, both source orders — tsz now matches 27/28 (residual: bare-`true`-with-literal unions render through an origin-preserving path, not `format_union`; noted, out of scope).
- Resolution: `.ts→.tsx`, `.ts→.d.ts`, `.tsx→.ts`, allowJs `.ts→.js`, `.mts`/`.cts` pairs; exact file still wins first; witness covers classic/node16/nodenext/bundler.
- TS1329: whole `decoratorOnClassProperty*` family PASS; ES member paths unchanged (already consulted the helper).

## Conformance flips (+3)

importCallExpressionSpecifierNotStringTypeError, allowImportingTsExtensions, decoratorOnClassProperty11.

## Verification

- Full conformance: 11,162/12,043 (vs 11,159 post-#15750; plus-list diff: +3 / −0)
- `cargo nextest run -p tsz-solver --lib` → 7,434/7,434
- `cargo nextest run -p tsz-checker --lib` → exactly the pre-existing 21-row pool
- `cargo nextest run -p tsz-core --lib` → 3,228/3,228
- Full emit: JS 11,563/11,563; DTS 1,372 at floor

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max