### PR TITLE
fix(checker): classify <this/> JSX tags through the normal component path

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -366,29 +366,17 @@ impl<'a> CheckerState<'a> {
         tag_name_idx: NodeIndex,
     ) {
         let tag_text = self.get_jsx_tag_name_text(tag_name_idx);
+        // A `<this/>` tag classifies like any component-typed tag — callable
+        // `this` takes the function-component path (return validation, TS2786
+        // with a reason chain when invalid), non-callable `this` falls through
+        // to TS2604 below. Its tag text is lowercase, so it must bypass the
+        // intrinsic-tag early return that swallows `<div/>`-style names.
         let is_this_tag = tag_text == "this";
-        if is_this_tag {
-            use crate::diagnostics::diagnostic_codes;
-
-            if let Some((start, _)) = self.get_node_span(tag_name_idx)
-                && self.ctx.diagnostics.iter().any(|diag| {
-                    diag.code == diagnostic_codes::CANNOT_BE_USED_AS_A_JSX_COMPONENT
-                        && diag.start == start
-                })
-            {
-                return;
-            }
-            self.error_at_node_msg(
-                tag_name_idx,
-                diagnostic_codes::JSX_ELEMENT_TYPE_DOES_NOT_HAVE_ANY_CONSTRUCT_OR_CALL_SIGNATURES,
-                &[&tag_text],
-            );
-            return;
-        }
-        if tag_text
-            .as_bytes()
-            .first()
-            .is_some_and(|ch| ch.is_ascii_lowercase())
+        if !is_this_tag
+            && tag_text
+                .as_bytes()
+                .first()
+                .is_some_and(|ch| ch.is_ascii_lowercase())
         {
             return;
         }
@@ -419,14 +407,14 @@ impl<'a> CheckerState<'a> {
             return;
         }
         // If props extraction succeeds, the type is already recognized as a
-        // valid JSX component shape (callable/constructable in JSX context).
-        // Keep `this` tags strict: `<this/>` should still report TS2604.
+        // valid JSX component shape (callable/constructable in JSX context) —
+        // including a callable `this` tag, whose validity is then owned by
+        // return validation (TS2786), not TS2604.
         // Pass `None` for element_idx so this probe doesn't emit its own
         // TS2607 — the call is purely a "did extraction succeed?" check.
-        if !is_this_tag
-            && self
-                .get_jsx_props_type_for_component_member(component_type, None)
-                .is_some()
+        if self
+            .get_jsx_props_type_for_component_member(component_type, None)
+            .is_some()
         {
             return;
         }
@@ -478,8 +466,12 @@ impl<'a> CheckerState<'a> {
                 || crate::query_boundaries::common::contains_type_parameters(self.ctx.types, ty)
                 || self.is_generic_jsx_component(ty)
             {
-                if is_this_tag || crate::query_boundaries::common::is_this_type(self.ctx.types, ty)
-                {
+                // A raw `this`-type marker is not yet a callable; a generic
+                // CALLABLE `this` (an expando function receiver) counts as
+                // having signatures like any other generic component — its
+                // validity is owned by return validation (TS2786), so forcing
+                // TS2604 here would double-report.
+                if crate::query_boundaries::common::is_this_type(self.ctx.types, ty) {
                     return false;
                 }
                 return true;
@@ -495,9 +487,7 @@ impl<'a> CheckerState<'a> {
             // Callable types with call/construct signatures.  Treat them as potentially
             // having signatures to avoid false TS2604.  The actual signature checking
             // happens during props extraction where these types are fully evaluated.
-            if !is_this_tag
-                && crate::query_boundaries::common::needs_evaluation_for_merge(self.ctx.types, ty)
-            {
+            if crate::query_boundaries::common::needs_evaluation_for_merge(self.ctx.types, ty) {
                 return true;
             }
             let direct_has_signatures =

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -1429,6 +1429,18 @@ impl<'a> CheckerState<'a> {
                 TypeId::UNKNOWN
             };
 
+            // Pre-cache the base function type before collecting expando
+            // members. Collecting a member like `F.useThis = function() {...}`
+            // checks the RHS body, whose implicit `this` binding forces
+            // `typeof F` while F is still on the resolution stack; without a
+            // cache entry that re-entry takes the circular-guard FUNCTION
+            // branch and yields the provisional no-return-inference signature
+            // (`() => any`), which then poisons every `this`-based read in the
+            // body (the jsxComponentTypeErrors `<this/>` TS2786 chain needs
+            // the real inferred return). The final augmented type overwrites
+            // this entry when the symbol's resolution completes. Mirrors the
+            // namespace-merge pre-cache below.
+            self.ctx.symbol_types.insert(sym_id, function_type);
             let function_type =
                 self.augment_callable_type_with_expandos(&escaped_name, sym_id, function_type);
 

--- a/crates/tsz-checker/tests/jsx_component_attribute_tests/part_03.rs
+++ b/crates/tsz-checker/tests/jsx_component_attribute_tests/part_03.rs
@@ -1372,7 +1372,13 @@ class Text extends Component<{{}}, {{}}> {{
 }
 
 #[test]
-fn test_ts2604_this_tag_not_suppressed_by_component_union_this_annotation() {
+fn test_this_tag_with_component_union_this_annotation_is_valid() {
+    // Oracle-adjudicated (tsc 7.0.2): a `<this/>` tag whose `this` is
+    // annotated as a union of valid component function types is a VALID JSX
+    // component — tsc emits nothing. The previous pin asserted TS2604, which
+    // was the unconditional this-tag hardcode's behavior, not tsc's; this-tag
+    // classification now flows through the normal component path (callable ->
+    // return validation; non-callable -> TS2604).
     let source = format!(
         r#"
 {JSX_PREAMBLE}
@@ -1386,11 +1392,15 @@ function render(this: C1 | C2) {{
     );
     let diags = jsx_diagnostics(&source);
     assert!(
-        has_code(
+        !has_code(
             &diags,
             diagnostic_codes::JSX_ELEMENT_TYPE_DOES_NOT_HAVE_ANY_CONSTRUCT_OR_CALL_SIGNATURES
         ),
-        "Expected TS2604 for <this/> even when `this` annotation is a component-union, got: {diags:?}"
+        "tsc accepts <this/> for a component-union `this` annotation (no TS2604), got: {diags:?}"
+    );
+    assert!(
+        !has_code(&diags, diagnostic_codes::CANNOT_BE_USED_AS_A_JSX_COMPONENT),
+        "tsc accepts <this/> for a component-union `this` annotation (no TS2786), got: {diags:?}"
     );
 }
 


### PR DESCRIPTION
Goal: hold

## Structural rule

A `<this/>` JSX tag classifies like any component-typed tag: when the this-type is callable, tsc takes the function-component path and validates the RETURN type (TS2786 "'this' cannot be used as a JSX component." with the return-type reason chain when invalid); when it is not callable (class instance, object-literal method), tsc reports TS2604. tsz hardcoded `tag_text == "this"` into an unconditional TS2604.

Two coupled owners:
1. **Checker symbol resolution** (`compute_type_of_symbol`): the expando path collected members without pre-caching the base function type, so the RHS body's implicit this-binding re-entered `typeof F` mid-resolution and got the provisional no-return-inference signature (`() => any`) — probe-verified this session. Fix mirrors the adjacent namespace-merge pre-cache: insert the return-inferred base signature before `augment_callable_type_with_expandos`; the final augmented type overwrites it at resolution completion.
2. **JSX classifier** (`check_jsx_element_has_signatures`): the this-tag hardcode existed only because 'this' is lowercase and the intrinsic-tag guard would swallow it. Removed; this-tags now bypass the lowercase guard and flow through normal classification (props-extraction success, generic-component handling, signature probing).

This flips the LAST conformance regression: **full conformance is now 11019 -> 11175 (+156) with ZERO regressions**.

## Oracle adjudication

The pre-existing pin `test_ts2604_this_tag_not_suppressed_by_component_union_this_annotation` asserted the hardcode's behavior; tsc 7.0.2 emits NOTHING for `<this ok/>` under a component-union `this` annotation (verified on the exact preamble). Pin flipped to assert acceptance (no TS2604, no TS2786).

## Adjacent matrix (all oracle-verified)

- generic expando this-tag (the conformance row): TS2786 + chain — flips ✓
- non-generic expando: TS2786 ✓
- callable this with VALID return: clean (fixes a previously-wrong spurious TS2604) ✓
- class-method `<this/>`: TS2604 (existing pin `test_ts2604_emitted_for_this_tag_in_class_method` still passes) ✓
- `<this.#prop/>` property-access tags: unaffected (not a this-tag) — analysis-verified
- Known residual (filed intent, not pinned anywhere): arrow-in-expando global-capture loses a companion TS2604 because tsz models a global-capturing arrow's `this` as `any` rather than `typeof globalThis` — separate modeling gap, no conformance/unit coverage exercises it.

Analysis credit: teammate deep-dive (deciding frame at the circular-guard FUNCTION branch; provisional signature at `provisional_circular_function_symbol_type`).

## Verification

- `scripts/conformance/conformance.sh run --filter jsxComponentTypeErrors` — PASS
- full conformance: 11019 -> 11175 (+156), ZERO PASS->FAIL regressions
- tsz-checker `--lib`: same 6 pre-existing pool failures, 0 new; jsx+expando families 437 -> all green (1 pin flipped by oracle adjudication)
- `./scripts/emit/run.sh`: JS 11563/11563 (100%), DTS 1372/1390 (floor)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max