### PR TITLE
fix(checker): variadic tuple alias references keep the alias name in TS2322 heads

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -562,6 +562,30 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // A target annotated by a type REFERENCE keeps its name only when the
+        // referenced alias body is already in tuple normal form:
+        // `type Rested = [...number[], boolean]; const bad: Rested = ["a"]`
+        // renders `'[string]' is not assignable to type 'Rested'` in tsc,
+        // while `type Unbounded = [...Numbers, boolean]` (spread of a NAMED
+        // array alias) normalizes the variadic element away, mints a fresh
+        // tuple without the alias identity, and renders the structural form
+        // (variadicTuples1.ts line 415). Both alias bodies EVALUATE to the
+        // same `TypeId` as an anonymous annotation of the same shape, so the
+        // alias declaration's AST is the only authoritative signal. The probe
+        // is resolution-free (syntax reads plus the binder's memoized
+        // read-only scope walk): mid-render SYMBOL resolution perturbs the
+        // checked program (the hazard `chain_rendering_does_not_leak_
+        // diagnostics_into_enclosing_call` guards). Spread-FLATTENED aliases
+        // never reach this hook — their evaluation has no rest element, so
+        // the structural-display probe below declines them.
+        if self
+            .direct_assignment_target_annotation_node(anchor_idx)
+            .is_some_and(|annotation_idx| {
+                self.annotation_references_normal_form_tuple_alias(annotation_idx)
+            })
+        {
+            return;
+        }
         let Some(target_str) = self.variadic_tuple_alias_structural_display(target, source) else {
             return;
         };
@@ -575,6 +599,99 @@ impl<'a> CheckerState<'a> {
             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             &[&source_str, &target_str],
         );
+    }
+
+    /// Whether `annotation_idx` is a plain (argument-free) type reference to
+    /// a type alias whose declared tuple body is in syntactic normal form:
+    /// every spread element's operand is written as an ARRAY type
+    /// (`...number[]`). tsc keeps the alias identity for such tuples because
+    /// `getTupleElementFlags` classifies an array-operand spread as `Rest`
+    /// (no normalization runs), while a named-operand spread (`...Numbers`)
+    /// is `Variadic` and `createNormalizedTupleType` mints a fresh tuple
+    /// without the alias symbol, so tsc displays the structural form there.
+    /// Resolution-free: the name lookup is `Binder::resolve_identifier`, a
+    /// memoized read-only scope walk. Lookup failures (qualified names,
+    /// generic references, imported aliases) return `false`, falling back to
+    /// the structural rewrite.
+    fn annotation_references_normal_form_tuple_alias(&self, annotation_idx: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(annotation_idx) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return false;
+        }
+        let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
+            return false;
+        };
+        if type_ref
+            .type_arguments
+            .as_ref()
+            .is_some_and(|args| !args.nodes.is_empty())
+        {
+            return false;
+        }
+        let Some(sym_id) = self
+            .ctx
+            .binder
+            .resolve_identifier(self.ctx.arena, type_ref.type_name)
+        else {
+            return false;
+        };
+        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+            return false;
+        };
+        if !symbol.has_any_flags(tsz_binder::symbol_flags::TYPE_ALIAS) {
+            return false;
+        }
+        let decl_idx = symbol.primary_declaration().unwrap_or(NodeIndex::NONE);
+        if decl_idx.is_none() {
+            return false;
+        }
+        let Some(alias) = self.ctx.arena.get_type_alias_at(decl_idx) else {
+            return false;
+        };
+        self.tuple_type_node_is_syntactic_normal_form(alias.type_node)
+    }
+
+    /// Whether a tuple type NODE is already in tsc's tuple normal form: each
+    /// spread element (`RestType` or a `...`-marked `NamedTupleMember`) has a
+    /// syntactic ARRAY-type operand. Purely syntactic — no symbol or type
+    /// resolution.
+    fn tuple_type_node_is_syntactic_normal_form(&self, type_node_idx: NodeIndex) -> bool {
+        let Some(body) = self.ctx.arena.get(type_node_idx) else {
+            return false;
+        };
+        if body.kind != syntax_kind_ext::TUPLE_TYPE {
+            return false;
+        }
+        let Some(tuple) = self.ctx.arena.get_tuple_type(body) else {
+            return false;
+        };
+        tuple.elements.nodes.iter().all(|&elem_idx| {
+            let Some(elem) = self.ctx.arena.get(elem_idx) else {
+                return true;
+            };
+            let spread_operand = if elem.kind == syntax_kind_ext::REST_TYPE {
+                self.ctx
+                    .arena
+                    .get_wrapped_type(elem)
+                    .map(|wrapped| wrapped.type_node)
+            } else if elem.kind == syntax_kind_ext::NAMED_TUPLE_MEMBER {
+                self.ctx
+                    .arena
+                    .get_named_tuple_member(elem)
+                    .filter(|member| member.dot_dot_dot_token)
+                    .map(|member| member.type_node)
+            } else {
+                None
+            };
+            spread_operand.is_none_or(|operand_idx| {
+                self.ctx
+                    .arena
+                    .get(operand_idx)
+                    .is_some_and(|operand| operand.kind == syntax_kind_ext::ARRAY_TYPE)
+            })
+        })
     }
 
     /// Internal helper that reports a detailed assignability failure using an

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_annotation_text.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_annotation_text.rs
@@ -12,7 +12,7 @@ impl<'a> CheckerState<'a> {
     /// `anchor_idx` (variable declaration, parameter, or — for a return-value
     /// source — the enclosing function's return annotation). Node-based
     /// sibling of [`Self::direct_assignment_target_annotation_text`].
-    pub(super) fn direct_assignment_target_annotation_node(
+    pub(in crate::error_reporter) fn direct_assignment_target_annotation_node(
         &self,
         anchor_idx: NodeIndex,
     ) -> Option<NodeIndex> {

--- a/crates/tsz-checker/src/tests/non_generic_spread_tuple_alias_display_tests.rs
+++ b/crates/tsz-checker/src/tests/non_generic_spread_tuple_alias_display_tests.rs
@@ -122,6 +122,33 @@ const bad: Rested = ["a"];
     );
 }
 
+/// A variadic spread whose operand is a NAMED array alias (`[...Nums, boolean]`
+/// where `Nums = number[]`) drops the alias name: tsc classifies a
+/// named-operand spread as `Variadic` (only a syntactic array-type operand is
+/// `Rest`), and normalizing the variadic element mints a fresh tuple without
+/// the alias symbol, so the structural form is rendered
+/// (`variadicTuples1.ts` line 415, TypeScript issue #40235 repro).
+#[test]
+fn named_array_operand_spread_alias_displays_structural_tuple() {
+    let messages = ts2322_messages(
+        r#"
+type Nums = number[];
+type Chain = [...Nums, boolean];
+const bad: Chain = [false, false];
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("[...number[], boolean]")),
+        "a named-array-operand spread alias should display structurally, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("Chain")),
+        "the alias name must not leak into the message, got: {messages:?}"
+    );
+}
+
 /// Per-def keying witness: a spread-flattened alias still drops its name even
 /// when a directly-written fixed tuple alias of the *same* interned shape
 /// coexists in the program. A body-`TypeId`-keyed flag could not do this — the


### PR DESCRIPTION
Goal: hold

## Structural rule

When a TS2322 assignment target is annotated by a plain (argument-free) type reference to a non-generic alias whose tuple body is written in syntactic normal form — every spread element's operand is an ARRAY type, e.g. `type Rested = [...number[], boolean]` — tsc keeps the alias identity in the message head; tsz does the same by gating the structural-rewrite hook (`rewrite_variadic_tuple_structural_ts2322`) on a resolution-free probe of the alias declaration's AST. When the body requires tuple normalization (a spread whose operand is a NAMED type, e.g. `type Unbounded = [...Numbers, boolean]` with `Numbers = number[]`), tsc's `createNormalizedTupleType` mints a fresh tuple without the alias symbol and displays the structural form — tsz falls through to the existing structural rewrite.

Owner layer: checker error_reporter (display-only). Both alias bodies EVALUATE to the same interned `TypeId` as an anonymous annotation of the same shape, so the alias declaration's AST is the only authoritative signal — no type-side discriminator exists.

## Side-effect lesson

The first draft gated on `assignment_target_annotation_alias_reference_verdict`, which performs symbol resolution mid-render and perturbed the checked program (regressed `variadicTuples1.ts` in the harness with byte-identical CLI output — the same hazard `chain_rendering_does_not_leak_diagnostics_into_enclosing_call` guards). The shipped probe is resolution-free: syntax reads plus `Binder::resolve_identifier`, a memoized read-only scope walk. Lookup failures (qualified names, generic references, imported aliases) conservatively fall back to the structural rewrite — the pre-existing behavior.

## Adjacent matrix

- normal-form alias reference keeps name: `rest_array_variadic_tuple_alias_keeps_name` (flipped pool row)
- named-array-operand spread drops name: NEW `named_array_operand_spread_alias_displays_structural_tuple` (variadicTuples1.ts:415, TS#40235 repro)
- anonymous annotation stays structural, spread-flattened aliases stay structural, direct fixed-tuple alias keeps name, per-def keying witness: pre-existing suite rows (binder names varied across cases)

## Verification

- `cargo nextest run -p tsz-checker --lib -E 'test(non_generic_spread_tuple)'` — 7/7
- full tsz-checker `--lib` battery: 6 failures, all pre-existing pool rows (was 7)
- `scripts/conformance/conformance.sh run --filter variadicTuples1.ts` — PASS
- full conformance: 11019 -> 11174 (+155), sole regression jsxComponentTypeErrors.tsx (pre-existing, owned by the TS2786 lane)
- `./scripts/emit/run.sh` — JS 11563/11563 (100%), DTS 1372/1390 (floor)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max