### PR TITLE
fix(solver): type rest params from the combined signature of overloaded contextual callables

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1439,6 +1439,9 @@ mod overload_two_pass_any_source_tests;
 #[path = "tests/overload_union_context_callback_tests.rs"]
 mod overload_union_context_callback_tests;
 #[cfg(test)]
+#[path = "tests/overloaded_contextual_rest_tuple_tests.rs"]
+mod overloaded_contextual_rest_tuple_tests;
+#[cfg(test)]
 #[path = "tests/partial_pick_indexed_access_write_tests.rs"]
 mod partial_pick_indexed_access_write_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/overloaded_contextual_rest_tuple_tests.rs
+++ b/crates/tsz-checker/src/tests/overloaded_contextual_rest_tuple_tests.rs
@@ -1,0 +1,146 @@
+//! A rest-parameter arrow contextually typed by an OVERLOADED callable takes
+//! its rest tuple from the COMBINED signature — the parameter-wise union
+//! across same-arity overloads (tsc's `getIntersectedSignatures` feeding the
+//! effective rest tuple) — not from the first overload.
+//!
+//! Witness (zustand devtools, canary Family A): `StoreApi<S>['setState']`
+//! with two `setState` overloads `(a: T, b?: false)` / `(a: T, b: true)`
+//! must type `(...a)` as `[S, (boolean | undefined)?]` so the arrow
+//! satisfies BOTH overloads; the first-overload tuple `[S, false |
+//! undefined]` fails the second and produced a false TS2322. Optionality
+//! merges per index (optional when ANY overload marks it optional) so
+//! call-site arity is unaffected.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322_count(source: &str) -> usize {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .count()
+}
+
+const OVERLOADED_STORE: &str = r#"
+interface StoreApi<T> {
+  setState: { (a: T, b?: false): void; (a: T, b: true): void }
+}
+"#;
+
+/// The canary witness: rest-param arrow against the alias-arg indexed access.
+#[test]
+fn rest_arrow_satisfies_overloaded_member_via_alias_arg() {
+    let source = format!(
+        "{OVERLOADED_STORE}
+type S = {{ a: number }}
+export function wire() {{
+  const s: StoreApi<S>['setState'] = (...a) => {{}}
+}}
+"
+    );
+    assert_eq!(ts2322_count(&source), 0, "tsc accepts the rest-param arrow");
+}
+
+/// Inline-argument form (was already green; pins that the merge did not
+/// regress it). Binder names varied.
+#[test]
+fn rest_arrow_satisfies_overloaded_member_via_inline_arg() {
+    let source = format!(
+        "{OVERLOADED_STORE}
+export function hook() {{
+  const s: StoreApi<{{ n: string }}>['setState'] = (...rest) => {{}}
+}}
+"
+    );
+    assert_eq!(ts2322_count(&source), 0, "inline-arg form stays accepted");
+}
+
+/// Function-local alias over the enclosing generic — the zustand shape.
+#[test]
+fn rest_arrow_satisfies_overloaded_member_via_local_alias() {
+    let source = format!(
+        "{OVERLOADED_STORE}
+export function wire<T>(fn: () => T) {{
+  type S = ReturnType<typeof fn> & {{ [k: string]: ReturnType<typeof fn> }}
+  const s: StoreApi<S>['setState'] = (...a) => {{}}
+}}
+"
+    );
+    assert_eq!(
+        ts2322_count(&source),
+        0,
+        "local-alias generic form accepted"
+    );
+}
+
+/// The merged tuple's second element unions the overloads' parameter types
+/// (`false | undefined` with `true` = `boolean | undefined`), revealed via a
+/// deliberate never-assignment.
+#[test]
+fn merged_rest_tuple_unions_parameter_types_across_overloads() {
+    let source = format!(
+        "{OVERLOADED_STORE}
+type S = {{ a: number }}
+export function reveal() {{
+  const s: StoreApi<S>['setState'] = (...a) => {{ const n: never = a }}
+}}
+"
+    );
+    let diags = check_source_diagnostics(&source);
+    let reveal = diags
+        .iter()
+        .find(|d| d.code == 2322 && d.message_text.contains("'never'"))
+        .expect("the never-assignment must fail");
+    assert!(
+        reveal.message_text.contains("boolean | undefined"),
+        "the rest tuple must union the overload parameter types, got: {}",
+        reveal.message_text
+    );
+    assert!(
+        !reveal.message_text.contains("false | undefined]"),
+        "the rest tuple must not be the first overload's shape, got: {}",
+        reveal.message_text
+    );
+}
+
+/// Negative control: a PRE-DECLARED mono-signature value (not a
+/// context-sensitive arrow) is genuinely not assignable to the overloaded
+/// member — tsc rejects it too.
+#[test]
+fn predeclared_mono_signature_still_fails_overloaded_member() {
+    let source = format!(
+        "{OVERLOADED_STORE}
+type S = {{ a: number }}
+declare const fixed: (...a: [a: S, b?: false | undefined]) => void
+const t: StoreApi<S>['setState'] = fixed
+"
+    );
+    assert_eq!(
+        ts2322_count(&source),
+        1,
+        "a pre-declared first-overload-shaped value must keep failing"
+    );
+}
+
+/// Negative control: merged optionality must not require the optional
+/// parameter at call sites through the contextual arrow.
+#[test]
+fn merged_tuple_keeps_single_argument_calls_working() {
+    let source = format!(
+        "{OVERLOADED_STORE}
+type S = {{ a: number }}
+export function relay(api: StoreApi<S>) {{
+  const s: StoreApi<S>['setState'] = (...a) => {{ api.setState(...a) }}
+  s({{ a: 1 }})
+}}
+"
+    );
+    let diags = check_source_diagnostics(&source);
+    assert!(
+        diags.is_empty(),
+        "single-argument dispatch through the merged tuple must stay clean, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-solver/src/contextual/extractors.rs
+++ b/crates/tsz-solver/src/contextual/extractors.rs
@@ -1374,6 +1374,43 @@ impl<'a> RestParameterExtractor<'a> {
     }
 
     pub(crate) fn extract(&mut self, type_id: TypeId) -> Option<TypeId> {
+        // A multi-signature (overloaded) contextual callable types a rest
+        // parameter from the COMBINED signature — the parameter-wise union
+        // across same-arity overloads (tsc's `getIntersectedSignatures`
+        // feeding the effective rest tuple) — not from the first overload.
+        // Witness (zustand devtools): `StoreApi<S>['setState']` with two
+        // `setState` overloads must type `(...a)` as `[S, boolean |
+        // undefined]` so the arrow satisfies BOTH overloads; the
+        // first-overload tuple `[S, false | undefined]` fails the second and
+        // produced the canary's false TS2322. Single-signature callables and
+        // non-combinable sets (mixed arity / generic members — the combiner
+        // returns `None` for those, matching tsc) keep the visitor path.
+        if let Some(TypeData::Callable(shape_id)) = self.db.lookup(type_id) {
+            let shape = self.db.callable_shape(shape_id);
+            let sigs = &shape.call_signatures;
+            if sigs.len() > 1
+                && sigs.iter().all(|sig| {
+                    sig.type_params.is_empty()
+                        && sig.params.len() == sigs[0].params.len()
+                        && !sig.params.iter().any(|p| p.rest)
+                })
+            {
+                let merged: Vec<ParamInfo> = (0..sigs[0].params.len())
+                    .map(|i| {
+                        let types: Vec<TypeId> =
+                            sigs.iter().map(|sig| sig.params[i].type_id).collect();
+                        let optional = sigs.iter().any(|sig| sig.params[i].optional);
+                        ParamInfo {
+                            name: None,
+                            type_id: self.db.union_literal_reduce(types),
+                            optional,
+                            rest: false,
+                        }
+                    })
+                    .collect();
+                return extract_rest_param_type_at(self.db, &merged, self.index);
+            }
+        }
         self.visit_type(self.db, type_id)
     }
 }


### PR DESCRIPTION
Goal: green

## Structural rule

When a rest-parameter arrow is contextually typed by an OVERLOADED callable, tsc types the rest tuple from the COMBINED signature — the parameter-wise union across same-arity overloads (`getIntersectedSignatures` feeding the effective rest tuple) — so the arrow satisfies every overload. tsz's `RestParameterExtractor` took the FIRST signature, inferring `[S, false | undefined]` for zustand's `StoreApi<S>['setState']` (overloads `replace?: false` / `replace: true`); that mono-shape genuinely fails the second overload (oracle-verified: a PRE-DECLARED value of that shape is rejected by tsc too), producing the last zustand-canary TS2322 (Family A).

Owner layer: solver contextual extraction (`contextual/extractors.rs`). Merge policy: per-index union of parameter types; OPTIONAL when any overload marks the position optional — a required merge regressed call-site arity across the canary (3 -> 11, measured) and was corrected (3 -> 2). Mixed-arity/generic sets keep the first-match path, matching tsc's refusal to combine those.

Oracle-adjudicated matrix (zam fixtures, every cell run on tsc 7.0.2): alias arg (file-level AND function-local generic), inline arg, revealed tuple shape `[S, boolean | undefined]` byte-matching tsc, pre-declared mono still rejected, single-argument dispatch arity preserved.

## Canary impact

zustand tsz-only delta **3 -> 2**; the `setStateFromDevtools` TS2322 is gone. Survivors: the two TS7006 at devtools.ts:217 (the `as NamedSet<S>` assertion-contextual leg — reduced probes of that form pass, needs the deeper TakeTwo chain; separate lane).

## Verification

- new suite `overloaded_contextual_rest_tuple_tests` 6/6 (witness FLIPS)
- tsz-checker `--lib`: same 4 pre-existing pool failures, 0 new; tsz-solver `--lib`: 7434/7434
- full conformance: 11019 -> 11175 (+156), zero regressions (unchanged)
- `./scripts/emit/run.sh`: JS 11563/11563 (100%), DTS 1372/1390 (floor)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max