### PR TITLE
test(checker): repair two pool rows pinned to harness-lib artifacts

### DIFF
--- a/crates/tsz-checker/tests/dynamic_import_defer_tests.rs
+++ b/crates/tsz-checker/tests/dynamic_import_defer_tests.rs
@@ -122,11 +122,41 @@ import.defer("./a.js");
 
 #[test]
 fn import_defer_then_callback_is_contextually_typed() {
-    let diagnostics = import_defer_diagnostics(ModuleKind::ES2020);
+    // Oracle-adjudicated rewrite (tsc 7.0.2): the previous single-file
+    // fixture pinned a scenario tsc REJECTS outright — `import.defer` under
+    // `--module es2020` is TS18060 (esnext/preserve only), and its
+    // `declare module "./a.js"` relative ambient name is TS2436 — so the
+    // no-TS7006 expectation held only degenerately. The valid form (module
+    // esnext, a real sibling module, the real es2015 Promise) is clean in
+    // BOTH compilers with the callback contextually typed; the CLI matches.
+    let libs = crate::test_utils::load_compiled_lib_files(&[
+        "lib.es5.d.ts",
+        "lib.es2015.promise.d.ts",
+        "lib.es2015.symbol.d.ts",
+        "lib.es2015.symbol.wellknown.d.ts",
+    ]);
+    let diagnostics = crate::test_utils::diagnostic_code_messages(
+        crate::test_utils::check_multi_file_with_libs_stamped(
+            &[
+                ("a.ts", "export function foo(): void {}\n"),
+                (
+                    "b.ts",
+                    "import.defer(\"./a.js\").then(ns => {\n  ns.foo();\n});\nexport {};\n",
+                ),
+            ],
+            "b.ts",
+            CheckerOptions {
+                strict: true,
+                module: ModuleKind::ESNext,
+                ..CheckerOptions::default()
+            },
+            &libs,
+        ),
+    );
 
     assert!(
         diagnostics.iter().all(|(code, _)| *code != 7006),
-        "Expected import.defer(...).then callback to be contextually typed, got: {diagnostics:?}"
+        "the import.defer(...).then callback must be contextually typed, got: {diagnostics:?}"
     );
 }
 

--- a/crates/tsz-checker/tests/yield_star_return_type_tests.rs
+++ b/crates/tsz-checker/tests/yield_star_return_type_tests.rs
@@ -18,7 +18,7 @@ use crate::test_utils::check_source;
 /// via `is_generator_like_name`.
 const GENERATOR_STUBS: &str = r#"
 interface SymbolConstructor {
-    readonly iterator: symbol;
+    readonly iterator: unique symbol;
 }
 declare var Symbol: SymbolConstructor;
 interface ReadonlyArray<T> {
@@ -255,6 +255,20 @@ function* g(): Iterator<Iterable<(x: string) => number>> {
 
 #[test]
 fn yield_star_generator_callback_mismatch_reports_outer_ts2345() {
+    // This fixture needs the REAL es2015 lib: its component type declares a
+    // `[Symbol.iterator]()` member, and the checker recognizes well-known
+    // symbol keys by the BUILTIN lib `Symbol` identity — the file-local
+    // `SymbolConstructor` stub cannot stand in for it, so under the stub the
+    // member never registers as the iterator method and the case degrades to
+    // TS2488. The CLI (real lib) has always produced the expected 2x TS2345.
+    let libs = crate::test_utils::load_compiled_lib_files(&[
+        "lib.es5.d.ts",
+        "lib.es2015.core.d.ts",
+        "lib.es2015.symbol.d.ts",
+        "lib.es2015.symbol.wellknown.d.ts",
+        "lib.es2015.iterable.d.ts",
+        "lib.es2015.generator.d.ts",
+    ]);
     let source = r#"
 declare const inner3: {
   <A>(value: A): {
@@ -278,7 +292,16 @@ outer3(function* <T>(value: T) {
   yield* x;
 });
 "#;
-    let diags = check_with_strict(source);
+    let options = crate::context::CheckerOptions {
+        strict_null_checks: true,
+        no_implicit_any: true,
+        ..crate::context::CheckerOptions::default()
+    };
+    let diags: Vec<(u32, String)> =
+        crate::test_utils::check_source_with_libs(source, "test.ts", options, &libs)
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect();
     let ts2345_count = diags.iter().filter(|(code, _)| *code == 2345).count();
     let ts2488_count = diags.iter().filter(|(code, _)| *code == 2488).count();
     assert_eq!(


### PR DESCRIPTION
Goal: hold

## Structural rule

Two pre-existing checker-pool failures were pins on harness-environment artifacts, not compiler defects — both CLI-verified against tsc 7.0.2 before repair:

1. **yield_star** (`yield_star_generator_callback_mismatch_reports_outer_ts2345`): tsz's well-known-symbol recognition keys on the BUILTIN lib `Symbol` identity; the file-local `SymbolConstructor` stub can't stand in, so the `[Symbol.iterator]()` member never registered and the case degraded to TS2488 in-harness. The CLI with the real lib has always produced the expected 2× TS2345 (verified). Converted the test to `check_source_with_libs` with the real es2015 lib set; also corrected the shared stub's `iterator: symbol` → `unique symbol` (matches lib; the other 15 tests in the file stay green with higher fidelity).
2. **import_defer** (`import_defer_then_callback_is_contextually_typed`): oracle-adjudicated — the single-file fixture is a scenario tsc REJECTS outright (`import.defer` under `--module es2020` → TS18060 esnext/preserve-only; relative `declare module \"./a.js\"` → TS2436). Rewritten to the valid multi-file esnext form with the real es2015 Promise: clean in BOTH compilers, callback contextually typed (CLI-verified byte-equal on the equivalent fixture).

Noted for a separate lane (pre-existing, currently-passing pin): tsz emits TS1323 for unsupported-module `import.defer` where tsc 7.0.2 emits TS18060.

## Verification

- yield_star family 16/16; import_defer family 5/5
- full tsz-checker `--lib` battery: **6 -> 4 failures** (remaining: template display, higher_order regen, overload_two_pass, zod_type_query), 0 new
- both rewritten scenarios oracle-run on tsc 7.0.2 (outputs in the test comments)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max