### PR TITLE
fix(checker): keep the overload set when normalizing multi-signature contextual callables

### DIFF
--- a/crates/tsz-checker/src/tests/overloaded_contextual_rest_tuple_tests.rs
+++ b/crates/tsz-checker/src/tests/overloaded_contextual_rest_tuple_tests.rs
@@ -144,3 +144,72 @@ export function relay(api: StoreApi<S>) {{
             .collect::<Vec<_>>()
     );
 }
+
+/// The full zustand devtools chain (canary Family A, final leg): an arrow
+/// with NAMED parameters cast to `NamedSet<S>` — a conditional that captures
+/// the two `setState` overloads with `infer` and rebuilds them with
+/// `[...TakeTwo<Sa>, action?: Action]` variadic rest tuples. The multi-sig
+/// contextual callable must keep its overload set (no mono-collapse) and
+/// each signature's deferred rest tuple must env-evaluate so the parameters
+/// contextually type (tsc reports nothing here; tsz emitted 2x TS7006).
+#[test]
+fn named_params_arrow_casts_to_infer_rebuilt_overload_set() {
+    let source = r#"
+type SetStateInternal<T> = {
+  _(
+    partial: T | Partial<T> | { _(state: T): T | Partial<T> }['_'],
+    replace?: false,
+  ): void
+  _(state: T | { _(state: T): T }['_'], replace: true): void
+}['_']
+interface StoreApi<T> {
+  setState: SetStateInternal<T>
+}
+type Cast<T, U> = T extends U ? T : U
+type TakeTwo<T> = T extends { length: 2 }
+  ? T
+  : T extends [infer A0, (infer A1)?, ...unknown[]]
+    ? [A0, A1?]
+    : never
+type Action = string | { type: string }
+type StoreDevtools<S> = S extends {
+  setState: {
+    (...args: infer Sa1): infer Sr1
+    (...args: infer Sa2): infer Sr2
+  }
+}
+  ? {
+      setState(...args: [...args: TakeTwo<Sa1>, action?: Action]): Sr1
+      setState(...args: [...args: TakeTwo<Sa2>, action?: Action]): Sr2
+    }
+  : never
+export type NamedSet<T> = StoreDevtools<StoreApi<T>>['setState']
+type S = { a: number }
+export function wire(api: StoreApi<S>) {
+  api.setState = ((state, replace, nameOrAction: Action) => {
+    void state
+    void replace
+    void nameOrAction
+  }) as NamedSet<S>
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    let implicit_any = diags.iter().filter(|d| d.code == 7006).count();
+    assert_eq!(
+        implicit_any,
+        0,
+        "state/replace must be contextually typed through the rebuilt overload set, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2352),
+        "the cast must sufficiently overlap, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
+++ b/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
@@ -1107,6 +1107,48 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // A MULTI-signature callable keeps its overload set. Collapsing it to
+        // the combined mono shape (the get_contextual_signature +
+        // function_type_from_shape path below) replaces per-overload
+        // positional extraction — which unions parameter types across the
+        // set — with a single signature whose merged rest tuple defeats
+        // positional mapping (probe: the pre-collapse callable extracts every
+        // position; the collapsed form loses parameter 1 and emitted false
+        // TS7006 on the zustand devtools `as NamedSet<S>` arrow). Instead,
+        // env-evaluate each signature's parameter types in place — the same
+        // service the mono path below provides — so deferred forms like the
+        // rebuilt overloads' `[...TakeTwo<Sa>, action?: Action]` rest tuples
+        // reduce (and spread-of-tuple normalization flattens them) while the
+        // overload set survives for the per-signature extractors.
+        if let Some(shape_id) =
+            crate::query_boundaries::common::callable_shape_id(self.ctx.types, expected)
+        {
+            let shape = self.ctx.types.callable_shape(shape_id);
+            if shape.call_signatures.len() > 1 {
+                let mut rebuilt = shape.as_ref().clone();
+                let mut changed = false;
+                for sig in &mut rebuilt.call_signatures {
+                    if !sig.type_params.is_empty() {
+                        continue;
+                    }
+                    for param in &mut sig.params {
+                        let evaluated = self.evaluate_type_with_env(param.type_id);
+                        if evaluated != param.type_id
+                            && evaluated != TypeId::ERROR
+                            && evaluated != TypeId::UNKNOWN
+                        {
+                            param.type_id = evaluated;
+                            changed = true;
+                        }
+                    }
+                }
+                if changed {
+                    return self.ctx.types.callable(rebuilt);
+                }
+                return expected;
+            }
+        }
+
         let Some(mut shape) = crate::query_boundaries::checkers::call::get_contextual_signature(
             self.ctx.types,
             expected,


### PR DESCRIPTION
Goal: green

## Structural rule

A function expression contextually typed by an OVERLOADED callable extracts each parameter position across the whole overload set (per-signature union). tsz's `normalize_contextual_signature_with_env` collapsed multi-signature callables into the combined mono `FunctionShape` — probe-verified to LOSE positions when the merged rest tuple defeats positional mapping. Witness (zustand devtools, the last canary lines): the `as NamedSet<S>` arrow, whose contextual type is the conditional-rebuilt `setState` overload pair carrying `[...TakeTwo<Sa>, action?: Action]` variadic rest tuples, emitted false TS7006 on `state`/`replace`.

Fix: for multi-signature callables, env-evaluate each signature's parameter types in place (reducing the deferred `TakeTwo` applications; tuple normalization flattens the spread-of-tuple forms) and KEEP the callable. Generic signature sets stay untouched, matching the mono combiner's refusal.

Owner layer: checker contextual normalization (`types/utilities/contextual_parameters.rs`). Probe chain recorded across three deciding frames: pre-collapse callable extracts p0/p1/p2; collapsed `Function` loses p1; per-sig extraction then starved on unevaluated `Application` spread operands (pure-db evaluation cannot reduce `TakeTwo` — the env-backed rebuild is the correct layer).

## Canary impact

**zustand tsz-only delta 2 -> 0 — BOTH canary rows (zustand + ofetch) are now fully clean** against the vendored tsc 7.0.2 on the tsz-guard configs. The zam8 witness matrix (incl. the raw-infer, Cast, no-Write variants) all match the oracle; the single-overload zam8d variant is a true positive in both compilers.

## Verification

- suite `overloaded_contextual_rest_tuple_tests` 7/7 (new NamedSet-chain pin FLIPS)
- tsz-checker `--lib`: same 4 pre-existing pool failures, 0 new; tsz-solver `--lib`: 7434/7434
- full conformance: 11019 -> 11175 (+156), zero regressions (unchanged)
- `./scripts/emit/run.sh`: JS 11563/11563 (100%), DTS 1372/1390 (floor)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max