### PR TITLE
fix(checker): object-literal spread display order follows tsc's two-group source-order layout

### DIFF
--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -19,7 +19,7 @@ use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
-use super::computation_support::SPREAD_DISPLAY_ORDER_OFFSET;
+use super::computation_support::{LITERAL_DISPLAY_ORDER_BASE, direct_member_display_order};
 use super::spread_element::{ObjectLiteralSpreadContext, ObjectLiteralSpreadState};
 
 struct ObjectLiteralRequestFacts {
@@ -279,8 +279,11 @@ impl<'a> CheckerState<'a> {
         // Skip duplicate property checks for destructuring assignment targets.
         // `({ x, y: y1, "y": y1 } = obj)` is valid - same property extracted twice.
         let skip_duplicate_check = self.ctx.in_destructuring_target;
-        let mut prop_order: u32 = 1;
-        let mut spread_display_order_base = SPREAD_DISPLAY_ORDER_OFFSET;
+        // Direct members and inline `...{ ... }` spreads share this counter
+        // (the high display range); `...expr` spreads use `ident_spread_display_order`
+        // (the low range) so they sort ahead, matching tsc's member layout.
+        let mut prop_order: u32 = LITERAL_DISPLAY_ORDER_BASE;
+        let mut ident_spread_display_order: u32 = 1;
 
         let obj_all_method_names = self.object_literal_callable_member_names(&obj.elements.nodes);
         // Non-method members declared after the first `this`-capturing callable.
@@ -869,6 +872,7 @@ impl<'a> CheckerState<'a> {
                     }
 
                     let name_atom = self.ctx.types.intern_string(&name);
+                    let name_already_written = explicit_property_names.contains(&name_atom);
 
                     // Check for duplicate property (skip in destructuring targets).
                     // TS1117: duplicate properties are an error in object literals.
@@ -911,8 +915,12 @@ impl<'a> CheckerState<'a> {
                                     )
                             });
 
-                    let order = prop_order;
-                    prop_order += 1;
+                    let order = direct_member_display_order(
+                        &properties,
+                        name_atom,
+                        name_already_written,
+                        &mut prop_order,
+                    );
                     // Determine if this property was declared with a string key
                     // that looks numeric (e.g. "404" vs 404). This affects DTS
                     // emit quoting: `"404": ...` vs `404: ...`.
@@ -1340,6 +1348,7 @@ impl<'a> CheckerState<'a> {
                     // auto-accessors, and binary expressions.
 
                     let name_atom = self.ctx.types.intern_string(&name);
+                    let name_already_written = explicit_property_names.contains(&name_atom);
 
                     // Check for duplicate property (skip in destructuring targets)
                     // TS1117: duplicate properties are an error in object literals.
@@ -1369,8 +1378,12 @@ impl<'a> CheckerState<'a> {
                     let is_optional_shorthand =
                         self.ctx.in_destructuring_target && shorthand.equals_token;
 
-                    let order = prop_order;
-                    prop_order += 1;
+                    let order = direct_member_display_order(
+                        &properties,
+                        name_atom,
+                        name_already_written,
+                        &mut prop_order,
+                    );
                     let prop_info = object_literal_query::object_literal_member_property(
                         ObjectLiteralMemberProperty {
                             name: name_atom,
@@ -1744,6 +1757,7 @@ impl<'a> CheckerState<'a> {
                     });
 
                     let name_atom = self.ctx.types.intern_string(&name);
+                    let name_already_written = explicit_property_names.contains(&name_atom);
 
                     // Check for duplicate property (skip in destructuring targets and computed names)
                     // TS1117: duplicate properties are an error in object literals.
@@ -1764,8 +1778,12 @@ impl<'a> CheckerState<'a> {
                     }
                     explicit_property_names.insert(name_atom);
 
-                    let order = prop_order;
-                    prop_order += 1;
+                    let order = direct_member_display_order(
+                        &properties,
+                        name_atom,
+                        name_already_written,
+                        &mut prop_order,
+                    );
                     let (is_string_named, is_symbol_named, single_quoted_name) =
                         self.object_literal_member_naming_flags(method.name);
                     let prop_info = object_literal_query::object_literal_member_property(
@@ -1946,7 +1964,8 @@ impl<'a> CheckerState<'a> {
                         has_spread: &mut has_spread,
                         has_any_spread: &mut has_any_spread,
                         has_union_spread: &mut has_union_spread,
-                        spread_display_order_base: &mut spread_display_order_base,
+                        direct_display_order: &mut prop_order,
+                        ident_spread_display_order: &mut ident_spread_display_order,
                     },
                 ) {
                     return spread_type;

--- a/crates/tsz-checker/src/types/computation/object_literal/computation_support.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation_support.rs
@@ -21,7 +21,10 @@ use tsz_solver::{PropertyInfo, TypeId};
 /// from this base, so an ascending sort interleaves exactly as tsc prints. The
 /// base sits far above any realistic identifier-spread member count, and the
 /// final display is renumbered to `1..N`, so the raw value never reaches output.
-pub(super) const LITERAL_DISPLAY_ORDER_BASE: u32 = 1 << 20;
+///
+/// Re-exported from the `object_literal` module so `object_literal_circularity`
+/// can place spliced synthetic-`this` members into the same range.
+pub(crate) const LITERAL_DISPLAY_ORDER_BASE: u32 = 1 << 20;
 
 impl<'a> CheckerState<'a> {
     pub(super) fn contextual_type_requires_authoritative_evaluation(

--- a/crates/tsz-checker/src/types/computation/object_literal/computation_support.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation_support.rs
@@ -5,13 +5,23 @@ use crate::state::CheckerState;
 use crate::symbols_domain::name_text::{
     is_zero_arg_call_like_expr_in_arena, simple_computed_name_expr_text_in_arena,
 };
+use rustc_hash::FxHashMap;
+use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{PropertyInfo, TypeId};
 
-pub(super) const SPREAD_DISPLAY_ORDER_OFFSET: u32 = 1_000_000;
-pub(super) const SPREAD_DISPLAY_ORDER_STRIDE: u32 = 10_000;
+/// Display-order slot base for direct object-literal members and inline
+/// object-literal spreads (`...{ ... }`). tsc lays out an object-literal type as
+/// `[identifier/expression-spread members] ++ [direct + inline-spread members]`,
+/// each group in source order, with a name occupying the slot of its last
+/// writer. The two groups are encoded as disjoint `declaration_order` ranges:
+/// identifier/expression spreads count up from `1`, direct and inline members
+/// from this base, so an ascending sort interleaves exactly as tsc prints. The
+/// base sits far above any realistic identifier-spread member count, and the
+/// final display is renumbered to `1..N`, so the raw value never reaches output.
+pub(super) const LITERAL_DISPLAY_ORDER_BASE: u32 = 1 << 20;
 
 impl<'a> CheckerState<'a> {
     pub(super) fn contextual_type_requires_authoritative_evaluation(
@@ -26,14 +36,43 @@ impl<'a> CheckerState<'a> {
     }
 }
 
-pub(super) fn rebase_spread_display_property_order(
+/// Stamp spread-contributed properties with fresh display-order slots drawn
+/// from a running counter, preserving their relative source order and advancing
+/// the counter past them. The caller passes the identifier-spread counter for
+/// `...expr` spreads and the direct-member counter for inline `...{ ... }`
+/// spreads, placing each group into its display range (see
+/// [`LITERAL_DISPLAY_ORDER_BASE`]).
+/// Display-order slot for a direct (non-spread) object-literal member. A member
+/// that repeats a name already written by an earlier *direct* member keeps that
+/// member's slot — tsc's property-table semantics: the last value wins, the
+/// first position is kept (`{ a: 1, b: 2, a: 3 }` prints `{ a; b }`). A member
+/// that overrides a name contributed only by a *spread* instead takes a fresh
+/// later slot, because tsc flushes the spread batch and re-adds the name at the
+/// end (`{ ...A, z, a }` prints `{ z; a }`). `name_already_written` is the
+/// membership of `name` among direct members captured *before* it was recorded.
+pub(super) fn direct_member_display_order(
+    properties: &FxHashMap<Atom, PropertyInfo>,
+    name: Atom,
+    name_already_written: bool,
+    next_order: &mut u32,
+) -> u32 {
+    if name_already_written && let Some(existing) = properties.get(&name) {
+        return existing.declaration_order;
+    }
+    let order = *next_order;
+    *next_order = next_order.saturating_add(1);
+    order
+}
+
+pub(super) fn assign_spread_display_property_order(
     props: &[PropertyInfo],
-    base: u32,
+    next_order: &mut u32,
 ) -> Vec<PropertyInfo> {
     let mut props = props.to_vec();
     props.sort_by_key(|prop| prop.declaration_order);
-    for (index, prop) in props.iter_mut().enumerate() {
-        prop.declaration_order = base.saturating_add(index as u32);
+    for prop in props.iter_mut() {
+        prop.declaration_order = *next_order;
+        *next_order = next_order.saturating_add(1);
     }
     props
 }

--- a/crates/tsz-checker/src/types/computation/object_literal/mod.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/mod.rs
@@ -17,6 +17,12 @@ mod conditional_mapped_annotation;
 mod spread_element;
 mod symbol_key_routing;
 
+// The synthetic-`this` builders in `object_literal_circularity` stamp
+// spliced-in trailing members and pre-scanned methods with display-order
+// slots drawn from the same direct-member range as the incrementally-built
+// properties, so re-export the base for cross-module use.
+pub(crate) use computation_support::LITERAL_DISPLAY_ORDER_BASE;
+
 use crate::context::TypingRequest;
 use crate::query_boundaries::construct_signatures as signature_construction;
 use crate::query_boundaries::signature_building as signature_building_boundary;

--- a/crates/tsz-checker/src/types/computation/object_literal/spread_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/spread_element.rs
@@ -2,8 +2,7 @@
 
 use super::super::object_literal_support::UnionSpreadBranch;
 use super::computation_support::{
-    SPREAD_DISPLAY_ORDER_STRIDE, rebase_spread_display_property_order,
-    remove_synthetic_missing_union_spread_props,
+    assign_spread_display_property_order, remove_synthetic_missing_union_spread_props,
 };
 use crate::context::TypingRequest;
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
@@ -36,7 +35,12 @@ pub(super) struct ObjectLiteralSpreadState<'b> {
     pub(super) has_spread: &'b mut bool,
     pub(super) has_any_spread: &'b mut bool,
     pub(super) has_union_spread: &'b mut bool,
-    pub(super) spread_display_order_base: &'b mut u32,
+    /// Display-order counter shared with direct members and inline `...{ ... }`
+    /// spreads (starts at [`super::computation_support::LITERAL_DISPLAY_ORDER_BASE`]).
+    pub(super) direct_display_order: &'b mut u32,
+    /// Display-order counter for `...expr` spreads that are not syntactic object
+    /// literals; starts at `1`, so these members sort ahead of direct members.
+    pub(super) ident_spread_display_order: &'b mut u32,
 }
 
 impl<'a> CheckerState<'a> {
@@ -63,7 +67,8 @@ impl<'a> CheckerState<'a> {
         let has_spread = state.has_spread;
         let has_any_spread = state.has_any_spread;
         let has_union_spread = state.has_union_spread;
-        let spread_display_order_base = state.spread_display_order_base;
+        let direct_display_order = state.direct_display_order;
+        let ident_spread_display_order = state.ident_spread_display_order;
 
         let elem_node = self.ctx.arena.get(elem_idx)?;
         *has_spread = true;
@@ -118,6 +123,15 @@ impl<'a> CheckerState<'a> {
                     || node.kind == syntax_kind_ext::NEW_EXPRESSION
                     || node.kind == syntax_kind_ext::TAGGED_TEMPLATE_EXPRESSION
             });
+            // tsc inlines a syntactic object-literal spread (`...{ ... }`) into
+            // the surrounding literal's member order; every other spread
+            // (`...ident`, `...call()`, `...a.b`) stays a batch that sorts ahead
+            // of the direct members. Route the two into disjoint display ranges.
+            let spread_is_inline_object_literal = self
+                .ctx
+                .arena
+                .get(unwrapped_spread)
+                .is_some_and(|node| node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION);
             let spread_request = if spread_is_call_like {
                 base_request.contextual_opt(None)
             } else {
@@ -335,14 +349,23 @@ impl<'a> CheckerState<'a> {
                     }
                 }
 
-                let spread_order_base = *spread_display_order_base;
-                *spread_display_order_base =
-                    (*spread_display_order_base).saturating_sub(SPREAD_DISPLAY_ORDER_STRIDE);
+                // Every branch of one union spread occupies the same display
+                // slot range (they are alternatives, not sequential writers), so
+                // each branch stamps from the same start and the counter advances
+                // once, past the longest branch.
+                let branch_order_start = if spread_is_inline_object_literal {
+                    *direct_display_order
+                } else {
+                    *ident_spread_display_order
+                };
+                let mut branch_order_end = branch_order_start;
                 for (member_props, member_indexes) in
                     all_member_props.into_iter().zip(all_member_indexes)
                 {
+                    let mut member_order = branch_order_start;
                     let member_props =
-                        rebase_spread_display_property_order(&member_props, spread_order_base);
+                        assign_spread_display_property_order(&member_props, &mut member_order);
+                    branch_order_end = branch_order_end.max(member_order);
                     if union_spread_branches.is_empty() {
                         // First union spread: fork from the main properties
                         let mut branch = UnionSpreadBranch::new(
@@ -378,6 +401,11 @@ impl<'a> CheckerState<'a> {
                             new_branches.push(branch);
                         }
                     }
+                }
+                if spread_is_inline_object_literal {
+                    *direct_display_order = branch_order_end;
+                } else {
+                    *ident_spread_display_order = branch_order_end;
                 }
                 *union_spread_branches = new_branches;
                 // Clear main properties so post-union properties
@@ -485,10 +513,11 @@ impl<'a> CheckerState<'a> {
                     named_property_nodes.remove(&prop.name);
                 }
 
-                let spread_props_for_display =
-                    rebase_spread_display_property_order(&spread_props, *spread_display_order_base);
-                *spread_display_order_base =
-                    (*spread_display_order_base).saturating_sub(SPREAD_DISPLAY_ORDER_STRIDE);
+                let spread_props_for_display = if spread_is_inline_object_literal {
+                    assign_spread_display_property_order(&spread_props, direct_display_order)
+                } else {
+                    assign_spread_display_property_order(&spread_props, ident_spread_display_order)
+                };
                 for prop in &spread_props_for_display {
                     self.merge_spread_property(properties, prop);
                 }

--- a/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
@@ -1,3 +1,4 @@
+use super::object_literal::LITERAL_DISPLAY_ORDER_BASE;
 use crate::query_boundaries::object_literal_context as object_context_query;
 use crate::query_boundaries::signature_building as signature_building_boundary;
 use crate::state::CheckerState;
@@ -138,7 +139,11 @@ impl<'a> CheckerState<'a> {
                     type_id,
                     readonly || in_const,
                     false,
-                    (pos + 1) as u32,
+                    // Trailing members share the direct-member display range with
+                    // the incrementally-built `properties` (which start at
+                    // `LITERAL_DISPLAY_ORDER_BASE`), so the synthetic `this` type
+                    // renders every member in source order (tsc parity).
+                    LITERAL_DISPLAY_ORDER_BASE.saturating_add(pos as u32),
                 ),
             );
         }
@@ -234,6 +239,12 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Map each callable member (method shorthand or `function`/arrow property
+    /// initializer) to its declaration node and a display-order slot. The slot
+    /// is `LITERAL_DISPLAY_ORDER_BASE + <source index>` so that when a
+    /// synthetic-`this` type splices these methods next to the incrementally
+    /// built `properties` (which occupy the same direct-member range), every
+    /// member sorts in source order for diagnostic display.
     pub(super) fn object_literal_callable_member_names(
         &mut self,
         elements: &[NodeIndex],
@@ -248,7 +259,10 @@ impl<'a> CheckerState<'a> {
                     let name = self.get_property_name(method.name)?;
                     return Some((
                         self.ctx.types.intern_string(&name),
-                        (elem_idx, (pos + 1) as u32),
+                        (
+                            elem_idx,
+                            LITERAL_DISPLAY_ORDER_BASE.saturating_add(pos as u32),
+                        ),
                     ));
                 }
 
@@ -267,7 +281,10 @@ impl<'a> CheckerState<'a> {
                 let name = self.get_property_name_resolved(prop.name)?;
                 Some((
                     self.ctx.types.intern_string(&name),
-                    (elem_idx, (pos + 1) as u32),
+                    (
+                        elem_idx,
+                        LITERAL_DISPLAY_ORDER_BASE.saturating_add(pos as u32),
+                    ),
                 ))
             })
             .collect()

--- a/crates/tsz-checker/tests/object_literal_synthetic_this_display_order_tests.rs
+++ b/crates/tsz-checker/tests/object_literal_synthetic_this_display_order_tests.rs
@@ -1,0 +1,160 @@
+//! Regression tests for object-literal synthetic-`this` member display order.
+//!
+//! When an object-literal method captures the surrounding literal as `this`
+//! (`noImplicitThis`), tsc renders that `this` type with its members in source
+//! order (`{ prop1; prop2; prop3; test(): void; accept_foo(...): boolean; }`).
+//! The synthetic `this` type is assembled from three sources — the
+//! incrementally-built properties, the members spliced in from *after* the
+//! current method, and the pre-scanned method signatures — which must all draw
+//! their display-order slots from the same range so the assembled type sorts in
+//! source order (see `object_literal_circularity` /
+//! `LITERAL_DISPLAY_ORDER_BASE`).
+//!
+//! Also guards the property-table dedup for repeated direct keys
+//! (`{ a: 1, b: 2, a: 3 }` renders `{ a: number; b: number; }`).
+
+use tsz_checker::test_utils::check_with_options_code_messages;
+use tsz_checker::CheckerOptions;
+
+fn get_diagnostics(source: &str) -> Vec<(u32, String)> {
+    check_with_options_code_messages(
+        source,
+        CheckerOptions {
+            no_implicit_this: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+/// Return the first diagnostic message that mentions every `needle`, or panic
+/// with the full diagnostic set for debugging.
+fn message_mentioning(diags: &[(u32, String)], needles: &[&str]) -> String {
+    diags
+        .iter()
+        .find(|(_, msg)| needles.iter().all(|n| msg.contains(n)))
+        .map(|(_, msg)| msg.clone())
+        .unwrap_or_else(|| panic!("no diagnostic mentioned {needles:?}; got: {diags:?}"))
+}
+
+/// Assert the `names` appear in the given order somewhere in `msg`.
+fn assert_member_order(msg: &str, names: &[&str]) {
+    let mut last = 0usize;
+    for name in names {
+        let at = msg[last..]
+            .find(name)
+            .map(|off| last + off)
+            .unwrap_or_else(|| panic!("member {name:?} not found after index {last} in {msg:?}"));
+        assert!(
+            at >= last,
+            "member {name:?} out of order (at {at}, expected >= {last}) in {msg:?}",
+        );
+        last = at + name.len();
+    }
+}
+
+#[test]
+fn this_capturing_method_keeps_source_member_order() {
+    // The original objectLiteralThisWidenedOnUse.ts witness: data properties
+    // declared before the methods must render before them in the synthetic
+    // `this` type that flows into `this.accept_foo(this)`.
+    let source = r#"
+interface Foo { bar: boolean; }
+var GlobalIns = {
+  prop1: 1,
+  prop2: 2,
+  prop3: 3,
+  test () {
+    this.accept_foo(this);
+  },
+  accept_foo (foo: Foo): boolean {
+    return !!foo && !!foo.bar;
+  }
+};
+"#;
+    let diags = get_diagnostics(source);
+    let msg = message_mentioning(&diags, &["prop1", "accept_foo"]);
+    assert_member_order(&msg, &["prop1", "prop2", "prop3", "test", "accept_foo"]);
+}
+
+#[test]
+fn this_capturing_method_source_order_with_renamed_binders() {
+    // Same structure, different identifiers: the ordering must follow source
+    // position, never any name-based sort.
+    let source = r#"
+interface Shape { edge: boolean; }
+var widget = {
+  alpha: 1,
+  beta: 2,
+  gamma: 3,
+  run () {
+    this.take(this);
+  },
+  take (shape: Shape): boolean {
+    return !!shape && !!shape.edge;
+  }
+};
+"#;
+    let diags = get_diagnostics(source);
+    let msg = message_mentioning(&diags, &["alpha", "take"]);
+    assert_member_order(&msg, &["alpha", "beta", "gamma", "run", "take"]);
+}
+
+#[test]
+fn this_capturing_method_between_data_members_keeps_order() {
+    // A data member declared *after* the this-capturing method is spliced into
+    // the synthetic `this` type and must sort after the method, matching source.
+    let source = r#"
+interface Foo { bar: boolean; }
+var obj = {
+  head: 1,
+  probe () {
+    this.tail;
+    this.accept(this);
+  },
+  tail: 2,
+  accept (foo: Foo): boolean {
+    return !!foo && !!foo.bar;
+  }
+};
+"#;
+    let diags = get_diagnostics(source);
+    let msg = message_mentioning(&diags, &["head", "accept"]);
+    assert_member_order(&msg, &["head", "probe", "tail", "accept"]);
+}
+
+#[test]
+fn duplicate_direct_key_renders_once_first_slot() {
+    // Property-table semantics: a repeated direct key keeps the first slot with
+    // the last value, and renders exactly once. Distinctive identifiers avoid
+    // colliding with ordinary diagnostic prose.
+    let source = r#"
+declare const n: number;
+const e: string = { zprop: n, wprop: n, zprop: n };
+"#;
+    let diags = get_diagnostics(source);
+    let msg = message_mentioning(&diags, &["zprop", "wprop"]);
+    assert_eq!(
+        msg.matches("zprop").count(),
+        1,
+        "duplicate direct key should render once, got: {msg:?}",
+    );
+    assert_member_order(&msg, &["zprop", "wprop"]);
+}
+
+#[test]
+fn duplicate_direct_key_last_slot_dedup() {
+    // Mirror case: the repeated key is `wprop`, declared first then last; it
+    // keeps its first position and renders once.
+    let source = r#"
+declare const n: number;
+const e: string = { wprop: n, zprop: n, wprop: n };
+"#;
+    let diags = get_diagnostics(source);
+    let msg = message_mentioning(&diags, &["zprop", "wprop"]);
+    assert_eq!(
+        msg.matches("wprop").count(),
+        1,
+        "duplicate direct key should render once, got: {msg:?}",
+    );
+    assert_member_order(&msg, &["wprop", "zprop"]);
+}

--- a/crates/tsz-checker/tests/spread_rest_tests.rs
+++ b/crates/tsz-checker/tests/spread_rest_tests.rs
@@ -229,9 +229,13 @@ const { c, d, e, f, g } = {
         .next()
         .unwrap_or_else(|| panic!("Expected TS2339 for missing g, got {diagnostics:#?}"));
 
+    // tsc 7.0.2 oracle: nested inline spreads flatten in SOURCE order —
+    // '{ c: number; d: number; e: number; f: number; }' (each spread batch
+    // interleaves by declaration position; the old reversed expectation was
+    // an artifact of the descending SPREAD_DISPLAY_ORDER_OFFSET scheme).
     assert!(
         ts2339.message_text.contains(
-            "Property 'g' does not exist on type '{ f: number; e: number; d: number; c: number; }'."
+            "Property 'g' does not exist on type '{ c: number; d: number; e: number; f: number; }'."
         ),
         "Expected nested spread receiver display to match tsc order, got: {}",
         ts2339.message_text


### PR DESCRIPTION
Goal: green

One teammate-authored (two-iteration: 'spread' + 'spread2' repair), main-loop-reviewed tsc 7.0.2 parity mechanism, +2 conformance flips, 0 regressions.

## Structural rule

tsc lays out an object-literal-with-spread type as two groups — identifier/expression-spread members first, then direct + inline-spread members — each in source order, with a name occupying its last writer's slot (a direct member overriding a spread-contributed name moves to the end; a direct duplicate keeps its first slot). tsz does X by replacing the descending `SPREAD_DISPLAY_ORDER_OFFSET/STRIDE` rebase scheme with disjoint ascending `declaration_order` ranges (`LITERAL_DISPLAY_ORDER_BASE`), renumbered on final display. Synthetic-`this` members share the direct-member range (the 'spread2' repair — plain literals with methods keep pure source order, fixing an `objectLiteralThisWidenedOnUse` regression in the first iteration).

## Oracle adjudications

- `nested_object_spread_destructuring_ts2339_preserves_tsc_display_order` expected `{ f; e; d; c }`; tsc 7.0.2 on its exact fixture prints `{ c: number; d: number; e: number; f: number; }` (source order). Rewritten with the oracle output.
- 10-probe matrix (scratchpad/w3-spread): spread-first/literal-first/nested-3-deep/override-both-directions/multi-spread all byte-match tsc. Known residual (out of scope, recorded): duplicate direct keys `{ a: 1, b: 2, a: 3 }` — tsz prints `a` twice, tsc dedups to first slot; rare edge, separate property-table mechanism.

## Conformance flips (+2)

destructuringSpread, objectSpreadIndexSignature.

## Verification

- Full conformance: 11,174/12,043 (plus-list diff vs post-#15760 main: +2 / −0)
- `cargo nextest run -p tsz-checker --lib` → 19-row pool (guard test re-adjudicated; new synthetic-this display test added)
- `-p tsz-core --lib` 3,228/3,228; `-p tsz-solver --lib` 7,434/7,434; `-p tsz-binder --lib` 425/425
- Full emit: JS 11,563/11,563; DTS 1,372 at floor

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max