### PR TITLE
fix(checker): builtin-lib basename split is separator-agnostic

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_paths.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_paths.rs
@@ -1,10 +1,12 @@
 use tsz_parser::parser::node::NodeArena;
 
 pub(crate) fn is_builtin_lib_file_name(file_name: &str) -> bool {
-    let basename = std::path::Path::new(file_name)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or(file_name);
+    // `Path::file_name` splits only on the platform separator, so a
+    // Windows-style path (`C:\libs\lib.dom.d.ts`) is not split on Unix and
+    // the whole string fails the `lib.` prefix test. tsc's fileExtensionIs
+    // path handling is separator-agnostic; take the basename after EITHER
+    // separator.
+    let basename = file_name.rsplit(['/', '\\']).next().unwrap_or(file_name);
 
     if basename.starts_with("lib.") && basename.ends_with(".d.ts") {
         return true;


### PR DESCRIPTION
Goal: hold

One harness-verified fix from the checker-pool triage: `is_builtin_lib_file_name` (cross_file_direct_paths.rs) used `Path::file_name`, which splits only on the platform separator — a Windows-style path never split on Unix, so builtin libs referenced by Windows paths were misclassified. The basename now splits on either separator, matching tsc's separator-agnostic path handling.

Flips 2 pre-existing checker-pool tests (pool 21 → 19): `non_dom_builtin_lib_keeps_existing_shared_name_path`, `detects_npm_and_source_tree_builtin_lib_names`.

## Verification

- `cargo nextest run -p tsz-checker --lib` → 19-row pool (the 2 targets pass; no new failures)
- Full conformance: plus-list diff vs main: +0 / −0 (platform-only classification path)

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max