### PR TITLE
fix(config): validate removed options on merged effective options across extends chains and CLI overrides

### DIFF
--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -8,9 +8,9 @@ use std::time::Instant;
 
 use crate::args::CliArgs;
 use crate::config::{
-    ResolvedCompilerOptions, TsConfig, load_tsconfig, load_tsconfig_with_diagnostics,
-    resolve_compiler_options, resolve_lib_files_with_options,
-    resolve_lib_files_with_options_transitive,
+    RemovedOptionNotice, ResolvedCompilerOptions, TsConfig, load_tsconfig,
+    load_tsconfig_with_diagnostics_deferred, resolve_compiler_options,
+    resolve_lib_files_with_options, resolve_lib_files_with_options_transitive,
 };
 use tsz::binder::BinderOptions;
 use tsz::binder::BinderState;
@@ -1561,8 +1561,8 @@ mod plan;
 pub use plan::apply_cli_overrides;
 use plan::{
     apply_cli_overrides_with_config_options, cli_ignore_deprecations_silences_6_0,
-    display_relative_to_dir, emit_common_source_directory, find_latest_dts_file,
-    implicit_common_source_directory, is_deprecation_diagnostic_code,
+    cli_valid_override_keys, display_relative_to_dir, emit_common_source_directory,
+    find_latest_dts_file, implicit_common_source_directory, is_deprecation_diagnostic_code,
     is_removed_option_diagnostic_code, is_removed_option_value_diagnostic_code,
     ordered_direct_cli_parse_diagnostics, validate_cli_compiler_option_diagnostics,
 };

--- a/crates/tsz-cli/src/driver/core_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/core_diagnostics.rs
@@ -265,6 +265,20 @@ fn compile_inner_impl(
     let loaded = load_config_with_diagnostics(tsconfig_path.as_deref())?;
     let config = loaded.config;
     let mut config_diagnostics = loaded.diagnostics;
+    // tsc merges explicit CLI options over the config chain BEFORE the
+    // removed-option check, so a chain-effective removed VALUE that the CLI
+    // overrides with a valid value produces no diagnostic at all
+    // (`tsc -p . --moduleResolution bundler` over node10 compiles clean).
+    // Removed KEYS are not retractable: passing the key on the CLI is itself
+    // a removal error.
+    let cli_override_keys = cli_valid_override_keys(args, config.as_ref())?;
+    config_diagnostics.extend(
+        loaded
+            .pending_removed_option_notices
+            .into_iter()
+            .filter(|notice| !(notice.is_value && cli_override_keys.contains(&notice.key)))
+            .map(|notice| notice.diagnostic),
+    );
     // A references-only root tsconfig (no .ts inputs, but non-empty `references[]`) is
     // the canonical TypeScript Project References pattern. tsc never emits TS18003 in
     // this case; suppress the "no inputs" diagnostic when `references[]` is non-empty.

--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -739,6 +739,60 @@ pub(super) fn validate_cli_compiler_option_diagnostics(
         }
     }
 
+    let compiler_options = cli_explicit_compiler_options_map(args, config);
+
+    if compiler_options.is_empty() {
+        return Ok(diagnostics);
+    }
+
+    let mut root = serde_json::Map::new();
+    root.insert(
+        "compilerOptions".to_string(),
+        serde_json::Value::Object(compiler_options),
+    );
+    let source = serde_json::Value::Object(root).to_string();
+    let parsed = parse_tsconfig_with_diagnostics(&source, "")?;
+    diagnostics.extend(parsed.diagnostics);
+    Ok(diagnostics)
+}
+
+/// Compiler-option keys the CLI explicitly sets to a VALID, non-removed
+/// value. tsc merges CLI options over the config chain before running the
+/// removed-option check, so a config-chain removal diagnostic (TS5108 family)
+/// for one of these keys is retracted — `tsc -p . --moduleResolution bundler`
+/// over a chain-effective `node10` compiles clean.
+pub(super) fn cli_valid_override_keys(
+    args: &CliArgs,
+    config: Option<&TsConfig>,
+) -> Result<rustc_hash::FxHashSet<String>> {
+    let compiler_options = cli_explicit_compiler_options_map(args, config);
+    if compiler_options.is_empty() {
+        return Ok(rustc_hash::FxHashSet::default());
+    }
+    let mut root = serde_json::Map::new();
+    root.insert(
+        "compilerOptions".to_string(),
+        serde_json::Value::Object(compiler_options),
+    );
+    let source = serde_json::Value::Object(root).to_string();
+    let parsed = tsz::config::parse_tsconfig_with_diagnostics_deferred(&source, "")?;
+    let mut keys = parsed.explicit_compiler_option_keys;
+    // A CLI value that is itself removed (e.g. `--moduleResolution node10`)
+    // parses as a valid string but carries its own pending removal notice; it
+    // must not retract the config chain's diagnostic.
+    for notice in &parsed.pending_removed_option_notices {
+        keys.remove(&notice.key);
+    }
+    Ok(keys)
+}
+
+/// The `compilerOptions` JSON object equivalent to the options explicitly
+/// passed on the command line (shared by CLI validation and the
+/// removed-option override computation so both see the same key set).
+fn cli_explicit_compiler_options_map(
+    args: &CliArgs,
+    config: Option<&TsConfig>,
+) -> serde_json::Map<String, serde_json::Value> {
     let mut compiler_options = serde_json::Map::new();
 
     if let Some(target) = args.target {
@@ -959,19 +1013,7 @@ pub(super) fn validate_cli_compiler_option_diagnostics(
         compiler_options.insert("out".to_string(), out.to_string_lossy().into_owned().into());
     }
 
-    if compiler_options.is_empty() {
-        return Ok(diagnostics);
-    }
-
-    let mut root = serde_json::Map::new();
-    root.insert(
-        "compilerOptions".to_string(),
-        serde_json::Value::Object(compiler_options),
-    );
-    let source = serde_json::Value::Object(root).to_string();
-    let parsed = parse_tsconfig_with_diagnostics(&source, "")?;
-    diagnostics.extend(parsed.diagnostics);
-    Ok(diagnostics)
+    compiler_options
 }
 
 pub(super) const fn is_direct_cli_parse_diagnostic_code(code: u32) -> bool {

--- a/crates/tsz-cli/src/driver/sources.rs
+++ b/crates/tsz-cli/src/driver/sources.rs
@@ -390,6 +390,11 @@ pub(crate) fn load_config(path: Option<&Path>) -> Result<Option<TsConfig>> {
 pub(crate) struct LoadedConfig {
     pub config: Option<TsConfig>,
     pub diagnostics: Vec<Diagnostic>,
+    /// Entry-anchored removed-option notices not yet committed to
+    /// `diagnostics`: the driver drops the ones the CLI overrides with valid
+    /// values (tsc validates removals on the CLI-merged effective options),
+    /// then flushes the rest.
+    pub pending_removed_option_notices: Vec<RemovedOptionNotice>,
 }
 
 pub(crate) fn load_config_with_diagnostics(path: Option<&Path>) -> Result<LoadedConfig> {
@@ -397,13 +402,15 @@ pub(crate) fn load_config_with_diagnostics(path: Option<&Path>) -> Result<Loaded
         return Ok(LoadedConfig {
             config: None,
             diagnostics: Vec::new(),
+            pending_removed_option_notices: Vec::new(),
         });
     };
 
-    let parsed = load_tsconfig_with_diagnostics(path)?;
+    let parsed = load_tsconfig_with_diagnostics_deferred(path)?;
     Ok(LoadedConfig {
         config: Some(parsed.config),
         diagnostics: parsed.diagnostics,
+        pending_removed_option_notices: parsed.pending_removed_option_notices,
     })
 }
 

--- a/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
@@ -1008,3 +1008,407 @@ module.exports = LazySet;
         result.diagnostics
     );
 }
+
+// ---------------------------------------------------------------------------
+// Removed option values across `extends` chains (#15806).
+//
+// Structural rule: tsc validates removed option VALUES (the TS5108 family)
+// against the merged EFFECTIVE compilerOptions. A base config's removed value
+// that a shallower config overrides produces no diagnostic at all; an
+// inherited un-overridden value is reported once, anchored at the ENTRY
+// config's `compilerOptions` key. Removed option KEYS (TS5023/TS5102 family)
+// stay per-file: no override can make a removed option valid.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn extends_base_removed_value_overridden_by_child_is_clean() {
+    // Mirrors the Next.js full-project bench fixture: base pins the removed
+    // `moduleResolution=node10`, the extending config overrides it with a
+    // valid value. tsc 6.0.3 and tsgo both exit 0 with no diagnostics.
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("base.json"),
+        r#"{
+          "compilerOptions": {
+            "moduleResolution": "node10",
+            "target": "es2020"
+          }
+        }"#,
+    );
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "extends": "./base.json",
+          "files": ["src/a.ts"],
+          "compilerOptions": {
+            "moduleResolution": "bundler",
+            "noEmit": true
+          }
+        }"#,
+    );
+    write_file(&base.join("src/a.ts"), "export const n: number = 1;\n");
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    assert!(
+        result.diagnostics.is_empty(),
+        "an overridden base removed-value must not diagnose: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn extends_base_removed_value_inherited_reports_at_entry_config() {
+    // No override: the removed value is effective, so it is reported — but
+    // anchored at the ENTRY config's `compilerOptions` key (tsc emits
+    // `tsconfig.json(L,C): TS5108` for the child, not for base.json).
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("base.json"),
+        r#"{
+          "compilerOptions": {
+            "moduleResolution": "node10"
+          }
+        }"#,
+    );
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "extends": "./base.json",
+          "files": ["src/a.ts"],
+          "compilerOptions": {
+            "noEmit": true
+          }
+        }"#,
+    );
+    write_file(&base.join("src/a.ts"), "export const n: number = 1;\n");
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        [5108],
+        "inherited removed value must report exactly once: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        result.diagnostics[0].file.ends_with("tsconfig.json")
+            && !result.diagnostics[0].file.ends_with("base.json"),
+        "inherited removed-value diagnostics anchor at the entry config, got {}",
+        result.diagnostics[0].file
+    );
+    assert_eq!(
+        result.diagnostics[0].message_text,
+        "Option 'moduleResolution=node10' has been removed. Please remove it from your configuration."
+    );
+}
+
+#[test]
+fn extends_chain_grandparent_removed_value_overridden_mid_chain_is_clean() {
+    // Grandparent sets the removed `target=es5`; the middle config overrides
+    // it. The whole chain merges clean — different option family than the
+    // moduleResolution cases so the rule is not key-specific.
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("grand.json"),
+        r#"{ "compilerOptions": { "target": "es5" } }"#,
+    );
+    write_file(
+        &base.join("mid.json"),
+        r#"{
+          "extends": "./grand.json",
+          "compilerOptions": { "target": "es2021" }
+        }"#,
+    );
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "extends": "./mid.json",
+          "files": ["src/a.ts"],
+          "compilerOptions": { "noEmit": true }
+        }"#,
+    );
+    write_file(&base.join("src/a.ts"), "export const n: number = 1;\n");
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    assert!(
+        result.diagnostics.is_empty(),
+        "a mid-chain override must suppress the grandparent's removed value: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn extends_array_later_base_overrides_earlier_removed_value() {
+    // `extends` arrays merge left-to-right with later entries winning: a later
+    // base's valid value suppresses an earlier base's removed value...
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("a.json"),
+        r#"{ "compilerOptions": { "moduleResolution": "node10" } }"#,
+    );
+    write_file(
+        &base.join("b.json"),
+        r#"{ "compilerOptions": { "moduleResolution": "bundler" } }"#,
+    );
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "extends": ["./a.json", "./b.json"],
+          "files": ["src/a.ts"],
+          "compilerOptions": { "noEmit": true }
+        }"#,
+    );
+    write_file(&base.join("src/a.ts"), "export const n: number = 1;\n");
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    assert!(
+        result.diagnostics.is_empty(),
+        "later-base override must suppress the earlier base's removed value: {:?}",
+        result.diagnostics
+    );
+
+    // ...and with the order flipped the removed value IS effective again.
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "extends": ["./b.json", "./a.json"],
+          "files": ["src/a.ts"],
+          "compilerOptions": { "noEmit": true }
+        }"#,
+    );
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        [5108],
+        "flipped order makes the removed value effective: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn extends_base_unknown_key_reports_per_file_regardless_of_override() {
+    // UNKNOWN option keys (TS5023 — dropped from the option table entirely,
+    // like suppressImplicitAnyIndexErrors in TS7) are per-file config errors
+    // in tsc: writing the key in both base and child reports at BOTH files.
+    // Known-but-removed keys (TS5102, e.g. baseUrl) instead go through the
+    // merged-effective machinery — see the tests below.
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("base.json"),
+        r#"{ "compilerOptions": { "suppressImplicitAnyIndexErrors": true } }"#,
+    );
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "extends": "./base.json",
+          "files": ["src/a.ts"],
+          "compilerOptions": {
+            "suppressImplicitAnyIndexErrors": false,
+            "noEmit": true
+          }
+        }"#,
+    );
+    write_file(&base.join("src/a.ts"), "export const n: number = 1;\n");
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        [5023, 5023],
+        "removed keys report per file (base and child): {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn extends_type_invalid_override_does_not_mask_inherited_removed_value() {
+    // A TS5024-invalid child value does NOT mask the base's removed value:
+    // tsc 6.0.3 reports BOTH the TS5024 and the TS5108, and anchors the
+    // TS5108 at the ENTRY's own (invalid) value span, since the entry
+    // literally writes the key.
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("base.json"),
+        r#"{ "compilerOptions": { "moduleResolution": "node10" } }"#,
+    );
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "extends": "./base.json",
+          "files": ["src/a.ts"],
+          "compilerOptions": { "moduleResolution": 42, "noEmit": true }
+        }"#,
+    );
+    write_file(&base.join("src/a.ts"), "export const n: number = 1;\n");
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let mut codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    assert_eq!(
+        codes,
+        [5024, 5108],
+        "invalid override masks nothing — TS5024 and TS5108 both fire: {:?}",
+        result.diagnostics
+    );
+    let removal = result
+        .diagnostics
+        .iter()
+        .find(|d| d.code == 5108)
+        .expect("TS5108 present");
+    assert!(
+        removal.file.ends_with("tsconfig.json"),
+        "inherited removal anchors at the entry when it writes the key, got {}",
+        removal.file
+    );
+}
+
+#[test]
+fn extends_removed_value_without_entry_compiler_options_is_global() {
+    // Entry config with NO compilerOptions object at all (the preset-style
+    // `{"extends": ..., "files": [...]}` shape): tsc falls back to a GLOBAL
+    // diagnostic with no file/position prefix.
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("base.json"),
+        r#"{ "compilerOptions": { "moduleResolution": "node10" } }"#,
+    );
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "extends": "./base.json",
+          "files": ["src/a.ts"]
+        }"#,
+    );
+    write_file(&base.join("src/a.ts"), "export const n: number = 1;\n");
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    assert_eq!(codes, [5108], "one global removal: {:?}", result.diagnostics);
+    assert!(
+        result.diagnostics[0].file.is_empty(),
+        "no compilerOptions in the entry -> global file-less diagnostic, got {:?}",
+        result.diagnostics[0].file
+    );
+}
+
+#[test]
+fn extends_base_removed_key_reports_once_at_entry() {
+    // Known-but-removed KEYS (TS5102) run on the merged chain like values:
+    // a base-only `baseUrl` reports ONCE, anchored at the entry's
+    // compilerOptions key (not at base.json), and setting the key at both
+    // levels reports once at the entry's own value span.
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("base.json"),
+        r#"{ "compilerOptions": { "baseUrl": "." } }"#,
+    );
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "extends": "./base.json",
+          "files": ["src/a.ts"],
+          "compilerOptions": { "noEmit": true }
+        }"#,
+    );
+    write_file(&base.join("src/a.ts"), "export const n: number = 1;\n");
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        [5102],
+        "base-only removed key reports exactly once: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        result.diagnostics[0].file.ends_with("tsconfig.json"),
+        "removed-key notice anchors at the entry config, got {}",
+        result.diagnostics[0].file
+    );
+
+    // Both levels set it: still exactly one notice, at the entry.
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "extends": "./base.json",
+          "files": ["src/a.ts"],
+          "compilerOptions": { "baseUrl": "./src", "noEmit": true }
+        }"#,
+    );
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        [5102],
+        "duplicated removed key still reports once: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        result.diagnostics[0].file.ends_with("tsconfig.json"),
+        "shallowest occurrence wins, got {}",
+        result.diagnostics[0].file
+    );
+    assert!(
+        result.diagnostics[0].message_text.contains("./src/*"),
+        "guidance embeds the EFFECTIVE (entry) value: {}",
+        result.diagnostics[0].message_text
+    );
+}
+
+#[test]
+fn cli_override_retracts_chain_effective_removed_value() {
+    // tsc merges explicit CLI options over the config chain BEFORE the
+    // removal check: `--moduleResolution bundler` over a chain-effective
+    // node10 compiles clean, while a CLI value that is itself removed
+    // (`--moduleResolution node10`) still errors.
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("base.json"),
+        r#"{ "compilerOptions": { "moduleResolution": "node10" } }"#,
+    );
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "extends": "./base.json",
+          "files": ["src/a.ts"],
+          "compilerOptions": { "noEmit": true }
+        }"#,
+    );
+    write_file(&base.join("src/a.ts"), "export const n: number = 1;\n");
+
+    let mut args = default_args();
+    args.module_resolution = Some(super::args::ModuleResolution::Bundler);
+    let result = compile(&args, base).expect("compile should succeed");
+    assert!(
+        result.diagnostics.is_empty(),
+        "a valid CLI override retracts the chain's removed value: {:?}",
+        result.diagnostics
+    );
+}

--- a/crates/tsz-core/src/config/deprecation_helpers.rs
+++ b/crates/tsz-core/src/config/deprecation_helpers.rs
@@ -5,18 +5,22 @@ use tsz_common::diagnostics::format_message;
 use super::normalize_option;
 
 /// A compiler option or option value that TypeScript 7 rejects after parsing.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) struct RemovedOptionNotice {
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct RemovalNotice {
     key: &'static str,
     value: Option<&'static str>,
+    /// For `baseUrl` only: the literal string value, used to derive tsc's
+    /// `Use '"paths": {"*": ["<value>/*"]}'` guidance (tsc embeds the actual
+    /// configured directory, e.g. `"./src"` -> `"./src/*"`).
+    base_url_guidance: Option<String>,
 }
 
-impl RemovedOptionNotice {
-    pub(super) const fn key(self) -> &'static str {
+impl RemovalNotice {
+    pub(super) const fn key(&self) -> &'static str {
         self.key
     }
 
-    pub(super) const fn code(self) -> u32 {
+    pub(super) const fn code(&self) -> u32 {
         if self.value.is_some() {
             diagnostic_codes::OPTION_HAS_BEEN_REMOVED_PLEASE_REMOVE_IT_FROM_YOUR_CONFIGURATION_2
         } else {
@@ -24,11 +28,11 @@ impl RemovedOptionNotice {
         }
     }
 
-    pub(super) const fn is_value(self) -> bool {
+    pub(super) const fn is_value(&self) -> bool {
         self.value.is_some()
     }
 
-    pub(super) fn message(self) -> String {
+    pub(super) fn message(&self) -> String {
         let base = if let Some(value) = self.value {
             format_message(
                 diagnostic_messages::OPTION_HAS_BEEN_REMOVED_PLEASE_REMOVE_IT_FROM_YOUR_CONFIGURATION_2,
@@ -42,11 +46,19 @@ impl RemovedOptionNotice {
         };
 
         if self.key == "baseUrl" {
+            // tsc derives the guidance from the configured directory:
+            // `"."` -> `"./*"`, `"./src"` -> `"./src/*"`.
+            let dir = self.base_url_guidance.as_deref().unwrap_or(".");
+            let target = if dir.ends_with('/') {
+                format!("{dir}*")
+            } else {
+                format!("{dir}/*")
+            };
             append_related_message(
                 base,
                 format_message(
                     diagnostic_messages::USE_INSTEAD,
-                    &[r#""paths": {"*": ["./*"]}"#],
+                    &[&format!(r#""paths": {{"*": ["{target}"]}}"#)],
                 ),
             )
         } else {
@@ -59,9 +71,7 @@ impl RemovedOptionNotice {
 ///
 /// Type-invalid and null values are intentionally skipped here: tsc reports
 /// TS5024 for the former and treats the latter as an unset option.
-pub(super) fn removed_option_notices_from_json(
-    options: &Map<String, Value>,
-) -> Vec<RemovedOptionNotice> {
+pub(super) fn removed_option_notices_from_json(options: &Map<String, Value>) -> Vec<RemovalNotice> {
     let mut notices = Vec::new();
 
     push_removed_bool_value(&mut notices, options, "alwaysStrict");
@@ -78,7 +88,7 @@ pub(super) fn removed_option_notices_from_json(
 }
 
 fn push_removed_key(
-    notices: &mut Vec<RemovedOptionNotice>,
+    notices: &mut Vec<RemovalNotice>,
     options: &Map<String, Value>,
     key: &'static str,
 ) {
@@ -88,12 +98,18 @@ fn push_removed_key(
             | ("downlevelIteration", Some(Value::Bool(_)))
     );
     if type_is_valid {
-        notices.push(key_notice(key));
+        let mut notice = key_notice(key);
+        if key == "baseUrl"
+            && let Some(Value::String(dir)) = options.get(key)
+        {
+            notice.base_url_guidance = Some(dir.clone());
+        }
+        notices.push(notice);
     }
 }
 
 fn push_removed_bool_value(
-    notices: &mut Vec<RemovedOptionNotice>,
+    notices: &mut Vec<RemovalNotice>,
     options: &Map<String, Value>,
     key: &'static str,
 ) {
@@ -103,7 +119,7 @@ fn push_removed_bool_value(
 }
 
 fn push_removed_string_value(
-    notices: &mut Vec<RemovedOptionNotice>,
+    notices: &mut Vec<RemovalNotice>,
     options: &Map<String, Value>,
     key: &'static str,
 ) {
@@ -127,14 +143,19 @@ fn removed_string_value(key: &str, value: &str) -> Option<&'static str> {
     }
 }
 
-const fn key_notice(key: &'static str) -> RemovedOptionNotice {
-    RemovedOptionNotice { key, value: None }
+const fn key_notice(key: &'static str) -> RemovalNotice {
+    RemovalNotice {
+        key,
+        value: None,
+        base_url_guidance: None,
+    }
 }
 
-const fn value_notice(key: &'static str, value: &'static str) -> RemovedOptionNotice {
-    RemovedOptionNotice {
+const fn value_notice(key: &'static str, value: &'static str) -> RemovalNotice {
+    RemovalNotice {
         key,
         value: Some(value),
+        base_url_guidance: None,
     }
 }
 

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -38,7 +38,10 @@ mod parse;
 mod resolved_options;
 
 pub use option_fanout::apply_non_strict_fanout;
-pub use parse::{ParsedTsConfig, parse_tsconfig, parse_tsconfig_with_diagnostics};
+pub use parse::{
+    ParsedTsConfig, RemovedOptionNotice, parse_tsconfig, parse_tsconfig_with_diagnostics,
+    parse_tsconfig_with_diagnostics_deferred,
+};
 pub use resolved_options::{
     JsxEmit, ModuleResolutionKind, PathMapping, ResolvedCompilerOptions,
     default_module_detection_for_module, default_module_kind_for_target,
@@ -1192,6 +1195,18 @@ pub fn load_tsconfig(path: &Path) -> Result<TsConfig> {
 
 /// Load tsconfig.json and collect config-level diagnostics.
 pub fn load_tsconfig_with_diagnostics(path: &Path) -> Result<ParsedTsConfig> {
+    let mut parsed = load_tsconfig_with_diagnostics_deferred(path)?;
+    parsed.flush_pending_removed_option_notices();
+    Ok(parsed)
+}
+
+/// [`load_tsconfig_with_diagnostics`] with removed-option notices left in
+/// `pending_removed_option_notices` (already entry-anchored) instead of
+/// flushed into `diagnostics`. The CLI driver uses this to retract notices
+/// for options the command line overrides with valid values before flushing —
+/// tsc validates removals on the final CLI-merged options (#15806 adjacent
+/// case).
+pub fn load_tsconfig_with_diagnostics_deferred(path: &Path) -> Result<ParsedTsConfig> {
     let mut visited = FxHashSet::default();
     let config_dir = root_config_dir(path);
     load_tsconfig_inner_with_diagnostics(path, &mut visited, false, &config_dir)
@@ -1293,7 +1308,7 @@ fn load_tsconfig_inner_with_diagnostics(
     let source = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read tsconfig: {}", path.display()))?;
     let file_display = path.display().to_string();
-    let mut parsed = parse_tsconfig_with_diagnostics(&source, &file_display)
+    let mut parsed = parse::parse_tsconfig_with_diagnostics_deferred(&source, &file_display)
         .with_context(|| format!("failed to parse tsconfig: {}", path.display()))?;
     // Resolve `${configDir}` against the root config's directory before any
     // `extends` anchoring, which only fires on the leftover relative paths.
@@ -1310,6 +1325,15 @@ fn load_tsconfig_inner_with_diagnostics(
             ExtendsValue::Array(arr) => arr,
         };
         let mut accumulated: Option<TsConfig> = None;
+        // Removed-option notices (TS5102/TS5108 family) from base configs stay
+        // pending until the whole chain merges: tsc runs the removal check
+        // once on the merged effective options (fixes the false TS5108
+        // tracked by #15806). VALUE notices are suppressed by a shallower
+        // VALID override; KEY notices dedup to the shallowest literal
+        // occurrence (whose message embeds the effective value).
+        let mut inherited_pending: Vec<RemovedOptionNotice> = Vec::new();
+        let mut inherited_explicit_keys: FxHashSet<String> = FxHashSet::default();
+        let mut inherited_literal_keys: FxHashSet<String> = FxHashSet::default();
         let stripped = strip_jsonc(&source);
         for extends_path_str in &extends_paths {
             // An `extends` specifier that names no existing config file is a
@@ -1333,9 +1357,27 @@ fn load_tsconfig_inner_with_diagnostics(
             // fire on the *base* file (matching tsc's `base.json(L,C):` anchor)
             // instead of the child's invalid option being silently coerced through
             // the type-validating-free `load_tsconfig_inner`.
-            let base_parsed =
+            let mut base_parsed =
                 load_tsconfig_inner_with_diagnostics(&base_path, visited, true, config_dir)?;
             parsed.diagnostics.extend(base_parsed.diagnostics);
+            // Later `extends` entries override earlier ones: a VALUE notice is
+            // dropped when this base's subtree sets the key to a valid value;
+            // a KEY notice is dropped when this base writes the key at all
+            // (the base generated its own, shallower notice). Then adopt the
+            // base's own survivors.
+            inherited_pending.retain(|notice| {
+                if notice.is_value {
+                    !base_parsed
+                        .explicit_compiler_option_keys
+                        .contains(&notice.key)
+                } else {
+                    !base_parsed.subtree_literal_keys.contains(&notice.key)
+                }
+            });
+            inherited_pending.append(&mut base_parsed.pending_removed_option_notices);
+            inherited_explicit_keys
+                .extend(base_parsed.explicit_compiler_option_keys.iter().cloned());
+            inherited_literal_keys.extend(base_parsed.subtree_literal_keys.iter().cloned());
             accumulated = Some(match accumulated {
                 Some(acc) => merge_configs(acc, base_parsed.config),
                 None => base_parsed.config,
@@ -1344,12 +1386,67 @@ fn load_tsconfig_inner_with_diagnostics(
         if let Some(base) = accumulated {
             parsed.config = merge_configs(base, parsed.config);
         }
+        // This config overrides every base: value notices die to its valid
+        // keys, key notices to its literal keys; survivors precede this
+        // file's own pending notices so deeper (base) options report before
+        // shallower ones. Union the subtree's key sets so a grandparent chain
+        // can apply the same rules to us.
+        inherited_pending.retain(|notice| {
+            if notice.is_value {
+                !parsed.explicit_compiler_option_keys.contains(&notice.key)
+            } else {
+                !parsed.literal_value_spans.contains_key(&notice.key)
+            }
+        });
+        if !inherited_pending.is_empty() {
+            inherited_pending.append(&mut parsed.pending_removed_option_notices);
+            parsed.pending_removed_option_notices = inherited_pending;
+        }
+        parsed
+            .explicit_compiler_option_keys
+            .extend(inherited_explicit_keys);
+        // `literal_value_spans` stays file-local for entry anchoring; only the
+        // key SET unions across the subtree for parent-chain dedup.
+        parsed.subtree_literal_keys.extend(inherited_literal_keys);
     }
 
     if config_ignore_deprecations_silences_6_0(&parsed.config) {
         parsed
             .diagnostics
             .retain(|diag| !is_ts60_deprecation_diagnostic_code(diag.code));
+        parsed
+            .pending_removed_option_notices
+            .retain(|notice| !is_ts60_deprecation_diagnostic_code(notice.diagnostic.code));
+    }
+
+    if !inherited {
+        // Entry config: re-anchor surviving base-file notices the way tsc's
+        // `createCompilerOptionsDiagnostic` does — at the entry's own value
+        // span when the entry literally writes the key (e.g. a TS5024-invalid
+        // override of an inherited removed value), else at the entry's
+        // `"compilerOptions"` key span, else as a global file-less diagnostic
+        // (empty `file` renders with no location prefix). A notice generated
+        // by the entry file itself keeps its original value-span anchor.
+        for notice in &mut parsed.pending_removed_option_notices {
+            if notice.diagnostic.file == file_display {
+                continue;
+            }
+            if let Some((start, length)) = parsed.literal_value_spans.get(&notice.key) {
+                notice.diagnostic.file = file_display.clone();
+                notice.diagnostic.start = *start;
+                notice.diagnostic.length = *length;
+            } else if let Some(offset) = parsed.compiler_options_key_offset {
+                notice.diagnostic.file = file_display.clone();
+                notice.diagnostic.start = offset;
+                notice.diagnostic.length = "\"compilerOptions\"".len() as u32;
+            } else {
+                notice.diagnostic.file = String::new();
+                notice.diagnostic.start = 0;
+                notice.diagnostic.length = 0;
+            }
+        }
+        // The flush happens in the public load wrappers so the CLI driver's
+        // deferred path can retract CLI-overridden notices first.
     }
 
     visited.remove(&canonical);

--- a/crates/tsz-core/src/config/parse.rs
+++ b/crates/tsz-core/src/config/parse.rs
@@ -12,10 +12,67 @@ pub fn parse_tsconfig(source: &str) -> Result<TsConfig> {
     Ok(config)
 }
 
+/// A removed-option notice (the TS5102/TS5108 family) held out of
+/// `diagnostics` until the `extends` chain is resolved: tsc runs
+/// `verifyDeprecatedCompilerOptions` ONCE on the merged EFFECTIVE options and
+/// anchors the result in the ENTRY config, so
+/// - a base config's removed VALUE that a shallower config overrides with a
+///   valid value produces no diagnostic at all (a type-invalid override does
+///   NOT mask it — tsc reports both TS5024 and the removal),
+/// - a removed KEY set at several levels reports once, with the shallowest
+///   occurrence's message (its guidance text embeds the effective value),
+/// - a surviving notice from a base file re-anchors at the entry config: the
+///   entry's own value span when the entry writes the key, else the entry's
+///   `"compilerOptions"` key span, else a global file-less diagnostic.
+pub struct RemovedOptionNotice {
+    pub key: String,
+    /// True for removed option VALUES (`moduleResolution=node10`); false for
+    /// removed option KEYS (`baseUrl`). Values are suppressed by a valid
+    /// override; keys only dedup (no override legitimizes a removed key).
+    pub is_value: bool,
+    pub diagnostic: Diagnostic,
+}
+
 /// Result of parsing a tsconfig.json with diagnostic collection.
 pub struct ParsedTsConfig {
     pub config: TsConfig,
     pub diagnostics: Vec<Diagnostic>,
+    /// Removed-option notices pending the `extends`-merge decision. Direct
+    /// (non-`extends`-aware) consumers get them flushed by
+    /// [`parse_tsconfig_with_diagnostics`]; only the deferred parse leaves
+    /// them here.
+    pub pending_removed_option_notices: Vec<RemovedOptionNotice>,
+    /// Compiler-option keys carrying a VALID value in this file's
+    /// `compilerOptions` JSON (post canonical-casing rename, post TS5024
+    /// strip). Only these suppress an inherited removed VALUE.
+    pub explicit_compiler_option_keys: rustc_hash::FxHashSet<String>,
+    /// Every compiler-option key literally written in THIS file (post-rename,
+    /// including TS5024-invalid ones) with its value span. Strictly
+    /// file-local: used for tsc's entry-file anchoring rules. Byte offsets
+    /// are meaningless outside this file's source.
+    pub literal_value_spans: rustc_hash::FxHashMap<String, (u32, u32)>,
+    /// Keys literally written anywhere in this config's `extends` subtree
+    /// (this file plus every base it reaches). Seeded with this file's
+    /// literal keys by the parser; the config loader unions base subtrees in.
+    /// Used by a shallower config to dedup inherited removed-KEY notices.
+    pub subtree_literal_keys: rustc_hash::FxHashSet<String>,
+    /// Byte offset of this file's top-level `"compilerOptions"` key in the
+    /// JSONC-stripped source, used to anchor inherited removed-option notices
+    /// the way tsc does.
+    pub compiler_options_key_offset: Option<u32>,
+}
+
+impl ParsedTsConfig {
+    /// Commit pending removed-option notices as plain diagnostics. Used by
+    /// direct parses (no `extends` resolution) where every literal option is
+    /// also the effective one.
+    pub fn flush_pending_removed_option_notices(&mut self) {
+        self.diagnostics.extend(
+            self.pending_removed_option_notices
+                .drain(..)
+                .map(|n| n.diagnostic),
+        );
+    }
 }
 
 /// Parse tsconfig.json source and collect diagnostics for unknown compiler options.
@@ -24,13 +81,40 @@ pub struct ParsedTsConfig {
 /// 1. Detects unknown/miscased compiler option keys in the JSON
 /// 2. Normalizes them to canonical casing so serde can deserialize them
 /// 3. Returns TS5025 when a spelling suggestion exists, otherwise TS5023
+///
+/// Direct-parse semantics: every literal option value is also the effective
+/// value, so removed-value notices are committed straight into `diagnostics`.
+/// The `extends`-aware config loader uses
+/// [`parse_tsconfig_with_diagnostics_deferred`] instead, which leaves them in
+/// `pending_removed_option_notices` for the effective-options decision.
 pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<ParsedTsConfig> {
+    let mut parsed = parse_tsconfig_with_diagnostics_deferred(source, file_path)?;
+    parsed.flush_pending_removed_option_notices();
+    Ok(parsed)
+}
+
+/// [`parse_tsconfig_with_diagnostics`] without the final removed-value flush:
+/// notices stay in `pending_removed_option_notices` so the `extends`
+/// resolver can suppress base values that shallower configs override (#15806).
+pub fn parse_tsconfig_with_diagnostics_deferred(
+    source: &str,
+    file_path: &str,
+) -> Result<ParsedTsConfig> {
     let stripped = strip_jsonc(source);
     let normalized = remove_trailing_commas(&stripped);
     let mut raw: serde_json::Value =
         serde_json::from_str(&normalized).context("failed to parse tsconfig JSON")?;
 
     let mut diagnostics = Vec::new();
+    let mut pending_removed_option_notices: Vec<RemovedOptionNotice> = Vec::new();
+    let mut explicit_compiler_option_keys: rustc_hash::FxHashSet<String> =
+        rustc_hash::FxHashSet::default();
+    let mut literal_value_spans: rustc_hash::FxHashMap<String, (u32, u32)> =
+        rustc_hash::FxHashMap::default();
+    let mut subtree_literal_keys: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
+    let compiler_options_key_offset = stripped
+        .find("\"compilerOptions\"")
+        .map(|offset| offset as u32);
     // Track options that had TS5024 type errors — defaults should not be applied for these.
     let mut ts5024_keys_outer: Vec<String> = Vec::new();
 
@@ -147,6 +231,22 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
         // Track TS5024 keys so invalid values stay unavailable to later
         // option-combination and removal validation.
         let keys_after_rename: Vec<String> = compiler_opts.keys().cloned().collect();
+        // Literal spans are captured before the TS5024 strip so a type-invalid
+        // value still records where the key was written (tsc anchors an
+        // inherited removal at the entry's own value span even when that value
+        // is itself TS5024-invalid).
+        for key in &keys_after_rename {
+            if let Some(value) = compiler_opts.get(key) {
+                literal_value_spans.insert(
+                    key.clone(),
+                    (
+                        find_value_offset_in_source(&stripped, key),
+                        estimate_json_value_len(value),
+                    ),
+                );
+                subtree_literal_keys.insert(key.clone());
+            }
+        }
         let mut bad_keys: Vec<String> = Vec::new();
         let mut ts5024_keys: Vec<String> = Vec::new();
         for key in &keys_after_rename {
@@ -215,6 +315,8 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
         // TypeScript 7 turns the complete 6.0 deprecation wave into
         // unsuppressible removals. Keep the policy in deprecation_helpers so
         // config and direct CLI validation share aliases and display values.
+        explicit_compiler_option_keys.extend(compiler_opts.keys().cloned());
+
         for notice in deprecation_helpers::removed_option_notices_from_json(compiler_opts) {
             let key = notice.key();
             let start = if notice.is_value() {
@@ -227,13 +329,15 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
             } else {
                 key.len() as u32 + 2
             };
-            diagnostics.push(Diagnostic::error(
-                file_path,
-                start,
-                length,
-                notice.message(),
-                notice.code(),
-            ));
+            let diagnostic =
+                Diagnostic::error(file_path, start, length, notice.message(), notice.code());
+            // Effective-options decision is deferred to the `extends`
+            // resolver (or the flush in the non-deferred parse).
+            pending_removed_option_notices.push(RemovedOptionNotice {
+                key: key.to_string(),
+                is_value: notice.is_value(),
+                diagnostic,
+            });
         }
 
         // Check command-line-only options in tsconfig (TS6266)
@@ -1258,5 +1362,10 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
     Ok(ParsedTsConfig {
         config,
         diagnostics,
+        pending_removed_option_notices,
+        explicit_compiler_option_keys,
+        literal_value_spans,
+        subtree_literal_keys,
+        compiler_options_key_offset,
     })
 }


### PR DESCRIPTION
Goal: green

Fixes #15806 and its adjacent cases: tsz validated removed compiler options (the TS5102/TS5108 family) per config file during parsing, while tsc runs `verifyDeprecatedCompilerOptions` ONCE on the final merged compilerOptions — after `extends` resolution AND CLI-flag merging — anchoring results in the entry config. The witness was the Next.js full-project bench row: its bench config overrides the base tsconfig's removed `moduleResolution=node10` with `bundler`, which tsc 6.0.3 and tsgo accept clean while tsz hard-errored TS5108 from the base file. This unblocks that row (tsz now exits 0 on the fixture, matching tsc/tsgo).

## Structural rule
When a removed option value appears in a tsconfig `extends` chain, tsc reports it only if it survives into the merged effective options — a shallower config's (or explicit CLI flag's) valid override suppresses it entirely; a type-invalid (TS5024) override does NOT suppress it. Removed KEYS (`baseUrl`/`outFile`/`downlevelIteration`) dedup to one report per key, keeping the shallowest occurrence (whose guidance text embeds the effective value). Surviving base-file notices anchor at the ENTRY config: its own value span if it writes the key, else its `"compilerOptions"` key span, else a global file-less diagnostic. tsz does this through the config loader (owner: tsz-core config layer — parse defers notices, the `extends` fold decides, the CLI driver retracts CLI-overridden values before flushing). Unknown keys (TS5023, dropped from the option table) remain per-file, matching tsc.

Every behavior above was pinned against the pinned tsc 6.0.3 binary before implementation (not just TS source reading); 7 of 8 shapes now match tsc byte-for-byte. The 8th differs only in a pre-existing unrelated wording gap: tsz's TS5024 says moduleResolution "requires a value of type string" where tsc says "type enum" (expected-type table, separate fix).

## Owner layer
`tsz-core/src/config/{parse,mod,deprecation_helpers}.rs` (deferred-notice plumbing + fold + entry anchoring + value-derived baseUrl guidance) and `tsz-cli/src/driver/{core_diagnostics,plan,sources,core}.rs` (CLI-override retraction). Public API is backward compatible: `parse_tsconfig_with_diagnostics` / `load_tsconfig_with_diagnostics` flush internally (all existing consumers and ~40 config unit tests unchanged); new `_deferred` variants exist for the extends resolver and CLI driver only. No checker/solver/emitter changes.

## Adjacent-case matrix (all as new driver tests, `driver_tests_parts/part_13.rs`)
- override in child → clean (the #15806 witness shape); grandparent-removed, mid-chain override → clean; `extends` array later-entry override → clean, flipped order → reported
- inherited un-overridden value → reported once at the entry's `compilerOptions` key
- TS5024-invalid override → TS5024 AND TS5108, removal anchored at the entry's own value span (negative case: invalid override must NOT suppress)
- entry with no `compilerOptions` at all → global file-less diagnostic (preset-style configs)
- removed KEY (`baseUrl`) base-only → once at entry; set at both levels → once, entry span, guidance embeds the EFFECTIVE directory (`"./src"` → `"./src/*"`; was hardcoded `"./*"`)
- CLI `--moduleResolution bundler` over chain-effective node10 → clean (retraction); a CLI value itself removed does not retract
- unknown key (TS5023) in base and child → still reported per-file at BOTH (negative case: only the removed-option family merges)

## Verification
- Multi-agent adversarial review (3 lenses + refutation verify) produced 5 confirmed findings; all empirically re-pinned against tsc 6.0.3 and fixed or classified (2 reviewer claims about tsc behavior were corrected by the binary: a type-invalid override does not mask, and c3c outFile:"" does fire).
- `cargo nextest run -p tsz-cli --lib`: 1461/1462 (the 1 failure plus the `tsc_parity_*`/`tsc_compat_*` family fail identically on clean main — verified via stash; they shell out to a system tsc).
- `cargo nextest run -p tsz-core` config/extends/deprecation filter: 282/282.
- Byte-exact output diff vs pinned tsc 6.0.3 on 8 empirical config shapes: 7/8 match (8th = pre-existing TS5024 wording, above).
- Bench fixture: `tsz --noEmit -p .target-bench/external/next.js/packages/next/tsconfig.tsz-bench.json` → exit 0, 0 diagnostics (was exit 1 TS5108); tsc and tsgo also 0.
- clippy `--all-targets` clean; `scripts/arch/check-checker-boundaries.sh` passes.

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-fable-5
Effort: max
