### PR TITLE
fix(checker): carry defaults into enclosing-type-param scope refinement

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -961,6 +961,9 @@ mod dynamic_import_relation_routing_arch_tests;
 #[path = "../tests/dynamic_import_ts2307_per_callsite_tests.rs"]
 mod dynamic_import_ts2307_per_callsite_tests;
 #[cfg(test)]
+#[path = "tests/enclosing_type_param_default_scope_tests.rs"]
+mod enclosing_type_param_default_scope_tests;
+#[cfg(test)]
 #[path = "../tests/enum_indexed_access_tests.rs"]
 mod enum_indexed_access_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/enclosing_type_param_default_scope_tests.rs
+++ b/crates/tsz-checker/src/tests/enclosing_type_param_default_scope_tests.rs
@@ -1,0 +1,123 @@
+//! An enclosing generic function's DEFAULTED type parameter must stay in
+//! scope inside nested-function bodies: `f<R = unknown>(box: Box<R>)` with
+//! `() => box.get()` types the member read as `R`, not `unknown`.
+//!
+//! Structural rule: `push_enclosing_type_parameters` (the scope push used
+//! when checking a nested function) must refine the enclosing parameter's
+//! scope entry with the SAME `TypeParamInfo` — constraint AND default — the
+//! canonical `push_type_parameters` mint carries. The decl-scoped intern
+//! cache is keyed on the full info, so an entry refined without the default
+//! interns to a DIFFERENT `TypeId` than the one member types reference;
+//! `resolve_unbound_property_member_defaults` then treats the parameter as
+//! dangling and collapses an application member read (`Box<R>.get`) to the
+//! parameter's declared default (tsc keeps `R`; zustand Family B witness).
+
+use crate::test_utils::check_source_diagnostics;
+
+fn diagnostics(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| format!("TS{}: {}", d.code, d.message_text))
+        .collect()
+}
+
+/// The Family B witness: an `unknown` default must not replace `R` in a
+/// nested arrow's member read (tsc reports no error here).
+#[test]
+fn unknown_default_param_member_read_stays_generic_in_closure() {
+    let diags = diagnostics(
+        r#"
+interface Box<R> { get(): R }
+function f<R = unknown>(box: Box<R>) {
+  const g: () => R = () => box.get()
+  return g
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "box.get() must type as R inside the closure, got: {diags:?}"
+    );
+}
+
+/// Default-value witness: a `string` default must not leak either — the
+/// poisoning used the DECLARED default, not a fixed `unknown`. (Binder names
+/// varied from the case above.)
+#[test]
+fn concrete_default_param_member_read_stays_generic_in_closure() {
+    let diags = diagnostics(
+        r#"
+interface Carton<Q> { peek(): Q }
+function open<Q = string>(carton: Carton<Q>) {
+  const view: () => Q = function () { return carton.peek() }
+  return view
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "carton.peek() must type as Q inside the function expression, got: {diags:?}"
+    );
+}
+
+/// Un-contextual closure: the collapse happened regardless of a contextual
+/// type, so pin the inferred-return form too.
+#[test]
+fn uncontextual_closure_member_read_stays_generic() {
+    let diags = diagnostics(
+        r#"
+interface Cell<V> { read(): V }
+function use<V = unknown>(cell: Cell<V>) {
+  const thunk = () => cell.read()
+  const value: V = thunk()
+  return value
+}
+"#,
+    );
+    assert!(diags.is_empty(), "thunk() must type as V, got: {diags:?}");
+}
+
+/// Negative control: a parameter with NO default (and no constraint) was
+/// never collapsed; it must keep working.
+#[test]
+fn bare_param_member_read_stays_generic_in_closure() {
+    let diags = diagnostics(
+        r#"
+interface Slot<T> { take(): T }
+function drain<T>(slot: Slot<T>) {
+  const g: () => T = () => slot.take()
+  return g
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "slot.take() must type as T inside the closure, got: {diags:?}"
+    );
+}
+
+/// The dangling-parameter fill this scope entry gates must keep firing for
+/// genuinely unbound base parameters: a class extending a generic base
+/// WITHOUT type arguments still resolves the omitted argument to its default
+/// (tsc's `fillMissingTypeArguments`), so the member read is concrete.
+#[test]
+fn omitted_base_type_args_still_fill_defaults() {
+    let diags = diagnostics(
+        r#"
+class Base<P = string> {
+  value!: P;
+}
+class Der extends Base {
+  m() {
+    const s: number = this.value;
+  }
+}
+"#,
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("2322") && d.contains("'string'")),
+        "omitted base arg must fill to its default 'string', got: {diags:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -1452,7 +1452,17 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // Pass 2: Resolve constraints now that all type parameters are in scope
+        // Pass 2: Resolve constraints AND defaults now that all type
+        // parameters are in scope. The refined intern must carry the
+        // declaration's DEFAULT as well: the canonical `push_type_parameters`
+        // mint for the same declaration includes it, and the decl-scoped
+        // cache is keyed on the full `TypeParamInfo`, so omitting the default
+        // here gives the enclosing-scope entry a DIFFERENT `TypeId` from the
+        // one the enclosing function's member types reference. The dangling-
+        // parameter fill (`resolve_unbound_property_member_defaults`) then
+        // treats the enclosing parameter as unbound and collapses e.g.
+        // `Box<R>.get`'s `R` to its declared default inside nested-function
+        // bodies (`f<R = unknown>(box: Box<R>) { () => box.get() }`).
         for param_idx in added_params {
             let Some(node) = self.ctx.arena.get(param_idx) else {
                 continue;
@@ -1461,7 +1471,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
 
-            if data.constraint == NodeIndex::NONE {
+            if data.constraint == NodeIndex::NONE && data.default == NodeIndex::NONE {
                 continue;
             }
 
@@ -1476,19 +1486,22 @@ impl<'a> CheckerState<'a> {
                 );
             let atom = self.ctx.types.intern_string(&name);
 
-            let constraint_type = self.get_type_from_type_node(data.constraint);
-            let constraint = (constraint_type != TypeId::ERROR).then_some(constraint_type);
+            let constraint = (data.constraint != NodeIndex::NONE)
+                .then(|| self.get_type_from_type_node(data.constraint))
+                .filter(|&constraint_type| constraint_type != TypeId::ERROR);
+            let default = (data.default != NodeIndex::NONE)
+                .then(|| self.get_type_from_type_node(data.default))
+                .filter(|&default_type| default_type != TypeId::ERROR);
 
             let is_const = self
                 .ctx
                 .arena
                 .has_modifier(&data.modifiers, tsz_scanner::SyntaxKind::ConstKeyword);
-            let info =
-                signature_building_boundary::user_type_param_info(atom, constraint, None, is_const);
-            let constrained_type_id = self.intern_type_param_for_decl(data.name, info);
-            self.ctx
-                .type_parameter_scope
-                .insert(name, constrained_type_id);
+            let info = signature_building_boundary::user_type_param_info(
+                atom, constraint, default, is_const,
+            );
+            let refined_type_id = self.intern_type_param_for_decl(data.name, info);
+            self.ctx.type_parameter_scope.insert(name, refined_type_id);
         }
 
         updates


### PR DESCRIPTION
Goal: green

## Structural rule

When a nested function's body reads a member of a generic application whose argument is an ENCLOSING function's type parameter (`f<R = unknown>(box: Box<R>) { () => box.get() }`), tsc types the member as `R` — the parameter is lexically in scope. tsz collapsed it to the parameter's DECLARED DEFAULT (`unknown`; `string` for `R = string`), producing false TS2322/TS2345 — the zustand-canary Family B family.

Owner layer: checker scope maintenance (`push_enclosing_type_parameters`). Its refinement pass re-interned the enclosing parameter with its constraint but WITHOUT its declared default, and skipped default-only parameters entirely. The decl-scoped intern cache is keyed on the full `TypeParamInfo`, so the scope entry interned to a DIFFERENT `TypeId` than the one the enclosing function's member types reference (probe witness: scope R=948 vs member R=976, same name). `resolve_unbound_property_member_defaults` — the compensating fill for genuinely dangling base-class parameters (tsc's `fillMissingTypeArguments`) — then saw the parameter as unbound and filled its default. Fix: resolve the default alongside the constraint in the refinement pass, mirroring the canonical `push_type_parameters` mint, so both paths intern the same `TypeId`.

Refuted along the way (probes, zero hits on the witness): `TypeSubstitution::from_args` Phase-3 default binding, `visit_lazy` all-defaulted instantiation, `erase_signature_type_params`, `return_context` arg padding, `sanitize_tuple_inference_candidate`.

## Adjacent matrix (new suite `enclosing_type_param_default_scope_tests`, 5 tests, binder names varied)

- `unknown`-default witness (zustand Family B crown jewel) — arrow closure, contextual
- concrete `string` default — function expression (proves the DECLARED default was leaking, not a fixed `unknown`)
- un-contextual closure + later use — collapse fired without contextual types
- bare parameter (no default/constraint) — negative control, never collapsed
- omitted base type args still fill to defaults (`class Der extends Base` with `Base<P = string>`) — the dangling-parameter fill this scope entry gates keeps firing; oracle-verified

## Canary impact

Real zustand canary (tsz-guard config, vendored tsc 7.0.2 diff): tsz-only delta 6 -> 4 lines; both `persist.ts` Family B TS2322s eliminated. Survivors are the known Family A (devtools `setState` contextual typing) and Family C (TS2352 thenable comparability), unrelated. Minimized suite /tmp/zustand-min/p (17 fixtures): all oracle-clean.

## Verification

- new suite 5/5; full tsz-checker `--lib` battery: same 6 pre-existing failures, 0 new
- full conformance: 11019 -> 11174 (+155), unchanged; sole regression remains jsxComponentTypeErrors.tsx (separate TS2786 lane)
- `./scripts/emit/run.sh`: JS 11563/11563 (100%), DTS 1372/1390 (floor)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max