### PR TITLE
TS7 parity: lift TS1096 index-signature suppression wall + TS1038 export/nested ambient declare (giant.ts)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -597,6 +597,9 @@ path = "tests/ts1249_method_overload_decorator_tests.rs"
 name = "ts1119_object_literal_property_accessor_tests"
 path = "tests/ts1119_object_literal_property_accessor_tests.rs"
 [[test]]
+name = "ts1038_ambient_declare_modifier_tests"
+path = "tests/ts1038_ambient_declare_modifier_tests.rs"
+[[test]]
 name = "es_member_decorator_arity_tests"
 path = "tests/es_member_decorator_arity_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -33,8 +33,11 @@ impl<'a> CheckerState<'a> {
         // uses early returns, so TS1021 only fires when ALL previous checks pass.
         let mut has_grammar_error = false;
 
-        // TS1096: multiple parameters — checked first by TSC and suppresses all later grammar errors.
-        if index_sig.parameters.nodes.len() != 1 {
+        // TS1096: wrong parameter count — checked first by TSC and suppresses all
+        // later grammar errors. A multi-parameter `[a, b]` signature is recovered
+        // to a single parameter node, so the parser records the arity error on the
+        // node; consult it as well as the recovered length.
+        if index_sig.parameters.nodes.len() != 1 || index_sig.had_parameter_arity_error {
             has_grammar_error = true;
             // TS1096 is already emitted by the parser.
         }

--- a/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
@@ -32,50 +32,103 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
 
-            // Check different declaration types for 'declare' modifier
-            let modifiers = match stmt_node.kind {
-                syntax_kind_ext::FUNCTION_DECLARATION => {
-                    self.ctx.arena.get_function(stmt_node).map(|f| &f.modifiers)
+            // `export declare X` parses as EXPORT_DECLARATION wrapping the real
+            // declaration; the wrapper's own modifiers are always None, so the
+            // `declare` modifier lives on the inner clause. Unwrap so both the
+            // modifier check and the nested-namespace recursion see the real
+            // declaration (mirrors `check_initializers_in_ambient_body`).
+            let decl_idx = if stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION {
+                match self.ctx.arena.get_export_decl(stmt_node) {
+                    Some(export_decl) if export_decl.export_clause.is_some() => {
+                        export_decl.export_clause
+                    }
+                    _ => continue,
                 }
-                syntax_kind_ext::VARIABLE_STATEMENT => {
-                    self.ctx.arena.get_variable(stmt_node).map(|v| &v.modifiers)
-                }
-                syntax_kind_ext::CLASS_DECLARATION => {
-                    self.ctx.arena.get_class(stmt_node).map(|c| &c.modifiers)
-                }
-                syntax_kind_ext::INTERFACE_DECLARATION => self
-                    .ctx
-                    .arena
-                    .get_interface(stmt_node)
-                    .map(|i| &i.modifiers),
-                syntax_kind_ext::TYPE_ALIAS_DECLARATION => self
-                    .ctx
-                    .arena
-                    .get_type_alias(stmt_node)
-                    .map(|t| &t.modifiers),
-                syntax_kind_ext::ENUM_DECLARATION => {
-                    self.ctx.arena.get_enum(stmt_node).map(|e| &e.modifiers)
-                }
-                syntax_kind_ext::MODULE_DECLARATION => {
-                    self.ctx.arena.get_module(stmt_node).map(|m| &m.modifiers)
-                }
-                syntax_kind_ext::IMPORT_EQUALS_DECLARATION
-                | syntax_kind_ext::IMPORT_DECLARATION => self
-                    .ctx
-                    .arena
-                    .get_import_decl(stmt_node)
-                    .map(|i| &i.modifiers),
-                _ => None,
+            } else {
+                stmt_idx
             };
 
-            if let Some(mods) = modifiers
-                && let Some(declare_mod) = self.get_declare_modifier(mods)
-            {
+            // Resolve the redundant `declare` modifier (if any) and the nested
+            // ambient body to recurse into, dropping all arena borrows before
+            // the mutable diagnostic emission below.
+            let (declare_mod, nested_body) = {
+                let Some(decl_node) = self.ctx.arena.get(decl_idx) else {
+                    continue;
+                };
+                let decl_kind = decl_node.kind;
+
+                // Check different declaration types for 'declare' modifier
+                let modifiers = match decl_kind {
+                    syntax_kind_ext::FUNCTION_DECLARATION => {
+                        self.ctx.arena.get_function(decl_node).map(|f| &f.modifiers)
+                    }
+                    syntax_kind_ext::VARIABLE_STATEMENT => {
+                        self.ctx.arena.get_variable(decl_node).map(|v| &v.modifiers)
+                    }
+                    syntax_kind_ext::CLASS_DECLARATION => {
+                        self.ctx.arena.get_class(decl_node).map(|c| &c.modifiers)
+                    }
+                    syntax_kind_ext::INTERFACE_DECLARATION => self
+                        .ctx
+                        .arena
+                        .get_interface(decl_node)
+                        .map(|i| &i.modifiers),
+                    syntax_kind_ext::TYPE_ALIAS_DECLARATION => self
+                        .ctx
+                        .arena
+                        .get_type_alias(decl_node)
+                        .map(|t| &t.modifiers),
+                    syntax_kind_ext::ENUM_DECLARATION => {
+                        self.ctx.arena.get_enum(decl_node).map(|e| &e.modifiers)
+                    }
+                    syntax_kind_ext::MODULE_DECLARATION => {
+                        self.ctx.arena.get_module(decl_node).map(|m| &m.modifiers)
+                    }
+                    syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+                    | syntax_kind_ext::IMPORT_DECLARATION => self
+                        .ctx
+                        .arena
+                        .get_import_decl(decl_node)
+                        .map(|i| &i.modifiers),
+                    _ => None,
+                };
+                let declare_mod = modifiers.and_then(|mods| self.get_declare_modifier(mods));
+
+                // A nested namespace body is itself ambient, so redundant
+                // `declare` modifiers inside it are equally invalid. Recurse
+                // into it unless it carries its OWN `declare` (a `declare`
+                // positioned at/after the module start; dotted-namespace
+                // continuations clone the parent's `declare` at an earlier
+                // position and are treated as inherited). Own-declare roots are
+                // visited independently by the own-declare callback, so
+                // recursing into them would double-report TS1038.
+                let mut nested_body = None;
+                if decl_kind == syntax_kind_ext::MODULE_DECLARATION
+                    && let Some(module) = self.ctx.arena.get_module(decl_node)
+                    && module.body.is_some()
+                {
+                    let own_declare = self
+                        .get_declare_modifier(&module.modifiers)
+                        .and_then(|mod_idx| self.ctx.arena.get(mod_idx))
+                        .is_some_and(|mod_node| mod_node.pos >= decl_node.pos);
+                    if !own_declare {
+                        nested_body = Some(module.body);
+                    }
+                }
+
+                (declare_mod, nested_body)
+            };
+
+            if let Some(declare_mod) = declare_mod {
                 self.error_at_node(
                         declare_mod,
                         "A 'declare' modifier cannot be used in an already ambient context.",
                         diagnostic_codes::A_DECLARE_MODIFIER_CANNOT_BE_USED_IN_AN_ALREADY_AMBIENT_CONTEXT,
                     );
+            }
+
+            if let Some(nested_body) = nested_body {
+                self.check_declare_modifiers_in_ambient_body(nested_body);
             }
         }
     }

--- a/crates/tsz-checker/tests/ts1038_ambient_declare_modifier_tests.rs
+++ b/crates/tsz-checker/tests/ts1038_ambient_declare_modifier_tests.rs
@@ -1,0 +1,125 @@
+//! Regression tests for TS1038 ("A 'declare' modifier cannot be used in an
+//! already ambient context.") inside ambient namespace bodies.
+//!
+//! Background
+//! ----------
+//! `tsc`'s `checkGrammarModifiers` reports TS1038 for any `declare` modifier on
+//! a declaration whose enclosing context is already ambient. tsz mirrors this in
+//! `check_declare_modifiers_in_ambient_body`. Two coverage gaps motivated these
+//! tests (witnessed by `compiler/giant.ts`):
+//!   1. `export declare X` parses as an `EXPORT_DECLARATION` wrapping the real
+//!      declaration; the modifier check must unwrap it (the wrapper's own
+//!      modifiers are always `None`).
+//!   2. a plain (non-`declare`) namespace nested inside a `declare namespace`
+//!      is still an ambient context, so redundant `declare` modifiers inside it
+//!      must be reported — the check must recurse into nested ambient bodies.
+//!
+//! Binder names are varied across cases so no fix can key on an identifier.
+
+use tsz_checker::context::CheckerOptions;
+
+fn check(source: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
+    let lib_files =
+        tsz_checker::test_utils::load_compiled_lib_files(&["lib.es5.d.ts", "lib.es2015.d.ts"]);
+    tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions::default(),
+        &lib_files,
+    )
+}
+
+fn count_ts1038(diags: &[tsz_checker::diagnostics::Diagnostic]) -> usize {
+    diags.iter().filter(|d| d.code == 1038).count()
+}
+
+#[test]
+fn export_declare_direct_children_of_declare_namespace_report_ts1038() {
+    // Each `export declare X` is EXPORT_DECLARATION-wrapped; the `declare` is
+    // redundant because `Outer` is already ambient.
+    let source = "\
+declare namespace Outer {\n\
+    export declare var alpha;\n\
+    export declare function beta(): void;\n\
+    export declare class Gamma { }\n\
+    export declare namespace Delta { }\n\
+}\n";
+    let diags = check(source);
+    assert_eq!(
+        count_ts1038(&diags),
+        4,
+        "expected one TS1038 per redundant `export declare`, got {diags:?}"
+    );
+}
+
+#[test]
+fn export_declare_nested_in_plain_namespace_reports_ts1038() {
+    // `Middle` has no `declare` of its own but is ambient by inheritance, so
+    // the check must recurse into it to reach the redundant modifiers.
+    let source = "\
+declare namespace Root {\n\
+    namespace Middle {\n\
+        export declare var epsilon;\n\
+        export declare function zeta(): void;\n\
+    }\n\
+}\n";
+    let diags = check(source);
+    assert_eq!(
+        count_ts1038(&diags),
+        2,
+        "expected TS1038 for each redundant `declare` in the nested ambient namespace, got {diags:?}"
+    );
+}
+
+#[test]
+fn nested_own_declare_namespace_reports_ts1038_without_double_counting() {
+    // Regression guard: an own-`declare` nested namespace is visited by the
+    // own-declare callback AND is a child of the outer body — the recursion
+    // must not double-report. Expect exactly two: one for the inner
+    // namespace's `declare`, one for the variable's `declare`.
+    let source = "\
+declare namespace Level1 {\n\
+    declare namespace Level2 {\n\
+        declare var theta;\n\
+    }\n\
+}\n";
+    let diags = check(source);
+    assert_eq!(
+        count_ts1038(&diags),
+        2,
+        "expected exactly two TS1038 (no double-report), got {diags:?}"
+    );
+}
+
+#[test]
+fn ambient_namespace_without_redundant_declare_reports_no_ts1038() {
+    // Plain declarations (no `declare` modifier) inside a `declare namespace`
+    // are correct — the outer `declare` supplies the ambient meaning.
+    let source = "\
+declare namespace Clean {\n\
+    var iota;\n\
+    function kappa(): void;\n\
+    export var lambda;\n\
+}\n";
+    let diags = check(source);
+    assert_eq!(
+        count_ts1038(&diags),
+        0,
+        "plain ambient members must not report TS1038, got {diags:?}"
+    );
+}
+
+#[test]
+fn top_level_export_declare_reports_no_ts1038() {
+    // At top level there is no enclosing ambient context, so `export declare`
+    // is meaningful and must not report TS1038.
+    let source = "\
+export declare var mu;\n\
+export declare function nu(): void;\n";
+    let diags = check(source);
+    assert_eq!(
+        count_ts1038(&diags),
+        0,
+        "top-level `export declare` must not report TS1038, got {diags:?}"
+    );
+}

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1344,6 +1344,7 @@ pub(super) const fn is_structural_parse_error(code: u32) -> bool {
 /// - TS1014: A rest parameter must be last in a parameter list
 /// - TS1047: A rest parameter cannot be optional
 /// - TS1048: A rest parameter cannot have an initializer
+/// - TS1096: An index signature must have exactly one parameter
 /// - TS1185: Merge conflict marker encountered
 /// - TS1214: Identifier expected (strict mode reserved word)
 /// - TS1262: 'await' at top level
@@ -1351,6 +1352,14 @@ pub(super) const fn is_structural_parse_error(code: u32) -> bool {
 ///
 /// tsc emits TS7006/TS7019 even in the presence of these errors because
 /// the parameter identity (name) is still valid and can be type-checked.
+///
+/// TS1096 belongs here because tsc reports it from
+/// `checkGrammarIndexSignatureParameters` at CHECK time on a well-formed index
+/// signature (the multi-parameter AST parses fine), so it never participates in
+/// tsc's `hasParseDiagnostics` suppression. tsz emits it during parsing instead,
+/// so without this entry a stray `[a, b]` would set `has_syntax_parse_errors` and
+/// suppress unrelated check-time grammar diagnostics elsewhere in the file
+/// (e.g. TS1036 in an ambient namespace, and nearby TS1021).
 pub(super) const fn is_non_suppressing_parse_error(code: u32) -> bool {
     matches!(
         code,
@@ -1358,6 +1367,7 @@ pub(super) const fn is_non_suppressing_parse_error(code: u32) -> bool {
         | 1014 // A rest parameter must be last in a parameter list
         | 1047 // A rest parameter cannot be optional
         | 1048 // A rest parameter cannot have an initializer
+        | 1096 // An index signature must have exactly one parameter (check-time grammar in tsc)
         | 1185 // Merge conflict marker
         | 1191 // An import declaration cannot have modifiers (grammar constraint, AST is valid)
         | 1214 // Identifier expected (strict mode reserved word)

--- a/crates/tsz-cli/src/driver/check_utils/tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/tests.rs
@@ -1502,6 +1502,27 @@ fn regex_flag_errors_do_not_suppress_semantic_diagnostics() {
     );
 }
 
+#[test]
+fn index_signature_arity_error_does_not_suppress_grammar_diagnostics() {
+    // TS1096 (An index signature must have exactly one parameter) is a check-time
+    // grammar error in tsc (checkGrammarIndexSignatureParameters) on a well-formed
+    // AST, so it must not set has_syntax_parse_errors — otherwise a stray `[a, b]`
+    // would suppress unrelated check-time grammar diagnostics elsewhere in the file
+    // (e.g. TS1036 in an ambient namespace, and nearby TS1021).
+    assert!(
+        is_non_suppressing_parse_error(1096),
+        "TS1096 (index signature arity) should be non-suppressing"
+    );
+    assert!(
+        !is_real_syntax_error(1096),
+        "TS1096 must not be a real syntax error (would still poison the flag)"
+    );
+    assert!(
+        !is_structural_parse_error(1096),
+        "TS1096 must not be a structural parse error (would still poison the flag)"
+    );
+}
+
 /// Helper: parse a single file and collect noCheck path diagnostics.
 fn collect_no_check_diags(file_name: &str, source: &str) -> Vec<Diagnostic> {
     let mut parse_results =

--- a/crates/tsz-parser/src/parser/node.rs
+++ b/crates/tsz-parser/src/parser/node.rs
@@ -506,6 +506,13 @@ pub struct IndexSignatureData {
     pub modifiers: Option<NodeList>,
     pub parameters: NodeList,
     pub type_annotation: NodeIndex,
+    /// True when the parser already reported a parameter-arity error (TS1096,
+    /// "An index signature must have exactly one parameter.") for an empty
+    /// `[]` or a multi-parameter `[a, b]` signature. The multi-parameter form
+    /// is recovered down to a single parameter node, so `parameters.len()`
+    /// alone cannot distinguish it; the checker consults this flag to replicate
+    /// tsc's early return (TS1096 suppresses the later TS1021).
+    pub had_parameter_arity_error: bool,
 }
 
 /// Data for property declarations

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -863,6 +863,7 @@ impl ParserState {
                     modifiers,
                     parameters: Self::make_node_list(vec![]),
                     type_annotation,
+                    had_parameter_arity_error: true,
                 },
             );
         }
@@ -1097,6 +1098,7 @@ impl ParserState {
                 modifiers,
                 parameters: Self::make_node_list(vec![param_node]),
                 type_annotation,
+                had_parameter_arity_error: has_multiple_params,
             },
         )
     }


### PR DESCRIPTION
Flips `compiler/giant.ts` (the sole conformance witness for both roots). Two independent roots, both required for the flip; giant needed all of TS1036 x5, TS1021 x2, TS1038 x4.

Goal: hold

## Root 1 — TS1096 mis-classified as a suppressing parse error (TS1036 x5 + TS1021 x2)
tsz emits TS1096 ("An index signature must have exactly one parameter.") at parse time; tsc emits it at check time (`checkGrammarIndexSignatureParameters`) on a well-formed AST, so it never enters `hasParseDiagnostics`. Because TS1096 was not in `is_non_suppressing_parse_error`, a stray `[a, b]` set `has_syntax_parse_errors` and populated `syntax_parse_error_positions` for the whole file, globally suppressing unrelated check-time grammar diagnostics (TS1036 in ambient namespaces via `declarations.rs`; position-local TS1021 via `node_has_nearby_parse_error`). Fix: classify TS1096 as non-suppressing.

Lifting the wall exposed a latent coupling: the parser recovers a multi-parameter `[a, b]` down to one parameter node, so the check-time TS1021 guard (`parameters.len() != 1`) could not see the arity error and fired a spurious TS1021 on the two-parameter line (previously masked by `node_has_nearby_parse_error`). The parser now records `had_parameter_arity_error` on the index-signature node so the checker replicates tsc's TS1096-XOR-TS1021 early return independent of file-level parse state.

Relocating TS1096 to check time (per the accessor-TS1005 pattern) was considered and rejected: the check-time index-signature path is wired only for class and interface members, whereas the parser emits TS1096 for all four contexts (type alias, variable annotation, interface, class) at tsc's exact anchor (the first parameter name); relocation would regress type-literal and variable-annotation index signatures.

## Root 2 — TS1038 export-wrap + nested-recursion gap (TS1038 x4)
`check_declare_modifiers_in_ambient_body` matched only bare declaration kinds and ran only over direct children of an own-`declare` namespace. It now unwraps `EXPORT_DECLARATION` before reading modifiers (giant's witnesses are `export declare var/function/class/namespace`) and recurses into nested ambient namespace bodies (mirroring `check_initializers_in_ambient_body`). Recursion is skipped for nested namespaces that carry their own `declare` (visited independently by the own-declare callback) to avoid a double report, while still covering dotted-namespace continuations.

## Blast radius
`has_syntax_parse_errors` is read in ~20 check-time paths (implicit-any, property refs, class-member circularity, object-literal, jsx). The direction is toward tsc (tsc runs those checks in the presence of a TS1096), but the corpus-wide magnitude is not locally measurable — full-conformance CI on this PR is the Root-1 blast-radius measurement.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5
Effort: max

## Verification
Local gates (bench-wt lane, dist-fast binary):
- `compiler/giant.ts` conformance: 1/1 PASS (was 0/1; all 11 missing diagnostics now flip, no extras)
- Conformance families scanned for spurious TS1036/1038/1096/1021 emissions across `ambient`, `indexSignature`, `declaration`: none found; `declareModifier` 2/2, `dts` 3/3; remaining failures in those families are pre-existing on unrelated codes (TS2322/2353/2411/2741/2433/5061/2339/2305/1039/1254 + fingerprint-only)
- `-p tsz-emitter` FULL: 4745/4745
- `-p tsz-parser`: 1491/1491
- `-p tsz-checker --lib` + new `ts1038_ambient_declare_modifier_tests`: 8225/8225 (5 new tests: export-wrap, nested recursion, no-double-report, 2 negatives)
- `-p tsz-cli --lib` new `index_signature_arity_error_does_not_suppress_grammar_diagnostics`: PASS
- `python3 scripts/arch/arch_guard.py`: passed
- `cargo clippy -p tsz-parser -p tsz-checker -p tsz-cli --lib --tests`: clean

Full-conformance CI on this PR is the authoritative Root-1 blast-radius measurement (movement toward tsc = accept; any new mismatch = adjudicate).