### PR TITLE
fix(checker): module.exports = require() types member writes as the required module

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/js_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports.rs
@@ -1455,6 +1455,20 @@ impl<'a> CheckerState<'a> {
         // 1. Collect direct `module.exports = X` assignment
         surface.direct_export_type = last_direct_export
             .map(|(_, rhs_expr)| {
+                // `module.exports = require('./y')` re-exports another module:
+                // tsc checks every `module.exports.<name>` member write
+                // (before or after it) against the required module's
+                // typeof-import type — TS2339 on 'typeof import("y")' — not
+                // against an expando-extensible `any`. Scoped to the current
+                // file: `build_typeof_import_namespace_type` resolves the
+                // specifier relative to `ctx.current_file_idx`.
+                if target_file_idx == self.ctx.current_file_idx
+                    && let Some(specifier) = self.get_require_module_specifier(rhs_expr)
+                    && let Some(namespace_type) =
+                        self.build_typeof_import_namespace_type(&specifier, None)
+                {
+                    return namespace_type;
+                }
                 let expando_root = target_arena
                     .get_identifier_at(rhs_expr)
                     .map(|ident| ident.escaped_text.as_str());


### PR DESCRIPTION
Goal: green

One oracle-adjudicated tsc 7.0.2 parity mechanism (miss-2339 satellite family), +1 conformance flip, 0 regressions.

## Structural rule

When a JS file contains a full `module.exports = require('./y')` assignment, tsc checks every `module.exports.<name>` member write (before or after it) against the required module's typeof-import type and emits TS2339 for missing members (`Property 'x' does not exist on type 'typeof import("y")'`); tsz does X in `query_boundaries/js_exports.rs::compute_js_export_surface`: a require-call RHS now resolves through `build_typeof_import_namespace_type` (scoped to `target_file_idx == current_file_idx`, since specifier resolution anchors at the current file), so `direct_export_type` carries the required module's namespace type and the member-write check takes the same concrete path that already handles object-literal direct exports.

## Adjacent matrix (probe pair in scratchpad/w3-req)

- `module.exports = {a:1}` + `.b` write → TS2339 on `{ a: number; }` (already matched; non-regression verified byte-identical).
- `module.exports = require("./y.js")` + `.x` write before it → TS2339 on `typeof import("y")` (was silent; now byte-matches tsc including receiver display).
- TS2309 (export assignment with other exports) unchanged in both probes.
- Siblings `jsExportMemberMergedWithModuleAugmentation{,2}` fail pre-existing on main (absent from all plus-lists; different causes).

## Conformance flips (+1)

jsExportMemberMergedWithModuleAugmentation3.

## Verification

- Full conformance: 11,168/12,043 (vs 11,167 post-#15753; plus-list diff: +1 / −0)
- `cargo nextest run -p tsz-checker --lib` → exactly the pre-existing 21-row pool
- `cargo nextest run -p tsz-core --lib` → 3,228/3,228
- `cargo nextest run -p tsz-solver --lib` → 7,434/7,434
- Full emit: JS 11,563/11,563; DTS 1,372 at floor

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max