### PR TITLE
fix(checker): preserve JSDoc template binder identity

### DIFF
--- a/crates/tsz-checker/src/checkers/signature_builder.rs
+++ b/crates/tsz-checker/src/checkers/signature_builder.rs
@@ -6,10 +6,7 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{CallSignature, TypeId, TypeParamInfo};
-
-type JsdocTemplateParamScopeUpdates = Vec<(String, Option<TypeId>, bool)>;
-type JsdocTemplateParamPushResult = (Vec<TypeParamInfo>, JsdocTemplateParamScopeUpdates);
+use tsz_solver::{CallSignature, TypeId};
 
 // =============================================================================
 // Signature Building Methods
@@ -83,7 +80,8 @@ impl<'a> CheckerState<'a> {
         overload_docs
             .into_iter()
             .map(|(jsdoc, comment_pos)| {
-                let (type_params, updates) = self.push_jsdoc_overload_template_params(&jsdoc);
+                let (type_params, updates) =
+                    self.push_jsdoc_template_type_parameters_for_comment(comment_pos, &jsdoc);
                 let mut signature = base_signature.clone();
                 signature.type_params = type_params;
                 let jsdoc_params = Self::extract_jsdoc_param_names(&jsdoc);
@@ -132,30 +130,6 @@ impl<'a> CheckerState<'a> {
             .collect()
     }
 
-    fn push_jsdoc_overload_template_params(&mut self, jsdoc: &str) -> JsdocTemplateParamPushResult {
-        let template_names = Self::jsdoc_template_type_params(jsdoc);
-        if template_names.is_empty() {
-            return (Vec::new(), Vec::new());
-        }
-
-        let mut type_params = Vec::with_capacity(template_names.len());
-        let mut updates = Vec::with_capacity(template_names.len());
-
-        for (name, is_const, default_str) in template_names {
-            let atom = self.ctx.types.intern_string(&name);
-            let default = default_str
-                .as_deref()
-                .and_then(|type_expr| self.resolve_jsdoc_reference(type_expr));
-            let info = signature_query::user_type_param_info(atom, None, default, is_const);
-            let type_id = signature_query::user_type_param(self.ctx.types, info);
-            let previous = self.ctx.type_parameter_scope.insert(name.clone(), type_id);
-            updates.push((name, previous, false));
-            type_params.push(info);
-        }
-
-        (type_params, updates)
-    }
-
     /// Build a `CallSignature` from a method declaration.
     pub(crate) fn call_signature_from_method(
         &mut self,
@@ -175,14 +149,25 @@ impl<'a> CheckerState<'a> {
     ) -> tsz_solver::CallSignature {
         let enclosing_updates = self.push_enclosing_type_parameters(method_idx);
         self.exclude_params_for_type_param_constraints(&method.parameters);
-        let (type_params, type_param_updates) = self.push_type_parameters(&method.type_parameters);
+        let (mut type_params, type_param_updates) =
+            self.push_type_parameters(&method.type_parameters);
         self.clear_excluded_params_for_type_param_constraints();
-        let (mut params, this_type) = self.extract_params_from_parameter_list(&method.parameters);
         let method_jsdoc = if self.is_js_file() {
             self.find_jsdoc_for_function(method_idx)
         } else {
             None
         };
+        let jsdoc_type_param_updates = if type_params.is_empty() {
+            let (jsdoc_type_params, updates) = method_jsdoc.as_ref().map_or_else(
+                || (Vec::new(), Vec::new()),
+                |jsdoc| self.push_jsdoc_template_type_parameters_for_owner(method_idx, jsdoc),
+            );
+            type_params = jsdoc_type_params;
+            updates
+        } else {
+            Vec::new()
+        };
+        let (mut params, this_type) = self.extract_params_from_parameter_list(&method.parameters);
         if let Some(jsdoc) = method_jsdoc.as_ref() {
             let comment_start = self.get_jsdoc_comment_pos_for_function(method_idx);
             let jsdoc_param_names: Vec<String> = Self::extract_jsdoc_param_names(jsdoc)
@@ -315,6 +300,7 @@ impl<'a> CheckerState<'a> {
                 .application(promise_base, vec![return_type]);
         }
 
+        self.pop_type_parameters(jsdoc_type_param_updates);
         self.pop_type_parameters(type_param_updates);
         self.pop_type_parameters(enclosing_updates);
 

--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -290,15 +290,33 @@ impl<'a> CheckerState<'a> {
         // distributive conditional, or template-`infer` capture. The source and
         // target displays are identical to the TS2322 form; only the suggestion
         // clause is appended, matching tsc's TS2820 wording.
-        let (message, code) = match self
-            .find_string_literal_spelling_suggestion_reduced(source_for_display, target_for_display)
-        {
+        let spelling_suggestion = self.find_string_literal_spelling_suggestion_reduced(
+            source_for_display,
+            target_for_display,
+        );
+        let same_surface_distinct_decl_binders = || {
+            crate::query_boundaries::assignability::
+                have_same_surface_distinct_decl_scoped_free_type_parameters(
+                    self.ctx.types,
+                    &self.ctx,
+                    source_for_display,
+                    target_for_display,
+                )
+        };
+        let (message, code) = match spelling_suggestion {
             Some(suggestion) => (
                 crate::diagnostics::format_message(
                     crate::diagnostics::diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_DID_YOU_MEAN,
                     &[&source_str, &target_str, &suggestion],
                 ),
                 crate::diagnostics::diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_DID_YOU_MEAN,
+            ),
+            None if source_str == target_str && same_surface_distinct_decl_binders() => (
+                crate::diagnostics::format_message(
+                    crate::diagnostics::diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_TWO_DIFFERENT_TYPES_WITH_THIS_NAME_EXIST_BUT_THEY,
+                    &[&source_str, &target_str],
+                ),
+                crate::diagnostics::diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_TWO_DIFFERENT_TYPES_WITH_THIS_NAME_EXIST_BUT_THEY,
             ),
             None => (
                 crate::diagnostics::format_message(

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -844,6 +844,44 @@ impl<'a> CheckerState<'a> {
                 self.normalized_anchor_span(idx, pos, end.saturating_sub(pos))
             });
         let file_name = self.ctx.file_name.clone();
+        // A reduced alias/application body can fail through a property reason
+        // even when the two value-level types have the same declared surface.
+        // Distinct free declaration origins prove the semantic unrelatedness;
+        // the final display equality only selects tsc's TS2719 presentation.
+        if depth == 0
+            && source_display_override.is_none()
+            && crate::query_boundaries::assignability::contains_type_parameters(
+                self.ctx.types,
+                source,
+            )
+            && crate::query_boundaries::assignability::contains_type_parameters(
+                self.ctx.types,
+                target,
+            )
+            && crate::query_boundaries::assignability::
+                have_same_surface_distinct_decl_scoped_free_type_parameters(
+                    self.ctx.types,
+                    &self.ctx,
+                    source,
+                    target,
+                )
+        {
+            let (source_str, target_str) =
+                self.format_top_level_assignability_message_types_at(source, target, idx);
+            if source_str == target_str {
+                let message = format_message(
+                    diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_TWO_DIFFERENT_TYPES_WITH_THIS_NAME_EXIST_BUT_THEY,
+                    &[&source_str, &target_str],
+                );
+                return Diagnostic::error(
+                    file_name,
+                    start,
+                    length,
+                    message,
+                    diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_TWO_DIFFERENT_TYPES_WITH_THIS_NAME_EXIST_BUT_THEY,
+                );
+            }
+        }
         // TS2696: property-only failures from the `Object` wrapper use the
         // specialized message unless the target is callable/constructable.
         if depth == 0 {

--- a/crates/tsz-checker/src/jsdoc/diagnostics_import_type_constraints.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics_import_type_constraints.rs
@@ -2,7 +2,7 @@
 
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use crate::jsdoc::types::JsdocTypedefInfo;
-use crate::query_boundaries::jsdoc_construction::{jsdoc_type_param_info, jsdoc_type_param_type};
+use crate::query_boundaries::jsdoc_construction::jsdoc_type_param_info;
 use crate::state::CheckerState;
 
 pub(super) struct JsdocImportTypeConstraintDiagnostic<'a> {
@@ -41,7 +41,7 @@ impl<'a> CheckerState<'a> {
                 .and_then(|c| self.resolve_jsdoc_type_str(c));
             let atom = self.ctx.types.intern_string(&tp.name);
             let param = jsdoc_type_param_info(atom, constraint, None);
-            let type_id = jsdoc_type_param_type(self.ctx.types, param);
+            let (type_id, _) = self.intern_jsdoc_type_param_for_comment_stamped(comment_pos, param);
             let previous = self
                 .ctx
                 .type_parameter_scope

--- a/crates/tsz-checker/src/jsdoc/resolution/generic_typedef.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/generic_typedef.rs
@@ -48,13 +48,17 @@ impl<'a> CheckerState<'a> {
             let content = get_jsdoc_content(comment, &source_file.text);
             for (name, typedef_info) in Self::parse_jsdoc_typedefs(&content) {
                 if name == base_name {
-                    best_def = Some(typedef_info);
+                    best_def = Some((typedef_info, comment.pos));
                 }
             }
         }
 
-        let (body_type, type_params) =
-            self.type_from_jsdoc_typedef_inner(best_def?, Some(base_name))?;
+        let (typedef_info, comment_pos) = best_def?;
+        let previous_anchor = self.ctx.jsdoc_typedef_anchor_pos.get();
+        self.ctx.jsdoc_typedef_anchor_pos.set(comment_pos);
+        let result = self.type_from_jsdoc_typedef_inner(typedef_info, Some(base_name), comment_pos);
+        self.ctx.jsdoc_typedef_anchor_pos.set(previous_anchor);
+        let (body_type, type_params) = result?;
         if type_args.is_empty() {
             return Some(body_type);
         }

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -1418,8 +1418,8 @@ impl<'a> CheckerState<'a> {
         // through to other resolution paths (matching TSC behavior where
         // function-scoped typedefs with duplicate names are not visible
         // at the module level).
-        let mut same_scope_def: Option<JsdocTypedefInfo> = None;
-        let mut deeper_defs: Vec<JsdocTypedefInfo> = Vec::new();
+        let mut same_scope_def: Option<(JsdocTypedefInfo, u32)> = None;
+        let mut deeper_defs: Vec<(JsdocTypedefInfo, u32)> = Vec::new();
 
         for comment in comments {
             if !is_jsdoc_comment(comment, source_text) {
@@ -1483,14 +1483,14 @@ impl<'a> CheckerState<'a> {
                     continue;
                 }
                 if is_same_scope {
-                    same_scope_def = Some(typedef_info);
+                    same_scope_def = Some((typedef_info, comment.pos));
                 } else if is_deeper {
-                    deeper_defs.push(typedef_info);
+                    deeper_defs.push((typedef_info, comment.pos));
                 } else {
                     // Shallower or same-depth-different-scope: use as fallback
                     // (last one wins, matching original behavior)
                     if same_scope_def.is_none() {
-                        same_scope_def = Some(typedef_info);
+                        same_scope_def = Some((typedef_info, comment.pos));
                     }
                 }
             }
@@ -1505,7 +1505,7 @@ impl<'a> CheckerState<'a> {
             // Multiple deeper-scope defs → ambiguous, or no defs at all
             None
         };
-        let typedef_info = best_def?;
+        let (typedef_info, typedef_comment_pos) = best_def?;
 
         // Mark this typedef as being resolved to prevent re-entrancy.
         self.ctx
@@ -1513,7 +1513,10 @@ impl<'a> CheckerState<'a> {
             .borrow_mut()
             .insert(type_expr.to_owned());
 
-        let result = self.type_from_jsdoc_typedef(typedef_info);
+        let previous_anchor = self.ctx.jsdoc_typedef_anchor_pos.get();
+        self.ctx.jsdoc_typedef_anchor_pos.set(typedef_comment_pos);
+        let result = self.type_from_jsdoc_typedef(typedef_info, typedef_comment_pos);
+        self.ctx.jsdoc_typedef_anchor_pos.set(previous_anchor);
 
         self.ctx
             .jsdoc_typedef_resolving
@@ -1528,8 +1531,9 @@ impl<'a> CheckerState<'a> {
     fn type_from_jsdoc_typedef(
         &mut self,
         info: JsdocTypedefInfo,
+        comment_pos: u32,
     ) -> Option<(TypeId, Vec<tsz_solver::TypeParamInfo>)> {
-        self.type_from_jsdoc_typedef_inner(info, None)
+        self.type_from_jsdoc_typedef_inner(info, None, comment_pos)
     }
 
     /// Build the type for a JSDoc `@typedef`. When `recursive_alias_name` is
@@ -1542,6 +1546,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         info: JsdocTypedefInfo,
         recursive_alias_name: Option<&str>,
+        comment_pos: u32,
     ) -> Option<(TypeId, Vec<tsz_solver::TypeParamInfo>)> {
         let import_alias_body = info
             .base_type
@@ -1556,7 +1561,8 @@ impl<'a> CheckerState<'a> {
                 .and_then(|expr| self.resolve_jsdoc_type_str(expr));
             let atom = self.ctx.types.intern_string(&template.name);
             let param = jsdoc_construct::jsdoc_type_param_info(atom, constraint, None);
-            let type_id = jsdoc_construct::jsdoc_type_param_type(self.ctx.types, param);
+            let (type_id, param) =
+                self.intern_jsdoc_type_param_for_comment_stamped(comment_pos, param);
             let previous = self
                 .ctx
                 .type_parameter_scope

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1178,6 +1178,7 @@ mod jsdoc_function_return_type_anchor_tests;
 #[cfg(test)]
 #[path = "tests/jsdoc_overload_call_resolution_tests.rs"]
 mod jsdoc_overload_call_resolution_tests;
+
 #[cfg(test)]
 #[path = "../tests/jsdoc_readonly_tests.rs"]
 mod jsdoc_readonly_tests;
@@ -1190,6 +1191,9 @@ mod jsdoc_reference_kernel_tests;
 #[cfg(test)]
 #[path = "../tests/jsdoc_satisfies_tests.rs"]
 mod jsdoc_satisfies_tests;
+#[cfg(test)]
+#[path = "tests/jsdoc_shadowed_type_param_identity_tests.rs"]
+mod jsdoc_shadowed_type_param_identity_tests;
 #[cfg(test)]
 #[path = "../tests/jsdoc_template_class_tests.rs"]
 mod jsdoc_template_class_tests;

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -731,7 +731,7 @@ pub(crate) use relation_kind_variants::{
     cached_bivariant_assignability_with_resolver, is_redeclaration_identical_with_resolver,
     is_subtype_with_resolver,
 };
-pub(crate) use shape::{is_index_access_for_assignability, union_members_for_assignability};
+pub(crate) use shape::*;
 
 pub(crate) fn classify_for_assignability_eval(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/query_boundaries/assignability/shape.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/shape.rs
@@ -11,7 +11,84 @@
 
 use tsz_solver::TypeId;
 use tsz_solver::construction::TypeDatabase;
+use tsz_solver::relations::subtype::TypeResolver;
 use tsz_solver::type_queries::TypeIdList;
+
+fn free_decl_origins_and_names(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> rustc_hash::FxHashSet<(tsz_solver::TypeParamOrigin, tsz_common::Atom)> {
+    tsz_solver::visitor::free_decl_scoped_type_parameter_origins_in(db, [type_id])
+}
+
+/// Whether `source` and `target` carry different authoritative declarations in
+/// their free type-parameter sets.
+///
+/// A declaration-scoped parameter nested in an object/alias body remains free
+/// at an ordinary value assignment. It is not alpha-renamable there: only an
+/// enclosing generic signature introduces an alpha-equivalence scope. Legacy
+/// `User` origins carry no authoritative declaration key and intentionally do
+/// not make this predicate true.
+pub(crate) fn have_distinct_decl_scoped_free_type_parameters(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    target: TypeId,
+) -> bool {
+    if source == target {
+        return false;
+    }
+    let source_entries = free_decl_origins_and_names(db, source);
+    let target_entries = free_decl_origins_and_names(db, target);
+    let source_origins: rustc_hash::FxHashSet<_> =
+        source_entries.iter().map(|(origin, _)| *origin).collect();
+    let target_origins: rustc_hash::FxHashSet<_> =
+        target_entries.iter().map(|(origin, _)| *origin).collect();
+
+    !source_origins.is_empty() && !target_origins.is_empty() && source_origins != target_origins
+}
+
+/// Whether a pair with different authoritative free-binder identities has the
+/// same structural surface after those identically named free binders are put
+/// into a shared comparison scope.
+///
+/// This is the semantic TS2719 selector for reduced alias/application bodies;
+/// callers do not infer unrelated duplicate declarations from rendered text.
+pub(crate) fn have_same_surface_distinct_decl_scoped_free_type_parameters<R: TypeResolver>(
+    db: &dyn TypeDatabase,
+    resolver: &R,
+    source: TypeId,
+    target: TypeId,
+) -> bool {
+    let source_entries = free_decl_origins_and_names(db, source);
+    let target_entries = free_decl_origins_and_names(db, target);
+    let source_origins: rustc_hash::FxHashSet<_> =
+        source_entries.iter().map(|(origin, _)| *origin).collect();
+    let target_origins: rustc_hash::FxHashSet<_> =
+        target_entries.iter().map(|(origin, _)| *origin).collect();
+    if source_origins.is_empty() || target_origins.is_empty() || source_origins == target_origins {
+        return false;
+    }
+
+    let source_names: rustc_hash::FxHashSet<_> =
+        source_entries.iter().map(|(_, name)| *name).collect();
+    let target_names: rustc_hash::FxHashSet<_> =
+        target_entries.iter().map(|(_, name)| *name).collect();
+    if source_names != target_names
+        || source_names.len() != source_entries.len()
+        || target_names.len() != target_entries.len()
+    {
+        return false;
+    }
+    let mut param_names: Vec<_> = source_names.into_iter().collect();
+    param_names.sort_unstable();
+    tsz_solver::computation::are_types_structurally_identical_in_param_scope(
+        db,
+        resolver,
+        source,
+        target,
+        &param_names,
+    )
+}
 
 /// Detect an indexed-access type (`T[K]`) during assignability normalization.
 ///
@@ -34,4 +111,137 @@ pub(crate) fn union_members_for_assignability(
     ty: TypeId,
 ) -> Option<TypeIdList> {
     tsz_solver::type_queries::get_union_members(db, ty)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsz_solver::construction::TypeInterner;
+    use tsz_solver::{PropertyInfo, TypeParamInfo, TypeParamOrigin};
+
+    fn declared_param(db: &TypeInterner, file: tsz_common::Atom, name: &str, node: u32) -> TypeId {
+        db.type_param(TypeParamInfo {
+            origin: TypeParamOrigin::DeclScoped { file, node },
+            ..TypeParamInfo::simple(db.intern_string(name))
+        })
+    }
+
+    fn boxed(db: &TypeInterner, value: TypeId) -> TypeId {
+        db.object(vec![PropertyInfo::new(db.intern_string("value"), value)])
+    }
+
+    #[test]
+    fn declaration_origin_queries_distinguish_identity_from_surface() {
+        let db = TypeInterner::new();
+        let file = db.intern_string("identity.js");
+        let first = boxed(&db, declared_param(&db, file, "Value", 10));
+        let second = boxed(&db, declared_param(&db, file, "Value", 20));
+        let renamed = boxed(&db, declared_param(&db, file, "Other", 30));
+
+        assert!(have_distinct_decl_scoped_free_type_parameters(
+            &db, first, second
+        ));
+        assert!(have_same_surface_distinct_decl_scoped_free_type_parameters(
+            &db, &db, first, second
+        ));
+        assert!(have_distinct_decl_scoped_free_type_parameters(
+            &db, first, renamed
+        ));
+        assert!(
+            !have_same_surface_distinct_decl_scoped_free_type_parameters(&db, &db, first, renamed)
+        );
+        assert!(!have_distinct_decl_scoped_free_type_parameters(
+            &db, first, first
+        ));
+    }
+
+    #[test]
+    fn declaration_origin_queries_ignore_legacy_and_reminted_identity() {
+        let db = TypeInterner::new();
+        let file = db.intern_string("identity.js");
+        let name = db.intern_string("Value");
+        let origin = TypeParamOrigin::DeclScoped { file, node: 40 };
+        let first_param = db.type_param(TypeParamInfo {
+            origin,
+            ..TypeParamInfo::simple(name)
+        });
+        let reminted_param = db.type_param(TypeParamInfo {
+            constraint: Some(TypeId::STRING),
+            origin,
+            ..TypeParamInfo::simple(name)
+        });
+        assert_ne!(first_param, reminted_param);
+        assert!(!have_distinct_decl_scoped_free_type_parameters(
+            &db,
+            boxed(&db, first_param),
+            boxed(&db, reminted_param),
+        ));
+
+        let legacy_left = boxed(
+            &db,
+            db.type_param(TypeParamInfo {
+                constraint: Some(TypeId::STRING),
+                ..TypeParamInfo::simple(name)
+            }),
+        );
+        let legacy_right = boxed(
+            &db,
+            db.type_param(TypeParamInfo {
+                constraint: Some(TypeId::NUMBER),
+                ..TypeParamInfo::simple(name)
+            }),
+        );
+        assert!(!have_distinct_decl_scoped_free_type_parameters(
+            &db,
+            legacy_left,
+            legacy_right,
+        ));
+    }
+
+    #[test]
+    fn declaration_origin_surface_query_traverses_application_wrappers() {
+        let db = TypeInterner::new();
+        let file = db.intern_string("application.js");
+        let base = db.lazy(tsz_solver::DefId(1));
+        let first = db.application(
+            base,
+            vec![boxed(&db, declared_param(&db, file, "Element", 50))],
+        );
+        let second = db.application(
+            base,
+            vec![boxed(&db, declared_param(&db, file, "Element", 60))],
+        );
+
+        assert!(have_same_surface_distinct_decl_scoped_free_type_parameters(
+            &db, &db, first, second
+        ));
+    }
+
+    #[test]
+    fn declaration_origin_surface_query_rejects_ambiguous_same_name_sets() {
+        let db = TypeInterner::new();
+        let file = db.intern_string("ambiguous.js");
+        let name = "Repeated";
+        let pair = |direct_node, nested_node| {
+            db.object(vec![
+                PropertyInfo::new(
+                    db.intern_string("direct"),
+                    declared_param(&db, file, name, direct_node),
+                ),
+                PropertyInfo::new(
+                    db.intern_string("nested"),
+                    boxed(&db, declared_param(&db, file, name, nested_node)),
+                ),
+            ])
+        };
+        let source = pair(70, 80);
+        let target = pair(90, 100);
+
+        assert!(have_distinct_decl_scoped_free_type_parameters(
+            &db, source, target
+        ));
+        assert!(
+            !have_same_surface_distinct_decl_scoped_free_type_parameters(&db, &db, source, target)
+        );
+    }
 }

--- a/crates/tsz-checker/src/query_boundaries/assignability_suppression.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability_suppression.rs
@@ -468,6 +468,18 @@ impl<'a> CheckerState<'a> {
             && !is_callable_or_function(target)
             && !target_contains_indexed_access()
             && !target_is_template_literal_from_bare_type_param;
+        // A free declaration-scoped parameter is an ordinary value-level type
+        // variable here, not a binder introduced by this relation. Distinct
+        // declaration sets therefore remain unrelated even when alias
+        // reduction leaves the same outer object shape. Generic callables are
+        // already excluded above and establish their own alpha-equivalence
+        // scope in the solver.
+        let distinct_decl_scoped_free_params = target_allows_complex_generic_suppression
+            && crate::query_boundaries::assignability::have_distinct_decl_scoped_free_type_parameters(
+                self.ctx.types,
+                source,
+                target,
+            );
 
         matches!(source, TypeId::ERROR)
             || matches!(target, TypeId::ERROR | TypeId::ANY)
@@ -501,7 +513,7 @@ impl<'a> CheckerState<'a> {
             // `\`...${Uppercase<T>}.4\`` vs `\`...${Uppercase<T>}.3\``) keep
             // their existing suppression — tsc tolerates those under generic
             // constraint relationships.
-            || target_allows_complex_generic_suppression
+            || (target_allows_complex_generic_suppression && !distinct_decl_scoped_free_params)
             // Suppress TS2322 for callable types where the source contains generic type
             // parameters that may not have been fully inferred from context. When both
             // source and target contain type parameters that are COMPLETELY disjoint

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -716,8 +716,17 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // Push type parameters (like <U> in `fn<U>(id: U)`) before checking types
-        let (_type_params, type_param_updates) = self.push_type_parameters(&method.type_parameters);
+        // Keep syntax and declaration-stamped JSDoc binders in scope while checking.
+        let (type_params, type_param_updates) = self.push_type_parameters(&method.type_parameters);
+        let method_jsdoc = self.get_jsdoc_for_function(member_idx);
+        let jsdoc_type_param_updates = if type_params.is_empty()
+            && let Some(jsdoc) = method_jsdoc.as_deref()
+        {
+            self.push_jsdoc_template_type_parameters_for_owner(member_idx, jsdoc)
+                .1
+        } else {
+            Vec::new()
+        };
 
         self.check_modifier_combinations(&method.modifiers);
 
@@ -852,8 +861,6 @@ impl<'a> CheckerState<'a> {
             .as_ref()
             .is_some_and(|c| c.is_declared)
             && self.has_private_modifier(&method.modifiers);
-        // Get method-level JSDoc for @param type checking
-        let method_jsdoc = self.get_jsdoc_for_function(member_idx);
         // Pre-extract ordered @param names for positional matching with binding patterns
         let jsdoc_param_names: Vec<String> = method_jsdoc
             .as_ref()
@@ -1140,6 +1147,7 @@ impl<'a> CheckerState<'a> {
             self.ctx.function_owned_this_stack.pop();
         }
 
+        self.pop_type_parameters(jsdoc_type_param_updates);
         self.pop_type_parameters(type_param_updates);
     }
 

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -9,7 +9,7 @@ use crate::query_boundaries::common::ContextualTypeContext;
 use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, node::NodeAccess, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{TypeId, TypeParamInfo};
+use tsz_solver::TypeId;
 
 struct FunctionBodyCtx<'a> {
     func_idx: NodeIndex,
@@ -197,7 +197,23 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // Keep the declaration's JSDoc template binders active for the entire
+        // callback. In particular, nested declarations must shadow an outer
+        // binder even when both tags use identical text; their owner nodes are
+        // the stable declaration identity used by signature construction too.
+        let func_decl_jsdoc = self.get_jsdoc_for_function(func_idx);
         let (_type_params, type_param_updates) = self.push_type_parameters(&func.type_parameters);
+        let (_jsdoc_type_params, jsdoc_type_param_updates) = if self.is_js_file()
+            && func
+                .type_parameters
+                .as_ref()
+                .is_none_or(|params| params.nodes.is_empty())
+            && let Some(jsdoc) = func_decl_jsdoc.as_deref()
+        {
+            self.push_jsdoc_template_type_parameters_for_owner(func_idx, jsdoc)
+        } else {
+            (Vec::new(), Vec::new())
+        };
 
         self.check_duplicate_type_parameters(&func.type_parameters);
         self.check_type_parameters_for_missing_names(&func.type_parameters);
@@ -298,9 +314,6 @@ impl<'a> CheckerState<'a> {
                 }
             }
         }
-
-        // Extract JSDoc for function declarations to suppress TS7006/TS7010 in JS files
-        let func_decl_jsdoc = self.get_jsdoc_for_function(func_idx);
 
         // TS7006: Check parameters for implicit any.
         // For closures (function expressions and arrow functions), TS7006 is already
@@ -419,6 +432,7 @@ impl<'a> CheckerState<'a> {
             self.check_overload_compatibility(func_idx);
         }
 
+        self.pop_type_parameters(jsdoc_type_param_updates);
         self.pop_type_parameters(type_param_updates);
     }
 
@@ -488,52 +502,6 @@ impl<'a> CheckerState<'a> {
             jsdoc_return_type,
             func_decl_jsdoc,
         } = ctx;
-        // For JS files, push the function's `@template T` JSDoc declarations
-        // into `type_parameter_scope` so that `@type {T}` annotations inside
-        // the function body resolve to the same type parameter the signature
-        // builder created. Without this, body checking sees `T` as an
-        // undeclared identifier and emits a false-positive TS2304.
-        // The signature builder (`function_type.rs`) push/pops these around
-        // signature construction, so by body-check time they have been
-        // popped — re-push them locally for the body walk and pop at end.
-        let body_jsdoc_template_updates: Vec<(String, Option<TypeId>, bool)> = if self.is_js_file()
-            && func
-                .type_parameters
-                .as_ref()
-                .is_none_or(|tp| tp.nodes.is_empty())
-            && let Some(jsdoc) = func_decl_jsdoc.as_ref()
-        {
-            let template_names = Self::jsdoc_template_type_params(jsdoc);
-            let mut updates = Vec::with_capacity(template_names.len());
-            let factory = self.ctx.types.factory();
-            let constraint_strs = Self::jsdoc_template_constraint_strings(jsdoc);
-            for (name, is_const, default_str) in template_names {
-                if self.ctx.type_parameter_scope.contains_key(&name) {
-                    continue;
-                }
-                let atom = self.ctx.types.intern_string(&name);
-                let default = default_str
-                    .as_deref()
-                    .and_then(|s| self.resolve_jsdoc_reference(s));
-                let constraint = constraint_strs
-                    .get(&name)
-                    .and_then(|s| self.resolve_jsdoc_reference(s));
-                let info = TypeParamInfo {
-                    name: atom,
-                    constraint,
-                    default,
-                    is_const,
-                    origin: tsz_solver::TypeParamOrigin::User,
-                };
-                let ty = factory.type_param(info);
-                let previous = self.ctx.type_parameter_scope.insert(name.clone(), ty);
-                updates.push((name, previous, false));
-            }
-            updates
-        } else {
-            Vec::new()
-        };
-
         let mut return_type = if has_type_annotation {
             self.get_type_from_type_node(func.type_annotation)
         } else if let Some(jsdoc_ret) = jsdoc_return_type {
@@ -858,9 +826,6 @@ impl<'a> CheckerState<'a> {
         if let Some(outer_this) = masked_outer_this {
             self.ctx.this_type_stack.push(outer_this);
         }
-
-        // Restore the @template T scope pushed at the top of this function.
-        self.pop_type_parameters(body_jsdoc_template_updates);
     }
 
     /// TS2677: Check that a type predicate's type is assignable to its parameter's type

--- a/crates/tsz-checker/src/state/type_analysis/jsdoc_type_param_identity.rs
+++ b/crates/tsz-checker/src/state/type_analysis/jsdoc_type_param_identity.rs
@@ -1,0 +1,165 @@
+//! Stable declaration identity for JSDoc `@template` binders.
+
+use crate::query_boundaries::signature_building as signature_query;
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+type TypeParamPushResult = (
+    Vec<tsz_solver::TypeParamInfo>,
+    Vec<(String, Option<TypeId>, bool)>,
+);
+
+#[derive(Clone, Copy)]
+enum JsdocTypeParamSite {
+    Owner(u32),
+    Comment(u32),
+}
+
+impl CheckerState<'_> {
+    /// Push JSDoc `@template` binders owned by `owner_node` into the active
+    /// type-parameter scope and return their declaration-stamped signature
+    /// records.
+    ///
+    /// The owner node supplies stable identity because raw JSDoc template tags
+    /// have no AST name nodes. Repeated construction of the same class or
+    /// callable therefore reuses the same `TypeId`, while a nested owner that
+    /// repeats the same spelling/constraint/default receives a distinct binder.
+    pub(crate) fn push_jsdoc_template_type_parameters_for_owner(
+        &mut self,
+        owner_node: NodeIndex,
+        jsdoc: &str,
+    ) -> TypeParamPushResult {
+        self.push_jsdoc_template_type_parameters_for_site(
+            JsdocTypeParamSite::Owner(owner_node.0),
+            jsdoc,
+        )
+    }
+
+    /// Push the JSDoc template binders declared by one overload comment.
+    /// The comment start is unique within its source file and lives in a
+    /// declaration-site namespace disjoint from AST node indices.
+    pub(crate) fn push_jsdoc_template_type_parameters_for_comment(
+        &mut self,
+        comment_pos: u32,
+        jsdoc: &str,
+    ) -> TypeParamPushResult {
+        self.push_jsdoc_template_type_parameters_for_site(
+            JsdocTypeParamSite::Comment(comment_pos),
+            jsdoc,
+        )
+    }
+
+    fn push_jsdoc_template_type_parameters_for_site(
+        &mut self,
+        declaration_site: JsdocTypeParamSite,
+        jsdoc: &str,
+    ) -> TypeParamPushResult {
+        let template_names = Self::jsdoc_template_type_params(jsdoc);
+        if template_names.is_empty() {
+            return (Vec::new(), Vec::new());
+        }
+
+        let constraint_strs = Self::jsdoc_template_constraint_strings(jsdoc);
+        let mut params = Vec::with_capacity(template_names.len());
+        let mut updates = Vec::with_capacity(template_names.len());
+
+        for (name, is_const, default_str) in template_names {
+            let atom = self.ctx.types.intern_string(&name);
+            let default = default_str
+                .as_deref()
+                .and_then(|type_expr| self.resolve_jsdoc_reference(type_expr));
+            let constraint = constraint_strs
+                .get(&name)
+                .and_then(|type_expr| self.resolve_jsdoc_reference(type_expr));
+            let info = signature_query::user_type_param_info(atom, constraint, default, is_const);
+            let (type_id, stamped_info) =
+                self.intern_jsdoc_type_param_for_site_stamped(declaration_site, info);
+
+            let mut shadowed_class_param = false;
+            if let Some(ref mut class) = self.ctx.enclosing_class
+                && let Some(position) = class.type_param_names.iter().position(|item| *item == name)
+            {
+                class.type_param_names.remove(position);
+                shadowed_class_param = true;
+            }
+
+            let previous = self.ctx.type_parameter_scope.insert(name.clone(), type_id);
+            updates.push((name, previous, shadowed_class_param));
+            params.push(stamped_info);
+        }
+
+        (params, updates)
+    }
+
+    /// Allocate (or reuse) the canonical type-parameter identity for a JSDoc
+    /// `@template` owned by an AST declaration.
+    ///
+    /// JSDoc template parameters do not have their own parser node, so the
+    /// containing class/function/method node is their stable declaration key.
+    /// These parameters are always stamped as
+    /// [`tsz_solver::TypeParamOrigin::DeclScoped`]: unlike syntax declarations,
+    /// they have no lowering-owned identity path and would otherwise collapse
+    /// structurally when a nested declaration repeats the same binder spelling,
+    /// constraint, and default. Structural interning then makes repeated
+    /// construction stable without the fresh-id declaration cache used by the
+    /// syntax/lowering convergence path.
+    pub(crate) fn intern_jsdoc_type_param_for_owner_stamped(
+        &mut self,
+        owner_node: NodeIndex,
+        info: tsz_solver::TypeParamInfo,
+    ) -> (tsz_solver::TypeId, tsz_solver::TypeParamInfo) {
+        self.intern_jsdoc_type_param_for_site_stamped(JsdocTypeParamSite::Owner(owner_node.0), info)
+    }
+
+    /// Allocate (or reuse) a type parameter declared by one JSDoc comment,
+    /// such as a generic `@typedef` or `@callback`.
+    pub(crate) fn intern_jsdoc_type_param_for_comment_stamped(
+        &mut self,
+        comment_pos: u32,
+        info: tsz_solver::TypeParamInfo,
+    ) -> (tsz_solver::TypeId, tsz_solver::TypeParamInfo) {
+        self.intern_jsdoc_type_param_for_site_stamped(
+            JsdocTypeParamSite::Comment(comment_pos),
+            info,
+        )
+    }
+
+    /// Cross-arena counterpart of
+    /// [`Self::intern_jsdoc_type_param_for_owner_stamped`].
+    ///
+    /// The declaration belongs to `file_name`, not the current checker arena,
+    /// so its file atom is supplied explicitly.
+    pub(crate) fn intern_cross_arena_jsdoc_type_param_for_owner_stamped(
+        &self,
+        file_name: &str,
+        owner_node: NodeIndex,
+        mut info: tsz_solver::TypeParamInfo,
+    ) -> (tsz_solver::TypeId, tsz_solver::TypeParamInfo) {
+        let file_atom = self.ctx.types.intern_string(file_name);
+        info.origin = tsz_solver::TypeParamOrigin::DeclScoped {
+            file: file_atom,
+            node: owner_node.0,
+        };
+        let type_id = signature_query::type_param(self.ctx.types, info);
+        (type_id, info)
+    }
+
+    fn intern_jsdoc_type_param_for_site_stamped(
+        &mut self,
+        declaration_site: JsdocTypeParamSite,
+        mut info: tsz_solver::TypeParamInfo,
+    ) -> (tsz_solver::TypeId, tsz_solver::TypeParamInfo) {
+        let file = self.ctx.types.intern_string(&self.ctx.file_name);
+        info.origin = match declaration_site {
+            JsdocTypeParamSite::Owner(node) => {
+                tsz_solver::TypeParamOrigin::DeclScoped { file, node }
+            }
+            JsdocTypeParamSite::Comment(pos) => {
+                tsz_solver::TypeParamOrigin::JsdocCommentScoped { file, pos }
+            }
+        };
+        let type_id = signature_query::type_param(self.ctx.types, info);
+        (type_id, info)
+    }
+}

--- a/crates/tsz-checker/src/state/type_analysis/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/mod.rs
@@ -42,6 +42,7 @@ mod cross_file_overlay_gate;
 pub(crate) mod cross_file_query_types;
 mod cross_file_residue;
 mod cross_file_shared_cache;
+mod jsdoc_type_param_identity;
 mod qualified_names;
 mod source_alias_attribution;
 mod symbol_env_registration;

--- a/crates/tsz-checker/src/state/type_environment/type_params.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_params.rs
@@ -186,13 +186,19 @@ impl<'a> CheckerState<'a> {
                 .get(&name)
                 .map(String::as_str)
                 .and_then(crate::types_domain::queries::lib_resolution::keyword_name_to_type_id);
-            params.push(tsz_solver::TypeParamInfo {
+            let info = tsz_solver::TypeParamInfo {
                 name: self.ctx.types.intern_string(&name),
                 constraint,
                 default,
                 is_const,
                 origin: tsz_solver::TypeParamOrigin::User,
-            });
+            };
+            let (_, stamped_info) = self.intern_cross_arena_jsdoc_type_param_for_owner_stamped(
+                &sf.file_name,
+                decl_idx,
+                info,
+            );
+            params.push(stamped_info);
         }
 
         if params.is_empty() {
@@ -360,13 +366,16 @@ impl<'a> CheckerState<'a> {
             let constraint = constraint_strs
                 .get(&name)
                 .and_then(|s| checker.resolve_jsdoc_reference(s));
-            params.push(tsz_solver::TypeParamInfo {
+            let info = tsz_solver::TypeParamInfo {
                 name: checker.ctx.types.intern_string(&name),
                 constraint,
                 default,
                 is_const,
                 origin: tsz_solver::TypeParamOrigin::User,
-            });
+            };
+            let (_, stamped_info) =
+                checker.intern_jsdoc_type_param_for_owner_stamped(decl_idx, info);
+            params.push(stamped_info);
         }
 
         if params.is_empty() {

--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -1203,13 +1203,15 @@ impl CheckerState<'_> {
             let constraint = constraint_strs
                 .get(&name)
                 .and_then(|s| self.resolve_jsdoc_reference(s));
-            params.push(tsz_solver::TypeParamInfo {
+            let info = tsz_solver::TypeParamInfo {
                 name: self.ctx.types.intern_string(&name),
                 constraint,
                 default,
                 is_const,
                 origin: tsz_solver::TypeParamOrigin::User,
-            });
+            };
+            let (_, stamped_info) = self.intern_jsdoc_type_param_for_owner_stamped(decl_idx, info);
+            params.push(stamped_info);
         }
         if params.is_empty() {
             None

--- a/crates/tsz-checker/src/tests/jsdoc_shadowed_type_param_identity_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_shadowed_type_param_identity_tests.rs
@@ -1,0 +1,1016 @@
+//! Declaration-identity coverage for checked-JS `@template` binders.
+//!
+//! JSDoc type parameters have no syntax name node. Their containing
+//! declaration (or, for `@overload`, the individual comment) must therefore
+//! supply identity so identical surface text does not merge unrelated binders.
+
+use crate::context::CheckerOptions;
+use crate::state::CheckerState;
+use crate::test_utils::{
+    check_js_source_code_messages_with_options, check_js_source_codes_with_options,
+};
+use tsz_parser::parser::{NodeIndex, ParserState};
+use tsz_solver::construction::{QueryDatabase, TypeInterner};
+
+fn strict_js_codes(source: &str) -> Vec<u32> {
+    check_js_source_codes_with_options(
+        source,
+        "test.js",
+        CheckerOptions {
+            strict: true,
+            strict_property_initialization: false,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+#[test]
+fn nested_jsdoc_functions_with_identical_binders_report_ts2719() {
+    let codes = strict_js_codes(
+        r#"
+/**
+ * @template T
+ * @param {T} outerValue
+ */
+function outer(outerValue) {
+    /**
+     * @template T
+     * @param {T} innerValue
+     */
+    function inner(innerValue) {
+        outerValue = innerValue;
+    }
+}
+"#,
+    );
+    assert!(codes.contains(&2719), "expected TS2719, got {codes:?}");
+}
+
+#[test]
+fn alias_application_bodies_preserve_alpha_equivalence_and_shadow_identity() {
+    let compatible = strict_js_codes(
+        r#"
+/**
+ * @template Payload
+ * @typedef {{ payload: Payload }} Envelope
+ */
+/**
+ * @template LeftValue
+ * @param {Envelope<LeftValue>} input
+ * @returns {Envelope<LeftValue>}
+ */
+function leftIdentity(input) { return input; }
+/**
+ * @template RightValue
+ * @param {Envelope<RightValue>} input
+ * @returns {Envelope<RightValue>}
+ */
+function rightIdentity(input) { return input; }
+/** @type {typeof leftIdentity} */
+const compatibleIdentity = rightIdentity;
+"#,
+    );
+    assert!(
+        !compatible
+            .iter()
+            .any(|code| matches!(code, 2322 | 2345 | 2719)),
+        "renamed alpha-equivalent alias applications must relate: {compatible:?}"
+    );
+
+    let shadowed_diagnostics = check_js_source_code_messages_with_options(
+        r#"
+/**
+ * @template Payload
+ * @typedef {{ payload: Payload }} Envelope
+ */
+/**
+ * @template ShadowValue
+ * @param {Envelope<ShadowValue>} outerValue
+ */
+function outer(outerValue) {
+    /**
+     * @template ShadowValue
+     * @param {Envelope<ShadowValue>} innerValue
+     */
+    function inner(innerValue) {
+        outerValue = innerValue;
+    }
+}
+"#,
+        "test.js",
+        CheckerOptions {
+            strict: true,
+            strict_property_initialization: false,
+            ..CheckerOptions::default()
+        },
+    );
+    let shadowed: Vec<_> = shadowed_diagnostics.iter().map(|(code, _)| *code).collect();
+    assert!(
+        shadowed.contains(&2719),
+        "an alias application must not erase the two declarations' binder identity: {shadowed_diagnostics:?}"
+    );
+
+    let different_aliases = strict_js_codes(
+        r#"
+/**
+ * @template Value
+ * @typedef {{ value: Value }} FirstBox
+ */
+/**
+ * @template Value
+ * @typedef {{ value: Value }} SecondBox
+ */
+/**
+ * @template Outer
+ * @param {FirstBox<Outer>} outerValue
+ */
+function outer(outerValue) {
+    /**
+     * @template Inner
+     * @param {SecondBox<Inner>} innerValue
+     */
+    function inner(innerValue) { outerValue = innerValue; }
+}
+"#,
+    );
+    assert!(
+        different_aliases.contains(&2322) && !different_aliases.contains(&2719),
+        "different visible alias surfaces must keep TS2322 routing: {different_aliases:?}"
+    );
+}
+
+#[test]
+fn alias_application_construction_keeps_shadowed_type_arguments_distinct() {
+    let source = r#"
+/**
+ * @template Payload
+ * @typedef {{ payload: Payload }} Envelope
+ */
+/**
+ * @template ShadowValue
+ * @param {Envelope<ShadowValue>} outerValue
+ */
+function outer(outerValue) {
+    /**
+     * @template ShadowValue
+     * @param {Envelope<ShadowValue>} innerValue
+     */
+    function inner(innerValue) { outerValue = innerValue; }
+}
+"#;
+    let mut parser = ParserState::new("applications.js".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.get_arena();
+    let outer = arena
+        .get_source_file(arena.get(root).expect("source-file node"))
+        .expect("source-file data")
+        .statements
+        .nodes[0];
+    let outer_function = arena
+        .get_function(arena.get(outer).expect("outer function node"))
+        .expect("outer function data");
+    let inner = arena
+        .get_block(arena.get(outer_function.body).expect("outer body node"))
+        .expect("outer body data")
+        .statements
+        .nodes[0];
+
+    let mut binder = tsz_binder::BinderState::new();
+    binder.bind_source_file(arena, root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        arena,
+        &binder,
+        &types,
+        "applications.js".to_string(),
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let outer_jsdoc = checker
+        .get_jsdoc_for_function(outer)
+        .expect("outer function JSDoc");
+    let (_, outer_updates) =
+        checker.push_jsdoc_template_type_parameters_for_owner(outer, &outer_jsdoc);
+    let outer_param = checker.ctx.type_parameter_scope["ShadowValue"];
+    let outer_envelope = checker
+        .resolve_jsdoc_reference("Envelope<ShadowValue>")
+        .expect("outer alias application");
+
+    let inner_jsdoc = checker
+        .get_jsdoc_for_function(inner)
+        .expect("inner function JSDoc");
+    let (_, inner_updates) =
+        checker.push_jsdoc_template_type_parameters_for_owner(inner, &inner_jsdoc);
+    let inner_param = checker.ctx.type_parameter_scope["ShadowValue"];
+    let inner_envelope = checker
+        .resolve_jsdoc_reference("Envelope<ShadowValue>")
+        .expect("inner alias application");
+
+    assert_ne!(outer_param, inner_param);
+    assert_ne!(outer_envelope, inner_envelope);
+    assert!(
+        !tsz_solver::relations::subtype::SubtypeChecker::new(&types)
+            .is_subtype_of(inner_envelope, outer_envelope),
+        "the reduced alias bodies must retain their free declaration origins"
+    );
+
+    checker.pop_type_parameters(inner_updates);
+    checker.pop_type_parameters(outer_updates);
+
+    let outer_type = checker.get_type_of_function(outer);
+    let inner_type = checker.get_type_of_function(inner);
+    let outer_shape = crate::query_boundaries::common::function_shape_for_type(&types, outer_type)
+        .expect("outer function shape");
+    let inner_shape = crate::query_boundaries::common::function_shape_for_type(&types, inner_type)
+        .expect("inner function shape");
+    assert_ne!(outer_shape.params[0].type_id, inner_shape.params[0].type_id);
+    assert!(
+        !tsz_solver::relations::subtype::SubtypeChecker::new(&types)
+            .is_subtype_of(inner_shape.params[0].type_id, outer_shape.params[0].type_id),
+        "function signatures must retain the reduced bodies' free origins"
+    );
+
+    let inner_function = arena
+        .get_function(arena.get(inner).expect("inner function node"))
+        .expect("inner function data");
+    let assignment_statement = arena
+        .get_block(arena.get(inner_function.body).expect("inner body node"))
+        .expect("inner body data")
+        .statements
+        .nodes[0];
+    let assignment_expression = arena
+        .get_expression_statement(
+            arena
+                .get(assignment_statement)
+                .expect("assignment statement node"),
+        )
+        .expect("assignment statement data")
+        .expression;
+    let assignment = arena
+        .get(assignment_expression)
+        .and_then(|expression| arena.get_binary_expr(expression))
+        .expect("assignment expression");
+    let lhs = checker.get_type_of_node(assignment.left);
+    let rhs = checker.get_type_of_node(assignment.right);
+    assert_ne!(lhs, rhs);
+    assert!(
+        !tsz_solver::relations::subtype::SubtypeChecker::new(&types).is_subtype_of(rhs, lhs),
+        "identifier reads must preserve the two cached parameter types"
+    );
+    assert!(
+        !checker.is_assignable_to(rhs, lhs),
+        "the checker assignability gateway must retain the free origins"
+    );
+
+    let checked_types = TypeInterner::new();
+    let mut checked = CheckerState::new(
+        arena,
+        &binder,
+        &checked_types,
+        "applications.js".to_string(),
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+    checked.ctx.set_lib_contexts(Vec::new());
+    checked.check_source_file(root);
+    let checked_lhs = checked.get_type_of_node(assignment.left);
+    let checked_rhs = checked.get_type_of_node(assignment.right);
+    let checked_assignment_target = checked.get_type_of_assignment_target(assignment.left);
+    assert_ne!(
+        checked_lhs, checked_rhs,
+        "the canonical check pipeline must cache distinct identifier types"
+    );
+    assert_eq!(
+        checked_assignment_target, checked_lhs,
+        "the assignment-target query must consume the cached declared parameter type"
+    );
+    assert!(
+        !checked.is_assignable_to(checked_rhs, checked_lhs),
+        "the post-check identifier types must remain unassignable"
+    );
+    let lhs_origins = tsz_solver::visitor::free_decl_scoped_type_parameter_origins_in(
+        &checked_types,
+        [checked_lhs],
+    );
+    let rhs_origins = tsz_solver::visitor::free_decl_scoped_type_parameter_origins_in(
+        &checked_types,
+        [checked_rhs],
+    );
+    assert_ne!(lhs_origins, rhs_origins);
+    assert!(
+        crate::query_boundaries::assignability::
+            have_same_surface_distinct_decl_scoped_free_type_parameters(
+                &checked_types,
+                &checked.ctx,
+                checked_rhs,
+                checked_lhs,
+            ),
+        "the reduced assignment types must retain one common declared surface: {rhs_origins:?} -> {lhs_origins:?}"
+    );
+    assert!(
+        checked
+            .ctx
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == 2719),
+        "the assignment boundary must report the unrelated same-surface declarations: {:?}",
+        checked
+            .ctx
+            .diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.code, diagnostic.message_text.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn identical_constraint_and_default_surfaces_still_get_distinct_binders() {
+    for (label, source) in [
+        (
+            "constraint",
+            r#"
+/**
+ * @template {object} Shape
+ * @param {Shape} outerValue
+ */
+function outer(outerValue) {
+    /**
+     * @template {object} Shape
+     * @param {Shape} innerValue
+     */
+    function inner(innerValue) { outerValue = innerValue; }
+}
+"#,
+        ),
+        (
+            "default",
+            r#"
+/**
+ * @template [Item=object]
+ * @param {Item} outerValue
+ */
+function outer(outerValue) {
+    /**
+     * @template [Item=object]
+     * @param {Item} innerValue
+     */
+    function inner(innerValue) { outerValue = innerValue; }
+}
+"#,
+        ),
+    ] {
+        let codes = strict_js_codes(source);
+        assert!(
+            codes.contains(&2719),
+            "{label}: identical declaration surfaces must still report TS2719, got {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn renamed_and_differently_named_shadowing_keep_diagnostic_routing() {
+    let renamed = strict_js_codes(
+        r#"
+/**
+ * @template Elem
+ * @param {Elem} outerValue
+ */
+function outer(outerValue) {
+    /**
+     * @template Elem
+     * @param {Elem} innerValue
+     */
+    function inner(innerValue) { outerValue = innerValue; }
+}
+"#,
+    );
+    assert!(renamed.contains(&2719), "renamed binder: {renamed:?}");
+
+    let different = strict_js_codes(
+        r#"
+/**
+ * @template Outer
+ * @param {Outer} outerValue
+ */
+function outer(outerValue) {
+    /**
+     * @template Inner
+     * @param {Inner} innerValue
+     */
+    function inner(innerValue) { outerValue = innerValue; }
+}
+"#,
+    );
+    assert!(
+        different.contains(&2322),
+        "different binders: {different:?}"
+    );
+    assert!(
+        !different.contains(&2719),
+        "different display names must not route to TS2719: {different:?}"
+    );
+}
+
+#[test]
+fn class_and_method_templates_infer_independently_across_surface_matrix() {
+    let cases = [
+        (
+            "plain",
+            r#"
+/** @template T */
+class Box {
+    /** @param {T} value */ constructor(value) { this.value = value; }
+    /**
+     * @template T
+     * @param {T} input
+     * @returns {T}
+     */
+    id(input) { return input; }
+}
+const box = new Box(1);
+/** @type {string} */ const result = box.id("ok");
+"#,
+        ),
+        (
+            "renamed",
+            r#"
+/** @template Elem */
+class Box {
+    /** @param {Elem} value */ constructor(value) { this.value = value; }
+    /**
+     * @template Elem
+     * @param {Elem} input
+     * @returns {Elem}
+     */
+    id(input) { return input; }
+}
+const box = new Box(1);
+/** @type {string} */ const result = box.id("ok");
+"#,
+        ),
+        (
+            "constraint",
+            r#"
+/** @template {object} T */
+class Box {
+    /** @param {T} value */ constructor(value) { this.value = value; }
+    /**
+     * @template {object} T
+     * @param {T} input
+     * @returns {T}
+     */
+    id(input) { return input; }
+}
+const box = new Box({ classOnly: 1 });
+/** @type {{methodOnly: string}} */ const result = box.id({ methodOnly: "ok" });
+"#,
+        ),
+        (
+            "default",
+            r#"
+/** @template [T=object] */
+class Box {
+    /** @param {T} value */ constructor(value) { this.value = value; }
+    /**
+     * @template [T=object]
+     * @param {T} input
+     * @returns {T}
+     */
+    id(input) { return input; }
+}
+const box = new Box({ classOnly: 1 });
+/** @type {{methodOnly: string}} */ const result = box.id({ methodOnly: "ok" });
+"#,
+        ),
+    ];
+
+    for (label, source) in cases {
+        let codes = strict_js_codes(source);
+        let identity_failures: Vec<_> = codes
+            .iter()
+            .copied()
+            .filter(|code| matches!(code, 2304 | 2322 | 2345 | 2719))
+            .collect();
+        assert!(
+            identity_failures.is_empty(),
+            "{label}: class and method binders must infer independently, got {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn class_expression_method_shadowing_reports_ts2719() {
+    let codes = strict_js_codes(
+        r#"
+/**
+ * @template T
+ * @param {T} outer
+ */
+function make(outer) {
+    const Local = class {
+        /**
+         * @template T
+         * @param {T} inner
+         */
+        id(inner) { outer = inner; }
+    };
+    return Local;
+}
+"#,
+    );
+    assert!(codes.contains(&2719), "expected TS2719, got {codes:?}");
+}
+
+#[test]
+fn non_shadowing_class_template_use_remains_valid() {
+    let codes = strict_js_codes(
+        r#"
+/** @template T */
+class Box {
+    /** @param {T} value */ constructor(value) { this.value = value; }
+    /** @param {T} input */ set(input) { this.value = input; }
+}
+new Box(1).set(2);
+"#,
+    );
+    assert!(
+        !codes
+            .iter()
+            .any(|code| matches!(code, 2304 | 2322 | 2345 | 2719)),
+        "non-shadowing uses of the class binder must remain valid: {codes:?}"
+    );
+}
+
+#[test]
+fn owner_pushes_reuse_ids_but_distinct_owners_do_not() {
+    let source = r#"
+/** @template T @param {T} value */
+function first(value) { return value; }
+/** @template T @param {T} value */
+function second(value) { return value; }
+"#;
+    let mut parser = ParserState::new("owners.js".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.get_arena();
+    let root_node = arena.get(root).expect("source-file node");
+    let owners = arena
+        .get_source_file(root_node)
+        .expect("source-file data")
+        .statements
+        .nodes
+        .clone();
+    assert_eq!(owners.len(), 2);
+
+    let mut binder = tsz_binder::BinderState::new();
+    binder.bind_source_file(arena, root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        arena,
+        &binder,
+        &types,
+        "owners.js".to_string(),
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let mut ids = Vec::new();
+    for &owner in &owners {
+        let jsdoc = checker
+            .get_jsdoc_for_function(owner)
+            .expect("function JSDoc");
+        let (params, updates) =
+            checker.push_jsdoc_template_type_parameters_for_owner(owner, &jsdoc);
+        let first_id = checker.ctx.type_parameter_scope["T"];
+        checker.pop_type_parameters(updates);
+
+        let (repeated_params, repeated_updates) =
+            checker.push_jsdoc_template_type_parameters_for_owner(owner, &jsdoc);
+        let repeated_id = checker.ctx.type_parameter_scope["T"];
+        checker.pop_type_parameters(repeated_updates);
+
+        assert_eq!(first_id, repeated_id, "same owner must reuse its TypeId");
+        assert_eq!(params, repeated_params, "same owner must reuse its origin");
+        assert!(matches!(
+            params[0].origin,
+            tsz_solver::TypeParamOrigin::DeclScoped {
+                node,
+                ..
+            } if node == owner.0
+        ));
+        ids.push(first_id);
+    }
+    assert_ne!(ids[0], ids[1], "different owners must not share a TypeId");
+}
+
+#[test]
+fn cross_arena_same_node_index_uses_the_declaring_file_identity() {
+    let source = "/** @template Element */\nclass Container {}";
+    let mut left_parser = ParserState::new("left.js".to_string(), source.to_string());
+    let left_root = left_parser.parse_source_file();
+    let left_arena = left_parser.get_arena();
+    let left_owner = left_arena
+        .get_source_file(left_arena.get(left_root).expect("left source-file node"))
+        .expect("left source-file data")
+        .statements
+        .nodes[0];
+
+    let mut right_parser = ParserState::new("right.js".to_string(), source.to_string());
+    let right_root = right_parser.parse_source_file();
+    let right_arena = right_parser.get_arena();
+    let right_owner = right_arena
+        .get_source_file(right_arena.get(right_root).expect("right source-file node"))
+        .expect("right source-file data")
+        .statements
+        .nodes[0];
+    assert_eq!(
+        left_owner, right_owner,
+        "identical parses should exercise the same numeric NodeIndex in two arenas"
+    );
+
+    let mut left_binder = tsz_binder::BinderState::new();
+    left_binder.bind_source_file(left_arena, left_root);
+    let types = TypeInterner::new();
+    let checker = CheckerState::new(
+        left_arena,
+        &left_binder,
+        &types,
+        "left.js".to_string(),
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let extract = |arena, owner, name| {
+        checker
+            .extract_simple_type_params_from_decl_in_arena(
+                arena,
+                tsz_binder::symbol_flags::CLASS,
+                owner,
+                name,
+            )
+            .expect("cross-arena class type parameters")
+    };
+    let left = extract(left_arena, left_owner, "Container");
+    let right = extract(right_arena, right_owner, "Container");
+    let repeated_right = extract(right_arena, right_owner, "Container");
+    assert_eq!(left.len(), 1);
+    assert_eq!(right.len(), 1);
+    assert_eq!(
+        right, repeated_right,
+        "cross-arena reconstruction must be stable"
+    );
+
+    let origin_parts = |origin| match origin {
+        tsz_solver::TypeParamOrigin::DeclScoped { file, node } => (file, node),
+        other => panic!("expected owner-scoped JSDoc binder, got {other:?}"),
+    };
+    let (left_file, left_node) = origin_parts(left[0].origin);
+    let (right_file, right_node) = origin_parts(right[0].origin);
+    assert_eq!(left_node, right_node);
+    assert_eq!(types.resolve_atom(left_file), "left.js");
+    assert_eq!(types.resolve_atom(right_file), "right.js");
+    assert_ne!(left[0].origin, right[0].origin);
+    assert_ne!(
+        types.factory().type_param(left[0]),
+        types.factory().type_param(right[0]),
+        "equal NodeIndex values in different files must not collide"
+    );
+}
+
+#[test]
+fn identical_overload_comments_have_distinct_stable_binders() {
+    let source = r#"
+/**
+ * @overload
+ * @template T
+ * @param {T} value
+ * @returns {T}
+ */
+/**
+ * @overload
+ * @template T
+ * @param {T} value
+ * @returns {T}
+ */
+/**
+ * @param {*} value
+ * @returns {*}
+ */
+function identity(value) { return value; }
+"#;
+    let mut parser = ParserState::new("overloads.js".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.get_arena();
+    let root_node = arena.get(root).expect("source-file node");
+    let function_idx = arena
+        .get_source_file(root_node)
+        .expect("source-file data")
+        .statements
+        .nodes[0];
+    let function_node = arena.get(function_idx).expect("function node");
+    let function = arena.get_function(function_node).expect("function data");
+
+    let mut binder = tsz_binder::BinderState::new();
+    binder.bind_source_file(arena, root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        arena,
+        &binder,
+        &types,
+        "overloads.js".to_string(),
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let signatures = checker.jsdoc_overload_call_signatures_for_function(function, function_idx);
+    let repeated = checker.jsdoc_overload_call_signatures_for_function(function, function_idx);
+    assert_eq!(signatures.len(), 2);
+    assert_eq!(repeated.len(), 2);
+
+    let infos: Vec<_> = signatures.iter().map(|sig| sig.type_params[0]).collect();
+    let repeated_infos: Vec<_> = repeated.iter().map(|sig| sig.type_params[0]).collect();
+    assert_eq!(
+        infos, repeated_infos,
+        "overload reconstruction must be stable"
+    );
+    assert_ne!(infos[0].origin, infos[1].origin);
+    let comment_positions: Vec<_> = infos
+        .iter()
+        .map(|info| match info.origin {
+            tsz_solver::TypeParamOrigin::JsdocCommentScoped { pos, .. } => pos,
+            other => panic!("expected comment-scoped overload binder, got {other:?}"),
+        })
+        .collect();
+    assert_ne!(comment_positions[0], comment_positions[1]);
+
+    let ids: Vec<_> = infos
+        .iter()
+        .map(|info| checker.ctx.types.factory().type_param(*info))
+        .collect();
+    assert_ne!(
+        ids[0], ids[1],
+        "separate overload comments need separate binders"
+    );
+}
+
+#[test]
+fn comment_binder_identity_survives_incremental_arena_growth_and_is_node_disjoint() {
+    use tsz_common::comments::get_jsdoc_content;
+
+    let initial_source = "/** @template T */\nconst marker = 1;";
+    let file_name = "incremental.js";
+    let mut parser = ParserState::new(file_name.to_string(), initial_source.to_string());
+    let root = parser.parse_source_file();
+    let comment = parser
+        .get_arena()
+        .source_files
+        .first()
+        .and_then(|source_file| source_file.comments.first())
+        .cloned()
+        .expect("JSDoc comment");
+    let jsdoc = get_jsdoc_content(&comment, initial_source);
+    let initial_arena_len = parser.get_arena().len();
+    let old_pseudo_node = u32::try_from(initial_arena_len).expect("arena length fits u32");
+    assert!(
+        parser.get_arena().get(NodeIndex(old_pseudo_node)).is_none(),
+        "the old arena-length pseudo-node starts outside the arena"
+    );
+
+    let mut binder = tsz_binder::BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let types = TypeInterner::new();
+    let (before_id, before_info) = {
+        let mut checker = CheckerState::new(
+            parser.get_arena(),
+            &binder,
+            &types,
+            file_name.to_string(),
+            CheckerOptions {
+                allow_js: true,
+                check_js: true,
+                ..CheckerOptions::default()
+            },
+        );
+        let (params, updates) =
+            checker.push_jsdoc_template_type_parameters_for_comment(comment.pos, &jsdoc);
+        let type_id = checker.ctx.type_parameter_scope["T"];
+        checker.pop_type_parameters(updates);
+        (type_id, params[0])
+    };
+
+    let edited_source = format!("{initial_source}\nconst appended_after_parse = 2;");
+    let incremental = parser.parse_source_file_statements_from_offset(
+        file_name.to_string(),
+        edited_source,
+        u32::try_from(initial_source.len()).expect("source length fits u32"),
+    );
+    assert_eq!(incremental.statements.nodes.len(), 1);
+    assert!(parser.get_arena().len() > initial_arena_len);
+    assert!(
+        parser.get_arena().get(NodeIndex(old_pseudo_node)).is_some(),
+        "incremental parsing turns the old pseudo-node value into a real NodeIndex"
+    );
+
+    let (after_id, after_info) = {
+        let mut checker = CheckerState::new(
+            parser.get_arena(),
+            &binder,
+            &types,
+            file_name.to_string(),
+            CheckerOptions {
+                allow_js: true,
+                check_js: true,
+                ..CheckerOptions::default()
+            },
+        );
+        let (params, updates) =
+            checker.push_jsdoc_template_type_parameters_for_comment(comment.pos, &jsdoc);
+        let type_id = checker.ctx.type_parameter_scope["T"];
+        checker.pop_type_parameters(updates);
+        (type_id, params[0])
+    };
+
+    assert_eq!(before_info.origin, after_info.origin);
+    assert_eq!(before_id, after_id);
+    assert!(matches!(
+        after_info.origin,
+        tsz_solver::TypeParamOrigin::JsdocCommentScoped { pos, .. } if pos == comment.pos
+    ));
+
+    let file = types.intern_string(file_name);
+    let syntax_info = tsz_solver::TypeParamInfo {
+        origin: tsz_solver::TypeParamOrigin::DeclScoped {
+            file,
+            node: old_pseudo_node,
+        },
+        ..after_info
+    };
+    let same_payload_comment_info = tsz_solver::TypeParamInfo {
+        origin: tsz_solver::TypeParamOrigin::JsdocCommentScoped {
+            file,
+            pos: old_pseudo_node,
+        },
+        ..after_info
+    };
+    let syntax_id = types.factory().type_param(syntax_info);
+    let same_payload_comment_id = types.factory().type_param(same_payload_comment_info);
+    assert_ne!(syntax_info.origin, same_payload_comment_info.origin);
+    assert_ne!(syntax_id, same_payload_comment_id);
+}
+
+#[test]
+fn nested_typedef_and_callback_comments_do_not_capture_outer_template() {
+    use tsz_common::comments::get_jsdoc_content;
+
+    let source = r#"
+/**
+ * @template T
+ * @param {T} outer
+ */
+function host(outer) {
+    /**
+     * @template T
+     * @typedef {{ value: T }} Box
+     */
+    /**
+     * @template T
+     * @callback Identity
+     * @param {T} value
+     * @returns {T}
+     */
+    /** @type {Box<string>} */
+    const box = { value: "ok" };
+    return [outer, box];
+}
+"#;
+    let mut parser = ParserState::new("typedefs.js".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.get_arena();
+    let root_node = arena.get(root).expect("source-file node");
+    let owner = arena
+        .get_source_file(root_node)
+        .expect("source-file data")
+        .statements
+        .nodes[0];
+    let source_file = arena.source_files.first().expect("source file");
+    let comments = source_file.comments.clone();
+    let source_text = source_file.text.to_string();
+
+    let mut binder = tsz_binder::BinderState::new();
+    binder.bind_source_file(arena, root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        arena,
+        &binder,
+        &types,
+        "typedefs.js".to_string(),
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let owner_jsdoc = checker
+        .get_jsdoc_for_function(owner)
+        .expect("outer function JSDoc");
+    let (outer_params, outer_updates) =
+        checker.push_jsdoc_template_type_parameters_for_owner(owner, &owner_jsdoc);
+    let outer_id = checker.ctx.type_parameter_scope["T"];
+
+    let use_pos = comments
+        .iter()
+        .find(|comment| get_jsdoc_content(comment, &source_text).contains("@type {Box"))
+        .expect("typedef use comment")
+        .pos;
+    checker.ctx.jsdoc_typedef_anchor_pos.set(use_pos);
+
+    let mut declared = Vec::new();
+    for name in ["Box", "Identity"] {
+        let (body, params) = checker
+            .resolve_jsdoc_typedef_info(name, &comments, &source_text)
+            .unwrap_or_else(|| panic!("missing {name} definition"));
+        assert_eq!(params.len(), 1, "{name} must have one template binder");
+        if name == "Identity" {
+            let binder_id = checker.ctx.types.factory().type_param(params[0]);
+            let signature =
+                crate::query_boundaries::common::function_shape_for_type(checker.ctx.types, body)
+                    .expect("callback function shape");
+            assert_eq!(signature.params[0].type_id, binder_id);
+            assert_eq!(signature.return_type, binder_id);
+        }
+        declared.push(params[0]);
+    }
+
+    assert_ne!(declared[0].origin, declared[1].origin);
+    let comment_positions: Vec<_> = declared
+        .iter()
+        .map(|param| match param.origin {
+            tsz_solver::TypeParamOrigin::JsdocCommentScoped { pos, .. } => pos,
+            other => panic!("expected comment-scoped typedef binder, got {other:?}"),
+        })
+        .collect();
+    assert_ne!(comment_positions[0], comment_positions[1]);
+    assert!(
+        declared
+            .iter()
+            .all(|param| param.origin != outer_params[0].origin)
+    );
+    assert!(
+        declared
+            .iter()
+            .all(|param| { checker.ctx.types.factory().type_param(*param) != outer_id })
+    );
+    assert_eq!(checker.ctx.type_parameter_scope["T"], outer_id);
+
+    checker.pop_type_parameters(outer_updates);
+}
+
+#[test]
+fn nested_generic_callback_use_does_not_capture_outer_template() {
+    let codes = strict_js_codes(
+        r#"
+/**
+ * @template T
+ * @param {T} outer
+ */
+function make(outer) {
+    /**
+     * @template T
+     * @callback Identity
+     * @param {T} value
+     * @returns {T}
+     */
+    /** @type {Identity<string>} */
+    const identity = value => value;
+    const result = identity("ok");
+    /** @type {string} */
+    const text = result;
+    return [outer, text];
+}
+"#,
+    );
+
+    assert!(
+        !codes
+            .iter()
+            .any(|code| matches!(code, 2304 | 2314 | 2322 | 2345 | 2719)),
+        "callback inference must not leak the outer declaration's T: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/class_type/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/helpers.rs
@@ -2,7 +2,6 @@
 
 use crate::query_boundaries::class_type::{self, callable_shape_for_type, object_shape_for_type};
 use crate::query_boundaries::common::is_plain_object_type;
-use crate::query_boundaries::signature_building as signature_building_boundary;
 use crate::state::CheckerState;
 use rustc_hash::FxHashMap;
 use tsz_parser::parser::NodeIndex;
@@ -497,31 +496,7 @@ impl<'a> CheckerState<'a> {
             }
         };
 
-        let template_names = Self::jsdoc_template_type_params(&jsdoc);
-        if template_names.is_empty() {
-            return (Vec::new(), Vec::new());
-        }
-
-        let mut type_params = Vec::with_capacity(template_names.len());
-        let mut scope_updates = Vec::with_capacity(template_names.len());
-        let constraint_strs = Self::jsdoc_template_constraint_strings(&jsdoc);
-        for (name, is_const, default_str) in template_names {
-            let atom = self.ctx.types.intern_string(&name);
-            let default = default_str
-                .as_deref()
-                .and_then(|s| self.resolve_jsdoc_reference(s));
-            let constraint = constraint_strs
-                .get(&name)
-                .and_then(|s| self.resolve_jsdoc_reference(s));
-            let info = signature_building_boundary::user_type_param_info(
-                atom, constraint, default, is_const,
-            );
-            let ty = signature_building_boundary::user_type_param(self.ctx.types, info);
-            type_params.push(info);
-            let previous = self.ctx.type_parameter_scope.insert(name.clone(), ty);
-            scope_updates.push((name, previous, false));
-        }
-        (type_params, scope_updates)
+        self.push_jsdoc_template_type_parameters_for_owner(class_idx, &jsdoc)
     }
 
     pub(super) fn register_final_class_instance_type(

--- a/crates/tsz-checker/src/types/class_type/js_class_properties.rs
+++ b/crates/tsz-checker/src/types/class_type/js_class_properties.rs
@@ -148,15 +148,12 @@ impl CheckerState<'_> {
                     let constraint = constraint_strs
                         .get(&name)
                         .and_then(|s| self.resolve_jsdoc_reference(s));
-                    template_types.entry(name).or_insert_with(|| {
-                        class_property_query::js_class_type_param_type(
-                            self.ctx.types,
-                            atom,
-                            constraint,
-                            default,
-                            is_const,
-                        )
-                    });
+                    let info = class_property_query::js_class_type_param_info(
+                        atom, constraint, default, is_const,
+                    );
+                    let (type_id, _) =
+                        self.intern_jsdoc_type_param_for_owner_stamped(parent_idx, info);
+                    template_types.entry(name).or_insert(type_id);
                 }
                 return template_types;
             }
@@ -216,15 +213,11 @@ impl CheckerState<'_> {
                 let constraint = constraint_strs
                     .get(&name)
                     .and_then(|s| self.resolve_jsdoc_reference(s));
-                function_template_types.entry(name).or_insert_with(|| {
-                    class_property_query::js_class_type_param_type(
-                        self.ctx.types,
-                        atom,
-                        constraint,
-                        default,
-                        is_const,
-                    )
-                });
+                let info = class_property_query::js_class_type_param_info(
+                    atom, constraint, default, is_const,
+                );
+                let (type_id, _) = self.intern_jsdoc_type_param_for_owner_stamped(parent_idx, info);
+                function_template_types.entry(name).or_insert(type_id);
             }
         }
         let jsdoc_param_names: Vec<String> = jsdoc
@@ -482,13 +475,12 @@ impl CheckerState<'_> {
                             let constraint = constraint_strs
                                 .get(&name)
                                 .and_then(|s| self.resolve_jsdoc_reference(s));
-                            return Some(class_property_query::js_class_type_param_type(
-                                self.ctx.types,
-                                atom,
-                                constraint,
-                                default,
-                                is_const,
-                            ));
+                            let info = class_property_query::js_class_type_param_info(
+                                atom, constraint, default, is_const,
+                            );
+                            let (type_id, _) =
+                                self.intern_jsdoc_type_param_for_owner_stamped(parent_idx, info);
+                            return Some(type_id);
                         }
                     }
                 }
@@ -560,13 +552,12 @@ impl CheckerState<'_> {
                         let constraint = constraint_strs
                             .get(&name)
                             .and_then(|s| self.resolve_jsdoc_reference(s));
-                        return Some(class_property_query::js_class_type_param_type(
-                            self.ctx.types,
-                            atom,
-                            constraint,
-                            default,
-                            is_const,
-                        ));
+                        let info = class_property_query::js_class_type_param_info(
+                            atom, constraint, default, is_const,
+                        );
+                        let (type_id, _) =
+                            self.intern_jsdoc_type_param_for_owner_stamped(parent_idx, info);
+                        return Some(type_id);
                     }
                 }
             }

--- a/crates/tsz-checker/src/types/computation/complex_constructors.rs
+++ b/crates/tsz-checker/src/types/computation/complex_constructors.rs
@@ -124,36 +124,11 @@ impl<'a> CheckerState<'a> {
                 })
                 .unwrap_or_default();
 
-            if type_parameters.is_none() {
-                let factory = self.ctx.types.factory();
-                let constraint_strs = func_jsdoc
-                    .as_ref()
-                    .map(|jsdoc| Self::jsdoc_template_constraint_strings(jsdoc))
-                    .unwrap_or_default();
-                for (name, is_const, default_str) in func_jsdoc
-                    .as_ref()
-                    .map(|jsdoc| Self::jsdoc_template_type_params(jsdoc))
-                    .unwrap_or_default()
-                {
-                    let atom = self.ctx.types.intern_string(&name);
-                    let default = default_str
-                        .as_deref()
-                        .and_then(|s| self.resolve_jsdoc_reference(s));
-                    let constraint = constraint_strs
-                        .get(&name)
-                        .and_then(|s| self.resolve_jsdoc_reference(s));
-                    let info = tsz_solver::TypeParamInfo {
-                        name: atom,
-                        constraint,
-                        default,
-                        is_const,
-                        origin: tsz_solver::TypeParamOrigin::User,
-                    };
-                    let ty = factory.type_param(info);
-                    let previous = self.ctx.type_parameter_scope.insert(name.clone(), ty);
-                    jsdoc_type_param_updates.push((name, previous, false));
-                    type_params.push(info);
-                }
+            if type_parameters.is_none()
+                && let Some(jsdoc) = func_jsdoc.as_deref()
+            {
+                (type_params, jsdoc_type_param_updates) =
+                    self.push_jsdoc_template_type_parameters_for_owner(callable_idx, jsdoc);
             }
         }
 

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -282,22 +282,9 @@ impl<'a> CheckerState<'a> {
             && let Some(owner_target) = prototype_owner_target
             && let Some(owner_jsdoc) = self.find_jsdoc_for_function(owner_target)
         {
-            let constraint_strs = Self::jsdoc_template_constraint_strings(&owner_jsdoc);
-            for (name, is_const, default_str) in Self::jsdoc_template_type_params(&owner_jsdoc) {
-                let atom = self.ctx.types.intern_string(&name);
-                let default = default_str
-                    .as_deref()
-                    .and_then(|s| self.resolve_jsdoc_reference(s));
-                let constraint = constraint_strs
-                    .get(&name)
-                    .and_then(|s| self.resolve_jsdoc_reference(s));
-                let info = signature_building_boundary::user_type_param_info(
-                    atom, constraint, default, is_const,
-                );
-                let ty = signature_building_boundary::user_type_param(self.ctx.types, info);
-                let previous = self.ctx.type_parameter_scope.insert(name.clone(), ty);
-                jsdoc_type_param_updates.push((name, previous, false));
-            }
+            let (_, updates) =
+                self.push_jsdoc_template_type_parameters_for_owner(owner_target, &owner_jsdoc);
+            jsdoc_type_param_updates.extend(updates);
         }
         if self.is_js_file()
             && type_params.is_empty()
@@ -305,26 +292,12 @@ impl<'a> CheckerState<'a> {
         {
             let template_names = Self::jsdoc_template_type_params(jsdoc);
             if !template_names.is_empty() {
-                let mut jsdoc_type_params = Vec::with_capacity(template_names.len());
-                let constraint_strs = Self::jsdoc_template_constraint_strings(jsdoc);
-                for (name, is_const, default_str) in template_names {
-                    let atom = self.ctx.types.intern_string(&name);
-                    let default = default_str
-                        .as_deref()
-                        .and_then(|s| self.resolve_jsdoc_reference(s));
-                    let constraint = constraint_strs
-                        .get(&name)
-                        .and_then(|s| self.resolve_jsdoc_reference(s));
-                    let info = signature_building_boundary::user_type_param_info(
-                        atom, constraint, default, is_const,
-                    );
-                    let ty = signature_building_boundary::user_type_param(self.ctx.types, info);
-                    jsdoc_type_params.push(info);
-                    // Register in type_parameter_scope so inline JSDoc casts
-                    // like `/** @type {T} */(expr)` can resolve `T`.
-                    let previous = self.ctx.type_parameter_scope.insert(name.clone(), ty);
-                    jsdoc_type_param_updates.push((name, previous, false));
-                }
+                let (jsdoc_type_params, updates) =
+                    self.push_jsdoc_template_type_parameters_for_owner(idx, jsdoc);
+                // The helper registers the binders in `type_parameter_scope`,
+                // so inline JSDoc casts like `/** @type {T} */(expr)` resolve
+                // the callable's own `T` rather than an enclosing declaration.
+                jsdoc_type_param_updates.extend(updates);
                 type_params = jsdoc_type_params;
             }
         }

--- a/crates/tsz-solver/src/evaluation/evaluate/meta_recursion_identity.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/meta_recursion_identity.rs
@@ -26,6 +26,7 @@ pub(super) enum MetaRecursionIdentity {
     InferSource(u64),
     BoundParameter(u32),
     Recursive(u32),
+    TypeParamJsdocComment { file: Atom, pos: u32 },
 }
 
 fn leftmost_index_access_object(
@@ -242,6 +243,9 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
         match info.origin {
             TypeParamOrigin::DeclScoped { file, node } => {
                 MetaRecursionIdentity::TypeParamDecl { file, node }
+            }
+            TypeParamOrigin::JsdocCommentScoped { file, pos } => {
+                MetaRecursionIdentity::TypeParamJsdocComment { file, pos }
             }
             TypeParamOrigin::InferPlaceholder { id } => MetaRecursionIdentity::InferPlaceholder(id),
             TypeParamOrigin::InferSource { id, .. } => MetaRecursionIdentity::InferSource(id),

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -231,7 +231,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // #14345 WAVE-1: when the decl-origin-through-reduction flag is on,
             // a reduced-body `Kind<F,A>` param leaf survives the name-keyed
             // re-mint as a THIRD id (not the registered pre-instantiate id) but
-            // KEEPS its carried `DeclScoped { file, node }` origin. The id-keyed
+            // KEEPS its carried authoritative declaration origin. The id-keyed
             // match below misses that leaf; the origin-keyed match bridges it
             // when — and only when — the leaf's origin pair was registered by
             // the alpha-rename (same declaration site on both sides). A

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -290,7 +290,7 @@ mod type_param_equivalence_tests {
     }
 
     /// A `User` (unstamped) leaf carries no declaration site and must never
-    /// match on origins, even against a registered decl-scoped pair.
+    /// match on origins, even against a registered declaration-origin pair.
     #[test]
     fn origin_equivalence_never_matches_user_leaves() {
         let eq = TypeParamEquivalence {
@@ -410,17 +410,17 @@ impl RelationEventCounter {
 ///
 /// The `source`/`target` `TypeId`s are the pre-instantiate signature-param ids
 /// (the historical `(TypeId, TypeId)` pair). `origins` additionally records the
-/// two params' declaration origins when BOTH carry a `DeclScoped { file, node }`
-/// construction stamp (`TSZ_TYPEPARAM_DECL_IDENTITY`).
+/// two params' declaration origins when both carry authoritative declaration
+/// stamps (`DeclScoped` or `JsdocCommentScoped`).
 ///
 /// #14345 WAVE-1 decl-origin-through-reduction: the name-keyed re-mint
 /// (`instantiate_function_shape`) rewrites deeper, arg-position `Kind<F,A>`
 /// param leaves to a THIRD id that the registered `TypeId` pair never contains,
 /// so the id-keyed consult (`check_subtype`) misses and the two alpha-equivalent
-/// bodies fail to relate. The decl-origin `(file, node)` is STABLE across that
-/// re-mint (the leaf's origin survives — a substitution hit maps it to the
-/// same-origin top-level param, a miss returns the original id, and the
-/// `TypeParameter` re-intern preserves the origin field). So the consult can
+/// bodies fail to relate. The declaration origin is stable across that re-mint
+/// (a substitution hit maps the leaf to the same-origin top-level param, a miss
+/// returns the original id, and the `TypeParameter` re-intern preserves the
+/// origin field). So the consult can
 /// additionally match a reduced-body leaf against a registered equivalence by
 /// its CARRIED origin: a same-origin leaf pair relates, a different-origin pair
 /// (never registered) does not. This is the sound discriminator the name-keyed
@@ -430,10 +430,10 @@ impl RelationEventCounter {
 pub(crate) struct TypeParamEquivalence {
     pub(crate) source: TypeId,
     pub(crate) target: TypeId,
-    /// Declaration origins of the two paired params, recorded only when BOTH are
-    /// `DeclScoped`. `None` for every other registration path (mapped-key
-    /// constraints, index-access keys, non-stamped params) so those keep the
-    /// pure id-keyed behavior.
+    /// Declaration origins of the two paired params, recorded only when both
+    /// carry authoritative declaration stamps. `None` for every other
+    /// registration path (mapped-key constraints, index-access keys,
+    /// non-stamped params) so those keep the pure id-keyed behavior.
     pub(crate) origins: Option<(TypeParamOrigin, TypeParamOrigin)>,
 }
 
@@ -459,9 +459,9 @@ impl TypeParamEquivalence {
 
     /// Whether this registered pair matches the given leaf ORIGIN pair
     /// (order-insensitive), for the #14345 WAVE-1 decl-origin consult. Both the
-    /// registered entry and the queried leaves must carry `DeclScoped` origins;
-    /// two `DeclScoped { file, node }` values are equal iff their `(file, node)`
-    /// declaration site is identical.
+    /// registered entry and the queried leaves must carry authoritative
+    /// declaration origins. Equality includes the origin variant, so an AST
+    /// node and a JSDoc comment remain distinct even with equal numeric payloads.
     #[inline]
     pub(crate) fn matches_origins(
         &self,
@@ -471,11 +471,9 @@ impl TypeParamEquivalence {
         let Some((reg_source, reg_target)) = self.origins else {
             return false;
         };
-        // Only decl-scoped origins are a sound discriminator; a `User` origin
-        // carries no declaration site so it must never match here.
-        if !matches!(source_origin, TypeParamOrigin::DeclScoped { .. })
-            || !matches!(target_origin, TypeParamOrigin::DeclScoped { .. })
-        {
+        // Only authoritative declaration origins are a sound discriminator; a
+        // `User` origin carries no declaration site so it must never match here.
+        if !source_origin.is_decl_scoped() || !target_origin.is_decl_scoped() {
             return false;
         }
         (reg_source == source_origin && reg_target == target_origin)

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -27,7 +27,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             && (!self.strict_function_types || (is_method_like && !self.disable_method_bivariance))
     }
 
-    /// Build a name-keyed substitution that erases `DeclScoped` construction
+    /// Build a name-keyed substitution that erases authoritative declaration
     /// stamps for genuinely alpha-equivalent free type parameters in `roots`.
     ///
     /// Only same-name, same-surface (`constraint`/`default`/`is_const`) params
@@ -46,7 +46,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             let Some(info) = type_param_info(self.interner, id) else {
                 continue;
             };
-            if !matches!(info.origin, TypeParamOrigin::DeclScoped { .. }) {
+            if !info.origin.is_decl_scoped() {
                 continue;
             }
 

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -8,7 +8,7 @@ use crate::type_param_info;
 use crate::types::{
     CallSignature, CallableShape, CallableShapeId, FunctionShape, FunctionShapeId, ObjectFlags,
     ObjectShape, ParamInfo, PropertyInfo, TupleElement, TypeData, TypeId, TypeParamInfo,
-    TypeParamOrigin, Visibility,
+    Visibility,
 };
 use crate::visitor::callable_shape_id;
 
@@ -147,20 +147,21 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// on top of `TSZ_TYPEPARAM_DECL_IDENTITY`).
     ///
     /// When ON (and the construction stamp is ON), the alpha-rename registration
-    /// records each paired param's `DeclScoped { file, node }` origin alongside
+    /// records each paired param's authoritative declaration origin alongside
     /// the pre-instantiate `TypeId` pair, and the consult
     /// (`check_subtype`) additionally accepts two reduced-body `TypeParameter`
     /// leaves whose carried decl-origins form a registered pair — the same-origin
     /// `B ≡ A` bridge that the name-keyed re-mint loses (the leaf id is a THIRD
-    /// identity, but its `(file, node)` origin survives). A different-origin pair
-    /// (`T`/`U` from distinct decls that were never registered) is NOT accepted,
-    /// which is the sound discriminator the name+surface structural strip cannot
-    /// express.
+    /// identity, but its declaration origin survives). A different-origin pair
+    /// (`T`/`U` from distinct declarations that were never registered) is not
+    /// accepted, which is the sound discriminator the name+surface structural
+    /// strip cannot express.
     ///
     /// Requires `TSZ_TYPEPARAM_DECL_IDENTITY=1` to have any effect: without the
-    /// construction stamp no leaf carries a `DeclScoped` origin, so the extra
-    /// match never fires. Flag-OFF the registered `origins` field is always
-    /// `None` and the consult is byte-identical to the id-only match.
+    /// construction stamp no leaf carries an authoritative declaration origin,
+    /// so the extra match never fires. With the flag off, the registered
+    /// `origins` field is always `None` and the consult is byte-identical to the
+    /// id-only match.
     pub(crate) fn decl_origin_reduction_enabled() -> bool {
         use std::sync::OnceLock;
         static ON: OnceLock<bool> = OnceLock::new();
@@ -170,25 +171,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         })
     }
 
-    /// Build a name-keyed substitution that maps every free `DeclScoped` type
-    /// parameter occurring in `source`/`target` back to its `User`-canonical
-    /// structural intern (origin erased, surface preserved). Applying it to both
-    /// cloned bodies collapses alpha-equivalent params from distinct decls to
-    /// ONE id — the flag-OFF identity — so the structural comparison relates
-    /// them.
+    /// Map every free declaration-origin type parameter in `source`/`target`
+    /// back to its `User`-canonical structural intern. Applying this substitution
+    /// to both bodies collapses alpha-equivalent parameters to the flag-off identity.
     ///
-    /// Soundness: collapsing two `DeclScoped` params to one `User` id is sound
-    /// ONLY when they are genuinely alpha-equivalent — same name AND same
-    /// surface (`constraint`/`default`/`is_const`). The interner's `type_param`
-    /// already enforces this: distinct surfaces produce distinct `User` ids, so
-    /// `<A>` and `<A extends string>` never collapse. The remaining hazard is a
-    /// name collision where the SAME name has TWO different `DeclScoped`
-    /// surfaces across the two bodies (one decl's `<A>` vs another's
-    /// `<A extends string>`): a name-keyed substitution cannot represent that
-    /// split, so such names are EXCLUDED from the strip entirely (left at their
-    /// distinct `DeclScoped` ids, the conservative non-collapsing choice — no
-    /// over-relate). Only names whose every `DeclScoped` occurrence shares one
-    /// surface are stripped.
+    /// This is sound only for equal names and surfaces (`constraint`, `default`,
+    /// and `is_const`). The interner keeps distinct surfaces in distinct `User`
+    /// ids. If one name has multiple declaration surfaces across the bodies, a
+    /// name-keyed substitution cannot represent the split, so that name remains
+    /// declaration-scoped. Only uniformly surfaced names are stripped.
     pub(crate) fn build_decl_param_structural_strip(
         &self,
         source: &FunctionShape,
@@ -416,16 +407,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     let target_tp_type = self.interner.type_param(*target_tp);
                     if source_tp_type != target_tp_type {
                         // #14345 WAVE-1: additionally record the decl-origin pair
-                        // when BOTH params carry a `DeclScoped { file, node }`
-                        // construction stamp, so the consult can bridge
+                        // when both params carry authoritative declaration
+                        // origins, so the consult can bridge
                         // reduced-body `Kind<F,A>` leaves that survive the
                         // name-keyed re-mint as a THIRD id but keep their carried
                         // origin. Gated behind `decl_origin_reduction_enabled`
                         // (composes with `TSZ_TYPEPARAM_DECL_IDENTITY`); OFF ->
                         // `origins: None`, byte-identical id-only behavior.
                         let origins = if Self::decl_origin_reduction_enabled()
-                            && matches!(source_tp.origin, TypeParamOrigin::DeclScoped { .. })
-                            && matches!(target_tp.origin, TypeParamOrigin::DeclScoped { .. })
+                            && source_tp.origin.is_decl_scoped()
+                            && target_tp.origin.is_decl_scoped()
                         {
                             Some((source_tp.origin, target_tp.origin))
                         } else {
@@ -451,19 +442,20 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // #14345 WAVE-1 register-through-reduction co-walk (flag-gated,
                 // byte-parity-inert OFF). Registers the DEEPER corresponding leaf
                 // origin-pairs the top-level registration misses; must run before
-                // the strip below (which erases `DeclScoped`). See `cowalk` module.
+                // the strip below (which erases declaration origins). See the
+                // `cowalk` module.
                 self.register_cowalk_leaf_origins(&source_instantiated, &target_instantiated);
                 // #14345 scoped structural-strip (flag-gated, byte-parity-inert
                 // OFF). The construction stamp gives every user-written type
-                // parameter a `DeclScoped { file, node }` origin so two distinct
-                // declarations sharing an identical surface intern to DISTINCT
+                // parameter an authoritative declaration origin so two distinct
+                // declarations sharing an identical surface intern to distinct
                 // ids — fixing the self-ref-guard over-collapse at
                 // construction/registration (the 278 fp-ts fixes). But that
                 // stamp also makes two ALPHA-EQUIVALENT signature bodies (e.g.
                 // `<A>(r: Record<string, A>) => number` vs
                 // `<A>(r: ReadonlyRecord<string, A>) => number` after their
                 // aliases reduce to the same shape) fail to relate: their `A`s
-                // carry distinct `DeclScoped` origins that are re-minted to a
+                // carry distinct declaration origins that are re-minted to a
                 // THIRD id through the name-keyed substitution + per-body
                 // `instantiate_type`, so the id-keyed equivalence registered
                 // above (lines ~289-300) never bridges them — the +53
@@ -472,10 +464,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // Flag-OFF, those same params intern to ONE structural (`User`)
                 // id and relate trivially (zero +53). This strip reproduces that
                 // flag-OFF identity SCOPED to the two cloned bodies used for the
-                // structural compare ONLY: each free `DeclScoped` parameter is
-                // mapped back to its `User`-canonical structural intern (origin
-                // erased, surface preserved), so alpha-equivalent params from
-                // distinct decls collapse to the SAME id and unify. It does NOT
+                // structural compare only: each free declaration-stamped
+                // parameter is mapped back to its `User`-canonical structural
+                // intern (origin erased, surface preserved), so alpha-equivalent
+                // params from distinct decls collapse to the SAME id and unify. It does NOT
                 // touch construction-time stamping (the 278 fire at a different
                 // level — registration/`is_identity_for`), so it is additive to
                 // the construction fix.

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/cowalk.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/cowalk.rs
@@ -10,18 +10,19 @@
 //!
 //! This co-walk closes that gap: it walks the two re-minted bodies STRUCTURALLY
 //! IN LOCKSTEP and registers the corresponding DEEPER leaf origin-pairs (the
-//! arg-position `TypeParameter`s carrying `DeclScoped { file, node }`) into
-//! `type_param_equivalences`.
+//! arg-position `TypeParameter`s carrying authoritative declaration origins)
+//! into `type_param_equivalences`.
 //!
 //! Soundness: a pair is registered ONLY at a structurally-CORRESPONDING
 //! position — the walk descends both bodies together and, the moment the two
 //! shapes DIVERGE in structural kind at any node, it stops descending that
 //! branch (a genuine structural mismatch must still fail to relate). Because the
-//! consult matches by carried `(file, node)`, registering the genuine structural
-//! correspondence is sound; the only hazard — pairing non-corresponding leaves —
-//! is prevented by the lockstep divergence guard. Registration is further
-//! limited to `TypeParameter`-vs-`TypeParameter` leaves where BOTH carry a
-//! `DeclScoped` origin; any other leaf pairing registers nothing.
+//! consult matches by exact carried declaration origin, registering the genuine
+//! structural correspondence is sound; the only hazard — pairing
+//! non-corresponding leaves — is prevented by the lockstep divergence guard.
+//! Registration is further limited to `TypeParameter`-vs-`TypeParameter`
+//! leaves where both carry authoritative declaration origins; any other leaf
+//! pairing registers nothing.
 //!
 //! Gated behind `TSZ_DECL_ORIGIN_REDUCTION` (composing with
 //! `TSZ_TYPEPARAM_DECL_IDENTITY`); flag-OFF this walk never runs.
@@ -38,7 +39,7 @@ const COWALK_MAX_DEPTH: u32 = 64;
 
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Co-walk the two re-minted bodies in lockstep and register the deeper
-    /// corresponding `DeclScoped` leaf origin-pairs. No-op unless the
+    /// corresponding authoritative declaration-origin pairs. No-op unless the
     /// decl-origin-reduction flag is on.
     ///
     /// The pushed equivalences are appended after the top-level pairs the caller
@@ -70,9 +71,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     }
 
     /// Walk `src`/`tgt` structurally in lockstep. At a `TypeParameter`-vs-
-    /// `TypeParameter` leaf where both carry `DeclScoped`, register the origin
-    /// pair. Recurse into corresponding children only while the two structural
-    /// kinds AGREE; on any kind divergence, stop (do not register past it).
+    /// `TypeParameter` leaf where both carry authoritative declaration origins,
+    /// register the origin pair. Recurse into corresponding children only while
+    /// the two structural kinds agree; on any kind divergence, stop (do not
+    /// register past it).
     fn cowalk_register(
         &mut self,
         src: TypeId,
@@ -99,7 +101,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
         match (s_data, t_data) {
             // The leaf we care about: two type parameters at the SAME structural
-            // position. Register their decl-origins when BOTH are stamped.
+            // position. Register their origins when both are authoritatively
+            // stamped.
             (TypeData::TypeParameter(s_info), TypeData::TypeParameter(t_info)) => {
                 self.register_leaf_origin_pair(src, tgt, s_info.origin, t_info.origin);
             }
@@ -212,7 +215,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     }
 
     /// Register a single deeper leaf origin-pair when both origins are
-    /// `DeclScoped` and the pair is not already present. Duplicate suppression
+    /// authoritative and the pair is not already present. Duplicate suppression
     /// keeps the equivalence vector small and avoids re-registering the
     /// top-level pairs the caller already pushed.
     fn register_leaf_origin_pair(
@@ -222,9 +225,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         s_origin: TypeParamOrigin,
         t_origin: TypeParamOrigin,
     ) {
-        if !matches!(s_origin, TypeParamOrigin::DeclScoped { .. })
-            || !matches!(t_origin, TypeParamOrigin::DeclScoped { .. })
-        {
+        if !s_origin.is_decl_scoped() || !t_origin.is_decl_scoped() {
             return;
         }
         // Same declaration site on both sides is already an identity; nothing to

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/name_pairing.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/name_pairing.rs
@@ -16,8 +16,8 @@ use crate::types::TypeParamInfo;
 /// Byte-parity-inert when OFF (the default): the pairing falls back to the
 /// historical positional `.zip`. The mis-pairing this flag fixes only becomes
 /// observable under the dormant `TSZ_TYPEPARAM_DECL_IDENTITY` keystone
-/// (#14696), whose distinct `DeclScoped` ids stop same-name source params from
-/// interning to a single id that masks the reorder.
+/// (#14696), whose distinct authoritative declaration-origin ids stop same-name
+/// source params from interning to a single id that masks the reorder.
 pub(super) fn alpha_name_pair_enabled() -> bool {
     use std::sync::OnceLock;
     static ON: OnceLock<bool> = OnceLock::new();

--- a/crates/tsz-solver/src/relations/subtype/rules/unions.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/unions.rs
@@ -67,8 +67,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Implements TypeScript's soundness rules for type parameter compatibility.
     ///
     /// ## TypeScript Soundness Rules:
-    /// - Same type parameter (shared name, not proven distinct by mutually
-    ///   incompatible constraints) → reflexive (always compatible)
+    /// - Same type parameter (shared declaration identity, or a legacy shared
+    ///   name not proven distinct) → reflexive (always compatible)
     /// - Different type parameters → check constraint transitivity
     /// - Type parameter vs concrete → constraint must be subtype of concrete
     /// - Unconstrained type parameter → acts like `unknown` (top type)
@@ -79,11 +79,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ) -> SubtypeResult {
         // Type parameter vs type parameter
         if let Some(t_info) = type_param_info(self.interner, target) {
-            // A shared *name* is only a proxy for parameter identity: a
-            // `TypeParamInfo` carries no declaration handle, so two distinct
-            // type parameters that happen to share a name (e.g. an inner generic
-            // shadowing an outer one) are not necessarily the same parameter.
-            // When both carry constraints that are provably incompatible
+            // A shared *name* is only a legacy proxy for parameter identity.
+            // Declaration-stamped parameters are distinguished directly;
+            // unstamped parameters retain the constraint-based fallback below.
+            // When two legacy parameters carry constraints that are provably incompatible
             // (neither assignable to the other), the parameters are definitely
             // distinct — `tsc` treats them as unrelated and reports the failure
             // (TS2719, "two different types with this name exist"). Related
@@ -179,11 +178,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Decide whether two same-named type parameters are *provably distinct*
     /// declarations rather than the same parameter seen twice.
     ///
-    /// `TypeParamInfo` has no declaration handle, so a shared name cannot prove
-    /// identity. The conservative signal that two same-named parameters are
-    /// genuinely different is that both carry constraints which are mutually
-    /// non-assignable: the same parameter always presents the same constraint
-    /// (interning to the same `TypeId`, or — when the constraint is reached
+    /// A pair of authoritative declaration origins provides authoritative
+    /// declaration identity. For legacy unstamped parameters, the conservative
+    /// signal that two same-named parameters are genuinely different is that
+    /// both carry constraints which are mutually non-assignable: the same
+    /// parameter always presents the same constraint (interning to the same
+    /// `TypeId`, or — when the constraint is reached
     /// through different-but-related representations — at least a one-way
     /// assignable one), so a constraint pair with no assignable direction can
     /// only come from two different declarations. Returning `true` here
@@ -191,16 +191,26 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// through to constraint transitivity and a real mismatch is reported,
     /// mirroring `tsc`'s handling of distinct identically-named type parameters.
     ///
-    /// Unconstrained (or one-sided-unconstrained) same-named pairs return
+    /// Unconstrained (or one-sided-unconstrained) same-named legacy pairs return
     /// `false`: they intern to one `TypeId` and never reach this path, or cannot
-    /// be told apart without a parameter identity, so the historical reflexive
-    /// behaviour is preserved to avoid regressing alpha-renamed generic-signature
-    /// comparisons.
+    /// be told apart without a declaration stamp, so the historical reflexive
+    /// behaviour is preserved.
     fn same_named_type_params_are_distinct(
         &mut self,
         s_info: &TypeParamInfo,
         t_info: &TypeParamInfo,
     ) -> bool {
+        // A declaration stamp is authoritative identity. Distinct owners stay
+        // unrelated even when their surface spelling, constraint, and default
+        // are byte-for-byte identical (for example a method-level JSDoc
+        // `@template T` shadowing a class-level `@template T`). Generic
+        // signature alpha-renaming registers an explicit equivalence before
+        // reaching this rule, so declaration identity does not reject valid
+        // `<T>(x: T) => T` / `<U>(x: U) => U` comparisons.
+        if s_info.origin.is_decl_scoped() && t_info.origin.is_decl_scoped() {
+            return s_info.origin != t_info.origin;
+        }
+
         let (Some(s_constraint), Some(t_constraint)) = (s_info.constraint, t_info.constraint)
         else {
             return false;

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -1423,6 +1423,15 @@ pub enum TypeParamOrigin {
     /// but the synthetic `name` must never reach diagnostics. `display_name`
     /// records the original declared name so the printer renders it instead.
     OverloadRenamed { display_name: Atom },
+    /// A user-written type parameter declared by a standalone JSDoc comment.
+    ///
+    /// JSDoc `@overload`, `@typedef`, and `@callback` declarations have no AST
+    /// name node. Their source position is stable when an incremental parse
+    /// appends arena nodes. This dedicated variant's discriminant keeps the
+    /// identity distinct from every real `NodeIndex`, even when the numeric
+    /// payloads match. The payload matches [`Self::DeclScoped`], so this remains
+    /// size-neutral. Kept last so existing variant discriminants remain stable.
+    JsdocCommentScoped { file: Atom, pos: u32 },
 }
 
 impl TypeParamOrigin {
@@ -1431,14 +1440,26 @@ impl TypeParamOrigin {
     /// Replaces the historical `starts_with("__infer_")` scan.
     #[inline]
     pub const fn is_infer_placeholder(self) -> bool {
-        // `DeclScoped` is a user-written param (decl-stamped for identity), NOT
-        // an inference placeholder — classify it with `User` (#14344 STEP-B).
+        // Declaration-scoped origins are user-written params, NOT inference
+        // placeholders — classify them with `User` (#14344 STEP-B).
         // `OverloadRenamed` is a declared overload type param that was renamed
         // for name-keyed inference; it too behaves as `User` (the rename does
         // not turn it into a HOFI/call-local placeholder).
         !matches!(
             self,
-            Self::User | Self::DeclScoped { .. } | Self::OverloadRenamed { .. }
+            Self::User
+                | Self::DeclScoped { .. }
+                | Self::JsdocCommentScoped { .. }
+                | Self::OverloadRenamed { .. }
+        )
+    }
+
+    /// Whether this origin carries authoritative user-declaration identity.
+    #[inline]
+    pub const fn is_decl_scoped(self) -> bool {
+        matches!(
+            self,
+            Self::DeclScoped { .. } | Self::JsdocCommentScoped { .. }
         )
     }
 

--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -593,6 +593,7 @@ pub use content::{
     contains_free_type_parameters_except_name, contains_infer_types, contains_this_type,
     contains_type_by_id, contains_type_matching, contains_type_parameter_identity_shallow,
     contains_type_parameter_named, contains_type_parameter_named_shallow, contains_type_parameters,
-    free_type_parameter_ids_in, mapped_context_references_type_param_named,
-    references_any_type_param_named, references_type_param_outside_id_set,
+    free_decl_scoped_type_parameter_origins_in, free_type_parameter_ids_in,
+    mapped_context_references_type_param_named, references_any_type_param_named,
+    references_type_param_outside_id_set,
 };

--- a/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
@@ -6,6 +6,7 @@
 //! child set each walker descends into is an explicit [`ChildPolicy`].
 
 use std::ops::ControlFlow;
+use std::sync::Arc;
 
 use crate::construction::TypeDatabase;
 use crate::types::IntrinsicKind;
@@ -622,6 +623,159 @@ pub fn free_type_parameter_ids_in(
     out
 }
 
+/// Collect authoritative declaration origins (and their display names) that
+/// occur free across `roots`.
+///
+/// Unlike [`free_type_parameter_ids_in`], this walk enters generic signature
+/// bodies. It scopes out only each signature's own declaration origins, so an
+/// object property such as `<Inner>(value: Outer) => Outer` still reports the
+/// captured `Outer` while excluding `Inner`. The visited key includes the
+/// active origin scope, making shared and recursive type graphs cycle-safe
+/// without confusing the same node reached under different binders.
+pub fn free_decl_scoped_type_parameter_origins_in(
+    types: &dyn TypeDatabase,
+    roots: impl IntoIterator<Item = TypeId>,
+) -> FxHashSet<(crate::types::TypeParamOrigin, Atom)> {
+    use crate::types::{CallSignature, TypeParamInfo, TypeParamOrigin};
+
+    fn with_signature_origins(
+        bound: &Arc<[TypeParamOrigin]>,
+        type_params: &[TypeParamInfo],
+    ) -> Arc<[TypeParamOrigin]> {
+        let mut next: Vec<_> = bound.iter().copied().collect();
+        for origin in type_params.iter().map(|param| param.origin) {
+            if origin.is_decl_scoped() && !next.contains(&origin) {
+                next.push(origin);
+            }
+        }
+        if next.len() == bound.len() {
+            Arc::clone(bound)
+        } else {
+            Arc::from(next)
+        }
+    }
+
+    fn push_signature(
+        stack: &mut Vec<(TypeId, Arc<[TypeParamOrigin]>)>,
+        bound: &Arc<[TypeParamOrigin]>,
+        signature: &CallSignature,
+    ) {
+        let signature_bound = with_signature_origins(bound, &signature.type_params);
+        stack.push((signature.return_type, Arc::clone(&signature_bound)));
+        if let Some(this_type) = signature.this_type {
+            stack.push((this_type, Arc::clone(&signature_bound)));
+        }
+        if let Some(predicate_type) = signature
+            .type_predicate
+            .as_ref()
+            .and_then(|predicate| predicate.type_id)
+        {
+            stack.push((predicate_type, Arc::clone(&signature_bound)));
+        }
+        for param in &signature.params {
+            stack.push((param.type_id, Arc::clone(&signature_bound)));
+        }
+        for type_param in &signature.type_params {
+            if let Some(constraint) = type_param.constraint {
+                stack.push((constraint, Arc::clone(&signature_bound)));
+            }
+            if let Some(default) = type_param.default {
+                stack.push((default, Arc::clone(&signature_bound)));
+            }
+        }
+    }
+
+    let empty_scope: Arc<[TypeParamOrigin]> = Arc::from([]);
+    let mut stack: Vec<_> = roots
+        .into_iter()
+        .map(|root| (root, Arc::clone(&empty_scope)))
+        .collect();
+    let mut visited: FxHashSet<(TypeId, Arc<[TypeParamOrigin]>)> = FxHashSet::default();
+    let mut origins = FxHashSet::default();
+
+    while let Some((type_id, bound)) = stack.pop() {
+        if type_id.is_intrinsic() || !visited.insert((type_id, Arc::clone(&bound))) {
+            continue;
+        }
+        let Some(key) = types.lookup(type_id) else {
+            continue;
+        };
+        match key {
+            TypeData::TypeParameter(info) => {
+                if info.origin.is_decl_scoped() && !bound.contains(&info.origin) {
+                    origins.insert((info.origin, info.name));
+                }
+            }
+            TypeData::Infer(_) => {}
+            TypeData::Function(shape_id) => {
+                let shape = types.function_shape(shape_id);
+                let signature_bound = with_signature_origins(&bound, &shape.type_params);
+                stack.push((shape.return_type, Arc::clone(&signature_bound)));
+                if let Some(this_type) = shape.this_type {
+                    stack.push((this_type, Arc::clone(&signature_bound)));
+                }
+                if let Some(predicate_type) = shape
+                    .type_predicate
+                    .as_ref()
+                    .and_then(|predicate| predicate.type_id)
+                {
+                    stack.push((predicate_type, Arc::clone(&signature_bound)));
+                }
+                for param in &shape.params {
+                    stack.push((param.type_id, Arc::clone(&signature_bound)));
+                }
+                for type_param in &shape.type_params {
+                    if let Some(constraint) = type_param.constraint {
+                        stack.push((constraint, Arc::clone(&signature_bound)));
+                    }
+                    if let Some(default) = type_param.default {
+                        stack.push((default, Arc::clone(&signature_bound)));
+                    }
+                }
+            }
+            TypeData::Callable(shape_id) => {
+                let shape = types.callable_shape(shape_id);
+                for signature in shape
+                    .call_signatures
+                    .iter()
+                    .chain(shape.construct_signatures.iter())
+                {
+                    push_signature(&mut stack, &bound, signature);
+                }
+                for property in &shape.properties {
+                    stack.push((property.type_id, Arc::clone(&bound)));
+                    stack.push((property.write_type, Arc::clone(&bound)));
+                }
+                for index in [shape.string_index.as_ref(), shape.number_index.as_ref()]
+                    .into_iter()
+                    .flatten()
+                {
+                    stack.push((index.key_type, Arc::clone(&bound)));
+                    stack.push((index.value_type, Arc::clone(&bound)));
+                }
+            }
+            TypeData::Mapped(mapped_id) => {
+                let mapped = types.get_mapped(mapped_id);
+                stack.push((mapped.constraint, Arc::clone(&bound)));
+                let mapped_bound =
+                    with_signature_origins(&bound, std::slice::from_ref(&mapped.type_param));
+                stack.push((mapped.template, Arc::clone(&mapped_bound)));
+                if let Some(name_type) = mapped.name_type {
+                    stack.push((name_type, Arc::clone(&mapped_bound)));
+                }
+                if let Some(default) = mapped.type_param.default {
+                    stack.push((default, Arc::clone(&mapped_bound)));
+                }
+            }
+            _ => for_each_child_with_policy(types, &key, &ChildPolicy::EVERYTHING, |child| {
+                stack.push((child, Arc::clone(&bound)));
+            }),
+        }
+    }
+
+    origins
+}
+
 struct FreeTypeParamCollector<'a> {
     types: &'a dyn TypeDatabase,
     /// Memoized free-parameter set per `TypeId`. Freeness is a pure function of
@@ -724,7 +878,67 @@ pub fn contains_free_type_parameters_except_name(
 mod tests {
     use super::*;
     use crate::intern::TypeInterner;
-    use crate::types::{TupleElement, TypeParamInfo};
+    use crate::types::{
+        FunctionShape, ParamInfo, PropertyInfo, TupleElement, TypeParamInfo, TypeParamOrigin,
+    };
+
+    #[test]
+    fn free_decl_origins_scope_nested_generic_binders_but_keep_outer_captures() {
+        let interner = TypeInterner::new();
+        let file = interner.intern_string("capture.js");
+        let outer_info = TypeParamInfo {
+            origin: TypeParamOrigin::DeclScoped { file, node: 10 },
+            ..TypeParamInfo::simple(interner.intern_string("OuterValue"))
+        };
+        let inner_info = TypeParamInfo {
+            origin: TypeParamOrigin::DeclScoped { file, node: 20 },
+            ..TypeParamInfo::simple(interner.intern_string("InnerValue"))
+        };
+        let outer = interner.type_param(outer_info);
+        let inner = interner.type_param(inner_info);
+        let nested_generic = interner.function(FunctionShape {
+            type_params: vec![inner_info],
+            ..FunctionShape::new(vec![ParamInfo::unnamed(inner)], outer)
+        });
+        let object = interner.object(vec![PropertyInfo::new(
+            interner.intern_string("transform"),
+            nested_generic,
+        )]);
+
+        let origins = free_decl_scoped_type_parameter_origins_in(&interner, [object]);
+        assert_eq!(origins.len(), 1);
+        assert!(origins.contains(&(outer_info.origin, outer_info.name)));
+        assert!(!origins.contains(&(inner_info.origin, inner_info.name)));
+    }
+
+    #[test]
+    fn free_decl_origins_deduplicate_reminted_ids_and_ignore_legacy_user_params() {
+        let interner = TypeInterner::new();
+        let file = interner.intern_string("remint.js");
+        let name = interner.intern_string("Value");
+        let origin = TypeParamOrigin::DeclScoped { file, node: 30 };
+        let first = interner.type_param(TypeParamInfo {
+            origin,
+            ..TypeParamInfo::simple(name)
+        });
+        let second = interner.type_param(TypeParamInfo {
+            constraint: Some(TypeId::STRING),
+            origin,
+            ..TypeParamInfo::simple(name)
+        });
+        let legacy = interner.type_param(TypeParamInfo::simple(name));
+        assert_ne!(first, second, "the witness must use separately minted ids");
+
+        let origins = free_decl_scoped_type_parameter_origins_in(
+            &interner,
+            [interner.tuple(vec![
+                TupleElement::fixed(first),
+                TupleElement::fixed(second),
+                TupleElement::fixed(legacy),
+            ])],
+        );
+        assert_eq!(origins, FxHashSet::from_iter([(origin, name)]));
+    }
 
     #[test]
     fn predicate_worklist_visit_state_names_intrinsic_entered_and_revisit() {

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_04.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_04.rs
@@ -471,6 +471,59 @@ fn test_deferred_hkt_index_access_relates_decl_scoped_alpha_equivalent_binders()
 }
 
 #[test]
+fn test_authoritative_origins_are_distinct_bare_but_alpha_equivalent_in_signatures() {
+    let interner = TypeInterner::new();
+    let file = interner.intern_string("generic.js");
+    let left_info = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: Some(TypeId::OBJECT),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::DeclScoped {
+            file,
+            node: 10,
+        },
+    };
+    let right_info = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: Some(TypeId::OBJECT),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::JsdocCommentScoped {
+            file,
+            pos: 10,
+        },
+    };
+    let left_param = interner.type_param(left_info);
+    let right_param = interner.type_param(right_info);
+
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        !checker.is_subtype_of(left_param, right_param),
+        "bare node/comment binders with the same numeric payload must remain unrelated"
+    );
+
+    let generic = |info: TypeParamInfo, param: TypeId| {
+        interner.function(FunctionShape {
+            type_params: vec![info],
+            params: vec![ParamInfo::unnamed(param)],
+            this_type: None,
+            return_type: param,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+    let left = generic(left_info, left_param);
+    let right = generic(right_info, right_param);
+
+    assert!(
+        checker.is_subtype_of(left, right) && checker.is_subtype_of(right, left),
+        "generic-signature alpha equivalence must dominate declaration identity"
+    );
+}
+
+#[test]
 fn test_generic_covariant_return_position() {
     // Producer<T> = { get(): T } - T is in covariant position
     // Producer<string> <: Producer<string | number> (covariant)

--- a/crates/tsz-solver/tests/types_tests.rs
+++ b/crates/tsz-solver/tests/types_tests.rs
@@ -583,10 +583,10 @@ fn test_property_info_eq_ignores_single_quoted_name() {
     );
 }
 
-/// #14344 layout guard: the `DeclScoped { file: Atom, node: u32 }` decl-identity
-/// variant must stay SIZE-NEUTRAL — its `(Atom, u32)` = 8-byte payload fits inside
-/// the pre-existing `InferSource { id: u64, origin_name: Option<Atom> }` 16-byte
-/// envelope, so `TypeParamOrigin` stays 16 bytes and `TypeParamInfo` stays 40.
+/// #14344 layout guard: authoritative declaration-origin variants must stay
+/// size-neutral. Their `(Atom, u32)` payload fits inside the pre-existing
+/// `InferSource { id: u64, origin_name: Option<Atom> }` 16-byte envelope, so
+/// `TypeParamOrigin` stays 16 bytes and `TypeParamInfo` stays 40 bytes.
 /// `TypeParamInfo` rides every `collect_type_parameters` frame in the deep
 /// `lower_type_parameter` recursion; any growth re-introduces the fp-ts
 /// stack-overflow the dispatch-split fixes. Keep this assertion green.
@@ -596,7 +596,7 @@ fn typeparam_origin_layout_is_size_neutral() {
     assert_eq!(
         size_of::<TypeParamOrigin>(),
         16,
-        "TypeParamOrigin must stay 16 bytes (DeclScoped fits inside InferSource's envelope)"
+        "TypeParamOrigin must stay 16 bytes (declaration origins fit InferSource's envelope)"
     );
     assert_eq!(align_of::<TypeParamOrigin>(), 8);
     assert_eq!(


### PR DESCRIPTION
Goal: hold

## Summary
- Give AST-owned JSDoc templates declaration-scoped identity keyed by file and node, and standalone comment templates a disjoint stable identity keyed by file and source position.
- Preserve exact binder origins through signature construction and solver relation pairing so generic binders alpha-equate within one declaration while same-spelled lexical binders from different declarations stay distinct.
- Use authoritative free-origin sets to lift the broad complex-generic suppression only for structurally distinct binders; rendered equality is used solely as the final TS2719 presentation choice.

## Structural rule
When two JSDoc template parameters are owned by the same declaration, tsc reuses one binder identity; parameters owned by different declarations remain distinct even when their names, constraints, defaults, and rendered surfaces match. The checker owns declaration/comment origin construction, the solver owns binder-aware relation and free-origin traversal, and the diagnostic layer uses display text only after semantic origin comparison.

Adjacent cases cover renamed binders, different names, identical constraints/defaults, nested aliases and applications, class and method templates, class expressions, overload comments, nested typedef/callback comments, cross-arena NodeIndex collisions, incremental arena growth, ambiguous repeated-name origin sets, legacy/reminted parameters, and the non-shadowing fallback. Recursive traversal is cycle-safe and scopes nested signature-owned binders while retaining captured outer binders.

## Performance
The origin and type-parameter layouts remain unchanged (16 and 40 bytes). The free-origin graph walk is confined to already-failed complex-generic suppression/diagnostic paths, has no persistent cache or residency cost, and is cycle-safe; common successful assignability paths do not invoke it.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker -p tsz-solver --lib -E "test(~jsdoc_shadowed_type_param_identity_tests) | test(~declaration_origin_) | test(~free_decl_origins_)"` (20 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E "test(~test_authoritative_origins_are_distinct_bare_but_alpha_equivalent_in_signatures)"` (1 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test application_member_type_parameter_substitution_tests` (10 passed)
- `scripts/safe-run.sh cargo clippy -p tsz-solver -p tsz-checker --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- Independent review of exact rebased head: approved with no blocking findings

## Provenance
Machine: Mac
Assistant: codex
Model: GPT-5
Effort: high