### PR TITLE
fix(checker): rebind cached class application members

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2392,6 +2392,10 @@ name = "required_never_property_union_tests"
 path = "tests/required_never_property_union_tests.rs"
 
 [[test]]
+name = "application_member_type_parameter_substitution_tests"
+path = "tests/application_member_type_parameter_substitution_tests.rs"
+
+[[test]]
 name = "partial_record_optional_index_assignability_tests"
 path = "tests/partial_record_optional_index_assignability_tests.rs"
 

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -7,6 +7,7 @@ use crate::query_boundaries::construct_signatures::call_only_callable_type;
 use crate::query_boundaries::definite_assignment::constructor_assigned_properties;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::cell::RefCell;
 use tsz_lowering::TypeLowering;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -23,6 +24,49 @@ pub(crate) struct ClassPropertyInitializationInfo {
     pub(crate) has_no_initializer: bool,
     pub(crate) is_abstract: bool,
     pub(crate) requires_initialization: bool,
+}
+
+#[cfg(test)]
+mod exact_rebind_cache_tests {
+    use super::ClassChainSummary;
+    use tsz_solver::construction::TypeInterner;
+    use tsz_solver::{FunctionShape, ParamInfo, TypeId, TypeParamInfo};
+
+    #[test]
+    fn repeated_member_rebind_reuses_nested_generic_identity() {
+        let db = TypeInterner::new();
+        let source_outer = db.fresh_type_param(TypeParamInfo::simple(db.intern_string("Outer")));
+        let active_outer = db.fresh_type_param(TypeParamInfo::simple(db.intern_string("Active")));
+        let nested = db.fresh_type_param(TypeParamInfo {
+            name: db.intern_string("Nested"),
+            constraint: Some(source_outer),
+            default: None,
+            is_const: false,
+            origin: tsz_solver::TypeParamOrigin::User,
+        });
+        let member = db.function(FunctionShape {
+            type_params: Vec::new(),
+            params: vec![ParamInfo {
+                type_id: nested,
+                ..ParamInfo::default()
+            }],
+            this_type: None,
+            return_type: TypeId::VOID,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: true,
+        });
+        let summary = ClassChainSummary {
+            root_type_params: vec![source_outer],
+            ..ClassChainSummary::default()
+        };
+
+        let first = summary.rebind_root_type_params(&db, &[active_outer], member);
+        let second = summary.rebind_root_type_params(&db, &[active_outer], member);
+
+        assert_eq!(first, second);
+        assert_ne!(first, member);
+    }
 }
 
 #[derive(Clone, Default)]
@@ -93,6 +137,10 @@ pub(crate) enum ClassMemberKind {
 pub(crate) struct ClassChainSummary {
     /// Root-class type parameter identities used to build this cached summary.
     root_type_params: Vec<TypeId>,
+    /// Exact rebinds are stable for one cached summary and active binder vector.
+    /// This prevents nested generic member binders from being freshly allocated
+    /// again on every property access.
+    rebound_root_types: RefCell<FxHashMap<Vec<TypeId>, FxHashMap<TypeId, TypeId>>>,
     /// Unified instance member map: name -> entry (replaces 6 maps + 1 set)
     instance_members: FxHashMap<String, MemberEntry>,
     /// Unified static member map: name -> entry (replaces 6 maps + 1 set)
@@ -119,12 +167,49 @@ impl ClassChainSummary {
         if self.root_type_params.len() != active_root_type_params.len() {
             return type_id;
         }
-        crate::query_boundaries::common::substitute_exact_types(
+        if let Some(cached) = self
+            .rebound_root_types
+            .borrow()
+            .get(active_root_type_params)
+            .and_then(|types| types.get(&type_id))
+            .copied()
+        {
+            return cached;
+        }
+
+        let rebound = crate::query_boundaries::common::substitute_exact_types(
             db,
             type_id,
             &self.root_type_params,
             active_root_type_params,
-        )
+        );
+        self.rebound_root_types
+            .borrow_mut()
+            .entry(active_root_type_params.to_vec())
+            .or_default()
+            .insert(type_id, rebound);
+        rebound
+    }
+
+    /// Resolve the cached summary's declaration-ordered binders through the
+    /// current name scope. This is used only during early class construction,
+    /// before `EnclosingClassInfo` is installed and before member-level binders
+    /// can shadow the class parameters.
+    pub(crate) fn root_type_params_from_active_scope(
+        &self,
+        db: &dyn tsz_solver::construction::TypeDatabase,
+        active_scope: &FxHashMap<String, TypeId>,
+    ) -> Option<Vec<TypeId>> {
+        self.root_type_params
+            .iter()
+            .map(|&type_id| {
+                let tsz_solver::TypeData::TypeParameter(info) = db.lookup(type_id)? else {
+                    return None;
+                };
+                let name = db.resolve_atom_ref(info.name);
+                active_scope.get(name.as_ref()).copied()
+            })
+            .collect()
     }
 
     pub(crate) fn lookup(
@@ -706,7 +791,7 @@ impl<'a> CheckerState<'a> {
             // cannot replace the type parameters, causing base member types to remain
             // as `any` and skipping TS2416 checks entirely.
             let (class_type_params, type_param_updates) =
-                self.push_type_parameters(&class.type_parameters);
+                self.push_effective_class_type_parameters(current_idx, class);
 
             if is_first {
                 summary.root_type_params = self
@@ -808,7 +893,7 @@ impl<'a> CheckerState<'a> {
             if let Some((base_class_idx, type_arg_ids)) = extends_info {
                 if let Some(base_class) = self.ctx.arena.get_class_at(base_class_idx) {
                     let (base_type_params, base_type_param_updates) =
-                        self.push_type_parameters(&base_class.type_parameters);
+                        self.push_effective_class_type_parameters(base_class_idx, base_class);
                     self.pop_type_parameters(base_type_param_updates);
 
                     if !base_type_params.is_empty() && !type_arg_ids.is_empty() {
@@ -859,7 +944,7 @@ impl<'a> CheckerState<'a> {
         include_private: bool,
     ) -> Option<TypeId> {
         let class = self.ctx.arena.get_class_at(class_idx)?;
-        let (_, type_param_updates) = self.push_type_parameters(&class.type_parameters);
+        let (_, type_param_updates) = self.push_effective_class_type_parameters(class_idx, class);
         let summary = self.collect_class_members_for_chain(class_idx, class);
         self.pop_type_parameters(type_param_updates);
 
@@ -1088,7 +1173,8 @@ impl<'a> CheckerState<'a> {
                     .map(|&arg_idx| self.get_type_from_type_node(arg_idx))
                     .collect()
             } else {
-                Vec::new()
+                self.jsdoc_extends_type_arguments_for_heritage(class_idx, expr_idx)
+                    .unwrap_or_default()
             };
 
             return Some((base_class_idx, type_arg_ids));

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -92,7 +92,7 @@ pub(crate) enum ClassMemberKind {
 #[derive(Clone, Default)]
 pub(crate) struct ClassChainSummary {
     /// Root-class type parameter identities used to build this cached summary.
-    root_type_params: Vec<(String, TypeId)>,
+    root_type_params: Vec<TypeId>,
     /// Unified instance member map: name -> entry (replaces 6 maps + 1 set)
     instance_members: FxHashMap<String, MemberEntry>,
     /// Unified static member map: name -> entry (replaces 6 maps + 1 set)
@@ -113,18 +113,20 @@ impl ClassChainSummary {
     pub(crate) fn rebind_root_type_params(
         &self,
         db: &dyn tsz_solver::construction::TypeDatabase,
-        active_scope: &FxHashMap<String, TypeId>,
+        active_root_type_params: &[TypeId],
         mut type_id: TypeId,
     ) -> TypeId {
-        for (name, cached_param) in &self.root_type_params {
-            let Some(&active_param) = active_scope.get(name) else {
-                continue;
-            };
-            if active_param != *cached_param {
+        if self.root_type_params.len() != active_root_type_params.len() {
+            return type_id;
+        }
+        for (&cached_param, &active_param) in
+            self.root_type_params.iter().zip(active_root_type_params)
+        {
+            if active_param != cached_param {
                 type_id = crate::query_boundaries::common::substitute_exact_type(
                     db,
                     type_id,
-                    *cached_param,
+                    cached_param,
                     active_param,
                 );
             }
@@ -714,19 +716,9 @@ impl<'a> CheckerState<'a> {
                 self.push_type_parameters(&class.type_parameters);
 
             if is_first {
-                summary.root_type_params = class_type_params
-                    .iter()
-                    .map(|param| {
-                        let name = self.ctx.types.resolve_atom(param.name);
-                        let type_id = self
-                            .ctx
-                            .type_parameter_scope
-                            .get(&name)
-                            .copied()
-                            .unwrap_or_else(|| self.ctx.types.type_param(*param));
-                        (name, type_id)
-                    })
-                    .collect();
+                summary.root_type_params = self
+                    .exact_type_parameter_ids_in_scope(&class_type_params)
+                    .unwrap_or_default();
             }
 
             let own_summary = self.collect_class_members_for_chain(current_idx, class);

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -1,7 +1,7 @@
 use crate::class_checker::ClassMemberInfo;
 use crate::flow_analysis::{ComputedKey, PropertyKey};
 use crate::query_boundaries::common::{
-    TypeSubstitution, callable_shape_for_type, object_shape_for_type,
+    ExactTypeRewriteSession, TypeSubstitution, callable_shape_for_type, object_shape_for_type,
 };
 use crate::query_boundaries::construct_signatures::call_only_callable_type;
 use crate::query_boundaries::definite_assignment::constructor_assigned_properties;
@@ -30,7 +30,8 @@ pub(crate) struct ClassPropertyInitializationInfo {
 mod exact_rebind_cache_tests {
     use super::ClassChainSummary;
     use tsz_solver::construction::TypeInterner;
-    use tsz_solver::{FunctionShape, ParamInfo, TypeId, TypeParamInfo};
+    use tsz_solver::def::DefId;
+    use tsz_solver::{FunctionShape, ParamInfo, TypeData, TypeId, TypeParamInfo};
 
     #[test]
     fn repeated_member_rebind_reuses_nested_generic_identity() {
@@ -66,6 +67,78 @@ mod exact_rebind_cache_tests {
 
         assert_eq!(first, second);
         assert_ne!(first, member);
+    }
+
+    #[test]
+    fn cached_member_rebind_refreshes_late_application_display_alias() {
+        let db = TypeInterner::new();
+        let source_outer = db.fresh_type_param(TypeParamInfo::simple(db.intern_string("Outer")));
+        let active_outer = db.fresh_type_param(TypeParamInfo::simple(db.intern_string("Active")));
+        let member = db.array(source_outer);
+        let summary = ClassChainSummary {
+            root_type_params: vec![source_outer],
+            ..ClassChainSummary::default()
+        };
+
+        let first = summary.rebind_root_type_params(&db, &[active_outer], member);
+        assert_eq!(db.get_display_alias(first), None);
+
+        let alias_base = db.lazy(DefId(27));
+        let source_alias = db.application(alias_base, vec![source_outer]);
+        db.store_display_alias_preferring_application(member, source_alias);
+        db.record_application_eval_origin(member, source_alias);
+
+        let second = summary.rebind_root_type_params(&db, &[active_outer], member);
+        let expected_alias = db.application(alias_base, vec![active_outer]);
+
+        assert_eq!(second, first);
+        assert_eq!(db.get_display_alias(second), Some(expected_alias));
+        assert_eq!(db.get_application_eval_origin(second), Some(expected_alias));
+    }
+
+    #[test]
+    fn cached_rebind_session_shares_nested_binder_across_member_roots() {
+        let db = TypeInterner::new();
+        let source_outer = db.fresh_type_param(TypeParamInfo::simple(db.intern_string("Outer")));
+        let active_outer = db.fresh_type_param(TypeParamInfo::simple(db.intern_string("Active")));
+        let nested = db.fresh_type_param(TypeParamInfo {
+            name: db.intern_string("Nested"),
+            constraint: Some(source_outer),
+            default: None,
+            is_const: false,
+            origin: tsz_solver::TypeParamOrigin::User,
+        });
+        let function_member = db.function(FunctionShape {
+            type_params: Vec::new(),
+            params: vec![ParamInfo {
+                type_id: nested,
+                ..ParamInfo::default()
+            }],
+            this_type: None,
+            return_type: TypeId::VOID,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: true,
+        });
+        let array_member = db.array(nested);
+        let summary = ClassChainSummary {
+            root_type_params: vec![source_outer],
+            ..ClassChainSummary::default()
+        };
+
+        let rewritten_function =
+            summary.rebind_root_type_params(&db, &[active_outer], function_member);
+        let rewritten_array = summary.rebind_root_type_params(&db, &[active_outer], array_member);
+
+        let Some(TypeData::Function(function_id)) = db.lookup(rewritten_function) else {
+            panic!("expected rewritten function member");
+        };
+        let rewritten_nested = db.function_shape(function_id).params[0].type_id;
+        let Some(TypeData::Array(array_nested)) = db.lookup(rewritten_array) else {
+            panic!("expected rewritten array member");
+        };
+        assert_eq!(rewritten_nested, array_nested);
+        assert_ne!(rewritten_nested, nested);
     }
 }
 
@@ -140,7 +213,7 @@ pub(crate) struct ClassChainSummary {
     /// Exact rebinds are stable for one cached summary and active binder vector.
     /// This prevents nested generic member binders from being freshly allocated
     /// again on every property access.
-    rebound_root_types: RefCell<FxHashMap<Vec<TypeId>, FxHashMap<TypeId, TypeId>>>,
+    rebind_sessions: RefCell<FxHashMap<Vec<TypeId>, ExactTypeRewriteSession>>,
     /// Unified instance member map: name -> entry (replaces 6 maps + 1 set)
     instance_members: FxHashMap<String, MemberEntry>,
     /// Unified static member map: name -> entry (replaces 6 maps + 1 set)
@@ -167,28 +240,30 @@ impl ClassChainSummary {
         if self.root_type_params.len() != active_root_type_params.len() {
             return type_id;
         }
-        if let Some(cached) = self
-            .rebound_root_types
-            .borrow()
-            .get(active_root_type_params)
-            .and_then(|types| types.get(&type_id))
-            .copied()
         {
-            return cached;
+            let mut cache = self.rebind_sessions.borrow_mut();
+            if let Some(session) = cache.get_mut(active_root_type_params) {
+                // A shared-frame abort must not publish a provenance-stale or
+                // partial result. Keep the completed session so the next access
+                // can retry without reminting structural fresh binders.
+                return session.rewrite_root(db, type_id).unwrap_or(type_id);
+            }
         }
 
-        let rebound = crate::query_boundaries::common::substitute_exact_types(
-            db,
-            type_id,
-            &self.root_type_params,
-            active_root_type_params,
-        );
-        self.rebound_root_types
+        let Some((result, session)) =
+            crate::query_boundaries::common::start_exact_type_rewrite_session(
+                db,
+                type_id,
+                &self.root_type_params,
+                active_root_type_params,
+            )
+        else {
+            return type_id;
+        };
+        self.rebind_sessions
             .borrow_mut()
-            .entry(active_root_type_params.to_vec())
-            .or_default()
-            .insert(type_id, rebound);
-        rebound
+            .insert(active_root_type_params.to_vec(), session);
+        result
     }
 
     /// Resolve the cached summary's declaration-ordered binders through the

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -203,9 +203,8 @@ impl ClassChainSummary {
         self.root_type_params
             .iter()
             .map(|&type_id| {
-                let tsz_solver::TypeData::TypeParameter(info) = db.lookup(type_id)? else {
-                    return None;
-                };
+                let info =
+                    crate::query_boundaries::checkers::generic::named_type_param_info(db, type_id)?;
                 let name = db.resolve_atom_ref(info.name);
                 active_scope.get(name.as_ref()).copied()
             })

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -1,10 +1,11 @@
 use crate::class_checker::ClassMemberInfo;
 use crate::flow_analysis::{ComputedKey, PropertyKey};
 use crate::query_boundaries::common::{
-    ExactTypeRewriteSession, TypeSubstitution, callable_shape_for_type, object_shape_for_type,
+    TypeSubstitution, callable_shape_for_type, object_shape_for_type,
 };
 use crate::query_boundaries::construct_signatures::call_only_callable_type;
 use crate::query_boundaries::definite_assignment::constructor_assigned_properties;
+use crate::query_boundaries::exact_rewrite::ExactTypeRewriteSession;
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
@@ -31,7 +32,7 @@ mod exact_rebind_cache_tests {
     use super::ClassChainSummary;
     use tsz_solver::construction::TypeInterner;
     use tsz_solver::def::DefId;
-    use tsz_solver::{FunctionShape, ParamInfo, TypeData, TypeId, TypeParamInfo};
+    use tsz_solver::{FunctionShape, ParamInfo, TypeId, TypeParamInfo};
 
     #[test]
     fn repeated_member_rebind_reuses_nested_generic_identity() {
@@ -134,13 +135,15 @@ mod exact_rebind_cache_tests {
             summary.rebind_root_type_params(&db, &[active_outer], function_member);
         let rewritten_array = summary.rebind_root_type_params(&db, &[active_outer], array_member);
 
-        let Some(TypeData::Function(function_id)) = db.lookup(rewritten_function) else {
-            panic!("expected rewritten function member");
-        };
-        let rewritten_nested = db.function_shape(function_id).params[0].type_id;
-        let Some(TypeData::Array(array_nested)) = db.lookup(rewritten_array) else {
-            panic!("expected rewritten array member");
-        };
+        let rewritten_nested = crate::query_boundaries::exact_rewrite::function_parameter_type(
+            &db,
+            rewritten_function,
+            0,
+        )
+        .expect("expected rewritten function member");
+        let array_nested =
+            crate::query_boundaries::exact_rewrite::array_element_type(&db, rewritten_array)
+                .expect("expected rewritten array member");
         assert_eq!(rewritten_nested, array_nested);
         assert_ne!(rewritten_nested, nested);
     }
@@ -254,14 +257,12 @@ impl ClassChainSummary {
             }
         }
 
-        let Some((result, session)) =
-            crate::query_boundaries::common::start_exact_type_rewrite_session(
-                db,
-                type_id,
-                &self.root_type_params,
-                active_root_type_params,
-            )
-        else {
+        let Some((result, session)) = crate::query_boundaries::exact_rewrite::start_session(
+            db,
+            type_id,
+            &self.root_type_params,
+            active_root_type_params,
+        ) else {
             return type_id;
         };
         self.rebind_sessions

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -71,6 +71,30 @@ mod exact_rebind_cache_tests {
     }
 
     #[test]
+    fn identical_or_empty_class_binder_scopes_skip_rewrite_sessions() {
+        let db = TypeInterner::new();
+        let outer = db.fresh_type_param(TypeParamInfo::simple(db.intern_string("Outer")));
+        let member = db.array(outer);
+        let generic_summary = ClassChainSummary {
+            root_type_params: vec![outer],
+            ..ClassChainSummary::default()
+        };
+
+        assert_eq!(
+            generic_summary.rebind_root_type_params(&db, &[outer], member),
+            member,
+        );
+        assert!(generic_summary.rebind_sessions.borrow().is_empty());
+
+        let plain_summary = ClassChainSummary::default();
+        assert_eq!(
+            plain_summary.rebind_root_type_params(&db, &[], TypeId::STRING),
+            TypeId::STRING,
+        );
+        assert!(plain_summary.rebind_sessions.borrow().is_empty());
+    }
+
+    #[test]
     fn cached_member_rebind_refreshes_late_application_display_alias() {
         let db = TypeInterner::new();
         let source_outer = db.fresh_type_param(TypeParamInfo::simple(db.intern_string("Outer")));
@@ -245,6 +269,11 @@ impl ClassChainSummary {
         type_id: TypeId,
     ) -> TypeId {
         if self.root_type_params.len() != active_root_type_params.len() {
+            return type_id;
+        }
+        if self.root_type_params.is_empty()
+            || self.root_type_params.as_slice() == active_root_type_params
+        {
             return type_id;
         }
         {

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -32,7 +32,7 @@ mod exact_rebind_cache_tests {
     use super::ClassChainSummary;
     use tsz_solver::construction::TypeInterner;
     use tsz_solver::def::DefId;
-    use tsz_solver::{FunctionShape, ParamInfo, TypeId, TypeParamInfo};
+    use tsz_solver::{ParamInfo, TypeId, TypeParamInfo};
 
     #[test]
     fn repeated_member_rebind_reuses_nested_generic_identity() {
@@ -46,18 +46,19 @@ mod exact_rebind_cache_tests {
             is_const: false,
             origin: tsz_solver::TypeParamOrigin::User,
         });
-        let member = db.function(FunctionShape {
-            type_params: Vec::new(),
-            params: vec![ParamInfo {
+        let member = crate::query_boundaries::construct_signatures::function_type_from_parts(
+            &db,
+            Vec::new(),
+            vec![ParamInfo {
                 type_id: nested,
                 ..ParamInfo::default()
             }],
-            this_type: None,
-            return_type: TypeId::VOID,
-            type_predicate: None,
-            is_constructor: false,
-            is_method: true,
-        });
+            None,
+            TypeId::VOID,
+            None,
+            false,
+            true,
+        );
         let summary = ClassChainSummary {
             root_type_params: vec![source_outer],
             ..ClassChainSummary::default()
@@ -137,18 +138,20 @@ mod exact_rebind_cache_tests {
             is_const: false,
             origin: tsz_solver::TypeParamOrigin::User,
         });
-        let function_member = db.function(FunctionShape {
-            type_params: Vec::new(),
-            params: vec![ParamInfo {
-                type_id: nested,
-                ..ParamInfo::default()
-            }],
-            this_type: None,
-            return_type: TypeId::VOID,
-            type_predicate: None,
-            is_constructor: false,
-            is_method: true,
-        });
+        let function_member =
+            crate::query_boundaries::construct_signatures::function_type_from_parts(
+                &db,
+                Vec::new(),
+                vec![ParamInfo {
+                    type_id: nested,
+                    ..ParamInfo::default()
+                }],
+                None,
+                TypeId::VOID,
+                None,
+                false,
+                true,
+            );
         let array_member = db.array(nested);
         let summary = ClassChainSummary {
             root_type_params: vec![source_outer],

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -112,26 +112,19 @@ pub(crate) struct ClassChainSummary {
 impl ClassChainSummary {
     pub(crate) fn rebind_root_type_params(
         &self,
-        db: &dyn tsz_solver::construction::TypeDatabase,
+        db: &dyn tsz_solver::construction::QueryDatabase,
         active_root_type_params: &[TypeId],
-        mut type_id: TypeId,
+        type_id: TypeId,
     ) -> TypeId {
         if self.root_type_params.len() != active_root_type_params.len() {
             return type_id;
         }
-        for (&cached_param, &active_param) in
-            self.root_type_params.iter().zip(active_root_type_params)
-        {
-            if active_param != cached_param {
-                type_id = crate::query_boundaries::common::substitute_exact_type(
-                    db,
-                    type_id,
-                    cached_param,
-                    active_param,
-                );
-            }
-        }
-        type_id
+        crate::query_boundaries::common::substitute_exact_types(
+            db,
+            type_id,
+            &self.root_type_params,
+            active_root_type_params,
+        )
     }
 
     pub(crate) fn lookup(

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -91,6 +91,8 @@ pub(crate) enum ClassMemberKind {
 
 #[derive(Clone, Default)]
 pub(crate) struct ClassChainSummary {
+    /// Root-class type parameter identities used to build this cached summary.
+    root_type_params: Vec<(String, TypeId)>,
     /// Unified instance member map: name -> entry (replaces 6 maps + 1 set)
     instance_members: FxHashMap<String, MemberEntry>,
     /// Unified static member map: name -> entry (replaces 6 maps + 1 set)
@@ -108,6 +110,28 @@ pub(crate) struct ClassChainSummary {
 }
 
 impl ClassChainSummary {
+    pub(crate) fn rebind_root_type_params(
+        &self,
+        db: &dyn tsz_solver::construction::TypeDatabase,
+        active_scope: &FxHashMap<String, TypeId>,
+        mut type_id: TypeId,
+    ) -> TypeId {
+        for (name, cached_param) in &self.root_type_params {
+            let Some(&active_param) = active_scope.get(name) else {
+                continue;
+            };
+            if active_param != *cached_param {
+                type_id = crate::query_boundaries::common::substitute_exact_type(
+                    db,
+                    type_id,
+                    *cached_param,
+                    active_param,
+                );
+            }
+        }
+        type_id
+    }
+
     pub(crate) fn lookup(
         &self,
         target_name: &str,
@@ -686,7 +710,24 @@ impl<'a> CheckerState<'a> {
             // Without this, the substitution in check_property_inheritance_compatibility
             // cannot replace the type parameters, causing base member types to remain
             // as `any` and skipping TS2416 checks entirely.
-            let (_, type_param_updates) = self.push_type_parameters(&class.type_parameters);
+            let (class_type_params, type_param_updates) =
+                self.push_type_parameters(&class.type_parameters);
+
+            if is_first {
+                summary.root_type_params = class_type_params
+                    .iter()
+                    .map(|param| {
+                        let name = self.ctx.types.resolve_atom(param.name);
+                        let type_id = self
+                            .ctx
+                            .type_parameter_scope
+                            .get(&name)
+                            .copied()
+                            .unwrap_or_else(|| self.ctx.types.type_param(*param));
+                        (name, type_id)
+                    })
+                    .collect();
+            }
 
             let own_summary = self.collect_class_members_for_chain(current_idx, class);
 

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -74,6 +74,11 @@ mod exact_rebind_cache_tests {
         let db = TypeInterner::new();
         let source_outer = db.fresh_type_param(TypeParamInfo::simple(db.intern_string("Outer")));
         let active_outer = db.fresh_type_param(TypeParamInfo::simple(db.intern_string("Active")));
+        // The application is discovered before its evaluated structural result,
+        // matching evaluator allocation order, but its provenance is attached
+        // only after the first cached rewrite.
+        let alias_base = db.lazy(DefId(27));
+        let source_alias = db.application(alias_base, vec![source_outer]);
         let member = db.array(source_outer);
         let summary = ClassChainSummary {
             root_type_params: vec![source_outer],
@@ -83,10 +88,9 @@ mod exact_rebind_cache_tests {
         let first = summary.rebind_root_type_params(&db, &[active_outer], member);
         assert_eq!(db.get_display_alias(first), None);
 
-        let alias_base = db.lazy(DefId(27));
-        let source_alias = db.application(alias_base, vec![source_outer]);
         db.store_display_alias_preferring_application(member, source_alias);
         db.record_application_eval_origin(member, source_alias);
+        assert_eq!(db.get_display_alias(member), Some(source_alias));
 
         let second = summary.rebind_root_type_params(&db, &[active_outer], member);
         let expected_alias = db.application(alias_base, vec![active_outer]);

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -178,6 +178,10 @@ pub struct EnclosingClassInfo {
     pub type_param_names: Vec<String>,
     /// The type parameter infos of the class's own type parameters.
     pub class_type_parameters: Vec<tsz_solver::TypeParamInfo>,
+    /// Exact interned identities of the class's own type parameters, in
+    /// declaration order. Kept separately from the name-keyed active scope so
+    /// method-level shadowing cannot hide the enclosing class binders.
+    pub class_type_parameter_ids: Vec<TypeId>,
 }
 
 /// Info about a label in scope for break/continue validation.

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -200,6 +200,16 @@ pub(crate) fn resolve_unbound_type_params_to_declared_fallbacks<S: std::hash::Bu
     )
 }
 
+/// Rebind one exact interned type identity throughout a type graph.
+pub(crate) fn substitute_exact_type(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    from: TypeId,
+    to: TypeId,
+) -> TypeId {
+    tsz_solver::computation::substitute_exact_type(db, type_id, from, to)
+}
+
 /// Free type parameters of `roots` whose declared name is in `names`, as
 /// `(name, TypeId)` pairs (the exact interned parameter ids). See
 /// [`tsz_solver::computation::free_type_params_named`].

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -200,43 +200,6 @@ pub(crate) fn resolve_unbound_type_params_to_declared_fallbacks<S: std::hash::Bu
     )
 }
 
-/// Completed exact-identity rewrite session retained for stable structural reuse.
-///
-/// The solver-owned memo stays opaque to checker orchestration. Cache owners
-/// reuse it for every root in the same binder scope so shared subgraphs and
-/// nested fresh binders keep one rewritten identity. The solver refreshes late
-/// provenance before returning a previously completed root.
-#[derive(Clone)]
-pub(crate) struct ExactTypeRewriteSession {
-    memo: c::ExactRewriteMemo,
-}
-
-impl ExactTypeRewriteSession {
-    /// Rewrite another root through the retained structural map. An aborted
-    /// attempt leaves the session reusable and does not cache that root.
-    pub(crate) fn rewrite_root(
-        &mut self,
-        db: &dyn QueryDatabase,
-        type_id: TypeId,
-    ) -> Option<TypeId> {
-        self.memo.rewrite_root(db, type_id).ok()
-    }
-}
-
-/// Rebind aligned exact interned identities in one graph walk, retaining the
-/// completed solver memo for provenance-safe cache hits. An aborted walk is
-/// reported as `None` and must not be cached.
-pub(crate) fn start_exact_type_rewrite_session(
-    db: &dyn QueryDatabase,
-    type_id: TypeId,
-    from: &[TypeId],
-    to: &[TypeId],
-) -> Option<(TypeId, ExactTypeRewriteSession)> {
-    let (result, memo) =
-        tsz_solver::computation::substitute_exact_types_with_memo(db, type_id, from, to).ok()?;
-    Some((result, ExactTypeRewriteSession { memo }))
-}
-
 /// Free type parameters of `roots` whose declared name is in `names`, as
 /// `(name, TypeId)` pairs (the exact interned parameter ids). See
 /// [`tsz_solver::computation::free_type_params_named`].

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -200,14 +200,14 @@ pub(crate) fn resolve_unbound_type_params_to_declared_fallbacks<S: std::hash::Bu
     )
 }
 
-/// Rebind one exact interned type identity throughout a type graph.
-pub(crate) fn substitute_exact_type(
-    db: &dyn TypeDatabase,
+/// Rebind aligned exact interned identities in one memoized graph walk.
+pub(crate) fn substitute_exact_types(
+    db: &dyn QueryDatabase,
     type_id: TypeId,
-    from: TypeId,
-    to: TypeId,
+    from: &[TypeId],
+    to: &[TypeId],
 ) -> TypeId {
-    tsz_solver::computation::substitute_exact_type(db, type_id, from, to)
+    tsz_solver::computation::substitute_exact_types(db, type_id, from, to)
 }
 
 /// Free type parameters of `roots` whose declared name is in `names`, as

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -200,14 +200,41 @@ pub(crate) fn resolve_unbound_type_params_to_declared_fallbacks<S: std::hash::Bu
     )
 }
 
-/// Rebind aligned exact interned identities in one memoized graph walk.
-pub(crate) fn substitute_exact_types(
+/// Completed exact-identity rewrite session retained for stable structural reuse.
+///
+/// The solver-owned memo stays opaque to checker orchestration. Cache owners
+/// reuse it for every root in the same binder scope so shared subgraphs and
+/// nested fresh binders keep one rewritten identity. The solver refreshes late
+/// provenance before returning a previously completed root.
+#[derive(Clone)]
+pub(crate) struct ExactTypeRewriteSession {
+    memo: c::ExactRewriteMemo,
+}
+
+impl ExactTypeRewriteSession {
+    /// Rewrite another root through the retained structural map. An aborted
+    /// attempt leaves the session reusable and does not cache that root.
+    pub(crate) fn rewrite_root(
+        &mut self,
+        db: &dyn QueryDatabase,
+        type_id: TypeId,
+    ) -> Option<TypeId> {
+        self.memo.rewrite_root(db, type_id).ok()
+    }
+}
+
+/// Rebind aligned exact interned identities in one graph walk, retaining the
+/// completed solver memo for provenance-safe cache hits. An aborted walk is
+/// reported as `None` and must not be cached.
+pub(crate) fn start_exact_type_rewrite_session(
     db: &dyn QueryDatabase,
     type_id: TypeId,
     from: &[TypeId],
     to: &[TypeId],
-) -> TypeId {
-    tsz_solver::computation::substitute_exact_types(db, type_id, from, to)
+) -> Option<(TypeId, ExactTypeRewriteSession)> {
+    let (result, memo) =
+        tsz_solver::computation::substitute_exact_types_with_memo(db, type_id, from, to).ok()?;
+    Some((result, ExactTypeRewriteSession { memo }))
 }
 
 /// Free type parameters of `roots` whose declared name is in `names`, as

--- a/crates/tsz-checker/src/query_boundaries/exact_rewrite.rs
+++ b/crates/tsz-checker/src/query_boundaries/exact_rewrite.rs
@@ -1,0 +1,60 @@
+//! Checker boundary for stable exact-identity graph-rewrite sessions.
+
+use tsz_solver::TypeId;
+use tsz_solver::construction::QueryDatabase;
+#[cfg(test)]
+use tsz_solver::construction::TypeDatabase;
+
+/// Completed exact-identity rewrite session retained for structural reuse.
+///
+/// The solver-owned memo stays opaque to checker orchestration. One session is
+/// reused for every root in the same binder scope, preserving shared subgraphs
+/// and nested fresh-binder identities while refreshing late provenance.
+#[derive(Clone)]
+pub(crate) struct ExactTypeRewriteSession {
+    memo: tsz_solver::computation::ExactRewriteMemo,
+}
+
+impl ExactTypeRewriteSession {
+    /// Rewrite another root through the retained structural map. An aborted
+    /// attempt leaves the session reusable and does not cache that root.
+    pub(crate) fn rewrite_root(
+        &mut self,
+        db: &dyn QueryDatabase,
+        type_id: TypeId,
+    ) -> Option<TypeId> {
+        self.memo.rewrite_root(db, type_id).ok()
+    }
+}
+
+/// Start a rewrite session. An aborted first walk is reported as `None` and
+/// must not be cached by checker orchestration.
+pub(crate) fn start_session(
+    db: &dyn QueryDatabase,
+    type_id: TypeId,
+    from: &[TypeId],
+    to: &[TypeId],
+) -> Option<(TypeId, ExactTypeRewriteSession)> {
+    let (result, memo) =
+        tsz_solver::computation::substitute_exact_types_with_memo(db, type_id, from, to).ok()?;
+    Some((result, ExactTypeRewriteSession { memo }))
+}
+
+#[cfg(test)]
+pub(crate) fn function_parameter_type(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    parameter_index: usize,
+) -> Option<TypeId> {
+    tsz_solver::type_queries::get_function_shape(db, type_id).and_then(|shape| {
+        shape
+            .params
+            .get(parameter_index)
+            .map(|parameter| parameter.type_id)
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn array_element_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
+    tsz_solver::type_queries::get_array_element_type(db, type_id)
+}

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod diagnostics;
 pub(crate) mod dispatch;
 pub(crate) mod enum_analysis;
 pub(crate) mod environment;
+pub(crate) mod exact_rewrite;
 pub(crate) mod flow;
 pub(crate) mod flow_analysis;
 pub(crate) mod function_returns;

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -376,7 +376,8 @@ impl<'a> CheckerState<'a> {
 
         // Push type parameters BEFORE checking heritage clauses and abstract members
         // This allows heritage clauses and member checks to reference the class's type parameters
-        let (_type_params, type_param_updates) = self.push_type_parameters(&class.type_parameters);
+        let (class_type_parameters, type_param_updates) =
+            self.push_type_parameters(&class.type_parameters);
 
         self.check_duplicate_type_parameters(&class.type_parameters);
         self.check_strict_mode_reserved_type_parameter_names(
@@ -404,6 +405,9 @@ impl<'a> CheckerState<'a> {
             .iter()
             .map(|(name, _, _)| name.clone())
             .collect();
+        let class_type_parameter_ids = self
+            .exact_type_parameter_ids_in_scope(&class_type_parameters)
+            .unwrap_or_default();
 
         // Check for unused type parameters (TS6133)
         self.check_unused_type_params(&class.type_parameters, stmt_idx);
@@ -777,7 +781,8 @@ impl<'a> CheckerState<'a> {
             has_super_call_in_current_constructor: false,
             cached_instance_this_type: prior_instance_type_snapshot,
             type_param_names: class_type_param_names,
-            class_type_parameters: _type_params,
+            class_type_parameters,
+            class_type_parameter_ids,
         });
 
         let preserve_stable_class_shape_cache = self.class_shape_cache_is_stable(stmt_idx, class);
@@ -1115,7 +1120,8 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let (_type_params, type_param_updates) = self.push_type_parameters(&class.type_parameters);
+        let (class_type_parameters, type_param_updates) =
+            self.push_type_parameters(&class.type_parameters);
 
         self.check_duplicate_type_parameters(&class.type_parameters);
         self.check_strict_mode_reserved_type_parameter_names(
@@ -1137,6 +1143,9 @@ impl<'a> CheckerState<'a> {
             .iter()
             .map(|(name, _, _)| name.clone())
             .collect();
+        let class_type_parameter_ids = self
+            .exact_type_parameter_ids_in_scope(&class_type_parameters)
+            .unwrap_or_default();
 
         // Class expressions are strict-mode class definitions too. Their
         // names and base expressions participate in the same recovered
@@ -1173,7 +1182,8 @@ impl<'a> CheckerState<'a> {
             has_super_call_in_current_constructor: false,
             cached_instance_this_type: None,
             type_param_names: class_type_param_names,
-            class_type_parameters: _type_params,
+            class_type_parameters,
+            class_type_parameter_ids,
         });
 
         // Class bodies reset the async context — field initializers don't

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -377,7 +377,7 @@ impl<'a> CheckerState<'a> {
         // Push type parameters BEFORE checking heritage clauses and abstract members
         // This allows heritage clauses and member checks to reference the class's type parameters
         let (class_type_parameters, type_param_updates) =
-            self.push_type_parameters(&class.type_parameters);
+            self.push_effective_class_type_parameters(stmt_idx, class);
 
         self.check_duplicate_type_parameters(&class.type_parameters);
         self.check_strict_mode_reserved_type_parameter_names(
@@ -1121,7 +1121,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let (class_type_parameters, type_param_updates) =
-            self.push_type_parameters(&class.type_parameters);
+            self.push_effective_class_type_parameters(class_idx, class);
 
         self.check_duplicate_type_parameters(&class.type_parameters);
         self.check_strict_mode_reserved_type_parameter_names(

--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -532,9 +532,9 @@ impl<'a> CheckerState<'a> {
         // If the receiver is an Application (e.g. Promise<number> or Pick<T, K>),
         // the QueryCache's noop TypeResolver can't expand it. Evaluate the
         // Application to its structural form so mapped-type revalidation can use
-        // the real object shape. Only retry the initial lookup when it already
-        // failed; otherwise preserve the original first-pass result and use the
-        // expanded type only for mapped-property validation below.
+        // the real object shape. The expanded identity is also authoritative for
+        // namespace-local nominal applications whose first pass resolved through
+        // a colliding global declaration.
         if crate::query_boundaries::common::is_generic_application(self.ctx.types, object_type) {
             let expanded = self.evaluate_application_type(object_type);
             if expanded != object_type && expanded != TypeId::ANY && expanded != TypeId::ERROR {

--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -282,8 +282,7 @@ impl<'a> CheckerState<'a> {
             return member_type;
         }
 
-        let in_scope: rustc_hash::FxHashSet<TypeId> =
-            self.ctx.type_parameter_scope.values().copied().collect();
+        let in_scope = self.member_type_parameter_ids_in_scope();
         crate::query_boundaries::common::resolve_unbound_type_params_to_declared_fallbacks(
             self.ctx.types,
             member_type,

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -269,19 +269,8 @@ impl<'a> CheckerState<'a> {
         apply_module_augmentations: bool,
     ) -> TypeId {
         let is_abstract_class = self.has_abstract_modifier(&class.modifiers);
-        let (mut class_type_params, mut type_param_updates) =
-            self.push_type_parameters(&class.type_parameters);
-
-        // In JS files, classes don't have syntax-level type parameters.
-        // JSDoc `@template T` tags serve the same purpose.
-        if class_type_params.is_empty() {
-            let (jsdoc_params, jsdoc_updates) =
-                self.push_jsdoc_class_template_type_params(class_idx);
-            if !jsdoc_params.is_empty() {
-                class_type_params = jsdoc_params;
-                type_param_updates.extend(jsdoc_updates);
-            }
-        }
+        let (class_type_params, type_param_updates) =
+            self.push_effective_class_type_parameters(class_idx, class);
 
         // NOTE: instance type is computed AFTER static member processing (see below).
         // This allows us to temporarily cache a partial constructor type with all static

--- a/crates/tsz-checker/src/types/class_type/core.rs
+++ b/crates/tsz-checker/src/types/class_type/core.rs
@@ -95,20 +95,8 @@ impl<'a> CheckerState<'a> {
 
         // Class member types can reference class type parameters (e.g. `class Box<T> { value: T }`).
         // Keep class type parameters in scope while constructing the instance type.
-        let (mut class_type_params, mut class_type_param_updates) =
-            self.push_type_parameters(&class.type_parameters);
-
-        // In JS files, classes don't have syntax-level type parameters.
-        // JSDoc `@template T` tags serve the same purpose. If no syntax type params
-        // were found, check for JSDoc @template tags on the class declaration.
-        if class_type_params.is_empty() {
-            let (jsdoc_params, jsdoc_updates) =
-                self.push_jsdoc_class_template_type_params(class_idx);
-            if !jsdoc_params.is_empty() {
-                class_type_params = jsdoc_params;
-                class_type_param_updates.extend(jsdoc_updates);
-            }
-        }
+        let (class_type_params, class_type_param_updates) =
+            self.push_effective_class_type_parameters(class_idx, class);
         let class_type_param_ids = self
             .exact_type_parameter_ids_in_scope(&class_type_params)
             .unwrap_or_default();

--- a/crates/tsz-checker/src/types/class_type/core.rs
+++ b/crates/tsz-checker/src/types/class_type/core.rs
@@ -109,6 +109,9 @@ impl<'a> CheckerState<'a> {
                 class_type_param_updates.extend(jsdoc_updates);
             }
         }
+        let class_type_param_ids = self
+            .exact_type_parameter_ids_in_scope(&class_type_params)
+            .unwrap_or_default();
 
         // PERF: Pre-size maps based on member count to avoid rehashing
         let member_count = class.members.nodes.len();
@@ -118,6 +121,7 @@ impl<'a> CheckerState<'a> {
             current_sym,
             flags,
             class_type_params,
+            class_type_param_ids,
             class_type_param_updates,
             member_count,
             properties: FxHashMap::with_capacity_and_hasher(member_count, Default::default()),

--- a/crates/tsz-checker/src/types/class_type/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/helpers.rs
@@ -6,6 +6,7 @@ use crate::query_boundaries::signature_building as signature_building_boundary;
 use crate::state::CheckerState;
 use rustc_hash::FxHashMap;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::ClassData;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{CallSignature, IndexSignature, TypeId, TypeParamInfo, Visibility};
@@ -15,7 +16,7 @@ use tsz_solver::{CallSignature, IndexSignature, TypeId, TypeParamInfo, Visibilit
 /// scope (so `pop_type_parameters` can restore it), and a flag indicating
 /// whether the push shadowed an enclosing class's type parameter (so the pop
 /// can restore the class scope entry too).
-type ScopeUpdate = (String, Option<TypeId>, bool);
+pub(crate) type ScopeUpdate = (String, Option<TypeId>, bool);
 
 pub(super) struct MethodAggregate {
     pub(super) overload_signatures: Vec<CallSignature>,
@@ -96,6 +97,29 @@ pub(super) fn declaration_is_module_augmentation(
 }
 
 impl<'a> CheckerState<'a> {
+    /// Push the effective class type parameters for either TypeScript syntax or
+    /// a JavaScript `@template` declaration.
+    ///
+    /// Keeping this selection in one place ensures class summaries, statement
+    /// checking, and instance construction all observe the same binder set.
+    pub(crate) fn push_effective_class_type_parameters(
+        &mut self,
+        class_idx: NodeIndex,
+        class: &ClassData,
+    ) -> (Vec<TypeParamInfo>, Vec<ScopeUpdate>) {
+        let (mut type_params, mut scope_updates) =
+            self.push_type_parameters(&class.type_parameters);
+        if type_params.is_empty() {
+            let (jsdoc_params, jsdoc_updates) =
+                self.push_jsdoc_class_template_type_params(class_idx);
+            if !jsdoc_params.is_empty() {
+                type_params = jsdoc_params;
+                scope_updates.extend(jsdoc_updates);
+            }
+        }
+        (type_params, scope_updates)
+    }
+
     /// Whether a just-computed constructor type for this class symbol may be
     /// cached. Two windows forbid caching:
     /// - the class's own constructor resolution is re-entrant

--- a/crates/tsz-checker/src/types/class_type/instance.rs
+++ b/crates/tsz-checker/src/types/class_type/instance.rs
@@ -94,6 +94,7 @@ pub(super) struct ClassInstanceBuilder<'b> {
     pub(super) current_sym: Option<SymbolId>,
     pub(super) flags: ClassInstanceFlags,
     pub(super) class_type_params: Vec<TypeParamInfo>,
+    pub(super) class_type_param_ids: Vec<TypeId>,
     pub(super) class_type_param_updates: Vec<(String, Option<TypeId>, bool)>,
     pub(super) member_count: usize,
     pub(super) properties: FxHashMap<Atom, PropertyInfo>,
@@ -882,6 +883,7 @@ impl<'a> CheckerState<'a> {
                     ),
                     type_param_names: class_type_param_names,
                     class_type_parameters: b.class_type_params.clone(),
+                    class_type_parameter_ids: b.class_type_param_ids.clone(),
                 });
                 RestoreEnclosingClass::To(prev_enclosing_class)
             } else {

--- a/crates/tsz-checker/src/types/property_access_type/class_recovery.rs
+++ b/crates/tsz-checker/src/types/property_access_type/class_recovery.rs
@@ -214,11 +214,13 @@ impl<'a> CheckerState<'a> {
         let member_type = summary
             .member_info(property_name, is_static_access, true)?
             .type_id;
-        Some(summary.rebind_root_type_params(
-            self.ctx.types,
-            &self.ctx.type_parameter_scope,
-            member_type,
-        ))
+        let active_root_type_params = self
+            .ctx
+            .enclosing_class
+            .as_ref()
+            .filter(|info| info.class_idx == class_idx)
+            .map_or(&[][..], |info| info.class_type_parameter_ids.as_slice());
+        Some(summary.rebind_root_type_params(self.ctx.types, active_root_type_params, member_type))
     }
 
     pub(super) fn recover_direct_this_class_chain_member(
@@ -239,7 +241,8 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let summary = self.summarize_class_chain(self.nearest_enclosing_class(receiver_expr)?);
+        let class_idx = self.nearest_enclosing_class(receiver_expr)?;
+        let summary = self.summarize_class_chain(class_idx);
         let member = summary.member_info(property_name, false, true)?;
         let member_is_method_like = member.is_method || member.is_accessor;
         if member.from_interface
@@ -254,9 +257,15 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
+        let active_root_type_params = self
+            .ctx
+            .enclosing_class
+            .as_ref()
+            .filter(|info| info.class_idx == class_idx)
+            .map_or(&[][..], |info| info.class_type_parameter_ids.as_slice());
         let member_type = summary.rebind_root_type_params(
             self.ctx.types,
-            &self.ctx.type_parameter_scope,
+            active_root_type_params,
             member.type_id,
         );
         Some((member_type, member_is_method_like))

--- a/crates/tsz-checker/src/types/property_access_type/class_recovery.rs
+++ b/crates/tsz-checker/src/types/property_access_type/class_recovery.rs
@@ -9,6 +9,26 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    fn active_class_summary_root_type_params(
+        &self,
+        class_idx: NodeIndex,
+        summary: &ClassChainSummary,
+        allow_construction_scope: bool,
+    ) -> Option<Vec<TypeId>> {
+        if let Some(info) = self
+            .ctx
+            .enclosing_class
+            .as_ref()
+            .filter(|info| info.class_idx == class_idx)
+        {
+            return Some(info.class_type_parameter_ids.clone());
+        }
+        allow_construction_scope.then(|| {
+            summary
+                .root_type_params_from_active_scope(self.ctx.types, &self.ctx.type_parameter_scope)
+        })?
+    }
+
     pub(crate) fn resolve_class_access_with_current_member_initializer_recovery(
         &mut self,
         expression: NodeIndex,
@@ -214,13 +234,13 @@ impl<'a> CheckerState<'a> {
         let member_type = summary
             .member_info(property_name, is_static_access, true)?
             .type_id;
-        let active_root_type_params = self
-            .ctx
-            .enclosing_class
-            .as_ref()
-            .filter(|info| info.class_idx == class_idx)
-            .map_or(&[][..], |info| info.class_type_parameter_ids.as_slice());
-        Some(summary.rebind_root_type_params(self.ctx.types, active_root_type_params, member_type))
+        let active_root_type_params =
+            self.active_class_summary_root_type_params(class_idx, summary, true);
+        Some(summary.rebind_root_type_params(
+            self.ctx.types,
+            active_root_type_params.as_deref().unwrap_or(&[]),
+            member_type,
+        ))
     }
 
     pub(super) fn recover_direct_this_class_chain_member(
@@ -233,10 +253,10 @@ impl<'a> CheckerState<'a> {
         object_type_for_access: TypeId,
         original_object_type: TypeId,
     ) -> Option<(TypeId, bool)> {
-        if used_class_chain_method_type
-            || !direct_class_this_receiver
+        if !direct_class_this_receiver
             || object_type_for_access != original_object_type
-            || self.enclosing_class_declares_member(property_name)
+            || (!used_class_chain_method_type
+                && self.enclosing_class_declares_member(property_name))
         {
             return None;
         }
@@ -245,27 +265,26 @@ impl<'a> CheckerState<'a> {
         let summary = self.summarize_class_chain(class_idx);
         let member = summary.member_info(property_name, false, true)?;
         let member_is_method_like = member.is_method || member.is_accessor;
-        if member.from_interface
-            || (member_is_method_like
-                && !matches!(prop_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR))
-            || matches!(
-                member.type_id,
-                TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR
-            )
-            || member.type_id == prop_type
+        if !used_class_chain_method_type
+            && (member.from_interface
+                || (member_is_method_like
+                    && !matches!(prop_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR))
+                || matches!(
+                    member.type_id,
+                    TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR
+                )
+                || member.type_id == prop_type)
         {
             return None;
         }
 
-        let active_root_type_params = self
-            .ctx
-            .enclosing_class
-            .as_ref()
-            .filter(|info| info.class_idx == class_idx)
-            .map_or(&[][..], |info| info.class_type_parameter_ids.as_slice());
+        let in_construction_scope = self.ctx.checking_computed_property_name.is_some()
+            || self.property_access_is_in_class_property_initializer(receiver_expr);
+        let active_root_type_params =
+            self.active_class_summary_root_type_params(class_idx, &summary, in_construction_scope);
         let member_type = summary.rebind_root_type_params(
             self.ctx.types,
-            active_root_type_params,
+            active_root_type_params.as_deref().unwrap_or(&[]),
             member.type_id,
         );
         Some((member_type, member_is_method_like))

--- a/crates/tsz-checker/src/types/property_access_type/class_recovery.rs
+++ b/crates/tsz-checker/src/types/property_access_type/class_recovery.rs
@@ -210,10 +210,15 @@ impl<'a> CheckerState<'a> {
         ) {
             return Some(member_type);
         }
-        summary
-            .as_ref()?
-            .member_info(property_name, is_static_access, true)
-            .map(|member| member.type_id)
+        let summary = summary.as_ref()?;
+        let member_type = summary
+            .member_info(property_name, is_static_access, true)?
+            .type_id;
+        Some(summary.rebind_root_type_params(
+            self.ctx.types,
+            &self.ctx.type_parameter_scope,
+            member_type,
+        ))
     }
 
     pub(super) fn recover_direct_this_class_chain_member(
@@ -249,7 +254,12 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        Some((member.type_id, member_is_method_like))
+        let member_type = summary.rebind_root_type_params(
+            self.ctx.types,
+            &self.ctx.type_parameter_scope,
+            member.type_id,
+        );
+        Some((member_type, member_is_method_like))
     }
 
     fn enclosing_class_declares_member(&self, property_name: &str) -> bool {

--- a/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
+++ b/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
@@ -69,8 +69,7 @@ impl<'a> CheckerState<'a> {
         {
             return member_type;
         }
-        let in_scope: rustc_hash::FxHashSet<TypeId> =
-            self.ctx.type_parameter_scope.values().copied().collect();
+        let in_scope = self.member_type_parameter_ids_in_scope();
         crate::query_boundaries::common::resolve_unbound_type_params_to_defaults(
             self.ctx.types,
             member_type,

--- a/crates/tsz-checker/src/types/queries/class.rs
+++ b/crates/tsz-checker/src/types/queries/class.rs
@@ -18,6 +18,41 @@ impl<'a> CheckerState<'a> {
     // Section 39: Type Parameter Scope Utilities
     // =========================================================================
 
+    /// Resolve declaration-ordered type-parameter infos to the exact identities
+    /// currently installed in the checker scope. Returns `None` rather than a
+    /// partial vector so callers never shift positional binder alignment.
+    pub(crate) fn exact_type_parameter_ids_in_scope(
+        &self,
+        params: &[tsz_solver::TypeParamInfo],
+    ) -> Option<Vec<TypeId>> {
+        params
+            .iter()
+            .map(|param| {
+                let name = self.ctx.types.resolve_atom_ref(param.name);
+                self.ctx.type_parameter_scope.get(name.as_ref()).copied()
+            })
+            .collect()
+    }
+
+    /// Exact type-parameter identities available to a member expression.
+    ///
+    /// The name-keyed scope contains the innermost binder for each spelling,
+    /// so a method parameter can hide an enclosing class parameter there. A
+    /// cached class member still carries the enclosing binder's exact identity;
+    /// retain both identities when deciding which free parameters are bound.
+    pub(crate) fn member_type_parameter_ids_in_scope(&self) -> rustc_hash::FxHashSet<TypeId> {
+        let mut in_scope = self
+            .ctx
+            .type_parameter_scope
+            .values()
+            .copied()
+            .collect::<rustc_hash::FxHashSet<_>>();
+        if let Some(class_info) = self.ctx.enclosing_class.as_ref() {
+            in_scope.extend(class_info.class_type_parameter_ids.iter().copied());
+        }
+        in_scope
+    }
+
     /// Pop type parameters from scope, restoring previous values.
     /// Used to restore the type parameter scope after exiting a generic context.
     pub(crate) fn pop_type_parameters(&mut self, updates: Vec<(String, Option<TypeId>, bool)>) {

--- a/crates/tsz-checker/tests/application_member_type_parameter_substitution_tests.rs
+++ b/crates/tsz-checker/tests/application_member_type_parameter_substitution_tests.rs
@@ -1,10 +1,27 @@
 //! Explicit generic arguments must retain their enclosing declaration's type-
 //! parameter identity through inherited application-member lookup.
 
-use tsz_checker::test_utils::check_source_strict_codes;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source, check_source_strict_codes};
 
 fn codes(source: &str) -> Vec<u32> {
     check_source_strict_codes(source)
+}
+
+fn js_codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "application-member-rebind.js",
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
 }
 
 #[test]
@@ -277,5 +294,100 @@ class Derived<Tail extends object | null = null> {
         codes(source),
         vec![2322],
         "a foreign omitted binder with the same spelling must retain its own default",
+    );
+}
+
+#[test]
+fn cached_class_summary_rebinds_inherited_member_in_field_initializer() {
+    let source = r#"
+abstract class Runnable {
+  abstract run(): void;
+}
+
+class Base<Payload> {
+  value!: Payload;
+}
+
+class Derived<Tail extends Runnable | null = null> extends Base<Tail> {
+  copy: Tail = this.value;
+  invoke = this.value?.run();
+}
+"#;
+
+    assert!(
+        codes(source).is_empty(),
+        "early class construction must rebind cached members to the active class binder",
+    );
+}
+
+#[test]
+fn jsdoc_class_template_rebinds_early_member_access() {
+    let source = r#"
+/**
+ * @template U
+ */
+class Box {
+  /** @type {U} */
+  value = /** @type {any} */ (null);
+
+  /** @type {U} */
+  copy = this.value;
+
+  /** @returns {U} */
+  read() {
+    return this.value;
+  }
+}
+"#;
+
+    let diagnostics = check_source(
+        source,
+        "application-member-rebind.js",
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+    assert!(
+        diagnostics.is_empty(),
+        "JSDoc class binders must stay active during early member recovery: {diagnostics:#?}",
+    );
+}
+
+#[test]
+fn jsdoc_method_template_does_not_hide_enclosing_class_binder() {
+    let source = r#"
+class Runnable {
+  run() {}
+}
+
+/**
+ * @template {Runnable | null} U
+ */
+class Derived {
+  /** @type {U} */
+  value = /** @type {any} */ (null);
+
+  /**
+   * @template U
+   * @param {U} local
+   * @returns {U}
+   */
+  use(local) {
+    const value = this.value;
+    if (value) {
+      value.run();
+    }
+    return local;
+  }
+}
+"#;
+
+    let actual = js_codes(source);
+    assert!(
+        actual.is_empty(),
+        "a same-named JSDoc method binder must not hide the constrained class binder: {actual:?}",
     );
 }

--- a/crates/tsz-checker/tests/application_member_type_parameter_substitution_tests.rs
+++ b/crates/tsz-checker/tests/application_member_type_parameter_substitution_tests.rs
@@ -82,6 +82,88 @@ class TupleSchema<
 }
 
 #[test]
+fn cached_class_summary_rebinds_refined_secondary_binder() {
+    let source = r#"
+type AnyRunner = Runner<any>;
+
+class Runner<Definition> {
+  readonly definition!: Definition;
+
+  prime<Other extends AnyRunner>() {}
+}
+
+interface SequenceDefinition<
+  Head,
+  Tail extends AnyRunner | null = null,
+> {
+  tail: Tail;
+}
+
+class Sequence<
+  Head,
+  Tail extends AnyRunner | null = null,
+> extends Runner<SequenceDefinition<Head, Tail>> {
+  use(): void {
+    const tail = this.definition.tail;
+    if (tail) {
+      tail.prime();
+    }
+  }
+
+  get tail() {
+    return this.definition.tail;
+  }
+}
+"#;
+
+    assert!(
+        codes(source).is_empty(),
+        "a cached inherited member must rebind the summary's exact class parameter identity",
+    );
+}
+
+#[test]
+fn method_shadow_does_not_capture_enclosing_class_binder() {
+    let source = r#"
+type AnyRunner = Runner<any>;
+
+class Runner<Definition> {
+  readonly definition!: Definition;
+
+  prime<Other extends AnyRunner>() {}
+}
+
+interface SequenceDefinition<
+  Head,
+  Tail extends AnyRunner | null = null,
+> {
+  tail: Tail;
+}
+
+class Sequence<
+  Head,
+  Tail extends AnyRunner | null = null,
+> extends Runner<SequenceDefinition<Head, Tail>> {
+  use<Tail extends object>(): void {
+    const tail = this.definition.tail;
+    if (tail) {
+      tail.prime();
+    }
+  }
+
+  get tail() {
+    return this.definition.tail;
+  }
+}
+"#;
+
+    assert!(
+        codes(source).is_empty(),
+        "a same-named method binder must neither capture nor hide the enclosing class binder",
+    );
+}
+
+#[test]
 fn inherited_member_application_uses_enclosing_renamed_binder() {
     let source = r#"
 abstract class Runnable {

--- a/crates/tsz-checker/tests/application_member_type_parameter_substitution_tests.rs
+++ b/crates/tsz-checker/tests/application_member_type_parameter_substitution_tests.rs
@@ -1,0 +1,199 @@
+//! Explicit generic arguments must retain their enclosing declaration's type-
+//! parameter identity through inherited application-member lookup.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_strict_codes(source)
+}
+
+#[test]
+fn inherited_definition_member_keeps_explicit_secondary_binder() {
+    let source = r#"
+interface TypeDefinition {}
+
+abstract class Schema<
+  Output,
+  Definition extends TypeDefinition = TypeDefinition,
+  Input = Output,
+> {
+  readonly output!: Output;
+  readonly input!: Input;
+  readonly definition!: Definition;
+
+  abstract parse(): Output;
+}
+
+type AnySchema = Schema<any, any, any>;
+type SchemaItems = [AnySchema, ...AnySchema[]];
+
+type Outputs<Items extends SchemaItems | []> = {
+  [Key in keyof Items]: Items[Key] extends Schema<infer Output, any, any>
+    ? Output
+    : never;
+};
+
+type Inputs<Items extends SchemaItems | []> = {
+  [Key in keyof Items]: Items[Key] extends Schema<any, any, infer Input>
+    ? Input
+    : never;
+};
+
+type OutputsWithTail<
+  Items extends SchemaItems | [],
+  Tail extends AnySchema | null = null,
+> = Tail extends AnySchema ? [...Outputs<Items>, ...Tail["output"][]] : Outputs<Items>;
+
+type InputsWithTail<
+  Items extends SchemaItems | [],
+  Tail extends AnySchema | null = null,
+> = Tail extends AnySchema ? [...Inputs<Items>, ...Tail["input"][]] : Inputs<Items>;
+
+interface TupleDefinition<
+  Items extends SchemaItems | [] = SchemaItems,
+  Tail extends AnySchema | null = null,
+> extends TypeDefinition {
+  items: Items;
+  tail: Tail;
+}
+
+class TupleSchema<
+  Items extends SchemaItems | [] = SchemaItems,
+  Tail extends AnySchema | null = null,
+> extends Schema<
+  OutputsWithTail<Items, Tail>,
+  TupleDefinition<Items, Tail>,
+  InputsWithTail<Items, Tail>
+> {
+  parse(): OutputsWithTail<Items, Tail> {
+    const tail = this.definition.tail;
+    if (tail) {
+      tail.parse();
+    }
+    return [] as any;
+  }
+}
+"#;
+
+    assert!(
+        codes(source).is_empty(),
+        "a successful member lookup on the instantiated definition must retain the secondary class binder",
+    );
+}
+
+#[test]
+fn inherited_member_application_uses_enclosing_renamed_binder() {
+    let source = r#"
+abstract class Runnable {
+  abstract run(): void;
+}
+
+interface Definition<Slot extends Runnable | null = null> {
+  tail: Slot;
+}
+
+class Base<Configuration> {
+  config!: Configuration;
+}
+
+class Derived<Tail extends Runnable | null = null>
+  extends Base<Definition<Tail>> {
+  exact(): Tail {
+    return this.config.tail;
+  }
+
+  call(): void {
+    const tail = this.config.tail;
+    if (tail) tail.run();
+  }
+}
+"#;
+
+    assert!(
+        codes(source).is_empty(),
+        "the explicit application argument must remain the enclosing class binder",
+    );
+}
+
+#[test]
+fn wrapped_inherited_member_application_keeps_explicit_binder() {
+    let source = r#"
+abstract class Runnable {
+  abstract run(): void;
+}
+
+interface Definition<Value extends Runnable | null = null> {
+  tail: Value;
+}
+
+type Wrapped<Item extends Runnable | null> = Definition<Item>;
+
+class Base<Configuration> {
+  config!: Configuration;
+}
+
+class Derived<Tail extends Runnable | null = null>
+  extends Base<Wrapped<Tail>> {
+  exact(): Tail {
+    return this.config.tail;
+  }
+}
+"#;
+
+    assert!(
+        codes(source).is_empty(),
+        "an alias wrapper must not replace the explicit outer binder with its own binder",
+    );
+}
+
+#[test]
+fn omitted_application_argument_uses_target_default() {
+    let source = r#"
+abstract class Runnable {
+  abstract run(): void;
+}
+
+interface Definition<Slot extends Runnable | null = null> {
+  tail: Slot;
+}
+
+class Base<Configuration> {
+  config!: Configuration;
+}
+
+class Derived<Tail extends Runnable | null = null> extends Base<Definition> {
+  invalid(): Tail {
+    return this.config.tail;
+  }
+}
+"#;
+
+    assert_eq!(
+        codes(source),
+        vec![2322],
+        "an omitted argument must keep `Definition`'s `null` default",
+    );
+}
+
+#[test]
+fn unrelated_same_named_default_is_not_captured() {
+    let source = r#"
+class Slot<Head, Tail = null> {
+  value!: Tail;
+}
+
+class Derived<Tail extends object | null = null> {
+  slot!: Slot<number>;
+
+  invalid(): Tail {
+    return this.slot.value;
+  }
+}
+"#;
+
+    assert_eq!(
+        codes(source),
+        vec![2322],
+        "a foreign omitted binder with the same spelling must retain its own default",
+    );
+}

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -1285,8 +1285,8 @@ impl TypeResolver for TypeInterner {
 }
 
 impl TypeRawIntersectionConstruction for TypeInterner {
-    fn intersect_types_raw(&self, members: Vec<TypeId>) -> TypeId {
-        TypeInterner::intersect_types_raw(self, members)
+    fn intersect_types_raw_for_replay(&self, members: Vec<TypeId>) -> TypeId {
+        TypeInterner::intersect_types_raw_for_replay(self, members)
     }
 }
 

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -72,7 +72,9 @@ impl<T: TypeDatabase + ?Sized> TypeStore for T {
     }
 }
 
-pub use super::db_base_traits::{TypeCompilerOptions, TypePredicateCache, TypeTupleLimitSignal};
+pub use super::db_base_traits::{
+    TypeCompilerOptions, TypePredicateCache, TypeRawIntersectionConstruction, TypeTupleLimitSignal,
+};
 
 /// Per-file cache hooks for evaluated generic applications.
 ///
@@ -1282,11 +1284,19 @@ impl TypeResolver for TypeInterner {
     }
 }
 
+impl TypeRawIntersectionConstruction for TypeInterner {
+    fn intersect_types_raw(&self, members: Vec<TypeId>) -> TypeId {
+        TypeInterner::intersect_types_raw(self, members)
+    }
+}
+
 /// Query layer for higher-level solver operations.
 ///
 /// This is the incremental boundary where caching and (future) salsa hooks live.
 /// Inherits from `TypeResolver` to enable Lazy/Ref type resolution through `evaluate_type()`.
-pub trait QueryDatabase: TypeDatabase + TypeResolver + CollectPropertiesResultCache {
+pub trait QueryDatabase:
+    TypeDatabase + TypeResolver + CollectPropertiesResultCache + TypeRawIntersectionConstruction
+{
     /// Expose the underlying `TypeDatabase` view for legacy entry points.
     fn as_type_database(&self) -> &dyn TypeDatabase;
 

--- a/crates/tsz-solver/src/caches/db_base_traits.rs
+++ b/crates/tsz-solver/src/caches/db_base_traits.rs
@@ -1,5 +1,16 @@
 use crate::types::TypeId;
 
+/// Construction capability for an unsimplified intersection member list.
+///
+/// This is intentionally narrower than [`crate::caches::db::TypeDatabase`].
+/// Structural graph replay needs to preserve an existing intersection without
+/// invoking semantic normalization or repeatedly folding two-member helpers.
+pub trait TypeRawIntersectionConstruction {
+    /// Flatten and order-deduplicate `members`, then intern the remaining raw
+    /// intersection in `O(N)` time without subtype or object-merge reduction.
+    fn intersect_types_raw(&self, members: Vec<TypeId>) -> TypeId;
+}
+
 /// Cache hooks for solver type-content traversal predicates.
 ///
 /// The answers are stable for a `TypeId` within one interner because interned

--- a/crates/tsz-solver/src/caches/db_base_traits.rs
+++ b/crates/tsz-solver/src/caches/db_base_traits.rs
@@ -1,14 +1,16 @@
 use crate::types::TypeId;
 
-/// Construction capability for an unsimplified intersection member list.
+/// Construction capability for replaying an unsimplified intersection member
+/// list without producing a new diagnostic signal.
 ///
 /// This is intentionally narrower than [`crate::caches::db::TypeDatabase`].
 /// Structural graph replay needs to preserve an existing intersection without
 /// invoking semantic normalization or repeatedly folding two-member helpers.
 pub trait TypeRawIntersectionConstruction {
     /// Flatten and order-deduplicate `members`, then intern the remaining raw
-    /// intersection in `O(N)` time without subtype or object-merge reduction.
-    fn intersect_types_raw(&self, members: Vec<TypeId>) -> TypeId;
+    /// intersection in `O(N)` time without subtype reduction, object merging,
+    /// or mutation of the interner-wide union-complexity flag.
+    fn intersect_types_raw_for_replay(&self, members: Vec<TypeId>) -> TypeId;
 }
 
 /// Cache hooks for solver type-content traversal predicates.

--- a/crates/tsz-solver/src/caches/display_provenance.rs
+++ b/crates/tsz-solver/src/caches/display_provenance.rs
@@ -110,6 +110,19 @@ pub trait TypeDisplayProvenance {
     /// See `TypeInterner::store_union_origin` for the full contract.
     fn store_union_origin(&self, _union_type_id: TypeId, _origin_members: Vec<TypeId>) {}
 
+    /// Store a union origin produced by an exact graph rewrite.
+    ///
+    /// A tagged fallback may be superseded by the first later real rewritten
+    /// source origin; an existing real target origin remains first-writer-wins.
+    fn store_rewritten_union_origin(
+        &self,
+        union_type_id: TypeId,
+        origin_members: Vec<TypeId>,
+        _is_fallback: bool,
+    ) {
+        self.store_union_origin(union_type_id, origin_members);
+    }
+
     /// Replace display-origin members for a union in a diagnostic-specific context.
     fn replace_union_origin_for_display(
         &self,
@@ -218,6 +231,15 @@ impl TypeDisplayProvenance for TypeInterner {
 
     fn store_union_origin(&self, union_type_id: TypeId, origin_members: Vec<TypeId>) {
         Self::store_union_origin(self, union_type_id, origin_members);
+    }
+
+    fn store_rewritten_union_origin(
+        &self,
+        union_type_id: TypeId,
+        origin_members: Vec<TypeId>,
+        is_fallback: bool,
+    ) {
+        Self::store_rewritten_union_origin(self, union_type_id, origin_members, is_fallback);
     }
 
     fn replace_union_origin_for_display(&self, union_type_id: TypeId, origin_members: Vec<TypeId>) {

--- a/crates/tsz-solver/src/caches/display_provenance.rs
+++ b/crates/tsz-solver/src/caches/display_provenance.rs
@@ -11,6 +11,13 @@ use std::sync::Arc;
 /// [`crate::caches::db::TypeDatabase`] makes display provenance a visible,
 /// narrower capability.
 pub trait TypeDisplayProvenance {
+    /// Monotonic generation changed by provenance side-table mutations.
+    ///
+    /// Implementations without mutable provenance may keep the default zero.
+    fn display_provenance_generation(&self) -> u64 {
+        0
+    }
+
     /// Store display-only properties for a fresh object literal.
     ///
     /// These are the pre-widened property types shown in error messages.
@@ -141,6 +148,10 @@ pub trait TypeDisplayProvenance {
 }
 
 impl TypeDisplayProvenance for TypeInterner {
+    fn display_provenance_generation(&self) -> u64 {
+        Self::display_provenance_generation(self)
+    }
+
     fn store_display_properties(&self, type_id: TypeId, props: Vec<PropertyInfo>) {
         Self::store_display_properties(self, type_id, props);
     }

--- a/crates/tsz-solver/src/caches/display_provenance.rs
+++ b/crates/tsz-solver/src/caches/display_provenance.rs
@@ -35,6 +35,15 @@ pub trait TypeDisplayProvenance {
         self.store_display_alias(evaluated, application);
     }
 
+    /// Transfer an already-validated application alias while rebuilding its
+    /// evaluated type graph.
+    ///
+    /// Unlike ordinary alias discovery, this operation must not depend on
+    /// whether the rebuilt application or rebuilt result was interned first.
+    /// Implementations still enforce intrinsic, scoped-parameter, and cycle
+    /// safety before accepting the transferred provenance.
+    fn transfer_rewritten_application_display_alias(&self, evaluated: TypeId, application: TypeId);
+
     /// Look up the original `Application` `TypeId` for a type produced by
     /// evaluating an `Application`. Returns `None` if no mapping exists.
     fn get_display_alias(&self, _type_id: TypeId) -> Option<TypeId> {
@@ -146,6 +155,10 @@ impl TypeDisplayProvenance for TypeInterner {
 
     fn store_display_alias_preferring_application(&self, evaluated: TypeId, application: TypeId) {
         Self::store_display_alias_preferring_application(self, evaluated, application);
+    }
+
+    fn transfer_rewritten_application_display_alias(&self, evaluated: TypeId, application: TypeId) {
+        Self::transfer_rewritten_application_display_alias(self, evaluated, application);
     }
 
     fn get_display_alias(&self, type_id: TypeId) -> Option<TypeId> {

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -781,6 +781,16 @@ impl TypeDisplayProvenance for QueryCache<'_> {
             .store_union_origin(union_type_id, origin_members);
     }
 
+    fn store_rewritten_union_origin(
+        &self,
+        union_type_id: TypeId,
+        origin_members: Vec<TypeId>,
+        is_fallback: bool,
+    ) {
+        self.interner
+            .store_rewritten_union_origin(union_type_id, origin_members, is_fallback);
+    }
+
     fn replace_union_origin_for_display(&self, union_type_id: TypeId, origin_members: Vec<TypeId>) {
         self.interner
             .replace_union_origin_for_display(union_type_id, origin_members);

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -10,7 +10,8 @@ use crate::caches::application_eval_index::{
 use crate::caches::db::{
     IntersectionMergeCacheEntry, QueryDatabase, TypeBuiltinAccess, TypeCompilerOptions,
     TypeContainsByIdCache, TypeDatabase, TypeDisplayProvenance, TypeExtractParamsCache,
-    TypePruneUnionCache, TypeSubstitutionConstruction, TypeTupleLimitSignal, TypeWidenCache,
+    TypePruneUnionCache, TypeRawIntersectionConstruction, TypeSubstitutionConstruction,
+    TypeTupleLimitSignal, TypeWidenCache,
 };
 use crate::caches::eval_dependency_index::{self, EvalDependencyIndex, EvalDependencyIndexState};
 use crate::caches::instantiation_cache::{InstantiationCache, InstantiationCacheKey};
@@ -720,6 +721,11 @@ impl TypeDisplayProvenance for QueryCache<'_> {
             .store_display_alias_preferring_application(evaluated, application);
     }
 
+    fn transfer_rewritten_application_display_alias(&self, evaluated: TypeId, application: TypeId) {
+        self.interner
+            .transfer_rewritten_application_display_alias(evaluated, application);
+    }
+
     fn get_display_alias(&self, type_id: TypeId) -> Option<TypeId> {
         self.interner.get_display_alias(type_id)
     }
@@ -790,6 +796,12 @@ impl TypeDisplayProvenance for QueryCache<'_> {
 
     fn mark_union_too_complex(&self) {
         self.interner.set_union_too_complex();
+    }
+}
+
+impl TypeRawIntersectionConstruction for QueryCache<'_> {
+    fn intersect_types_raw(&self, members: Vec<TypeId>) -> TypeId {
+        self.interner.intersect_types_raw(members)
     }
 }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -704,6 +704,10 @@ impl TypeTupleLimitSignal for QueryCache<'_> {
 }
 
 impl TypeDisplayProvenance for QueryCache<'_> {
+    fn display_provenance_generation(&self) -> u64 {
+        self.interner.display_provenance_generation()
+    }
+
     fn store_display_properties(&self, type_id: TypeId, props: Vec<PropertyInfo>) {
         self.interner.store_display_properties(type_id, props);
     }

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -800,8 +800,8 @@ impl TypeDisplayProvenance for QueryCache<'_> {
 }
 
 impl TypeRawIntersectionConstruction for QueryCache<'_> {
-    fn intersect_types_raw(&self, members: Vec<TypeId>) -> TypeId {
-        self.interner.intersect_types_raw(members)
+    fn intersect_types_raw_for_replay(&self, members: Vec<TypeId>) -> TypeId {
+        self.interner.intersect_types_raw_for_replay(members)
     }
 }
 

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -1169,7 +1169,10 @@ use self::api_lazy::{
     mapped_constraint_needs_resolver, template_has_lazy_application_in_composite,
     type_contains_lazy_application,
 };
-pub use self::exact_rewrite::{substitute_exact_type, substitute_exact_types};
+pub use self::exact_rewrite::{
+    ExactRewriteAborted, ExactRewriteMemo, substitute_exact_type, substitute_exact_types,
+    substitute_exact_types_with_memo,
+};
 pub use self::substitution::TypeSubstitution;
 #[cfg(test)]
 #[path = "../../tests/instantiate_tests.rs"]

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -1155,6 +1155,7 @@ mod api_lazy;
 mod cache_stability;
 mod conditional;
 mod display_properties;
+mod exact_rewrite;
 pub(crate) mod flags;
 mod homomorphic;
 mod indexed;
@@ -1168,6 +1169,7 @@ use self::api_lazy::{
     mapped_constraint_needs_resolver, template_has_lazy_application_in_composite,
     type_contains_lazy_application,
 };
+pub use self::exact_rewrite::{substitute_exact_type, substitute_exact_types};
 pub use self::substitution::TypeSubstitution;
 #[cfg(test)]
 #[path = "../../tests/instantiate_tests.rs"]

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -1230,27 +1230,6 @@ pub fn resolve_unbound_type_params_to_declared_fallbacks<S: std::hash::BuildHash
     })
 }
 
-/// Replace one exact interned type identity throughout a type graph.
-///
-/// Unlike [`TypeSubstitution`], this operation is keyed by [`TypeId`] rather
-/// than a type-parameter name. It can therefore rebind a cached declaration
-/// parameter without capturing an unrelated shadowed parameter that happens
-/// to use the same spelling.
-pub fn substitute_exact_type(
-    db: &dyn TypeDatabase,
-    type_id: TypeId,
-    from: TypeId,
-    to: TypeId,
-) -> TypeId {
-    if from == to {
-        return type_id;
-    }
-    let mut memo = FxHashMap::default();
-    crate::evaluation::evaluate_rules::substitute::substitute_exact_type_db(
-        db, type_id, from, to, &mut memo,
-    )
-}
-
 /// Resolve the type parameters whose declared name is in `names` and appear
 /// free in `ty` to their `default → constraint → unknown`, matching tsc's
 /// instantiation of a *failed* generic call's result with default type

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -1230,6 +1230,27 @@ pub fn resolve_unbound_type_params_to_declared_fallbacks<S: std::hash::BuildHash
     })
 }
 
+/// Replace one exact interned type identity throughout a type graph.
+///
+/// Unlike [`TypeSubstitution`], this operation is keyed by [`TypeId`] rather
+/// than a type-parameter name. It can therefore rebind a cached declaration
+/// parameter without capturing an unrelated shadowed parameter that happens
+/// to use the same spelling.
+pub fn substitute_exact_type(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    from: TypeId,
+    to: TypeId,
+) -> TypeId {
+    if from == to {
+        return type_id;
+    }
+    let mut memo = FxHashMap::default();
+    crate::evaluation::evaluate_rules::substitute::substitute_exact_type_db(
+        db, type_id, from, to, &mut memo,
+    )
+}
+
 /// Resolve the type parameters whose declared name is in `names` and appear
 /// free in `ty` to their `default → constraint → unknown`, matching tsc's
 /// instantiation of a *failed* generic call's result with default type

--- a/crates/tsz-solver/src/instantiation/instantiate/exact_rewrite.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/exact_rewrite.rs
@@ -17,10 +17,13 @@ use std::collections::hash_map::Entry;
 /// Replace aligned exact identities throughout `root` in one graph walk.
 ///
 /// Replacements are simultaneous: a replacement value is terminal and is not
-/// itself rewritten through another pair. The walk is `O(P + N)`, where `P` is
-/// the number of non-identity replacement pairs and `N` is the reachable graph
-/// size. Shared nodes are rebuilt once, and a no-op graph retains its original
-/// interned identity.
+/// itself rewritten through another pair. The walk is `O(P + V + E)`, where
+/// `P` is the number of non-identity replacement pairs, `V` is the number of
+/// reachable interned nodes, and `E` is the number of structural and provenance
+/// slots traversed. Shared nodes are rebuilt once, every union/intersection
+/// member list is reconstructed in one linear pass, and a no-op graph retains
+/// its original interned identity. Auxiliary storage is `O(P + V + Q)`, where
+/// `Q` is the provenance transfer count staged for all-or-nothing commit.
 pub fn substitute_exact_types(
     db: &dyn QueryDatabase,
     root: TypeId,
@@ -54,7 +57,14 @@ pub fn substitute_exact_types(
         return root;
     }
 
-    ExactTypeRewriter { db, rewritten }.rewrite(root)
+    let mut rewriter = ExactTypeRewriter {
+        db,
+        rewritten,
+        aborted: false,
+        pending_provenance: Vec::new(),
+    };
+    let result = rewriter.rewrite(root);
+    rewriter.finish(root, result)
 }
 
 /// Replace one exact interned identity throughout a type graph.
@@ -77,10 +87,32 @@ struct ExactTypeRewriter<'a> {
     /// Preloaded with direct replacements, then extended with per-node memoized
     /// results. Direct replacements therefore remain terminal.
     rewritten: FxHashMap<TypeId, TypeId>,
+    /// Sticky shared-frame bailout. Once set, every active caller preserves its
+    /// source node and the public operation returns its original root.
+    aborted: bool,
+    /// Provenance writes are transactional: speculative structural nodes may be
+    /// interned during a walk, but no side table is mutated unless the whole
+    /// reachable graph completes within the shared solver-frame budget.
+    pending_provenance: Vec<PendingProvenance>,
+}
+
+enum PendingProvenance {
+    DisplayProperties(TypeId, Vec<PropertyInfo>),
+    UnionOrigin(TypeId, Vec<TypeId>),
+    ApplicationEvalOrigin(TypeId, TypeId),
+    MergedIntersectionOrigin(TypeId, TypeId),
+    RewrittenApplicationDisplayAlias(TypeId, TypeId),
+    DisplayAliasIfAbsent(TypeId, TypeId),
+    ConditionalAliasBase(TypeId),
+    GlobalThisSurfaceDisplay(TypeId),
+    LiteralObjectAnnotation(TypeId),
 }
 
 impl ExactTypeRewriter<'_> {
     fn rewrite(&mut self, type_id: TypeId) -> TypeId {
+        if self.aborted {
+            return type_id;
+        }
         if let Some(&cached) = self.rewritten.get(&type_id) {
             return cached;
         }
@@ -88,6 +120,15 @@ impl ExactTypeRewriter<'_> {
             return type_id;
         }
 
+        let Some(result) = crate::recursion::with_solver_frame(|| self.rewrite_in_frame(type_id))
+        else {
+            self.aborted = true;
+            return type_id;
+        };
+        result
+    }
+
+    fn rewrite_in_frame(&mut self, type_id: TypeId) -> TypeId {
         // A self-map is the cycle placeholder. Interned types are normally a
         // DAG with `Lazy`/`Recursive` cut points, but provenance can add edges.
         self.rewritten.insert(type_id, type_id);
@@ -131,10 +172,11 @@ impl ExactTypeRewriter<'_> {
                     .symbol_index
                     .as_ref()
                     .and_then(|index| self.rewrite_index_signature(index));
-                if properties.is_none()
-                    && string_index.is_none()
-                    && number_index.is_none()
-                    && symbol_index.is_none()
+                if self.aborted
+                    || (properties.is_none()
+                        && string_index.is_none()
+                        && number_index.is_none()
+                        && symbol_index.is_none())
                 {
                     type_id
                 } else {
@@ -150,13 +192,13 @@ impl ExactTypeRewriter<'_> {
             }
             TypeData::Union(list_id) => self
                 .rewrite_type_ids(self.db.type_list(list_id).as_ref())
-                .map_or(type_id, |members| self.db.union(members)),
+                .map_or(type_id, |members| self.db.union_preserve_members(members)),
             TypeData::Intersection(list_id) => self
                 .rewrite_type_ids(self.db.type_list(list_id).as_ref())
-                .map_or(type_id, |members| self.db.intersection(members)),
+                .map_or(type_id, |members| self.db.intersect_types_raw(members)),
             TypeData::Array(element) => {
                 let rewritten = self.rewrite(element);
-                if rewritten == element {
+                if self.aborted || rewritten == element {
                     type_id
                 } else {
                     self.db.array(rewritten)
@@ -180,7 +222,7 @@ impl ExactTypeRewriter<'_> {
                 .map_or(type_id, |info| self.db.fresh_type_param(info)),
             TypeData::Enum(def_id, member_type) => {
                 let rewritten = self.rewrite(member_type);
-                if rewritten == member_type {
+                if self.aborted || rewritten == member_type {
                     type_id
                 } else {
                     self.db.enum_type(def_id, rewritten)
@@ -190,7 +232,7 @@ impl ExactTypeRewriter<'_> {
                 let app = self.db.type_application(app_id);
                 let base = self.rewrite(app.base);
                 let args = self.rewrite_type_ids(&app.args);
-                if base == app.base && args.is_none() {
+                if self.aborted || (base == app.base && args.is_none()) {
                     type_id
                 } else {
                     self.db
@@ -206,7 +248,7 @@ impl ExactTypeRewriter<'_> {
                     false_type: self.rewrite(cond.false_type),
                     is_distributive: cond.is_distributive,
                 };
-                if rewritten == cond {
+                if self.aborted || rewritten == cond {
                     type_id
                 } else {
                     self.db.conditional(rewritten)
@@ -218,10 +260,11 @@ impl ExactTypeRewriter<'_> {
                 let constraint = self.rewrite(mapped.constraint);
                 let name_type = mapped.name_type.map(|name_type| self.rewrite(name_type));
                 let template = self.rewrite(mapped.template);
-                if type_param.is_none()
-                    && constraint == mapped.constraint
-                    && name_type == mapped.name_type
-                    && template == mapped.template
+                if self.aborted
+                    || (type_param.is_none()
+                        && constraint == mapped.constraint
+                        && name_type == mapped.name_type
+                        && template == mapped.template)
                 {
                     type_id
                 } else {
@@ -238,7 +281,9 @@ impl ExactTypeRewriter<'_> {
             TypeData::IndexAccess(object_type, index_type) => {
                 let object_type_rewritten = self.rewrite(object_type);
                 let index_type_rewritten = self.rewrite(index_type);
-                if object_type_rewritten == object_type && index_type_rewritten == index_type {
+                if self.aborted
+                    || (object_type_rewritten == object_type && index_type_rewritten == index_type)
+                {
                     type_id
                 } else {
                     self.db
@@ -271,7 +316,9 @@ impl ExactTypeRewriter<'_> {
             } => {
                 let base_type_rewritten = self.rewrite(base_type);
                 let constraint_rewritten = self.rewrite(constraint);
-                if base_type_rewritten == base_type && constraint_rewritten == constraint {
+                if self.aborted
+                    || (base_type_rewritten == base_type && constraint_rewritten == constraint)
+                {
                     type_id
                 } else {
                     self.db
@@ -286,6 +333,47 @@ impl ExactTypeRewriter<'_> {
         if result != type_id {
             self.propagate_provenance(type_id, result);
         }
+        if self.aborted { type_id } else { result }
+    }
+
+    fn finish(self, original: TypeId, result: TypeId) -> TypeId {
+        if self.aborted {
+            return original;
+        }
+        for provenance in self.pending_provenance {
+            match provenance {
+                PendingProvenance::DisplayProperties(type_id, properties) => {
+                    self.db.store_display_properties(type_id, properties);
+                }
+                PendingProvenance::UnionOrigin(type_id, members) => {
+                    self.db.store_union_origin(type_id, members);
+                }
+                PendingProvenance::ApplicationEvalOrigin(type_id, origin) => {
+                    self.db.record_application_eval_origin(type_id, origin);
+                }
+                PendingProvenance::MergedIntersectionOrigin(type_id, origin) => {
+                    self.db.store_merged_intersection_origin(type_id, origin);
+                }
+                PendingProvenance::RewrittenApplicationDisplayAlias(type_id, alias) => {
+                    self.db
+                        .transfer_rewritten_application_display_alias(type_id, alias);
+                }
+                PendingProvenance::DisplayAliasIfAbsent(type_id, alias) => {
+                    if self.db.get_display_alias(type_id).is_none() {
+                        self.db.store_display_alias(type_id, alias);
+                    }
+                }
+                PendingProvenance::ConditionalAliasBase(type_id) => {
+                    self.db.mark_conditional_alias_base(type_id);
+                }
+                PendingProvenance::GlobalThisSurfaceDisplay(type_id) => {
+                    self.db.mark_global_this_surface_display(type_id);
+                }
+                PendingProvenance::LiteralObjectAnnotation(type_id) => {
+                    self.db.mark_literal_object_annotation(type_id);
+                }
+            }
+        }
         result
     }
 
@@ -296,7 +384,7 @@ impl ExactTypeRewriter<'_> {
         build: impl FnOnce(&dyn TypeDatabase, TypeId) -> TypeId,
     ) -> TypeId {
         let rewritten = self.rewrite(inner);
-        if rewritten == inner {
+        if self.aborted || rewritten == inner {
             original
         } else {
             build(self.db, rewritten)
@@ -316,7 +404,7 @@ impl ExactTypeRewriter<'_> {
                 changed = Some(values);
             }
         }
-        changed
+        (!self.aborted).then_some(changed).flatten()
     }
 
     fn rewrite_tuple_elements(&mut self, elements: &[TupleElement]) -> Option<Vec<TupleElement>> {
@@ -336,7 +424,7 @@ impl ExactTypeRewriter<'_> {
                 changed = Some(values);
             }
         }
-        changed
+        (!self.aborted).then_some(changed).flatten()
     }
 
     fn rewrite_properties(&mut self, properties: &[PropertyInfo]) -> Option<Vec<PropertyInfo>> {
@@ -362,17 +450,19 @@ impl ExactTypeRewriter<'_> {
                 changed = Some(values);
             }
         }
-        changed
+        (!self.aborted).then_some(changed).flatten()
     }
 
     fn rewrite_index_signature(&mut self, index: &IndexSignature) -> Option<IndexSignature> {
         let key_type = self.rewrite(index.key_type);
         let value_type = self.rewrite(index.value_type);
-        (key_type != index.key_type || value_type != index.value_type).then_some(IndexSignature {
-            key_type,
-            value_type,
-            ..*index
-        })
+        (!self.aborted && (key_type != index.key_type || value_type != index.value_type)).then_some(
+            IndexSignature {
+                key_type,
+                value_type,
+                ..*index
+            },
+        )
     }
 
     fn rewrite_params(&mut self, params: &[ParamInfo]) -> Option<Vec<ParamInfo>> {
@@ -389,7 +479,7 @@ impl ExactTypeRewriter<'_> {
                 changed = Some(values);
             }
         }
-        changed
+        (!self.aborted).then_some(changed).flatten()
     }
 
     fn rewrite_type_param(&mut self, param: TypeParamInfo) -> Option<TypeParamInfo> {
@@ -400,7 +490,7 @@ impl ExactTypeRewriter<'_> {
             default,
             ..param
         };
-        (rewritten != param).then_some(rewritten)
+        (!self.aborted && rewritten != param).then_some(rewritten)
     }
 
     fn rewrite_type_params(&mut self, params: &[TypeParamInfo]) -> Option<Vec<TypeParamInfo>> {
@@ -416,12 +506,12 @@ impl ExactTypeRewriter<'_> {
                 changed = Some(values);
             }
         }
-        changed
+        (!self.aborted).then_some(changed).flatten()
     }
 
     fn rewrite_predicate(&mut self, predicate: TypePredicate) -> Option<TypePredicate> {
         let type_id = predicate.type_id.map(|type_id| self.rewrite(type_id));
-        (type_id != predicate.type_id).then_some(TypePredicate {
+        (!self.aborted && type_id != predicate.type_id).then_some(TypePredicate {
             type_id,
             ..predicate
         })
@@ -435,11 +525,12 @@ impl ExactTypeRewriter<'_> {
         let type_predicate = shape
             .type_predicate
             .and_then(|predicate| self.rewrite_predicate(predicate));
-        if type_params.is_none()
-            && params.is_none()
-            && this_type == shape.this_type
-            && return_type == shape.return_type
-            && type_predicate.is_none()
+        if self.aborted
+            || (type_params.is_none()
+                && params.is_none()
+                && this_type == shape.this_type
+                && return_type == shape.return_type
+                && type_predicate.is_none())
         {
             None
         } else {
@@ -463,11 +554,12 @@ impl ExactTypeRewriter<'_> {
         let type_predicate = signature
             .type_predicate
             .and_then(|predicate| self.rewrite_predicate(predicate));
-        if type_params.is_none()
-            && params.is_none()
-            && this_type == signature.this_type
-            && return_type == signature.return_type
-            && type_predicate.is_none()
+        if self.aborted
+            || (type_params.is_none()
+                && params.is_none()
+                && this_type == signature.this_type
+                && return_type == signature.return_type
+                && type_predicate.is_none())
         {
             None
         } else {
@@ -497,7 +589,7 @@ impl ExactTypeRewriter<'_> {
                 changed = Some(values);
             }
         }
-        changed
+        (!self.aborted).then_some(changed).flatten()
     }
 
     fn rewrite_callable_shape(&mut self, shape: &CallableShape) -> Option<CallableShape> {
@@ -512,11 +604,12 @@ impl ExactTypeRewriter<'_> {
             .number_index
             .as_ref()
             .and_then(|index| self.rewrite_index_signature(index));
-        if call_signatures.is_none()
-            && construct_signatures.is_none()
-            && properties.is_none()
-            && string_index.is_none()
-            && number_index.is_none()
+        if self.aborted
+            || (call_signatures.is_none()
+                && construct_signatures.is_none()
+                && properties.is_none()
+                && string_index.is_none()
+                && number_index.is_none())
         {
             None
         } else {
@@ -549,7 +642,7 @@ impl ExactTypeRewriter<'_> {
                 changed = Some(values);
             }
         }
-        changed
+        (!self.aborted).then_some(changed).flatten()
     }
 
     fn propagate_provenance(&mut self, source: TypeId, result: TypeId) {
@@ -557,24 +650,27 @@ impl ExactTypeRewriter<'_> {
             let properties = self
                 .rewrite_properties(properties.as_ref())
                 .unwrap_or_else(|| properties.as_ref().clone());
-            self.db.store_display_properties(result, properties);
+            self.pending_provenance
+                .push(PendingProvenance::DisplayProperties(result, properties));
         }
 
         if let Some(origin) = self.db.get_union_origin(source) {
             let origin = self
                 .rewrite_type_ids(origin.as_ref())
                 .unwrap_or_else(|| origin.as_ref().clone());
-            self.db.store_union_origin(result, origin);
+            self.pending_provenance
+                .push(PendingProvenance::UnionOrigin(result, origin));
         }
 
-        // Application provenance is first-write-wins. Publish it before
-        // replaying a merged origin, whose member reconstruction can intern the
-        // same structural result through a different application.
+        // Application provenance is first-write-wins. Stage it before replaying
+        // a merged origin, whose member reconstruction can intern the same
+        // structural result through a different application.
         if self.db.get_application_eval_origin(result).is_none()
             && let Some(origin) = self.db.get_application_eval_origin(source)
         {
             let origin = self.rewrite(origin);
-            self.db.record_application_eval_origin(result, origin);
+            self.pending_provenance
+                .push(PendingProvenance::ApplicationEvalOrigin(result, origin));
         }
 
         if self.db.get_merged_intersection_origin(result).is_none()
@@ -585,27 +681,36 @@ impl ExactTypeRewriter<'_> {
                 .db
                 .get_merged_intersection_origin(rewritten_origin)
                 .unwrap_or(rewritten_origin);
-            self.db.store_merged_intersection_origin(result, raw_origin);
+            self.pending_provenance
+                .push(PendingProvenance::MergedIntersectionOrigin(
+                    result, raw_origin,
+                ));
         }
 
         if let Some(alias) = self.db.get_display_alias(source) {
             let alias = self.rewrite(alias);
             if matches!(self.db.lookup(alias), Some(TypeData::Application(_))) {
-                self.db
-                    .store_display_alias_preferring_application(result, alias);
+                self.pending_provenance
+                    .push(PendingProvenance::RewrittenApplicationDisplayAlias(
+                        result, alias,
+                    ));
             } else if self.db.get_display_alias(result).is_none() {
-                self.db.store_display_alias(result, alias);
+                self.pending_provenance
+                    .push(PendingProvenance::DisplayAliasIfAbsent(result, alias));
             }
         }
 
         if self.db.is_conditional_alias_base(source) {
-            self.db.mark_conditional_alias_base(result);
+            self.pending_provenance
+                .push(PendingProvenance::ConditionalAliasBase(result));
         }
         if self.db.is_global_this_surface_display(source) {
-            self.db.mark_global_this_surface_display(result);
+            self.pending_provenance
+                .push(PendingProvenance::GlobalThisSurfaceDisplay(result));
         }
         if self.db.is_literal_object_annotation(source) {
-            self.db.mark_literal_object_annotation(result);
+            self.pending_provenance
+                .push(PendingProvenance::LiteralObjectAnnotation(result));
         }
     }
 }
@@ -675,6 +780,38 @@ mod tests {
             substitute_exact_type(&db, no_match, declaration, TypeId::STRING),
             no_match,
         );
+    }
+
+    #[test]
+    fn exact_rewrite_preserves_union_members_and_raw_intersection_shape() {
+        let db = TypeInterner::new();
+        let outer = fresh_param(&db, "Outer");
+        let subtype_member = db.literal_string("member");
+        assert_eq!(
+            db.union(vec![subtype_member, TypeId::STRING]),
+            TypeId::STRING,
+            "ordinary union construction absorbs the literal subtype",
+        );
+        let union = db.union_preserve_members(vec![outer, TypeId::STRING]);
+
+        let rewritten_union = substitute_exact_type(&db, union, outer, subtype_member);
+        let Some(TypeData::Union(list_id)) = db.lookup(rewritten_union) else {
+            panic!("exact replay must not subtype-reduce the literal member");
+        };
+        assert_eq!(db.type_list(list_id).len(), 2);
+
+        let left = db.object(vec![PropertyInfo::new(db.intern_string("left"), outer)]);
+        let right = db.object(vec![PropertyInfo::new(
+            db.intern_string("right"),
+            TypeId::NUMBER,
+        )]);
+        let intersection = db.intersect_types_raw(vec![left, right]);
+        let rewritten_intersection =
+            substitute_exact_type(&db, intersection, outer, subtype_member);
+        let Some(TypeData::Intersection(list_id)) = db.lookup(rewritten_intersection) else {
+            panic!("exact replay must not normalize raw object intersections");
+        };
+        assert_eq!(db.type_list(list_id).len(), 2);
     }
 
     #[test]
@@ -964,5 +1101,95 @@ mod tests {
         };
         assert_eq!(db.type_application(app_id).args, vec![TypeId::STRING]);
         assert_eq!(db.get_display_alias(result), Some(origin));
+    }
+
+    #[test]
+    fn exact_rewrite_transfers_generic_display_alias_in_both_allocation_orders() {
+        fn run(alias_before_result: bool) {
+            let db = TypeInterner::new();
+            let source_param = fresh_param(&db, "Source");
+            let replacement = fresh_param(&db, "Replacement");
+            let base = db.lazy(DefId(21));
+
+            // Seed valid source provenance in the ordinary evaluator order:
+            // the application exists before its evaluated structural result.
+            let source_alias = db.application(base, vec![source_param]);
+            let source = db.array(source_param);
+            db.store_display_alias_preferring_application(source, source_alias);
+            assert_eq!(db.get_display_alias(source), Some(source_alias));
+
+            let expected_alias =
+                alias_before_result.then(|| db.application(base, vec![replacement]));
+            let expected_result = (!alias_before_result).then(|| db.array(replacement));
+
+            let result = substitute_exact_type(&db, source, source_param, replacement);
+            let expected_result = expected_result.unwrap_or_else(|| db.array(replacement));
+            let expected_alias =
+                expected_alias.unwrap_or_else(|| db.application(base, vec![replacement]));
+
+            assert_eq!(result, expected_result);
+            assert_eq!(db.get_display_alias(result), Some(expected_alias));
+        }
+
+        run(true);
+        run(false);
+    }
+
+    #[test]
+    fn rewritten_display_alias_transfer_retains_global_identity_and_cycle_guards() {
+        let db = TypeInterner::new();
+        let parameter = fresh_param(&db, "Parameter");
+        let base = db.lazy(DefId(23));
+        let safe_alias = db.application(base, vec![TypeId::STRING]);
+
+        db.transfer_rewritten_application_display_alias(TypeId::STRING, safe_alias);
+        db.transfer_rewritten_application_display_alias(parameter, safe_alias);
+        assert_eq!(db.get_display_alias(TypeId::STRING), None);
+        assert_eq!(db.get_display_alias(parameter), None);
+
+        let evaluated = db.array(TypeId::STRING);
+        let cyclic_alias = db.application(base, vec![evaluated]);
+        db.transfer_rewritten_application_display_alias(evaluated, cyclic_alias);
+        assert_eq!(db.get_display_alias(evaluated), None);
+    }
+
+    #[test]
+    fn exact_rewrite_depth_bail_returns_original_without_provenance_writes() {
+        let db = TypeInterner::new();
+        let outer = fresh_param(&db, "Outer");
+        let base = db.lazy(DefId(22));
+        let source_alias = db.application(base, vec![outer]);
+        let property = db.intern_string("value");
+        let shallow = db.object(vec![PropertyInfo::new(property, outer)]);
+        db.store_display_alias_preferring_application(shallow, source_alias);
+        assert_eq!(db.get_display_alias(shallow), Some(source_alias));
+
+        // This canonical node is the speculative shallow rewrite the first
+        // tuple slot would produce before the second slot exceeds the shared
+        // solver-frame budget. Its provenance must remain untouched on bail.
+        let rewritten_shallow = db.object(vec![PropertyInfo::new(property, TypeId::STRING)]);
+        assert_eq!(db.get_display_alias(rewritten_shallow), None);
+
+        let mut deep = outer;
+        for _ in 0..=crate::recursion::MAX_SOLVER_STACK_FRAMES {
+            deep = db.array(deep);
+        }
+        let root = db.tuple(vec![
+            TupleElement::fixed(shallow),
+            TupleElement::fixed(deep),
+        ]);
+
+        assert_eq!(
+            substitute_exact_type(&db, root, outer, TypeId::STRING),
+            root,
+        );
+        assert_eq!(db.get_display_alias(rewritten_shallow), None);
+
+        // The RAII frame budget and sticky bailout are request-scoped.
+        let shallow_array = db.array(outer);
+        assert_eq!(
+            substitute_exact_type(&db, shallow_array, outer, TypeId::STRING),
+            db.array(TypeId::STRING),
+        );
     }
 }

--- a/crates/tsz-solver/src/instantiation/instantiate/exact_rewrite.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/exact_rewrite.rs
@@ -17,13 +17,15 @@ use std::collections::hash_map::Entry;
 /// Replace aligned exact identities throughout `root` in one graph walk.
 ///
 /// Replacements are simultaneous: a replacement value is terminal and is not
-/// itself rewritten through another pair. The walk is `O(P + V + E)`, where
+/// itself rewritten through another pair. The walk is
+/// `O(P + V + E + Σ Uₖ log Uₖ)`, where
 /// `P` is the number of non-identity replacement pairs, `V` is the number of
 /// reachable interned nodes, and `E` is the number of structural and provenance
-/// slots traversed. Shared nodes are rebuilt once, every union/intersection
-/// member list is reconstructed in one linear pass, and a no-op graph retains
-/// its original interned identity. Auxiliary storage is `O(P + V + Q)`, where
-/// `Q` is the provenance transfer count staged for all-or-nothing commit.
+/// slots traversed; each `Uₖ` is the size of a changed union whose canonical
+/// member order is restored. Shared nodes are rebuilt once, intersection member
+/// lists are reconstructed in one linear pass, and a no-op graph retains its
+/// original interned identity. Auxiliary storage is `O(P + V + Q)`, where `Q`
+/// is the provenance transfer count staged for all-or-nothing commit.
 pub fn substitute_exact_types(
     db: &dyn QueryDatabase,
     root: TypeId,
@@ -190,9 +192,18 @@ impl ExactTypeRewriter<'_> {
                     })
                 }
             }
-            TypeData::Union(list_id) => self
-                .rewrite_type_ids(self.db.type_list(list_id).as_ref())
-                .map_or(type_id, |members| self.db.union_preserve_members(members)),
+            TypeData::Union(list_id) => {
+                let Some(members) = self.rewrite_type_ids(self.db.type_list(list_id).as_ref())
+                else {
+                    return type_id;
+                };
+                let result = self.db.union_preserve_members(members.clone());
+                if self.db.get_union_origin(type_id).is_none() {
+                    self.pending_provenance
+                        .push(PendingProvenance::UnionOrigin(result, members));
+                }
+                result
+            }
             TypeData::Intersection(list_id) => self
                 .rewrite_type_ids(self.db.type_list(list_id).as_ref())
                 .map_or(type_id, |members| self.db.intersect_types_raw(members)),
@@ -815,6 +826,44 @@ mod tests {
     }
 
     #[test]
+    fn exact_rewrite_preserves_pre_sort_union_member_order() {
+        let db = TypeInterner::new();
+        let source = fresh_param(&db, "Source");
+        let other = fresh_param(&db, "Other");
+        let union = db.union_preserve_members(vec![source, other]);
+        assert_eq!(db.get_union_origin(union), None);
+
+        let replacement = fresh_param(&db, "Replacement");
+        let result = substitute_exact_type(&db, union, source, replacement);
+
+        assert_eq!(
+            db.get_union_origin(result).map(|origin| origin.to_vec()),
+            Some(vec![replacement, other]),
+        );
+    }
+
+    #[test]
+    fn exact_rewrite_prefers_an_existing_union_origin() {
+        let db = TypeInterner::new();
+        let first = fresh_param(&db, "First");
+        let source = fresh_param(&db, "Source");
+        let union = db.union_preserve_members(vec![first, source]);
+        db.store_union_origin(union, vec![source, first]);
+        assert_eq!(
+            db.get_union_origin(union).map(|origin| origin.to_vec()),
+            Some(vec![source, first]),
+        );
+
+        let replacement = fresh_param(&db, "Replacement");
+        let result = substitute_exact_type(&db, union, source, replacement);
+
+        assert_eq!(
+            db.get_union_origin(result).map(|origin| origin.to_vec()),
+            Some(vec![replacement, first]),
+        );
+    }
+
+    #[test]
     fn exact_rewrite_reaches_mapped_binder_and_surface_fields() {
         let db = TypeInterner::new();
         let outer = fresh_param(&db, "Outer");
@@ -1136,6 +1185,29 @@ mod tests {
     }
 
     #[test]
+    fn exact_rewrite_does_not_repaint_an_existing_application_alias() {
+        let db = TypeInterner::new();
+        let source_param = fresh_param(&db, "Source");
+        let replacement = fresh_param(&db, "Replacement");
+        let source_base = db.lazy(DefId(24));
+        let existing_base = db.lazy(DefId(25));
+
+        let source_alias = db.application(source_base, vec![source_param]);
+        let source = db.array(source_param);
+        db.store_display_alias_preferring_application(source, source_alias);
+
+        let existing_alias = db.application(existing_base, vec![replacement]);
+        let expected = db.array(replacement);
+        db.store_display_alias_preferring_application(expected, existing_alias);
+        assert_eq!(db.get_display_alias(expected), Some(existing_alias));
+
+        let result = substitute_exact_type(&db, source, source_param, replacement);
+
+        assert_eq!(result, expected);
+        assert_eq!(db.get_display_alias(result), Some(existing_alias));
+    }
+
+    #[test]
     fn rewritten_display_alias_transfer_retains_global_identity_and_cycle_guards() {
         let db = TypeInterner::new();
         let parameter = fresh_param(&db, "Parameter");
@@ -1151,6 +1223,23 @@ mod tests {
         let cyclic_alias = db.application(base, vec![evaluated]);
         db.transfer_rewritten_application_display_alias(evaluated, cyclic_alias);
         assert_eq!(db.get_display_alias(evaluated), None);
+    }
+
+    #[test]
+    fn rewritten_application_alias_replaces_structural_provenance() {
+        let db = TypeInterner::new();
+        let evaluated = db.array(TypeId::STRING);
+        let structural_alias = db.object(vec![PropertyInfo::new(
+            db.intern_string("value"),
+            TypeId::STRING,
+        )]);
+        db.store_display_alias(evaluated, structural_alias);
+        assert_eq!(db.get_display_alias(evaluated), Some(structural_alias));
+
+        let application = db.application(db.lazy(DefId(26)), vec![TypeId::STRING]);
+        db.transfer_rewritten_application_display_alias(evaluated, application);
+
+        assert_eq!(db.get_display_alias(evaluated), Some(application));
     }
 
     #[test]

--- a/crates/tsz-solver/src/instantiation/instantiate/exact_rewrite.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/exact_rewrite.rs
@@ -301,7 +301,7 @@ struct ExactRewriteDelta {
 
 enum PendingProvenance {
     DisplayProperties(TypeId, Vec<PropertyInfo>),
-    UnionOrigin(TypeId, Vec<TypeId>),
+    RewrittenUnionOrigin(TypeId, Vec<TypeId>, bool),
     ApplicationEvalOrigin(TypeId, TypeId),
     MergedIntersectionOrigin(TypeId, TypeId),
     RewrittenApplicationDisplayAlias(TypeId, TypeId),
@@ -407,7 +407,9 @@ impl ExactTypeRewriter<'_> {
                 let result = self.db.union_preserve_members(members.clone());
                 if self.db.get_union_origin(type_id).is_none() {
                     self.pending_provenance
-                        .push(PendingProvenance::UnionOrigin(result, members));
+                        .push(PendingProvenance::RewrittenUnionOrigin(
+                            result, members, true,
+                        ));
                 }
                 result
             }
@@ -566,8 +568,9 @@ impl ExactTypeRewriter<'_> {
                 PendingProvenance::DisplayProperties(type_id, properties) => {
                     self.db.store_display_properties(type_id, properties);
                 }
-                PendingProvenance::UnionOrigin(type_id, members) => {
-                    self.db.store_union_origin(type_id, members);
+                PendingProvenance::RewrittenUnionOrigin(type_id, members, is_fallback) => {
+                    self.db
+                        .store_rewritten_union_origin(type_id, members, is_fallback);
                 }
                 PendingProvenance::ApplicationEvalOrigin(type_id, origin) => {
                     self.db.record_application_eval_origin(type_id, origin);
@@ -888,7 +891,9 @@ impl ExactTypeRewriter<'_> {
                 .rewrite_type_ids(origin.as_ref())
                 .unwrap_or_else(|| origin.as_ref().clone());
             self.pending_provenance
-                .push(PendingProvenance::UnionOrigin(result, origin));
+                .push(PendingProvenance::RewrittenUnionOrigin(
+                    result, origin, false,
+                ));
         }
 
         // Application provenance is first-write-wins. Stage it before replaying
@@ -1565,19 +1570,23 @@ mod tests {
     fn exact_rewrite_memo_refreshes_late_provenance_and_converges_generation() {
         let db = TypeInterner::new();
         let outer = fresh_param(&db, "Outer");
-        let replacement = fresh_param(&db, "Replacement");
+        let other = fresh_param(&db, "Other");
+        let third = fresh_param(&db, "Third");
         let alias_base = db.lazy(DefId(31));
         let source_application = db.application(alias_base, vec![outer]);
-        let nested_source = db.union_preserve_members(vec![outer, TypeId::STRING]);
-        let source = db.union_preserve_members(vec![nested_source, TypeId::NUMBER]);
+        let nested_source = db.array(outer);
+        let source = db.union_preserve_members(vec![outer, other, third]);
+        let replacement = fresh_param(&db, "Replacement");
 
         let (result, mut memo) =
             substitute_exact_types_with_memo(&db, source, &[outer], &[replacement])
                 .expect("the initial exact rewrite should complete");
-        let rewritten_nested = db.union_preserve_members(vec![replacement, TypeId::STRING]);
+        let rewritten_nested = db.array(replacement);
         let rewritten_application = db.application(alias_base, vec![replacement]);
         assert!(db.get_display_properties(result).is_none());
-        assert!(db.get_union_origin(result).is_none());
+        let synthesized_union_fallback = db
+            .get_union_origin(result)
+            .expect("changed union should retain its pre-sort rewritten members");
         assert!(db.get_application_eval_origin(result).is_none());
         assert!(db.get_display_alias(result).is_none());
 
@@ -1589,7 +1598,7 @@ mod tests {
                 ..PropertyInfo::new(shown, nested_source)
             }],
         );
-        db.store_union_origin(source, vec![nested_source, TypeId::NUMBER]);
+        db.replace_union_origin_for_display(source, vec![third, other, outer]);
         db.record_application_eval_origin(source, source_application);
         db.store_display_alias_preferring_application(source, source_application);
 
@@ -1600,11 +1609,16 @@ mod tests {
             .expect("late display properties should reach the rewritten root");
         assert_eq!(properties[0].type_id, rewritten_nested);
         assert_eq!(properties[0].declaration_order, 1);
+        assert_ne!(
+            synthesized_union_fallback.as_slice(),
+            &[third, other, replacement],
+            "the test must replace a distinct synthesized fallback",
+        );
         assert_eq!(
             db.get_union_origin(result)
                 .expect("late union origin should reach the rewritten root")
                 .as_slice(),
-            &[rewritten_nested, TypeId::NUMBER],
+            &[third, other, replacement],
         );
         assert_eq!(
             db.get_application_eval_origin(result),
@@ -1640,6 +1654,73 @@ mod tests {
                 .expect("rewritten display properties should be replaced")[0]
                 .declaration_order,
             9,
+        );
+    }
+
+    #[test]
+    fn exact_rewrite_union_fallback_never_repaints_unrelated_real_origin() {
+        let db = TypeInterner::new();
+        let source_param = fresh_param(&db, "Source");
+        let other = fresh_param(&db, "Other");
+        let replacement = fresh_param(&db, "Replacement");
+        let source = db.union_preserve_members(vec![source_param, other]);
+        let expected = db.union_preserve_members(vec![replacement, other]);
+        let unrelated_target_origin = vec![replacement, other];
+        db.replace_union_origin_for_display(expected, unrelated_target_origin.clone());
+
+        let (result, mut memo) =
+            substitute_exact_types_with_memo(&db, source, &[source_param], &[replacement])
+                .expect("the initial exact rewrite should complete");
+        assert_eq!(result, expected);
+        assert_eq!(
+            db.get_union_origin(result).map(|origin| origin.to_vec()),
+            Some(unrelated_target_origin.clone()),
+            "a synthesized fallback must not replace a real target origin",
+        );
+
+        db.replace_union_origin_for_display(source, vec![other, source_param]);
+        memo.refresh_provenance(&db)
+            .expect("late real source provenance should replay");
+        assert_eq!(
+            db.get_union_origin(result).map(|origin| origin.to_vec()),
+            Some(unrelated_target_origin),
+            "late provenance from another rewrite session must remain sticky",
+        );
+    }
+
+    #[test]
+    fn exact_rewrite_late_canonical_union_origin_clears_fallback() {
+        let db = TypeInterner::new();
+        let source_param = fresh_param(&db, "Source");
+        let other = fresh_param(&db, "Other");
+        let replacement = fresh_param(&db, "Replacement");
+        let source = db.union_preserve_members(vec![source_param, other]);
+        let (result, mut memo) =
+            substitute_exact_types_with_memo(&db, source, &[source_param], &[replacement])
+                .expect("the initial exact rewrite should complete");
+        assert!(db.get_union_origin(result).is_some());
+
+        let Some(TypeData::Union(result_list)) = db.lookup(result) else {
+            panic!("expected rewritten union");
+        };
+        let canonical_source_origin = db
+            .type_list(result_list)
+            .iter()
+            .map(|&member| {
+                if member == replacement {
+                    source_param
+                } else {
+                    member
+                }
+            })
+            .collect();
+        db.replace_union_origin_for_display(source, canonical_source_origin);
+        memo.refresh_provenance(&db)
+            .expect("late canonical provenance should replay");
+        assert_eq!(
+            db.get_union_origin(result),
+            None,
+            "a canonical real origin should clear the stale tagged fallback",
         );
     }
 

--- a/crates/tsz-solver/src/instantiation/instantiate/exact_rewrite.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/exact_rewrite.rs
@@ -1,0 +1,968 @@
+//! Simultaneous exact-identity rewrites for cached type graphs.
+//!
+//! This is deliberately separate from the evaluator's distributive
+//! substitution walker. That walker owns conditional/mapped evaluation policy;
+//! this one only rebuilds the interned graph while replacing selected exact
+//! [`TypeId`] identities.
+
+use crate::construction::{QueryDatabase, TypeDatabase};
+use crate::types::{
+    CallSignature, CallableShape, ConditionalType, FunctionShape, IndexSignature, MappedType,
+    ObjectShape, ParamInfo, PropertyInfo, TemplateSpan, TupleElement, TypeData, TypeId,
+    TypeParamInfo, TypePredicate,
+};
+use rustc_hash::FxHashMap;
+use std::collections::hash_map::Entry;
+
+/// Replace aligned exact identities throughout `root` in one graph walk.
+///
+/// Replacements are simultaneous: a replacement value is terminal and is not
+/// itself rewritten through another pair. The walk is `O(P + N)`, where `P` is
+/// the number of non-identity replacement pairs and `N` is the reachable graph
+/// size. Shared nodes are rebuilt once, and a no-op graph retains its original
+/// interned identity.
+pub fn substitute_exact_types(
+    db: &dyn QueryDatabase,
+    root: TypeId,
+    from: &[TypeId],
+    to: &[TypeId],
+) -> TypeId {
+    debug_assert_eq!(from.len(), to.len());
+    if from.len() != to.len() || from.is_empty() {
+        return root;
+    }
+
+    let mut rewritten = FxHashMap::with_capacity_and_hasher(from.len(), Default::default());
+    for (&source, &replacement) in from.iter().zip(to) {
+        if source == replacement {
+            continue;
+        }
+        match rewritten.entry(source) {
+            Entry::Vacant(entry) => {
+                entry.insert(replacement);
+            }
+            Entry::Occupied(entry) => {
+                debug_assert_eq!(
+                    *entry.get(),
+                    replacement,
+                    "one exact type identity cannot have conflicting replacements",
+                );
+            }
+        }
+    }
+    if rewritten.is_empty() {
+        return root;
+    }
+
+    ExactTypeRewriter { db, rewritten }.rewrite(root)
+}
+
+/// Replace one exact interned identity throughout a type graph.
+pub fn substitute_exact_type(
+    db: &dyn QueryDatabase,
+    root: TypeId,
+    from: TypeId,
+    to: TypeId,
+) -> TypeId {
+    substitute_exact_types(
+        db,
+        root,
+        std::slice::from_ref(&from),
+        std::slice::from_ref(&to),
+    )
+}
+
+struct ExactTypeRewriter<'a> {
+    db: &'a dyn QueryDatabase,
+    /// Preloaded with direct replacements, then extended with per-node memoized
+    /// results. Direct replacements therefore remain terminal.
+    rewritten: FxHashMap<TypeId, TypeId>,
+}
+
+impl ExactTypeRewriter<'_> {
+    fn rewrite(&mut self, type_id: TypeId) -> TypeId {
+        if let Some(&cached) = self.rewritten.get(&type_id) {
+            return cached;
+        }
+        if type_id.is_intrinsic() {
+            return type_id;
+        }
+
+        // A self-map is the cycle placeholder. Interned types are normally a
+        // DAG with `Lazy`/`Recursive` cut points, but provenance can add edges.
+        self.rewritten.insert(type_id, type_id);
+
+        let Some(data) = self.db.lookup(type_id) else {
+            return type_id;
+        };
+        let result = match data {
+            TypeData::Intrinsic(_)
+            | TypeData::Literal(_)
+            | TypeData::BoundParameter(_)
+            | TypeData::Lazy(_)
+            | TypeData::Recursive(_)
+            | TypeData::TypeQuery(_)
+            | TypeData::UniqueSymbol(_)
+            | TypeData::ThisType
+            | TypeData::ModuleNamespace(_)
+            | TypeData::Error
+            | TypeData::UnresolvedTypeName(_) => type_id,
+
+            TypeData::Object(shape_id) => {
+                let shape = self.db.object_shape(shape_id);
+                self.rewrite_properties(&shape.properties)
+                    .map_or(type_id, |properties| {
+                        self.db
+                            .object_with_flags_and_symbol(properties, shape.flags, shape.symbol)
+                    })
+            }
+            TypeData::ObjectWithIndex(shape_id) => {
+                let shape = self.db.object_shape(shape_id);
+                let properties = self.rewrite_properties(&shape.properties);
+                let string_index = shape
+                    .string_index
+                    .as_ref()
+                    .and_then(|index| self.rewrite_index_signature(index));
+                let number_index = shape
+                    .number_index
+                    .as_ref()
+                    .and_then(|index| self.rewrite_index_signature(index));
+                let symbol_index = shape
+                    .symbol_index
+                    .as_ref()
+                    .and_then(|index| self.rewrite_index_signature(index));
+                if properties.is_none()
+                    && string_index.is_none()
+                    && number_index.is_none()
+                    && symbol_index.is_none()
+                {
+                    type_id
+                } else {
+                    self.db.object_with_index(ObjectShape {
+                        flags: shape.flags,
+                        properties: properties.unwrap_or_else(|| shape.properties.clone()),
+                        string_index: string_index.or(shape.string_index),
+                        number_index: number_index.or(shape.number_index),
+                        symbol_index: symbol_index.or(shape.symbol_index),
+                        symbol: shape.symbol,
+                    })
+                }
+            }
+            TypeData::Union(list_id) => self
+                .rewrite_type_ids(self.db.type_list(list_id).as_ref())
+                .map_or(type_id, |members| self.db.union(members)),
+            TypeData::Intersection(list_id) => self
+                .rewrite_type_ids(self.db.type_list(list_id).as_ref())
+                .map_or(type_id, |members| self.db.intersection(members)),
+            TypeData::Array(element) => {
+                let rewritten = self.rewrite(element);
+                if rewritten == element {
+                    type_id
+                } else {
+                    self.db.array(rewritten)
+                }
+            }
+            TypeData::Tuple(list_id) => self
+                .rewrite_tuple_elements(self.db.tuple_list(list_id).as_ref())
+                .map_or(type_id, |elements| self.db.tuple(elements)),
+            TypeData::Function(shape_id) => {
+                let shape = self.db.function_shape(shape_id);
+                self.rewrite_function_shape(&shape)
+                    .map_or(type_id, |shape| self.db.function(shape))
+            }
+            TypeData::Callable(shape_id) => {
+                let shape = self.db.callable_shape(shape_id);
+                self.rewrite_callable_shape(&shape)
+                    .map_or(type_id, |shape| self.db.callable(shape))
+            }
+            TypeData::TypeParameter(info) => self
+                .rewrite_type_param(info)
+                .map_or(type_id, |info| self.db.fresh_type_param(info)),
+            TypeData::Enum(def_id, member_type) => {
+                let rewritten = self.rewrite(member_type);
+                if rewritten == member_type {
+                    type_id
+                } else {
+                    self.db.enum_type(def_id, rewritten)
+                }
+            }
+            TypeData::Application(app_id) => {
+                let app = self.db.type_application(app_id);
+                let base = self.rewrite(app.base);
+                let args = self.rewrite_type_ids(&app.args);
+                if base == app.base && args.is_none() {
+                    type_id
+                } else {
+                    self.db
+                        .application(base, args.unwrap_or_else(|| app.args.clone()))
+                }
+            }
+            TypeData::Conditional(cond_id) => {
+                let cond = self.db.get_conditional(cond_id);
+                let rewritten = ConditionalType {
+                    check_type: self.rewrite(cond.check_type),
+                    extends_type: self.rewrite(cond.extends_type),
+                    true_type: self.rewrite(cond.true_type),
+                    false_type: self.rewrite(cond.false_type),
+                    is_distributive: cond.is_distributive,
+                };
+                if rewritten == cond {
+                    type_id
+                } else {
+                    self.db.conditional(rewritten)
+                }
+            }
+            TypeData::Mapped(mapped_id) => {
+                let mapped = self.db.get_mapped(mapped_id);
+                let type_param = self.rewrite_type_param(mapped.type_param);
+                let constraint = self.rewrite(mapped.constraint);
+                let name_type = mapped.name_type.map(|name_type| self.rewrite(name_type));
+                let template = self.rewrite(mapped.template);
+                if type_param.is_none()
+                    && constraint == mapped.constraint
+                    && name_type == mapped.name_type
+                    && template == mapped.template
+                {
+                    type_id
+                } else {
+                    self.db.mapped(MappedType {
+                        type_param: type_param.unwrap_or(mapped.type_param),
+                        constraint,
+                        name_type,
+                        template,
+                        readonly_modifier: mapped.readonly_modifier,
+                        optional_modifier: mapped.optional_modifier,
+                    })
+                }
+            }
+            TypeData::IndexAccess(object_type, index_type) => {
+                let object_type_rewritten = self.rewrite(object_type);
+                let index_type_rewritten = self.rewrite(index_type);
+                if object_type_rewritten == object_type && index_type_rewritten == index_type {
+                    type_id
+                } else {
+                    self.db
+                        .index_access(object_type_rewritten, index_type_rewritten)
+                }
+            }
+            TypeData::TemplateLiteral(template_id) => self
+                .rewrite_template_spans(self.db.template_list(template_id).as_ref())
+                .map_or(type_id, |spans| self.db.template_literal(spans)),
+            TypeData::KeyOf(inner) => {
+                self.rewrite_unary(type_id, inner, |db, inner| db.keyof(inner))
+            }
+            TypeData::ReadonlyType(inner) => {
+                self.rewrite_unary(type_id, inner, |db, inner| db.readonly_type(inner))
+            }
+            TypeData::Infer(info) => self
+                .rewrite_type_param(info)
+                .map_or(type_id, |info| self.db.infer(info)),
+            TypeData::StringIntrinsic { kind, type_arg } => {
+                self.rewrite_unary(type_id, type_arg, |db, inner| {
+                    db.string_intrinsic(kind, inner)
+                })
+            }
+            TypeData::NoInfer(inner) => {
+                self.rewrite_unary(type_id, inner, |db, inner| db.no_infer(inner))
+            }
+            TypeData::Substitution {
+                base_type,
+                constraint,
+            } => {
+                let base_type_rewritten = self.rewrite(base_type);
+                let constraint_rewritten = self.rewrite(constraint);
+                if base_type_rewritten == base_type && constraint_rewritten == constraint {
+                    type_id
+                } else {
+                    self.db
+                        .substitution(base_type_rewritten, constraint_rewritten)
+                }
+            }
+        };
+
+        // Publish the structural result before walking side-table provenance;
+        // provenance can point back into the source graph.
+        self.rewritten.insert(type_id, result);
+        if result != type_id {
+            self.propagate_provenance(type_id, result);
+        }
+        result
+    }
+
+    fn rewrite_unary(
+        &mut self,
+        original: TypeId,
+        inner: TypeId,
+        build: impl FnOnce(&dyn TypeDatabase, TypeId) -> TypeId,
+    ) -> TypeId {
+        let rewritten = self.rewrite(inner);
+        if rewritten == inner {
+            original
+        } else {
+            build(self.db, rewritten)
+        }
+    }
+
+    fn rewrite_type_ids(&mut self, ids: &[TypeId]) -> Option<Vec<TypeId>> {
+        let mut changed: Option<Vec<TypeId>> = None;
+        for (index, &type_id) in ids.iter().enumerate() {
+            let rewritten = self.rewrite(type_id);
+            if let Some(changed) = &mut changed {
+                changed.push(rewritten);
+            } else if rewritten != type_id {
+                let mut values = Vec::with_capacity(ids.len());
+                values.extend_from_slice(&ids[..index]);
+                values.push(rewritten);
+                changed = Some(values);
+            }
+        }
+        changed
+    }
+
+    fn rewrite_tuple_elements(&mut self, elements: &[TupleElement]) -> Option<Vec<TupleElement>> {
+        let mut changed: Option<Vec<TupleElement>> = None;
+        for (index, element) in elements.iter().enumerate() {
+            let type_id = self.rewrite(element.type_id);
+            let rewritten = TupleElement {
+                type_id,
+                ..*element
+            };
+            if let Some(changed) = &mut changed {
+                changed.push(rewritten);
+            } else if rewritten != *element {
+                let mut values = Vec::with_capacity(elements.len());
+                values.extend_from_slice(&elements[..index]);
+                values.push(rewritten);
+                changed = Some(values);
+            }
+        }
+        changed
+    }
+
+    fn rewrite_properties(&mut self, properties: &[PropertyInfo]) -> Option<Vec<PropertyInfo>> {
+        let mut changed: Option<Vec<PropertyInfo>> = None;
+        for (index, property) in properties.iter().enumerate() {
+            let type_id = self.rewrite(property.type_id);
+            let write_type = if property.write_type == property.type_id {
+                type_id
+            } else {
+                self.rewrite(property.write_type)
+            };
+            let rewritten = PropertyInfo {
+                type_id,
+                write_type,
+                ..property.clone()
+            };
+            if let Some(changed) = &mut changed {
+                changed.push(rewritten);
+            } else if type_id != property.type_id || write_type != property.write_type {
+                let mut values = Vec::with_capacity(properties.len());
+                values.extend_from_slice(&properties[..index]);
+                values.push(rewritten);
+                changed = Some(values);
+            }
+        }
+        changed
+    }
+
+    fn rewrite_index_signature(&mut self, index: &IndexSignature) -> Option<IndexSignature> {
+        let key_type = self.rewrite(index.key_type);
+        let value_type = self.rewrite(index.value_type);
+        (key_type != index.key_type || value_type != index.value_type).then_some(IndexSignature {
+            key_type,
+            value_type,
+            ..*index
+        })
+    }
+
+    fn rewrite_params(&mut self, params: &[ParamInfo]) -> Option<Vec<ParamInfo>> {
+        let mut changed: Option<Vec<ParamInfo>> = None;
+        for (index, param) in params.iter().enumerate() {
+            let type_id = self.rewrite(param.type_id);
+            let rewritten = ParamInfo { type_id, ..*param };
+            if let Some(changed) = &mut changed {
+                changed.push(rewritten);
+            } else if rewritten != *param {
+                let mut values = Vec::with_capacity(params.len());
+                values.extend_from_slice(&params[..index]);
+                values.push(rewritten);
+                changed = Some(values);
+            }
+        }
+        changed
+    }
+
+    fn rewrite_type_param(&mut self, param: TypeParamInfo) -> Option<TypeParamInfo> {
+        let constraint = param.constraint.map(|constraint| self.rewrite(constraint));
+        let default = param.default.map(|default| self.rewrite(default));
+        let rewritten = TypeParamInfo {
+            constraint,
+            default,
+            ..param
+        };
+        (rewritten != param).then_some(rewritten)
+    }
+
+    fn rewrite_type_params(&mut self, params: &[TypeParamInfo]) -> Option<Vec<TypeParamInfo>> {
+        let mut changed: Option<Vec<TypeParamInfo>> = None;
+        for (index, &param) in params.iter().enumerate() {
+            let rewritten = self.rewrite_type_param(param).unwrap_or(param);
+            if let Some(changed) = &mut changed {
+                changed.push(rewritten);
+            } else if rewritten != param {
+                let mut values = Vec::with_capacity(params.len());
+                values.extend_from_slice(&params[..index]);
+                values.push(rewritten);
+                changed = Some(values);
+            }
+        }
+        changed
+    }
+
+    fn rewrite_predicate(&mut self, predicate: TypePredicate) -> Option<TypePredicate> {
+        let type_id = predicate.type_id.map(|type_id| self.rewrite(type_id));
+        (type_id != predicate.type_id).then_some(TypePredicate {
+            type_id,
+            ..predicate
+        })
+    }
+
+    fn rewrite_function_shape(&mut self, shape: &FunctionShape) -> Option<FunctionShape> {
+        let type_params = self.rewrite_type_params(&shape.type_params);
+        let params = self.rewrite_params(&shape.params);
+        let this_type = shape.this_type.map(|this_type| self.rewrite(this_type));
+        let return_type = self.rewrite(shape.return_type);
+        let type_predicate = shape
+            .type_predicate
+            .and_then(|predicate| self.rewrite_predicate(predicate));
+        if type_params.is_none()
+            && params.is_none()
+            && this_type == shape.this_type
+            && return_type == shape.return_type
+            && type_predicate.is_none()
+        {
+            None
+        } else {
+            Some(FunctionShape {
+                type_params: type_params.unwrap_or_else(|| shape.type_params.clone()),
+                params: params.unwrap_or_else(|| shape.params.clone()),
+                this_type,
+                return_type,
+                type_predicate: type_predicate.or(shape.type_predicate),
+                is_constructor: shape.is_constructor,
+                is_method: shape.is_method,
+            })
+        }
+    }
+
+    fn rewrite_call_signature(&mut self, signature: &CallSignature) -> Option<CallSignature> {
+        let type_params = self.rewrite_type_params(&signature.type_params);
+        let params = self.rewrite_params(&signature.params);
+        let this_type = signature.this_type.map(|this_type| self.rewrite(this_type));
+        let return_type = self.rewrite(signature.return_type);
+        let type_predicate = signature
+            .type_predicate
+            .and_then(|predicate| self.rewrite_predicate(predicate));
+        if type_params.is_none()
+            && params.is_none()
+            && this_type == signature.this_type
+            && return_type == signature.return_type
+            && type_predicate.is_none()
+        {
+            None
+        } else {
+            Some(CallSignature {
+                type_params: type_params.unwrap_or_else(|| signature.type_params.clone()),
+                params: params.unwrap_or_else(|| signature.params.clone()),
+                this_type,
+                return_type,
+                type_predicate: type_predicate.or(signature.type_predicate),
+                is_method: signature.is_method,
+            })
+        }
+    }
+
+    fn rewrite_signatures(&mut self, signatures: &[CallSignature]) -> Option<Vec<CallSignature>> {
+        let mut changed: Option<Vec<CallSignature>> = None;
+        for (index, signature) in signatures.iter().enumerate() {
+            let rewritten = self
+                .rewrite_call_signature(signature)
+                .unwrap_or_else(|| signature.clone());
+            if let Some(changed) = &mut changed {
+                changed.push(rewritten);
+            } else if rewritten != *signature {
+                let mut values = Vec::with_capacity(signatures.len());
+                values.extend_from_slice(&signatures[..index]);
+                values.push(rewritten);
+                changed = Some(values);
+            }
+        }
+        changed
+    }
+
+    fn rewrite_callable_shape(&mut self, shape: &CallableShape) -> Option<CallableShape> {
+        let call_signatures = self.rewrite_signatures(&shape.call_signatures);
+        let construct_signatures = self.rewrite_signatures(&shape.construct_signatures);
+        let properties = self.rewrite_properties(&shape.properties);
+        let string_index = shape
+            .string_index
+            .as_ref()
+            .and_then(|index| self.rewrite_index_signature(index));
+        let number_index = shape
+            .number_index
+            .as_ref()
+            .and_then(|index| self.rewrite_index_signature(index));
+        if call_signatures.is_none()
+            && construct_signatures.is_none()
+            && properties.is_none()
+            && string_index.is_none()
+            && number_index.is_none()
+        {
+            None
+        } else {
+            Some(CallableShape {
+                call_signatures: call_signatures.unwrap_or_else(|| shape.call_signatures.clone()),
+                construct_signatures: construct_signatures
+                    .unwrap_or_else(|| shape.construct_signatures.clone()),
+                properties: properties.unwrap_or_else(|| shape.properties.clone()),
+                string_index: string_index.or(shape.string_index),
+                number_index: number_index.or(shape.number_index),
+                symbol: shape.symbol,
+                is_abstract: shape.is_abstract,
+            })
+        }
+    }
+
+    fn rewrite_template_spans(&mut self, spans: &[TemplateSpan]) -> Option<Vec<TemplateSpan>> {
+        let mut changed: Option<Vec<TemplateSpan>> = None;
+        for (index, span) in spans.iter().enumerate() {
+            let rewritten = match span {
+                TemplateSpan::Text(text) => TemplateSpan::Text(*text),
+                TemplateSpan::Type(type_id) => TemplateSpan::Type(self.rewrite(*type_id)),
+            };
+            if let Some(changed) = &mut changed {
+                changed.push(rewritten);
+            } else if rewritten != *span {
+                let mut values = Vec::with_capacity(spans.len());
+                values.extend_from_slice(&spans[..index]);
+                values.push(rewritten);
+                changed = Some(values);
+            }
+        }
+        changed
+    }
+
+    fn propagate_provenance(&mut self, source: TypeId, result: TypeId) {
+        if let Some(properties) = self.db.get_display_properties(source) {
+            let properties = self
+                .rewrite_properties(properties.as_ref())
+                .unwrap_or_else(|| properties.as_ref().clone());
+            self.db.store_display_properties(result, properties);
+        }
+
+        if let Some(origin) = self.db.get_union_origin(source) {
+            let origin = self
+                .rewrite_type_ids(origin.as_ref())
+                .unwrap_or_else(|| origin.as_ref().clone());
+            self.db.store_union_origin(result, origin);
+        }
+
+        // Application provenance is first-write-wins. Publish it before
+        // replaying a merged origin, whose member reconstruction can intern the
+        // same structural result through a different application.
+        if self.db.get_application_eval_origin(result).is_none()
+            && let Some(origin) = self.db.get_application_eval_origin(source)
+        {
+            let origin = self.rewrite(origin);
+            self.db.record_application_eval_origin(result, origin);
+        }
+
+        if self.db.get_merged_intersection_origin(result).is_none()
+            && let Some(origin) = self.db.get_merged_intersection_origin(source)
+        {
+            let rewritten_origin = self.rewrite(origin);
+            let raw_origin = self
+                .db
+                .get_merged_intersection_origin(rewritten_origin)
+                .unwrap_or(rewritten_origin);
+            self.db.store_merged_intersection_origin(result, raw_origin);
+        }
+
+        if let Some(alias) = self.db.get_display_alias(source) {
+            let alias = self.rewrite(alias);
+            if matches!(self.db.lookup(alias), Some(TypeData::Application(_))) {
+                self.db
+                    .store_display_alias_preferring_application(result, alias);
+            } else if self.db.get_display_alias(result).is_none() {
+                self.db.store_display_alias(result, alias);
+            }
+        }
+
+        if self.db.is_conditional_alias_base(source) {
+            self.db.mark_conditional_alias_base(result);
+        }
+        if self.db.is_global_this_surface_display(source) {
+            self.db.mark_global_this_surface_display(result);
+        }
+        if self.db.is_literal_object_annotation(source) {
+            self.db.mark_literal_object_annotation(result);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::def::DefId;
+    use crate::intern::TypeInterner;
+
+    fn fresh_param(db: &TypeInterner, name: &str) -> TypeId {
+        db.fresh_type_param(TypeParamInfo::simple(db.intern_string(name)))
+    }
+
+    fn tuple_members(db: &TypeInterner, type_id: TypeId) -> Vec<TypeId> {
+        let Some(TypeData::Tuple(list_id)) = db.lookup(type_id) else {
+            panic!("expected tuple, got {:?}", db.lookup(type_id));
+        };
+        db.tuple_list(list_id)
+            .iter()
+            .map(|element| element.type_id)
+            .collect()
+    }
+
+    #[test]
+    fn exact_rewrite_batches_shared_nodes_and_is_simultaneous() {
+        let db = TypeInterner::new();
+        let first = fresh_param(&db, "First");
+        let second = fresh_param(&db, "Second");
+        let shared = db.application(TypeId::OBJECT, vec![first, second]);
+        let root = db.tuple(vec![
+            TupleElement::fixed(first),
+            TupleElement::fixed(second),
+            TupleElement::fixed(shared),
+            TupleElement::fixed(shared),
+        ]);
+
+        let result = substitute_exact_types(&db, root, &[first, second], &[second, first]);
+        let members = tuple_members(&db, result);
+        assert_eq!(members[0], second);
+        assert_eq!(members[1], first);
+        assert_eq!(members[2], members[3]);
+
+        let Some(TypeData::Application(app_id)) = db.lookup(members[2]) else {
+            panic!("expected application");
+        };
+        let app = db.type_application(app_id);
+        assert_eq!(app.args, vec![second, first]);
+    }
+
+    #[test]
+    fn exact_rewrite_uses_identity_not_same_named_binder() {
+        let db = TypeInterner::new();
+        let declaration = fresh_param(&db, "Tail");
+        let foreign = fresh_param(&db, "Tail");
+        assert_ne!(declaration, foreign);
+        let root = db.tuple(vec![
+            TupleElement::fixed(declaration),
+            TupleElement::fixed(foreign),
+        ]);
+
+        let result = substitute_exact_type(&db, root, declaration, TypeId::STRING);
+        assert_eq!(tuple_members(&db, result), vec![TypeId::STRING, foreign]);
+
+        let no_match = db.array(foreign);
+        assert_eq!(
+            substitute_exact_type(&db, no_match, declaration, TypeId::STRING),
+            no_match,
+        );
+    }
+
+    #[test]
+    fn exact_rewrite_reaches_mapped_binder_and_surface_fields() {
+        let db = TypeInterner::new();
+        let outer = fresh_param(&db, "Outer");
+        let iter_info = TypeParamInfo {
+            name: db.intern_string("Key"),
+            constraint: Some(outer),
+            default: Some(db.array(outer)),
+            is_const: true,
+            origin: crate::types::TypeParamOrigin::User,
+        };
+        let mapped = db.mapped(MappedType {
+            type_param: iter_info,
+            constraint: outer,
+            name_type: Some(db.readonly_type(outer)),
+            template: db.array(outer),
+            readonly_modifier: None,
+            optional_modifier: None,
+        });
+
+        let result = substitute_exact_type(&db, mapped, outer, TypeId::STRING);
+        let Some(TypeData::Mapped(mapped_id)) = db.lookup(result) else {
+            panic!("expected mapped type");
+        };
+        let mapped = db.get_mapped(mapped_id);
+        assert_eq!(mapped.type_param.constraint, Some(TypeId::STRING));
+        assert_eq!(mapped.type_param.default, Some(db.array(TypeId::STRING)));
+        assert!(mapped.type_param.is_const);
+        assert_eq!(mapped.constraint, TypeId::STRING);
+        assert_eq!(mapped.name_type, Some(db.readonly_type(TypeId::STRING)));
+        assert_eq!(mapped.template, db.array(TypeId::STRING));
+    }
+
+    #[test]
+    fn exact_rewrite_reaches_function_callable_and_index_metadata() {
+        let db = TypeInterner::new();
+        let outer = fresh_param(&db, "Outer");
+        let signature_param = TypeParamInfo {
+            name: db.intern_string("Inner"),
+            constraint: Some(outer),
+            default: Some(db.array(outer)),
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        };
+        let predicate = TypePredicate {
+            asserts: false,
+            target: crate::types::TypePredicateTarget::This,
+            type_id: Some(outer),
+            parameter_index: None,
+        };
+        let function = db.function(FunctionShape {
+            type_params: vec![signature_param],
+            params: vec![ParamInfo {
+                type_id: outer,
+                ..ParamInfo::default()
+            }],
+            this_type: Some(outer),
+            return_type: db.array(outer),
+            type_predicate: Some(predicate),
+            is_constructor: false,
+            is_method: true,
+        });
+        let call_signature = CallSignature {
+            type_params: vec![signature_param],
+            params: vec![ParamInfo {
+                type_id: outer,
+                ..ParamInfo::default()
+            }],
+            this_type: Some(outer),
+            return_type: outer,
+            type_predicate: Some(predicate),
+            is_method: true,
+        };
+        let callable = db.callable(CallableShape {
+            call_signatures: vec![call_signature],
+            construct_signatures: Vec::new(),
+            properties: vec![PropertyInfo::new(db.intern_string("value"), outer)],
+            string_index: Some(IndexSignature {
+                key_type: outer,
+                value_type: db.array(outer),
+                readonly: true,
+                param_name: None,
+            }),
+            number_index: None,
+            symbol: None,
+            is_abstract: false,
+        });
+        let root = db.tuple(vec![
+            TupleElement::fixed(function),
+            TupleElement::fixed(callable),
+        ]);
+
+        let result = substitute_exact_type(&db, root, outer, TypeId::NUMBER);
+        let members = tuple_members(&db, result);
+        let Some(TypeData::Function(function_id)) = db.lookup(members[0]) else {
+            panic!("expected function");
+        };
+        let function = db.function_shape(function_id);
+        assert_eq!(function.type_params[0].constraint, Some(TypeId::NUMBER));
+        assert_eq!(function.params[0].type_id, TypeId::NUMBER);
+        assert_eq!(function.this_type, Some(TypeId::NUMBER));
+        assert_eq!(function.return_type, db.array(TypeId::NUMBER));
+        assert_eq!(
+            function
+                .type_predicate
+                .expect("rewritten function should retain its predicate")
+                .type_id,
+            Some(TypeId::NUMBER)
+        );
+
+        let Some(TypeData::Callable(callable_id)) = db.lookup(members[1]) else {
+            panic!("expected callable");
+        };
+        let callable = db.callable_shape(callable_id);
+        assert_eq!(
+            callable.call_signatures[0].type_params[0].default,
+            Some(db.array(TypeId::NUMBER)),
+        );
+        assert_eq!(callable.properties[0].type_id, TypeId::NUMBER);
+        let index = callable
+            .string_index
+            .expect("rewritten callable should retain its string index");
+        assert_eq!(index.key_type, TypeId::NUMBER);
+        assert_eq!(index.value_type, db.array(TypeId::NUMBER));
+    }
+
+    #[test]
+    fn exact_rewrite_reaches_parameter_infer_enum_and_substitution_fields() {
+        let db = TypeInterner::new();
+        let outer = fresh_param(&db, "Outer");
+        let base = fresh_param(&db, "Base");
+        let info = TypeParamInfo {
+            name: db.intern_string("Nested"),
+            constraint: Some(outer),
+            default: Some(db.array(outer)),
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        };
+        let nested_param = db.type_param(info);
+        let infer = db.infer(info);
+        let enum_type = db.enum_type(DefId(7), outer);
+        let substitution = db.substitution(base, outer);
+        assert!(matches!(
+            db.lookup(substitution),
+            Some(TypeData::Substitution { .. })
+        ));
+        let root = db.tuple(vec![
+            TupleElement::fixed(nested_param),
+            TupleElement::fixed(infer),
+            TupleElement::fixed(enum_type),
+            TupleElement::fixed(substitution),
+        ]);
+
+        let result = substitute_exact_type(&db, root, outer, TypeId::STRING);
+        let members = tuple_members(&db, result);
+        for member in &members[..2] {
+            let info = match db.lookup(*member) {
+                Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => info,
+                other => panic!("expected parameter metadata, got {other:?}"),
+            };
+            assert_eq!(info.constraint, Some(TypeId::STRING));
+            assert_eq!(info.default, Some(db.array(TypeId::STRING)));
+        }
+        assert_eq!(
+            db.lookup(members[2]),
+            Some(TypeData::Enum(DefId(7), TypeId::STRING))
+        );
+        assert_eq!(
+            db.lookup(members[3]),
+            Some(TypeData::Substitution {
+                base_type: base,
+                constraint: TypeId::STRING,
+            }),
+        );
+    }
+
+    #[test]
+    fn exact_rewrite_preserves_distinct_fresh_type_parameter_identities() {
+        let db = TypeInterner::new();
+        let outer = fresh_param(&db, "Outer");
+        let nested_info = TypeParamInfo {
+            name: db.intern_string("Nested"),
+            constraint: Some(outer),
+            default: None,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        };
+        let first = db.fresh_type_param(nested_info);
+        let second = db.fresh_type_param(nested_info);
+        assert_ne!(first, second);
+
+        let function = db.function(FunctionShape {
+            type_params: Vec::new(),
+            params: vec![ParamInfo {
+                type_id: first,
+                ..ParamInfo::default()
+            }],
+            this_type: None,
+            return_type: TypeId::VOID,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        });
+        let callable = db.callable(CallableShape {
+            call_signatures: vec![CallSignature {
+                type_params: Vec::new(),
+                params: vec![ParamInfo {
+                    type_id: second,
+                    ..ParamInfo::default()
+                }],
+                this_type: None,
+                return_type: TypeId::VOID,
+                type_predicate: None,
+                is_method: false,
+            }],
+            construct_signatures: Vec::new(),
+            properties: Vec::new(),
+            string_index: None,
+            number_index: None,
+            symbol: None,
+            is_abstract: false,
+        });
+        let root = db.tuple(vec![
+            TupleElement::fixed(function),
+            TupleElement::fixed(callable),
+        ]);
+
+        let result = substitute_exact_type(&db, root, outer, TypeId::STRING);
+        let members = tuple_members(&db, result);
+        let Some(TypeData::Function(function_id)) = db.lookup(members[0]) else {
+            panic!("expected function");
+        };
+        let rewritten_first = db.function_shape(function_id).params[0].type_id;
+        let Some(TypeData::Callable(callable_id)) = db.lookup(members[1]) else {
+            panic!("expected callable");
+        };
+        let rewritten_second = db.callable_shape(callable_id).call_signatures[0].params[0].type_id;
+
+        assert_ne!(rewritten_first, rewritten_second);
+        for rewritten in [rewritten_first, rewritten_second] {
+            let Some(TypeData::TypeParameter(info)) = db.lookup(rewritten) else {
+                panic!("expected fresh type parameter");
+            };
+            assert_eq!(info.constraint, Some(TypeId::STRING));
+        }
+    }
+
+    #[test]
+    fn exact_rewrite_preserves_rewritten_object_provenance() {
+        let db = TypeInterner::new();
+        let outer = fresh_param(&db, "Outer");
+        // Application display aliases are preferred only when they predate the
+        // evaluated structural result, matching normal evaluator allocation.
+        let application_origin = db.application(db.lazy(DefId(11)), vec![outer]);
+        let left = db.object(vec![PropertyInfo::new(db.intern_string("left"), outer)]);
+        let right = db.object(vec![PropertyInfo::new(
+            db.intern_string("right"),
+            TypeId::NUMBER,
+        )]);
+        let source = db.intersection(vec![left, right]);
+        assert!(db.get_merged_intersection_origin(source).is_some());
+
+        db.store_display_properties(
+            source,
+            vec![PropertyInfo::new(db.intern_string("shown"), outer)],
+        );
+        db.record_application_eval_origin(source, application_origin);
+        db.store_display_alias_preferring_application(source, application_origin);
+
+        let result = substitute_exact_type(&db, source, outer, TypeId::STRING);
+        assert_ne!(result, source);
+        assert_eq!(
+            db.get_display_properties(result)
+                .expect("rewritten object should retain display properties")[0]
+                .type_id,
+            TypeId::STRING,
+        );
+        assert!(db.get_merged_intersection_origin(result).is_some());
+
+        let origin = db
+            .get_application_eval_origin(result)
+            .expect("rewritten object should retain its application origin");
+        let Some(TypeData::Application(app_id)) = db.lookup(origin) else {
+            panic!("expected application origin");
+        };
+        assert_eq!(db.type_application(app_id).args, vec![TypeId::STRING]);
+        assert_eq!(db.get_display_alias(result), Some(origin));
+    }
+}

--- a/crates/tsz-solver/src/instantiation/instantiate/exact_rewrite.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/exact_rewrite.rs
@@ -14,6 +14,144 @@ use crate::types::{
 use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
 
+/// Reusable mapping produced by one completed exact-identity rewrite.
+///
+/// The representation is intentionally opaque. It retains direct replacement
+/// pairs and structurally changed source-to-target pairs, but drops unchanged
+/// visitation entries. One memo is reusable for every root that shares the
+/// same exact replacement pairs; root results and shared structural mappings
+/// are retained once per session. Cache owners use
+/// [`Self::refresh_provenance`] before returning an associated rewritten type.
+#[derive(Clone, Debug)]
+pub struct ExactRewriteMemo {
+    mapped: FxHashMap<TypeId, TypeId>,
+    provenance_sources: Vec<TypeId>,
+    root_results: FxHashMap<TypeId, TypeId>,
+    provenance_generation: u64,
+}
+
+/// A shared solver-frame limit prevented an exact rewrite from completing.
+///
+/// Aborted attempts do not publish provenance or reusable memo state. Callers
+/// must preserve the original type and may retry under a fresh frame budget.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExactRewriteAborted;
+
+impl ExactRewriteMemo {
+    fn merge_delta(&mut self, delta: ExactRewriteDelta) {
+        self.mapped.extend(delta.mapped);
+        self.provenance_sources.extend(delta.provenance_sources);
+    }
+
+    /// Replay all currently attached source provenance onto the previously
+    /// mapped target nodes.
+    ///
+    /// Existing structural mappings seed the walk, so refreshing provenance
+    /// never remints a nested fresh type parameter that the completed rewrite
+    /// already rebuilt. New provenance-only subgraphs extend the memo only after
+    /// the whole refresh completes. On [`ExactRewriteAborted`], neither this memo
+    /// nor any provenance side table is mutated.
+    pub fn refresh_provenance(
+        &mut self,
+        db: &dyn QueryDatabase,
+    ) -> Result<(), ExactRewriteAborted> {
+        let provenance_generation = db.display_provenance_generation();
+        if provenance_generation == self.provenance_generation {
+            return Ok(());
+        }
+
+        let delta = {
+            let mut rewriter = ExactTypeRewriter {
+                db,
+                base_mappings: Some(&self.mapped),
+                rewritten: FxHashMap::default(),
+                provenance_sources: Vec::new(),
+                aborted: false,
+                pending_provenance: Vec::new(),
+            };
+            for &source in &self.provenance_sources {
+                debug_assert!(
+                    self.mapped.contains_key(&source),
+                    "provenance source must have a retained mapping",
+                );
+                let Some(&result) = self.mapped.get(&source) else {
+                    continue;
+                };
+                rewriter.propagate_provenance(source, result);
+                if rewriter.aborted {
+                    break;
+                }
+            }
+            rewriter.commit()?
+        };
+
+        self.merge_delta(delta);
+        // Retain the pre-scan snapshot. Provenance committed by this replay or
+        // written concurrently advances the universe generation and therefore
+        // forces another scan; a no-op scan then converges to the current value.
+        // Reading after commit could acknowledge a write that landed behind the
+        // scan cursor and permanently skip it.
+        self.provenance_generation = provenance_generation;
+        Ok(())
+    }
+
+    /// Rewrite another root with this session's exact replacement pairs.
+    ///
+    /// A previously completed root is an `O(1)` result lookup plus the
+    /// provenance-generation check. A new root reuses all retained structural
+    /// mappings, so shared subgraphs and nested fresh binders keep their exact
+    /// rewritten identities. Provenance refresh and the new root walk commit as
+    /// one transaction: on [`ExactRewriteAborted`], neither the memo nor any
+    /// provenance side table is mutated. Callers must not cache the failed root
+    /// result and may retry it under a fresh frame budget.
+    pub fn rewrite_root(
+        &mut self,
+        db: &dyn QueryDatabase,
+        root: TypeId,
+    ) -> Result<TypeId, ExactRewriteAborted> {
+        if let Some(&result) = self.root_results.get(&root) {
+            self.refresh_provenance(db)?;
+            return Ok(result);
+        }
+
+        let provenance_generation = db.display_provenance_generation();
+        let refresh_provenance = provenance_generation != self.provenance_generation;
+        let (result, delta) = {
+            let mut rewriter = ExactTypeRewriter {
+                db,
+                base_mappings: Some(&self.mapped),
+                rewritten: FxHashMap::default(),
+                provenance_sources: Vec::new(),
+                aborted: false,
+                pending_provenance: Vec::new(),
+            };
+            if refresh_provenance {
+                for &source in &self.provenance_sources {
+                    debug_assert!(
+                        self.mapped.contains_key(&source),
+                        "provenance source must have a retained mapping",
+                    );
+                    let Some(&mapped) = self.mapped.get(&source) else {
+                        continue;
+                    };
+                    rewriter.propagate_provenance(source, mapped);
+                    if rewriter.aborted {
+                        break;
+                    }
+                }
+            }
+            let result = rewriter.rewrite(root);
+            let delta = rewriter.commit()?;
+            (result, delta)
+        };
+
+        self.merge_delta(delta);
+        self.root_results.insert(root, result);
+        self.provenance_generation = provenance_generation;
+        Ok(result)
+    }
+}
+
 /// Replace aligned exact identities throughout `root` in one graph walk.
 ///
 /// Replacements are simultaneous: a replacement value is terminal and is not
@@ -32,9 +170,38 @@ pub fn substitute_exact_types(
     from: &[TypeId],
     to: &[TypeId],
 ) -> TypeId {
+    substitute_exact_types_with_memo(db, root, from, to).map_or(root, |(result, _memo)| result)
+}
+
+/// Replace aligned exact identities and retain the completed structural map
+/// for provenance refreshes by cache owners.
+///
+/// [`ExactRewriteAborted`] is distinct from a successful no-op rewrite. No
+/// provenance is published and no memo is returned when the shared solver-frame
+/// budget aborts the walk. The aligned pairs must be scoped binder identities:
+/// direct replacements are terminal and their source provenance is deliberately
+/// not copied onto the replacement identity. Copying it would repaint a shared
+/// active binder that belongs to the destination scope.
+pub fn substitute_exact_types_with_memo(
+    db: &dyn QueryDatabase,
+    root: TypeId,
+    from: &[TypeId],
+    to: &[TypeId],
+) -> Result<(TypeId, ExactRewriteMemo), ExactRewriteAborted> {
     debug_assert_eq!(from.len(), to.len());
+    let provenance_generation = db.display_provenance_generation();
     if from.len() != to.len() || from.is_empty() {
-        return root;
+        let mut root_results = FxHashMap::default();
+        root_results.insert(root, root);
+        return Ok((
+            root,
+            ExactRewriteMemo {
+                mapped: FxHashMap::default(),
+                provenance_sources: Vec::new(),
+                root_results,
+                provenance_generation,
+            },
+        ));
     }
 
     let mut rewritten = FxHashMap::with_capacity_and_hasher(from.len(), Default::default());
@@ -56,17 +223,40 @@ pub fn substitute_exact_types(
         }
     }
     if rewritten.is_empty() {
-        return root;
+        let mut root_results = FxHashMap::default();
+        root_results.insert(root, root);
+        return Ok((
+            root,
+            ExactRewriteMemo {
+                mapped: rewritten,
+                provenance_sources: Vec::new(),
+                root_results,
+                provenance_generation,
+            },
+        ));
     }
 
     let mut rewriter = ExactTypeRewriter {
         db,
+        base_mappings: None,
         rewritten,
+        provenance_sources: Vec::new(),
         aborted: false,
         pending_provenance: Vec::new(),
     };
     let result = rewriter.rewrite(root);
-    rewriter.finish(root, result)
+    let delta = rewriter.commit()?;
+    let mut root_results = FxHashMap::default();
+    root_results.insert(root, result);
+    Ok((
+        result,
+        ExactRewriteMemo {
+            mapped: delta.mapped,
+            provenance_sources: delta.provenance_sources,
+            root_results,
+            provenance_generation,
+        },
+    ))
 }
 
 /// Replace one exact interned identity throughout a type graph.
@@ -86,9 +276,15 @@ pub fn substitute_exact_type(
 
 struct ExactTypeRewriter<'a> {
     db: &'a dyn QueryDatabase,
-    /// Preloaded with direct replacements, then extended with per-node memoized
-    /// results. Direct replacements therefore remain terminal.
+    /// Retained mappings from a previous completed walk. These are read-only
+    /// until this attempt commits, so an abort cannot poison reusable state.
+    base_mappings: Option<&'a FxHashMap<TypeId, TypeId>>,
+    /// Preloaded with direct replacements on the first walk, then extended with
+    /// this attempt's per-node results. Direct replacements remain terminal.
     rewritten: FxHashMap<TypeId, TypeId>,
+    /// Structurally changed sources discovered by this attempt. Only these
+    /// sources can need future provenance replay.
+    provenance_sources: Vec<TypeId>,
     /// Sticky shared-frame bailout. Once set, every active caller preserves its
     /// source node and the public operation returns its original root.
     aborted: bool,
@@ -96,6 +292,11 @@ struct ExactTypeRewriter<'a> {
     /// interned during a walk, but no side table is mutated unless the whole
     /// reachable graph completes within the shared solver-frame budget.
     pending_provenance: Vec<PendingProvenance>,
+}
+
+struct ExactRewriteDelta {
+    mapped: FxHashMap<TypeId, TypeId>,
+    provenance_sources: Vec<TypeId>,
 }
 
 enum PendingProvenance {
@@ -116,6 +317,12 @@ impl ExactTypeRewriter<'_> {
             return type_id;
         }
         if let Some(&cached) = self.rewritten.get(&type_id) {
+            return cached;
+        }
+        if let Some(&cached) = self
+            .base_mappings
+            .and_then(|mappings| mappings.get(&type_id))
+        {
             return cached;
         }
         if type_id.is_intrinsic() {
@@ -344,14 +551,15 @@ impl ExactTypeRewriter<'_> {
         // provenance can point back into the source graph.
         self.rewritten.insert(type_id, result);
         if result != type_id {
+            self.provenance_sources.push(type_id);
             self.propagate_provenance(type_id, result);
         }
         if self.aborted { type_id } else { result }
     }
 
-    fn finish(self, original: TypeId, result: TypeId) -> TypeId {
+    fn commit(self) -> Result<ExactRewriteDelta, ExactRewriteAborted> {
         if self.aborted {
-            return original;
+            return Err(ExactRewriteAborted);
         }
         for provenance in self.pending_provenance {
             match provenance {
@@ -387,7 +595,15 @@ impl ExactTypeRewriter<'_> {
                 }
             }
         }
-        result
+        let mapped = self
+            .rewritten
+            .into_iter()
+            .filter(|(source, result)| source != result)
+            .collect();
+        Ok(ExactRewriteDelta {
+            mapped,
+            provenance_sources: self.provenance_sources,
+        })
     }
 
     fn rewrite_unary(
@@ -1342,6 +1558,240 @@ mod tests {
         assert_eq!(
             substitute_exact_type(&db, shallow_array, outer, TypeId::STRING),
             db.array(TypeId::STRING),
+        );
+    }
+
+    #[test]
+    fn exact_rewrite_memo_refreshes_late_provenance_and_converges_generation() {
+        let db = TypeInterner::new();
+        let outer = fresh_param(&db, "Outer");
+        let replacement = fresh_param(&db, "Replacement");
+        let alias_base = db.lazy(DefId(31));
+        let source_application = db.application(alias_base, vec![outer]);
+        let nested_source = db.union_preserve_members(vec![outer, TypeId::STRING]);
+        let source = db.union_preserve_members(vec![nested_source, TypeId::NUMBER]);
+
+        let (result, mut memo) =
+            substitute_exact_types_with_memo(&db, source, &[outer], &[replacement])
+                .expect("the initial exact rewrite should complete");
+        let rewritten_nested = db.union_preserve_members(vec![replacement, TypeId::STRING]);
+        let rewritten_application = db.application(alias_base, vec![replacement]);
+        assert!(db.get_display_properties(result).is_none());
+        assert!(db.get_union_origin(result).is_none());
+        assert!(db.get_application_eval_origin(result).is_none());
+        assert!(db.get_display_alias(result).is_none());
+
+        let shown = db.intern_string("shown");
+        db.store_display_properties(
+            source,
+            vec![PropertyInfo {
+                declaration_order: 1,
+                ..PropertyInfo::new(shown, nested_source)
+            }],
+        );
+        db.store_union_origin(source, vec![nested_source, TypeId::NUMBER]);
+        db.record_application_eval_origin(source, source_application);
+        db.store_display_alias_preferring_application(source, source_application);
+
+        memo.refresh_provenance(&db)
+            .expect("late provenance replay should complete");
+        let properties = db
+            .get_display_properties(result)
+            .expect("late display properties should reach the rewritten root");
+        assert_eq!(properties[0].type_id, rewritten_nested);
+        assert_eq!(properties[0].declaration_order, 1);
+        assert_eq!(
+            db.get_union_origin(result)
+                .expect("late union origin should reach the rewritten root")
+                .as_slice(),
+            &[rewritten_nested, TypeId::NUMBER],
+        );
+        assert_eq!(
+            db.get_application_eval_origin(result),
+            Some(rewritten_application),
+        );
+        assert_eq!(db.get_display_alias(result), Some(rewritten_application));
+
+        // A replay can advance the universe generation with its own target
+        // writes. One no-op scan converges; later hits take the `O(1)` gate.
+        let replay_generation = db.display_provenance_generation();
+        memo.refresh_provenance(&db)
+            .expect("the convergence replay should complete");
+        assert_eq!(db.display_provenance_generation(), replay_generation);
+        assert_eq!(memo.provenance_generation, replay_generation);
+        memo.refresh_provenance(&db)
+            .expect("an unchanged generation should be an immediate hit");
+        assert_eq!(db.display_provenance_generation(), replay_generation);
+
+        // `PropertyInfo` structural equality intentionally ignores declaration
+        // order. The provenance epoch must still notice this display-only edit.
+        db.store_display_properties(
+            source,
+            vec![PropertyInfo {
+                declaration_order: 9,
+                ..PropertyInfo::new(shown, nested_source)
+            }],
+        );
+        assert_ne!(db.display_provenance_generation(), replay_generation);
+        memo.refresh_provenance(&db)
+            .expect("display-only metadata changes must replay");
+        assert_eq!(
+            db.get_display_properties(result)
+                .expect("rewritten display properties should be replaced")[0]
+                .declaration_order,
+            9,
+        );
+    }
+
+    #[test]
+    fn exact_rewrite_memo_reuses_nested_fresh_binders_across_roots() {
+        let db = TypeInterner::new();
+        let outer = fresh_param(&db, "Outer");
+        let nested = db.fresh_type_param(TypeParamInfo {
+            name: db.intern_string("Nested"),
+            constraint: Some(outer),
+            default: None,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        });
+        let first_root = db.tuple(vec![
+            TupleElement::fixed(nested),
+            TupleElement::fixed(db.array(nested)),
+        ]);
+
+        let (first_result, mut memo) =
+            substitute_exact_types_with_memo(&db, first_root, &[outer], &[TypeId::STRING])
+                .expect("the initial exact rewrite should complete");
+        let rewritten_nested = tuple_members(&db, first_result)[0];
+        assert_ne!(rewritten_nested, nested);
+        let Some(TypeData::TypeParameter(info)) = db.lookup(rewritten_nested) else {
+            panic!("expected a rewritten fresh type parameter");
+        };
+        assert_eq!(info.constraint, Some(TypeId::STRING));
+
+        db.store_display_properties(
+            first_root,
+            vec![PropertyInfo::new(db.intern_string("shown"), nested)],
+        );
+        memo.refresh_provenance(&db)
+            .expect("late provenance replay should complete");
+        assert_eq!(
+            db.get_display_properties(first_result)
+                .expect("rewritten root should receive late display properties")[0]
+                .type_id,
+            rewritten_nested,
+        );
+        memo.refresh_provenance(&db)
+            .expect("the generation should converge after target writes");
+
+        let second_root = db.array(nested);
+        let second_result = memo
+            .rewrite_root(&db, second_root)
+            .expect("a second root should reuse the completed session");
+        assert_eq!(second_result, db.array(rewritten_nested));
+        assert_eq!(
+            memo.rewrite_root(&db, second_root)
+                .expect("a completed root should be reusable"),
+            second_result,
+        );
+    }
+
+    #[test]
+    fn exact_rewrite_direct_binder_pairs_do_not_repaint_replacements() {
+        let db = TypeInterner::new();
+        let source_binder = fresh_param(&db, "Source");
+        let active_binder = fresh_param(&db, "Active");
+        let shown = db.intern_string("shown");
+        db.store_display_properties(
+            source_binder,
+            vec![PropertyInfo::new(shown, TypeId::STRING)],
+        );
+
+        let root = db.array(source_binder);
+        let (result, mut memo) =
+            substitute_exact_types_with_memo(&db, root, &[source_binder], &[active_binder])
+                .expect("the binder rewrite should complete");
+        assert_eq!(result, db.array(active_binder));
+        assert!(db.get_display_properties(active_binder).is_none());
+
+        db.store_display_properties(
+            source_binder,
+            vec![PropertyInfo::new(shown, TypeId::NUMBER)],
+        );
+        memo.refresh_provenance(&db)
+            .expect("late structural provenance should refresh");
+        assert!(
+            db.get_display_properties(active_binder).is_none(),
+            "a terminal direct pair must not repaint the destination binder",
+        );
+    }
+
+    #[test]
+    fn exact_rewrite_abort_is_retryable_and_refresh_is_transactional() {
+        let db = TypeInterner::new();
+        let outer = fresh_param(&db, "Outer");
+        let shown = db.intern_string("shown");
+        let source = db.array(db.array(outer));
+        let expected = db.array(db.array(TypeId::STRING));
+        db.store_display_properties(source, vec![PropertyInfo::new(shown, outer)]);
+
+        let held_frames: Vec<_> = (0..crate::recursion::MAX_SOLVER_STACK_FRAMES - 1)
+            .map(|_| {
+                crate::recursion::try_enter_solver_frame()
+                    .expect("test should reserve all but one solver frame")
+            })
+            .collect();
+        assert!(matches!(
+            substitute_exact_types_with_memo(&db, source, &[outer], &[TypeId::STRING]),
+            Err(ExactRewriteAborted),
+        ));
+        assert!(db.get_display_properties(expected).is_none());
+        drop(held_frames);
+
+        let (result, mut memo) =
+            substitute_exact_types_with_memo(&db, source, &[outer], &[TypeId::STRING])
+                .expect("the same rewrite should retry under a fresh frame budget");
+        assert_eq!(result, expected);
+        assert_eq!(
+            db.get_display_properties(result)
+                .expect("the completed retry should commit provenance")[0]
+                .type_id,
+            TypeId::STRING,
+        );
+
+        let late_source = db.readonly_type(db.tuple(vec![TupleElement::fixed(outer)]));
+        let late_result = db.readonly_type(db.tuple(vec![TupleElement::fixed(TypeId::STRING)]));
+        db.store_display_properties(source, vec![PropertyInfo::new(shown, late_source)]);
+        let mapped_before = memo.mapped.clone();
+        let sources_before = memo.provenance_sources.clone();
+        let roots_before = memo.root_results.clone();
+        let generation_before = memo.provenance_generation;
+        let held_frames: Vec<_> = (0..crate::recursion::MAX_SOLVER_STACK_FRAMES - 1)
+            .map(|_| {
+                crate::recursion::try_enter_solver_frame()
+                    .expect("test should reserve all but one solver frame")
+            })
+            .collect();
+        assert_eq!(memo.refresh_provenance(&db), Err(ExactRewriteAborted));
+        assert_eq!(memo.mapped, mapped_before);
+        assert_eq!(memo.provenance_sources, sources_before);
+        assert_eq!(memo.root_results, roots_before);
+        assert_eq!(memo.provenance_generation, generation_before);
+        assert_eq!(
+            db.get_display_properties(result)
+                .expect("failed refresh must preserve prior target provenance")[0]
+                .type_id,
+            TypeId::STRING,
+        );
+        drop(held_frames);
+
+        memo.refresh_provenance(&db)
+            .expect("the provenance refresh should retry after frames unwind");
+        assert_eq!(
+            db.get_display_properties(result)
+                .expect("successful retry should commit late provenance")[0]
+                .type_id,
+            late_result,
         );
     }
 }

--- a/crates/tsz-solver/src/instantiation/instantiate/exact_rewrite.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/exact_rewrite.rs
@@ -206,7 +206,9 @@ impl ExactTypeRewriter<'_> {
             }
             TypeData::Intersection(list_id) => self
                 .rewrite_type_ids(self.db.type_list(list_id).as_ref())
-                .map_or(type_id, |members| self.db.intersect_types_raw(members)),
+                .map_or(type_id, |members| {
+                    self.db.intersect_types_raw_for_replay(members)
+                }),
             TypeData::Array(element) => {
                 let rewritten = self.rewrite(element);
                 if self.aborted || rewritten == element {
@@ -746,6 +748,25 @@ mod tests {
             .collect()
     }
 
+    const COMPLEX_REPLAY_UNION_WIDTH: usize = 317;
+    const _: () = assert!(COMPLEX_REPLAY_UNION_WIDTH * COMPLEX_REPLAY_UNION_WIDTH >= 100_000);
+
+    fn complex_replay_intersection(db: &TypeInterner, outer: TypeId) -> TypeId {
+        let mut left = Vec::with_capacity(COMPLEX_REPLAY_UNION_WIDTH);
+        left.push(outer);
+        for index in 1..COMPLEX_REPLAY_UNION_WIDTH {
+            left.push(db.literal_string(&format!("left{index}")));
+        }
+        let left = db.union_preserve_members(left);
+
+        let right = (0..COMPLEX_REPLAY_UNION_WIDTH)
+            .map(|index| db.literal_number(index as f64))
+            .collect();
+        let right = db.union_preserve_members(right);
+
+        db.intersect_types_raw_for_replay(vec![left, right])
+    }
+
     #[test]
     fn exact_rewrite_batches_shared_nodes_and_is_simultaneous() {
         let db = TypeInterner::new();
@@ -860,6 +881,48 @@ mod tests {
         assert_eq!(
             db.get_union_origin(result).map(|origin| origin.to_vec()),
             Some(vec![replacement, first]),
+        );
+    }
+
+    #[test]
+    fn exact_rewrite_complex_intersection_replay_does_not_signal_union_complexity() {
+        let db = TypeInterner::new();
+        let outer = fresh_param(&db, "Outer");
+        let source = complex_replay_intersection(&db, outer);
+        assert!(!db.is_union_too_complex());
+
+        let result = substitute_exact_type(&db, source, outer, db.literal_string("replacement"));
+        assert_ne!(result, source);
+        assert!(matches!(db.lookup(result), Some(TypeData::Intersection(_))));
+        assert!(
+            !db.is_union_too_complex(),
+            "replaying admitted structure must not request TS2590",
+        );
+    }
+
+    #[test]
+    fn exact_rewrite_complex_intersection_before_depth_bail_does_not_leak_flag() {
+        let db = TypeInterner::new();
+        let outer = fresh_param(&db, "Outer");
+        let intersection = complex_replay_intersection(&db, outer);
+        assert!(!db.is_union_too_complex());
+
+        let mut deep = outer;
+        for _ in 0..=crate::recursion::MAX_SOLVER_STACK_FRAMES {
+            deep = db.array(deep);
+        }
+        let root = db.tuple(vec![
+            TupleElement::fixed(intersection),
+            TupleElement::fixed(deep),
+        ]);
+
+        assert_eq!(
+            substitute_exact_type(&db, root, outer, TypeId::STRING),
+            root,
+        );
+        assert!(
+            !db.is_union_too_complex(),
+            "discarded replay work must not leak a TS2590 signal",
         );
     }
 

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -1133,6 +1133,26 @@ impl TypeInterner {
     /// Do NOT use for final compiler output (like .d.ts generation) as the
     /// resulting type will be "unsimplified".
     pub fn intersect_types_raw(&self, members: Vec<TypeId>) -> TypeId {
+        self.intersect_types_raw_impl(members, true)
+    }
+
+    /// Replay an existing raw intersection without emitting a new complexity
+    /// signal.
+    ///
+    /// Exact identity substitution preserves already-admitted structure; it is
+    /// not a new semantic intersection request. This constructor therefore has
+    /// the same `O(N)` flattening, order-preserving deduplication, sentinel
+    /// handling, and interning behavior as [`Self::intersect_types_raw`], but it
+    /// never sets the interner-wide `union_too_complex` diagnostic flag.
+    pub fn intersect_types_raw_for_replay(&self, members: Vec<TypeId>) -> TypeId {
+        self.intersect_types_raw_impl(members, false)
+    }
+
+    fn intersect_types_raw_impl(
+        &self,
+        members: Vec<TypeId>,
+        signal_cross_product_complexity: bool,
+    ) -> TypeId {
         // Use SmallVec to keep stack allocation benefits
         let mut flat: TypeListBuffer = SmallVec::new();
 
@@ -1191,7 +1211,7 @@ impl TypeInterner {
         // TS2590: Cross-product union size check for raw intersections.
         // When an intersection contains union members, the cross-product
         // can grow exponentially. tsc bails at 100,000 constituents.
-        {
+        if signal_cross_product_complexity {
             let mut cross_product_size: u64 = 1;
             for &id in flat.iter() {
                 if let Some(TypeData::Union(members)) = self.lookup(id) {

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -34,6 +34,14 @@ use tsz_common::interner::{Atom, ShardedInterner};
 /// that gates replaying it under a different resolver.
 pub type SharedDefVariance = (Arc<[crate::types::Variance]>, Arc<[DefId]>);
 
+/// One as-written union display order plus whether it is only the exact
+/// rewriter's pre-sort fallback. Real source provenance may atomically replace
+/// a fallback, while unrelated real origins remain first-writer-wins.
+pub(super) struct DisplayUnionOrigin {
+    pub(super) members: Arc<Vec<TypeId>>,
+    pub(super) exact_rewrite_fallback: bool,
+}
+
 mod cache;
 mod display;
 mod storage;
@@ -494,7 +502,7 @@ pub struct TypeInterner {
     ///
     /// Key: the flattened Union `TypeId` returned to the checker.
     /// Value: the unflattened input member list, in the order the user wrote.
-    pub(super) display_union_origin: DashMap<TypeId, Arc<Vec<TypeId>>, FxBuildHasher>,
+    pub(super) display_union_origin: DashMap<TypeId, DisplayUnionOrigin, FxBuildHasher>,
     /// Flag set when union normalization detects that a union type is too complex
     /// to represent (would require > 1M pairwise subtype comparisons during
     /// reduction). Mirrors tsc's `removeSubtypes` complexity heuristic that

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -25,7 +25,7 @@ use smallvec::SmallVec;
 use std::hash::{Hash, Hasher};
 use std::sync::{
     Arc, OnceLock,
-    atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering},
 };
 use tsz_common::interner::{Atom, ShardedInterner};
 
@@ -406,6 +406,10 @@ pub struct TypeInterner {
     pub(super) no_unchecked_indexed_access: AtomicBool,
     /// Effective value for `exactOptionalPropertyTypes` used by query-boundary helpers.
     pub(super) exact_optional_property_types: AtomicBool,
+    /// Monotonic invalidation generation for diagnostic and semantic provenance
+    /// side tables. Exact graph-rewrite sessions compare this before replaying
+    /// retained source provenance, making unchanged cache hits `O(1)`.
+    pub(super) display_provenance_generation: AtomicU64,
     /// Display properties for fresh object literal types.
     ///
     /// When object literal properties are widened (e.g., `"hello"` → `string`),
@@ -790,6 +794,7 @@ impl TypeInterner {
             poisoned: std::sync::atomic::AtomicBool::new(false),
             no_unchecked_indexed_access: AtomicBool::new(false),
             exact_optional_property_types: AtomicBool::new(false),
+            display_provenance_generation: AtomicU64::new(0),
             display_properties: DashMap::with_hasher(FxBuildHasher),
             display_alias: DashMap::with_hasher(FxBuildHasher),
             merged_intersection_origin: DashMap::with_hasher(FxBuildHasher),

--- a/crates/tsz-solver/src/intern/core/interner/display.rs
+++ b/crates/tsz-solver/src/intern/core/interner/display.rs
@@ -6,7 +6,7 @@
 //! union member order. None of this affects type identity or semantics; it is
 //! purely the provenance the formatter reads to match `tsc` display.
 
-use super::TypeInterner;
+use super::{DisplayUnionOrigin, TypeInterner};
 use crate::types::{LiteralValue, PropertyInfo, TypeData, TypeId};
 use dashmap::mapref::entry::Entry;
 use std::sync::{Arc, atomic::Ordering};
@@ -431,6 +431,30 @@ impl TypeInterner {
     /// anonymous-object cases (e.g., user wrote `"foo" | Refrigerator` but
     /// the interner sorted to `Refrigerator | "foo"` — tsc does the same).
     pub fn store_union_origin(&self, union_type_id: TypeId, origin_members: Vec<TypeId>) {
+        self.store_union_origin_kind(union_type_id, origin_members, false);
+    }
+
+    /// Store union order reconstructed by an exact graph rewrite.
+    ///
+    /// A fallback captures changed members before canonical sorting when the
+    /// source had no explicit origin. It only fills a vacant target slot. Real
+    /// rewritten source provenance atomically replaces such a tagged fallback,
+    /// but never replaces an untagged origin owned by another source/session.
+    pub fn store_rewritten_union_origin(
+        &self,
+        union_type_id: TypeId,
+        origin_members: Vec<TypeId>,
+        is_fallback: bool,
+    ) {
+        self.store_union_origin_kind(union_type_id, origin_members, is_fallback);
+    }
+
+    fn store_union_origin_kind(
+        &self,
+        union_type_id: TypeId,
+        origin_members: Vec<TypeId>,
+        exact_rewrite_fallback: bool,
+    ) {
         if origin_members.len() < 2 {
             return;
         }
@@ -475,14 +499,38 @@ impl TypeInterner {
                     &origin_members,
                 );
             if !needs_origin {
+                if !exact_rewrite_fallback
+                    && let Entry::Occupied(entry) = self.display_union_origin.entry(union_type_id)
+                    && entry.get().exact_rewrite_fallback
+                {
+                    entry.remove();
+                    self.advance_display_provenance_generation();
+                }
                 return;
             }
         }
-        // First writer wins so deterministic display order is preserved when
-        // the same flattened union is reached from multiple annotation sites.
-        if let Entry::Vacant(entry) = self.display_union_origin.entry(union_type_id) {
-            entry.insert(Arc::new(origin_members));
-            self.advance_display_provenance_generation();
+        match self.display_union_origin.entry(union_type_id) {
+            Entry::Vacant(entry) => {
+                entry.insert(DisplayUnionOrigin {
+                    members: Arc::new(origin_members),
+                    exact_rewrite_fallback,
+                });
+                self.advance_display_provenance_generation();
+            }
+            Entry::Occupied(mut entry)
+                if !exact_rewrite_fallback && entry.get().exact_rewrite_fallback =>
+            {
+                entry.insert(DisplayUnionOrigin {
+                    members: Arc::new(origin_members),
+                    exact_rewrite_fallback: false,
+                });
+                self.advance_display_provenance_generation();
+            }
+            Entry::Occupied(_) => {
+                // Real origins are first-writer-wins. In particular, a later
+                // exact-rewrite session cannot repaint unrelated provenance on
+                // a shared canonical union target.
+            }
         }
     }
 
@@ -502,8 +550,17 @@ impl TypeInterner {
         let origin_members = Arc::new(origin_members);
         let changed = self
             .display_union_origin
-            .insert(union_type_id, Arc::clone(&origin_members))
-            .is_none_or(|previous| previous.as_ref() != origin_members.as_ref());
+            .insert(
+                union_type_id,
+                DisplayUnionOrigin {
+                    members: Arc::clone(&origin_members),
+                    exact_rewrite_fallback: false,
+                },
+            )
+            .is_none_or(|previous| {
+                previous.exact_rewrite_fallback
+                    || previous.members.as_ref() != origin_members.as_ref()
+            });
         if changed {
             self.advance_display_provenance_generation();
         }
@@ -798,6 +855,8 @@ impl TypeInterner {
 
     /// Look up the as-written origin members for a flattened Union TypeId.
     pub fn get_union_origin(&self, type_id: TypeId) -> Option<Arc<Vec<TypeId>>> {
-        self.display_union_origin.get(&type_id).map(|r| r.clone())
+        self.display_union_origin
+            .get(&type_id)
+            .map(|origin| Arc::clone(&origin.members))
     }
 }

--- a/crates/tsz-solver/src/intern/core/interner/display.rs
+++ b/crates/tsz-solver/src/intern/core/interner/display.rs
@@ -210,6 +210,16 @@ impl TypeInterner {
         if preserves_conditional_branch_alias {
             return;
         }
+        // Replaying provenance must not repaint a canonical result that
+        // already has a stable application spelling from another path. A
+        // structural provenance entry is still replaceable by the concrete
+        // rewritten application, matching `store_display_alias_preferring_application`.
+        if self
+            .get_display_alias(evaluated)
+            .is_some_and(|existing| matches!(self.lookup(existing), Some(TypeData::Application(_))))
+        {
+            return;
+        }
         self.display_alias.insert(evaluated, application);
     }
 

--- a/crates/tsz-solver/src/intern/core/interner/display.rs
+++ b/crates/tsz-solver/src/intern/core/interner/display.rs
@@ -175,6 +175,44 @@ impl TypeInterner {
         self.display_alias.insert(evaluated, application);
     }
 
+    /// Transfer application display provenance while structurally rebuilding
+    /// an already-validated source graph.
+    ///
+    /// The source mapping proves that this is provenance replay rather than a
+    /// new alias-discovery decision, so allocation order must not affect the
+    /// result. The normal global-identity and formatting-cycle safety checks
+    /// still apply.
+    ///
+    /// Callers must only pass an application alias read from an existing
+    /// source graph and structurally rewritten through the same substitution.
+    pub fn transfer_rewritten_application_display_alias(
+        &self,
+        evaluated: TypeId,
+        application: TypeId,
+    ) {
+        if evaluated == application || evaluated.is_intrinsic() {
+            return;
+        }
+        if matches!(self.lookup(evaluated), Some(TypeData::TypeParameter(_))) {
+            return;
+        }
+        let Some(TypeData::Application(app_id)) = self.lookup(application) else {
+            return;
+        };
+        let app = self.type_application(app_id);
+        if app.args.contains(&evaluated) {
+            return;
+        }
+        let preserves_conditional_branch_alias = self.is_conditional_alias_base(app.base)
+            && self.get_display_alias(evaluated).is_some_and(|existing| {
+                matches!(self.lookup(existing), Some(TypeData::Intersection(_)))
+            });
+        if preserves_conditional_branch_alias {
+            return;
+        }
+        self.display_alias.insert(evaluated, application);
+    }
+
     /// Look up the original Application TypeId for a type that was produced
     /// by evaluating an Application.
     ///

--- a/crates/tsz-solver/src/intern/core/interner/display.rs
+++ b/crates/tsz-solver/src/intern/core/interner/display.rs
@@ -8,16 +8,81 @@
 
 use super::TypeInterner;
 use crate::types::{LiteralValue, PropertyInfo, TypeData, TypeId};
-use std::sync::Arc;
+use dashmap::mapref::entry::Entry;
+use std::sync::{Arc, atomic::Ordering};
+
+fn display_properties_equal(left: &[PropertyInfo], right: &[PropertyInfo]) -> bool {
+    left.len() == right.len()
+        && left.iter().zip(right).all(|(left, right)| {
+            let PropertyInfo {
+                name,
+                type_id,
+                write_type,
+                optional,
+                readonly,
+                is_method,
+                is_class_prototype,
+                visibility,
+                parent_id,
+                declaration_order,
+                is_string_named,
+                is_symbol_named,
+                single_quoted_name,
+                non_widening,
+            } = left;
+            *name == right.name
+                && *type_id == right.type_id
+                && *write_type == right.write_type
+                && *optional == right.optional
+                && *readonly == right.readonly
+                && *is_method == right.is_method
+                && *is_class_prototype == right.is_class_prototype
+                && *visibility == right.visibility
+                && *parent_id == right.parent_id
+                && *declaration_order == right.declaration_order
+                && *is_string_named == right.is_string_named
+                && *is_symbol_named == right.is_symbol_named
+                && *single_quoted_name == right.single_quoted_name
+                && *non_widening == right.non_widening
+        })
+}
 
 impl TypeInterner {
+    /// Current universe-wide provenance invalidation generation.
+    ///
+    /// The value changes only when a side-table fact changes, so retained exact
+    /// graph-rewrite sessions can skip provenance scans on unchanged cache hits.
+    #[inline]
+    pub fn display_provenance_generation(&self) -> u64 {
+        self.display_provenance_generation.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    fn advance_display_provenance_generation(&self) {
+        self.display_provenance_generation
+            .fetch_add(1, Ordering::Release);
+    }
+
+    fn replace_display_alias(&self, evaluated: TypeId, application: TypeId) {
+        if self.display_alias.insert(evaluated, application) != Some(application) {
+            self.advance_display_provenance_generation();
+        }
+    }
+
     /// Store display-only properties for a fresh object literal.
     ///
     /// These are the pre-widened property types shown in error messages.
     /// The `shape_id` is the widened (interned) shape; `props` contains
     /// the original literal types from the source code.
     pub fn store_display_properties(&self, type_id: TypeId, props: Vec<PropertyInfo>) {
-        self.display_properties.insert(type_id, Arc::new(props));
+        let props = Arc::new(props);
+        let changed = self
+            .display_properties
+            .insert(type_id, Arc::clone(&props))
+            .is_none_or(|previous| !display_properties_equal(&previous, &props));
+        if changed {
+            self.advance_display_provenance_generation();
+        }
     }
 
     /// Retrieve display-only properties for a fresh object literal.
@@ -113,7 +178,7 @@ impl TypeInterner {
         {
             return;
         }
-        self.display_alias.insert(evaluated, application);
+        self.replace_display_alias(evaluated, application);
     }
 
     /// Prefer a concrete Application display alias over structural provenance
@@ -172,7 +237,7 @@ impl TypeInterner {
         {
             return;
         }
-        self.display_alias.insert(evaluated, application);
+        self.replace_display_alias(evaluated, application);
     }
 
     /// Transfer application display provenance while structurally rebuilding
@@ -220,7 +285,7 @@ impl TypeInterner {
         {
             return;
         }
-        self.display_alias.insert(evaluated, application);
+        self.replace_display_alias(evaluated, application);
     }
 
     /// Look up the original Application TypeId for a type that was produced
@@ -254,9 +319,10 @@ impl TypeInterner {
                 return;
             }
         }
-        self.application_eval_origin
-            .entry(evaluated)
-            .or_insert(application);
+        if let Entry::Vacant(entry) = self.application_eval_origin.entry(evaluated) {
+            entry.insert(application);
+            self.advance_display_provenance_generation();
+        }
     }
 
     /// Look up the semantic application origin of an evaluated structural
@@ -279,9 +345,10 @@ impl TypeInterner {
         if !matches!(self.lookup(intersection), Some(TypeData::Intersection(_))) {
             return;
         }
-        self.merged_intersection_origin
-            .entry(merged)
-            .or_insert(intersection);
+        if let Entry::Vacant(entry) = self.merged_intersection_origin.entry(merged) {
+            entry.insert(intersection);
+            self.advance_display_provenance_generation();
+        }
     }
 
     /// Look up the original `Intersection` TypeId a merged object was
@@ -293,7 +360,9 @@ impl TypeInterner {
     /// Record that an application base belongs to a type alias whose body is a
     /// conditional type. This is diagnostic-only provenance.
     pub fn mark_conditional_alias_base(&self, base: TypeId) {
-        self.conditional_alias_bases.insert(base, ());
+        if self.conditional_alias_bases.insert(base, ()).is_none() {
+            self.advance_display_provenance_generation();
+        }
     }
 
     pub fn is_conditional_alias_base(&self, base: TypeId) -> bool {
@@ -304,7 +373,13 @@ impl TypeInterner {
     /// so the formatter renders it as `typeof globalThis` rather than its full
     /// member body. Display-only provenance.
     pub fn mark_global_this_surface_display(&self, type_id: TypeId) {
-        self.global_this_surface_display.insert(type_id, ());
+        if self
+            .global_this_surface_display
+            .insert(type_id, ())
+            .is_none()
+        {
+            self.advance_display_provenance_generation();
+        }
     }
 
     /// Whether `type_id` is a recorded synthetic `typeof globalThis` surface.
@@ -321,7 +396,13 @@ impl TypeInterner {
         if type_id.is_intrinsic() {
             return;
         }
-        self.literal_object_annotations.insert(type_id, ());
+        if self
+            .literal_object_annotations
+            .insert(type_id, ())
+            .is_none()
+        {
+            self.advance_display_provenance_generation();
+        }
     }
 
     /// Whether `type_id` is a recorded hand-written object-type literal
@@ -399,9 +480,10 @@ impl TypeInterner {
         }
         // First writer wins so deterministic display order is preserved when
         // the same flattened union is reached from multiple annotation sites.
-        self.display_union_origin
-            .entry(union_type_id)
-            .or_insert_with(|| Arc::new(origin_members));
+        if let Entry::Vacant(entry) = self.display_union_origin.entry(union_type_id) {
+            entry.insert(Arc::new(origin_members));
+            self.advance_display_provenance_generation();
+        }
     }
 
     /// Replace the display origin for a union whose diagnostic context has a
@@ -417,8 +499,14 @@ impl TypeInterner {
         let Some(TypeData::Union(_)) = self.lookup(union_type_id) else {
             return;
         };
-        self.display_union_origin
-            .insert(union_type_id, Arc::new(origin_members));
+        let origin_members = Arc::new(origin_members);
+        let changed = self
+            .display_union_origin
+            .insert(union_type_id, Arc::clone(&origin_members))
+            .is_none_or(|previous| previous.as_ref() != origin_members.as_ref());
+        if changed {
+            self.advance_display_provenance_generation();
+        }
     }
 
     /// Decide whether storing the as-written origin is needed even when no

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -172,16 +172,17 @@ pub mod computation {
     #[cfg(any(test, debug_assertions))]
     pub use crate::instantiation::instantiate::ProjectInstCacheDisabledGuard;
     pub use crate::instantiation::instantiate::{
-        MAX_INSTANTIATION_DEPTH, TypeInstantiator, TypeSubstitution, fill_application_defaults,
-        free_type_params_named, instantiate_function_with_type_args, instantiate_generic,
-        instantiate_generic_cached, instantiate_type, instantiate_type_cached,
-        instantiate_type_params_to_constraints, instantiate_type_preserving,
-        instantiate_type_preserving_cached, instantiate_type_preserving_meta,
-        instantiate_type_preserving_meta_cached, instantiate_type_with_depth_status,
-        instantiate_type_with_infer, instantiate_type_with_infer_cached,
-        instantiate_type_with_request, resolve_named_type_params_to_defaults,
-        resolve_unbound_type_params_to_declared_fallbacks, resolve_unbound_type_params_to_defaults,
-        substitute_exact_type, substitute_exact_types, substitute_this_type,
+        ExactRewriteAborted, ExactRewriteMemo, MAX_INSTANTIATION_DEPTH, TypeInstantiator,
+        TypeSubstitution, fill_application_defaults, free_type_params_named,
+        instantiate_function_with_type_args, instantiate_generic, instantiate_generic_cached,
+        instantiate_type, instantiate_type_cached, instantiate_type_params_to_constraints,
+        instantiate_type_preserving, instantiate_type_preserving_cached,
+        instantiate_type_preserving_meta, instantiate_type_preserving_meta_cached,
+        instantiate_type_with_depth_status, instantiate_type_with_infer,
+        instantiate_type_with_infer_cached, instantiate_type_with_request,
+        resolve_named_type_params_to_defaults, resolve_unbound_type_params_to_declared_fallbacks,
+        resolve_unbound_type_params_to_defaults, substitute_exact_type, substitute_exact_types,
+        substitute_exact_types_with_memo, substitute_this_type,
         substitute_this_type_at_return_position, substitute_this_type_cached,
     };
     pub use crate::instantiation::request::{InstantiationOptions, InstantiationRequest};

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -181,8 +181,8 @@ pub mod computation {
         instantiate_type_with_infer, instantiate_type_with_infer_cached,
         instantiate_type_with_request, resolve_named_type_params_to_defaults,
         resolve_unbound_type_params_to_declared_fallbacks, resolve_unbound_type_params_to_defaults,
-        substitute_exact_type, substitute_this_type, substitute_this_type_at_return_position,
-        substitute_this_type_cached,
+        substitute_exact_type, substitute_exact_types, substitute_this_type,
+        substitute_this_type_at_return_position, substitute_this_type_cached,
     };
     pub use crate::instantiation::request::{InstantiationOptions, InstantiationRequest};
     pub use crate::instantiation::result::{InstantiationResult, InstantiationTermination};

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -250,7 +250,8 @@ pub mod observability {
 /// `query_boundaries` in the checker crate.
 pub mod construction {
     pub use crate::caches::db::{
-        QueryDatabase, TypeBuiltinAccess, TypeDatabase, TypeSubstitutionConstruction,
+        QueryDatabase, TypeBuiltinAccess, TypeDatabase, TypeRawIntersectionConstruction,
+        TypeSubstitutionConstruction,
     };
     pub use crate::caches::query_cache::{QueryCache, RelationCacheProbe, SharedQueryCache};
     pub use crate::caches::query_cache_statistics::{QueryCacheStatistics, RelationCacheStats};

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -181,7 +181,8 @@ pub mod computation {
         instantiate_type_with_infer, instantiate_type_with_infer_cached,
         instantiate_type_with_request, resolve_named_type_params_to_defaults,
         resolve_unbound_type_params_to_declared_fallbacks, resolve_unbound_type_params_to_defaults,
-        substitute_this_type, substitute_this_type_at_return_position, substitute_this_type_cached,
+        substitute_exact_type, substitute_this_type, substitute_this_type_at_return_position,
+        substitute_this_type_cached,
     };
     pub use crate::instantiation::request::{InstantiationOptions, InstantiationRequest};
     pub use crate::instantiation::result::{InstantiationResult, InstantiationTermination};


### PR DESCRIPTION
Goal: green

## Summary
- Rebind cached class-chain member graphs from declaration binders to the active class binder identities before use.
- Preserve nested fresh binders and semantic/display provenance through one transactional solver rewrite session per active binder vector.
- Keep raw intersection replay diagnostic-neutral and retain rewritten union display order without repainting unrelated canonical types.
- Make non-generic and identity-equal binder scopes an O(1) no-op.

## Structural rule
When a cached class member type was constructed under one exact class-binder vector and is consumed under an aligned active vector, TypeScript substitutes those binder identities throughout the member graph while preserving member-owned binders. The checker owns scope selection and caching; the solver owns the simultaneous graph rewrite, provenance replay, recursion bailout, and raw type construction.

Adjacent cases cover renamed binders, same-named shadowing, inherited and wrapped applications, multiple class parameters, omitted defaults, JSDoc class templates, unrelated same-named defaults, shared nested binders across member roots, allocation-order variants, late provenance, retryable recursion aborts, and existing target provenance. Arity mismatch or solver-frame exhaustion returns the original type without caching a partial result. Generic arrow-initializer binder capture is tracked as a separate construction-phase follow-up and is not claimed by this cached-member slice.

## Performance
Pinned Zod, optimized binaries, 20 alternating main/head pairs: main mean 1.732743s, head mean 1.692718s (-2.310%); paired median delta -2.617%. Empty or identical binder vectors skip session creation entirely.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-solver exact_rewrite` (23 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test application_member_type_parameter_substitution_tests` (10 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib exact_rebind_cache_tests` (4 passed)
- `scripts/safe-run.sh cargo clippy -p tsz-solver -p tsz-checker --lib -- -D warnings`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `TSZ_PROJECT_COMPILE_FILTER=^zod-project$ TSZ_PROJECT_COMPILE_SET=canary scripts/ci/project-compile-guard.sh` with the optimized head binary (pass; current main exits 1)

## Provenance
Machine: Mac
Assistant: codex
Model: GPT-5
Effort: high