### PR TITLE
fix(checker): lib-baseline checkers must not freeze the shared Array base

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -475,6 +475,35 @@ impl CheckerContext<'_> {
             return def_id;
         }
 
+        // A checker whose current arena IS a builtin lib file (the lib-baseline
+        // diagnostics passes) re-binds that lib's own declarations under its
+        // LOCAL file index, so the `is_current_file_local_symbol` attribution
+        // above yields a per-pass file id for a lib type that already has a
+        // pre-populated `u32::MAX`-sentinel def in the shared store. Minting
+        // there creates a SECOND identity for the lib type; member references
+        // baked into shared bases (e.g. `Array.prototype.flatMap`'s
+        // `ReadonlyArray<U>`) then bind to whichever copy an election sees,
+        // and the split breaks Application evaluation downstream (witness:
+        // `[1].flatMap(x => [[x]])` inferring `number[][][]` under a user
+        // lib-global augmentation because `ReadonlyArray<U>` stopped
+        // matching). Adopt the pre-populated sentinel def instead.
+        if crate::state_type_analysis::cross_file_direct::is_builtin_lib_declaration_arena(
+            self.arena,
+        ) {
+            let atom = self.types.intern_string(expected_name);
+            if let Some(defs) = self.definition_store.find_defs_by_name(atom)
+                && let Some(&sentinel_def) = defs.iter().find(|&&candidate| {
+                    self.definition_store.get(candidate).is_some_and(|info| {
+                        info.file_id == Some(u32::MAX) && info.symbol_id == Some(sym_id.0)
+                    })
+                })
+            {
+                self.symbol_to_def.borrow_mut().insert(sym_id, sentinel_def);
+                self.def_to_symbol.borrow_mut().insert(sentinel_def, sym_id);
+                return sentinel_def;
+            }
+        }
+
         self.mint_def_for_symbol_in_file(sym_id, symbol, file_idx)
     }
 

--- a/crates/tsz-checker/src/types/type_checking/global.rs
+++ b/crates/tsz-checker/src/types/type_checking/global.rs
@@ -139,6 +139,24 @@ impl<'a> CheckerState<'a> {
             let _ = self.resolve_lib_type_by_name("ArrayIterator");
         }
 
+        // Pre-resolve the lib types Array's own member signatures reference
+        // (`concat`'s `ConcatArray`, `flat`/`flatMap`'s `FlatArray` and
+        // `ReadonlyArray`) so their name-keyed defs exist BEFORE the Array
+        // base is baked below. The bake permanently interns those referents
+        // into the shared display base; a referent whose name is not yet in
+        // the definition store resolves through the raw binder-relative
+        // `SymbolId` fallback, and under a user interface merging into a lib
+        // global the shifted merged id aliases an unrelated lib symbol
+        // (`ReadonlyArray -> isNaN`), baking a collided referent into every
+        // checker's Array. Witness: `[1].flatMap(x => [[x]])` inferring
+        // `number[][][]` (the callback-return `ReadonlyArray<U>` position
+        // stops matching, so `U` falls back to the whole return type).
+        // Follows the `ArrayIterator` pre-resolve pattern above; these are
+        // true built-ins resolved through binder-owned lib lookup.
+        for array_member_referent in ["ReadonlyArray", "ConcatArray", "FlatArray"] {
+            let _ = self.resolve_lib_type_by_name(array_member_referent);
+        }
+
         // For Array<T>, resolve the merged lib type once, then reuse the type
         // parameters registered for its canonical symbol. Re-running the
         // per-lib parameter resolver in every project checker repeatedly lowers
@@ -267,7 +285,25 @@ impl<'a> CheckerState<'a> {
         // PropertyAccessEvaluator runs through multiple database backends
         // (query cache, interner, binder-backed resolver). Register Array<T>
         // through the query database so all backends see the same base type.
-        if let Some(ty) = array_instance_type {
+        //
+        // Do NOT let a lib-baseline checker (current arena IS a builtin lib
+        // file — those passes only run when a user augmentation touches a lib
+        // global) freeze the shared base: it is first-use via the reuse fast
+        // path in `resolve_lib_type_with_params`, so a baseline-baked
+        // instance type becomes every sibling checker's Array. A base baked
+        // in that pass's environment carries member signatures whose
+        // inference positions do not behave in the main program checkers
+        // (witness: `[1].flatMap(x => [[x]])` inferring `number[][][]` under
+        // an `interface ErrorConstructor` augmentation because the baked
+        // `ReadonlyArray<U>` candidate stopped matching). The main checkers
+        // bake it instead, exactly as in the unaugmented program.
+        let current_arena_is_builtin_lib =
+            crate::state_type_analysis::cross_file_direct::is_builtin_lib_declaration_arena(
+                self.ctx.arena,
+            );
+        if let Some(ty) = array_instance_type
+            && !current_arena_is_builtin_lib
+        {
             self.ctx
                 .types
                 .register_array_base_type(ty, array_type_params.clone());
@@ -313,12 +349,13 @@ impl<'a> CheckerState<'a> {
         // resolve_lib_type_by_name which processes global augmentation heritage
         // and type argument substitution. resolve_lib_type_with_params only reads
         // from lib binders and misses user augmentations.
-        if self
-            .ctx
-            .binder
-            .global_augmentations
-            .get("Array")
-            .is_some_and(|v| !v.is_empty())
+        if !current_arena_is_builtin_lib
+            && self
+                .ctx
+                .binder
+                .global_augmentations
+                .get("Array")
+                .is_some_and(|v| !v.is_empty())
             && let Some(augmented_type) = self.resolve_lib_type_by_name("Array")
         {
             let augmented_prop_count = crate::query_boundaries::common::object_shape_for_type(
@@ -446,7 +483,23 @@ impl<'a> CheckerState<'a> {
 
         // Register the Array<T> interface for array property resolution. Use
         // the instance type (Array<T> interface), not the constructor (Callable).
-        if let Some(ty) = array_instance_type {
+        //
+        // Do NOT let a lib-baseline checker (current arena IS a builtin lib
+        // file — those passes only run when a user augmentation touches a lib
+        // global) freeze the SHARED base: `set_array_base_type` is first-use
+        // via the reuse fast path in `resolve_lib_type_with_params`, so a
+        // baseline-baked instance type becomes every sibling checker's Array.
+        // A base baked in that pass's environment carries member signatures
+        // whose inference positions do not behave in the main checkers
+        // (witness: `[1].flatMap(x => [[x]])` inferring `number[][][]` under
+        // an `interface ErrorConstructor` augmentation because the baked
+        // `ReadonlyArray<U>` candidate stopped matching). The main program
+        // checkers bake it instead, exactly as in the unaugmented program.
+        if let Some(ty) = array_instance_type
+            && !crate::state_type_analysis::cross_file_direct::is_builtin_lib_declaration_arena(
+                self.ctx.arena,
+            )
+        {
             self.ctx
                 .register_array_base_type_in_envs(ty, array_type_params);
         }

--- a/crates/tsz-cli/tests/lib_interface_merge_flatarray_cli_tests.rs
+++ b/crates/tsz-cli/tests/lib_interface_merge_flatarray_cli_tests.rs
@@ -153,3 +153,63 @@ fn no_augmentation_control_keeps_lib_array_surfaces_clean() {
         "control: exec() keeps its Array surface with no augmentation"
     );
 }
+
+/// The multi-file facet: a user global augmentation in a SEPARATE .d.ts
+/// (here `ErrorConstructor`) triggers the lib-baseline passes, and the first
+/// of those must not freeze the shared `Array<T>` base — a baseline-baked
+/// base broke `flatMap`'s `ReadonlyArray<U>` inference position so the
+/// callback return stopped flattening (`number[][][]` instead of
+/// `number[][]`). Assert the flatten via an exact reveal-type mismatch.
+#[test]
+fn declaration_file_augmentation_keeps_flatmap_flattening() {
+    let files = [
+        (
+            "globals.d.ts",
+            "interface ErrorConstructor {\n\
+             \x20   captureStackTrace?(targetObject: object, constructorOpt?: Function): void;\n\
+             }\n",
+        ),
+        (
+            "main.ts",
+            "const r = [1, 2, 3].flatMap(x => [[x]]);\n\
+             const reveal: null = r;\n",
+        ),
+    ];
+    let diags = compile_files(&files);
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly the reveal-type mismatch, got: {diags:?}"
+    );
+    assert!(
+        ts2322[0].message_text.contains("'number[][]'"),
+        "flatMap must flatten one level under a lib-global augmentation \
+         (tsc infers number[][]); got: {}",
+        ts2322[0].message_text
+    );
+}
+
+/// Control for the flatMap facet: without the augmentation the same program
+/// already flattens, pinning that the guard above measures the augmentation
+/// effect.
+#[test]
+fn no_augmentation_control_keeps_flatmap_flattening() {
+    let files = [(
+        "main.ts",
+        "const r = [1, 2, 3].flatMap(x => [[x]]);\n\
+         const reveal: null = r;\n",
+    )];
+    let diags = compile_files(&files);
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "control: one reveal mismatch, got: {diags:?}"
+    );
+    assert!(
+        ts2322[0].message_text.contains("'number[][]'"),
+        "control: flatMap flattens with no augmentation; got: {}",
+        ts2322[0].message_text
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes the surviving multi-file facet of the lib-augmentation corruption family (ofetch canary row): under ANY user augmentation touching a lib global, `[1].flatMap(x => [[x]])` inferred `number[][][]` instead of `number[][]` — the callback-return `ReadonlyArray<U>` inference position stopped matching, so `U` fell back to the whole return and flatMap stopped flattening. tsc 7.0.2 is clean.

## Structural rule
When a user augmentation triggers the lib-baseline diagnostics passes, tsc's equivalent of the shared `Array<T>` apparent type is still the main program's; tsz now enforces this in the checker: a checker whose current arena IS a builtin lib file must not freeze the shared Array base (`register_array_base_type` is first-use via the reuse fast path in `resolve_lib_type_with_params`, so the baseline-baked instance type became every sibling checker's Array, and its member signatures' inference positions do not behave in the main checkers).

## Changes
- `register_boxed_types` (checker `type_checking/global.rs`): both shared-base bakes (plain + augmented re-bake) gated on the current arena not being a builtin lib declaration file. The main program checkers bake, exactly as in the unaugmented program.
- `get_or_create_def_id_for_symbol_name` (checker `def_mapping.rs`): a lib-baseline checker resolving that lib's OWN declaration now adopts the pre-populated `u32::MAX`-sentinel def instead of minting a file-attributed duplicate (probe-traced `ReadonlyArray` def split 162 vs 449 — the #13255 family).
- Pre-resolve Array's member referents (`ReadonlyArray`/`ConcatArray`/`FlatArray`) before the bake so their name-keyed defs exist first (follows the existing `ArrayIterator` pattern).

## Adjacent matrix
Augmentation in a separate .d.ts (`ErrorConstructor`) and unaugmented control; single-file merge forms (all 5 prior FlatArray guards); flat() vs flatMap(); DOM (`createElement` TS2430 guard) and core-only lib sets; all 8 collision witnesses + thislessFunctionsNotContextSensitive3 re-verified.

## Verification
- Minimal repro (2-file, parallel driver): `number[][][]` -> `number[][]`, byte-matching tsc; unaugmented control unchanged
- ofetch canary row: 2 -> 1 tsz-only errors (survivor is the unrelated `RequestInit["body"]` indexed-access gap, separately triaged)
- New CLI guards: flatMap flatten under declaration-file augmentation + control (`lib_interface_merge_flatarray_cli_tests`, 7/7)
- `cargo nextest -p tsz-checker --lib`: 12 failures (= pre-existing pool, no new); solver 7434/7434; core 3228/3228
- Full conformance: 11,169 (+150 vs baseline, unchanged; same 6 stale-runner-cache rows that fail identically on main)
- Emit: JS 100% (11,563), DTS 1,372/1,390 (recorded floor)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max
