### PR TITLE
fix(checker,binder,solver): instanceof JS-ctor '{}' narrowing, TS expando container gates, structural callable receiver display

### DIFF
--- a/crates/tsz-binder/src/binding/expression_flow.rs
+++ b/crates/tsz-binder/src/binding/expression_flow.rs
@@ -778,6 +778,42 @@ impl BinderState {
             || is_js_class_root)
             && !is_prototype_element_access
         {
+            // Nearest function-like/module container, `NONE` for the source
+            // file itself (blocks and loop/if heads are transparent).
+            fn nearest_expando_container(arena: &NodeArena, start: NodeIndex) -> NodeIndex {
+                let mut current = start;
+                for _ in 0..256 {
+                    let Some(ext) = arena.get_extended(current) else {
+                        return NodeIndex::NONE;
+                    };
+                    let parent = ext.parent;
+                    if parent.is_none() {
+                        return NodeIndex::NONE;
+                    }
+                    let Some(node) = arena.get(parent) else {
+                        return NodeIndex::NONE;
+                    };
+                    if node.is_function_like() || node.kind == syntax_kind_ext::MODULE_DECLARATION {
+                        return parent;
+                    }
+                    current = parent;
+                }
+                NodeIndex::NONE
+            }
+            // In TS files, `fn.prop = e` declares an expando property only
+            // when the assignment's enclosing container equals the container
+            // of `fn`'s declaration — an assignment inside another function's
+            // body (or parameter default), or targeting a namespace-declared
+            // function from file scope, is TS2339 in tsc. Block/if/loop
+            // nesting shares the file container and stays declared. JS files
+            // keep the permissive expando model.
+            if !is_js_like_source
+                && symbol.value_declaration.is_some()
+                && nearest_expando_container(arena, lhs)
+                    != nearest_expando_container(arena, symbol.value_declaration)
+            {
+                return;
+            }
             Arc::make_mut(&mut self.expando_properties)
                 .entry(obj_key.clone())
                 .or_default()

--- a/crates/tsz-checker/src/flow/control_flow/narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/narrowing.rs
@@ -668,19 +668,33 @@ impl<'a> FlowAnalyzer<'a> {
             return self.resolve_symbol_to_instance_type(symbol_ref);
         }
 
-        // For FUNCTION symbols (e.g., JS constructor functions with @constructor),
-        // resolve the function's type and extract the instance type from construct
-        // signatures or prototype property.
-        if symbol.has_any_flags(symbol_flags::FUNCTION)
-            && let Some(env) = &self.type_environment
-        {
-            let env_borrow = env.borrow();
-            if let Some(func_type) = env_borrow.get(symbol_ref)
-                && let Some(instance_type) =
-                    flow_query::instance_type_from_constructor(self.interner, func_type)
-            {
-                return Some(instance_type);
+        // For FUNCTION symbols (e.g., JS constructor functions with @constructor,
+        // or any plain function value), resolve the function's type and extract
+        // the instance type from construct signatures or prototype property.
+        if symbol.has_any_flags(symbol_flags::FUNCTION) {
+            if let Some(env) = &self.type_environment {
+                let env_borrow = env.borrow();
+                if let Some(func_type) = env_borrow.get(symbol_ref)
+                    && let Some(instance_type) =
+                        flow_query::instance_type_from_constructor(self.interner, func_type)
+                {
+                    return Some(instance_type);
+                }
             }
+
+            // tsc's `getInstanceType` falls back to the empty object type `{}`
+            // when the constructor has no `[Symbol.hasInstance]` predicate, no
+            // non-`any` `prototype` property, and no construct signature: "we use
+            // the empty object type to indicate we don't know the type of values
+            // that may be instances of the constructor type". A function used as
+            // an `instanceof` right operand is derived from the global `Function`
+            // type, so this fallback applies. For a JS `@constructor`/`this`-property
+            // function under checked JS, `this` is implicitly `any` (TS2683) so no
+            // instance members are established and the instance type is exactly
+            // `{}`; narrowing `x: any` therefore yields `{}` and later property
+            // reads report TS2339 on `{}`, matching tsc. (Class constructors are
+            // handled by the `CLASS` branch above and never reach here.)
+            return Some(flow_query::empty_object_type(self.interner));
         }
 
         // For plain VARIABLE symbols (e.g., `declare var C: CConstructor`),

--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -750,6 +750,48 @@ impl<'a> CheckerState<'a> {
             let symbol_declarations = symbol.declarations.clone();
             let symbol_escaped_name = symbol.escaped_name.clone();
 
+            // In TS files, `fn.prop = e` is an expando DECLARATION only when
+            // the assignment shares its enclosing container (nearest
+            // function-like/module, `NONE` = source file; blocks and loop/if
+            // heads are transparent) with `fn`'s declaration — mirrors the
+            // binder's record-time gate. A nested-function assignment falls
+            // through to the normal property check and reports TS2339. Scoped
+            // to locally-bound symbols so a cross-arena declaration index is
+            // never compared against this file's nodes.
+            fn nearest_expando_container(
+                arena: &tsz_parser::parser::node::NodeArena,
+                start: NodeIndex,
+            ) -> NodeIndex {
+                let mut current = start;
+                for _ in 0..256 {
+                    let Some(ext) = arena.get_extended(current) else {
+                        return NodeIndex::NONE;
+                    };
+                    let parent = ext.parent;
+                    if parent.is_none() {
+                        return NodeIndex::NONE;
+                    }
+                    let Some(node) = arena.get(parent) else {
+                        return NodeIndex::NONE;
+                    };
+                    if node.is_function_like()
+                        || node.kind == tsz_parser::parser::syntax_kind_ext::MODULE_DECLARATION
+                    {
+                        return parent;
+                    }
+                    current = parent;
+                }
+                NodeIndex::NONE
+            }
+            if !self.is_js_file()
+                && symbol_value_declaration.is_some()
+                && self.ctx.binder.get_symbol(sym_id).is_some()
+                && nearest_expando_container(self.ctx.arena, property_access_idx)
+                    != nearest_expando_container(self.ctx.arena, symbol_value_declaration)
+            {
+                return false;
+            }
+
             if self.is_js_file()
                 && self.ctx.compiler_options.check_js
                 && prototype_root_expr.is_none()

--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -161,7 +161,21 @@ impl<'a> TypeFormatter<'a> {
                     {
                         return format!("typeof {name}").into();
                     }
-                    return name.into();
+                    // A function symbol whose callable carries appended value
+                    // properties (expando assignments) renders structurally in
+                    // tsc (`{ (): void; declared: number; }`), never as the
+                    // bare name; `prototype` is not an appended property.
+                    let expando_augmented_function = self
+                        .symbol_arena
+                        .and_then(|arena| arena.get(sym_id))
+                        .is_some_and(|sym| sym.has_flags(tsz_binder::symbol_flags::FUNCTION))
+                        && shape
+                            .properties
+                            .iter()
+                            .any(|prop| &*self.atom(prop.name) != "prototype");
+                    if !expando_augmented_function {
+                        return name.into();
+                    }
                 }
                 self.format_callable(shape.as_ref()).into()
             }


### PR DESCRIPTION
Goal: green

Three tsc 7.0.2 parity mechanisms (+1 conformance flip, 0 regressions). The instanceof mechanism was implemented by an Opus teammate agent and reviewed + independently verified here.

## Structural rules

1. **instanceof '{}' fallback** — When the right operand of `instanceof` is a function whose type has no `[Symbol.hasInstance]` predicate, no construct signature, and no typed `prototype`, tsc's `getInstanceType` falls back to the empty object type, so `x instanceof F` narrows `any` to `{}` — for checked-JS constructor functions under this-implicitly-any (TS2683) subsequent property reads are TS2339 on `'{}'`; tsz does X in `flow/control_flow/narrowing.rs` (FUNCTION-symbol branch now returns the `{}` fallback instead of bailing). Class-based instanceof is handled by the CLASS branch and is unaffected (adjacent witnesses `controlFlowInstanceofExtendsFunction`, `controlFlowInstanceofWithSymbolHasInstance` still PASS).
2. **TS-file expando container rule** — `fn.prop = e` declares an expando property only when the assignment's enclosing container (nearest function-like/module; block/if/loop nesting is transparent) equals the container of `fn`'s declaration; a nested-function assignment falls through to the normal property check (TS2339). Gated at both owners: binder record time (`binding/expression_flow.rs`) and checker write acceptance (`property_access_helpers/expando.rs::is_expando_function_assignment`, scoped to locally-bound symbols). JS files keep the permissive model. Oracle matrix: file-scope + block-nested assignments stay declared; another function's body/parameter default errors.
3. **Structural callable receiver display** — A function symbol whose callable carries appended value properties (expando assignments) renders structurally in diagnostics, never as the bare function name (`prototype` doesn't count); classes keep `typeof C`. Owner: the diagnostics formatter's Callable arm (`solver diagnostics/format/key.rs`), found via an 11-probe instrumentation hunt; the arm returns the bare symbol name before the structural formatter runs.

## Notes

- `expandoFunctionNestedAssigments` itself does not flip yet: its diagnostics now match structurally but expando property TYPES render `any` vs tsc's assigned types, ordering is hash-scrambled, and tsc elides with `... N more ...` — a follow-up patch from a second teammate is in review.
- `test_ts_expando_reads_remain_any_typed` was oracle-checked during review: tsc 7.0.2 DOES emit TS2322 for `fn.answer = 1; let text: string = fn.answer` — that stale test is order-flaky (passes in isolation and in 2/3 full runs) and is left for the typing follow-up which will re-adjudicate it.

## Conformance flips (+1)

controlFlowInstanceof (TS2339 'val' on '{}' + TS2683, byte-matching tsc).

## Verification

- Full conformance: 11,169/12,043 (plus-list diff vs 11,168 main: +1 / −0)
- `cargo nextest run -p tsz-checker --lib` → exactly the pre-existing 21-row pool (2 consecutive runs; one transient order-dependent flake pair investigated, both pass isolated)
- `-p tsz-core --lib` 3,228/3,228; `-p tsz-solver --lib` 7,434/7,434; `-p tsz-binder --lib` 425/425
- Full emit: JS 11,563/11,563; DTS 1,372 at floor

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max