### PR TITLE
fix(solver): report TS2589 for infer-wrapped divergent tuple growth

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -489,6 +489,15 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     const REAL_INSTANTIATION_BAILOUT_THRESHOLD: u32 =
         crate::limits::REAL_INSTANTIATION_BAILOUT_THRESHOLD;
 
+    /// Whether `def_id`'s application is currently in-flight (a recursive
+    /// back-edge). Used by the conditional array-arm fast paths to route a
+    /// self-recursive branch through the shared tail-call loop instead of
+    /// nesting through `evaluate_application` (see
+    /// `eval_conditional_array_concrete`).
+    pub(in crate::evaluation) fn def_application_in_flight(&self, def_id: DefId) -> bool {
+        self.def_depth.get(&def_id).is_some_and(|&depth| depth > 0)
+    }
+
     fn increment_def_depth(&mut self, def_id: DefId) -> bool {
         let depth = self.def_depth.entry(def_id).or_insert(0);
         // #14101 step-2 probe: a non-zero prior depth means this def's application

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/array_infer.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/array_infer.rs
@@ -228,13 +228,47 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let mut checker = self.conditional_subtype_checker();
         checker.allow_bivariant_rest = true;
         match super::classify_branch_relation(|| checker.is_subtype_of(check_elem, target_elem)) {
-            super::BranchRelation::Holds => Some(self.evaluate(cond.true_type)),
-            super::BranchRelation::Fails => Some(self.evaluate(cond.false_type)),
+            // A SELF-RECURSIVE application branch must join the tail-call
+            // growth loop (bounded at `MAX_TAIL_RECURSION_DEPTH`, which
+            // reports TS2589 on exhaustion) instead of nesting through
+            // `evaluate_application` here: for an `infer`-substituted growing
+            // tuple (`Push<[...X, 1]>`), each nested expansion's structural
+            // walk trips the depth-100 per-`TypeId` guard BELOW the
+            // `def_depth` escalation floor, and the silent-bail arm returns
+            // an opaque type with no TS2589 (issue #9777 witness). Falling
+            // through (`None`) re-runs the cheap cached element relation in
+            // the full pipeline, whose result branch reaches
+            // `try_dispatch_tail_call`.
+            super::BranchRelation::Holds => {
+                if self.branch_is_self_recursive_application(cond.true_type) {
+                    return None;
+                }
+                Some(self.evaluate(cond.true_type))
+            }
+            super::BranchRelation::Fails => {
+                if self.branch_is_self_recursive_application(cond.false_type) {
+                    return None;
+                }
+                Some(self.evaluate(cond.false_type))
+            }
             // The element relation's `false` depended on an unregistered `Lazy`
             // body, so it is undetermined. Fall through (`None`) to the full
             // conditional pipeline, which defers rather than committing the
             // spurious false branch (issue #14238).
             super::BranchRelation::Undetermined => None,
+        }
+    }
+
+    /// TRUE when `branch` is an `Application` whose base def is currently
+    /// in-flight (a recursive back-edge). Keyed on `DefId`s, never names.
+    fn branch_is_self_recursive_application(&self, branch: TypeId) -> bool {
+        let Some(TypeData::Application(app_id)) = self.interner().lookup(branch) else {
+            return false;
+        };
+        let base = self.interner().type_application(app_id).base;
+        match self.interner().lookup(base) {
+            Some(TypeData::Lazy(def_id)) => self.def_application_in_flight(def_id),
+            _ => false,
         }
     }
 


### PR DESCRIPTION
Goal: hold

Fixes the missing TS2589 for infer-wrapped divergent tuple growth (issue #9777; drains the 2-row ts2589 checker pool pair, 12 -> 10).

## Structural rule
When a conditional's branch is a self-recursive alias application, tsc charges the recursion against its tail-recursion/instantiation budget and reports TS2589 on divergence; tsz does the same through the solver's shared tail-call loop (`try_dispatch_tail_call`, capped at `MAX_TAIL_RECURSION_DEPTH`) — the concrete-array fast arm must not evaluate such a branch by nesting.

## Mechanism
`type Push<T extends any[]> = T extends infer X ? (X extends any[] ? Push<[...X, 1]> : never) : never; type R = Push<[]>` — the outer conditional binds `X` and recurses, but the inner conditional's `extends any[]` routed through `eval_conditional_array_concrete`, whose Holds arm evaluated `Push<[...X, 1]>` by NESTING through `evaluate_application`. The infer-substituted growing tuple made each nested expansion's structural walk trip the depth-100 per-`TypeId` guard below the `def_depth = 40` escalation floor, landing in the silent-bail arm: no TS2589, `R` opaque (`any`). tsc 7.0.2 reports `TS2589: Type instantiation is excessively deep and possibly infinite.`

The fix: when the selected branch is an `Application` whose base def is already in-flight (`DefId`-keyed via the new `def_application_in_flight` accessor — no name checks), the fast arm falls through (`None`) to the full conditional pipeline, whose result branch reaches `try_dispatch_tail_call`. The tail loop re-instantiates via `instantiate_generic_cached` (normalizing the tuple each step) and reports TS2589 at the 1000-iteration cap — exactly the path the passing template-growth sibling already takes.

## Adjacent matrix
Both pool fixtures (infer-indirection + renamed-binder `Append<[...M, true]>` — one root, rename-invariant); the non-infer direct form (already TS2589, unchanged); the template-growth sibling (unchanged); convergent accumulators `BuildTuple<40>` and bounded infer loops (clean in both compilers — they recurse in a terminating conditional's branch that already uses the tail loop and never enter the patched arm); full ts2589 family incl. issue_9784/issue_10859 negatives.

## Verification
- Oracle: `tsc --target esnext` emits TS2589 on both fixtures, clean on `BuildTuple<40>`; tsz now byte-matches all three
- `cargo nextest -p tsz-checker --lib -E 'test(ts2589)'`: 68/68
- Full checker battery: 10 failures (was 12; both flips are the pool pair, no new failures); solver 7434/7434; core 3228/3228
- Full conformance: 11,169 (+150, unchanged; same 6 stale-runner-cache rows that fail identically on main)
- Emit: JS 100% (11,563), DTS 1,372/1,390 (recorded floor)
- Performance: the error path now iterates ≤1000 tail steps (same cost as the existing template divergence path); the hot path adds one `def_depth` map lookup per array-arm branch dispatch

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max
