### PR TITLE
fix(checker): empty @augments keeps extends edge; relative imports skip ambient modules

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
@@ -673,59 +673,6 @@ impl<'a> CheckerState<'a> {
         (!args.is_empty()).then_some(args)
     }
 
-    /// Returns `true` when the class has a JSDoc `@augments`/`@extends` tag
-    /// whose type argument is empty (e.g. `/** @augments */`).  tsc treats
-    /// such a tag as an invalid override of the structural `extends` clause,
-    /// which prevents base-class property merging.
-    pub(crate) fn has_empty_jsdoc_augments_tag(&self, class_idx: NodeIndex) -> bool {
-        let sf = match self.ctx.arena.source_files.first() {
-            Some(sf) => sf,
-            None => return false,
-        };
-        let source_text: &str = &sf.text;
-        let comments = &sf.comments;
-        let node = match self.ctx.arena.get(class_idx) {
-            Some(n) => n,
-            None => return false,
-        };
-
-        use tsz_common::comments::{get_leading_comments_from_cache, is_jsdoc_comment};
-        let leading = get_leading_comments_from_cache(comments, node.pos, source_text);
-        let comment = match leading.last() {
-            Some(c) => c,
-            None => return false,
-        };
-        if !is_jsdoc_comment(comment, source_text) {
-            return false;
-        }
-
-        let comment_text = comment.get_text(source_text);
-        for tag in ["augments", "extends"] {
-            let needle = format!("@{tag}");
-            for (match_pos, _) in comment_text.match_indices(&needle) {
-                let after = match_pos + needle.len();
-                if after >= comment_text.len() {
-                    return true;
-                }
-                let next_ch = comment_text[after..]
-                    .chars()
-                    .next()
-                    .expect("after < len checked above");
-                if next_ch.is_ascii_alphanumeric() {
-                    continue;
-                }
-                if self
-                    .attached_jsdoc_extends_or_augments_tag(class_idx)
-                    .is_none()
-                {
-                    return true;
-                }
-                return false;
-            }
-        }
-        false
-    }
-
     fn type_params_for_jsdoc_extends_name(
         &mut self,
         base_name: &str,

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -690,20 +690,12 @@ impl<'a> CheckerState<'a> {
 
             let own_summary = self.collect_class_members_for_chain(current_idx, class);
 
-            // In checked JS, an empty `@extends`/`@augments` tag deliberately
-            // invalidates the structural `extends` edge for instance members.
-            // Keep this summary aligned with `class_instance_merge_base_members`
-            // so recovery lookups do not resurrect suppressed base properties.
-            let skip_heritage_merge =
-                self.ctx.is_js_file() && self.has_empty_jsdoc_augments_tag(current_idx);
-
             // Extract extends-clause type arguments while the current class's type
             // parameters are still in scope (so expressions like `RT[RT['a']]` resolve).
-            let extends_info = if skip_heritage_merge {
-                None
-            } else {
-                self.get_extends_clause_type_args(current_idx)
-            };
+            // A malformed empty `@augments`/`@extends` tag reports TS8023+TS1003
+            // but does not invalidate the structural `extends` edge (aligned
+            // with `class_instance_merge_base_members`).
+            let extends_info = self.get_extends_clause_type_args(current_idx);
 
             self.pop_type_parameters(type_param_updates);
 
@@ -782,10 +774,6 @@ impl<'a> CheckerState<'a> {
                         .entry(name)
                         .or_insert(substituted);
                 }
-            }
-
-            if skip_heritage_merge {
-                break;
             }
 
             // Build the substitution for the next level: map the base class's type

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1250,6 +1250,32 @@ impl<'a> CheckerContext<'a> {
             } else {
                 binder.module_exports.as_ref()
             };
+        // tsc consults ambient `declare module "x"` names only for
+        // NON-relative specifiers: a relative import ('./x') resolves to a
+        // file and never merges an ambient module's exports, even when the
+        // ambient name equals the './'-stripped specifier. The map keys both
+        // file names and ambient names, so the relative path must guard the
+        // stripped candidate against declared ambient modules (wildcard
+        // patterns below are unaffected — './logo.svg' still matches
+        // 'declare module "*.svg"').
+        let is_relative_specifier = module_key.starts_with("./")
+            || module_key.starts_with("../")
+            || module_key.starts_with(".\\")
+            || module_key.starts_with("..\\");
+        if is_relative_specifier {
+            if let Some(table) = map.get(module_key) {
+                return Some(table);
+            }
+            if let Some(stripped) = module_key
+                .strip_prefix("./")
+                .or_else(|| module_key.strip_prefix(".\\"))
+                && !self.declared_modules_contains(binder, stripped)
+                && let Some(table) = map.get(stripped)
+            {
+                return Some(table);
+            }
+            return self.lookup_wildcard_module_exports(module_key, map);
+        }
         if let Some(table) = Self::lookup_any_file_key(module_key, map) {
             return Some(table);
         }

--- a/crates/tsz-checker/src/tests/jsdoc_empty_augments_class_chain_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_empty_augments_class_chain_tests.rs
@@ -1,5 +1,9 @@
-//! Empty checked-JS `@augments`/`@extends` tags suppress inherited instance
-//! members in class-chain recovery, matching the class instance merge owner.
+//! A malformed empty checked-JS `@augments`/`@extends` tag reports
+//! TS8023+TS1003 but does NOT override a syntactic `extends` clause: tsc
+//! 7.0.2 still resolves the base class, so inherited instance members stay
+//! visible on the derived class (oracle: `class Root{constructor(){this.y=0}}
+//! /** @augments */ class Leaf extends Root { probe(){this.y} }` emits only
+//! TS8023+TS1003, no TS2339).
 
 use crate::test_utils::check_js_source_code_messages;
 
@@ -11,7 +15,7 @@ fn codes(source: &str) -> Vec<u32> {
 }
 
 #[test]
-fn empty_augments_keeps_base_instance_member_missing_but_own_member_visible() {
+fn empty_augments_keeps_inherited_and_own_members_visible() {
     let codes = codes(
         r#"
 class Root {
@@ -34,12 +38,12 @@ class Leaf extends Root {
     );
 
     assert!(
-        codes.contains(&2339),
-        "expected TS2339 for inherited member suppressed by empty @augments, got {codes:?}"
+        !codes.contains(&2339),
+        "a malformed empty @augments must not suppress the syntactic extends edge; \
+         inherited `y` and own `z` both stay visible (tsc: TS8023+TS1003 only), got {codes:?}"
     );
-    assert_eq!(
-        codes.iter().filter(|&&code| code == 2339).count(),
-        1,
-        "own checked-JS member should remain visible while inherited member is suppressed: {codes:?}"
+    assert!(
+        codes.contains(&8023),
+        "the malformed tag itself still reports TS8023, got {codes:?}"
     );
 }

--- a/crates/tsz-checker/src/types/class_type/core.rs
+++ b/crates/tsz-checker/src/types/class_type/core.rs
@@ -140,8 +140,7 @@ impl<'a> CheckerState<'a> {
 
         // Merge base class members. A detected cycle/forward reference performs
         // the resolution-set cleanup inline and short-circuits the whole call.
-        if let Some(early) =
-            self.class_instance_merge_base_members(class, class_idx, walk_state, &mut builder)
+        if let Some(early) = self.class_instance_merge_base_members(class, walk_state, &mut builder)
         {
             return early;
         }

--- a/crates/tsz-checker/src/types/class_type/instance_merge.rs
+++ b/crates/tsz-checker/src/types/class_type/instance_merge.rs
@@ -31,18 +31,17 @@ impl CheckerState<'_> {
     pub(super) fn class_instance_merge_base_members<'b>(
         &mut self,
         class: &'b tsz_parser::parser::node::ClassData,
-        class_idx: NodeIndex,
         walk_state: &mut ClassInstanceWalkState,
         b: &mut ClassInstanceBuilder<'b>,
     ) -> Option<TypeId> {
         let current_sym = b.current_sym;
         let did_insert_into_global_set = b.did_insert_into_global_set();
         // Merge base class instance properties (derived members take precedence).
-        // In JS files, an empty @augments/@extends tag overrides the structural
-        // extends clause — tsc does not merge base-class properties in that case.
-        let skip_heritage_merge =
-            self.ctx.is_js_file() && self.has_empty_jsdoc_augments_tag(class_idx);
-        if !skip_heritage_merge && let Some(ref heritage_clauses) = class.heritage_clauses {
+        // A malformed empty `@augments`/`@extends` tag reports TS8023+TS1003
+        // but does NOT override a syntactic `extends` clause — tsc still
+        // resolves the base class, so inherited JS this-properties stay
+        // visible on the derived class.
+        if let Some(ref heritage_clauses) = class.heritage_clauses {
             for &clause_idx in &heritage_clauses.nodes {
                 let Some(clause_node) = self.ctx.arena.get(clause_idx) else {
                     continue;


### PR DESCRIPTION
Goal: green

Two oracle-adjudicated tsc 7.0.2 parity mechanisms from the Wave-3 miss-2339 satellite family, +2 conformance flips, 0 regressions.

## Structural rules

1. **Empty `@augments` vs `extends`** — When a JS class has a malformed empty `/** @augments */` (or `@extends`) tag AND a syntactic `extends A` clause, tsc reports TS8023+TS1003 but still resolves the base class, so inherited JS this-properties stay visible on the derived class; tsz does X by deleting the empty-augments skip at both owners (`types/class_type/instance_merge.rs` and `classes/class_summary.rs`) plus the now-dead `has_empty_jsdoc_augments_tag` helper. The old code's premise ("tsc does not merge base-class properties in that case") is refuted by the 7.0.2 oracle. The unit test encoding the refuted behavior (`jsdoc_empty_augments_class_chain_tests`) was re-adjudicated against the oracle (its exact fixture: TS8023+TS1003 only, no TS2339) and rewritten.
2. **Relative specifiers never consult ambient modules** — A relative import (`./x`) that resolves to an actual source file never merges ambient `declare module "x"` exports in tsc (ambient names only serve non-relative specifiers); tsz does X in `context/core.rs::module_exports_for_module`: the relative-specifier path guards the `./`-stripped candidate against `declared_modules_contains` before matching, while keeping direct path-key matches and the wildcard-pattern fallback (`./logo.svg` vs `declare module "*.svg"`) intact. `resolve_ambient_module_export` routes through the same lookup, covering the import-equals form.

## Adjacent matrix (oracle-verified)

- Augments: empty tag + extends (no TS2339, both single-class and multi-level chain with own+inherited probes), valid `@augments A` + extends (clean), plain extends without JSDoc (clean), TS8023/TS1003 anchors unchanged; `jsdocAugments_*` family — 6/7 PASS, `jsdocAugments_notAClass` fails pre-existing on main (absent from all plus-lists).
- Ambient: non-relative import of the same name still resolves to the ambient module (the witness's file2 path), wildcard patterns unaffected, backslash-normalized relative forms guarded symmetrically.

## Conformance flips (+2)

jsdocAugmentsMissingType, externalModuleRefernceResolutionOrderInImportDeclaration.

## Verification

- Full conformance: 11,164/12,043 (vs 11,162 post-#15751; plus-list diff: +2 / −0)
- `cargo nextest run -p tsz-checker --lib` → exactly the pre-existing 21-row pool (the one new failure was the refuted-behavior test, re-adjudicated)
- `cargo nextest run -p tsz-core --lib` → 3,228/3,228 (3 consecutive clean runs)
- `cargo nextest run -p tsz-solver --lib` → 7,434/7,434
- Full emit: JS 11,563/11,563; DTS 1,372 at floor

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max