### PR TITLE
fix(checker): keep union-instantiated same-generic alias applications at the TS2322 head

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -89,6 +89,18 @@ impl<'a> CheckerState<'a> {
         ) -> bool {
             crate::query_boundaries::dispatch::is_object_like_type(db, ty)
                 || crate::query_boundaries::dispatch::is_callable_type(db, ty)
+                // A UNION-bodied generic alias (`type ValueOrArray<E> =
+                // E | ValueOrArray<E>[]`, `type Maybe<T> = T | undefined`)
+                // instantiates to a union; tsc keeps BOTH alias applications
+                // at the top of the TS2322 (`'ValueOrArray<string>' is not
+                // assignable to 'ValueOrArray<number>'`) exactly as for
+                // object/callable instantiations. Without this arm the
+                // renderer collapsed the target to the failing type ARGUMENT
+                // (`'number'`). Transparent aliases (`type Id<T> = T`) never
+                // reach this predicate (their evaluation is not an
+                // application mismatch), so bare-argument display for those
+                // is unaffected.
+                || crate::query_boundaries::common::is_union_type(db, ty)
         }
 
         let source_eval = self.evaluate_type_for_assignability(source);


### PR DESCRIPTION
Goal: hold

Drains the recursive-alias display pair from the checker pool (9 -> 7).

## Structural rule
When source and target are applications of the SAME generic alias and the instantiation evaluates to a UNION (`type ValueOrArray<E> = E | ValueOrArray<E>[]`, `type Maybe<T> = T | undefined`), tsc keeps BOTH alias applications at the top of the TS2322 (`'ValueOrArray<string>' is not assignable to 'ValueOrArray<number>'`) exactly as it does for object/callable instantiations; tsz collapsed the target to the failing type argument (`'number'`) because the checker display predicate `same_generic_mismatch_keeps_application_top_level` only recognized object-like/callable evaluations. One arm added: `is_union_type`.

## Adjacent matrix (oracle-verified by teammate rec2322 + re-verified here)
Recursive union alias + renamed-binder twin (both pool rows, now byte-matching tsc's top line); non-recursive union alias (`Maybe<T>`, same family, fixed); recursive OBJECT alias (`Tree<T>` — already correct, unchanged); non-generic union alias (`type U = number | string` keeps `U`, unchanged); direct union target (unchanged); transparent aliases (`type Id<T> = T` — never reach the predicate, bare display unchanged); object/callable same-generic mismatches (`Wrap<T>`, `Map/Set/Promise` — already the true branch); tuple alias (`Pair<T>` — separate known gap, untouched); intersection tests in the same pool file (object-like, unchanged).

## Residual (filed, not bundled)
tsc's NESTED line keeps the whole alias target (`Type 'string' is not assignable to type 'ValueOrArray<number>'`); tsz drills argument-vs-argument (`'string'` → `'number'`), inherent to the TypeArgumentMismatch reason shape. The pool tests do not assert the nested target; full nested parity is a separate missing-elaboration family.

## Verification
- `/tmp/recalias.ts` + alt-names twin + `Maybe<T>` all match tsc 7.0.2's top line
- `cargo nextest -p tsz-checker --lib`: 7 failures (was 9; both pool rows flip, no new); all 9 tests in the pool file green
- Full conformance: 11,174 (+155, unchanged); emit JS 100%, DTS at floor

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max
