### PR TITLE
fix(cli): TS7 parity wave 4 — showConfig removed-option tolerance + fixture modernization

### DIFF
--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -633,11 +633,16 @@ fn handle_show_config(args: &CliArgs, cwd: &std::path::Path) -> Result<()> {
     } else {
         (None, Vec::new())
     };
-    if config_diagnostics.iter().any(|d| {
-        d.code == diagnostic_codes::COMPILER_OPTION_REQUIRES_A_VALUE_OF_TYPE
-            || d.code
-                == diagnostic_codes::OPTION_HAS_BEEN_REMOVED_PLEASE_REMOVE_IT_FROM_YOUR_CONFIGURATION
-    }) {
+    // A removed option (TS5102/TS5108 family) does NOT block --showConfig:
+    // tsc 7.0.2 prints the resolved configuration — including the removed
+    // option, normalized — with exit 0, and only a normal compile reports
+    // the removal (oracle: a tsconfig with 'baseUrl' shows
+    // '"baseUrl": "./"' under --showConfig). Only malformed VALUES still
+    // abort the render.
+    if config_diagnostics
+        .iter()
+        .any(|d| d.code == diagnostic_codes::COMPILER_OPTION_REQUIRES_A_VALUE_OF_TYPE)
+    {
         let pretty = args
             .pretty
             .unwrap_or_else(|| std::io::stdout().is_terminal());

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
@@ -185,6 +185,10 @@ fn accessor_modifier_below_es2015_reports_ts18045() {
 
 #[test]
 fn bigint_and_symbol_availability_follow_target_and_lib() {
+    // Oracle-adjudicated (tsc 7.0.2): 'target=es5' was removed, so the
+    // below-ES2020 premise now uses es2017 — the oracle still reports both
+    // TS2737 (BigInt below ES2020) and TS2585 (Symbol value without an
+    // es2015+ lib) on these flags, byte-matched by tsz.
     let temp = TempDir::new("bigint_symbol_target_lib").expect("temp dir");
     write_file(
         &temp.path.join("test.ts"),
@@ -199,9 +203,7 @@ const sym = Symbol("unique");
             "--noEmit",
             "--strict",
             "--target",
-            "es5",
-            "--ignoreDeprecations",
-            "6.0",
+            "es2017",
             "--lib",
             "es5",
             "--pretty",
@@ -213,7 +215,7 @@ const sym = Symbol("unique");
         return;
     };
 
-    assert_ne!(code, 0, "ES5 BigInt/Symbol availability should fail");
+    assert_ne!(code, 0, "BigInt/Symbol availability below ES2020/es2015-lib should fail");
     assert!(
         output.contains(
             "error TS2737: BigInt literals are not available when targeting lower than ES2020."
@@ -623,7 +625,9 @@ fn trace_resolution_prints_relative_import_resolution() {
     let temp = TempDir::new("trace_resolution_relative_import").expect("temp dir");
     write_file(
         &temp.path.join("tsconfig.json"),
-        r#"{"compilerOptions":{"noEmit":true,"moduleResolution":"node","ignoreDeprecations":"6.0"},"files":["index.ts"]}"#,
+        // tsc 7.0.2 removed 'moduleResolution=node10' (TS5108); 'bundler' is
+        // the supported kind whose trace shape both compilers share.
+        r#"{"compilerOptions":{"noEmit":true,"moduleResolution":"bundler","module":"esnext"},"files":["index.ts"]}"#,
     );
     write_file(&temp.path.join("dep.ts"), "export const dep = 2;\n");
     write_file(
@@ -654,7 +658,7 @@ fn trace_resolution_prints_relative_import_resolution() {
         "expected trace to include module resolution start, got:\n{stdout}"
     );
     assert!(
-        stdout.contains("Explicitly specified module resolution kind: 'Node10'."),
+        stdout.contains("Explicitly specified module resolution kind: 'Bundler'."),
         "expected trace to include effective module resolution kind, got:\n{stdout}"
     );
     assert!(


### PR DESCRIPTION
Goal: hold

## Structural rule

Fourth oracle-adjudicated parity wave vs tsc 7.0.2:

1. **`--showConfig` with removed options**: the native compiler prints the resolved configuration — including the removed option, normalized (`\"baseUrl\": \"./\"`) — with exit 0; only a normal compile reports TS5102 (both behaviors oracle-measured). tsz's showConfig gate no longer aborts on the removed-option family; malformed values still do.
2. **bigint/symbol availability row**: `target=es5` is gone — the below-ES2020 premise moves to `es2017` + `lib es5`, where the oracle still reports TS2737 + TS2585 and tsz byte-matches (verified side by side).
3. **trace_resolution row**: `moduleResolution=node10` is gone — fixture moved to `bundler`; all four asserted trace lines match on both compilers.

## Verification

- show_config family 60/60; bigint + trace rows green
- tsz-cli suite: **47 -> 39** failing instances
- checker/solver untouched

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max