### PR TITLE
fix(binder,checker): TS nested expando chains require a function root

### DIFF
--- a/crates/tsz-binder/src/binding/expression_flow.rs
+++ b/crates/tsz-binder/src/binding/expression_flow.rs
@@ -778,6 +778,30 @@ impl BinderState {
             || is_js_class_root)
             && !is_prototype_element_access
         {
+            // A NESTED object chain (`a.b.…x.p = e`, `obj_key` has a dot)
+            // declares an expando in a TS file only when the chain's ROOT is
+            // itself a callable expando-host — i.e. carries FUNCTION. A bare
+            // namespace/value-module root declares nothing even though the
+            // deeper member is function-typed: `declare namespace app { function
+            // foo(): void }` with `app.foo.bar = e` is TS2339 at the write and
+            // at every later read, whereas a function-merged root
+            // (`function app(){}; namespace app { export function foo(){} }`)
+            // stays a valid host. Symmetrically a member that is itself an
+            // expando cannot carry a further expando (`foo.bar = {}; foo.bar.baz
+            // = e` is TS2339 on `baz`). JS files keep the permissive model.
+            if !is_js_like_source && obj_key.contains('.') {
+                if (symbol.flags & symbol_flags::FUNCTION) == 0 {
+                    return;
+                }
+                if let Some((parent_key, member_name)) = obj_key.rsplit_once('.')
+                    && self
+                        .expando_properties
+                        .get(parent_key)
+                        .is_some_and(|members| members.contains(member_name))
+                {
+                    return;
+                }
+            }
             // Nearest function-like/module container, `NONE` for the source
             // file itself (blocks and loop/if heads are transparent).
             fn nearest_expando_container(arena: &NodeArena, start: NodeIndex) -> NodeIndex {

--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -1028,9 +1028,14 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        // Namespace member fallback: allow expando assignment for function-typed
-        // members accessed through namespace/value-module chains (e.g., `app.foo.bar = ...`).
-        // Binder tracks these expandos by chain key, so reads can observe them later.
+        // Namespace-member fallback (checked JS only): under the permissive JS
+        // model a namespace/value-module chain whose target member is
+        // function-typed hosts expando writes like `app.foo.bar = ...`, and the
+        // binder tracks them by chain key so reads observe them later. In TS
+        // files this is never a valid expando declaration — the primary symbol
+        // path above, with its same-container gate, is authoritative, so
+        // `app.foo.bar = e` against a namespace-declared function stays TS2339.
+        // The binder mirrors the split, declining to record TS nested chains.
         fn root_identifier(
             arena: &tsz_parser::parser::node::NodeArena,
             idx: NodeIndex,
@@ -1046,7 +1051,8 @@ impl<'a> CheckerState<'a> {
             None
         }
 
-        if object_type_is_function
+        if self.is_js_file()
+            && object_type_is_function
             && let Some(root_name) = root_identifier(self.ctx.arena, object_expr_idx)
             && let Some(root_sym) = self.ctx.binder.file_locals.get(&root_name)
             && let Some(root_symbol) = self.ctx.binder.get_symbol(root_sym)


### PR DESCRIPTION
Goal: green

One teammate-authored, main-loop-reviewed tsc 7.0.2 parity mechanism (the final miss-2339 expando satellite), +1 conformance flip, 0 regressions.

## Structural rule

In TS files, a nested chain write `a.b.c = e` declares an expando property only when the chain's ROOT symbol carries FUNCTION flags; a bare namespace/value-module root declares nothing even when the deeper member is function-typed (`declare namespace app { function foo(): void }` with `app.foo.bar = e` is TS2339 at the write and at every later read), and a member that is itself an expando cannot host a further expando (`foo.bar = {}; foo.bar.baz = e` errors on `baz`). tsz does X at both owners: the binder's nested-chain record guard (`binding/expression_flow.rs`) and the checker's namespace-member write-acceptance fallback (`property_access_helpers/expando.rs`, now scoped to checked JS). JS files keep the permissive expando model.

## Adjacent matrix (15 oracle probes, scratchpad/w3-iife)

Ambient-namespace fn member from file scope (errors), real namespace + file-scope write (errors), function-merged root (stays a valid host), top-level fn single-segment (declared), namespace-internal writes, two-level namespaces, expando-member chaining (errors), fn-root nested member combinations, value-module roots — tsz matches tsc on all after the patch.

## Conformance flips (+1)

contextualReturnTypeOfIIFE2 (both missing TS2339 'bar' on '() => void').

## Verification

- Full conformance: 11,171/12,043 (plus-list diff vs post-#15757 main: +1 / −0)
- `cargo nextest run -p tsz-checker --lib` → exactly the pre-existing 21-row pool
- `-p tsz-binder --lib` 425/425; `-p tsz-core --lib` 3,228/3,228; `-p tsz-solver --lib` 7,434/7,434
- Full emit: JS 11,563/11,563; DTS 1,372 at floor

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max