### PR TITLE
fix(checker): validate cross-file class declaration ownership

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
@@ -393,27 +393,37 @@ impl<'a> CheckerState<'a> {
         value_decl: NodeIndex,
         declarations: &[NodeIndex],
     ) -> (TypeId, Vec<tsz_solver::TypeParamInfo>) {
-        let decl_idx = if value_decl.is_some()
-            && self
-                .ctx
-                .arena
-                .get(value_decl)
-                .and_then(|n| self.ctx.arena.get_class(n))
-                .is_some()
-        {
+        // `NodeIndex` is only meaningful together with its arena. Cross-file class
+        // symbols carry declaration indices from the owner arena; the same raw index
+        // can name an unrelated class in the requester. Accept a current-arena class
+        // only when declaration provenance is local and either the symbol's stable
+        // owner is this file or the current binder maps the node back to this exact
+        // symbol. The owner alternative preserves export/self-import wrappers whose
+        // related symbol identity differs; the O(1) provenance check still rejects a
+        // foreign declaration collision. Foreign classes fall through to the
+        // owner-arena search below.
+        let symbol_is_owned_by_current_file =
+            self.ctx.resolve_symbol_file_index_stable(sym_id) == Some(self.ctx.current_file_idx);
+        let is_local_class_declaration = |decl_idx: NodeIndex| {
+            decl_idx.is_some()
+                && self
+                    .ctx
+                    .declaration_is_local_to_current_arena(sym_id, decl_idx)
+                && (symbol_is_owned_by_current_file
+                    || self.ctx.binder.get_node_symbol(decl_idx) == Some(sym_id))
+                && self
+                    .ctx
+                    .arena
+                    .get(decl_idx)
+                    .and_then(|node| self.ctx.arena.get_class(node))
+                    .is_some()
+        };
+        let decl_idx = if is_local_class_declaration(value_decl) {
             value_decl
         } else {
             declarations
                 .iter()
-                .find(|&&d| {
-                    d.is_some()
-                        && self
-                            .ctx
-                            .arena
-                            .get(d)
-                            .and_then(|n| self.ctx.arena.get_class(n))
-                            .is_some()
-                })
+                .find(|&&decl_idx| is_local_class_declaration(decl_idx))
                 .copied()
                 .unwrap_or(NodeIndex::NONE)
         };

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -261,6 +261,13 @@ impl CheckerState<'_> {
         // `class Foo {}` in file2.js), delegating to the other file's arena would cause
         // compute_class_symbol_type to fail to find the class node and return UNKNOWN,
         // triggering false TS18046 errors. Handle the class locally instead.
+        //
+        // A declaration `NodeIndex` is arena-relative. A foreign class can have the
+        // same raw index as an unrelated class in the requesting file, so seeing class
+        // syntax at that index does not prove this symbol has a local declaration. As
+        // with the FUNCTION guard below, require the current binder's node-to-symbol
+        // map to round-trip to `sym_id`. This keeps the local merge fast path O(1) while
+        // allowing genuine foreign classes to delegate to their owning arena.
         {
             let sym_found = cross_file_symbol;
             if let Some(symbol) = sym_found
@@ -272,6 +279,7 @@ impl CheckerState<'_> {
                         .get(d)
                         .and_then(|n| self.ctx.arena.get_class(n))
                         .is_some()
+                        && self.ctx.binder.get_node_symbol(d) == Some(sym_id)
                 });
                 if has_class_in_current_arena {
                     return None; // Handle locally, don't delegate

--- a/crates/tsz-core/src/parallel/core/checking.rs
+++ b/crates/tsz-core/src/parallel/core/checking.rs
@@ -1257,3 +1257,7 @@ mod tests;
 #[cfg(test)]
 #[path = "../../../tests/cross_file_interface_merge_ts2717_driver_tests.rs"]
 mod cross_file_interface_merge_ts2717_driver_tests;
+
+#[cfg(test)]
+#[path = "../../../tests/cross_file_class_decl_owner_driver_tests.rs"]
+mod cross_file_class_decl_owner_driver_tests;

--- a/crates/tsz-core/tests/cross_file_class_decl_owner_driver_tests.rs
+++ b/crates/tsz-core/tests/cross_file_class_decl_owner_driver_tests.rs
@@ -1,0 +1,184 @@
+//! Driver-level regressions for cross-file class declaration ownership.
+//!
+//! `NodeIndex` is arena-relative. An imported class declaration can therefore
+//! have the same raw index as an unrelated class in the importing file. These
+//! tests check only the consumer file against a fully merged program so the
+//! exporting class has not already published a cached type.
+
+use super::{MergedProgram, ParallelCheckPlan, compile_files_with_libs};
+use crate::checker::context::CheckerOptions;
+use crate::parser::NodeIndex;
+
+fn compile(files: &[(&str, &str)]) -> MergedProgram {
+    compile_files_with_libs(
+        files
+            .iter()
+            .map(|(name, source)| ((*name).to_owned(), (*source).to_owned()))
+            .collect(),
+        &[],
+    )
+}
+
+fn exported_value_declaration(
+    program: &MergedProgram,
+    file_name: &str,
+    export_name: &str,
+) -> NodeIndex {
+    let symbol_id = program
+        .module_exports
+        .get(file_name)
+        .and_then(|exports| exports.get(export_name))
+        .unwrap_or_else(|| panic!("missing export {export_name:?} from {file_name:?}"));
+    program
+        .symbols
+        .get(symbol_id)
+        .unwrap_or_else(|| panic!("missing merged symbol for {export_name:?}"))
+        .value_declaration
+}
+
+fn check_consumer_cold(program: &MergedProgram, file_name: &str) -> Vec<u32> {
+    let file_idx = program
+        .files
+        .iter()
+        .position(|file| file.file_name == file_name)
+        .unwrap_or_else(|| panic!("missing consumer file {file_name:?}"));
+    let options = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    let plan = ParallelCheckPlan::build(program, &options, &[]);
+    plan.check_one_file(file_idx, &program.files[file_idx])
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+#[test]
+fn imported_class_ignores_same_index_local_class_when_checked_cold() {
+    // The empty statement and otherwise-unused members intentionally align
+    // `ImportedCompiler` with `EnclosingDialect` at the same raw `NodeIndex`.
+    let program = compile(&[
+        (
+            "compiler.ts",
+            r#"
+export abstract class BaseCompiler { compileQuery(): void {} }
+;
+export class ImportedCompiler extends BaseCompiler {
+    first(): void {}
+    second(): void {}
+    third(): void {}
+    fourth(): void {}
+    static {}
+}
+"#,
+        ),
+        (
+            "dialect.ts",
+            r#"
+import { ImportedCompiler } from './compiler.js'
+interface Compiler { compileQuery(): void }
+export class EnclosingDialect {
+    constructor(config: string) { void config }
+    createCompiler(): Compiler { return new ImportedCompiler() }
+}
+"#,
+        ),
+    ]);
+
+    let imported_declaration =
+        exported_value_declaration(&program, "compiler.ts", "ImportedCompiler");
+    let unrelated_local_declaration =
+        exported_value_declaration(&program, "dialect.ts", "EnclosingDialect");
+    assert_eq!(
+        imported_declaration, unrelated_local_declaration,
+        "the regression requires equal raw NodeIndex values from different arenas"
+    );
+
+    let codes = check_consumer_cold(&program, "dialect.ts");
+    assert!(
+        !codes.contains(&2741),
+        "the imported class instance must retain its inherited compileQuery member: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2554),
+        "the unrelated local constructor must not become the imported constructor: {codes:?}"
+    );
+}
+
+#[test]
+fn imported_class_owner_is_name_and_declaration_position_independent() {
+    let program = compile(&[
+        (
+            "engine.ts",
+            r#"
+export abstract class EngineBase { compileQuery(): void {} }
+export class RenamedEngine extends EngineBase {
+    first(): void {}
+    second(): void {}
+    third(): void {}
+    fourth(): void {}
+    static {}
+}
+"#,
+        ),
+        (
+            "factory.ts",
+            r#"
+import { RenamedEngine } from './engine.js'
+interface EngineContract { compileQuery(): void }
+export class RenamedFactory {
+    constructor(config: string) { void config }
+    create(): EngineContract { return new RenamedEngine() }
+}
+"#,
+        ),
+    ]);
+
+    let imported_declaration = exported_value_declaration(&program, "engine.ts", "RenamedEngine");
+    let local_declaration = exported_value_declaration(&program, "factory.ts", "RenamedFactory");
+    assert_ne!(
+        imported_declaration, local_declaration,
+        "this adjacent case must exercise different raw declaration positions"
+    );
+
+    let codes = check_consumer_cold(&program, "factory.ts");
+    assert!(
+        !codes.contains(&2741) && !codes.contains(&2554),
+        "renaming and shifting declarations must preserve the imported class type: {codes:?}"
+    );
+}
+
+#[test]
+fn imported_required_constructor_still_reports_ts2554_when_checked_cold() {
+    let program = compile(&[
+        (
+            "required.ts",
+            r#"
+export class RequiredEngine {
+    constructor(config: string) { void config }
+    compileQuery(): void {}
+}
+"#,
+        ),
+        (
+            "consumer.ts",
+            r#"
+import { RequiredEngine } from './required.js'
+interface EngineContract { compileQuery(): void }
+export function create(): EngineContract { return new RequiredEngine() }
+"#,
+        ),
+    ]);
+
+    let codes = check_consumer_cold(&program, "consumer.ts");
+    assert_eq!(
+        codes.iter().filter(|&&code| code == 2554).count(),
+        1,
+        "a real required constructor must still report exactly one TS2554: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2741),
+        "constructor checking must preserve the imported instance members: {codes:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary

- Structural rule: a `NodeIndex` identifies a declaration only together with its owning arena; class syntax is local only when declaration provenance is local and either the stable symbol owner is the current file or the current binder round-trips the exact merged `SymbolId`.
- Owner layer: checker cross-file delegation retains the exact round-trip required to reject foreign raw-index collisions, while class-symbol computation also accepts same-file export/self-import wrappers whose related symbol identity differs.
- This prevents an imported class from being computed from an unrelated requester class at the same raw node index, which caused Kysely's `SqliteQueryCompiler` to inherit the `SqliteDialect` constructor and instance shape.
- Adjacent matrix covers an exact raw-index collision, renamed/shifted declarations, inherited instance members, a genuine required-constructor TS2554 control, a self-imported default class under shadowing, and a type-only exported class used through `typeof`.
- Fallback remains conservative: foreign declarations delegate to their registered owner arena; all ownership and provenance checks are O(1), with no new scans or caches.

## Project evidence

- Exact Kysely guard on base `68ca432740` versus this head: 82 -> 80 diagnostics at both default Rayon width and `RAYON_NUM_THREADS=1`.
- The diagnostic multiset changes only by removing one false TS2741 and one false TS2554 at `sqlite-dialect.ts`; no other code changes.
- Alternating three-run medians on the same guard config: 20.12s / 1,166,540,800 B peak RSS on base versus 20.03s / 1,158,152,192 B on this head (-0.45% wall, -0.72% RSS; treated as no regression).

## Verification

- `scripts/safe-run.sh cargo nextest run -p tsz-core cross_file_class_decl_owner_driver_tests` (3 passed; the exact-base binary produces `[2741, 2554]` for the regression witness)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test js_class_constructor_merge_tests --test class_interface_namespace_merge_tests --test cross_file_function_node_index_collision_tests --test cross_file_delegation_lookup_consolidation_tests` (21 passed)
- `scripts/emit/run.sh --filter=defaultDeclarationEmitShadowedNamedCorrectly --dts-only --verbose` (1 passed)
- `scripts/emit/run.sh --filter=typeofImportTypeOnlyExport --dts-only --verbose` (1 passed)
- `RAYON_NUM_THREADS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 <immutable-tsz> --noEmit -p /Users/mohsen/code/tsz-canary-fixtures/kysely/tsconfig.tsz-guard.json` (base/head exact diagnostic multiset comparison)
- `cargo fmt --all`
- `git diff --check`

## Provenance

Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
