### PR TITLE
perf(parser,scanner): share interned identifier text via IdentText handle

### DIFF
--- a/crates/tsz-binder/src/binding/expression_flow.rs
+++ b/crates/tsz-binder/src/binding/expression_flow.rs
@@ -668,7 +668,7 @@ impl BinderState {
                     let name_node = arena.get(access.name_or_argument)?;
                     arena
                         .get_identifier(name_node)
-                        .map(|ident| ident.escaped_text.clone())
+                        .map(|ident| ident.escaped_text.to_string())
                 }
                 syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => {
                     let access = arena.get_access_expr(node)?;
@@ -682,7 +682,7 @@ impl BinderState {
                                 .and_then(|sym_id| {
                                     resolved_const_expando_key(binder, arena, sym_id, 0)
                                 })
-                                .or_else(|| Some(ident.escaped_text.clone()))
+                                .or_else(|| Some(ident.escaped_text.to_string()))
                         }
                         k if k == SyntaxKind::StringLiteral as u16
                             || k == SyntaxKind::NumericLiteral as u16

--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -499,12 +499,12 @@ impl BinderState {
                                             && let Some(name_node) = arena.get(decl.name)
                                             && let Some(ident) = arena.get_identifier(name_node)
                                         {
-                                            exported_names.push(ident.escaped_text.clone());
+                                            exported_names.push(ident.escaped_text.to_string());
                                             if let Some(&sym_id) =
                                                 self.node_symbols.get(&decl.name.0)
                                             {
                                                 exported_symbols
-                                                    .push((ident.escaped_text.clone(), sym_id));
+                                                    .push((ident.escaped_text.to_string(), sym_id));
                                             }
                                         }
                                     }
@@ -513,9 +513,10 @@ impl BinderState {
                                     && let Some(name_node) = arena.get(decl.name)
                                     && let Some(ident) = arena.get_identifier(name_node)
                                 {
-                                    exported_names.push(ident.escaped_text.clone());
+                                    exported_names.push(ident.escaped_text.to_string());
                                     if let Some(&sym_id) = self.node_symbols.get(&decl.name.0) {
-                                        exported_symbols.push((ident.escaped_text.clone(), sym_id));
+                                        exported_symbols
+                                            .push((ident.escaped_text.to_string(), sym_id));
                                     }
                                 }
                             }
@@ -842,8 +843,9 @@ impl BinderState {
                                                             && let Some(ident) =
                                                                 arena.get_identifier(name_node)
                                                         {
-                                                            exported_names
-                                                                .push(ident.escaped_text.clone());
+                                                            exported_names.push(
+                                                                ident.escaped_text.to_string(),
+                                                            );
                                                         }
                                                     }
                                                 }

--- a/crates/tsz-binder/src/nodes/names.rs
+++ b/crates/tsz-binder/src/nodes/names.rs
@@ -142,7 +142,7 @@ impl BinderState {
         let node = arena.get(idx)?;
         // Simple identifier
         if let Some(id) = arena.get_identifier(node) {
-            return Some(id.escaped_text.clone());
+            return Some(id.escaped_text.to_string());
         }
         // Property access expression: expression.name (e.g., ns.Base)
         if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -1602,8 +1602,8 @@ impl BinderState {
                 let Some(id) = arena.get_identifier(expr_node) else {
                     continue;
                 };
-                if !targets.contains(&id.escaped_text) {
-                    targets.push(id.escaped_text.clone());
+                if !targets.iter().any(|t| *t == id.escaped_text) {
+                    targets.push(id.escaped_text.to_string());
                 }
             }
 

--- a/crates/tsz-binder/src/state/export_surface.rs
+++ b/crates/tsz-binder/src/state/export_surface.rs
@@ -282,7 +282,8 @@ impl ExportSurface {
                             && let Some(name_node) = arena.get(func.name)
                             && let Some(ident) = arena.get_identifier(name_node)
                         {
-                            self.overloaded_functions.insert(ident.escaped_text.clone());
+                            self.overloaded_functions
+                                .insert(ident.escaped_text.to_string());
                         }
                     }
                 }

--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -301,7 +301,7 @@ impl<'a> CheckerState<'a> {
         target_arena.get(value_decl)?;
         target_arena
             .is_const_variable_declaration(value_decl)
-            .then_some(name)
+            .then_some(name.to_string())
     }
 
     /// Strip wrappers that preserve assignment target identity for symbol checks.

--- a/crates/tsz-checker/src/assignability/assignment_checker/commonjs_assignment.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/commonjs_assignment.rs
@@ -677,12 +677,12 @@ impl<'a> CheckerState<'a> {
 
         let has_root_prop = self
             .collect_expando_properties_for_root(&object_key)
-            .contains(&prop_name);
+            .contains(prop_name.as_str());
         let has_last_segment_prop = object_key
             .rsplit_once('.')
             .is_some_and(|(_, last_segment)| {
                 self.collect_expando_properties_for_root(last_segment)
-                    .contains(&prop_name)
+                    .contains(prop_name.as_str())
             });
         has_root_prop || has_last_segment_prop
     }

--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -140,7 +140,7 @@ impl<'a> CheckerState<'a> {
                         .arena
                         .get(shorthand.name)
                         .and_then(|node| self.ctx.arena.get_identifier(node))
-                        .map(|ident| ident.escaped_text.clone());
+                        .map(|ident| ident.escaped_text.to_string());
                     // Use the non-tracking resolver: this shorthand appears as a
                     // destructuring-assignment WRITE target (`({x} = expr)`), not a
                     // read. The tracking resolver would mark `x` as referenced and
@@ -284,7 +284,7 @@ impl<'a> CheckerState<'a> {
                                 .arena
                                 .get(shorthand.name)
                                 .and_then(|node| self.ctx.arena.get_identifier(node))
-                                .map(|ident| ident.escaped_text.clone()),
+                                .map(|ident| ident.escaped_text.to_string()),
                             shorthand.name,
                         )
                     } else {
@@ -390,7 +390,7 @@ impl<'a> CheckerState<'a> {
                 && let Some(name_node) = self.ctx.arena.get(shorthand.name)
                 && let Some(ident) = self.ctx.arena.get_identifier(name_node)
             {
-                named_properties.push(ident.escaped_text.clone());
+                named_properties.push(ident.escaped_text.to_string());
             }
         }
 

--- a/crates/tsz-checker/src/assignability/assignment_checker/js_constructor_provisional.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/js_constructor_provisional.rs
@@ -84,7 +84,7 @@ impl<'a> CheckerState<'a> {
             .arena
             .get(access.name_or_argument)
             .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-            .map(|ident| ident.escaped_text.clone())
+            .map(|ident| ident.escaped_text.to_string())
     }
 
     fn direct_this_property_assignment(&self, stmt_idx: NodeIndex) -> Option<(String, NodeIndex)> {

--- a/crates/tsz-checker/src/checkers/call_context/bare_return_overlap.rs
+++ b/crates/tsz-checker/src/checkers/call_context/bare_return_overlap.rs
@@ -195,7 +195,7 @@ impl CheckerState<'_> {
                 .ctx
                 .arena
                 .get_identifier(node)
-                .is_some_and(|ident| pinned_param_names.contains(&ident.escaped_text));
+                .is_some_and(|ident| pinned_param_names.contains(ident.escaped_text.as_str()));
         }
         if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
             || node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
@@ -260,6 +260,6 @@ impl CheckerState<'_> {
         }
         let name_node = self.ctx.arena.get(param.name)?;
         let ident = self.ctx.arena.get_identifier(name_node)?;
-        Some(ident.escaped_text.clone())
+        Some(ident.escaped_text.to_string())
     }
 }

--- a/crates/tsz-checker/src/checkers/generic_checker/mapped_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mapped_constraint_helpers.rs
@@ -37,7 +37,7 @@ impl<'a> CheckerState<'a> {
             && self
                 .ctx
                 .type_parameter_scope
-                .contains_key(&identifier.escaped_text)
+                .contains_key(identifier.escaped_text.as_str())
         {
             return true;
         }

--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -521,10 +521,10 @@ impl<'a> CheckerState<'a> {
             let tr = self.ctx.arena.get_type_ref(arg_node)?;
             let name_node = self.ctx.arena.get(tr.type_name)?;
             let ident = self.ctx.arena.get_identifier(name_node)?;
-            Some(ident.escaped_text.clone())
+            Some(ident.escaped_text.to_string())
         } else if arg_node.kind == SyntaxKind::Identifier as u16 {
             let ident = self.ctx.arena.get_identifier(arg_node)?;
-            Some(ident.escaped_text.clone())
+            Some(ident.escaped_text.to_string())
         } else {
             None
         }

--- a/crates/tsz-checker/src/checkers/jsx/props/declaration_heritage.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/declaration_heritage.rs
@@ -175,7 +175,7 @@ impl<'a> CheckerState<'a> {
         if node.kind == SyntaxKind::Identifier as u16 {
             return arena
                 .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone());
+                .map(|ident| ident.escaped_text.to_string());
         }
         if node.kind == syntax_kind_ext::QUALIFIED_NAME {
             let qn = arena.get_qualified_name(node)?;

--- a/crates/tsz-checker/src/checkers/jsx/props/special_attribute_callbacks.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/special_attribute_callbacks.rs
@@ -45,7 +45,7 @@ impl<'a> CheckerState<'a> {
                     && let Some(name_node) = self.ctx.arena.get(param.name)
                     && let Some(name) = self.ctx.arena.get_identifier(name_node)
                 {
-                    param_contexts.push((name.escaped_text.clone(), param_type));
+                    param_contexts.push((name.escaped_text.to_string(), param_type));
                 }
                 param_type
             })

--- a/crates/tsz-checker/src/classes/class_abstract_checker.rs
+++ b/crates/tsz-checker/src/classes/class_abstract_checker.rs
@@ -69,7 +69,7 @@ impl<'a> CheckerState<'a> {
             if let Some(name_node) = self.ctx.arena.get(class_data.name)
                 && let Some(ident) = self.ctx.arena.get_identifier(name_node)
             {
-                ident.escaped_text.clone()
+                ident.escaped_text.to_string()
             } else {
                 String::from("<anonymous>")
             }

--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -319,7 +319,7 @@ impl<'a> CheckerState<'a> {
                         .and_then(|n| self.ctx.arena.get_identifier(n))
                         .map_or_else(
                             || String::from("(Anonymous class)"),
-                            |id| id.escaped_text.clone(),
+                            |id| id.escaped_text.to_string(),
                         )
                 } else {
                     String::from("(Anonymous class)")
@@ -419,7 +419,7 @@ impl<'a> CheckerState<'a> {
                         && let Some(name_node) = self.ctx.arena.get(cls.name)
                         && let Some(ident) = self.ctx.arena.get_identifier(name_node)
                     {
-                        base_class_name = ident.escaped_text.clone();
+                        base_class_name = ident.escaped_text.to_string();
                     } else {
                         base_class_name = String::from("(Anonymous class)");
                     }
@@ -427,13 +427,13 @@ impl<'a> CheckerState<'a> {
                     // Get the class name from the expression (identifier or property access)
                     if let Some(expr_node) = self.ctx.arena.get(expr_idx) {
                         if let Some(ident) = self.ctx.arena.get_identifier(expr_node) {
-                            base_class_name = ident.escaped_text.clone();
+                            base_class_name = ident.escaped_text.to_string();
                         } else if let Some(access) = self.ctx.arena.get_access_expr(expr_node)
                             && let Some(name_node) = self.ctx.arena.get(access.name_or_argument)
                             && let Some(name_ident) = self.ctx.arena.get_identifier(name_node)
                         {
                             // e.g., `extends React.Component` — show rightmost name.
-                            base_class_name = name_ident.escaped_text.clone();
+                            base_class_name = name_ident.escaped_text.to_string();
                         }
                     }
 
@@ -464,7 +464,7 @@ impl<'a> CheckerState<'a> {
         let derived_class_name = if class_data.name.is_some() {
             if let Some(name_node) = self.ctx.arena.get(class_data.name) {
                 if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
-                    let mut name = ident.escaped_text.clone();
+                    let mut name = ident.escaped_text.to_string();
                     // Append type parameters for tsc parity: "Foo<T, U>"
                     self.append_type_param_names(&mut name, &class_data.type_parameters);
                     name

--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -59,7 +59,7 @@ impl<'a> CheckerState<'a> {
         let derived_name = if iface_data.name.is_some() {
             if let Some(name_node) = self.ctx.arena.get(iface_data.name) {
                 if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
-                    let mut name = ident.escaped_text.clone();
+                    let mut name = ident.escaped_text.to_string();
                     // Append type parameters for tsc parity: "Foo<T, U>"
                     self.append_type_param_names(&mut name, &iface_data.type_parameters);
                     name
@@ -209,8 +209,10 @@ impl<'a> CheckerState<'a> {
                             && let Some(tp_data) = self.ctx.arena.get_type_parameter(tp_node)
                             && let Some(name_node) = self.ctx.arena.get(tp_data.name)
                             && let Some(ident) = self.ctx.arena.get_identifier(name_node)
-                            && let Some(&tp_type_id) =
-                                self.ctx.type_parameter_scope.get(&ident.escaped_text)
+                            && let Some(&tp_type_id) = self
+                                .ctx
+                                .type_parameter_scope
+                                .get(ident.escaped_text.as_str())
                         {
                             tp_type_ids.push(tp_type_id);
                         }

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -631,7 +631,7 @@ impl<'a> CheckerState<'a> {
                 if let Some(expr_node) = self.ctx.arena.get(expr_idx)
                     && let Some(ident) = self.ctx.arena.get_identifier(expr_node)
                 {
-                    base_class_name = ident.escaped_text.clone();
+                    base_class_name = ident.escaped_text.to_string();
 
                     if let Some(sym_id) = self.resolve_heritage_symbol(expr_idx) {
                         base_class_idx = self.get_class_declaration_from_symbol(sym_id);
@@ -760,7 +760,7 @@ impl<'a> CheckerState<'a> {
             let derived_class_name = if class_data.name.is_some() {
                 if let Some(name_node) = self.ctx.arena.get(class_data.name) {
                     if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
-                        ident.escaped_text.clone()
+                        ident.escaped_text.to_string()
                     } else {
                         String::from("<anonymous>")
                     }
@@ -944,7 +944,7 @@ impl<'a> CheckerState<'a> {
                 let Some(ident) = self.ctx.arena.get_identifier(name_node) else {
                     continue;
                 };
-                class_type_param_names.insert(ident.escaped_text.clone());
+                class_type_param_names.insert(ident.escaped_text.to_string());
             }
         }
 
@@ -1066,7 +1066,7 @@ impl<'a> CheckerState<'a> {
                     && let Some(expr_node) = self.ctx.arena.get(expr_idx)
                     && expr_node.kind == SyntaxKind::Identifier as u16
                     && let Some(ident) = self.ctx.arena.get_identifier(expr_node)
-                    && class_type_param_names.contains(&ident.escaped_text)
+                    && class_type_param_names.contains(ident.escaped_text.as_str())
                 {
                     self.error_at_node(
                         expr_idx,

--- a/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
@@ -1243,7 +1243,7 @@ impl<'a> CheckerState<'a> {
         let class_name = if class_data.name.is_some() {
             if let Some(name_node) = self.ctx.arena.get(class_data.name) {
                 if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
-                    ident.escaped_text.clone()
+                    ident.escaped_text.to_string()
                 } else {
                     String::from("<anonymous>")
                 }

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -1459,7 +1459,7 @@ impl<'a> CheckerState<'a> {
                     let Some(ident) = self.ctx.arena.get_identifier(name_node) else {
                         continue;
                     };
-                    aliases.insert(ident.escaped_text.clone());
+                    aliases.insert(ident.escaped_text.to_string());
                 }
             }
         }
@@ -1542,8 +1542,8 @@ impl<'a> CheckerState<'a> {
             }
             let ident = self.ctx.arena.get_identifier(name_node)?;
             Some(JsImplicitMemberName {
-                lookup_name: ident.escaped_text.clone(),
-                display_name: ident.escaped_text.clone(),
+                lookup_name: ident.escaped_text.to_string(),
+                display_name: ident.escaped_text.to_string(),
             })
         }
     }

--- a/crates/tsz-checker/src/context/module_entity.rs
+++ b/crates/tsz-checker/src/context/module_entity.rs
@@ -131,7 +131,7 @@ fn collect_export_equals_targets(
             && let Some(expr_node) = arena.get(assign.expression)
             && let Some(id) = arena.get_identifier(expr_node)
         {
-            out.push(id.escaped_text.clone());
+            out.push(id.escaped_text.to_string());
         }
         return;
     }
@@ -273,7 +273,7 @@ impl<'a> CheckerContext<'a> {
                             continue;
                         };
                         if let Some(id) = arena.get_identifier(expr_node) {
-                            return Some(id.escaped_text.clone());
+                            return Some(id.escaped_text.to_string());
                         }
                     }
 

--- a/crates/tsz-checker/src/declarations/declarations_module.rs
+++ b/crates/tsz-checker/src/declarations/declarations_module.rs
@@ -1165,7 +1165,7 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
                             && let Some(name_node) = self.ctx.arena.get(mod_data.name)
                             && let Some(ident) = self.ctx.arena.get_identifier(name_node)
                         {
-                            names.push(ident.escaped_text.clone());
+                            names.push(ident.escaped_text.to_string());
                         }
                     }
                     names.reverse(); // outermost first

--- a/crates/tsz-checker/src/declarations/import/ambient_default_dup_collect.rs
+++ b/crates/tsz-checker/src/declarations/import/ambient_default_dup_collect.rs
@@ -30,7 +30,7 @@ impl<'a> CheckerState<'a> {
             && name_node.kind == SyntaxKind::Identifier as u16
             && let Some(ident) = self.ctx.arena.get_identifier(name_node)
         {
-            namespaces.insert(ident.escaped_text.clone(), module_decl.name);
+            namespaces.insert(ident.escaped_text.to_string(), module_decl.name);
             return;
         }
 
@@ -42,7 +42,8 @@ impl<'a> CheckerState<'a> {
                 && exported_node.kind == SyntaxKind::Identifier as u16
                 && let Some(ident) = self.ctx.arena.get_identifier(exported_node)
             {
-                default_export_names.push((ident.escaped_text.clone(), export_decl.export_clause));
+                default_export_names
+                    .push((ident.escaped_text.to_string(), export_decl.export_clause));
                 return;
             }
             // `export function foo(){}` / `export class C {}` / `export const x = ...`
@@ -63,7 +64,7 @@ impl<'a> CheckerState<'a> {
             && let Some(func) = self.ctx.arena.get_function(node)
             && let Some(ident) = self.ctx.arena.get_identifier_at(func.name)
         {
-            sibling_value_names.insert(ident.escaped_text.clone());
+            sibling_value_names.insert(ident.escaped_text.to_string());
             return;
         }
 
@@ -71,7 +72,7 @@ impl<'a> CheckerState<'a> {
             && let Some(class) = self.ctx.arena.get_class(node)
             && let Some(ident) = self.ctx.arena.get_identifier_at(class.name)
         {
-            sibling_value_names.insert(ident.escaped_text.clone());
+            sibling_value_names.insert(ident.escaped_text.to_string());
             return;
         }
 
@@ -93,7 +94,7 @@ impl<'a> CheckerState<'a> {
                         continue;
                     };
                     if let Some(ident) = self.ctx.arena.get_identifier_at(var_decl.name) {
-                        sibling_value_names.insert(ident.escaped_text.clone());
+                        sibling_value_names.insert(ident.escaped_text.to_string());
                     }
                 }
             }

--- a/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
@@ -449,7 +449,7 @@ impl<'a> CheckerState<'a> {
             // Get the attribute name (identifier or string literal)
             let name = if let Some(name_node) = self.ctx.arena.get(attr_data.name) {
                 if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
-                    Some(ident.escaped_text.clone())
+                    Some(ident.escaped_text.to_string())
                 } else {
                     self.ctx
                         .arena

--- a/crates/tsz-checker/src/declarations/import/declaration_resolution.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_resolution.rs
@@ -832,7 +832,7 @@ impl<'a> CheckerState<'a> {
                             );
                         // Record so TS2456 can be suppressed for type aliases
                         // whose apparent circularity is caused by this conflict.
-                        self.ctx.import_conflict_names.insert(name.clone());
+                        self.ctx.import_conflict_names.insert(name.to_string());
                     }
                 }
             }

--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -599,7 +599,7 @@ impl<'a> CheckerState<'a> {
                         &message,
                         diagnostic_codes::IMPORT_DECLARATION_CONFLICTS_WITH_LOCAL_DECLARATION_OF,
                     );
-                    self.ctx.import_conflict_names.insert(name.clone());
+                    self.ctx.import_conflict_names.insert(name.to_string());
                     return;
                 }
             }
@@ -721,7 +721,7 @@ impl<'a> CheckerState<'a> {
                             &message,
                             diagnostic_codes::IMPORT_DECLARATION_CONFLICTS_WITH_LOCAL_DECLARATION_OF,
                         );
-                        self.ctx.import_conflict_names.insert(name.clone());
+                        self.ctx.import_conflict_names.insert(name.to_string());
                         return; // Don't emit further errors for this import
                     }
                 }
@@ -1628,7 +1628,7 @@ impl<'a> CheckerState<'a> {
         let node = self.ctx.arena.get(idx)?;
         if node.kind == SyntaxKind::Identifier as u16 {
             let ident = self.ctx.arena.get_identifier(node)?;
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
         if node.kind == syntax_kind_ext::QUALIFIED_NAME {
             let qn = self.ctx.arena.get_qualified_name(node)?;

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1817,6 +1817,6 @@ impl<'a> CheckerState<'a> {
         // Get the property name
         let name_node = self.ctx.arena.get(access.name_or_argument)?;
         let name_ident = self.ctx.arena.get_identifier(name_node)?;
-        Some(name_ident.escaped_text.clone())
+        Some(name_ident.escaped_text.to_string())
     }
 }

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
@@ -137,7 +137,7 @@ impl<'a> CheckerState<'a> {
             let param = self.ctx.arena.get_parameter(param_node)?;
             let name = if let Some(name_node) = self.ctx.arena.get(param.name) {
                 if let Some(name_data) = self.ctx.arena.get_identifier(name_node) {
-                    name_data.escaped_text.clone()
+                    name_data.escaped_text.to_string()
                 } else if matches!(
                     name_node.kind,
                     k if k == tsz_parser::parser::syntax_kind_ext::OBJECT_BINDING_PATTERN

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1154,7 +1154,7 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get_identifier(name_node)?
                     .escaped_text
-                    .clone(),
+                    .to_string(),
                 k if k == tsz_scanner::SyntaxKind::StringLiteral as u16
                     || k == tsz_scanner::SyntaxKind::NoSubstitutionTemplateLiteral as u16 =>
                 {

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -1784,7 +1784,7 @@ impl<'a> CheckerState<'a> {
                 Some((
                     file_idx == current_file_idx,
                     decl_node.pos,
-                    ident.escaped_text.clone(),
+                    ident.escaped_text.to_string(),
                 ))
             })
             .max_by_key(|(same_file, decl_pos, _)| (*same_file, *decl_pos))

--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -686,7 +686,7 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .arena
                 .get_identifier(name_node)
-                .map(|ident| ident.escaped_text.clone());
+                .map(|ident| ident.escaped_text.to_string());
         }
         if receiver_node.kind != SyntaxKind::Identifier as u16 {
             return None;
@@ -718,7 +718,7 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .arena
                 .get_identifier(ctor_node)
-                .map(|ident| ident.escaped_text.clone());
+                .map(|ident| ident.escaped_text.to_string());
         }
 
         if ctor_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
@@ -728,7 +728,7 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .arena
                 .get_identifier(name)
-                .map(|ident| ident.escaped_text.clone());
+                .map(|ident| ident.escaped_text.to_string());
         }
 
         None

--- a/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
+++ b/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
@@ -1003,7 +1003,7 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .arena
                 .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone());
+                .map(|ident| ident.escaped_text.to_string());
         }
 
         if node.kind == SyntaxKind::ThisKeyword as u16 {

--- a/crates/tsz-checker/src/flow/control_flow/narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/narrowing.rs
@@ -1096,7 +1096,7 @@ impl<'a> FlowAnalyzer<'a> {
         // Get the member name — identifier for En.B, string literal for En["B"]
         let member_name_owned: String;
         if let Some(member_ident) = self.arena.get_identifier_at(member_name_node) {
-            member_name_owned = member_ident.escaped_text.clone();
+            member_name_owned = member_ident.escaped_text.to_string();
         } else {
             let member_node = self.arena.get(member_name_node)?;
             if member_node.kind != tsz_scanner::SyntaxKind::StringLiteral as u16

--- a/crates/tsz-checker/src/flow/control_flow/zod_literal_helpers.rs
+++ b/crates/tsz-checker/src/flow/control_flow/zod_literal_helpers.rs
@@ -29,7 +29,7 @@ impl<'a> FlowAnalyzer<'a> {
         let name = self.skip_parens_and_assertions(name);
         let node = self.arena.get(name)?;
         if let Some(ident) = self.arena.get_identifier(node) {
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
         if node.kind == SyntaxKind::StringLiteral as u16
             || node.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16

--- a/crates/tsz-checker/src/flow/flow_analysis/core.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/core.rs
@@ -920,9 +920,9 @@ impl<'a> CheckerState<'a> {
 
         if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
             if name_node.kind == SyntaxKind::PrivateIdentifier as u16 {
-                return Some(PropertyKey::Private(ident.escaped_text.clone()));
+                return Some(PropertyKey::Private(ident.escaped_text.to_string()));
             }
-            return Some(PropertyKey::Ident(ident.escaped_text.clone()));
+            return Some(PropertyKey::Ident(ident.escaped_text.to_string()));
         }
 
         if matches!(
@@ -964,9 +964,9 @@ impl<'a> CheckerState<'a> {
             let name_node = self.ctx.arena.get(access.name_or_argument)?;
             if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
                 if name_node.kind == SyntaxKind::PrivateIdentifier as u16 {
-                    return Some(PropertyKey::Private(ident.escaped_text.clone()));
+                    return Some(PropertyKey::Private(ident.escaped_text.to_string()));
                 }
-                return Some(PropertyKey::Ident(ident.escaped_text.clone()));
+                return Some(PropertyKey::Ident(ident.escaped_text.to_string()));
             }
             return None;
         }
@@ -985,7 +985,7 @@ impl<'a> CheckerState<'a> {
         let expr_node = self.ctx.arena.get(expr_idx)?;
 
         if let Some(ident) = self.ctx.arena.get_identifier(expr_node) {
-            return Some(ComputedKey::Ident(ident.escaped_text.clone()));
+            return Some(ComputedKey::Ident(ident.escaped_text.to_string()));
         }
 
         if let Some(lit) = self.ctx.arena.get_literal(expr_node) {

--- a/crates/tsz-checker/src/flow/flow_analysis/usage.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/usage.rs
@@ -508,7 +508,7 @@ impl<'a> CheckerState<'a> {
         let name_idx = self.get_declaration_name_node(decl_idx)?;
         let name_node = self.ctx.arena.get(name_idx)?;
         let ident = self.ctx.arena.get_identifier(name_node)?;
-        ident.original_text.clone()
+        ident.original_text.as_ref().map(|t| t.to_string())
     }
 
     /// Check if a node is within a parameter's default value initializer.

--- a/crates/tsz-checker/src/jsdoc/diagnostics.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics.rs
@@ -171,7 +171,7 @@ impl<'a> CheckerState<'a> {
                 && let Some(ident) = arena.get_identifier(name_node)
             {
                 decls.push(JsdocNamedDecl {
-                    name: ident.escaped_text.clone(),
+                    name: ident.escaped_text.to_string(),
                     pos: name_node.pos,
                     len: name_node.end.saturating_sub(name_node.pos),
                     file_idx: target_file_idx,
@@ -247,7 +247,7 @@ impl<'a> CheckerState<'a> {
             && rhs_node.kind == SyntaxKind::Identifier as u16
             && let Some(ident) = arena.get_identifier(rhs_node)
         {
-            roots.insert(ident.escaped_text.clone());
+            roots.insert(ident.escaped_text.to_string());
         }
 
         Self::collect_commonjs_export_object_roots_from_expression(arena, binary.right, roots);
@@ -370,7 +370,7 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|ident| export_object_roots.contains(ident.escaped_text.as_str()));
         base_is_export_root.then(|| {
             (
-                name_ident.escaped_text.clone(),
+                name_ident.escaped_text.to_string(),
                 name_node.pos,
                 name_node.end.saturating_sub(name_node.pos),
             )

--- a/crates/tsz-checker/src/query_boundaries/js_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports.rs
@@ -1731,7 +1731,7 @@ impl<'a> CheckerState<'a> {
 
         // Get the member name (rightmost part: `.member`)
         let member_ident = arena.get_identifier_at(outer_access.name_or_argument)?;
-        let member_name = member_ident.escaped_text.clone();
+        let member_name = member_ident.escaped_text.to_string();
 
         // Check that the expression is `Ctor.prototype`
         let proto_node = arena.get(outer_access.expression)?;
@@ -1753,7 +1753,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         let ctor_ident = arena.get_identifier(ctor_node)?;
-        let ctor_name = ctor_ident.escaped_text.clone();
+        let ctor_name = ctor_ident.escaped_text.to_string();
 
         Some((ctor_name, member_name))
     }

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -887,10 +887,10 @@ impl<'a> CheckerState<'a> {
         // interface that has heritage must report static-side incompatibility with `null`.
         if self.class_extends_null(class) && self.class_has_merged_interface_extends(class) {
             let class_name = if let Some(name_node) = self.ctx.arena.get(class.name) {
-                self.ctx
-                    .arena
-                    .get_identifier(name_node)
-                    .map_or_else(|| "<anonymous>".to_string(), |id| id.escaped_text.clone())
+                self.ctx.arena.get_identifier(name_node).map_or_else(
+                    || "<anonymous>".to_string(),
+                    |id| id.escaped_text.to_string(),
+                )
             } else {
                 "<anonymous>".to_string()
             };

--- a/crates/tsz-checker/src/state/state_checking/heritage_call_expression.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage_call_expression.rs
@@ -125,7 +125,9 @@ impl CheckerState<'_> {
                 if let Some(type_ref) = self.ctx.arena.get_type_ref(node) {
                     if let Some(name_node) = self.ctx.arena.get(type_ref.type_name)
                         && let Some(ident) = self.ctx.arena.get_identifier(name_node)
-                        && class_type_param_names.contains(&ident.escaped_text)
+                        && class_type_param_names
+                            .iter()
+                            .any(|n| *n == ident.escaped_text)
                     {
                         return Some(type_ref.type_name);
                     }
@@ -207,7 +209,7 @@ impl CheckerState<'_> {
                 && let Some(name_node) = self.ctx.arena.get(param.name)
                 && let Some(ident) = self.ctx.arena.get_identifier(name_node)
             {
-                names.push(ident.escaped_text.clone());
+                names.push(ident.escaped_text.to_string());
             }
         }
         names

--- a/crates/tsz-checker/src/state/state_checking/heritage_support.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage_support.rs
@@ -27,7 +27,7 @@ impl<'a> CheckerState<'a> {
                             && let Some(name_node) = self.ctx.arena.get(param.name)
                             && let Some(ident) = self.ctx.arena.get_identifier(name_node)
                         {
-                            names.insert(ident.escaped_text.clone());
+                            names.insert(ident.escaped_text.to_string());
                         }
                     }
                 }
@@ -155,7 +155,7 @@ impl<'a> CheckerState<'a> {
             .ctx
             .arena
             .get_identifier_at(right_idx)
-            .map(|ident| ident.escaped_text.clone())
+            .map(|ident| ident.escaped_text.to_string())
         else {
             return false;
         };

--- a/crates/tsz-checker/src/state/state_checking_members/class_type_param_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/class_type_param_checks.rs
@@ -28,7 +28,9 @@ impl<'a> CheckerState<'a> {
         match node.kind {
             k if k == SyntaxKind::Identifier as u16 => {
                 if let Some(ident) = self.ctx.arena.get_identifier(node)
-                    && class_type_param_names.contains(&ident.escaped_text)
+                    && class_type_param_names
+                        .iter()
+                        .any(|n| *n == ident.escaped_text)
                 {
                     self.error_at_node(
                         type_idx,
@@ -42,7 +44,9 @@ impl<'a> CheckerState<'a> {
                     // Check if type_name is an identifier matching a class type param
                     if let Some(name_node) = self.ctx.arena.get(type_ref.type_name)
                         && let Some(ident) = self.ctx.arena.get_identifier(name_node)
-                        && class_type_param_names.contains(&ident.escaped_text)
+                        && class_type_param_names
+                            .iter()
+                            .any(|n| *n == ident.escaped_text)
                     {
                         self.error_at_node(
                             type_idx,
@@ -227,7 +231,7 @@ impl<'a> CheckerState<'a> {
                 && let Some(name_node) = self.ctx.arena.get(param.name)
                 && let Some(ident) = self.ctx.arena.get_identifier(name_node)
             {
-                names.push(ident.escaped_text.clone());
+                names.push(ident.escaped_text.to_string());
             }
         }
         names

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -427,7 +427,7 @@ impl<'a> CheckerState<'a> {
                     continue;
                 };
                 method_groups
-                    .entry(ident.escaped_text.clone())
+                    .entry(ident.escaped_text.to_string())
                     .or_default()
                     .push((member_idx, sig.question_token));
             }
@@ -625,7 +625,7 @@ impl<'a> CheckerState<'a> {
                 .arena
                 .get(param.name)
                 .and_then(|n| self.ctx.arena.get_identifier(n))
-                .map(|id| id.escaped_text.clone())
+                .map(|id| id.escaped_text.to_string())
                 .unwrap_or_default();
 
             let atom = self.ctx.types.intern_string(&param_name);
@@ -705,7 +705,7 @@ impl<'a> CheckerState<'a> {
                 let param = self.ctx.arena.get_type_parameter(param_node)?;
                 let name_node = self.ctx.arena.get(param.name)?;
                 let ident = self.ctx.arena.get_identifier(name_node)?;
-                Some(ident.escaped_text.clone())
+                Some(ident.escaped_text.to_string())
             })
             .collect();
 
@@ -1369,7 +1369,7 @@ impl<'a> CheckerState<'a> {
 
         // Identifier — same as canonical
         if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
 
         // String literal — wrap in single quotes like TSC's declarationNameToString

--- a/crates/tsz-checker/src/state/state_checking_members/mapped_type_param_provisional.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/mapped_type_param_provisional.rs
@@ -21,7 +21,7 @@ impl<'a> CheckerState<'a> {
         let name_node = self.ctx.arena.get(param.name)?;
         let ident = self.ctx.arena.get_identifier(name_node)?;
         let atom = self.ctx.types.intern_string(&ident.escaped_text);
-        let name = ident.escaped_text.clone();
+        let name = ident.escaped_text.to_string();
         let constraint_type = if param.constraint != NodeIndex::NONE {
             match self.get_type_from_type_node(param.constraint) {
                 TypeId::ERROR => TypeId::UNKNOWN,

--- a/crates/tsz-checker/src/state/state_checking_members/member_access.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_access.rs
@@ -716,7 +716,7 @@ impl<'a> CheckerState<'a> {
 
         if node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
             if let Some(ident) = self.ctx.arena.get_identifier(node) {
-                refs.push((ident.escaped_text.clone(), node_idx));
+                refs.push((ident.escaped_text.to_string(), node_idx));
             }
             return;
         }

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -726,7 +726,7 @@ impl<'a> CheckerState<'a> {
             let Some(ident) = self.ctx.arena.get_identifier(name_node) else {
                 continue;
             };
-            let name = ident.escaped_text.clone();
+            let name = ident.escaped_text.to_string();
             let atom = self.ctx.types.intern_string(&name);
             let is_const = self
                 .ctx
@@ -809,7 +809,7 @@ impl<'a> CheckerState<'a> {
             let Some(ident) = self.ctx.arena.get_identifier(name_node) else {
                 continue;
             };
-            let name = ident.escaped_text.clone();
+            let name = ident.escaped_text.to_string();
             self.ctx
                 .typeof_param_scope
                 .insert(name.clone(), TypeId::ANY);

--- a/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
@@ -853,7 +853,7 @@ impl CheckerState<'_> {
                 && object_name_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
                 && let Some(object_ident) = decl_arena.get_identifier(object_name_node)
             {
-                indexed_object_names.push(object_ident.escaped_text.clone());
+                indexed_object_names.push(object_ident.escaped_text.to_string());
             }
 
             stack.extend(decl_arena.get_children(node_idx));

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
@@ -602,7 +602,7 @@ impl<'a> CheckerState<'a> {
         match node.kind {
             k if k == SyntaxKind::Identifier as u16 => arena
                 .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone()),
+                .map(|ident| ident.escaped_text.to_string()),
             syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
                 let access = arena.get_access_expr(node)?;
                 let left = Self::commonjs_expando_assignment_access_key(arena, access.expression)?;

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
@@ -569,7 +569,7 @@ impl<'a> CheckerState<'a> {
                 self.ctx
                     .arena
                     .get_identifier_at(access.name_or_argument)
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
             }
             syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => {
                 let access = self.ctx.arena.get_access_expr(node)?;
@@ -797,7 +797,7 @@ impl<'a> CheckerState<'a> {
             && Self::is_exports_or_module_exports_or_chain_in_arena(arena, var_decl.initializer)
             && let Some(name_ident) = arena.get_identifier_at(var_decl.name)
         {
-            aliases.insert(name_ident.escaped_text.clone());
+            aliases.insert(name_ident.escaped_text.to_string());
         }
     }
 

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
@@ -1039,7 +1039,7 @@ impl<'a> CheckerState<'a> {
             if let Some(name_node) = self.ctx.arena.get(type_param.name)
                 && let Some(ident) = self.ctx.arena.get_identifier(name_node)
             {
-                let name = ident.escaped_text.clone();
+                let name = ident.escaped_text.to_string();
                 let atom = self.ctx.types.intern_string(&name);
                 let provisional = self
                     .ctx
@@ -1089,7 +1089,7 @@ impl<'a> CheckerState<'a> {
             }
 
             if let Some((name, previous)) = local_update {
-                self.ctx.type_parameter_scope.remove(&name);
+                self.ctx.type_parameter_scope.remove(name.as_str());
                 if let Some(previous) = previous {
                     self.ctx.type_parameter_scope.insert(name, previous);
                 }
@@ -1143,7 +1143,7 @@ impl<'a> CheckerState<'a> {
             && let Some(name_node) = self.ctx.arena.get(type_param.name)
             && let Some(ident) = self.ctx.arena.get_identifier(name_node)
         {
-            let name = ident.escaped_text.clone();
+            let name = ident.escaped_text.to_string();
             if shadowed_params.insert(name.clone()) {
                 inserted_shadow = Some(name);
             }
@@ -1157,14 +1157,14 @@ impl<'a> CheckerState<'a> {
                 shadowed_params,
             ) {
                 if let Some(name) = inserted_shadow {
-                    shadowed_params.remove(&name);
+                    shadowed_params.remove(name.as_str());
                 }
                 return true;
             }
         }
 
         if let Some(name) = inserted_shadow {
-            shadowed_params.remove(&name);
+            shadowed_params.remove(name.as_str());
         }
 
         false

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -637,7 +637,10 @@ impl CheckerState<'_> {
                 .arena
                 .get(data.name)
                 .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                .map_or_else(|| "T".to_string(), |id_data| id_data.escaped_text.clone());
+                .map_or_else(
+                    || "T".to_string(),
+                    |id_data| id_data.escaped_text.to_string(),
+                );
 
             // Check for duplicate type parameter names (TS2300)
             if !seen_names.insert(name.clone()) {
@@ -697,7 +700,10 @@ impl CheckerState<'_> {
                     .arena
                     .get(data.name)
                     .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                    .map_or_else(|| "T".to_string(), |id_data| id_data.escaped_text.clone());
+                    .map_or_else(
+                        || "T".to_string(),
+                        |id_data| id_data.escaped_text.to_string(),
+                    );
                 let atom = self.ctx.types.intern_string(&name);
 
                 let constraint = if data.constraint != NodeIndex::NONE {

--- a/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
@@ -1157,7 +1157,7 @@ impl<'a> CheckerState<'a> {
         let name = self.ctx.arena.skip_parenthesized_and_assertions(name);
         let node = self.ctx.arena.get(name)?;
         if let Some(ident) = self.ctx.arena.get_identifier(node) {
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
         if node.kind == SyntaxKind::StringLiteral as u16
             || node.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
@@ -1352,14 +1352,14 @@ impl<'a> CheckerState<'a> {
                     let access = self.ctx.arena.get_access_expr(node)?;
                     let name_node = self.ctx.arena.get(access.name_or_argument)?;
                     let ident = self.ctx.arena.get_identifier(name_node)?;
-                    segments.push((access.name_or_argument, ident.escaped_text.clone()));
+                    segments.push((access.name_or_argument, ident.escaped_text.to_string()));
                     current = access.expression;
                 }
                 tsz_parser::parser::syntax_kind_ext::QUALIFIED_NAME => {
                     let name = self.ctx.arena.get_qualified_name(node)?;
                     let right_node = self.ctx.arena.get(name.right)?;
                     let ident = self.ctx.arena.get_identifier(right_node)?;
-                    segments.push((name.right, ident.escaped_text.clone()));
+                    segments.push((name.right, ident.escaped_text.to_string()));
                     current = name.left;
                 }
                 tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_EXPRESSION => {

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_alias_cycle.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_alias_cycle.rs
@@ -365,7 +365,7 @@ impl<'a> CheckerState<'a> {
                         && let Some(name_node) = owner_arena.get(tp.name)
                         && let Some(ident) = owner_arena.get_identifier(name_node)
                     {
-                        tp_names.insert(ident.escaped_text.clone());
+                        tp_names.insert(ident.escaped_text.to_string());
                     }
                 }
             }

--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -80,7 +80,7 @@ impl<'a> CheckerState<'a> {
 
         let right_name = if let Some(right_node) = self.ctx.arena.get(qn.right) {
             if let Some(id) = self.ctx.arena.get_identifier(right_node) {
-                id.escaped_text.clone()
+                id.escaped_text.to_string()
             } else {
                 return TypeId::ERROR; // Missing identifier data - propagate error
             }
@@ -195,7 +195,7 @@ impl<'a> CheckerState<'a> {
                             let right_name = if let Some(right_node) = self.ctx.arena.get(qn.right)
                                 && let Some(id) = self.ctx.arena.get_identifier(right_node)
                             {
-                                id.escaped_text.clone()
+                                id.escaped_text.to_string()
                             } else {
                                 String::new()
                             };
@@ -209,7 +209,7 @@ impl<'a> CheckerState<'a> {
                                     if let Some(rn) = self.ctx.arena.get(left_qn.right)
                                         && let Some(id) = self.ctx.arena.get_identifier(rn)
                                     {
-                                        id.escaped_text.clone()
+                                        id.escaped_text.to_string()
                                     } else {
                                         left_name.clone()
                                     }

--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -659,7 +659,7 @@ impl<'a> CheckerState<'a> {
                         && let Some(name_node) = self.ctx.arena.get(tp_data.name)
                         && let Some(ident) = self.ctx.arena.get_identifier(name_node)
                     {
-                        names.insert(ident.escaped_text.clone());
+                        names.insert(ident.escaped_text.to_string());
                     }
                 }
             }
@@ -716,7 +716,7 @@ impl<'a> CheckerState<'a> {
                 && let Some(name_node) = self.ctx.arena.get(tp_data.name)
                 && let Some(ident) = self.ctx.arena.get_identifier(name_node)
             {
-                names.insert(ident.escaped_text.clone());
+                names.insert(ident.escaped_text.to_string());
             }
         }
     }

--- a/crates/tsz-checker/src/state/type_resolution/constructors.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors.rs
@@ -1490,10 +1490,10 @@ impl<'a> CheckerState<'a> {
             let tr = self.ctx.arena.get_type_ref(arg_node)?;
             let name_node = self.ctx.arena.get(tr.type_name)?;
             let ident = self.ctx.arena.get_identifier(name_node)?;
-            Some(ident.escaped_text.clone())
+            Some(ident.escaped_text.to_string())
         } else if arg_node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
             let ident = self.ctx.arena.get_identifier(arg_node)?;
-            Some(ident.escaped_text.clone())
+            Some(ident.escaped_text.to_string())
         } else {
             None
         }

--- a/crates/tsz-checker/src/state/type_resolution/import_type.rs
+++ b/crates/tsz-checker/src/state/type_resolution/import_type.rs
@@ -374,7 +374,7 @@ impl<'a> CheckerState<'a> {
         let mut segments = self.import_type_member_segments(qn.left)?;
         let right_node = self.ctx.arena.get(qn.right)?;
         let right_ident = self.ctx.arena.get_identifier(right_node)?;
-        segments.push(right_ident.escaped_text.clone());
+        segments.push(right_ident.escaped_text.to_string());
         Some(segments)
     }
 

--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -1466,7 +1466,7 @@ impl CheckerState<'_> {
             && self
                 .ctx
                 .type_parameter_scope
-                .contains_key(&identifier.escaped_text)
+                .contains_key(identifier.escaped_text.as_str())
         {
             return true;
         }

--- a/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
+++ b/crates/tsz-checker/src/state/variable_checking/binding_rest.rs
@@ -203,7 +203,7 @@ impl<'a> CheckerState<'a> {
                 {
                     names.push(keyword.to_string());
                 } else if let Some(ident) = self.ctx.arena.get_identifier(prop_node) {
-                    names.push(ident.escaped_text.clone());
+                    names.push(ident.escaped_text.to_string());
                 } else if let Some(lit) = self.ctx.arena.get_literal(prop_node) {
                     names.push(lit.text.clone());
                 } else if let Some(computed) = self.ctx.arena.get_computed_property(prop_node) {
@@ -226,7 +226,7 @@ impl<'a> CheckerState<'a> {
                 .get(element_data.name)
                 .and_then(|n| self.ctx.arena.get_identifier(n))
             {
-                names.push(ident.escaped_text.clone());
+                names.push(ident.escaped_text.to_string());
             }
         }
 

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -474,7 +474,7 @@ impl<'a> CheckerState<'a> {
                 self.ctx
                     .arena
                     .get_identifier(name_node)
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
             } else {
                 None
             }

--- a/crates/tsz-checker/src/state/variable_checking/destructuring/recording.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring/recording.rs
@@ -45,7 +45,7 @@ impl CheckerState<'_> {
                     self.ctx
                         .arena
                         .get_identifier(prop_node)
-                        .map(|ident| ident.escaped_text.clone())
+                        .map(|ident| ident.escaped_text.to_string())
                 } else {
                     None
                 }
@@ -54,7 +54,7 @@ impl CheckerState<'_> {
                 self.ctx
                     .arena
                     .get_identifier(name_node)
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
             };
 
             let Some(prop_atom) = prop_name else {
@@ -203,7 +203,7 @@ impl CheckerState<'_> {
                             self.ctx
                                 .arena
                                 .get_identifier(prop_node)
-                                .map(|ident| ident.escaped_text.clone())
+                                .map(|ident| ident.escaped_text.to_string())
                                 .unwrap_or_default()
                         } else {
                             String::new()
@@ -212,7 +212,7 @@ impl CheckerState<'_> {
                         self.ctx
                             .arena
                             .get_identifier(name_node)
-                            .map(|ident| ident.escaped_text.clone())
+                            .map(|ident| ident.escaped_text.to_string())
                             .unwrap_or_default()
                     }
                 } else {

--- a/crates/tsz-checker/src/state/variable_checking/destructuring/tail.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring/tail.rs
@@ -434,7 +434,7 @@ impl<'a> CheckerState<'a> {
             self.ctx
                 .arena
                 .get_identifier(name_node)
-                .map(|ident| ident.escaped_text.clone())
+                .map(|ident| ident.escaped_text.to_string())
         }
     }
 
@@ -564,7 +564,7 @@ impl<'a> CheckerState<'a> {
                                 .arena
                                 .get(elem.name)
                                 .and_then(|n| self.ctx.arena.get_identifier(n))
-                                .map(|id| id.escaped_text.clone())
+                                .map(|id| id.escaped_text.to_string())
                         })
                 })
                 .collect();

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
@@ -86,7 +86,7 @@ impl<'a> CheckerState<'a> {
         let mut bound_names: Vec<(String, NodeIndex)> = Vec::new();
         if name_node.kind == SyntaxKind::Identifier as u16 {
             if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
-                bound_names.push((ident.escaped_text.clone(), var_decl.name));
+                bound_names.push((ident.escaped_text.to_string(), var_decl.name));
             }
         } else {
             // Destructuring pattern — collect all binding element names
@@ -355,7 +355,7 @@ impl<'a> CheckerState<'a> {
 
         if node.kind == SyntaxKind::Identifier as u16 {
             if let Some(ident) = self.ctx.arena.get_identifier(node) {
-                names.push((ident.escaped_text.clone(), node_idx));
+                names.push((ident.escaped_text.to_string(), node_idx));
             }
             return;
         }

--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -1686,7 +1686,7 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .arena
                 .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone()),
+                .map(|ident| ident.escaped_text.to_string()),
             k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
                 let access = self.ctx.arena.get_access_expr(node)?;
                 let left = self.expression_text(access.expression)?;

--- a/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
@@ -1638,7 +1638,7 @@ impl<'a> CheckerState<'a> {
                             .binder
                             .get_symbol_with_libs(sym_id, &lib_binders)
                             .map_or_else(
-                                || ident.escaped_text.clone(),
+                                || ident.escaped_text.to_string(),
                                 |symbol| symbol.escaped_name.clone(),
                             )
                     };

--- a/crates/tsz-checker/src/types/class_type/constructor_parts/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor_parts/helpers.rs
@@ -492,7 +492,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
 
-            let name = name_ident.escaped_text.clone();
+            let name = name_ident.escaped_text.to_string();
             let type_id = class_type_boundary::enclosing_function_type_param_type(
                 self.ctx.types,
                 self.ctx.types.intern_string(&name),

--- a/crates/tsz-checker/src/types/class_type/js_class_properties.rs
+++ b/crates/tsz-checker/src/types/class_type/js_class_properties.rs
@@ -268,7 +268,7 @@ impl CheckerState<'_> {
                 self.jsdoc_type_annotation_for_node(param_idx)
             };
             if let Some(param_type) = param_type {
-                param_type_map.insert(name_ident.escaped_text.clone(), param_type);
+                param_type_map.insert(name_ident.escaped_text.to_string(), param_type);
             }
         }
 
@@ -887,7 +887,7 @@ impl CheckerState<'_> {
                         if let Some(name_node) = self.ctx.arena.get(var_decl.name)
                             && let Some(ident) = self.ctx.arena.get_identifier(name_node)
                         {
-                            aliases.push(ident.escaped_text.clone());
+                            aliases.push(ident.escaped_text.to_string());
                         }
                     }
                 }
@@ -1055,7 +1055,7 @@ impl CheckerState<'_> {
             let ident = self.ctx.arena.get_identifier(name_node)?;
             let is_private = name_node.kind == SyntaxKind::PrivateIdentifier as u16;
             Some((
-                ident.escaped_text.clone(),
+                ident.escaped_text.to_string(),
                 binary.right,
                 is_private,
                 access.name_or_argument,
@@ -1124,7 +1124,11 @@ impl CheckerState<'_> {
             return Some((String::new(), true, access.name_or_argument));
         }
         let ident = self.ctx.arena.get_identifier(name_node)?;
-        Some((ident.escaped_text.clone(), false, access.name_or_argument))
+        Some((
+            ident.escaped_text.to_string(),
+            false,
+            access.name_or_argument,
+        ))
     }
 
     fn js_statement_has_direct_jsdoc_type_annotation(&self, idx: NodeIndex) -> bool {

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -311,7 +311,7 @@ impl<'a> CheckerState<'a> {
                     return Some(format!("__unique_{}", sym_ref.0));
                 }
 
-                Some(name.clone())
+                Some(name.to_string())
             }
             k if k == SyntaxKind::StringLiteral as u16
                 || k == SyntaxKind::NumericLiteral as u16

--- a/crates/tsz-checker/src/types/computation/class_member_annotation_circularity.rs
+++ b/crates/tsz-checker/src/types/computation/class_member_annotation_circularity.rs
@@ -228,7 +228,7 @@ impl CheckerState<'_> {
                 .arena
                 .get_identifier_at(qn.right)?
                 .escaped_text
-                .clone();
+                .to_string();
             return Some((side, MemberKey::Named(name)));
         }
 

--- a/crates/tsz-checker/src/types/computation/class_member_circularity.rs
+++ b/crates/tsz-checker/src/types/computation/class_member_circularity.rs
@@ -338,7 +338,7 @@ impl CheckerState<'_> {
             .ctx
             .arena
             .get_identifier_at(access.name_or_argument)
-            .map(|ident| ident.escaped_text.clone())?;
+            .map(|ident| ident.escaped_text.to_string())?;
         Some((target_static, name))
     }
 }

--- a/crates/tsz-checker/src/types/computation/complex_js_constructor.rs
+++ b/crates/tsz-checker/src/types/computation/complex_js_constructor.rs
@@ -135,7 +135,7 @@ impl<'a> CheckerState<'a> {
                         .get(name_idx)
                         .and_then(|n| self.ctx.arena.get_identifier(n))
                 })
-                .map(|ident| ident.escaped_text.clone())
+                .map(|ident| ident.escaped_text.to_string())
                 .or_else(|| {
                     expando_constructor_assignment
                         .as_ref()
@@ -152,7 +152,7 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get(var_decl.name)
                     .and_then(|n| self.ctx.arena.get_identifier(n))
-                    .map(|ident| ident.escaped_text.clone());
+                    .map(|ident| ident.escaped_text.to_string());
             }
             (func, func_name, analysis_expr_idx)
         } else {
@@ -180,7 +180,7 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get(func.name)
                     .and_then(|n| self.ctx.arena.get_identifier(n))
-                    .map(|ident| ident.escaped_text.clone());
+                    .map(|ident| ident.escaped_text.to_string());
                 (func, func_name, value_decl)
             } else if let Some(var_decl) = self.ctx.arena.get_variable_declaration(node) {
                 let init_node = self.ctx.arena.get(var_decl.initializer)?;
@@ -193,13 +193,13 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get(func.name)
                     .and_then(|n| self.ctx.arena.get_identifier(n))
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
                     .or_else(|| {
                         self.ctx
                             .arena
                             .get(var_decl.name)
                             .and_then(|n| self.ctx.arena.get_identifier(n))
-                            .map(|ident| ident.escaped_text.clone())
+                            .map(|ident| ident.escaped_text.to_string())
                     });
                 (func, func_name, var_decl.initializer)
             } else {
@@ -234,7 +234,7 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get(func.name)
                     .and_then(|n| self.ctx.arena.get_identifier(n))
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
                     .or_else(|| self.expression_text(value_decl));
                 (func, func_name, owner_idx)
             }
@@ -282,7 +282,7 @@ impl<'a> CheckerState<'a> {
                             .and_then(|param_node| self.ctx.arena.get_parameter(param_node))
                             .and_then(|param| self.ctx.arena.get(param.name))
                             .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                            .and_then(|ident| fallback.get(&ident.escaped_text).copied())
+                            .and_then(|ident| fallback.get(ident.escaped_text.as_str()).copied())
                             .unwrap_or(TypeId::ANY)
                     })
                     .collect();
@@ -326,7 +326,7 @@ impl<'a> CheckerState<'a> {
                         let param_data = self.ctx.arena.get_parameter(param_node)?;
                         let name_node = self.ctx.arena.get(param_data.name)?;
                         let ident = self.ctx.arena.get_identifier(name_node)?;
-                        Some((ident.escaped_text.clone(), param_info.type_id))
+                        Some((ident.escaped_text.to_string(), param_info.type_id))
                     })
                     .collect()
             } else {
@@ -809,7 +809,7 @@ impl<'a> CheckerState<'a> {
         }
         let name_node = self.ctx.arena.get(access.name_or_argument)?;
         let ident = self.ctx.arena.get_identifier(name_node)?;
-        let prop_name = ident.escaped_text.clone();
+        let prop_name = ident.escaped_text.to_string();
 
         // Determine type: @type annotation > param type > get_type_of_node
         let type_id = if let Some(jsdoc_type) = self.js_statement_declared_type(stmt_idx) {
@@ -819,7 +819,7 @@ impl<'a> CheckerState<'a> {
             let rhs_node = self.ctx.arena.get(rhs_idx)?;
             if rhs_node.kind == SyntaxKind::Identifier as u16 {
                 if let Some(rhs_ident) = self.ctx.arena.get_identifier(rhs_node) {
-                    if let Some(&param_type) = param_type_map.get(&rhs_ident.escaped_text) {
+                    if let Some(&param_type) = param_type_map.get(rhs_ident.escaped_text.as_str()) {
                         param_type
                     } else {
                         self.get_type_of_node(rhs_idx)

--- a/crates/tsz-checker/src/types/computation/delete_optionality.rs
+++ b/crates/tsz-checker/src/types/computation/delete_optionality.rs
@@ -59,7 +59,7 @@ impl<'a> CheckerState<'a> {
             self.ctx
                 .arena
                 .get_identifier_at(access.name_or_argument)
-                .map(|ident| ident.escaped_text.clone())
+                .map(|ident| ident.escaped_text.to_string())
                 .or_else(|| self.get_literal_string_from_node(access.name_or_argument))
                 .or_else(|| {
                     self.get_literal_index_from_node(access.name_or_argument)

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -1373,13 +1373,13 @@ impl<'a> CheckerState<'a> {
                 object_key.is_some_and(|object_key| {
                     let has_expando_property = self
                         .collect_expando_properties_for_root(&object_key)
-                        .contains(&member_name);
+                        .contains(member_name.as_str());
                     let has_last_segment_property =
                         object_key
                             .rsplit_once('.')
                             .is_some_and(|(_, last_segment)| {
                                 self.collect_expando_properties_for_root(last_segment)
-                                    .contains(&member_name)
+                                    .contains(member_name.as_str())
                             });
                     has_expando_property || has_last_segment_property
                 })

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -1135,7 +1135,7 @@ impl<'a> CheckerState<'a> {
                         );
                     }
 
-                    let name = ident.escaped_text.clone();
+                    let name = ident.escaped_text.to_string();
                     let shorthand_name_idx = shorthand.name;
 
                     // Get contextual type for this property

--- a/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
@@ -931,7 +931,7 @@ impl<'a> CheckerState<'a> {
         }
         let name_node = self.ctx.arena.get(var_decl.name)?;
         let ident = self.ctx.arena.get_identifier(name_node)?;
-        Some(ident.escaped_text.clone())
+        Some(ident.escaped_text.to_string())
     }
 
     /// Whether the expression subtree contains an identifier with the given

--- a/crates/tsz-checker/src/types/computed_names.rs
+++ b/crates/tsz-checker/src/types/computed_names.rs
@@ -93,7 +93,7 @@ fn member_access_parts(arena: &NodeArena, expr_idx: NodeIndex) -> Option<MemberA
 
     let name_node = arena.get(name)?;
     let member = if let Some(ident) = arena.get_identifier(name_node) {
-        Some(ident.escaped_text.clone())
+        Some(ident.escaped_text.to_string())
     } else if matches!(
         name_node.kind,
         k if k == SyntaxKind::StringLiteral as u16
@@ -108,7 +108,7 @@ fn member_access_parts(arena: &NodeArena, expr_idx: NodeIndex) -> Option<MemberA
 
     Some(MemberAccessParts {
         base,
-        base_text: base_ident.escaped_text.clone(),
+        base_text: base_ident.escaped_text.to_string(),
         member,
     })
 }

--- a/crates/tsz-checker/src/types/function_type/js_prototype.rs
+++ b/crates/tsz-checker/src/types/function_type/js_prototype.rs
@@ -324,7 +324,7 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get(name_idx)
                     .and_then(|n| self.ctx.arena.get_identifier(n))
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
             })
             && let Some(sym_id) = self.ctx.binder.get_node_symbol(func_idx)
         {
@@ -342,7 +342,7 @@ impl<'a> CheckerState<'a> {
             .arena
             .get(var_decl.name)
             .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-            .map(|ident| ident.escaped_text.clone())?;
+            .map(|ident| ident.escaped_text.to_string())?;
         let sym_id = self.ctx.binder.get_node_symbol(parent)?;
         Some((name, sym_id))
     }

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -1424,7 +1424,10 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get(data.name)
                     .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                    .map_or_else(|| "T".to_string(), |id_data| id_data.escaped_text.clone());
+                    .map_or_else(
+                        || "T".to_string(),
+                        |id_data| id_data.escaped_text.to_string(),
+                    );
                 let atom = self.ctx.types.intern_string(&name);
 
                 let is_const = self
@@ -1467,7 +1470,10 @@ impl<'a> CheckerState<'a> {
                 .arena
                 .get(data.name)
                 .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                .map_or_else(|| "T".to_string(), |id_data| id_data.escaped_text.clone());
+                .map_or_else(
+                    || "T".to_string(),
+                    |id_data| id_data.escaped_text.to_string(),
+                );
             let atom = self.ctx.types.intern_string(&name);
 
             let constraint_type = self.get_type_from_type_node(data.constraint);

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -268,7 +268,7 @@ impl<'a> CheckerState<'a> {
                                     .arena
                                     .get(param.name)
                                     .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                                    .map(|ident| ident.escaped_text.clone())
+                                    .map(|ident| ident.escaped_text.to_string())
                             })
                     })
                     .collect()

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -795,7 +795,7 @@ impl<'a> CheckerState<'a> {
                     };
                     let member_name = arena
                         .get_identifier(name_node)
-                        .map(|ident| ident.escaped_text.clone())
+                        .map(|ident| ident.escaped_text.to_string())
                         .or_else(|| arena.get_literal(name_node).map(|lit| lit.text.clone()));
                     let Some(member_name) = member_name else {
                         continue;
@@ -1372,7 +1372,7 @@ impl<'a> CheckerState<'a> {
         use tsz_parser::parser::syntax_kind_ext::COMPUTED_PROPERTY_NAME;
         let name_node = arena.get(name_idx)?;
         if let Some(ident) = arena.get_identifier(name_node) {
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
         if let Some(lit) = arena.get_literal(name_node) {
             return Some(lit.text.clone());

--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -94,7 +94,7 @@ impl<'a> CheckerState<'a> {
         match node.kind {
             k if k == SyntaxKind::Identifier as u16 => arena
                 .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone()),
+                .map(|ident| ident.escaped_text.to_string()),
             syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
                 let access = arena.get_access_expr(node)?;
                 let left = Self::expando_assignment_access_key_in_arena(arena, access.expression)?;
@@ -610,7 +610,7 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .arena
                 .get_identifier(name_node)
-                .map(|ident| ident.escaped_text.clone()),
+                .map(|ident| ident.escaped_text.to_string()),
             k if k == SyntaxKind::StringLiteral as u16
                 || k == SyntaxKind::NoSubstitutionTemplateLiteral as u16 =>
             {
@@ -1465,7 +1465,7 @@ impl<'a> CheckerState<'a> {
                     .ctx
                     .arena
                     .get_identifier_at(access.name_or_argument)
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
                 else {
                     return true;
                 };
@@ -1793,7 +1793,7 @@ impl<'a> CheckerState<'a> {
                 self.ctx
                     .arena
                     .get_identifier_at(access.name_or_argument)
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
             }
             syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => {
                 let access = self.ctx.arena.get_access_expr(node)?;
@@ -1880,7 +1880,7 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .arena
                 .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone()),
+                .map(|ident| ident.escaped_text.to_string()),
             syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
                 let access = self.ctx.arena.get_access_expr(node)?;
                 let left = self.expando_assignment_access_key(access.expression)?;
@@ -1961,7 +1961,7 @@ impl<'a> CheckerState<'a> {
                 self.ctx
                     .arena
                     .get_identifier_at(access.name_or_argument)
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
             }
             syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => {
                 let access = self.ctx.arena.get_access_expr(node)?;
@@ -2116,7 +2116,7 @@ impl<'a> CheckerState<'a> {
                 self.ctx
                     .arena
                     .get_identifier_at(access.name_or_argument)
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
             }
             syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => {
                 let access = self.ctx.arena.get_access_expr(node)?;

--- a/crates/tsz-checker/src/types/property_access_type/imported_array_to_enum.rs
+++ b/crates/tsz-checker/src/types/property_access_type/imported_array_to_enum.rs
@@ -18,7 +18,7 @@ impl<'a> CheckerState<'a> {
             self.ctx
                 .arena
                 .get_identifier(member_node)
-                .map(|ident| ident.escaped_text.clone())?
+                .map(|ident| ident.escaped_text.to_string())?
         } else if member_node.kind == SyntaxKind::StringLiteral as u16 {
             self.ctx
                 .arena

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -236,7 +236,7 @@ impl<'a> CheckerState<'a> {
             && self
                 .ctx
                 .import_conflict_names
-                .contains(&base_ident.escaped_text)
+                .contains(base_ident.escaped_text.as_str())
             && let Some(namespace_sym_id) = self
                 .ctx
                 .binder
@@ -680,7 +680,7 @@ impl<'a> CheckerState<'a> {
             .ctx
             .arena
             .get_identifier(name_node)
-            .map(|ident| ident.escaped_text.clone())
+            .map(|ident| ident.escaped_text.to_string())
             .or_else(|| self.current_file_commonjs_static_member_name(access.name_or_argument));
 
         if self.is_js_file()

--- a/crates/tsz-checker/src/types/queries/class.rs
+++ b/crates/tsz-checker/src/types/queries/class.rs
@@ -81,7 +81,7 @@ impl<'a> CheckerState<'a> {
         if let Some(ident) = self.ctx.arena.get_identifier(node) {
             self.ctx
                 .type_param_constraint_excluded_params
-                .insert(ident.escaped_text.clone());
+                .insert(ident.escaped_text.to_string());
             return;
         }
         if let Some(pattern) = self.ctx.arena.get_binding_pattern(node) {
@@ -137,7 +137,7 @@ impl<'a> CheckerState<'a> {
                 .arena
                 .get(data.name)
                 .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                .map(|id_data| id_data.escaped_text.clone())
+                .map(|id_data| id_data.escaped_text.to_string())
                 .unwrap_or_default();
             if !name.is_empty() && !name.starts_with('_') {
                 params.push((name, data.name, param_idx));
@@ -512,7 +512,7 @@ impl<'a> CheckerState<'a> {
                 return display_name;
             }
             if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
-                return ident.escaped_text.clone();
+                return ident.escaped_text.to_string();
             }
             if let Some(lit) = self.ctx.arena.get_literal(name_node) {
                 return lit.text.clone();
@@ -666,7 +666,7 @@ impl<'a> CheckerState<'a> {
                     .get_shorthand_property(elem_node)
                     .and_then(|shorthand| self.ctx.arena.get(shorthand.name))
                     .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
             } else {
                 None
             };
@@ -815,7 +815,8 @@ impl<'a> CheckerState<'a> {
                 binding_sym,
                 receiver_aliases,
             )
-            && (ident.escaped_text == name || !object_member_names.contains(&ident.escaped_text))
+            && (ident.escaped_text == name
+                || !object_member_names.contains(ident.escaped_text.as_str()))
         {
             return true;
         }
@@ -1067,7 +1068,7 @@ impl<'a> CheckerState<'a> {
             && let Some(name_node) = self.ctx.arena.get(access.name_or_argument)
             && let Some(ident) = self.ctx.arena.get_identifier(name_node)
         {
-            refs.push((access.name_or_argument, ident.escaped_text.clone()));
+            refs.push((access.name_or_argument, ident.escaped_text.to_string()));
         }
 
         match node.kind {

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -70,7 +70,7 @@ pub(crate) fn get_literal_property_name(arena: &NodeArena, name_idx: NodeIndex) 
 
     // Identifier
     if let Some(ident) = arena.get_identifier(name_node) {
-        return Some(ident.escaped_text.clone());
+        return Some(ident.escaped_text.to_string());
     }
 
     // String literal, no-substitution template literal, or numeric literal
@@ -468,7 +468,7 @@ impl<'a> CheckerState<'a> {
                         .arena
                         .get(class_data.name)
                         .and_then(|node| self.ctx.arena.get_identifier(node))
-                        .map(|ident| ident.escaped_text.clone())
+                        .map(|ident| ident.escaped_text.to_string())
                         .unwrap_or_default()
                 } else {
                     // Anonymous class expression — infer the name from an
@@ -513,7 +513,7 @@ impl<'a> CheckerState<'a> {
         }
         let name_node = self.ctx.arena.get(var_decl.name)?;
         let ident = self.ctx.arena.get_identifier(name_node)?;
-        Some(ident.escaped_text.clone())
+        Some(ident.escaped_text.to_string())
     }
 
     /// Returns true when `idx` is inside an instance property initializer of the
@@ -1567,7 +1567,7 @@ impl<'a> CheckerState<'a> {
             self.ctx
                 .arena
                 .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone())
+                .map(|ident| ident.escaped_text.to_string())
                 .or_else(|| {
                     (node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION)
                         .then(|| self.expression_text(idx))
@@ -1697,7 +1697,7 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get(class.name)
                     .and_then(|n| self.ctx.arena.get_identifier(n))
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
             });
         if let Some(name) = syntactic {
             return name;
@@ -1711,7 +1711,7 @@ impl<'a> CheckerState<'a> {
                 .arena
                 .get(var_decl.name)
                 .and_then(|n| self.ctx.arena.get_identifier(n))
-                .map(|ident| ident.escaped_text.clone())
+                .map(|ident| ident.escaped_text.to_string())
         {
             return name;
         }

--- a/crates/tsz-checker/src/types/queries/core_names.rs
+++ b/crates/tsz-checker/src/types/queries/core_names.rs
@@ -578,7 +578,7 @@ impl<'a> CheckerState<'a> {
         self.ctx.arena.get_identifier(base_node)?;
         let name_node = self.ctx.arena.get(access.name_or_argument)?;
         if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
-            return Some((access.expression, ident.escaped_text.clone()));
+            return Some((access.expression, ident.escaped_text.to_string()));
         }
         if matches!(
             name_node.kind,
@@ -710,7 +710,7 @@ impl<'a> CheckerState<'a> {
             && let Some(name_node) = self.ctx.arena.get(class.name)
             && let Some(ident) = self.ctx.arena.get_identifier(name_node)
         {
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
 
         let parent_idx = self
@@ -724,7 +724,7 @@ impl<'a> CheckerState<'a> {
         }
         let var_decl = self.ctx.arena.get_variable_declaration(parent_node)?;
         let name_ident = self.ctx.arena.get_identifier_at(var_decl.name)?;
-        Some(name_ident.escaped_text.clone())
+        Some(name_ident.escaped_text.to_string())
     }
 
     /// Get class name from a class declaration node.
@@ -904,7 +904,7 @@ impl<'a> CheckerState<'a> {
         {
             let name_node = self.ctx.arena.get(func.name)?;
             if let Some(id) = self.ctx.arena.get_identifier(name_node) {
-                return Some(id.escaped_text.clone());
+                return Some(id.escaped_text.to_string());
             }
         }
 
@@ -915,6 +915,6 @@ impl<'a> CheckerState<'a> {
     /// Returns None for destructuring patterns.
     pub(crate) fn get_parameter_name(&self, name_idx: NodeIndex) -> Option<String> {
         let ident = self.ctx.arena.get_identifier_at(name_idx)?;
-        Some(ident.escaped_text.clone())
+        Some(ident.escaped_text.to_string())
     }
 }

--- a/crates/tsz-checker/src/types/queries/infer_bindings.rs
+++ b/crates/tsz-checker/src/types/queries/infer_bindings.rs
@@ -49,7 +49,7 @@ impl<'a> CheckerState<'a> {
                     && let Some(ident) = self.ctx.arena.get_identifier(name_node)
                 {
                     params.push((
-                        ident.escaped_text.clone(),
+                        ident.escaped_text.to_string(),
                         param.constraint,
                         infer.type_parameter,
                     ));
@@ -240,7 +240,7 @@ impl<'a> CheckerState<'a> {
                     && let Some(name_node) = self.ctx.arena.get(param.name)
                     && let Some(ident) = self.ctx.arena.get_identifier(name_node)
                 {
-                    let name = ident.escaped_text.clone();
+                    let name = ident.escaped_text.to_string();
                     if !params.contains(&name) {
                         params.push(name);
                     }
@@ -453,7 +453,7 @@ impl<'a> CheckerState<'a> {
                         && let Some(name_node) = self.ctx.arena.get(tp_data.name)
                         && let Some(ident) = self.ctx.arena.get_identifier(name_node)
                     {
-                        let name = ident.escaped_text.clone();
+                        let name = ident.escaped_text.to_string();
                         if seen.insert(name.clone()) {
                             let constraint =
                                 span_infer_nodes.contains(&idx).then_some(TypeId::STRING);

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -459,7 +459,7 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .arena
                 .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone());
+                .map(|ident| ident.escaped_text.to_string());
         }
 
         if node.kind == syntax_kind_ext::QUALIFIED_NAME {

--- a/crates/tsz-checker/src/types/queries/lib_name_text.rs
+++ b/crates/tsz-checker/src/types/queries/lib_name_text.rs
@@ -10,7 +10,7 @@ pub(super) fn entity_name_text_in_arena(arena: &NodeArena, idx: NodeIndex) -> Op
     if node.kind == SyntaxKind::Identifier as u16 {
         return arena
             .get_identifier(node)
-            .map(|ident| ident.escaped_text.clone());
+            .map(|ident| ident.escaped_text.to_string());
     }
 
     if node.kind == syntax_kind_ext::QUALIFIED_NAME {

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -162,7 +162,7 @@ impl<'a> CheckerState<'a> {
         self.ctx
             .arena
             .get_identifier(node)
-            .map(|ident| ident.escaped_text.clone())
+            .map(|ident| ident.escaped_text.to_string())
     }
 
     /// Get identifier text from a node index, if it's an identifier.
@@ -300,7 +300,7 @@ impl<'a> CheckerState<'a> {
             }
 
             let name_text = if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
-                ident.escaped_text.clone()
+                ident.escaped_text.to_string()
             } else {
                 continue;
             };
@@ -1069,7 +1069,7 @@ impl<'a> CheckerState<'a> {
                 ) && self
                     .ctx
                     .type_parameter_scope
-                    .contains_key(&identifier.escaped_text)
+                    .contains_key(identifier.escaped_text.as_str())
             }
             k if k == syntax_kind_ext::PARENTHESIZED_TYPE => {
                 self.ctx.arena.get_wrapped_type(node).is_some_and(|paren| {

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -724,7 +724,7 @@ impl<'a> CheckerState<'a> {
                 && let Some(name_node) = self.ctx.arena.get(tp_data.name)
                 && let Some(ident) = self.ctx.arena.get_identifier(name_node)
             {
-                infer_params.push((ident.escaped_text.clone(), tp_data.name));
+                infer_params.push((ident.escaped_text.to_string(), tp_data.name));
             }
             for child in self.ctx.arena.get_children(idx) {
                 stack.push(child);
@@ -817,7 +817,7 @@ impl<'a> CheckerState<'a> {
         let Some(ident) = self.ctx.arena.get_identifier(name_node) else {
             return;
         };
-        let name = ident.escaped_text.clone();
+        let name = ident.escaped_text.to_string();
         let atom = self.ctx.types.intern_string(&name);
         let provisional_type_id = query::user_type_param(self.ctx.types, atom, None, None, false);
         let previous = self
@@ -829,7 +829,7 @@ impl<'a> CheckerState<'a> {
         // rather than the whole mapped type, to avoid side effects.
         let mut constraint_type = self.get_type_from_type_node(tp_data.constraint);
         if constraint_type == TypeId::ERROR {
-            self.ctx.type_parameter_scope.remove(&name);
+            self.ctx.type_parameter_scope.remove(name.as_str());
             if let Some(prev_type) = previous {
                 self.ctx.type_parameter_scope.insert(name, prev_type);
             }
@@ -882,7 +882,7 @@ impl<'a> CheckerState<'a> {
                 message,
                 2313,
             );
-            self.ctx.type_parameter_scope.remove(&name);
+            self.ctx.type_parameter_scope.remove(name.as_str());
             if let Some(prev_type) = previous {
                 self.ctx.type_parameter_scope.insert(name, prev_type);
             }
@@ -924,7 +924,7 @@ impl<'a> CheckerState<'a> {
                 message,
                 2313,
             );
-            self.ctx.type_parameter_scope.remove(&name);
+            self.ctx.type_parameter_scope.remove(name.as_str());
             if let Some(prev_type) = previous {
                 self.ctx.type_parameter_scope.insert(name, prev_type);
             }
@@ -1017,14 +1017,14 @@ impl<'a> CheckerState<'a> {
                 message,
                 2313,
             );
-            self.ctx.type_parameter_scope.remove(&name);
+            self.ctx.type_parameter_scope.remove(name.as_str());
             if let Some(prev_type) = previous {
                 self.ctx.type_parameter_scope.insert(name, prev_type);
             }
             return;
         }
         if is_deferred_index_access {
-            self.ctx.type_parameter_scope.remove(&name);
+            self.ctx.type_parameter_scope.remove(name.as_str());
             if let Some(prev_type) = previous {
                 self.ctx.type_parameter_scope.insert(name, prev_type);
             }
@@ -1081,7 +1081,7 @@ impl<'a> CheckerState<'a> {
             .type_parameter_scope
             .insert(name.clone(), constrained_type_id);
 
-        self.ctx.type_parameter_scope.remove(&name);
+        self.ctx.type_parameter_scope.remove(name.as_str());
         if let Some(prev_type) = previous {
             self.ctx.type_parameter_scope.insert(name, prev_type);
         }

--- a/crates/tsz-checker/src/types/type_checking/cross_file_conflicts.rs
+++ b/crates/tsz-checker/src/types/type_checking/cross_file_conflicts.rs
@@ -589,13 +589,13 @@ impl<'a> CheckerState<'a> {
                     .ctx
                     .arena
                     .get_identifier(clause_node)
-                    .map(|ident| ident.escaped_text.clone());
+                    .map(|ident| ident.escaped_text.to_string());
             }
         }
 
         self.get_declaration_name_node_in_arena(self.ctx.arena, decl_idx)
             .and_then(|name_idx| self.ctx.arena.get_identifier_at(name_idx))
-            .map(|ident| ident.escaped_text.clone())
+            .map(|ident| ident.escaped_text.to_string())
             .or_else(|| {
                 self.ctx
                     .binder

--- a/crates/tsz-checker/src/types/type_checking/declarations.rs
+++ b/crates/tsz-checker/src/types/type_checking/declarations.rs
@@ -60,7 +60,7 @@ impl<'a> CheckerState<'a> {
                 && let Some(ident) = self.ctx.arena.get_identifier(expr_node)
             {
                 if self.identifier_refers_to_unique_symbol(computed.expression) {
-                    return Some(ident.escaped_text.clone());
+                    return Some(ident.escaped_text.to_string());
                 }
 
                 // Plain identifiers that are not unique symbols are not
@@ -177,7 +177,7 @@ impl<'a> CheckerState<'a> {
             let name_node = self.ctx.arena.get(method.name)?;
 
             if let Some(id) = self.ctx.arena.get_identifier(name_node) {
-                return Some(id.escaped_text.clone());
+                return Some(id.escaped_text.to_string());
             }
 
             if let Some(lit) = self.ctx.arena.get_literal(name_node) {
@@ -1902,7 +1902,7 @@ impl<'a> CheckerState<'a> {
         let name_idx = self.get_declaration_name_node(decl_idx)?;
         let name_node = self.ctx.arena.get(name_idx)?;
         if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
         if let Some(lit) = self.ctx.arena.get_literal(name_node) {
             return Some(lit.text.clone());

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_constructor.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_constructor.rs
@@ -73,7 +73,7 @@ impl<'a> CheckerState<'a> {
                     continue;
                 };
                 let access = self.parameter_access_modifier(prop_data.modifiers.as_ref());
-                explicit_props.push((ident.escaped_text.clone(), prop_data.name, access));
+                explicit_props.push((ident.escaped_text.to_string(), prop_data.name, access));
             }
 
             let mut seen_param_props: FxHashSet<String> = FxHashSet::default();
@@ -197,7 +197,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
 
-            if !seen_param_props.insert(param_ident.escaped_text.clone()) {
+            if !seen_param_props.insert(param_ident.escaped_text.to_string()) {
                 let dup_msg = format_message(
                     diagnostic_messages::DUPLICATE_IDENTIFIER,
                     &[&param_ident.escaped_text],

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_global_augmentation.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_global_augmentation.rs
@@ -91,7 +91,7 @@ impl<'a> CheckerState<'a> {
                     };
                     let Some(member_name) = self.ctx.arena.get(member.name).and_then(|name_node| {
                         if let Some(ident) = self.ctx.arena.get_identifier(name_node) {
-                            Some(ident.escaped_text.clone())
+                            Some(ident.escaped_text.to_string())
                         } else {
                             self.ctx
                                 .arena

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
@@ -894,7 +894,7 @@ impl<'a> CheckerState<'a> {
 
                 let member_name =
                     if let Some(ident) = self.ctx.arena.get_identifier(member_name_node) {
-                        ident.escaped_text.clone()
+                        ident.escaped_text.to_string()
                     } else if let Some(literal) = self.ctx.arena.get_literal(member_name_node) {
                         literal.text.clone()
                     } else {
@@ -1000,7 +1000,7 @@ impl<'a> CheckerState<'a> {
                     continue;
                 };
                 let name = if let Some(ident) = self.ctx.arena.get_identifier(name_data) {
-                    ident.escaped_text.clone()
+                    ident.escaped_text.to_string()
                 } else if let Some(literal) = self.ctx.arena.get_literal(name_data) {
                     literal.text.clone()
                 } else {

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -1714,11 +1714,11 @@ impl<'a> CheckerState<'a> {
             let type_ref = self.ctx.arena.get_type_ref(node)?;
             let name_node = self.ctx.arena.get(type_ref.type_name)?;
             let ident = self.ctx.arena.get_identifier(name_node)?;
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
         if node.kind == SyntaxKind::Identifier as u16 {
             let ident = self.ctx.arena.get_identifier(node)?;
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
         None
     }

--- a/crates/tsz-checker/src/types/type_checking/property_init.rs
+++ b/crates/tsz-checker/src/types/type_checking/property_init.rs
@@ -297,7 +297,7 @@ impl<'a> CheckerState<'a> {
                     if let Some(name_node) = self.ctx.arena.get(access.name_or_argument)
                         && let Some(ident) = self.ctx.arena.get_identifier(name_node)
                     {
-                        accesses.push((ident.escaped_text.clone(), access.name_or_argument));
+                        accesses.push((ident.escaped_text.to_string(), access.name_or_argument));
                     }
                     return;
                 }
@@ -309,7 +309,8 @@ impl<'a> CheckerState<'a> {
                     if let Some(name_node) = self.ctx.arena.get(access.name_or_argument)
                         && let Some(prop_ident) = self.ctx.arena.get_identifier(name_node)
                     {
-                        accesses.push((prop_ident.escaped_text.clone(), access.name_or_argument));
+                        accesses
+                            .push((prop_ident.escaped_text.to_string(), access.name_or_argument));
                     }
                     return;
                 }
@@ -546,7 +547,7 @@ impl<'a> CheckerState<'a> {
                                 && let Some(prop_ident) = self.ctx.arena.get_identifier(name_node)
                             {
                                 accesses.push((
-                                    prop_ident.escaped_text.clone(),
+                                    prop_ident.escaped_text.to_string(),
                                     access.name_or_argument,
                                 ));
                             }
@@ -788,7 +789,8 @@ impl<'a> CheckerState<'a> {
                         if let Some(name_node) = self.ctx.arena.get(access.name_or_argument)
                             && let Some(ident) = self.ctx.arena.get_identifier(name_node)
                         {
-                            accesses.push((ident.escaped_text.clone(), access.name_or_argument));
+                            accesses
+                                .push((ident.escaped_text.to_string(), access.name_or_argument));
                         }
                     } else {
                         // Recurse into the expression part

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -253,7 +253,7 @@ impl<'a> CheckerState<'a> {
                 );
                 self.ctx
                     .type_parameter_scope
-                    .insert(ident.escaped_text.clone(), constrained_param);
+                    .insert(ident.escaped_text.to_string(), constrained_param);
             }
         }
         record_type_alias_phase_timing(
@@ -1091,7 +1091,7 @@ impl<'a> CheckerState<'a> {
                         && let Some(name_node) = self.ctx.arena.get(tp_data.name)
                         && let Some(ident) = self.ctx.arena.get_identifier(name_node)
                     {
-                        let name = ident.escaped_text.clone();
+                        let name = ident.escaped_text.to_string();
                         if !infer_names.contains(&name) {
                             infer_names.push(name);
                         }
@@ -1659,7 +1659,7 @@ impl<'a> CheckerState<'a> {
                         && let Some(name_node) = self.ctx.arena.get(tp_data.name)
                         && let Some(ident) = self.ctx.arena.get_identifier(name_node)
                     {
-                        let name = ident.escaped_text.clone();
+                        let name = ident.escaped_text.to_string();
                         let atom = self.ctx.types.intern_string(&name);
                         let mut constraint_type = TypeId::UNKNOWN;
                         if tp_data.constraint != tsz_parser::parser::NodeIndex::NONE {
@@ -1960,7 +1960,10 @@ impl<'a> CheckerState<'a> {
                 let param = self.ctx.arena.get_type_parameter(param_node)?;
                 let name_node = self.ctx.arena.get(param.name)?;
                 let ident = self.ctx.arena.get_identifier(name_node)?;
-                let type_id = self.ctx.type_parameter_scope.get(&ident.escaped_text)?;
+                let type_id = self
+                    .ctx
+                    .type_parameter_scope
+                    .get(ident.escaped_text.as_str())?;
                 crate::query_boundaries::checkers::generic::named_type_param_info(
                     self.ctx.types,
                     *type_id,

--- a/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
@@ -31,7 +31,7 @@ impl<'a> CheckerState<'a> {
             && self
                 .ctx
                 .type_parameter_scope
-                .contains_key(&identifier.escaped_text)
+                .contains_key(identifier.escaped_text.as_str())
         {
             return true;
         }
@@ -586,7 +586,7 @@ impl<'a> CheckerState<'a> {
 
         self.ctx
             .type_parameter_scope
-            .contains_key(&identifier.escaped_text)
+            .contains_key(identifier.escaped_text.as_str())
             || self
                 .identifier_references_enclosing_infer_binding(name_idx, &identifier.escaped_text)
     }
@@ -782,7 +782,7 @@ impl<'a> CheckerState<'a> {
             .ctx
             .arena
             .get_identifier(node)
-            .is_some_and(|identifier| names.contains(&identifier.escaped_text))
+            .is_some_and(|identifier| names.iter().any(|n| *n == identifier.escaped_text))
         {
             return true;
         }

--- a/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
@@ -491,7 +491,7 @@ impl<'a> CheckerState<'a> {
         let param = self.ctx.arena.get_type_parameter(param_node)?;
         let name_node = self.ctx.arena.get(param.name)?;
         let ident = self.ctx.arena.get_identifier(name_node)?;
-        Some(ident.escaped_text.clone())
+        Some(ident.escaped_text.to_string())
     }
 
     fn type_member_missing_name_coverage_is_safe(

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -807,12 +807,12 @@ impl<'a> CheckerState<'a> {
                 k if k == syntax_kind_ext::TYPE_ALIAS_DECLARATION => {
                     let alias = self.ctx.arena.get_type_alias(node)?;
                     let ident = self.ctx.arena.get_identifier_at(alias.name)?;
-                    return Some(ident.escaped_text.clone());
+                    return Some(ident.escaped_text.to_string());
                 }
                 k if k == syntax_kind_ext::VARIABLE_DECLARATION => {
                     let decl = self.ctx.arena.get_variable_declaration(node)?;
                     let ident = self.ctx.arena.get_identifier_at(decl.name)?;
-                    return Some(ident.escaped_text.clone());
+                    return Some(ident.escaped_text.to_string());
                 }
                 _ => {}
             }

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -707,7 +707,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     && let Some(name_node) = self.ctx.arena.get(tp_data.name)
                     && let Some(ident) = self.ctx.arena.get_identifier(name_node)
                 {
-                    local_type_params.insert(ident.escaped_text.clone());
+                    local_type_params.insert(ident.escaped_text.to_string());
                 }
             }
         }
@@ -784,14 +784,14 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             && let Some(name_node) = self.ctx.arena.get(tr.type_name)
             && let Some(ident) = self.ctx.arena.get_identifier(name_node)
         {
-            let name = &ident.escaped_text;
+            let name = ident.escaped_text.as_str();
             let is_builtin = is_builtin_type(name);
             let is_local_type_param = local_type_params.contains(name);
             let is_type_param = self.ctx.type_parameter_scope.contains_key(name);
             let in_scope = is_name_resolvable(self.ctx, name, tr.type_name);
 
             if !is_builtin && !is_local_type_param && !is_type_param && !in_scope {
-                undefined_types.push((tr.type_name, name.clone()));
+                undefined_types.push((tr.type_name, name.to_string()));
             }
         }
 
@@ -812,14 +812,14 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 && let Some(name_node) = self.ctx.arena.get(tr.type_name)
                 && let Some(ident) = self.ctx.arena.get_identifier(name_node)
             {
-                let name = &ident.escaped_text;
+                let name = ident.escaped_text.as_str();
                 let is_builtin = is_builtin_type(name);
                 let is_local_type_param = local_type_params.contains(name);
                 let is_type_param = self.ctx.type_parameter_scope.contains_key(name);
                 let in_scope = is_name_resolvable(self.ctx, name, tr.type_name);
 
                 if !is_builtin && !is_local_type_param && !is_type_param && !in_scope {
-                    undefined_types.push((tr.type_name, name.clone()));
+                    undefined_types.push((tr.type_name, name.to_string()));
                 }
             }
         }
@@ -1719,7 +1719,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         && name_node.kind == SyntaxKind::Identifier as u16
                         && let Some(name_ident) = self.ctx.arena.get_identifier(name_node)
                     {
-                        prefixes.push(name_ident.escaped_text.clone());
+                        prefixes.push(name_ident.escaped_text.to_string());
                     }
 
                     parent = self

--- a/crates/tsz-checker/src/types/type_node_helpers.rs
+++ b/crates/tsz-checker/src/types/type_node_helpers.rs
@@ -159,7 +159,7 @@ fn collect_names_in_type(
         if let Some(name) = ctx
             .arena
             .get_identifier(node)
-            .map(|i| i.escaped_text.clone())
+            .map(|i| i.escaped_text.to_string())
             && !seen.insert(name.clone())
         {
             let msg = crate::diagnostics::format_message(
@@ -514,7 +514,10 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 .arena
                 .get(data.name)
                 .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                .map_or_else(|| "T".to_string(), |id_data| id_data.escaped_text.clone());
+                .map_or_else(
+                    || "T".to_string(),
+                    |id_data| id_data.escaped_text.to_string(),
+                );
             let atom = self.ctx.types.intern_string(&name);
             let info = signature_building_boundary::user_type_param_info(atom, None, None, false);
             let type_id = signature_building_boundary::user_type_param(self.ctx.types, info);
@@ -536,7 +539,10 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 .arena
                 .get(data.name)
                 .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                .map_or_else(|| "T".to_string(), |id_data| id_data.escaped_text.clone());
+                .map_or_else(
+                    || "T".to_string(),
+                    |id_data| id_data.escaped_text.to_string(),
+                );
             let atom = self.ctx.types.intern_string(&name);
             let constraint =
                 (data.constraint != NodeIndex::NONE).then(|| self.check(data.constraint));

--- a/crates/tsz-checker/src/types/type_node_merged_value_query.rs
+++ b/crates/tsz-checker/src/types/type_node_merged_value_query.rs
@@ -11,7 +11,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         let name = self.ctx.arena.skip_parenthesized_and_assertions(name);
         let node = self.ctx.arena.get(name)?;
         if let Some(ident) = self.ctx.arena.get_identifier(node) {
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
         if node.kind == SyntaxKind::StringLiteral as u16
             || node.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -1332,7 +1332,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     let name = decl_arena
                         .get(param_data.name)
                         .and_then(|n| decl_arena.get_identifier(n))
-                        .map_or_else(|| "T".to_string(), |id| id.escaped_text.clone());
+                        .map_or_else(|| "T".to_string(), |id| id.escaped_text.to_string());
 
                     let atom = self.ctx.types.intern_string(&name);
                     let placeholder = tsz_solver::TypeParamInfo {
@@ -1358,7 +1358,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     let name = decl_arena
                         .get(param_data.name)
                         .and_then(|n| decl_arena.get_identifier(n))
-                        .map_or_else(|| "T".to_string(), |id| id.escaped_text.clone());
+                        .map_or_else(|| "T".to_string(), |id| id.escaped_text.to_string());
                     let atom = self.ctx.types.intern_string(&name);
 
                     let lowering = make_lowering(bindings.clone());

--- a/crates/tsz-checker/src/types/utilities/enum_eval.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_eval.rs
@@ -1191,13 +1191,13 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get_identifier(prop_node)?
                     .escaped_text
-                    .clone();
+                    .to_string();
 
                 // Recursively collect the object chain.
                 let obj_node = self.ctx.arena.get(access.expression)?;
                 if obj_node.kind == SyntaxKind::Identifier as u16 {
                     let ident = self.ctx.arena.get_identifier(obj_node)?;
-                    Some((vec![ident.escaped_text.clone()], member_name))
+                    Some((vec![ident.escaped_text.to_string()], member_name))
                 } else if obj_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
                     let (mut segments, last_segment) =
                         self.collect_access_chain(access.expression)?;
@@ -1223,7 +1223,7 @@ impl<'a> CheckerState<'a> {
                 let obj_node = self.ctx.arena.get(access.expression)?;
                 if obj_node.kind == SyntaxKind::Identifier as u16 {
                     let ident = self.ctx.arena.get_identifier(obj_node)?;
-                    Some((vec![ident.escaped_text.clone()], member_name))
+                    Some((vec![ident.escaped_text.to_string()], member_name))
                 } else if obj_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
                     let (mut segments, last_segment) =
                         self.collect_access_chain(access.expression)?;

--- a/crates/tsz-checker/src/types/utilities/enum_utils_readonly.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils_readonly.rs
@@ -160,6 +160,6 @@ impl<'a> CheckerState<'a> {
         }
 
         let ident = self.ctx.arena.get_identifier_at(class.name)?;
-        Some(ident.escaped_text.clone())
+        Some(ident.escaped_text.to_string())
     }
 }

--- a/crates/tsz-checker/tests/type_only_import_reexport_tests.rs
+++ b/crates/tsz-checker/tests/type_only_import_reexport_tests.rs
@@ -124,7 +124,7 @@ fn check_two_files_collect_export_specifiers(
                 let Some(ident) = arena.get_identifier(name_node) else {
                     continue;
                 };
-                specifiers.push((ident.escaped_text.clone(), spec_idx));
+                specifiers.push((ident.escaped_text.to_string(), spec_idx));
             }
         }
     }

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_structure.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_structure.rs
@@ -901,7 +901,7 @@ impl Server {
                             && let Some(name_node) = arena.get(clause.name)
                             && let Some(ident) = arena.get_identifier(name_node)
                         {
-                            local_bindings.push((clause.name, ident.escaped_text.clone()));
+                            local_bindings.push((clause.name, ident.escaped_text.to_string()));
                         }
                         // Namespace import (`import * as ns from "./a"`):
                         // record the local namespace identifier so the
@@ -959,7 +959,7 @@ impl Server {
                                     };
                                     let local = arena
                                         .get_identifier(name_node)
-                                        .map(|i| i.escaped_text.clone())
+                                        .map(|i| i.escaped_text.to_string())
                                         .unwrap_or_else(|| target_name.clone());
                                     local_bindings.push((specifier.name, local));
                                 }

--- a/crates/tsz-cli/src/driver/checker_lib_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/checker_lib_diagnostics.rs
@@ -203,9 +203,9 @@ fn collect_lib_interface_node_symbols(
         if stmt_node.kind == tsz::parser::syntax_kind_ext::INTERFACE_DECLARATION {
             if let Some(interface) = arena.get_interface(stmt_node)
                 && let Some(name) = arena.get_identifier_at(interface.name)
-                && affected_interfaces.contains(&name.escaped_text)
+                && affected_interfaces.contains(name.escaped_text.as_str())
                 && let Some(sym_id) = globals
-                    .get(&name.escaped_text)
+                    .get(name.escaped_text.as_str())
                     .or_else(|| fallback_node_symbols.get(&stmt_idx.0).copied())
             {
                 node_symbols.insert(stmt_idx.0, sym_id);
@@ -288,7 +288,7 @@ fn interface_name_text(arena: &NodeArena, stmt_idx: NodeIndex) -> Option<String>
     let node = arena.get(stmt_idx)?;
     let interface = arena.get_interface(node)?;
     let ident = arena.get_identifier_at(interface.name)?;
-    Some(ident.escaped_text.clone())
+    Some(ident.escaped_text.to_string())
 }
 
 fn entity_name_text_in_arena(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
@@ -301,7 +301,7 @@ fn entity_name_text_in_arena(arena: &NodeArena, idx: NodeIndex) -> Option<String
     if node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
         return arena
             .get_identifier(node)
-            .map(|ident| ident.escaped_text.clone());
+            .map(|ident| ident.escaped_text.to_string());
     }
     if node.kind == tsz::parser::syntax_kind_ext::QUALIFIED_NAME {
         let qn = arena.get_qualified_name(node)?;
@@ -422,13 +422,13 @@ fn member_name_text(arena: &NodeArena, member_idx: NodeIndex) -> Option<String> 
         return arena
             .get(sig.name)
             .and_then(|name_node| arena.get_identifier(name_node))
-            .map(|ident| ident.escaped_text.clone());
+            .map(|ident| ident.escaped_text.to_string());
     }
     if let Some(accessor) = arena.get_accessor(member_node) {
         return arena
             .get(accessor.name)
             .and_then(|name_node| arena.get_identifier(name_node))
-            .map(|ident| ident.escaped_text.clone());
+            .map(|ident| ident.escaped_text.to_string());
     }
     None
 }

--- a/crates/tsz-common/src/interner/ident_text.rs
+++ b/crates/tsz-common/src/interner/ident_text.rs
@@ -1,0 +1,311 @@
+//! Shared, immutable identifier text.
+//!
+//! [`IdentText`] is a cheap-to-clone handle to identifier text: a refcounted
+//! pointer into the per-file [`Interner`](super::Interner)'s string table (or,
+//! for synthesized/recovery identifiers, a standalone shared string). It
+//! replaces per-node owned `String`s so that the many occurrences of the same
+//! identifier in a file share one allocation instead of each carrying a copy.
+//!
+//! The type intentionally mirrors `String`'s read surface (`Deref<Target =
+//! str>`, `as_str`, `Display`, `Debug`, comparisons against `str`/`String`,
+//! ordering, hashing) so that read-only call sites compile unchanged. It has
+//! no mutation surface: identifier text is fixed at construction.
+//!
+//! Serialization is byte-compatible with `String` (serde serializes it as a
+//! plain string), so JSON IPC payloads and bincode arena snapshots keep their
+//! existing format.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Borrow;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, OnceLock};
+
+/// Shared immutable identifier text (see module docs).
+#[derive(Clone)]
+pub struct IdentText(Arc<str>);
+
+fn empty_arc() -> &'static Arc<str> {
+    static EMPTY: OnceLock<Arc<str>> = OnceLock::new();
+    EMPTY.get_or_init(|| Arc::from(""))
+}
+
+impl IdentText {
+    /// The empty identifier text. Does not allocate.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self(Arc::clone(empty_arc()))
+    }
+
+    /// Wrap an existing shared string without copying it.
+    #[must_use]
+    pub const fn from_arc(text: Arc<str>) -> Self {
+        Self(text)
+    }
+
+    /// View as `&str`.
+    #[must_use]
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Clone the underlying shared string handle.
+    #[must_use]
+    pub fn to_arc(&self) -> Arc<str> {
+        Arc::clone(&self.0)
+    }
+}
+
+impl Default for IdentText {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl std::ops::Deref for IdentText {
+    type Target = str;
+    #[inline]
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for IdentText {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<str> for IdentText {
+    #[inline]
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for IdentText {
+    fn from(s: &str) -> Self {
+        if s.is_empty() {
+            return Self::empty();
+        }
+        Self(Arc::from(s))
+    }
+}
+
+impl From<String> for IdentText {
+    fn from(s: String) -> Self {
+        if s.is_empty() {
+            return Self::empty();
+        }
+        Self(Arc::from(s))
+    }
+}
+
+impl From<Arc<str>> for IdentText {
+    fn from(s: Arc<str>) -> Self {
+        Self(s)
+    }
+}
+
+impl From<IdentText> for String {
+    fn from(s: IdentText) -> Self {
+        s.as_str().to_string()
+    }
+}
+
+impl From<IdentText> for std::borrow::Cow<'_, str> {
+    fn from(s: IdentText) -> Self {
+        std::borrow::Cow::Owned(s.as_str().to_string())
+    }
+}
+
+impl<'a> From<&'a IdentText> for std::borrow::Cow<'a, str> {
+    fn from(s: &'a IdentText) -> Self {
+        std::borrow::Cow::Borrowed(s.as_str())
+    }
+}
+
+impl From<&IdentText> for String {
+    fn from(s: &IdentText) -> Self {
+        s.as_str().to_string()
+    }
+}
+
+impl fmt::Display for IdentText {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.as_str(), f)
+    }
+}
+
+/// Matches `String`'s `Debug` (quoted string) so log/trace output is
+/// unchanged by the `String -> IdentText` migration.
+impl fmt::Debug for IdentText {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl PartialEq for IdentText {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        // Same-interner occurrences share one Arc; fall back to content
+        // comparison for text minted by different interners.
+        Arc::ptr_eq(&self.0, &other.0) || self.0 == other.0
+    }
+}
+
+impl Eq for IdentText {}
+
+impl PartialEq<str> for IdentText {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<&str> for IdentText {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl PartialEq<String> for IdentText {
+    #[inline]
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<IdentText> for str {
+    #[inline]
+    fn eq(&self, other: &IdentText) -> bool {
+        self == other.as_str()
+    }
+}
+
+impl PartialEq<IdentText> for &str {
+    #[inline]
+    fn eq(&self, other: &IdentText) -> bool {
+        *self == other.as_str()
+    }
+}
+
+impl PartialEq<IdentText> for String {
+    #[inline]
+    fn eq(&self, other: &IdentText) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+/// Hashes like `str`/`String` (and consistently with the `Borrow<str>` impl),
+/// so `IdentText` map keys behave exactly like the `String` keys they replace.
+impl Hash for IdentText {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
+impl PartialOrd for IdentText {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for IdentText {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl Serialize for IdentText {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for IdentText {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct V;
+        impl serde::de::Visitor<'_> for V {
+            type Value = IdentText;
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a string")
+            }
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<IdentText, E> {
+                Ok(IdentText::from(v))
+            }
+            fn visit_string<E: serde::de::Error>(self, v: String) -> Result<IdentText, E> {
+                Ok(IdentText::from(v))
+            }
+        }
+        deserializer.deserialize_str(V)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_is_shared_and_empty() {
+        let a = IdentText::empty();
+        let b = IdentText::default();
+        assert!(a.is_empty());
+        assert_eq!(a, b);
+        assert!(Arc::ptr_eq(&a.0, &b.0));
+    }
+
+    #[test]
+    fn compares_like_string() {
+        let t = IdentText::from("foo");
+        assert_eq!(t, "foo");
+        assert_eq!(t, *"foo");
+        assert_eq!("foo", t);
+        assert_eq!(t, String::from("foo"));
+        assert_eq!(String::from("foo"), t);
+        assert_ne!(t, "bar");
+    }
+
+    #[test]
+    fn ptr_sharing_and_content_equality() {
+        let shared: Arc<str> = Arc::from("name");
+        let a = IdentText::from_arc(Arc::clone(&shared));
+        let b = IdentText::from_arc(shared);
+        let c = IdentText::from("name");
+        assert_eq!(a, b);
+        assert_eq!(a, c); // different Arc, same content
+    }
+
+    #[test]
+    fn debug_and_display_match_string() {
+        let t = IdentText::from("x\\y");
+        let s = String::from("x\\y");
+        assert_eq!(format!("{t}"), format!("{s}"));
+        assert_eq!(format!("{t:?}"), format!("{s:?}"));
+    }
+
+    #[test]
+    fn serde_is_string_compatible() {
+        let t = IdentText::from("hello");
+        let json = serde_json::to_string(&t).unwrap();
+        assert_eq!(json, "\"hello\"");
+        let back: IdentText = serde_json::from_str("\"hello\"").unwrap();
+        assert_eq!(back, t);
+        // A String round-trips into IdentText and vice versa.
+        let from_string: IdentText =
+            serde_json::from_str(&serde_json::to_string(&String::from("s")).unwrap()).unwrap();
+        assert_eq!(from_string, "s");
+    }
+
+    #[test]
+    fn hashes_like_str() {
+        use std::collections::HashMap;
+        let mut m: HashMap<IdentText, u32> = HashMap::new();
+        m.insert(IdentText::from("k"), 1);
+        // Borrow<str> lookup
+        assert_eq!(m.get("k"), Some(&1));
+    }
+}

--- a/crates/tsz-common/src/interner/mod.rs
+++ b/crates/tsz-common/src/interner/mod.rs
@@ -12,6 +12,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, RwLock};
 
+mod ident_text;
+pub use ident_text::IdentText;
+
 // Interned string handle types. Each handle type names a distinct atom
 // namespace: handles minted by one interner kind must not be resolved by or
 // compared against another, and the distinct types make such cross-namespace
@@ -243,6 +246,20 @@ impl Interner {
     #[inline]
     pub fn try_resolve(&self, atom: AstAtom) -> Option<&str> {
         self.strings.get(atom.0 as usize).map(AsRef::as_ref)
+    }
+
+    /// Resolve an `AstAtom` to a shared [`IdentText`] handle.
+    ///
+    /// Clones the interner's existing `Arc<str>` (a refcount bump, no string
+    /// copy), so every resolution of the same atom shares one allocation.
+    /// Returns the empty text for out-of-bounds atoms, mirroring
+    /// [`Self::resolve`].
+    #[must_use]
+    #[inline]
+    pub fn resolve_text(&self, atom: AstAtom) -> IdentText {
+        self.strings
+            .get(atom.0 as usize)
+            .map_or_else(IdentText::empty, |s| IdentText::from_arc(Arc::clone(s)))
     }
 
     /// Get the number of interned strings.

--- a/crates/tsz-core/src/parallel/diagnostics.rs
+++ b/crates/tsz-core/src/parallel/diagnostics.rs
@@ -418,7 +418,7 @@ fn parallel_global_augmentation_member_name(
     if node.kind == SyntaxKind::Identifier as u16 {
         return arena
             .get_identifier(node)
-            .map(|ident| ident.escaped_text.clone());
+            .map(|ident| ident.escaped_text.to_string());
     }
     arena.get_literal(node).map(|literal| literal.text.clone())
 }
@@ -659,9 +659,9 @@ fn collect_lib_interface_node_symbols(
         if stmt_node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
             if let Some(interface) = arena.get_interface(stmt_node)
                 && let Some(name) = arena.get_identifier_at(interface.name)
-                && affected_interfaces.contains(&name.escaped_text)
+                && affected_interfaces.contains(name.escaped_text.as_str())
                 && let Some(sym_id) = globals
-                    .get(&name.escaped_text)
+                    .get(name.escaped_text.as_str())
                     .or_else(|| fallback_node_symbols.get(&stmt_idx.0).copied())
             {
                 node_symbols.insert(stmt_idx.0, sym_id);
@@ -742,7 +742,7 @@ fn interface_name_text(arena: &NodeArena, stmt_idx: NodeIndex) -> Option<String>
     let node = arena.get(stmt_idx)?;
     let interface = arena.get_interface(node)?;
     let ident = arena.get_identifier_at(interface.name)?;
-    Some(ident.escaped_text.clone())
+    Some(ident.escaped_text.to_string())
 }
 
 fn entity_name_text_in_arena(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
@@ -755,7 +755,7 @@ fn entity_name_text_in_arena(arena: &NodeArena, idx: NodeIndex) -> Option<String
     if node.kind == SyntaxKind::Identifier as u16 {
         return arena
             .get_identifier(node)
-            .map(|ident| ident.escaped_text.clone());
+            .map(|ident| ident.escaped_text.to_string());
     }
     if node.kind == syntax_kind_ext::QUALIFIED_NAME {
         let qn = arena.get_qualified_name(node)?;
@@ -876,13 +876,13 @@ fn member_name_text(arena: &NodeArena, member_idx: NodeIndex) -> Option<String> 
         return arena
             .get(sig.name)
             .and_then(|name_node| arena.get_identifier(name_node))
-            .map(|ident| ident.escaped_text.clone());
+            .map(|ident| ident.escaped_text.to_string());
     }
     if let Some(accessor) = arena.get_accessor(member_node) {
         return arena
             .get(accessor.name)
             .and_then(|name_node| arena.get_identifier(name_node))
-            .map(|ident| ident.escaped_text.clone());
+            .map(|ident| ident.escaped_text.to_string());
     }
     None
 }

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit_binding_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit_binding_types.rs
@@ -657,7 +657,7 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
 
-        Some(name.clone())
+        Some(name.to_string())
     }
 
     pub(in crate::declaration_emitter) fn initializer_references_elided_namespace_require_import(

--- a/crates/tsz-emitter/src/declaration_emitter/core/setup.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/setup.rs
@@ -549,7 +549,7 @@ impl<'a> DeclarationEmitter<'a> {
                         .arena
                         .get(import_eq.import_clause)
                         .and_then(|n| self.arena.get_identifier(n))
-                        .map(|id| id.escaped_text.clone())
+                        .map(|id| id.escaped_text.to_string())
                     else {
                         continue;
                     };

--- a/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
@@ -1262,7 +1262,7 @@ impl<'a> DeclarationEmitter<'a> {
                     continue;
                 };
                 if !names.iter().any(|name| name == &name_ident.escaped_text) {
-                    names.push(name_ident.escaped_text.clone());
+                    names.push(name_ident.escaped_text.to_string());
                 }
             }
         }

--- a/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
@@ -135,7 +135,7 @@ impl<'a> DeclarationEmitter<'a> {
             return Some(lit.text.clone());
         }
         if let Some(ident) = self.arena.get_identifier(node) {
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
         self.get_source_slice(node.pos, node.end)
     }
@@ -223,7 +223,7 @@ impl<'a> DeclarationEmitter<'a> {
             && let Some(ident) = self.arena.get_identifier(expr_node)
             && self
                 .emitted_js_export_default_names
-                .contains(&ident.escaped_text)
+                .contains(ident.escaped_text.as_str())
         {
             return;
         }
@@ -508,7 +508,7 @@ impl<'a> DeclarationEmitter<'a> {
                 && let Some(ident) = self.arena.get_identifier(expr_node)
                 && !self
                     .emitted_js_export_equals_names
-                    .insert(ident.escaped_text.clone())
+                    .insert(ident.escaped_text.to_string())
             {
                 return;
             }
@@ -1166,7 +1166,7 @@ impl<'a> DeclarationEmitter<'a> {
                 .source_is_js_file
                 .then(|| self.arena.get_identifier(expr_node))
                 .flatten()
-                .map(|ident| ident.escaped_text.clone())
+                .map(|ident| ident.escaped_text.to_string())
                 .filter(|name| self.js_export_default_names.contains(name));
             if deferred_name.is_some() {
                 self.emit_jsdoc_default_typedef_aliases_for_js_default_export_in_current_file();

--- a/crates/tsz-emitter/src/declaration_emitter/exports/value_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/value_declarations.rs
@@ -42,7 +42,7 @@ impl<'a> DeclarationEmitter<'a> {
     pub(crate) fn get_enum_member_name(&self, name_idx: NodeIndex) -> String {
         if let Some(name_node) = self.arena.get(name_idx) {
             if let Some(ident) = self.arena.get_identifier(name_node) {
-                return ident.escaped_text.clone();
+                return ident.escaped_text.to_string();
             }
             if let Some(lit) = self.arena.get_literal(name_node) {
                 return lit.text.clone();

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/emit_node.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/emit_node.rs
@@ -615,7 +615,7 @@ impl<'a> DeclarationEmitter<'a> {
                     let Some(name_ident) = self.arena.get_identifier(name_node) else {
                         continue;
                     };
-                    targets.insert(name_ident.escaped_text.clone(), stmt_idx);
+                    targets.insert(name_ident.escaped_text.to_string(), stmt_idx);
                 }
                 k if k == syntax_kind_ext::CLASS_DECLARATION => {
                     let Some(class) = self.arena.get_class(stmt_node) else {
@@ -627,7 +627,7 @@ impl<'a> DeclarationEmitter<'a> {
                     let Some(name_ident) = self.arena.get_identifier(name_node) else {
                         continue;
                     };
-                    targets.insert(name_ident.escaped_text.clone(), stmt_idx);
+                    targets.insert(name_ident.escaped_text.to_string(), stmt_idx);
                 }
                 k if k == syntax_kind_ext::VARIABLE_STATEMENT => {
                     let Some(var_stmt) = self.arena.get_variable(stmt_node) else {
@@ -666,7 +666,7 @@ impl<'a> DeclarationEmitter<'a> {
                                 supported = false;
                                 break;
                             };
-                            declaration_names.push(name_ident.escaped_text.clone());
+                            declaration_names.push(name_ident.escaped_text.to_string());
                         }
                         if !supported {
                             break;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/function_analysis.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/function_analysis.rs
@@ -658,7 +658,7 @@ impl<'a> DeclarationEmitter<'a> {
     ) -> Option<String> {
         let expr_node = self.arena.get(expr_idx)?;
         if let Some(identifier) = self.arena.get_identifier(expr_node) {
-            return Some(identifier.escaped_text.clone());
+            return Some(identifier.escaped_text.to_string());
         }
         self.arena
             .get_literal(expr_node)

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/js_exports.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/js_exports.rs
@@ -329,7 +329,7 @@ impl<'a> DeclarationEmitter<'a> {
             let Some(ident) = self.arena.get_identifier(expr_node) else {
                 continue;
             };
-            names.insert(ident.escaped_text.clone());
+            names.insert(ident.escaped_text.to_string());
         }
 
         if !self.source_file_has_native_esm_syntax(source_file) {
@@ -421,10 +421,10 @@ impl<'a> DeclarationEmitter<'a> {
             let Some(ident) = self.arena.get_identifier(expr_node) else {
                 continue;
             };
-            if !top_level_names.contains(&ident.escaped_text) {
+            if !top_level_names.contains(ident.escaped_text.as_str()) {
                 continue;
             }
-            names.insert(ident.escaped_text.clone());
+            names.insert(ident.escaped_text.to_string());
         }
 
         names
@@ -986,7 +986,7 @@ impl<'a> DeclarationEmitter<'a> {
             let Some(ident) = self.arena.get_identifier(expr_node) else {
                 continue;
             };
-            names.insert(ident.escaped_text.clone());
+            names.insert(ident.escaped_text.to_string());
         }
 
         names

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/js_exports_namespace.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/js_exports_namespace.rs
@@ -342,7 +342,7 @@ impl<'a> DeclarationEmitter<'a> {
             return false;
         };
         self.js_named_export_names
-            .contains(&name_ident.escaped_text)
+            .contains(name_ident.escaped_text.as_str())
     }
 
     pub(in crate::declaration_emitter) fn record_js_require_property_import_alias_statement(
@@ -752,7 +752,7 @@ impl<'a> DeclarationEmitter<'a> {
             return false;
         };
         self.js_export_equals_names
-            .contains(&name_ident.escaped_text)
+            .contains(name_ident.escaped_text.as_str())
     }
 
     pub(crate) fn emit_js_namespace_export_aliases_for_name(
@@ -890,7 +890,7 @@ impl<'a> DeclarationEmitter<'a> {
         };
         if !self
             .emitted_js_export_equals_names
-            .insert(name_ident.escaped_text.clone())
+            .insert(name_ident.escaped_text.to_string())
         {
             return;
         }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_check.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_check.rs
@@ -1008,7 +1008,7 @@ impl<'a> DeclarationEmitter<'a> {
                         collect.results.push(result);
                     }
                     if let Some(from_path) = self.check_nested_transitive_import(sym_id, binder) {
-                        let result = (from_path, identifier.escaped_text.clone());
+                        let result = (from_path, identifier.escaped_text.to_string());
                         if collect.seen.insert(result.clone()) {
                             collect.results.push(result);
                         }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
@@ -752,7 +752,7 @@ impl<'a> DeclarationEmitter<'a> {
     ) -> Option<String> {
         let node = arena.get(idx)?;
         if let Some(ident) = arena.get_identifier(node) {
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
         if let Some(qn) = arena.get_qualified_name(node) {
             return Self::rightmost_name_text_in_arena(arena, qn.right);

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_call.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_call.rs
@@ -1268,7 +1268,7 @@ fn arena_property_name_text(source_arena: &NodeArena, idx: NodeIndex) -> Option<
     match node.kind {
         k if k == SyntaxKind::Identifier as u16 => source_arena
             .get_identifier(node)
-            .map(|ident| ident.escaped_text.clone()),
+            .map(|ident| ident.escaped_text.to_string()),
         k if k == SyntaxKind::StringLiteral as u16 || k == SyntaxKind::NumericLiteral as u16 => {
             source_arena.get_literal(node).map(|lit| lit.text.clone())
         }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
@@ -226,14 +226,14 @@ impl<'a> DeclarationEmitter<'a> {
             self.arena
                 .get(ni)
                 .and_then(|n| self.arena.get_identifier(n))
-                .map(|ident| ident.escaped_text.clone())
+                .map(|ident| ident.escaped_text.to_string())
         } else if let Some(ident) = self.arena.get_identifier(decl_node) {
-            Some(ident.escaped_text.clone())
+            Some(ident.escaped_text.to_string())
         } else if let Some(clause_idx) = import_clause_idx {
             self.arena
                 .get(clause_idx)
                 .and_then(|n| self.arena.get_identifier(n))
-                .map(|ident| ident.escaped_text.clone())
+                .map(|ident| ident.escaped_text.to_string())
         } else {
             None
         };
@@ -1258,7 +1258,7 @@ impl<'a> DeclarationEmitter<'a> {
                 return self
                     .arena
                     .get_identifier(node)
-                    .map(|id| id.escaped_text.clone());
+                    .map(|id| id.escaped_text.to_string());
             }
         }
     }
@@ -1298,7 +1298,7 @@ impl<'a> DeclarationEmitter<'a> {
         // Extract identifier names directly
         if name_node.is_identifier() {
             let ident = self.arena.get_identifier(name_node)?;
-            Some(ident.escaped_text.clone())
+            Some(ident.escaped_text.to_string())
         } else {
             // For computed property names and other non-identifier names,
             // use the source text span as a key for overload tracking
@@ -1744,7 +1744,7 @@ impl<'a> DeclarationEmitter<'a> {
 
         // Try identifier first
         if let Some(ident) = self.arena.get_identifier(decl_node) {
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
 
         // For class/function/interface, the name is in a specific field
@@ -1752,7 +1752,7 @@ impl<'a> DeclarationEmitter<'a> {
             && let Some(name_node) = self.arena.get(func.name)
         {
             if let Some(ident) = self.arena.get_identifier(name_node) {
-                return Some(ident.escaped_text.clone());
+                return Some(ident.escaped_text.to_string());
             }
             if let Some(lit) = self.arena.get_literal(name_node) {
                 return Some(lit.text.clone());
@@ -1762,7 +1762,7 @@ impl<'a> DeclarationEmitter<'a> {
             && let Some(name_node) = self.arena.get(class.name)
         {
             if let Some(ident) = self.arena.get_identifier(name_node) {
-                return Some(ident.escaped_text.clone());
+                return Some(ident.escaped_text.to_string());
             }
             if let Some(lit) = self.arena.get_literal(name_node) {
                 return Some(lit.text.clone());
@@ -1772,7 +1772,7 @@ impl<'a> DeclarationEmitter<'a> {
             && let Some(name_node) = self.arena.get(iface.name)
         {
             if let Some(ident) = self.arena.get_identifier(name_node) {
-                return Some(ident.escaped_text.clone());
+                return Some(ident.escaped_text.to_string());
             }
             if let Some(lit) = self.arena.get_literal(name_node) {
                 return Some(lit.text.clone());
@@ -1782,7 +1782,7 @@ impl<'a> DeclarationEmitter<'a> {
             && let Some(name_node) = self.arena.get(alias.name)
         {
             if let Some(ident) = self.arena.get_identifier(name_node) {
-                return Some(ident.escaped_text.clone());
+                return Some(ident.escaped_text.to_string());
             }
             if let Some(lit) = self.arena.get_literal(name_node) {
                 return Some(lit.text.clone());
@@ -1792,7 +1792,7 @@ impl<'a> DeclarationEmitter<'a> {
             && let Some(name_node) = self.arena.get(enum_data.name)
         {
             if let Some(ident) = self.arena.get_identifier(name_node) {
-                return Some(ident.escaped_text.clone());
+                return Some(ident.escaped_text.to_string());
             }
             if let Some(lit) = self.arena.get_literal(name_node) {
                 return Some(lit.text.clone());

--- a/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/symbol_references.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/symbol_references.rs
@@ -49,7 +49,7 @@ impl UsageAnalyzer<'_> {
             return Some(sym_id);
         }
 
-        if let Some(&sym_id) = self.import_name_map.get(&ident.escaped_text)
+        if let Some(&sym_id) = self.import_name_map.get(ident.escaped_text.as_str())
             && let Some(sym_id) = self.type_query_value_dependency_symbol(sym_id)
         {
             return Some(sym_id);
@@ -212,7 +212,7 @@ impl UsageAnalyzer<'_> {
                             return;
                         }
                     }
-                    if let Some(&sym_id) = self.import_name_map.get(&ident.escaped_text) {
+                    if let Some(&sym_id) = self.import_name_map.get(ident.escaped_text.as_str()) {
                         if !self.is_current_ambient_module_self_import(sym_id, &ident.escaped_text)
                         {
                             self.mark_symbol_used(sym_id, kind);
@@ -289,7 +289,7 @@ impl UsageAnalyzer<'_> {
                     self.mark_symbol_used(sym_id, kind);
                 }
                 if let Some(ident) = self.arena.get_identifier(name_node) {
-                    if let Some(&sym_id) = self.import_name_map.get(&ident.escaped_text) {
+                    if let Some(&sym_id) = self.import_name_map.get(ident.escaped_text.as_str()) {
                         self.mark_symbol_used(sym_id, kind);
                     }
                     if let Some(sym_id) = self.binder.file_locals.get(&ident.escaped_text) {

--- a/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/value_references.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/value_references.rs
@@ -97,7 +97,7 @@ impl UsageAnalyzer<'_> {
             let ident = self.arena.get_identifier(expr_node)?;
             return self
                 .import_name_map
-                .get(&ident.escaped_text)
+                .get(ident.escaped_text.as_str())
                 .copied()
                 .or_else(|| self.binder.file_locals.get(&ident.escaped_text));
         }

--- a/crates/tsz-emitter/src/emitter/binding_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/binding_patterns.rs
@@ -1328,7 +1328,7 @@ impl<'a> Printer<'a> {
         if elem.property_name.is_some() {
             if let Some(prop_node) = self.arena.get(elem.property_name) {
                 if let Some(ident) = self.arena.get_identifier(prop_node) {
-                    return (ident.escaped_text.clone(), false);
+                    return (ident.escaped_text.to_string(), false);
                 }
                 if let Some(lit) = self.arena.get_literal(prop_node) {
                     return (lit.text.clone(), false);

--- a/crates/tsz-emitter/src/emitter/block_scope_shadow_seed.rs
+++ b/crates/tsz-emitter/src/emitter/block_scope_shadow_seed.rs
@@ -196,7 +196,7 @@ impl<'a> Printer<'a> {
         if name_node.is_identifier()
             && let Some(ident) = self.arena.get_identifier(name_node)
         {
-            out.push(ident.escaped_text.clone());
+            out.push(ident.escaped_text.to_string());
             return;
         }
         if matches!(

--- a/crates/tsz-emitter/src/emitter/declarations/namespace_export_destructuring.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/namespace_export_destructuring.rs
@@ -255,7 +255,7 @@ impl<'a> Printer<'a> {
     fn binding_element_export_name(&self, idx: NodeIndex) -> Option<String> {
         let node = self.arena.get(idx)?;
         if let Some(ident) = self.arena.get_identifier(node) {
-            return Some(ident.escaped_text.clone());
+            return Some(ident.escaped_text.to_string());
         }
         self.arena.get_literal(node).map(|lit| lit.text.clone())
     }
@@ -314,7 +314,7 @@ impl<'a> Printer<'a> {
                     && let Some(name_node) = self.arena.get(func.name)
                     && let Some(ident) = self.arena.get_identifier(name_node)
                 {
-                    return vec![ident.escaped_text.clone()];
+                    return vec![ident.escaped_text.to_string()];
                 }
             }
             k if k == syntax_kind_ext::CLASS_DECLARATION => {
@@ -322,7 +322,7 @@ impl<'a> Printer<'a> {
                     && let Some(name_node) = self.arena.get(class.name)
                     && let Some(ident) = self.arena.get_identifier(name_node)
                 {
-                    return vec![ident.escaped_text.clone()];
+                    return vec![ident.escaped_text.to_string()];
                 }
             }
             k if k == syntax_kind_ext::ENUM_DECLARATION => {
@@ -330,7 +330,7 @@ impl<'a> Printer<'a> {
                     && let Some(name_node) = self.arena.get(enum_decl.name)
                     && let Some(ident) = self.arena.get_identifier(name_node)
                 {
-                    return vec![ident.escaped_text.clone()];
+                    return vec![ident.escaped_text.to_string()];
                 }
             }
             k if k == syntax_kind_ext::IMPORT_EQUALS_DECLARATION => {

--- a/crates/tsz-emitter/src/emitter/es5/helpers_class_expression_names.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_class_expression_names.rs
@@ -89,7 +89,7 @@ impl<'a> Printer<'a> {
             return self
                 .arena
                 .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone());
+                .map(|ident| ident.escaped_text.to_string());
         }
         if node.kind == SyntaxKind::StringLiteral as u16
             || node.kind == SyntaxKind::NumericLiteral as u16

--- a/crates/tsz-emitter/src/emitter/expressions/call.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/call.rs
@@ -324,7 +324,7 @@ impl<'a> Printer<'a> {
             && let Some(ident) = self.arena.get_identifier(expr_node)
             && let Some(subst) = self
                 .commonjs_named_import_substitutions
-                .get(&ident.escaped_text)
+                .get(ident.escaped_text.as_str())
         {
             let subst = subst.clone();
             // In System modules, import substitutions are already property accesses

--- a/crates/tsz-emitter/src/emitter/expressions/literals.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/literals.rs
@@ -1037,7 +1037,7 @@ impl<'a> Printer<'a> {
                 let next_ident = self.arena.get_identifier(next_name)?;
                 let after_dot = cursor + 1;
                 let dot_tail = crate::safe_slice::slice(source, after_dot, search_end).ok()?;
-                let next_rel = dot_tail.find(&next_ident.escaped_text)?;
+                let next_rel = dot_tail.find(next_ident.escaped_text.as_str())?;
                 if dot_tail[..next_rel].contains('\n') {
                     return None;
                 }
@@ -1133,7 +1133,7 @@ impl<'a> Printer<'a> {
                 let has_import_subst = !self.suppress_commonjs_named_import_substitution
                     && self
                         .commonjs_named_import_substitutions
-                        .contains_key(&ident.escaped_text);
+                        .contains_key(ident.escaped_text.as_str());
                 let has_export_var = !self.suppress_ns_qualification
                     && self
                         .commonjs_exported_var_names
@@ -1325,7 +1325,7 @@ impl<'a> Printer<'a> {
             let has_import_subst = !self.suppress_commonjs_named_import_substitution
                 && self
                     .commonjs_named_import_substitutions
-                    .contains_key(&ident.escaped_text);
+                    .contains_key(ident.escaped_text.as_str());
             let has_export_var = !self.suppress_ns_qualification
                 && self
                     .commonjs_exported_var_names
@@ -1429,7 +1429,7 @@ impl<'a> Printer<'a> {
             || name_node.kind == SyntaxKind::PrivateIdentifier as u16
         {
             let ident = self.arena.get_identifier(name_node)?;
-            return (!ident.escaped_text.is_empty()).then(|| ident.escaped_text.clone());
+            return (!ident.escaped_text.is_empty()).then(|| ident.escaped_text.to_string());
         }
         if name_node.kind == SyntaxKind::StringLiteral as u16
             || name_node.kind == SyntaxKind::NumericLiteral as u16

--- a/crates/tsz-emitter/src/emitter/literals/core.rs
+++ b/crates/tsz-emitter/src/emitter/literals/core.rs
@@ -159,7 +159,9 @@ impl<'a> Printer<'a> {
             self.write("exports.");
             self.write_identifier(emit_text);
         } else if !self.suppress_commonjs_named_import_substitution
-            && let Some(subst) = self.commonjs_named_import_substitutions.get(original_text)
+            && let Some(subst) = self
+                .commonjs_named_import_substitutions
+                .get(original_text.as_str())
         {
             let subst = subst.clone();
             self.write(&subst);

--- a/crates/tsz-emitter/src/emitter/literals/template.rs
+++ b/crates/tsz-emitter/src/emitter/literals/template.rs
@@ -118,7 +118,7 @@ impl<'a> Printer<'a> {
             && let Some(ident) = self.arena.get_identifier(tag_node)
         {
             self.commonjs_named_import_substitutions
-                .get(&ident.escaped_text)
+                .get(ident.escaped_text.as_str())
                 .cloned()
         } else {
             None

--- a/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
@@ -301,12 +301,12 @@ impl<'a> Printer<'a> {
                     .ctx
                     .module_state
                     .iife_exported_names
-                    .contains(&name_str)
+                    .contains(name_str.as_str())
                     || self
                         .ctx
                         .module_state
                         .inline_exported_names
-                        .contains(&name_str)
+                        .contains(name_str.as_str())
                 {
                     continue;
                 }
@@ -1274,7 +1274,7 @@ impl<'a> Printer<'a> {
                     return None;
                 }
                 let ident = self.arena.get_identifier(name_node)?;
-                let decoded_name = ident.escaped_text.clone();
+                let decoded_name = ident.escaped_text.to_string();
                 // Use original_text (preserving unicode escapes) when available,
                 // falling back to escaped_text (decoded name). TSC preserves
                 // unicode escape sequences in emitted CJS inline exports.

--- a/crates/tsz-emitter/src/emitter/source_file/const_enums.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/const_enums.rs
@@ -878,7 +878,7 @@ impl<'a> Printer<'a> {
                     && let Some(name_node) = self.arena.get(decl.name)
                     && let Some(ident) = self.arena.get_identifier(name_node)
                 {
-                    names.push(ident.escaped_text.clone());
+                    names.push(ident.escaped_text.to_string());
                 }
             }
         }

--- a/crates/tsz-emitter/src/emitter/source_file/emit_parts/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit_parts/helpers.rs
@@ -45,7 +45,7 @@ impl<'a> Printer<'a> {
         // This mirrors TypeScript's `sourceFile.identifiers` used by `makeUniqueName`.
         self.file_identifiers.clear();
         for ident in &self.arena.identifiers {
-            self.file_identifiers.insert(ident.escaped_text.clone());
+            self.file_identifiers.insert(ident.escaped_text.to_string());
         }
         if !self.ctx.is_inside_module_wrapper_body() {
             self.commonjs_named_import_substitutions.clear();

--- a/crates/tsz-emitter/src/emitter/special_expressions.rs
+++ b/crates/tsz-emitter/src/emitter/special_expressions.rs
@@ -338,7 +338,7 @@ impl<'a> Printer<'a> {
         match expr_node.kind {
             k if k == SyntaxKind::Identifier as u16 => {
                 if let Some(ident) = self.arena.get_identifier(expr_node) {
-                    return ident.escaped_text.clone();
+                    return ident.escaped_text.to_string();
                 }
             }
             k if k == syntax_kind_ext::CALL_EXPRESSION => {

--- a/crates/tsz-emitter/src/emitter/statements/control_flow.rs
+++ b/crates/tsz-emitter/src/emitter/statements/control_flow.rs
@@ -830,7 +830,7 @@ impl<'a> Printer<'a> {
             let Some(ident) = self.arena.get_identifier(name_node) else {
                 return Vec::new();
             };
-            let local_name = ident.escaped_text.clone();
+            let local_name = ident.escaped_text.to_string();
             let Some(export_name) = bindings.get(&local_name).cloned() else {
                 return Vec::new();
             };
@@ -884,7 +884,7 @@ impl<'a> Printer<'a> {
             let Some(ident) = self.arena.get_identifier(name_node) else {
                 return Vec::new();
             };
-            let local_name = ident.escaped_text.clone();
+            let local_name = ident.escaped_text.to_string();
             let Some(export_name) = bindings.get(&local_name).cloned() else {
                 return Vec::new();
             };

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -1476,7 +1476,7 @@ impl<'a> Printer<'a> {
                     let Some(ident) = self.arena.get_identifier(name_node) else {
                         continue;
                     };
-                    deferred_names.push(ident.escaped_text.clone());
+                    deferred_names.push(ident.escaped_text.to_string());
                 }
             }
 

--- a/crates/tsz-emitter/src/emitter/transform_dispatch.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch.rs
@@ -1712,7 +1712,7 @@ impl<'a> Printer<'a> {
                             self.arena
                                 .identifiers
                                 .get(export_name as usize)
-                                .map(|ident| ident.escaped_text.clone())
+                                .map(|ident| ident.escaped_text.to_string())
                                 .unwrap_or_default()
                         } else {
                             String::new()

--- a/crates/tsz-emitter/src/emitter/transform_dispatch_chain.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch_chain.rs
@@ -575,7 +575,7 @@ impl<'a> Printer<'a> {
                 self.arena
                     .identifiers
                     .get(*name_id as usize)
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
             })
             .filter(|name| !name.is_empty())
             .collect();
@@ -622,7 +622,7 @@ impl<'a> Printer<'a> {
                 self.arena
                     .identifiers
                     .get(*name_id as usize)
-                    .map(|ident| ident.escaped_text.clone())
+                    .map(|ident| ident.escaped_text.to_string())
             })
             .filter(|name| !name.is_empty() && seen.insert(name.clone()))
             .collect()

--- a/crates/tsz-emitter/src/enums/evaluator.rs
+++ b/crates/tsz-emitter/src/enums/evaluator.rs
@@ -317,7 +317,7 @@ impl<'a> EnumEvaluator<'a> {
             k if k == SyntaxKind::Identifier as u16 => {
                 if let Some(ident) = self.arena.get_identifier(node) {
                     // Check current enum members first
-                    if let Some(value) = self.member_values.get(&ident.escaped_text) {
+                    if let Some(value) = self.member_values.get(ident.escaped_text.as_str()) {
                         return value.clone();
                     }
                     // Check prior blocks of the same merged enum (e.g.,
@@ -325,7 +325,7 @@ impl<'a> EnumEvaluator<'a> {
                     // are from earlier `enum Animals` blocks)
                     if let Some(ref enum_name) = self.current_enum_name
                         && let Some(prior) = self.all_enum_values.get(enum_name)
-                        && let Some(value) = prior.get(&ident.escaped_text)
+                        && let Some(value) = prior.get(ident.escaped_text.as_str())
                     {
                         return value.clone();
                     }
@@ -711,7 +711,7 @@ impl<'a> EnumEvaluator<'a> {
         };
 
         let prop_name = if let Some(ident) = self.arena.get_identifier(prop_node) {
-            ident.escaped_text.clone()
+            ident.escaped_text.to_string()
         } else if (prop_node.kind == SyntaxKind::StringLiteral as u16
             || prop_node.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16)
             && let Some(lit) = self.arena.get_literal(prop_node)

--- a/crates/tsz-emitter/src/enums/transform.rs
+++ b/crates/tsz-emitter/src/enums/transform.rs
@@ -325,7 +325,7 @@ impl<'a> EnumTransformer<'a> {
             }
             k if k == SyntaxKind::Identifier as u16 => {
                 if let Some(ident) = self.arena.get_identifier(node) {
-                    ident.escaped_text.clone()
+                    ident.escaped_text.to_string()
                 } else {
                     "undefined".to_string()
                 }

--- a/crates/tsz-emitter/src/lowering/core.rs
+++ b/crates/tsz-emitter/src/lowering/core.rs
@@ -155,7 +155,7 @@ impl<'a> LoweringPass<'a> {
                             self.arena
                                 .identifiers
                                 .get(*id as usize)
-                                .map(|ident| ident.escaped_text.clone())
+                                .map(|ident| ident.escaped_text.to_string())
                         })
                         .filter(|name| !name.is_empty())
                         .collect();

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -1315,7 +1315,7 @@ impl<'a> LoweringPass<'a> {
     pub(super) fn get_module_root_name_text(&self, name_idx: NodeIndex) -> Option<String> {
         let id = self.get_module_root_name(name_idx)?;
         let ident = self.arena.identifiers.get(id as usize)?;
-        Some(ident.escaped_text.clone())
+        Some(ident.escaped_text.to_string())
     }
 
     pub(super) fn get_block_like(

--- a/crates/tsz-emitter/src/passes/import_value_usage.rs
+++ b/crates/tsz-emitter/src/passes/import_value_usage.rs
@@ -276,7 +276,7 @@ impl<'a> UsageScan<'a> {
         let Some(name) = self
             .arena
             .get_identifier_at(import.import_clause)
-            .map(|ident| ident.escaped_text.clone())
+            .map(|ident| ident.escaped_text.to_string())
             .filter(|name| !name.is_empty())
         else {
             return;
@@ -845,7 +845,7 @@ impl<'a> UsageScan<'a> {
             return false;
         };
         let member = if let Some(ident) = self.arena.get_identifier(member_node) {
-            ident.escaped_text.clone()
+            ident.escaped_text.to_string()
         } else if let Some(lit) = self.arena.get_literal(member_node) {
             lit.text.clone()
         } else {

--- a/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
+++ b/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
@@ -537,7 +537,7 @@ fn collect_binding_pattern_names(arena: &NodeArena, name_idx: NodeIndex, out: &m
     };
     if name_node.is_identifier() {
         if let Some(ident) = arena.get_identifier(name_node) {
-            out.push(ident.escaped_text.clone());
+            out.push(ident.escaped_text.to_string());
         }
     } else if matches!(
         name_node.kind,
@@ -726,8 +726,8 @@ fn check_closure_capture(
                 && let Some(ident) = arena.get_identifier(node)
                 && loop_vars.contains(ident.escaped_text.as_str())
             {
-                if !info.captured_vars.contains(&ident.escaped_text) {
-                    info.captured_vars.push(ident.escaped_text.clone());
+                if !info.captured_vars.iter().any(|v| *v == ident.escaped_text) {
+                    info.captured_vars.push(ident.escaped_text.to_string());
                 }
                 info.needs_capture = true;
             }
@@ -1014,7 +1014,7 @@ pub fn collect_loop_vars(arena: &NodeArena, initializer_idx: NodeIndex) -> Vec<S
                 && name_node.is_identifier()
                 && let Some(ident) = arena.get_identifier(name_node)
             {
-                vars.push(ident.escaped_text.clone());
+                vars.push(ident.escaped_text.to_string());
             }
         }
     }

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -606,7 +606,7 @@ impl<'a> AstToIr<'a> {
                             .arena
                             .get(qn.right)
                             .and_then(|n| self.arena.get_identifier(n))
-                            .map_or_else(String::new, |id| id.escaped_text.clone())
+                            .map_or_else(String::new, |id| id.escaped_text.to_string())
                             .into(),
                     }
                 } else {
@@ -786,7 +786,10 @@ impl<'a> AstToIr<'a> {
                 return None; // Handled via ASTRef
             }
             // Try getting identifier via IdentifierData
-            self.arena.get_identifier(name_node)?.escaped_text.clone()
+            self.arena
+                .get_identifier(name_node)?
+                .escaped_text
+                .to_string()
         };
 
         let initializer = if var_decl.initializer.is_none() {

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_auto_accessor.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_auto_accessor.rs
@@ -420,7 +420,7 @@ impl<'a> ES5ClassTransformer<'a> {
             }
         } else if name_node.kind == SyntaxKind::Identifier as u16 {
             if let Some(ident) = self.arena.get_identifier(name_node) {
-                return Some(PropertyNameIR::Identifier(ident.escaped_text.clone()));
+                return Some(PropertyNameIR::Identifier(ident.escaped_text.to_string()));
             }
         } else if name_node.kind == SyntaxKind::StringLiteral as u16 {
             if let Some(lit) = self.arena.get_literal(name_node) {

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
@@ -507,7 +507,7 @@ pub(super) fn collect_auto_accessor_fields(
             if name_node.kind == SyntaxKind::Identifier as u16 {
                 let Some(name) = arena
                     .get_identifier(name_node)
-                    .map(|id| id.escaped_text.clone())
+                    .map(|id| id.escaped_text.to_string())
                 else {
                     continue;
                 };

--- a/crates/tsz-emitter/src/transforms/destructuring_es5.rs
+++ b/crates/tsz-emitter/src/transforms/destructuring_es5.rs
@@ -741,7 +741,7 @@ impl<'a> ES5DestructuringTransformer<'a> {
         };
 
         if let Some(ident) = self.arena.get_identifier(node) {
-            return ident.escaped_text.clone();
+            return ident.escaped_text.to_string();
         }
         if let Some(lit) = self.arena.get_literal(node) {
             return lit.text.clone();

--- a/crates/tsz-emitter/src/transforms/emit_utils.rs
+++ b/crates/tsz-emitter/src/transforms/emit_utils.rs
@@ -628,7 +628,9 @@ pub(crate) fn identifier_emit_text_or_empty(arena: &NodeArena, idx: NodeIndex) -
 pub(crate) fn specifier_name_text(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
     let node = arena.get(idx)?;
     if node.kind == SyntaxKind::Identifier as u16 {
-        arena.get_identifier(node).map(|id| id.escaped_text.clone())
+        arena
+            .get_identifier(node)
+            .map(|id| id.escaped_text.to_string())
     } else if node.kind == SyntaxKind::StringLiteral as u16 {
         arena.get_literal(node).map(|lit| lit.text.clone())
     } else {
@@ -651,7 +653,7 @@ pub(crate) fn enum_member_name(arena: &NodeArena, idx: NodeIndex) -> String {
         return String::new();
     }
     if let Some(ident) = arena.get_identifier(node) {
-        return ident.escaped_text.clone();
+        return ident.escaped_text.to_string();
     }
     if let Some(lit) = arena.get_literal(node) {
         return lit.text.clone();

--- a/crates/tsz-emitter/src/transforms/enum_es5.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5.rs
@@ -938,7 +938,7 @@ impl<'a> EnumES5Transformer<'a> {
                     let obj = self.transform_expression(access.expression);
                     let prop = if let Some(prop_node) = self.arena.get(access.name_or_argument) {
                         if let Some(ident) = self.arena.get_identifier(prop_node) {
-                            ident.escaped_text.clone()
+                            ident.escaped_text.to_string()
                         } else if let Some(lit) = self.arena.get_literal(prop_node) {
                             lit.text.clone()
                         } else {

--- a/crates/tsz-emitter/src/transforms/es_decorators_collection.rs
+++ b/crates/tsz-emitter/src/transforms/es_decorators_collection.rs
@@ -364,7 +364,7 @@ impl<'a> TC39DecoratorEmitter<'a> {
                 let text = self
                     .arena
                     .get_identifier(name_node)
-                    .map(|id| id.escaped_text.clone())
+                    .map(|id| id.escaped_text.to_string())
                     .unwrap_or_default();
                 (MemberName::Identifier(text), false)
             }
@@ -372,7 +372,7 @@ impl<'a> TC39DecoratorEmitter<'a> {
                 let text = self
                     .arena
                     .get_identifier(name_node)
-                    .map(|id| id.escaped_text.clone())
+                    .map(|id| id.escaped_text.to_string())
                     .unwrap_or_default();
                 (MemberName::Private(text), true)
             }

--- a/crates/tsz-emitter/src/transforms/module_commonjs.rs
+++ b/crates/tsz-emitter/src/transforms/module_commonjs.rs
@@ -1315,7 +1315,7 @@ pub fn collect_export_names_categorized(
     let mut reserved_default_names: FxHashSet<String> = arena
         .identifiers
         .iter()
-        .map(|ident| ident.escaped_text.clone())
+        .map(|ident| ident.escaped_text.to_string())
         .collect();
 
     // First pass: collect all function declaration names in the file (including

--- a/crates/tsz-emitter/src/transforms/module_commonjs_bindings.rs
+++ b/crates/tsz-emitter/src/transforms/module_commonjs_bindings.rs
@@ -40,7 +40,7 @@ fn collect_binding_names(arena: &NodeArena, name_idx: NodeIndex, exports: &mut V
 
     if node.kind == SyntaxKind::Identifier as u16 {
         if let Some(id) = arena.get_identifier(node) {
-            exports.push(id.escaped_text.clone());
+            exports.push(id.escaped_text.to_string());
         }
         return;
     }

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
@@ -934,7 +934,7 @@ impl<'a> NamespaceES5Transformer<'a> {
         } else if node.kind == SyntaxKind::Identifier as u16
             && let Some(ident) = self.arena.get_identifier(node)
         {
-            parts.push(ident.escaped_text.clone());
+            parts.push(ident.escaped_text.to_string());
         }
     }
 
@@ -960,7 +960,7 @@ impl<'a> NamespaceES5Transformer<'a> {
             // Get the name of this level
             let name_node = self.arena.get(ns_data.name)?;
             if let Some(ident) = self.arena.get_identifier(name_node) {
-                parts.push(ident.escaped_text.clone());
+                parts.push(ident.escaped_text.to_string());
             }
 
             // Check if body is another MODULE_DECLARATION (nested namespace) or MODULE_BLOCK

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir_helpers.rs
@@ -278,7 +278,7 @@ fn collect_binding_names(
     };
 
     if let Some(ident) = arena.get_identifier(node) {
-        names.insert(ident.escaped_text.clone());
+        names.insert(ident.escaped_text.to_string());
         return;
     }
 
@@ -391,7 +391,7 @@ fn collect_identifier_references_outside_blocks(
     match node.kind {
         k if k == SyntaxKind::Identifier as u16 => {
             if let Some(ident) = arena.get_identifier(node) {
-                names.insert(ident.escaped_text.clone());
+                names.insert(ident.escaped_text.to_string());
             }
         }
         k if k == syntax_kind_ext::BLOCK
@@ -813,7 +813,7 @@ fn namespace_assignment(ns_name: &str, name: &str, value: IRNode) -> IRNode {
 fn binding_property_name_text(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
     let node = arena.get(idx)?;
     if let Some(ident) = arena.get_identifier(node) {
-        return Some(ident.escaped_text.clone());
+        return Some(ident.escaped_text.to_string());
     }
     arena.get_literal(node).map(|lit| lit.text.clone())
 }
@@ -1310,7 +1310,7 @@ pub(super) fn collect_qualified_name_parts(
 
     if node.is_identifier() {
         if let Some(id) = arena.get_identifier(node) {
-            return Some(vec![id.escaped_text.clone()]);
+            return Some(vec![id.escaped_text.to_string()]);
         }
         return None;
     }
@@ -1603,7 +1603,7 @@ pub(super) fn collect_module_decl_parts_for_body_lookup(
         if let Some(name_node) = arena.get(ns_data.name)
             && let Some(id) = arena.get_identifier(name_node)
         {
-            parts.push(id.escaped_text.clone());
+            parts.push(id.escaped_text.to_string());
         }
 
         let body_node = arena.get(ns_data.body)?;

--- a/crates/tsz-emitter/src/transforms/private_fields_es5.rs
+++ b/crates/tsz-emitter/src/transforms/private_fields_es5.rs
@@ -193,7 +193,7 @@ pub fn get_private_field_name(arena: &NodeArena, name_idx: NodeIndex) -> Option<
         return None;
     }
     let ident = arena.get_identifier(node)?;
-    Some(ident.escaped_text.clone())
+    Some(ident.escaped_text.to_string())
 }
 
 /// Collect top-level value bindings visible to generated private-name helpers.
@@ -430,7 +430,7 @@ fn collect_identifier_binding_name(
     if node.kind == SyntaxKind::Identifier as u16
         && let Some(identifier) = arena.get_identifier(node)
     {
-        names.insert(identifier.escaped_text.clone());
+        names.insert(identifier.escaped_text.to_string());
     }
 }
 

--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -947,7 +947,7 @@ impl<'a> TypeLowering<'a> {
             return self
                 .arena
                 .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone());
+                .map(|ident| ident.escaped_text.to_string());
         }
 
         if node.kind == syntax_kind_ext::QUALIFIED_NAME {

--- a/crates/tsz-lsp/src/hierarchy/call_hierarchy.rs
+++ b/crates/tsz-lsp/src/hierarchy/call_hierarchy.rs
@@ -636,7 +636,7 @@ impl<'a> CallHierarchyProvider<'a> {
             } else if let Some(ident_node) = self.arena.get(callee_ident) {
                 // Last-resort fallback: no symbol found at all
                 if let Some(ident_data) = self.arena.get_identifier(ident_node) {
-                    let name = ident_data.escaped_text.clone();
+                    let name = ident_data.escaped_text.to_string();
                     let ident_range =
                         node_range(self.arena, self.line_map, self.source_text, callee_ident);
                     let entry = callees.entry(callee_ident.0).or_insert_with(|| {
@@ -863,7 +863,7 @@ impl<'a> CallHierarchyProvider<'a> {
             && let Some(symbol) = self.binder.symbols.get(sym_id)
             && let Some(&decl) = symbol.declarations.first()
         {
-            return Some((sym_id, decl, name.clone()));
+            return Some((sym_id, decl, name.to_string()));
         }
 
         None

--- a/crates/tsz-lsp/src/hierarchy/call_hierarchy/item_builder.rs
+++ b/crates/tsz-lsp/src/hierarchy/call_hierarchy/item_builder.rs
@@ -180,7 +180,7 @@ impl<'a> CallHierarchyProvider<'a> {
                     && let Some(prop_node) = self.arena.get(specifier.property_name)
                     && let Some(ident) = self.arena.get_identifier(prop_node)
                 {
-                    exported_name = Some(ident.escaped_text.clone());
+                    exported_name = Some(ident.escaped_text.to_string());
                 }
             }
             saw_import_kind = true;
@@ -226,7 +226,7 @@ impl<'a> CallHierarchyProvider<'a> {
                     && let Some(prop_node) = self.arena.get(specifier.property_name)
                     && let Some(ident) = self.arena.get_identifier(prop_node)
                 {
-                    exported_name = Some(ident.escaped_text.clone());
+                    exported_name = Some(ident.escaped_text.to_string());
                 }
                 saw_import_kind = true;
             }

--- a/crates/tsz-lsp/src/hover/core.rs
+++ b/crates/tsz-lsp/src/hover/core.rs
@@ -551,7 +551,7 @@ impl<'a> HoverProvider<'a> {
                     break self
                         .arena
                         .get_identifier(name_node)
-                        .map(|id| id.escaped_text.clone())
+                        .map(|id| id.escaped_text.to_string())
                         .filter(|s| !s.is_empty())
                         .unwrap_or_else(|| "this".to_string());
                 }
@@ -665,7 +665,7 @@ impl<'a> HoverProvider<'a> {
             let name_node = self.arena.get(class_data.name)?;
             self.arena
                 .get_identifier(name_node)
-                .map(|id| id.escaped_text.clone())
+                .map(|id| id.escaped_text.to_string())
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| "(Anonymous class)".to_string())
         } else {

--- a/crates/tsz-lsp/src/symbols/document_symbols/support.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols/support.rs
@@ -70,13 +70,13 @@ impl<'a> DocumentSymbolProvider<'a> {
                     if id.escaped_text.is_empty() {
                         None
                     } else {
-                        Some(id.escaped_text.clone())
+                        Some(id.escaped_text.to_string())
                     }
                 });
             } else if node.kind == SyntaxKind::PrivateIdentifier as u16 {
                 return self.arena.get_identifier(node).map(|id| {
                     if id.escaped_text.starts_with('#') {
-                        id.escaped_text.clone()
+                        id.escaped_text.to_string()
                     } else {
                         format!("#{}", id.escaped_text)
                     }

--- a/crates/tsz-lsp/src/symbols/symbol_index.rs
+++ b/crates/tsz-lsp/src/symbols/symbol_index.rs
@@ -352,15 +352,15 @@ impl SymbolIndex {
 
             // Add to name_to_files index
             self.name_to_files
-                .entry(text.clone())
+                .entry(text.to_string())
                 .or_default()
                 .insert(file_name_owned.clone());
 
             // Add to sorted names for prefix search
-            self.insert_sorted_name(text.clone());
+            self.insert_sorted_name(text.to_string());
 
             // Track in reverse mapping for efficient cleanup
-            file_symbol_names.insert(text.clone());
+            file_symbol_names.insert(text.to_string());
         }
 
         // Index all symbols in file_locals (top-level symbols/declarations)

--- a/crates/tsz-parser/src/parser/node.rs
+++ b/crates/tsz-parser/src/parser/node.rs
@@ -29,6 +29,7 @@ use super::base::{NodeIndex, NodeList};
 use super::node_pools::for_each_node_pool;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+pub use tsz_common::interner::IdentText;
 use tsz_common::interner::{AstAtom, Interner};
 
 /// A thin 16-byte node header for cache-efficient AST storage.
@@ -230,9 +231,13 @@ pub struct IdentifierData {
     /// the field became serialised).
     #[serde(default = "AstAtom::none")]
     pub atom: AstAtom,
-    /// The identifier text (DEPRECATED: kept for backward compatibility during migration)
-    pub escaped_text: String,
-    pub original_text: Option<String>,
+    /// The identifier's cooked text as a shared handle into the arena
+    /// interner's string table: all occurrences of the same identifier in a
+    /// file share one allocation instead of each node owning a `String` copy.
+    pub escaped_text: IdentText,
+    /// The original source spelling when it differs from the cooked text
+    /// (identifiers written with unicode escapes); `None` otherwise.
+    pub original_text: Option<IdentText>,
 }
 
 /// Data for string literals (`StringLiteral`, template parts)
@@ -1232,11 +1237,13 @@ impl NodeArenaInner {
 
         // ---- Heap strings inside pool elements ----
 
-        // IdentifierData: escaped_text + original_text
+        // IdentifierData: escaped_text is a shared handle into the interner's
+        // string table (counted by the interner's own estimate below), so only
+        // original_text — a standalone shared string — adds heap here
+        // (16-byte Arc header + string bytes).
         for id in &self.identifiers {
-            size += id.escaped_text.capacity();
             if let Some(ref s) = id.original_text {
-                size += s.capacity();
+                size += 16 + s.len();
             }
         }
 

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -969,7 +969,7 @@ impl Node {
 mod is_missing_recovery_identifier_tests {
     use super::*;
     use crate::parser::node::NodeArena;
-    use tsz_common::interner::AstAtom;
+    use tsz_common::interner::{AstAtom, IdentText};
     use tsz_scanner::SyntaxKind;
 
     #[test]
@@ -981,7 +981,7 @@ mod is_missing_recovery_identifier_tests {
             0,
             IdentifierData {
                 atom: AstAtom::NONE,
-                escaped_text: String::new(),
+                escaped_text: IdentText::empty(),
                 original_text: None,
             },
         );
@@ -999,7 +999,7 @@ mod is_missing_recovery_identifier_tests {
             3,
             IdentifierData {
                 atom: AstAtom(1),
-                escaped_text: "foo".to_string(),
+                escaped_text: IdentText::from("foo"),
                 original_text: None,
             },
         );
@@ -1015,7 +1015,7 @@ mod is_missing_recovery_identifier_tests {
             0,
             IdentifierData {
                 atom: AstAtom(1),
-                escaped_text: String::new(),
+                escaped_text: IdentText::empty(),
                 original_text: None,
             },
         );
@@ -1031,7 +1031,7 @@ mod is_missing_recovery_identifier_tests {
             3,
             IdentifierData {
                 atom: AstAtom::NONE,
-                escaped_text: "x".to_string(),
+                escaped_text: IdentText::from("x"),
                 original_text: None,
             },
         );

--- a/crates/tsz-parser/src/parser/node_arena/mod.rs
+++ b/crates/tsz-parser/src/parser/node_arena/mod.rs
@@ -281,6 +281,7 @@ impl NodeArenaInner {
 mod tests {
     use super::super::node::NodeArena;
     use super::*;
+    use tsz_common::interner::IdentText;
 
     #[test]
     fn estimated_size_bytes_is_nonzero_for_empty_arena() {
@@ -358,7 +359,7 @@ mod tests {
 
         let data = IdentifierData {
             atom: stale_atom,
-            escaped_text: "uniquely_named_identifier".to_string(),
+            escaped_text: IdentText::from("uniquely_named_identifier"),
             original_text: None,
         };
 
@@ -391,7 +392,7 @@ mod tests {
             atom,
             // escaped_text intentionally differs from the canonical so we
             // can confirm which branch was taken.
-            escaped_text: "stale_escaped_form".to_string(),
+            escaped_text: IdentText::from("stale_escaped_form"),
             original_text: None,
         };
 

--- a/crates/tsz-parser/src/parser/speculation.rs
+++ b/crates/tsz-parser/src/parser/speculation.rs
@@ -157,7 +157,7 @@ impl ParserState {
 mod tests {
     use super::*;
     use crate::parser::node::IdentifierData;
-    use tsz_common::interner::AstAtom;
+    use tsz_common::interner::{AstAtom, IdentText};
     use tsz_scanner::SyntaxKind;
 
     fn fresh_parser(source: &str) -> ParserState {
@@ -169,7 +169,7 @@ mod tests {
     fn make_test_identifier(text: &str) -> IdentifierData {
         IdentifierData {
             atom: AstAtom::NONE,
-            escaped_text: text.to_string(),
+            escaped_text: IdentText::from(text),
             original_text: None,
         }
     }

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -819,7 +819,7 @@ impl ParserState {
             end_pos,
             IdentifierData {
                 atom: AstAtom::NONE,
-                escaped_text: recovered,
+                escaped_text: recovered.into(),
                 original_text: None,
             },
         )

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -6,7 +6,7 @@ use crate::parser::{
     node::{EnumData, EnumMemberData, IdentifierData, ParameterData},
     syntax_kind_ext,
 };
-use tsz_common::interner::AstAtom;
+use tsz_common::interner::{AstAtom, IdentText};
 use tsz_scanner::SyntaxKind;
 
 fn is_reserved_interface_type_name(name: &str) -> bool {
@@ -115,7 +115,7 @@ impl ParserState {
                 name_end,
                 IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             )
@@ -1210,7 +1210,7 @@ impl ParserState {
             let id_start = self.token_pos();
             let id_end = self.token_end();
             let atom = self.scanner.get_token_atom();
-            let text = self.scanner.get_token_value_ref().to_string();
+            let text = self.scanner.token_ident_text();
             self.next_token(); // consume `void`
             // Emit TS1109 at the `=` position (matching TSC behavior)
             use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
@@ -1247,7 +1247,7 @@ impl ParserState {
                 id_end,
                 crate::parser::node::IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             )
@@ -1386,7 +1386,7 @@ impl ParserState {
                 end_pos,
                 IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             );

--- a/crates/tsz-parser/src/parser/state_declarations_modules.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_modules.rs
@@ -6,7 +6,7 @@ use crate::parser::{
     node::{IdentifierData, ImportClauseData, ImportDeclData, NamedImportsData, SpecifierData},
     node_flags, syntax_kind_ext,
 };
-use tsz_common::interner::AstAtom;
+use tsz_common::interner::{AstAtom, IdentText};
 use tsz_scanner::SyntaxKind;
 
 impl ParserState {
@@ -34,7 +34,7 @@ impl ParserState {
                 name_end,
                 IdentifierData {
                     atom: self.scanner.interner_mut().intern("global"),
-                    escaped_text: "global".to_string(),
+                    escaped_text: IdentText::from("global"),
                     original_text: None,
                 },
             )
@@ -58,7 +58,7 @@ impl ParserState {
                     name_end,
                     IdentifierData {
                         atom: AstAtom::NONE,
-                        escaped_text: String::new(),
+                        escaped_text: IdentText::empty(),
                         original_text: None,
                     },
                 )
@@ -83,7 +83,7 @@ impl ParserState {
                     name_end,
                     IdentifierData {
                         atom: AstAtom::NONE,
-                        escaped_text: String::new(),
+                        escaped_text: IdentText::empty(),
                         original_text: None,
                     },
                 )
@@ -130,7 +130,7 @@ impl ParserState {
                         name_end,
                         IdentifierData {
                             atom: AstAtom::NONE,
-                            escaped_text: String::new(),
+                            escaped_text: IdentText::empty(),
                             original_text: None,
                         },
                     )
@@ -210,7 +210,7 @@ impl ParserState {
                 name_end,
                 IdentifierData {
                     atom: self.scanner.interner_mut().intern("global"),
-                    escaped_text: "global".to_string(),
+                    escaped_text: IdentText::from("global"),
                     original_text: None,
                 },
             )
@@ -234,7 +234,7 @@ impl ParserState {
                     name_end,
                     IdentifierData {
                         atom: AstAtom::NONE,
-                        escaped_text: String::new(),
+                        escaped_text: IdentText::empty(),
                         original_text: None,
                     },
                 )
@@ -259,7 +259,7 @@ impl ParserState {
                     name_end,
                     IdentifierData {
                         atom: AstAtom::NONE,
-                        escaped_text: String::new(),
+                        escaped_text: IdentText::empty(),
                         original_text: None,
                     },
                 )
@@ -293,7 +293,7 @@ impl ParserState {
                         name_end,
                         IdentifierData {
                             atom: AstAtom::NONE,
-                            escaped_text: String::new(),
+                            escaped_text: IdentText::empty(),
                             original_text: None,
                         },
                     )
@@ -926,7 +926,7 @@ impl ParserState {
                 name_end,
                 IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             )
@@ -1164,7 +1164,7 @@ impl ParserState {
                 start_pos,
                 IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             );
@@ -1178,7 +1178,7 @@ impl ParserState {
             end_pos,
             IdentifierData {
                 atom: AstAtom::NONE,
-                escaped_text: String::new(),
+                escaped_text: IdentText::empty(),
                 original_text: None,
             },
         )

--- a/crates/tsz-parser/src/parser/state_exports_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_exports_recovery.rs
@@ -2,6 +2,7 @@ use super::state::*;
 use crate::parser::parse_rules::*;
 use crate::parser::{NodeIndex, syntax_kind_ext};
 use tsz_common::diagnostics::diagnostic_codes;
+use tsz_common::interner::IdentText;
 use tsz_scanner::{SyntaxKind, keyword_text_len};
 
 impl ParserState {
@@ -213,7 +214,7 @@ impl ParserState {
                 id_end,
                 crate::parser::node::IdentifierData {
                     atom: tsz_common::interner::AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             )

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -14,7 +14,7 @@ use crate::parser::{
     syntax_kind_ext,
 };
 use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
-use tsz_common::interner::AstAtom;
+use tsz_common::interner::{AstAtom, IdentText};
 use tsz_scanner::SyntaxKind;
 use tsz_scanner::keyword_text_len;
 use tsz_scanner::scanner_impl::TokenFlags;
@@ -111,7 +111,7 @@ impl ParserState {
                             end,
                             IdentifierData {
                                 atom: AstAtom::NONE,
-                                escaped_text: String::new(),
+                                escaped_text: IdentText::empty(),
                                 original_text: None,
                             },
                         )
@@ -1672,7 +1672,7 @@ impl ParserState {
             {
                 let msg = format_message(
                     diagnostic_messages::IS_NOT_A_VALID_META_PROPERTY_FOR_KEYWORD_DID_YOU_MEAN,
-                    &[&ident.escaped_text.to_string(), "new", "target"],
+                    &[ident.escaped_text.as_ref(), "new", "target"],
                 );
                 self.parse_error_at(
                     name_node.pos,

--- a/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
@@ -8,6 +8,7 @@ use crate::parser::{
     NodeIndex, node::IdentifierData, state::CONTEXT_FLAG_GENERATOR_MEMBER_NAME, syntax_kind_ext,
 };
 use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
+use tsz_common::interner::IdentText;
 use tsz_scanner::SyntaxKind;
 use tsz_scanner::scanner_impl::TokenFlags;
 
@@ -1124,7 +1125,7 @@ impl ParserState {
                             start_pos,
                             IdentifierData {
                                 atom: self.scanner.interner_mut().intern(""),
-                                escaped_text: String::new(),
+                                escaped_text: IdentText::empty(),
                                 original_text: None,
                             },
                         );
@@ -1133,8 +1134,8 @@ impl ParserState {
 
                 // OPTIMIZATION: Capture atom for O(1) comparison
                 let atom = self.scanner.get_token_atom();
-                // Use zero-copy accessor
-                let text = self.scanner.get_token_value_ref().to_string();
+                // Share the interner's allocation for the cooked text
+                let text = self.scanner.token_ident_text();
                 // Preserve unicode escape sequences for emission parity with tsc
                 let original_text =
                     if (self.scanner.get_token_flags() & TokenFlags::UnicodeEscape as u32) != 0 {
@@ -1143,8 +1144,8 @@ impl ParserState {
                         let end = self.scanner.get_token_end();
                         if start < end && end <= src.len() {
                             let slice = &src[start..end];
-                            if slice != text {
-                                Some(slice.to_string())
+                            if slice != text.as_str() {
+                                Some(IdentText::from(slice))
                             } else {
                                 None
                             }

--- a/crates/tsz-parser/src/parser/state_expressions_literals_object.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_object.rs
@@ -7,6 +7,7 @@ use crate::parser::{
     syntax_kind_ext,
 };
 use tsz_common::diagnostics::diagnostic_codes;
+use tsz_common::interner::IdentText;
 use tsz_scanner::SyntaxKind;
 
 impl ParserState {
@@ -140,7 +141,7 @@ impl ParserState {
             pos,
             IdentifierData {
                 atom,
-                escaped_text: String::new(),
+                escaped_text: IdentText::empty(),
                 original_text: None,
             },
         )

--- a/crates/tsz-parser/src/parser/state_expressions_tail.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_tail.rs
@@ -68,7 +68,7 @@ impl ParserState {
             end_pos,
             IdentifierData {
                 atom: AstAtom::NONE,
-                escaped_text: String::from("#"),
+                escaped_text: IdentText::from("#"),
                 original_text: None,
             },
         )
@@ -85,7 +85,7 @@ impl ParserState {
             end_pos,
             IdentifierData {
                 atom: AstAtom::NONE,
-                escaped_text: String::from("#"),
+                escaped_text: IdentText::from("#"),
                 original_text: None,
             },
         )
@@ -763,28 +763,31 @@ impl ParserState {
     /// Shared by [`Self::parse_identifier`] and [`Self::parse_identifier_name`]
     /// so identifier text/escape handling stays a single source of truth.
     #[inline]
-    fn read_cooked_identifier_text(&mut self) -> (AstAtom, String, Option<String>) {
+    fn read_cooked_identifier_text(&mut self) -> (AstAtom, IdentText, Option<IdentText>) {
         // OPTIMIZATION: Capture atom for O(1) comparison
         let atom = self.scanner.get_token_atom();
         let has_unicode_escape =
             (self.scanner.get_token_flags() & TokenFlags::UnicodeEscape as u32) != 0;
-        let src = self.scanner.source_text();
-        let start = self.scanner.get_token_start();
-        let end = self.scanner.get_token_end();
-        let source_slice = (start < end && end <= src.len()).then(|| &src[start..end]);
 
-        // Without escapes the raw source slice is the cooked text; otherwise
-        // fall back to the scanner's already-cooked token value.
-        let text = match source_slice {
-            Some(slice) if !has_unicode_escape => slice.to_string(),
-            _ => self.scanner.get_token_value_ref().to_string(),
-        };
+        // The scanner already interned the cooked text (the raw source slice
+        // when there are no escapes, the cooked value otherwise); share that
+        // allocation instead of copying it per identifier occurrence.
+        let text = self.scanner.token_ident_text();
+
         // tsc preserves unicode escape sequences in emitted identifiers: when the
         // scanner detected escapes, keep the original source slice if it differs
         // from the cooked text.
-        let original_text = match source_slice {
-            Some(slice) if has_unicode_escape && slice != text => Some(slice.to_string()),
-            _ => None,
+        let original_text = if has_unicode_escape {
+            let src = self.scanner.source_text();
+            let start = self.scanner.get_token_start();
+            let end = self.scanner.get_token_end();
+            let source_slice = (start < end && end <= src.len()).then(|| &src[start..end]);
+            match source_slice {
+                Some(slice) if slice != text.as_str() => Some(IdentText::from(slice)),
+                _ => None,
+            }
+        } else {
+            None
         };
         self.next_token();
         (atom, text, original_text)
@@ -808,7 +811,7 @@ impl ParserState {
                 end_pos,
                 IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             );
@@ -821,7 +824,7 @@ impl ParserState {
             self.read_cooked_identifier_text()
         } else {
             self.error_identifier_expected();
-            (AstAtom::NONE, String::new(), None)
+            (AstAtom::NONE, IdentText::empty(), None)
         };
 
         self.arena.add_identifier(
@@ -877,7 +880,7 @@ impl ParserState {
             (atom, text, original_text)
         } else {
             self.error_identifier_expected();
-            (AstAtom::NONE, String::new(), None)
+            (AstAtom::NONE, IdentText::empty(), None)
         };
 
         self.arena.add_identifier(
@@ -899,7 +902,7 @@ impl ParserState {
         let end_pos = self.token_end();
         // OPTIMIZATION: Capture atom for O(1) comparison
         let atom = self.scanner.get_token_atom();
-        let text = self.scanner.get_token_value_ref().to_string();
+        let text = self.scanner.token_ident_text();
         self.parse_expected(SyntaxKind::PrivateIdentifier);
 
         self.arena.add_identifier(

--- a/crates/tsz-parser/src/parser/state_expressions_unary.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_unary.rs
@@ -1,4 +1,5 @@
 use tsz_common::diagnostics::diagnostic_codes;
+use tsz_common::interner::IdentText;
 
 /// Parser state - unary, postfix, await, and yield expression parsing
 use super::state::{CONTEXT_FLAG_ARROW_PARAMETERS, ParserState};
@@ -215,7 +216,7 @@ impl ParserState {
                     end_pos,
                     crate::parser::node::IdentifierData {
                         atom,
-                        escaped_text: String::from("await"),
+                        escaped_text: IdentText::from("await"),
                         original_text: None,
                     },
                 );
@@ -402,7 +403,7 @@ impl ParserState {
                 end_pos,
                 IdentifierData {
                     atom,
-                    escaped_text: String::from("yield"),
+                    escaped_text: IdentText::from("yield"),
                     original_text: None,
                 },
             );

--- a/crates/tsz-parser/src/parser/state_recovery_helpers.rs
+++ b/crates/tsz-parser/src/parser/state_recovery_helpers.rs
@@ -514,7 +514,7 @@ impl ParserState {
             pos,
             IdentifierData {
                 atom: AstAtom::NONE,
-                escaped_text: String::new(),
+                escaped_text: IdentText::empty(),
                 original_text: None,
             },
         )

--- a/crates/tsz-parser/src/parser/state_statements_class.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class.rs
@@ -10,7 +10,7 @@ use crate::parser::{
     syntax_kind_ext,
 };
 use tsz_common::diagnostics::diagnostic_codes;
-use tsz_common::interner::AstAtom;
+use tsz_common::interner::{AstAtom, IdentText};
 use tsz_scanner::SyntaxKind;
 
 impl ParserState {
@@ -1071,7 +1071,7 @@ impl ParserState {
                 reserved_end,
                 IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             )
@@ -1130,7 +1130,7 @@ impl ParserState {
                 reserved_end,
                 IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             )
@@ -1155,7 +1155,7 @@ impl ParserState {
                     reserved_end,
                     IdentifierData {
                         atom: AstAtom::NONE,
-                        escaped_text: String::new(),
+                        escaped_text: IdentText::empty(),
                         original_text: None,
                     },
                 )
@@ -1177,7 +1177,7 @@ impl ParserState {
                     reserved_end,
                     IdentifierData {
                         atom: AstAtom::NONE,
-                        escaped_text: String::new(),
+                        escaped_text: IdentText::empty(),
                         original_text: None,
                     },
                 )

--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -11,7 +11,7 @@ use crate::parser::{
     syntax_kind_ext,
 };
 use tsz_common::diagnostics::diagnostic_codes;
-use tsz_common::interner::AstAtom;
+use tsz_common::interner::{AstAtom, IdentText};
 use tsz_scanner::SyntaxKind;
 
 /// Pre-classified modifier flags for a single class member, computed in one
@@ -1753,7 +1753,7 @@ impl ParserState {
                 pos,
                 node::IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             )
@@ -1975,7 +1975,7 @@ impl ParserState {
             .get_identifier(name_node)
             .and_then(|ident| ident.original_text.clone())
         {
-            return Some(original);
+            return Some(String::from(original));
         }
         let text = self.arena.identifier_text(name)?;
         if text.is_empty() {

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -890,7 +890,7 @@ impl ParserState {
         if let Some(label_name) = label_name
             && let Some(current_scope) = self.label_scopes.last_mut()
         {
-            current_scope.remove(&label_name);
+            current_scope.remove(label_name.as_str());
         }
 
         let end_pos = self.token_end();
@@ -941,7 +941,7 @@ impl ParserState {
                 name_end,
                 IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             )

--- a/crates/tsz-parser/src/parser/state_type_parameters.rs
+++ b/crates/tsz-parser/src/parser/state_type_parameters.rs
@@ -15,7 +15,7 @@ use crate::parser::{
     syntax_kind_ext,
 };
 use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
-use tsz_common::interner::AstAtom;
+use tsz_common::interner::{AstAtom, IdentText};
 use tsz_scanner::SyntaxKind;
 
 impl ParserState {
@@ -146,7 +146,7 @@ impl ParserState {
                 pos,
                 IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             )

--- a/crates/tsz-parser/src/parser/state_types.rs
+++ b/crates/tsz-parser/src/parser/state_types.rs
@@ -2,7 +2,7 @@
 
 use super::state::ParserState;
 use crate::parser::{NodeIndex, NodeList, syntax_kind_ext};
-use tsz_common::interner::AstAtom;
+use tsz_common::interner::{AstAtom, IdentText};
 use tsz_scanner::SyntaxKind;
 
 impl ParserState {
@@ -500,7 +500,7 @@ impl ParserState {
                     q_end,
                     crate::parser::node::IdentifierData {
                         atom: AstAtom::NONE,
-                        escaped_text: String::new(),
+                        escaped_text: IdentText::empty(),
                         original_text: None,
                     },
                 );
@@ -550,7 +550,7 @@ impl ParserState {
                     bang_end,
                     crate::parser::node::IdentifierData {
                         atom: tsz_common::interner::AstAtom::NONE,
-                        escaped_text: String::new(),
+                        escaped_text: IdentText::empty(),
                         original_text: None,
                     },
                 );
@@ -604,7 +604,7 @@ impl ParserState {
                 end,
                 crate::parser::node::IdentifierData {
                     atom: tsz_common::interner::AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             );
@@ -627,7 +627,7 @@ impl ParserState {
                 self.token_pos(),
                 crate::parser::node::IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             );
@@ -820,7 +820,7 @@ impl ParserState {
                 name_pos,
                 crate::parser::node::IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: format!("arg{index}"),
+                    escaped_text: format!("arg{index}").into(),
                     original_text: None,
                 },
             );

--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -2,6 +2,7 @@
 
 use super::state::ParserState;
 use crate::parser::{NodeIndex, NodeList, node, syntax_kind_ext};
+use tsz_common::interner::IdentText;
 use tsz_scanner::SyntaxKind;
 
 impl ParserState {
@@ -1503,7 +1504,7 @@ impl ParserState {
                 question_end,
                 crate::parser::node::IdentifierData {
                     atom: tsz_common::interner::AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             );
@@ -1523,7 +1524,7 @@ impl ParserState {
                 question_end,
                 crate::parser::node::IdentifierData {
                     atom: tsz_common::interner::AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             );

--- a/crates/tsz-parser/src/parser/state_types_jsx.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx.rs
@@ -2,6 +2,7 @@
 
 use super::state::{ParseDiagnostic, ParserState};
 use crate::parser::{NodeArena, NodeIndex, NodeList, node, syntax_kind_ext};
+use tsz_common::interner::IdentText;
 use tsz_scanner::SyntaxKind;
 
 impl ParserState {
@@ -390,7 +391,7 @@ impl ParserState {
 
             // Advance manually because we are returning early in this branch.
             let atom = self.scanner.get_token_atom();
-            let text = self.scanner.get_token_value_ref().to_string();
+            let text = self.scanner.token_ident_text();
             self.next_token();
             return self.arena.add_identifier(
                 SyntaxKind::Identifier as u16,
@@ -408,7 +409,7 @@ impl ParserState {
         let end_pos = self.token_end();
         // OPTIMIZATION: Capture atom for O(1) comparison
         let atom = self.scanner.get_token_atom();
-        let text = self.scanner.get_token_value_ref().to_string();
+        let text = self.scanner.token_ident_text();
         self.next_token();
 
         self.arena.add_identifier(
@@ -499,7 +500,7 @@ impl ParserState {
                             dot_end,
                             crate::parser::node::IdentifierData {
                                 atom: tsz_common::interner::AstAtom::NONE,
-                                escaped_text: String::new(),
+                                escaped_text: IdentText::empty(),
                                 original_text: None,
                             },
                         )

--- a/crates/tsz-parser/src/parser/state_types_jsx_elements.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx_elements.rs
@@ -781,7 +781,7 @@ impl ParserState {
                 missing_pos,
                 node::IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             );
@@ -889,7 +889,7 @@ impl ParserState {
                     end,
                     crate::parser::node::IdentifierData {
                         atom: AstAtom::NONE,
-                        escaped_text: String::new(),
+                        escaped_text: IdentText::empty(),
                         original_text: None,
                     },
                 )

--- a/crates/tsz-parser/src/parser/state_variable_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_variable_declarations.rs
@@ -172,7 +172,7 @@ impl ParserState {
                 end_pos,
                 IdentifierData {
                     atom: AstAtom::NONE,
-                    escaped_text: String::new(),
+                    escaped_text: IdentText::empty(),
                     original_text: None,
                 },
             )
@@ -439,7 +439,7 @@ impl ParserState {
             let name_start = self.token_pos();
             let name_end = self.token_end();
             let atom = self.scanner.get_token_atom();
-            let text = self.scanner.get_token_value_ref().to_string();
+            let text = self.scanner.token_ident_text();
             self.error_reserved_word_identifier();
             // tsc emits TS1359 + TS1003 specifically when the function name is
             // itself the `function` keyword (e.g. `function function() {}`).

--- a/crates/tsz-parser/tests/incremental_parse_interner_tests.rs
+++ b/crates/tsz-parser/tests/incremental_parse_interner_tests.rs
@@ -30,7 +30,7 @@ fn collect_identifier_atom_text(arena: &NodeArena) -> Vec<(AstAtom, String, Stri
         };
         out.push((
             data.atom,
-            data.escaped_text.clone(),
+            data.escaped_text.to_string(),
             arena.resolve_identifier_text(data).to_string(),
         ));
     }

--- a/crates/tsz-parser/tests/node_tests.rs
+++ b/crates/tsz-parser/tests/node_tests.rs
@@ -3,6 +3,7 @@ use crate::parser::test_fixture::parse_source;
 use crate::{ParserState, syntax_kind_ext};
 use std::mem::size_of;
 use tsz_common::interner::AstAtom;
+use tsz_common::interner::IdentText;
 use tsz_scanner::SyntaxKind;
 
 #[test]
@@ -35,7 +36,7 @@ fn test_node_arena_basic() {
         15,
         IdentifierData {
             atom: AstAtom::NONE,
-            escaped_text: "hello".to_string(),
+            escaped_text: IdentText::from("hello"),
             original_text: None,
         },
     );
@@ -86,7 +87,7 @@ fn test_node_view() {
         15,
         IdentifierData {
             atom: AstAtom::NONE,
-            escaped_text: "myVar".to_string(),
+            escaped_text: IdentText::from("myVar"),
             original_text: None,
         },
     );
@@ -140,7 +141,7 @@ fn test_node_access_trait() {
         20,
         IdentifierData {
             atom: AstAtom::NONE,
-            escaped_text: "testVar".to_string(),
+            escaped_text: IdentText::from("testVar"),
             original_text: None,
         },
     );
@@ -192,7 +193,7 @@ fn test_parent_mapping() {
         1,
         IdentifierData {
             atom: AstAtom::NONE,
-            escaped_text: "a".to_string(),
+            escaped_text: IdentText::from("a"),
             original_text: None,
         },
     );
@@ -203,7 +204,7 @@ fn test_parent_mapping() {
         5,
         IdentifierData {
             atom: AstAtom::NONE,
-            escaped_text: "b".to_string(),
+            escaped_text: IdentText::from("b"),
             original_text: None,
         },
     );
@@ -316,7 +317,7 @@ fn test_parent_mapping_nested() {
         1,
         IdentifierData {
             atom: AstAtom::NONE,
-            escaped_text: "a".to_string(),
+            escaped_text: IdentText::from("a"),
             original_text: None,
         },
     );
@@ -326,7 +327,7 @@ fn test_parent_mapping_nested() {
         5,
         IdentifierData {
             atom: AstAtom::NONE,
-            escaped_text: "b".to_string(),
+            escaped_text: IdentText::from("b"),
             original_text: None,
         },
     );
@@ -347,7 +348,7 @@ fn test_parent_mapping_nested() {
         10,
         IdentifierData {
             atom: AstAtom::NONE,
-            escaped_text: "c".to_string(),
+            escaped_text: IdentText::from("c"),
             original_text: None,
         },
     );
@@ -415,7 +416,7 @@ fn test_parent_mapping_function() {
         12,
         IdentifierData {
             atom: AstAtom::NONE,
-            escaped_text: "foo".to_string(),
+            escaped_text: IdentText::from("foo"),
             original_text: None,
         },
     );
@@ -572,7 +573,7 @@ fn estimated_size_bytes_grows_with_identifiers() {
             10,
             IdentifierData {
                 atom: AstAtom::NONE,
-                escaped_text: name,
+                escaped_text: name.into(),
                 original_text: None,
             },
         );

--- a/crates/tsz-parser/tests/parser_improvement_object_array_literal_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_object_array_literal_recovery_tests.rs
@@ -414,7 +414,9 @@ fn first_object_literal_members(parser: &crate::parser::ParserState) -> Vec<Node
 fn identifier_text(parser: &crate::parser::ParserState, node: NodeIndex) -> Option<String> {
     let arena = parser.get_arena();
     let n = arena.get(node)?;
-    arena.get_identifier(n).map(|id| id.escaped_text.clone())
+    arena
+        .get_identifier(n)
+        .map(|id| id.escaped_text.to_string())
 }
 
 /// Structural rule: when a reserved word is used as an object-literal property

--- a/crates/tsz-scanner/src/scanner_impl.rs
+++ b/crates/tsz-scanner/src/scanner_impl.rs
@@ -10,7 +10,7 @@ use crate::char_codes::CharacterCodes;
 use std::sync::Arc;
 use tsz_common::ScriptTarget;
 use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
-use tsz_common::interner::{AstAtom, Interner};
+use tsz_common::interner::{AstAtom, IdentText, Interner};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 mod identifiers;
@@ -1279,6 +1279,26 @@ impl ScannerState {
     #[must_use]
     pub fn get_token_text_ref(&self) -> &str {
         &self.source[self.token_start..self.pos]
+    }
+
+    /// Get the current token's cooked text as a shared [`IdentText`] handle.
+    ///
+    /// For interned tokens (identifiers, keywords, no-escape string literals)
+    /// this clones the interner's existing `Arc<str>` — a refcount bump, no
+    /// allocation. Tokens without an atom (recovery paths, escaped values)
+    /// are interned first so repeated occurrences still share one allocation.
+    #[must_use]
+    pub fn token_ident_text(&mut self) -> IdentText {
+        if self.token_atom != AstAtom::NONE {
+            return self.interner.resolve_text(self.token_atom);
+        }
+        let value = self.get_token_value_ref();
+        if value.is_empty() {
+            return IdentText::empty();
+        }
+        let value = value.to_string();
+        let atom = self.interner.intern_owned(value);
+        self.interner.resolve_text(atom)
     }
 
     /// ZERO-COPY: Get a slice of the source text by positions.

--- a/crates/tsz-wasm/src/wasm_api/source_file.rs
+++ b/crates/tsz-wasm/src/wasm_api/source_file.rs
@@ -244,7 +244,7 @@ impl TsSourceFile {
         let arena = self.arena.as_ref()?;
         let node = arena.get(NodeIndex(handle))?;
         let ident = arena.get_identifier(node)?;
-        Some(ident.escaped_text.clone())
+        Some(ident.escaped_text.to_string())
     }
 
     /// Check if a node is a specific kind


### PR DESCRIPTION
Goal: fast

## Summary

Identifiers are the most numerous data-bearing node kind (39.8% of nodes in `lib.dom.d.ts`), and every `IdentifierData` carried an owned `String` copy of text the per-file interner already stores (the field itself was marked "DEPRECATED: kept for backward compatibility during migration"), plus an almost-always-`None` `Option<String>`. This PR finishes that migration in the direction of the data-oriented-parser playbook ("intern once, hand out shared handles"; ref: [Engineering high-performance parsers](https://www.arshad.fyi/writings/engineering-high-performance-parsers)):

- `tsz-common`: new `interner::IdentText` — a refcounted handle (`Arc<str>`) into the interner's existing string table. It mirrors `String`'s read surface (`Deref<Target=str>`, `as_str`, `Display`/`Debug`, comparisons against `str`/`&str`/`String`, `Hash`/`Ord` as `str`, `Borrow<str>`) so read-only call sites compile unchanged, and its serde form is byte-compatible with `String` (plain string), so bincode arena snapshots and JSON IPC keep their existing format with no version bump. No mutation surface: identifier text is fixed at construction.
- `tsz-scanner`: `ScannerState::token_ident_text()` resolves the current token's cooked text as a shared handle — a refcount bump for interned tokens (identifiers, keywords); cold recovery values are interned on demand.
- `tsz-parser`: `IdentifierData.escaped_text: IdentText`, `original_text: Option<IdentText>`; every construction site migrated (`read_cooked_identifier_text`, keyword-as-identifier, private identifiers, JSX names, recovery/synthesized identifiers, speculation).
- downstream (binder/checker/emitter/lowering/lsp/cli/core): sites that need an owned `String` convert with `.to_string()` at the boundary — exactly the allocation the previous per-node `.clone()` performed, so behavior and cost there are unchanged; the parse-time per-identifier allocation is what disappears.

## Structural rule

When the parser materializes an identifier's cooked text, tsc keeps one `escapedText` string per identifier node; tsz now represents that text as a shared interned handle into the arena interner's string table, so all occurrences of one identifier in a file share a single allocation and `IdentifierData` shrinks from 56 to 40 bytes. Owner layer: scanner/parser data plane (`tsz-common` interner + `tsz-scanner` token accessor + `tsz-parser` node payloads). No semantic operation, relation, or diagnostic decision changes; text *values* are identical everywhere.

## Adjacent cases

- plain identifiers (no escapes): handle == interned source slice
- keyword-as-identifier (`string`, `await`, `yield`, type-keyword names): same path via `token_ident_text`
- unicode-escape identifiers: cooked text from the interner; raw spelling kept in `original_text` only when it differs (tsc emit parity)
- private identifiers (`#x`), with and without escapes
- recovery/missing identifiers: shared static empty text (no allocation)
- synthesized identifiers (`arg{N}`, bare-`#` recovery, `global`): standalone shared strings
- speculation re-parse: checkpoint/rollback unchanged (truncate-based)
- serde: JSON and bincode round-trip byte-compatible with the old `String` form (old snapshots deserialize unchanged)

## Performance

Criterion (`cargo bench -p tsz-core --bench parser_bench -- --baseline main`, Apple M4 Pro):

| bench | change |
|---|---|
| parse_complex | −6.7% |
| parser_throughput (5c_5m…50c_5m) | −4.1% … −11.8% |
| node_allocation | −7.0% |
| parse_medium | −3.3% |

Real file (`lib.dom.d.ts`, 2.35 MB, 113,121 nodes): steady-state parse 10.9 ms → 10.2 ms (−6.4%); per-parse identifier heap allocations 45,021 → 0 (8,112 unique strings, already interned); arena `estimated_size_bytes` 21.21 MB → 19.80 MB (−6.6%).

Invariant protected: `AstAtom` numbering and interner contents are unchanged for all previously-interned tokens (recovery-path values are additionally interned, append-only), so no cache key or semantic identity shifts; cache-enabled and cache-disabled runs see identical text values.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo nextest run --workspace` — 43,882 run, 7 failures, all reproduced on unmodified `origin/main` in the same environment (path/tsconfig-shaped: `tsz-cli` `show_config_*`/`trace_resolution_*`, `tsz-conformance` `tsz_wrapper::*`) — pre-existing, unrelated
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` — all crates this PR touches are clean; the run stops on pre-existing `tsz-solver` lints (`manual_contains`, `clone_on_copy`, `unused_mut` at `operations/expression_ops.rs:1046`) that reproduce identically on unmodified `origin/main` (this PR touches no solver files)
- `scripts/arch/check-checker-boundaries.sh` — same pre-existing size-ratchet findings as unmodified `origin/main` (`types/utilities/core.rs`, `state/variable_checking/core.rs`); this PR adds net 0 lines to those files
- `scripts/conformance/conformance.sh run` — 11,168 / 12,043 runnable passing; per-test PASS/FAIL results **byte-identical to a freshly built, unmodified `origin/main`** (`diff` over all 12,043 `--print-test` lines: no differences). The 6 "regressions" the stale checked-in snapshot baseline reports (expandoFunction*, jsxComponentTypeErrors, propertyAssignmentUseParentType1, typeFromPropertyAssignment36) fail identically on unmodified main — they came in with recent expando work while CI was down, not from this PR
- `scripts/emit/run.sh` — JS emit 11,563/11,563 (100%); DTS 1,372/1,390 with a failure set byte-identical to unmodified `origin/main` (18 pre-existing, same names)
- `scripts/fourslash/run-fourslash.sh` — 6,558/6,562 (99.9%), exactly the documented Hold floor; the 4 failures are the roadmap's known remaining 4
- `cargo bench -p tsz-core --bench parser_bench/scanner_bench -- --baseline main` — table above

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-fable-5
Effort: max
