### PR TITLE
fix(cli): tsc 7.0.2 exit codes for --noEmit errors + stale TS6048 pins (parity wave 2)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz/run.rs
+++ b/crates/tsz-cli/src/bin/tsz/run.rs
@@ -209,20 +209,17 @@ pub(crate) fn run_compile(args: &CliArgs, cwd: &std::path::Path) -> Result<()> {
         .any(|diag| diag.category == DiagnosticCategory::Error);
 
     if has_errors {
-        // Match tsc exit codes:
-        // Exit code 1 (DiagnosticsPresent_OutputsSkipped): emit was suppressed due to errors
-        //   (--noEmitOnError with errors means no outputs were generated).
-        // Exit code 2 (DiagnosticsPresent_OutputsGenerated): errors exist but outputs were
-        //   still generated (or --noEmit where there's nothing to emit regardless).
-        // `result.no_emit` reflects the resolved option (CLI + tsconfig.json),
-        // so a tsconfig-only `noEmit` selects exit 2 just like the CLI flag.
-        if args.no_emit_on_error {
-            std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED);
-        } else if result.no_emit || !result.emitted_files.is_empty() {
+        // Match tsc 7.0.2 exit codes (oracle-measured):
+        // Exit code 1 (DiagnosticsPresent_OutputsSkipped): errors and NO
+        //   outputs were generated — including --noEmit (the native compiler
+        //   changed this from the 6.x behavior, which returned 2 for
+        //   --noEmit) and --noEmitOnError suppression.
+        // Exit code 2 (DiagnosticsPresent_OutputsGenerated): errors exist but
+        //   outputs were still written.
+        if !args.no_emit_on_error && !result.emitted_files.is_empty() {
             std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_GENERATED);
-        } else {
-            std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED);
         }
+        std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED);
     }
 
     std::process::exit(EXIT_SUCCESS);

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -174,10 +174,10 @@ pub struct CompilationResult {
     /// Files with their inclusion reasons (for --explainFiles)
     pub file_infos: Vec<FileInfo>,
     /// Resolved `noEmit` option (merged from tsconfig.json + CLI overrides).
-    /// Used by the CLI to pick the correct exit code: tsc returns
-    /// `DiagnosticsPresent_OutputsGenerated` (2) for `--noEmit` regardless of
-    /// where the option originated, since emit was disabled by configuration
-    /// rather than skipped due to errors.
+    /// tsc 7.0.2 exits `DiagnosticsPresent_OutputsSkipped` (1) for `--noEmit`
+    /// with errors (no outputs were generated); the exit-code decision now
+    /// keys on `emitted_files` alone, but the resolved flag stays available
+    /// for other consumers.
     pub no_emit: bool,
     pub request_cache_counters: tsz::checker::context::RequestCacheCounters,
     /// Number of interned types in the shared `TypeInterner` after checking.

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
@@ -417,7 +417,7 @@ fn invalid_locale_with_explicit_file_reports_ts6048() {
     assert_eq!(code, 1, "invalid locale should exit 1: {output}");
     assert_eq!(
         output,
-        "error TS6048: Locale must be of the form <language> or <language>-<territory>. For example 'en' or 'ja-jp'.\n"
+        "error TS6048: Locale must be an IETF BCP 47 language tag. Examples: 'en', 'ja-jp'.\n"
     );
 }
 
@@ -439,7 +439,7 @@ fn invalid_locale_with_discovered_config_reports_ts6048() {
     assert_eq!(code, 1, "invalid locale should exit 1: {output}");
     assert_eq!(
         output,
-        "error TS6048: Locale must be of the form <language> or <language>-<territory>. For example 'en' or 'ja-jp'.\n"
+        "error TS6048: Locale must be an IETF BCP 47 language tag. Examples: 'en', 'ja-jp'.\n"
     );
 }
 


### PR DESCRIPTION
Goal: hold

## Structural rule

Two more oracle-adjudicated CLI parity deltas vs tsc 7.0.2:

1. **Exit codes** (measured): errors + NO outputs generated → exit 1 (`DiagnosticsPresent_OutputsSkipped`), including `--noEmit` — a native-compiler change from 6.x, which returned 2 there and which tsz mirrored. Errors + outputs written → exit 2. The decision now keys on `emitted_files` alone; `--noEmitOnError` suppression stays 1.
2. **TS6048**: the invalid-locale pins expected the retired 6.x wording; 7.0.2 emits 'Locale must be an IETF BCP 47 language tag. Examples: 'en', 'ja-jp'.' — exactly tsz's existing output (oracle-verified). Pins flipped.

## Verification

- exit-code + locale families: 16/16
- tsz-cli suite: 55 -> 53 failing instances (remaining clusters: show_config paths, trace_resolution, driver AMD/es5 emit fixtures, declaration-emit quoting/expansion, build oracle-message drift)
- tsz-checker `--lib`: same 4 pre-existing pool rows, 0 new

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max