### PR TITLE
fix(solver): rebind dependent local constraints

### DIFF
--- a/crates/tsz-checker/tests/kysely_callback_context_tests.rs
+++ b/crates/tsz-checker/tests/kysely_callback_context_tests.rs
@@ -1,8 +1,8 @@
 use tsz_checker::context::CheckerOptions;
 use tsz_checker::diagnostics::Diagnostic;
 use tsz_checker::test_utils::{
-    check_multi_file_with_libs, check_source_with_libs, diagnostic_line_column,
-    load_default_lib_files,
+    check_multi_file_with_libs, check_multi_file_with_libs_stamped, check_source_with_libs,
+    diagnostic_line_column, load_default_lib_files,
 };
 
 fn strict_default_lib_diagnostics(source: &str) -> Vec<Diagnostic> {
@@ -108,6 +108,179 @@ builder.select([
     assert!(
         lacks_any_diagnostic_code(&diagnostics, &[7006, 2347, 2693]),
         "imported callback aliases should contextually type selection factories. Got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn imported_overloaded_method_rebinds_dependent_local_constraint() {
+    let lib_files = load_default_lib_files();
+    let options = CheckerOptions {
+        strict: true,
+        no_implicit_any: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    let files = [
+        (
+            "builder.ts",
+            r#"
+type PreserveOuter<Value> = [Value] extends [unknown] ? Value : never;
+type AnyField<Schema, Visible extends keyof Schema> = {
+  [Table in Visible]: keyof Schema[Table]
+}[Visible] & string;
+type AnyQualifiedField<Schema, Visible extends keyof Schema> = {
+  [Table in Visible]: `${Table & string}.${keyof Schema[Table] & string}`
+}[Visible];
+
+interface NamedExpression<Output, Name extends string> {
+  readonly output: Output;
+  readonly name: Name;
+}
+type NamedExpressionFactory<Schema, Visible extends keyof Schema> = (
+  builder: { schema: Schema; visible: Visible },
+) => NamedExpression<any, any>;
+type SourceExpression<Schema, Visible extends keyof Schema> =
+  | (keyof Schema & string)
+  | `${keyof Schema & string} as ${string}`
+  | NamedExpression<any, any>
+  | NamedExpressionFactory<Schema, Visible>;
+
+type ExtractSourceName<Schema, Source> = Source extends string
+  ? Source extends `${string} as ${infer Name}`
+    ? Name
+    : Source extends keyof Schema
+      ? Source
+      : never
+  : Source extends NamedExpression<any, infer Name>
+    ? Name
+    : Source extends (builder: any) => NamedExpression<any, infer Name>
+      ? Name
+      : never;
+type ExtractSourceRow<Schema, Source, Name extends keyof any> =
+  Source extends `${infer Table} as ${infer Alias}`
+    ? Alias extends Name
+      ? Table extends keyof Schema
+        ? Schema[Table]
+        : never
+      : never
+    : Source extends Name
+      ? Source extends keyof Schema
+        ? Schema[Source]
+        : never
+      : Source extends NamedExpression<infer Output, infer Alias>
+        ? Alias extends Name ? Output : never
+        : never;
+type JoinedSchema<Schema, Source> = PreserveOuter<{
+  [Name in keyof Schema | ExtractSourceName<Schema, Source>]:
+    Name extends ExtractSourceName<Schema, Source>
+      ? ExtractSourceRow<Schema, Source, Name>
+      : Name extends keyof Schema ? Schema[Name] : never;
+}>;
+type JoinedVisible<Schema, Visible extends keyof Schema, Source> = PreserveOuter<
+  Visible | ExtractSourceName<Schema, Source>
+>;
+type ReferenceConstraint<
+  Schema,
+  Visible extends keyof Schema,
+  Source,
+> = PreserveOuter<
+  | AnyField<JoinedSchema<Schema, Source>, JoinedVisible<Schema, Visible, Source>>
+  | AnyQualifiedField<
+      JoinedSchema<Schema, Source>,
+      JoinedVisible<Schema, Visible, Source>
+    >
+>;
+
+export interface OverloadedBuilder<Schema, Visible extends keyof Schema> {
+  attach<
+    Source extends SourceExpression<Schema, Visible>,
+    Reference extends ReferenceConstraint<Schema, Visible, Source>,
+  >(source: Source, left: string, right: string): unknown;
+  attach(source: string, callback: unknown): unknown;
+}
+
+export interface SingleBuilder<Schema, Visible extends keyof Schema> {
+  attach<
+    Source extends SourceExpression<Schema, Visible>,
+    Reference extends ReferenceConstraint<Schema, Visible, Source>,
+  >(source: Source, left: string, right: string): unknown;
+}
+
+export interface IndependentOverloadBuilder<Schema, Visible extends keyof Schema> {
+  attach<
+    Source extends SourceExpression<Schema, Visible>,
+    Reference extends string,
+  >(source: Source, left: string, right: string): unknown;
+  attach(source: string, callback: unknown): unknown;
+}
+"#,
+        ),
+        (
+            "main.ts",
+            r#"
+import type {
+  IndependentOverloadBuilder,
+  OverloadedBuilder,
+  SingleBuilder,
+} from "./builder.js";
+
+interface Catalog {
+  "system.tables": { schemaId: number };
+  "system.schemas": { schemaId: number };
+  tables: { schemaId: number };
+}
+
+declare const overloaded: OverloadedBuilder<Catalog, "tables">;
+declare const single: SingleBuilder<Catalog, "tables">;
+declare const independent: IndependentOverloadBuilder<Catalog, "tables">;
+
+overloaded.attach(
+  "system.schemas as joined_schemas",
+  "joined_schemas.schemaId",
+  "tables.schemaId",
+);
+single.attach(
+  "system.schemas as joined_schemas",
+  "joined_schemas.schemaId",
+  "tables.schemaId",
+);
+independent.attach(
+  "system.schemas as joined_schemas",
+  "joined_schemas.schemaId",
+  "tables.schemaId",
+);
+overloaded.attach(
+  123,
+  "joined_schemas.schemaId",
+  "tables.schemaId",
+);
+"#,
+        ),
+    ];
+
+    let diagnostics = check_multi_file_with_libs_stamped(&files, "main.ts", options, &lib_files)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code != 2318)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "the three valid calls must compile and the adjacent invalid reference must fail once. Got: {diagnostics:#?}"
+    );
+    let diagnostic = &diagnostics[0];
+    let main_source = files[1].1;
+    let invalid_call_start = main_source
+        .rfind("overloaded.attach(")
+        .expect("invalid adjacent call must remain in the witness")
+        as u32;
+    assert_eq!(
+        diagnostic.code, 2345,
+        "the invalid reference must report TS2345"
+    );
+    assert!(diagnostic.file.ends_with("main.ts"));
+    assert!(
+        diagnostic.start >= invalid_call_start,
+        "the sole diagnostic must belong to the invalid adjacent call. Got: {diagnostic:#?}"
     );
 }
 

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -45,6 +45,57 @@ enum InstantiationFrameState {
     DepthExceeded,
 }
 
+/// Per-walk instantiation memo state.
+///
+/// Active entries are cycle breakers and remain valid while a nested generic
+/// installs rewritten local bindings. Completed entries depend on the exact
+/// shadowing, local-binding, and declaration-preservation environment in which
+/// they were computed, so their epoch must match before reuse.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InstantiationMemoEntry {
+    Active,
+    Completed {
+        result: TypeId,
+        environment_epoch: u64,
+    },
+}
+
+/// State restored after leaving a generic shadowing scope.
+struct ShadowingScopeSnapshot {
+    visiting: FxHashMap<TypeId, InstantiationMemoEntry>,
+    environment_epoch: u64,
+}
+
+/// One rewritten type parameter in a nested generic scope.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct LocalTypeParamBinding {
+    declaration: TypeParamInfo,
+    placeholder: TypeParamInfo,
+    instantiated: TypeId,
+}
+
+impl LocalTypeParamBinding {
+    const fn new(declaration: TypeParamInfo, instantiated: TypeId) -> Self {
+        // Lowering first binds this declaration-shaped placeholder so its own
+        // constraint/default can refer to it, then replaces that binding with
+        // the complete declaration info for later signature positions.
+        let placeholder = TypeParamInfo {
+            constraint: None,
+            default: None,
+            ..declaration
+        };
+        Self {
+            declaration,
+            placeholder,
+            instantiated,
+        }
+    }
+
+    fn matches(&self, candidate: &TypeParamInfo) -> bool {
+        *candidate == self.declaration || *candidate == self.placeholder
+    }
+}
+
 impl InstantiationWalkState {
     const fn new(max_depth: u32) -> Self {
         Self {
@@ -90,11 +141,21 @@ pub struct TypeInstantiator<'a> {
     query_db: Option<&'a dyn QueryDatabase>,
     substitution: &'a TypeSubstitution,
     /// Track visited types to handle cycles
-    visiting: FxHashMap<TypeId, TypeId>,
+    visiting: FxHashMap<TypeId, InstantiationMemoEntry>,
     /// Type parameter names that are shadowed in the current scope.
     shadowed: Vec<Atom>,
     /// Freshly-instantiated local type parameters for the current nested generic scope.
-    local_type_params: Vec<(Atom, TypeId)>,
+    ///
+    /// Bindings match full declaration/placeholder info, including a
+    /// `DeclScoped` origin when present; a user-chosen name alone never selects
+    /// a local. Legacy `User` parameters with byte-identical full info remain
+    /// indistinguishable because signatures store `TypeParamInfo`, not the
+    /// declaration-scoped fresh `TypeId` (#14344).
+    local_type_params: Vec<LocalTypeParamBinding>,
+    /// Version of the semantic environment that affects per-walk memo results.
+    /// Incrementing this is O(1); completed entries from older versions are
+    /// recomputed lazily, while active entries continue to break cycles.
+    memo_environment_epoch: u64,
     substitute_infer: bool,
     preserve_meta_types: bool,
     preserve_unsubstituted_type_params: bool,
@@ -141,6 +202,7 @@ impl<'a> TypeInstantiator<'a> {
             visiting: FxHashMap::default(),
             shadowed: Vec::new(),
             local_type_params: Vec::new(),
+            memo_environment_epoch: 0,
             substitute_infer: false,
             preserve_meta_types: false,
             preserve_unsubstituted_type_params: false,
@@ -474,13 +536,28 @@ impl<'a> TypeInstantiator<'a> {
         })
     }
 
-    /// Instantiate type parameter constraints and defaults.
+    /// Instantiate type parameter constraints and defaults, binding each changed
+    /// declaration before walking later dependent declarations.
+    ///
+    /// A signature such as `<T extends Outer<X>, U extends Ref<X, T>>`
+    /// needs every occurrence of `T` after outer `X` is substituted to refer to
+    /// the rewritten `T`, not the declaration-scoped pre-instantiation `TypeId`.
+    /// Bind changed parameters incrementally so later constraints/defaults and
+    /// the signature body share that identity. Unchanged parameters stay fresh
+    /// and unbound, preserving their declaration identity.
     fn instantiate_type_params_if_changed(
         &mut self,
         type_params: &[TypeParamInfo],
     ) -> Option<Vec<TypeParamInfo>> {
+        // Nongeneric functions and call signatures reach this helper too.
+        // Their empty declaration list changes no semantic environment, so do
+        // not churn the epoch and invalidate sibling memo entries twice.
+        if type_params.is_empty() {
+            return None;
+        }
+
         let saved_preserve_unsubstituted = self.preserve_unsubstituted_type_params;
-        self.preserve_unsubstituted_type_params = true;
+        self.set_preserve_unsubstituted_type_params(true);
 
         let mut instantiated: Option<Vec<TypeParamInfo>> = None;
         for (index, type_param) in type_params.iter().enumerate() {
@@ -493,6 +570,18 @@ impl<'a> TypeInstantiator<'a> {
                 default,
                 origin: type_param.origin,
             };
+            if new_type_param != *type_param {
+                let local_type = self.interner.type_param(new_type_param);
+                self.local_type_params
+                    .push(LocalTypeParamBinding::new(*type_param, local_type));
+
+                // Constraints/defaults walked before this binding may have
+                // completed memo entries that contain the old local identity,
+                // including shared composite nodes. Advance the environment
+                // version so those entries miss lazily in O(1); active entries
+                // remain usable cycle breakers.
+                self.advance_memo_environment();
+            }
             if let Some(instantiated) = &mut instantiated {
                 instantiated.push(new_type_param);
             } else if new_type_param != *type_param {
@@ -503,7 +592,7 @@ impl<'a> TypeInstantiator<'a> {
             }
         }
 
-        self.preserve_unsubstituted_type_params = saved_preserve_unsubstituted;
+        self.set_preserve_unsubstituted_type_params(saved_preserve_unsubstituted);
         instantiated
     }
 
@@ -549,12 +638,12 @@ impl<'a> TypeInstantiator<'a> {
 
     /// Enter a shadowing scope for type parameters.
     ///
-    /// Returns `(saved_shadowed_len, saved_visiting)` for restoring via
+    /// Returns `(saved_shadowed_len, saved_scope)` for restoring via
     /// [`exit_shadowing_scope`].
     fn enter_shadowing_scope(
         &mut self,
         type_params: &[TypeParamInfo],
-    ) -> (usize, Option<FxHashMap<TypeId, TypeId>>) {
+    ) -> (usize, Option<ShadowingScopeSnapshot>) {
         let shadowed_len = self.shadowed.len();
         let saved_visiting = if type_params.is_empty() {
             None
@@ -563,15 +652,28 @@ impl<'a> TypeInstantiator<'a> {
             // instantiation), no clone needed — just remove the type params
             // (which are no-ops on an empty map) and return an empty map
             // as the "saved" state.
-            Some(FxHashMap::default())
+            Some(ShadowingScopeSnapshot {
+                visiting: FxHashMap::default(),
+                environment_epoch: self.memo_environment_epoch,
+            })
         } else {
             let saved = self.visiting.clone();
             for tp in type_params {
                 let tp_id = self.interner.type_param(*tp);
                 self.visiting.remove(&tp_id);
             }
-            Some(saved)
+            Some(ShadowingScopeSnapshot {
+                visiting: saved,
+                environment_epoch: self.memo_environment_epoch,
+            })
         };
+        if !type_params.is_empty() {
+            // Completed composite entries can contain a type parameter whose
+            // name becomes shadowed here. Advance the environment version so
+            // those entries miss lazily; removing only the direct parameter
+            // entry would leave composites rewritten by an outer binding.
+            self.advance_memo_environment();
+        }
         self.shadowed.extend(type_params.iter().map(|tp| tp.name));
         (shadowed_len, saved_visiting)
     }
@@ -580,19 +682,37 @@ impl<'a> TypeInstantiator<'a> {
     fn exit_shadowing_scope(
         &mut self,
         shadowed_len: usize,
-        saved_visiting: Option<FxHashMap<TypeId, TypeId>>,
+        saved_visiting: Option<ShadowingScopeSnapshot>,
     ) {
         self.shadowed.truncate(shadowed_len);
         if let Some(saved) = saved_visiting {
-            self.visiting = saved;
+            self.visiting = saved.visiting;
+            self.memo_environment_epoch = saved.environment_epoch;
         }
     }
 
-    fn lookup_local_type_param(&self, name: Atom) -> Option<TypeId> {
+    /// Advance the semantic environment used by completed per-walk memo
+    /// entries. A single walk cannot approach 2^64 transitions, so wrapping
+    /// cannot alias a live epoch.
+    const fn advance_memo_environment(&mut self) {
+        self.memo_environment_epoch = self.memo_environment_epoch.wrapping_add(1);
+    }
+
+    /// Set declaration-preservation mode and invalidate completed memo entries
+    /// when the mode changes. Constraint fallback is deliberately disabled in
+    /// preservation mode, so cached results cannot cross this boundary.
+    const fn set_preserve_unsubstituted_type_params(&mut self, preserve: bool) {
+        if self.preserve_unsubstituted_type_params != preserve {
+            self.preserve_unsubstituted_type_params = preserve;
+            self.advance_memo_environment();
+        }
+    }
+
+    fn lookup_local_type_param(&self, info: &TypeParamInfo) -> Option<TypeId> {
         self.local_type_params
             .iter()
             .rev()
-            .find_map(|(bound_name, type_id)| (*bound_name == name).then_some(*type_id))
+            .find_map(|binding| binding.matches(info).then_some(binding.instantiated))
     }
 
     /// Apply the substitution to a type, returning the instantiated type.
@@ -672,7 +792,7 @@ impl<'a> TypeInstantiator<'a> {
             // node, and we are not walking into the structure here.
             return type_id;
         };
-        if let Some(local_type_param) = self.lookup_local_type_param(info.name) {
+        if let Some(local_type_param) = self.lookup_local_type_param(&info) {
             return local_type_param;
         }
         if self.is_shadowed(info.name) {
@@ -683,21 +803,36 @@ impl<'a> TypeInstantiator<'a> {
 
     fn instantiate_inner(&mut self, type_id: TypeId) -> TypeId {
         // Check if we're already processing this type (cycle detection)
-        if let Some(&cached) = self.visiting.get(&type_id) {
-            if cached != type_id
-                || matches!(
-                    self.interner.lookup(type_id),
-                    Some(TypeData::TypeParameter(_))
-                )
-            {
-                tracing::trace!(
-                    type_id = type_id.0,
-                    cached = cached.0,
-                    key = ?self.interner.lookup(type_id),
-                    "instantiate_inner: VISITING CACHE HIT"
-                );
+        if let Some(entry) = self.visiting.get(&type_id).copied() {
+            let cached = match entry {
+                InstantiationMemoEntry::Active => Some(type_id),
+                InstantiationMemoEntry::Completed {
+                    result,
+                    environment_epoch,
+                } if environment_epoch == self.memo_environment_epoch => Some(result),
+                InstantiationMemoEntry::Completed { .. } => None,
+            };
+            if let Some(cached) = cached {
+                if cached != type_id
+                    || matches!(
+                        self.interner.lookup(type_id),
+                        Some(TypeData::TypeParameter(_))
+                    )
+                {
+                    tracing::trace!(
+                        type_id = type_id.0,
+                        cached = cached.0,
+                        key = ?self.interner.lookup(type_id),
+                        "instantiate_inner: VISITING CACHE HIT"
+                    );
+                }
+                return cached;
+            } else {
+                // The type graph is immutable, but its instantiated result can
+                // depend on a newly-installed nested-local binding. Overwrite
+                // stale completed state on the recomputation path below.
+                self.visiting.remove(&type_id);
             }
-            return cached;
         }
 
         // Look up the type structure
@@ -710,13 +845,21 @@ impl<'a> TypeInstantiator<'a> {
             return type_id;
         }
 
-        // Mark as visiting (with original ID as placeholder for cycles)
-        self.visiting.insert(type_id, type_id);
+        // Mark as active before descending so recursive references break their
+        // cycle even if a nested generic advances the completed-entry epoch.
+        self.visiting
+            .insert(type_id, InstantiationMemoEntry::Active);
 
         let result = self.instantiate_key(type_id, &key);
 
         // Update the cache with the actual result
-        self.visiting.insert(type_id, result);
+        self.visiting.insert(
+            type_id,
+            InstantiationMemoEntry::Completed {
+                result,
+                environment_epoch: self.memo_environment_epoch,
+            },
+        );
 
         result
     }
@@ -754,7 +897,7 @@ impl<'a> TypeInstantiator<'a> {
         match key {
             // Type parameters get substituted
             TypeData::TypeParameter(info) => {
-                if let Some(local_type_param) = self.lookup_local_type_param(info.name) {
+                if let Some(local_type_param) = self.lookup_local_type_param(info) {
                     return local_type_param;
                 }
                 if self.is_shadowed(info.name) {

--- a/crates/tsz-solver/src/instantiation/instantiate/display_properties.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/display_properties.rs
@@ -254,7 +254,14 @@ impl<'a> TypeInstantiator<'a> {
 
     #[inline]
     fn completed_instantiation(&self, type_id: TypeId) -> TypeId {
-        self.visiting.get(&type_id).copied().unwrap_or(type_id)
+        match self.visiting.get(&type_id).copied() {
+            Some(InstantiationMemoEntry::Completed {
+                result,
+                environment_epoch,
+            }) if environment_epoch == self.memo_environment_epoch => result,
+            Some(InstantiationMemoEntry::Active | InstantiationMemoEntry::Completed { .. })
+            | None => type_id,
+        }
     }
 
     fn raw_intersection(&self, members: Vec<TypeId>) -> TypeId {

--- a/crates/tsz-solver/src/instantiation/instantiate/mapped.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/mapped.rs
@@ -486,7 +486,7 @@ impl<'a> TypeInstantiator<'a> {
             "instantiate Mapped: about to instantiate constraint"
         );
         let saved_preserve_unsubstituted = self.preserve_unsubstituted_type_params;
-        self.preserve_unsubstituted_type_params = true;
+        self.set_preserve_unsubstituted_type_params(true);
 
         let new_constraint = self.instantiate(mapped.constraint);
         let new_template = self.instantiate(mapped.template);
@@ -494,7 +494,7 @@ impl<'a> TypeInstantiator<'a> {
         let new_param_constraint = mapped.type_param.constraint.map(|c| self.instantiate(c));
         let new_param_default = mapped.type_param.default.map(|d| self.instantiate(d));
 
-        self.preserve_unsubstituted_type_params = saved_preserve_unsubstituted;
+        self.set_preserve_unsubstituted_type_params(saved_preserve_unsubstituted);
 
         self.exit_shadowing_scope(shadowed_len, saved_visiting);
 

--- a/crates/tsz-solver/src/instantiation/instantiate/signatures.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/signatures.rs
@@ -16,20 +16,11 @@ impl<'a> TypeInstantiator<'a> {
     ) -> Option<CallSignature> {
         let (shadowed_len, saved_visiting) = self.enter_shadowing_scope(&sig.type_params);
 
-        let type_params = self.instantiate_type_params_if_changed(&sig.type_params);
         let local_start = self.local_type_params.len();
-        // Redirect occurrences of the signature's own params only when their
-        // infos actually changed (constraint/default instantiated). When
-        // unchanged, pushing a structural re-intern would rewrite
-        // declaration-scoped fresh params to the structural canonical and
-        // erase declaration identity; the shadowing scope already preserves
-        // them as-is (#13044).
-        if let Some(changed_params) = type_params.as_deref() {
-            for type_param in changed_params {
-                self.local_type_params
-                    .push((type_param.name, self.interner.type_param(*type_param)));
-            }
-        }
+        // This also binds each changed local parameter before walking later
+        // dependent constraints; unchanged fresh params remain untouched
+        // (#13044).
+        let type_params = self.instantiate_type_params_if_changed(&sig.type_params);
         let type_predicate = sig
             .type_predicate
             .as_ref()
@@ -150,17 +141,10 @@ impl<'a> TypeInstantiator<'a> {
         }
         let (shadowed_len, saved_visiting) = self.enter_shadowing_scope(&shape.type_params);
 
-        let instantiated_type_params = self.instantiate_type_params_if_changed(&shape.type_params);
         let local_start = self.local_type_params.len();
-        // Redirect own-param occurrences only when the param infos
-        // changed; see `instantiate_call_signature_if_changed` for
-        // the declaration-identity rationale (#13044).
-        if let Some(changed_params) = instantiated_type_params.as_deref() {
-            for type_param in changed_params {
-                self.local_type_params
-                    .push((type_param.name, self.interner.type_param(*type_param)));
-            }
-        }
+        // This also binds each changed local parameter before walking later
+        // dependent constraints; unchanged fresh params remain untouched.
+        let instantiated_type_params = self.instantiate_type_params_if_changed(&shape.type_params);
         let type_predicate = shape
             .type_predicate
             .as_ref()

--- a/crates/tsz-solver/tests/instantiate_tests_parts/part_02.rs
+++ b/crates/tsz-solver/tests/instantiate_tests_parts/part_02.rs
@@ -41,6 +41,394 @@ fn cached_index_access_fast_path_uses_resolver_rereduce_when_flagged() {
 }
 
 #[test]
+fn overloaded_member_rebinds_dependent_local_constraint_after_outer_instantiation() {
+    let interner = TypeInterner::new();
+    let outer_info = TypeParamInfo::simple(interner.intern_string("OuterDb"));
+    let key_info = TypeParamInfo::simple(interner.intern_string("OuterKey"));
+    let outer_type = interner.fresh_type_param(outer_info);
+    let key_type = interner.fresh_type_param(key_info);
+
+    let table_base = interner.lazy(DefId(902_010));
+    let table_expression = interner.application(table_base, vec![outer_type, key_type]);
+    let table_info = TypeParamInfo {
+        constraint: Some(table_expression),
+        ..TypeParamInfo::simple(interner.intern_string("Table"))
+    };
+    let table_type = interner.fresh_type_param(table_info);
+
+    let reference_base = interner.lazy(DefId(902_011));
+    let reference_expression =
+        interner.application(reference_base, vec![outer_type, key_type, table_type]);
+    let reference_info = TypeParamInfo {
+        constraint: Some(reference_expression),
+        ..TypeParamInfo::simple(interner.intern_string("Reference"))
+    };
+
+    let primary = CallSignature {
+        type_params: vec![table_info, reference_info],
+        params: vec![
+            ParamInfo::unnamed(table_type),
+            ParamInfo::unnamed(TypeId::STRING),
+            ParamInfo::unnamed(TypeId::STRING),
+        ],
+        this_type: None,
+        return_type: TypeId::UNKNOWN,
+        type_predicate: None,
+        is_method: true,
+    };
+    let fallback = CallSignature {
+        type_params: Vec::new(),
+        params: vec![
+            ParamInfo::unnamed(TypeId::STRING),
+            ParamInfo::unnamed(TypeId::UNKNOWN),
+        ],
+        this_type: None,
+        return_type: TypeId::UNKNOWN,
+        type_predicate: None,
+        is_method: true,
+    };
+    let callable = interner.callable(CallableShape {
+        call_signatures: vec![primary, fallback],
+        ..Default::default()
+    });
+    let method_name = interner.intern_string("method");
+    let interface_body = interner.object(vec![PropertyInfo {
+        is_method: true,
+        ..PropertyInfo::new(method_name, callable)
+    }]);
+
+    let concrete_outer = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("table"),
+        TypeId::NUMBER,
+    )]);
+    let concrete_key = interner.literal_string("table");
+    let substitution = TypeSubstitution::from_args(
+        &interner,
+        &[outer_info, key_info],
+        &[concrete_outer, concrete_key],
+    );
+    let instantiated = instantiate_type(&interner, interface_body, &substitution);
+
+    let Some(TypeData::Object(shape_id)) = interner.lookup(instantiated) else {
+        panic!("instantiated interface body must remain an object");
+    };
+    let method = interner
+        .object_shape(shape_id)
+        .properties
+        .iter()
+        .find(|property| property.name == method_name)
+        .expect("instantiated interface body must retain its overloaded method")
+        .type_id;
+    let Some(TypeData::Callable(callable_id)) = interner.lookup(method) else {
+        panic!("overloaded method must remain callable");
+    };
+    let callable = interner.callable_shape(callable_id);
+    let primary = &callable.call_signatures[0];
+    let rewritten_table = interner.type_param(primary.type_params[0]);
+    assert_eq!(primary.params[0].type_id, rewritten_table);
+
+    let rewritten_reference = primary.type_params[1]
+        .constraint
+        .expect("dependent type parameter must retain its constraint");
+    let Some(TypeData::Application(reference_id)) = interner.lookup(rewritten_reference) else {
+        panic!("dependent constraint must remain an application");
+    };
+    let rewritten_reference = interner.type_application(reference_id);
+    assert_eq!(
+        rewritten_reference.args.as_slice(),
+        &[concrete_outer, concrete_key, rewritten_table]
+    );
+}
+
+#[test]
+fn changed_local_rebinding_preserves_same_name_foreign_seen_before_binding() {
+    let interner = TypeInterner::new();
+    let outer_info = TypeParamInfo::simple(interner.intern_string("OuterValue"));
+    let outer_type = interner.fresh_type_param(outer_info);
+    let shared_name = interner.intern_string("Item");
+    let scope_file = interner.intern_string("scope.ts");
+    let foreign_info = TypeParamInfo {
+        constraint: Some(TypeId::NUMBER),
+        origin: crate::types::TypeParamOrigin::DeclScoped {
+            file: scope_file,
+            node: 10,
+        },
+        ..TypeParamInfo::simple(shared_name)
+    };
+    let foreign_type = interner.fresh_type_param(foreign_info);
+
+    let constraint_base = interner.lazy(DefId(902_012));
+    let local_constraint =
+        interner.application(constraint_base, vec![outer_type, foreign_type]);
+    let local_info = TypeParamInfo {
+        constraint: Some(local_constraint),
+        origin: crate::types::TypeParamOrigin::DeclScoped {
+            file: scope_file,
+            node: 20,
+        },
+        ..TypeParamInfo::simple(shared_name)
+    };
+    let local_type = interner.fresh_type_param(local_info);
+    let method = interner.function(FunctionShape {
+        type_params: vec![local_info],
+        params: vec![
+            ParamInfo::unnamed(local_type),
+            ParamInfo::unnamed(foreign_type),
+        ],
+        this_type: None,
+        return_type: TypeId::UNKNOWN,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: true,
+    });
+
+    let substitution = TypeSubstitution::single(outer_info.name, TypeId::STRING);
+    let instantiated = instantiate_type(&interner, method, &substitution);
+    let Some(TypeData::Function(method_id)) = interner.lookup(instantiated) else {
+        panic!("instantiated method must remain a function");
+    };
+    let method = interner.function_shape(method_id);
+    let rewritten_local = interner.type_param(method.type_params[0]);
+    assert_eq!(method.params[0].type_id, rewritten_local);
+    assert_eq!(method.params[1].type_id, foreign_type);
+    assert_ne!(method.params[1].type_id, rewritten_local);
+
+    let rewritten_constraint = method.type_params[0]
+        .constraint
+        .expect("rewritten local must retain its constraint");
+    let Some(TypeData::Application(constraint_id)) = interner.lookup(rewritten_constraint) else {
+        panic!("rewritten constraint must remain an application");
+    };
+    assert_eq!(
+        interner.type_application(constraint_id).args.as_slice(),
+        &[TypeId::STRING, foreign_type]
+    );
+}
+
+#[test]
+fn changed_local_rebinding_preserves_same_name_foreign_seen_after_binding() {
+    let interner = TypeInterner::new();
+    let outer_info = TypeParamInfo::simple(interner.intern_string("OuterValue"));
+    let outer_type = interner.fresh_type_param(outer_info);
+    let shared_name = interner.intern_string("Item");
+    let scope_file = interner.intern_string("scope.ts");
+    let foreign_info = TypeParamInfo {
+        constraint: Some(TypeId::NUMBER),
+        origin: crate::types::TypeParamOrigin::DeclScoped {
+            file: scope_file,
+            node: 30,
+        },
+        ..TypeParamInfo::simple(shared_name)
+    };
+    let foreign_type = interner.fresh_type_param(foreign_info);
+
+    let constraint_base = interner.lazy(DefId(902_013));
+    let local_constraint = interner.application(constraint_base, vec![outer_type]);
+    let local_info = TypeParamInfo {
+        constraint: Some(local_constraint),
+        origin: crate::types::TypeParamOrigin::DeclScoped {
+            file: scope_file,
+            node: 40,
+        },
+        ..TypeParamInfo::simple(shared_name)
+    };
+    let local_type = interner.fresh_type_param(local_info);
+    let method = interner.function(FunctionShape {
+        type_params: vec![local_info],
+        params: vec![ParamInfo::unnamed(local_type)],
+        this_type: None,
+        // This foreign binder is first encountered after the changed local
+        // declaration has been instantiated and bound.
+        return_type: foreign_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: true,
+    });
+
+    let substitution = TypeSubstitution::single(outer_info.name, TypeId::STRING);
+    let instantiated = instantiate_type(&interner, method, &substitution);
+    let Some(TypeData::Function(method_id)) = interner.lookup(instantiated) else {
+        panic!("instantiated method must remain a function");
+    };
+    let method = interner.function_shape(method_id);
+    let rewritten_local = interner.type_param(method.type_params[0]);
+    assert_eq!(method.params[0].type_id, rewritten_local);
+    assert_eq!(method.return_type, foreign_type);
+    assert_ne!(method.return_type, rewritten_local);
+}
+
+#[test]
+fn changed_local_binding_invalidates_completed_composite_cache_entries() {
+    let interner = TypeInterner::new();
+    let outer_info = TypeParamInfo::simple(interner.intern_string("OuterValue"));
+    let outer_type = interner.fresh_type_param(outer_info);
+    let scope_file = interner.intern_string("scope.ts");
+
+    // Lowering binds this declaration-shaped placeholder before it lowers the
+    // self-referential constraint, then replaces the binding with the complete
+    // declaration info for later signature positions.
+    let local_placeholder_info = TypeParamInfo {
+        origin: crate::types::TypeParamOrigin::DeclScoped {
+            file: scope_file,
+            node: 50,
+        },
+        ..TypeParamInfo::simple(interner.intern_string("Item"))
+    };
+    let local_placeholder = interner.fresh_type_param(local_placeholder_info);
+    let box_base = interner.lazy(DefId(902_014));
+    let shared_box = interner.application(box_base, vec![outer_type, local_placeholder]);
+    let local_info = TypeParamInfo {
+        constraint: Some(shared_box),
+        ..local_placeholder_info
+    };
+    let local_type = interner.fresh_type_param(local_info);
+
+    let dependent_info = TypeParamInfo {
+        constraint: Some(shared_box),
+        origin: crate::types::TypeParamOrigin::DeclScoped {
+            file: scope_file,
+            node: 60,
+        },
+        ..TypeParamInfo::simple(interner.intern_string("Dependent"))
+    };
+    let method = interner.function(FunctionShape {
+        type_params: vec![local_info, dependent_info],
+        params: vec![ParamInfo::unnamed(local_type)],
+        this_type: None,
+        return_type: shared_box,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: true,
+    });
+
+    let substitution = TypeSubstitution::single(outer_info.name, TypeId::STRING);
+    let instantiated = instantiate_type(&interner, method, &substitution);
+    let Some(TypeData::Function(method_id)) = interner.lookup(instantiated) else {
+        panic!("instantiated method must remain a function");
+    };
+    let method = interner.function_shape(method_id);
+    let rewritten_local = interner.type_param(method.type_params[0]);
+    assert_eq!(method.params[0].type_id, rewritten_local);
+
+    let rewritten_dependent = method.type_params[1]
+        .constraint
+        .expect("dependent parameter must retain its shared constraint");
+    let Some(TypeData::Application(dependent_id)) = interner.lookup(rewritten_dependent) else {
+        panic!("dependent constraint must remain an application");
+    };
+    assert_eq!(
+        interner.type_application(dependent_id).args.as_slice(),
+        &[TypeId::STRING, rewritten_local]
+    );
+
+    let Some(TypeData::Application(return_id)) = interner.lookup(method.return_type) else {
+        panic!("shared return type must remain an application");
+    };
+    assert_eq!(
+        interner.type_application(return_id).args.as_slice(),
+        &[TypeId::STRING, rewritten_local]
+    );
+}
+
+#[test]
+fn shadowing_scope_invalidates_completed_composite_cache_entries() {
+    let interner = TypeInterner::new();
+    let local_info = TypeParamInfo::simple(interner.intern_string("Item"));
+    let local_type = interner.type_param(local_info);
+    let shared_array = interner.array(local_type);
+    let method = interner.function(FunctionShape {
+        type_params: vec![local_info],
+        params: vec![ParamInfo::unnamed(shared_array)],
+        this_type: None,
+        return_type: shared_array,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: true,
+    });
+    // The first element caches `Item[] -> string[]` before the method's own
+    // `<Item>` enters scope. Reusing that composite inside the method must
+    // observe shadowing even though the local declaration itself is unchanged.
+    let container = interner.tuple(vec![
+        crate::types::TupleElement::fixed(shared_array),
+        crate::types::TupleElement::fixed(method),
+    ]);
+
+    let substitution = TypeSubstitution::single(local_info.name, TypeId::STRING);
+    let instantiated = instantiate_type(&interner, container, &substitution);
+    let Some(TypeData::Tuple(tuple_id)) = interner.lookup(instantiated) else {
+        panic!("instantiated container must remain a tuple");
+    };
+    let elements = interner.tuple_list(tuple_id);
+    assert_eq!(elements.len(), 2);
+    assert_eq!(elements[0].type_id, interner.array(TypeId::STRING));
+
+    let Some(TypeData::Function(method_id)) = interner.lookup(elements[1].type_id) else {
+        panic!("second element must remain a function");
+    };
+    let method = interner.function_shape(method_id);
+    assert_eq!(method.type_params, vec![local_info]);
+    assert_eq!(method.params[0].type_id, shared_array);
+    assert_eq!(method.return_type, shared_array);
+}
+
+#[test]
+fn declaration_preservation_mode_invalidates_completed_type_param_cache_entries() {
+    let interner = TypeInterner::new();
+    let outer_info = TypeParamInfo::simple(interner.intern_string("OuterValue"));
+    let outer_type = interner.fresh_type_param(outer_info);
+    let scope_file = interner.intern_string("scope.ts");
+    let foreign_info = TypeParamInfo {
+        constraint: Some(interner.array(outer_type)),
+        origin: crate::types::TypeParamOrigin::DeclScoped {
+            file: scope_file,
+            node: 70,
+        },
+        ..TypeParamInfo::simple(interner.intern_string("Foreign"))
+    };
+    let foreign_type = interner.fresh_type_param(foreign_info);
+    let local_info = TypeParamInfo {
+        constraint: Some(foreign_type),
+        origin: crate::types::TypeParamOrigin::DeclScoped {
+            file: scope_file,
+            node: 80,
+        },
+        ..TypeParamInfo::simple(interner.intern_string("Local"))
+    };
+    let method = interner.function(FunctionShape {
+        type_params: vec![local_info],
+        params: vec![ParamInfo::unnamed(foreign_type)],
+        this_type: None,
+        return_type: TypeId::UNKNOWN,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: true,
+    });
+
+    let substitution = TypeSubstitution::single(outer_info.name, TypeId::STRING);
+    let instantiated = instantiate_type(&interner, method, &substitution);
+    let Some(TypeData::Function(method_id)) = interner.lookup(instantiated) else {
+        panic!("instantiated method must remain a function");
+    };
+    let method = interner.function_shape(method_id);
+    assert_eq!(method.type_params, vec![local_info]);
+    let Some(TypeData::Array(element)) = interner.lookup(method.params[0].type_id) else {
+        panic!("normal signature-body mode must apply the foreign constraint fallback");
+    };
+    assert_eq!(element, TypeId::STRING);
+}
+
+#[test]
+fn empty_type_param_list_does_not_advance_memo_environment() {
+    let interner = TypeInterner::new();
+    let substitution = TypeSubstitution::new();
+    let mut instantiator = TypeInstantiator::new(&interner, &substitution);
+    let initial_epoch = instantiator.memo_environment_epoch;
+
+    assert_eq!(instantiator.instantiate_type_params_if_changed(&[]), None);
+    assert_eq!(instantiator.memo_environment_epoch, initial_epoch);
+}
+
+#[test]
 fn instantiated_keyof_uses_store_backed_rereduce_when_flagged() {
     let interner = TypeInterner::new();
     let store = crate::def::DefinitionStore::new();


### PR DESCRIPTION
Goal: green

## Summary

- Rebind signature-local type parameters and their dependent constraints by exact declaration/placeholder identity during outer instantiation.
- Make completed per-walk instantiation memo entries reusable only in the same local-binding, shadowing, and declaration-preservation environment; active entries remain cycle breakers.
- Remove 23 false positives from the pinned Kysely canary, including all four mssql-introspector callback errors.

Structural rule: When an outer generic application materializes a nested generic signature, tsc keeps that signature's local binders local and rewrites dependent constraints against the freshly rebound local declarations. TSZ now performs that rewrite through solver instantiation using exact TypeParamInfo identity.

Owner layer: solver instantiation owns binder rebinding, substitution-domain membership, and environment-sensitive memo reuse. The checker change is a cross-file integration witness only.

Adjacent matrix: renamed local binders; foreign same-named declarations before and after local binding; repeated composites across binding changes; shadowing-scope transitions; declaration-preservation transitions; empty nongeneric parameter lists; and a valid/invalid imported overloaded-method pair.

Fallback: unmatched or foreign type parameters remain untouched. Active memo entries continue to terminate cycles. Completed entries from a stale environment are recomputed lazily instead of being reused.

Performance: environment transitions are O(1) epoch increments; empty parameter lists do not churn the epoch; residency stays per instantiation walk. The final Kysely run used 39.78s user CPU versus 39.14s before hardening (+1.6% under heavy concurrent load).

## Verification

- focused solver instantiation matrix: 7/7 passed on the rebased head
- cargo nextest run -p tsz-checker --test kysely_callback_context_tests imported_overloaded_method_rebinds_dependent_local_constraint (1/1 passed)
- pinned Kysely d4911be compile guard: 279 files, tsc 7.0.2 = 0 diagnostics, tsz = 53 tsz-only diagnostics versus 76 at base (-23)
- cargo clippy -p tsz-solver --lib -- -D warnings
- focused cargo clippy -p tsz-checker --lib -- -D warnings
- cargo fmt --all --check
- git diff --check origin/main..HEAD
- python3 scripts/arch/arch_guard.py
- independent final review: clean, no blockers

## Provenance

Machine: Mac
Assistant: codex
Model: GPT-5
Effort: high
