### PR TITLE
fix(cli): TS7 parity wave 3 — removed-target pins, build TS6053, positional --build paths

### DIFF
--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -867,29 +867,32 @@ fn handle_build(args: &CliArgs, cwd: &std::path::Path) -> Result<()> {
     use tsz_cli::build;
     use tsz_cli::project_refs::ProjectReferenceGraph;
 
+    // `tsc --build [projects...]` takes its project paths POSITIONALLY; a
+    // directory means `<dir>/tsconfig.json`. Fall back to -p/--project, then
+    // to the cwd default.
     let tsconfig_path = args
-        .project
-        .as_ref()
+        .files
+        .first()
+        .map(std::path::PathBuf::from)
+        .or_else(|| args.project.clone())
         .map(|p| {
             if p.is_dir() {
                 p.join("tsconfig.json")
             } else {
-                p.clone()
+                p
             }
         })
         .unwrap_or_else(|| cwd.join("tsconfig.json"));
 
     if !tsconfig_path.exists() {
-        // Match tsc behavior: TS5083 to stdout, exit code 1
+        // tsc 7.0.2 reports a missing build tsconfig as TS6053 "File ... not
+        // found." (the 6.x TS5083 "Cannot read file" is retired), exit 1.
         let display_path = if tsconfig_path.is_absolute() {
             tsconfig_path
         } else {
             cwd.join(&tsconfig_path)
         };
-        println!(
-            "error TS5083: Cannot read file '{}'.",
-            display_path.display()
-        );
+        println!("error TS6053: File '{}' not found.", display_path.display());
         std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED);
     }
 

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
@@ -170,10 +170,16 @@ fn accessor_modifier_below_es2015_reports_ts18045() {
         return;
     };
 
-    assert_ne!(code, 0, "ES5 accessor property should fail");
+    // Oracle-adjudicated (tsc 7.0.2): 'target=ES5' was REMOVED — the native
+    // compiler reports TS5108 (exit 1) before any checking runs, so TS18045
+    // (which required a sub-ES2015 target) can no longer fire. tsz matches
+    // byte-for-byte (verified side by side on this exact fixture).
+    assert_ne!(code, 0, "a removed-option report is an error exit");
     assert!(
-        output.contains("error TS18045: Properties with the 'accessor' modifier are only available when targeting ECMAScript 2015 and higher."),
-        "expected TS18045 for ES5 accessor property, got:\n{output}"
+        output.contains(
+            "error TS5108: Option 'target=ES5' has been removed. Please remove it from your configuration."
+        ),
+        "expected the 7.0.2 removed-option report, got:\n{output}"
     );
 }
 
@@ -251,15 +257,16 @@ fn async_function_without_promise_constructor_reports_ts2705() {
         return;
     };
 
-    assert_ne!(
-        code, 0,
-        "ES5 async function without Promise constructor should fail"
-    );
+    // Oracle-adjudicated (tsc 7.0.2): 'target=ES5' was REMOVED — the native
+    // compiler reports TS5108 (exit 1) before checking, so the ES5-specific
+    // TS2705 can no longer fire (an es2017 target with lib=es5 is silent in
+    // both compilers). tsz matches byte-for-byte.
+    assert_ne!(code, 0, "a removed-option report is an error exit");
     assert!(
         output.contains(
-            "error TS2705: An async function or method in ES5 requires the 'Promise' constructor."
+            "error TS5108: Option 'target=ES5' has been removed. Please remove it from your configuration."
         ),
-        "expected TS2705 for async function without Promise constructor, got:\n{output}"
+        "expected the 7.0.2 removed-option report, got:\n{output}"
     );
 }
 

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
@@ -224,13 +224,14 @@ fn tsc_parity_build_missing_tsconfig() {
         tsc_code, tsz_code,
         "build missing tsconfig exit code: tsc={tsc_code}, tsz={tsz_code}"
     );
-    // Both should mention TS5083
+    // tsc 7.0.2 reports the missing build tsconfig as TS6053 "File ... not
+    // found." (the 6.x TS5083 "Cannot read file" is gone) and exits 0.
     assert!(
-        tsc_out.contains("TS5083") || tsc_out.contains("Cannot read file"),
+        tsc_out.contains("TS6053") || tsc_out.contains("not found"),
         "tsc should report missing file: {tsc_out}"
     );
     assert!(
-        tsz_out.contains("TS5083") || tsz_out.contains("Cannot read file"),
+        tsz_out.contains("TS6053") || tsz_out.contains("not found"),
         "tsz should report missing file: {tsz_out}"
     );
 }


### PR DESCRIPTION
Goal: hold

## Structural rule

Third oracle-adjudicated CLI parity wave vs tsc 7.0.2:

1. **Removed-target fixtures** (accessor TS18045, async TS2705): both pins fix 'target=es5', which 7.0.2 REMOVED — the native compiler reports `TS5108: Option 'target=ES5' has been removed.` (exit 1) before checking, so the pinned diagnostics are dead in 7.0.2 (an es2017 target with lib=es5 is silent in both compilers). tsz already byte-matches the TS5108 report; pins flipped.
2. **`--build` missing tsconfig**: 7.0.2 reports `TS6053: File '<path>' not found.` — the 6.x `TS5083: Cannot read file` is retired. tsz's report updated, and the build-mode project path now comes from the POSITIONAL argument (`tsc --build path/tsconfig.json`) before `-p`/cwd fallback — previously tsz ignored the positional and reported the wrong file.

## Verification

- build family 69/69; ts18045/ts2705/build_missing rows all green
- tsz-cli suite: **53 -> 47** failing instances
- exit codes measured un-piped after an earlier piped-$? mismeasure (both compilers exit 1 on TS5108; recorded)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max