### PR TITLE
fix(cli): TS7 parity wave 5 — config removals, function-type recovery, TS2883 mapped keys, mapped-literal probe

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -419,6 +419,21 @@ pub(crate) fn collect_referenced_types(
     tsz_solver::visitor::collect_referenced_types(db, type_id)
 }
 
+/// [`collect_referenced_types`] for declaration-emit portability checks
+/// (TS2883 and friends): mapped key positions are excluded, since a mapped
+/// type with a concrete key constraint serializes its keys as property
+/// names, never as printed type references.
+pub(crate) fn collect_portability_referenced_types(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> rustc_hash::FxHashSet<TypeId> {
+    let mut collected = rustc_hash::FxHashSet::default();
+    tsz_solver::visitor::walk_declaration_portability_referenced_types(db, type_id, |t| {
+        collected.insert(t);
+    });
+    collected
+}
+
 pub(crate) fn collect_enum_def_ids(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs
+++ b/crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs
@@ -783,11 +783,16 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
+            let target_prop_type_for_check = self.evaluate_type_for_assignability(target_prop_type);
+            // Type the initializer under the per-property contextual target,
+            // exactly like the real assignment does: without it a fresh
+            // literal widens (`"str"` → `string`) and the probe reports a
+            // false mismatch against a literal member type (e.g. the bare-`K`
+            // identity mapped type `{ [K in keyof V]: K }`).
             let source_type = self.get_type_of_node_with_request(
                 prop.initializer,
-                &crate::context::TypingRequest::NONE,
+                &crate::context::TypingRequest::with_contextual_type(target_prop_type_for_check),
             );
-            let target_prop_type_for_check = self.evaluate_type_for_assignability(target_prop_type);
             if matches!(source_type, TypeId::ANY | TypeId::ERROR | TypeId::UNKNOWN) {
                 continue;
             }

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
@@ -392,7 +392,15 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let referenced_types = collect_referenced_types(self.ctx.types, inferred_type);
+        // Portability walk: mapped key positions are excluded — declaration
+        // emit serializes a concrete-keyed mapped type's keys as property
+        // names (see `collect_portability_referenced_types`), so an alias
+        // referenced only from a key constraint is never a printed reference.
+        let referenced_types =
+            crate::query_boundaries::common::collect_portability_referenced_types(
+                self.ctx.types,
+                inferred_type,
+            );
         for &type_id in &referenced_types {
             if let Some(info) = check_type(self, type_id) {
                 return Some(info);

--- a/crates/tsz-cli/src/commands/help.rs
+++ b/crates/tsz-cli/src/commands/help.rs
@@ -623,7 +623,7 @@ type: boolean
 default: false
 
 --generateCpuProfile
-Emit a v8 CPU profile of the compiler run for debugging.
+Unsupported in tsz; use --generateTrace for native trace output.
 type: string
 default: profile.cpuprofile
 

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
@@ -436,6 +436,80 @@ const bad: Mc = { str: 123 };
         );
     }
 
+    /// Fresh-literal object-literal assignment to a bare-`K` identity mapped
+    /// type: the per-property probe must type the initializer under the
+    /// per-property contextual target, or the fresh literal widens
+    /// (`"lo"` → `string`) and a false TS2322 fires against the literal
+    /// member type. Adjacent matrix: multi-key, single-key, non-fresh
+    /// source, and the negative (wrong literal / wrong primitive) which must
+    /// keep erroring. Binder names vary per case (anti-hardcoding).
+    #[test]
+    fn fresh_literal_object_to_identity_mapped_type_matrix() {
+        // Positive: two keys, fresh string literals.
+        let diagnostics = collect_test_diagnostics(&[(
+            "main.ts",
+            r#"
+type Cfg = { lo: number; hi: boolean };
+type Names = { [K in keyof Cfg]: K };
+const ok: Names = { lo: "lo", hi: "hi" };
+"#,
+        )]);
+        assert!(
+            diagnostics.is_empty(),
+            "fresh literals must satisfy the identity mapped type: {diagnostics:?}"
+        );
+
+        // Positive: single key (the `keyof` collapses to one literal).
+        let diagnostics = collect_test_diagnostics(&[(
+            "main.ts",
+            r#"
+const seed = { field: 1 };
+type S = typeof seed;
+type Keys = { [P in keyof S]: P };
+const ok: Keys = { field: "field" };
+"#,
+        )]);
+        assert!(
+            diagnostics.is_empty(),
+            "single-key identity mapped type must accept its literal: {diagnostics:?}"
+        );
+
+        // Positive: non-fresh sources behave identically.
+        let diagnostics = collect_test_diagnostics(&[(
+            "main.ts",
+            r#"
+type Rec = { alpha: string };
+type Ident = { [Q in keyof Rec]: Q };
+declare const a: "alpha";
+const ok1: Ident = { alpha: a };
+const ok2: Ident = { alpha: "alpha" as const };
+"#,
+        )]);
+        assert!(
+            diagnostics.is_empty(),
+            "non-fresh literal sources must also pass: {diagnostics:?}"
+        );
+
+        // Negative: a wrong literal and a wrong primitive must still error.
+        let diagnostics = collect_test_diagnostics(&[(
+            "main.ts",
+            r#"
+type Row = { cell: number };
+type Tags = { [K in keyof Row]: K };
+const bad1: Tags = { cell: "other" };
+const bad2: Tags = { cell: 42 };
+"#,
+        )]);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .filter(|diag| diag.code == 2322)
+                .count(),
+            2,
+            "wrong values must keep failing against the literal member type: {diagnostics:?}"
+        );
+    }
+
     /// Same shape with different binder names (anti-hardcoding): the behavior
     /// follows the structural pattern, not the spellings
     /// `Validator`/`Requireable`/`str`/`P`.

--- a/crates/tsz-cli/src/driver/emit_tests.rs
+++ b/crates/tsz-cli/src/driver/emit_tests.rs
@@ -256,7 +256,11 @@ fn outfile_non_amd_system_skips_external_module_js_chunk() {
 }
 
 #[test]
-fn outfile_skips_node_modules_source_js_chunk() {
+fn outfile_reports_removed_options_and_bundler_conflict() {
+    // TS 7.0.2 removed `--module system` (TS5108) and `--outFile` (TS5102),
+    // and `--moduleResolution bundler` is incompatible with the System module
+    // kind (TS5095). The command-line form is rejected exactly like the
+    // tsconfig form and nothing is bundled.
     let temp = tempdir().unwrap();
     let dep = temp.path().join("node_modules/projB/index.ts");
     std::fs::create_dir_all(dep.parent().unwrap()).unwrap();
@@ -282,13 +286,19 @@ fn outfile_skips_node_modules_source_js_chunk() {
         "a.ts",
     ])
     .unwrap();
-    compile(&args, temp.path()).unwrap();
-    let output = std::fs::read_to_string(temp.path().join("out.js")).unwrap();
+    let result = compile(&args, temp.path()).unwrap();
 
-    assert!(!output.contains("projB/index"));
+    let mut codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
     assert_eq!(
-        output,
-        "System.register(\"a\", [], function (exports_1, context_1) {\n    \"use strict\";\n    var __moduleName = context_1 && context_1.id;\n    return {\n        setters: [],\n        execute: function () {\n        }\n    };\n});"
+        codes,
+        [5095, 5102, 5108],
+        "expected bundler-conflict + removed-option rejections: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        !temp.path().join("out.js").exists(),
+        "removed-option command line must not emit a bundle"
     );
 }
 

--- a/crates/tsz-cli/src/reporting/reporter.rs
+++ b/crates/tsz-cli/src/reporting/reporter.rs
@@ -512,7 +512,7 @@ impl Reporter {
             // tsc adds a trailing blank line after single-file summaries
             out.push('\n');
         } else {
-            // "Found N errors in M files." + file table (no trailing blank line)
+            // "Found N errors in M files." + file table + trailing blank line
             let _ = write!(
                 out,
                 "Found {error_count} {error_word} in {unique_file_count} files."
@@ -536,6 +536,9 @@ impl Reporter {
                     let _ = write!(out, "{count:>6}  {file}:{first_line}");
                 }
             }
+            out.push('\n');
+            // tsc 7.0.2 ends the table with a trailing blank line, matching
+            // the single-file summaries above.
             out.push('\n');
         }
     }

--- a/crates/tsz-cli/tests/driver_tests_parts/part_02.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_02.rs
@@ -279,7 +279,11 @@ fn compile_emit_bom_prefixes_output_files() {
 }
 
 #[test]
-fn compile_single_source_amd_outfile_emits_bundle() {
+fn compile_single_source_amd_outfile_reports_removed_options() {
+    // TS 7.0.2 removed `module: amd` (TS5108) and `outFile` (TS5102), and the
+    // default `moduleResolution: bundler` is incompatible with AMD (TS5095,
+    // anchored at the "compilerOptions" key since the option is defaulted).
+    // No bundle is emitted.
     let temp = TempDir::new().expect("temp dir");
     let base = &temp.path;
 
@@ -303,33 +307,27 @@ fn compile_single_source_amd_outfile_emits_bundle() {
         compile(&args, base).expect("compile should succeed")
     });
 
-    assert!(result.diagnostics.is_empty());
+    let mut codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    assert_eq!(
+        codes,
+        [5095, 5102, 5108],
+        "expected bundler-conflict + removed-option rejections: {:?}",
+        result.diagnostics
+    );
     assert!(
-        base.join("dist/bundle.js").is_file(),
-        "expected outFile bundle, emitted: {:?}",
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.message_text
+                == "Option 'module=AMD' has been removed. Please remove it from your configuration."),
+        "expected the module=AMD removal message: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        !base.join("dist").exists() && !base.join("main.js").exists(),
+        "removed-option config must not emit, emitted: {:?}",
         result.emitted_files
-    );
-    assert!(
-        !base.join("main.js").exists(),
-        "single-source outFile should not emit per-file main.js"
-    );
-    let bundle = std::fs::read_to_string(base.join("dist/bundle.js")).expect("read bundle");
-    // tsc does NOT prepend a top-level `"use strict";` to AMD outFile bundles
-    // when every chunk is a module wrapped in `define(...)` — each chunk
-    // emits its own strict directive inside the wrapper callback. The
-    // top-level prologue is reserved for bundles that include at least one
-    // script chunk (a non-module file) which has no enclosing wrapper.
-    assert!(
-        bundle.starts_with("define(\"main\","),
-        "AMD all-modules outFile bundle should start with the `define(...)` wrapper, got:\n{bundle}"
-    );
-    assert!(
-        bundle.contains("    \"use strict\";"),
-        "expected the inner strict prologue inside the AMD wrapper, got:\n{bundle}"
-    );
-    assert!(
-        bundle.contains("define(\"main\", [\"require\", \"exports\"], function"),
-        "expected named AMD outFile wrapper, got:\n{bundle}"
     );
 }
 
@@ -446,7 +444,10 @@ fn compile_module_none_outfile_cache_keeps_rejection_stable() {
 }
 
 #[test]
-fn compile_single_source_amd_declaration_outfile_wraps_module_name() {
+fn compile_single_source_amd_declaration_outfile_reports_removed_options() {
+    // Declaration-only variant of the AMD outFile pin: TS 7.0.2 rejects the
+    // removed `module: amd`/`outFile` pair (plus the TS5095 bundler default
+    // conflict) before any declaration bundling happens.
     let temp = TempDir::new().expect("temp dir");
     let base = &temp.path;
 
@@ -471,19 +472,26 @@ fn compile_single_source_amd_declaration_outfile_wraps_module_name() {
         compile(&args, base).expect("compile should succeed")
     });
 
-    assert!(result.diagnostics.is_empty());
-    let bundle =
-        std::fs::read_to_string(base.join("dist/bundle.d.ts")).expect("read declaration bundle");
+    let mut codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
     assert_eq!(
-        bundle,
-        r#"declare module "index" {
-    export const value = 1;
-}"#
+        codes,
+        [5095, 5102, 5108],
+        "expected bundler-conflict + removed-option rejections: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        !base.join("dist").exists(),
+        "removed-option config must not emit a declaration bundle, emitted: {:?}",
+        result.emitted_files
     );
 }
 
 #[test]
-fn compile_amd_declaration_outfile_uses_source_name_with_dependency_directive() {
+fn compile_amd_declaration_outfile_with_dependency_directive_reports_removed_options() {
+    // An `amd-dependency` triple-slash directive in the source does not
+    // change the outcome: the removed `module: amd`/`outFile` pair is
+    // rejected up front and no declaration bundle is produced.
     let temp = TempDir::new().expect("temp dir");
     let base = &temp.path;
 
@@ -512,15 +520,18 @@ export const value = 1;"#,
         compile(&args, base).expect("compile should succeed")
     });
 
-    assert!(result.diagnostics.is_empty());
-    let bundle =
-        std::fs::read_to_string(base.join("dist/bundle.d.ts")).expect("read declaration bundle");
+    let mut codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
     assert_eq!(
-        bundle,
-        r#"/// <amd-dependency name="legacyAlias" path="legacy/module" />
-declare module "index" {
-    export const value = 1;
-}"#
+        codes,
+        [5095, 5102, 5108],
+        "expected bundler-conflict + removed-option rejections: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        !base.join("dist").exists(),
+        "removed-option config must not emit a declaration bundle, emitted: {:?}",
+        result.emitted_files
     );
 }
 

--- a/crates/tsz-cli/tests/driver_tests_parts/part_08.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_08.rs
@@ -967,7 +967,10 @@ export function copy(a: number[]): number[] {
 }
 
 #[test]
-fn compile_es5_downlevel_iteration_single_call_spread_uses_read() {
+fn compile_es5_downlevel_iteration_config_reports_removed_options() {
+    // TS 7.0.2 removed `target: es5` (TS5108) and `downlevelIteration`
+    // (TS5102): the config is rejected and nothing is emitted, regardless of
+    // `ignoreDeprecations`.
     let temp = TempDir::new().expect("temp dir");
     let base = &temp.path;
 
@@ -999,25 +1002,43 @@ export const value = f(...s);
     let args = default_args();
     let result = compile(&args, base).expect("compile should succeed");
 
-    assert!(
-        result.diagnostics.is_empty(),
-        "Should compile without errors: {:?}",
+    let mut codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    assert_eq!(
+        codes,
+        [5102, 5108],
+        "expected removed-option rejections: {:?}",
         result.diagnostics
     );
-
-    let js = std::fs::read_to_string(base.join("dist/src/calls.js")).expect("read js");
     assert!(
-        js.contains("f.apply(void 0, __spreadArray([], __read(s), false))"),
-        "single call spread with downlevelIteration should read iterables before apply:\n{js}"
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.message_text
+                == "Option 'target=ES5' has been removed. Please remove it from your configuration."),
+        "expected the target=ES5 removal message: {:?}",
+        result.diagnostics
     );
     assert!(
-        !js.contains("f.apply(void 0, s)"),
-        "single call spread must not pass iterable directly to apply:\n{js}"
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.message_text
+                == "Option 'downlevelIteration' has been removed. Please remove it from your configuration."),
+        "expected the downlevelIteration removal message: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        !base.join("dist").exists(),
+        "removed-option config must not emit, emitted: {:?}",
+        result.emitted_files
     );
 }
 
 #[test]
-fn compile_es5_array_spread_packs_sparse_spread_segments() {
+fn compile_es5_target_config_is_rejected_as_removed() {
+    // TS 7.0.2 removed `target: es5`: the sole diagnostic is TS5108 (the
+    // other options here are all still valid) and nothing is emitted.
     let temp = TempDir::new().expect("temp dir");
     let base = &temp.path;
 
@@ -1047,20 +1068,21 @@ export const middle = [1, ...xs, 4];
     let args = default_args();
     let result = compile(&args, base).expect("compile should succeed");
 
-    assert!(
-        result.diagnostics.is_empty(),
-        "Should compile without errors: {:?}",
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        [5108],
+        "expected only the target=ES5 removal: {:?}",
         result.diagnostics
     );
-
-    let js = std::fs::read_to_string(base.join("dist/src/arrays.js")).expect("read js");
-    assert!(
-        js.contains("__spreadArray(__spreadArray([], xs, true), [4], false)"),
-        "leading sparse spread should pack holes before appending literals:\n{js}"
+    assert_eq!(
+        result.diagnostics[0].message_text,
+        "Option 'target=ES5' has been removed. Please remove it from your configuration."
     );
     assert!(
-        js.contains("__spreadArray(__spreadArray([1], xs, true), [4], false)"),
-        "middle sparse spread should pack holes between literal segments:\n{js}"
+        !base.join("dist").exists(),
+        "removed-option config must not emit, emitted: {:?}",
+        result.emitted_files
     );
 }
 
@@ -1369,7 +1391,11 @@ export function getSecond(arr: number[]): number {
 }
 
 #[test]
-fn compile_es5_downlevel_iteration_array_rest_reads_full_iterator() {
+fn compile_es5_downlevel_iteration_rejection_suppresses_emit() {
+    // Adjacent case to the removed-option pins above: a different option
+    // spelling order and an explicit `lib` list must not change the outcome —
+    // TS 7.0.2 rejects `target: es5` (TS5108) plus `downlevelIteration`
+    // (TS5102) and emits nothing.
     let temp = TempDir::new().expect("temp dir");
     let base = &temp.path;
 
@@ -1400,24 +1426,18 @@ console.log(first, rest.join(","));
     let args = default_args();
     let result = compile(&args, base).expect("compile should succeed");
 
-    assert!(
-        result.diagnostics.is_empty(),
-        "Should compile without errors: {:?}",
+    let mut codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    assert_eq!(
+        codes,
+        [5102, 5108],
+        "expected removed-option rejections: {:?}",
         result.diagnostics
     );
-
-    let js = std::fs::read_to_string(base.join("dist/src/rest.js")).expect("read js");
     assert!(
-        js.contains("__read(iter)"),
-        "array rest binding should read the full iterator: {js}"
-    );
-    assert!(
-        !js.contains("__read(iter, 1)"),
-        "array rest binding must not truncate the iterator read: {js}"
-    );
-    assert!(
-        js.contains("rest = _a.slice(1)") || js.contains("rest = _b.slice(1)"),
-        "array rest binding should slice after the fixed element: {js}"
+        !base.join("dist").exists(),
+        "removed-option config must not emit, emitted: {:?}",
+        result.emitted_files
     );
 }
 

--- a/crates/tsz-cli/tests/generator_yield_inference_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/generator_yield_inference_dts_emit_tests.rs
@@ -10,7 +10,8 @@
 //! one unique yield type, so it over-widened `yield "x"; yield "y"` to
 //! `Generator<string>` and collapsed mixed operands (`yield "x"; yield 1`) all the
 //! way to `Generator<any>`. These guards pin the corrected behavior against
-//! `tsc` 6.0.2.
+//! `tsc` 7.0.2, whose display rank orders union members independently of the
+//! source yield order.
 //!
 //! Every case uses a distinct generator/binder name so the assertions track the
 //! structural rule, not any identifier (anti-hardcoding gate).
@@ -97,8 +98,8 @@ fn distinct_string_literal_yields_preserve_the_union() {
     };
 
     assert!(
-        dts.contains("greetings(): Generator<\"hi\" | \"bye\", void, unknown>"),
-        "two distinct string-literal yields must stay a literal union:\n{dts}"
+        dts.contains("greetings(): Generator<\"bye\" | \"hi\", void, unknown>"),
+        "two distinct string-literal yields must stay a literal union (TS7 display rank, not source order):\n{dts}"
     );
 }
 

--- a/crates/tsz-cli/tests/generator_yield_literal_widening_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/generator_yield_literal_widening_dts_emit_tests.rs
@@ -125,8 +125,8 @@ fn exported_generator_preserves_mixed_literal_yield_union() {
     };
 
     assert!(
-        dts.contains("mix(): Generator<1 | \"s\", void, unknown>"),
-        "mixed literal yield union must be preserved:\n{dts}"
+        dts.contains("mix(): Generator<\"s\" | 1, void, unknown>"),
+        "mixed literal yield union must be preserved (TS7 ranks string literals before number literals):\n{dts}"
     );
 }
 

--- a/crates/tsz-cli/tests/triple_slash_reference_not_found_relative_path_tests.rs
+++ b/crates/tsz-cli/tests/triple_slash_reference_not_found_relative_path_tests.rs
@@ -1,11 +1,12 @@
 //! End-to-end regression for issue #14855 — TS6053 ("File '...' not found.")
-//! for an unresolved `/// <reference path="..." />` must report the path
-//! relative to the program's current directory, matching `tsc`. tsz previously
-//! interpolated the resolved *absolute* path into the message.
+//! for an unresolved `/// <reference path="..." />` must report the reference
+//! path exactly as written in the source, matching `tsc` 7.0.2 (which dropped
+//! the 6.x cwd-relative/resolved-path display). tsz previously interpolated
+//! the resolved *absolute* path into the message.
 //!
 //! These tests run the real binary in a subprocess with `current_dir` set to a
 //! temp project, exercising the full driver → checker wiring that supplies the
-//! program's current directory used for relativization.
+//! diagnostic's display path.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -129,11 +130,11 @@ fn unresolved_reference_paths_are_reported_relative_to_cwd() {
     );
 }
 
-/// Project/config mode stores root files as resolved paths. `tsc --project`
-/// therefore reports the normalized resolved reference path, not the
-/// cwd-relative spelling used by explicit `tsc entry.ts`.
+/// `tsc --project` prints the same as-written reference path as explicit-file
+/// mode: tsc 7.0.2 no longer substitutes the resolved (absolute) path that
+/// 6.x project mode used.
 #[test]
-fn project_mode_reports_resolved_reference_path() {
+fn project_mode_reports_reference_path_as_written() {
     let temp = TempDir::new("project").expect("temp dir");
     write_file(
         &temp.path.join("pkg/entry.ts"),
@@ -150,33 +151,20 @@ fn project_mode_reports_resolved_reference_path() {
         return;
     };
 
-    let expected = temp
-        .path
-        .join("escaped-parent.d.ts")
-        .to_string_lossy()
-        .replace('\\', "/");
-    let canonical_expected = temp
-        .path
-        .canonicalize()
-        .expect("canonicalize temp dir")
-        .join("escaped-parent.d.ts")
-        .to_string_lossy()
-        .replace('\\', "/");
     assert!(
-        out.contains(&format!("File '{expected}' not found."))
-            || out.contains(&format!("File '{canonical_expected}' not found.")),
-        "project-mode reference must use resolved path; got:\n{out}"
+        out.contains("File '../escaped-parent.d.ts' not found."),
+        "project-mode reference must print the path as written in the source; got:\n{out}"
     );
     assert!(
-        !out.contains("File 'escaped-parent.d.ts' not found."),
-        "project-mode reference must not use explicit-file cwd-relative display; got:\n{out}"
+        !out.contains(&format!("File '{}", temp.path.display())),
+        "TS6053 must not contain an absolute path; got:\n{out}"
     );
 }
 
-/// When the entry file sits in a subdirectory, a sibling reference resolves to a
-/// path prefixed with that subdirectory — matching tsc's cwd-relative output.
+/// When the entry file sits in a subdirectory, tsc 7.0.2 still prints the
+/// sibling reference exactly as written — no subdirectory prefix is added.
 #[test]
-fn reference_from_nested_entry_keeps_subdir_prefix() {
+fn reference_from_nested_entry_prints_path_as_written() {
     let temp = TempDir::new("nested").expect("temp dir");
     write_file(
         &temp.path.join("pkg/entry.ts"),
@@ -190,8 +178,12 @@ fn reference_from_nested_entry_keeps_subdir_prefix() {
     };
 
     assert!(
-        out.contains("File 'pkg/absent-neighbor.d.ts' not found."),
-        "reference from a nested entry must carry the subdir prefix; got:\n{out}"
+        out.contains("File 'absent-neighbor.d.ts' not found."),
+        "reference from a nested entry must print the path as written; got:\n{out}"
+    );
+    assert!(
+        !out.contains("File 'pkg/absent-neighbor.d.ts' not found."),
+        "the 6.x subdir-prefixed display must not come back; got:\n{out}"
     );
     assert!(
         !out.contains(&format!("File '{}", temp.path.display())),

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
@@ -828,8 +828,8 @@ fn positional_file_no_lib_no_emit_returns_from_binary() {
 
     assert_eq!(
         output.status.code(),
-        Some(2),
-        "expected diagnostics-with-no-emit exit\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        Some(1),
+        "expected diagnostics-with-outputs-skipped exit (tsc 7.0.2 exits 1 for noEmit runs with errors)\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(
         stdout.contains("error TS2318: Cannot find global type 'Array'."),
@@ -852,8 +852,6 @@ fn declaration_emit_expands_foreign_import_mapped_keys_from_nested_package() {
             "rootDir": "r",
             "target": "es2017",
             "module": "commonjs",
-            "moduleResolution": "node",
-            "ignoreDeprecations": "6.0",
             "skipLibCheck": true,
             "strict": true,
             "typeRoots": ["./empty-types"]
@@ -916,8 +914,6 @@ fn declaration_emit_reports_single_quoted_transitive_import_type() {
             "rootDir": "r",
             "target": "es2017",
             "module": "commonjs",
-            "moduleResolution": "node",
-            "ignoreDeprecations": "6.0",
             "skipLibCheck": true,
             "strict": true,
             "typeRoots": ["./empty-types"]
@@ -969,8 +965,6 @@ fn declaration_emit_default_object_assign_reports_namespace_alias_for_default_on
             "rootDir": "r",
             "target": "es2017",
             "module": "commonjs",
-            "moduleResolution": "node",
-            "ignoreDeprecations": "6.0",
             "skipLibCheck": true,
             "strict": true,
             "typeRoots": ["./empty-types"]
@@ -1062,8 +1056,6 @@ fn declaration_emit_preserves_template_literal_type_text_from_dependency() {
             "rootDir": "r",
             "target": "es2017",
             "module": "commonjs",
-            "moduleResolution": "node",
-            "ignoreDeprecations": "6.0",
             "skipLibCheck": true,
             "strict": true,
             "typeRoots": ["./empty-types"]

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
@@ -900,6 +900,72 @@ export const x = foo();
     );
 }
 
+/// Adjacent negative case to the mapped-key expansion above: a foreign type
+/// in the mapped VALUE position does get printed, so tsc reports TS2883 for
+/// it even though the key alias from the same nested package stays silent.
+/// Binder and package names differ from the positive case (anti-hardcoding).
+#[test]
+fn declaration_emit_reports_foreign_mapped_value_from_nested_package() {
+    let temp = TempDir::new("foreign_mapped_value").expect("temp dir");
+
+    write_file(
+        &temp.path.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "declaration": true,
+            "emitDeclarationOnly": true,
+            "outDir": "dist",
+            "rootDir": "r",
+            "target": "es2017",
+            "module": "commonjs",
+            "skipLibCheck": true,
+            "strict": true,
+            "typeRoots": ["./empty-types"]
+          },
+          "files": ["r/entry.ts"]
+        }"#,
+    );
+    std::fs::create_dir_all(temp.path.join("empty-types")).expect("empty typeRoots");
+    write_file(
+        &temp.path.join("r/entry.ts"),
+        r#"import { makeTable } from "tablepkg";
+
+export const table = makeTable();
+"#,
+    );
+    write_file(
+        &temp.path.join("r/node_modules/tablepkg/index.d.ts"),
+        r#"export function makeTable(): { [C in import("cols").Col]?: import("cells").CellInfo };
+"#,
+    );
+    write_file(
+        &temp
+            .path
+            .join("r/node_modules/tablepkg/node_modules/cols/index.d.ts"),
+        r#"export type Col = "left" | "right";
+"#,
+    );
+    write_file(
+        &temp
+            .path
+            .join("r/node_modules/tablepkg/node_modules/cells/index.d.ts"),
+        r#"export interface CellInfo { width: number; }
+"#,
+    );
+
+    let (code, output) =
+        run_tsz_with_exit_code(&temp.path, &["-p", "tsconfig.json"]).expect("tsz should run");
+    assert_ne!(code, 0, "tsz should report TS2883, got output:\n{output}");
+    assert!(
+        output.contains("TS2883") && output.contains("CellInfo"),
+        "expected TS2883 for the mapped VALUE position type, got:\n{output}",
+    );
+    assert!(
+        !output.contains("'Col'"),
+        "the key alias must not be reported — keys serialize as property names:\n{output}",
+    );
+}
+
 #[test]
 fn declaration_emit_reports_single_quoted_transitive_import_type() {
     let temp = TempDir::new("single_quoted_transitive_import_type").expect("temp dir");

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
@@ -603,11 +603,10 @@ fn tsc_parity_ts2427_any_alone_still_reported() {
     );
 }
 
-/// Regression for #3908: when `noEmit` comes from tsconfig.json (not the
-/// CLI flag), tsz must exit with `DiagnosticsPresent_OutputsGenerated` (2),
-/// matching tsc. Previously the exit-code branch only consulted the CLI
-/// arg, so config-only `noEmit` fell through to the outputs-skipped path
-/// (1).
+/// tsc 7.0.2 exits `DiagnosticsPresent_OutputsSkipped` (1) when `noEmit`
+/// comes from tsconfig.json and the program has errors: nothing was
+/// written, so the outputs-generated code (2) of the 6.x era no longer
+/// applies. CLI-driven and config-driven `noEmit` agree (companion below).
 #[test]
 fn tsconfig_no_emit_with_errors_exits_outputs_generated() {
     let Some(_) = find_tsz_binary() else {
@@ -629,8 +628,8 @@ fn tsconfig_no_emit_with_errors_exits_outputs_generated() {
         "expected TS2322 diagnostic, got:\n{output}"
     );
     assert_eq!(
-        code, 2,
-        "tsconfig noEmit with errors should exit 2 (DiagnosticsPresent_OutputsGenerated), got {code}\n{output}"
+        code, 1,
+        "tsconfig noEmit with errors should exit 1 (DiagnosticsPresent_OutputsSkipped), got {code}\n{output}"
     );
 }
 
@@ -660,8 +659,8 @@ fn cli_no_emit_with_errors_exits_outputs_generated() {
         "expected TS2322 diagnostic, got:\n{output}"
     );
     assert_eq!(
-        code, 2,
-        "CLI --noEmit with errors should exit 2 (DiagnosticsPresent_OutputsGenerated), got {code}\n{output}"
+        code, 1,
+        "CLI --noEmit with errors should exit 1 (DiagnosticsPresent_OutputsSkipped), got {code}\n{output}"
     );
 }
 

--- a/crates/tsz-core/src/config/parse.rs
+++ b/crates/tsz-core/src/config/parse.rs
@@ -275,10 +275,29 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
 
         // Check moduleResolution/module compatibility (TS5095)
         // `moduleResolution: "bundler"` requires `module` to be "preserve" or ES2015+.
-        if let Some(serde_json::Value::String(mr_value)) = compiler_opts.get("moduleResolution") {
-            let mr_normalized =
-                normalize_enum_option_value(mr_value.split(',').next().unwrap_or(mr_value));
-            if mr_normalized == "bundler" {
+        // In TS7 `bundler` is also the default resolution, so the check applies
+        // when the option is absent; tsc then anchors the diagnostic at the
+        // "compilerOptions" key instead of an explicit option value.
+        {
+            let mr_explicit = if let Some(serde_json::Value::String(mr_value)) =
+                compiler_opts.get("moduleResolution")
+            {
+                Some((
+                    normalize_enum_option_value(mr_value.split(',').next().unwrap_or(mr_value)),
+                    mr_value.len() as u32,
+                ))
+            } else {
+                None
+            };
+            let bundler_effective = match &mr_explicit {
+                Some((mr_normalized, _)) => mr_normalized == "bundler",
+                // moduleResolution not set — TS7 defaults to bundler. Module
+                // kinds that imply their own resolution (node16/nodenext/...)
+                // are all in the compatible list below, so treating the
+                // default as bundler cannot misfire for them.
+                None => true,
+            };
+            if bundler_effective {
                 let module_ok = if let Some(serde_json::Value::String(mod_value)) =
                     compiler_opts.get("module")
                 {
@@ -309,8 +328,18 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                     true
                 };
                 if !module_ok {
-                    let start = find_value_offset_in_source(&stripped, "moduleResolution");
-                    let value_len = mr_value.len() as u32 + 2; // include quotes
+                    // Explicit option → point at its value; defaulted option →
+                    // point at the "compilerOptions" key (matching tsc).
+                    let (start, value_len) = if let Some((_, raw_len)) = mr_explicit {
+                        (
+                            find_value_offset_in_source(&stripped, "moduleResolution"),
+                            raw_len + 2, // include quotes
+                        )
+                    } else {
+                        let search = "\"compilerOptions\"";
+                        let s = stripped.find(search).map_or(0, |p| p as u32);
+                        (s, search.len() as u32)
+                    };
                     let msg = "Option 'bundler' can only be used when 'module' is set to 'preserve', 'commonjs', or 'es2015' or later.".to_string();
                     diagnostics.push(Diagnostic::error(
                         file_path,
@@ -849,88 +878,11 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
             ));
         }
 
-        // TS5070: Option '--resolveJsonModule' cannot be specified when 'moduleResolution' is set to 'classic'.
-        // TS5071: Option '--resolveJsonModule' cannot be specified when 'module' is set to 'none', 'system', or 'umd'.
-        // Note: moduleResolution: bundler implies resolveJsonModule=true even when not explicitly set.
-        let resolve_json_explicit = option_is_truthy(compiler_opts.get("resolveJsonModule"));
-        let resolve_json_implied_by_bundler = !resolve_json_explicit
-            && compiler_opts.get("resolveJsonModule").is_none()
-            && matches!(
-                compiler_opts.get("moduleResolution").and_then(|v| v.as_str()).map(normalize_option),
-                Some(ref mr) if mr == "bundler"
-            );
-        if resolve_json_explicit || resolve_json_implied_by_bundler {
-            // Compute effective moduleResolution from raw JSON options
-            let effective_mr = if let Some(serde_json::Value::String(mr_value)) =
-                compiler_opts.get("moduleResolution")
-            {
-                normalize_enum_option_value(mr_value.split(',').next().unwrap_or(mr_value))
-            } else {
-                // Default moduleResolution based on module setting
-                let effective_module = if let Some(serde_json::Value::String(mod_value)) =
-                    compiler_opts.get("module")
-                {
-                    normalize_enum_option_value(mod_value.split(',').next().unwrap_or(mod_value))
-                } else {
-                    String::new() // no module set
-                };
-                match effective_module.as_str() {
-                    // Only map EXPLICITLY-set classic-implying module values to "classic".
-                    // When module is not set (""), tsc determines the default from target
-                    // (typically commonjs → node resolution), so do not assume "classic".
-                    "none" | "amd" | "umd" | "system" => "classic".to_string(),
-                    "commonjs" => "node".to_string(),
-                    "node16" => "node16".to_string(),
-                    "nodenext" => "nodenext".to_string(),
-                    _ => "bundler".to_string(),
-                }
-            };
-
-            if resolve_json_explicit && effective_mr == "classic" {
-                push_key_diagnostic(
-                    &mut diagnostics,
-                    file_path,
-                    &stripped,
-                    "resolveJsonModule",
-                    diagnostic_messages::OPTION_RESOLVEJSONMODULE_CANNOT_BE_SPECIFIED_WHEN_MODULERESOLUTION_IS_SET_TO_CLA,
-                    diagnostic_codes::OPTION_RESOLVEJSONMODULE_CANNOT_BE_SPECIFIED_WHEN_MODULERESOLUTION_IS_SET_TO_CLA,
-                );
-            }
-
-            // TS5071: fires when module=none/system/umd but ONLY when effective_mr is NOT
-            // "classic". When effective_mr IS "classic" (implied or explicit), TS5070 already
-            // covers the resolveJsonModule restriction; tsc never emits both errors at once.
-            if effective_mr != "classic"
-                && let Some(serde_json::Value::String(mod_value)) = compiler_opts.get("module")
-            {
-                let mod_normalized =
-                    normalize_enum_option_value(mod_value.split(',').next().unwrap_or(mod_value));
-                if matches!(mod_normalized.as_str(), "none" | "system" | "umd") {
-                    let msg = diagnostic_messages::OPTION_RESOLVEJSONMODULE_CANNOT_BE_SPECIFIED_WHEN_MODULE_IS_SET_TO_NONE_SYSTEM_O;
-                    let code = diagnostic_codes::OPTION_RESOLVEJSONMODULE_CANNOT_BE_SPECIFIED_WHEN_MODULE_IS_SET_TO_NONE_SYSTEM_O;
-                    // tsc reports the invalid pairing on both participating options when
-                    // resolveJsonModule is explicitly present in the config.
-                    push_key_diagnostic(
-                        &mut diagnostics,
-                        file_path,
-                        &stripped,
-                        "module",
-                        msg,
-                        code,
-                    );
-                    if resolve_json_explicit {
-                        push_key_diagnostic(
-                            &mut diagnostics,
-                            file_path,
-                            &stripped,
-                            "resolveJsonModule",
-                            msg,
-                            code,
-                        );
-                    }
-                }
-            }
-        }
+        // TS5070/TS5071 (`resolveJsonModule` vs classic resolution or
+        // none/system/umd modules) are unreachable in TS7: every module or
+        // resolution kind that could trigger them is itself removed (TS5108)
+        // or invalid (TS6046), and tsc does not layer the resolveJsonModule
+        // conflict on top of those reports.
 
         // TS5098: Option '{0}' can only be used when 'moduleResolution' is set to 'node16', 'nodenext', or 'bundler'.
         let requires_modern_mr: &[&str] = &[

--- a/crates/tsz-core/src/config/tests/module_resolution.rs
+++ b/crates/tsz-core/src/config/tests/module_resolution.rs
@@ -1,8 +1,8 @@
 //! Module and module-resolution diagnostic tests
-//! (TS6046 enum options, module + resolution defaults, TS5095 / TS5070 /
-//! TS5071 / TS5098 `resolveJsonModule` and `package.json` resolution, TS5102 /
-//! TS5103 `ignoreDeprecations` validation, TS5110, inherited `extends`
-//! anchoring).
+//! (TS6046 enum options, module + resolution defaults, TS5095 bundler
+//! compatibility, TS5098 `package.json` resolution, TS5102 / TS5103
+//! `ignoreDeprecations` validation, TS5108 removed options, TS5110,
+//! inherited `extends` anchoring).
 //!
 //! Split from `config/mod.rs` to keep each file under the 2000-line limit
 //! (§19; ratchet tracked by #8280).
@@ -1269,13 +1269,19 @@ fn test_resolve_compiler_options_check_js_implies_allow_js() {
 }
 
 #[test]
-fn test_ts5070_resolve_json_module_with_classic_module_resolution() {
+fn test_classic_module_resolution_is_rejected_as_removed() {
+    // TS7 removed `moduleResolution: classic`; the TS5070 resolveJsonModule
+    // conflict is never layered on top of the removal.
     let source = r#"{"compilerOptions":{"resolveJsonModule":true,"moduleResolution":"classic"}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
-        codes.contains(&5070),
-        "Expected TS5070 for resolveJsonModule with classic moduleResolution, got: {codes:?}"
+        codes.contains(&5108),
+        "Expected TS5108 for removed classic moduleResolution, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&5070) && !codes.contains(&5071),
+        "TS5070/TS5071 are unreachable in TS7, got: {codes:?}"
     );
 }
 
@@ -1310,43 +1316,55 @@ fn test_resolve_json_module_implied_by_bundler_resolution() {
 }
 
 #[test]
-fn test_ts5070_resolve_json_module_with_amd_module() {
-    // module=amd defaults to moduleResolution=classic
+fn test_amd_module_reports_removal_and_default_bundler_conflict() {
+    // TS7 removed `module: amd` (TS5108) and its default
+    // `moduleResolution: bundler` is incompatible with AMD (TS5095); the old
+    // TS5070 classic-resolution conflict is gone.
     let source = r#"{"compilerOptions":{"resolveJsonModule":true,"module":"amd"}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
-        codes.contains(&5070),
-        "Expected TS5070 for resolveJsonModule with module=amd (implies classic), got: {codes:?}"
+        codes.contains(&5108) && codes.contains(&5095),
+        "Expected TS5108 + TS5095 for module=amd, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&5070) && !codes.contains(&5071),
+        "TS5070/TS5071 are unreachable in TS7, got: {codes:?}"
     );
 }
 
 #[test]
-fn test_ts5071_resolve_json_module_with_system_module() {
-    // module=system without explicit moduleResolution implies classic resolution →
-    // tsc emits TS5070 (not TS5071) because the moduleResolution-based check takes precedence.
+fn test_system_module_reports_removal_and_default_bundler_conflict() {
+    // module=system without explicit moduleResolution: TS5108 for the
+    // removed module kind plus TS5095 for the defaulted bundler resolution.
     let source = r#"{"compilerOptions":{"resolveJsonModule":true,"module":"system"}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
-        codes.contains(&5070),
-        "Expected TS5070 (not TS5071) for resolveJsonModule with module=system (implies classic), got: {codes:?}"
+        codes.contains(&5108) && codes.contains(&5095),
+        "Expected TS5108 + TS5095 for module=system, got: {codes:?}"
     );
     assert!(
-        !codes.contains(&5071),
-        "Should NOT emit TS5071 when effective moduleResolution is classic (TS5070 takes precedence), got: {codes:?}"
+        !codes.contains(&5070) && !codes.contains(&5071),
+        "TS5070/TS5071 are unreachable in TS7, got: {codes:?}"
     );
 }
 
 #[test]
-fn test_ts5071_resolve_json_module_with_system_module_explicit_resolution() {
-    // module=system with explicit non-classic moduleResolution → TS5071 fires
+fn test_system_module_with_explicit_bundler_resolution_reports_both() {
+    // Explicit `moduleResolution: bundler` anchors TS5095 at the option
+    // value instead of the "compilerOptions" key; the outcome is the same
+    // TS5108 + TS5095 pair, never TS5071.
     let source = r#"{"compilerOptions":{"resolveJsonModule":true,"module":"system","moduleResolution":"bundler"}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
-        codes.contains(&5071),
-        "Expected TS5071 for resolveJsonModule with module=system + moduleResolution=bundler, got: {codes:?}"
+        codes.contains(&5108) && codes.contains(&5095),
+        "Expected TS5108 + TS5095 for module=system + explicit bundler, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&5071),
+        "TS5071 is unreachable in TS7, got: {codes:?}"
     );
 }
 

--- a/crates/tsz-core/src/config/tests/strict_lib_extends.rs
+++ b/crates/tsz-core/src/config/tests/strict_lib_extends.rs
@@ -94,26 +94,35 @@ fn test_ts6082_not_emitted_without_outfile() {
 }
 
 #[test]
-fn test_ts5071_bundler_implied_resolve_json_module_with_umd() {
-    // moduleResolution: bundler implies resolveJsonModule=true.
-    // Combined with module=umd, this should emit TS5071.
+fn test_bundler_with_umd_module_reports_removal_and_conflict() {
+    // TS7: module=umd is removed (TS5108) and incompatible with bundler
+    // resolution (TS5095); the old bundler-implied-resolveJsonModule TS5071
+    // conflict is unreachable.
     let source = r#"{"compilerOptions":{"moduleResolution":"bundler","module":"umd"}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
-        codes.contains(&5071),
-        "Expected TS5071 for bundler-implied resolveJsonModule with module=umd, got: {codes:?}"
+        codes.contains(&5108) && codes.contains(&5095),
+        "Expected TS5108 + TS5095 for bundler + module=umd, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&5071),
+        "TS5071 is unreachable in TS7, got: {codes:?}"
     );
 }
 
 #[test]
-fn test_ts5071_bundler_implied_resolve_json_module_with_system() {
+fn test_bundler_with_system_module_reports_removal_and_conflict() {
     let source = r#"{"compilerOptions":{"moduleResolution":"bundler","module":"system"}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
-        codes.contains(&5071),
-        "Expected TS5071 for bundler-implied resolveJsonModule with module=system, got: {codes:?}"
+        codes.contains(&5108) && codes.contains(&5095),
+        "Expected TS5108 + TS5095 for bundler + module=system, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&5071),
+        "TS5071 is unreachable in TS7, got: {codes:?}"
     );
 }
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_check.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_check.rs
@@ -872,6 +872,24 @@ impl<'a> DeclarationEmitter<'a> {
             return;
         };
 
+        if let Some(mapped) = arena.get_mapped_type(node) {
+            // Mapped key positions (the iteration variable's constraint and
+            // the `as` name type) serialize as property names — declaration
+            // emit evaluates a concrete-keyed mapped type into its members
+            // (`expand_mapped_type_to_portable_properties`), so an alias
+            // referenced only from a key position is never a printed type
+            // reference. Only the value position can force a foreign name
+            // into the output.
+            self.collect_non_portable_references_in_type_node(
+                arena,
+                mapped.type_node,
+                source_path,
+                collect,
+                visit,
+            );
+            return;
+        }
+
         if let Some(indexed) = arena.get_indexed_access_type(node) {
             let mut collected_object_refs = false;
             if let Some(sym_id) =

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
@@ -1879,8 +1879,18 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         // Collect all types referenced by this type (deeply walks into
-        // objects, tuples, unions, intersections, etc.)
-        let referenced_types = tsz_solver::visitor::collect_referenced_types(interner, type_id);
+        // objects, tuples, unions, intersections, etc.). Mapped key positions
+        // are excluded: a concrete-keyed mapped type serializes its keys as
+        // property names (`expand_mapped_type_to_portable_properties`), so an
+        // alias referenced only from a key constraint is never printed.
+        let mut referenced_types = rustc_hash::FxHashSet::default();
+        tsz_solver::visitor::walk_declaration_portability_referenced_types(
+            interner,
+            type_id,
+            |t| {
+                referenced_types.insert(t);
+            },
+        );
         for &ref_type_id in &referenced_types {
             if let Some(symbol_ref) = tsz_solver::visitor::type_query_symbol(interner, ref_type_id)
                 && let Some(sym_id) = binder

--- a/crates/tsz-parser/src/parser/state_expressions_arrow.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_arrow.rs
@@ -361,7 +361,12 @@ impl ParserState {
                         | SyntaxKind::OpenBracketToken
                         | SyntaxKind::OpenBraceToken
                 )
-                && !self.is_identifier_or_keyword()
+                // tsc's lookahead accepts an identifier (including contextual
+                // keywords) or `this` as a parameter name; a reserved word
+                // (`new`, `typeof`, ...) rejects the arrow interpretation and
+                // the parens reparse as a parenthesized expression.
+                && !self.is_identifier()
+                && !self.is_token(SyntaxKind::ThisKeyword)
             {
                 self.scanner.restore_state(snapshot);
                 self.current_token = current;

--- a/crates/tsz-parser/src/parser/state_types.rs
+++ b/crates/tsz-parser/src/parser/state_types.rs
@@ -1,7 +1,7 @@
 //! Parser state - type parsing, JSX, accessors, and `into_parts` methods
 
 use super::state::ParserState;
-use crate::parser::{NodeIndex, NodeList, syntax_kind_ext};
+use crate::parser::{NodeIndex, syntax_kind_ext};
 use tsz_common::interner::{AstAtom, IdentText};
 use tsz_scanner::SyntaxKind;
 
@@ -583,9 +583,27 @@ impl ParserState {
         }
 
         if self.is_token(SyntaxKind::FunctionKeyword) {
-            // `function(...)` is JSDoc legacy syntax in type positions.
-            // Parse it as a function type for recovery so checker diagnostics continue.
-            return self.parse_jsdoc_legacy_function_type();
+            // TS 7.0.2 dropped the JSDoc-legacy `function(...)` type recovery
+            // (the 6.x TS8020 path): `function` in a type position now parses
+            // as an ordinary type-reference identifier — the checker reports
+            // the unresolved name (TS2552 with the `Function` suggestion) and
+            // any following `(` re-enters normal statement recovery.
+            let first_name = self.parse_type_identifier_or_keyword();
+            let (type_name, jsdoc_type_arguments) = self.parse_qualified_name_rest(first_name);
+            let type_arguments = jsdoc_type_arguments.or_else(|| {
+                (self.is_less_than_or_compound() && !self.scanner.has_preceding_line_break())
+                    .then(|| self.parse_type_arguments())
+            });
+            let base_type = self.arena.add_type_ref(
+                syntax_kind_ext::TYPE_REFERENCE,
+                start_pos,
+                self.token_full_start(),
+                crate::parser::node::TypeRefData {
+                    type_name,
+                    type_arguments,
+                },
+            );
+            return self.parse_primary_type_array_suffix(start_pos, base_type);
         }
 
         if self.is_token(SyntaxKind::AsteriskToken) {
@@ -655,209 +673,6 @@ impl ParserState {
         }
 
         self.parse_primary_type_array_suffix(start_pos, base_type)
-    }
-
-    fn parse_jsdoc_legacy_function_type(&mut self) -> NodeIndex {
-        let start_pos = self.token_pos();
-        let token_end = self.token_end();
-
-        self.parse_error_at(
-            start_pos,
-            token_end - start_pos,
-            "JSDoc types can only be used inside documentation comments.",
-            tsz_common::diagnostics::diagnostic_codes::JSDOC_TYPES_CAN_ONLY_BE_USED_INSIDE_DOCUMENTATION_COMMENTS,
-        );
-
-        self.next_token(); // consume `function`
-
-        let mut is_constructor = false;
-        let mut constructor_return_type = NodeIndex::NONE;
-        let mut starting_param_index: u32 = 0;
-        let mut parameters = Self::make_node_list(Vec::new());
-
-        if self.is_token(SyntaxKind::OpenParenToken) {
-            self.parse_expected(SyntaxKind::OpenParenToken);
-
-            // JSDoc-legacy `function(new: R, …)` denotes a constructor type whose
-            // return type is R.  Detect the leading `new:` before normal param
-            // parsing so we can feed it back into the type as the construct
-            // signature's return type rather than treating `new` as a parameter
-            // name (which would inflate the arity and cascade into TS2554).
-            if self.is_token(SyntaxKind::NewKeyword) && self.next_token_is_colon_lookahead() {
-                is_constructor = true;
-                self.next_token(); // consume `new`
-                self.next_token(); // consume `:`
-                constructor_return_type = self.parse_type();
-                // Consume the trailing `,` if there are more params, otherwise
-                // fall through and let the `)` handling below close the list.
-                let _ = self.parse_optional(SyntaxKind::CommaToken);
-                starting_param_index = 1;
-            }
-
-            if !self.is_token(SyntaxKind::CloseParenToken) {
-                parameters = self.parse_jsdoc_legacy_function_parameters(starting_param_index);
-            }
-        }
-
-        if self.is_token(SyntaxKind::CloseParenToken) {
-            self.parse_expected(SyntaxKind::CloseParenToken);
-        }
-
-        // When `new:` consumed the return type already, ignore any further
-        // `: T` suffix (it would be a stray annotation), but still consume it
-        // so it cannot cascade into the outer parser.
-        let type_annotation = if is_constructor {
-            if self.parse_optional(SyntaxKind::ColonToken) {
-                let _ = self.parse_type();
-            }
-            constructor_return_type
-        } else if self.parse_optional(SyntaxKind::ColonToken) {
-            self.parse_type()
-        } else {
-            NodeIndex::NONE
-        };
-
-        let end_pos = self.token_full_start();
-
-        let kind = if is_constructor {
-            syntax_kind_ext::CONSTRUCTOR_TYPE
-        } else {
-            syntax_kind_ext::FUNCTION_TYPE
-        };
-
-        self.arena.add_function_type(
-            kind,
-            start_pos,
-            end_pos,
-            crate::parser::node::FunctionTypeData {
-                type_parameters: None,
-                parameters,
-                type_annotation,
-                is_abstract: false,
-            },
-        )
-    }
-
-    /// Lookahead that returns true when the *next* token (after the current one)
-    /// is `:`.  Used to detect the `new:` and `this:` JSDoc function-type markers.
-    fn next_token_is_colon_lookahead(&mut self) -> bool {
-        let snapshot = self.scanner.save_state();
-        let saved_token = self.current_token;
-        self.next_token();
-        let is_colon = self.is_token(SyntaxKind::ColonToken);
-        self.scanner.restore_state(snapshot);
-        self.current_token = saved_token;
-        is_colon
-    }
-
-    /// Parse a JSDoc-legacy function type parameter list such as
-    /// `(this: number, string, number)`.  Unlike a normal TS parameter list, entries
-    /// may be bare types (no `name:`) — tsc treats `function(T1, T2)` as
-    /// `(arg0: T1, arg1: T2) => …`.  Without synthesizing names for bare types the
-    /// checker would emit cascading TS7051 ("parameter has a name but no type") and
-    /// TS2300 ("duplicate identifier") on top of the TS8020 that was already
-    /// reported for this JSDoc syntax.  `starting_index` lets callers skip the
-    /// indices taken up by a preceding `new:` slot so bare names line up with
-    /// tsc's `argN` convention.
-    fn parse_jsdoc_legacy_function_parameters(&mut self, starting_index: u32) -> NodeList {
-        let mut params = Vec::new();
-        let mut index: u32 = starting_index;
-
-        while !self.is_token(SyntaxKind::CloseParenToken)
-            && !self.is_token(SyntaxKind::EndOfFileToken)
-        {
-            let param = self.parse_jsdoc_legacy_function_parameter(index);
-            params.push(param);
-            index += 1;
-            if !self.parse_optional(SyntaxKind::CommaToken) {
-                break;
-            }
-        }
-
-        Self::make_node_list(params)
-    }
-
-    fn parse_jsdoc_legacy_function_parameter(&mut self, index: u32) -> NodeIndex {
-        let param_start = self.token_pos();
-        let dot_dot_dot_token = self.parse_optional(SyntaxKind::DotDotDotToken);
-
-        if self.looks_like_jsdoc_named_parameter() {
-            // Conventional `name [?]: type` entry (also covers `this: T` and `new: T`).
-            let name = if self.is_identifier_or_keyword() {
-                self.parse_identifier_name()
-            } else {
-                self.parse_identifier()
-            };
-            let question_token = self.parse_optional(SyntaxKind::QuestionToken);
-            let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {
-                self.parse_type()
-            } else {
-                NodeIndex::NONE
-            };
-            let param_end = self.token_full_start();
-            self.arena.add_parameter(
-                syntax_kind_ext::PARAMETER,
-                param_start,
-                param_end,
-                crate::parser::node::ParameterData {
-                    modifiers: None,
-                    dot_dot_dot_token,
-                    name,
-                    question_token,
-                    type_annotation,
-                    initializer: NodeIndex::NONE,
-                },
-            )
-        } else {
-            // Bare type — synthesize an `argN` identifier so the checker sees a
-            // well-typed parameter rather than a nameless type that would cascade
-            // into TS7051 / TS2300 after the TS8020 we already emitted.
-            let name_pos = self.token_pos();
-            let type_annotation = self.parse_type();
-            let name = self.arena.add_identifier(
-                SyntaxKind::Identifier as u16,
-                name_pos,
-                name_pos,
-                crate::parser::node::IdentifierData {
-                    atom: AstAtom::NONE,
-                    escaped_text: format!("arg{index}").into(),
-                    original_text: None,
-                },
-            );
-            let param_end = self.token_full_start();
-            self.arena.add_parameter(
-                syntax_kind_ext::PARAMETER,
-                param_start,
-                param_end,
-                crate::parser::node::ParameterData {
-                    modifiers: None,
-                    dot_dot_dot_token,
-                    name,
-                    question_token: false,
-                    type_annotation,
-                    initializer: NodeIndex::NONE,
-                },
-            )
-        }
-    }
-
-    /// Lookahead: does the current token stream start with `name [?]:` — i.e. a
-    /// conventional parameter declaration — as opposed to a bare type?  Used to
-    /// decide how to parse entries in a JSDoc-legacy function type parameter list.
-    fn looks_like_jsdoc_named_parameter(&mut self) -> bool {
-        if !self.is_identifier_or_keyword() {
-            return false;
-        }
-        let snapshot = self.scanner.save_state();
-        let saved_token = self.current_token;
-        self.next_token();
-        if self.is_token(SyntaxKind::QuestionToken) {
-            self.next_token();
-        }
-        let is_colon = self.is_token(SyntaxKind::ColonToken);
-        self.scanner.restore_state(snapshot);
-        self.current_token = saved_token;
-        is_colon
     }
 
     fn should_parse_abstract_constructor_type(&mut self) -> bool {

--- a/crates/tsz-parser/tests/parser_improvement_jsdoc_type_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_jsdoc_type_recovery_tests.rs
@@ -159,6 +159,10 @@ type T = Array.<string>;
 
 #[test]
 fn test_jsdoc_legacy_function_type_reports_ts8020_without_parse_cascade() {
+    // TS 7.0.2 removed the JSDoc-legacy `function(...)` type recovery: in a
+    // parameter type position each `function` parses as a type-reference
+    // identifier and the following `(` re-enters normal recovery, so the
+    // parser reports plain TS1005 recoveries and never TS8020.
     let source = r#"
 function hof(ctor: function(new: number, string)) {
     return new ctor('hi');
@@ -172,28 +176,16 @@ function hof2(f: function(this: number, string): string) {
 
     let diagnostics: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
 
-    let ts8020_count = diagnostics
-        .iter()
-        .filter(|code| {
-            **code == diagnostic_codes::JSDOC_TYPES_CAN_ONLY_BE_USED_INSIDE_DOCUMENTATION_COMMENTS
-        })
-        .count();
-    assert_eq!(
-        ts8020_count,
-        2,
-        "Expected TS8020 for both legacy function types, got {:?}",
+    assert!(
+        !diagnostics.contains(
+            &diagnostic_codes::JSDOC_TYPES_CAN_ONLY_BE_USED_INSIDE_DOCUMENTATION_COMMENTS
+        ),
+        "The removed TS8020 JSDoc-legacy recovery must not fire, got {:?}",
         parser.get_diagnostics()
     );
-
-    // TS2554 (too many arguments) is a checker-level diagnostic; it cannot appear
-    // in parser diagnostics. The parser's job is to recover JSDoc `function(...)` into
-    // a well-formed FunctionType so the checker can later produce TS2554.
-
     assert!(
-        !diagnostics
-            .iter()
-            .any(|code| *code == 1003 || *code == 1005 || *code == 1109),
-        "Did not expect parser-level recovery diagnostics for legacy function types, got {:?}",
+        diagnostics.iter().filter(|code| **code == 1005).count() >= 2,
+        "Expected a TS1005 recovery at each `function(` parameter type, got {:?}",
         parser.get_diagnostics()
     );
 }

--- a/crates/tsz-parser/tests/state_type_tests.rs
+++ b/crates/tsz-parser/tests/state_type_tests.rs
@@ -282,86 +282,77 @@ fn jsdoc_dot_generic_type_reference_does_not_cascade_into_qualified_name() {
 
 #[test]
 fn jsdoc_legacy_function_type_with_bare_types_does_not_cascade() {
-    // `function(T1, T2): R` is tsc's JSDoc-legacy function-type form.  tsc
-    // treats the bare types as positional parameters with synthetic `argN`
-    // names (`(arg0: T1, arg1: T2) => R`) and emits only TS8020.  Our parser
-    // must mirror that — emitting TS7051 or TS2300 would be a cascade.
+    // TS 7.0.2 dropped the JSDoc-legacy `function(...)` type recovery:
+    // `function` parses as a plain type-reference identifier and the `(`
+    // re-enters declarator recovery. tsc reports exactly `','` expected at
+    // the `(` and `';'` expected at the second `:` — no TS8020.
     let source = "var g: function(number, number): number = (n, m) => n + m;";
     let (parser, _root) = parse_source(source);
     let diagnostics = parser.get_diagnostics();
 
-    assert!(
-        diagnostics.iter().any(|d| d.code == 8020),
-        "Expected TS8020 for JSDoc legacy function type, got {diagnostics:?}"
-    );
-    assert!(
-        diagnostics
-            .iter()
-            .all(|d| d.code != 17019 && d.code != 17020),
-        "Bare-type parameter list should not trigger postfix/prefix nullable diagnostics, got {diagnostics:?}"
+    let codes: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        vec![1005, 1005],
+        "expected tsc 7.0.2's two TS1005 recoveries, got {diagnostics:?}"
     );
 }
 
 #[test]
 fn jsdoc_legacy_function_type_with_this_binding_preserves_it() {
-    // `function(this: T, string)` — `this:` is a this-binding (index 0), and
-    // the bare `string` should be parsed as the 1-based `arg1: string` so the
-    // resulting call-site arity is 1, matching tsc.
+    // TS 7.0.2: after the TS1005 at `(`, the `(this: number, string)` tail
+    // speculates as arrow-function parameters (`this` is a valid parameter
+    // name), so recovery ends with `'=>' expected` — never TS8020.
     let source = "var f: function(this: number, string): string;";
     let (parser, _root) = parse_source(source);
     let diagnostics = parser.get_diagnostics();
 
-    assert!(
-        diagnostics.iter().any(|d| d.code == 8020),
-        "Expected TS8020 for JSDoc legacy function type, got {diagnostics:?}"
-    );
-    // Only TS8020 should surface.  A cascading TS7051 for the bare `string`
-    // parameter would indicate the parameter lost its type annotation.
-    let unexpected: Vec<_> = diagnostics.iter().filter(|d| d.code != 8020).collect();
-    assert!(
-        unexpected.is_empty(),
-        "JSDoc `function(this: T, X)` should only emit TS8020, got {unexpected:?}"
+    let codes: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        vec![1005, 1005],
+        "expected tsc 7.0.2's `','`/`'=>'` TS1005 pair, got {diagnostics:?}"
     );
 }
 
 #[test]
 fn jsdoc_legacy_function_type_with_new_marker_is_parsed_as_constructor() {
-    // `function(new: R, A)` denotes a constructor type whose return type is R.
-    // Without the `new:` shortcut the parser would model it as a 2-arity
-    // function `(new: R, A)`, which cascades into TS2554 at call sites such
-    // as `new ctor('hi')`.  The parser should only emit TS8020.
+    // TS 7.0.2: `new` is a reserved word, so `(new: number, string)` cannot
+    // be arrow parameters — the parens reparse as a parenthesized expression
+    // whose `new` lacks an operand: `','` expected, `Expression expected`,
+    // then `';'` expected. Never TS8020, never a constructor type.
     let source = "var c: function(new: number, string);";
     let (parser, _root) = parse_source(source);
     let diagnostics = parser.get_diagnostics();
 
-    assert!(
-        diagnostics.iter().any(|d| d.code == 8020),
-        "Expected TS8020 for JSDoc legacy constructor function type, got {diagnostics:?}"
-    );
-    let unexpected: Vec<_> = diagnostics.iter().filter(|d| d.code != 8020).collect();
-    assert!(
-        unexpected.is_empty(),
-        "JSDoc `function(new: R, A)` should only emit TS8020, got {unexpected:?}"
+    let codes: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        vec![1005, 1109, 1005],
+        "expected tsc 7.0.2's paren-expression recovery, got {diagnostics:?}"
     );
 }
 
 #[test]
 fn jsdoc_legacy_constructor_function_suffix_does_not_cascade() {
-    // `function(new: R): T` is still legacy JSDoc syntax. The `new:` marker
-    // already supplies the constructor return type, so the trailing `: T`
-    // should be consumed for recovery but not leak into the outer declaration.
+    // TS 7.0.2 parses `function` as a type-reference identifier and the
+    // reserved `new` rejects the arrow speculation: `','` expected at `(`
+    // and `Expression expected` at the `:` after `new`. tsc additionally
+    // recovers the tail as garbage statements (TS1434/TS1128); tsz's
+    // remaining tail recovery differs there (known gap) — this pin holds the
+    // prefix and the absence of the removed TS8020 path.
     let source = "var c: function(new: number): string;";
     let (parser, _root) = parse_source(source);
     let diagnostics = parser.get_diagnostics();
 
+    let codes: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
     assert!(
-        diagnostics.iter().any(|d| d.code == 8020),
-        "Expected TS8020 for JSDoc legacy constructor function type, got {diagnostics:?}"
+        codes.starts_with(&[1005, 1109]),
+        "expected the TS1005 + TS1109 recovery prefix, got {diagnostics:?}"
     );
-    let unexpected: Vec<_> = diagnostics.iter().filter(|d| d.code != 8020).collect();
     assert!(
-        unexpected.is_empty(),
-        "JSDoc `function(new: R): T` should only emit TS8020, got {unexpected:?}"
+        !codes.contains(&8020),
+        "the removed TS8020 JSDoc-legacy recovery must not fire, got {diagnostics:?}"
     );
 }
 

--- a/crates/tsz-solver/src/visitors/child_policy.rs
+++ b/crates/tsz-solver/src/visitors/child_policy.rs
@@ -42,8 +42,17 @@ pub struct ChildPolicy {
     pub type_param_default: bool,
     /// Visit a mapped type's iteration-variable `constraint`/`default`
     /// metadata (`mapped.type_param`); the mapped `constraint`, `template`,
-    /// and `name_type` are always visited.
+    /// and `name_type` are visited per [`Self::FULL`] unless
+    /// `mapped_key_positions` turns the key positions off.
     pub mapped_type_param_metadata: bool,
+    /// Visit a mapped type's key positions (`constraint` and `name_type`).
+    ///
+    /// Declaration-emit portability walks turn this off: a mapped type with a
+    /// concrete key constraint serializes its keys as property *names*
+    /// (evaluation regime), so an alias referenced only from a key position is
+    /// never an emit-time type reference. The `template` (value position) is
+    /// always visited.
+    pub mapped_key_positions: bool,
     /// Skip the entire body (params, return, `this`, predicate, metadata) of a
     /// *generic* signature. Free-occurrence walkers use this: a generic
     /// signature binds its own type parameters, so references inside its body
@@ -83,6 +92,7 @@ impl ChildPolicy {
         type_param_constraint: true,
         type_param_default: false,
         mapped_type_param_metadata: true,
+        mapped_key_positions: true,
         skip_generic_signature_bodies: false,
         property_write_types: true,
         index_key_types: true,
@@ -119,6 +129,7 @@ impl ChildPolicy {
         type_param_constraint: true,
         type_param_default: true,
         mapped_type_param_metadata: true,
+        mapped_key_positions: true,
         skip_generic_signature_bodies: false,
         property_write_types: false,
         index_key_types: false,
@@ -227,6 +238,22 @@ impl ChildPolicy {
         type_param_constraint: false,
         type_param_default: false,
         ..Self::STRUCTURAL_USES
+    };
+
+    /// Declaration-emit portability walks (TS2883 and friends): the full
+    /// surface minus mapped key positions. When declaration emit serializes a
+    /// mapped type with a concrete key constraint, the keys become property
+    /// *names* (tsc's evaluation regime), so an alias that appears only in a
+    /// key position (`constraint`/`name_type`) is never a printed type
+    /// reference. Value positions (`template`) are still walked — a
+    /// non-portable type there does get printed and must keep reporting.
+    pub const DECLARATION_PORTABILITY: Self = Self {
+        mapped_key_positions: false,
+        // The iteration variable's declared constraint/default duplicate the
+        // key positions (`K in Key` stores Key both as the mapped constraint
+        // and as K's metadata) — exclude them for the same reason.
+        mapped_type_param_metadata: false,
+        ..Self::FULL
     };
 }
 
@@ -468,9 +495,13 @@ pub fn try_for_each_child_with_policy<B, F: FnMut(TypeId) -> ControlFlow<B>>(
                     f(default)?;
                 }
             }
-            f(mapped.constraint)?;
+            if policy.mapped_key_positions {
+                f(mapped.constraint)?;
+            }
             f(mapped.template)?;
-            if let Some(name_type) = mapped.name_type {
+            if policy.mapped_key_positions
+                && let Some(name_type) = mapped.name_type
+            {
                 f(name_type)?;
             }
             ControlFlow::Continue(())

--- a/crates/tsz-solver/src/visitors/visitor.rs
+++ b/crates/tsz-solver/src/visitors/visitor.rs
@@ -406,8 +406,37 @@ impl ReferencedTypeWalkState {
 }
 
 /// The callback is invoked once per unique reachable type (including `root`).
-pub fn walk_referenced_types<F>(types: &dyn TypeDatabase, root: TypeId, mut f: F)
+pub fn walk_referenced_types<F>(types: &dyn TypeDatabase, root: TypeId, f: F)
 where
+    F: FnMut(TypeId),
+{
+    walk_referenced_types_with_policy(types, root, &ChildPolicy::FULL, f);
+}
+
+/// [`walk_referenced_types`] for declaration-emit portability checks
+/// (TS2883 and friends): mapped key positions (`constraint`/`name_type`)
+/// are not treated as references — declaration emit serializes a mapped
+/// type's keys as property names, never as printed type references. Value
+/// positions (`template`) are still walked.
+pub fn walk_declaration_portability_referenced_types<F>(
+    types: &dyn TypeDatabase,
+    root: TypeId,
+    f: F,
+) where
+    F: FnMut(TypeId),
+{
+    walk_referenced_types_with_policy(types, root, &ChildPolicy::DECLARATION_PORTABILITY, f);
+}
+
+/// [`walk_referenced_types`] with an explicit [`ChildPolicy`] selecting which
+/// child positions count as references. The callback is invoked once per
+/// unique reachable type (including `root`).
+pub(crate) fn walk_referenced_types_with_policy<F>(
+    types: &dyn TypeDatabase,
+    root: TypeId,
+    policy: &ChildPolicy,
+    mut f: F,
+) where
     F: FnMut(TypeId),
 {
     let mut pool = WALK_POOL
@@ -437,7 +466,7 @@ where
         let Some(key) = types.lookup(current) else {
             continue;
         };
-        for_each_child(types, &key, |child| stack.push(child));
+        for_each_child_with_policy(types, &key, policy, |child| stack.push(child));
     }
 
     // Return the pool, keeping whichever allocation has the larger visited-set


### PR DESCRIPTION
Goal: hold

TS7 parity wave 5: drains the tsz-cli failing-test inventory from 26 instances to 9 (unique clusters 13 → 6), with three real compiler fixes and the removed-option/behavioral-drift pins that TS 7.0.2 requires.

## What changed

**Config validation (tsz-core)**
- TS5070/TS5071 (`resolveJsonModule` vs classic resolution / none-system-umd modules) are unreachable in 7.0.2 — every trigger kind is itself removed (TS5108) or invalid (TS6046), and tsc does not layer them on top. The emission block is retired and its six unit pins flipped to 7.0.2 expectations.
- TS5095 now fires for the **defaulted** bundler resolution too (7.0.2 defaults `moduleResolution: bundler`), anchored at the `compilerOptions` key when the option is absent — exactly where tsc anchors it.
- Seven dead-surface driver rows (es5 downlevel ×3, AMD outFile ×3, CLI-flag outfile) converted to removed-option pins: `target=es5`, `downlevelIteration`, `module amd/umd/system`, `outFile` all report TS5108/TS5102 (+TS5095) with no emit.

**Parser**
- Dropped the 6.x JSDoc-legacy `function(...)` type recovery (TS8020): `function` in a type position parses as an ordinary type-reference identifier — the checker then reports TS2552 with the `Function` suggestion via the generic spelling machinery — and the arrow-function lookahead now matches tsc's rule that a parameter slot must start with an identifier/contextual keyword or `this` (a reserved word like `new` rejects arrow speculation, so `(new: number)` reparses as a parenthesized expression). Four of five variant forms byte-match the oracle; the residual tail needs Corsa's TS1434 garbage-statement recovery (noted below).

**Declaration-emit portability (solver + checker + emitter)**
- Structural rule: tsc serializes a concrete-keyed mapped type's keys as property *names*, so an alias referenced only from a key position (constraint, iteration-variable metadata, `as` name type) is never a printed type reference and must not trip TS2883. A new solver-owned `ChildPolicy::DECLARATION_PORTABILITY` excludes key positions from the referenced-type walk; all three portability layers (checker `first_non_portable_type_reference`, emitter deep type walk, emitter callee-return AST scan) use it. The value position still reports (adjacent negative pin added, renamed binders).

**Checker mapped object-literal probe**
- The mapped/Partial per-property probe typed initializers with `TypingRequest::NONE`, so fresh literals widened (`"lo"` → `string`) and a false TS2322 fired against literal member types (`{ [K in keyof V]: K }`; tsc clean). The probe now passes the evaluated per-property target as the contextual type. Four-case adjacent matrix added.

**Behavioral-drift pins (oracle-adjudicated, tsz already matching)**
- noEmit-with-errors exits 1 (`DiagnosticsPresent_OutputsSkipped`) — three 6.x exit-2 pins flipped.
- TS6053 for unresolved triple-slash references prints the path **as written** in both explicit-file and project mode — two 6.x display pins flipped, tests renamed to match the rule.
- Pretty multi-file `Errors  Files` table ends with a trailing blank line (reporter fix).
- Restored the documented #3941 honest `--generateCpuProfile` help line that wave 4's full-text sync accidentally replaced.
- Generator yield-union pins updated to TS7 display rank (`"bye" | "hi"`, `"s" | 1`).
- Four declaration-emit fixtures modernized off removed `moduleResolution: "node"` (two rows flipped green immediately; the other two exposed the real TS2883 bug fixed above / the dts3 residual below).

## Remaining (wave 6)

Six unique clusters stay red, all adjudicated: default_object_assign (solver preserve-meta on member-access mapped-alias instantiation), batch_mode JS ctor-fn JSDoc classification, cross-file class statics lost in import cycles (order-dependent provisional cache), checked-JS self-referential prototype method, promise-like imported class, and the Corsa TS1434 statement-recovery tail behind `tsc_parity_jsdoc_constructor_function_suffix`.

## Verification

- `cargo nextest run -p tsz-parser` — 1490/1490.
- `cargo nextest run -p tsz-solver -p tsz-emitter` — 12209/12209.
- `CARGO_PROFILE_DEV_DEBUG=0 cargo nextest run -p tsz-checker --lib` — 8142/8146 (4 pre-existing pool failures: higher_order, overload_two_pass, template display, zod_type_query).
- `cargo nextest run -p tsz-cli` — 2448/2457 (9 pre-existing, the six clusters above).
- Every flipped pin oracle-adjudicated side-by-side against `node scripts/node_modules/typescript/bin/tsc` (7.0.2): removed-option sets, exit codes, TS6053 display, pretty tail, generator unions, TS2883 fixtures (positive + negative), mapped-literal matrix.
- Full conformance/emit suites: ready-review CI.

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max
