### PR TITLE
fix(solver,checker): independent source/target positions in tuple TS2626 elaborations

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -1273,6 +1273,7 @@ impl<'a> CheckerState<'a> {
             }
             SubtypeFailureReason::TupleElementTypeMismatch {
                 index,
+                target_index,
                 source_element,
                 target_element,
                 nested_reason,
@@ -1280,6 +1281,7 @@ impl<'a> CheckerState<'a> {
             } => self.render_tuple_element_type_mismatch(
                 &rctx,
                 *index,
+                *target_index,
                 *source_element,
                 *target_element,
                 nested_reason.as_deref(),

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -683,6 +683,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         ctx: &RenderContext,
         index: usize,
+        target_index: usize,
         source_element: TypeId,
         target_element: TypeId,
         nested_reason: Option<&tsz_solver::SubtypeFailureReason>,
@@ -699,12 +700,13 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        let index_str = index.to_string();
-        // TS2626: source and target positions are both the element index for a
-        // fixed tuple element mismatch.
+        // TS2626: the source and target positions coincide for a fixed
+        // element, but a failing element that trails a rest slot reports its
+        // own TARGET position (`[...number[], boolean]` fails at source 0
+        // vs target 1).
         let detail = format_message(
             diagnostic_messages::TYPE_AT_POSITION_IN_SOURCE_IS_NOT_COMPATIBLE_WITH_TYPE_AT_POSITION_IN_TARGET,
-            &[&index_str, &index_str],
+            &[&index.to_string(), &target_index.to_string()],
         );
         self.render_tuple_positional_chain(
             ctx,

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -183,6 +183,11 @@ pub enum SubtypeFailureReason {
     /// can reproduce the exact chain shape.
     TupleElementTypeMismatch {
         index: usize,
+        /// Target-side position. Differs from `index` when the failing target
+        /// element trails a rest slot (`[...number[], boolean]`: a one-element
+        /// source fails at source position 0 against TARGET position 1 —
+        /// tsc numbers the positions independently).
+        target_index: usize,
         source_element: TypeId,
         target_element: TypeId,
         nested_reason: Option<Box<Self>>,
@@ -1119,6 +1124,7 @@ impl SubtypeFailureReason {
 
             Self::TupleElementTypeMismatch {
                 index,
+                target_index,
                 source_element,
                 target_element,
                 nested_reason,
@@ -1134,7 +1140,7 @@ impl SubtypeFailureReason {
                 if *multi_element {
                     diag = diag.with_related(PendingDiagnostic::error(
                         codes::TUPLE_ELEMENT_POSITION_MISMATCH,
-                        vec![(*index).into(), (*index).into()],
+                        vec![(*index).into(), (*target_index).into()],
                     ));
                 }
                 Self::with_element_relation(diag, nested_reason, *source_element, *target_element)

--- a/crates/tsz-solver/src/relations/subtype/explain_tuple.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_tuple.rs
@@ -20,6 +20,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     fn tuple_element_type_mismatch(
         &mut self,
         index: usize,
+        target_index: usize,
         source_element: TypeId,
         target_element: TypeId,
         multi_element: bool,
@@ -29,6 +30,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             .map(Box::new);
         SubtypeFailureReason::TupleElementTypeMismatch {
             index,
+            target_index,
             source_element,
             target_element,
             nested_reason,
@@ -67,16 +69,25 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             if t_elem.rest {
                 let expansion = self.expand_tuple_rest(t_elem.type_id);
                 let outer_tail = &target[i + 1..];
-                // Combined suffix = expansion.tail + outer_tail
-                let combined_suffix: Vec<_> = expansion
+                // Combined suffix = expansion.tail + outer_tail, each paired
+                // with its TARGET position: elements expanded out of the rest
+                // slot report the slot's own position `i` (tsc numbers the
+                // target as written), while outer-tail elements keep their
+                // written index after the rest slot.
+                let combined_suffix: Vec<(usize, TupleElement)> = expansion
                     .tail
                     .iter()
-                    .chain(outer_tail.iter())
-                    .cloned()
+                    .map(|element| (i, element.clone()))
+                    .chain(
+                        outer_tail
+                            .iter()
+                            .enumerate()
+                            .map(|(k, element)| (i + 1 + k, element.clone())),
+                    )
                     .collect();
 
                 let mut source_end = source.len();
-                for tail_elem in combined_suffix.iter().rev() {
+                for (tail_target_pos, tail_elem) in combined_suffix.iter().rev() {
                     if source_end <= i {
                         if !tail_elem.optional {
                             return Some(SubtypeFailureReason::TupleElementMismatch {
@@ -94,6 +105,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                             if !self.check_subtype(s_elem.type_id, tp_array).is_true() {
                                 return Some(self.tuple_element_type_mismatch(
                                     source_end - 1,
+                                    *tail_target_pos,
                                     s_elem.type_id,
                                     tail_elem.type_id,
                                     // Rest/variadic tuples are multi-position;
@@ -128,6 +140,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     if !assignable {
                         return Some(self.tuple_element_type_mismatch(
                             source_end - 1,
+                            *tail_target_pos,
                             s_elem.type_id,
                             tail_elem.type_id,
                             true,
@@ -153,6 +166,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                             {
                                 return Some(self.tuple_element_type_mismatch(
                                     j,
+                                    i,
                                     s_elem.type_id,
                                     t_fixed.type_id,
                                     true,
@@ -187,6 +201,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                             if !self.check_subtype(s_elem.type_id, variadic_array).is_true() {
                                 return Some(self.tuple_element_type_mismatch(
                                     j,
+                                    i,
                                     s_elem.type_id,
                                     variadic_array,
                                     true,
@@ -266,6 +281,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     }
                     return Some(SubtypeFailureReason::TupleElementTypeMismatch {
                         index: i,
+                        target_index: i,
                         source_element: s_elem.type_id,
                         target_element: t_elem.type_id,
                         nested_reason: nested.map(Box::new),


### PR DESCRIPTION
Goal: hold

Fixes the variadic-tuple positional numbering in TS2626 elaborations (half of the `non_generic_spread_tuple_alias_display_tests::rest_array_variadic_tuple_alias_keeps_name` pool row; the alias-name half is tracked separately).

## Structural rule
tsc numbers the two positions in `Type at position {s} in source is not compatible with type at position {t} in target.` independently over each side AS WRITTEN: a failing target element that trails a rest slot reports its own written position (`const bad: [...number[], boolean] = ["a"]` fails at source position 0 against TARGET position 1), while fixed-vs-fixed element mismatches share one position. tsz reused the source index for both sides.

## Changes
- `SubtypeFailureReason::TupleElementTypeMismatch` (solver diagnostics) carries a `target_index`, rendered as the second `{}` of TS2626 in both the solver pending-diagnostic renderer and the checker `render_tuple_element_type_mismatch`.
- `explain_tuple_failure` threads the written target position through every construction: suffix-walk elements pair with their written index after the rest slot (expansion-tail elements report the rest slot's own position), the `expansion.fixed` and variadic rest-source arms report the rest slot, and the fixed-vs-fixed arm keeps the shared index.

## Adjacent matrix
Trailing-required-after-rest (`[...number[], boolean]`, alias and direct forms — both now byte-match tsc); fixed-vs-fixed (positions still coincide, `[number, boolean]` control unchanged); the existing variadic-span TS2626/TS2627 path (`TupleVariadicPositionMismatch`) already carried an independent target position and is untouched; readonly-tuple peeling unaffected.

## Verification
- `/tmp/rested.ts` + direct form byte-identical to tsc 7.0.2 (`position 0 in source ... position 1 in target`)
- solver 7434/7434; checker 9 failures (= pre-existing pool, no new)
- Full conformance: 11,174 (+155, unchanged; the one remaining runner row is the pre-existing jsxComponentTypeErrors)
- Emit: JS 100%, DTS 1,372/1,390 (floor)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max
