### PR TITLE
fix(bench): repair 15 canary fixture configs to a valid tsc-6 reference and refresh the website snapshot

### DIFF
--- a/crates/tsz-website/bench-snapshot.json
+++ b/crates/tsz-website/bench-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-16T04:27:16.098Z",
+  "generated_at": "2026-07-16T11:39:30.165Z",
   "source_commit": "5cb74ae454460ba730a5661f565fdd7cd58f01db",
   "workflow_name": "local",
   "workflow_run_id": "local",
@@ -8,15 +8,127 @@
   "run_status": "local",
   "benchmark_runner": "scripts/bench/bench-vs-tsgo.sh",
   "merged_from": [
-    "bench-main-pruned.json",
-    "bench-toolbelt-rerun.json"
+    "bench-base-pruned.json",
+    "bench-canary-rerun.json"
   ],
   "validation": {
     "hyperfine_exit_codes_required": true,
     "project_compatibility_required_fields": true,
     "runner_signature_required": false,
     "runner_environment_warnings": [],
-    "measurement_profile_warnings": [],
+    "measurement_profile_warnings": [
+      {
+        "file": "bench-canary-rerun.json",
+        "mismatched_fields": [
+          "profile_guided_optimization.profile_fingerprint",
+          "profile_guided_optimization.training_fingerprint",
+          "profile_guided_optimization.training_input_count",
+          "profile_guided_optimization.training_inputs"
+        ],
+        "expected": {
+          "mode": "release-pgo",
+          "tsz_binary_source": "bench-dist",
+          "rust_target_cpu": "native",
+          "profile_guided_optimization": {
+            "requested": true,
+            "required": false,
+            "optimized": true,
+            "profile_fingerprint": "830459bc1458134decd4fc0392489fcfaae173c1accb34cfd097bb0a3af8fd28",
+            "training_fingerprint": "dfdf747c7904c65877145785c51fe00bdae3f891c9672ddb4cde5412f4f7d1df",
+            "profile_data_source": "fresh",
+            "training_metadata_available": true,
+            "training_input_count": 19,
+            "training_failure_count": 1,
+            "training_inputs": [
+              "synthetic:complex_generics.ts",
+              "synthetic:deeppartial_optional_chain.ts",
+              "synthetic:recursive_utility_alias.ts",
+              "synthetic:shallow_optional_chain.ts",
+              "synthetic:union_members.ts",
+              "synthetic:recursive_generic.ts",
+              "synthetic:conditional_dist.ts",
+              "synthetic:mapped_type.ts",
+              "synthetic:template_literal.ts",
+              "synthetic:deep_subtype.ts",
+              "synthetic:intersection.ts",
+              "synthetic:infer_stress.ts",
+              "synthetic:cfa_stress.ts",
+              "synthetic:bct_stress.ts",
+              "synthetic:constraint_conflict.ts",
+              "synthetic:mapped_complex_template.ts",
+              "utility-types",
+              "manyConstExports.ts",
+              "manyConstExports.ts"
+            ],
+            "training_failed_inputs": [
+              "synthetic:template_literal.ts:1"
+            ],
+            "config": {
+              "synthetic": true,
+              "fetch_utility_types": true,
+              "fetch_core_projects": false,
+              "panic_unwind": false,
+              "extra_inputs": null,
+              "training_timeout_seconds": 900,
+              "cache_enabled": true
+            }
+          }
+        },
+        "actual": {
+          "mode": "release-pgo",
+          "tsz_binary_source": "bench-dist",
+          "rust_target_cpu": "native",
+          "profile_guided_optimization": {
+            "requested": true,
+            "required": false,
+            "optimized": true,
+            "profile_fingerprint": "5bcf08888162a6bc34b3646b0fd10fac884d8e22a1d41bab06664ccdb06742f8",
+            "training_fingerprint": "c3bd39ab8dbb33a951adc13d8534e0cbff393f977a3bfe8947ba7ed590e02d69",
+            "profile_data_source": "fresh",
+            "training_metadata_available": true,
+            "training_input_count": 23,
+            "training_failure_count": 1,
+            "training_inputs": [
+              "synthetic:complex_generics.ts",
+              "synthetic:deeppartial_optional_chain.ts",
+              "synthetic:recursive_utility_alias.ts",
+              "synthetic:shallow_optional_chain.ts",
+              "synthetic:union_members.ts",
+              "synthetic:recursive_generic.ts",
+              "synthetic:conditional_dist.ts",
+              "synthetic:mapped_type.ts",
+              "synthetic:template_literal.ts",
+              "synthetic:deep_subtype.ts",
+              "synthetic:intersection.ts",
+              "synthetic:infer_stress.ts",
+              "synthetic:cfa_stress.ts",
+              "synthetic:bct_stress.ts",
+              "synthetic:constraint_conflict.ts",
+              "synthetic:mapped_complex_template.ts",
+              "utility-types",
+              "rxjs",
+              "type-fest",
+              "vite-vanilla-ts-app",
+              "nextjs-fresh-app",
+              "manyConstExports.ts",
+              "manyConstExports.ts"
+            ],
+            "training_failed_inputs": [
+              "synthetic:template_literal.ts:1"
+            ],
+            "config": {
+              "synthetic": true,
+              "fetch_utility_types": true,
+              "fetch_core_projects": false,
+              "panic_unwind": false,
+              "extra_inputs": null,
+              "training_timeout_seconds": 900,
+              "cache_enabled": true
+            }
+          }
+        }
+      }
+    ],
     "project_compatibility_advisory": [
       "type-challenges-solutions-project: missing project row"
     ],
@@ -98,13 +210,13 @@
     "tsz_profile": "release-pgo"
   },
   "totals": {
-    "benchmarks_run": 147,
+    "benchmarks_run": 169,
     "rows": 138,
-    "tsz_wins": 97,
-    "tsgo_wins": 9,
-    "green_tsz_wins": 97,
-    "green_tsgo_wins": 9,
-    "error_cases": 32
+    "tsz_wins": 99,
+    "tsgo_wins": 10,
+    "green_tsz_wins": 99,
+    "green_tsgo_wins": 10,
+    "error_cases": 29
   },
   "results": [
     {
@@ -1051,262 +1163,6 @@
       }
     },
     {
-      "name": "valibot-project",
-      "lines": 106848,
-      "kb": 2854,
-      "project_files": 1083,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:01:42.286Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/valibot/library/src/actions/args/args.ts(19,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/args/argsAsync.ts(26,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/args/index.ts(1,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/args/index.ts(2,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/await/index.ts(1,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/base64/base64.ts(1,30): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/base64/base64.ts(7,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/base64/index.ts(1,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/bic/bic.ts(1,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/bic/bic.ts(7,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/bic/index.ts(1,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/brand/index.ts(1,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/bytes/bytes.ts(6,42): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/bytes/index.ts(1,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/check/check.ts(2,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/check/checkAsync.ts(6,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/check/index.ts(1,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/check/index.ts(2,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/check/index.ts(3,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/checkItems/checkItems.ts(2,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled."
-        ],
-        "diagnostic_codes": [
-          "TS5097"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "unclassified diagnostic",
-            "codes": [
-              "TS5097"
-            ],
-            "count": 20,
-            "examples": [
-              "tsc: .target-bench/external/valibot/library/src/actions/args/args.ts(19,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-              "tsc: .target-bench/external/valibot/library/src/actions/args/argsAsync.ts(26,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-              "tsc: .target-bench/external/valibot/library/src/actions/args/index.ts(1,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled."
-            ]
-          }
-        ],
-        "primary_subsystem": "unclassified diagnostic",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/valibot/library/src/actions/args/args.ts(19,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/args/argsAsync.ts(26,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/args/index.ts(1,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/args/index.ts(2,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.",
-          "tsc: .target-bench/external/valibot/library/src/actions/await/index.ts(1,15): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "unclassified diagnostic"
-        ],
-        "reduced_repro_path": ".target-bench/external/valibot/library/src/actions/args/args.ts",
-        "repro": {
-          "tsconfig_path": "valibot/tsconfig.tsz-bench.json",
-          "source_root": "valibot/library/src",
-          "first_failure_path": ".target-bench/external/valibot/library/src/actions/args/args.ts",
-          "first_failure_line": 19,
-          "first_failure_column": 27,
-          "first_failure_code": "TS5097",
-          "reduced_repro_path": ".target-bench/external/valibot/library/src/actions/args/args.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p valibot/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "schema-builder generics with recursive conditionals",
-        "files_reached": 1083,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "valibot",
-            "repository": "https://github.com/fabian-hiller/valibot.git",
-            "ref": "e7bcacb107b1c5a74dfd564babd2c8697037ee06"
-          }
-        ]
-      }
-    },
-    {
-      "name": "msw-project",
-      "lines": 15376,
-      "kb": 437,
-      "project_files": 156,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:01:45.105Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/msw/src/browser/setup-worker.ts(1,27): error TS2307: Cannot find module 'outvariant' or its corresponding type declarations.",
-          "tsc: .target-bench/external/msw/src/browser/setup-worker.ts(2,31): error TS2307: Cannot find module 'is-node-process' or its corresponding type declarations.",
-          "tsc: .target-bench/external/msw/src/browser/setup-worker.ts(3,38): error TS2307: Cannot find module '@mswjs/interceptors/WebSocket' or its corresponding type declarations.",
-          "tsc: .target-bench/external/msw/src/browser/sources/fallback-http-source.ts(1,34): error TS2307: Cannot find module '@mswjs/interceptors/fetch' or its corresponding type declarations.",
-          "tsc: .target-bench/external/msw/src/browser/sources/fallback-http-source.ts(2,43): error TS2307: Cannot find module '@mswjs/interceptors/XMLHttpRequest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(1,27): error TS2307: Cannot find module 'outvariant' or its corresponding type declarations.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(2,30): error TS2307: Cannot find module 'rettime' or its corresponding type declarations.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(3,33): error TS2307: Cannot find module '@open-draft/deferred-promise' or its corresponding type declarations.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(4,31): error TS2307: Cannot find module '@mswjs/interceptors' or its corresponding type declarations.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(48,44): error TS2339: Property 'data' does not exist on type 'WorkerEvent<{ client: { id: string; frameType: string; }; }, any, string>'.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(96,50): error TS7031: Binding element 'worker' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(115,42): error TS7031: Binding element 'registration' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(119,19): error TS2339: Property 'removeAllListeners' does not exist on type 'WorkerChannel'.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(150,19): error TS2339: Property 'once' does not exist on type 'WorkerChannel'.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(150,44): error TS7006: Parameter 'event' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(272,49): error TS7006: Parameter 'resolve' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(277,19): error TS2339: Property 'on' does not exist on type 'WorkerChannel'.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(278,19): error TS2339: Property 'on' does not exist on type 'WorkerChannel'.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(408,19): error TS2339: Property 'once' does not exist on type 'WorkerChannel'.",
-          "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(408,53): error TS7006: Parameter 'event' implicitly has an 'any' type."
-        ],
-        "diagnostic_codes": [
-          "TS2307",
-          "TS2339",
-          "TS7031",
-          "TS7006"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "module-symbol-resolution",
-            "codes": [
-              "TS2307"
-            ],
-            "count": 9,
-            "examples": [
-              "tsc: .target-bench/external/msw/src/browser/setup-worker.ts(1,27): error TS2307: Cannot find module 'outvariant' or its corresponding type declarations.",
-              "tsc: .target-bench/external/msw/src/browser/setup-worker.ts(2,31): error TS2307: Cannot find module 'is-node-process' or its corresponding type declarations.",
-              "tsc: .target-bench/external/msw/src/browser/setup-worker.ts(3,38): error TS2307: Cannot find module '@mswjs/interceptors/WebSocket' or its corresponding type declarations."
-            ]
-          },
-          {
-            "subsystem": "keyspace-property-indexed",
-            "codes": [
-              "TS2339"
-            ],
-            "count": 6,
-            "examples": [
-              "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(48,44): error TS2339: Property 'data' does not exist on type 'WorkerEvent<{ client: { id: string; frameType: string; }; }, any, string>'.",
-              "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(119,19): error TS2339: Property 'removeAllListeners' does not exist on type 'WorkerChannel'.",
-              "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(150,19): error TS2339: Property 'once' does not exist on type 'WorkerChannel'."
-            ]
-          },
-          {
-            "subsystem": "contextual-inference",
-            "codes": [
-              "TS7031",
-              "TS7006"
-            ],
-            "count": 5,
-            "examples": [
-              "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(96,50): error TS7031: Binding element 'worker' implicitly has an 'any' type.",
-              "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(115,42): error TS7031: Binding element 'registration' implicitly has an 'any' type.",
-              "tsc: .target-bench/external/msw/src/browser/sources/service-worker-source.ts(150,44): error TS7006: Parameter 'event' implicitly has an 'any' type."
-            ]
-          }
-        ],
-        "primary_subsystem": "module-symbol-resolution",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/msw/src/browser/setup-worker.ts(1,27): error TS2307: Cannot find module 'outvariant' or its corresponding type declarations.",
-          "tsc: .target-bench/external/msw/src/browser/setup-worker.ts(2,31): error TS2307: Cannot find module 'is-node-process' or its corresponding type declarations.",
-          "tsc: .target-bench/external/msw/src/browser/setup-worker.ts(3,38): error TS2307: Cannot find module '@mswjs/interceptors/WebSocket' or its corresponding type declarations.",
-          "tsc: .target-bench/external/msw/src/browser/sources/fallback-http-source.ts(1,34): error TS2307: Cannot find module '@mswjs/interceptors/fetch' or its corresponding type declarations.",
-          "tsc: .target-bench/external/msw/src/browser/sources/fallback-http-source.ts(2,43): error TS2307: Cannot find module '@mswjs/interceptors/XMLHttpRequest' or its corresponding type declarations."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "module-symbol-resolution",
-          "keyspace-property-indexed",
-          "contextual-inference"
-        ],
-        "reduced_repro_path": ".target-bench/external/msw/src/browser/setup-worker.ts",
-        "repro": {
-          "tsconfig_path": "msw/tsconfig.tsz-bench.json",
-          "source_root": "msw/src",
-          "first_failure_path": ".target-bench/external/msw/src/browser/setup-worker.ts",
-          "first_failure_line": 1,
-          "first_failure_column": 27,
-          "first_failure_code": "TS2307",
-          "reduced_repro_path": ".target-bench/external/msw/src/browser/setup-worker.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p msw/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "pnpm-symlinked @types graph plus project references",
-        "files_reached": 156,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "msw",
-            "repository": "https://github.com/mswjs/msw.git",
-            "ref": "8a19d5485adad2b8a816e04a937f4c76169cd5b9"
-          }
-        ]
-      }
-    },
-    {
       "name": "comlink-project",
       "lines": 814,
       "kb": 22,
@@ -1373,249 +1229,6 @@
             "name": "comlink",
             "repository": "https://github.com/GoogleChromeLabs/comlink.git",
             "ref": "114a4a6448a855a613f1cb9a7c89290606c003cf"
-          }
-        ]
-      }
-    },
-    {
-      "name": "effect-project",
-      "lines": 187839,
-      "kb": 5526,
-      "project_files": 363,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:02:05.367Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(22,37): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'Arbitrary'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(63,74): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'Arbitrary'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(67,35): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'StringSharedConstraints'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(95,35): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'FloatConstraints'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(137,35): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'BigIntConstraints'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(160,35): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'ArrayConstraints'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(183,35): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'DateConstraints'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(665,5): error TS2322: Type 'Date | undefined' is not assignable to type 'number | undefined'.",
-          "tsc:   Type 'Date' is not assignable to type 'number'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(666,5): error TS2322: Type 'Date | undefined' is not assignable to type 'number | undefined'.",
-          "tsc:   Type 'Date' is not assignable to type 'number'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(697,5): error TS2322: Type 'Date | undefined' is not assignable to type 'bigint | undefined'.",
-          "tsc:   Type 'Date' is not assignable to type 'bigint'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(698,5): error TS2322: Type 'Date | undefined' is not assignable to type 'bigint | undefined'.",
-          "tsc:   Type 'Date' is not assignable to type 'bigint'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(817,27): error TS2339: Property 'date' does not exist on type 'typeof import(\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\")'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(823,27): error TS2339: Property 'constant' does not exist on type 'typeof import(\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\")'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(825,27): error TS2339: Property 'constant' does not exist on type 'typeof import(\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\")'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(829,31): error TS2339: Property 'constant' does not exist on type 'typeof import(\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\")'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(833,31): error TS2339: Property 'anything' does not exist on type 'typeof import(\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\")'."
-        ],
-        "diagnostic_codes": [
-          "TS2694",
-          "TS2322",
-          "TS2339"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "module-symbol-resolution",
-            "codes": [
-              "TS2694"
-            ],
-            "count": 7,
-            "examples": [
-              "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(22,37): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'Arbitrary'.",
-              "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(63,74): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'Arbitrary'.",
-              "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(67,35): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'StringSharedConstraints'."
-            ]
-          },
-          {
-            "subsystem": "relations-assignability",
-            "codes": [
-              "TS2322"
-            ],
-            "count": 4,
-            "examples": [
-              "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(665,5): error TS2322: Type 'Date | undefined' is not assignable to type 'number | undefined'.",
-              "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(666,5): error TS2322: Type 'Date | undefined' is not assignable to type 'number | undefined'.",
-              "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(697,5): error TS2322: Type 'Date | undefined' is not assignable to type 'bigint | undefined'."
-            ]
-          },
-          {
-            "subsystem": "uncoded diagnostic",
-            "codes": [],
-            "count": 4,
-            "examples": [
-              "tsc:   Type 'Date' is not assignable to type 'number'.",
-              "tsc:   Type 'Date' is not assignable to type 'number'.",
-              "tsc:   Type 'Date' is not assignable to type 'bigint'."
-            ]
-          },
-          {
-            "subsystem": "keyspace-property-indexed",
-            "codes": [
-              "TS2339"
-            ],
-            "count": 5,
-            "examples": [
-              "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(817,27): error TS2339: Property 'date' does not exist on type 'typeof import(\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\")'.",
-              "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(823,27): error TS2339: Property 'constant' does not exist on type 'typeof import(\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\")'.",
-              "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(825,27): error TS2339: Property 'constant' does not exist on type 'typeof import(\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\")'."
-            ]
-          }
-        ],
-        "primary_subsystem": "module-symbol-resolution",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(22,37): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'Arbitrary'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(63,74): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'Arbitrary'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(67,35): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'StringSharedConstraints'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(95,35): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'FloatConstraints'.",
-          "tsc: .target-bench/external/effect/packages/effect/src/Arbitrary.ts(137,35): error TS2694: Namespace '\"/Users/mohsen/code/tsz/.target-bench/external/effect/packages/effect/src/FastCheck\"' has no exported member 'BigIntConstraints'."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "module-symbol-resolution",
-          "relations-assignability",
-          "uncoded diagnostic",
-          "keyspace-property-indexed"
-        ],
-        "reduced_repro_path": ".target-bench/external/effect/packages/effect/src/Arbitrary.ts",
-        "repro": {
-          "tsconfig_path": "effect/tsconfig.tsz-bench.json",
-          "source_root": "effect/packages/effect/src",
-          "first_failure_path": ".target-bench/external/effect/packages/effect/src/Arbitrary.ts",
-          "first_failure_line": 22,
-          "first_failure_column": 37,
-          "first_failure_code": "TS2694",
-          "reduced_repro_path": ".target-bench/external/effect/packages/effect/src/Arbitrary.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p effect/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "large-scale schema/effect generics, ~296k LOC parity canary",
-        "files_reached": 363,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "effect",
-            "repository": "https://github.com/Effect-TS/effect.git",
-            "ref": "626c61b3ef0dce59ffb038590bc834d36afc5d1d"
-          }
-        ]
-      }
-    },
-    {
-      "name": "drizzle-orm-project",
-      "lines": 61831,
-      "kb": 1868,
-      "project_files": 448,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:02:08.866Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/drizzle-orm/tsconfig.tsz-bench.json(15,15): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-          "tsc: .target-bench/external/drizzle-orm/tsconfig.tsz-bench.json(16,13): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"
-        ],
-        "diagnostic_codes": [
-          "TS5090"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "unclassified diagnostic",
-            "codes": [
-              "TS5090"
-            ],
-            "count": 2,
-            "examples": [
-              "tsc: .target-bench/external/drizzle-orm/tsconfig.tsz-bench.json(15,15): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-              "tsc: .target-bench/external/drizzle-orm/tsconfig.tsz-bench.json(16,13): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"
-            ]
-          }
-        ],
-        "primary_subsystem": "unclassified diagnostic",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/drizzle-orm/tsconfig.tsz-bench.json(15,15): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-          "tsc: .target-bench/external/drizzle-orm/tsconfig.tsz-bench.json(16,13): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "unclassified diagnostic"
-        ],
-        "reduced_repro_path": ".target-bench/external/drizzle-orm/tsconfig.tsz-bench.json",
-        "repro": {
-          "tsconfig_path": "drizzle-orm/tsconfig.tsz-bench.json",
-          "source_root": "drizzle-orm/drizzle-orm/src",
-          "first_failure_path": ".target-bench/external/drizzle-orm/tsconfig.tsz-bench.json",
-          "first_failure_line": 15,
-          "first_failure_column": 15,
-          "first_failure_code": "TS5090",
-          "reduced_repro_path": ".target-bench/external/drizzle-orm/tsconfig.tsz-bench.json",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p drizzle-orm/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "JSON file routing + contextual-keyword binders + pnpm @types graph",
-        "files_reached": 448,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "drizzle-orm",
-            "repository": "https://github.com/drizzle-team/drizzle-orm.git",
-            "ref": "48e5406027103a9fca6eb66417187c4a8b5c6aa3"
           }
         ]
       }
@@ -2028,136 +1641,6 @@
       }
     },
     {
-      "name": "valtio-project",
-      "lines": 1627,
-      "kb": 46,
-      "project_files": 15,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:02:33.635Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/valtio/src/react.ts(9,8): error TS2307: Cannot find module 'react' or its corresponding type declarations.",
-          "tsc: .target-bench/external/valtio/src/react.ts(14,8): error TS2307: Cannot find module 'proxy-compare' or its corresponding type declarations.",
-          "tsc: .target-bench/external/valtio/src/react.ts(133,8): error TS7006: Parameter 'callback' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/valtio/src/react/utils/useProxy.ts(1,33): error TS2307: Cannot find module 'react' or its corresponding type declarations.",
-          "tsc: .target-bench/external/valtio/src/vanilla.ts(1,43): error TS2307: Cannot find module 'proxy-compare' or its corresponding type declarations.",
-          "tsc: .target-bench/external/valtio/src/vanilla/utils/devtools.ts(2,21): error TS2307: Cannot find module '@redux-devtools/extension' or its corresponding type declarations.",
-          "tsc: .target-bench/external/valtio/src/vanilla/utils/devtools.ts(43,34): error TS2339: Property '__REDUX_DEVTOOLS_EXTENSION__' does not exist on type 'Window & typeof globalThis'.",
-          "tsc: .target-bench/external/valtio/src/vanilla/utils/devtools.ts(47,14): error TS2339: Property '__REDUX_DEVTOOLS_EXTENSION__' does not exist on type 'Window & typeof globalThis'.",
-          "tsc: .target-bench/external/valtio/src/vanilla/utils/proxyMap.ts(182,5): error TS2353: Object literal may only specify known properties, and 'getOrInsert' does not exist in type 'InternalProxyObject<K, V>'."
-        ],
-        "diagnostic_codes": [
-          "TS2307",
-          "TS7006",
-          "TS2339",
-          "TS2353"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "module-symbol-resolution",
-            "codes": [
-              "TS2307"
-            ],
-            "count": 5,
-            "examples": [
-              "tsc: .target-bench/external/valtio/src/react.ts(9,8): error TS2307: Cannot find module 'react' or its corresponding type declarations.",
-              "tsc: .target-bench/external/valtio/src/react.ts(14,8): error TS2307: Cannot find module 'proxy-compare' or its corresponding type declarations.",
-              "tsc: .target-bench/external/valtio/src/react/utils/useProxy.ts(1,33): error TS2307: Cannot find module 'react' or its corresponding type declarations."
-            ]
-          },
-          {
-            "subsystem": "contextual-inference",
-            "codes": [
-              "TS7006"
-            ],
-            "count": 1,
-            "examples": [
-              "tsc: .target-bench/external/valtio/src/react.ts(133,8): error TS7006: Parameter 'callback' implicitly has an 'any' type."
-            ]
-          },
-          {
-            "subsystem": "keyspace-property-indexed",
-            "codes": [
-              "TS2339",
-              "TS2353"
-            ],
-            "count": 3,
-            "examples": [
-              "tsc: .target-bench/external/valtio/src/vanilla/utils/devtools.ts(43,34): error TS2339: Property '__REDUX_DEVTOOLS_EXTENSION__' does not exist on type 'Window & typeof globalThis'.",
-              "tsc: .target-bench/external/valtio/src/vanilla/utils/devtools.ts(47,14): error TS2339: Property '__REDUX_DEVTOOLS_EXTENSION__' does not exist on type 'Window & typeof globalThis'.",
-              "tsc: .target-bench/external/valtio/src/vanilla/utils/proxyMap.ts(182,5): error TS2353: Object literal may only specify known properties, and 'getOrInsert' does not exist in type 'InternalProxyObject<K, V>'."
-            ]
-          }
-        ],
-        "primary_subsystem": "module-symbol-resolution",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/valtio/src/react.ts(9,8): error TS2307: Cannot find module 'react' or its corresponding type declarations.",
-          "tsc: .target-bench/external/valtio/src/react.ts(14,8): error TS2307: Cannot find module 'proxy-compare' or its corresponding type declarations.",
-          "tsc: .target-bench/external/valtio/src/react.ts(133,8): error TS7006: Parameter 'callback' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/valtio/src/react/utils/useProxy.ts(1,33): error TS2307: Cannot find module 'react' or its corresponding type declarations.",
-          "tsc: .target-bench/external/valtio/src/vanilla.ts(1,43): error TS2307: Cannot find module 'proxy-compare' or its corresponding type declarations."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "module-symbol-resolution",
-          "contextual-inference",
-          "keyspace-property-indexed"
-        ],
-        "reduced_repro_path": ".target-bench/external/valtio/src/react.ts",
-        "repro": {
-          "tsconfig_path": "valtio/tsconfig.tsz-bench.json",
-          "source_root": "valtio/src",
-          "first_failure_path": ".target-bench/external/valtio/src/react.ts",
-          "first_failure_line": 9,
-          "first_failure_column": 8,
-          "first_failure_code": "TS2307",
-          "reduced_repro_path": ".target-bench/external/valtio/src/react.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p valtio/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "proxy-state reactive store; canary for cross-file context-dependent FPs (#14344 identity/relation family) — clean per-file, fires only on whole-project compile",
-        "files_reached": 15,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "valtio",
-            "repository": "https://github.com/pmndrs/valtio.git",
-            "ref": "c24a93a1b62d1fb95a7fa78c840d32cf95bef348"
-          }
-        ]
-      }
-    },
-    {
       "name": "scule-project",
       "lines": 364,
       "kb": 10,
@@ -2371,558 +1854,6 @@
       }
     },
     {
-      "name": "tiny-invariant-project",
-      "lines": 48,
-      "kb": 1,
-      "project_files": 1,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:02:57.253Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/tiny-invariant/src/tiny-invariant.ts(1,31): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig."
-        ],
-        "diagnostic_codes": [
-          "TS2591"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "unclassified diagnostic",
-            "codes": [
-              "TS2591"
-            ],
-            "count": 1,
-            "examples": [
-              "tsc: .target-bench/external/tiny-invariant/src/tiny-invariant.ts(1,31): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig."
-            ]
-          }
-        ],
-        "primary_subsystem": "unclassified diagnostic",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/tiny-invariant/src/tiny-invariant.ts(1,31): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "unclassified diagnostic"
-        ],
-        "reduced_repro_path": ".target-bench/external/tiny-invariant/src/tiny-invariant.ts",
-        "repro": {
-          "tsconfig_path": "tiny-invariant/tsconfig.tsz-bench.json",
-          "source_root": "tiny-invariant/src",
-          "first_failure_path": ".target-bench/external/tiny-invariant/src/tiny-invariant.ts",
-          "first_failure_line": 1,
-          "first_failure_column": 31,
-          "first_failure_code": "TS2591",
-          "reduced_repro_path": ".target-bench/external/tiny-invariant/src/tiny-invariant.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p tiny-invariant/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "tiny runtime invariant assertion helper; clean green row — tsz byte-parity-clean vs tsc (both emit only the shared TS2591 process baseline line, 0 tsz-only delta) on the whole-project compile",
-        "files_reached": 1,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "tiny-invariant",
-            "repository": "https://github.com/alexreardon/tiny-invariant.git",
-            "ref": "b5587cf4ba45e257bce49053c3345b6614324252"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ts-belt-project",
-      "lines": 3907,
-      "kb": 119,
-      "project_files": 28,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:02:59.216Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/ts-belt/src/Dict/Dict.ts(2,17): error TS2305: Module '\"../types\"' has no exported member 'NonNullable'."
-        ],
-        "diagnostic_codes": [
-          "TS2305"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "module-symbol-resolution",
-            "codes": [
-              "TS2305"
-            ],
-            "count": 1,
-            "examples": [
-              "tsc: .target-bench/external/ts-belt/src/Dict/Dict.ts(2,17): error TS2305: Module '\"../types\"' has no exported member 'NonNullable'."
-            ]
-          }
-        ],
-        "primary_subsystem": "module-symbol-resolution",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/ts-belt/src/Dict/Dict.ts(2,17): error TS2305: Module '\"../types\"' has no exported member 'NonNullable'."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "module-symbol-resolution"
-        ],
-        "reduced_repro_path": ".target-bench/external/ts-belt/src/Dict/Dict.ts",
-        "repro": {
-          "tsconfig_path": "ts-belt/tsconfig.tsz-bench.json",
-          "source_root": "ts-belt/src",
-          "first_failure_path": ".target-bench/external/ts-belt/src/Dict/Dict.ts",
-          "first_failure_line": 2,
-          "first_failure_column": 17,
-          "first_failure_code": "TS2305",
-          "reduced_repro_path": ".target-bench/external/ts-belt/src/Dict/Dict.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p ts-belt/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "zero-dependency functional utility belt; first-blocker = named-import of a global type through a `/// <reference>`-bearing module reported TS2305 (export-resolution divergence — bounded, tsz-only, repros standalone)",
-        "files_reached": 28,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "ts-belt",
-            "repository": "https://github.com/mobily/ts-belt.git",
-            "ref": "c825d9709de1e5d15b1b362429e0cee56c96c516"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ts-extras-project",
-      "lines": 1404,
-      "kb": 49,
-      "project_files": 35,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:03:01.055Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/ts-extras/source/array-at.ts(1,37): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/array-join.ts(1,25): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/array-last.ts(1,37): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/as-writable.ts(1,29): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/internal-types.ts(1,28): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/is-equal-type.ts(1,28): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/is-finite.ts(1,27): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/is-infinite.ts(1,60): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/is-integer.ts(1,28): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/is-safe-integer.ts(1,28): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/key-in.ts(1,45): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/object-map-values.ts(1,38): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/string-split.ts(1,26): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations."
-        ],
-        "diagnostic_codes": [
-          "TS2307"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "module-symbol-resolution",
-            "codes": [
-              "TS2307"
-            ],
-            "count": 13,
-            "examples": [
-              "tsc: .target-bench/external/ts-extras/source/array-at.ts(1,37): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-              "tsc: .target-bench/external/ts-extras/source/array-join.ts(1,25): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-              "tsc: .target-bench/external/ts-extras/source/array-last.ts(1,37): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations."
-            ]
-          }
-        ],
-        "primary_subsystem": "module-symbol-resolution",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/ts-extras/source/array-at.ts(1,37): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/array-join.ts(1,25): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/array-last.ts(1,37): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/as-writable.ts(1,29): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-extras/source/internal-types.ts(1,28): error TS2307: Cannot find module 'type-fest' or its corresponding type declarations."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "module-symbol-resolution"
-        ],
-        "reduced_repro_path": ".target-bench/external/ts-extras/source/array-at.ts",
-        "repro": {
-          "tsconfig_path": "ts-extras/tsconfig.tsz-bench.json",
-          "source_root": "ts-extras/source",
-          "first_failure_path": ".target-bench/external/ts-extras/source/array-at.ts",
-          "first_failure_line": 1,
-          "first_failure_column": 37,
-          "first_failure_code": "TS2307",
-          "reduced_repro_path": ".target-bench/external/ts-extras/source/array-at.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p ts-extras/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "type-fest-based assertion/guard helpers; fully tsc-parity under the guard config (tsz-only delta = 0). NOTE: type-fest is unresolved under the shared `types: []` baseline (its TS2307 cancels in both tsz and tsc), so the type-fest-typed paths are any-stubbed — a thin parity row, not a deep witness",
-        "files_reached": 35,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "ts-extras",
-            "repository": "https://github.com/sindresorhus/ts-extras.git",
-            "ref": "1e886239c7f7010c1cfa194e13d4d123b160cbb3"
-          }
-        ]
-      }
-    },
-    {
-      "name": "superjson-project",
-      "lines": 3055,
-      "kb": 73,
-      "project_files": 19,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:03:02.455Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/superjson/src/index.ts(14,22): error TS2307: Cannot find module 'copy-anything' or its corresponding type declarations."
-        ],
-        "diagnostic_codes": [
-          "TS2307"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "module-symbol-resolution",
-            "codes": [
-              "TS2307"
-            ],
-            "count": 1,
-            "examples": [
-              "tsc: .target-bench/external/superjson/src/index.ts(14,22): error TS2307: Cannot find module 'copy-anything' or its corresponding type declarations."
-            ]
-          }
-        ],
-        "primary_subsystem": "module-symbol-resolution",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/superjson/src/index.ts(14,22): error TS2307: Cannot find module 'copy-anything' or its corresponding type declarations."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "module-symbol-resolution"
-        ],
-        "reduced_repro_path": ".target-bench/external/superjson/src/index.ts",
-        "repro": {
-          "tsconfig_path": "superjson/tsconfig.tsz-bench.json",
-          "source_root": "superjson/src",
-          "first_failure_path": ".target-bench/external/superjson/src/index.ts",
-          "first_failure_line": 14,
-          "first_failure_column": 22,
-          "first_failure_code": "TS2307",
-          "reduced_repro_path": ".target-bench/external/superjson/src/index.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p superjson/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "JSON (de)serialization with type metadata; first-blocker = cross-file context-dependent FP cluster (#14344 identity/relation family) in transformer.ts/plainer.ts — fires only on whole-project compile",
-        "files_reached": 19,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "superjson",
-            "repository": "https://github.com/flightcontrolhq/superjson.git",
-            "ref": "aaa65e36e8e31da740265a56b27c965ca1c7b754"
-          }
-        ]
-      }
-    },
-    {
-      "name": "trpc-project",
-      "lines": 14505,
-      "kb": 380,
-      "project_files": 107,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:03:05.377Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: error TS2318: Cannot find global type 'AsyncDisposable'.",
-          "tsc: error TS2318: Cannot find global type 'Disposable'.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(1,41): error TS2591: Cannot find name 'node:stream'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(2,26): error TS2591: Cannot find name 'node:stream/promises'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(8,8): error TS2307: Cannot find module 'aws-lambda' or its corresponding type declarations.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(89,34): error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'.",
-          "tsc:   Type 'null' is not assignable to type 'string'.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(106,16): error TS2339: Property 'forEach' does not exist on type '{}'.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(106,25): error TS7006: Parameter 'v' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(114,29): error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'.",
-          "tsc:   Type 'null' is not assignable to type 'string'.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(142,28): error TS2304: Cannot find name 'awslambda'.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(175,29): error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'.",
-          "tsc:   Type 'null' is not assignable to type 'string'.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(207,28): error TS2304: Cannot find name 'awslambda'.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(242,9): error TS2591: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/index.ts(10,64): error TS2307: Cannot find module 'aws-lambda' or its corresponding type declarations.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/index.ts(90,17): error TS7006: Parameter 'event' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/index.ts(90,24): error TS7006: Parameter 'responseStream' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/index.ts(90,40): error TS7006: Parameter 'context' implicitly has an 'any' type."
-        ],
-        "diagnostic_codes": [
-          "TS2318",
-          "TS2591",
-          "TS2307",
-          "TS2345",
-          "TS2339",
-          "TS7006",
-          "TS2304"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "unclassified diagnostic",
-            "codes": [
-              "TS2318",
-              "TS2591"
-            ],
-            "count": 5,
-            "examples": [
-              "tsc: error TS2318: Cannot find global type 'AsyncDisposable'.",
-              "tsc: error TS2318: Cannot find global type 'Disposable'.",
-              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(1,41): error TS2591: Cannot find name 'node:stream'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig."
-            ]
-          },
-          {
-            "subsystem": "module-symbol-resolution",
-            "codes": [
-              "TS2307",
-              "TS2304"
-            ],
-            "count": 4,
-            "examples": [
-              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(8,8): error TS2307: Cannot find module 'aws-lambda' or its corresponding type declarations.",
-              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(142,28): error TS2304: Cannot find name 'awslambda'.",
-              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(207,28): error TS2304: Cannot find name 'awslambda'."
-            ]
-          },
-          {
-            "subsystem": "relations-assignability",
-            "codes": [
-              "TS2345"
-            ],
-            "count": 3,
-            "examples": [
-              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(89,34): error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'.",
-              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(114,29): error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'.",
-              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(175,29): error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'."
-            ]
-          },
-          {
-            "subsystem": "uncoded diagnostic",
-            "codes": [],
-            "count": 3,
-            "examples": [
-              "tsc:   Type 'null' is not assignable to type 'string'.",
-              "tsc:   Type 'null' is not assignable to type 'string'.",
-              "tsc:   Type 'null' is not assignable to type 'string'."
-            ]
-          },
-          {
-            "subsystem": "keyspace-property-indexed",
-            "codes": [
-              "TS2339"
-            ],
-            "count": 1,
-            "examples": [
-              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(106,16): error TS2339: Property 'forEach' does not exist on type '{}'."
-            ]
-          },
-          {
-            "subsystem": "contextual-inference",
-            "codes": [
-              "TS7006"
-            ],
-            "count": 4,
-            "examples": [
-              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(106,25): error TS7006: Parameter 'v' implicitly has an 'any' type.",
-              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/index.ts(90,17): error TS7006: Parameter 'event' implicitly has an 'any' type.",
-              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/index.ts(90,24): error TS7006: Parameter 'responseStream' implicitly has an 'any' type."
-            ]
-          }
-        ],
-        "primary_subsystem": "unclassified diagnostic",
-        "reduction_candidates": [
-          "tsc: error TS2318: Cannot find global type 'AsyncDisposable'.",
-          "tsc: error TS2318: Cannot find global type 'Disposable'.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(1,41): error TS2591: Cannot find name 'node:stream'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(2,26): error TS2591: Cannot find name 'node:stream/promises'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(8,8): error TS2307: Cannot find module 'aws-lambda' or its corresponding type declarations."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "unclassified diagnostic",
-          "module-symbol-resolution",
-          "relations-assignability",
-          "uncoded diagnostic",
-          "keyspace-property-indexed",
-          "contextual-inference"
-        ],
-        "reduced_repro_path": ".target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts",
-        "repro": {
-          "tsconfig_path": "trpc/tsconfig.tsz-bench.json",
-          "source_root": "trpc/packages/server/src",
-          "first_failure_path": ".target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts",
-          "first_failure_line": 1,
-          "first_failure_column": 41,
-          "first_failure_code": "TS2591",
-          "reduced_repro_path": ".target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p trpc/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "end-to-end inference: recursive router builders, deep generic procedure chaining, input/output type propagation",
-        "files_reached": 107,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "trpc",
-            "repository": "https://github.com/trpc/trpc.git",
-            "ref": "f8f0c0e3979ecb980d38e9369fa8c98df95d212b"
-          }
-        ]
-      }
-    },
-    {
       "name": "tanstack-query-project",
       "lines": 21993,
       "kb": 623,
@@ -3089,135 +2020,6 @@
             "name": "tanstack-query",
             "repository": "https://github.com/TanStack/query.git",
             "ref": "feb1efd804c1262106f72c8adc1d82a8ce9cfbb0"
-          }
-        ]
-      }
-    },
-    {
-      "name": "tanstack-router-project",
-      "lines": 16629,
-      "kb": 472,
-      "project_files": 62,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:03:15.366Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/history.ts(1,38): error TS2307: Cannot find module '@tanstack/history' or its corresponding type declarations.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/history.ts(3,16): error TS2664: Invalid module name in augmentation, module '@tanstack/history' cannot be found.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/isServer/server.ts(1,25): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/link.ts(1,55): error TS2307: Cannot find module '@tanstack/history' or its corresponding type declarations.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/load-matches.ts(1,26): error TS2307: Cannot find module '@tanstack/router-core/isServer' or its corresponding type declarations.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/load-matches.ts(1078,11): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/location.ts(1,41): error TS2307: Cannot find module '@tanstack/history' or its corresponding type declarations.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/new-process-route-tree.ts(799,11): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/path.ts(1,26): error TS2307: Cannot find module '@tanstack/router-core/isServer' or its corresponding type declarations.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/route.ts(1798,11): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/router.ts(1,49): error TS2307: Cannot find module '@tanstack/history' or its corresponding type declarations.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/router.ts(2,26): error TS2307: Cannot find module '@tanstack/router-core/isServer' or its corresponding type declarations.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/router.ts(60,8): error TS2307: Cannot find module '@tanstack/history' or its corresponding type declarations.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/router.ts(869,9): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/router.ts(1063,9): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/router.ts(1126,9): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/router.ts(1139,11): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/router.ts(1847,9): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/router.ts(1959,9): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/router.ts(2352,13): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig."
-        ],
-        "diagnostic_codes": [
-          "TS2307",
-          "TS2664",
-          "TS2591"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "module-symbol-resolution",
-            "codes": [
-              "TS2307",
-              "TS2664"
-            ],
-            "count": 9,
-            "examples": [
-              "tsc: .target-bench/external/tanstack-router/packages/router-core/src/history.ts(1,38): error TS2307: Cannot find module '@tanstack/history' or its corresponding type declarations.",
-              "tsc: .target-bench/external/tanstack-router/packages/router-core/src/history.ts(3,16): error TS2664: Invalid module name in augmentation, module '@tanstack/history' cannot be found.",
-              "tsc: .target-bench/external/tanstack-router/packages/router-core/src/link.ts(1,55): error TS2307: Cannot find module '@tanstack/history' or its corresponding type declarations."
-            ]
-          },
-          {
-            "subsystem": "unclassified diagnostic",
-            "codes": [
-              "TS2591"
-            ],
-            "count": 11,
-            "examples": [
-              "tsc: .target-bench/external/tanstack-router/packages/router-core/src/isServer/server.ts(1,25): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-              "tsc: .target-bench/external/tanstack-router/packages/router-core/src/load-matches.ts(1078,11): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-              "tsc: .target-bench/external/tanstack-router/packages/router-core/src/new-process-route-tree.ts(799,11): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig."
-            ]
-          }
-        ],
-        "primary_subsystem": "module-symbol-resolution",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/history.ts(1,38): error TS2307: Cannot find module '@tanstack/history' or its corresponding type declarations.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/history.ts(3,16): error TS2664: Invalid module name in augmentation, module '@tanstack/history' cannot be found.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/isServer/server.ts(1,25): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/link.ts(1,55): error TS2307: Cannot find module '@tanstack/history' or its corresponding type declarations.",
-          "tsc: .target-bench/external/tanstack-router/packages/router-core/src/load-matches.ts(1,26): error TS2307: Cannot find module '@tanstack/router-core/isServer' or its corresponding type declarations."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "module-symbol-resolution",
-          "unclassified diagnostic"
-        ],
-        "reduced_repro_path": ".target-bench/external/tanstack-router/packages/router-core/src/history.ts",
-        "repro": {
-          "tsconfig_path": "tanstack-router/tsconfig.tsz-bench.json",
-          "source_root": "tanstack-router/packages/router-core/src",
-          "first_failure_path": ".target-bench/external/tanstack-router/packages/router-core/src/history.ts",
-          "first_failure_line": 1,
-          "first_failure_column": 38,
-          "first_failure_code": "TS2307",
-          "reduced_repro_path": ".target-bench/external/tanstack-router/packages/router-core/src/history.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p tanstack-router/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "template-literal route path parsing, nested route-tree generics, search-param inference",
-        "files_reached": 62,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "tanstack-router",
-            "repository": "https://github.com/TanStack/router.git",
-            "ref": "36ed57409a98878e5c1a7aabf50d3aa65ebde1e0"
           }
         ]
       }
@@ -3590,94 +2392,6 @@
       }
     },
     {
-      "name": "io-ts-project",
-      "lines": 6202,
-      "kb": 152,
-      "project_files": 16,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:05:21.364Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/io-ts/tsconfig.tsz-bench.json(15,23): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"
-        ],
-        "diagnostic_codes": [
-          "TS5090"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "unclassified diagnostic",
-            "codes": [
-              "TS5090"
-            ],
-            "count": 1,
-            "examples": [
-              "tsc: .target-bench/external/io-ts/tsconfig.tsz-bench.json(15,23): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"
-            ]
-          }
-        ],
-        "primary_subsystem": "unclassified diagnostic",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/io-ts/tsconfig.tsz-bench.json(15,23): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "unclassified diagnostic"
-        ],
-        "reduced_repro_path": ".target-bench/external/io-ts/tsconfig.tsz-bench.json",
-        "repro": {
-          "tsconfig_path": "io-ts/tsconfig.tsz-bench.json",
-          "source_root": "io-ts/src",
-          "first_failure_path": ".target-bench/external/io-ts/tsconfig.tsz-bench.json",
-          "first_failure_line": 15,
-          "first_failure_column": 23,
-          "first_failure_code": "TS5090",
-          "reduced_repro_path": ".target-bench/external/io-ts/tsconfig.tsz-bench.json",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p io-ts/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "codec generics, recursive/branded runtime type definitions, decode-result inference",
-        "files_reached": 16,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "io-ts",
-            "repository": "https://github.com/gcanti/io-ts.git",
-            "ref": "864a3a2f03c5d7b974afeb1da0faf46c21758779"
-          }
-        ]
-      }
-    },
-    {
       "name": "immer-project",
       "lines": 3170,
       "kb": 85,
@@ -3888,240 +2602,6 @@
       }
     },
     {
-      "name": "ts-morph-project",
-      "lines": 82887,
-      "kb": 3177,
-      "project_files": 1007,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:05:42.884Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/codeBlockWriter/code-block-writer.ts(1,29): error TS2307: Cannot find module 'code-block-writer' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(1,20): error TS2307: Cannot find module '@ts-morph/common' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(2,37): error TS2307: Cannot find module 'conditional-type-checks' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(62,71): error TS2344: Type 'AssertionKey' does not satisfy the constraint 'Node<ts.Node>'.",
-          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<ts.Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(72,71): error TS2344: Type 'PropertyName' does not satisfy the constraint 'Node<ts.Node>'.",
-          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<ts.Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(75,69): error TS2344: Type 'ModuleName' does not satisfy the constraint 'Node<ts.Node>'.",
-          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<ts.Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(84,70): error TS2344: Type 'BindingName' does not satisfy the constraint 'Node<ts.Node>'.",
-          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<ts.Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(96,79): error TS2344: Type 'EntityNameExpression' does not satisfy the constraint 'Node<ts.Node>'.",
-          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<ts.Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(107,74): error TS2344: Type 'DeclarationName' does not satisfy the constraint 'Node<ts.Node>'.",
-          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<ts.Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(110,69): error TS2344: Type 'EntityName' does not satisfy the constraint 'Node<ts.Node>'.",
-          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<ts.Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(113,67): error TS2344: Type 'JsxChild' does not satisfy the constraint 'Node<ts.Node>'.",
-          "tsc:   Type 'JsxExpression' is missing the following properties from type 'Node<ts.Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(116,75): error TS2344: Type 'JsxAttributeName' does not satisfy the constraint 'Node<ts.Node>'."
-        ],
-        "diagnostic_codes": [
-          "TS2307",
-          "TS2344"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "module-symbol-resolution",
-            "codes": [
-              "TS2307"
-            ],
-            "count": 3,
-            "examples": [
-              "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/codeBlockWriter/code-block-writer.ts(1,29): error TS2307: Cannot find module 'code-block-writer' or its corresponding type declarations.",
-              "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(1,20): error TS2307: Cannot find module '@ts-morph/common' or its corresponding type declarations.",
-              "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(2,37): error TS2307: Cannot find module 'conditional-type-checks' or its corresponding type declarations."
-            ]
-          },
-          {
-            "subsystem": "evaluation-inference-instantiation",
-            "codes": [
-              "TS2344"
-            ],
-            "count": 9,
-            "examples": [
-              "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(62,71): error TS2344: Type 'AssertionKey' does not satisfy the constraint 'Node<ts.Node>'.",
-              "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(72,71): error TS2344: Type 'PropertyName' does not satisfy the constraint 'Node<ts.Node>'.",
-              "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(75,69): error TS2344: Type 'ModuleName' does not satisfy the constraint 'Node<ts.Node>'."
-            ]
-          },
-          {
-            "subsystem": "uncoded diagnostic",
-            "codes": [],
-            "count": 8,
-            "examples": [
-              "tsc:   Type 'Identifier' is missing the following properties from type 'Node<ts.Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
-              "tsc:   Type 'Identifier' is missing the following properties from type 'Node<ts.Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
-              "tsc:   Type 'Identifier' is missing the following properties from type 'Node<ts.Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more."
-            ]
-          }
-        ],
-        "primary_subsystem": "module-symbol-resolution",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/codeBlockWriter/code-block-writer.ts(1,29): error TS2307: Cannot find module 'code-block-writer' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(1,20): error TS2307: Cannot find module '@ts-morph/common' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(2,37): error TS2307: Cannot find module 'conditional-type-checks' or its corresponding type declarations.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(62,71): error TS2344: Type 'AssertionKey' does not satisfy the constraint 'Node<ts.Node>'.",
-          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(72,71): error TS2344: Type 'PropertyName' does not satisfy the constraint 'Node<ts.Node>'."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "module-symbol-resolution",
-          "evaluation-inference-instantiation",
-          "uncoded diagnostic"
-        ],
-        "reduced_repro_path": ".target-bench/external/ts-morph/packages/ts-morph/src/codeBlockWriter/code-block-writer.ts",
-        "repro": {
-          "tsconfig_path": "ts-morph/tsconfig.tsz-bench.json",
-          "source_root": "ts-morph/packages/ts-morph/src",
-          "first_failure_path": ".target-bench/external/ts-morph/packages/ts-morph/src/codeBlockWriter/code-block-writer.ts",
-          "first_failure_line": 1,
-          "first_failure_column": 29,
-          "first_failure_code": "TS2307",
-          "reduced_repro_path": ".target-bench/external/ts-morph/packages/ts-morph/src/codeBlockWriter/code-block-writer.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p ts-morph/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "large AST wrapper class hierarchy, compiler-API generic surface, declaration-heavy graph",
-        "files_reached": 1007,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "ts-morph",
-            "repository": "https://github.com/dsherret/ts-morph.git",
-            "ref": "699815f54ae9b5c2a93f016ba1a9df1e8ac1c014"
-          }
-        ]
-      }
-    },
-    {
-      "name": "arktype-project",
-      "lines": 33661,
-      "kb": 808,
-      "project_files": 154,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:05:45.353Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/arktype/tsconfig.tsz-bench.json(15,21): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-          "tsc: .target-bench/external/arktype/tsconfig.tsz-bench.json(16,30): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-          "tsc: .target-bench/external/arktype/tsconfig.tsz-bench.json(17,23): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-          "tsc: .target-bench/external/arktype/tsconfig.tsz-bench.json(18,20): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"
-        ],
-        "diagnostic_codes": [
-          "TS5090"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "unclassified diagnostic",
-            "codes": [
-              "TS5090"
-            ],
-            "count": 4,
-            "examples": [
-              "tsc: .target-bench/external/arktype/tsconfig.tsz-bench.json(15,21): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-              "tsc: .target-bench/external/arktype/tsconfig.tsz-bench.json(16,30): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-              "tsc: .target-bench/external/arktype/tsconfig.tsz-bench.json(17,23): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"
-            ]
-          }
-        ],
-        "primary_subsystem": "unclassified diagnostic",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/arktype/tsconfig.tsz-bench.json(15,21): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-          "tsc: .target-bench/external/arktype/tsconfig.tsz-bench.json(16,30): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-          "tsc: .target-bench/external/arktype/tsconfig.tsz-bench.json(17,23): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-          "tsc: .target-bench/external/arktype/tsconfig.tsz-bench.json(18,20): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "unclassified diagnostic"
-        ],
-        "reduced_repro_path": ".target-bench/external/arktype/tsconfig.tsz-bench.json",
-        "repro": {
-          "tsconfig_path": "arktype/tsconfig.tsz-bench.json",
-          "source_root": "arktype/ark/type",
-          "first_failure_path": ".target-bench/external/arktype/tsconfig.tsz-bench.json",
-          "first_failure_line": 15,
-          "first_failure_column": 21,
-          "first_failure_code": "TS5090",
-          "reduced_repro_path": ".target-bench/external/arktype/tsconfig.tsz-bench.json",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p arktype/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "type-level string parser, recursive schema inference, extreme conditional/template evaluation",
-        "files_reached": 154,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "arktype",
-            "repository": "https://github.com/arktypeio/arktype.git",
-            "ref": "d075962caee162bb28e241723863e8f11cb58390"
-          }
-        ]
-      }
-    },
-    {
       "name": "superstruct-project",
       "lines": 1803,
       "kb": 43,
@@ -4250,94 +2730,6 @@
             "name": "superstruct",
             "repository": "https://github.com/ianstormtaylor/superstruct.git",
             "ref": "e414c8afd3b69f6bc0173b8ee25f71d8e5694f01"
-          }
-        ]
-      }
-    },
-    {
-      "name": "runtypes-project",
-      "lines": 6613,
-      "kb": 206,
-      "project_files": 76,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:05:48.516Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/runtypes/src/Tuple.ts(251,48): error TS2339: Property 'toReversed' does not exist on type 'readonly Runtype<any, any>[]'."
-        ],
-        "diagnostic_codes": [
-          "TS2339"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "keyspace-property-indexed",
-            "codes": [
-              "TS2339"
-            ],
-            "count": 1,
-            "examples": [
-              "tsc: .target-bench/external/runtypes/src/Tuple.ts(251,48): error TS2339: Property 'toReversed' does not exist on type 'readonly Runtype<any, any>[]'."
-            ]
-          }
-        ],
-        "primary_subsystem": "keyspace-property-indexed",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/runtypes/src/Tuple.ts(251,48): error TS2339: Property 'toReversed' does not exist on type 'readonly Runtype<any, any>[]'."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "keyspace-property-indexed"
-        ],
-        "reduced_repro_path": ".target-bench/external/runtypes/src/Tuple.ts",
-        "repro": {
-          "tsconfig_path": "runtypes/tsconfig.tsz-bench.json",
-          "source_root": "runtypes/src",
-          "first_failure_path": ".target-bench/external/runtypes/src/Tuple.ts",
-          "first_failure_line": 251,
-          "first_failure_column": 48,
-          "first_failure_code": "TS2339",
-          "reduced_repro_path": ".target-bench/external/runtypes/src/Tuple.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p runtypes/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "runtime type combinator generics, static type extraction, recursive records",
-        "files_reached": 76,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "runtypes",
-            "repository": "https://github.com/runtypes/runtypes.git",
-            "ref": "16d83ca56a54569e4a2375a965567b31191c0035"
           }
         ]
       }
@@ -4501,626 +2893,6 @@
       }
     },
     {
-      "name": "class-transformer-project",
-      "lines": 1765,
-      "kb": 63,
-      "project_files": 35,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:08:34.652Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(25,50): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function | TypeMetadata'.",
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(52,52): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function | TypeMetadata'.",
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(77,54): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function'.",
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(100,49): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function | TypeMetadata'.",
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(113,50): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function | TypeMetadata'.",
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(128,51): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function | TypeMetadata'.",
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(137,48): error TS2769: No overload matches this call.",
-          "tsc:   Overload 1 of 2, '(object: Record<string, any>, options?: ClassTransformOptions | undefined): Record<string, any>', gave the following error.",
-          "tsc:     Argument of type 'T | T[]' is not assignable to parameter of type 'Record<string, any>'.",
-          "tsc:       Type 'T' is not assignable to type 'Record<string, any>'.",
-          "tsc:   Overload 2 of 2, '(object: Record<string, any>[], options?: ClassTransformOptions | undefined): Record<string, any>[]', gave the following error.",
-          "tsc:     Argument of type 'T | T[]' is not assignable to parameter of type 'Record<string, any>[]'.",
-          "tsc:       Type 'T' is not assignable to type 'Record<string, any>[]'.",
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(145,5): error TS2322: Type 'Record<string, any>[]' is not assignable to type 'T'.",
-          "tsc:   'T' could be instantiated with an arbitrary type which could be unrelated to 'Record<string, any>[]'.",
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(145,33): error TS2769: No overload matches this call.",
-          "tsc:   Overload 1 of 2, '(cls: ClassConstructor<Record<string, any>>, plain: any[], options?: ClassTransformOptions | undefined): Record<string, any>[]', gave the following error.",
-          "tsc:     Argument of type 'ClassConstructor<T>' is not assignable to parameter of type 'ClassConstructor<Record<string, any>>'.",
-          "tsc:       Type 'T' is not assignable to type 'Record<string, any>'.",
-          "tsc:   Overload 2 of 2, '(cls: ClassConstructor<Record<string, any>>, plain: T, options?: ClassTransformOptions | undefined): Record<string, any>', gave the following error."
-        ],
-        "diagnostic_codes": [
-          "TS2345",
-          "TS2769",
-          "TS2322"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "relations-assignability",
-            "codes": [
-              "TS2345",
-              "TS2769",
-              "TS2322"
-            ],
-            "count": 9,
-            "examples": [
-              "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(25,50): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function | TypeMetadata'.",
-              "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(52,52): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function | TypeMetadata'.",
-              "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(77,54): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function'."
-            ]
-          },
-          {
-            "subsystem": "uncoded diagnostic",
-            "codes": [],
-            "count": 11,
-            "examples": [
-              "tsc:   Overload 1 of 2, '(object: Record<string, any>, options?: ClassTransformOptions | undefined): Record<string, any>', gave the following error.",
-              "tsc:     Argument of type 'T | T[]' is not assignable to parameter of type 'Record<string, any>'.",
-              "tsc:       Type 'T' is not assignable to type 'Record<string, any>'."
-            ]
-          }
-        ],
-        "primary_subsystem": "relations-assignability",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(25,50): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function | TypeMetadata'.",
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(52,52): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function | TypeMetadata'.",
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(77,54): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function'.",
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(100,49): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function | TypeMetadata'.",
-          "tsc: .target-bench/external/class-transformer/src/ClassTransformer.ts(113,50): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function | TypeMetadata'."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "relations-assignability",
-          "uncoded diagnostic"
-        ],
-        "reduced_repro_path": ".target-bench/external/class-transformer/src/ClassTransformer.ts",
-        "repro": {
-          "tsconfig_path": "class-transformer/tsconfig.tsz-bench.json",
-          "source_root": "class-transformer/src",
-          "first_failure_path": ".target-bench/external/class-transformer/src/ClassTransformer.ts",
-          "first_failure_line": 25,
-          "first_failure_column": 50,
-          "first_failure_code": "TS2345",
-          "reduced_repro_path": ".target-bench/external/class-transformer/src/ClassTransformer.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p class-transformer/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "decorator metadata typing, class transform generics",
-        "files_reached": 35,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "class-transformer",
-            "repository": "https://github.com/typestack/class-transformer.git",
-            "ref": "a2734a5d154c9b0beb9a10555a04416bc371de06"
-          }
-        ]
-      }
-    },
-    {
-      "name": "type-graphql-project",
-      "lines": 5172,
-      "kb": 169,
-      "project_files": 116,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:08:36.975Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/type-graphql/tsconfig.tsz-bench.json(16,15): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-          "tsc: .target-bench/external/type-graphql/tsconfig.tsz-bench.json(17,13): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"
-        ],
-        "diagnostic_codes": [
-          "TS5090"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "unclassified diagnostic",
-            "codes": [
-              "TS5090"
-            ],
-            "count": 2,
-            "examples": [
-              "tsc: .target-bench/external/type-graphql/tsconfig.tsz-bench.json(16,15): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-              "tsc: .target-bench/external/type-graphql/tsconfig.tsz-bench.json(17,13): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"
-            ]
-          }
-        ],
-        "primary_subsystem": "unclassified diagnostic",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/type-graphql/tsconfig.tsz-bench.json(16,15): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?",
-          "tsc: .target-bench/external/type-graphql/tsconfig.tsz-bench.json(17,13): error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?"
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "unclassified diagnostic"
-        ],
-        "reduced_repro_path": ".target-bench/external/type-graphql/tsconfig.tsz-bench.json",
-        "repro": {
-          "tsconfig_path": "type-graphql/tsconfig.tsz-bench.json",
-          "source_root": "type-graphql/src",
-          "first_failure_path": ".target-bench/external/type-graphql/tsconfig.tsz-bench.json",
-          "first_failure_line": 16,
-          "first_failure_column": 15,
-          "first_failure_code": "TS5090",
-          "reduced_repro_path": ".target-bench/external/type-graphql/tsconfig.tsz-bench.json",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p type-graphql/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "decorator + generic resolver typing, schema class hierarchy",
-        "files_reached": 116,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "type-graphql",
-            "repository": "https://github.com/MichalLytek/type-graphql.git",
-            "ref": "4535c3192fd321be6bade6192f0cf8d264de9baf"
-          }
-        ]
-      }
-    },
-    {
-      "name": "neverthrow-project",
-      "lines": 1202,
-      "kb": 36,
-      "project_files": 5,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:08:38.172Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/neverthrow/src/result-async.ts(50,5): error TS2322: Type '(...args: A) => ResultAsync<R, unknown>' is not assignable to type '(...args: A) => ResultAsync<R, E>'.",
-          "tsc:   Type 'ResultAsync<R, unknown>' is not assignable to type 'ResultAsync<R, E>'.",
-          "tsc:     Type 'unknown' is not assignable to type 'E'.",
-          "tsc:       'E' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.",
-          "tsc: .target-bench/external/neverthrow/src/result.ts(27,5): error TS2322: Type '(...args: Parameters<Fn>) => Ok<any, E> | Err<ReturnType<Fn>, unknown>' is not assignable to type '(...args: Parameters<Fn>) => Result<ReturnType<Fn>, E>'.",
-          "tsc:   Type 'Ok<any, E> | Err<ReturnType<Fn>, unknown>' is not assignable to type 'Result<ReturnType<Fn>, E>'.",
-          "tsc:     Type 'Err<ReturnType<Fn>, unknown>' is not assignable to type 'Result<ReturnType<Fn>, E>'.",
-          "tsc:       Type 'Err<ReturnType<Fn>, unknown>' is not assignable to type 'Err<ReturnType<Fn>, E>'.",
-          "tsc:         Type 'unknown' is not assignable to type 'E'.",
-          "tsc:           'E' could be instantiated with an arbitrary type which could be unrelated to 'unknown'."
-        ],
-        "diagnostic_codes": [
-          "TS2322"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "relations-assignability",
-            "codes": [
-              "TS2322"
-            ],
-            "count": 2,
-            "examples": [
-              "tsc: .target-bench/external/neverthrow/src/result-async.ts(50,5): error TS2322: Type '(...args: A) => ResultAsync<R, unknown>' is not assignable to type '(...args: A) => ResultAsync<R, E>'.",
-              "tsc: .target-bench/external/neverthrow/src/result.ts(27,5): error TS2322: Type '(...args: Parameters<Fn>) => Ok<any, E> | Err<ReturnType<Fn>, unknown>' is not assignable to type '(...args: Parameters<Fn>) => Result<ReturnType<Fn>, E>'."
-            ]
-          },
-          {
-            "subsystem": "uncoded diagnostic",
-            "codes": [],
-            "count": 8,
-            "examples": [
-              "tsc:   Type 'ResultAsync<R, unknown>' is not assignable to type 'ResultAsync<R, E>'.",
-              "tsc:     Type 'unknown' is not assignable to type 'E'.",
-              "tsc:       'E' could be instantiated with an arbitrary type which could be unrelated to 'unknown'."
-            ]
-          }
-        ],
-        "primary_subsystem": "relations-assignability",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/neverthrow/src/result-async.ts(50,5): error TS2322: Type '(...args: A) => ResultAsync<R, unknown>' is not assignable to type '(...args: A) => ResultAsync<R, E>'.",
-          "tsc: .target-bench/external/neverthrow/src/result.ts(27,5): error TS2322: Type '(...args: Parameters<Fn>) => Ok<any, E> | Err<ReturnType<Fn>, unknown>' is not assignable to type '(...args: Parameters<Fn>) => Result<ReturnType<Fn>, E>'."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "relations-assignability",
-          "uncoded diagnostic"
-        ],
-        "reduced_repro_path": ".target-bench/external/neverthrow/src/result-async.ts",
-        "repro": {
-          "tsconfig_path": "neverthrow/tsconfig.tsz-bench.json",
-          "source_root": "neverthrow/src",
-          "first_failure_path": ".target-bench/external/neverthrow/src/result-async.ts",
-          "first_failure_line": 50,
-          "first_failure_column": 5,
-          "first_failure_code": "TS2322",
-          "reduced_repro_path": ".target-bench/external/neverthrow/src/result-async.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p neverthrow/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "Result/Ok/Err generic monad chaining, combine overloads",
-        "files_reached": 5,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "neverthrow",
-            "repository": "https://github.com/supermacro/neverthrow.git",
-            "ref": "5ef3a018bda74fb960e44b68fc3672635ee8037d"
-          }
-        ]
-      }
-    },
-    {
-      "name": "xstate-project",
-      "lines": 18184,
-      "kb": 455,
-      "project_files": 72,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:08:41.098Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/xstate/packages/core/src/dev/index.ts(31,14): error TS2304: Cannot find name 'global'.",
-          "tsc: .target-bench/external/xstate/packages/core/src/dev/index.ts(32,12): error TS2304: Cannot find name 'global'.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(1,47): error TS2307: Cannot find module 'xml-js' or its corresponding type declarations.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(228,34): error TS7006: Parameter 'acc' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(228,39): error TS7006: Parameter 'child' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(379,10): error TS7006: Parameter 'element' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(396,8): error TS7006: Parameter 'element' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(404,8): error TS7006: Parameter 'element' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(408,8): error TS7006: Parameter 'element' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(412,8): error TS7006: Parameter 'element' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(416,8): error TS7006: Parameter 'element' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(424,33): error TS7006: Parameter 'element' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(429,10): error TS7006: Parameter 'element' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(438,33): error TS7006: Parameter 'value' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(500,34): error TS7006: Parameter 'onEntryElement' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(506,33): error TS7006: Parameter 'onExitElement' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(511,40): error TS7006: Parameter 'element' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(522,10): error TS7006: Parameter 'el' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(566,6): error TS7006: Parameter 'element' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(570,6): error TS7006: Parameter 'element' implicitly has an 'any' type."
-        ],
-        "diagnostic_codes": [
-          "TS2304",
-          "TS2307",
-          "TS7006"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "module-symbol-resolution",
-            "codes": [
-              "TS2304",
-              "TS2307"
-            ],
-            "count": 3,
-            "examples": [
-              "tsc: .target-bench/external/xstate/packages/core/src/dev/index.ts(31,14): error TS2304: Cannot find name 'global'.",
-              "tsc: .target-bench/external/xstate/packages/core/src/dev/index.ts(32,12): error TS2304: Cannot find name 'global'.",
-              "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(1,47): error TS2307: Cannot find module 'xml-js' or its corresponding type declarations."
-            ]
-          },
-          {
-            "subsystem": "contextual-inference",
-            "codes": [
-              "TS7006"
-            ],
-            "count": 17,
-            "examples": [
-              "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(228,34): error TS7006: Parameter 'acc' implicitly has an 'any' type.",
-              "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(228,39): error TS7006: Parameter 'child' implicitly has an 'any' type.",
-              "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(379,10): error TS7006: Parameter 'element' implicitly has an 'any' type."
-            ]
-          }
-        ],
-        "primary_subsystem": "module-symbol-resolution",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/xstate/packages/core/src/dev/index.ts(31,14): error TS2304: Cannot find name 'global'.",
-          "tsc: .target-bench/external/xstate/packages/core/src/dev/index.ts(32,12): error TS2304: Cannot find name 'global'.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(1,47): error TS2307: Cannot find module 'xml-js' or its corresponding type declarations.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(228,34): error TS7006: Parameter 'acc' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/xstate/packages/core/src/scxml.ts(228,39): error TS7006: Parameter 'child' implicitly has an 'any' type."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "module-symbol-resolution",
-          "contextual-inference"
-        ],
-        "reduced_repro_path": ".target-bench/external/xstate/packages/core/src/dev/index.ts",
-        "repro": {
-          "tsconfig_path": "xstate/tsconfig.tsz-bench.json",
-          "source_root": "xstate/packages/core/src",
-          "first_failure_path": ".target-bench/external/xstate/packages/core/src/dev/index.ts",
-          "first_failure_line": 31,
-          "first_failure_column": 14,
-          "first_failure_code": "TS2304",
-          "reduced_repro_path": ".target-bench/external/xstate/packages/core/src/dev/index.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p xstate/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "state-machine config generics, template-literal event/state typing, deep recursive typegen surface",
-        "files_reached": 72,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "xstate",
-            "repository": "https://github.com/statelyai/xstate.git",
-            "ref": "afa374afd52dc4f05baad1ead66c977a46aa5b47"
-          }
-        ]
-      }
-    },
-    {
-      "name": "mobx-project",
-      "lines": 8463,
-      "kb": 263,
-      "project_files": 58,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:08:43.904Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/action.ts(56,49): error TS7006: Parameter 'arg1' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/action.ts(56,55): error TS7006: Parameter 'arg2' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/action.ts(102,69): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/annotation.ts(23,5): error TS7010: 'decorate_20223_', which lacks return-type annotation, implicitly has an 'any' return type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/autorun.ts(110,37): error TS2345: Argument of type 'Lambda' is not assignable to parameter of type 'TimerHandler'.",
-          "tsc:   Type 'Lambda' is not assignable to type 'Function'.",
-          "tsc:     Types of property 'name' are incompatible.",
-          "tsc:       Type 'string | undefined' is not assignable to type 'string'.",
-          "tsc:         Type 'undefined' is not assignable to type 'string'.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/autorun.ts(190,27): error TS7006: Parameter 'errorHandler' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/autorun.ts(190,41): error TS7006: Parameter 'baseFn' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/autorun.ts(193,33): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/autorun.ts(195,31): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/become-observed.ts(31,34): error TS7006: Parameter 'thing' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/become-observed.ts(31,41): error TS7006: Parameter 'arg2' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/become-observed.ts(31,47): error TS7006: Parameter 'arg3' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/become-observed.ts(50,36): error TS7006: Parameter 'thing' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/become-observed.ts(50,43): error TS7006: Parameter 'arg2' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/become-observed.ts(50,49): error TS7006: Parameter 'arg3' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/become-observed.ts(54,48): error TS7006: Parameter 'thing' implicitly has an 'any' type."
-        ],
-        "diagnostic_codes": [
-          "TS7006",
-          "TS2683",
-          "TS7010",
-          "TS2345"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "contextual-inference",
-            "codes": [
-              "TS7006"
-            ],
-            "count": 11,
-            "examples": [
-              "tsc: .target-bench/external/mobx/packages/mobx/src/api/action.ts(56,49): error TS7006: Parameter 'arg1' implicitly has an 'any' type.",
-              "tsc: .target-bench/external/mobx/packages/mobx/src/api/action.ts(56,55): error TS7006: Parameter 'arg2' implicitly has an 'any' type.",
-              "tsc: .target-bench/external/mobx/packages/mobx/src/api/autorun.ts(190,27): error TS7006: Parameter 'errorHandler' implicitly has an 'any' type."
-            ]
-          },
-          {
-            "subsystem": "class-this-accessor",
-            "codes": [
-              "TS2683"
-            ],
-            "count": 3,
-            "examples": [
-              "tsc: .target-bench/external/mobx/packages/mobx/src/api/action.ts(102,69): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.",
-              "tsc: .target-bench/external/mobx/packages/mobx/src/api/autorun.ts(193,33): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.",
-              "tsc: .target-bench/external/mobx/packages/mobx/src/api/autorun.ts(195,31): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation."
-            ]
-          },
-          {
-            "subsystem": "unclassified diagnostic",
-            "codes": [
-              "TS7010"
-            ],
-            "count": 1,
-            "examples": [
-              "tsc: .target-bench/external/mobx/packages/mobx/src/api/annotation.ts(23,5): error TS7010: 'decorate_20223_', which lacks return-type annotation, implicitly has an 'any' return type."
-            ]
-          },
-          {
-            "subsystem": "relations-assignability",
-            "codes": [
-              "TS2345"
-            ],
-            "count": 1,
-            "examples": [
-              "tsc: .target-bench/external/mobx/packages/mobx/src/api/autorun.ts(110,37): error TS2345: Argument of type 'Lambda' is not assignable to parameter of type 'TimerHandler'."
-            ]
-          },
-          {
-            "subsystem": "uncoded diagnostic",
-            "codes": [],
-            "count": 4,
-            "examples": [
-              "tsc:   Type 'Lambda' is not assignable to type 'Function'.",
-              "tsc:     Types of property 'name' are incompatible.",
-              "tsc:       Type 'string | undefined' is not assignable to type 'string'."
-            ]
-          }
-        ],
-        "primary_subsystem": "contextual-inference",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/action.ts(56,49): error TS7006: Parameter 'arg1' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/action.ts(56,55): error TS7006: Parameter 'arg2' implicitly has an 'any' type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/action.ts(102,69): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/annotation.ts(23,5): error TS7010: 'decorate_20223_', which lacks return-type annotation, implicitly has an 'any' return type.",
-          "tsc: .target-bench/external/mobx/packages/mobx/src/api/autorun.ts(110,37): error TS2345: Argument of type 'Lambda' is not assignable to parameter of type 'TimerHandler'."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "contextual-inference",
-          "class-this-accessor",
-          "unclassified diagnostic",
-          "relations-assignability",
-          "uncoded diagnostic"
-        ],
-        "reduced_repro_path": ".target-bench/external/mobx/packages/mobx/src/api/action.ts",
-        "repro": {
-          "tsconfig_path": "mobx/tsconfig.tsz-bench.json",
-          "source_root": "mobx/packages/mobx/src",
-          "first_failure_path": ".target-bench/external/mobx/packages/mobx/src/api/action.ts",
-          "first_failure_line": 56,
-          "first_failure_column": 49,
-          "first_failure_code": "TS7006",
-          "reduced_repro_path": ".target-bench/external/mobx/packages/mobx/src/api/action.ts",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p mobx/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "observable/computed generic typing, decorator + annotation surface, reaction inference",
-        "files_reached": 58,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "mobx",
-            "repository": "https://github.com/mobxjs/mobx.git",
-            "ref": "2a069e41024433da401f3e8b3470adf194924911"
-          }
-        ]
-      }
-    },
-    {
       "name": "vite-vanilla-ts-app",
       "lines": 86,
       "kb": 2,
@@ -5188,176 +2960,6 @@
             "name": "vite-vanilla-ts",
             "repository": "generated:scripts/bench/generate-vite-app-fixture.mjs",
             "ref": "package-lock:0ceaff8c3f9768609ca30247b8002513ab2982cd77bfd7d2f99f69736cfb9c22"
-          }
-        ]
-      }
-    },
-    {
-      "name": "nextjs-fresh-app",
-      "lines": 282,
-      "kb": 7,
-      "project_files": 7,
-      "tsz_ms": 88.46,
-      "tsgo_ms": 112.06,
-      "tsz_lps": 3188,
-      "tsgo_lps": 2516,
-      "winner": "tsz",
-      "factor": 1.27,
-      "status": null,
-      "readme": "# Fresh Next.js app benchmark\n\nThis fixture is generated by `scripts/bench/generate-next-app-fixture.mjs`.\n\nEach benchmark run recreates the app, installs current npm versions, and type-checks the generated Next.js project with:\n\n```sh\ntsz --noEmit -p tsconfig.json\ntsgo --noEmit -p tsconfig.json\n```\n\nThe app intentionally imports and uses common type-heavy dependencies:\n\n- `zod`\n- `@tanstack/react-query`\n- `react-hook-form`\n- `type-fest`\n- `ts-pattern`\n- `superjson`\n- `date-fns`\n- `clsx`\n- `zustand`\n- `valibot`\n\nThe generated source mixes App Router pages, server actions, schema inference, discriminated unions, form helpers, query typing, store typing, and JSON-safe utility types so the benchmark reflects a modern application rather than a tiny startup file.",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:09:10.916Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "green",
-        "exit_class": "exit success",
-        "first_failure_class": null,
-        "owner_track": null,
-        "phase": "check",
-        "last_successful_phase": "check",
-        "diagnostic_status": "none",
-        "diagnostic_deltas": [],
-        "diagnostic_codes": [],
-        "diagnostic_subsystems": [],
-        "primary_subsystem": null,
-        "reduction_candidates": [],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [],
-        "reduced_repro_path": "next-app-live",
-        "repro": {
-          "tsconfig_path": "next-app-live/tsconfig.json",
-          "source_root": "next-app-live",
-          "first_failure_path": null,
-          "first_failure_line": null,
-          "first_failure_column": null,
-          "first_failure_code": null,
-          "reduced_repro_path": "next-app-live",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p next-app-live/tsconfig.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            0
-          ],
-          "tsz": [
-            0
-          ],
-          "tsgo": [
-            0
-          ]
-        },
-        "semantic_owner_family": "generated app-router dependency/config sanity",
-        "files_reached": 7,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "next-app-router",
-            "repository": "generated:scripts/bench/generate-next-app-fixture.mjs",
-            "ref": "package-lock:87905aa7e4f527624e631345fa3e43497b114da0750fa619c8b9f65d1f044f37"
-          }
-        ]
-      }
-    },
-    {
-      "name": "nextjs",
-      "lines": 251222,
-      "kb": 7832,
-      "project_files": 1546,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsc fixture error",
-      "compatibility": {
-        "generated_at": "2026-07-16T00:09:20.418Z",
-        "source_commit": "local",
-        "workflow_name": "local",
-        "workflow_run_id": "local",
-        "workflow_run_url": null,
-        "workflow_run_attempt": null,
-        "run_status": "local",
-        "state": "gray",
-        "exit_class": "fixture invalid",
-        "first_failure_class": "reference fixture invalid",
-        "owner_track": "Track 1 project-corpus harness/config",
-        "phase": "fixture setup",
-        "last_successful_phase": null,
-        "diagnostic_status": "tsc fixture failed",
-        "diagnostic_deltas": [
-          "tsc: .target-bench/external/next.js/packages/next/tsconfig.tsz-bench.json(3,3): error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '\"ignoreDeprecations\": \"6.0\"' to silence this error.",
-          "tsc:   Visit https://aka.ms/ts6 for migration information."
-        ],
-        "diagnostic_codes": [
-          "TS5107"
-        ],
-        "diagnostic_subsystems": [
-          {
-            "subsystem": "unclassified diagnostic",
-            "codes": [
-              "TS5107"
-            ],
-            "count": 1,
-            "examples": [
-              "tsc: .target-bench/external/next.js/packages/next/tsconfig.tsz-bench.json(3,3): error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '\"ignoreDeprecations\": \"6.0\"' to silence this error."
-            ]
-          },
-          {
-            "subsystem": "uncoded diagnostic",
-            "codes": [],
-            "count": 1,
-            "examples": [
-              "tsc:   Visit https://aka.ms/ts6 for migration information."
-            ]
-          }
-        ],
-        "primary_subsystem": "unclassified diagnostic",
-        "reduction_candidates": [
-          "tsc: .target-bench/external/next.js/packages/next/tsconfig.tsz-bench.json(3,3): error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '\"ignoreDeprecations\": \"6.0\"' to silence this error."
-        ],
-        "emit_status": "not in scope (noEmit project check)",
-        "dts_status": "not in scope (noEmit project check)",
-        "known_blockers": [
-          "reference fixture invalid",
-          "fixture setup phase blocker",
-          "unclassified diagnostic",
-          "uncoded diagnostic"
-        ],
-        "reduced_repro_path": ".target-bench/external/next.js/packages/next/tsconfig.tsz-bench.json",
-        "repro": {
-          "tsconfig_path": "next.js/packages/next/tsconfig.tsz-bench.json",
-          "source_root": "next.js/packages/next/src",
-          "first_failure_path": ".target-bench/external/next.js/packages/next/tsconfig.tsz-bench.json",
-          "first_failure_line": 3,
-          "first_failure_column": 3,
-          "first_failure_code": "TS5107",
-          "reduced_repro_path": ".target-bench/external/next.js/packages/next/tsconfig.tsz-bench.json",
-          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p next.js/packages/next/tsconfig.tsz-bench.json"
-        },
-        "exit_codes": {
-          "tsc": [
-            2
-          ],
-          "tsz": [],
-          "tsgo": []
-        },
-        "semantic_owner_family": "module graph plus generated app dependencies",
-        "files_reached": 1546,
-        "files_reached_reason": null,
-        "peak_memory_bytes": null,
-        "peak_memory_bytes_reason": "not measured on platform",
-        "fixture_sources": [
-          {
-            "name": "nextjs",
-            "repository": "https://github.com/vercel/next.js.git",
-            "ref": "09851e208cc62c8b6fe7a953b42c88e843129178"
           }
         ]
       }
@@ -6799,6 +4401,2634 @@
             "name": "ts-toolbelt",
             "repository": "https://github.com/millsp/ts-toolbelt.git",
             "ref": "b8a49285e3ed3a7d8bb8e0b433389eac46a5f140"
+          }
+        ]
+      }
+    },
+    {
+      "name": "valibot-project",
+      "lines": 40905,
+      "kb": 1032,
+      "project_files": 557,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsz error; tsc ok",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:28:33.642Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "yellow",
+        "exit_class": "nonzero exit",
+        "first_failure_class": "relations-assignability",
+        "owner_track": "Track 4 relation diagnostics/compatibility",
+        "phase": "check",
+        "last_successful_phase": null,
+        "diagnostic_status": "diagnostic mismatch or compiler error",
+        "diagnostic_deltas": [
+          "tsz: .target-bench/external/valibot/library/src/actions/args/args.ts(77,3): error TS2322: Type '{ kind: \"transformation\"; type: \"args\"; reference: <TInput extends (...args: any[]) => unknown, TSchema extends Schema>(schema: TSchema) => ArgsAction<TInput, TSchema>; async: false; schema: Schema; \"~run\"(dataset: SuccessDataset<(...args: unknown[]) => unknown>, config: Config<BaseIssue<unknown>>): SuccessDataset<(...args: unknown[]) => unknown>; }' is not assignable to type 'ArgsAction<(...args: unknown[]) => unknown, Schema>'.",
+          "tsz:   Types of property 'schema' are incompatible.",
+          "tsz:     Type 'Schema' is not assignable to type 'LooseTupleSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, ErrorMessage<LooseTupleIssue> | undefined> | StrictTupleSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, ErrorMessage<StrictTupleIssue> | undefined> | TupleSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, ErrorMessage<TupleIssue> | undefined> | TupleWithRestSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, BaseSchema<unknown, unknown, BaseIssue<unknown>>, ErrorMessage<TupleWithRestIssue> | undefined>'.",
+          "tsz:       Property 'rest' is missing in type 'LooseTupleSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, ErrorMessage<LooseTupleIssue> | undefined>' but required in type 'TupleWithRestSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, BaseSchema<unknown, unknown, BaseIssue<unknown>>, ErrorMessage<TupleWithRestIssue> | undefined>'.",
+          "tsz: .target-bench/external/valibot/library/src/actions/args/args.ts(88,31): error TS2345: Argument of type '[TupleWithRestIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<...>>[] | BaseSchema<unknown, unknown, BaseIssue<...>>[]>, ...(TupleWithRestIssue | InferTupleIssue<readonly BaseSchema<..., ..., ...>[] | BaseSchema<..., ..., ...>[]>)[]] | [LooseTupleIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<...>>[] | BaseSchema<unknown, unknown, BaseIssue<...>>[]>, ...(LooseTupleIssue | InferTupleIssue<readonly BaseSchema<..., ..., ...>[] | BaseSchema<..., ..., ...>[]>)[]] | [StrictTupleIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<...>>[] | BaseSchema<unknown, unknown, BaseIssue<...>>[]>, ...(StrictTupleIssue | InferTupleIssue<readonly BaseSchema<..., ..., ...>[] | BaseSchema<..., ..., ...>[]>)[]] | [TupleIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<...>>[] | BaseSchema<unknown, unknown, BaseIssue<...>>[]>, ...(TupleIssue | InferTupleIssue<readonly BaseSchema<..., ..., ...>[] | BaseSchema<..., ..., ...>[]>)[]]' is not assignable to parameter of type '[InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>, ...InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>[]]'.",
+          "tsz:   Type '[TupleWithRestIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<unknown>>[] | BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, ...(TupleWithRestIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<...>>[] | BaseSchema<unknown, unknown, BaseIssue<...>>[]>)[]]' is not assignable to type '[InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>, ...InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>[]]'.",
+          "tsz: .target-bench/external/valibot/library/src/actions/args/argsAsync.ts(99,3): error TS2322: Type '{ kind: \"transformation\"; type: \"args\"; reference: <TInput extends (...args: any[]) => unknown, TSchema extends Schema>(schema: TSchema) => ArgsActionAsync<TInput, TSchema>; async: false; schema: Schema; \"~run\"(dataset: SuccessDataset<(...args: unknown[]) => unknown>, config: Config<BaseIssue<unknown>>): SuccessDataset<(...args: unknown[]) => Promise<unknown>>; }' is not assignable to type 'ArgsActionAsync<(...args: unknown[]) => unknown, Schema>'.",
+          "tsz:   Types of property 'schema' are incompatible.",
+          "tsz:     Type 'Schema' is not assignable to type 'LooseTupleSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, ErrorMessage<LooseTupleIssue> | undefined> | LooseTupleSchemaAsync<MaybeReadonly<(BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>)[]>, ErrorMessage<LooseTupleIssue> | undefined> | StrictTupleSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, ErrorMessage<StrictTupleIssue> | undefined> | StrictTupleSchemaAsync<MaybeReadonly<(BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>)[]>, ErrorMessage<StrictTupleIssue> | undefined> | TupleSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, ErrorMessage<TupleIssue> | undefined> | TupleSchemaAsync<MaybeReadonly<(BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>)[]>, ErrorMessage<TupleIssue> | undefined> | TupleWithRestSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, BaseSchema<unknown, unknown, BaseIssue<unknown>>, ErrorMessage<TupleWithRestIssue> | undefined> | TupleWithRestSchemaAsync<MaybeReadonly<(BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>)[]>, BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>, ErrorMessage<TupleWithRestIssue> | undefined>'.",
+          "tsz:       Property 'rest' is missing in type 'LooseTupleSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, ErrorMessage<LooseTupleIssue> | undefined>' but required in type 'TupleWithRestSchemaAsync<MaybeReadonly<(BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>)[]>, BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>, ErrorMessage<TupleWithRestIssue> | undefined>'.",
+          "tsz: .target-bench/external/valibot/library/src/actions/args/argsAsync.ts(110,31): error TS2345: Argument of type '[TupleWithRestIssue | InferTupleIssue<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<...>>[]>>, ...(TupleWithRestIssue | InferTupleIssue<MaybeReadonly<BaseSchema<..., ..., ...>[]>>)[]] | [StrictTupleIssue | InferTupleIssue<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<...>>[]>>, ...(StrictTupleIssue | InferTupleIssue<MaybeReadonly<BaseSchema<..., ..., ...>[]>>)[]] | [TupleIssue | InferTupleIssue<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<...>>[]>>, ...(TupleIssue | InferTupleIssue<MaybeReadonly<BaseSchema<..., ..., ...>[]>>)[]] | [TupleIssue | InferTupleIssue<MaybeReadonly<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[]>>, ...(TupleIssue | InferTupleIssue<MaybeReadonly<(...)[]>>)[]] | [LooseTupleIssue | InferTupleIssue<MaybeReadonly<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[]>>, ...(LooseTupleIssue | InferTupleIssue<MaybeReadonly<(...)[]>>)[]] | [StrictTupleIssue | InferTupleIssue<MaybeReadonly<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[]>>, ...(StrictTupleIssue | InferTupleIssue<MaybeReadonly<(...)[]>>)[]] | [TupleWithRestIssue | InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>> | InferTupleIssue<MaybeReadonly<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[]>>, ...(TupleWithRestIssue | InferIssue<BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>> | InferTupleIssue<MaybeReadonly<(...)[]>>)[]] | [LooseTupleIssue | InferTupleIssue<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<...>>[]>>, ...(LooseTupleIssue | InferTupleIssue<MaybeReadonly<BaseSchema<..., ..., ...>[]>>)[]]' is not assignable to parameter of type '[InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>, ...InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>[]]'.",
+          "tsz:   Type '[TupleWithRestIssue | InferTupleIssue<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>>, ...(TupleWithRestIssue | InferTupleIssue<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<...>>[]>>)[]]' is not assignable to type '[InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>, ...InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>[]]'.",
+          "tsz: .target-bench/external/valibot/library/src/actions/args/argsAsync.ts(112,24): error TS2488: Type 'unknown[] | InferOutput<(BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>)[][number]>[] | [...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>>>[], ...unknown[]] | [...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>>>[], ...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>>>[]] | [...InferOutput<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[][number]>[], ...unknown[]] | [...InferOutput<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[][number]>[], ...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>[]] | [...{ -readonly [TKey in keyof readonly (BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>)[]]: InferOutput<readonly (BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[][TKey]>; }, ...unknown[]] | [...{ -readonly [TKey in keyof readonly (BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>)[]]: InferOutput<readonly (BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[][TKey]>; }, ...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>[]] | { -readonly [TKey in keyof readonly (BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>)[]]: InferOutput<readonly (BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>)[][TKey]>; }' must have a '[Symbol.iterator]()' method that returns an iterator.",
+          "tsz: .target-bench/external/valibot/library/src/actions/base64/base64.ts(100,19): error TS2345: Argument of type 'Base64Action<string, ErrorMessage<Base64Issue<string>> | undefined>' is not assignable to parameter of type '{ readonly type: \"base64\"; readonly reference: typeof base64; readonly expects: null; readonly requirement: RegExp; readonly message: ErrorMessage<Base64Issue<string>> | undefined; readonly kind: \"validation\"; readonly async: false; readonly \"~run\": (dataset: OutputDataset<string, BaseIssue<unknown>>, config: Config<BaseIssue<unknown>>) => OutputDataset<string, Base64Issue<string> | BaseIssue<unknown>>; readonly \"~types\"?: { readonly input: string; readonly output: string; readonly issue: Base64Issue<string>; } | undefined; } & { expects?: string | null | undefined; requirement?: unknown; message?: ErrorMessage<Extract<InferIssue<{ readonly type: \"base64\"; readonly reference: typeof base64; readonly expects: null; readonly requirement: RegExp; readonly message: ...; readonly kind: \"validation\"; readonly async: false; readonly \"~run\": (dataset: ..., config: ...) => ...; readonly \"~types\"?: { ...; } | ...; }>, { type: \"base64\"; }>> | undefined; }'.",
+          "tsz:   Type 'Base64Action<string, ErrorMessage<Base64Issue<string>> | undefined>' is not assignable to type '{ expects?: string | null | undefined; requirement?: unknown; message?: ErrorMessage<Extract<InferIssue<{ readonly type: \"base64\"; readonly reference: typeof base64; readonly expects: null; readonly requirement: RegExp; readonly message: ErrorMessage<...> | undefined; readonly kind: \"validation\"; readonly async: false; readonly \"~run\": (dataset: OutputDataset<..., ...>, config: Config<...>) => OutputDataset<..., ...>; readonly \"~types\"?: { readonly input: ...; readonly output: ...; readonly issue: ...; } | undefined; }>, { type: \"base64\"; }>> | undefined; }'.",
+          "tsz:     Types of property 'message' are incompatible.",
+          "tsz:       Type 'ErrorMessage<Base64Issue<string>> | undefined' is not assignable to type 'ErrorMessage<Extract<InferIssue<{ readonly type: \"base64\"; readonly reference: typeof base64; readonly expects: null; readonly requirement: RegExp; readonly message: ErrorMessage<Base64Issue<...>> | undefined; readonly kind: \"validation\"; readonly async: false; readonly \"~run\": (dataset: OutputDataset<string, BaseIssue<...>>, config: Config<BaseIssue<...>>) => OutputDataset<string, ...>; readonly \"~types\"?: { readonly input: string; readonly output: string; readonly issue: Base64Issue<...>; } | undefined; }>, { type: \"base64\"; }>> | undefined'.",
+          "tsz: .target-bench/external/valibot/library/src/actions/bic/bic.ts(97,19): error TS2345: Argument of type 'BicAction<string, ErrorMessage<BicIssue<string>> | undefined>' is not assignable to parameter of type '{ readonly type: \"bic\"; readonly reference: typeof bic; readonly expects: null; readonly requirement: RegExp; readonly message: ErrorMessage<BicIssue<string>> | undefined; readonly kind: \"validation\"; readonly async: false; readonly \"~run\": (dataset: OutputDataset<string, BaseIssue<unknown>>, config: Config<BaseIssue<unknown>>) => OutputDataset<string, BaseIssue<unknown> | BicIssue<string>>; readonly \"~types\"?: { readonly input: string; readonly output: string; readonly issue: BicIssue<string>; } | undefined; } & { expects?: string | null | undefined; requirement?: unknown; message?: ErrorMessage<Extract<InferIssue<{ readonly type: \"bic\"; readonly reference: typeof bic; readonly expects: null; readonly requirement: RegExp; readonly message: ...; readonly kind: \"validation\"; readonly async: false; readonly \"~run\": (dataset: ..., config: ...) => ...; readonly \"~types\"?: { ...; } | ...; }>, { type: \"bic\"; }>> | undefined; }'.",
+          "tsz:   Type 'BicAction<string, ErrorMessage<BicIssue<string>> | undefined>' is not assignable to type '{ expects?: string | null | undefined; requirement?: unknown; message?: ErrorMessage<Extract<InferIssue<{ readonly type: \"bic\"; readonly reference: typeof bic; readonly expects: null; readonly requirement: RegExp; readonly message: ErrorMessage<...> | undefined; readonly kind: \"validation\"; readonly async: false; readonly \"~run\": (dataset: OutputDataset<..., ...>, config: Config<...>) => OutputDataset<..., ...>; readonly \"~types\"?: { readonly input: ...; readonly output: ...; readonly issue: ...; } | undefined; }>, { type: \"bic\"; }>> | undefined; }'.",
+          "tsz:     Types of property 'message' are incompatible."
+        ],
+        "diagnostic_codes": [
+          "TS2322",
+          "TS2345",
+          "TS2488"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "relations-assignability",
+            "codes": [
+              "TS2322",
+              "TS2345"
+            ],
+            "count": 6,
+            "examples": [
+              "tsz: .target-bench/external/valibot/library/src/actions/args/args.ts(77,3): error TS2322: Type '{ kind: \"transformation\"; type: \"args\"; reference: <TInput extends (...args: any[]) => unknown, TSchema extends Schema>(schema: TSchema) => ArgsAction<TInput, TSchema>; async: false; schema: Schema; \"~run\"(dataset: SuccessDataset<(...args: unknown[]) => unknown>, config: Config<BaseIssue<unknown>>): SuccessDataset<(...args: unknown[]) => unknown>; }' is not assignable to type 'ArgsAction<(...args: unknown[]) => unknown, Schema>'.",
+              "tsz: .target-bench/external/valibot/library/src/actions/args/args.ts(88,31): error TS2345: Argument of type '[TupleWithRestIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<...>>[] | BaseSchema<unknown, unknown, BaseIssue<...>>[]>, ...(TupleWithRestIssue | InferTupleIssue<readonly BaseSchema<..., ..., ...>[] | BaseSchema<..., ..., ...>[]>)[]] | [LooseTupleIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<...>>[] | BaseSchema<unknown, unknown, BaseIssue<...>>[]>, ...(LooseTupleIssue | InferTupleIssue<readonly BaseSchema<..., ..., ...>[] | BaseSchema<..., ..., ...>[]>)[]] | [StrictTupleIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<...>>[] | BaseSchema<unknown, unknown, BaseIssue<...>>[]>, ...(StrictTupleIssue | InferTupleIssue<readonly BaseSchema<..., ..., ...>[] | BaseSchema<..., ..., ...>[]>)[]] | [TupleIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<...>>[] | BaseSchema<unknown, unknown, BaseIssue<...>>[]>, ...(TupleIssue | InferTupleIssue<readonly BaseSchema<..., ..., ...>[] | BaseSchema<..., ..., ...>[]>)[]]' is not assignable to parameter of type '[InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>, ...InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>[]]'.",
+              "tsz: .target-bench/external/valibot/library/src/actions/args/argsAsync.ts(99,3): error TS2322: Type '{ kind: \"transformation\"; type: \"args\"; reference: <TInput extends (...args: any[]) => unknown, TSchema extends Schema>(schema: TSchema) => ArgsActionAsync<TInput, TSchema>; async: false; schema: Schema; \"~run\"(dataset: SuccessDataset<(...args: unknown[]) => unknown>, config: Config<BaseIssue<unknown>>): SuccessDataset<(...args: unknown[]) => Promise<unknown>>; }' is not assignable to type 'ArgsActionAsync<(...args: unknown[]) => unknown, Schema>'."
+            ]
+          },
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 13,
+            "examples": [
+              "tsz:   Types of property 'schema' are incompatible.",
+              "tsz:     Type 'Schema' is not assignable to type 'LooseTupleSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, ErrorMessage<LooseTupleIssue> | undefined> | StrictTupleSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, ErrorMessage<StrictTupleIssue> | undefined> | TupleSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, ErrorMessage<TupleIssue> | undefined> | TupleWithRestSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, BaseSchema<unknown, unknown, BaseIssue<unknown>>, ErrorMessage<TupleWithRestIssue> | undefined>'.",
+              "tsz:       Property 'rest' is missing in type 'LooseTupleSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, ErrorMessage<LooseTupleIssue> | undefined>' but required in type 'TupleWithRestSchema<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<unknown>>[]>, BaseSchema<unknown, unknown, BaseIssue<unknown>>, ErrorMessage<TupleWithRestIssue> | undefined>'."
+            ]
+          },
+          {
+            "subsystem": "unclassified diagnostic",
+            "codes": [
+              "TS2488"
+            ],
+            "count": 1,
+            "examples": [
+              "tsz: .target-bench/external/valibot/library/src/actions/args/argsAsync.ts(112,24): error TS2488: Type 'unknown[] | InferOutput<(BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>)[][number]>[] | [...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>>>[], ...unknown[]] | [...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>>>[], ...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>>>[]] | [...InferOutput<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[][number]>[], ...unknown[]] | [...InferOutput<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[][number]>[], ...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>[]] | [...{ -readonly [TKey in keyof readonly (BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>)[]]: InferOutput<readonly (BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[][TKey]>; }, ...unknown[]] | [...{ -readonly [TKey in keyof readonly (BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>)[]]: InferOutput<readonly (BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[][TKey]>; }, ...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>[]] | { -readonly [TKey in keyof readonly (BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>)[]]: InferOutput<readonly (BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>)[][TKey]>; }' must have a '[Symbol.iterator]()' method that returns an iterator."
+            ]
+          }
+        ],
+        "primary_subsystem": "relations-assignability",
+        "reduction_candidates": [
+          "tsz: .target-bench/external/valibot/library/src/actions/args/args.ts(77,3): error TS2322: Type '{ kind: \"transformation\"; type: \"args\"; reference: <TInput extends (...args: any[]) => unknown, TSchema extends Schema>(schema: TSchema) => ArgsAction<TInput, TSchema>; async: false; schema: Schema; \"~run\"(dataset: SuccessDataset<(...args: unknown[]) => unknown>, config: Config<BaseIssue<unknown>>): SuccessDataset<(...args: unknown[]) => unknown>; }' is not assignable to type 'ArgsAction<(...args: unknown[]) => unknown, Schema>'.",
+          "tsz: .target-bench/external/valibot/library/src/actions/args/args.ts(88,31): error TS2345: Argument of type '[TupleWithRestIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<...>>[] | BaseSchema<unknown, unknown, BaseIssue<...>>[]>, ...(TupleWithRestIssue | InferTupleIssue<readonly BaseSchema<..., ..., ...>[] | BaseSchema<..., ..., ...>[]>)[]] | [LooseTupleIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<...>>[] | BaseSchema<unknown, unknown, BaseIssue<...>>[]>, ...(LooseTupleIssue | InferTupleIssue<readonly BaseSchema<..., ..., ...>[] | BaseSchema<..., ..., ...>[]>)[]] | [StrictTupleIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<...>>[] | BaseSchema<unknown, unknown, BaseIssue<...>>[]>, ...(StrictTupleIssue | InferTupleIssue<readonly BaseSchema<..., ..., ...>[] | BaseSchema<..., ..., ...>[]>)[]] | [TupleIssue | InferTupleIssue<readonly BaseSchema<unknown, unknown, BaseIssue<...>>[] | BaseSchema<unknown, unknown, BaseIssue<...>>[]>, ...(TupleIssue | InferTupleIssue<readonly BaseSchema<..., ..., ...>[] | BaseSchema<..., ..., ...>[]>)[]]' is not assignable to parameter of type '[InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>, ...InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>[]]'.",
+          "tsz: .target-bench/external/valibot/library/src/actions/args/argsAsync.ts(99,3): error TS2322: Type '{ kind: \"transformation\"; type: \"args\"; reference: <TInput extends (...args: any[]) => unknown, TSchema extends Schema>(schema: TSchema) => ArgsActionAsync<TInput, TSchema>; async: false; schema: Schema; \"~run\"(dataset: SuccessDataset<(...args: unknown[]) => unknown>, config: Config<BaseIssue<unknown>>): SuccessDataset<(...args: unknown[]) => Promise<unknown>>; }' is not assignable to type 'ArgsActionAsync<(...args: unknown[]) => unknown, Schema>'.",
+          "tsz: .target-bench/external/valibot/library/src/actions/args/argsAsync.ts(110,31): error TS2345: Argument of type '[TupleWithRestIssue | InferTupleIssue<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<...>>[]>>, ...(TupleWithRestIssue | InferTupleIssue<MaybeReadonly<BaseSchema<..., ..., ...>[]>>)[]] | [StrictTupleIssue | InferTupleIssue<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<...>>[]>>, ...(StrictTupleIssue | InferTupleIssue<MaybeReadonly<BaseSchema<..., ..., ...>[]>>)[]] | [TupleIssue | InferTupleIssue<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<...>>[]>>, ...(TupleIssue | InferTupleIssue<MaybeReadonly<BaseSchema<..., ..., ...>[]>>)[]] | [TupleIssue | InferTupleIssue<MaybeReadonly<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[]>>, ...(TupleIssue | InferTupleIssue<MaybeReadonly<(...)[]>>)[]] | [LooseTupleIssue | InferTupleIssue<MaybeReadonly<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[]>>, ...(LooseTupleIssue | InferTupleIssue<MaybeReadonly<(...)[]>>)[]] | [StrictTupleIssue | InferTupleIssue<MaybeReadonly<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[]>>, ...(StrictTupleIssue | InferTupleIssue<MaybeReadonly<(...)[]>>)[]] | [TupleWithRestIssue | InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>> | InferTupleIssue<MaybeReadonly<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[]>>, ...(TupleWithRestIssue | InferIssue<BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>> | InferTupleIssue<MaybeReadonly<(...)[]>>)[]] | [LooseTupleIssue | InferTupleIssue<MaybeReadonly<BaseSchema<unknown, unknown, BaseIssue<...>>[]>>, ...(LooseTupleIssue | InferTupleIssue<MaybeReadonly<BaseSchema<..., ..., ...>[]>>)[]]' is not assignable to parameter of type '[InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>, ...InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>[]]'.",
+          "tsz: .target-bench/external/valibot/library/src/actions/args/argsAsync.ts(112,24): error TS2488: Type 'unknown[] | InferOutput<(BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>)[][number]>[] | [...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>>>[], ...unknown[]] | [...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>>>[], ...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>>>[]] | [...InferOutput<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[][number]>[], ...unknown[]] | [...InferOutput<(BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[][number]>[], ...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>[]] | [...{ -readonly [TKey in keyof readonly (BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>)[]]: InferOutput<readonly (BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[][TKey]>; }, ...unknown[]] | [...{ -readonly [TKey in keyof readonly (BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>)[]]: InferOutput<readonly (BaseSchema<..., ..., ...> | BaseSchemaAsync<..., ..., ...>)[][TKey]>; }, ...InferOutput<BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>>[]] | { -readonly [TKey in keyof readonly (BaseSchema<unknown, unknown, BaseIssue<unknown>> | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>)[]]: InferOutput<readonly (BaseSchema<unknown, unknown, BaseIssue<...>> | BaseSchemaAsync<unknown, unknown, BaseIssue<...>>)[][TKey]>; }' must have a '[Symbol.iterator]()' method that returns an iterator."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "relations-assignability",
+          "uncoded diagnostic",
+          "unclassified diagnostic"
+        ],
+        "reduced_repro_path": ".target-bench/external/valibot/library/src/actions/args/args.ts",
+        "repro": {
+          "tsconfig_path": "valibot/tsconfig.tsz-bench.json",
+          "source_root": "valibot/library/src",
+          "first_failure_path": ".target-bench/external/valibot/library/src/actions/args/args.ts",
+          "first_failure_line": 77,
+          "first_failure_column": 3,
+          "first_failure_code": "TS2322",
+          "reduced_repro_path": ".target-bench/external/valibot/library/src/actions/args/args.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p valibot/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            1
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "schema-builder generics with recursive conditionals",
+        "files_reached": 557,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "valibot",
+            "repository": "https://github.com/fabian-hiller/valibot.git",
+            "ref": "e7bcacb107b1c5a74dfd564babd2c8697037ee06"
+          }
+        ]
+      }
+    },
+    {
+      "name": "msw-project",
+      "lines": 9469,
+      "kb": 272,
+      "project_files": 101,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsc fixture error",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:28:35.761Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "gray",
+        "exit_class": "fixture invalid",
+        "first_failure_class": "reference fixture invalid",
+        "owner_track": "Track 1 project-corpus harness/config",
+        "phase": "fixture setup",
+        "last_successful_phase": null,
+        "diagnostic_status": "tsc fixture failed",
+        "diagnostic_deltas": [
+          "tsc: .target-bench/external/msw/src/browser/utils/workerChannel.ts(85,7): error TS2578: Unused '@ts-expect-error' directive.",
+          "tsc: .target-bench/external/msw/src/core/experimental/define-network.ts(187,33): error TS7006: Parameter 'event' implicitly has an 'any' type.",
+          "tsc: .target-bench/external/msw/src/core/experimental/sources/network-source.ts(40,7): error TS2578: Unused '@ts-expect-error' directive."
+        ],
+        "diagnostic_codes": [
+          "TS2578",
+          "TS7006"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "unclassified diagnostic",
+            "codes": [
+              "TS2578"
+            ],
+            "count": 2,
+            "examples": [
+              "tsc: .target-bench/external/msw/src/browser/utils/workerChannel.ts(85,7): error TS2578: Unused '@ts-expect-error' directive.",
+              "tsc: .target-bench/external/msw/src/core/experimental/sources/network-source.ts(40,7): error TS2578: Unused '@ts-expect-error' directive."
+            ]
+          },
+          {
+            "subsystem": "contextual-inference",
+            "codes": [
+              "TS7006"
+            ],
+            "count": 1,
+            "examples": [
+              "tsc: .target-bench/external/msw/src/core/experimental/define-network.ts(187,33): error TS7006: Parameter 'event' implicitly has an 'any' type."
+            ]
+          }
+        ],
+        "primary_subsystem": "unclassified diagnostic",
+        "reduction_candidates": [
+          "tsc: .target-bench/external/msw/src/browser/utils/workerChannel.ts(85,7): error TS2578: Unused '@ts-expect-error' directive.",
+          "tsc: .target-bench/external/msw/src/core/experimental/define-network.ts(187,33): error TS7006: Parameter 'event' implicitly has an 'any' type.",
+          "tsc: .target-bench/external/msw/src/core/experimental/sources/network-source.ts(40,7): error TS2578: Unused '@ts-expect-error' directive."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "reference fixture invalid",
+          "fixture setup phase blocker",
+          "unclassified diagnostic",
+          "contextual-inference"
+        ],
+        "reduced_repro_path": ".target-bench/external/msw/src/browser/utils/workerChannel.ts",
+        "repro": {
+          "tsconfig_path": "msw/tsconfig.tsz-bench.json",
+          "source_root": "msw/src",
+          "first_failure_path": ".target-bench/external/msw/src/browser/utils/workerChannel.ts",
+          "first_failure_line": 85,
+          "first_failure_column": 7,
+          "first_failure_code": "TS2578",
+          "reduced_repro_path": ".target-bench/external/msw/src/browser/utils/workerChannel.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p msw/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            1
+          ],
+          "tsz": [],
+          "tsgo": []
+        },
+        "semantic_owner_family": "pnpm-symlinked @types graph plus project references",
+        "files_reached": 101,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "msw",
+            "repository": "https://github.com/mswjs/msw.git",
+            "ref": "8a19d5485adad2b8a816e04a937f4c76169cd5b9"
+          }
+        ]
+      }
+    },
+    {
+      "name": "effect-project",
+      "lines": 187887,
+      "kb": 5529,
+      "project_files": 364,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsc fixture error",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:28:41.254Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "gray",
+        "exit_class": "fixture invalid",
+        "first_failure_class": "reference fixture invalid",
+        "owner_track": "Track 1 project-corpus harness/config",
+        "phase": "fixture setup",
+        "last_successful_phase": null,
+        "diagnostic_status": "tsc fixture failed",
+        "diagnostic_deltas": [
+          "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(205,16): error TS7006: Parameter 'value' implicitly has an 'any' type.",
+          "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(3770,5): error TS2345: Argument of type 'SchemaClass<any, any, never>' is not assignable to parameter of type 'S'.",
+          "tsc:   'SchemaClass<any, any, never>' is assignable to the constraint of type 'S', but 'S' could be instantiated with a different subtype of constraint 'Any'.",
+          "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(7141,5): error TS2322: Type 'Arbitrary<Option<unknown>>' is not assignable to type 'Arbitrary<Option<A>>'.",
+          "tsc:   Type 'Option<unknown>' is not assignable to type 'Option<A>'.",
+          "tsc:     Type 'None<unknown>' is not assignable to type 'Option<A>'.",
+          "tsc:       Type 'None<unknown>' is not assignable to type 'None<A>'.",
+          "tsc:         Type 'unknown' is not assignable to type 'A'.",
+          "tsc:           'A' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.",
+          "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(7388,3): error TS2322: Type 'Arbitrary<Either<unknown, L>>' is not assignable to type 'Arbitrary<Either<R, L>>'.",
+          "tsc:   Type 'Either<unknown, L>' is not assignable to type 'Either<R, L>'.",
+          "tsc:     Type 'Left<L, unknown>' is not assignable to type 'Either<R, L>'.",
+          "tsc:       Type 'Left<L, unknown>' is not assignable to type 'Left<L, R>'.",
+          "tsc:         Type 'unknown' is not assignable to type 'R'.",
+          "tsc:           'R' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.",
+          "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(9619,3): error TS2322: Type 'Arbitrary<Exit<unknown, E>>' is not assignable to type 'Arbitrary<Exit<A, E>>'.",
+          "tsc:   Type 'Exit<unknown, E>' is not assignable to type 'Exit<A, E>'.",
+          "tsc:     Type 'Failure<unknown, E>' is not assignable to type 'Exit<A, E>'.",
+          "tsc:       Type 'Failure<unknown, E>' is not assignable to type 'Failure<A, E>'.",
+          "tsc:         Type 'unknown' is not assignable to type 'A'."
+        ],
+        "diagnostic_codes": [
+          "TS7006",
+          "TS2345",
+          "TS2322"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "contextual-inference",
+            "codes": [
+              "TS7006"
+            ],
+            "count": 1,
+            "examples": [
+              "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(205,16): error TS7006: Parameter 'value' implicitly has an 'any' type."
+            ]
+          },
+          {
+            "subsystem": "relations-assignability",
+            "codes": [
+              "TS2345",
+              "TS2322"
+            ],
+            "count": 4,
+            "examples": [
+              "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(3770,5): error TS2345: Argument of type 'SchemaClass<any, any, never>' is not assignable to parameter of type 'S'.",
+              "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(7141,5): error TS2322: Type 'Arbitrary<Option<unknown>>' is not assignable to type 'Arbitrary<Option<A>>'.",
+              "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(7388,3): error TS2322: Type 'Arbitrary<Either<unknown, L>>' is not assignable to type 'Arbitrary<Either<R, L>>'."
+            ]
+          },
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 15,
+            "examples": [
+              "tsc:   'SchemaClass<any, any, never>' is assignable to the constraint of type 'S', but 'S' could be instantiated with a different subtype of constraint 'Any'.",
+              "tsc:   Type 'Option<unknown>' is not assignable to type 'Option<A>'.",
+              "tsc:     Type 'None<unknown>' is not assignable to type 'Option<A>'."
+            ]
+          }
+        ],
+        "primary_subsystem": "contextual-inference",
+        "reduction_candidates": [
+          "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(205,16): error TS7006: Parameter 'value' implicitly has an 'any' type.",
+          "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(3770,5): error TS2345: Argument of type 'SchemaClass<any, any, never>' is not assignable to parameter of type 'S'.",
+          "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(7141,5): error TS2322: Type 'Arbitrary<Option<unknown>>' is not assignable to type 'Arbitrary<Option<A>>'.",
+          "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(7388,3): error TS2322: Type 'Arbitrary<Either<unknown, L>>' is not assignable to type 'Arbitrary<Either<R, L>>'.",
+          "tsc: .target-bench/external/effect/packages/effect/src/Schema.ts(9619,3): error TS2322: Type 'Arbitrary<Exit<unknown, E>>' is not assignable to type 'Arbitrary<Exit<A, E>>'."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "reference fixture invalid",
+          "fixture setup phase blocker",
+          "contextual-inference",
+          "relations-assignability",
+          "uncoded diagnostic"
+        ],
+        "reduced_repro_path": ".target-bench/external/effect/packages/effect/src/Schema.ts",
+        "repro": {
+          "tsconfig_path": "effect/tsconfig.tsz-bench.json",
+          "source_root": "effect/packages/effect/src",
+          "first_failure_path": ".target-bench/external/effect/packages/effect/src/Schema.ts",
+          "first_failure_line": 205,
+          "first_failure_column": 16,
+          "first_failure_code": "TS7006",
+          "reduced_repro_path": ".target-bench/external/effect/packages/effect/src/Schema.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p effect/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            1
+          ],
+          "tsz": [],
+          "tsgo": []
+        },
+        "semantic_owner_family": "large-scale schema/effect generics, ~296k LOC parity canary",
+        "files_reached": 364,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "effect",
+            "repository": "https://github.com/Effect-TS/effect.git",
+            "ref": "626c61b3ef0dce59ffb038590bc834d36afc5d1d"
+          }
+        ]
+      }
+    },
+    {
+      "name": "drizzle-orm-project",
+      "lines": 53229,
+      "kb": 1611,
+      "project_files": 354,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsz timeout; tsc ok",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:30:45.797Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "red",
+        "exit_class": "timeout",
+        "first_failure_class": "timeout during project check",
+        "owner_track": "Track 1 runtime/timeout triage",
+        "phase": "check",
+        "last_successful_phase": null,
+        "diagnostic_status": "compiler timed out",
+        "diagnostic_deltas": [
+          "tsz timed out after 120s"
+        ],
+        "diagnostic_codes": [],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 1,
+            "examples": [
+              "tsz timed out after 120s"
+            ]
+          }
+        ],
+        "primary_subsystem": "uncoded diagnostic",
+        "reduction_candidates": [
+          "tsz timed out after 120s"
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "timeout during project check",
+          "uncoded diagnostic"
+        ],
+        "reduced_repro_path": "drizzle-orm/drizzle-orm/src",
+        "repro": {
+          "tsconfig_path": "drizzle-orm/tsconfig.tsz-bench.json",
+          "source_root": "drizzle-orm/drizzle-orm/src",
+          "first_failure_path": null,
+          "first_failure_line": null,
+          "first_failure_column": null,
+          "first_failure_code": null,
+          "reduced_repro_path": "drizzle-orm/drizzle-orm/src",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p drizzle-orm/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            124
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "JSON file routing + contextual-keyword binders + pnpm @types graph",
+        "files_reached": 354,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "drizzle-orm",
+            "repository": "https://github.com/drizzle-team/drizzle-orm.git",
+            "ref": "48e5406027103a9fca6eb66417187c4a8b5c6aa3"
+          }
+        ]
+      }
+    },
+    {
+      "name": "valtio-project",
+      "lines": 1669,
+      "kb": 48,
+      "project_files": 17,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsc fixture error",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:30:46.944Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "gray",
+        "exit_class": "fixture invalid",
+        "first_failure_class": "reference fixture invalid",
+        "owner_track": "Track 1 project-corpus harness/config",
+        "phase": "fixture setup",
+        "last_successful_phase": null,
+        "diagnostic_status": "tsc fixture failed",
+        "diagnostic_deltas": [
+          "tsc: .target-bench/external/valtio/src/vanilla/utils/proxyMap.ts(182,5): error TS2353: Object literal may only specify known properties, and 'getOrInsert' does not exist in type 'InternalProxyObject<K, V>'."
+        ],
+        "diagnostic_codes": [
+          "TS2353"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "keyspace-property-indexed",
+            "codes": [
+              "TS2353"
+            ],
+            "count": 1,
+            "examples": [
+              "tsc: .target-bench/external/valtio/src/vanilla/utils/proxyMap.ts(182,5): error TS2353: Object literal may only specify known properties, and 'getOrInsert' does not exist in type 'InternalProxyObject<K, V>'."
+            ]
+          }
+        ],
+        "primary_subsystem": "keyspace-property-indexed",
+        "reduction_candidates": [
+          "tsc: .target-bench/external/valtio/src/vanilla/utils/proxyMap.ts(182,5): error TS2353: Object literal may only specify known properties, and 'getOrInsert' does not exist in type 'InternalProxyObject<K, V>'."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "reference fixture invalid",
+          "fixture setup phase blocker",
+          "keyspace-property-indexed"
+        ],
+        "reduced_repro_path": ".target-bench/external/valtio/src/vanilla/utils/proxyMap.ts",
+        "repro": {
+          "tsconfig_path": "valtio/tsconfig.tsz-bench.json",
+          "source_root": "valtio/src",
+          "first_failure_path": ".target-bench/external/valtio/src/vanilla/utils/proxyMap.ts",
+          "first_failure_line": 182,
+          "first_failure_column": 5,
+          "first_failure_code": "TS2353",
+          "reduced_repro_path": ".target-bench/external/valtio/src/vanilla/utils/proxyMap.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p valtio/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            1
+          ],
+          "tsz": [],
+          "tsgo": []
+        },
+        "semantic_owner_family": "proxy-state reactive store; canary for cross-file context-dependent FPs (#14344 identity/relation family) — clean per-file, fires only on whole-project compile",
+        "files_reached": 17,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "valtio",
+            "repository": "https://github.com/pmndrs/valtio.git",
+            "ref": "c24a93a1b62d1fb95a7fa78c840d32cf95bef348"
+          }
+        ]
+      }
+    },
+    {
+      "name": "tiny-invariant-project",
+      "lines": 49,
+      "kb": 1,
+      "project_files": 2,
+      "tsz_ms": 37.13,
+      "tsgo_ms": 109.76,
+      "tsz_lps": 1320,
+      "tsgo_lps": 446,
+      "winner": "tsz",
+      "factor": 2.96,
+      "status": null,
+      "compatibility": {
+        "generated_at": "2026-07-16T11:30:53.729Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "green",
+        "exit_class": "exit success",
+        "first_failure_class": null,
+        "owner_track": null,
+        "phase": "check",
+        "last_successful_phase": "check",
+        "diagnostic_status": "none",
+        "diagnostic_deltas": [],
+        "diagnostic_codes": [],
+        "diagnostic_subsystems": [],
+        "primary_subsystem": null,
+        "reduction_candidates": [],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [],
+        "reduced_repro_path": "tiny-invariant/src",
+        "repro": {
+          "tsconfig_path": "tiny-invariant/tsconfig.tsz-bench.json",
+          "source_root": "tiny-invariant/src",
+          "first_failure_path": null,
+          "first_failure_line": null,
+          "first_failure_column": null,
+          "first_failure_code": null,
+          "reduced_repro_path": "tiny-invariant/src",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p tiny-invariant/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            0
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "tiny runtime invariant assertion helper; clean green row — tsz byte-parity-clean vs tsc (both emit only the shared TS2591 process baseline line, 0 tsz-only delta) on the whole-project compile",
+        "files_reached": 2,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "tiny-invariant",
+            "repository": "https://github.com/alexreardon/tiny-invariant.git",
+            "ref": "b5587cf4ba45e257bce49053c3345b6614324252"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ts-belt-project",
+      "lines": 2794,
+      "kb": 88,
+      "project_files": 14,
+      "tsz_ms": 122.52,
+      "tsgo_ms": 114.48,
+      "tsz_lps": 22805,
+      "tsgo_lps": 24406,
+      "winner": "tsgo",
+      "factor": 1.07,
+      "status": null,
+      "compatibility": {
+        "generated_at": "2026-07-16T11:31:02.746Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "green",
+        "exit_class": "exit success",
+        "first_failure_class": null,
+        "owner_track": null,
+        "phase": "check",
+        "last_successful_phase": "check",
+        "diagnostic_status": "none",
+        "diagnostic_deltas": [],
+        "diagnostic_codes": [],
+        "diagnostic_subsystems": [],
+        "primary_subsystem": null,
+        "reduction_candidates": [],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [],
+        "reduced_repro_path": "ts-belt/src",
+        "repro": {
+          "tsconfig_path": "ts-belt/tsconfig.tsz-bench.json",
+          "source_root": "ts-belt/src",
+          "first_failure_path": null,
+          "first_failure_line": null,
+          "first_failure_column": null,
+          "first_failure_code": null,
+          "reduced_repro_path": "ts-belt/src",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p ts-belt/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            0
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "zero-dependency functional utility belt; first-blocker = named-import of a global type through a `/// <reference>`-bearing module reported TS2305 (export-resolution divergence — bounded, tsz-only, repros standalone)",
+        "files_reached": 14,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "ts-belt",
+            "repository": "https://github.com/mobily/ts-belt.git",
+            "ref": "c825d9709de1e5d15b1b362429e0cee56c96c516"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ts-extras-project",
+      "lines": 1434,
+      "kb": 50,
+      "project_files": 36,
+      "tsz_ms": 88.6,
+      "tsgo_ms": 117.38,
+      "tsz_lps": 16185,
+      "tsgo_lps": 12217,
+      "winner": "tsz",
+      "factor": 1.32,
+      "status": null,
+      "compatibility": {
+        "generated_at": "2026-07-16T11:31:11.357Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "green",
+        "exit_class": "exit success",
+        "first_failure_class": null,
+        "owner_track": null,
+        "phase": "check",
+        "last_successful_phase": "check",
+        "diagnostic_status": "none",
+        "diagnostic_deltas": [],
+        "diagnostic_codes": [],
+        "diagnostic_subsystems": [],
+        "primary_subsystem": null,
+        "reduction_candidates": [],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [],
+        "reduced_repro_path": "ts-extras/source",
+        "repro": {
+          "tsconfig_path": "ts-extras/tsconfig.tsz-bench.json",
+          "source_root": "ts-extras/source",
+          "first_failure_path": null,
+          "first_failure_line": null,
+          "first_failure_column": null,
+          "first_failure_code": null,
+          "reduced_repro_path": "ts-extras/source",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p ts-extras/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            0
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "type-fest-based assertion/guard helpers; fully tsc-parity under the guard config (tsz-only delta = 0). NOTE: type-fest is unresolved under the shared `types: []` baseline (its TS2307 cancels in both tsz and tsc), so the type-fest-typed paths are any-stubbed — a thin parity row, not a deep witness",
+        "files_reached": 36,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "ts-extras",
+            "repository": "https://github.com/sindresorhus/ts-extras.git",
+            "ref": "1e886239c7f7010c1cfa194e13d4d123b160cbb3"
+          }
+        ]
+      }
+    },
+    {
+      "name": "superjson-project",
+      "lines": 1375,
+      "kb": 33,
+      "project_files": 13,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsz error; tsc ok",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:31:14.253Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "yellow",
+        "exit_class": "nonzero exit",
+        "first_failure_class": "relations-assignability",
+        "owner_track": "Track 4 relation diagnostics/compatibility",
+        "phase": "check",
+        "last_successful_phase": null,
+        "diagnostic_status": "diagnostic mismatch or compiler error",
+        "diagnostic_deltas": [
+          "tsz: .target-bench/external/superjson/src/plainer.ts(43,25): error TS2345: Argument of type '(v: T, path: string[]) => void' is not assignable to parameter of type '(v: unknown, path: string[]) => void'.",
+          "tsz:   Types of parameters 'v' and 'v' are incompatible.",
+          "tsz:     Type 'unknown' is not assignable to type 'T'.",
+          "tsz:       'T' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.",
+          "tsz: .target-bench/external/superjson/src/plainer.ts(54,23): error TS2345: Argument of type '(v: T, path: string[]) => void' is not assignable to parameter of type '(v: unknown, path: string[]) => void'.",
+          "tsz:   Types of parameters 'v' and 'v' are incompatible.",
+          "tsz:     Type 'unknown' is not assignable to type 'T'.",
+          "tsz:       'T' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.",
+          "tsz: .target-bench/external/superjson/src/plainer.ts(179,7): error TS2322: Type 'never[]' is not assignable to type 'ReferentialEqualityAnnotations | undefined'.",
+          "tsz: .target-bench/external/superjson/src/plainer.ts(181,7): error TS2322: Type 'never[]' is not assignable to type 'ReferentialEqualityAnnotations | undefined'.",
+          "tsz: .target-bench/external/superjson/src/plainer.ts(216,11): error TS2322: Type '{ transformedValue: any; annotations: TypeAnnotation[]; } | { transformedValue: any; annotations?: undefined; }' is not assignable to type 'Result'.",
+          "tsz:   Type '{ transformedValue: any; annotations: TypeAnnotation[]; }' is not assignable to type 'Result'.",
+          "tsz:     Types of property 'annotations' are incompatible.",
+          "tsz:       Type 'TypeAnnotation[]' is not assignable to type 'MinimisedTree<TypeAnnotation> | undefined'.",
+          "tsz: .target-bench/external/superjson/src/plainer.ts(270,9): error TS2322: Type 'unknown' is not assignable to type 'Tree<TypeAnnotation>'.",
+          "tsz: .target-bench/external/superjson/src/plainer.ts(275,9): error TS2322: Type '{ transformedValue: any; annotations: TypeAnnotation[] | undefined; } | { transformedValue: any; annotations: TypeAnnotation[]; }' is not assignable to type 'Result'.",
+          "tsz:   Types of property 'annotations' are incompatible.",
+          "tsz:     Type 'TypeAnnotation[] | undefined' is not assignable to type 'MinimisedTree<TypeAnnotation> | undefined'.",
+          "tsz: .target-bench/external/superjson/src/transformer.ts(64,10): error TS18046: 'v' is of type 'unknown'.",
+          "tsz: .target-bench/external/superjson/src/transformer.ts(120,15): error TS18046: 'v' is of type 'unknown'."
+        ],
+        "diagnostic_codes": [
+          "TS2345",
+          "TS2322",
+          "TS18046"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "relations-assignability",
+            "codes": [
+              "TS2345",
+              "TS2322"
+            ],
+            "count": 7,
+            "examples": [
+              "tsz: .target-bench/external/superjson/src/plainer.ts(43,25): error TS2345: Argument of type '(v: T, path: string[]) => void' is not assignable to parameter of type '(v: unknown, path: string[]) => void'.",
+              "tsz: .target-bench/external/superjson/src/plainer.ts(54,23): error TS2345: Argument of type '(v: T, path: string[]) => void' is not assignable to parameter of type '(v: unknown, path: string[]) => void'.",
+              "tsz: .target-bench/external/superjson/src/plainer.ts(179,7): error TS2322: Type 'never[]' is not assignable to type 'ReferentialEqualityAnnotations | undefined'."
+            ]
+          },
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 11,
+            "examples": [
+              "tsz:   Types of parameters 'v' and 'v' are incompatible.",
+              "tsz:     Type 'unknown' is not assignable to type 'T'.",
+              "tsz:       'T' could be instantiated with an arbitrary type which could be unrelated to 'unknown'."
+            ]
+          },
+          {
+            "subsystem": "unclassified diagnostic",
+            "codes": [
+              "TS18046"
+            ],
+            "count": 2,
+            "examples": [
+              "tsz: .target-bench/external/superjson/src/transformer.ts(64,10): error TS18046: 'v' is of type 'unknown'.",
+              "tsz: .target-bench/external/superjson/src/transformer.ts(120,15): error TS18046: 'v' is of type 'unknown'."
+            ]
+          }
+        ],
+        "primary_subsystem": "relations-assignability",
+        "reduction_candidates": [
+          "tsz: .target-bench/external/superjson/src/plainer.ts(43,25): error TS2345: Argument of type '(v: T, path: string[]) => void' is not assignable to parameter of type '(v: unknown, path: string[]) => void'.",
+          "tsz: .target-bench/external/superjson/src/plainer.ts(54,23): error TS2345: Argument of type '(v: T, path: string[]) => void' is not assignable to parameter of type '(v: unknown, path: string[]) => void'.",
+          "tsz: .target-bench/external/superjson/src/plainer.ts(179,7): error TS2322: Type 'never[]' is not assignable to type 'ReferentialEqualityAnnotations | undefined'.",
+          "tsz: .target-bench/external/superjson/src/plainer.ts(181,7): error TS2322: Type 'never[]' is not assignable to type 'ReferentialEqualityAnnotations | undefined'.",
+          "tsz: .target-bench/external/superjson/src/plainer.ts(216,11): error TS2322: Type '{ transformedValue: any; annotations: TypeAnnotation[]; } | { transformedValue: any; annotations?: undefined; }' is not assignable to type 'Result'."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "relations-assignability",
+          "uncoded diagnostic",
+          "unclassified diagnostic"
+        ],
+        "reduced_repro_path": ".target-bench/external/superjson/src/plainer.ts",
+        "repro": {
+          "tsconfig_path": "superjson/tsconfig.tsz-bench.json",
+          "source_root": "superjson/src",
+          "first_failure_path": ".target-bench/external/superjson/src/plainer.ts",
+          "first_failure_line": 43,
+          "first_failure_column": 25,
+          "first_failure_code": "TS2345",
+          "reduced_repro_path": ".target-bench/external/superjson/src/plainer.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p superjson/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            1
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "JSON (de)serialization with type metadata; first-blocker = cross-file context-dependent FP cluster (#14344 identity/relation family) in transformer.ts/plainer.ts — fires only on whole-project compile",
+        "files_reached": 13,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "superjson",
+            "repository": "https://github.com/flightcontrolhq/superjson.git",
+            "ref": "aaa65e36e8e31da740265a56b27c965ca1c7b754"
+          }
+        ]
+      }
+    },
+    {
+      "name": "trpc-project",
+      "lines": 10448,
+      "kb": 282,
+      "project_files": 84,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsc fixture error",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:31:16.760Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "gray",
+        "exit_class": "fixture invalid",
+        "first_failure_class": "reference fixture invalid",
+        "owner_track": "Track 1 project-corpus harness/config",
+        "phase": "fixture setup",
+        "last_successful_phase": null,
+        "diagnostic_status": "tsc fixture failed",
+        "diagnostic_deltas": [
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(1,41): error TS2591: Cannot find name 'node:stream'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(2,26): error TS2591: Cannot find name 'node:stream/promises'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(8,8): error TS2307: Cannot find module 'aws-lambda' or its corresponding type declarations.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(89,34): error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'.",
+          "tsc:   Type 'null' is not assignable to type 'string'.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(106,16): error TS2339: Property 'forEach' does not exist on type '{}'.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(106,25): error TS7006: Parameter 'v' implicitly has an 'any' type.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(114,29): error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'.",
+          "tsc:   Type 'null' is not assignable to type 'string'.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(142,28): error TS2304: Cannot find name 'awslambda'.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(175,29): error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'.",
+          "tsc:   Type 'null' is not assignable to type 'string'.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(207,28): error TS2304: Cannot find name 'awslambda'.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/index.ts(10,64): error TS2307: Cannot find module 'aws-lambda' or its corresponding type declarations.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/index.ts(90,17): error TS7006: Parameter 'event' implicitly has an 'any' type.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/index.ts(90,24): error TS7006: Parameter 'responseStream' implicitly has an 'any' type.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/index.ts(90,40): error TS7006: Parameter 'context' implicitly has an 'any' type.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/express.ts(10,31): error TS2307: Cannot find module 'express' or its corresponding type declarations.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/express.ts(28,11): error TS7006: Parameter 'req' implicitly has an 'any' type.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/express.ts(28,16): error TS7006: Parameter 'res' implicitly has an 'any' type."
+        ],
+        "diagnostic_codes": [
+          "TS2591",
+          "TS2307",
+          "TS2345",
+          "TS2339",
+          "TS7006",
+          "TS2304"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "unclassified diagnostic",
+            "codes": [
+              "TS2591"
+            ],
+            "count": 2,
+            "examples": [
+              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(1,41): error TS2591: Cannot find name 'node:stream'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
+              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(2,26): error TS2591: Cannot find name 'node:stream/promises'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig."
+            ]
+          },
+          {
+            "subsystem": "module-symbol-resolution",
+            "codes": [
+              "TS2307",
+              "TS2304"
+            ],
+            "count": 5,
+            "examples": [
+              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(8,8): error TS2307: Cannot find module 'aws-lambda' or its corresponding type declarations.",
+              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(142,28): error TS2304: Cannot find name 'awslambda'.",
+              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(207,28): error TS2304: Cannot find name 'awslambda'."
+            ]
+          },
+          {
+            "subsystem": "relations-assignability",
+            "codes": [
+              "TS2345"
+            ],
+            "count": 3,
+            "examples": [
+              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(89,34): error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'.",
+              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(114,29): error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'.",
+              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(175,29): error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'."
+            ]
+          },
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 3,
+            "examples": [
+              "tsc:   Type 'null' is not assignable to type 'string'.",
+              "tsc:   Type 'null' is not assignable to type 'string'.",
+              "tsc:   Type 'null' is not assignable to type 'string'."
+            ]
+          },
+          {
+            "subsystem": "keyspace-property-indexed",
+            "codes": [
+              "TS2339"
+            ],
+            "count": 1,
+            "examples": [
+              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(106,16): error TS2339: Property 'forEach' does not exist on type '{}'."
+            ]
+          },
+          {
+            "subsystem": "contextual-inference",
+            "codes": [
+              "TS7006"
+            ],
+            "count": 6,
+            "examples": [
+              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(106,25): error TS7006: Parameter 'v' implicitly has an 'any' type.",
+              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/index.ts(90,17): error TS7006: Parameter 'event' implicitly has an 'any' type.",
+              "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/index.ts(90,24): error TS7006: Parameter 'responseStream' implicitly has an 'any' type."
+            ]
+          }
+        ],
+        "primary_subsystem": "unclassified diagnostic",
+        "reduction_candidates": [
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(1,41): error TS2591: Cannot find name 'node:stream'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(2,26): error TS2591: Cannot find name 'node:stream/promises'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(8,8): error TS2307: Cannot find module 'aws-lambda' or its corresponding type declarations.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(89,34): error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'.",
+          "tsc: .target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts(106,16): error TS2339: Property 'forEach' does not exist on type '{}'."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "reference fixture invalid",
+          "fixture setup phase blocker",
+          "unclassified diagnostic",
+          "module-symbol-resolution",
+          "relations-assignability",
+          "uncoded diagnostic",
+          "keyspace-property-indexed",
+          "contextual-inference"
+        ],
+        "reduced_repro_path": ".target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts",
+        "repro": {
+          "tsconfig_path": "trpc/tsconfig.tsz-bench.json",
+          "source_root": "trpc/packages/server/src",
+          "first_failure_path": ".target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts",
+          "first_failure_line": 1,
+          "first_failure_column": 41,
+          "first_failure_code": "TS2591",
+          "reduced_repro_path": ".target-bench/external/trpc/packages/server/src/adapters/aws-lambda/getPlanner.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p trpc/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            1
+          ],
+          "tsz": [],
+          "tsgo": []
+        },
+        "semantic_owner_family": "end-to-end inference: recursive router builders, deep generic procedure chaining, input/output type propagation",
+        "files_reached": 84,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "trpc",
+            "repository": "https://github.com/trpc/trpc.git",
+            "ref": "f8f0c0e3979ecb980d38e9369fa8c98df95d212b"
+          }
+        ]
+      }
+    },
+    {
+      "name": "tanstack-router-project",
+      "lines": 16724,
+      "kb": 475,
+      "project_files": 64,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsz timeout; tsc ok",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:33:22.644Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "red",
+        "exit_class": "timeout",
+        "first_failure_class": "timeout during project check",
+        "owner_track": "Track 1 runtime/timeout triage",
+        "phase": "check",
+        "last_successful_phase": null,
+        "diagnostic_status": "compiler timed out",
+        "diagnostic_deltas": [
+          "tsz timed out after 120s"
+        ],
+        "diagnostic_codes": [],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 1,
+            "examples": [
+              "tsz timed out after 120s"
+            ]
+          }
+        ],
+        "primary_subsystem": "uncoded diagnostic",
+        "reduction_candidates": [
+          "tsz timed out after 120s"
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "timeout during project check",
+          "uncoded diagnostic"
+        ],
+        "reduced_repro_path": "tanstack-router/packages/router-core/src",
+        "repro": {
+          "tsconfig_path": "tanstack-router/tsconfig.tsz-bench.json",
+          "source_root": "tanstack-router/packages/router-core/src",
+          "first_failure_path": null,
+          "first_failure_line": null,
+          "first_failure_column": null,
+          "first_failure_code": null,
+          "reduced_repro_path": "tanstack-router/packages/router-core/src",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p tanstack-router/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            124
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "template-literal route path parsing, nested route-tree generics, search-param inference",
+        "files_reached": 64,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "tanstack-router",
+            "repository": "https://github.com/TanStack/router.git",
+            "ref": "36ed57409a98878e5c1a7aabf50d3aa65ebde1e0"
+          }
+        ]
+      }
+    },
+    {
+      "name": "io-ts-project",
+      "lines": 6202,
+      "kb": 152,
+      "project_files": 16,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsc fixture error",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:33:23.835Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "gray",
+        "exit_class": "fixture invalid",
+        "first_failure_class": "reference fixture invalid",
+        "owner_track": "Track 1 project-corpus harness/config",
+        "phase": "fixture setup",
+        "last_successful_phase": null,
+        "diagnostic_status": "tsc fixture failed",
+        "diagnostic_deltas": [
+          "tsc: .target-bench/external/io-ts/src/Codec.ts(11,10): error TS2305: Module '\"fp-ts/lib/function\"' has no exported member 'identity'.",
+          "tsc: .target-bench/external/io-ts/src/Codec.ts(11,20): error TS2305: Module '\"fp-ts/lib/function\"' has no exported member 'Refinement'.",
+          "tsc: .target-bench/external/io-ts/src/Codec.ts(12,10): error TS2305: Module '\"fp-ts/lib/function\"' has no exported member 'Invariant3'.",
+          "tsc: .target-bench/external/io-ts/src/Codec.ts(13,10): error TS2305: Module '\"fp-ts/lib/function\"' has no exported member 'pipe'.",
+          "tsc: .target-bench/external/io-ts/src/Codec.ts(328,41): error TS7006: Parameter 'fa' implicitly has an 'any' type.",
+          "tsc: .target-bench/external/io-ts/src/Codec.ts(328,45): error TS7006: Parameter 'f' implicitly has an 'any' type.",
+          "tsc: .target-bench/external/io-ts/src/Codec.ts(328,48): error TS7006: Parameter 'g' implicitly has an 'any' type.",
+          "tsc: .target-bench/external/io-ts/src/Codec.ts(358,16): error TS2671: Cannot augment module 'fp-ts/lib/HKT' because it resolves to a non-module entity.",
+          "tsc: .target-bench/external/io-ts/src/DecodeError.ts(11,10): error TS2305: Module '\"fp-ts/lib/Semigroup\"' has no exported member 'Semigroup'.",
+          "tsc: .target-bench/external/io-ts/src/Decoder.ts(11,10): error TS2305: Module '\"fp-ts/lib/Alt\"' has no exported member 'Alt2'.",
+          "tsc: .target-bench/external/io-ts/src/Decoder.ts(11,16): error TS2305: Module '\"fp-ts/lib/Alt\"' has no exported member 'Alt2C'.",
+          "tsc: .target-bench/external/io-ts/src/Decoder.ts(12,10): error TS2305: Module '\"fp-ts/lib/Alt\"' has no exported member 'Bifunctor2'.",
+          "tsc: .target-bench/external/io-ts/src/Decoder.ts(13,10): error TS2305: Module '\"fp-ts/lib/Alt\"' has no exported member 'Category2'.",
+          "tsc: .target-bench/external/io-ts/src/Decoder.ts(15,10): error TS2305: Module '\"fp-ts/lib/Alt\"' has no exported member 'identity'.",
+          "tsc: .target-bench/external/io-ts/src/Decoder.ts(15,20): error TS2305: Module '\"fp-ts/lib/Alt\"' has no exported member 'Refinement'.",
+          "tsc: .target-bench/external/io-ts/src/Decoder.ts(16,10): error TS2305: Module '\"fp-ts/lib/Alt\"' has no exported member 'Functor2'.",
+          "tsc: .target-bench/external/io-ts/src/Decoder.ts(17,10): error TS2305: Module '\"fp-ts/lib/Alt\"' has no exported member 'MonadThrow2C'.",
+          "tsc: .target-bench/external/io-ts/src/Decoder.ts(18,10): error TS2305: Module '\"fp-ts/lib/Alt\"' has no exported member 'pipe'.",
+          "tsc: .target-bench/external/io-ts/src/Decoder.ts(41,8): error TS2503: Cannot find namespace 'E'.",
+          "tsc: .target-bench/external/io-ts/src/Decoder.ts(42,7): error TS2503: Cannot find namespace 'E'."
+        ],
+        "diagnostic_codes": [
+          "TS2305",
+          "TS7006",
+          "TS2671",
+          "TS2503"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "module-symbol-resolution",
+            "codes": [
+              "TS2305",
+              "TS2503"
+            ],
+            "count": 16,
+            "examples": [
+              "tsc: .target-bench/external/io-ts/src/Codec.ts(11,10): error TS2305: Module '\"fp-ts/lib/function\"' has no exported member 'identity'.",
+              "tsc: .target-bench/external/io-ts/src/Codec.ts(11,20): error TS2305: Module '\"fp-ts/lib/function\"' has no exported member 'Refinement'.",
+              "tsc: .target-bench/external/io-ts/src/Codec.ts(12,10): error TS2305: Module '\"fp-ts/lib/function\"' has no exported member 'Invariant3'."
+            ]
+          },
+          {
+            "subsystem": "contextual-inference",
+            "codes": [
+              "TS7006"
+            ],
+            "count": 3,
+            "examples": [
+              "tsc: .target-bench/external/io-ts/src/Codec.ts(328,41): error TS7006: Parameter 'fa' implicitly has an 'any' type.",
+              "tsc: .target-bench/external/io-ts/src/Codec.ts(328,45): error TS7006: Parameter 'f' implicitly has an 'any' type.",
+              "tsc: .target-bench/external/io-ts/src/Codec.ts(328,48): error TS7006: Parameter 'g' implicitly has an 'any' type."
+            ]
+          },
+          {
+            "subsystem": "unclassified diagnostic",
+            "codes": [
+              "TS2671"
+            ],
+            "count": 1,
+            "examples": [
+              "tsc: .target-bench/external/io-ts/src/Codec.ts(358,16): error TS2671: Cannot augment module 'fp-ts/lib/HKT' because it resolves to a non-module entity."
+            ]
+          }
+        ],
+        "primary_subsystem": "module-symbol-resolution",
+        "reduction_candidates": [
+          "tsc: .target-bench/external/io-ts/src/Codec.ts(11,10): error TS2305: Module '\"fp-ts/lib/function\"' has no exported member 'identity'.",
+          "tsc: .target-bench/external/io-ts/src/Codec.ts(11,20): error TS2305: Module '\"fp-ts/lib/function\"' has no exported member 'Refinement'.",
+          "tsc: .target-bench/external/io-ts/src/Codec.ts(12,10): error TS2305: Module '\"fp-ts/lib/function\"' has no exported member 'Invariant3'.",
+          "tsc: .target-bench/external/io-ts/src/Codec.ts(13,10): error TS2305: Module '\"fp-ts/lib/function\"' has no exported member 'pipe'.",
+          "tsc: .target-bench/external/io-ts/src/Codec.ts(328,41): error TS7006: Parameter 'fa' implicitly has an 'any' type."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "reference fixture invalid",
+          "fixture setup phase blocker",
+          "module-symbol-resolution",
+          "contextual-inference",
+          "unclassified diagnostic"
+        ],
+        "reduced_repro_path": ".target-bench/external/io-ts/src/Codec.ts",
+        "repro": {
+          "tsconfig_path": "io-ts/tsconfig.tsz-bench.json",
+          "source_root": "io-ts/src",
+          "first_failure_path": ".target-bench/external/io-ts/src/Codec.ts",
+          "first_failure_line": 11,
+          "first_failure_column": 10,
+          "first_failure_code": "TS2305",
+          "reduced_repro_path": ".target-bench/external/io-ts/src/Codec.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p io-ts/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            1
+          ],
+          "tsz": [],
+          "tsgo": []
+        },
+        "semantic_owner_family": "codec generics, recursive/branded runtime type definitions, decode-result inference",
+        "files_reached": 16,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "io-ts",
+            "repository": "https://github.com/gcanti/io-ts.git",
+            "ref": "864a3a2f03c5d7b974afeb1da0faf46c21758779"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ts-morph-project",
+      "lines": 40205,
+      "kb": 1473,
+      "project_files": 686,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsc fixture error",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:33:28.384Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "gray",
+        "exit_class": "fixture invalid",
+        "first_failure_class": "reference fixture invalid",
+        "owner_track": "Track 1 project-corpus harness/config",
+        "phase": "fixture setup",
+        "last_successful_phase": null,
+        "diagnostic_status": "tsc fixture failed",
+        "diagnostic_deltas": [
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(62,71): error TS2344: Type 'AssertionKey' does not satisfy the constraint 'Node<Node>'.",
+          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(72,71): error TS2344: Type 'PropertyName' does not satisfy the constraint 'Node<Node>'.",
+          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(75,69): error TS2344: Type 'ModuleName' does not satisfy the constraint 'Node<Node>'.",
+          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(84,70): error TS2344: Type 'BindingName' does not satisfy the constraint 'Node<Node>'.",
+          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(96,79): error TS2344: Type 'EntityNameExpression' does not satisfy the constraint 'Node<Node>'.",
+          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(107,74): error TS2344: Type 'DeclarationName' does not satisfy the constraint 'Node<Node>'.",
+          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(110,69): error TS2344: Type 'EntityName' does not satisfy the constraint 'Node<Node>'.",
+          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(113,67): error TS2344: Type 'JsxChild' does not satisfy the constraint 'Node<Node>'.",
+          "tsc:   Type 'JsxExpression' is missing the following properties from type 'Node<Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(116,75): error TS2344: Type 'JsxAttributeName' does not satisfy the constraint 'Node<Node>'.",
+          "tsc:   Type 'Identifier' is missing the following properties from type 'Node<Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(131,18): error TS2430: Interface 'JsxTagNamePropertyAccess' incorrectly extends interface 'PropertyAccessExpression<PropertyAccessExpression>'.",
+          "tsc:   The types returned by 'getExpression()' are incompatible between these types."
+        ],
+        "diagnostic_codes": [
+          "TS2344",
+          "TS2430"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "evaluation-inference-instantiation",
+            "codes": [
+              "TS2344"
+            ],
+            "count": 9,
+            "examples": [
+              "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(62,71): error TS2344: Type 'AssertionKey' does not satisfy the constraint 'Node<Node>'.",
+              "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(72,71): error TS2344: Type 'PropertyName' does not satisfy the constraint 'Node<Node>'.",
+              "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(75,69): error TS2344: Type 'ModuleName' does not satisfy the constraint 'Node<Node>'."
+            ]
+          },
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 10,
+            "examples": [
+              "tsc:   Type 'Identifier' is missing the following properties from type 'Node<Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
+              "tsc:   Type 'Identifier' is missing the following properties from type 'Node<Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more.",
+              "tsc:   Type 'Identifier' is missing the following properties from type 'Node<Node>': #compilerNode, #forgottenText, #childStringRanges, #leadingCommentRanges, and 157 more."
+            ]
+          },
+          {
+            "subsystem": "relations-assignability",
+            "codes": [
+              "TS2430"
+            ],
+            "count": 1,
+            "examples": [
+              "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(131,18): error TS2430: Interface 'JsxTagNamePropertyAccess' incorrectly extends interface 'PropertyAccessExpression<PropertyAccessExpression>'."
+            ]
+          }
+        ],
+        "primary_subsystem": "evaluation-inference-instantiation",
+        "reduction_candidates": [
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(62,71): error TS2344: Type 'AssertionKey' does not satisfy the constraint 'Node<Node>'.",
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(72,71): error TS2344: Type 'PropertyName' does not satisfy the constraint 'Node<Node>'.",
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(75,69): error TS2344: Type 'ModuleName' does not satisfy the constraint 'Node<Node>'.",
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(84,70): error TS2344: Type 'BindingName' does not satisfy the constraint 'Node<Node>'.",
+          "tsc: .target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts(96,79): error TS2344: Type 'EntityNameExpression' does not satisfy the constraint 'Node<Node>'."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "reference fixture invalid",
+          "fixture setup phase blocker",
+          "evaluation-inference-instantiation",
+          "uncoded diagnostic",
+          "relations-assignability"
+        ],
+        "reduced_repro_path": ".target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts",
+        "repro": {
+          "tsconfig_path": "ts-morph/tsconfig.tsz-bench.json",
+          "source_root": "ts-morph/packages/ts-morph/src",
+          "first_failure_path": ".target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts",
+          "first_failure_line": 62,
+          "first_failure_column": 71,
+          "first_failure_code": "TS2344",
+          "reduced_repro_path": ".target-bench/external/ts-morph/packages/ts-morph/src/compiler/ast/aliases.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p ts-morph/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            1
+          ],
+          "tsz": [],
+          "tsgo": []
+        },
+        "semantic_owner_family": "large AST wrapper class hierarchy, compiler-API generic surface, declaration-heavy graph",
+        "files_reached": 686,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "ts-morph",
+            "repository": "https://github.com/dsherret/ts-morph.git",
+            "ref": "699815f54ae9b5c2a93f016ba1a9df1e8ac1c014"
+          }
+        ]
+      }
+    },
+    {
+      "name": "arktype-project",
+      "lines": 29789,
+      "kb": 804,
+      "project_files": 142,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsz timeout; tsc ok",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:35:31.235Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "red",
+        "exit_class": "timeout",
+        "first_failure_class": "timeout during project check",
+        "owner_track": "Track 1 runtime/timeout triage",
+        "phase": "check",
+        "last_successful_phase": null,
+        "diagnostic_status": "compiler timed out",
+        "diagnostic_deltas": [
+          "tsz timed out after 120s"
+        ],
+        "diagnostic_codes": [],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 1,
+            "examples": [
+              "tsz timed out after 120s"
+            ]
+          }
+        ],
+        "primary_subsystem": "uncoded diagnostic",
+        "reduction_candidates": [
+          "tsz timed out after 120s"
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "timeout during project check",
+          "uncoded diagnostic"
+        ],
+        "reduced_repro_path": "arktype/ark/type",
+        "repro": {
+          "tsconfig_path": "arktype/tsconfig.tsz-bench.json",
+          "source_root": "arktype/ark/type",
+          "first_failure_path": null,
+          "first_failure_line": null,
+          "first_failure_column": null,
+          "first_failure_code": null,
+          "reduced_repro_path": "arktype/ark/type",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p arktype/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            124
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "type-level string parser, recursive schema inference, extreme conditional/template evaluation",
+        "files_reached": 142,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "arktype",
+            "repository": "https://github.com/arktypeio/arktype.git",
+            "ref": "d075962caee162bb28e241723863e8f11cb58390"
+          }
+        ]
+      }
+    },
+    {
+      "name": "runtypes-project",
+      "lines": 3437,
+      "kb": 111,
+      "project_files": 54,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsz error; tsc ok",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:35:59.810Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "yellow",
+        "exit_class": "nonzero exit",
+        "first_failure_class": "keyspace-property-indexed",
+        "owner_track": "Track 5 keyspace/property/indexed access",
+        "phase": "check",
+        "last_successful_phase": null,
+        "diagnostic_status": "diagnostic mismatch or compiler error",
+        "diagnostic_deltas": [
+          "tsz: .target-bench/external/runtypes/src/Array.ts(44,76): error TS2353: Object literal may only specify known properties, and 'expected' does not exist in type '{ [K in keyof { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } | keyof { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ...)[K]; }]: ({ [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } & { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ...)[K]; })[K]; }'.",
+          "tsz: .target-bench/external/runtypes/src/Array.ts(47,47): error TS7006: Parameter 'key' implicitly has an 'any' type.",
+          "tsz: .target-bench/external/runtypes/src/Array.ts(58,39): error TS2353: Object literal may only specify known properties, and 'expected' does not exist in type '{ [K in keyof { [K in keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } | keyof { [K in keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ...)[K]; }]: ({ [K in keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } & { [K in keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ...)[K]; })[K]; }'.",
+          "tsz: .target-bench/external/runtypes/src/BigInt.ts(16,7): error TS2322: Type 'R' is not assignable to type 'BigInt'.",
+          "tsz:   Types of property 'tag' are incompatible.",
+          "tsz:     Type 'string' is not assignable to type '\"bigint\"'.",
+          "tsz: .target-bench/external/runtypes/src/BigInt.ts(16,39): error TS2739: Type 'BigInt' is missing the following properties from type 'Runtype<any, any>': create, assertIsRuntype, #createInnerValidate, prototype, isRuntype",
+          "tsz: .target-bench/external/runtypes/src/BigInt.ts(20,31): error TS2353: Object literal may only specify known properties, and 'expected' does not exist in type '{ [K in keyof { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } | keyof { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ...)[K]; }]: ({ [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } & { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ...)[K]; })[K]; }'.",
+          "tsz: .target-bench/external/runtypes/src/Boolean.ts(16,7): error TS2322: Type 'R' is not assignable to type 'Boolean'.",
+          "tsz:   Types of property 'tag' are incompatible.",
+          "tsz:     Type 'string' is not assignable to type '\"boolean\"'.",
+          "tsz: .target-bench/external/runtypes/src/Boolean.ts(16,41): error TS2344: Type 'Boolean' does not satisfy the constraint 'Runtype<any, any>'.",
+          "tsz: .target-bench/external/runtypes/src/Boolean.ts(20,31): error TS2353: Object literal may only specify known properties, and 'expected' does not exist in type '{ [K in keyof { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } | keyof { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ...)[K]; }]: ({ [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } & { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ...)[K]; })[K]; }'.",
+          "tsz: .target-bench/external/runtypes/src/Brand.ts(46,3): error TS2345: Argument of type '({ received, innerValidate, expected, parsing }: { expected: Brand<B, R>; received: unknown; parsing: boolean; } & { innerValidate: InnerValidate; memoParsed?: WeakMap<object, object> | undefined; }) => default<any>' is not assignable to parameter of type '(context: { expected: Brand<B, R>; received: unknown; parsing: boolean; } & { innerValidate: InnerValidate; memoParsed?: WeakMap<object, object> | undefined; }) => Result<Parsed<Brand<B, R>> | Static<Brand<B, R>>>'.",
+          "tsz:   Types of parameters '{ received, innerValidate, expected, parsing }' and 'context' are incompatible.",
+          "tsz:     Type '{ expected: Brand<B, R>; received: unknown; parsing: boolean; } & { innerValidate: InnerValidate; memoParsed?: WeakMap<object, object> | undefined; }' is not assignable to type '{ expected: Brand; received: unknown; parsing: boolean; } & { innerValidate: InnerValidate; memoParsed?: WeakMap<object, object> | undefined; }'.",
+          "tsz:       Types of property 'expected' are incompatible.",
+          "tsz:         Type 'Brand<B, R>' is missing the following properties from type 'Brand': create, assertIsRuntype, #createInnerValidate, prototype, isRuntype",
+          "tsz: .target-bench/external/runtypes/src/Constraint.ts(33,40): error TS2353: Object literal may only specify known properties, and 'expected' does not exist in type '{ [K in keyof { [K in keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } | keyof { [K in keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ...)[K]; }]: ({ [K in keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } & { [K in keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONSTRAINT_FAILED\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ...)[K]; })[K]; }'.",
+          "tsz: .target-bench/external/runtypes/src/Constraint.ts(33,60): error TS2322: Type 'unknown' is not assignable to type 'undefined'."
+        ],
+        "diagnostic_codes": [
+          "TS2353",
+          "TS7006",
+          "TS2322",
+          "TS2739",
+          "TS2344",
+          "TS2345"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "keyspace-property-indexed",
+            "codes": [
+              "TS2353"
+            ],
+            "count": 5,
+            "examples": [
+              "tsz: .target-bench/external/runtypes/src/Array.ts(44,76): error TS2353: Object literal may only specify known properties, and 'expected' does not exist in type '{ [K in keyof { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } | keyof { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ...)[K]; }]: ({ [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } & { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ...)[K]; })[K]; }'.",
+              "tsz: .target-bench/external/runtypes/src/Array.ts(58,39): error TS2353: Object literal may only specify known properties, and 'expected' does not exist in type '{ [K in keyof { [K in keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } | keyof { [K in keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ...)[K]; }]: ({ [K in keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } & { [K in keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ...)[K]; })[K]; }'.",
+              "tsz: .target-bench/external/runtypes/src/BigInt.ts(20,31): error TS2353: Object literal may only specify known properties, and 'expected' does not exist in type '{ [K in keyof { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } | keyof { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ...)[K]; }]: ({ [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } & { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ...)[K]; })[K]; }'."
+            ]
+          },
+          {
+            "subsystem": "contextual-inference",
+            "codes": [
+              "TS7006"
+            ],
+            "count": 1,
+            "examples": [
+              "tsz: .target-bench/external/runtypes/src/Array.ts(47,47): error TS7006: Parameter 'key' implicitly has an 'any' type."
+            ]
+          },
+          {
+            "subsystem": "relations-assignability",
+            "codes": [
+              "TS2322",
+              "TS2345"
+            ],
+            "count": 4,
+            "examples": [
+              "tsz: .target-bench/external/runtypes/src/BigInt.ts(16,7): error TS2322: Type 'R' is not assignable to type 'BigInt'.",
+              "tsz: .target-bench/external/runtypes/src/Boolean.ts(16,7): error TS2322: Type 'R' is not assignable to type 'Boolean'.",
+              "tsz: .target-bench/external/runtypes/src/Brand.ts(46,3): error TS2345: Argument of type '({ received, innerValidate, expected, parsing }: { expected: Brand<B, R>; received: unknown; parsing: boolean; } & { innerValidate: InnerValidate; memoParsed?: WeakMap<object, object> | undefined; }) => default<any>' is not assignable to parameter of type '(context: { expected: Brand<B, R>; received: unknown; parsing: boolean; } & { innerValidate: InnerValidate; memoParsed?: WeakMap<object, object> | undefined; }) => Result<Parsed<Brand<B, R>> | Static<Brand<B, R>>>'."
+            ]
+          },
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 8,
+            "examples": [
+              "tsz:   Types of property 'tag' are incompatible.",
+              "tsz:     Type 'string' is not assignable to type '\"bigint\"'.",
+              "tsz:   Types of property 'tag' are incompatible."
+            ]
+          },
+          {
+            "subsystem": "unclassified diagnostic",
+            "codes": [
+              "TS2739"
+            ],
+            "count": 1,
+            "examples": [
+              "tsz: .target-bench/external/runtypes/src/BigInt.ts(16,39): error TS2739: Type 'BigInt' is missing the following properties from type 'Runtype<any, any>': create, assertIsRuntype, #createInnerValidate, prototype, isRuntype"
+            ]
+          },
+          {
+            "subsystem": "evaluation-inference-instantiation",
+            "codes": [
+              "TS2344"
+            ],
+            "count": 1,
+            "examples": [
+              "tsz: .target-bench/external/runtypes/src/Boolean.ts(16,41): error TS2344: Type 'Boolean' does not satisfy the constraint 'Runtype<any, any>'."
+            ]
+          }
+        ],
+        "primary_subsystem": "keyspace-property-indexed",
+        "reduction_candidates": [
+          "tsz: .target-bench/external/runtypes/src/Array.ts(44,76): error TS2353: Object literal may only specify known properties, and 'expected' does not exist in type '{ [K in keyof { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } | keyof { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ...)[K]; }]: ({ [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } & { [K in keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"TYPE_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ...)[K]; })[K]; }'.",
+          "tsz: .target-bench/external/runtypes/src/Array.ts(47,47): error TS7006: Parameter 'key' implicitly has an 'any' type.",
+          "tsz: .target-bench/external/runtypes/src/Array.ts(58,39): error TS2353: Object literal may only specify known properties, and 'expected' does not exist in type '{ [K in keyof { [K in keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } | keyof { [K in keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof Pick<..., ...> | keyof { code: ...; }]: (... & ... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof Pick<..., ...> | keyof { code: ...; }]: (... & { ...; })[K]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) | ...)[K]; }]: ({ [K in keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"expected\" ? K : never]: Core<any, any>; } & { [K in keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) & keyof ({ code: \"CONTENT_INCORRECT\"; } & { [K in keyof ... | keyof { ...; }]: ...[...]; }) as K extends \"code\" | \"expected\" | \"message\" | \"success\" ? never : K]: (({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ({ code: ...; } & { [K in ...]: ...; }) | ...)[K]; })[K]; }'.",
+          "tsz: .target-bench/external/runtypes/src/BigInt.ts(16,7): error TS2322: Type 'R' is not assignable to type 'BigInt'.",
+          "tsz: .target-bench/external/runtypes/src/BigInt.ts(16,39): error TS2739: Type 'BigInt' is missing the following properties from type 'Runtype<any, any>': create, assertIsRuntype, #createInnerValidate, prototype, isRuntype"
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "keyspace-property-indexed",
+          "contextual-inference",
+          "relations-assignability",
+          "uncoded diagnostic",
+          "unclassified diagnostic",
+          "evaluation-inference-instantiation"
+        ],
+        "reduced_repro_path": ".target-bench/external/runtypes/src/Array.ts",
+        "repro": {
+          "tsconfig_path": "runtypes/tsconfig.tsz-bench.json",
+          "source_root": "runtypes/src",
+          "first_failure_path": ".target-bench/external/runtypes/src/Array.ts",
+          "first_failure_line": 44,
+          "first_failure_column": 76,
+          "first_failure_code": "TS2353",
+          "reduced_repro_path": ".target-bench/external/runtypes/src/Array.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p runtypes/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            1
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "runtime type combinator generics, static type extraction, recursive records",
+        "files_reached": 54,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "runtypes",
+            "repository": "https://github.com/runtypes/runtypes.git",
+            "ref": "16d83ca56a54569e4a2375a965567b31191c0035"
+          }
+        ]
+      }
+    },
+    {
+      "name": "class-transformer-project",
+      "lines": 1773,
+      "kb": 64,
+      "project_files": 36,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsz error; tsc ok",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:36:01.069Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "yellow",
+        "exit_class": "nonzero exit",
+        "first_failure_class": "relations-assignability",
+        "owner_track": "Track 4 relation diagnostics/compatibility",
+        "phase": "check",
+        "last_successful_phase": null,
+        "diagnostic_status": "diagnostic mismatch or compiler error",
+        "diagnostic_deltas": [
+          "tsz: .target-bench/external/class-transformer/src/ClassTransformer.ts(137,48): error TS2769: No overload matches this call.",
+          "tsz:   The last overload gave the following error.",
+          "tsz:     Argument of type 'T | T[]' is not assignable to parameter of type 'Record<string, any>[]'.",
+          "tsz:       Type 'T[]' is not assignable to type 'Record<string, any>[]'.",
+          "tsz: .target-bench/external/class-transformer/src/ClassTransformer.ts(145,5): error TS2322: Type 'Record<string, any>[]' is not assignable to type 'T'.",
+          "tsz:   'T' could be instantiated with an arbitrary type which could be unrelated to 'Record<string, any>[]'.",
+          "tsz: .target-bench/external/class-transformer/src/ClassTransformer.ts(145,33): error TS2769: No overload matches this call.",
+          "tsz:   The last overload gave the following error.",
+          "tsz:     Argument of type 'ClassConstructor<T>' is not assignable to parameter of type 'ClassConstructor<Record<string, any>>'.",
+          "tsz: .target-bench/external/class-transformer/src/ClassTransformer.ts(153,5): error TS2322: Type 'Record<string, any>[]' is not assignable to type 'T[]'.",
+          "tsz:   Type 'Record<string, any>' is not assignable to type 'T'.",
+          "tsz:     'T' could be instantiated with an arbitrary type which could be unrelated to 'Record<string, any>'.",
+          "tsz: .target-bench/external/class-transformer/src/ClassTransformer.ts(153,33): error TS2769: No overload matches this call.",
+          "tsz:   The last overload gave the following error.",
+          "tsz:     Argument of type 'ClassConstructor<T>' is not assignable to parameter of type 'ClassConstructor<Record<string, any>>'.",
+          "tsz: .target-bench/external/class-transformer/src/MetadataStorage.ts(229,47): error TS2488: Type 'T[] | undefined' must have a '[Symbol.iterator]()' method that returns an iterator.",
+          "tsz: .target-bench/external/class-transformer/src/index.ts(23,43): error TS2769: No overload matches this call.",
+          "tsz:   The last overload gave the following error.",
+          "tsz:     Argument of type 'T | T[]' is not assignable to parameter of type 'Record<string, any>[]'.",
+          "tsz:       Type 'T[]' is not assignable to type 'Record<string, any>[]'."
+        ],
+        "diagnostic_codes": [
+          "TS2769",
+          "TS2322",
+          "TS2488"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "relations-assignability",
+            "codes": [
+              "TS2769",
+              "TS2322"
+            ],
+            "count": 6,
+            "examples": [
+              "tsz: .target-bench/external/class-transformer/src/ClassTransformer.ts(137,48): error TS2769: No overload matches this call.",
+              "tsz: .target-bench/external/class-transformer/src/ClassTransformer.ts(145,5): error TS2322: Type 'Record<string, any>[]' is not assignable to type 'T'.",
+              "tsz: .target-bench/external/class-transformer/src/ClassTransformer.ts(145,33): error TS2769: No overload matches this call."
+            ]
+          },
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 13,
+            "examples": [
+              "tsz:   The last overload gave the following error.",
+              "tsz:     Argument of type 'T | T[]' is not assignable to parameter of type 'Record<string, any>[]'.",
+              "tsz:       Type 'T[]' is not assignable to type 'Record<string, any>[]'."
+            ]
+          },
+          {
+            "subsystem": "unclassified diagnostic",
+            "codes": [
+              "TS2488"
+            ],
+            "count": 1,
+            "examples": [
+              "tsz: .target-bench/external/class-transformer/src/MetadataStorage.ts(229,47): error TS2488: Type 'T[] | undefined' must have a '[Symbol.iterator]()' method that returns an iterator."
+            ]
+          }
+        ],
+        "primary_subsystem": "relations-assignability",
+        "reduction_candidates": [
+          "tsz: .target-bench/external/class-transformer/src/ClassTransformer.ts(137,48): error TS2769: No overload matches this call.",
+          "tsz: .target-bench/external/class-transformer/src/ClassTransformer.ts(145,5): error TS2322: Type 'Record<string, any>[]' is not assignable to type 'T'.",
+          "tsz: .target-bench/external/class-transformer/src/ClassTransformer.ts(145,33): error TS2769: No overload matches this call.",
+          "tsz: .target-bench/external/class-transformer/src/ClassTransformer.ts(153,5): error TS2322: Type 'Record<string, any>[]' is not assignable to type 'T[]'.",
+          "tsz: .target-bench/external/class-transformer/src/ClassTransformer.ts(153,33): error TS2769: No overload matches this call."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "relations-assignability",
+          "uncoded diagnostic",
+          "unclassified diagnostic"
+        ],
+        "reduced_repro_path": ".target-bench/external/class-transformer/src/ClassTransformer.ts",
+        "repro": {
+          "tsconfig_path": "class-transformer/tsconfig.tsz-bench.json",
+          "source_root": "class-transformer/src",
+          "first_failure_path": ".target-bench/external/class-transformer/src/ClassTransformer.ts",
+          "first_failure_line": 137,
+          "first_failure_column": 48,
+          "first_failure_code": "TS2769",
+          "reduced_repro_path": ".target-bench/external/class-transformer/src/ClassTransformer.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p class-transformer/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            1
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "decorator metadata typing, class transform generics",
+        "files_reached": 36,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "class-transformer",
+            "repository": "https://github.com/typestack/class-transformer.git",
+            "ref": "a2734a5d154c9b0beb9a10555a04416bc371de06"
+          }
+        ]
+      }
+    },
+    {
+      "name": "type-graphql-project",
+      "lines": 5394,
+      "kb": 177,
+      "project_files": 117,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsz error; tsc ok",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:36:04.239Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "yellow",
+        "exit_class": "nonzero exit",
+        "first_failure_class": "relations-assignability",
+        "owner_track": "Track 4 relation diagnostics/compatibility",
+        "phase": "check",
+        "last_successful_phase": null,
+        "diagnostic_status": "diagnostic mismatch or compiler error",
+        "diagnostic_deltas": [
+          "tsz: .target-bench/external/type-graphql/src/decorators/Arg.ts(39,23): error TS2345: Argument of type '{ prototype: Object; propertyKey: string | symbol; parameterIndex: number; returnTypeFunc: ((returns?: void) => (RecursiveArray<... | Function> | symbol | object | Function | ClassType | GraphQLScalarType)[] | TypeValue) | undefined; options: Partial<DecoratorTypeOptions & DescriptionOptions & ValidateOptions & DeprecationOptions>; argName: string; }' is not assignable to parameter of type 'ParamInfo'.",
+          "tsz:   Types of property 'options' are incompatible.",
+          "tsz:     Type 'Partial<DecoratorTypeOptions & DescriptionOptions & ValidateOptions & DeprecationOptions>' is not assignable to type '(TypeOptions & ValidateOptions) | undefined'.",
+          "tsz: .target-bench/external/type-graphql/src/decorators/Args.ts(21,23): error TS2345: Argument of type '{ prototype: Object; propertyKey: string | symbol; parameterIndex: number; returnTypeFunc: ((returns?: void) => (RecursiveArray<... | Function> | symbol | object | Function | ClassType | GraphQLScalarType)[] | TypeValue) | undefined; options: Partial<ValidateOptions>; }' is not assignable to parameter of type 'ParamInfo'.",
+          "tsz:   Types of property 'options' are incompatible.",
+          "tsz:     Type 'Partial<ValidateOptions>' is not assignable to type '(TypeOptions & ValidateOptions) | undefined'.",
+          "tsz: .target-bench/external/type-graphql/src/decorators/Directive.ts(27,11): error TS2322: Type '{ nameOrDefinition: string; args: {}; }' is not assignable to type 'DirectiveMetadata'.",
+          "tsz:   Types of property 'args' are incompatible.",
+          "tsz:     Type '{}' is not assignable to type 'Record<string, any>'.",
+          "tsz: .target-bench/external/type-graphql/src/decorators/Directive.ts(33,11): error TS2322: Type '{ nameOrDefinition: string; args: {}; }' is not assignable to type 'DirectiveMetadata'.",
+          "tsz:   Types of property 'args' are incompatible.",
+          "tsz:     Type '{}' is not assignable to type 'Record<string, any>'.",
+          "tsz: .target-bench/external/type-graphql/src/decorators/Directive.ts(39,9): error TS2322: Type '{ nameOrDefinition: string; args: {}; }' is not assignable to type 'DirectiveMetadata'.",
+          "tsz:   Types of property 'args' are incompatible.",
+          "tsz:     Type '{}' is not assignable to type 'Record<string, any>'.",
+          "tsz: .target-bench/external/type-graphql/src/helpers/auth-middleware.ts(29,12): error TS2349: This expression is not callable.",
+          "tsz:   Type 'NextFn' has no call signatures.",
+          "tsz: .target-bench/external/type-graphql/src/metadata/metadata-storage.ts(232,40): error TS2345: Argument of type 'Set<unknown>' is not assignable to parameter of type 'Set<MiddlewareMetadata>'.",
+          "tsz:   Type 'unknown' is not assignable to type 'MiddlewareMetadata'.",
+          "tsz: .target-bench/external/type-graphql/src/metadata/metadata-storage.ts(253,58): error TS2345: Argument of type 'Set<unknown>' is not assignable to parameter of type 'Set<ResolverMiddlewareMetadata>'."
+        ],
+        "diagnostic_codes": [
+          "TS2345",
+          "TS2322",
+          "TS2349"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "relations-assignability",
+            "codes": [
+              "TS2345",
+              "TS2322"
+            ],
+            "count": 7,
+            "examples": [
+              "tsz: .target-bench/external/type-graphql/src/decorators/Arg.ts(39,23): error TS2345: Argument of type '{ prototype: Object; propertyKey: string | symbol; parameterIndex: number; returnTypeFunc: ((returns?: void) => (RecursiveArray<... | Function> | symbol | object | Function | ClassType | GraphQLScalarType)[] | TypeValue) | undefined; options: Partial<DecoratorTypeOptions & DescriptionOptions & ValidateOptions & DeprecationOptions>; argName: string; }' is not assignable to parameter of type 'ParamInfo'.",
+              "tsz: .target-bench/external/type-graphql/src/decorators/Args.ts(21,23): error TS2345: Argument of type '{ prototype: Object; propertyKey: string | symbol; parameterIndex: number; returnTypeFunc: ((returns?: void) => (RecursiveArray<... | Function> | symbol | object | Function | ClassType | GraphQLScalarType)[] | TypeValue) | undefined; options: Partial<ValidateOptions>; }' is not assignable to parameter of type 'ParamInfo'.",
+              "tsz: .target-bench/external/type-graphql/src/decorators/Directive.ts(27,11): error TS2322: Type '{ nameOrDefinition: string; args: {}; }' is not assignable to type 'DirectiveMetadata'."
+            ]
+          },
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 12,
+            "examples": [
+              "tsz:   Types of property 'options' are incompatible.",
+              "tsz:     Type 'Partial<DecoratorTypeOptions & DescriptionOptions & ValidateOptions & DeprecationOptions>' is not assignable to type '(TypeOptions & ValidateOptions) | undefined'.",
+              "tsz:   Types of property 'options' are incompatible."
+            ]
+          },
+          {
+            "subsystem": "unclassified diagnostic",
+            "codes": [
+              "TS2349"
+            ],
+            "count": 1,
+            "examples": [
+              "tsz: .target-bench/external/type-graphql/src/helpers/auth-middleware.ts(29,12): error TS2349: This expression is not callable."
+            ]
+          }
+        ],
+        "primary_subsystem": "relations-assignability",
+        "reduction_candidates": [
+          "tsz: .target-bench/external/type-graphql/src/decorators/Arg.ts(39,23): error TS2345: Argument of type '{ prototype: Object; propertyKey: string | symbol; parameterIndex: number; returnTypeFunc: ((returns?: void) => (RecursiveArray<... | Function> | symbol | object | Function | ClassType | GraphQLScalarType)[] | TypeValue) | undefined; options: Partial<DecoratorTypeOptions & DescriptionOptions & ValidateOptions & DeprecationOptions>; argName: string; }' is not assignable to parameter of type 'ParamInfo'.",
+          "tsz: .target-bench/external/type-graphql/src/decorators/Args.ts(21,23): error TS2345: Argument of type '{ prototype: Object; propertyKey: string | symbol; parameterIndex: number; returnTypeFunc: ((returns?: void) => (RecursiveArray<... | Function> | symbol | object | Function | ClassType | GraphQLScalarType)[] | TypeValue) | undefined; options: Partial<ValidateOptions>; }' is not assignable to parameter of type 'ParamInfo'.",
+          "tsz: .target-bench/external/type-graphql/src/decorators/Directive.ts(27,11): error TS2322: Type '{ nameOrDefinition: string; args: {}; }' is not assignable to type 'DirectiveMetadata'.",
+          "tsz: .target-bench/external/type-graphql/src/decorators/Directive.ts(33,11): error TS2322: Type '{ nameOrDefinition: string; args: {}; }' is not assignable to type 'DirectiveMetadata'.",
+          "tsz: .target-bench/external/type-graphql/src/decorators/Directive.ts(39,9): error TS2322: Type '{ nameOrDefinition: string; args: {}; }' is not assignable to type 'DirectiveMetadata'."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "relations-assignability",
+          "uncoded diagnostic",
+          "unclassified diagnostic"
+        ],
+        "reduced_repro_path": ".target-bench/external/type-graphql/src/decorators/Arg.ts",
+        "repro": {
+          "tsconfig_path": "type-graphql/tsconfig.tsz-bench.json",
+          "source_root": "type-graphql/src",
+          "first_failure_path": ".target-bench/external/type-graphql/src/decorators/Arg.ts",
+          "first_failure_line": 39,
+          "first_failure_column": 23,
+          "first_failure_code": "TS2345",
+          "reduced_repro_path": ".target-bench/external/type-graphql/src/decorators/Arg.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p type-graphql/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            1
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "decorator + generic resolver typing, schema class hierarchy",
+        "files_reached": 117,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "type-graphql",
+            "repository": "https://github.com/MichalLytek/type-graphql.git",
+            "ref": "4535c3192fd321be6bade6192f0cf8d264de9baf"
+          }
+        ]
+      }
+    },
+    {
+      "name": "neverthrow-project",
+      "lines": 1202,
+      "kb": 36,
+      "project_files": 5,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsz error; tsc ok",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:37:08.930Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "yellow",
+        "exit_class": "nonzero exit",
+        "first_failure_class": "keyspace-property-indexed",
+        "owner_track": "Track 5 keyspace/property/indexed access",
+        "phase": "check",
+        "last_successful_phase": null,
+        "diagnostic_status": "diagnostic mismatch or compiler error",
+        "diagnostic_deltas": [
+          "tsz: .target-bench/external/neverthrow/src/result-async.ts(109,20): error TS2339: Property 'isErr' does not exist on type 'Err<unknown, F> | Ok<unknown, F> | ResultAsync<unknown, F>'.",
+          "tsz: .target-bench/external/neverthrow/src/result.ts(129,30): error TS2339: Property 'then' does not exist on type 'IteratorResult<Err<never, E>, Err<T, E> | Ok<T, E>> | Promise<IteratorResult<Err<never, E>, Err<T, E> | Ok<T, E>>>'.",
+          "tsz: .target-bench/external/neverthrow/src/result.ts(129,36): error TS7006: Parameter 'r' implicitly has an 'any' type.",
+          "tsz: .target-bench/external/neverthrow/src/result.ts(131,12): error TS2339: Property 'value' does not exist on type 'never'.",
+          "tsz: .target-bench/external/neverthrow/src/result.ts(384,5): error TS2322: Type 'ResultAsync<U, never>' is not assignable to type 'ResultAsync<U, E>'.",
+          "tsz:     Type '<A, B>(successCallback?: ((res: Result<U, never>) => A | PromiseLike<A>) | undefined, failureCallback?: ((reason: unknown) => B | PromiseLike<B>) | undefined) => PromiseLike<A | B>' is not assignable to type '<A, B>(successCallback?: ((res: Result<U, E>) => A | PromiseLike<A>) | undefined, failureCallback?: ((reason: unknown) => B | PromiseLike<B>) | undefined) => PromiseLike<A | B>'.",
+          "tsz: .target-bench/external/neverthrow/src/result.ts(516,5): error TS2578: Unused '@ts-expect-error' directive."
+        ],
+        "diagnostic_codes": [
+          "TS2339",
+          "TS7006",
+          "TS2322",
+          "TS2578"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "keyspace-property-indexed",
+            "codes": [
+              "TS2339"
+            ],
+            "count": 3,
+            "examples": [
+              "tsz: .target-bench/external/neverthrow/src/result-async.ts(109,20): error TS2339: Property 'isErr' does not exist on type 'Err<unknown, F> | Ok<unknown, F> | ResultAsync<unknown, F>'.",
+              "tsz: .target-bench/external/neverthrow/src/result.ts(129,30): error TS2339: Property 'then' does not exist on type 'IteratorResult<Err<never, E>, Err<T, E> | Ok<T, E>> | Promise<IteratorResult<Err<never, E>, Err<T, E> | Ok<T, E>>>'.",
+              "tsz: .target-bench/external/neverthrow/src/result.ts(131,12): error TS2339: Property 'value' does not exist on type 'never'."
+            ]
+          },
+          {
+            "subsystem": "contextual-inference",
+            "codes": [
+              "TS7006"
+            ],
+            "count": 1,
+            "examples": [
+              "tsz: .target-bench/external/neverthrow/src/result.ts(129,36): error TS7006: Parameter 'r' implicitly has an 'any' type."
+            ]
+          },
+          {
+            "subsystem": "relations-assignability",
+            "codes": [
+              "TS2322"
+            ],
+            "count": 1,
+            "examples": [
+              "tsz: .target-bench/external/neverthrow/src/result.ts(384,5): error TS2322: Type 'ResultAsync<U, never>' is not assignable to type 'ResultAsync<U, E>'."
+            ]
+          },
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 1,
+            "examples": [
+              "tsz:     Type '<A, B>(successCallback?: ((res: Result<U, never>) => A | PromiseLike<A>) | undefined, failureCallback?: ((reason: unknown) => B | PromiseLike<B>) | undefined) => PromiseLike<A | B>' is not assignable to type '<A, B>(successCallback?: ((res: Result<U, E>) => A | PromiseLike<A>) | undefined, failureCallback?: ((reason: unknown) => B | PromiseLike<B>) | undefined) => PromiseLike<A | B>'."
+            ]
+          },
+          {
+            "subsystem": "unclassified diagnostic",
+            "codes": [
+              "TS2578"
+            ],
+            "count": 1,
+            "examples": [
+              "tsz: .target-bench/external/neverthrow/src/result.ts(516,5): error TS2578: Unused '@ts-expect-error' directive."
+            ]
+          }
+        ],
+        "primary_subsystem": "keyspace-property-indexed",
+        "reduction_candidates": [
+          "tsz: .target-bench/external/neverthrow/src/result-async.ts(109,20): error TS2339: Property 'isErr' does not exist on type 'Err<unknown, F> | Ok<unknown, F> | ResultAsync<unknown, F>'.",
+          "tsz: .target-bench/external/neverthrow/src/result.ts(129,30): error TS2339: Property 'then' does not exist on type 'IteratorResult<Err<never, E>, Err<T, E> | Ok<T, E>> | Promise<IteratorResult<Err<never, E>, Err<T, E> | Ok<T, E>>>'.",
+          "tsz: .target-bench/external/neverthrow/src/result.ts(129,36): error TS7006: Parameter 'r' implicitly has an 'any' type.",
+          "tsz: .target-bench/external/neverthrow/src/result.ts(131,12): error TS2339: Property 'value' does not exist on type 'never'.",
+          "tsz: .target-bench/external/neverthrow/src/result.ts(384,5): error TS2322: Type 'ResultAsync<U, never>' is not assignable to type 'ResultAsync<U, E>'."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "keyspace-property-indexed",
+          "contextual-inference",
+          "relations-assignability",
+          "uncoded diagnostic",
+          "unclassified diagnostic"
+        ],
+        "reduced_repro_path": ".target-bench/external/neverthrow/src/result-async.ts",
+        "repro": {
+          "tsconfig_path": "neverthrow/tsconfig.tsz-bench.json",
+          "source_root": "neverthrow/src",
+          "first_failure_path": ".target-bench/external/neverthrow/src/result-async.ts",
+          "first_failure_line": 109,
+          "first_failure_column": 20,
+          "first_failure_code": "TS2339",
+          "reduced_repro_path": ".target-bench/external/neverthrow/src/result-async.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p neverthrow/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            1
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "Result/Ok/Err generic monad chaining, combine overloads",
+        "files_reached": 5,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "neverthrow",
+            "repository": "https://github.com/supermacro/neverthrow.git",
+            "ref": "5ef3a018bda74fb960e44b68fc3672635ee8037d"
+          }
+        ]
+      }
+    },
+    {
+      "name": "xstate-project",
+      "lines": 15453,
+      "kb": 393,
+      "project_files": 62,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsz error; tsc ok",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:37:41.027Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "yellow",
+        "exit_class": "nonzero exit",
+        "first_failure_class": "relations-assignability",
+        "owner_track": "Track 4 relation diagnostics/compatibility",
+        "phase": "check",
+        "last_successful_phase": null,
+        "diagnostic_status": "diagnostic mismatch or compiler error",
+        "diagnostic_deltas": [
+          "tsz: .target-bench/external/xstate/packages/core/src/State.ts(372,3): error TS2322: Type '{ status: never; output: any; error: unknown; machine: StateMachine<any, any, any, any, any, any, any, any, any, any, any, any, any, any>; context: TContext; _nodes: StateNode<TContext, TEvent>[]; value: never; tags: Set<string>; children: any; historyValue: { [x: string]: StateNode<TContext, TEvent>[]; }; matches: never; hasTag: (this: MachineSnapshot<any, any, any, any, any, any, any, any>, tag: string) => boolean; can: (this: MachineSnapshot<any, any, any, any, any, any, any, any>, event: EventObject) => boolean; getMeta: (this: MachineSnapshot<any, any, any, any, any, any, any, any>) => Record<string, any>; toJSON: (this: MachineSnapshot<any, any, any, any, any, any, any, any>) => { status: string; output: undefined; error: unknown; value: any; context: any; historyValue: Readonly<HistoryValue<any, any>>; children: any; tags: unknown[]; }; }' is not assignable to type 'MachineSnapshot<TContext, TEvent, TChildren, TStateValue, TTag, undefined, TMeta, TStateSchema>'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/State.ts(493,26): error TS2339: Property 'slice' does not exist on type 'never'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/State.ts(503,28): error TS2339: Property 'slice' does not exist on type 'never'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/StateMachine.ts(153,5): error TS2322: Type 'StateNode' is not assignable to type 'StateNode<TContext, TEvent>'.",
+          "tsz:   Types of property 'parent' are incompatible.",
+          "tsz:     Type 'undefined' is not assignable to type 'StateNode<TContext, TEvent>'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/StateMachine.ts(153,31): error TS2345: Argument of type 'MachineConfig<TContext, TEvent, any, any, any, any, any, any, TOutput, any, any> & { schemas?: unknown; }' is not assignable to parameter of type 'StateNodeConfig<TContext, TEvent | DoneStateEvent<unknown>, any, any, any, any, any, any, any, any>'.",
+          "tsz:   Types of property 'parent' are incompatible.",
+          "tsz:     Type 'StateNode<DoNotInfer<TContext>, DoNotInfer<TEvent>> | undefined' is not assignable to type 'StateNode<TContext, TEvent | DoneStateEvent<unknown>> | undefined'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/StateMachine.ts(161,5): error TS2322: Type 'StateNodesConfig<TContext, TEvent>' is not assignable to type 'StateNode<TContext, TEvent>[\"states\"]'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/StateMachine.ts(168,20): error TS18046: 'state' is of type 'unknown'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/StateMachine.ts(168,58): error TS18046: 'state' is of type 'unknown'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/StateMachine.ts(215,29): error TS2345: Argument of type 'MachineConfig<TContext, TEvent, any, any, any, any, any, any, TOutput, any, any> & { schemas?: unknown; }' is not assignable to parameter of type 'MachineConfig<ResolvedStateMachineTypes<TContext, DoNotInfer<TEvent>, TActor, TAction, TGuard, TDelay, TTag, TEmitted>, EventObject, any, any, any, any, any, any, unknown, any, any> & { schemas?: unknown; }'.",
+          "tsz:   Type 'MachineConfig<TContext, TEvent, any, any, any, any, any, any, TOutput, any, any> & { schemas?: unknown; }' is not assignable to type 'MachineConfig<ResolvedStateMachineTypes<TContext, DoNotInfer<TEvent>, TActor, TAction, TGuard, TDelay, TTag, TEmitted>, EventObject, any, any, any, any, any, any, unknown, any, any>'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/StateNode.ts(170,39): error TS2339: Property 'id' does not exist on type 'typeof StateMachine'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/StateNode.ts(180,31): error TS2339: Property 'idMap' does not exist on type 'typeof StateMachine'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/StateNode.ts(181,18): error TS2339: Property 'idMap' does not exist on type 'typeof StateMachine'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/StateNode.ts(224,5): error TS2322: Type 'Map<string, TransitionDefinition<TContext & Record<string, any>, TEvent & EventObject>[]>' is not assignable to type 'Map<string, TransitionDefinition<TContext, TEvent>[]>'.",
+          "tsz:     Type '(key: string, value: TransitionDefinition & { actions?: Actions<TContext & Record<string, any>, TEvent & EventObject, TEvent & EventObject, undefined, any, any, any, any, any> | undefined; reenter?: boolean | undefined; meta?: any; description?: string | undefined; }[]) => Map' is not assignable to type '(key: string, value: TransitionDefinition & { actions?: Actions<TContext, TEvent, TEvent, undefined, any, any, any, any, any> | undefined; reenter?: boolean | undefined; meta?: any; description?: string | undefined; }[]) => Map'.",
+          "tsz:       Types of parameters 'value' and 'value' are incompatible."
+        ],
+        "diagnostic_codes": [
+          "TS2322",
+          "TS2339",
+          "TS2345",
+          "TS18046"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "relations-assignability",
+            "codes": [
+              "TS2322",
+              "TS2345"
+            ],
+            "count": 6,
+            "examples": [
+              "tsz: .target-bench/external/xstate/packages/core/src/State.ts(372,3): error TS2322: Type '{ status: never; output: any; error: unknown; machine: StateMachine<any, any, any, any, any, any, any, any, any, any, any, any, any, any>; context: TContext; _nodes: StateNode<TContext, TEvent>[]; value: never; tags: Set<string>; children: any; historyValue: { [x: string]: StateNode<TContext, TEvent>[]; }; matches: never; hasTag: (this: MachineSnapshot<any, any, any, any, any, any, any, any>, tag: string) => boolean; can: (this: MachineSnapshot<any, any, any, any, any, any, any, any>, event: EventObject) => boolean; getMeta: (this: MachineSnapshot<any, any, any, any, any, any, any, any>) => Record<string, any>; toJSON: (this: MachineSnapshot<any, any, any, any, any, any, any, any>) => { status: string; output: undefined; error: unknown; value: any; context: any; historyValue: Readonly<HistoryValue<any, any>>; children: any; tags: unknown[]; }; }' is not assignable to type 'MachineSnapshot<TContext, TEvent, TChildren, TStateValue, TTag, undefined, TMeta, TStateSchema>'.",
+              "tsz: .target-bench/external/xstate/packages/core/src/StateMachine.ts(153,5): error TS2322: Type 'StateNode' is not assignable to type 'StateNode<TContext, TEvent>'.",
+              "tsz: .target-bench/external/xstate/packages/core/src/StateMachine.ts(153,31): error TS2345: Argument of type 'MachineConfig<TContext, TEvent, any, any, any, any, any, any, TOutput, any, any> & { schemas?: unknown; }' is not assignable to parameter of type 'StateNodeConfig<TContext, TEvent | DoneStateEvent<unknown>, any, any, any, any, any, any, any, any>'."
+            ]
+          },
+          {
+            "subsystem": "keyspace-property-indexed",
+            "codes": [
+              "TS2339"
+            ],
+            "count": 5,
+            "examples": [
+              "tsz: .target-bench/external/xstate/packages/core/src/State.ts(493,26): error TS2339: Property 'slice' does not exist on type 'never'.",
+              "tsz: .target-bench/external/xstate/packages/core/src/State.ts(503,28): error TS2339: Property 'slice' does not exist on type 'never'.",
+              "tsz: .target-bench/external/xstate/packages/core/src/StateNode.ts(170,39): error TS2339: Property 'id' does not exist on type 'typeof StateMachine'."
+            ]
+          },
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 7,
+            "examples": [
+              "tsz:   Types of property 'parent' are incompatible.",
+              "tsz:     Type 'undefined' is not assignable to type 'StateNode<TContext, TEvent>'.",
+              "tsz:   Types of property 'parent' are incompatible."
+            ]
+          },
+          {
+            "subsystem": "unclassified diagnostic",
+            "codes": [
+              "TS18046"
+            ],
+            "count": 2,
+            "examples": [
+              "tsz: .target-bench/external/xstate/packages/core/src/StateMachine.ts(168,20): error TS18046: 'state' is of type 'unknown'.",
+              "tsz: .target-bench/external/xstate/packages/core/src/StateMachine.ts(168,58): error TS18046: 'state' is of type 'unknown'."
+            ]
+          }
+        ],
+        "primary_subsystem": "relations-assignability",
+        "reduction_candidates": [
+          "tsz: .target-bench/external/xstate/packages/core/src/State.ts(372,3): error TS2322: Type '{ status: never; output: any; error: unknown; machine: StateMachine<any, any, any, any, any, any, any, any, any, any, any, any, any, any>; context: TContext; _nodes: StateNode<TContext, TEvent>[]; value: never; tags: Set<string>; children: any; historyValue: { [x: string]: StateNode<TContext, TEvent>[]; }; matches: never; hasTag: (this: MachineSnapshot<any, any, any, any, any, any, any, any>, tag: string) => boolean; can: (this: MachineSnapshot<any, any, any, any, any, any, any, any>, event: EventObject) => boolean; getMeta: (this: MachineSnapshot<any, any, any, any, any, any, any, any>) => Record<string, any>; toJSON: (this: MachineSnapshot<any, any, any, any, any, any, any, any>) => { status: string; output: undefined; error: unknown; value: any; context: any; historyValue: Readonly<HistoryValue<any, any>>; children: any; tags: unknown[]; }; }' is not assignable to type 'MachineSnapshot<TContext, TEvent, TChildren, TStateValue, TTag, undefined, TMeta, TStateSchema>'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/State.ts(493,26): error TS2339: Property 'slice' does not exist on type 'never'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/State.ts(503,28): error TS2339: Property 'slice' does not exist on type 'never'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/StateMachine.ts(153,5): error TS2322: Type 'StateNode' is not assignable to type 'StateNode<TContext, TEvent>'.",
+          "tsz: .target-bench/external/xstate/packages/core/src/StateMachine.ts(153,31): error TS2345: Argument of type 'MachineConfig<TContext, TEvent, any, any, any, any, any, any, TOutput, any, any> & { schemas?: unknown; }' is not assignable to parameter of type 'StateNodeConfig<TContext, TEvent | DoneStateEvent<unknown>, any, any, any, any, any, any, any, any>'."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "relations-assignability",
+          "keyspace-property-indexed",
+          "uncoded diagnostic",
+          "unclassified diagnostic"
+        ],
+        "reduced_repro_path": ".target-bench/external/xstate/packages/core/src/State.ts",
+        "repro": {
+          "tsconfig_path": "xstate/tsconfig.tsz-bench.json",
+          "source_root": "xstate/packages/core/src",
+          "first_failure_path": ".target-bench/external/xstate/packages/core/src/State.ts",
+          "first_failure_line": 372,
+          "first_failure_column": 3,
+          "first_failure_code": "TS2322",
+          "reduced_repro_path": ".target-bench/external/xstate/packages/core/src/State.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p xstate/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            1
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "state-machine config generics, template-literal event/state typing, deep recursive typegen surface",
+        "files_reached": 62,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "xstate",
+            "repository": "https://github.com/statelyai/xstate.git",
+            "ref": "afa374afd52dc4f05baad1ead66c977a46aa5b47"
+          }
+        ]
+      }
+    },
+    {
+      "name": "mobx-project",
+      "lines": 8470,
+      "kb": 263,
+      "project_files": 59,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsz error; tsc ok",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:37:44.327Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "yellow",
+        "exit_class": "nonzero exit",
+        "first_failure_class": "relations-assignability",
+        "owner_track": "Track 4 relation diagnostics/compatibility",
+        "phase": "check",
+        "last_successful_phase": null,
+        "diagnostic_status": "diagnostic mismatch or compiler error",
+        "diagnostic_deltas": [
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/makeObservable.ts(43,60): error TS2345: Argument of type '((AnnotationMapEntry | undefined) & { [P in AdditionalKeys]: AnnotationMapEntry; }[string]) | ({ [P in Exclude<keyof T, \"toString\">]?: AnnotationMapEntry | undefined; }[string] & Record<NoInfer<AdditionalKeys>, AnnotationMapEntry>[string]) | ({ [P in keyof T]?: AnnotationMapEntry | undefined; }[symbol] & { [P in AdditionalKeys]: AnnotationMapEntry; }[symbol]) | ({ [P in Exclude<keyof T, \"toString\">]?: AnnotationMapEntry | undefined; }[symbol] & Record<NoInfer<AdditionalKeys>, AnnotationMapEntry>[symbol])' is not assignable to parameter of type 'boolean | Annotation'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(31,20): error TS2339: Property 'map' does not exist on type 'IObservableArray<any>'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(51,20): error TS2339: Property 'slice' does not exist on type 'IObservableArray<any>'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(73,20): error TS2339: Property 'map' does not exist on type 'IObservableArray<any>'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(111,24): error TS2339: Property 'length' does not exist on type 'IObservableArray<any>'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(112,17): error TS2339: Property 'length' does not exist on type 'IObservableArray<any>'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(136,13): error TS2339: Property 'splice' does not exist on type 'IObservableArray<any>'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(154,38): error TS2339: Property 'length' does not exist on type 'IObservableArray<any>'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/tojs.ts(35,67): error TS2339: Property 'length' does not exist on type 'IObservableArray<any>'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/tojs.ts(36,16): error TS2339: Property 'forEach' does not exist on type 'IObservableArray<any>'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/core/computedvalue.ts(269,19): error TS2339: Property 'equals_' does not exist on type 'never'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/core/observable.ts(257,23): error TS2339: Property 'name_' does not exist on type 'never'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/core/observable.ts(259,68): error TS2339: Property 'name_' does not exist on type 'never'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/core/observable.ts(263,3): error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/core/observable.ts(263,52): error TS2339: Property 'derivation' does not exist on type 'never'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/core/reaction.ts(187,36): error TS18048: 'startTime' is possibly 'undefined'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/types/observablearray.ts(318,15): error TS2322: Type '{ readonly observableKind: \"array\"; readonly object: IObservableArray<any>; readonly debugObjectName: string; readonly type: \"splice\"; readonly index: number; readonly removed: readonly any[]; readonly added: readonly any[]; readonly removedCount: number; readonly addedCount: number; } | null' is not assignable to type 'IArraySplice<any> | null'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/types/observablemap.ts(503,73): error TS2345: Argument of type 'ObservableMap<K, V>' is not assignable to parameter of type 'new (...args: any[]) => unknown'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/types/observableset.ts(221,13): error TS2322: Type '() => { value: (T | undefined)[]; done: false | undefined; } | { value: undefined; done: true; }' is not assignable to type '(..._: [] | [any]) => IteratorResult<[T, T], any>'.",
+          "tsz:   Type '{ value: (T | undefined)[]; done: false | undefined; } | { done: true; value: undefined; }' is not assignable to type 'IteratorReturnResult<any> | IteratorYieldResult'."
+        ],
+        "diagnostic_codes": [
+          "TS2345",
+          "TS2339",
+          "TS2358",
+          "TS18048",
+          "TS2322"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "relations-assignability",
+            "codes": [
+              "TS2345",
+              "TS2322"
+            ],
+            "count": 4,
+            "examples": [
+              "tsz: .target-bench/external/mobx/packages/mobx/src/api/makeObservable.ts(43,60): error TS2345: Argument of type '((AnnotationMapEntry | undefined) & { [P in AdditionalKeys]: AnnotationMapEntry; }[string]) | ({ [P in Exclude<keyof T, \"toString\">]?: AnnotationMapEntry | undefined; }[string] & Record<NoInfer<AdditionalKeys>, AnnotationMapEntry>[string]) | ({ [P in keyof T]?: AnnotationMapEntry | undefined; }[symbol] & { [P in AdditionalKeys]: AnnotationMapEntry; }[symbol]) | ({ [P in Exclude<keyof T, \"toString\">]?: AnnotationMapEntry | undefined; }[symbol] & Record<NoInfer<AdditionalKeys>, AnnotationMapEntry>[symbol])' is not assignable to parameter of type 'boolean | Annotation'.",
+              "tsz: .target-bench/external/mobx/packages/mobx/src/types/observablearray.ts(318,15): error TS2322: Type '{ readonly observableKind: \"array\"; readonly object: IObservableArray<any>; readonly debugObjectName: string; readonly type: \"splice\"; readonly index: number; readonly removed: readonly any[]; readonly added: readonly any[]; readonly removedCount: number; readonly addedCount: number; } | null' is not assignable to type 'IArraySplice<any> | null'.",
+              "tsz: .target-bench/external/mobx/packages/mobx/src/types/observablemap.ts(503,73): error TS2345: Argument of type 'ObservableMap<K, V>' is not assignable to parameter of type 'new (...args: any[]) => unknown'."
+            ]
+          },
+          {
+            "subsystem": "keyspace-property-indexed",
+            "codes": [
+              "TS2339"
+            ],
+            "count": 13,
+            "examples": [
+              "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(31,20): error TS2339: Property 'map' does not exist on type 'IObservableArray<any>'.",
+              "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(51,20): error TS2339: Property 'slice' does not exist on type 'IObservableArray<any>'.",
+              "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(73,20): error TS2339: Property 'map' does not exist on type 'IObservableArray<any>'."
+            ]
+          },
+          {
+            "subsystem": "unclassified diagnostic",
+            "codes": [
+              "TS2358"
+            ],
+            "count": 1,
+            "examples": [
+              "tsz: .target-bench/external/mobx/packages/mobx/src/core/observable.ts(263,3): error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter."
+            ]
+          },
+          {
+            "subsystem": "flow-narrowing",
+            "codes": [
+              "TS18048"
+            ],
+            "count": 1,
+            "examples": [
+              "tsz: .target-bench/external/mobx/packages/mobx/src/core/reaction.ts(187,36): error TS18048: 'startTime' is possibly 'undefined'."
+            ]
+          },
+          {
+            "subsystem": "uncoded diagnostic",
+            "codes": [],
+            "count": 1,
+            "examples": [
+              "tsz:   Type '{ value: (T | undefined)[]; done: false | undefined; } | { done: true; value: undefined; }' is not assignable to type 'IteratorReturnResult<any> | IteratorYieldResult'."
+            ]
+          }
+        ],
+        "primary_subsystem": "relations-assignability",
+        "reduction_candidates": [
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/makeObservable.ts(43,60): error TS2345: Argument of type '((AnnotationMapEntry | undefined) & { [P in AdditionalKeys]: AnnotationMapEntry; }[string]) | ({ [P in Exclude<keyof T, \"toString\">]?: AnnotationMapEntry | undefined; }[string] & Record<NoInfer<AdditionalKeys>, AnnotationMapEntry>[string]) | ({ [P in keyof T]?: AnnotationMapEntry | undefined; }[symbol] & { [P in AdditionalKeys]: AnnotationMapEntry; }[symbol]) | ({ [P in Exclude<keyof T, \"toString\">]?: AnnotationMapEntry | undefined; }[symbol] & Record<NoInfer<AdditionalKeys>, AnnotationMapEntry>[symbol])' is not assignable to parameter of type 'boolean | Annotation'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(31,20): error TS2339: Property 'map' does not exist on type 'IObservableArray<any>'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(51,20): error TS2339: Property 'slice' does not exist on type 'IObservableArray<any>'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(73,20): error TS2339: Property 'map' does not exist on type 'IObservableArray<any>'.",
+          "tsz: .target-bench/external/mobx/packages/mobx/src/api/object-api.ts(111,24): error TS2339: Property 'length' does not exist on type 'IObservableArray<any>'."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "relations-assignability",
+          "keyspace-property-indexed",
+          "unclassified diagnostic",
+          "flow-narrowing",
+          "uncoded diagnostic"
+        ],
+        "reduced_repro_path": ".target-bench/external/mobx/packages/mobx/src/api/makeObservable.ts",
+        "repro": {
+          "tsconfig_path": "mobx/tsconfig.tsz-bench.json",
+          "source_root": "mobx/packages/mobx/src",
+          "first_failure_path": ".target-bench/external/mobx/packages/mobx/src/api/makeObservable.ts",
+          "first_failure_line": 43,
+          "first_failure_column": 60,
+          "first_failure_code": "TS2345",
+          "reduced_repro_path": ".target-bench/external/mobx/packages/mobx/src/api/makeObservable.ts",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p mobx/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            1
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "observable/computed generic typing, decorator + annotation surface, reaction inference",
+        "files_reached": 59,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "mobx",
+            "repository": "https://github.com/mobxjs/mobx.git",
+            "ref": "2a069e41024433da401f3e8b3470adf194924911"
+          }
+        ]
+      }
+    },
+    {
+      "name": "nextjs-fresh-app",
+      "lines": 282,
+      "kb": 7,
+      "project_files": 7,
+      "tsz_ms": 86.8,
+      "tsgo_ms": 111.83,
+      "tsz_lps": 3249,
+      "tsgo_lps": 2522,
+      "winner": "tsz",
+      "factor": 1.29,
+      "status": null,
+      "readme": "# Fresh Next.js app benchmark\n\nThis fixture is generated by `scripts/bench/generate-next-app-fixture.mjs`.\n\nEach benchmark run recreates the app, installs current npm versions, and type-checks the generated Next.js project with:\n\n```sh\ntsz --noEmit -p tsconfig.json\ntsgo --noEmit -p tsconfig.json\n```\n\nThe app intentionally imports and uses common type-heavy dependencies:\n\n- `zod`\n- `@tanstack/react-query`\n- `react-hook-form`\n- `type-fest`\n- `ts-pattern`\n- `superjson`\n- `date-fns`\n- `clsx`\n- `zustand`\n- `valibot`\n\nThe generated source mixes App Router pages, server actions, schema inference, discriminated unions, form helpers, query typing, store typing, and JSON-safe utility types so the benchmark reflects a modern application rather than a tiny startup file.",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:38:00.687Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "green",
+        "exit_class": "exit success",
+        "first_failure_class": null,
+        "owner_track": null,
+        "phase": "check",
+        "last_successful_phase": "check",
+        "diagnostic_status": "none",
+        "diagnostic_deltas": [],
+        "diagnostic_codes": [],
+        "diagnostic_subsystems": [],
+        "primary_subsystem": null,
+        "reduction_candidates": [],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [],
+        "reduced_repro_path": "next-app-live",
+        "repro": {
+          "tsconfig_path": "next-app-live/tsconfig.json",
+          "source_root": "next-app-live",
+          "first_failure_path": null,
+          "first_failure_line": null,
+          "first_failure_column": null,
+          "first_failure_code": null,
+          "reduced_repro_path": "next-app-live",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p next-app-live/tsconfig.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            0
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "generated app-router dependency/config sanity",
+        "files_reached": 7,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "next-app-router",
+            "repository": "generated:scripts/bench/generate-next-app-fixture.mjs",
+            "ref": "package-lock:3e49419997a31281d6861c4b133ebf7d7fd327ae97a8b65f7af75216e92f5251"
+          }
+        ]
+      }
+    },
+    {
+      "name": "nextjs",
+      "lines": 222594,
+      "kb": 6946,
+      "project_files": 1396,
+      "tsz_ms": null,
+      "tsgo_ms": null,
+      "tsz_lps": null,
+      "tsgo_lps": null,
+      "winner": "error",
+      "factor": 0,
+      "status": "tsz error; tsc ok",
+      "compatibility": {
+        "generated_at": "2026-07-16T11:38:01.442Z",
+        "source_commit": "local",
+        "workflow_name": "local",
+        "workflow_run_id": "local",
+        "workflow_run_url": null,
+        "workflow_run_attempt": null,
+        "run_status": "local",
+        "state": "yellow",
+        "exit_class": "nonzero exit",
+        "first_failure_class": "unclassified diagnostic",
+        "owner_track": "Track 1 triage",
+        "phase": "check",
+        "last_successful_phase": null,
+        "diagnostic_status": "diagnostic mismatch or compiler error",
+        "diagnostic_deltas": [
+          "tsz: .target-bench/external/next.js/packages/next/tsconfig.json(11,25): error TS5108: Option 'moduleResolution=node10' has been removed. Please remove it from your configuration."
+        ],
+        "diagnostic_codes": [
+          "TS5108"
+        ],
+        "diagnostic_subsystems": [
+          {
+            "subsystem": "unclassified diagnostic",
+            "codes": [
+              "TS5108"
+            ],
+            "count": 1,
+            "examples": [
+              "tsz: .target-bench/external/next.js/packages/next/tsconfig.json(11,25): error TS5108: Option 'moduleResolution=node10' has been removed. Please remove it from your configuration."
+            ]
+          }
+        ],
+        "primary_subsystem": "unclassified diagnostic",
+        "reduction_candidates": [
+          "tsz: .target-bench/external/next.js/packages/next/tsconfig.json(11,25): error TS5108: Option 'moduleResolution=node10' has been removed. Please remove it from your configuration."
+        ],
+        "emit_status": "not in scope (noEmit project check)",
+        "dts_status": "not in scope (noEmit project check)",
+        "known_blockers": [
+          "unclassified diagnostic"
+        ],
+        "reduced_repro_path": ".target-bench/external/next.js/packages/next/tsconfig.json",
+        "repro": {
+          "tsconfig_path": "next.js/packages/next/tsconfig.tsz-bench.json",
+          "source_root": "next.js/packages/next/src",
+          "first_failure_path": ".target-bench/external/next.js/packages/next/tsconfig.json",
+          "first_failure_line": 11,
+          "first_failure_column": 25,
+          "first_failure_code": "TS5108",
+          "reduced_repro_path": ".target-bench/external/next.js/packages/next/tsconfig.json",
+          "command": "TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 $TSZ_BIN --noEmit -p next.js/packages/next/tsconfig.tsz-bench.json"
+        },
+        "exit_codes": {
+          "tsc": [
+            0
+          ],
+          "tsz": [
+            1
+          ],
+          "tsgo": [
+            0
+          ]
+        },
+        "semantic_owner_family": "module graph plus generated app dependencies",
+        "files_reached": 1396,
+        "files_reached_reason": null,
+        "peak_memory_bytes": null,
+        "peak_memory_bytes_reason": "not measured on platform",
+        "fixture_sources": [
+          {
+            "name": "nextjs",
+            "repository": "https://github.com/vercel/next.js.git",
+            "ref": "09851e208cc62c8b6fe7a953b42c88e843129178"
           }
         ]
       }

--- a/scripts/bench/lib/project-fixture-stubs-canary.sh
+++ b/scripts/bench/lib/project-fixture-stubs-canary.sh
@@ -1,0 +1,630 @@
+#!/usr/bin/env bash
+#
+# External-module stub writers for the 2026-07 canary-fixture repair campaign
+# (msw, valtio, ts-extras, superjson, tanstack-router, ts-morph). Sourced by
+# scripts/bench/project-fixtures.sh next to project-fixture-stubs.sh; split into
+# its own shard to keep both files under the 2000-line ceiling. Same contract:
+# each function takes the fixture tsconfig output path and derives the fixture
+# directory. Stub contents were produced by iterative pinned-tsc fixpoint runs
+# (add a declaration per unresolved-name error until tsc converges) and are
+# emitted verbatim; the fixtures they green were validated at tsc 6.0.3 exit 0
+# (superjson, ts-extras, tanstack-router) or best-effort honest residuals
+# (valtio 1, msw 3, ts-morph ~180 — see the per-config comments in
+# project-fixtures.sh).
+
+if [ -n "${_TSZ_PROJECT_FIXTURE_STUBS_CANARY_SOURCED:-}" ]; then
+  return 0 2>/dev/null || true
+fi
+_TSZ_PROJECT_FIXTURE_STUBS_CANARY_SOURCED=1
+
+
+tsz_write_superjson_canary_stubs() {
+  local output="$1"
+  local fixture_dir
+  fixture_dir="$(dirname "$output")"
+  cat > "$fixture_dir/tsz-bench-external-modules.d.ts" <<'TYPES'
+declare module 'copy-anything' {
+  export type copy<A = any, B = any, C = any, D = any, E = any> = any;
+  export const copy: any;
+  const __tszDefault: any;
+  export default __tszDefault;
+}
+TYPES
+}
+
+tsz_write_ts_extras_canary_stubs() {
+  local output="$1"
+  local fixture_dir
+  fixture_dir="$(dirname "$output")"
+  cat > "$fixture_dir/tsz-bench-external-modules.d.ts" <<'TYPES'
+declare module 'type-fest' {
+  export type Finite<A = any, B = any, C = any, D = any, E = any> = any;
+  export const Finite: any;
+  export type Integer<A = any, B = any, C = any, D = any, E = any> = any;
+  export const Integer: any;
+  export type IsEqual<A = any, B = any, C = any, D = any, E = any> = any;
+  export const IsEqual: any;
+  export type IsLiteral<A = any, B = any, C = any, D = any, E = any> = any;
+  export const IsLiteral: any;
+  export type IsTuple<A = any, B = any, C = any, D = any, E = any> = any;
+  export const IsTuple: any;
+  export type Join<A = any, B = any, C = any, D = any, E = any> = any;
+  export const Join: any;
+  export type LastArrayElement<A = any, B = any, C = any, D = any, E = any> = any;
+  export const LastArrayElement: any;
+  export type NegativeInfinity<A = any, B = any, C = any, D = any, E = any> = any;
+  export const NegativeInfinity: any;
+  export type PositiveInfinity<A = any, B = any, C = any, D = any, E = any> = any;
+  export const PositiveInfinity: any;
+  export type Simplify<A = any, B = any, C = any, D = any, E = any> = any;
+  export const Simplify: any;
+  export type Split<A = any, B = any, C = any, D = any, E = any> = any;
+  export const Split: any;
+  export type UnknownRecord<A = any, B = any, C = any, D = any, E = any> = any;
+  export const UnknownRecord: any;
+  export type Writable<A = any, B = any, C = any, D = any, E = any> = any;
+  export const Writable: any;
+  const __tszDefault: any;
+  export default __tszDefault;
+}
+TYPES
+}
+
+tsz_write_valtio_canary_stubs() {
+  local output="$1"
+  local fixture_dir
+  fixture_dir="$(dirname "$output")"
+  cat > "$fixture_dir/tsz-bench-external-modules.d.ts" <<'TYPES'
+declare module 'proxy-compare' {
+  export type affectedToPathList<A = any, B = any, C = any, D = any, E = any> = any;
+  export const affectedToPathList: any;
+  export type createProxy<A = any, B = any, C = any, D = any, E = any> = any;
+  export const createProxy: any;
+  export type getUntracked<A = any, B = any, C = any, D = any, E = any> = any;
+  export const getUntracked: any;
+  export type isChanged<A = any, B = any, C = any, D = any, E = any> = any;
+  export const isChanged: any;
+  export type markToTrack<A = any, B = any, C = any, D = any, E = any> = any;
+  export const markToTrack: any;
+  const __tszDefault: any;
+  export default __tszDefault;
+}
+TYPES
+  cat > "$fixture_dir/tsz-bench-globals.d.ts" <<'TYPES'
+// react hooks are called with explicit type arguments (`useRef<T>(...)`,
+// `useMemo<T>(...)`) and receive inline callbacks whose parameters must pick up
+// a contextual type (otherwise noImplicitAny trips TS7006). Generic call
+// signatures satisfy the type-arg calls; the index signature keeps every other
+// member `any`.
+declare module 'react' {
+  export const useCallback: <T = any>(cb: (...args: any[]) => any, deps?: any) => any;
+  export const useDebugValue: (...args: any[]) => any;
+  export const useEffect: (effect: (...args: any[]) => any, deps?: any) => any;
+  export const useLayoutEffect: (effect: (...args: any[]) => any, deps?: any) => any;
+  export const useMemo: <T = any>(factory: (...args: any[]) => any, deps?: any) => any;
+  export const useRef: <T = any>(initial?: any) => any;
+  export const useSyncExternalStore: <T = any>(...args: any[]) => any;
+  const _default: any;
+  export default _default;
+}
+
+// `@redux-devtools/extension` augments the global `Window` with the devtools
+// connector; valtio reads `window.__REDUX_DEVTOOLS_EXTENSION__` directly, so the
+// property must exist on `Window` rather than tripping TS2339.
+declare module '@redux-devtools/extension';
+
+interface Window {
+  __REDUX_DEVTOOLS_EXTENSION__?: {
+    connect(options: { [key: string]: any }): any;
+    [key: string]: any;
+  };
+}
+TYPES
+}
+
+tsz_write_msw_canary_stubs() {
+  local output="$1"
+  local fixture_dir
+  fixture_dir="$(dirname "$output")"
+  cat > "$fixture_dir/tsz-bench-external-modules.d.ts" <<'TYPES'
+declare module '@mswjs/interceptors/ClientRequest' {
+  export type ClientRequestInterceptor<A = any, B = any, C = any, D = any, E = any> = any;
+  export const ClientRequestInterceptor: any;
+  const __tszDefault: any;
+  export default __tszDefault;
+}
+declare module '@mswjs/interceptors/XMLHttpRequest' {
+  export type XMLHttpRequestInterceptor<A = any, B = any, C = any, D = any, E = any> = any;
+  export const XMLHttpRequestInterceptor: any;
+  const __tszDefault: any;
+  export default __tszDefault;
+}
+declare module '@mswjs/interceptors/fetch' {
+  export type FetchInterceptor<A = any, B = any, C = any, D = any, E = any> = any;
+  export const FetchInterceptor: any;
+  const __tszDefault: any;
+  export default __tszDefault;
+}
+declare module 'cookie' {
+  export type parse<A = any, B = any, C = any, D = any, E = any> = any;
+  export const parse: any;
+  export type serialize<A = any, B = any, C = any, D = any, E = any> = any;
+  export const serialize: any;
+  const __tszDefault: any;
+  export default __tszDefault;
+}
+declare module 'is-node-process' {
+  export type isNodeProcess<A = any, B = any, C = any, D = any, E = any> = any;
+  export const isNodeProcess: any;
+  const __tszDefault: any;
+  export default __tszDefault;
+}
+declare module 'path-to-regexp' {
+  export type match<A = any, B = any, C = any, D = any, E = any> = any;
+  export const match: any;
+  const __tszDefault: any;
+  export default __tszDefault;
+}
+declare module 'statuses' {
+  export type message<A = any, B = any, C = any, D = any, E = any> = any;
+  export const message: any;
+  const __tszDefault: any;
+  export default __tszDefault;
+}
+declare module 'tough-cookie' {
+  export type Cookie<A = any, B = any, C = any, D = any, E = any> = any;
+  export const Cookie: any;
+  export type CookieJar<A = any, B = any, C = any, D = any, E = any> = any;
+  export const CookieJar: any;
+  export type MemoryCookieStore<A = any, B = any, C = any, D = any, E = any> = any;
+  export const MemoryCookieStore: any;
+  export type MemoryCookieStoreIndex<A = any, B = any, C = any, D = any, E = any> = any;
+  export const MemoryCookieStoreIndex: any;
+  export type SerializedCookie<A = any, B = any, C = any, D = any, E = any> = any;
+  export const SerializedCookie: any;
+  const __tszDefault: any;
+  export default __tszDefault;
+}
+declare module 'type-fest' {
+  export type PartialDeep<A = any, B = any, C = any, D = any, E = any> = any;
+  export const PartialDeep: any;
+  const __tszDefault: any;
+  export default __tszDefault;
+}
+TYPES
+  cat > "$fixture_dir/tsz-bench-globals.d.ts" <<'TYPES'
+// msw builds for a dual Node.js + browser environment; its real tsconfig pulls
+// in @types/node. The clone installs nothing and the bench baseline pins
+// `types: []` with a DOM-only lib, so the Node-flavored globals msw relies on
+// (the `require` fallback, the `NodeJS` namespace, and `setTimeout` returning a
+// ref-counted handle rather than a `number`) are missing and tsc emits spurious
+// TS2591/TS2503/TS2339/TS2345. Provide the minimal Node ambient surface so
+// msw's own source type-checks like it does against @types/node.
+declare function require(id: string): any;
+
+declare namespace NodeJS {
+  // msw's `hasRefCounted` narrows to `T & NodeJS.RefCounted` before calling
+  // `.unref()` on a timer/BroadcastChannel handle.
+  interface RefCounted {
+    ref(): this;
+    unref(): this;
+    hasRef(): boolean;
+  }
+  interface Timeout extends RefCounted {
+    [Symbol.toPrimitive](): number;
+  }
+  type Immediate = RefCounted;
+  type Timer = Timeout;
+  interface ProcessEnv {
+    [key: string]: string | undefined;
+  }
+}
+
+// With @types/node, `setTimeout` returns an object handle (not the DOM `number`),
+// which msw's `hasRefCounted(timeoutId)` guard (constrained `T extends object`)
+// depends on. The generic `@types/node` signature is preferred over lib.dom's
+// non-generic `TimerHandler` overload during resolution, so this return type
+// wins even when the callback is a pre-typed function (e.g. a Promise executor's
+// `resolve`).
+declare function setTimeout<TArgs extends any[]>(
+  callback: (...args: TArgs) => void,
+  ms?: number,
+  ...args: TArgs
+): NodeJS.Timeout;
+
+// ---------------------------------------------------------------------------
+// External runtime dependencies used with real shapes (not resolvable as bare
+// `any`, or `any` would break a real relation such as HttpResponse's Response
+// inheritance chain). Each remaining external is stubbed generically in
+// tsz-bench-external-modules.d.ts.
+// ---------------------------------------------------------------------------
+
+declare module '@mswjs/interceptors' {
+  // msw's HttpResponse `extends FetchResponse`; FetchResponse itself extends the
+  // global Response, so HttpResponse must remain a structural Response. Stubbing
+  // FetchResponse as bare `any` severs that chain and cascades into TS2345/TS2352
+  // wherever an HttpResponse flows into a Response position.
+  export class FetchResponse extends Response {
+    constructor(body?: any, init?: any);
+    static error(): any;
+    static json(body?: any, init?: any): any;
+    static isResponse(value: any): value is Response;
+    static isResponseWithBody(status: number): boolean;
+    static isConfigurableStatusCode(status: number): boolean;
+    static isRedirectResponse(status: number): boolean;
+    static parseRawHeaders(rawHeaders: any): Headers;
+    [key: string]: any;
+  }
+  export class Interceptor<E = any> {
+    constructor(...args: any[]);
+    [key: string]: any;
+  }
+  export class BatchInterceptor<E = any, F = any> {
+    constructor(...args: any[]);
+    [key: string]: any;
+  }
+  export class RequestController {
+    constructor(...args: any[]);
+    respondWith(response: any): void;
+    [key: string]: any;
+  }
+  export type HttpRequestEventMap = any;
+  export function createRequestId(): string;
+  export function getCleanUrl(url: any, isAbsolute?: boolean): string;
+  export function resolveWebSocketUrl(url: any): any;
+}
+
+// The WebSocket interceptor subpath drives msw's WebSocket handling: connection
+// objects are destructured and their `addEventListener` callbacks must receive a
+// contextual `event` type (otherwise noImplicitAny trips TS7006 on every
+// listener). Model the connection surface explicitly; other members stay `any`.
+declare module '@mswjs/interceptors/WebSocket' {
+  // The minimal connection protocol (no raw `socket`) is what msw's
+  // `WebSocketRemoteClientConnection` implements and what `WebSocketHandler`
+  // consumes; `removeEventListener` is optional since the remote client omits it.
+  interface WebSocketConnectionProtocol {
+    id: string;
+    url: URL;
+    addEventListener(type: any, listener: (event: any) => any, options?: any): void;
+    removeEventListener?(type: any, listener: (event: any) => any, options?: any): void;
+    send(data: any): void;
+    close(code?: any, reason?: any): void;
+    [key: string]: any;
+  }
+  export type WebSocketClientConnectionProtocol = WebSocketConnectionProtocol;
+  export type WebSocketServerConnectionProtocol = WebSocketConnectionProtocol;
+  // The full connection additionally exposes the underlying `socket` that the
+  // logger attaches listeners to.
+  interface WebSocketConnectionFull extends WebSocketConnectionProtocol {
+    socket: {
+      addEventListener(type: any, listener: (event: any) => any, options?: any): void;
+      removeEventListener(type: any, listener: (event: any) => any, options?: any): void;
+      send(data: any): void;
+      close(code?: any, reason?: any): void;
+      readyState: number;
+      [key: string]: any;
+    };
+  }
+  export type WebSocketClientConnection = WebSocketConnectionFull;
+  export type WebSocketServerConnection = WebSocketConnectionFull;
+  export interface WebSocketConnectionData {
+    client: WebSocketConnectionFull;
+    server: WebSocketConnectionFull;
+    // Required (not optional): msw's WebSocketHandlerConnection declares
+    // `info: WebSocketConnectionData['info']` as a required property and builds
+    // it by spreading a connection, so an optional `info` here is not assignable.
+    info: any;
+    [key: string]: any;
+  }
+  export type WebSocketData = any;
+  export interface WebSocketClientEventMap {
+    [key: string]: any;
+  }
+  export interface WebSocketEventMap {
+    [key: string]: any;
+  }
+  export class WebSocketInterceptor {
+    constructor(...args: any[]);
+    on(event: any, listener: (...args: any[]) => any): this;
+    once(event: any, listener: (...args: any[]) => any): this;
+    off(event: any, listener?: (...args: any[]) => any): this;
+    apply(): void;
+    dispose(): void;
+    [key: string]: any;
+  }
+}
+
+declare module '@open-draft/deferred-promise' {
+  // Constructed with an optional executor and awaited; the class extends Promise
+  // so `.then`/`.catch`/`.finally` resolve and the executor callback parameters
+  // pick up a contextual type (avoiding TS7031/TS7006).
+  export class DeferredPromise<T = any> extends Promise<T> {
+    constructor(
+      executor?: (
+        resolve: (value?: T | PromiseLike<T>) => void,
+        reject: (reason?: any) => void,
+      ) => void,
+    );
+    resolve(value?: T | PromiseLike<T>): void;
+    reject(reason?: any): void;
+    state: 'pending' | 'fulfilled' | 'rejected';
+    rejectionReason: any;
+    [key: string]: any;
+  }
+  export type DeferredPromiseExecutor<T = any> = any;
+}
+
+declare module 'graphql' {
+  // Parsed documents are iterated (`node.definitions.find(...)`), so `parse` must
+  // return a real DocumentNode shape rather than bare `any` (which collapses the
+  // callback parameter to implicit-any, tripping TS7006, and narrows dependent
+  // unions to `never`).
+  export interface DocumentNode {
+    kind: any;
+    definitions: readonly any[];
+    [key: string]: any;
+  }
+  export interface OperationDefinitionNode {
+    kind: any;
+    operation: any;
+    name?: any;
+    [key: string]: any;
+  }
+  export type OperationTypeNode = 'query' | 'mutation' | 'subscription';
+  export function parse(source: any, options?: any): DocumentNode;
+  export function print(ast: any): string;
+  export class GraphQLError extends Error {
+    constructor(message: string, ...args: any[]);
+    [key: string]: any;
+  }
+  const _default: any;
+  export default _default;
+}
+
+declare module 'until-async' {
+  // Called with explicit type arguments (`until<Error, Tuple>(cb)`) and its result
+  // destructured as `[error, data]`.
+  export function until<Err = any, Data = any>(
+    callback: () => Promise<Data> | Data,
+  ): Promise<[Err | null, Data]>;
+}
+
+declare module 'headers-polyfill' {
+  // `stringToHeaders` must return a real `Headers` so downstream `.get(...)`
+  // narrows to `string | null` (a bare `any` collapses callbacks over the parsed
+  // result into implicit-any parameters, tripping TS7006).
+  export function stringToHeaders(str: string): Headers;
+  export function headersToString(headers: Headers): string;
+  export function headersToObject(headers: Headers): Record<string, any>;
+  export function objectToHeaders(obj: any): Headers;
+  export function reduceHeadersObject<T = any>(headers: any, reducer: any, initial: T): T;
+  export function flattenHeadersObject(obj: any): Record<string, string>;
+  export const Headers: typeof globalThis.Headers;
+}
+
+declare module 'outvariant' {
+  export function invariant(
+    predicate: any,
+    message: string,
+    ...positionals: any[]
+  ): asserts predicate;
+  export namespace invariant {
+    function as(
+      ErrorConstructor: any,
+      predicate: any,
+      message: string,
+      ...positionals: any[]
+    ): asserts predicate;
+  }
+  export function format(message: string, ...positionals: any[]): string;
+  export class InvariantError extends Error {}
+}
+
+// strict-event-emitter and rettime both export an `Emitter` used as a generic
+// type, constructed, called with typed listeners, and dereferenced as a
+// namespace (`Emitter.Listener<...>`). A class+namespace merge with generic
+// methods covers value, type, generic-call, and namespace-member positions.
+declare module 'strict-event-emitter' {
+  export class Emitter<E = any> {
+    on<T = any>(type: any, listener: (...args: any[]) => any): this;
+    once<T = any>(type: any, listener: (...args: any[]) => any): this;
+    off<T = any>(type: any, listener?: (...args: any[]) => any): this;
+    emit<T = any>(type: any, ...args: any[]): boolean;
+    addListener<T = any>(type: any, listener: (...args: any[]) => any): this;
+    removeListener<T = any>(type: any, listener: (...args: any[]) => any): this;
+    removeAllListeners<T = any>(type?: any): this;
+    listeners<T = any>(type: any): Array<(...args: any[]) => any>;
+    listenerCount<T = any>(type: any): number;
+    [key: string]: any;
+  }
+  export namespace Emitter {
+    type Listener<A = any, B = any> = (...args: any[]) => any;
+    type EventMap = any;
+  }
+  export type EventMap = any;
+  export class MemoryLeakError extends Error {}
+}
+
+declare module 'rettime' {
+  export class Emitter<E = any> {
+    on<T = any>(type: any, listener: (...args: any[]) => any, options?: any): any;
+    once<T = any>(type: any, listener: (...args: any[]) => any, options?: any): any;
+    off<T = any>(type: any, listener?: (...args: any[]) => any): any;
+    emit<T = any>(type: any, ...args: any[]): any;
+    emitAsPromise<T = any>(type: any, ...args: any[]): Promise<any>;
+    addListener<T = any>(type: any, listener: (...args: any[]) => any, options?: any): any;
+    removeListener<T = any>(type: any, listener?: (...args: any[]) => any): any;
+    removeAllListeners<T = any>(type?: any): any;
+    listeners<T = any>(type?: any): Array<(...args: any[]) => any>;
+    listenerCount<T = any>(type?: any): number;
+    [key: string]: any;
+  }
+  export namespace Emitter {
+    type Listener<A = any, B = any> = (...args: any[]) => any;
+    type Event<A = any, B = any, C = any> = any;
+    type EventMap = any;
+  }
+  export class TypedEvent<A = any, B = any, C = any, D = any, E = any> {
+    // msw's frame subclasses call `super(...([type, {}] as any))`, spreading an
+    // `any`-typed array into the constructor; a rest parameter accepts it.
+    constructor(...args: any[]);
+    type: any;
+    data: any;
+    [key: string]: any;
+  }
+  export type TypedListenerOptions<A = any, B = any, C = any> = any;
+  export type DefaultEventMap = any;
+}
+
+// msw's Node adapter uses `AsyncLocalStorage` from `node:async_hooks` as both a
+// generic type and a constructor; @types/node supplies it in the real build.
+declare module 'node:async_hooks' {
+  export class AsyncLocalStorage<T = any> {
+    getStore(): T | undefined;
+    run<R>(store: T, callback: (...args: any[]) => R, ...args: any[]): R;
+    enterWith(store: T): void;
+    disable(): void;
+    [key: string]: any;
+  }
+  export class AsyncResource {
+    constructor(type: string, options?: any);
+    [key: string]: any;
+  }
+}
+TYPES
+}
+
+tsz_write_tanstack_router_canary_stubs() {
+  local output="$1"
+  local fixture_dir
+  fixture_dir="$(dirname "$output")"
+  cat > "$fixture_dir/tsz-bench-external-modules.d.ts" <<'TYPES'
+
+TYPES
+  cat > "$fixture_dir/tsz-bench-globals.d.ts" <<'TYPES'
+// tanstack router-core reads `process.env.NODE_ENV` for dev/prod branching; its
+// real build resolves `process` via @types/node, absent in the clone-only
+// fixture. Provide an ambient any `process` (mirroring @types/node's global).
+declare var process: any;
+
+// seroval's plugin API: `createPlugin({ test, parse, serialize, deserialize })`
+// registers custom serializers. The config callbacks must carry typed parameters
+// (a bare `any` config collapses `serialize(node, ctx, data)` params to
+// implicit-any, tripping TS7006). Model the config surface; payloads stay `any`.
+declare module 'seroval' {
+  export type SerovalNode = any;
+  export type PluginData = any;
+  export interface PluginInfo {
+    [key: string]: any;
+  }
+  export interface Plugin<T = any, N = any> {
+    [key: string]: any;
+  }
+  interface SerovalPluginParse {
+    sync?(value: any, ctx: any, data?: any): any;
+    async?(value: any, ctx: any, data?: any): any;
+    stream?(value: any, ctx: any, data?: any): any;
+    parse?(value: any, ctx: any, data?: any): any;
+  }
+  interface CreatePluginArgs<T = any, N = any> {
+    tag: any;
+    extends?: any;
+    test(value: unknown): boolean;
+    parse: SerovalPluginParse | ((value: any, ctx: any, data?: any) => any);
+    serialize(node: any, ctx: any, data?: any): any;
+    deserialize?: ((node: any, ctx: any, data?: any) => any) | undefined;
+    [key: string]: any;
+  }
+  export function createPlugin<T = any, N = any>(def: CreatePluginArgs<T, N>): Plugin<T, N>;
+  export function createStream<T = any>(): any;
+  export function crossSerializeStream(
+    source: any,
+    options?: {
+      onSerialize?: (data: any, initial: any) => any;
+      onDone?: (...args: any[]) => any;
+      [key: string]: any;
+    },
+  ): any;
+  export function getCrossReferenceHeader(...args: any[]): any;
+  const _default: any;
+  export default _default;
+}
+
+declare module 'seroval-plugins/web' {
+  export const ReadableStreamPlugin: any;
+  const _default: any;
+  export default _default;
+}
+
+// router-core's SSR path imports Node stream/http2 APIs. `node:stream/web`'s
+// WHATWG streams mirror the DOM lib globals (present here), so alias them for
+// real typing; `node:stream` / `node:http2` are Node-only, stubbed permissively.
+declare module 'node:stream/web' {
+  export const ReadableStream: typeof globalThis.ReadableStream;
+  export type ReadableStream<R = any> = globalThis.ReadableStream<R>;
+  export const WritableStream: typeof globalThis.WritableStream;
+  export type WritableStream<W = any> = globalThis.WritableStream<W>;
+  export const TransformStream: typeof globalThis.TransformStream;
+  export type TransformStream<I = any, O = any> = globalThis.TransformStream<I, O>;
+}
+declare module 'node:stream' {
+  export class Readable {
+    [key: string]: any;
+    static from(iterable: any, options?: any): Readable;
+    static toWeb(stream: any, options?: any): any;
+    static fromWeb(stream: any, options?: any): any;
+  }
+  export class Writable {
+    [key: string]: any;
+  }
+  const _default: any;
+  export default _default;
+}
+declare module 'node:http2' {
+  export type OutgoingHttpHeaders = Record<string, any>;
+  const _default: any;
+  export default _default;
+}
+
+declare module 'cookie-es' {
+  // `splitSetCookieString` returns a string[] that router-core iterates; a bare
+  // `any` collapses the `.forEach((cookie) => ...)` callback to implicit-any.
+  export function splitSetCookieString(cookiesString: string | string[]): string[];
+  export function parse(str: string, options?: any): Record<string, string>;
+  export function serialize(name: string, value: string, options?: any): string;
+  export function parseSetCookie(setCookieValue: string, options?: any): any;
+  const _default: any;
+  export default _default;
+}
+TYPES
+}
+
+tsz_write_ts_morph_canary_stubs() {
+  local output="$1"
+  local fixture_dir
+  fixture_dir="$(dirname "$output")"
+  cat > "$fixture_dir/tsz-bench-external-modules.d.ts" <<'TYPES'
+declare module 'conditional-type-checks' {
+  export type AssertTrue<A = any, B = any, C = any, D = any, E = any> = any;
+  export const AssertTrue: any;
+  export type IsExact<A = any, B = any, C = any, D = any, E = any> = any;
+  export const IsExact: any;
+  const __tszDefault: any;
+  export default __tszDefault;
+}
+TYPES
+  cat > "$fixture_dir/tsz-bench-globals.d.ts" <<'TYPES'
+// ts-morph re-exports `code-block-writer`'s default export as the value AND type
+// `CodeBlockWriter` (`writer: CodeBlockWriter`). A bare `any` default export is a
+// value only, so every type-position use trips TS2749. A default-exported class
+// is usable in both positions; the index signature keeps all methods `any` while
+// preserving fluent chaining.
+declare module 'code-block-writer' {
+  export default class CodeBlockWriter {
+    constructor(opts?: any);
+    [key: string]: any;
+  }
+  export type Options = any;
+}
+TYPES
+}

--- a/scripts/bench/lib/project-fixture-stubs.sh
+++ b/scripts/bench/lib/project-fixture-stubs.sh
@@ -38,10 +38,11 @@ declare const Buffer: {
   isBuffer(value: unknown): boolean;
   compare(left: unknown, right: unknown): number;
   from(value: unknown, encoding?: string): Buffer;
+  from(value: unknown, byteOffset: number, length?: number): Buffer;
 };
 
 interface ErrorConstructor {
-  captureStackTrace?(targetObject: object, constructorOpt?: Function): void;
+  captureStackTrace(targetObject: object, constructorOpt?: Function): void;
 }
 
 interface DurableObjectStorage {
@@ -249,6 +250,8 @@ declare module '@opentelemetry/api' {
   export type Span<T = any, U = any, V = any, W = any> = any;
   export const Tracer: any;
   export type Tracer<T = any, U = any, V = any, W = any> = any;
+  export const trace: any;
+  export const SpanStatusCode: any;
 }
 
 declare module '@planetscale/database' {
@@ -501,22 +504,32 @@ declare module 'mysql2' {
 }
 
 declare module 'mysql2/promise' {
-  export const Connection: any;
-  export type Connection<T = any, U = any, V = any, W = any> = any;
-  export const FieldPacket: any;
-  export type FieldPacket<T = any, U = any, V = any, W = any> = any;
-  export const OkPacket: any;
-  export type OkPacket<T = any, U = any, V = any, W = any> = any;
-  export const Pool: any;
-  export type Pool<T = any, U = any, V = any, W = any> = any;
-  export const PoolConnection: any;
-  export type PoolConnection<T = any, U = any, V = any, W = any> = any;
-  export const QueryOptions: any;
-  export type QueryOptions<T = any, U = any, V = any, W = any> = any;
-  export const ResultSetHeader: any;
-  export type ResultSetHeader<T = any, U = any, V = any, W = any> = any;
-  export const RowDataPacket: any;
-  export type RowDataPacket<T = any, U = any, V = any, W = any> = any;
+  // Typed just enough for drizzle's singlestore session (transitively checked via
+  // singlestore-core): a generic `query`/`execute` returning the real
+  // `[rows, fields]` tuple, mirroring @types/mysql2, so `client.query<T>()` is a
+  // generic call (not an untyped one) and its rows carry a real type.
+  export interface FieldPacket { [key: string]: any; }
+  export interface OkPacket { [key: string]: any; }
+  export interface ResultSetHeader { [key: string]: any; }
+  export interface RowDataPacket { [key: string]: any; }
+  export interface QueryOptions { [key: string]: any; }
+  export interface Connection {
+    query<T = any>(sql: any, values?: any): Promise<[T, FieldPacket[]]>;
+    execute<T = any>(sql: any, values?: any): Promise<[T, FieldPacket[]]>;
+    [key: string]: any;
+  }
+  export interface Pool extends Connection {}
+  export interface PoolConnection extends Connection {}
+}
+
+declare module 'node:fs' {
+  // drizzle's core `migrator.ts` does `readFileSync(...).toString().split(...)`;
+  // typing `readFileSync` as string-returning (vs the bare any-stub) gives the
+  // downstream string ops real types, mirroring @types/node for this call site.
+  const readFileSync: (path: any, options?: any) => string;
+  const _default: { readFileSync: typeof readFileSync; [key: string]: any };
+  export default _default;
+  export { readFileSync };
 }
 
 declare module 'node:events' {
@@ -679,6 +692,106 @@ declare namespace NodeJS {
   type Timer = any;
   type Immediate = any;
   type ErrnoException = any;
+}
+declare var Buffer: any;
+declare var process: any;
+TYPES
+}
+
+tsz_write_effect_external_stubs() {
+  # effect's real build installs `fast-check` + `@standard-schema/spec` and pins
+  # `types: ["node"]`; the bench clone installs none. The two-file split is
+  # load-bearing: `FastCheck.ts` does `export * from "fast-check"`, which only
+  # re-surfaces named types when the fast-check ambient module lives in a SCRIPT
+  # file (no top-level export), while `declare global` requires a MODULE file
+  # (hence the `export {}`). Row is still red after this (5 residual errors:
+  # effect threads element types through fast-check's real generic factory
+  # surface, which a hand stub cannot fully reproduce — needs vendored
+  # fast-check .d.ts); the stubs remove the ~220 spurious resolution errors so
+  # the residual diagnostic set is the honest one.
+  local output="$1"
+  local fixture_dir
+  fixture_dir="$(dirname "$output")"
+  cat > "$fixture_dir/tsz-bench-globals.d.ts" <<'TYPES'
+// node globals effect's source reads (real config pins `types: ["node"]`; the
+// bench clone installs none). `declare global` requires module scope, hence the
+// `export {}`. Ambient external-module stubs live in tsz-bench-modules.d.ts,
+// which must stay a script file so `export * from "fast-check"` re-exports them.
+export {};
+
+declare global {
+  var process: any;
+  var setImmediate: (...args: any[]) => any;
+  interface ErrorConstructor {
+    stackTraceLimit: number;
+    captureStackTrace(targetObject: object, constructorOpt?: Function): void;
+  }
+}
+TYPES
+  cat > "$fixture_dir/tsz-bench-modules.d.ts" <<'TYPES'
+// effect installs `fast-check` + `@standard-schema/spec`; the bench clone does
+// not. Mirror only the surface effect's own source consumes. `FastCheck.ts` does
+// `export * from "fast-check"`, so this MUST be a script (no top-level export)
+// ambient module declaration for the re-export to surface these named types.
+declare module '@standard-schema/spec' {
+  export type StandardSchemaV1<Input = unknown, Output = Input> = any;
+  export namespace StandardSchemaV1 {
+    export type Props<Input = unknown, Output = Input> = any;
+    export type Result<Output> = any;
+    export type InferInput<Schema> = any;
+    export type InferOutput<Schema> = any;
+    export type FailureResult = any;
+    export type Issue = any;
+  }
+}
+
+declare module 'fast-check' {
+  export interface Arbitrary<T = any> {
+    map<U>(f: (t: T) => U): Arbitrary<U>;
+    chain<U>(f: (t: T) => Arbitrary<U>): Arbitrary<U>;
+    filter(f: (t: T) => boolean): Arbitrary<T>;
+    noBias(): Arbitrary<T>;
+    noShrink(): Arbitrary<T>;
+  }
+  export interface StringSharedConstraints { minLength?: number; maxLength?: number; }
+  export interface FloatConstraints {
+    min?: number; max?: number; minExcluded?: boolean; maxExcluded?: boolean;
+    noNaN?: boolean; noDefaultInfinity?: boolean;
+  }
+  export interface BigIntConstraints { min?: bigint; max?: bigint; }
+  export interface ArrayConstraints { minLength?: number; maxLength?: number; }
+  export interface DateConstraints { min?: Date; max?: Date; noInvalidDate?: boolean; }
+  type ArbFactory = <A = any, B = any, C = any>(...args: any[]) => Arbitrary<any>;
+  export const anything: ArbFactory;
+  // Type-preserving signatures for the factories whose element type effect
+  // threads through into `LazyArbitrary<F<A>>` results (matching fast-check's
+  // real generics); an `any`-returning factory would collapse A to `unknown`.
+  export function array<T>(arb: Arbitrary<T>, constraints?: ArrayConstraints): Arbitrary<T[]>;
+  export function constant<T>(value: T): Arbitrary<T>;
+  export function constantFrom<T>(...values: T[]): Arbitrary<T>;
+  export function oneof<T>(...args: Array<Arbitrary<T> | object>): Arbitrary<T>;
+  export function tuple<T extends readonly unknown[]>(
+    ...arbs: { [K in keyof T]: Arbitrary<T[K]> }
+  ): Arbitrary<T>;
+  export const bigInt: ArbFactory;
+  export const boolean: ArbFactory;
+  export const date: ArbFactory;
+  export const float: ArbFactory;
+  export const integer: ArbFactory;
+  // `letrec` returns a record of named arbitraries; effect destructures the
+  // result (`const { FiberId } = fc.letrec((tie) => ({ FiberId: ... }))`), so it
+  // must be `any` (not `Arbitrary`) with a typed builder param.
+  export const letrec: (builder: (tie: (key: string) => Arbitrary<any>) => any) => any;
+  export const maxSafeNat: ArbFactory;
+  export const object: ArbFactory;
+  export function record<T>(fields: { [K in keyof T]: Arbitrary<T[K]> }): Arbitrary<T>;
+  export function record<T, C>(fields: { [K in keyof T]: Arbitrary<T[K]> }, constraints: C): Arbitrary<any>;
+  export const string: ArbFactory;
+  export const stringMatching: ArbFactory;
+  export const uint8Array: ArbFactory;
+  export const ulid: ArbFactory;
+  export const uuid: ArbFactory;
+  export const webUrl: ArbFactory;
 }
 TYPES
 }

--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -23,6 +23,8 @@ TSZ_PROJECT_ROWS_MJS="$TSZ_PROJECT_FIXTURES_ROOT/scripts/bench/project-rows.mjs"
 # functions that call the stub writers are invoked.
 # shellcheck source=lib/project-fixture-stubs.sh
 source "$TSZ_PROJECT_FIXTURES_ROOT/scripts/bench/lib/project-fixture-stubs.sh"
+# shellcheck source=lib/project-fixture-stubs-canary.sh
+source "$TSZ_PROJECT_FIXTURES_ROOT/scripts/bench/lib/project-fixture-stubs-canary.sh"
 
 # Canonical project row groups for runners that share fixture handling.
 # Keep row names here aligned with the project-corpus workflows.
@@ -773,13 +775,20 @@ tsz_write_basic_external_project_config() {
   # for projects that import sibling modules with explicit `.ts` extensions).
   local extra_compiler_options="${3:-}"
   local extra_include="${4:-}"
+  # Optional 5th arg: extra exclude JSON lines (each with its own trailing
+  # comma) injected before the shared node_modules/dist/build tail. Used by
+  # fixtures that must drop optional-dependency or test-scaffolding subtrees.
+  local extra_exclude="${5:-}"
+  # Optional 6th arg: inner JSON of the lib array, for fixtures whose real
+  # tsconfig pins a different lib set (e.g. esnext, or es2023 + disposable).
+  local lib_entries="${6:-\"es2022\", \"dom\", \"dom.iterable\"}"
   cat > "$output" <<JSON
 {
   "compilerOptions": {
     "target": "es2022",
     "module": "esnext",
     "strict": true,
-    "lib": ["es2022", "dom", "dom.iterable"],
+    "lib": [${lib_entries}],
     "types": [],
     "skipLibCheck": true,
     "noEmit": true,
@@ -798,7 +807,7 @@ ${extra_compiler_options}    "resolveJsonModule": true
     "**/*.spec.ts",
     "**/*.spec.tsx",
     "**/__tests__/**",
-    "**/node_modules/**",
+${extra_exclude}    "**/node_modules/**",
     "**/dist/**",
     "**/build/**"
   ]
@@ -807,7 +816,17 @@ JSON
 }
 
 tsz_write_valibot_config() {
-  tsz_write_basic_external_project_config "$1" "library/src"
+  # valibot imports sibling modules with explicit `.ts` extensions; its real
+  # library/tsconfig.json sets allowImportingTsExtensions (paired with noEmit).
+  # Its only external import is `vitest`, a devDependency used solely by the
+  # test-scaffolding helpers under library/src/vitest/** (not re-exported by
+  # the shipped barrel), so exclude that subtree instead of stubbing vitest.
+  tsz_write_basic_external_project_config "$1" "library/src" \
+    '    "allowImportingTsExtensions": true,
+' \
+    "" \
+    '    "**/vitest/**",
+'
 }
 
 tsz_write_msw_config() {
@@ -819,15 +838,22 @@ tsz_write_msw_config() {
   # `moduleResolution: bundler` does not probe with a `.ts` extension -- bundled
   # tsc emits the same TS2307 on those specifiers without the `paths` mapping.
   # Mirror upstream's `paths` so the fixture replicates msw's actual resolution
-  # setup; both tsc and tsz then bind `#core/...` to src/core sources. (External
-  # dependency specifiers such as `outvariant`/`@mswjs/interceptors` remain
-  # unresolved because the clone installs nothing, matching tsc.)
+  # setup; both tsc and tsz then bind `#core/...` to src/core sources. External
+  # dependency specifiers (outvariant, @mswjs/interceptors, graphql, rettime,
+  # cookie/tough-cookie, path-to-regexp, ...) are ambient-stubbed — see
+  # tsz_write_msw_canary_stubs; FetchResponse must extend the real Response or
+  # msw's HttpResponse loses its Response inheritance chain and cascades. Row
+  # keeps 3 honest residuals (rettime's real conditional-type machinery cannot
+  # be reproduced by permissive stubs: 2 now-unused upstream @ts-expect-error
+  # directives + 1 contextual-param implicit any).
+  tsz_write_msw_canary_stubs "$1"
   tsz_write_basic_external_project_config "$1" "src" \
     '    "paths": {
       "#core": ["./src/core"],
       "#core/*": ["./src/core/*"]
     },
-'
+' \
+    ', "tsz-bench-external-modules.d.ts", "tsz-bench-globals.d.ts"'
 }
 
 tsz_write_comlink_config() {
@@ -835,7 +861,13 @@ tsz_write_comlink_config() {
 }
 
 tsz_write_effect_config() {
-  tsz_write_basic_external_project_config "$1" "packages/effect/src"
+  # Best-effort dependency stubs (fast-check + @standard-schema/spec + node
+  # globals) cut the tsc-side wall from ~228 spurious resolution errors to 5
+  # honest residuals; see tsz_write_effect_external_stubs for why the row is
+  # still red and what a full fix needs.
+  tsz_write_effect_external_stubs "$1"
+  tsz_write_basic_external_project_config "$1" "packages/effect/src" "" \
+    ', "tsz-bench-globals.d.ts", "tsz-bench-modules.d.ts"'
 }
 
 tsz_write_drizzle_orm_config() {
@@ -846,15 +878,45 @@ tsz_write_drizzle_orm_config() {
   # drizzle-orm/src rather than upstream's config-relative src. The fixture does
   # not install the optional driver dependency graph, so unknown package imports
   # use local any stubs while package-internal paths still bind source.
+  # Driver adapter subtrees wrapping uninstalled optional peer dependencies
+  # (package.json peerDependenciesMeta marks all 29 driver deps optional) are
+  # excluded: each mostly re-types an absent client library, exploding under
+  # strict/noImplicitAny in a no-install clone. Core dialect logic
+  # (pg/mysql/sqlite/singlestore-core, sql, query-builders) stays fully
+  # checked; op-sqlite and tidb-serverless compile clean and stay included.
+  # Path targets are ./-prefixed: with baseUrl unset, tsc 6 rejects
+  # non-relative paths targets with TS5090.
   tsz_write_drizzle_orm_external_stubs "$1"
   tsz_write_basic_external_project_config "$1" "drizzle-orm/src" \
     '    "paths": {
-      "~/*": ["drizzle-orm/src/*"],
-      "*": ["tsz-bench-external-module.d.ts"]
+      "~/*": ["./drizzle-orm/src/*"],
+      "*": ["./tsz-bench-external-module.d.ts"]
     },
     "allowImportingTsExtensions": true,
 ' \
-    ', "tsz-bench-external-named-modules.d.ts"'
+    ', "tsz-bench-external-named-modules.d.ts"' \
+    '    "drizzle-orm/src/aws-data-api/**",
+    "drizzle-orm/src/better-sqlite3/**",
+    "drizzle-orm/src/bun-sql/**",
+    "drizzle-orm/src/d1/**",
+    "drizzle-orm/src/expo-sqlite/**",
+    "drizzle-orm/src/gel/**",
+    "drizzle-orm/src/knex/**",
+    "drizzle-orm/src/libsql/**",
+    "drizzle-orm/src/mysql2/**",
+    "drizzle-orm/src/neon-http/**",
+    "drizzle-orm/src/neon-serverless/**",
+    "drizzle-orm/src/netlify-db/**",
+    "drizzle-orm/src/node-postgres/**",
+    "drizzle-orm/src/pglite/**",
+    "drizzle-orm/src/planetscale-serverless/**",
+    "drizzle-orm/src/postgres-js/**",
+    "drizzle-orm/src/prisma/**",
+    "drizzle-orm/src/singlestore/**",
+    "drizzle-orm/src/sql-js/**",
+    "drizzle-orm/src/vercel-postgres/**",
+    "drizzle-orm/src/xata-http/**",
+'
 }
 
 tsz_write_ts_rest_config() {
@@ -900,11 +962,17 @@ tsz_write_radash_config() {
 tsz_write_valtio_config() {
   # valtio's `src/index.ts` re-exports `./vanilla.ts` / `./react.ts` with
   # explicit `.ts` extensions, permitted upstream via allowImportingTsExtensions
-  # (paired with noEmit). Without it tsc/tsz emit TS5097 and cascade; carry the
-  # option so the guard matches tsc.
+  # (paired with noEmit). External deps (react, proxy-compare,
+  # @redux-devtools/extension) are ambient-stubbed — react hooks keep generic
+  # call signatures so valtio's own hook usage stays contextually typed. One
+  # honest residual remains: proxyMap.ts guards Map.getOrInsert behind an
+  # upstream `[ONLY-TS-5.9.3]` @ts-expect-error marker not extended to tsc 6,
+  # and es2022 lib has no getOrInsert — genuine upstream source rot.
+  tsz_write_valtio_canary_stubs "$1"
   tsz_write_basic_external_project_config "$1" "src" \
     '    "allowImportingTsExtensions": true,
-'
+' \
+    ', "tsz-bench-external-modules.d.ts", "tsz-bench-globals.d.ts"'
 }
 
 tsz_write_scule_config() {
@@ -933,36 +1001,89 @@ tsz_write_change_case_config() {
 }
 
 tsz_write_tiny_invariant_config() {
-  # tiny-invariant is zero-dependency; its `src/tiny-invariant.ts` implements
-  # the runtime invariant helper. Both tsz and tsc emit only the shared TS2591
-  # process baseline line (0 tsz-only delta), so this is a clean green row.
-  tsz_write_basic_external_project_config "$1" "src"
+  # tiny-invariant is zero-dependency; its `src/tiny-invariant.ts` reads
+  # `process.env.NODE_ENV`, which upstream resolves via ambient @types/node
+  # (its real tsconfig sets no `types` pin). The no-install clone lacks node
+  # typings and the baseline pins types:[], so stub `process` as any (the
+  # immer/tanstack-query pattern); tsc then validates the fixture clean.
+  local fixture_dir
+  fixture_dir="$(dirname "$1")"
+  cat > "$fixture_dir/tsz-bench-globals.d.ts" <<'TYPES'
+declare const process: any;
+TYPES
+  tsz_write_basic_external_project_config "$1" "src" "" \
+    ', "tsz-bench-globals.d.ts"'
 }
 
 tsz_write_ts_belt_config() {
-  # ts-belt is zero-dependency; its source compiles under the shared baseline.
-  tsz_write_basic_external_project_config "$1" "src"
+  # ts-belt's REAL tsconfig compiles only `./src/**/index.ts` (each module's
+  # barrel); stray non-index sources like src/Dict/Dict.ts are stale
+  # ReScript-adjacent leftovers upstream never compiles, and Dict.ts contains a
+  # genuinely broken import (`NonNullable` is not exported by ../types).
+  # Mirroring upstream's include is alignment, not a check-weakening. lib
+  # esnext mirrors upstream's target/lib "esnext".
+  cat > "$1" <<'JSON'
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "strict": true,
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "types": [],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/index.ts"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.test-d.ts",
+    "**/*.test-d.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**",
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/build/**"
+  ]
+}
+JSON
 }
 
 tsz_write_ts_extras_config() {
-  # ts-extras imports `type-fest`, which is unresolved under the shared
-  # `types: []` baseline (the clone installs nothing). The resulting TS2307 set
-  # is identical under tsc and tsz, so the tsc-oracle delta cancels it — the
-  # type-fest-typed paths are any-stubbed. The row is fully tsc-parity (tsz-only
-  # delta = 0) but a thin parity row rather than a deep witness.
-  tsz_write_basic_external_project_config "$1" "source"
+  # ts-extras imports `type-fest` (a real dependency the no-install clone
+  # lacks); the named types it consumes are any-stubbed so the reference
+  # compile is clean (bare-any install semantics) instead of a TS2307 wall.
+  tsz_write_ts_extras_canary_stubs "$1"
+  tsz_write_basic_external_project_config "$1" "source" "" \
+    ', "tsz-bench-external-modules.d.ts"'
 }
 
 tsz_write_superjson_config() {
-  # superjson depends on `copy-anything` (unresolved under `types: []`, cancels
-  # in the tsc-oracle delta like other external imports).
-  tsz_write_basic_external_project_config "$1" "src"
+  # superjson depends on `copy-anything`; ambient-stub it (bare-any install
+  # semantics) so the reference compile validates clean.
+  tsz_write_superjson_canary_stubs "$1"
+  tsz_write_basic_external_project_config "$1" "src" "" \
+    ', "tsz-bench-external-modules.d.ts"'
 }
 
 tsz_write_trpc_config() {
+  # trpc's real packages/server/tsconfig.json pins lib es2023 + DOM.AsyncIterable
+  # (+ the disposable surface: core stream utils use `using`/Symbol.dispose and
+  # AsyncDisposable); the es2022 baseline lib turned that whole cluster into
+  # spurious TS2318/TS2339. Row remains red on the adapter files' real external
+  # deps (fastify/aws-lambda/express/ws/next + node builtins) — see the
+  # canary-fixture campaign notes; the lib alignment still removes the spurious
+  # half of the wall.
   tsz_write_trpc_external_stubs "$1"
   tsz_write_basic_external_project_config "$1" "packages/server/src" "" \
-    ', "tsz-bench-globals.d.ts"'
+    ', "tsz-bench-globals.d.ts"' \
+    "" '"es2023", "dom", "dom.iterable", "dom.asynciterable", "esnext.disposable"'
 }
 tsz_write_tanstack_query_config() {
   # tanstack-query's real root tsconfig pins `"types": ["node"]`, so its build
@@ -982,7 +1103,25 @@ TYPES
     ', "tsz-bench-globals.d.ts"'
 }
 tsz_write_tanstack_router_config() {
-  tsz_write_basic_external_project_config "$1" "packages/router-core/src"
+  # tanstack-router is a pnpm workspace: router-core imports its sibling
+  # workspace package @tanstack/history (and itself via @tanstack/router-core
+  # self-references, whose `isServer` export condition resolves to
+  # isServer/development.ts). Map those onto the real sibling source instead of
+  # any-stubs so router-core's own types stay load-bearing. Genuinely external
+  # deps (seroval, cookie-es, node builtins) are ambient-stubbed — see
+  # tsz_write_tanstack_router_canary_stubs. Its source imports sibling modules
+  # with explicit .ts extensions (upstream allowImportingTsExtensions).
+  tsz_write_tanstack_router_canary_stubs "$1"
+  tsz_write_basic_external_project_config "$1" "packages/router-core/src" \
+    '    "paths": {
+      "@tanstack/history": ["./packages/history/src"],
+      "@tanstack/router-core": ["./packages/router-core/src"],
+      "@tanstack/router-core/*": ["./packages/router-core/src/*"],
+      "@tanstack/router-core/isServer": ["./packages/router-core/src/isServer/development.ts"]
+    },
+    "allowImportingTsExtensions": true,
+' \
+    ', "tsz-bench-external-modules.d.ts", "tsz-bench-globals.d.ts"'
 }
 tsz_write_zustand_config() {
   # zustand imports sibling modules with explicit `.ts` extensions; its real
@@ -1005,9 +1144,16 @@ tsz_write_io_ts_config() {
   tsz_write_io_ts_external_stubs "$1"
   # TS7 resolves `paths` targets relative to the config directory without the
   # removed `baseUrl` option.
+  # NOTE (2026-07 canary campaign): with the ./-prefixed target the config is
+  # VALID under tsc 6 (TS5090 gone) but the row is genuinely red (~203 errors):
+  # io-ts consumes fp-ts's HKT type-classes as named TYPE imports and augments
+  # fp-ts/lib/HKT, which no small any-stub can satisfy (export=any fails named
+  # imports/augmentation; a wildcard ambient module resolves named type
+  # positions to a namespace and is worse). Greening io-ts needs fp-ts's real
+  # type surface vendored.
   tsz_write_basic_external_project_config "$1" "src" \
     '    "paths": {
-      "fp-ts/lib/*": ["tsz-bench-external-module.d.ts"]
+      "fp-ts/lib/*": ["./tsz-bench-external-module.d.ts"]
     },
 '
 }
@@ -1034,7 +1180,25 @@ tsz_write_remeda_config() {
   tsz_write_basic_external_project_config "$1" "packages/remeda/src"
 }
 tsz_write_ts_morph_config() {
-  tsz_write_basic_external_project_config "$1" "packages/ts-morph/src"
+  # ts-morph's @ts-morph/common workspace dep maps to its BUILT declaration
+  # bundle (packages/common/lib/ts-morph-common.d.ts): mapping to common/src
+  # instead pulls in ts-morph's typescript-internals augmentation source and
+  # ~4.7x more errors. Test suites (mocha describe/it) are excluded like
+  # upstream. code-block-writer must stub as a default-exported CLASS (a
+  # bare-any default is value-only and every `writer: CodeBlockWriter` type
+  # position trips TS2749). Row remains red (~180 honest residuals in
+  # ts-morph's own compiler-node->wrapper mapped-type/mixin machinery under
+  # the stripped no-install config).
+  tsz_write_ts_morph_canary_stubs "$1"
+  tsz_write_basic_external_project_config "$1" "packages/ts-morph/src" \
+    '    "paths": {
+      "@ts-morph/common": ["./packages/common/lib/ts-morph-common.d.ts"]
+    },
+' \
+    ', "tsz-bench-external-modules.d.ts", "tsz-bench-globals.d.ts"' \
+    '    "**/tests/**",
+    "**/*Tests.ts",
+'
 }
 tsz_write_arktype_config() {
   # arktype is a pnpm workspace: ark/type imports its sibling workspace packages
@@ -1061,10 +1225,10 @@ TYPES
   # tsconfig sets allowImportingTsExtensions: true (paired with noEmit).
   tsz_write_basic_external_project_config "$1" "ark/type" \
     '    "paths": {
-      "@ark/util": ["ark/util/index.ts"],
-      "@ark/schema/config": ["ark/schema/config.ts"],
-      "@ark/schema": ["ark/schema/index.ts"],
-      "arkregex": ["ark/regex/index.ts"]
+      "@ark/util": ["./ark/util/index.ts"],
+      "@ark/schema/config": ["./ark/schema/config.ts"],
+      "@ark/schema": ["./ark/schema/index.ts"],
+      "arkregex": ["./ark/regex/index.ts"]
     },
     "allowImportingTsExtensions": true,
 ' \
@@ -1075,10 +1239,14 @@ tsz_write_superstruct_config() {
 }
 tsz_write_runtypes_config() {
   # runtypes imports sibling modules with explicit `.ts` extensions; its real
-  # tsconfig sets allowImportingTsExtensions: true (paired with noEmit).
+  # tsconfig sets allowImportingTsExtensions: true (paired with noEmit). Its
+  # real tsconfig also targets "esnext" with no explicit lib (effective lib
+  # esnext); the source uses Array.prototype.toReversed (es2023), which the
+  # es2022 baseline lib lacks, so mirror lib esnext.
   tsz_write_basic_external_project_config "$1" "src" \
     '    "allowImportingTsExtensions": true,
-'
+' \
+    "" "" '"esnext", "dom", "dom.iterable"'
 }
 tsz_write_hotscript_config() {
   tsz_write_basic_external_project_config "$1" "src"
@@ -1092,7 +1260,47 @@ tsz_write_typebox_config() {
 '
 }
 tsz_write_class_transformer_config() {
-  tsz_write_basic_external_project_config "$1" "src"
+  # class-transformer's SHIPPING build (tsconfig.prod.cjs.json -> tsconfig.prod.json)
+  # compiles with strict:false plus decorator metadata at target es2018; the repo
+  # root tsconfig.json's strict:true is not what upstream builds, so mirroring the
+  # prod options is faithful, not a weakening. The clone has no @types/node or
+  # @types/jest (types:[]), and src/utils/get-global.util.spect.ts (upstream typo
+  # for .spec.ts, so it ships in the prod include) reads jest + Node globals that
+  # upstream resolves via devDependency typings; stub those globals as any.
+  local fixture_dir
+  fixture_dir="$(dirname "$1")"
+  cat > "$fixture_dir/tsz-bench-globals.d.ts" <<'TYPES'
+declare var global: any;
+declare var Buffer: any;
+declare var process: any;
+declare function describe(...args: any[]): any;
+declare function it(...args: any[]): any;
+declare function expect(...args: any[]): any;
+declare function beforeEach(...args: any[]): any;
+declare function afterEach(...args: any[]): any;
+TYPES
+  cat > "$1" <<'JSON'
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "esnext",
+    "strict": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "lib": ["es2018"],
+    "types": [],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts", "tsz-bench-globals.d.ts"],
+  "exclude": ["**/*.spec.ts", "**/node_modules/**", "build/**", "test/**"]
+}
+JSON
 }
 tsz_write_type_graphql_config() {
   # type-graphql uses `@/` path aliases and depends on graphql,
@@ -1107,8 +1315,8 @@ tsz_write_type_graphql_config() {
   tsz_write_basic_external_project_config "$1" "src" \
     '    "useDefineForClassFields": false,
     "paths": {
-      "@/*": ["src/*"],
-      "*": ["tsz-bench-external-module.d.ts"]
+      "@/*": ["./src/*"],
+      "*": ["./tsz-bench-external-module.d.ts"]
     },
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
@@ -1116,17 +1324,121 @@ tsz_write_type_graphql_config() {
     ', "tsz-bench-external-named-modules.d.ts"'
 }
 tsz_write_neverthrow_config() {
-  tsz_write_basic_external_project_config "$1" "src"
+  # Upstream neverthrow/tsconfig.json is strict:false with the explicit
+  # sub-flags noImplicitAny/strictNullChecks/strictFunctionTypes; the shared
+  # baseline's full strict:true is stricter than upstream and produces a
+  # spurious TS2322 on ResultAsync error-channel widening. Upstream's lib list
+  # ("dom","es2016","es2017.object") predates the pinned source's use of
+  # AsyncGenerator/Symbol.asyncIterator, so lib is raised to es2018 (a runtime
+  # lib requirement, not a strictness change).
+  cat > "$1" <<'JSON'
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "esnext",
+    "strict": false,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "lib": ["dom", "es2018"],
+    "types": [],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.spec.ts", "**/node_modules/**", "**/dist/**"]
+}
+JSON
 }
 tsz_write_xstate_config() {
   # xstate imports sibling modules with explicit `.ts` extensions; its real
   # tsconfig sets allowImportingTsExtensions: true (paired with noEmit).
+  # dev/index.ts reads `global` (upstream sees it via @types/node; the clone
+  # installs none) and scxml.ts imports the real uninstalled dep `xml-js`.
+  # The xml-js Element stub must be a STRUCTURAL interface (not `any`): the
+  # scxml callbacks over `.elements` only get contextual parameter types when
+  # Element has real members, mirroring xml-js's actual typings — a bare any
+  # leaves 20 spurious TS7006 implicit-any errors.
+  local fixture_dir
+  fixture_dir="$(dirname "$1")"
+  cat > "$fixture_dir/tsz-bench-globals.d.ts" <<'TYPES'
+declare var global: any;
+declare module 'xml-js' {
+  export interface Element {
+    declaration?: any; instruction?: any; attributes?: Record<string, any>;
+    name?: string; type?: string; elements?: Element[]; [key: string]: any;
+  }
+  export const xml2js: any;
+  const _default: any;
+  export default _default;
+}
+TYPES
   tsz_write_basic_external_project_config "$1" "packages/core/src" \
     '    "allowImportingTsExtensions": true,
-'
+' \
+    ', "tsz-bench-globals.d.ts"'
 }
 tsz_write_mobx_config() {
-  tsz_write_basic_external_project_config "$1" "packages/mobx/src"
+  # Upstream packages/mobx/tsconfig.json runs with noImplicitAny:false,
+  # noImplicitThis:false, experimentalDecorators, useDefineForClassFields,
+  # jsx:react, and lib ["esnext"] (no dom); the shared baseline's full
+  # strict:true + dom lib is stricter than upstream and produces spurious
+  # implicit-any and dom-TimerHandler errors. Upstream's downlevelIteration is
+  # dropped (tsc 6.x deprecation hard-error TS5101; no-op at target es2022).
+  # Upstream resolves process/global/console/timer globals via @types/node,
+  # which the no-install clone lacks (types:[]), so stub them as any.
+  local fixture_dir
+  fixture_dir="$(dirname "$1")"
+  cat > "$fixture_dir/tsz-bench-globals.d.ts" <<'TYPES'
+declare var process: any;
+declare var global: any;
+declare var console: any;
+declare function setTimeout(...args: any[]): any;
+declare function clearTimeout(...args: any[]): any;
+declare function setInterval(...args: any[]): any;
+declare function clearInterval(...args: any[]): any;
+TYPES
+  cat > "$1" <<'JSON'
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "strict": true,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": true,
+    "jsx": "react",
+    "lib": ["esnext"],
+    "types": [],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["packages/mobx/src/**/*.ts", "packages/mobx/src/**/*.tsx", "tsz-bench-globals.d.ts"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.test-d.ts",
+    "**/*.test-d.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**",
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/build/**"
+  ]
+}
+JSON
 }
 
 # The full Next.js row uses a sparse source checkout, not an installed Next.js
@@ -1162,6 +1474,7 @@ tsz_write_nextjs_config() {
     "noEmit": true,
     "noCheck": true,
     "skipLibCheck": true,
+    "moduleResolution": "bundler",
     "target": "ES2020",
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "types": [],

--- a/scripts/bench/test-project-rows.mjs
+++ b/scripts/bench/test-project-rows.mjs
@@ -397,8 +397,8 @@ assert.equal(
 );
 assert.deepEqual(
   shellProjectConfig("tsz_write_drizzle_orm_config").compilerOptions.paths,
-  { "~/*": ["drizzle-orm/src/*"], "*": ["tsz-bench-external-module.d.ts"] },
-  "drizzle-orm guard config must match upstream tilde import path support",
+  { "~/*": ["./drizzle-orm/src/*"], "*": ["./tsz-bench-external-module.d.ts"] },
+  "drizzle-orm guard config must match upstream tilde import path support (./-prefixed: tsc 6 rejects non-relative paths targets without baseUrl)",
 );
 assert.equal(
   shellProjectConfig("tsz_write_drizzle_orm_config").compilerOptions.baseUrl,


### PR DESCRIPTION
Goal: green

Repair the canary benchmark fixtures whose tsc-side reference compile broke under the tsc 6.0.3 pin (deprecation hard-errors, `./`-less `paths` targets, missing no-install stubs, strictness/lib drift from upstream), then re-measure every affected row and refresh the website snapshot so tsz.dev publishes accurate, recent data. Follow-up to #15804; empirical per-row states for the #13512 corpus tracker.

## Structural rule
When a generated fixture config carries an option value tsc 6 rejects (removed/deprecated option, non-relative `paths` target without `baseUrl`) or is stricter than the project's REAL tsconfig, the reference compiler fails fixture validation and the row reports "fixture invalid" instead of its true state; the fix lives in the bench fixture harness (`scripts/bench/project-fixtures.sh` config writers + stub shards) — no compiler-code change. Every option change is justified against the fixture project's own tsconfig (never weaker than upstream); external deps absent by no-install design are ambient-stubbed with bare-any-install semantics (io-ts precedent).

## What changed
- **15 fixtures now validate clean (tsc 6.0.3 exit 0)**: mobx, class-transformer, neverthrow (mirror upstream's real strictness — class-transformer's SHIPPING build is `tsconfig.prod` `strict:false`); valibot (upstream `allowImportingTsExtensions` + exclude vitest test scaffolding); drizzle-orm (`./`-prefixed paths + exclude 21 optional-peer driver dirs, stub completions incl. typed `mysql2/promise`); arktype, type-graphql (`./`-prefix paths targets — TS5090); nextjs full project (override the base config's removed `node10` with `bundler`; `ignoreDeprecations` refuted — tsgo reports TS5108 removed, not deprecated); tiny-invariant, xstate (globals stubs; xstate's xml-js `Element` must be a structural interface for contextual callback params); runtypes, ts-belt (lib `esnext` mirrors upstream; ts-belt's include `src/**/index.ts` IS upstream's include — the broken `Dict.ts` is code upstream never compiles); superjson, ts-extras, tanstack-router (dep stubs; tanstack maps its own workspace sibling source via paths, incl. the `isServer` export-condition target).
- **Honest-residual best-effort (still red, spurious walls removed)**: msw (3 residuals — rettime's real conditional types), valtio (1 — upstream `[ONLY-TS-5.9.3]` @ts-expect-error marker not extended to tsc 6), effect (228→5 — needs real fast-check generics), trpc (80→54 with the genuine `es2023`+`esnext.disposable` lib fix), ts-morph (~180 — own mapped-type/mixin machinery; `@ts-morph/common` maps to its BUILT lib .d.ts), io-ts (config-valid now; needs vendored fp-ts type surface).
- **Confirmed genuine tsc-6 rot, unchanged (tsc AND tsgo agree)**: superstruct (upstream uses removed `suppressImplicitAnyIndexErrors` → TS5102; residual TS2365 + 7×TS7053), radash (TS2322 concrete→unresolved-conditional-return), remeda (needs real type-fest — 52 load-bearing imports; any-stub would change computed types).
- **New shard** `scripts/bench/lib/project-fixture-stubs-canary.sh` (630 lines) holds the six new stub writers, keeping `project-fixtures.sh` (1704) and `project-fixture-stubs.sh` (1319) under the 2000-line ceiling. Stub contents emitted verbatim from pinned-tsc fixpoint iteration.
- **Snapshot refreshed** from the re-measured rows merged onto the #15804 full-run base (same PGO binary from `5cb74ae454`, same machine, `merge-results.mjs` with per-shard provenance): totals tsz **99** vs tsgo **10**, error rows **33 → 29**, new timed rows tiny-invariant (tsz 2.96x), ts-extras, ts-belt, ts-toolbelt. 12 previously fixture-invalid rows now publish honest tsz-vs-tsc states: 9 real tsz FP witness rows (mobx, xstate, valibot 673 diffs, type-graphql, superjson, runtypes, neverthrow, class-transformer, nextjs-full → #15806) and 3 tsz timeout rows (tanstack-router, drizzle-orm, arktype — #13508 family witnesses).
- Filed #15806: tsz validates removed options on the base config before `extends` merge (TS5108 despite child override; tsc/tsgo validate merged options).

## Adjacent-case matrix
Config-error family (TS5090/5101/5107/5108): positive = drizzle/arktype/type-graphql/nextjs/ts-toolbelt fixed; negative = io-ts config-valid but red (real type errors), superstruct left red (removed-option rot). Strictness family: positive = mobx/class-transformer/neverthrow mirrored to upstream; negative = remeda NOT weakened (generated config already weaker than upstream's very-strict set). Stub family: positive = superjson/ts-extras/tanstack-router/xstate; negative = effect/trpc/ts-morph stubs kept but rows honestly red (deep dependency type surfaces refuted as stub-able).

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-fable-5
Effort: high

## Verification
- Round-trip: every writer regenerated its fixture config from a clean state and re-validated with the pinned reference: 15× tsc exit 0; residual counts match the empirical fixpoint (valtio 1, msw 3, effect 5, trpc 54, ts-morph 180, io-ts 203).
- `node scripts/bench/test-project-rows.mjs` exit 0 (drizzle paths expectation updated to the `./`-prefixed form); `node scripts/bench/validate-project-metadata.mjs` exit 0; `node scripts/bench/test-project-fixture-deprecations.mjs` exit 0; full `scripts/bench/test-*.mjs` sweep — only the 4 failures that already fail on clean main (environmental: TS7-sync-API/local-workflow asserts) remain, verified via stash.
- Re-measure run: `bench-vs-tsgo.sh --filter '<21 affected rows>'` full mode on the quiet m1, merged via `merge-results.mjs` (readiness gate exit 0: 8 green required rows, 8 timing pairs, 0 blocking gaps, 0 duplicates, source freshness current for `5cb74ae454`).
- Website: `npm run test:benchmarks` exit 0; local `npm run build` exit 0 (189 files); `dist/benchmark-data/latest.json` = 138 rows @ `2026-07-16T11:39:30Z`; repaired rows render on `/benchmarks/`.
- Deploy path: gh-pages "Prepare benchmark data" prefers this snapshot (`generated_at` newer than any CI artifact), same as #15804/#15673.
