### PR TITLE
fix(cli): sync help text and unknown-option diagnostics to tsc 7.0.2 (parity wave 1)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz/clap_errors.rs
+++ b/crates/tsz-cli/src/bin/tsz/clap_errors.rs
@@ -17,15 +17,12 @@ pub(super) fn handle_clap_error(err: clap::Error, args: &[OsString]) -> Result<(
                 println!("error TS5023: Unknown compiler option.");
             } else {
                 for flag in &unknown_flags {
-                    // Try to find a close match for TS5025
-                    if let Some(suggestion) = find_closest_option(flag) {
-                        let suggestion_name = suggestion.strip_prefix("--").unwrap_or(suggestion);
-                        println!(
-                            "error TS5025: Unknown compiler option '{flag}'. Did you mean '{suggestion_name}'?"
-                        );
-                    } else {
-                        println!("error TS5023: Unknown compiler option '{flag}'.");
-                    }
+                    // tsc 7.0.2 (native) reports every unknown option as a
+                    // bare TS5023 — the TS5025 "Did you mean" suggestion was
+                    // dropped (oracle: `tsc --targett esnext` and
+                    // `tsc --tagret esnext` both emit TS5023 with no
+                    // suggestion). Match it.
+                    println!("error TS5023: Unknown compiler option '{flag}'.");
                 }
             }
             std::process::exit(1);
@@ -348,59 +345,3 @@ pub(super) const KNOWN_TSC_OPTIONS: &[&str] = &[
     "--watchDirectory",
     "--watchFile",
 ];
-
-/// Compute Levenshtein edit distance between two strings (case-insensitive).
-fn edit_distance(a: &str, b: &str) -> usize {
-    let a_lower = a.to_lowercase();
-    let b_lower = b.to_lowercase();
-    let a_chars: Vec<char> = a_lower.chars().collect();
-    let b_chars: Vec<char> = b_lower.chars().collect();
-    let m = a_chars.len();
-    let n = b_chars.len();
-
-    let mut dp = vec![vec![0usize; n + 1]; m + 1];
-    for (i, row) in dp.iter_mut().enumerate().take(m + 1) {
-        row[0] = i;
-    }
-    for (j, val) in dp[0].iter_mut().enumerate().take(n + 1) {
-        *val = j;
-    }
-    for i in 1..=m {
-        for j in 1..=n {
-            let cost = if a_chars[i - 1] == b_chars[j - 1] {
-                0
-            } else {
-                1
-            };
-            dp[i][j] = (dp[i - 1][j] + 1)
-                .min(dp[i][j - 1] + 1)
-                .min(dp[i - 1][j - 1] + cost);
-        }
-    }
-    dp[m][n]
-}
-
-/// Find the closest known tsc option to the given unknown flag.
-/// Returns `Some(suggestion)` if a reasonably close match exists (edit distance <= 3).
-fn find_closest_option(unknown: &str) -> Option<&'static str> {
-    let mut best: Option<(&str, usize)> = None;
-    for &known in KNOWN_TSC_OPTIONS {
-        let dist = edit_distance(unknown, known);
-        if let Some((_, best_dist)) = best {
-            if dist < best_dist {
-                best = Some((known, dist));
-            }
-        } else {
-            best = Some((known, dist));
-        }
-    }
-
-    // Only suggest if the distance is small enough to be a plausible typo.
-    // tsc uses a threshold proportional to the option name length.
-    // We use max(unknown_len, candidate_len) * 0.4 as the cutoff, with a minimum of 1.
-    best.and_then(|(name, dist)| {
-        let max_len = unknown.len().max(name.len());
-        let threshold = (max_len * 2 / 5).max(1); // ~40% of the longer name
-        if dist <= threshold { Some(name) } else { None }
-    })
-}

--- a/crates/tsz-cli/src/commands/help.rs
+++ b/crates/tsz-cli/src/commands/help.rs
@@ -123,7 +123,7 @@ default: false
 
 --jsx
 Specify what JSX code is generated.
-one of: preserve, react, react-native, react-jsx, react-jsxdev
+one of: preserve, react-native, react-jsx, react-jsxdev, react
 default: undefined
 
 --outFile
@@ -171,6 +171,9 @@ Show all compiler options.
 --build, -b
 Build one or more projects and their dependencies, if out of date
 
+--checkers
+Set the number of checkers per project.
+
 --help, -h
 Print this message.
 
@@ -189,11 +192,20 @@ Print names of files that are part of the compilation and then stop processing.
 --locale
 Set the language of the messaging from TypeScript. This does not affect emit.
 
+--pprofDir
+Generate pprof CPU/memory profiles to the given directory.
+
 --project, -p
 Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.
 
+--quiet, -q
+Do not print diagnostics.
+
 --showConfig
 Print the final configuration instead of building.
+
+--singleThreaded
+Run in single threaded mode.
 
 --version, -v
 Print the compiler's version.
@@ -363,6 +375,11 @@ Ensure 'use strict' is always emitted.
 type: boolean
 default: true
 
+--deduplicatePackages
+Deduplicate packages with the same name and version.
+type: boolean
+default: true
+
 --exactOptionalPropertyTypes
 Interpret optional property types as written, rather than adding 'undefined'.
 type: boolean
@@ -413,6 +430,11 @@ Raise an error when a function parameter isn't read.
 type: boolean
 default: false
 
+--stableTypeOrdering
+Ensure types are ordered stably and deterministically across compilations.
+type: boolean
+default: true
+
 --strict
 Enable all strict type-checking options.
 type: boolean
@@ -452,51 +474,6 @@ default: `true`, unless `strict` is `false`
 
 --assumeChangesOnlyAffectDirectDependencies
 Have recompiles in projects that use 'incremental' and 'watch' mode assume that changes within a file will only affect files directly depending on it.
-type: boolean
-default: false
-
-### Backwards Compatibility
-
---charset
-No longer supported. In early versions, manually set the text encoding for reading files.
-type: string
-default: utf8
-
---importsNotUsedAsValues
-Specify emit/checking behavior for imports that are only used for types.
-one of: remove, preserve, error
-default: remove
-
---keyofStringsOnly
-Make keyof only return strings instead of string, numbers or symbols. Legacy option.
-type: boolean
-default: false
-
---noImplicitUseStrict
-Disable adding 'use strict' directives in emitted JavaScript files.
-type: boolean
-default: false
-
---noStrictGenericChecks
-Disable strict checking of generic signatures in function types.
-type: boolean
-default: false
-
---out
-Deprecated setting. Use 'outFile' instead.
-
---preserveValueImports
-Preserve unused imported values in the JavaScript output that would otherwise be removed.
-type: boolean
-default: false
-
---suppressExcessPropertyErrors
-Disable reporting of excess property errors during the creation of object literals.
-type: boolean
-default: false
-
---suppressImplicitAnyIndexErrors
-Suppress 'noImplicitAny' errors when indexing objects that lack index signatures.
 type: boolean
 default: false
 
@@ -646,7 +623,7 @@ type: boolean
 default: false
 
 --generateCpuProfile
-Unsupported in tsz; use --generateTrace for native trace output.
+Emit a v8 CPU profile of the compiler run for debugging.
 type: string
 default: profile.cpuprofile
 
@@ -699,7 +676,7 @@ default: false
 
 --jsx
 Specify what JSX code is generated.
-one of: preserve, react, react-native, react-jsx, react-jsxdev
+one of: preserve, react-native, react-jsx, react-jsxdev, react
 default: undefined
 
 --jsxFactory
@@ -729,7 +706,7 @@ default: false
 
 --moduleDetection
 Control what method is used to detect module-format JS files.
-one of: legacy, auto, force
+one of: auto, legacy, force
 default: \"auto\": Treat files with imports, exports, import.meta, jsx (with jsx: react-jsx), or esm format (with module: node16+) as modules.
 
 --noLib
@@ -787,6 +764,11 @@ WATCH OPTIONS
 
 Including --watch, -w will start watching the current project for the file changes. Once set, you can config watch mode with:
 
+--watchInterval
+
+type: number
+default: undefined
+
 --watchFile
 Specify how the TypeScript watch mode works.
 one of: fixedpollinginterval, prioritypollinginterval, dynamicprioritypolling, fixedchunksizepolling, usefsevents, usefseventsonparentdirectory
@@ -828,6 +810,9 @@ Build all projects, including those that appear to be up to date.
 
 --clean
 Delete the outputs of all projects.
+
+--builders
+Set the number of projects to build concurrently.
 
 --stopBuildOnErrors
 Skip building downstream projects on error in upstream project.

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_01.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_01.rs
@@ -635,18 +635,21 @@ fn unknown_flag_ts5023_format() {
 
 #[test]
 fn unknown_flag_ts5025_suggestion_format() {
+    // Oracle-adjudicated (tsc 7.0.2): the native compiler dropped the TS5025
+    // "Did you mean" suggestion — every unknown option is a bare TS5023
+    // (`tsc --strct` emits `error TS5023: Unknown compiler option '--strct'.`).
     let temp = TempDir::new("unknown_flag_ts5025").expect("temp dir");
-    // --strct is close to --strict, should trigger TS5025 with suggestion
     let (code, output) =
         run_tsz_with_exit_code(&temp.path, &["--strct"]).expect("tsz binary not found");
 
-    assert_eq!(
-        code, 1,
-        "Expected exit code 1 for unknown flag with suggestion, got {code}"
+    assert_eq!(code, 1, "Expected exit code 1 for unknown flag, got {code}");
+    assert!(
+        output.contains("error TS5023: Unknown compiler option '--strct'."),
+        "Expected the bare TS5023 diagnostic (7.0.2 parity), got:\n{output}"
     );
     assert!(
-        output.contains("error TS5025: Unknown compiler option '--strct'. Did you mean 'strict'?"),
-        "Expected TS5025 diagnostic with suggestion, got:\n{output}"
+        !output.contains("TS5025"),
+        "tsc 7.0.2 emits no TS5025 suggestion, got:\n{output}"
     );
 }
 


### PR DESCRIPTION
Goal: hold

## Structural rule

The `tsc_compat`/`tsc_parity_*` suites compare tsz's CLI output byte-for-byte against the live vendored oracle, which is now tsc 7.0.2 (native) — the help text and several CLI diagnostics drifted with the TS7 pin. Wave 1 restores parity for the two highest-fanout deltas:

1. **`--help` / `--help --all`**: full text sync against the 7.0.2 oracle, verified `diff = 0` on both outputs. Adds the native compiler's new entries (`--checkers`, `--pprofDir`, `--quiet, -q`, `--singleThreaded`, `--deduplicatePackages`, `--stableTypeOrdering`, `--watchInterval`, `--builders`), removes the dropped Backwards-Compatibility section (nine retired options), fixes the `--jsx`/`--moduleDetection` enum orders, and restores the real `--generateCpuProfile` description.
2. **Unknown options**: tsc 7.0.2 emits a bare TS5023 for every unknown flag — the TS5025 "Did you mean" suggestion is gone (oracle-verified on `--targett`, `--tagret`, `--strct`). tsz now matches; the dead suggestion machinery is removed and the one pin asserting the old format is oracle-flipped.

## Verification

- tsz-cli suite: **126 -> 55** failing instances (help fan-out: `tsc_parity_help`, `tsc_parity_help_all`, `tsc_parity_no_input`, both `ts5025` rows, and every parity flow that embeds the help banner)
- `tsz --help` and `tsz --help --all` diff EMPTY vs `node scripts/node_modules/typescript/bin/tsc` 7.0.2
- checker/solver batteries and conformance untouched (no compiler-semantics changes; CLI presentation layer only)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max