### PR TITLE
fix(checker): gate TS7039 on noImplicitAny

### DIFF
--- a/crates/tsz-checker/src/context/diagnostic_push.rs
+++ b/crates/tsz-checker/src/context/diagnostic_push.rs
@@ -217,6 +217,9 @@ impl<'a> CheckerContext<'a> {
         &mut self,
         mapped_idx: tsz_parser::parser::NodeIndex,
     ) {
+        if !self.compiler_options.no_implicit_any {
+            return;
+        }
         let Some((start, end)) = self.get_node_span(mapped_idx) else {
             return;
         };

--- a/crates/tsz-checker/tests/mapped_type_missing_template_single_ts7039_tests.rs
+++ b/crates/tsz-checker/tests/mapped_type_missing_template_single_ts7039_tests.rs
@@ -117,3 +117,27 @@ fn mapped_type_with_template_emits_no_ts7039() {
         "a mapped type with a template type must not emit TS7039, got: {diags:#?}",
     );
 }
+
+#[test]
+fn mapped_type_without_template_is_silent_when_no_implicit_any_is_disabled() {
+    let source = "type Result<Input> = ({[Slot in keyof Input]}) extends ({[key in Slot]: Input[Slot]}) ? number : never;";
+    let diagnostics = check_with_options(
+        source,
+        CheckerOptions {
+            strict: false,
+            no_implicit_any: false,
+            ..CheckerOptions::default()
+        },
+    );
+    let relevant_codes: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| matches!(diagnostic.code, 2304 | 7039))
+        .map(|diagnostic| diagnostic.code)
+        .collect();
+
+    assert_eq!(
+        relevant_codes,
+        vec![2304, 2304],
+        "without noImplicitAny, the malformed mapped type should retain only the two unresolved-name diagnostics: {diagnostics:#?}",
+    );
+}


### PR DESCRIPTION
Goal: hold

## Summary

- Gate TS7039 on the effective noImplicitAny option in the checker-owned diagnostic helper.
- Preserve the two unresolved-name diagnostics for malformed mapped types when noImplicitAny is disabled.
- Add a renamed-binder regression matching mappedTypeNoTypeNoCrash.ts without keying compiler behavior to fixture text.

Structural rule: When a mapped type omits its template type, tsc emits TS7039 only if effective noImplicitAny is enabled; the checker emits it through the centralized mapped-type diagnostic helper.

Owner layer: checker diagnostic orchestration. All three emission paths already converge on this helper.

Adjacent matrix: existing tests retain exactly one TS7039 for aliases, members, nested conditionals, and remapped types when enabled; complete mapped types remain silent; the new disabled-option case retains exactly two TS2304 diagnostics.

Fallback: no mapped-type shape, solver relation, or lowering behavior changes. Only the TS7039 diagnostic is suppressed when its controlling option is disabled.

Performance: one predictable boolean check on the rare malformed-mapped-type path; the disabled case now returns before span lookup, message allocation, and diagnostic deduplication.

## Verification

- cargo nextest run -p tsz-checker --test mapped_type_missing_template_single_ts7039_tests (7 passed)
- cargo clippy -p tsz-checker --lib -- -D warnings
- cargo fmt --check
- python3 scripts/arch/arch_guard.py
- scripts/arch/check-checker-boundaries.sh
- optimized targeted conformance: mappedTypeNoTypeNoCrash.ts (1/1 passed, fingerprints matched)
- pinned tsc cache: expected TS2304 at both unresolved K references and no TS7039 with strict/noImplicitAny disabled

## Provenance

Machine: Mac
Assistant: codex
Model: GPT-5
Effort: high
