### PR TITLE
fix(checker): overload callback-body errors commit the first signature match

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
@@ -977,7 +977,6 @@ impl<'a> CheckerState<'a> {
         // body errors against the resolved signature; it does not treat a body error
         // as an overload mismatch. When no overload resolves cleanly we commit to
         // this candidate and surface its diagnostics instead of silently recovering.
-        let mut callback_body_only_success: Option<BestTypeMismatch> = None;
         for (idx, original_sig) in signatures.iter().enumerate() {
             // See the first-pass loop: an open-ended spread requires an effective
             // rest parameter, so fixed-arity overloads are skipped here too.
@@ -1593,20 +1592,28 @@ impl<'a> CheckerState<'a> {
                         all_arg_count_mismatches = false;
                         has_non_count_non_type_failure = true;
                         // A non-generic overload matched at the signature level, so its
-                        // callback body diagnostics are real. Keep the last such overload
-                        // (mirroring tsc's final-candidate choice) to commit if no other
-                        // overload resolves cleanly. Generic overloads are left to the
-                        // instantiation machinery, whose transient body errors must not leak.
+                        // callback body diagnostics are real. tsc's chooseOverload
+                        // commits to the FIRST such candidate — callback-body
+                        // diagnostics never disqualify a signature-level match, so
+                        // later overloads are not consulted (they would retype the
+                        // callback under a different parameter type and report the
+                        // wrong body errors). Generic overloads are left to the
+                        // instantiation machinery, whose transient body errors must
+                        // not leak.
                         if sig.type_params.is_empty() {
-                            callback_body_only_success =
-                                Some(self.build_callback_body_only_candidate(
-                                    args,
-                                    &overload_snap.diag,
-                                    &candidate_snap,
-                                    sig_arg_types.clone(),
-                                    return_type,
-                                    selected_type_predicate.clone(),
-                                ));
+                            let candidate = self.build_callback_body_only_candidate(
+                                args,
+                                &overload_snap.diag,
+                                &candidate_snap,
+                                sig_arg_types.clone(),
+                                return_type,
+                                selected_type_predicate.clone(),
+                            );
+                            return Some(self.commit_callback_body_only_candidate(
+                                candidate,
+                                &overload_snap,
+                                &mut original_node_types,
+                            ));
                         }
                         let nested_no_overload_diags =
                             self.callback_body_no_overload_diagnostics_since(args, &candidate_snap);
@@ -1858,18 +1865,6 @@ impl<'a> CheckerState<'a> {
             self.ctx.node_types = std::mem::take(&mut original_node_types);
             self.ctx.node_types.merge_owned(sig_node_types);
             return Some(best_type_mismatch);
-        }
-
-        // No overload resolved cleanly, but at least one matched at the signature
-        // level and failed only inside a callback body. Commit to it and surface its
-        // diagnostics instead of silently recovering (via `callback_body_failure_return`),
-        // which would hide real errors only visible under the resolved parameter type.
-        if let Some(candidate) = callback_body_only_success {
-            return Some(self.commit_callback_body_only_candidate(
-                candidate,
-                &overload_snap,
-                &mut original_node_types,
-            ));
         }
 
         // No overload matched: drop speculative diagnostics from overload argument

--- a/crates/tsz-checker/src/tests/dispatch_tests/part_00.rs
+++ b/crates/tsz-checker/src/tests/dispatch_tests/part_00.rs
@@ -1062,7 +1062,12 @@ const assigned: (x: string) => string = (x) => 1;
 }
 
 #[test]
-fn speculative_overload_check_does_not_poison_successful_candidate() {
+fn overload_callback_body_error_commits_first_signature_match() {
+    // tsc 7.0.2 oracle: chooseOverload commits to the FIRST overload whose
+    // signature-level argument relation succeeds; callback-body diagnostics
+    // never disqualify it, so `s` types as `number` from the first overload
+    // and the body reports TS2339 'toUpperCase' does not exist on 'number'
+    // (NOT a silent fall-through to the string overload).
     let diags = check_source_diagnostics(
         r#"
 declare function fn(cb: (s: number) => void): void;
@@ -1071,14 +1076,16 @@ declare function fn(cb: (s: string) => void): void;
 fn(s => s.toUpperCase());
 "#,
     );
-    let relevant: Vec<_> = diags
-        .iter()
-        .filter(|d| matches!(d.code, 7006 | 2339 | 2345))
-        .collect();
+    let ts2339: Vec<_> = diags.iter().filter(|d| d.code == 2339).collect();
     assert_eq!(
-        relevant.len(),
-        0,
-        "Expected speculative overload rollback to avoid poisoning the successful candidate, got: {relevant:?}"
+        ts2339.len(),
+        1,
+        "Expected exactly one TS2339 from the first overload's callback body, got: {diags:?}"
+    );
+    assert!(
+        ts2339[0].message_text.contains("'number'"),
+        "The callback parameter must type from the FIRST overload (number), got: {:?}",
+        ts2339[0].message_text
     );
 }
 


### PR DESCRIPTION
Goal: green

One oracle-adjudicated tsc 7.0.2 parity mechanism (miss-2339 satellite family), +3 conformance flips, 0 regressions.

## Structural rule

When resolving overloads with a context-sensitive callback argument, tsc's `chooseOverload` commits to the FIRST overload whose signature-level argument relation succeeds and reports that candidate's callback-body errors — body diagnostics never disqualify a candidate; tsz does X in `overload_resolution/resolve_signatures.rs`: a non-generic candidate whose only failures since `candidate_snap` are callback-body diagnostics now commits immediately through `commit_callback_body_only_candidate` (keeping its body diagnostics) instead of stashing the LAST such candidate and falling through to later overloads, which retyped the callback under a different parameter type and reported the wrong errors. Generic candidates keep the deferred instantiation path (their transient body errors must not leak).

## Oracle adjudication

The unit test `speculative_overload_check_does_not_poison_successful_candidate` encoded the fall-through (expected zero diagnostics for `fn(s => s.toUpperCase())` against `(number)=>void | (string)=>void`). tsc 7.0.2 on that exact fixture emits `TS2339: Property 'toUpperCase' does not exist on type 'number'` — the first overload wins and its body error is reported. The test was rewritten as `overload_callback_body_error_commits_first_signature_match` asserting exactly one TS2339 mentioning 'number'.

## Adjacent matrix

First-overload body-error + later clean overload (commits first, tsz now byte-matches tsc), generic-overload body errors (unchanged deferred path), single-signature calls (branch requires multiple arity-compatible signatures — unchanged), arity-mismatch and hard non-callback argument errors (unchanged rejection paths).

## Conformance flips (+3)

contextualTypingOfLambdaReturnExpression, functionAssignment, functionOverloadAmbiguity1.

## Verification

- Full conformance: 11,167/12,043 (vs 11,164 post-#15752; plus-list diff: +3 / −0)
- `cargo nextest run -p tsz-checker --lib` → exactly the pre-existing 21-row pool
- `cargo nextest run -p tsz-core --lib` → 3,228/3,228
- `cargo nextest run -p tsz-solver --lib` → 7,434/7,434
- Full emit: JS 11,563/11,563; DTS 1,372 at floor

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max