### PR TITLE
fix(solver,checker): tsc 7.0.2 last-overload failure shape for multi-candidate calls

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -1148,10 +1148,13 @@ impl<'a> CheckerState<'a> {
             /// Fewer than 2 argument-error candidates, or a candidate without
             /// a declared signature: historical flat rendering.
             Flat,
-            /// 2-3 argument-error candidates: one `TS2772` header each.
-            PerOverload,
-            /// 4+ argument-error candidates: one `TS2770` header wrapping only
-            /// the last candidate.
+            /// 2+ argument-error candidates: one `TS2770` header wrapping only
+            /// the last candidate. tsc 7.0.2 (the native tsgo port) renders
+            /// EVERY multi-candidate overload failure this way — the 6.0.x
+            /// per-candidate `Overload {i} of {N}` (TS2772) elaboration for
+            /// 2-3 candidates is unreachable in the pinned compiler (verified
+            /// against the pinned binary across 2/3/4/5-overload calls,
+            /// constructors, duplicates, generics, and union-combined sets).
             LastOverload,
         }
         let shape = if !every_candidate_signed {
@@ -1159,13 +1162,11 @@ impl<'a> CheckerState<'a> {
         } else {
             match chain_candidates.len() {
                 0 | 1 => ChainShape::Flat,
-                2 | 3 => ChainShape::PerOverload,
                 _ => ChainShape::LastOverload,
             }
         };
         let wrapped_candidates: &[&tsz_solver::PendingDiagnostic] = match shape {
             ChainShape::Flat => &[],
-            ChainShape::PerOverload => &chain_candidates,
             ChainShape::LastOverload => &chain_candidates[chain_candidates.len() - 1..],
         };
 
@@ -1176,12 +1177,40 @@ impl<'a> CheckerState<'a> {
         // path — never at the call node: the renderer's display probes climb
         // from their anchor to enclosing initializers and would type the
         // surrounding expression mid-flight.
-        let candidate_chains: Vec<Vec<DiagnosticRelatedInformation>> = wrapped_candidates
+        // Each candidate's reason chain plus whether its applicability failure
+        // HEAD-PROMOTES: exactly as on the single-signature path, a failure
+        // whose top elaboration is a property-level diagnostic
+        // (TS2741/TS2739/TS2740, the `reportUnmatchedProperty` family) renders
+        // that diagnostic directly under the overload header with no
+        // `Argument of type ... is not assignable` wrapper:
+        //   The last overload gave the following error.
+        //     Property 'beta' is missing in type ... .
+        // Decided here, before the type formatter takes its context borrow
+        // (the promotion predicate needs `&mut self`).
+        let candidate_chains: Vec<(Vec<DiagnosticRelatedInformation>, bool)> = wrapped_candidates
             .iter()
             .map(|failure| {
-                self.overload_failure_argument_node(idx, failure)
+                let chain = self
+                    .overload_failure_argument_node(idx, failure)
                     .map(|arg_idx| self.overload_candidate_reason_chain(failure, arg_idx, &span))
-                    .unwrap_or_default()
+                    .unwrap_or_default();
+                let source_target = (failure.code
+                    == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE)
+                    .then(|| match (failure.args.first(), failure.args.get(1)) {
+                        (
+                            Some(&tsz_solver::DiagnosticArg::Type(source)),
+                            Some(&tsz_solver::DiagnosticArg::Type(target)),
+                        ) => Some((source, target)),
+                        _ => None,
+                    })
+                    .flatten();
+                let promoted = chain
+                    .first()
+                    .is_some_and(|line| matches!(line.code, 2741 | 2739 | 2740))
+                    && source_target.is_some_and(|(source, target)| {
+                        self.missing_property_head_promotion_applies(source, target)
+                    });
+                (chain, promoted)
             })
             .collect();
 
@@ -1212,7 +1241,7 @@ impl<'a> CheckerState<'a> {
             }
             RelatedInformationPolicy::OVERLOAD_FAILURES
         } else {
-            for (ordinal, (failure, chain)) in
+            for (ordinal, (failure, (chain, promoted))) in
                 wrapped_candidates.iter().zip(candidate_chains).enumerate()
             {
                 let (header_message, header_code) = if matches!(shape, ChainShape::LastOverload) {
@@ -1244,24 +1273,35 @@ impl<'a> CheckerState<'a> {
                     )
                 };
                 related.push(related_line(&span, header_message, header_code, 0));
-                let pending = self.overload_failure_generalized_pending(failure, &span);
-                let diag = formatter.render(&pending);
-                let diag_span = diag.span.as_ref().unwrap_or(&span);
-                // The candidate's applicability error nests one level under its
-                // TS2772 header; any deeper chain it carries nests below that.
-                related.push(related_line(diag_span, diag.message, diag.code, 1));
-                for nested in &diag.related {
-                    related.push(related_line(
-                        &nested.span,
-                        nested.message.clone(),
-                        0,
-                        nested.depth.saturating_add(2),
-                    ));
-                }
-                // The reason chain nests under the applicability error.
-                for mut line in chain {
-                    line.depth = line.depth.saturating_add(2);
-                    related.push(line);
+                if promoted {
+                    for (position, mut line) in chain.into_iter().enumerate() {
+                        line.depth = if position == 0 {
+                            1
+                        } else {
+                            line.depth.saturating_add(1)
+                        };
+                        related.push(line);
+                    }
+                } else {
+                    let pending = self.overload_failure_generalized_pending(failure, &span);
+                    let diag = formatter.render(&pending);
+                    let diag_span = diag.span.as_ref().unwrap_or(&span);
+                    // The candidate's applicability error nests one level under
+                    // its header; any deeper chain it carries nests below that.
+                    related.push(related_line(diag_span, diag.message, diag.code, 1));
+                    for nested in &diag.related {
+                        related.push(related_line(
+                            &nested.span,
+                            nested.message.clone(),
+                            0,
+                            nested.depth.saturating_add(2),
+                        ));
+                    }
+                    // The reason chain nests under the applicability error.
+                    for mut line in chain {
+                        line.depth = line.depth.saturating_add(2);
+                        related.push(line);
+                    }
                 }
             }
             RelatedInformationPolicy::OVERLOAD_CHAINS

--- a/crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_overload_tests.rs
@@ -35,25 +35,25 @@ fn(true);
         diag.length, 4,
         "TS2769 should cover only the argument token"
     );
-    assert!(
-        diag.related_information.len() >= 2,
-        "expected overload related info, got: {diag:?}"
-    );
-    // Verify both overload failures are present in the related info.
-    // Note: tsc shows them in declaration order (string, number), but our
-    // current overload resolution may produce them in a different order
-    // depending on the call resolution path taken.
-    let has_string = diag
+    // tsc 7.0.2 renders one TS2770 last-overload header holding only the LAST
+    // argument-error candidate (the number overload); the string candidate
+    // does not appear (differential-verified against the pinned binary).
+    let chain: Vec<(u8, u32, &str)> = diag
         .related_information
         .iter()
-        .any(|info| info.message_text.contains("parameter of type 'string'"));
-    let has_number = diag
-        .related_information
-        .iter()
-        .any(|info| info.message_text.contains("parameter of type 'number'"));
-    assert!(
-        has_string && has_number,
-        "expected both overload failures in related info, got: {diag:?}"
+        .map(|r| (r.depth, r.code, r.message_text.as_str()))
+        .collect();
+    assert_eq!(
+        chain,
+        vec![
+            (0, 2770, "The last overload gave the following error."),
+            (
+                1,
+                2345,
+                "Argument of type 'boolean' is not assignable to parameter of type 'number'."
+            ),
+        ],
+        "expected the last-overload chain, got: {diag:?}"
     );
 }
 

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -157,7 +157,13 @@ pub(crate) fn generalized_literal_source_for_display(
     source: TypeId,
     target: TypeId,
 ) -> TypeId {
-    if tsz_solver::type_queries::is_literal_type(db, source)
+    // A `never` target keeps the raw literal: tsc renders
+    // `Argument of type '10' is not assignable to parameter of type 'never'`
+    // (the widen-to-base rule only applies when the target could hold SOME
+    // non-singleton type; nothing is assignable to `never`, so widening
+    // would misattribute the failure to the literal's base type).
+    if target != TypeId::NEVER
+        && tsz_solver::type_queries::is_literal_type(db, source)
         && !tsz_solver::type_queries::type_could_have_top_level_singleton_types(db, target)
     {
         tsz_solver::operations::widening::widen_type(db, source)

--- a/crates/tsz-checker/src/tests/overload_argument_reason_chain_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_argument_reason_chain_tests.rs
@@ -1,27 +1,23 @@
-//! Regression tests for the relation failure-reason sub-chain nested under each
-//! candidate's argument line in a TS2769 ("No overload matches this call")
-//! elaboration.
+//! Regression tests for the relation failure-reason sub-chain nested under the
+//! last candidate's argument line in a TS2769 ("No overload matches this
+//! call") elaboration.
 //!
-//! When 2-3 candidates fail argument checking, tsc wraps each candidate in a
-//! depth-0 `Overload N of M, '<signature>', gave the following error.` (TS2772)
-//! header with the candidate's `Argument of type … is not assignable …`
+//! tsc 7.0.2 wraps every multi-candidate failure in a single depth-0
+//! `The last overload gave the following error.` (TS2770) header with the LAST
+//! argument-error candidate's `Argument of type … is not assignable …`
 //! (TS2345) line nested one level beneath it. When that argument mismatch has
 //! an elaborable relation failure reason (e.g. a contravariant
 //! callback-parameter incompatibility), tsc nests the full reason chain under
 //! the argument line — the same `checkTypeRelatedToAndOptionallyElaborate`
 //! chain the single-signature TS2345 path renders
 //! (`getSignatureApplicabilityError` reuses the single-signature relation
-//! elaboration). Previously tsz rendered each candidate from a bare
-//! two-argument solver diagnostic and dropped the reason chain, so an
-//! overloaded callback mismatch printed only the flat `Argument of type … is
-//! not assignable …` line while the identical single-signature call printed
-//! the nested `Types of parameters 'a' and 'x' are incompatible.` sub-chain.
+//! elaboration).
 //!
-//! The fix routes each candidate's argument failure through the shared
-//! `related_from_failure_reason` gateway (owner:
-//! `crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs`,
-//! `error_no_overload_matches_at`) and re-anchors the chain two nesting levels
-//! beneath the candidate's TS2772 header (header 0, argument line 1, chain 2+).
+//! The chain routes through the shared `related_from_failure_reason` gateway
+//! (owner: `crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs`,
+//! `error_no_overload_matches_at`), anchored two nesting levels beneath the
+//! TS2770 header (header 0, argument line 1, chain 2+). Every expectation is
+//! differential-verified against the pinned tsc 7.0.2 binary.
 
 use crate::test_utils::check_source_diagnostics;
 
@@ -49,11 +45,8 @@ fn overload_related_chain(source: &str) -> Vec<RelatedLine> {
         .collect()
 }
 
-/// Assert the per-candidate TS2772 wrapper shape: every depth-0 entry is an
-/// `Overload N of M, '…', gave the following error.` header, there are at
-/// least two of them (both overloads contribute), and each header is
-/// immediately followed by its depth-1 TS2345 argument line (no interleaving
-/// of the candidates' chains).
+/// Assert the last-overload wrapper shape: exactly one depth-0 `TS2770`
+/// header, immediately followed by its depth-1 `TS2345` argument line.
 fn assert_overload_wrapper_shape(chain: &[RelatedLine]) {
     let header_positions: Vec<usize> = chain
         .iter()
@@ -61,26 +54,22 @@ fn assert_overload_wrapper_shape(chain: &[RelatedLine]) {
         .filter(|(_, (d, _, _))| *d == 0)
         .map(|(i, _)| i)
         .collect();
-    assert!(
-        header_positions.len() >= 2,
-        "both overloads must contribute a depth-0 header line, got: {chain:?}"
+    assert_eq!(
+        header_positions,
+        vec![0],
+        "exactly one depth-0 TS2770 header, got: {chain:?}"
     );
-    for &pos in &header_positions {
-        let (_, code, msg) = &chain[pos];
-        assert!(
-            *code == 2772
-                && msg.starts_with("Overload ")
-                && msg.ends_with("gave the following error."),
-            "each depth-0 entry must be a TS2772 overload header, got: {chain:?}"
-        );
-        let followup = chain.get(pos + 1);
-        assert!(
-            followup.is_some_and(|(depth, code, msg)| *depth == 1
-                && *code == 2345
-                && msg.starts_with("Argument of type")),
-            "each TS2772 header must be directly followed by its depth-1 TS2345 argument line, got: {chain:?}"
-        );
-    }
+    let (_, code, msg) = &chain[0];
+    assert!(
+        *code == 2770 && msg == "The last overload gave the following error.",
+        "the depth-0 entry must be the TS2770 last-overload header, got: {chain:?}"
+    );
+    assert!(
+        chain.get(1).is_some_and(|(depth, code, msg)| *depth == 1
+            && *code == 2345
+            && msg.starts_with("Argument of type")),
+        "the header must be directly followed by its depth-1 TS2345 argument line, got: {chain:?}"
+    );
 }
 
 /// Assert the contravariant callback-parameter sub-chain nests beneath a
@@ -95,11 +84,13 @@ fn assert_contravariant_nesting(chain: &[RelatedLine], param_frame: &str) {
         chain
             .iter()
             .any(|(depth, _, msg)| *depth >= 2 && msg == param_frame),
-        "expected the nested parameter-incompatibility frame `{param_frame}` under a candidate's argument line, got: {chain:?}"
+        "expected the nested parameter-incompatibility frame `{param_frame}` under the last candidate's argument line, got: {chain:?}"
     );
+    // The shown candidate is the LAST overload (the number-typed callback),
+    // so the contravariant leaf names `number`.
     assert!(
         chain.iter().any(|(depth, _, msg)| *depth >= 3
-            && msg == "Type 'string' is not assignable to type 'boolean'."),
+            && msg == "Type 'number' is not assignable to type 'boolean'."),
         "expected the contravariant leaf under the parameter frame, got: {chain:?}"
     );
 }
@@ -184,13 +175,22 @@ save(partial);
 "#,
     );
 
-    // At least one candidate nests a missing-property reason (TS2741)
-    // beneath its argument line instead of leaving a bare argument line.
-    assert!(
+    // The missing-property reason HEAD-PROMOTES: it replaces the argument
+    // line directly under the TS2770 header (tsc renders no
+    // `Argument of type ...` wrapper for this shape).
+    assert_eq!(
         chain
             .iter()
-            .any(|(depth, _, msg)| *depth >= 2 && msg.contains("is missing in type")),
-        "expected a nested missing-property reason under a candidate's argument line, got: {chain:?}"
+            .map(|(depth, _, msg)| (*depth, msg.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (0, "The last overload gave the following error."),
+            (
+                1,
+                "Property 'id' is missing in type '{ tag: string; }' but required in type 'WithBoth'."
+            ),
+        ],
+        "expected the promoted missing-property reason directly under the header, got: {chain:?}"
     );
 }
 
@@ -216,7 +216,7 @@ f(true);
     assert!(
         chain.iter().any(|(depth, _, msg)| *depth == 1
             && msg
-                == "Argument of type 'boolean' is not assignable to parameter of type 'number'."),
-        "expected the widened boolean argument line against the number overload, got: {chain:?}"
+                == "Argument of type 'boolean' is not assignable to parameter of type 'string'."),
+        "expected the widened boolean argument line against the LAST (string) overload, got: {chain:?}"
     );
 }

--- a/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_elaboration_tests.rs
@@ -1,22 +1,22 @@
-//! Regression tests for tsc's per-overload `TS2772`/`TS2770` elaboration under
+//! Regression tests for tsc 7.0.2's `TS2770` last-overload elaboration under
 //! a `TS2769` ("No overload matches this call.") diagnostic.
 //!
-//! When a call matches no overload, tsc elaborates the candidates that matched
-//! arity but failed argument checks (`candidatesForArgumentError`): 2 or 3
-//! such candidates each get an `Overload {i} of {N}, '{signature}', gave the
-//! following error.` chain node (`TS2772`) — in declaration order, with the
-//! applicability error nested one level deeper — and four or more collapse to
-//! a single `The last overload gave the following error.` node (`TS2770`)
-//! wrapping only the last candidate. `{i}` is the candidate's 1-based position
-//! among the argument-error candidates while `{N}` counts every overload;
-//! arity-failing overloads never appear in the chain but still count toward
-//! `{N}`. A single argument-error candidate collapses to a plain `TS2345`
-//! (no `TS2769`).
-//!
-//! Before the fix tsz defined the `TS2772`/`TS2770` strings but never emitted
-//! them: it flattened every candidate's argument error directly under `TS2769`
-//! and, due to the related-info `(file, start, depth, message)` sort, rendered
-//! them out of declaration order.
+//! When a call matches no overload, tsc 7.0.2 (the native port) wraps EVERY
+//! multi-candidate failure — 2, 3, or more argument-error candidates alike —
+//! in a single `The last overload gave the following error.` chain node
+//! (`TS2770`) holding only the LAST argument-error candidate's applicability
+//! error and its relation reason chain. The 6.0.x per-candidate
+//! `Overload {i} of {N}, '{signature}', gave the following error.` (`TS2772`)
+//! elaboration is unreachable in the pinned compiler (verified against the
+//! pinned binary across 2/3/4/5-overload calls, constructors, duplicates,
+//! generics, and union-combined signature sets). Arity-failing overloads are
+//! excluded from the candidate set, and a SINGLE argument-error candidate
+//! collapses to a plain `TS2345` (no `TS2769`). When the last candidate's
+//! failure head-promotes to a property-level diagnostic
+//! (`TS2741`/`TS2739`/`TS2740`), that diagnostic replaces the
+//! `Argument of type ...` line directly under the header, exactly as on the
+//! single-signature path. Every expectation below is differential-verified
+//! against the pinned tsc 7.0.2 binary.
 //!
 //! See `crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs`
 //! (`error_no_overload_matches_at`) and
@@ -46,12 +46,10 @@ fn overload_chain(source: &str) -> Vec<(u8, u32, String)> {
         .collect()
 }
 
-/// Two failing overloads: both wrapped in `TS2772`, in declaration order, each
-/// header at depth 0 with its applicability error nested at depth 1. The
-/// signature is the `signatureToString` colon form, not the `=>` function-type
-/// form.
+/// Two failing overloads collapse to a single `TS2770` header wrapping only
+/// the LAST candidate's applicability error.
 #[test]
-fn two_failing_overloads_wrap_each_candidate_in_declaration_order() {
+fn two_failing_overloads_collapse_to_last_overload_header() {
     let chain = overload_chain(
         r#"
 declare function f(x: number): number;
@@ -65,19 +63,8 @@ f(true);
         vec![
             (
                 0,
-                2772,
-                "Overload 1 of 2, '(x: number): number', gave the following error.".to_string()
-            ),
-            (
-                1,
-                2345,
-                "Argument of type 'boolean' is not assignable to parameter of type 'number'."
-                    .to_string()
-            ),
-            (
-                0,
-                2772,
-                "Overload 2 of 2, '(x: string): string', gave the following error.".to_string()
+                2770,
+                "The last overload gave the following error.".to_string()
             ),
             (
                 1,
@@ -86,16 +73,15 @@ f(true);
                     .to_string()
             ),
         ],
-        "expected two declaration-ordered TS2772 chains with the colon signature form"
+        "expected a single TS2770 chain holding only the last candidate's error"
     );
 }
 
-/// Three failing overloads: all wrapped, `of 3`, and declaration order is
-/// preserved rather than re-sorted. The bodies' alphabetical order
-/// (`boolean` < `number` < `string`) differs from declaration order
-/// (`number`, `string`, `boolean`); the fix must keep declaration order.
+/// Three failing overloads: still one `TS2770` header, and the shown
+/// candidate is the LAST in declaration order (`boolean`), not the
+/// alphabetically-first — proving the selection keys on declaration order.
 #[test]
-fn three_failing_overloads_preserve_declaration_order() {
+fn three_failing_overloads_show_last_in_declaration_order() {
     let chain = overload_chain(
         r#"
 declare function g(x: number): number;
@@ -105,42 +91,28 @@ g({});
 "#,
     );
 
-    let headers: Vec<&String> = chain
-        .iter()
-        .filter(|(_, code, _)| *code == 2772)
-        .map(|(_, _, m)| m)
-        .collect();
     assert_eq!(
-        headers,
+        chain,
         vec![
-            "Overload 1 of 3, '(x: number): number', gave the following error.",
-            "Overload 2 of 3, '(x: string): string', gave the following error.",
-            "Overload 3 of 3, '(x: boolean): boolean', gave the following error.",
+            (
+                0,
+                2770,
+                "The last overload gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                "Argument of type '{}' is not assignable to parameter of type 'boolean'."
+                    .to_string()
+            ),
         ],
-        "expected declaration-ordered `of 3` headers, got: {chain:?}"
-    );
-
-    // Bodies stay under their header in declaration order (number, string,
-    // boolean) — not the alphabetical (boolean, number, string) the old
-    // unconditional sort produced.
-    let bodies: Vec<&String> = chain
-        .iter()
-        .filter(|(_, code, _)| *code == 2345)
-        .map(|(_, _, m)| m)
-        .collect();
-    assert_eq!(
-        bodies,
-        vec![
-            "Argument of type '{}' is not assignable to parameter of type 'number'.",
-            "Argument of type '{}' is not assignable to parameter of type 'string'.",
-            "Argument of type '{}' is not assignable to parameter of type 'boolean'.",
-        ],
-        "expected declaration-ordered bodies, got: {chain:?}"
+        "expected the LAST declaration's error (boolean, not the alphabetical \
+         or first candidate) under the single TS2770 header, got: {chain:?}"
     );
 }
 
-/// Anti-hardcoding: the wrapping is structural, independent of the callee and
-/// parameter binder names. Renaming them only changes the rendered signature.
+/// Anti-hardcoding: the collapse is structural, independent of the callee and
+/// parameter binder names.
 #[test]
 fn wrapping_is_independent_of_binder_names() {
     let chain = overload_chain(
@@ -151,26 +123,29 @@ pick(true);
 "#,
     );
 
-    let headers: Vec<&String> = chain
-        .iter()
-        .filter(|(_, code, _)| *code == 2772)
-        .map(|(_, _, m)| m)
-        .collect();
     assert_eq!(
-        headers,
+        chain,
         vec![
-            "Overload 1 of 2, '(value: number): number', gave the following error.",
-            "Overload 2 of 2, '(other: string): string', gave the following error.",
+            (
+                0,
+                2770,
+                "The last overload gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                "Argument of type 'boolean' is not assignable to parameter of type 'string'."
+                    .to_string()
+            ),
         ],
-        "signature renders the declared parameter names, got: {chain:?}"
+        "renamed binders change nothing but the rendered types, got: {chain:?}"
     );
 }
 
-/// Constructor (`new`) overloads are wrapped identically, and tsc's
-/// `signatureToString` renders them in the call-signature colon form
-/// (`(x: number): C`) — no `new` prefix.
+/// Constructor (`new`) overload sets collapse through the same last-overload
+/// policy as call overloads.
 #[test]
-fn constructor_overloads_wrap_in_call_signature_form() {
+fn constructor_overloads_collapse_like_call_overloads() {
     let chain = overload_chain(
         r#"
 declare class C {
@@ -181,22 +156,22 @@ new C(true);
 "#,
     );
 
-    let headers: Vec<&String> = chain
-        .iter()
-        .filter(|(_, code, _)| *code == 2772)
-        .map(|(_, _, m)| m)
-        .collect();
     assert_eq!(
-        headers,
+        chain,
         vec![
-            "Overload 1 of 2, '(x: number): C', gave the following error.",
-            "Overload 2 of 2, '(x: string): C', gave the following error.",
+            (
+                0,
+                2770,
+                "The last overload gave the following error.".to_string()
+            ),
+            (
+                1,
+                2345,
+                "Argument of type 'boolean' is not assignable to parameter of type 'string'."
+                    .to_string()
+            ),
         ],
-        "constructor overloads render as call signatures returning the class, got: {chain:?}"
-    );
-    assert!(
-        headers.iter().all(|h| !h.contains("new ")),
-        "constructor overload headers must not carry a `new` prefix, got: {headers:?}"
+        "expected the last constructor candidate under a single TS2770 header, got: {chain:?}"
     );
 }
 
@@ -279,12 +254,12 @@ fn lines_at_depth(chain: &[(u8, String)], depth: u8) -> Vec<&str> {
 }
 
 /// The witness from #15387: a callback parameter incompatibility nests the
-/// full relation reason chain under each candidate's `TS2772` header — the
-/// `Types of parameters 'a' and 'x' are incompatible.` frame and the
-/// contravariant leaf — exactly as the single-signature `TS2345` path
-/// renders them (differential-verified against tsc 6.0.2).
+/// full relation reason chain — the `Types of parameters 'a' and 'x' are
+/// incompatible.` frame and the contravariant leaf — under the last
+/// candidate's applicability error, exactly as the single-signature `TS2345`
+/// path renders them.
 #[test]
-fn callback_parameter_mismatch_nests_reason_chain_per_candidate() {
+fn callback_parameter_mismatch_nests_reason_chain_under_last_candidate() {
     let chain = chain_lines(
         r#"
 declare function each(cb: (x: string) => void): void;
@@ -296,20 +271,7 @@ each((a: boolean) => {});
     assert_eq!(
         as_pairs(&chain),
         vec![
-            (
-                0,
-                "Overload 1 of 2, '(cb: (x: string) => void): void', gave the following error."
-            ),
-            (
-                1,
-                "Argument of type '(a: boolean) => void' is not assignable to parameter of type '(x: string) => void'."
-            ),
-            (2, "Types of parameters 'a' and 'x' are incompatible."),
-            (3, "Type 'string' is not assignable to type 'boolean'."),
-            (
-                0,
-                "Overload 2 of 2, '(cb: (x: number, i: number) => void): void', gave the following error."
-            ),
+            (0, "The last overload gave the following error."),
             (
                 1,
                 "Argument of type '(a: boolean) => void' is not assignable to parameter of type '(x: number, i: number) => void'."
@@ -317,15 +279,15 @@ each((a: boolean) => {});
             (2, "Types of parameters 'a' and 'x' are incompatible."),
             (3, "Type 'number' is not assignable to type 'boolean'."),
         ],
-        "expected the full per-candidate reason chain under each TS2772 header"
+        "expected the last candidate's full reason chain under the TS2770 header"
     );
 }
 
-/// A missing-property failure nests its `Property 'p' is missing …` line
-/// under each candidate, and the two candidates keep their distinct leaves
-/// (dedupe is off under `OVERLOAD_CHAINS`).
+/// A missing-property failure HEAD-PROMOTES under the header: the property
+/// diagnostic replaces the `Argument of type ...` wrapper entirely, exactly
+/// as on the single-signature path (which reports TS2741 directly).
 #[test]
-fn missing_property_reason_chain_nests_under_each_header() {
+fn missing_property_promotes_directly_under_last_overload_header() {
     let chain = chain_lines(
         r#"
 declare function take(o: { alpha: string }): void;
@@ -336,12 +298,16 @@ take(arg);
     );
 
     assert_eq!(
-        lines_at_depth(&chain, 2),
+        as_pairs(&chain),
         vec![
-            "Property 'alpha' is missing in type '{ gamma: boolean; }' but required in type '{ alpha: string; }'.",
-            "Property 'beta' is missing in type '{ gamma: boolean; }' but required in type '{ beta: number; }'.",
+            (0, "The last overload gave the following error."),
+            (
+                1,
+                "Property 'beta' is missing in type '{ gamma: boolean; }' but required in type '{ beta: number; }'."
+            ),
         ],
-        "expected one missing-property leaf under each header, got: {chain:?}"
+        "expected the promoted property diagnostic directly under the header \
+         (no `Argument of type ...` wrapper), got: {chain:?}"
     );
 }
 
@@ -359,19 +325,18 @@ new Widget((a: boolean) => {});
 "#,
     );
 
-    let depth2plus: Vec<(u8, &str)> = as_pairs(&chain)
-        .into_iter()
-        .filter(|(depth, _)| *depth >= 2)
-        .collect();
     assert_eq!(
-        depth2plus,
+        as_pairs(&chain),
         vec![
-            (2, "Types of parameters 'a' and 'x' are incompatible."),
-            (3, "Type 'string' is not assignable to type 'boolean'."),
+            (0, "The last overload gave the following error."),
+            (
+                1,
+                "Argument of type '(a: boolean) => void' is not assignable to parameter of type '(x: number) => void'."
+            ),
             (2, "Types of parameters 'a' and 'x' are incompatible."),
             (3, "Type 'number' is not assignable to type 'boolean'."),
         ],
-        "expected reason chains under both constructor candidates, got: {chain:?}"
+        "expected the last constructor candidate's reason chain, got: {chain:?}"
     );
 }
 
@@ -394,11 +359,8 @@ invoke((a: boolean) => {});
 
     assert_eq!(
         lines_at_depth(&chain, 0),
-        vec![
-            "Overload 1 of 2, '(cb: (x: string) => void): void', gave the following error.",
-            "Overload 2 of 2, '(cb: (x: number, i: number) => void): void', gave the following error.",
-        ],
-        "expected TS2772 headers on the callable-interface path, got: {chain:?}"
+        vec!["The last overload gave the following error."],
+        "expected the TS2770 header on the callable-interface path, got: {chain:?}"
     );
     assert!(
         chain
@@ -441,14 +403,14 @@ visit((row: boolean) => {});
 
     assert!(
         chain.iter().any(|(depth, m)| *depth == 2
-            && m == "Types of parameters 'row' and 'item' are incompatible."),
-        "expected the renamed-binder parameter frame, got: {chain:?}"
+            && m == "Types of parameters 'row' and 'entry' are incompatible."),
+        "expected the renamed-binder parameter frame for the LAST candidate, got: {chain:?}"
     );
     assert!(
         chain
             .iter()
             .any(|(depth, m)| *depth == 3
-                && m == "Type 'string' is not assignable to type 'boolean'."),
+                && m == "Type 'number' is not assignable to type 'boolean'."),
         "expected the contravariant leaf under the renamed frame, got: {chain:?}"
     );
 }
@@ -468,18 +430,15 @@ pair(t);
 
     assert_eq!(
         lines_at_depth(&chain, 2),
-        vec![
-            "Type at position 0 in source is not compatible with type at position 0 in target.",
-            "Type at position 0 in source is not compatible with type at position 0 in target.",
-        ],
-        "expected a positional disambiguator under each header, got: {chain:?}"
+        vec!["Type at position 0 in source is not compatible with type at position 0 in target."],
+        "expected the positional disambiguator under the single header, got: {chain:?}"
     );
     assert!(
         chain
             .iter()
             .any(|(depth, m)| *depth == 3
-                && m == "Type 'boolean' is not assignable to type 'string'."),
-        "expected the position-0 leaf under the first header, got: {chain:?}"
+                && m == "Type 'boolean' is not assignable to type 'number'."),
+        "expected the LAST candidate's position-0 leaf, got: {chain:?}"
     );
 }
 
@@ -563,10 +522,10 @@ f(sym);
 
 /// Shared scenario for the arity-exclusion rule: a `string`/arity/`boolean`
 /// overload triple called with a `symbol` argument. The arity candidate is
-/// excluded from the chain but still counts toward `{N}`, so the third
-/// declaration renders as `Overload 2 of 3` and the arity error line
-/// disappears entirely (differential-verified against tsc 6.0.2). Invoked
-/// with two distinct binder-name sets so the rule is proven structural.
+/// excluded from the argument-error set, leaving TWO candidates, so the set
+/// still wraps in the single `TS2770` header showing the LAST argument-error
+/// candidate (`boolean`); the arity error line never appears. Invoked with
+/// two distinct binder-name sets so the rule is proven structural.
 fn assert_arity_exclusion_chain(callee: &str, param: &str, extra: &str) {
     let chain = overload_chain(&format!(
         r#"
@@ -578,24 +537,14 @@ declare const sym: symbol;
 "#
     ));
 
+    let _ = param;
     assert_eq!(
         chain,
         vec![
             (
                 0,
-                2772,
-                format!("Overload 1 of 3, '({param}: string): void', gave the following error.")
-            ),
-            (
-                1,
-                2345,
-                "Argument of type 'symbol' is not assignable to parameter of type 'string'."
-                    .to_string()
-            ),
-            (
-                0,
-                2772,
-                format!("Overload 2 of 3, '({param}: boolean): void', gave the following error.")
+                2770,
+                "The last overload gave the following error.".to_string()
             ),
             (
                 1,
@@ -604,7 +553,8 @@ declare const sym: symbol;
                     .to_string()
             ),
         ],
-        "expected the arity candidate dropped from the chain yet counted in {{N}}"
+        "expected the arity candidate excluded and the last argument-error \
+         candidate under a single TS2770 header"
     );
 }
 

--- a/crates/tsz-checker/src/tests/overload_literal_source_generalization_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_literal_source_generalization_tests.rs
@@ -2,12 +2,12 @@
 //! failure in a TS2769 ("No overload matches this call") elaboration.
 //!
 //! tsc's `reportRelationError` generalizes a fresh literal source to its base
-//! type unless the target could hold a top-level singleton type. This rule is
-//! already applied on the single-overload TS2345 path; before the fix the
-//! multi-overload TS2769 path rendered the raw literal source, so a boolean
-//! literal argument against a `number`/`string` parameter showed `'true'`
-//! instead of `'boolean'` (and `1` against `string` showed `'1'` instead of
-//! `'number'`), diverging from tsc and from the single-overload display.
+//! type unless the target could hold a top-level singleton type (a `never`
+//! target also preserves the raw literal). tsc 7.0.2 renders only the LAST
+//! argument-error candidate under the single `The last overload gave the
+//! following error.` header, so the assertions below key on that candidate's
+//! message. Every expectation is differential-verified against the pinned
+//! tsc 7.0.2 binary.
 //!
 //! See `crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs`
 //! (`error_no_overload_matches_at`) and
@@ -52,15 +52,8 @@ f(true);
         messages
             .iter()
             .any(|m| m
-                == "Argument of type 'boolean' is not assignable to parameter of type 'number'."),
-        "expected widened 'boolean' source against the number overload, got: {messages:?}"
-    );
-    assert!(
-        messages
-            .iter()
-            .any(|m| m
                 == "Argument of type 'boolean' is not assignable to parameter of type 'string'."),
-        "expected widened 'boolean' source against the string overload, got: {messages:?}"
+        "expected widened 'boolean' source against the LAST (string) overload, got: {messages:?}"
     );
     assert!(
         !messages
@@ -86,15 +79,8 @@ f(1);
         messages
             .iter()
             .any(|m| m
-                == "Argument of type 'number' is not assignable to parameter of type 'string'."),
-        "expected widened 'number' source against the string overload, got: {messages:?}"
-    );
-    assert!(
-        messages
-            .iter()
-            .any(|m| m
                 == "Argument of type 'number' is not assignable to parameter of type 'boolean'."),
-        "expected widened 'number' source against the boolean overload, got: {messages:?}"
+        "expected widened 'number' source against the LAST (boolean) overload, got: {messages:?}"
     );
 }
 
@@ -114,8 +100,8 @@ f(true);
     assert!(
         messages
             .iter()
-            .any(|m| m == "Argument of type 'true' is not assignable to parameter of type '1'."),
-        "literal source must be preserved against a literal target, got: {messages:?}"
+            .any(|m| m == "Argument of type 'true' is not assignable to parameter of type '2'."),
+        "literal source must be preserved against the LAST literal target, got: {messages:?}"
     );
     assert!(
         !messages.iter().any(|m| m.contains("'boolean'")),
@@ -167,7 +153,7 @@ pick(false);
         messages
             .iter()
             .any(|m| m
-                == "Argument of type 'boolean' is not assignable to parameter of type 'number'."),
+                == "Argument of type 'boolean' is not assignable to parameter of type 'string'."),
         "expected widened 'boolean' regardless of binder names, got: {messages:?}"
     );
 }

--- a/crates/tsz-checker/src/tests/union_multi_overload_unified_sig_tests.rs
+++ b/crates/tsz-checker/src/tests/union_multi_overload_unified_sig_tests.rs
@@ -70,12 +70,16 @@ const r = f(10);
     );
 }
 
-/// Negative lock: when the multi-overload member has NO sig matching the
-/// single-overload member (e.g. M1=`(a: number)` vs M2=`(a: boolean)/(a: string)`),
-/// the union is not callable at all (TS2349). This was already correct prior
-/// to the fix; locked here so the unified-sig path doesn't regress it.
+/// When the multi-overload member has NO sig matching the single-overload
+/// member (M1=`(a: number)` vs M2=`(a: boolean)/(a: string)`), tsc 7.0.2's
+/// `getUnionSignatures` pass 2 combines each of M2's overloads with M1's sig,
+/// intersecting the params to `never` — so the union IS callable, both
+/// combined candidates fail on the argument, and the failure reports as one
+/// TS2769 with the last-overload TS2770 header and the `never`-param TS2345
+/// (the literal `10` is preserved against `never`). Differential-verified
+/// against the pinned tsc 7.0.2 binary.
 #[test]
-fn union_single_plus_multi_overload_no_match_emits_ts2349() {
+fn union_single_plus_multi_overload_no_match_reports_ts2769_last_overload() {
     let diags = check_source_diagnostics(
         r#"
 declare var f: { (a: number): number; } | { (a: boolean): string; (a: string): boolean; };
@@ -83,14 +87,36 @@ f(10);
 "#,
     );
 
-    let ts2349: Vec<_> = diags.iter().filter(|d| d.code == 2349).collect();
+    let ts2769: Vec<_> = diags.iter().filter(|d| d.code == 2769).collect();
     assert_eq!(
-        ts2349.len(),
+        ts2769.len(),
         1,
-        "Expected TS2349 — no compatible sig pair across union members. Got: {:?}",
+        "Expected one TS2769 for the union combined-signature failure. Got: {:?}",
         diags
             .iter()
             .map(|d| (d.code, &d.message_text))
             .collect::<Vec<_>>()
+    );
+    let chain: Vec<(u8, u32, &str)> = ts2769[0]
+        .related_information
+        .iter()
+        .map(|r| (r.depth, r.code, r.message_text.as_str()))
+        .collect();
+    assert_eq!(
+        chain,
+        vec![
+            (0, 2770, "The last overload gave the following error."),
+            (
+                1,
+                2345,
+                "Argument of type '10' is not assignable to parameter of type 'never'."
+            ),
+        ],
+        "expected the last-overload chain with the raw literal preserved against 'never'"
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2349),
+        "the union IS callable through the combined signatures; TS2349 must not fire. Got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
     );
 }

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -1573,13 +1573,11 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // tsc reports TS2345 (the inner type error) rather than TS2769 (no overload matched).
         let mut type_mismatch_count: usize = 0;
         let mut first_type_mismatch: Option<(usize, TypeId, TypeId)> = None; // (index, expected, actual)
-        let mut all_mismatches_identical = true;
         let mut has_non_count_non_type_failure = false;
         // Also track this-type mismatches for TS2345 optimization (tsc reports TS2345 not TS2769
         // when all failures are identical this-type mismatches)
         let mut this_mismatch_count: usize = 0;
         let mut first_this_mismatch: Option<(TypeId, TypeId)> = None; // (expected, actual)
-        let mut all_this_mismatches_identical = true;
         // Snapshot incoming generic-instantiation params so a *failed* overload attempt's `cache_generic_result` `unknown[]` params can't leak into the winner/caller; a generic winner re-populates them (#14963).
         let saved_instantiated_params = self.last_instantiated_params.clone();
 
@@ -1609,8 +1607,6 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     type_mismatch_count += 1;
                     if type_mismatch_count == 1 {
                         first_type_mismatch = Some((index, expected, actual));
-                    } else if first_type_mismatch != Some((index, expected, actual)) {
-                        all_mismatches_identical = false;
                     }
                     failures.push(
                         crate::diagnostics::PendingDiagnosticBuilder::argument_not_assignable(
@@ -1652,8 +1648,6 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     this_mismatch_count += 1;
                     if this_mismatch_count == 1 {
                         first_this_mismatch = Some((expected_this, actual_this));
-                    } else if first_this_mismatch != Some((expected_this, actual_this)) {
-                        all_this_mismatches_identical = false;
                     }
                     failures.push(
                         crate::diagnostics::PendingDiagnosticBuilder::this_type_mismatch(
@@ -1706,12 +1700,16 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             };
         }
 
-        // If all type mismatches are identical (or there's exactly one), and no other failures occurred,
-        // report TS2345 (the inner type error) instead of TS2769. This handles duplicate signatures
-        // or overloads where the failing parameter has the exact same type in all matching overloads.
+        // Exactly ONE arity-compatible candidate failing on an argument type
+        // reports the plain inner TS2345. Two or more failing candidates are
+        // an overload failure (TS2769) even when every candidate fails
+        // identically — tsc 7.0.2 wraps duplicate signatures and
+        // union-combined signature sets (e.g. two `(a: never)` combined
+        // sigs from `getUnionSignatures` pass 2) in `No overload matches
+        // this call.`; collapsing them here discarded the candidate count
+        // before the checker's overload emitter could see it.
         if !has_non_count_non_type_failure
-            && type_mismatch_count > 0
-            && all_mismatches_identical
+            && type_mismatch_count == 1
             && let Some((index, expected, actual)) = first_type_mismatch
         {
             return CallResult::ArgumentTypeMismatch {
@@ -1722,11 +1720,9 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             };
         }
 
-        // If all this-type mismatches are identical (or there's exactly one), and no other failures
-        // occurred, report TS2345 instead of TS2769. Use index 0 for the this-type mismatch.
+        // Same single-candidate rule for `this`-type mismatches.
         if !has_non_count_non_type_failure
-            && this_mismatch_count > 0
-            && all_this_mismatches_identical
+            && this_mismatch_count == 1
             && type_mismatch_count == 0
             && let Some((expected_this, actual_this)) = first_this_mismatch
         {


### PR DESCRIPTION
Goal: hold

Recalibrates multi-candidate overload/union-call failure reporting to the pinned tsc 7.0.2 shape (drains the union pool row; checker pool 10 -> 9).

## Structural rule
When a call/construct has >= 2 arity-compatible candidates that all fail argument/`this` assignability, tsc 7.0.2 emits one TS2769 with the single `The last overload gave the following error.` (TS2770) header wrapping only the LAST argument-error candidate's applicability error and its relation reason chain; a head-promotable property-level failure (TS2741/TS2739/TS2740) renders directly under the header with no `Argument of type ...` wrapper; exactly ONE arity-compatible failing candidate collapses to the plain inner TS2345; a `never`-target keeps the raw literal source. tsz enforces this through the solver's `resolve_callable_call` result classification and the checker's `error_no_overload_matches_at` chain shape.

The 6.0.x per-candidate `Overload {i} of {N}` (TS2772) elaboration is UNREACHABLE in the pinned binary — verified against it across 2/3/4/5-overload calls, constructors, exact duplicates, generics, object-literal excess, and union-combined signature sets (the TS2772 string survives in the catalog but no shape triggers it). If a future pin advance restores per-overload rendering, gate the shape by pin version rather than reverting.

## Changes
- solver `resolve_callable_call`: the identical-mismatch collapse now fires only for a SINGLE candidate (`type_mismatch_count == 1`, same for `this`); 2+ candidates return `NoOverloadMatch`, so duplicate signatures and `getUnionSignatures` pass-2 combined sets (two `(a: never)` sigs from the union fixture) reach the TS2769 emitter instead of collapsing to bare TS2345.
- checker `ChainShape`: 2+ signed argument-error candidates → the TS2770 last-overload header (the PerOverload/TS2772 rendering removed).
- Head promotion under the header, decided by the same `missing_property_head_promotion_applies` predicate as the single-signature path.
- `generalized_literal_source_for_display`: `never` targets keep the raw literal (`'10'` vs `never`).
- 22 tests across 5 suites recalibrated, each fixture oracle-verified byte-identical; the stale `union_..._emits_ts2349` pool row is now the TS2769+TS2770 never-param chain.

## Adjacent matrix
Union combined sets (2- and 3-overload members), plain function overloads (2/3/4/5), constructors (declare class + interface construct sigs), callable interfaces, callback contravariance chains, tuple positional chains, missing-property promotion (fresh literal + declared variable), arity-exclusion, lone-argument-error TS2345 collapse (with and without arity failures), literal preservation vs `never` and vs singleton/union-singleton targets, renamed-binder twins throughout.

## Verification
- Oracle matrix byte-identical (union, plain 2-overload, single-sig, promoted missing-property, all chain fixtures)
- `cargo nextest -p tsz-checker --lib`: 9 failures (was 10; the union row flips, no new failures); solver 7434/7434
- Full conformance: 11,169 (+150, unchanged — the corpus comparison is code+location; the shape change is message-facing)
- Emit: JS 100% (11,563), DTS 1,372/1,390 (recorded floor)
- Pre-existing, out of scope: TS2769 anchors at the call node instead of the empty-object argument for `g({})` (same on main)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max
