### PR TITLE
fix(checker): expando property type is the union of all assignment types

### DIFF
--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -404,16 +404,20 @@ impl<'a> CheckerState<'a> {
         checker.ctx.current_file_idx = file_idx;
 
         let source_file = arena.source_files.first()?;
-        let mut best_match: Option<(u32, TypeId)> = None;
+        let mut collected: Vec<(u32, TypeId)> = Vec::new();
         for &stmt_idx in &source_file.statements.nodes {
             checker.collect_expando_property_assignment_type(
                 stmt_idx,
                 expected_key,
                 u32::MAX,
-                &mut best_match,
+                &mut collected,
             );
         }
-        best_match.map(|(_, ty)| ty)
+        // Historical last-position-wins semantics for the JS cross-file reader.
+        collected
+            .into_iter()
+            .max_by_key(|&(pos, _)| pos)
+            .map(|(_, ty)| ty)
     }
 
     fn js_expando_property_read_type_from_all_files(
@@ -1517,17 +1521,19 @@ impl<'a> CheckerState<'a> {
             .source_files
             .get(self.ctx.current_file_idx)
             .or_else(|| self.ctx.arena.source_files.first())?;
-        let mut best_match: Option<(u32, TypeId)> = None;
+        let mut collected: Vec<(u32, TypeId)> = Vec::new();
 
         for &stmt_idx in &source_file.statements.nodes {
             self.collect_expando_property_assignment_type(
                 stmt_idx,
                 &expected_key,
                 read_node.pos,
-                &mut best_match,
+                &mut collected,
             );
         }
 
+        // Historical last-position-wins semantics for the prior-assignment read.
+        let best_match = collected.into_iter().max_by_key(|&(pos, _)| pos);
         if let Some((_, ty)) = best_match {
             self.ctx
                 .expando_property_resolution_set
@@ -1596,7 +1602,7 @@ impl<'a> CheckerState<'a> {
                 .expando_property_resolution_set
                 .insert(recursion_key.clone())
         {
-            let mut best_match: Option<(u32, TypeId)> = None;
+            let mut collected: Vec<(u32, TypeId)> = Vec::new();
             // Walk from the QUERIED symbol's enclosing lexical scope, not
             // unconditionally from the top level: a block-scoped shadowing
             // root (`if (...) { const Y = function Y() {}; Y.test = 42; }`)
@@ -1609,17 +1615,35 @@ impl<'a> CheckerState<'a> {
                     stmt_idx,
                     &expected_key,
                     u32::MAX,
-                    &mut best_match,
+                    &mut collected,
                 );
             }
             self.ctx
                 .expando_property_resolution_set
                 .remove(&recursion_key);
-            if let Some((_, ty)) = best_match {
-                return crate::query_boundaries::widening::widen_type_for_display_preserving_non_fresh(
-                    self.ctx.types,
-                    ty,
-                );
+            if !collected.is_empty() {
+                // Every assignment is a DECLARATION of the property; the
+                // property type is the union of the (widened) assignment
+                // types, exactly as tsc merges multi-branch expando
+                // assignments (`if (b) { g.both = 'hi' } else { g.both = 0 }`
+                // gives `string | number`, and neither branch is checked
+                // against the other).
+                let mut widened: Vec<TypeId> = collected
+                    .iter()
+                    .map(|&(_, ty)| {
+                        crate::query_boundaries::widening::widen_type_for_display_preserving_non_fresh(
+                            self.ctx.types,
+                            ty,
+                        )
+                    })
+                    .collect();
+                widened.sort_unstable_by_key(|ty| ty.0);
+                widened.dedup();
+                return if widened.len() == 1 {
+                    widened[0]
+                } else {
+                    self.ctx.types.factory().union_from_slice(&widened)
+                };
             }
         }
 
@@ -1936,7 +1960,7 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         expected_key: &str,
         read_pos: u32,
-        best_match: &mut Option<(u32, TypeId)>,
+        collected: &mut Vec<(u32, TypeId)>,
     ) {
         let Some(node) = self.ctx.arena.get(idx) else {
             return;
@@ -1976,9 +2000,8 @@ impl<'a> CheckerState<'a> {
                 if rhs_type != TypeId::ANY
                     && rhs_type != TypeId::ERROR
                     && rhs_type != TypeId::UNDEFINED
-                    && best_match.is_none_or(|(best_pos, _)| node.pos >= best_pos)
                 {
-                    *best_match = Some((node.pos, rhs_type));
+                    collected.push((node.pos, rhs_type));
                 }
             }
         }
@@ -1988,7 +2011,7 @@ impl<'a> CheckerState<'a> {
                 child_idx,
                 expected_key,
                 read_pos,
-                best_match,
+                collected,
             );
         }
     }


### PR DESCRIPTION
Goal: green

Flips salsa/typeFromPropertyAssignment36 (conformance +154 → +155; the runner regression list is down to the single pre-existing jsxComponentTypeErrors row).

## Structural rule
tsc treats every `F.p = value` on an annotation-less expando root as a DECLARATION of the property: the property's type is the union of the (widened) assignment types, and no branch's assignment is checked against another branch's. tsz's declared-type walk kept only the last-position assignment, so `if (b) { g.both = 'hi' } else { g.both = 0 }` typed `both` from one branch and reported a false TS2322 on the other.

## Changes (`expando.rs`)
- The declared-type walk collects ALL matching assignment types, widens each (`widen_type_for_display_preserving_non_fresh`), dedups, and unions.
- The JS cross-file reader and the prior-assignment read keep their historical last-position-wins semantics (adapted to the shared collector signature, behavior unchanged).

## Adjacent matrix
Two-branch if/else with distinct primitive types (string|number); sequential same-type re-assignments (dedup to one); single assignment (union of one); the four rows fixed in #15771 stay clean (annotation gate + lexical scoping unaffected); full expando unit family 14/14; TS2565 use-before-assign flow diagnostics in the same fixture unchanged.

## Verification
- salsa/typeFromPropertyAssignment36 byte-identical to tsc 7.0.2 (`--strict --target es2015`) and harness-PASS
- Full conformance: 11,174 (+155); regression list = 1 (jsxComponentTypeErrors, pre-existing on main)
- `cargo nextest -p tsz-checker --lib`: 9 failures (= pool, no new); core 3228/3228
- Emit: JS 100%, DTS 1,372/1,390 (floor)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max
