### PR TITLE
fix(checker): match TypeScript 7 spelling suggestions

### DIFF
--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -440,7 +440,9 @@ impl BinderState {
     }
 
     /// Collect visible symbol names filtered by meaning flags.
-    /// If `meaning_flags` is non-zero, only include symbols whose flags overlap with `meaning_flags`.
+    /// If `meaning_flags` is non-zero, only include symbols whose flags overlap with
+    /// `meaning_flags`. Receiver-only class members are excluded because they are
+    /// not bare lexical names; class type parameters remain eligible.
     pub fn collect_visible_symbol_names_filtered(
         &self,
         arena: &NodeArena,
@@ -449,12 +451,28 @@ impl BinderState {
     ) -> Vec<String> {
         let mut names = FxHashSet::default();
 
-        let passes_filter = |sym_id: &SymbolId| -> bool {
-            if meaning_flags == 0 {
-                return true;
-            }
-            self.get_symbol(*sym_id)
-                .is_none_or(|sym| sym.flags & meaning_flags != 0)
+        const RECEIVER_MEMBER_FLAGS: u32 = symbol_flags::PROPERTY
+            | symbol_flags::METHOD
+            | symbol_flags::GET_ACCESSOR
+            | symbol_flags::SET_ACCESSOR
+            | symbol_flags::CONSTRUCTOR;
+        const SEMANTIC_MEANING_FLAGS: u32 = symbol_flags::VALUE
+            | symbol_flags::TYPE
+            | symbol_flags::NAMESPACE
+            | symbol_flags::ALIAS;
+        let passes_filter = |sym_id: &SymbolId, class_scope: bool| -> bool {
+            self.get_symbol(*sym_id).is_none_or(|symbol| {
+                let lexical_flags = if class_scope {
+                    symbol.flags & !RECEIVER_MEMBER_FLAGS
+                } else {
+                    symbol.flags
+                };
+                if meaning_flags == 0 {
+                    lexical_flags & SEMANTIC_MEANING_FLAGS != 0
+                } else {
+                    lexical_flags & meaning_flags != 0
+                }
+            })
         };
 
         if let Some(mut scope_id) = self.find_enclosing_scope(arena, node_idx) {
@@ -468,7 +486,7 @@ impl BinderState {
                     break;
                 };
                 for (symbol_name, sym_id) in scope.table.iter() {
-                    if passes_filter(sym_id) {
+                    if passes_filter(sym_id, scope.kind == ContainerKind::Class) {
                         names.insert(symbol_name.clone());
                     }
                 }
@@ -477,7 +495,7 @@ impl BinderState {
         }
 
         for (symbol_name, sym_id) in self.file_locals.iter() {
-            if passes_filter(sym_id) {
+            if passes_filter(sym_id, false) {
                 names.insert(symbol_name.clone());
             }
         }

--- a/crates/tsz-checker/src/context/cache_statistics.rs
+++ b/crates/tsz-checker/src/context/cache_statistics.rs
@@ -2,13 +2,18 @@
 
 use rustc_hash::FxHashMap;
 use std::mem;
+#[cfg(test)]
+use std::rc::Rc;
+#[cfg(test)]
+use tsz_binder::ScopeId;
 use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
 use tsz_solver::def::DefId;
 use tsz_solver::{TypeId, TypeParamInfo};
 
 use super::{
-    CheckerContext, accessor_levels_cache_entries, accessor_levels_cache_estimated_size_bytes,
+    CheckerContext, SpellingCandidateCache, SpellingSuggestionScanCache,
+    accessor_levels_cache_entries, accessor_levels_cache_estimated_size_bytes,
     callback_mismatch_memo_entries, callback_mismatch_memo_estimated_size_bytes,
     cross_file_type_params_cache_statistics, env_eval_cache, export_equals_named_cache_entries,
     export_equals_named_cache_estimated_size_bytes, member_access_info_cache_entries,
@@ -39,6 +44,8 @@ pub struct CheckerContextCacheStatistics {
     pub lazy_lib_member_resolution_cache_estimated_size_bytes: usize,
     pub symbol_name_candidates_cache_entries: usize,
     pub symbol_name_candidates_cache_estimated_size_bytes: usize,
+    pub spelling_candidate_cache_entries: usize,
+    pub spelling_candidate_cache_estimated_size_bytes: usize,
     pub suggestion_scan_cache_entries: usize,
     pub suggestion_scan_cache_estimated_size_bytes: usize,
     pub namespace_member_resolution_cache_entries: usize,
@@ -120,6 +127,7 @@ impl CheckerContextCacheStatistics {
             + self.lib_type_resolution_cache_estimated_size_bytes
             + self.lazy_lib_member_resolution_cache_estimated_size_bytes
             + self.symbol_name_candidates_cache_estimated_size_bytes
+            + self.spelling_candidate_cache_estimated_size_bytes
             + self.suggestion_scan_cache_estimated_size_bytes
             + self.namespace_member_resolution_cache_estimated_size_bytes
             + self.export_equals_named_cache_estimated_size_bytes
@@ -165,6 +173,7 @@ impl CheckerContextCacheStatistics {
             + self.lib_type_resolution_cache_entries
             + self.lazy_lib_member_resolution_cache_entries
             + self.symbol_name_candidates_cache_entries
+            + self.spelling_candidate_cache_entries
             + self.suggestion_scan_cache_entries
             + self.namespace_member_resolution_cache_entries
             + self.export_equals_named_cache_entries
@@ -223,6 +232,10 @@ impl<'a> CheckerContext<'a> {
             .lazy_member_receiver_properties
             .borrow();
         let symbol_name_candidates_cache = self.symbol_name_candidates_cache.borrow();
+        let spelling_candidate_cache = self
+            .name_resolution_diagnostics
+            .spelling_candidate_cache
+            .borrow();
         let suggestion_scan_cache = self
             .name_resolution_diagnostics
             .suggestion_scan_cache
@@ -314,10 +327,12 @@ impl<'a> CheckerContext<'a> {
             symbol_name_candidates_cache_entries: symbol_name_candidates_cache.len(),
             symbol_name_candidates_cache_estimated_size_bytes:
                 string_symbol_vec_cache_estimated_size_bytes(&symbol_name_candidates_cache),
-            suggestion_scan_cache_entries: suggestion_scan_cache.len(),
-            suggestion_scan_cache_estimated_size_bytes: keyed_string_vec_cache_estimated_size_bytes(
-                &suggestion_scan_cache,
-            ),
+            spelling_candidate_cache_entries: spelling_candidate_cache.len(),
+            spelling_candidate_cache_estimated_size_bytes:
+                scoped_string_slice_cache_estimated_size_bytes(&spelling_candidate_cache),
+            suggestion_scan_cache_entries: suggestion_scan_cache.values().map(FxHashMap::len).sum(),
+            suggestion_scan_cache_estimated_size_bytes:
+                scoped_name_string_vec_cache_estimated_size_bytes(&suggestion_scan_cache),
             namespace_member_resolution_cache_entries: namespace_member_resolution_cache_entries(
                 &namespace_member_resolution_cache,
             ),
@@ -547,6 +562,32 @@ fn keyed_string_vec_cache_estimated_size_bytes<K>(cache: &FxHashMap<K, Vec<Strin
     )
 }
 
+fn scoped_name_string_vec_cache_estimated_size_bytes(cache: &SpellingSuggestionScanCache) -> usize {
+    fx_hash_map_estimated_size_bytes(cache).saturating_add(
+        cache
+            .values()
+            .map(|by_name| {
+                keyed_string_vec_cache_estimated_size_bytes(by_name)
+                    .saturating_add(by_name.keys().map(String::len).sum::<usize>())
+            })
+            .sum::<usize>(),
+    )
+}
+
+fn scoped_string_slice_cache_estimated_size_bytes(cache: &SpellingCandidateCache) -> usize {
+    fx_hash_map_estimated_size_bytes(cache).saturating_add(
+        cache
+            .values()
+            .map(|names| {
+                mem::size_of::<usize>()
+                    .saturating_mul(2)
+                    .saturating_add(names.len().saturating_mul(mem::size_of::<String>()))
+                    .saturating_add(names.iter().map(String::len).sum::<usize>())
+            })
+            .sum::<usize>(),
+    )
+}
+
 fn string_symbol_vec_cache_estimated_size_bytes(cache: &FxHashMap<String, Vec<SymbolId>>) -> usize {
     fx_hash_map_estimated_size_bytes(cache)
         .saturating_add(cache.keys().map(String::len).sum::<usize>())
@@ -586,17 +627,36 @@ mod tests {
     #[test]
     fn suggestion_scan_cache_statistics_report_entries_and_size() {
         let mut cache = FxHashMap::default();
-        assert_eq!(keyed_string_vec_cache_estimated_size_bytes(&cache), 0);
+        assert_eq!(scoped_name_string_vec_cache_estimated_size_bytes(&cache), 0);
 
-        cache.insert((7, 1), vec!["candidate".to_string()]);
+        cache.insert(
+            (ScopeId(7), 1),
+            FxHashMap::from_iter([("misspelled".to_string(), vec!["candidate".to_string()])]),
+        );
 
         assert_eq!(cache.len(), 1);
-        assert!(keyed_string_vec_cache_estimated_size_bytes(&cache) > 0);
+        assert!(scoped_name_string_vec_cache_estimated_size_bytes(&cache) > 0);
+    }
+
+    #[test]
+    fn spelling_candidate_cache_statistics_report_entries_and_size() {
+        let mut cache = FxHashMap::default();
+        assert_eq!(scoped_string_slice_cache_estimated_size_bytes(&cache), 0);
+
+        cache.insert(
+            (ScopeId(7), 1),
+            Rc::<[String]>::from(vec!["candidate".to_string()]),
+        );
+
+        assert_eq!(cache.len(), 1);
+        assert!(scoped_string_slice_cache_estimated_size_bytes(&cache) > 0);
     }
 
     #[test]
     fn checker_context_cache_statistics_roll_up_diagnostic_and_switch_caches() {
         let stats = CheckerContextCacheStatistics {
+            spelling_candidate_cache_entries: 2,
+            spelling_candidate_cache_estimated_size_bytes: 3,
             suggestion_scan_cache_entries: 1,
             suggestion_scan_cache_estimated_size_bytes: 2,
             flow_switch_case_literal_cache_entries: 4,
@@ -606,7 +666,7 @@ mod tests {
             ..CheckerContextCacheStatistics::default()
         };
 
-        assert_eq!(stats.entries(), 21);
-        assert_eq!(stats.estimated_size_bytes(), 42);
+        assert_eq!(stats.entries(), 23);
+        assert_eq!(stats.estimated_size_bytes(), 45);
     }
 }

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -181,16 +181,13 @@ impl<'a> CheckerContext<'a> {
         self.object_literal_tracking.property_diag_targets.clear();
         self.object_literal_tracking.contextual_targets.clear();
         self.object_literal_tracking.partial_initializers.clear();
-        // `name_resolution_diagnostics.reported_nodes` holds the
-        // `NodeIndex` set per file for TS2304/TS2552 dedup; clear it
-        // alongside the counter.
-        self.name_resolution_diagnostics.reported_nodes.clear();
+        // Spelling candidates and scan results are keyed by binder-local
+        // `ScopeId`; clear both so a new file's identically-numbered scopes never
+        // inherit the previous file's symbol universe or suggestions.
         self.name_resolution_diagnostics
-            .spelling_suggestions_emitted
-            .set(0);
-        // The suggestion-scan memo is keyed by per-file `NodeIndex`; clear it
-        // alongside `reported_nodes` so a new file's identically-numbered nodes
-        // never inherit the previous file's cached suggestions.
+            .spelling_candidate_cache
+            .borrow_mut()
+            .clear();
         self.name_resolution_diagnostics
             .suggestion_scan_cache
             .borrow_mut()

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -87,7 +87,7 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 use std::sync::Arc;
 pub use symbol_file_targets::SymbolFileTargetsOverlay;
-use tsz_binder::SymbolId;
+use tsz_binder::{ScopeId, SymbolId};
 use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
@@ -415,26 +415,27 @@ pub struct DestructuredBindingInfo {
     pub(crate) is_rest: bool,
 }
 
-/// Name-resolution diagnostic counters that must stay coordinated.
+/// Visible spelling candidates for one file session.
+pub type SpellingCandidateCache = FxHashMap<(ScopeId, u32), Rc<[String]>>;
+
+/// Per-spelling suggestion results for one file session.
+pub type SpellingSuggestionScanCache = FxHashMap<(ScopeId, u32), FxHashMap<String, Vec<String>>>;
+
+/// Name-resolution diagnostic caches that must stay coordinated.
 #[derive(Debug, Default)]
 pub struct NameResolutionDiagnostics {
-    /// Count of name resolution attempts (TS2304/TS2552) to limit spelling suggestions.
-    /// tsc caps at 10, counting every resolution failure (not just successful suggestions).
-    pub spelling_suggestions_emitted: Cell<u32>,
+    /// Visible spelling candidates keyed by lexical scope and symbol-meaning
+    /// mask. Binder/lib tables are immutable during a file session, so every
+    /// miss in the same scope can reuse one candidate universe.
+    pub spelling_candidate_cache: RefCell<SpellingCandidateCache>,
 
-    /// Node indices for which a name resolution failure (TS2304/TS2552) has already
-    /// been reported. Used to deduplicate the `spelling_suggestions_emitted` counter
-    /// when the same type reference is resolved multiple times (e.g., due to
-    /// re-evaluation in generic/contextual typing contexts).
-    pub reported_nodes: FxHashSet<NodeIndex>,
-
-    /// Memoized spelling-suggestion candidate scans keyed by failing reference
-    /// node and symbol-meaning mask (`VALUE`/`TYPE`/`NAMESPACE`). The
-    /// full-symbol-universe Levenshtein walk depends only on stable binder/lib
-    /// tables, reference site, and meaning; caching `(node, meaning)` collapses
-    /// repeated demand-driven revisits without reusing the wrong candidate set.
-    /// Cleared at the file-session boundary alongside `reported_nodes`.
-    pub suggestion_scan_cache: RefCell<FxHashMap<(NodeIndex, u32), Vec<String>>>,
+    /// Memoized spelling-suggestion candidate scans keyed by lexical scope,
+    /// misspelled name, and symbol-meaning mask (`VALUE`/`TYPE`/`NAMESPACE`). The
+    /// full-symbol-universe Levenshtein walk depends only on immutable binder/lib
+    /// tables and that key. This collapses both demand-driven revisits and repeated
+    /// misses in one scope without leaking candidates across scopes.
+    /// Cleared at the file-session boundary because `ScopeId` is binder-local.
+    pub suggestion_scan_cache: RefCell<SpellingSuggestionScanCache>,
 }
 
 /// File-session memo tables shared by flow narrowing helpers.
@@ -638,7 +639,7 @@ pub struct CheckerContext<'a> {
     /// Tracking the current computed property name node for TS2467
     pub checking_computed_property_name: Option<NodeIndex>,
 
-    /// Name-resolution diagnostic counters and dedupe state.
+    /// Name-resolution diagnostic scan cache.
     pub name_resolution_diagnostics: NameResolutionDiagnostics,
 
     /// `TypeId`s that represent interfaces extending arrays/tuples.

--- a/crates/tsz-checker/src/error_reporter/name_resolution.rs
+++ b/crates/tsz-checker/src/error_reporter/name_resolution.rs
@@ -1056,8 +1056,7 @@ impl<'a> CheckerState<'a> {
 
         // The boundary's `report_name_resolution_failure` already checked for
         // spelling suggestions via `collect_spelling_suggestions` before calling
-        // this function. The suggestion counter was incremented eagerly in
-        // `collect_spelling_suggestions`, so no counter update is needed here.
+        // this fallback.
 
         // Emit standard TS2304 "Cannot find name" error without suggestions
         if let Some(loc) = self.get_source_location(idx) {
@@ -1136,8 +1135,8 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Collect spelling suggestions for an unresolved name, respecting all
-    /// suppression rules (accessibility modifiers, `arguments`,
-    /// max-suggestion cap, parse-error suppression).
+    /// suppression rules (accessibility modifiers, `arguments`, and parse
+    /// errors).
     ///
     /// Returns an empty `Vec` when suggestions should be suppressed.
     /// This is the single source of truth for suggestion collection, shared by
@@ -1152,20 +1151,12 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Cheap half of `collect_spelling_suggestions`: apply every suppression
-    /// predicate and advance the eager cap counter, returning whether the
-    /// expensive candidate scan (`scan_similar_identifiers`) should run.
-    ///
-    /// This is split out so the resolution boundary can charge the counter in
-    /// resolution order (matching tsc's sequential `suggestionCount`) while
-    /// deferring the full-symbol-universe Levenshtein scan to the
-    /// diagnostic-emission path. The counter side effects here are identical to
-    /// the previous eager `collect_spelling_suggestions`, so cap behavior and
-    /// the resulting diagnostics are unchanged.
+    /// predicate before the expensive candidate scan
+    /// (`scan_similar_identifiers`) runs.
     pub(crate) fn suggestion_scan_eligible(&self, name: &str, idx: NodeIndex) -> bool {
         // A failure site whose diagnostic can never be emitted from this
-        // checker (node not addressable in the current arena) must skip both
-        // the scan and the cap-counter charge: tsc's `suggestionCount` only
-        // ever advances for failures it reports, and it never reports these.
+        // checker (node not addressable in the current arena) must skip the
+        // presentation-only candidate scan.
         if !self.can_emit_diagnostic_at(idx) {
             return false;
         }
@@ -1185,42 +1176,6 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        // Eagerly increment the suggestion counter for each unique name resolution
-        // attempt. tsc increments `suggestionCount` synchronously during sequential
-        // checking, but our demand-driven type resolution can resolve many names
-        // before any diagnostics are emitted. Counting eagerly here (via Cell)
-        // ensures the cap of 10 is reached regardless of processing order.
-        let is_new_node = !self
-            .ctx
-            .name_resolution_diagnostics
-            .reported_nodes
-            .contains(&idx);
-        if is_new_node {
-            self.ctx
-                .name_resolution_diagnostics
-                .spelling_suggestions_emitted
-                .set(
-                    self.ctx
-                        .name_resolution_diagnostics
-                        .spelling_suggestions_emitted
-                        .get()
-                        + 1,
-                );
-        }
-
-        // Suppress suggestions when the cap is reached for a new node.
-        // Already-counted nodes can still get suggestions (repeated resolution).
-        if self
-            .ctx
-            .name_resolution_diagnostics
-            .spelling_suggestions_emitted
-            .get()
-            > 10
-            && is_new_node
-        {
-            return false;
-        }
-
         // Suppress spelling suggestions in files with parse errors.
         // When the AST is malformed, symbols may not be properly bound and
         // name resolution cascades are unhelpful.  tsc keeps only primary
@@ -1234,8 +1189,8 @@ impl<'a> CheckerState<'a> {
 
     /// Expensive half of `collect_spelling_suggestions`: the full-symbol-universe
     /// candidate scan. Call only after `suggestion_scan_eligible` returned `true`
-    /// (it does not re-apply the suppression predicates or touch the cap
-    /// counter), and only when a diagnostic is actually being emitted.
+    /// (it does not re-apply the suppression predicates), and only when a
+    /// diagnostic is actually being emitted.
     pub(crate) fn scan_similar_identifiers(&self, name: &str, idx: NodeIndex) -> Vec<String> {
         // Bail before the meaning-detection parent walk: a discarded context
         // returns no candidates regardless of meaning (the same gate inside
@@ -1257,20 +1212,6 @@ impl<'a> CheckerState<'a> {
         self.scan_similar_identifiers_for_meaning(name, idx, suggestion_meaning)
     }
 
-    /// Memoized full-symbol-universe candidate scan for an explicit symbol
-    /// meaning. This is the single owner of `find_similar_identifiers`: every
-    /// spelling-suggestion call site (ordinary `VALUE`/`TYPE` name lookups via
-    /// `scan_similar_identifiers`, and the `Cannot find namespace` path via
-    /// `error_cannot_find_namespace_with_suggestion`) routes through here so the
-    /// expensive Levenshtein walk is memoized exactly once per
-    /// `(reference site, meaning)`.
-    ///
-    /// Before this consolidation the namespace path called
-    /// `find_similar_identifiers` directly, bypassing the memo, so a missing
-    /// namespace re-resolved during demand-driven evaluation re-ran the whole
-    /// scan on every revisit (issue #14349). Callers that need cap/suppression
-    /// gating must still consult `suggestion_scan_eligible` first; this method
-    /// only owns the candidate scan and its cache.
     /// Whether `idx` lives inside a built-in `lib.*.d.ts` declaration file.
     pub(crate) fn node_is_in_builtin_lib_file(&self, idx: NodeIndex) -> bool {
         let mut current = idx;
@@ -1295,6 +1236,20 @@ impl<'a> CheckerState<'a> {
             })
     }
 
+    /// Memoized full-symbol-universe candidate scan for an explicit symbol
+    /// meaning. This is the single owner of `find_similar_identifiers`: every
+    /// spelling-suggestion call site (ordinary `VALUE`/`TYPE` name lookups via
+    /// `scan_similar_identifiers`, and the `Cannot find namespace` path via
+    /// `error_cannot_find_namespace_with_suggestion`) routes through here so the
+    /// expensive Levenshtein walk is memoized exactly once per
+    /// `(lexical scope, misspelled name, meaning)`.
+    ///
+    /// Before this consolidation the namespace path called
+    /// `find_similar_identifiers` directly, bypassing the memo, so a missing
+    /// namespace re-resolved during demand-driven evaluation re-ran the whole
+    /// scan on every revisit (issue #14349). Callers that need suppression
+    /// gating must still consult `suggestion_scan_eligible` first; this method
+    /// only owns the candidate scan and its cache.
     pub(crate) fn scan_similar_identifiers_for_meaning(
         &self,
         name: &str,
@@ -1311,16 +1266,24 @@ impl<'a> CheckerState<'a> {
         if self.ctx.diagnostics_discarded {
             return Vec::new();
         }
-        // Memoize per (reference site, meaning): the same unresolved reference is
-        // re-resolved many times under demand-driven evaluation, and each
-        // revisit would otherwise repeat the full-symbol-universe scan below.
+        // Binder/lib symbol tables are immutable during a file session, so the
+        // candidate set is stable for a lexical scope, spelling, and meaning.
+        // This covers both demand-driven revisits and distinct occurrences of the
+        // same unresolved name without leaking local candidates across scopes.
         // See `NameResolutionDiagnostics::suggestion_scan_cache`.
+        let scope_id = self
+            .ctx
+            .binder
+            .find_enclosing_scope(self.ctx.arena, idx)
+            .unwrap_or(tsz_binder::ScopeId::NONE);
+        let scope_key = (scope_id, meaning);
         if let Some(cached) = self
             .ctx
             .name_resolution_diagnostics
             .suggestion_scan_cache
             .borrow()
-            .get(&(idx, meaning))
+            .get(&scope_key)
+            .and_then(|by_name| by_name.get(name))
         {
             return cached.clone();
         }
@@ -1333,7 +1296,9 @@ impl<'a> CheckerState<'a> {
             .name_resolution_diagnostics
             .suggestion_scan_cache
             .borrow_mut()
-            .insert((idx, meaning), suggestions.clone());
+            .entry(scope_key)
+            .or_default()
+            .insert(name.to_owned(), suggestions.clone());
 
         suggestions
     }
@@ -1475,7 +1440,6 @@ impl<'a> CheckerState<'a> {
 
     /// Report error 2304/2552: Cannot find name 'X' with suggestions.
     /// Provides a list of similar names that might be what the user intended.
-    /// tsc limits spelling suggestions to 10 per file; after that, emits TS2304 only.
     pub fn error_cannot_find_name_with_suggestions(
         &mut self,
         name: &str,
@@ -1488,14 +1452,6 @@ impl<'a> CheckerState<'a> {
         if self.should_suppress_name_in_export_default_namespace(idx) {
             return;
         }
-
-        // The suggestion counter was already incremented eagerly in
-        // `collect_spelling_suggestions`. Just mark the node as reported
-        // to prevent future double-counting.
-        self.ctx
-            .name_resolution_diagnostics
-            .reported_nodes
-            .insert(idx);
 
         // Skip TS2304 for identifiers that are clearly not valid names.
         // These are likely parse errors that were added to the AST for error recovery.
@@ -1642,7 +1598,7 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Report TS2503/TS2833 after the name-resolution boundary has already
-    /// charged the spelling-suggestion cap for this namespace lookup.
+    /// precomputed whether suggestions are eligible for this namespace lookup.
     pub(crate) fn error_cannot_find_namespace_with_precomputed_eligibility(
         &mut self,
         name: &str,
@@ -1675,42 +1631,18 @@ impl<'a> CheckerState<'a> {
         // type (interface / class / type alias) as a namespace suggestion, so
         // including `TYPE` here wrongly suggested e.g. the DOM `Node` interface for
         // a missing `NodeJS` namespace (TS2833) where tsc emits plain TS2503.
-        // Route through the shared memoized scan gateway (keyed by node +
-        // `NAMESPACE` meaning) so a missing namespace re-resolved during
+        // Route through the shared memoized scan gateway so a missing namespace
+        // re-resolved during
         // demand-driven evaluation does not re-run the full-symbol-universe
-        // walk on every revisit (issue #14349). Namespace diagnostics also
-        // share the same spelling-suggestion cap as ordinary missing names; a
-        // capped site records an empty scan result so revisits stay capped.
+        // walk on every revisit (issue #14349).
         let suggestion_meaning = symbol_flags::NAMESPACE;
-        let cache_key = (idx, suggestion_meaning);
-        let cached_suggestions = self
-            .ctx
-            .name_resolution_diagnostics
-            .suggestion_scan_cache
-            .borrow()
-            .get(&cache_key)
-            .cloned();
-        let suggestions = if let Some(suggestions) = cached_suggestions {
-            suggestions
+        let eligible =
+            suggestions_eligible.unwrap_or_else(|| self.suggestion_scan_eligible(name, idx));
+        let suggestions = if eligible {
+            self.scan_similar_identifiers_for_meaning(name, idx, suggestion_meaning)
         } else {
-            let eligible =
-                suggestions_eligible.unwrap_or_else(|| self.suggestion_scan_eligible(name, idx));
-            if eligible {
-                self.scan_similar_identifiers_for_meaning(name, idx, suggestion_meaning)
-            } else {
-                self.ctx
-                    .name_resolution_diagnostics
-                    .suggestion_scan_cache
-                    .borrow_mut()
-                    .insert(cache_key, Vec::new());
-                Vec::new()
-            }
+            Vec::new()
         };
-        self.ctx
-            .name_resolution_diagnostics
-            .reported_nodes
-            .insert(idx);
-
         if let Some(suggestion) = suggestions.first() {
             self.error_at_node_msg(
                 idx,

--- a/crates/tsz-checker/src/error_reporter/suggestions.rs
+++ b/crates/tsz-checker/src/error_reporter/suggestions.rs
@@ -375,17 +375,39 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         meaning_flags: u32,
     ) -> Option<Vec<String>> {
-        let visible_names = self.ctx.binder.collect_visible_symbol_names_filtered(
-            self.ctx.arena,
-            idx,
-            meaning_flags,
-        );
+        let scope_id = self
+            .ctx
+            .binder
+            .find_enclosing_scope(self.ctx.arena, idx)
+            .unwrap_or(tsz_binder::ScopeId::NONE);
+        let candidate_key = (scope_id, meaning_flags);
+        let visible_names = if let Some(cached) = self
+            .ctx
+            .name_resolution_diagnostics
+            .spelling_candidate_cache
+            .borrow()
+            .get(&candidate_key)
+        {
+            std::rc::Rc::clone(cached)
+        } else {
+            let candidates: std::rc::Rc<[String]> = self
+                .ctx
+                .binder
+                .collect_visible_symbol_names_filtered(self.ctx.arena, idx, meaning_flags)
+                .into();
+            self.ctx
+                .name_resolution_diagnostics
+                .spelling_candidate_cache
+                .borrow_mut()
+                .insert(candidate_key, std::rc::Rc::clone(&candidates));
+            candidates
+        };
 
         let name_len = name.len();
         let (maximum_length_difference, mut best_distance) = Self::spelling_thresholds(name_len);
         let mut best_candidate: Option<String> = None;
 
-        for candidate in &visible_names {
+        for candidate in visible_names.iter() {
             Self::consider_identifier_suggestion(
                 name,
                 candidate,
@@ -396,16 +418,18 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        // For TYPE-only lookups, restrict the lib search to *core* lib files
-        // (lib.es*, lib.scripthost, lib.decorators) to surface useful
-        // suggestions like `Array`, `Promise`, `Map` while keeping DOM
-        // interface noise (`ParentNode`, `Cache`, `CSSStyleDeclaration`, ...)
-        // from drowning out matches in user code (#3282).
-        // VALUE-meaning and unconstrained lookups search the full set as
-        // before so suggestions like `array` -> `Array` keep working.
+        // Production binders merge every loaded lib into the visible-symbol table,
+        // so rescanning each `LibContext` would duplicate the largest candidate
+        // universe for every unresolved name. Direct checker/test contexts can
+        // attach lib contexts without merging them; retain the explicit fallback
+        // only for that shape. TYPE-only fallback stays scoped to core lib files
+        // because an unmerged DOM context historically did not participate here.
+        // Built-in keywords are still searched when this slice is empty.
         let lib_globals_filtered: Vec<crate::context::LibContext>;
         let lib_globals_for_search: &[crate::context::LibContext] =
-            if meaning_flags == tsz_binder::symbol_flags::TYPE {
+            if self.ctx.binder.lib_symbols_are_merged() {
+                &[]
+            } else if meaning_flags == tsz_binder::symbol_flags::TYPE {
                 lib_globals_filtered = self
                     .ctx
                     .lib_contexts
@@ -452,40 +476,13 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // Suppress suggestions from lib-only TYPE symbols (DOM interfaces like
-        // ParentNode, Cache, CSSStyleDeclaration, etc.) that were merged into
-        // the user binder's scope tables during checker init. tsc does not
-        // surface these as spelling suggestions for user code. Lib globals
-        // with VALUE meaning (Error, RegExp, Array, etc.) are kept because
-        // they're directly usable.
-        // Suppress lib-origin suggestions for TYPE-only lookups.
-        // tsc's sequential processing and per-file suggestion cap (10) effectively
-        // prevents most lib-origin suggestions from appearing in files with many
-        // unresolved type names. Our demand-driven resolution processes names in a
-        // different order, so the cap doesn't always match. For TYPE-only lookups,
-        // conservatively suppress all lib-origin suggestions to avoid false TS2552
-        // (e.g., TypeDeclaration -> CSSStyleDeclaration, ParseNode -> ParentNode).
-        // VALUE-meaning lookups keep lib suggestions (e.g., array -> Array).
-        if let Some(ref candidate) = best_candidate {
-            // TYPE-only lookup: meaning_flags is exactly TYPE (from type context)
-            let is_type_only_lookup = meaning_flags == tsz_binder::symbol_flags::TYPE;
-            if is_type_only_lookup
-                && self.is_lib_origin_symbol(candidate)
-                && !self.lib_origin_symbol_is_core_typing(candidate)
-                && !is_builtin_lib_file_name(&self.ctx.file_name)
-            {
-                return None;
-            }
-        }
-
         best_candidate.map(|c| vec![c])
     }
 
-    /// Whether a `LibContext` represents one of the *core* TypeScript lib
-    /// files (`lib.es*.d.ts`, `lib.scripthost.d.ts`, `lib.decorators*.d.ts`)
-    /// rather than a DOM-flavoured lib like `lib.dom.d.ts`. Used to scope
-    /// TYPE-only spelling suggestions to widely-used types and avoid
-    /// drowning user diagnostics in DOM interface noise (#3282).
+    /// Whether a `LibContext` represents one of the core TypeScript lib files
+    /// (`lib.es*.d.ts`, `lib.scripthost.d.ts`, `lib.decorators*.d.ts`). Used to
+    /// bound the explicit TYPE-only fallback scan for checker contexts whose lib
+    /// symbols have not been merged into the file binder.
     fn lib_context_is_core_typings(lib_ctx: &crate::context::LibContext) -> bool {
         let Some(file_name) = lib_ctx
             .arena
@@ -511,62 +508,6 @@ impl<'a> CheckerState<'a> {
         base.starts_with("lib.es")
             || base.starts_with("lib.scripthost")
             || base.starts_with("lib.decorators")
-    }
-
-    /// Whether `candidate` is declared (and *only* declared) in one of
-    /// the core lib files. Used to refine the TYPE-only post-filter so
-    /// `Array`, `Promise`, `Map`, etc. survive when they're the closest
-    /// match to a user-typed type name (#3282).
-    fn lib_origin_symbol_is_core_typing(&self, candidate: &str) -> bool {
-        // If the user shadowed the name in their own file, defer to the
-        // existing non-suppressed logic.
-        if let Some(sym_id) = self.ctx.binder.file_locals.get(candidate)
-            && !self.ctx.binder.lib_symbol_ids.contains(&sym_id)
-        {
-            return false;
-        }
-        for lib_ctx in self.ctx.lib_contexts.iter() {
-            if lib_ctx.binder.file_locals.get(candidate).is_some()
-                && Self::lib_context_is_core_typings(lib_ctx)
-            {
-                return true;
-            }
-        }
-        false
-    }
-
-    /// Check if a candidate suggestion originates from a lib file.
-    ///
-    /// Returns true if the symbol was merged from a lib file into the user
-    /// binder's scope tables, or if it exists in any lib binder's `file_locals`.
-    /// User-defined symbols that shadow lib symbols are NOT considered lib-origin.
-    fn is_lib_origin_symbol(&self, candidate: &str) -> bool {
-        // Check 1: candidate is in user binder's file_locals and tracked as lib symbol
-        if let Some(sym_id) = self.ctx.binder.file_locals.get(candidate)
-            && self.ctx.binder.lib_symbol_ids.contains(&sym_id)
-        {
-            return true;
-        }
-
-        // Check 2: candidate exists in a lib binder but not defined by the user
-        let exists_in_lib = self
-            .ctx
-            .lib_contexts
-            .iter()
-            .any(|lib_ctx| lib_ctx.binder.file_locals.get(candidate).is_some());
-
-        if exists_in_lib {
-            // But if the user's own file defines this name (not from lib merge),
-            // don't suppress it.
-            if let Some(sym_id) = self.ctx.binder.file_locals.get(candidate)
-                && !self.ctx.binder.lib_symbol_ids.contains(&sym_id)
-            {
-                return false; // User-defined, keep it
-            }
-            return true;
-        }
-
-        false
     }
 
     /// Search lib globals and built-in type keywords for spelling suggestion
@@ -881,11 +822,96 @@ impl<'a> CheckerState<'a> {
     // Levenshtein Distance
     // =========================================================================
 
+    /// Allocation-free common path for ASCII identifiers. TypeScript source
+    /// identifiers and bundled-lib names are overwhelmingly ASCII, so building
+    /// four heap vectors for every candidate dominated large diagnostic sets.
+    /// The scalar fallback below retains exact Unicode behavior.
+    fn levenshtein_ascii_with_max(s1: &[u8], s2: &[u8], max: f64) -> Option<f64> {
+        if s1.len().abs_diff(s2.len()) as f64 > max {
+            return None;
+        }
+
+        if s1.is_empty() {
+            let dist = s2.len() as f64;
+            return (dist <= max).then_some(dist);
+        }
+        if s2.is_empty() {
+            let dist = s1.len() as f64;
+            return (dist <= max).then_some(dist);
+        }
+
+        let mut previous = smallvec::SmallVec::<[f64; 64]>::new();
+        previous.extend((0..=s2.len()).map(|index| index as f64));
+        let mut current = smallvec::SmallVec::<[f64; 64]>::new();
+        current.resize(s2.len() + 1, 0.0);
+        let big = max + 0.01;
+
+        for (row, &c1) in s1.iter().enumerate() {
+            let i = row + 1;
+            let min_j = if (i as f64) > max {
+                ((i as f64) - max).ceil() as usize
+            } else {
+                1
+            };
+            let max_j = if (s2.len() as f64) > (max + i as f64) {
+                (max + i as f64).floor() as usize
+            } else {
+                s2.len()
+            };
+
+            current[0] = i as f64;
+            let mut col_min = i as f64;
+
+            for value in current.iter_mut().take(min_j).skip(1) {
+                *value = big;
+            }
+
+            for j in min_j..=max_j {
+                let c2 = s2[j - 1];
+                let substitution_distance = if c1.eq_ignore_ascii_case(&c2) {
+                    previous[j - 1] + 0.1
+                } else {
+                    previous[j - 1] + 2.0
+                };
+                let dist = if c1 == c2 {
+                    previous[j - 1]
+                } else {
+                    (previous[j] + 1.0)
+                        .min(current[j - 1] + 1.0)
+                        .min(substitution_distance)
+                };
+                current[j] = dist;
+                col_min = col_min.min(dist);
+            }
+
+            for value in current.iter_mut().take(s2.len() + 1).skip(max_j + 1) {
+                *value = big;
+            }
+
+            if col_min > max {
+                return None;
+            }
+
+            std::mem::swap(&mut previous, &mut current);
+        }
+
+        let result = previous[s2.len()];
+        (result <= max).then_some(result)
+    }
+
     /// Levenshtein distance with threshold pruning, matching tsc's behavior.
     /// Case-only substitutions are cheaper than other substitutions.
     pub(crate) fn levenshtein_with_max(s1: &str, s2: &str, max: f64) -> Option<f64> {
+        if s1.is_ascii() && s2.is_ascii() {
+            return Self::levenshtein_ascii_with_max(s1.as_bytes(), s2.as_bytes(), max);
+        }
+
         let s1_chars: Vec<char> = s1.chars().collect();
         let s2_chars: Vec<char> = s2.chars().collect();
+
+        if s1_chars.len().abs_diff(s2_chars.len()) as f64 > max {
+            return None;
+        }
 
         if s1_chars.is_empty() {
             let dist = s2_chars.len() as f64;
@@ -954,6 +980,39 @@ impl<'a> CheckerState<'a> {
 
         let result = previous[s2_chars.len()];
         (result <= max).then_some(result)
+    }
+}
+
+#[cfg(test)]
+mod spelling_distance_tests {
+    use super::CheckerState;
+
+    fn assert_distance(left: &str, right: &str, max: f64, expected: Option<f64>) {
+        let actual = CheckerState::levenshtein_with_max(left, right, max);
+        match (actual, expected) {
+            (Some(actual), Some(expected)) => assert!(
+                (actual - expected).abs() < f64::EPSILON,
+                "distance for {left:?} -> {right:?}: expected {expected}, got {actual}"
+            ),
+            (actual, expected) => assert_eq!(actual, expected),
+        }
+    }
+
+    #[test]
+    fn ascii_spelling_distance_preserves_weighting_and_thresholds() {
+        assert_distance("ParentNode", "ParentNode", 0.0, Some(0.0));
+        assert_distance("array", "Array", 1.0, Some(0.1));
+        assert_distance("sting", "string", 1.0, Some(1.0));
+        assert_distance("becon", "bacon", 2.0, Some(2.0));
+        assert_distance("becon", "bacon", 1.9, None);
+        assert_distance("", "Map", 3.0, Some(3.0));
+    }
+
+    #[test]
+    fn unicode_spelling_distance_retains_scalar_case_folding() {
+        assert_distance("École", "école", 1.0, Some(0.1));
+        assert_distance("café", "cafe", 1.9, None);
+        assert_distance("café", "cafe", 2.0, Some(2.0));
     }
 }
 

--- a/crates/tsz-checker/src/jsdoc/base_types.rs
+++ b/crates/tsz-checker/src/jsdoc/base_types.rs
@@ -830,24 +830,7 @@ impl<'a> CheckerState<'a> {
 
         // Try spelling suggestions (e.g. "sting" → "string") to emit TS2552
         // instead of plain TS2304, matching tsc behavior.
-        if self
-            .ctx
-            .name_resolution_diagnostics
-            .spelling_suggestions_emitted
-            .get()
-            < 10
-            && let Some(suggestion) = self.find_jsdoc_type_spelling_suggestion(name)
-        {
-            self.ctx
-                .name_resolution_diagnostics
-                .spelling_suggestions_emitted
-                .set(
-                    self.ctx
-                        .name_resolution_diagnostics
-                        .spelling_suggestions_emitted
-                        .get()
-                        + 1,
-                );
+        if let Some(suggestion) = self.find_jsdoc_type_spelling_suggestion(name) {
             let message = format!("Cannot find name '{name}'. Did you mean '{suggestion}'?");
             self.error_at_position(
                 start,

--- a/crates/tsz-checker/src/query_boundaries/name_resolution.rs
+++ b/crates/tsz-checker/src/query_boundaries/name_resolution.rs
@@ -154,9 +154,9 @@ pub(crate) struct ResolutionFailure {
     pub suggestions: Vec<String>,
     /// For `NotFound` failures whose suggestion scan was deferred: whether the
     /// spelling-suggestion candidate scan should still run when (and only when)
-    /// a diagnostic is actually emitted. The cap counter and the cheap
-    /// suppression predicates have already been applied to produce this flag, so
-    /// the deferred scan reproduces exactly what an eager
+    /// a diagnostic is actually emitted. The cheap suppression predicates have
+    /// already been applied to produce this flag, so the deferred scan reproduces
+    /// exactly what an eager
     /// `collect_spelling_suggestions` would have returned — without paying for
     /// the full-symbol-universe Levenshtein walk on failures that are suppressed
     /// or recovered before any diagnostic is emitted.
@@ -184,8 +184,8 @@ impl ResolutionFailure {
 
     /// Create a "not found" failure whose spelling-suggestion scan is deferred to
     /// the diagnostic-emission path. `eligible` is the result of the cheap
-    /// eligibility check (suppression predicates + cap counter), which has
-    /// already been applied; pass `true` only when an eager scan would have run.
+    /// eligibility check (the suppression predicates), which has already been
+    /// applied; pass `true` only when an eager scan would have run.
     pub const fn not_found_deferred(eligible: bool) -> Self {
         Self {
             kind: ResolutionFailureKind::NotFound,
@@ -349,10 +349,8 @@ impl<'a> CheckerState<'a> {
     fn resolve_scoped_name(&self, request: &NameResolutionRequest<'_>) -> NameResolutionResult {
         let sym_id = self.resolve_identifier_symbol(request.idx);
         let Some(sym_id) = sym_id else {
-            // Not found. Apply the cheap suggestion bookkeeping now (suppression
-            // predicates + the eager cap counter, which must advance in
-            // resolution order to match tsc's sequential `suggestionCount`), but
-            // *defer* the expensive full-symbol-universe candidate scan to the
+            // Not found. Apply the cheap suggestion suppression predicates now,
+            // but *defer* the expensive full-symbol-universe candidate scan to the
             // diagnostic-emission path. Many of these failures are suppressed or
             // recovered before any diagnostic is emitted (e.g. clean projects
             // that ultimately resolve every name), so scanning here would be
@@ -777,9 +775,9 @@ impl<'a> CheckerState<'a> {
                     // deferred `NotFound` failures run the full candidate scan
                     // here — and *only* here, so failures that were suppressed
                     // above or never reached a diagnostic never pay for it. The
-                    // cap counter / suppression predicates were already applied
-                    // when `suggestions_eligible` was computed, so this produces
-                    // the same suggestions an eager scan would have.
+                    // Suppression predicates were already applied when
+                    // `suggestions_eligible` was computed, so this produces the
+                    // same suggestions an eager scan would have.
                     // `suggestions_eligible` already excludes the parse-error case
                     // that drives `suppress_suggestions`, so the scan only runs
                     // when suggestions could actually be emitted; the emission
@@ -1065,8 +1063,8 @@ impl<'a> CheckerState<'a> {
     ///
     /// Collects spelling suggestions via `collect_spelling_suggestions` (which
     /// respects all tsc suppression rules: accessibility modifiers, spread
-    /// elements, `arguments`, max-suggestion cap, parse-error suppression) and
-    /// emits TS2304 or TS2552 accordingly.
+    /// elements, `arguments`, and parse errors) and emits TS2304 or TS2552
+    /// accordingly.
     ///
     /// Use this when the caller already knows the name is not found (e.g.,
     /// after binder resolution failed) but wants suggestion-enriched diagnostics
@@ -1089,7 +1087,7 @@ impl<'a> CheckerState<'a> {
 
         // Delegate to the shared suggestion collector which applies all
         // suppression predicates (accessibility modifiers, spread elements,
-        // arguments, max cap, parse errors).
+        // `arguments`, and parse errors).
         let suggestions = self.collect_spelling_suggestions(name, idx);
 
         let failure = if suggestions.is_empty() {

--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -330,8 +330,8 @@ impl<'a> CheckerState<'a> {
                                     // The boundary precomputes suggestion eligibility for true
                                     // not-found failures. Wrong-meaning namespace anchors (for
                                     // example a value-only `m` near namespace `M`) still need the
-                                    // namespace diagnostic owner to apply the suggestion cap at
-                                    // emission time.
+                                    // namespace diagnostic owner to apply suppression eligibility
+                                    // at emission time.
                                     if matches!(
                                         &failure.kind,
                                         crate::query_boundaries::name_resolution::ResolutionFailureKind::NotFound

--- a/crates/tsz-checker/src/tests/spurious_suggestion_suppression_tests.rs
+++ b/crates/tsz-checker/src/tests/spurious_suggestion_suppression_tests.rs
@@ -102,10 +102,9 @@ var p: m.Point;
 }
 
 #[test]
-fn namespace_suggestion_respects_spelling_cap() {
-    // tsc's spelling-suggestion cap is shared by namespace "did you mean?"
-    // diagnostics. Once distinct missing namespace sites consume the cap, a
-    // later near-match should stay plain TS2503 rather than escaping as TS2833.
+fn ts7_namespace_suggestions_continue_after_ten_failures() {
+    // TypeScript 7 no longer caps namespace "did you mean?" diagnostics at ten
+    // sites. Every distinct near-match remains TS2833.
     let codes = check_strict(
         r#"
 namespace Foobar { export type X = number; }
@@ -124,13 +123,13 @@ type T10 = Foobaz.X;
     );
     assert_eq!(
         count(&codes, TS2833),
-        10,
-        "only the first ten namespace sites should get suggestions: {codes:?}"
+        11,
+        "every namespace site should get its suggestion: {codes:?}"
     );
     assert_eq!(
         count(&codes, TS2503),
-        1,
-        "the capped namespace failure should fall back to plain TS2503: {codes:?}"
+        0,
+        "no namespace site should fall back to plain TS2503: {codes:?}"
     );
 }
 

--- a/crates/tsz-checker/tests/arch_source_scans/spelling_suggestion_gateway_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/spelling_suggestion_gateway_scans.rs
@@ -2,7 +2,7 @@
 //!
 //! `find_similar_identifiers` walks the visible symbol universe and performs
 //! spelling-distance work. Namespace diagnostics used to call it directly,
-//! bypassing the memoized `(node, meaning)` gateway and the shared cap. Keep
+//! bypassing the memoized `(scope, name, meaning)` gateway. Keep
 //! production checker call sites routed through
 //! `error_reporter::name_resolution::scan_similar_identifiers_for_meaning`.
 
@@ -65,7 +65,7 @@ fn production_spelling_suggestions_use_memoized_gateway() {
     assert!(
         violations.is_empty(),
         "checker production code should route spelling scans through \
-         scan_similar_identifiers_for_meaning so memoization and cap gating stay shared:\n{}",
+         scan_similar_identifiers_for_meaning so memoization and suppression gating stay shared:\n{}",
         violations.join("\n")
     );
 }

--- a/crates/tsz-checker/tests/jsdoc_type_expression_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_type_expression_tests.rs
@@ -11,6 +11,41 @@ struct Diag {
     message: String,
 }
 
+#[test]
+fn ts7_jsdoc_keeps_spelling_suggestions_after_ten_failures() {
+    let diags = check_js(
+        r#"
+/** @type {sting} */ var a;
+/** @type {sting} */ var b;
+/** @type {sting} */ var c;
+/** @type {sting} */ var d;
+/** @type {sting} */ var e;
+/** @type {sting} */ var f;
+/** @type {sting} */ var g;
+/** @type {sting} */ var h;
+/** @type {sting} */ var i;
+/** @type {sting} */ var j;
+/** @type {sting} */ var k;
+/** @type {sting} */ var l;
+"#,
+    );
+    let suggestion_count = diags
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.code == 2552
+                && diagnostic.message.contains("'sting'")
+                && diagnostic.message.contains("'string'")
+        })
+        .count();
+    let bare_not_found_count = diags
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2304 && diagnostic.message.contains("'sting'"))
+        .count();
+
+    assert_eq!(suggestion_count, 12, "expected TS2552 at every site");
+    assert_eq!(bare_not_found_count, 0, "unexpected TS2304 fallback");
+}
+
 fn check_js(source: &str) -> Vec<Diag> {
     tsz_checker::test_utils::check_source(
         source,

--- a/crates/tsz-checker/tests/lib_type_spelling_suggestions_tests.rs
+++ b/crates/tsz-checker/tests/lib_type_spelling_suggestions_tests.rs
@@ -1,8 +1,7 @@
-//! Issue #3282: TYPE-position lookups must surface spelling suggestions
-//! for core lib globals (`Array`, `Promise`, `Map`, ...). tsz used to
-//! suppress every lib-origin candidate for TYPE-only lookups, so typos
-//! like `Arrray`, `Prommise`, `Mapp` reported plain TS2304 instead of
-//! tsc's TS2552 with a "Did you mean 'Array'?" suggestion.
+//! TYPE-position lookups must surface spelling suggestions from every loaded
+//! lib. Core globals (`Array`, `Promise`, `Map`, ...) cover issue #3282, while
+//! TypeScript 7 also exposes loaded DOM candidates such as `ParentNode` and
+//! `CSSStyleDeclaration`. An unloaded lib must not contribute candidates.
 
 use tsz_checker::context::CheckerOptions;
 use tsz_checker::diagnostics::Diagnostic;
@@ -21,6 +20,24 @@ fn check_with_es2015(source: &str) -> Vec<Diagnostic> {
     assert!(
         !lib_files.is_empty(),
         "expected lib.es*.d.ts to be available"
+    );
+    tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "repro.ts",
+        CheckerOptions::default(),
+        &lib_files,
+    )
+}
+
+fn check_with_dom(source: &str) -> Vec<Diagnostic> {
+    let lib_files = tsz_checker::test_utils::load_compiled_lib_files(&[
+        "lib.es5.d.ts",
+        "lib.dom.d.ts",
+        "lib.dom.iterable.d.ts",
+    ]);
+    assert!(
+        !lib_files.is_empty(),
+        "expected DOM lib files to be available"
     );
     tsz_checker::test_utils::check_source_with_libs(
         source,
@@ -65,6 +82,39 @@ fn type_position_mapp_suggests_map() {
     assert!(
         finds_suggestion(&diags, "Mapp", "Map"),
         "expected TS2552 'Mapp' -> 'Map', got: {diags:?}"
+    );
+}
+
+/// TypeScript 7 surfaces loaded DOM/lib types even after many unresolved names;
+/// the old cap-compensation filter incorrectly discarded these candidates.
+#[test]
+fn type_position_dom_lib_candidates_are_suggested() {
+    let diags = check_with_dom(
+        r#"
+let declaration: TypeDeclaration;
+let parsed: ParseNode;
+let parent: ParentNod;
+"#,
+    );
+    for (typo, suggestion) in [
+        ("TypeDeclaration", "CSSStyleDeclaration"),
+        ("ParseNode", "ParentNode"),
+        ("ParentNod", "ParentNode"),
+    ] {
+        assert!(
+            finds_suggestion(&diags, typo, suggestion),
+            "expected TS2552 '{typo}' -> '{suggestion}', got: {diags:?}"
+        );
+    }
+}
+
+/// Candidates from an unloaded lib must not leak into the visible-name scan.
+#[test]
+fn type_position_dom_lib_candidate_requires_dom_lib() {
+    let diags = check_with_es2015("let declaration: TypeDeclaration;\n");
+    assert!(
+        is_bare_not_found(&diags, "TypeDeclaration"),
+        "expected bare TS2304 without lib.dom, got: {diags:?}"
     );
 }
 

--- a/crates/tsz-checker/tests/name_resolution_boundary_tests.rs
+++ b/crates/tsz-checker/tests/name_resolution_boundary_tests.rs
@@ -954,3 +954,156 @@ const a = Foo;
         diagnostic_codes(&diags)
     );
 }
+
+#[test]
+fn ts7_keeps_spelling_suggestions_after_ten_failures() {
+    let diags = check(
+        r#"
+const beacon = 1;
+becon; becon; becon; becon; becon; becon;
+becon; becon; becon; becon; becon; becon;
+"#,
+    );
+    let suggestion_count = diags
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.code == 2552
+                && diagnostic.message_text.contains("'becon'")
+                && diagnostic.message_text.contains("'beacon'")
+        })
+        .count();
+    let bare_not_found_count = diags
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2304 && diagnostic.message_text.contains("'becon'"))
+        .count();
+
+    assert_eq!(
+        suggestion_count, 12,
+        "expected TS2552 at every site: {diags:#?}"
+    );
+    assert_eq!(
+        bare_not_found_count, 0,
+        "unexpected TS2304 fallback: {diags:#?}"
+    );
+}
+
+#[test]
+fn spelling_suggestions_exclude_receiver_only_class_members() {
+    let diags = check(
+        r#"
+class Example<TargetType> {
+    instanceTarget!: number;
+    static staticTarget: number;
+    methodTarget() {}
+    get accessorTarget() { return 1; }
+
+    method() {
+        let typed: InstanceTarget;
+        StaticTarget;
+        MethodTarget;
+        AccessorTarget;
+        let generic: TargetTyp;
+        const localTarget = 1;
+        localTarge;
+    }
+}
+"#,
+    );
+
+    for missing_name in [
+        "InstanceTarget",
+        "StaticTarget",
+        "MethodTarget",
+        "AccessorTarget",
+    ] {
+        assert!(
+            diags.iter().any(|diagnostic| {
+                diagnostic.code == 2304
+                    && diagnostic
+                        .message_text
+                        .contains(&format!("'{missing_name}'"))
+            }),
+            "expected bare TS2304 for receiver-only class member near-match {missing_name}: {diags:#?}"
+        );
+        assert!(
+            !diags.iter().any(|diagnostic| {
+                diagnostic.code == 2552
+                    && diagnostic
+                        .message_text
+                        .contains(&format!("'{missing_name}'"))
+            }),
+            "receiver-only class member must not become a bare-name suggestion: {diags:#?}"
+        );
+    }
+
+    for (typo, suggestion) in [("TargetTyp", "TargetType"), ("localTarge", "localTarget")] {
+        assert!(
+            diags.iter().any(|diagnostic| {
+                diagnostic.code == 2552
+                    && diagnostic.message_text.contains(&format!("'{typo}'"))
+                    && diagnostic.message_text.contains(&format!("'{suggestion}'"))
+            }),
+            "lexically visible name should remain a suggestion: {diags:#?}"
+        );
+    }
+}
+
+#[test]
+fn spelling_suggestions_preserve_type_params_merged_with_class_members() {
+    let diags = check(
+        r#"
+class PropertyMerge<PropertyType> {
+    PropertyType!: number;
+    method() { let value: PropertyTyp; PropertyTyp; }
+}
+class MethodMerge<MethodType> {
+    MethodType() {}
+    method() { let value: MethodTyp; MethodTyp; }
+}
+"#,
+    );
+
+    for (typo, suggestion) in [("PropertyTyp", "PropertyType"), ("MethodTyp", "MethodType")] {
+        assert!(
+            diags.iter().any(|diagnostic| {
+                diagnostic.code == 2552
+                    && diagnostic.message_text.contains(&format!("'{typo}'"))
+                    && diagnostic.message_text.contains(&format!("'{suggestion}'"))
+            }),
+            "the lexical type-parameter meaning must survive a same-name receiver member: {diags:#?}"
+        );
+        assert!(
+            diags.iter().any(|diagnostic| {
+                diagnostic.code == 2304 && diagnostic.message_text.contains(&format!("'{typo}'"))
+            }),
+            "the same merged symbol must remain receiver-only in value position: {diags:#?}"
+        );
+    }
+}
+
+#[test]
+fn spelling_suggestion_cache_is_lexically_scope_sensitive() {
+    let diags = check(
+        r#"
+function first() {
+    const beacon = 1;
+    becon;
+}
+function second() {
+    const bacon = 1;
+    becon;
+}
+"#,
+    );
+
+    for suggestion in ["beacon", "bacon"] {
+        assert!(
+            diags.iter().any(|diagnostic| {
+                diagnostic.code == 2552
+                    && diagnostic.message_text.contains("'becon'")
+                    && diagnostic.message_text.contains(&format!("'{suggestion}'"))
+            }),
+            "same spelling in distinct lexical scopes must keep its local candidate: {diags:#?}"
+        );
+    }
+}

--- a/docs/how-tsz-works/internals/checker-error-reporter-diagnostics.md
+++ b/docs/how-tsz-works/internals/checker-error-reporter-diagnostics.md
@@ -421,14 +421,18 @@ floor(len * 0.34))` and initial `bestDistance = floor(len * 0.4) + 1`.
 case-only rule for short names, and `best_spelling_suggestion` owns the
 single per-candidate loop.
 
-`find_similar_identifiers` searches local visible binder names, then global lib
-contexts. A documented divergence from `tsc`'s ordering is corrected here:
-because tsz resolves names demand-driven rather than sequentially with a per-file
-suggestion cap, TYPE-only lookups conservatively restrict the lib search to
-*core* lib files (`lib.es*`, `lib.scripthost`, `lib.decorators` — see
-`lib_context_is_core_typings`) and suppress non-core lib-origin TYPE candidates,
-so user code is not flooded with DOM-interface noise like
-`ParseNode -> ParentNode` (#3282). `find_similar_property` collects accessible
+`find_similar_identifiers` searches local visible binder names, including the
+loaded lib symbols merged into the file binder, then uses global lib contexts as
+a fallback. TypeScript 7 has no per-file suggestion cap or core-vs-DOM filter, so
+loaded DOM candidates such as `ParseNode -> ParentNode` participate normally.
+Direct checker contexts whose binders have not merged their attached libs retain
+a TYPE-only lib-context fallback scoped to core lib files (`lib.es*`,
+`lib.scripthost`, `lib.decorators` — see `lib_context_is_core_typings`).
+Production binders skip that duplicate scan because the merged visible-name
+table already covers every loaded lib. Candidate scans are deferred until a diagnostic is emitted.
+The visible candidate universe is memoized per `(lexical scope, meaning)`, and
+the final suggestion per `(lexical scope, misspelled name, meaning)`.
+`find_similar_property` collects accessible
 property names through the query boundary (resolving primitives to their boxed
 interface types, and enum/namespace members from binder exports), and never
 suggests a public property for a `#private` access.


### PR DESCRIPTION
Goal: hold

## Summary

- Match TypeScript 7 by emitting eligible TS2552/TS2833 spelling suggestions beyond the old ten-site cap, including JSDoc and loaded DOM types.
- Keep receiver-only class members out of bare-name suggestions while preserving a same-name class type parameter's lexical TYPE meaning.
- Bound the additional diagnostic work with file-local scope caches, merged-lib scan deduplication, and an allocation-free ASCII distance path.

Structural rule: For every eligible unresolved name or namespace, TypeScript 7 searches the visible lexical and loaded-lib symbol universe without a per-file cap. Receiver-only class members are not bare lexical names; any merged type-parameter meaning remains visible in TYPE position.

Owner layer: the checker name-resolution diagnostic gateway owns eligibility, candidate/result memoization, and diagnostic selection. The binder owns the structurally visible name set. JSDoc uses the same uncapped TS7 policy without moving semantic validation into the reporter.

Adjacent matrix: twelve ordinary misses; twelve JSDoc misses; eleven namespace misses; loaded and unloaded DOM candidates; pure instance/static/method/accessor members; class type parameters merged with property/method symbols in TYPE and VALUE positions; distinct lexical scopes with the same typo; discarded-diagnostic contexts; parser-error and accessibility suppression; ASCII and Unicode distance behavior.

Fallback: unloaded libs never contribute candidates; parse-invalid, inaccessible, `arguments`, `super`, and discarded-diagnostic sites retain their existing suppression; foreign lexical scopes do not share result entries; Unicode identifiers stay on the scalar distance implementation.

Performance: candidate universes are cached per `(scope, meaning)`, final results per `(scope, name, meaning)`, and both are cleared at the file-session boundary and included in cache residency statistics. Production merged binders skip a duplicate lib-context scan. On 100 optimized runs, maximum10SpellingSuggestions improved from 24.4ms to 23.7ms. The invalid parserindenter stress case is 58.5ms versus the capped base's 41.8ms (+40%, down from the initial ~2.8x regression) while doing the additional TS7-required scans; measured RSS increased about 2MB.

## Verification

- explicit spelling/JSDoc/lib/architecture integration binaries: 242/242 passed (2 skipped)
- focused namespace, discarded-context, cache-statistics, ASCII, and Unicode lib tests: 7/7 passed
- cargo clippy -p tsz-binder --lib -- -D warnings
- cargo clippy -p tsz-checker --lib -- -D warnings
- cargo fmt --all --check
- git diff --check
- python3 scripts/arch/arch_guard.py
- scripts/arch/check-checker-boundaries.sh
- optimized targeted conformance: 20/20 passed versus 10/20 at base (+10 tests)
- exact TypeScript 7.0.2 merged class member/type-parameter oracle: TYPE typos TS2552; VALUE typos TS2304
- independent final review: clean, no blockers

## Provenance

Machine: Mac
Assistant: codex
Model: GPT-5
Effort: high
