### PR TITLE
fix(binder,checker,solver): defineProperty expando links + empty-object marker-render display rule

### DIFF
--- a/crates/tsz-binder/src/binding/expression_flow.rs
+++ b/crates/tsz-binder/src/binding/expression_flow.rs
@@ -802,6 +802,24 @@ impl BinderState {
                     return;
                 }
             }
+            // In JS files, a nested object chain (`a.b.…x.p = e`, `obj_key` has a
+            // dot) declares an expando member only when the immediate base link
+            // (`a.b.…x`) is itself an assignment-declared expando.
+            // `Object.defineProperty(root, 'seg', …)` never records into
+            // `expando_properties`, so a defineProperty-only base does not
+            // qualify — tsc types it as `{}` and reports TS2339 on the nested
+            // write. `prototype` chains are exempt: `prototype` is a built-in
+            // member handled by the dedicated prototype-expando paths.
+            if is_js_like_source
+                && !obj_key.split('.').any(|segment| segment == "prototype")
+                && let Some((parent_key, member_name)) = obj_key.rsplit_once('.')
+                && !self
+                    .expando_properties
+                    .get(parent_key)
+                    .is_some_and(|members| members.contains(member_name))
+            {
+                return;
+            }
             // Nearest function-like/module container, `NONE` for the source
             // file itself (blocks and loop/if heads are transparent).
             fn nearest_expando_container(arena: &NodeArena, start: NodeIndex) -> NodeIndex {
@@ -875,6 +893,22 @@ impl BinderState {
                     && (init_node.kind == syntax_kind_ext::CLASS_EXPRESSION
                         || init_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION));
             if is_expando_init {
+                // Mirror the function-root branch: in a JS file a nested chain
+                // declares its member only when the immediate base link is an
+                // assignment-declared expando. This blocks
+                // `Object.defineProperty(root, 'seg', …)` bases, which tsc types
+                // as `{}` and rejects the nested write with TS2339. `prototype`
+                // chains are exempt (dedicated prototype-expando handling).
+                if is_js_like_source
+                    && !obj_key.split('.').any(|segment| segment == "prototype")
+                    && let Some((parent_key, member_name)) = obj_key.rsplit_once('.')
+                    && !self
+                        .expando_properties
+                        .get(parent_key)
+                        .is_some_and(|members| members.contains(member_name))
+                {
+                    return;
+                }
                 Arc::make_mut(&mut self.expando_properties)
                     .entry(obj_key)
                     .or_default()

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -696,6 +696,12 @@ impl<'a> CheckerState<'a> {
                     self.ctx.types.get_display_alias(ty).filter(|&alias| {
                         crate::query_boundaries::common::type_application(self.ctx.types, alias)
                             .is_some()
+                            && !crate::query_boundaries::diagnostics::empty_object_display_alias_is_marker_render(
+                                self.ctx.types,
+                                &self.ctx.definition_store,
+                                ty,
+                                alias,
+                            )
                     })
                 });
         if let Some(application_display) = application_display

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -1378,3 +1378,16 @@ mod tests {
         ));
     }
 }
+
+/// An empty-object `evaluated` whose display alias is an application of an
+/// interface/class base is a marker render (`ThisType<any>` from
+/// `Object.defineProperty`): tsc prints the shared `{}` structurally, never
+/// the marker's name.
+pub(crate) fn empty_object_display_alias_is_marker_render(
+    db: &dyn tsz_solver::construction::TypeDatabase,
+    def_store: &tsz_solver::def::DefinitionStore,
+    evaluated: tsz_solver::TypeId,
+    alias_origin: tsz_solver::TypeId,
+) -> bool {
+    tsz_solver::empty_object_display_alias_is_marker_render(db, def_store, evaluated, alias_origin)
+}

--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -1427,6 +1427,16 @@ impl<'a> CheckerState<'a> {
         }
 
         if let Some(file_idx) = self.expando_root_js_file_idx(object_expr_idx) {
+            // A nested chain re-discovered only by this source scan (the binder
+            // never recorded it) is a valid expando member only when its
+            // immediate base link is itself a declared expando. Without this the
+            // scan would accept the very write it is inspecting — e.g.
+            // `chrome.devtools.inspectedWindow = {}` where `chrome.devtools` is a
+            // `{}`-typed `Object.defineProperty` member. `prototype` chains keep
+            // their dedicated handling.
+            if !self.nested_expando_base_link_is_declared(object_expr_idx) {
+                return false;
+            }
             return self.js_file_has_expando_assignment_for_keys(
                 file_idx,
                 &self.expando_read_root_keys(object_expr_idx),
@@ -1435,6 +1445,53 @@ impl<'a> CheckerState<'a> {
         }
 
         false
+    }
+
+    /// Whether a nested expando base chain (`a.b` in `a.b.c = e`) is itself a
+    /// declared expando member. A single-identifier base has no intermediate
+    /// link and is vacuously valid. `prototype` links are exempt — `prototype`
+    /// is a built-in member carried by the prototype-expando paths, not by
+    /// assignment records.
+    fn nested_expando_base_link_is_declared(&self, object_expr_idx: NodeIndex) -> bool {
+        let Some(object_node) = self.ctx.arena.get(object_expr_idx) else {
+            return true;
+        };
+        let (base_expr, member_name) = match object_node.kind {
+            syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
+                let Some(access) = self.ctx.arena.get_access_expr(object_node) else {
+                    return true;
+                };
+                let Some(member) = self
+                    .ctx
+                    .arena
+                    .get_identifier_at(access.name_or_argument)
+                    .map(|ident| ident.escaped_text.clone())
+                else {
+                    return true;
+                };
+                (access.expression, member)
+            }
+            syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => {
+                let Some(access) = self.ctx.arena.get_access_expr(object_node) else {
+                    return true;
+                };
+                let Some(member) = static_element_access_key_text_in_arena(
+                    self.ctx.arena,
+                    access.name_or_argument,
+                ) else {
+                    return true;
+                };
+                (access.expression, member)
+            }
+            // Single-identifier base: no intermediate link to validate.
+            _ => return true,
+        };
+
+        if member_name == "prototype" {
+            return true;
+        }
+
+        self.is_expando_property_read(base_expr, &member_name)
     }
 
     pub(in crate::types_domain) fn expando_property_read_type(

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -679,6 +679,46 @@ impl<'a> TypeFormatter<'a> {
             .is_some_and(|def| def.kind == crate::def::DefKind::TypeAlias)
     }
 
+    /// Whether `alias_origin` is an application whose base resolves to an
+    /// interface or class definition. Combined with the empty-object guard at
+    /// the read site, this recognizes a marker instantiation: an application
+    /// only records a display alias on the shared empty object `{}` when
+    /// instantiating its base produced `{}`, so at this read the base
+    /// contributed no members for these arguments — a pure marker such as the
+    /// lib's `interface ThisType<T> {}`. `tsc` treats `ThisType` as a
+    /// contextual-`this` marker and never renders a value as `ThisType<...>`;
+    /// more generally it prints the shared empty object structurally as `{}`.
+    /// Following the alias here would repaint every empty object in the file
+    /// with the marker's name — the `Object.defineProperty`
+    /// `PropertyDescriptor & ThisType<any>` witness. Genuinely named generic
+    /// interfaces/classes whose instantiation is non-empty never intern to
+    /// `{}` and never reach this read; those carrying a def registered against
+    /// the `{}` `TypeId` are resolved earlier by the def-name path, which keeps
+    /// their application display (e.g. `AsyncGenerator<number, void, unknown>`).
+    fn display_alias_application_base_is_marker_interface(&self, alias_origin: TypeId) -> bool {
+        let Some(TypeData::Application(app_id)) = self.interner.lookup(alias_origin) else {
+            return false;
+        };
+        let app = self.interner.type_application(app_id);
+        let Some(def_store) = self.def_store else {
+            return false;
+        };
+
+        let def_id = match self.interner.lookup(app.base) {
+            Some(TypeData::Lazy(def_id)) => Some(def_id),
+            _ => def_store.find_def_for_type(app.base),
+        };
+
+        def_id
+            .and_then(|def_id| def_store.get(def_id))
+            .is_some_and(|def| {
+                matches!(
+                    def.kind,
+                    crate::def::DefKind::Interface | crate::def::DefKind::Class
+                )
+            })
+    }
+
     fn display_alias_application_base_has_conditional_body(&self, alias_origin: TypeId) -> bool {
         let Some(TypeData::Application(app_id)) = self.interner.lookup(alias_origin) else {
             return false;
@@ -1500,7 +1540,8 @@ impl<'a> TypeFormatter<'a> {
                             | TypeData::Mapped(_)
                     ))
                 || (is_empty_object
-                    && self.display_alias_application_base_is_type_alias(alias_origin));
+                    && (self.display_alias_application_base_is_type_alias(alias_origin)
+                        || self.display_alias_application_base_is_marker_interface(alias_origin)));
             if (!is_simple_type
                 || use_keyof_alias
                 || use_application_alias
@@ -1544,4 +1585,44 @@ impl<'a> TypeFormatter<'a> {
     fn strip_module_extension(module_name: &str) -> &str {
         tsz_common::file_extensions::strip_known_extension(module_name)
     }
+}
+
+/// Standalone form of the marker-instantiation rule for non-formatter
+/// consumers (e.g. the checker's property-receiver display): an EMPTY-object
+/// `evaluated` whose display alias is an application of an interface/class
+/// base is a marker render — tsc prints the shared `{}` structurally, never
+/// the marker's name (`ThisType<any>` from `Object.defineProperty`).
+pub fn empty_object_display_alias_is_marker_render(
+    interner: &dyn crate::construction::TypeDatabase,
+    def_store: &crate::def::DefinitionStore,
+    evaluated: TypeId,
+    alias_origin: TypeId,
+) -> bool {
+    let empty = match interner.lookup(evaluated) {
+        Some(TypeData::Object(shape_id)) => interner.object_shape(shape_id).properties.is_empty(),
+        Some(TypeData::ObjectWithIndex(shape_id)) => {
+            let shape = interner.object_shape(shape_id);
+            shape.properties.is_empty()
+                && shape.string_index.is_none()
+                && shape.number_index.is_none()
+        }
+        _ => false,
+    };
+    if !empty {
+        return false;
+    }
+    let Some(TypeData::Application(app_id)) = interner.lookup(alias_origin) else {
+        return false;
+    };
+    let app = interner.type_application(app_id);
+    let def_id = match interner.lookup(app.base) {
+        Some(TypeData::Lazy(def_id)) => Some(def_id),
+        _ => def_store.find_def_for_type(app.base),
+    };
+    def_id.and_then(|d| def_store.get(d)).is_some_and(|def| {
+        matches!(
+            def.kind,
+            crate::def::DefKind::Interface | crate::def::DefKind::Class
+        )
+    })
 }

--- a/crates/tsz-solver/src/intern/core/interner/display.rs
+++ b/crates/tsz-solver/src/intern/core/interner/display.rs
@@ -28,25 +28,6 @@ impl TypeInterner {
         self.display_properties.get(&type_id).map(|r| r.clone())
     }
 
-    /// The empty object type `{}` is a shared display sentinel: every widened
-    /// empty object literal in the program interns to the same `TypeId`, so a
-    /// display alias recorded on it would repaint every unrelated empty object.
-    /// Like intrinsics, it must never carry an alias. A shape with an index
-    /// signature is a distinct, meaningful surface and is not the bare-`{}`
-    /// sentinel. Mirrors `visitors::visitor_predicates::is_empty_object_type`.
-    fn is_empty_object_display_sentinel(&self, type_id: TypeId) -> bool {
-        match self.lookup(type_id) {
-            Some(TypeData::Object(shape_id)) => self.object_shape(shape_id).properties.is_empty(),
-            Some(TypeData::ObjectWithIndex(shape_id)) => {
-                let shape = self.object_shape(shape_id);
-                shape.properties.is_empty()
-                    && shape.string_index.is_none()
-                    && shape.number_index.is_none()
-            }
-            _ => false,
-        }
-    }
-
     /// Store a reverse mapping from an evaluated Application result to its
     /// original Application TypeId for diagnostic display.
     ///
@@ -114,16 +95,6 @@ impl TypeInterner {
         if evaluated.is_intrinsic() {
             return;
         }
-        // The empty object type `{}` is a shared structural sentinel for the
-        // same reason: every widened empty object literal in the program
-        // interns to it. Recording `{} -> Alias<...>` — e.g. `ThisType<any>`,
-        // whose empty interface body is evaluated when the checker resolves the
-        // `PropertyDescriptor & ThisType<any>` parameter of `Object.defineProperty`
-        // — repaints EVERY empty object in the file. tsc always renders an empty
-        // object as `{}`, never the alias.
-        if self.is_empty_object_display_sentinel(evaluated) {
-            return;
-        }
         // Guard against self-referential cycles: if the Application's args
         // contain the evaluated type itself, storing this alias would create
         // a formatting cycle (e.g., `Wrap<T> = T | T[]` where evaluating
@@ -157,11 +128,6 @@ impl TypeInterner {
             return;
         }
         if evaluated == application || evaluated.is_intrinsic() {
-            return;
-        }
-        // See `store_display_alias`: the empty object type is a shared display
-        // sentinel and must never be repainted by a named application.
-        if self.is_empty_object_display_sentinel(evaluated) {
             return;
         }
         if matches!(self.lookup(evaluated), Some(TypeData::TypeParameter(_))) {

--- a/crates/tsz-solver/src/intern/core/interner/display.rs
+++ b/crates/tsz-solver/src/intern/core/interner/display.rs
@@ -28,6 +28,25 @@ impl TypeInterner {
         self.display_properties.get(&type_id).map(|r| r.clone())
     }
 
+    /// The empty object type `{}` is a shared display sentinel: every widened
+    /// empty object literal in the program interns to the same `TypeId`, so a
+    /// display alias recorded on it would repaint every unrelated empty object.
+    /// Like intrinsics, it must never carry an alias. A shape with an index
+    /// signature is a distinct, meaningful surface and is not the bare-`{}`
+    /// sentinel. Mirrors `visitors::visitor_predicates::is_empty_object_type`.
+    fn is_empty_object_display_sentinel(&self, type_id: TypeId) -> bool {
+        match self.lookup(type_id) {
+            Some(TypeData::Object(shape_id)) => self.object_shape(shape_id).properties.is_empty(),
+            Some(TypeData::ObjectWithIndex(shape_id)) => {
+                let shape = self.object_shape(shape_id);
+                shape.properties.is_empty()
+                    && shape.string_index.is_none()
+                    && shape.number_index.is_none()
+            }
+            _ => false,
+        }
+    }
+
     /// Store a reverse mapping from an evaluated Application result to its
     /// original Application TypeId for diagnostic display.
     ///
@@ -95,6 +114,16 @@ impl TypeInterner {
         if evaluated.is_intrinsic() {
             return;
         }
+        // The empty object type `{}` is a shared structural sentinel for the
+        // same reason: every widened empty object literal in the program
+        // interns to it. Recording `{} -> Alias<...>` — e.g. `ThisType<any>`,
+        // whose empty interface body is evaluated when the checker resolves the
+        // `PropertyDescriptor & ThisType<any>` parameter of `Object.defineProperty`
+        // — repaints EVERY empty object in the file. tsc always renders an empty
+        // object as `{}`, never the alias.
+        if self.is_empty_object_display_sentinel(evaluated) {
+            return;
+        }
         // Guard against self-referential cycles: if the Application's args
         // contain the evaluated type itself, storing this alias would create
         // a formatting cycle (e.g., `Wrap<T> = T | T[]` where evaluating
@@ -128,6 +157,11 @@ impl TypeInterner {
             return;
         }
         if evaluated == application || evaluated.is_intrinsic() {
+            return;
+        }
+        // See `store_display_alias`: the empty object type is a shared display
+        // sentinel and must never be repainted by a named application.
+        if self.is_empty_object_display_sentinel(evaluated) {
             return;
         }
         if matches!(self.lookup(evaluated), Some(TypeData::TypeParameter(_))) {

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -303,7 +303,8 @@ pub use diagnostics::builders::{
 };
 pub use diagnostics::format::tracing_helpers::{RelationDisplay, TypeDisplay};
 pub use diagnostics::format::{
-    TypeFormatter, application_reduces_to_displayable_shape, format_excess_property_name,
+    TypeFormatter, application_reduces_to_displayable_shape,
+    empty_object_display_alias_is_marker_render, format_excess_property_name,
     type_alias_displayed_as_underlying,
 };
 pub use diagnostics::reduce::deep_reduce_for_display;


### PR DESCRIPTION
Goal: green

Two teammate-authored, main-loop-reviewed tsc 7.0.2 parity mechanisms, +1 conformance flip, 0 regressions. Three teammates iterated under review (defp → defp2 → defp4; a write-side variant was rejected by the solver's own design-constraint tests and redesigned read-side).

## Structural rules

1. **defineProperty link validation** — For a nested JS expando write `a.b.c = v`, every intermediate link must be declared by a plain expando ASSIGNMENT; a member declared only via `Object.defineProperty(a,'b',{value:{}})` types as `{}` and the nested write is TS2339. Gated at both binder record branches (`binding/expression_flow.rs`, complementary to #15758's TS-file guard) and the checker's fallback scan (`nested_expando_base_link_is_declared` in `property_access_helpers/expando.rs`). Positive chains (`chrome.devtools = {}` then deeper writes) stay accepted; `prototype` links keep their dedicated handling. [teammate 'defp']
2. **Empty-object marker-render rule** — Evaluating `Object.defineProperty`'s `PropertyDescriptor & ThisType<any>` parameter records a display alias on the SHARED `{}` TypeId; following it repainted every empty object as `ThisType<any>`. Per the solver's established design (empty-object aliases must remain storable — `display_alias_can_be_stored_for_empty_object_type` et al.), the discrimination is READ-side: an empty-`{}` alias whose application base resolves to an interface/class def is a *marker instantiation* (the base contributed no members for these args) and renders structurally, extending the existing type-alias-base skip. Applied at the formatter skip site and the checker's property-receiver alias consumer via a `query_boundaries::diagnostics` wrapper. [teammate 'defp4'; write-side variant by 'defp2' rejected in review — broke 4 solver design tests]

## Conformance flips (+1)

jsExpandoObjectDefineProperty (TS2339 at 3:17 with receiver `'{}'`, byte-matching tsc).

## Verification

- Full conformance: 11,172/12,043 (plus-list diff vs post-#15758: +1 / −0; objectLiteralThisWidenedOnUse explicitly verified PASS — an earlier false attribution came from a teammate-polluted binary, re-verified on clean rebuilds)
- `cargo nextest run -p tsz-solver --lib` → 7,434/7,434 (including the 4 empty-object-alias design-constraint tests)
- `-p tsz-checker --lib` → 21-row pool (pre-#15759 baseline for this branch; architecture boundary gate green after routing through query_boundaries)
- `-p tsz-core --lib` 3,228/3,228; `-p tsz-binder --lib` 425/425
- Full emit: JS 11,563/11,563; DTS 1,372 at floor

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max