### PR TITLE
fix(checker): align overloaded conditional return variance

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -1085,6 +1085,18 @@ impl<'a> CheckerState<'a> {
         {
             return false;
         }
+        if source_args
+            .iter()
+            .zip(target_args.iter())
+            .any(|(&source_arg, &target_arg)| {
+                (source_arg.is_any() && target_arg == TypeId::NEVER)
+                    || (source_arg == TypeId::NEVER && target_arg.is_any())
+            })
+        {
+            // The option-aware solver classifier owns this exceptional pair;
+            // a partial declared mask cannot safely reject it here.
+            return false;
+        }
         let def_id = crate::query_boundaries::conditional_infer_alias::application_base_def_id(
             self.ctx.types.as_type_database(),
             &self.ctx,

--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_declared_types.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_declared_types.rs
@@ -107,6 +107,19 @@ impl<'a> CheckerState<'a> {
         else {
             return false;
         };
+        if source_args
+            .iter()
+            .zip(target_args.iter())
+            .any(|(&source_arg, &target_arg)| {
+                (source_arg.is_any() && target_arg == TypeId::NEVER)
+                    || (source_arg == TypeId::NEVER && target_arg.is_any())
+            })
+        {
+            // Directional any/never application compatibility is owned by the
+            // option-aware solver classifier, not this blanket target-any
+            // assignment shortcut.
+            return false;
+        }
         source_base == target_base
             && source_args.len() == target_args.len()
             && target_args.iter().any(|arg| arg.is_any())

--- a/crates/tsz-checker/src/assignability/generic_mapped_alias_helpers.rs
+++ b/crates/tsz-checker/src/assignability/generic_mapped_alias_helpers.rs
@@ -60,6 +60,18 @@ impl<'a> CheckerState<'a> {
         {
             return false;
         }
+        if source_args
+            .iter()
+            .zip(target_args.iter())
+            .any(|(&source_arg, &target_arg)| {
+                (source_arg.is_any() && target_arg == TypeId::NEVER)
+                    || (source_arg == TypeId::NEVER && target_arg.is_any())
+            })
+        {
+            // The option-aware solver classifier owns this exceptional pair;
+            // a partial declared mask cannot safely accept it here.
+            return false;
+        }
 
         let Some(variances) =
             crate::query_boundaries::variance::compute_type_param_variances_with_resolver_cached(

--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -1807,11 +1807,10 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            // Method overload coverage check: the 'derived_loop above only compares
-            // each derived overload against the FIRST matching base overload. When the
-            // base has multiple overloads for the same method, we must verify that EACH
-            // base overload is matched by at least one derived overload. If any base
-            // overload is unmatched, emit TS2430.
+            // Method overload coverage check: the loop above defers a name when
+            // either side has multiple signatures. Compare both full sets so every
+            // base signature is matched, including the derived-overloads/base-single
+            // shape that a per-declaration comparison cannot represent.
             if !ts2430_emitted_for_base {
                 self.check_interface_overload_coverage(
                     super::class_checker_compat_overloads::InterfaceOverloadCoverageCtx {

--- a/crates/tsz-checker/src/classes/class_checker_compat_overloads.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat_overloads.rs
@@ -31,7 +31,7 @@ impl<'a> CheckerState<'a> {
             substitution,
             interface_self_type,
         } = ctx;
-        let base_method_overloads: Vec<(String, Vec<TypeId>)>;
+        let base_method_groups: Vec<(String, Vec<TypeId>)>;
         {
             let mut by_name: rustc_hash::FxHashMap<String, Vec<TypeId>> =
                 rustc_hash::FxHashMap::default();
@@ -68,7 +68,7 @@ impl<'a> CheckerState<'a> {
                     }
                 }
             }
-            base_method_overloads = by_name.into_iter().filter(|(_, v)| v.len() > 1).collect();
+            base_method_groups = by_name.into_iter().collect();
         }
 
         let mut derived_method_overloads: rustc_hash::FxHashMap<String, Vec<(TypeId, NodeIndex)>> =
@@ -89,7 +89,8 @@ impl<'a> CheckerState<'a> {
         tracing::debug!(
             derived = derived_name,
             base = base_name,
-            n_base_overloaded = base_method_overloads.len(),
+            n_base_method_names = base_method_groups.len(),
+            n_derived_method_names = derived_method_overloads.len(),
             interface_self_type = interface_self_type.map(|t| t.0),
             "overload coverage check"
         );
@@ -111,11 +112,24 @@ impl<'a> CheckerState<'a> {
         // both sides and route them through the standard relation, which already
         // implements the N×M rule (`check_callable_subtype`), including method
         // bivariance and method-local generic erasure for multi-signature shapes.
-        'overload_check: for (method_name, base_sigs) in &base_method_overloads {
+        'overload_check: for (method_name, base_sigs) in &base_method_groups {
             let Some(derived_sigs) = derived_method_overloads.get(method_name) else {
                 tracing::debug!(method = method_name, "no derived overloads found");
                 continue;
             };
+            tracing::trace!(
+                method = method_name,
+                base_signatures = base_sigs.len(),
+                derived_signatures = derived_sigs.len(),
+                "checking deferred interface method overload set"
+            );
+            // The member loop defers a method name when either side is
+            // overloaded. Keep single/single names out of this second pass,
+            // while still checking a derived overload set against a single
+            // tuple-union/rest signature on the base.
+            if base_sigs.len() < 2 && derived_sigs.len() < 2 {
+                continue;
+            }
             if base_sigs.iter().copied().any(signature_contains_error)
                 || derived_sigs
                     .iter()
@@ -125,10 +139,11 @@ impl<'a> CheckerState<'a> {
             }
 
             let Some(base_callable) =
-                crate::query_boundaries::class::combine_overloaded_method_callable(
+                crate::query_boundaries::class::build_method_overload_callable(
                     self.ctx.types,
-                    base_sigs,
+                    base_sigs.iter().copied(),
                     method_name,
+                    1,
                 )
             else {
                 continue;

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -6,7 +6,7 @@ use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
 use crate::query_boundaries::class::{
     should_report_member_type_mismatch, should_report_own_member_type_mismatch,
 };
-use crate::query_boundaries::common::{PropertyAccessResult, TypeResolver};
+use crate::query_boundaries::common::TypeResolver;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -190,12 +190,17 @@ impl<'a> CheckerState<'a> {
             (Vec::new(), false)
         };
 
-        // Track interface method-signature names already rebuilt from the AST in
-        // this loop. The first declaration of a name replaces the object-shape
-        // property (which only stores the return type for methods); subsequent
-        // declarations of the same name are overload signatures and must be
-        // *combined* into one callable rather than overwriting each other.
-        let mut method_sig_rebuilt: rustc_hash::FxHashSet<tsz_common::interner::Atom> =
+        // Accumulate each overload family as member type ids and construct its
+        // callable once after scanning. Rebuilding the growing callable for every
+        // declaration would clone and reintern O(n²) signatures for a family of n
+        // overloads.
+        let mut method_signature_accumulators: rustc_hash::FxHashMap<
+            tsz_common::interner::Atom,
+            (Vec<TypeId>, PropertyInfo),
+        > = rustc_hash::FxHashMap::default();
+        let mut rebuilt_member_names: rustc_hash::FxHashSet<tsz_common::interner::Atom> =
+            rustc_hash::FxHashSet::default();
+        let mut frozen_member_names: rustc_hash::FxHashSet<tsz_common::interner::Atom> =
             rustc_hash::FxHashSet::default();
 
         for &decl_idx in interface_declarations {
@@ -233,30 +238,16 @@ impl<'a> CheckerState<'a> {
                 // object-shape property type which only stores the return type.
                 // This ensures proper TS2416 detection when comparing a class
                 // method against a generic interface method signature.
-                let member_type = if member_node.kind == syntax_kind_ext::METHOD_SIGNATURE {
-                    let member_type = self.get_type_of_interface_member_simple(member_idx);
-                    crate::query_boundaries::common::instantiate_type(
-                        self.ctx.types,
-                        member_type,
-                        substitution,
-                    )
-                } else {
-                    match self.resolve_property_access_with_env(interface_type, &name) {
-                        PropertyAccessResult::Success {
-                            type_id,
-                            write_type,
-                            ..
-                        } => write_type.unwrap_or(type_id),
-                        _ => {
-                            let member_type = self.get_type_of_interface_member_simple(member_idx);
-                            crate::query_boundaries::common::instantiate_type(
-                                self.ctx.types,
-                                member_type,
-                                substitution,
-                            )
-                        }
-                    }
-                };
+                // Reconstruct the exact declaration being scanned. A property
+                // lookup on the merged interface shape can return a later
+                // duplicate's type and make property-first recovery silently
+                // adopt a following method declaration.
+                let member_type = self.get_type_of_interface_member_simple(member_idx);
+                let member_type = crate::query_boundaries::common::instantiate_type(
+                    self.ctx.types,
+                    member_type,
+                    substitution,
+                );
 
                 let member_atom = self.ctx.types.intern_string(&name);
                 let property_info = PropertyInfo {
@@ -275,67 +266,74 @@ impl<'a> CheckerState<'a> {
                     single_quoted_name: false,
                     non_widening: false,
                 };
-                if let Some(existing) = properties.iter_mut().find(|p| p.name == member_atom) {
-                    if member_node.kind == syntax_kind_ext::METHOD_SIGNATURE
-                        && existing.is_method
-                        && method_sig_rebuilt.contains(&member_atom)
-                    {
-                        // Overloaded interface method: this is a second (or later)
-                        // overload of an already-rebuilt method. Combine the
-                        // accumulated signature(s) with this declaration's
-                        // signature(s) into one callable so the implements-compat
-                        // check relates the class member against the FULL overload
-                        // set. tsc's `signaturesRelatedTo` erases type parameters
-                        // for the multi-signature (N×M) case; comparing the class
-                        // member against a single overload in isolation produces a
-                        // false TS2416 when the overload's return type depends on
-                        // the method type parameter.
-                        let mut sigs = crate::query_boundaries::class::member_call_signatures(
-                            self.ctx.types,
-                            existing.type_id,
-                        );
-                        sigs.extend(crate::query_boundaries::class::member_call_signatures(
-                            self.ctx.types,
-                            member_type,
-                        ));
-                        if sigs.is_empty() {
-                            // Defensive: if neither declaration yielded a call
-                            // signature, an empty callable would print as `{}` and
-                            // accept anything. Fall back to the single-declaration
-                            // type rather than silently dropping the check.
-                            *existing = property_info;
-                        } else {
-                            // Relate the overload set as a plain call-signature list
-                            // (`is_method = false`). tsc compares a class member
-                            // against an overloaded target with contravariant
-                            // parameters and type-parameter erasure (the N×M
-                            // `signaturesRelatedTo` path), not the bivariant
-                            // single-method parameter rule. Keeping `is_method =
-                            // true` would over-accept — e.g. a narrower impl
-                            // parameter would pass bivariantly — and miss real
-                            // TS2416s.
-                            for sig in &mut sigs {
-                                sig.is_method = false;
-                            }
-                            let combined =
-                                crate::query_boundaries::construct_signatures::call_only_callable_type(
-                                    self.ctx.types,
-                                    sigs,
-                                );
-                            existing.type_id = combined;
-                            existing.write_type = combined;
-                            existing.is_method = false;
-                        }
+                let is_method = member_node.kind == syntax_kind_ext::METHOD_SIGNATURE;
+                if rebuilt_member_names.insert(member_atom) {
+                    if let Some(existing) = properties.iter_mut().find(|p| p.name == member_atom) {
+                        *existing = property_info.clone();
                     } else {
-                        *existing = property_info;
+                        properties.push(property_info.clone());
+                    }
+                    if is_method {
+                        method_signature_accumulators
+                            .insert(member_atom, (vec![member_type], property_info));
+                    } else {
+                        // In invalid mixed method/property declarations, tsc's
+                        // recovery keeps the first property authoritative and
+                        // ignores later same-name method declarations.
+                        frozen_member_names.insert(member_atom);
+                    }
+                    continue;
+                }
+                if frozen_member_names.contains(&member_atom) {
+                    continue;
+                }
+                if is_method {
+                    if let Some((member_types, _)) =
+                        method_signature_accumulators.get_mut(&member_atom)
+                    {
+                        member_types.push(member_type);
                     }
                 } else {
-                    properties.push(property_info);
-                }
-                if member_node.kind == syntax_kind_ext::METHOD_SIGNATURE {
-                    method_sig_rebuilt.insert(member_atom);
+                    // A property terminates an initial method overload family.
+                    // Preserve the methods accumulated before it and ignore all
+                    // later duplicates for member-type reconstruction.
+                    frozen_member_names.insert(member_atom);
                 }
             }
+        }
+
+        for (member_atom, (member_types, fallback)) in method_signature_accumulators {
+            if member_types.len() < 2 {
+                continue;
+            }
+            let mut sigs = Vec::with_capacity(member_types.len());
+            for member_type in member_types {
+                sigs.extend(crate::query_boundaries::class::member_call_signatures(
+                    self.ctx.types,
+                    member_type,
+                ));
+            }
+            let Some(existing) = properties.iter_mut().find(|p| p.name == member_atom) else {
+                continue;
+            };
+            if sigs.is_empty() {
+                // An empty callable would print as `{}` and accept anything.
+                // Preserve the first declaration instead of dropping the check.
+                *existing = fallback;
+                continue;
+            }
+            // tsc relates overload sets as plain call-signature lists through
+            // contravariant N×M parameter comparison with type-parameter erasure.
+            for sig in &mut sigs {
+                sig.is_method = false;
+            }
+            let combined = crate::query_boundaries::construct_signatures::call_only_callable_type(
+                self.ctx.types,
+                sigs,
+            );
+            existing.type_id = combined;
+            existing.write_type = combined;
+            existing.is_method = false;
         }
 
         (properties, has_index_signature, display_name)

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -503,6 +503,9 @@ pub(crate) fn should_report_member_type_mismatch(
     if checker.should_suppress_assignability_for_parse_recovery(node_idx, node_idx) {
         return false;
     }
+    if implementation_signature_has_incompatible_erased_overload_return(checker, source, target) {
+        return true;
+    }
     if checker
         .no_erase_generics_relation_outcome(source, target)
         .related
@@ -547,13 +550,28 @@ pub(crate) fn interface_overload_set_assignable(
     target: TypeId,
     allow_fresh_generic_retry: bool,
 ) -> bool {
-    checker
+    let strict_related = checker
         .no_erase_generics_relation_outcome(source, target)
-        .related
-        || (allow_fresh_generic_retry
-            && checker
-                .interface_heritage_generic_method_relation_outcome(source, target)
-                .related)
+        .related;
+    if strict_related {
+        tracing::trace!(?source, ?target, "interface overload set related strictly");
+        return true;
+    }
+    let has_generic_signature = checker.callable_has_own_generic_signatures(source)
+        || checker.callable_has_own_generic_signatures(target);
+    if !allow_fresh_generic_retry || !has_generic_signature {
+        return false;
+    }
+    let retry_related = checker
+        .interface_heritage_generic_method_relation_outcome(source, target)
+        .related;
+    tracing::trace!(
+        ?source,
+        ?target,
+        retry_related,
+        "interface overload set fresh-generic retry"
+    );
+    retry_related
 }
 
 fn call_signature_function_type(
@@ -633,6 +651,48 @@ fn overload_return_base_matches_and_params_cover(
     .is_related()
 }
 
+/// True when an implementation/overload pair has a determinate erased
+/// conditional return with a proven `any`/`never` variance mismatch.
+///
+/// The regular coverage helper intentionally returns only a boolean, so a false
+/// result can mean either an ordinary parameter mismatch or this stronger return
+/// rejection. Preserve that distinction before the whole-member compatibility
+/// relation structurally expands the return applications and loses their generic
+/// identity.
+pub(crate) fn implementation_signature_has_incompatible_erased_overload_return(
+    checker: &mut CheckerState<'_>,
+    source: TypeId,
+    target: TypeId,
+) -> bool {
+    let source = unwrap_single_property_value_type(checker, source);
+    let target = unwrap_single_property_value_type(checker, target);
+    let source_sigs = member_call_signatures(checker.ctx.types, source);
+    let target_sigs = member_call_signatures(checker.ctx.types, target);
+    if source_sigs.len() != 1 || target_sigs.len() < 2 {
+        return false;
+    }
+
+    let source_type = call_signature_function_type(checker, &source_sigs[0]);
+    target_sigs.iter().any(|target_sig| {
+        let target_type = call_signature_function_type(checker, target_sig);
+        let policy = relation_policy::from_checker_flags_u16(checker.ctx.pack_relation_flags());
+        let context = tsz_solver::relations::relation_queries::RelationContext {
+            query_db: Some(checker.ctx.types),
+            evaluation_session: Some(checker.ctx.eval_session.as_ref()),
+            inheritance_graph: Some(&checker.ctx.inheritance_graph),
+            class_check: None,
+        };
+        tsz_solver::relations::relation_queries::query_erased_overload_return_variance_rejects(
+            checker.ctx.types.as_type_database(),
+            &checker.ctx,
+            source_type,
+            target_type,
+            policy,
+            context,
+        )
+    })
+}
+
 /// Check if a DIRECT (own) member type mismatch should be reported (TS2416).
 ///
 /// Unlike `should_report_member_type_mismatch`, this variant uses a targeted
@@ -659,6 +719,9 @@ pub(crate) fn should_report_own_member_type_mismatch(
     }
     if implementation_signature_covers_interface_overloads(checker, source, target) {
         return false;
+    }
+    if implementation_signature_has_incompatible_erased_overload_return(checker, source, target) {
+        return true;
     }
     if checker
         .no_erase_generics_relation_outcome(source, target)
@@ -1007,9 +1070,10 @@ pub(crate) fn combine_overloaded_method_callable(
 ///   - `2` builds a callable only for genuinely overloaded members
 ///     (`combine_overloaded_method_callable`).
 ///   - `1` keeps a single-signature member as a one-signature callable, which
-///     the interface-heritage overload-coverage check needs for the derived
-///     side: a derived interface may legitimately collapse a base's overload
-///     set down to a single compatible signature.
+///     the interface-heritage overload-coverage check needs whenever only one
+///     side is overloaded: a derived interface may legitimately collapse a
+///     base overload set, and a derived overload set must still be checked
+///     against a single base signature.
 pub(crate) fn build_method_overload_callable(
     db: &dyn QueryDatabase,
     member_object_types: impl IntoIterator<Item = TypeId>,

--- a/crates/tsz-checker/tests/class_implements_overloaded_method_ts2416_tests.rs
+++ b/crates/tsz-checker/tests/class_implements_overloaded_method_ts2416_tests.rs
@@ -13,7 +13,7 @@
 //! The reported witness was kysely's `RawBuilderImpl.as` vs `RawBuilder.as`.
 
 use tsz_checker::context::CheckerOptions;
-use tsz_checker::test_utils::check_source;
+use tsz_checker::test_utils::{check_source, check_source_strict};
 
 fn ts2416_count(source: &str) -> usize {
     check_source(source, "test.ts", CheckerOptions::default())
@@ -21,6 +21,72 @@ fn ts2416_count(source: &str) -> usize {
         .filter(|d| d.code == 2416)
         .count()
 }
+
+fn ts2416_count_strict(source: &str) -> usize {
+    check_source_strict(source)
+        .iter()
+        .filter(|d| d.code == 2416)
+        .count()
+}
+
+fn ts2416_count_nonstrict(source: &str) -> usize {
+    let options = CheckerOptions {
+        strict: false,
+        strict_function_types: false,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.ts", options)
+        .iter()
+        .filter(|d| d.code == 2416)
+        .count()
+}
+
+fn ts2322_count_nonstrict(source: &str) -> usize {
+    let options = CheckerOptions {
+        strict: false,
+        strict_function_types: false,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.ts", options)
+        .iter()
+        .filter(|d| d.code == 2322)
+        .count()
+}
+
+fn heritage_mismatch_count_strict(source: &str) -> usize {
+    check_source_strict(source)
+        .iter()
+        .filter(|d| matches!(d.code, 2416 | 2420))
+        .count()
+}
+
+const CONTRAVARIANT_NEVER_ANY_OVERLOAD: &str = r#"
+interface Failure { readonly failure: true; }
+interface Sink<T> { accept: (value: T) => void; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Sink<any> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Sink<any> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Sink<never> {
+    return { accept: (_value: never) => {} };
+  }
+}
+"#;
+
+const EXPLICIT_CONTRAVARIANT_NEVER_ANY_OVERLOAD: &str = r#"
+interface Failure { readonly failure: true; }
+interface Sink<in T> { accept: (value: T) => void; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Sink<any> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Sink<any> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Sink<never> {
+    return { accept: (_value: never) => {} };
+  }
+}
+"#;
 
 /// The reported repro shape: an overloaded generic interface method whose
 /// return type depends on the type parameter, implemented by a non-generic
@@ -217,4 +283,1633 @@ class Impl implements Base {
 }
 "#;
     assert_eq!(ts2416_count(source), 0);
+}
+
+/// Kysely's `$asTuple` shape: erasing each overload's method-local key
+/// parameters makes the return conditional unconditionally select the
+/// `ExpressionWrapper` branch. The non-generic implementation's `any` type
+/// argument then satisfies every selected wrapper instantiation.
+#[test]
+fn overloaded_tuple_conditional_return_erased_to_true_branch_no_ts2416() {
+    let source = r#"
+interface Failure<Message extends string> { readonly failure: Message; }
+declare class Chained<T> { readonly value?: T; }
+declare class Wrapper<T> {
+  readonly value?: T;
+  chain(): T extends boolean ? Chained<boolean> : Failure<'not boolean'>;
+  notNull(): Wrapper<Exclude<T, null>>;
+}
+interface Base<O> {
+  tuple<K1 extends keyof O, K2 extends Exclude<keyof O, K1>>(
+    key1: K1, key2: K2
+  ): keyof O extends K1 | K2
+    ? Wrapper<[O[K1], O[K2]]>
+    : Failure<'missing key'>;
+  tuple<
+    K1 extends keyof O,
+    K2 extends Exclude<keyof O, K1>,
+    K3 extends Exclude<keyof O, K1 | K2>
+  >(key1: K1, key2: K2, key3: K3): keyof O extends K1 | K2 | K3
+    ? Wrapper<[O[K1], O[K2], O[K3]]>
+    : Failure<'missing key'>;
+  tuple<
+    K1 extends keyof O,
+    K2 extends Exclude<keyof O, K1>,
+    K3 extends Exclude<keyof O, K1 | K2>,
+    K4 extends Exclude<keyof O, K1 | K2 | K3>
+  >(key1: K1, key2: K2, key3: K3, key4: K4): keyof O extends K1 | K2 | K3 | K4
+    ? Wrapper<[O[K1], O[K2], O[K3], O[K4]]>
+    : Failure<'missing key'>;
+  tuple<
+    K1 extends keyof O,
+    K2 extends Exclude<keyof O, K1>,
+    K3 extends Exclude<keyof O, K1 | K2>,
+    K4 extends Exclude<keyof O, K1 | K2 | K3>,
+    K5 extends Exclude<keyof O, K1 | K2 | K3 | K4>
+  >(
+    key1: K1, key2: K2, key3: K3, key4: K4, key5: K5
+  ): keyof O extends K1 | K2 | K3 | K4 | K5
+    ? Wrapper<[O[K1], O[K2], O[K3], O[K4], O[K5]]>
+    : Failure<'missing key'>;
+}
+class Impl<O> implements Base<O> {
+  tuple(): Wrapper<any> {
+    return undefined as any;
+  }
+}
+"#;
+    assert_eq!(
+        ts2416_count(source),
+        0,
+        "method-local erasure makes every tuple return conditional select the wrapper branch"
+    );
+}
+
+/// The check operand need not be spelled as `keyof`: any non-distributive
+/// outer-generic expression takes the true branch once the method-local
+/// extends operand erases to `any`.
+#[test]
+fn overloaded_indexed_conditional_return_erased_to_true_branch_no_ts2416() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface Wrapped<T> { readonly wrapped: T; }
+interface Base<O extends { value: unknown }> {
+  choose<K>(value: K): O['value'] extends K ? Wrapped<O> : Failure;
+  choose<K>(value: readonly K[]): O['value'] extends K ? Wrapped<O> : Failure;
+}
+class Impl<O extends { value: unknown }> implements Base<O> {
+  choose(): Wrapped<any> {
+    return undefined as any;
+  }
+}
+"#;
+    assert_eq!(
+        ts2416_count(source),
+        0,
+        "a non-distributive indexed check must select the true branch after local erasure"
+    );
+}
+
+/// Binder names and an alias around the conditional result must not affect the
+/// erased-overload rule.
+#[test]
+fn overloaded_tuple_conditional_return_renamed_alias_no_ts2416() {
+    let source = r#"
+interface Problem<Message extends string> { readonly problem: Message; }
+declare class Parcel<Value> { readonly value?: Value; }
+type TupleResult<Row, Left extends keyof Row, Right extends keyof Row> =
+  keyof Row extends Left | Right
+    ? Parcel<[Row[Left], Row[Right]]>
+    : Problem<'incomplete'>;
+interface Contract<Row> {
+  pack<Left extends keyof Row, Right extends Exclude<keyof Row, Left>>(
+    left: Left, right: Right
+  ): TupleResult<Row, Left, Right>;
+  pack<
+    First extends keyof Row,
+    Second extends Exclude<keyof Row, First>,
+    Third extends Exclude<keyof Row, First | Second>
+  >(first: First, second: Second, third: Third):
+    keyof Row extends First | Second | Third
+      ? Parcel<[Row[First], Row[Second], Row[Third]]>
+      : Problem<'incomplete'>;
+}
+class Provider<Row> implements Contract<Row> {
+  pack(): Parcel<any> {
+    return undefined as any;
+  }
+}
+"#;
+    assert_eq!(
+        ts2416_count(source),
+        0,
+        "renamed binders and an alias wrapper must preserve erased conditional-return parity"
+    );
+}
+
+/// Erasing a method-local check parameter to `any` keeps tsc's wildcard rule:
+/// both conditional branches remain reachable. An implementation returning the
+/// false branch is therefore valid and must not be forced through the true
+/// branch's application family.
+#[test]
+fn overloaded_wildcard_any_conditional_keeps_both_return_branches() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface Wrapped<T> { readonly wrapped: T; }
+interface Base {
+  choose<T>(value: T): T extends string ? Wrapped<T> : Failure;
+  choose<T>(value: readonly T[]): T extends number ? Wrapped<T> : Failure;
+}
+class Impl implements Base {
+  choose(_value: unknown): Failure {
+    return { failure: true };
+  }
+}
+"#;
+    assert_eq!(
+        ts2416_count(source),
+        0,
+        "an `any` check must retain both return branches after erasure"
+    );
+}
+
+/// A conditional that still depends on an outer type parameter after erasing
+/// method-local binders is not decidable. The implementation cannot assume its
+/// wrapper branch, so the genuine mismatch remains.
+#[test]
+fn overloaded_outer_deferred_conditional_still_ts2416() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface Wrapped<T> { readonly wrapped: T; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K):
+    O extends { ready: true } ? Wrapped<O[K]> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]):
+    O extends { ready: true } ? Wrapped<O[K]> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(): Wrapped<any> {
+    return undefined as any;
+  }
+}
+"#;
+    assert!(
+        ts2416_count(source) >= 1,
+        "an outer-generic conditional must remain deferred and reject the wrapper-only implementation"
+    );
+}
+
+/// A deferred outer-generic conditional remains semantically observable even
+/// when it is nested below the same application base as the implementation.
+/// The historical same-base fallback must not discard that argument.
+#[test]
+fn overloaded_nested_deferred_conditional_does_not_reach_same_base_fallback() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Outer<T> { readonly outer: T; }
+interface Failure { readonly failure: true; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K):
+    Outer<O extends { ready: true } ? Box<number> : Failure>;
+  choose<K extends keyof O>(keys: readonly K[]):
+    Outer<O extends { ready: true } ? Box<number> : Failure>;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Outer<Box<any>> { return undefined as any; }
+}
+"#;
+    assert!(ts2416_count_strict(source) >= 1);
+}
+
+/// A deferred child does not hide an independent determinate rejection in a
+/// sibling property. Normalization leaves the deferred child intact while
+/// selecting the method-local conditional in place.
+#[test]
+fn overloaded_mixed_determinate_and_deferred_return_keeps_known_mismatch() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Failure { readonly failure: true; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K): {
+    known: keyof O extends K ? Box<never> : Failure;
+    pending: O extends { ready: true } ? { yes: O } : { no: O };
+  };
+  choose<K extends keyof O>(keys: readonly K[]): {
+    known: keyof O extends K ? Box<never> : Failure;
+    pending: O extends { ready: true } ? { yes: O } : { no: O };
+  };
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): {
+    known: Box<any>;
+    pending: O extends { ready: true } ? { yes: O } : { no: O };
+  } { return undefined as any; }
+}
+"#;
+    assert!(ts2416_count_strict(source) >= 1);
+}
+
+/// An `infer` binder confined to the unreachable false branch does not make an
+/// erased conditional indeterminate. Branch selection inspects only the check,
+/// extends, and selected true-branch types.
+#[test]
+fn overloaded_erased_conditional_ignores_infer_in_unreachable_false_branch() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K):
+    keyof O extends K ? Box<any> : (K extends infer U ? { bad: U } : never);
+  choose<K extends keyof O>(keys: readonly K[]):
+    keyof O extends K ? Box<any> : (K extends infer U ? { bad: U } : never);
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Box<any> { return undefined as any; }
+}
+"#;
+    assert_eq!(ts2416_count_strict(source), 0);
+}
+
+/// Resolving the conditional branch must not erase the identity of the outer
+/// return family.
+#[test]
+fn overloaded_conditional_unrelated_return_wrapper_still_ts2416() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface TargetWrap<T> { readonly target: T; }
+interface SourceWrap<T> { readonly source: T; }
+interface Base<O> {
+  tuple<K1 extends keyof O, K2 extends Exclude<keyof O, K1>>(
+    key1: K1, key2: K2
+  ): keyof O extends K1 | K2 ? TargetWrap<[O[K1], O[K2]]> : Failure;
+  tuple<
+    K1 extends keyof O,
+    K2 extends Exclude<keyof O, K1>,
+    K3 extends Exclude<keyof O, K1 | K2>
+  >(key1: K1, key2: K2, key3: K3):
+    keyof O extends K1 | K2 | K3
+      ? TargetWrap<[O[K1], O[K2], O[K3]]>
+      : Failure;
+}
+class Impl<O> implements Base<O> {
+  tuple(): SourceWrap<any> {
+    return undefined as any;
+  }
+}
+"#;
+    assert!(
+        ts2416_count(source) >= 1,
+        "an unrelated top-level wrapper family must remain incompatible"
+    );
+}
+
+/// Selecting a determinate conditional branch must retain its application
+/// arguments. Matching outer wrapper identities do not make incompatible
+/// payloads interchangeable.
+#[test]
+fn overloaded_conditional_same_wrapper_incompatible_payload_still_ts2416() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface Box<T> { readonly value: T; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Box<number> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Box<number> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Box<string> {
+    return { value: 'wrong' };
+  }
+}
+"#;
+    assert!(
+        ts2416_count(source) >= 1,
+        "the selected return branch must compare Box<string> against Box<number>"
+    );
+}
+
+/// An erased `any` slot must not hide an independent concrete mismatch in a
+/// different application argument.
+#[test]
+fn overloaded_conditional_any_slot_keeps_other_payload_mismatch_ts2416() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface Pair<Left, Right> { readonly left: Left; readonly right: Right; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K):
+    keyof O extends K ? Pair<number, boolean> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]):
+    keyof O extends K ? Pair<number, boolean> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Pair<any, string> {
+    return { left: undefined as any, right: 'wrong' };
+  }
+}
+"#;
+    assert!(
+        ts2416_count(source) >= 1,
+        "the wildcard first slot must not silence the string/boolean mismatch"
+    );
+}
+
+/// `any` is not assignable to `never`; overload erasure must preserve that
+/// bottom-type exception even when the enclosing generic identity matches.
+#[test]
+fn overloaded_conditional_any_payload_does_not_satisfy_never_ts2416() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface Box<T> { readonly value: T; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Box<never> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Box<never> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Box<any> {
+    return { value: undefined as any };
+  }
+}
+"#;
+    assert!(
+        ts2416_count_strict(source) >= 1,
+        "the erased wildcard must not make any assignable to never"
+    );
+}
+
+/// Inherited public members use the general heritage relation boundary rather
+/// than the direct-member boundary. Preserve the raw overload return identity
+/// there as well, before whole-member preparation expands `Box<any>`.
+#[test]
+fn inherited_overloaded_conditional_any_never_reports_heritage_mismatch() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface Box<T> { readonly value: T; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Box<never> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Box<never> : Failure;
+}
+class Parent<O> {
+  choose(_value: unknown): Box<any> {
+    return { value: undefined as any };
+  }
+}
+class Impl<O> extends Parent<O> implements Base<O> {}
+"#;
+    assert!(
+        heritage_mismatch_count_strict(source) >= 1,
+        "an inherited implementation must retain the overload return mismatch"
+    );
+}
+
+/// The `any`/`never` exception is directional. In a contravariant application
+/// slot, relating `Sink<any>` to `Sink<never>` checks `never` against `any` and
+/// remains valid under strict function types.
+#[test]
+fn overloaded_conditional_contravariant_any_never_no_ts2416() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface Sink<T> { accept: (value: T) => void; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Sink<never> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Sink<never> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Sink<any> {
+    return { accept: (_value: any) => {} };
+  }
+}
+"#;
+    assert_eq!(
+        ts2416_count_strict(source),
+        0,
+        "the contravariant slot must compare never to any in reverse"
+    );
+}
+
+/// Reversing the intrinsic arguments also reverses the contravariant relation:
+/// this would require `any` to be assignable to `never`, which tsc rejects.
+#[test]
+fn overloaded_conditional_contravariant_never_any_still_ts2416() {
+    assert!(
+        ts2416_count_strict(CONTRAVARIANT_NEVER_ANY_OVERLOAD) >= 1,
+        "contravariance reverses the pair and must reject any to never"
+    );
+}
+
+/// Without strict function types, function-property parameters are bivariant.
+/// The same `Sink<never>`/`Sink<any>` pair that fails above is therefore valid.
+#[test]
+fn overloaded_conditional_contravariant_never_any_nonstrict_no_ts2416() {
+    assert_eq!(
+        ts2416_count_nonstrict(CONTRAVARIANT_NEVER_ANY_OVERLOAD),
+        0,
+        "non-strict callback bivariance must remain authoritative"
+    );
+}
+
+/// Explicit variance annotations remain authoritative even when callback
+/// parameters would otherwise be bivariant.
+#[test]
+fn explicit_contravariant_never_any_nonstrict_still_ts2416() {
+    assert!(
+        ts2416_count_nonstrict(EXPLICIT_CONTRAVARIANT_NEVER_ANY_OVERLOAD) >= 1,
+        "an explicit `in` annotation must reject the reverse pair"
+    );
+}
+
+/// A declared variance mask can be partial. Unannotated slots still use their
+/// structurally inferred variance instead of becoming independent.
+#[test]
+fn partial_declared_variance_keeps_unannotated_any_never_rejection() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface Pair<out Left, Right> {
+  readonly left: Left;
+  readonly right: Right;
+}
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Pair<string, never> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Pair<string, never> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Pair<string, any> {
+    return { left: 'ok', right: undefined as any };
+  }
+}
+"#;
+    assert!(
+        ts2416_count_strict(source) >= 1,
+        "the unannotated covariant slot must still reject any to never"
+    );
+}
+
+/// The same partially annotated mask applies outside overload checking. A
+/// mixed argument list must inspect the exceptional slot rather than treating
+/// an unrelated identical slot as permission for `any` to satisfy `never`.
+#[test]
+fn partial_declared_variance_direct_mixed_any_never_rejection() {
+    let source = r#"
+interface Pair<out Left, Right> {
+  readonly left: Left;
+  readonly right: Right;
+}
+declare const pair: Pair<string, any>;
+const target: Pair<string, never> = pair;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 1);
+}
+
+/// Computing the structural variance of an unannotated root slot must still
+/// honor explicit annotations on nested generics. Here the second `Pair` slot
+/// inherits `Cell`'s explicit invariance even with callback bivariance enabled.
+#[test]
+fn partial_declared_variance_honors_nested_explicit_variance() {
+    let source = r#"
+interface Cell<in out T> { readonly value: T; }
+interface Pair<out Left, Right> {
+  readonly left: Left;
+  readonly inner: Cell<Right>;
+}
+declare const pair: Pair<string, never>;
+const target: Pair<string, any> = pair;
+"#;
+    assert_eq!(ts2322_count_nonstrict(source), 1);
+}
+
+/// A failed exceptional classifier is undecided rather than incompatible.
+/// Nonstrict function-property bivariance therefore remains owned by the
+/// structural relation.
+#[test]
+fn direct_generic_any_never_keeps_nonstrict_callback_bivariance() {
+    let source = r#"
+interface Sink<T> { accept: (value: T) => void; }
+declare const sink: Sink<never>;
+const target: Sink<any> = sink;
+"#;
+    assert_eq!(ts2322_count_nonstrict(source), 0);
+}
+
+/// Conversely, a non-callback structural operator can reject the same raw
+/// argument pair in nonstrict mode. The all-`any` shortcut must not accept an
+/// undecided variance classification before `keyof` is expanded.
+#[test]
+fn direct_generic_any_never_nonstrict_keyof_uses_structural_relation() {
+    let source = r#"
+interface Keys<T> { readonly key: keyof T; }
+declare const keys: Keys<never>;
+const target: Keys<any> = keys;
+"#;
+    assert_eq!(ts2322_count_nonstrict(source), 1);
+}
+
+/// A transparent source alias must inherit the body generic's variance instead
+/// of letting its `any` argument bypass the `never` exception.
+#[test]
+fn pass_through_source_alias_any_does_not_satisfy_body_never() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface Box<T> { readonly value: T; }
+type Alias<T> = Box<T>;
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Box<never> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Box<never> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Alias<any> { return undefined as any; }
+}
+"#;
+    assert!(
+        ts2416_count_strict(source) >= 1,
+        "the alias/body shortcut must preserve covariant any-to-never rejection"
+    );
+}
+
+/// The opposite alias orientation retains contravariant argument direction.
+#[test]
+fn pass_through_target_alias_any_keeps_contravariant_never_rejection() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface Sink<T> { accept: (value: T) => void; }
+type Alias<T> = Sink<T>;
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Alias<any> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Alias<any> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Sink<never> { return undefined as any; }
+}
+"#;
+    assert!(
+        ts2416_count_strict(source) >= 1,
+        "the body/alias shortcut must preserve contravariant any-to-never rejection"
+    );
+}
+
+/// Exact pass-through alias chains inherit the ultimate interface variance;
+/// each wrapper level must preserve the covariant `any`/`never` rejection.
+#[test]
+fn pass_through_alias_chain_any_never_keeps_body_rejection() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Outer<T> { readonly value: T; }
+type Middle<T> = Box<T>;
+type Alias<T> = Middle<T>;
+declare const direct: Alias<any>;
+declare const nested: Outer<Alias<any>>;
+const badDirect: Middle<never> = direct;
+const badNested: Outer<Middle<never>> = nested;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 2);
+}
+
+/// Turning off strict function types makes callback-derived contravariance
+/// bivariant even when one side retains a transparent pass-through alias.
+#[test]
+fn target_alias_nonstrict_keeps_callback_bivariance() {
+    let callback = r#"
+interface Failure { readonly failure: true; }
+interface Sink<T> { accept: (value: T) => void; }
+type Alias<T> = Sink<T>;
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Alias<any> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Alias<any> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Sink<never> { return undefined as any; }
+}
+"#;
+    assert_eq!(ts2416_count_nonstrict(callback), 0);
+}
+
+/// Matching base/arity is not enough to prove pass-through: this alias ignores
+/// its parameter, so `Alias<any>` is exactly `Box<never>` and remains valid.
+#[test]
+fn constant_body_alias_any_still_satisfies_body_never() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface Box<T> { readonly value: T; }
+type Alias<T> = Box<never>;
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Box<never> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Box<never> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Alias<any> { return undefined as any; }
+}
+"#;
+    assert_eq!(
+        ts2416_count_strict(source),
+        0,
+        "a constant-body alias must not be classified as pass-through"
+    );
+}
+
+/// An indexed-access alias is a transparent transform, so its expanded result
+/// remains authoritative even when the raw application arguments are
+/// `any`/`never`. Here both target and implementation normalize compatibly.
+#[test]
+fn indexed_access_alias_any_never_uses_structural_result() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+type Field<T> = ({ value: T } | { value: string })['value'];
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Field<never> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Field<never> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Field<any> { return undefined as any; }
+}
+"#;
+    assert_eq!(
+        ts2416_count_strict(source),
+        0,
+        "indexed-access aliases must be decided by their expanded result"
+    );
+}
+
+/// Ordinary type aliases are transparent too. Under a nominal outer wrapper,
+/// expanding the union makes the nested source `any` and target `string`, so
+/// raw alias arguments cannot force a rejection before normalization.
+#[test]
+fn nested_transparent_union_alias_any_never_uses_normalized_result() {
+    let source = r#"
+type Alias<T> = T | string;
+interface Outer<T> { readonly value: T; }
+declare const nested: Outer<Alias<any>>;
+const nestedTarget: Outer<Alias<never>> = nested;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 0);
+}
+
+/// Alias applications use variance only for the body kinds on which
+/// TypeScript supports variance measurement. Object and mapped bodies retain
+/// the raw argument mismatch; union, tuple, and conditional transforms expand
+/// to their normalized results.
+#[test]
+fn alias_any_never_respects_variance_supported_body_kinds() {
+    let source = r#"
+type ObjectAlias<T> = { readonly value: T | string };
+type MappedAlias<T> = { [K in 'value']: T | string };
+type UnionAlias<T> = T | string;
+type TupleAlias<T> = [T | string];
+type ConditionalAlias<T> = [T] extends [unknown] ? string : string;
+interface Holder<T> { readonly value: T; }
+
+declare const objectAny: Holder<ObjectAlias<any>>;
+declare const mappedAny: Holder<MappedAlias<any>>;
+declare const unionAny: Holder<UnionAlias<any>>;
+declare const tupleAny: Holder<TupleAlias<any>>;
+declare const conditionalAny: Holder<ConditionalAlias<any>>;
+
+const badObject: Holder<ObjectAlias<never>> = objectAny;
+const badMapped: Holder<MappedAlias<never>> = mappedAny;
+const goodUnion: Holder<UnionAlias<never>> = unionAny;
+const goodTuple: Holder<TupleAlias<never>> = tupleAny;
+const goodConditional: Holder<ConditionalAlias<never>> = conditionalAny;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 2);
+}
+
+/// A supported alias body's explicit variance annotation is authoritative in
+/// the reverse direction too, even though the expanded object alone would
+/// accept `never` as a source for an `any` property.
+#[test]
+fn explicit_invariant_object_alias_rejects_never_to_any() {
+    let source = r#"
+type Alias<in out T> = { readonly value: T };
+declare const alias: Alias<never>;
+const target: Alias<any> = alias;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 1);
+}
+
+/// Instantiation comparison honors a supported alias body's declared
+/// contravariance even when validation separately reports that the annotation
+/// disagrees with the body. The declaration error must not be compounded by a
+/// spurious assignment error.
+#[test]
+fn explicit_contravariant_object_alias_accepts_declared_direction() {
+    let source = r#"
+type Alias<in T> = { readonly value: T };
+declare const alias: Alias<any>;
+const target: Alias<never> = alias;
+"#;
+    let diagnostics = check_source_strict(source);
+    assert!(diagnostics.iter().any(|diagnostic| diagnostic.code == 2636));
+    assert_eq!(
+        diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == 2322)
+            .count(),
+        0
+    );
+}
+
+/// The erased-overload classifier also defers same-base transparent aliases to
+/// their expanded result. A normalizing union stays valid, while an exact
+/// pass-through to a covariant interface retains the genuine mismatch.
+#[test]
+fn overloaded_same_alias_any_never_follows_expanded_body() {
+    let union_alias = r#"
+interface Failure { readonly failure: true; }
+type Alias<T> = T | string;
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Alias<never> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Alias<never> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Alias<any> { return undefined as any; }
+}
+"#;
+    assert_eq!(ts2416_count_strict(union_alias), 0);
+
+    let pass_through = r#"
+interface Failure { readonly failure: true; }
+interface Box<T> { readonly value: T; }
+type Alias<T> = Box<T>;
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Alias<never> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Alias<never> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Alias<any> { return undefined as any; }
+}
+"#;
+    assert!(
+        ts2416_count_strict(pass_through) > 0,
+        "a pass-through alias must retain the expanded interface mismatch"
+    );
+}
+
+fn nested_overload_source(
+    declarations: &str,
+    target_return: &str,
+    implementation_return: &str,
+) -> String {
+    format!(
+        r#"
+{declarations}
+interface Failure {{ readonly failure: true; }}
+interface Outer<T> {{ readonly outer: T; }}
+interface Base<O> {{
+  choose<K extends keyof O>(key: K): keyof O extends K ? {target_return} : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? {target_return} : Failure;
+}}
+class Impl<O> implements Base<O> {{
+  choose(_value: unknown): {implementation_return} {{ return undefined as any; }}
+}}
+"#
+    )
+}
+
+/// Reliable variance composes through nested applications. Covariance keeps
+/// argument direction while contravariance reverses it at the inner wrapper.
+#[test]
+fn nested_any_never_variance_composes_in_strict_mode() {
+    let declarations = r#"
+interface Box<T> { readonly value: T; }
+interface Sink<T> { accept: (value: T) => void; }
+"#;
+    let cases = [
+        ("Outer<Box<never>>", "Outer<Box<any>>", true),
+        ("Outer<Box<any>>", "Outer<Box<never>>", false),
+        ("Outer<Sink<any>>", "Outer<Sink<never>>", true),
+        ("Outer<Sink<never>>", "Outer<Sink<any>>", false),
+    ];
+    for (target, implementation, rejects) in cases {
+        let source = nested_overload_source(declarations, target, implementation);
+        assert_eq!(
+            ts2416_count_strict(&source) > 0,
+            rejects,
+            "unexpected nested variance result for {implementation} -> {target}"
+        );
+    }
+}
+
+/// Explicit invariance remains bidirectional through a covariant outer
+/// wrapper, while an unused type parameter is independent in both directions.
+#[test]
+fn nested_explicit_invariant_and_independent_positions() {
+    let invariant = "interface Cell<in out T> { get(): T; set: (value: T) => void; }";
+    for (target, implementation) in [
+        ("Outer<Cell<never>>", "Outer<Cell<any>>"),
+        ("Outer<Cell<any>>", "Outer<Cell<never>>"),
+    ] {
+        let source = nested_overload_source(invariant, target, implementation);
+        assert!(
+            ts2416_count_nonstrict(&source) > 0,
+            "explicit invariance must reject {implementation} -> {target}"
+        );
+    }
+
+    let independent = "interface Phantom<T> { readonly tag: string; }";
+    for (target, implementation) in [
+        ("Outer<Phantom<never>>", "Outer<Phantom<any>>"),
+        ("Outer<Phantom<any>>", "Outer<Phantom<never>>"),
+    ] {
+        let source = nested_overload_source(independent, target, implementation);
+        assert_eq!(
+            ts2416_count_strict(&source),
+            0,
+            "independent arguments must accept {implementation} -> {target}"
+        );
+    }
+}
+
+/// In non-strict mode inferred parameter variance retains callback bivariance;
+/// an explicit `in` annotation remains authoritative. Inferred invariance keeps
+/// only its covariant rejection direction.
+#[test]
+fn nested_any_never_variance_respects_nonstrict_bivariance() {
+    let inferred_sink = "interface Sink<T> { accept: (value: T) => void; }";
+    let source = nested_overload_source(inferred_sink, "Outer<Sink<any>>", "Outer<Sink<never>>");
+    assert_eq!(ts2416_count_nonstrict(&source), 0);
+
+    let explicit_sink = "interface Sink<in T> { accept: (value: T) => void; }";
+    let source = nested_overload_source(explicit_sink, "Outer<Sink<any>>", "Outer<Sink<never>>");
+    assert!(ts2416_count_nonstrict(&source) > 0);
+
+    let inferred_cell = "interface Cell<T> { get(): T; set: (value: T) => void; }";
+    let reverse = nested_overload_source(inferred_cell, "Outer<Cell<any>>", "Outer<Cell<never>>");
+    assert_eq!(ts2416_count_nonstrict(&reverse), 0);
+    let forward = nested_overload_source(inferred_cell, "Outer<Cell<never>>", "Outer<Cell<any>>");
+    assert!(ts2416_count_nonstrict(&forward) > 0);
+}
+
+/// The general application fast path follows the same directional rule outside
+/// heritage and overload checking.
+#[test]
+fn direct_generic_any_never_assignments_follow_strict_variance() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Sink<T> { accept: (value: T) => void; }
+declare const boxAny: Box<any>;
+declare const sinkAny: Sink<any>;
+declare const sinkNever: Sink<never>;
+const badBox: Box<never> = boxAny;
+const badSink: Sink<any> = sinkNever;
+const goodSink: Sink<never> = sinkAny;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|d| d.code == 2322)
+        .count();
+    assert_eq!(errors, 2, "covariance and contravariance are directional");
+}
+
+/// Four overloads exercise accumulation beyond the first combined pair. The
+/// implementation is too narrow only for the first overload; dropping that
+/// signature would hide tsc's genuine TS2416.
+#[test]
+fn four_overloads_preserve_first_incompatible_signature() {
+    let source = r#"
+interface Animal { name: string; }
+interface Dog extends Animal { bark(): void; }
+interface Base {
+  handle(value: Animal): void;
+  handle(value: string): void;
+  handle(value: number): void;
+  handle(value: boolean): void;
+}
+class Impl implements Base {
+  handle(_value: Dog | string | number | boolean): void {}
+}
+"#;
+    assert!(
+        ts2416_count(source) >= 1,
+        "the first overload must survive accumulation and retain its contravariant mismatch"
+    );
+}
+
+/// Invalid mixed method/property declarations still retain the complete method
+/// overload family for recovery. Duplicate-declaration diagnostics do not make
+/// it safe to discard the first method and hide its implementation mismatch.
+#[test]
+fn intervening_property_does_not_discard_first_method_overload() {
+    let source = r#"
+interface Animal { name: string; }
+interface Base {
+  handle(value: Animal): void;
+  handle: (value: string) => void;
+  handle(value: number): void;
+  handle(value: boolean): void;
+}
+class Impl implements Base {
+  handle(_value: number | boolean): void {}
+}
+"#;
+    assert!(
+        ts2416_count(source) >= 1,
+        "invalid mixed-declaration recovery must retain the first method overload"
+    );
+}
+
+/// Once a property terminates an invalid mixed declaration family, later
+/// methods do not become a replacement overload set. An implementation that
+/// satisfies the initial method therefore remains compatible.
+#[test]
+fn intervening_property_freezes_initial_method_family() {
+    let source = r#"
+interface Animal { name: string; }
+interface Base {
+  handle(value: Animal): void;
+  handle: (value: string) => void;
+  handle(value: number): void;
+  handle(value: boolean): void;
+}
+class Impl implements Base {
+  handle(_value: Animal): void {}
+}
+"#;
+    assert_eq!(ts2416_count(source), 0);
+}
+
+/// When the first declaration is a property, that property remains the
+/// implementation target and later same-name methods are ignored for recovery.
+#[test]
+fn property_first_mixed_declaration_remains_authoritative() {
+    let source = r#"
+interface Animal { name: string; }
+interface Base {
+  handle: (value: Animal) => void;
+  handle(value: number): void;
+  handle(value: boolean): void;
+}
+class Impl implements Base {
+  handle(_value: number | boolean): void {}
+}
+"#;
+    assert!(ts2416_count(source) >= 1);
+}
+
+/// A determinate erased conditional remains a semantic part of the return when
+/// nested below a generic application. Matching only the outer `Outer` base
+/// must not erase the selected branch's incompatible payload.
+#[test]
+fn overloaded_erased_conditional_nested_in_application_keeps_payload_mismatch() {
+    let source = r#"
+interface Outer<T> { readonly outer: T; }
+interface Box<T> { readonly value: T; }
+interface Failure { readonly failure: true; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K):
+    Outer<keyof O extends K ? Box<number> : Failure>;
+  choose<K extends keyof O>(keys: readonly K[]):
+    Outer<keyof O extends K ? Box<number> : Failure>;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Outer<Box<string>> { return undefined as any; }
+}
+"#;
+    assert!(
+        ts2416_count_strict(source) >= 1,
+        "normalizing the nested conditional must retain Box<string>/Box<number> incompatibility"
+    );
+}
+
+/// Intersection is another value-projection wrapper. The unreachable false
+/// branch must not make a compatible selected branch fail merely because the
+/// conditional is not the top-level return node.
+#[test]
+fn overloaded_erased_conditional_nested_in_intersection_selects_true_branch() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Marker { readonly marker: true; }
+interface Failure { readonly failure: true; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K):
+    (keyof O extends K ? Box<any> : Failure) & Marker;
+  choose<K extends keyof O>(keys: readonly K[]):
+    (keyof O extends K ? Box<any> : Failure) & Marker;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Box<any> & Marker { return undefined as any; }
+}
+"#;
+    assert_eq!(ts2416_count_strict(source), 0);
+}
+
+/// The tuple-union parameter shortcut proves only overload parameter coverage.
+/// It must not make a derived overload family compatible when every matching
+/// signature has an erased conditional return rejected by `any`/`never`
+/// variance.
+#[test]
+fn tuple_union_overload_coverage_does_not_bypass_conditional_return_mismatch() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Failure { readonly failure: true; }
+interface Base<O> {
+  choose<K extends keyof O>(...args: [K] | [readonly K[]]):
+    keyof O extends K ? Box<never> : Failure;
+  choose<K extends keyof O>(...args: [K, K] | [readonly K[], readonly K[]]):
+    keyof O extends K ? Box<never> : Failure;
+}
+
+interface Derived<O> extends Base<O> {
+  choose<K extends keyof O>(value: K): Box<any>;
+  choose<K extends keyof O>(value: readonly K[]): Box<any>;
+  choose<K extends keyof O>(left: K, right: K): Box<any>;
+  choose<K extends keyof O>(left: readonly K[], right: readonly K[]): Box<any>;
+}
+"#;
+    let mismatches = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2430)
+        .count();
+    assert!(
+        mismatches >= 1,
+        "parameter-only tuple coverage must not suppress the return mismatch"
+    );
+}
+
+/// Tuple-union coverage is never a return-type shortcut, even when the target
+/// return is a plain generic application with no conditional to normalize.
+#[test]
+fn tuple_union_overload_coverage_does_not_bypass_plain_return_mismatch() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Base {
+  choose(...args: [string] | [number]): Box<number>;
+}
+interface Derived extends Base {
+  choose(value: string): Box<string>;
+  choose(value: number): Box<string>;
+}
+"#;
+    let diagnostics = check_source_strict(source);
+    let mismatches = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2430)
+        .count();
+    assert_eq!(mismatches, 1, "{diagnostics:?}");
+}
+
+/// A tuple is part of the returned value shape, not an opaque boundary. Once
+/// erasure selects the true branch, the tuple element is the same `Box<any>`
+/// supplied by the implementation.
+#[test]
+fn overloaded_erased_conditional_nested_in_tuple_selects_true_branch() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Failure { readonly failure: true; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K):
+    [keyof O extends K ? Box<any> : Failure];
+  choose<K extends keyof O>(keys: readonly K[]):
+    [keyof O extends K ? Box<any> : Failure];
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): [Box<any>] { return undefined as any; }
+}
+"#;
+    assert_eq!(ts2416_count_strict(source), 0);
+}
+
+/// Object properties are covariant return projections. An erased conditional
+/// nested in a property is selected before the ordinary object relation runs.
+#[test]
+fn overloaded_erased_conditional_nested_in_object_property_selects_true_branch() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Failure { readonly failure: true; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K):
+    { value: keyof O extends K ? Box<any> : Failure };
+  choose<K extends keyof O>(keys: readonly K[]):
+    { value: keyof O extends K ? Box<any> : Failure };
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): { value: Box<any> } { return undefined as any; }
+}
+"#;
+    assert_eq!(ts2416_count_strict(source), 0);
+}
+
+/// The returned function's result is still part of the outer method's return
+/// value. Normalization descends through that function shape before relating it.
+#[test]
+fn overloaded_erased_conditional_nested_in_function_return_selects_true_branch() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Failure { readonly failure: true; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K):
+    () => (keyof O extends K ? Box<any> : Failure);
+  choose<K extends keyof O>(keys: readonly K[]):
+    () => (keyof O extends K ? Box<any> : Failure);
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): () => Box<any> { return undefined as any; }
+}
+"#;
+    assert_eq!(ts2416_count_strict(source), 0);
+}
+
+/// Tuple-union rest coverage is a parameter-only proof. It cannot suppress a
+/// conditional return mismatch merely because that mismatch is nested in an
+/// object property rather than exposed as the top-level application.
+#[test]
+fn tuple_union_overload_coverage_checks_nested_conditional_return() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Failure { readonly failure: true; }
+interface Base<O> {
+  choose<K extends keyof O>(...args: [K] | [readonly K[]]):
+    { value: keyof O extends K ? Box<never> : Failure };
+  choose<K extends keyof O>(...args: [K, K] | [readonly K[], readonly K[]]):
+    { value: keyof O extends K ? Box<never> : Failure };
+}
+interface Derived<O> extends Base<O> {
+  choose<K extends keyof O>(value: K): { value: Box<any> };
+  choose<K extends keyof O>(value: readonly K[]): { value: Box<any> };
+  choose<K extends keyof O>(left: K, right: K): { value: Box<any> };
+  choose<K extends keyof O>(left: readonly K[], right: readonly K[]): { value: Box<any> };
+}
+"#;
+    let mismatches = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2430)
+        .count();
+    assert!(
+        mismatches >= 1,
+        "tuple coverage must preserve nested conditional return incompatibility"
+    );
+}
+
+/// Per-slot masking must not turn an accepted explicitly contravariant slot or
+/// an unused slot into a whole-application rejection. The deliberately invalid
+/// declaration still reports TS2636, but tsc does not add TS2322: its declared
+/// `in` direction remains authoritative for assignment, and `B` is independent.
+#[test]
+fn partial_declared_variance_masks_accepted_and_independent_slots() {
+    let source = r#"
+interface Mix<in A, B> { readonly value: A; }
+declare const mixed: Mix<any, any>;
+const target: Mix<never, never> = mixed;
+"#;
+    let diagnostics = check_source_strict(source);
+    assert!(diagnostics.iter().any(|diagnostic| diagnostic.code == 2636));
+    assert_eq!(
+        diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == 2322)
+            .count(),
+        0
+    );
+}
+
+/// Partial masks compose through more than one generic declaration. Both
+/// unannotated second slots are structurally covariant and therefore preserve
+/// the nested `any`-to-`never` rejection.
+#[test]
+fn nested_partial_declared_variance_fills_structural_holes_directly() {
+    let source = r#"
+interface Inner<out A, B> { readonly left: A; readonly right: B; }
+interface Outer<out X, Y> { readonly inner: Inner<X, Y>; }
+declare const outer: Outer<string, any>;
+const target: Outer<string, never> = outer;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 1);
+}
+
+/// The same nested partial-mask rule is visible after method-local erasure in
+/// an overload return; it is not only an ordinary assignment fast-path rule.
+#[test]
+fn nested_partial_declared_variance_fills_structural_holes_in_overload() {
+    let source = r#"
+interface Failure { readonly failure: true; }
+interface Inner<out A, B> { readonly left: A; readonly right: B; }
+interface Shell<out X, Y> { readonly inner: Inner<X, Y>; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K):
+    keyof O extends K ? Shell<string, never> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]):
+    keyof O extends K ? Shell<string, never> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Shell<string, any> { return undefined as any; }
+}
+"#;
+    assert!(ts2416_count_strict(source) >= 1);
+}
+
+/// Mapped modifiers make a variance-only result insufficient. Structural
+/// fallback must still expose the required `x` property and preserve direction:
+/// `any` cannot flow to `never`, while the reverse assignment remains valid.
+#[test]
+fn mapped_modifier_any_never_uses_structural_fallback() {
+    let source = r#"
+type RequiredValue<T> = { [K in 'x']-?: T };
+declare const anyValue: RequiredValue<any>;
+const rejected: RequiredValue<never> = anyValue;
+declare const neverValue: RequiredValue<never>;
+const accepted: RequiredValue<any> = neverValue;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 1);
+}
+
+/// In non-strict mode each callback-property parameter is bivariant. Two
+/// nested callback layers therefore accept both directions, for direct
+/// assignments and for erased overloaded-method returns.
+#[test]
+fn double_sink_is_bivariant_nonstrict_direct_and_overload() {
+    let direct = r#"
+interface Sink<T> { accept: (value: T) => void; }
+interface Envelope<T> { readonly inner: Sink<Sink<T>>; }
+declare const anyEnvelope: Envelope<any>;
+const neverEnvelope: Envelope<never> = anyEnvelope;
+declare const sourceNever: Envelope<never>;
+const targetAny: Envelope<any> = sourceNever;
+"#;
+    assert_eq!(ts2322_count_nonstrict(direct), 0);
+
+    let declarations = "interface Sink<T> { accept: (value: T) => void; }";
+    for (target, implementation) in [
+        ("Outer<Sink<Sink<any>>>", "Outer<Sink<Sink<never>>>"),
+        ("Outer<Sink<Sink<never>>>", "Outer<Sink<Sink<any>>>"),
+    ] {
+        let source = nested_overload_source(declarations, target, implementation);
+        assert_eq!(
+            ts2416_count_nonstrict(&source),
+            0,
+            "nested callbacks must remain bivariant for {implementation} -> {target}"
+        );
+    }
+}
+
+/// An explicit variance annotation nested inside a callback does not override
+/// the enclosing callback's non-strict bivariance. The direct covariant path is
+/// retained as a negative control, and the overload path follows the callback.
+#[test]
+fn nested_explicit_variance_respects_enclosing_nonstrict_callback() {
+    let direct = r#"
+interface Covariant<out T> { readonly value: T; }
+interface CallbackOuter<T> { callback: (value: Covariant<T>) => void; }
+interface DirectOuter<T> { readonly nested: Covariant<T>; }
+declare const callbackNever: CallbackOuter<never>;
+const callbackAny: CallbackOuter<any> = callbackNever;
+declare const directAny: DirectOuter<any>;
+const directNever: DirectOuter<never> = directAny;
+"#;
+    assert_eq!(
+        ts2322_count_nonstrict(direct),
+        1,
+        "only the direct covariant path should reject"
+    );
+
+    let declarations = r#"
+interface Covariant<out T> { readonly value: T; }
+interface CallbackOuter<T> { callback: (value: Covariant<T>) => void; }
+"#;
+    let source = nested_overload_source(
+        declarations,
+        "Outer<CallbackOuter<any>>",
+        "Outer<CallbackOuter<never>>",
+    );
+    assert_eq!(ts2416_count_nonstrict(&source), 0);
+}
+
+/// Alias traversal is cycle-safe rather than depth-limited. A transparent
+/// chain beyond the former 32-level guard must still reach the covariant body.
+#[test]
+fn pass_through_alias_chain_beyond_32_levels_keeps_rejection() {
+    let mut source = String::from(
+        "interface Box<T> { readonly value: T; }\n\
+         type Alias0<T> = Box<T>;\n",
+    );
+    for depth in 1..=40 {
+        source.push_str(&format!("type Alias{depth}<T> = Alias{}<T>;\n", depth - 1));
+    }
+    source.push_str(
+        "declare const value: Alias40<any>;\n\
+         const target: Alias40<never> = value;\n",
+    );
+    let errors = check_source_strict(&source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 1);
+}
+
+/// The recursive any/never prefilter likewise has no fixed nesting limit.
+/// Forty covariant applications around the rejected payload remain observable
+/// through the erased-overload return path.
+#[test]
+fn deep_application_chain_beyond_32_levels_keeps_overload_rejection() {
+    let mut target = String::from("Box<never>");
+    let mut implementation = String::from("Box<any>");
+    for _ in 0..40 {
+        target = format!("Outer<{target}>");
+        implementation = format!("Outer<{implementation}>");
+    }
+    let source = nested_overload_source(
+        "interface Box<T> { readonly value: T; }",
+        &target,
+        &implementation,
+    );
+    assert!(ts2416_count_strict(&source) >= 1);
+}
+
+/// Bivariance permits either subtype direction; it does not make a parameter
+/// independent for unrelated concrete types. Effective any/never masks must
+/// therefore stay scoped to that exceptional relation path.
+#[test]
+fn effective_any_never_bivariance_does_not_accept_unrelated_arguments() {
+    let method = r#"
+interface Method<T> { consume(value: T): void; }
+declare const strings: Method<string>;
+const numbers: Method<number> = strings;
+"#;
+    let strict_errors = check_source_strict(method)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(strict_errors, 1);
+
+    let callback = r#"
+interface Callback<T> { consume: (value: T) => void; }
+declare const strings: Callback<string>;
+const numbers: Callback<number> = strings;
+"#;
+    assert_eq!(ts2322_count_nonstrict(callback), 1);
+}
+
+/// Callback bivariance can choose either parameter direction, but neither
+/// direction is valid when the nested generic explicitly requires invariance.
+#[test]
+fn nonstrict_callback_preserves_nested_explicit_invariance() {
+    let source = r#"
+interface Cell<in out T> { get(): T; set(value: T): void; }
+interface Outer<T> { callback: (value: Cell<T>) => void; }
+declare const anyOuter: Outer<any>;
+const neverTarget: Outer<never> = anyOuter;
+declare const neverOuter: Outer<never>;
+const anyTarget: Outer<any> = neverOuter;
+"#;
+    assert_eq!(ts2322_count_nonstrict(source), 2);
+
+    let aliased_method = r#"
+interface Cell<in out T> { get(): T; set(value: T): void; }
+type Vessel<Item> = Cell<Item>;
+interface MethodOuter<Row> { consume(value: Vessel<Row>): void; }
+declare const anyOuter: MethodOuter<any>;
+const neverTarget: MethodOuter<never> = anyOuter;
+declare const neverOuter: MethodOuter<never>;
+const anyTarget: MethodOuter<any> = neverOuter;
+"#;
+    let strict_errors = check_source_strict(aliased_method)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(strict_errors, 2);
+}
+
+/// An accepted any/never method slot must not short-circuit the remaining
+/// ordinary compatibility rules. Here the second slot is valid specifically
+/// because a value-returning function is assignable to a void-return target.
+#[test]
+fn accepted_any_never_slot_preserves_void_return_compatibility() {
+    let source = r#"
+interface Generic<A, B> { consume(value: A): void; readonly callback: B; }
+declare const sourceValue: Generic<any, () => number>;
+const targetValue: Generic<never, () => void> = sourceValue;
+"#;
+    let diagnostics = check_source_strict(source);
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+/// An explicit `this` parameter originates in a method parameter position. It
+/// keeps method bivariance for the exceptional any/never pair, while unrelated
+/// concrete receivers still require a structural relation in either direction.
+#[test]
+fn explicit_method_this_parameter_keeps_bivariance() {
+    let source = r#"
+interface MethodReceiver<T> { invoke(this: T): void; }
+declare const anyReceiver: MethodReceiver<any>;
+const neverReceiver: MethodReceiver<never> = anyReceiver;
+declare const sourceNever: MethodReceiver<never>;
+const targetAny: MethodReceiver<any> = sourceNever;
+declare const stringReceiver: MethodReceiver<string>;
+const numberReceiver: MethodReceiver<number> = stringReceiver;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 1);
+}
+
+/// Type-predicate payloads contribute covariantly like return types. Both a
+/// method predicate and a function-valued property reject any-to-never while
+/// retaining the valid never-to-any direction.
+#[test]
+fn type_predicate_payload_contributes_covariant_variance() {
+    let source = r#"
+interface MethodPredicate<T> { matches(value: unknown): value is T; }
+declare const anyMethod: MethodPredicate<any>;
+const neverMethod: MethodPredicate<never> = anyMethod;
+declare const sourceNeverMethod: MethodPredicate<never>;
+const targetAnyMethod: MethodPredicate<any> = sourceNeverMethod;
+
+interface PropertyPredicate<Item> { matches: (value: unknown) => value is Item; }
+declare const anyProperty: PropertyPredicate<any>;
+const neverProperty: PropertyPredicate<never> = anyProperty;
+declare const sourceNeverProperty: PropertyPredicate<never>;
+const targetAnyProperty: PropertyPredicate<any> = sourceNeverProperty;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 2);
+}
+
+/// `NoInfer` blocks inference candidates, not structural variance. Its inner
+/// type remains a covariant occurrence for application relations.
+#[test]
+fn no_infer_wrapper_preserves_covariant_variance() {
+    let source = r#"
+interface Boxed<T> { readonly value: NoInfer<T>; }
+declare const anyBox: Boxed<any>;
+const neverBox: Boxed<never> = anyBox;
+declare const sourceNever: Boxed<never>;
+const targetAny: Boxed<any> = sourceNever;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 1);
+}
+
+/// Signature-local generic binders and their constraints do not witness the
+/// enclosing application's variance. Shadowed binder names remain local too.
+#[test]
+fn signature_local_generic_constraints_do_not_pin_outer_variance() {
+    let source = r#"
+interface GenericConstraint<T> { callback: <U extends T>(value: U) => void; }
+declare const anyValue: GenericConstraint<any>;
+const neverValue: GenericConstraint<never> = anyValue;
+declare const sourceNever: GenericConstraint<never>;
+const targetAny: GenericConstraint<any> = sourceNever;
+declare const strings: GenericConstraint<string>;
+const numbers: GenericConstraint<number> = strings;
+
+interface Shadowed<Outer> { callback: <Outer>(value: Outer) => void; }
+declare const shadowStrings: Shadowed<string>;
+const shadowNumbers: Shadowed<number> = shadowStrings;
+"#;
+    let diagnostics = check_source_strict(source);
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+/// Symbol index signatures contribute the same covariant value surface as
+/// string and number index signatures.
+#[test]
+fn symbol_index_signature_contributes_covariant_variance() {
+    let source = r#"
+interface SymbolTable<T> { [key: symbol]: T; }
+declare const anyTable: SymbolTable<any>;
+const neverTable: SymbolTable<never> = anyTable;
+declare const sourceNever: SymbolTable<never>;
+const targetAny: SymbolTable<any> = sourceNever;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 1);
+}
+
+/// Adding a call signature does not change ordinary mutable-property variance;
+/// a split accessor remains invariant because it has a distinct write surface.
+#[test]
+fn callable_properties_match_object_variance_rules() {
+    let source = r#"
+interface CallableMutable<T> { (): void; value: T; }
+declare const anyMutable: CallableMutable<any>;
+const neverMutable: CallableMutable<never> = anyMutable;
+declare const sourceNeverMutable: CallableMutable<never>;
+const targetAnyMutable: CallableMutable<any> = sourceNeverMutable;
+
+interface CallableAccessor<T> { (): void; get value(): T; set value(input: T); }
+declare const anyAccessor: CallableAccessor<any>;
+const neverAccessor: CallableAccessor<never> = anyAccessor;
+declare const sourceNeverAccessor: CallableAccessor<never>;
+const targetAnyAccessor: CallableAccessor<any> = sourceNeverAccessor;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 2);
+}
+
+/// Assignment-expression shortcuts must leave directional any/never pairs to
+/// the same variance classifier as variable initializers.
+#[test]
+fn assignment_expressions_preserve_directional_any_never_variance() {
+    let source = r#"
+interface Boxed<T> { readonly value: T; }
+let neverBox!: Boxed<never>;
+declare const anyBox: Boxed<any>;
+neverBox = anyBox;
+let anyBoxTarget!: Boxed<any>;
+declare const sourceNeverBox: Boxed<never>;
+anyBoxTarget = sourceNeverBox;
+
+interface Sink<T> { accept: (value: T) => void; }
+let anySink!: Sink<any>;
+declare const neverSink: Sink<never>;
+anySink = neverSink;
+let neverSinkTarget!: Sink<never>;
+declare const sourceAnySink: Sink<any>;
+neverSinkTarget = sourceAnySink;
+"#;
+    let errors = check_source_strict(source)
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .count();
+    assert_eq!(errors, 2);
+}
+
+/// Exact positional aliases forward every generic slot to the body owner; the
+/// exceptional mismatch is not limited to one-parameter aliases.
+#[test]
+fn multi_parameter_pass_through_alias_preserves_any_never_rejection() {
+    let source = r#"
+interface Pair<A, B> { readonly first: A; readonly second: B; }
+type Alias<X, Y> = Pair<X, Y>;
+interface Failure { readonly failure: true; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K): keyof O extends K ? Pair<never, string> : Failure;
+  choose<K extends keyof O>(keys: readonly K[]): keyof O extends K ? Pair<never, string> : Failure;
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): Alias<any, string> { return undefined as any; }
+}
+"#;
+    assert!(ts2416_count_strict(source) >= 1);
+}
+
+/// Determinate erased conditionals are normalized through inline callable
+/// return wrappers; compatible payloads remain accepted.
+#[test]
+fn erased_conditional_nested_in_callable_return_selects_true_branch() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Failure { readonly failure: true; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K): { (): keyof O extends K ? Box<any> : Failure };
+  choose<K extends keyof O>(keys: readonly K[]): { (): keyof O extends K ? Box<any> : Failure };
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): { (): Box<any> } { return undefined as any; }
+}
+"#;
+    assert_eq!(ts2416_count_strict(source), 0);
+}
+
+/// The same callable projection must preserve a proven any-to-never payload
+/// rejection through both the direct N×M pass and its erased retry.
+#[test]
+fn erased_conditional_nested_in_callable_return_keeps_rejection() {
+    let source = r#"
+interface Box<T> { readonly value: T; }
+interface Failure { readonly failure: true; }
+interface Base<O> {
+  choose<K extends keyof O>(key: K): { (): keyof O extends K ? Box<never> : Failure };
+  choose<K extends keyof O>(keys: readonly K[]): { (): keyof O extends K ? Box<never> : Failure };
+}
+class Impl<O> implements Base<O> {
+  choose(_value: unknown): { (): Box<any> } { return undefined as any; }
+}
+"#;
+    assert!(ts2416_count_strict(source) >= 1);
 }

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -502,7 +502,7 @@ pub trait TypeDatabase:
     /// its resolution-failure fingerprint.
     ///
     /// Callers must only insert canonical masks whose every resolution gap is
-    /// listed in `gaps` (see [`Self::shared_def_variance`]). First write wins.
+    /// listed in `gaps` (see [`Self::shared_def_variance`]).
     /// Default is a no-op.
     fn insert_shared_def_variance(
         &self,

--- a/crates/tsz-solver/src/evaluation/session.rs
+++ b/crates/tsz-solver/src/evaluation/session.rs
@@ -9,12 +9,13 @@
 //! via `Rc` across parent/child contexts so counters survive cross-arena
 //! delegation without implicit global state.
 
+use crate::def::DefId;
 use crate::evaluation::request::EvaluationCacheKey;
 use crate::evaluation::result::EvaluationResult;
-use crate::types::RelationCacheKey;
-use crate::types::TypeId;
+use crate::types::{RelationCacheKey, TypeId, Variance};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::{Cell, RefCell};
+use std::sync::Arc;
 
 /// Maximum global instantiation depth — bounds nesting of
 /// `evaluate_application_type` calls across all `CheckerContext` instances.
@@ -134,6 +135,45 @@ pub(crate) struct CompoundSubtypePairKey {
     resolver_generation: u64,
     bypass_evaluation: bool,
     max_depth: u32,
+}
+
+/// Per-query effective-variance memo scope.
+///
+/// Resolver identity is safe here because the memo cannot outlive the
+/// `EvaluationSession` that owns the borrowed resolver contexts. The current
+/// resolver generation lives in the value so publication replaces, rather
+/// than accumulates, stale facts for this scope.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct EffectiveVarianceCacheKey {
+    def_id: DefId,
+    strict_function_types: bool,
+    disable_method_bivariance: bool,
+    type_database_identity: usize,
+    resolver_identity: usize,
+}
+
+impl EffectiveVarianceCacheKey {
+    pub(crate) const fn new(
+        def_id: DefId,
+        strict_function_types: bool,
+        disable_method_bivariance: bool,
+        type_database_identity: usize,
+        resolver_identity: usize,
+    ) -> Self {
+        Self {
+            def_id,
+            strict_function_types,
+            disable_method_bivariance,
+            type_database_identity,
+            resolver_identity,
+        }
+    }
+}
+
+struct EffectiveVarianceCacheEntry {
+    resolver_generation: u64,
+    variances: Arc<[Variance]>,
+    incomplete: bool,
 }
 
 impl CompoundSubtypePairKey {
@@ -267,6 +307,11 @@ pub struct EvaluationSession {
     /// cached here; each simplification reruns them after reading the raw
     /// subtype answer.
     compound_subtype_probe_cache: RefCell<FxHashMap<CompoundSubtypePairKey, bool>>,
+    /// Resolver-scoped effective-variance facts for exceptional `any`/`never`
+    /// application relations. Generation validation makes publication-safe
+    /// hits O(1); replacing the value bounds residency to one entry per scope.
+    effective_variance_cache:
+        RefCell<FxHashMap<EffectiveVarianceCacheKey, EffectiveVarianceCacheEntry>>,
     /// In-flight expansion count per `Application` node across every
     /// evaluator instance in this session. A fresh evaluator re-entering a
     /// node that [`MAX_CROSS_EVAL_APPLICATION_EXPANSION`] instances are
@@ -371,6 +416,7 @@ impl EvaluationSession {
             cross_eval_active: RefCell::new(FxHashSet::default()),
             query_memo: RefCell::new(FxHashMap::default()),
             compound_subtype_probe_cache: RefCell::new(FxHashMap::default()),
+            effective_variance_cache: RefCell::new(FxHashMap::default()),
             application_expansion_active: InFlightTypeCounter::default(),
         }
     }
@@ -708,6 +754,58 @@ impl EvaluationSession {
         self.query_memo.borrow_mut().insert(key, result);
     }
 
+    pub(crate) fn effective_variance_get(
+        &self,
+        key: EffectiveVarianceCacheKey,
+        resolver_generation: u64,
+    ) -> Option<(Arc<[Variance]>, bool)> {
+        let cache = self.effective_variance_cache.borrow();
+        let entry = cache.get(&key)?;
+        (entry.resolver_generation == resolver_generation)
+            .then(|| (entry.variances.clone(), entry.incomplete))
+    }
+
+    pub(crate) fn effective_variance_put(
+        &self,
+        key: EffectiveVarianceCacheKey,
+        resolver_generation: u64,
+        variances: Arc<[Variance]>,
+        incomplete: bool,
+    ) {
+        self.effective_variance_cache.borrow_mut().insert(
+            key,
+            EffectiveVarianceCacheEntry {
+                resolver_generation,
+                variances,
+                incomplete,
+            },
+        );
+    }
+
+    /// Number of option-aware effective-variance masks retained by this query.
+    #[cfg(test)]
+    pub(crate) fn effective_variance_cache_entries(&self) -> usize {
+        self.effective_variance_cache.borrow().len()
+    }
+
+    /// Approximate bytes retained by the effective-variance memo.
+    #[cfg(test)]
+    pub(crate) fn effective_variance_cache_estimated_size_bytes(&self) -> usize {
+        self.effective_variance_cache
+            .borrow()
+            .values()
+            .map(|entry| {
+                std::mem::size_of::<(EffectiveVarianceCacheKey, EffectiveVarianceCacheEntry)>()
+                    .saturating_add(
+                        entry
+                            .variances
+                            .len()
+                            .saturating_mul(std::mem::size_of::<Variance>()),
+                    )
+            })
+            .sum()
+    }
+
     /// Look up a stable compound simplification subtype probe for this query.
     #[inline]
     pub(crate) fn compound_subtype_probe_get(&self, key: CompoundSubtypePairKey) -> Option<bool> {
@@ -752,6 +850,7 @@ impl EvaluationSession {
     #[inline]
     pub(crate) fn reset_query_memo(&self) {
         self.query_memo.borrow_mut().clear();
+        self.effective_variance_cache.borrow_mut().clear();
         self.reset_compound_subtype_probe_cache();
     }
 }
@@ -1171,5 +1270,44 @@ mod tests {
         );
         drop(entries);
         assert_eq!(session.type_reference_resolution_depth(), 0);
+    }
+
+    #[test]
+    fn effective_variance_cache_partitions_options_replaces_generation_and_resets() {
+        let session = EvaluationSession::new();
+        let strict_key = EffectiveVarianceCacheKey::new(DefId(1), true, false, 10, 20);
+        let loose_key = EffectiveVarianceCacheKey::new(DefId(1), false, false, 10, 20);
+        let identity_key = EffectiveVarianceCacheKey::new(DefId(1), true, true, 10, 20);
+        let covariant: Arc<[Variance]> = Arc::from([Variance::COVARIANT]);
+        let contravariant: Arc<[Variance]> = Arc::from([Variance::CONTRAVARIANT]);
+
+        session.effective_variance_put(strict_key, 1, covariant.clone(), false);
+        assert_eq!(
+            session.effective_variance_get(strict_key, 1),
+            Some((covariant, false))
+        );
+        assert_eq!(session.effective_variance_get(strict_key, 2), None);
+
+        session.effective_variance_put(strict_key, 2, contravariant.clone(), true);
+        assert_eq!(
+            session.effective_variance_get(strict_key, 2),
+            Some((contravariant.clone(), true))
+        );
+        assert_eq!(
+            session.effective_variance_cache_entries(),
+            1,
+            "a new resolver generation must replace the stale scope value"
+        );
+
+        session.effective_variance_put(loose_key, 2, contravariant, false);
+        session.effective_variance_put(identity_key, 2, Arc::from([Variance::COVARIANT]), false);
+        assert_eq!(session.effective_variance_cache_entries(), 3);
+        assert!(session.effective_variance_cache_estimated_size_bytes() > 0);
+
+        session.reset_query_memo();
+        assert_eq!(session.effective_variance_cache_entries(), 0);
+        assert_eq!(session.effective_variance_get(strict_key, 2), None);
+        assert_eq!(session.effective_variance_get(loose_key, 2), None);
+        assert_eq!(session.effective_variance_get(identity_key, 2), None);
     }
 }

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -29,11 +29,6 @@ use std::sync::{
 };
 use tsz_common::interner::{Atom, ShardedInterner};
 
-/// A universe-shared variance result: the def's variance mask plus the
-/// resolution-gap fingerprint (defs whose resolution failed during the walk)
-/// that gates replaying it under a different resolver.
-pub type SharedDefVariance = (Arc<[crate::types::Variance]>, Arc<[DefId]>);
-
 /// One as-written union display order plus whether it is only the exact
 /// rewriter's pre-sort fallback. Real source provenance may atomically replace
 /// a fallback, while unrelated real origins remain first-writer-wins.
@@ -45,6 +40,9 @@ pub(super) struct DisplayUnionOrigin {
 mod cache;
 mod display;
 mod storage;
+mod variance_cache;
+
+pub use variance_cache::SharedDefVariance;
 
 pub(super) use storage::{AppComponentKey, CachedUnionMember, TypeShard};
 use storage::{ConcurrentSliceInterner, ConcurrentValueInterner, write_id_slot};
@@ -816,37 +814,6 @@ impl TypeInterner {
             def_variance_masks: DashMap::with_hasher(FxBuildHasher),
             instance_id: NEXT_INTERNER_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
         }
-    }
-
-    /// Read a universe-shared variance mask for a generic definition.
-    ///
-    /// Returns `(mask, gap_defs)`. Only canonical masks are stored, together
-    /// with their resolution-failure fingerprint (see `def_variance_masks`);
-    /// callers must validate the fingerprint against their resolver before
-    /// replaying the mask.
-    #[inline]
-    pub fn shared_def_variance(&self, def_id: DefId) -> Option<SharedDefVariance> {
-        self.def_variance_masks
-            .get(&def_id)
-            .map(|entry| entry.value().clone())
-    }
-
-    /// Store a universe-shared variance mask for a generic definition with
-    /// its resolution-failure fingerprint.
-    ///
-    /// Callers must only insert canonical masks whose every resolution gap is
-    /// listed in `gaps`. First write wins, keeping replays deterministic
-    /// within a session.
-    #[inline]
-    pub fn insert_shared_def_variance(
-        &self,
-        def_id: DefId,
-        mask: Arc<[crate::types::Variance]>,
-        gaps: Arc<[DefId]>,
-    ) {
-        self.def_variance_masks
-            .entry(def_id)
-            .or_insert((mask, gaps));
     }
 
     #[inline]

--- a/crates/tsz-solver/src/intern/core/interner/variance_cache.rs
+++ b/crates/tsz-solver/src/intern/core/interner/variance_cache.rs
@@ -1,0 +1,32 @@
+//! Universe-shared variance-cache data and accessors.
+
+use super::TypeInterner;
+use crate::def::DefId;
+use crate::types::Variance;
+use std::sync::Arc;
+
+/// A declared-variance result plus its unresolved-definition fingerprint.
+pub type SharedDefVariance = (Arc<[Variance]>, Arc<[DefId]>);
+
+impl TypeInterner {
+    /// Read a universe-shared declared-variance mask.
+    #[inline]
+    pub fn shared_def_variance(&self, def_id: DefId) -> Option<SharedDefVariance> {
+        self.def_variance_masks
+            .get(&def_id)
+            .map(|entry| entry.value().clone())
+    }
+
+    /// Store a canonical universe-shared declared-variance mask.
+    #[inline]
+    pub fn insert_shared_def_variance(
+        &self,
+        def_id: DefId,
+        mask: Arc<[Variance]>,
+        gaps: Arc<[DefId]>,
+    ) {
+        self.def_variance_masks
+            .entry(def_id)
+            .or_insert((mask, gaps));
+    }
+}

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -741,6 +741,25 @@ pub fn query_erased_overload_params_with_matching_return_base<'a, R: TypeResolve
     )
 }
 
+/// Classify the proven return-variance failure hidden inside the erased
+/// overload fallback.
+///
+/// Kept separate from the boolean relation query so the checker can distinguish
+/// a definite `any`/`never` application mismatch from an ordinary uncovered
+/// overload. The latter may still be accepted by another compatibility rule;
+/// the former may not.
+pub fn query_erased_overload_return_variance_rejects<'a, R: TypeResolver>(
+    interner: &'a dyn TypeDatabase,
+    resolver: &'a R,
+    source: TypeId,
+    target: TypeId,
+    policy: RelationPolicy,
+    context: RelationContext<'a>,
+) -> bool {
+    let checker = configured_subtype_checker(interner, resolver, policy, context);
+    checker.erased_function_type_params_return_variance_rejects(source, target)
+}
+
 /// Bundled inputs for relation queries.
 pub struct RelationQueryInputs<'a, R: TypeResolver, P: AssignabilityOverrideProvider + ?Sized> {
     pub interner: &'a dyn TypeDatabase,
@@ -919,6 +938,29 @@ pub fn check_application_variance<R: TypeResolver>(
     }
 
     if !same_base_same_arity {
+        return None;
+    }
+
+    let has_any_never_pair = s_app
+        .args
+        .iter()
+        .zip(t_app.args.iter())
+        .any(|(&source, &target)| {
+            (source.is_any() && target == TypeId::NEVER)
+                || (source == TypeId::NEVER && target.is_any())
+        });
+    if has_any_never_pair {
+        let checker = configured_subtype_checker(db, resolver, policy, context);
+        let def_id = base_def_id(s_app.base)?;
+        if checker
+            .classify_application_args_any_never_variance(def_id, &s_app.args, &t_app.args)?
+            .rejects
+        {
+            return Some(false);
+        }
+        // Non-rejecting exceptional slots may coexist with arguments that
+        // require lawyer-only compatibility (for example the void-return
+        // exception). Leave those to the downstream full relation.
         return None;
     }
 

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -6,8 +6,8 @@
 use crate::instantiation::instantiate::TypeSubstitution;
 use crate::type_param_info;
 use crate::types::{
-    CallSignature, CallableShape, CallableShapeId, FunctionShape, FunctionShapeId, ObjectFlags,
-    ObjectShape, ParamInfo, PropertyInfo, TupleElement, TypeData, TypeId, TypeParamInfo, Visibility,
+    CallableShape, CallableShapeId, FunctionShape, FunctionShapeId, ObjectFlags, ObjectShape,
+    ParamInfo, PropertyInfo, TypeData, TypeId, TypeParamInfo, Visibility,
 };
 use crate::visitor::callable_shape_id;
 

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -7,7 +7,7 @@ use crate::instantiation::instantiate::TypeSubstitution;
 use crate::type_param_info;
 use crate::types::{
     CallSignature, CallableShape, CallableShapeId, FunctionShape, FunctionShapeId, ObjectFlags,
-    ObjectShape, ParamInfo, PropertyInfo, TypeData, TypeId, TypeParamInfo, Visibility,
+    ObjectShape, ParamInfo, PropertyInfo, TupleElement, TypeData, TypeId, TypeParamInfo, Visibility,
 };
 use crate::visitor::callable_shape_id;
 
@@ -1350,6 +1350,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             if s_fn.is_constructor {
                 return SubtypeResult::False;
             }
+            if has_multiple_target_sigs
+                && self.erased_fn_to_sig_return_variance_rejects(&s_fn, t_sig)
+            {
+                return SubtypeResult::False;
+            }
             if !self.check_call_signature_subtype_fn(&s_fn, t_sig).is_true() {
                 // tsc N×M path: when the target has multiple call signatures, try
                 // erasing type params to `any` before rejecting. This matches tsc's
@@ -1602,7 +1607,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 found_match = true;
             }
             for s_sig in &source.call_signatures {
-                if self.check_call_signature_subtype(s_sig, t_sig).is_true() {
+                if (!is_multi_sig || !self.erased_call_sig_return_variance_rejects(s_sig, t_sig))
+                    && self.check_call_signature_subtype(s_sig, t_sig).is_true()
+                {
                     found_match = true;
                     break;
                 }
@@ -1611,6 +1618,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // type params to `any` (matching tsc's `getErasedSignature` behavior).
             if !found_match && is_multi_sig {
                 for s_sig in &source.call_signatures {
+                    if self.erased_call_sig_return_variance_rejects(s_sig, t_sig) {
+                        continue;
+                    }
                     if self
                         .check_erased_call_signature_subtype(s_sig, t_sig)
                         .is_true()
@@ -1763,79 +1773,5 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
 
         SubtypeResult::True
-    }
-
-    fn method_overloads_cover_tuple_union_rest_target(
-        &mut self,
-        source_sigs: &[CallSignature],
-        target_sig: &CallSignature,
-    ) -> bool {
-        use crate::type_queries::data::get_union_members;
-        use crate::type_queries::unpack_tuple_rest_parameter;
-
-        let Some(last_target_param) = target_sig.params.last().filter(|param| param.rest) else {
-            return false;
-        };
-        let Some(union_members) = get_union_members(self.interner, last_target_param.type_id)
-        else {
-            return false;
-        };
-
-        let prefix_params = &target_sig.params[..target_sig.params.len().saturating_sub(1)];
-        union_members.iter().all(|member_type_id| {
-            let member_param = ParamInfo {
-                type_id: *member_type_id,
-                rest: true,
-                ..*last_target_param
-            };
-            let mut variant_params = prefix_params.to_vec();
-            variant_params.extend(unpack_tuple_rest_parameter(self.interner, &member_param));
-            source_sigs.iter().any(|source_sig| {
-                let source_fn = FunctionShape {
-                    type_params: source_sig.type_params.clone(),
-                    params: source_sig.params.clone(),
-                    this_type: source_sig.this_type,
-                    return_type: source_sig.return_type,
-                    type_predicate: source_sig.type_predicate,
-                    is_constructor: false,
-                    is_method: source_sig.is_method,
-                };
-                let variant_fn = FunctionShape {
-                    type_params: target_sig.type_params.clone(),
-                    params: variant_params.clone(),
-                    this_type: target_sig.this_type,
-                    return_type: target_sig.return_type,
-                    type_predicate: target_sig.type_predicate,
-                    is_constructor: false,
-                    is_method: target_sig.is_method,
-                };
-                self.check_function_subtype(&source_fn, &variant_fn)
-                    .is_true()
-                    || self.method_overload_prefix_covers_variant(source_sig, &variant_params)
-            })
-        })
-    }
-
-    fn method_overload_prefix_covers_variant(
-        &mut self,
-        source_sig: &CallSignature,
-        variant_params: &[ParamInfo],
-    ) -> bool {
-        if !source_sig.is_method || variant_params.is_empty() {
-            return false;
-        }
-        if source_sig.params.len() < variant_params.len() {
-            return false;
-        }
-        source_sig
-            .params
-            .iter()
-            .zip(variant_params.iter())
-            .take(variant_params.len())
-            .all(|(source_param, target_param)| {
-                let (source_type, target_type) =
-                    self.effective_param_type_pair(source_param, target_param);
-                self.are_parameters_compatible_impl(source_type, target_type, true)
-            })
     }
 }

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
@@ -928,7 +928,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let s_erased = erase_call_sig_to_any(source, self.interner);
         let t_erased = erase_call_sig_to_any(target, self.interner);
         let normalization = self.normalize_erased_target_return(t_erased.return_type);
-        if self.erased_normalized_return_rejects(s_erased.return_type, normalization) {
+        // Preserve the hard plain-return variance veto without recursively
+        // relating the full returned value here. Conditional returns and the
+        // same-base generic fallback are owned by the helper below.
+        if !normalization.contains_conditional
+            && self.erased_structural_return_variance_rejects(
+                s_erased.return_type,
+                normalization.type_id,
+            )
+        {
             return SubtypeResult::False;
         }
         self.check_erased_function_shapes_params_with_matching_return_base(

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
@@ -1,10 +1,73 @@
-use crate::types::{CallSignature, FunctionShape, TypeId};
-use crate::visitor::function_shape_id;
+use crate::types::{CallSignature, FunctionShape, ParamInfo, TypeData, TypeId};
+use crate::visitor::{application_id, function_shape_id};
 
 use super::super::super::super::{SubtypeChecker, SubtypeResult, TypeResolver};
 use super::super::{erase_call_sig_to_any, erase_fn_shape_to_any};
 
+#[derive(Clone, Copy)]
+struct ErasedReturnNormalization {
+    type_id: TypeId,
+    contains_conditional: bool,
+    contains_deferred: bool,
+}
+
+impl ErasedReturnNormalization {
+    const fn unchanged(type_id: TypeId) -> Self {
+        Self {
+            type_id,
+            contains_conditional: false,
+            contains_deferred: false,
+        }
+    }
+}
+
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
+    pub(super) fn erased_fn_to_sig_return_variance_rejects(
+        &self,
+        source: &FunctionShape,
+        target: &CallSignature,
+    ) -> bool {
+        let source = erase_fn_shape_to_any(source, self.interner);
+        let target = erase_call_sig_to_any(target, self.interner);
+        let normalization = self.normalize_erased_target_return(target.return_type);
+        if !normalization.contains_conditional {
+            return false;
+        }
+        self.erased_structural_return_variance_rejects(source.return_type, normalization.type_id)
+    }
+
+    pub(super) fn erased_call_sig_return_variance_rejects(
+        &self,
+        source: &CallSignature,
+        target: &CallSignature,
+    ) -> bool {
+        let source = erase_call_sig_to_any(source, self.interner);
+        let target = erase_call_sig_to_any(target, self.interner);
+        let normalization = self.normalize_erased_target_return(target.return_type);
+        if !normalization.contains_conditional {
+            return false;
+        }
+        self.erased_structural_return_variance_rejects(source.return_type, normalization.type_id)
+    }
+
+    fn erased_normalized_return_rejects(
+        &mut self,
+        source_return: TypeId,
+        normalization: ErasedReturnNormalization,
+    ) -> bool {
+        // Deferred/distributive children stay present in the normalized shape
+        // and therefore remain under the ordinary return relation; determinate
+        // siblings are selected in place. Plain returns use the same complete
+        // verdict unchanged. This is deliberately broader than the top-level
+        // application variance classifier: the tuple-union prefix shortcut is
+        // allowed to prove only parameters and therefore must never bypass any
+        // incompatible return.
+        self.erased_structural_return_variance_rejects(source_return, normalization.type_id)
+            || !self
+                .check_return_compat(source_return, normalization.type_id)
+                .is_true()
+    }
+
     /// Compare a function type against a call signature after erasing both signatures'
     /// type parameters to `any`. Matches tsc's N x M `signaturesRelatedTo` path.
     pub(super) fn check_erased_fn_subtype_to_sig(
@@ -14,6 +77,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ) -> SubtypeResult {
         let s_erased = erase_fn_shape_to_any(s_fn, self.interner);
         let t_erased = erase_call_sig_to_any(t_sig, self.interner);
+        if self.erased_return_variance_rejects(s_erased.return_type, t_erased.return_type) {
+            return SubtypeResult::False;
+        }
         self.check_function_subtype(&s_erased, &t_erased)
     }
 
@@ -22,6 +88,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         s_fn: &FunctionShape,
         t_sig: &CallSignature,
     ) -> SubtypeResult {
+        if s_fn.type_params.is_empty() && t_sig.type_params.is_empty() {
+            return SubtypeResult::False;
+        }
         let s_erased = erase_fn_shape_to_any(s_fn, self.interner);
         let t_erased = erase_call_sig_to_any(t_sig, self.interner);
         self.check_erased_function_shapes_params_with_matching_return_base(
@@ -42,9 +111,42 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         };
         let s_shape = self.interner.function_shape(s_fn_id);
         let t_shape = self.interner.function_shape(t_fn_id);
+        if s_shape.type_params.is_empty() && t_shape.type_params.is_empty() {
+            return SubtypeResult::False;
+        }
         let s_erased = erase_fn_shape_to_any(&s_shape, self.interner);
         let t_erased = erase_fn_shape_to_any(&t_shape, self.interner);
         self.check_erased_function_shapes_params_with_matching_return_base(s_erased, t_erased, true)
+    }
+
+    /// Whether erasing the two function signatures exposes a determinate
+    /// conditional return whose selected application arguments have a proven
+    /// `any`/`never` variance mismatch.
+    ///
+    /// This is a classification query for checker diagnostic routing. The
+    /// ordinary erased-overload relation returns only false for both a parameter
+    /// mismatch and this stronger return mismatch; callers need to distinguish
+    /// the latter so a later compatibility fallback cannot re-accept it after
+    /// application identity has been structurally expanded away.
+    pub(crate) fn erased_function_type_params_return_variance_rejects(
+        &self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        let (Some(s_fn_id), Some(t_fn_id)) = (
+            function_shape_id(self.interner, source),
+            function_shape_id(self.interner, target),
+        ) else {
+            return false;
+        };
+        let source = erase_fn_shape_to_any(&self.interner.function_shape(s_fn_id), self.interner);
+        let target = self.interner.function_shape(t_fn_id);
+        let target = erase_fn_shape_to_any(&target, self.interner);
+        let normalization = self.normalize_erased_target_return(target.return_type);
+        if !normalization.contains_conditional {
+            return false;
+        }
+        self.erased_structural_return_variance_rejects(source.return_type, normalization.type_id)
     }
 
     fn check_erased_function_shapes_params_with_matching_return_base(
@@ -53,6 +155,38 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         mut target: FunctionShape,
         reject_exact_params: bool,
     ) -> SubtypeResult {
+        let normalization = self.normalize_erased_target_return(target.return_type);
+        if normalization.contains_conditional {
+            target.return_type = normalization.type_id;
+            if self
+                .erased_structural_return_variance_rejects(source.return_type, target.return_type)
+            {
+                return SubtypeResult::False;
+            }
+            let related = self.check_function_subtype(&source, &target);
+            if related.is_true() {
+                return related;
+            }
+            // Deferred/distributive conditionals stay under the ordinary return
+            // relation. They must never reach the same-base fallback below,
+            // which intentionally discards application arguments.
+            if normalization.contains_deferred {
+                return SubtypeResult::False;
+            }
+            if !self.erased_return_args_are_identical_or_any(source.return_type, target.return_type)
+            {
+                return SubtypeResult::False;
+            }
+            // The N×M overload relation deliberately erases method-local binders
+            // to `any`. For the same generic definition, tsc lets that wildcard
+            // silence only the differing application slots; retain the normal
+            // parameter relation after proving every return argument identical or
+            // `any` instead of accepting on generic-base identity alone.
+            source.return_type = TypeId::ANY;
+            target.return_type = TypeId::ANY;
+            return self.check_function_subtype(&source, &target);
+        }
+
         if !self.return_application_bases_match(source.return_type, target.return_type) {
             return SubtypeResult::False;
         }
@@ -78,6 +212,679 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source_base == target_base
     }
 
+    fn erased_return_variance_rejects(&self, source_return: TypeId, target_return: TypeId) -> bool {
+        let (Some(source_app), Some(target_app)) = (
+            application_id(self.interner, source_return),
+            application_id(self.interner, target_return),
+        ) else {
+            return false;
+        };
+        self.application_any_never_variance_rejects(source_app, target_app)
+    }
+
+    /// Reuse the generic application's authoritative variance classifier at
+    /// covariant built-in projections of a returned value. This is intentionally
+    /// narrow: application arguments are left to the generic relation, while
+    /// tuples, arrays, readable object members, and nested function returns are
+    /// transparent value containers. The paired memo makes recursive shapes
+    /// linear in the number of distinct source/target projections.
+    fn erased_structural_return_variance_rejects(
+        &self,
+        source_return: TypeId,
+        target_return: TypeId,
+    ) -> bool {
+        let mut visited = rustc_hash::FxHashSet::default();
+        self.erased_structural_return_variance_rejects_inner(
+            source_return,
+            target_return,
+            &mut visited,
+        )
+    }
+
+    fn erased_structural_return_variance_rejects_inner(
+        &self,
+        source: TypeId,
+        target: TypeId,
+        visited: &mut rustc_hash::FxHashSet<(TypeId, TypeId)>,
+    ) -> bool {
+        if !visited.insert((source, target)) {
+            return false;
+        }
+        if self.erased_return_variance_rejects(source, target) {
+            return true;
+        }
+
+        match (self.interner.lookup(source), self.interner.lookup(target)) {
+            (
+                Some(TypeData::Object(source_id) | TypeData::ObjectWithIndex(source_id)),
+                Some(TypeData::Object(target_id) | TypeData::ObjectWithIndex(target_id)),
+            ) => {
+                let source = self.interner.object_shape(source_id);
+                let target = self.interner.object_shape(target_id);
+                let mut source_index = 0;
+                for target_property in &target.properties {
+                    while source_index < source.properties.len()
+                        && source.properties[source_index].name < target_property.name
+                    {
+                        source_index += 1;
+                    }
+                    if let Some(source_property) = source.properties.get(source_index)
+                        && source_property.name == target_property.name
+                        && self.erased_structural_return_variance_rejects_inner(
+                            source_property.type_id,
+                            target_property.type_id,
+                            visited,
+                        )
+                    {
+                        return true;
+                    }
+                }
+                [
+                    (source.string_index, target.string_index),
+                    (source.number_index, target.number_index),
+                    (source.symbol_index, target.symbol_index),
+                ]
+                .into_iter()
+                .any(|(source_index, target_index)| {
+                    source_index
+                        .zip(target_index)
+                        .is_some_and(|(source, target)| {
+                            self.erased_structural_return_variance_rejects_inner(
+                                source.value_type,
+                                target.value_type,
+                                visited,
+                            )
+                        })
+                })
+            }
+            (Some(TypeData::Array(source)), Some(TypeData::Array(target))) => {
+                self.erased_structural_return_variance_rejects_inner(source, target, visited)
+            }
+            (Some(TypeData::Tuple(source_id)), Some(TypeData::Tuple(target_id))) => {
+                let source = self.interner.tuple_list(source_id);
+                let target = self.interner.tuple_list(target_id);
+                source.len() == target.len()
+                    && source.iter().zip(target.iter()).any(|(source, target)| {
+                        source.optional == target.optional
+                            && source.rest == target.rest
+                            && self.erased_structural_return_variance_rejects_inner(
+                                source.type_id,
+                                target.type_id,
+                                visited,
+                            )
+                    })
+            }
+            (Some(TypeData::Function(source_id)), Some(TypeData::Function(target_id))) => {
+                let source = self.interner.function_shape(source_id);
+                let target = self.interner.function_shape(target_id);
+                target.return_type != TypeId::VOID
+                    && self.erased_structural_return_variance_rejects_inner(
+                        source.return_type,
+                        target.return_type,
+                        visited,
+                    )
+            }
+            (Some(TypeData::Callable(source_id)), Some(TypeData::Callable(target_id))) => {
+                let source = self.interner.callable_shape(source_id);
+                let target = self.interner.callable_shape(target_id);
+                // Positional pairing is a hard proof only for a single
+                // signature. Overload sets use N×M coverage and may be
+                // reordered, so leave those to the full callable relation.
+                let signature_return_rejects = match (
+                    source.call_signatures.as_slice(),
+                    target.call_signatures.as_slice(),
+                ) {
+                    ([source], [target]) => {
+                        target.return_type != TypeId::VOID
+                            && self.erased_structural_return_variance_rejects_inner(
+                                source.return_type,
+                                target.return_type,
+                                visited,
+                            )
+                    }
+                    _ => false,
+                };
+                let construct_return_rejects = match (
+                    source.construct_signatures.as_slice(),
+                    target.construct_signatures.as_slice(),
+                ) {
+                    ([source], [target]) => {
+                        target.return_type != TypeId::VOID
+                            && self.erased_structural_return_variance_rejects_inner(
+                                source.return_type,
+                                target.return_type,
+                                visited,
+                            )
+                    }
+                    _ => false,
+                };
+                let mut source_index = 0;
+                let property_rejects = target.properties.iter().any(|target_property| {
+                    while source_index < source.properties.len()
+                        && source.properties[source_index].name < target_property.name
+                    {
+                        source_index += 1;
+                    }
+                    source
+                        .properties
+                        .get(source_index)
+                        .is_some_and(|source_property| {
+                            source_property.name == target_property.name
+                                && self.erased_structural_return_variance_rejects_inner(
+                                    source_property.type_id,
+                                    target_property.type_id,
+                                    visited,
+                                )
+                        })
+                });
+                let index_rejects = [
+                    (source.string_index, target.string_index),
+                    (source.number_index, target.number_index),
+                ]
+                .into_iter()
+                .any(|(source_index, target_index)| {
+                    source_index
+                        .zip(target_index)
+                        .is_some_and(|(source, target)| {
+                            self.erased_structural_return_variance_rejects_inner(
+                                source.value_type,
+                                target.value_type,
+                                visited,
+                            )
+                        })
+                });
+                signature_return_rejects
+                    || construct_return_rejects
+                    || property_rejects
+                    || index_rejects
+            }
+            (
+                Some(TypeData::ReadonlyType(source) | TypeData::NoInfer(source)),
+                Some(TypeData::ReadonlyType(target) | TypeData::NoInfer(target)),
+            ) => self.erased_structural_return_variance_rejects_inner(source, target, visited),
+            _ => false,
+        }
+    }
+
+    /// Select determinate erased overload conditionals anywhere in the returned
+    /// value's structural shape without expanding lazy aliases.
+    ///
+    /// Erasing method-local parameters can make a non-distributive conditional
+    /// definitively choose its true branch. For example, `keyof O extends K`
+    /// becomes `keyof O extends any`, so tsc compares the application in that
+    /// branch when checking an implementation against its overloads. Container,
+    /// object-property, and nested-function projections all contribute to the
+    /// returned value, so they are rebuilt in place before the return relation
+    /// runs. The tri-state flags distinguish absence from a still-deferred
+    /// conditional; only absence may reach the historical same-base fallback.
+    fn normalize_erased_target_return(&self, type_id: TypeId) -> ErasedReturnNormalization {
+        let mut memo = rustc_hash::FxHashMap::default();
+        self.normalize_erased_overload_return(type_id, &mut memo)
+    }
+
+    fn normalize_erased_call_signature_fields(
+        &self,
+        signature: &mut CallSignature,
+        memo: &mut rustc_hash::FxHashMap<TypeId, ErasedReturnNormalization>,
+    ) -> (bool, bool, bool) {
+        let mut contains_conditional = false;
+        let mut contains_deferred = false;
+        let mut changed = false;
+
+        for type_param in &mut signature.type_params {
+            for slot in [&mut type_param.constraint, &mut type_param.default]
+                .into_iter()
+                .flatten()
+            {
+                let child = self.normalize_erased_overload_return(*slot, memo);
+                contains_conditional |= child.contains_conditional;
+                contains_deferred |= child.contains_deferred;
+                changed |= child.type_id != *slot;
+                *slot = child.type_id;
+            }
+        }
+        for param in &mut signature.params {
+            let child = self.normalize_erased_overload_return(param.type_id, memo);
+            contains_conditional |= child.contains_conditional;
+            contains_deferred |= child.contains_deferred;
+            changed |= child.type_id != param.type_id;
+            param.type_id = child.type_id;
+        }
+        if let Some(this_type) = &mut signature.this_type {
+            let child = self.normalize_erased_overload_return(*this_type, memo);
+            contains_conditional |= child.contains_conditional;
+            contains_deferred |= child.contains_deferred;
+            changed |= child.type_id != *this_type;
+            *this_type = child.type_id;
+        }
+        let returned = self.normalize_erased_overload_return(signature.return_type, memo);
+        contains_conditional |= returned.contains_conditional;
+        contains_deferred |= returned.contains_deferred;
+        changed |= returned.type_id != signature.return_type;
+        signature.return_type = returned.type_id;
+        if let Some(type_predicate) = &mut signature.type_predicate
+            && let Some(predicate_type) = &mut type_predicate.type_id
+        {
+            let child = self.normalize_erased_overload_return(*predicate_type, memo);
+            contains_conditional |= child.contains_conditional;
+            contains_deferred |= child.contains_deferred;
+            changed |= child.type_id != *predicate_type;
+            *predicate_type = child.type_id;
+        }
+
+        (contains_conditional, contains_deferred, changed)
+    }
+
+    fn normalize_erased_overload_return(
+        &self,
+        type_id: TypeId,
+        memo: &mut rustc_hash::FxHashMap<TypeId, ErasedReturnNormalization>,
+    ) -> ErasedReturnNormalization {
+        if type_id.is_intrinsic() {
+            return ErasedReturnNormalization::unchanged(type_id);
+        }
+        if let Some(&cached) = memo.get(&type_id) {
+            return cached;
+        }
+        // Mark before descending so recursive/shared structural graphs terminate.
+        memo.insert(type_id, ErasedReturnNormalization::unchanged(type_id));
+
+        let normalized = match self.interner.lookup(type_id) {
+            Some(TypeData::Conditional(conditional_id)) => {
+                let conditional = self.interner.get_conditional(conditional_id);
+                if conditional.is_distributive
+                    || conditional.check_type == TypeId::ERROR
+                    || conditional.true_type == TypeId::ERROR
+                    || conditional.extends_type != TypeId::ANY
+                    || crate::type_queries::contains_infer_types_db(
+                        self.interner,
+                        conditional.check_type,
+                    )
+                    || crate::type_queries::contains_infer_types_db(
+                        self.interner,
+                        conditional.extends_type,
+                    )
+                {
+                    ErasedReturnNormalization {
+                        type_id,
+                        contains_conditional: true,
+                        contains_deferred: true,
+                    }
+                } else {
+                    let selected =
+                        self.normalize_erased_overload_return(conditional.true_type, memo);
+                    ErasedReturnNormalization {
+                        type_id: selected.type_id,
+                        contains_conditional: true,
+                        // An infer in the selected result still belongs to the
+                        // ordinary inference relation. Infer in the discarded
+                        // false branch is intentionally irrelevant.
+                        contains_deferred: selected.contains_deferred
+                            || crate::type_queries::contains_infer_types_db(
+                                self.interner,
+                                selected.type_id,
+                            ),
+                    }
+                }
+            }
+            Some(TypeData::Application(application_id)) => {
+                let application = self.interner.type_application(application_id);
+                let mut contains_conditional = false;
+                let mut contains_deferred = false;
+                let mut changed = false;
+                let args = application
+                    .args
+                    .iter()
+                    .map(|&arg| {
+                        let child = self.normalize_erased_overload_return(arg, memo);
+                        contains_conditional |= child.contains_conditional;
+                        contains_deferred |= child.contains_deferred;
+                        changed |= child.type_id != arg;
+                        child.type_id
+                    })
+                    .collect();
+                ErasedReturnNormalization {
+                    type_id: if changed {
+                        self.interner.application(application.base, args)
+                    } else {
+                        type_id
+                    },
+                    contains_conditional,
+                    contains_deferred,
+                }
+            }
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+                let is_indexed = matches!(
+                    self.interner.lookup(type_id),
+                    Some(TypeData::ObjectWithIndex(_))
+                );
+                let mut shape = self.interner.object_shape(shape_id).as_ref().clone();
+                let mut contains_conditional = false;
+                let mut contains_deferred = false;
+                let mut changed = false;
+
+                for property in &mut shape.properties {
+                    let read = self.normalize_erased_overload_return(property.type_id, memo);
+                    contains_conditional |= read.contains_conditional;
+                    contains_deferred |= read.contains_deferred;
+                    changed |= read.type_id != property.type_id;
+                    property.type_id = read.type_id;
+
+                    let write = self.normalize_erased_overload_return(property.write_type, memo);
+                    contains_conditional |= write.contains_conditional;
+                    contains_deferred |= write.contains_deferred;
+                    changed |= write.type_id != property.write_type;
+                    property.write_type = write.type_id;
+                }
+
+                for index in [
+                    &mut shape.string_index,
+                    &mut shape.number_index,
+                    &mut shape.symbol_index,
+                ]
+                .into_iter()
+                .flatten()
+                {
+                    let key = self.normalize_erased_overload_return(index.key_type, memo);
+                    let value = self.normalize_erased_overload_return(index.value_type, memo);
+                    contains_conditional |= key.contains_conditional || value.contains_conditional;
+                    contains_deferred |= key.contains_deferred || value.contains_deferred;
+                    changed |= key.type_id != index.key_type || value.type_id != index.value_type;
+                    index.key_type = key.type_id;
+                    index.value_type = value.type_id;
+                }
+
+                ErasedReturnNormalization {
+                    type_id: if !changed {
+                        type_id
+                    } else if is_indexed {
+                        self.interner.object_with_index(shape)
+                    } else {
+                        self.interner.object_with_flags_and_symbol(
+                            shape.properties,
+                            shape.flags,
+                            shape.symbol,
+                        )
+                    },
+                    contains_conditional,
+                    contains_deferred,
+                }
+            }
+            Some(TypeData::Function(shape_id)) => {
+                let mut shape = self.interner.function_shape(shape_id).as_ref().clone();
+                let mut contains_conditional = false;
+                let mut contains_deferred = false;
+                let mut changed = false;
+
+                for type_param in &mut shape.type_params {
+                    for slot in [&mut type_param.constraint, &mut type_param.default]
+                        .into_iter()
+                        .flatten()
+                    {
+                        let child = self.normalize_erased_overload_return(*slot, memo);
+                        contains_conditional |= child.contains_conditional;
+                        contains_deferred |= child.contains_deferred;
+                        changed |= child.type_id != *slot;
+                        *slot = child.type_id;
+                    }
+                }
+                for param in &mut shape.params {
+                    let child = self.normalize_erased_overload_return(param.type_id, memo);
+                    contains_conditional |= child.contains_conditional;
+                    contains_deferred |= child.contains_deferred;
+                    changed |= child.type_id != param.type_id;
+                    param.type_id = child.type_id;
+                }
+                if let Some(this_type) = &mut shape.this_type {
+                    let child = self.normalize_erased_overload_return(*this_type, memo);
+                    contains_conditional |= child.contains_conditional;
+                    contains_deferred |= child.contains_deferred;
+                    changed |= child.type_id != *this_type;
+                    *this_type = child.type_id;
+                }
+                let returned = self.normalize_erased_overload_return(shape.return_type, memo);
+                contains_conditional |= returned.contains_conditional;
+                contains_deferred |= returned.contains_deferred;
+                changed |= returned.type_id != shape.return_type;
+                shape.return_type = returned.type_id;
+                if let Some(type_predicate) = &mut shape.type_predicate
+                    && let Some(predicate_type) = &mut type_predicate.type_id
+                {
+                    let child = self.normalize_erased_overload_return(*predicate_type, memo);
+                    contains_conditional |= child.contains_conditional;
+                    contains_deferred |= child.contains_deferred;
+                    changed |= child.type_id != *predicate_type;
+                    *predicate_type = child.type_id;
+                }
+
+                ErasedReturnNormalization {
+                    type_id: if changed {
+                        self.interner.function(shape)
+                    } else {
+                        type_id
+                    },
+                    contains_conditional,
+                    contains_deferred,
+                }
+            }
+            Some(TypeData::Callable(shape_id)) => {
+                let mut shape = self.interner.callable_shape(shape_id).as_ref().clone();
+                let mut contains_conditional = false;
+                let mut contains_deferred = false;
+                let mut changed = false;
+
+                for signature in shape
+                    .call_signatures
+                    .iter_mut()
+                    .chain(shape.construct_signatures.iter_mut())
+                {
+                    let (signature_conditional, signature_deferred, signature_changed) =
+                        self.normalize_erased_call_signature_fields(signature, memo);
+                    contains_conditional |= signature_conditional;
+                    contains_deferred |= signature_deferred;
+                    changed |= signature_changed;
+                }
+                for property in &mut shape.properties {
+                    let read = self.normalize_erased_overload_return(property.type_id, memo);
+                    let write = self.normalize_erased_overload_return(property.write_type, memo);
+                    contains_conditional |= read.contains_conditional || write.contains_conditional;
+                    contains_deferred |= read.contains_deferred || write.contains_deferred;
+                    changed |=
+                        read.type_id != property.type_id || write.type_id != property.write_type;
+                    property.type_id = read.type_id;
+                    property.write_type = write.type_id;
+                }
+                for index in [&mut shape.string_index, &mut shape.number_index]
+                    .into_iter()
+                    .flatten()
+                {
+                    let key = self.normalize_erased_overload_return(index.key_type, memo);
+                    let value = self.normalize_erased_overload_return(index.value_type, memo);
+                    contains_conditional |= key.contains_conditional || value.contains_conditional;
+                    contains_deferred |= key.contains_deferred || value.contains_deferred;
+                    changed |= key.type_id != index.key_type || value.type_id != index.value_type;
+                    index.key_type = key.type_id;
+                    index.value_type = value.type_id;
+                }
+
+                ErasedReturnNormalization {
+                    type_id: if changed {
+                        self.interner.callable(shape)
+                    } else {
+                        type_id
+                    },
+                    contains_conditional,
+                    contains_deferred,
+                }
+            }
+            Some(TypeData::Union(list_id) | TypeData::Intersection(list_id)) => {
+                let members = self.interner.type_list(list_id);
+                let is_union = matches!(self.interner.lookup(type_id), Some(TypeData::Union(_)));
+                let mut contains_conditional = false;
+                let mut contains_deferred = false;
+                let mut changed = false;
+                let members = members
+                    .iter()
+                    .map(|&member| {
+                        let child = self.normalize_erased_overload_return(member, memo);
+                        contains_conditional |= child.contains_conditional;
+                        contains_deferred |= child.contains_deferred;
+                        changed |= child.type_id != member;
+                        child.type_id
+                    })
+                    .collect();
+                ErasedReturnNormalization {
+                    type_id: if !changed {
+                        type_id
+                    } else if is_union {
+                        self.interner.union(members)
+                    } else {
+                        self.interner.intersection(members)
+                    },
+                    contains_conditional,
+                    contains_deferred,
+                }
+            }
+            Some(TypeData::Array(element)) => {
+                let child = self.normalize_erased_overload_return(element, memo);
+                ErasedReturnNormalization {
+                    type_id: if child.type_id == element {
+                        type_id
+                    } else {
+                        self.interner.array(child.type_id)
+                    },
+                    contains_conditional: child.contains_conditional,
+                    contains_deferred: child.contains_deferred,
+                }
+            }
+            Some(TypeData::Tuple(list_id)) => {
+                let elements = self.interner.tuple_list(list_id);
+                let mut contains_conditional = false;
+                let mut contains_deferred = false;
+                let mut changed = false;
+                let elements = elements
+                    .iter()
+                    .copied()
+                    .map(|mut element| {
+                        let child = self.normalize_erased_overload_return(element.type_id, memo);
+                        contains_conditional |= child.contains_conditional;
+                        contains_deferred |= child.contains_deferred;
+                        changed |= child.type_id != element.type_id;
+                        element.type_id = child.type_id;
+                        element
+                    })
+                    .collect();
+                ErasedReturnNormalization {
+                    type_id: if changed {
+                        self.interner.tuple(elements)
+                    } else {
+                        type_id
+                    },
+                    contains_conditional,
+                    contains_deferred,
+                }
+            }
+            Some(TypeData::IndexAccess(object, index)) => {
+                let normalized_object = self.normalize_erased_overload_return(object, memo);
+                let normalized_index = self.normalize_erased_overload_return(index, memo);
+                let changed =
+                    normalized_object.type_id != object || normalized_index.type_id != index;
+                ErasedReturnNormalization {
+                    type_id: if changed {
+                        self.interner
+                            .index_access(normalized_object.type_id, normalized_index.type_id)
+                    } else {
+                        type_id
+                    },
+                    contains_conditional: normalized_object.contains_conditional
+                        || normalized_index.contains_conditional,
+                    contains_deferred: normalized_object.contains_deferred
+                        || normalized_index.contains_deferred,
+                }
+            }
+            Some(TypeData::ReadonlyType(inner)) => {
+                let child = self.normalize_erased_overload_return(inner, memo);
+                ErasedReturnNormalization {
+                    type_id: if child.type_id == inner {
+                        type_id
+                    } else {
+                        self.interner.readonly_type(child.type_id)
+                    },
+                    contains_conditional: child.contains_conditional,
+                    contains_deferred: child.contains_deferred,
+                }
+            }
+            Some(TypeData::NoInfer(inner)) => {
+                let child = self.normalize_erased_overload_return(inner, memo);
+                ErasedReturnNormalization {
+                    type_id: if child.type_id == inner {
+                        type_id
+                    } else {
+                        self.interner.no_infer(child.type_id)
+                    },
+                    contains_conditional: child.contains_conditional,
+                    contains_deferred: child.contains_deferred,
+                }
+            }
+            Some(TypeData::Substitution {
+                base_type,
+                constraint,
+            }) => {
+                let base = self.normalize_erased_overload_return(base_type, memo);
+                let normalized_constraint = self.normalize_erased_overload_return(constraint, memo);
+                let changed =
+                    base.type_id != base_type || normalized_constraint.type_id != constraint;
+                ErasedReturnNormalization {
+                    type_id: if changed {
+                        self.interner
+                            .substitution(base.type_id, normalized_constraint.type_id)
+                    } else {
+                        type_id
+                    },
+                    contains_conditional: base.contains_conditional
+                        || normalized_constraint.contains_conditional,
+                    contains_deferred: base.contains_deferred
+                        || normalized_constraint.contains_deferred,
+                }
+            }
+            _ => ErasedReturnNormalization::unchanged(type_id),
+        };
+        memo.insert(type_id, normalized);
+        normalized
+    }
+
+    fn erased_return_args_are_identical_or_any(
+        &self,
+        source_return: TypeId,
+        target_return: TypeId,
+    ) -> bool {
+        let Some((source_base, source_args)) =
+            crate::type_queries::get_application_info(self.interner, source_return)
+        else {
+            return false;
+        };
+        let Some((target_base, target_args)) =
+            crate::type_queries::get_application_info(self.interner, target_return)
+        else {
+            return false;
+        };
+        source_base == target_base
+            && source_args.len() == target_args.len()
+            && source_args
+                .iter()
+                .zip(target_args.iter())
+                .all(|(&source_arg, &target_arg)| {
+                    source_arg == target_arg
+                        || ((source_arg.is_any() || target_arg.is_any())
+                            && source_arg != TypeId::NEVER
+                            && target_arg != TypeId::NEVER)
+                })
+            && source_args
+                .iter()
+                .zip(target_args.iter())
+                .any(|(&source_arg, &target_arg)| source_arg != target_arg)
+    }
+
     /// Compare a call signature against a function type after erasing both signatures'
     /// type parameters to `any`. Matches tsc's N x M `signaturesRelatedTo` path.
     pub(super) fn check_erased_signature_subtype_to_fn(
@@ -89,6 +896,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // Preserve constructor-vs-callable intent from the target function shape.
         s_erased.is_constructor = t_fn.is_constructor;
         let t_erased = erase_fn_shape_to_any(t_fn, self.interner);
+        if self.erased_return_variance_rejects(s_erased.return_type, t_erased.return_type) {
+            return SubtypeResult::False;
+        }
         self.check_function_subtype(&s_erased, &t_erased)
     }
 
@@ -101,6 +911,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ) -> SubtypeResult {
         let s_erased = erase_call_sig_to_any(source, self.interner);
         let t_erased = erase_call_sig_to_any(target, self.interner);
+        if self.erased_return_variance_rejects(s_erased.return_type, t_erased.return_type) {
+            return SubtypeResult::False;
+        }
         self.check_function_subtype(&s_erased, &t_erased)
     }
 
@@ -109,8 +922,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: &CallSignature,
         target: &CallSignature,
     ) -> SubtypeResult {
+        if source.type_params.is_empty() && target.type_params.is_empty() {
+            return SubtypeResult::False;
+        }
         let s_erased = erase_call_sig_to_any(source, self.interner);
         let t_erased = erase_call_sig_to_any(target, self.interner);
+        let normalization = self.normalize_erased_target_return(t_erased.return_type);
+        if self.erased_normalized_return_rejects(s_erased.return_type, normalization) {
+            return SubtypeResult::False;
+        }
         self.check_erased_function_shapes_params_with_matching_return_base(
             s_erased, t_erased, false,
         )
@@ -141,6 +961,103 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         s_erased.is_constructor = true;
         t_erased.is_constructor = true;
         self.check_function_subtype(&s_erased, &t_erased)
+    }
+
+    pub(super) fn method_overloads_cover_tuple_union_rest_target(
+        &mut self,
+        source_sigs: &[CallSignature],
+        target_sig: &CallSignature,
+    ) -> bool {
+        use crate::type_queries::data::get_union_members;
+        use crate::type_queries::unpack_tuple_rest_parameter;
+
+        let Some(last_target_param) = target_sig.params.last().filter(|param| param.rest) else {
+            return false;
+        };
+        let Some(union_members) = get_union_members(self.interner, last_target_param.type_id)
+        else {
+            return false;
+        };
+        // The tuple-union prefix shortcut below exists only to prove parameter
+        // coverage. Normalize the target once and compute the erased return
+        // rejection once per source signature so a params-only match cannot
+        // bypass a determinate conditional return mismatch (and so V tuple
+        // variants do not repeat the return walk).
+        let erased_target = erase_call_sig_to_any(target_sig, self.interner);
+        let target_normalization = self.normalize_erased_target_return(erased_target.return_type);
+        let return_rejections: Vec<bool> = source_sigs
+            .iter()
+            .map(|source_sig| {
+                let erased_source = erase_call_sig_to_any(source_sig, self.interner);
+                self.erased_normalized_return_rejects(
+                    erased_source.return_type,
+                    target_normalization,
+                )
+            })
+            .collect();
+
+        let prefix_params = &target_sig.params[..target_sig.params.len().saturating_sub(1)];
+        union_members.iter().all(|member_type_id| {
+            let member_param = ParamInfo {
+                type_id: *member_type_id,
+                rest: true,
+                ..*last_target_param
+            };
+            let mut variant_params = prefix_params.to_vec();
+            variant_params.extend(unpack_tuple_rest_parameter(self.interner, &member_param));
+            source_sigs
+                .iter()
+                .zip(&return_rejections)
+                .any(|(source_sig, &return_rejects)| {
+                    if return_rejects {
+                        return false;
+                    }
+                    let source_fn = FunctionShape {
+                        type_params: source_sig.type_params.clone(),
+                        params: source_sig.params.clone(),
+                        this_type: source_sig.this_type,
+                        return_type: source_sig.return_type,
+                        type_predicate: source_sig.type_predicate,
+                        is_constructor: false,
+                        is_method: source_sig.is_method,
+                    };
+                    let variant_fn = FunctionShape {
+                        type_params: target_sig.type_params.clone(),
+                        params: variant_params.clone(),
+                        this_type: target_sig.this_type,
+                        return_type: target_sig.return_type,
+                        type_predicate: target_sig.type_predicate,
+                        is_constructor: false,
+                        is_method: target_sig.is_method,
+                    };
+                    self.check_function_subtype(&source_fn, &variant_fn)
+                        .is_true()
+                        || self.method_overload_prefix_covers_variant(source_sig, &variant_params)
+                })
+        })
+    }
+
+    fn method_overload_prefix_covers_variant(
+        &mut self,
+        source_sig: &CallSignature,
+        variant_params: &[ParamInfo],
+    ) -> bool {
+        if !source_sig.is_method || variant_params.is_empty() {
+            return false;
+        }
+        if source_sig.params.len() < variant_params.len() {
+            return false;
+        }
+        source_sig
+            .params
+            .iter()
+            .zip(variant_params.iter())
+            .take(variant_params.len())
+            .all(|(source_param, target_param)| {
+                let (source_type, target_type) =
+                    self.effective_param_type_pair(source_param, target_param);
+                self.are_parameters_compatible_impl(source_type, target_type, true)
+            })
     }
 
     fn check_function_subtype_either_direction(

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -453,6 +453,22 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let same_application_family =
             (same_arity && s_app.base == t_app.base) || variance_def_id.is_some();
 
+        let same_base_any_never_pair = same_arity
+            && s_app.base == t_app.base
+            && s_app
+                .args
+                .iter()
+                .zip(t_app.args.iter())
+                .any(|(&source, &target)| {
+                    (source.is_any() && target == TypeId::NEVER)
+                        || (source == TypeId::NEVER && target.is_any())
+                });
+        if same_base_any_never_pair
+            && let Some(result) = self.try_same_base_any_never_variance_result(s_app_id, t_app_id)
+        {
+            return result;
+        }
+
         if !same_application_family
             && s_app.args.len() == 1
             && t_app.args.len() == 1
@@ -491,7 +507,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // concrete shapes. (Conditional-bodied alias bases keep their existing
         // variance handling, which is intentionally retained for differing args.)
         // =======================================================================
-        if same_application_family && !self.is_indexed_access_alias_base_inline(s_app.base) {
+        if same_application_family
+            && !same_base_any_never_pair
+            && !self.is_indexed_access_alias_base_inline(s_app.base)
+        {
             // Try to resolve DefId from the base to query variance
             let def_id = variance_def_id;
 
@@ -942,20 +961,45 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             (s_app.args.clone(), t_app.args.clone())
         };
 
-        let variances = self.resolver.get_type_param_variance(def_id).or_else(|| {
-            crate::relations::variance::compute_type_param_variances_with_resolver_cached(
-                self.interner,
-                self.resolver,
-                self.query_db,
-                def_id,
-            )
+        let has_any_never_pair = s_args.iter().zip(t_args.iter()).any(|(&source, &target)| {
+            (source.is_any() && target == TypeId::NEVER)
+                || (source == TypeId::NEVER && target.is_any())
         });
-        // T<X> <: T<any> and T<any> <: T<X> are always true when
-        // any-propagation is enabled; skip variance computation entirely rather
-        // than risking structural expansion. The shortcut requires `any` to be
-        // permissive on BOTH sides: under asymmetric modes (overload subtype
-        // pass) `T<any> <: T<X>` must fall through to the per-argument variance
-        // checks so an `any` source argument is rejected there.
+        if has_any_never_pair {
+            let classification =
+                self.classify_application_args_any_never_variance(def_id, &s_args, &t_args)?;
+            if classification.rejects {
+                return Some(SubtypeResult::False);
+            }
+            if !classification.has_unresolved_exceptional
+                && let Some(result) = self.try_application_variance_with_mask(
+                    &classification.variances,
+                    &s_args,
+                    &t_args,
+                )
+            {
+                return Some(result);
+            }
+            if classification.accepted_indices.is_empty() {
+                // Transform aliases, inferred nonstrict variance, unreliable
+                // masks, and registration gaps remain structural decisions.
+                return None;
+            }
+            let mut masked_source_args = s_args.to_vec();
+            for index in classification.accepted_indices {
+                masked_source_args[index] = t_args[index];
+            }
+            let masked_source = self.interner.application(s_app.base, masked_source_args);
+            let target = self.interner.application(t_app.base, t_args.to_vec());
+            return Some(self.check_subtype(masked_source, target));
+        }
+
+        // T<X> <: T<any> and T<any> <: T<X> are true when any-propagation is
+        // enabled, except for the directional `any`/`never` variance rule. Skip
+        // the general variance walk for the common case rather than risking
+        // structural expansion. The shortcut requires `any` to be permissive on
+        // BOTH sides: under asymmetric modes (overload subtype pass)
+        // `T<any> <: T<X>` must fall through to the per-argument variance checks.
         let allow_any = self
             .any_propagation
             .allows_any_source_at_depth(self.guard.depth())
@@ -966,7 +1010,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return Some(SubtypeResult::True);
         }
 
-        let variances = variances?;
+        let variances = self.resolve_application_variances(def_id)?;
 
         if variances.len() != s_args.len() {
             return None;

--- a/crates/tsz-solver/src/relations/subtype/rules/generics_application_helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics_application_helpers.rs
@@ -5,7 +5,15 @@ use crate::diagnostics::SubtypeFailureReason;
 use crate::types::{TypeApplication, TypeApplicationId, TypeData, TypeId, Variance};
 use crate::visitor::{application_id, object_shape_id, object_with_index_shape_id};
 use rustc_hash::FxHashSet;
+use smallvec::SmallVec;
 use std::sync::Arc;
+
+pub(crate) struct AnyNeverVarianceClassification {
+    pub(crate) rejects: bool,
+    pub(super) accepted_indices: SmallVec<[usize; 4]>,
+    pub(super) has_unresolved_exceptional: bool,
+    pub(super) variances: Arc<[Variance]>,
+}
 
 /// Maximum nesting depth, per generic `DefId`, for the one-sided application
 /// expansion relation paths (`App <: T` and `T <: App`).
@@ -22,6 +30,374 @@ use std::sync::Arc;
 pub(crate) const ONE_SIDED_APP_EXPANSION_MAX_DEPTH: u32 = 5;
 
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
+    /// Reject a same-base application when a direct `any`/`never` argument pair
+    /// is incompatible in a reliably measured variance position.
+    ///
+    /// The two orientations cannot use the generic `any` shortcut: covariance
+    /// rejects `any -> never`; contravariance rejects `never -> any`, and
+    /// invariance rejects both. The effective mask has already applied callback
+    /// bivariance for the active `strictFunctionTypes` setting and retained
+    /// explicit `in`/`out` annotations. An independent position accepts both.
+    /// Unknown or structurally unreliable variance remains undecided.
+    pub(crate) fn try_same_base_any_never_variance_result(
+        &mut self,
+        s_app_id: TypeApplicationId,
+        t_app_id: TypeApplicationId,
+    ) -> Option<SubtypeResult> {
+        let s_app = self.interner.type_application(s_app_id);
+        let t_app = self.interner.type_application(t_app_id);
+        if s_app.base != t_app.base || s_app.args.len() != t_app.args.len() {
+            return None;
+        }
+        if !s_app
+            .args
+            .iter()
+            .zip(t_app.args.iter())
+            .any(|(&source, &target)| {
+                (source.is_any() && target == TypeId::NEVER)
+                    || (source == TypeId::NEVER && target.is_any())
+            })
+        {
+            return None;
+        }
+        // Indexed-access aliases are transparent transforms. Their expanded
+        // result can normalize an apparent raw-argument mismatch away, so the
+        // established structural fallback remains authoritative.
+        if self.is_indexed_access_alias_base_inline(s_app.base) {
+            return None;
+        }
+        let def_id = self.application_base_def_id(s_app.base)?;
+        let classification =
+            self.classify_application_args_any_never_variance(def_id, &s_app.args, &t_app.args)?;
+        if classification.rejects {
+            return Some(SubtypeResult::False);
+        }
+        if !classification.has_unresolved_exceptional
+            && let Some(result) = self.try_application_variance_with_mask(
+                &classification.variances,
+                &s_app.args,
+                &t_app.args,
+            )
+        {
+            return Some(result);
+        }
+        if classification.accepted_indices.is_empty() {
+            return None;
+        }
+        let mut masked_source_args = s_app.args.to_vec();
+        for index in classification.accepted_indices {
+            masked_source_args[index] = t_app.args[index];
+        }
+        let masked_source = self.interner.application(s_app.base, masked_source_args);
+        let target = self.interner.application(t_app.base, t_app.args.to_vec());
+        Some(self.check_subtype(masked_source, target))
+    }
+
+    /// Apply a pre-resolved variance mask to every application argument.
+    ///
+    /// The exceptional `any`/`never` positions have already been classified;
+    /// this second pass is what keeps mismatches in other slots visible,
+    /// including structurally filled holes of partial variance declarations.
+    pub(super) fn try_application_variance_with_mask(
+        &mut self,
+        variances: &[Variance],
+        source_args: &[TypeId],
+        target_args: &[TypeId],
+    ) -> Option<SubtypeResult> {
+        if variances.len() != source_args.len() || source_args.len() != target_args.len() {
+            return None;
+        }
+        let needs_structural_fallback = variances.iter().any(Variance::needs_structural_fallback);
+        let rejection_unreliable = variances.iter().any(Variance::rejection_unreliable);
+        let outcome = crate::relations::variance::run_application_variance_arg_loop(
+            variances,
+            source_args,
+            target_args,
+            |source, target| self.check_subtype(source, target).is_true(),
+        );
+        if outcome.all_ok
+            && !needs_structural_fallback
+            && (outcome.any_checked || !variances.is_empty())
+        {
+            return Some(SubtypeResult::True);
+        }
+        if outcome.any_checked
+            && !outcome.all_ok
+            && !needs_structural_fallback
+            && !rejection_unreliable
+            && !args_contain_type_parameters(self.interner, source_args)
+        {
+            return Some(SubtypeResult::False);
+        }
+        None
+    }
+
+    /// Reject `any`/`never` through reliable nested application variance.
+    ///
+    /// Each level must be the same generic identity or an exact one-parameter
+    /// pass-through alias of the opposite identity. Indexed-access transforms,
+    /// unreliable variance, and unknown application shapes remain undecided so
+    /// the ordinary structural relation owns them. A cycle-safe worklist avoids
+    /// treating arbitrary nesting depth or traversal fuel as compatibility.
+    pub(crate) fn application_any_never_variance_rejects(
+        &self,
+        s_app_id: TypeApplicationId,
+        t_app_id: TypeApplicationId,
+    ) -> bool {
+        if !self.application_pair_reaches_any_never(s_app_id, t_app_id) {
+            // This query also runs for ordinary erased overload return pairs.
+            // Keep pairs without a corresponding exceptional leaf on the
+            // shape-only path with no `DefId` or variance resolution.
+            return false;
+        }
+
+        let mut pending = SmallVec::<[(TypeApplicationId, TypeApplicationId); 8]>::new();
+        let mut seen = FxHashSet::default();
+        pending.push((s_app_id, t_app_id));
+        while let Some((s_app_id, t_app_id)) = pending.pop() {
+            if !seen.insert((s_app_id, t_app_id)) {
+                continue;
+            }
+            let s_app = self.interner.type_application(s_app_id);
+            let t_app = self.interner.type_application(t_app_id);
+            if s_app.args.len() != t_app.args.len() {
+                continue;
+            }
+
+            let (Some(s_def), Some(t_def)) = (
+                self.application_base_def_id(s_app.base),
+                self.application_base_def_id(t_app.base),
+            ) else {
+                continue;
+            };
+            let def_id = if s_app.base == t_app.base {
+                if self.is_indexed_access_alias_base_inline(s_app.base) {
+                    continue;
+                }
+                s_def
+            } else if self.alias_body_forwards_positionally_to_generic(s_def, t_def) {
+                if self.is_indexed_access_alias_base_inline(t_app.base) {
+                    continue;
+                }
+                t_def
+            } else if self.alias_body_forwards_positionally_to_generic(t_def, s_def) {
+                if self.is_indexed_access_alias_base_inline(s_app.base) {
+                    continue;
+                }
+                s_def
+            } else {
+                continue;
+            };
+            let Some(def_id) = self.any_never_variance_owner_def(def_id) else {
+                // A non-pass-through type alias is a transparent transform.
+                // Its expanded result, rather than raw arguments, is authoritative.
+                continue;
+            };
+
+            let Some(variances) = self.resolve_any_never_application_variances(def_id) else {
+                continue;
+            };
+            if variances.len() != s_app.args.len() {
+                continue;
+            }
+
+            for ((&source_arg, &target_arg), variance) in s_app
+                .args
+                .iter()
+                .zip(t_app.args.iter())
+                .zip(variances.iter())
+            {
+                if variance.needs_structural_fallback() || variance.rejection_unreliable() {
+                    continue;
+                }
+                let forward = variance.is_covariant() || variance.is_invariant();
+                let reverse = variance.is_contravariant() || variance.is_invariant();
+
+                if (forward && source_arg.is_any() && target_arg == TypeId::NEVER)
+                    || (reverse && source_arg == TypeId::NEVER && target_arg.is_any())
+                {
+                    return true;
+                }
+                let (Some(source_child), Some(target_child)) = (
+                    application_id(self.interner, source_arg),
+                    application_id(self.interner, target_arg),
+                ) else {
+                    continue;
+                };
+                if forward {
+                    pending.push((source_child, target_child));
+                }
+                if reverse {
+                    pending.push((target_child, source_child));
+                }
+            }
+        }
+        false
+    }
+
+    /// Shape-only prefilter for the exceptional classifier. It follows paired
+    /// application arguments without alias, `DefId`, or variance queries and
+    /// uses application-pair identity to terminate cycles at any finite depth.
+    fn application_pair_reaches_any_never(
+        &self,
+        s_app_id: TypeApplicationId,
+        t_app_id: TypeApplicationId,
+    ) -> bool {
+        let mut pending = SmallVec::<[(TypeId, TypeId); 16]>::new();
+        let mut seen = FxHashSet::default();
+        let s_app = self.interner.type_application(s_app_id);
+        let t_app = self.interner.type_application(t_app_id);
+        if s_app.args.len() != t_app.args.len() {
+            return false;
+        }
+        pending.extend(s_app.args.iter().copied().zip(t_app.args.iter().copied()));
+        while let Some((source, target)) = pending.pop() {
+            if (source.is_any() && target == TypeId::NEVER)
+                || (source == TypeId::NEVER && target.is_any())
+            {
+                return true;
+            }
+            if source == target {
+                continue;
+            }
+            let (Some(source_app_id), Some(target_app_id)) = (
+                application_id(self.interner, source),
+                application_id(self.interner, target),
+            ) else {
+                continue;
+            };
+            if !seen.insert((source_app_id, target_app_id)) {
+                continue;
+            }
+            let source_app = self.interner.type_application(source_app_id);
+            let target_app = self.interner.type_application(target_app_id);
+            if source_app.args.len() == target_app.args.len() {
+                pending.extend(
+                    source_app
+                        .args
+                        .iter()
+                        .copied()
+                        .zip(target_app.args.iter().copied()),
+                );
+            }
+        }
+        false
+    }
+
+    /// Apply the `any`/`never` exception using the variance of `def_id`.
+    ///
+    /// Accepts argument slices separately from their application bases so a
+    /// transparent pass-through alias can be compared against the generic body
+    /// it forwards to without losing argument orientation.
+    pub(crate) fn classify_application_args_any_never_variance(
+        &self,
+        def_id: DefId,
+        source_args: &[TypeId],
+        target_args: &[TypeId],
+    ) -> Option<AnyNeverVarianceClassification> {
+        if source_args.len() != target_args.len()
+            || !source_args
+                .iter()
+                .zip(target_args.iter())
+                .any(|(&s_arg, &t_arg)| {
+                    (s_arg.is_any() && t_arg == TypeId::NEVER)
+                        || (s_arg == TypeId::NEVER && t_arg.is_any())
+                })
+        {
+            // Keep the common same-application path O(arity) with no resolver
+            // or variance-cache traffic unless the exceptional pair exists.
+            return None;
+        }
+        let def_id = self.any_never_variance_owner_def(def_id)?;
+        let variances = self.resolve_any_never_application_variances(def_id)?;
+        if variances.len() != source_args.len() {
+            return None;
+        }
+
+        let mut accepted_indices = SmallVec::<[usize; 4]>::new();
+        let mut has_unresolved_exceptional = false;
+        for (index, ((&s_arg, &t_arg), variance)) in source_args
+            .iter()
+            .zip(target_args.iter())
+            .zip(variances.iter())
+            .enumerate()
+        {
+            let source_any_to_never = s_arg.is_any() && t_arg == TypeId::NEVER;
+            let source_never_to_any = s_arg == TypeId::NEVER && t_arg.is_any();
+            if !source_any_to_never && !source_never_to_any {
+                continue;
+            }
+            if variance.is_pure_bivariant_usage() {
+                accepted_indices.push(index);
+                continue;
+            }
+            let reliable =
+                !variance.needs_structural_fallback() && !variance.rejection_unreliable();
+            if !reliable {
+                has_unresolved_exceptional = true;
+                continue;
+            }
+            let covariant = variance.is_covariant();
+            let contravariant = variance.is_contravariant();
+            let invariant = variance.is_invariant();
+            if (source_any_to_never && (covariant || invariant))
+                || (source_never_to_any && (contravariant || invariant))
+            {
+                return Some(AnyNeverVarianceClassification {
+                    rejects: true,
+                    accepted_indices,
+                    has_unresolved_exceptional,
+                    variances,
+                });
+            }
+            if (source_any_to_never && contravariant)
+                || (source_never_to_any && covariant)
+                || variance.is_independent()
+            {
+                accepted_indices.push(index);
+            } else {
+                has_unresolved_exceptional = true;
+            }
+        }
+
+        Some(AnyNeverVarianceClassification {
+            rejects: false,
+            accepted_indices,
+            has_unresolved_exceptional,
+            variances,
+        })
+    }
+
+    /// Resolve variance for the already-proven exceptional `any`/`never` path.
+    ///
+    /// The result merges partial annotations at every nested declaration and
+    /// observes the active `strictFunctionTypes` callback rule. The
+    /// generation-scoped evaluation-session cache keeps repeated exceptional
+    /// queries O(arity) without retaining stale publication generations.
+    fn resolve_any_never_application_variances(&self, def_id: DefId) -> Option<Arc<[Variance]>> {
+        let outcome =
+            crate::relations::variance::compute_effective_type_param_variances_with_resolver_cached(
+                self.interner,
+                self.resolver,
+                self.eval_session,
+                def_id,
+                self.strict_function_types,
+                self.disable_method_bivariance,
+            );
+        let Some(outcome) = outcome else {
+            // The effective query is registration-dependent. Taint the
+            // enclosing relation so a provisional structural fallback cannot
+            // be persisted before the definition finishes registration.
+            self.note_unresolved_lazy_relation_event();
+            return None;
+        };
+        if outcome.incomplete {
+            self.note_unresolved_lazy_relation_event();
+            return None;
+        }
+        Some(outcome.variances)
+    }
+
     /// Same-base all-`any`-target-args lawyer shortcut.
     pub(crate) fn try_same_base_all_any_target_args(
         &mut self,
@@ -31,6 +407,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ) -> Option<SubtypeResult> {
         let t_app = self.interner.type_application(t_app_id);
         if t_app.args.is_empty() || !t_app.args.iter().all(|arg| arg.is_any()) {
+            return None;
+        }
+        if s_app_id.is_some_and(|s_app_id| {
+            self.interner
+                .type_application(s_app_id)
+                .args
+                .contains(&TypeId::NEVER)
+        }) {
+            // `never` against target `any` depends on the generic parameter's
+            // variance. Leave that pair to the variance-aware relation.
             return None;
         }
         let allow_any = self
@@ -250,10 +636,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Generalizes [`Self::try_same_base_all_any_target_args`] to mixed
     /// argument lists: when source and target are applications of the SAME
     /// generic definition with equal arity and every argument pair is either
-    /// the identical `TypeId` or has `any` on at least one side, tsc relates
-    /// the two instantiations (`relateVariances`: an invariant-strength
-    /// per-argument check passes in both directions for `any`, regardless of
-    /// the measured variance and before any structural expansion). This is
+    /// the identical `TypeId` or has a compatible `any`, tsc relates the two
+    /// instantiations. An `any`/`never` pair in either orientation must fall
+    /// through to the ordinary variance relation because covariance and
+    /// contravariance give those two orientations opposite answers. This is
     /// the kysely `ExpressionWrapper<DB, TB, any>` vs
     /// `ExpressionWrapper<DB, TB, O[K]>` shape, whose deferred-conditional
     /// members can never relate structurally.
@@ -283,11 +669,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if !same_definition {
             return None;
         }
-        let args_identical_or_any = s_app
-            .args
-            .iter()
-            .zip(t_app.args.iter())
-            .all(|(&s_arg, &t_arg)| s_arg == t_arg || s_arg.is_any() || t_arg.is_any());
+        let args_identical_or_any =
+            s_app
+                .args
+                .iter()
+                .zip(t_app.args.iter())
+                .all(|(&s_arg, &t_arg)| {
+                    s_arg == t_arg
+                        || ((s_arg.is_any() || t_arg.is_any())
+                            && s_arg != TypeId::NEVER
+                            && t_arg != TypeId::NEVER)
+                });
         if !args_identical_or_any {
             return None;
         }
@@ -344,16 +736,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         })
     }
 
-    /// Acceptance-only unification of a single-argument pass-through type alias
+    /// Acceptance-only unification of an exact positional pass-through type alias
     /// against the body generic it forwards to, restricted to the permissive
     /// `any`-argument shortcut.
     ///
     /// Fires only when `try_variance_fast_path` is about to bail on a
     /// different-base pair whose bases neither share a raw definition nor unify
     /// through import-alias forwarding. It recognizes the
-    /// `Async<T> = Promise<T>` shape: a `DefKind::TypeAlias` whose resolved body
-    /// is a single-argument `Application` of the *other* side's base, where the
-    /// alias's sole argument is `any`. Because the alias is a pass-through, its
+    /// `Alias<X, Y> = Body<X, Y>` shape: a `DefKind::TypeAlias` whose resolved
+    /// body is an `Application` of the *other* side's base, where every differing
+    /// alias argument is `any`. Because the alias is a pass-through, each
     /// `any` argument flows unchanged into the body application, so the pair is
     /// `Body<any>` vs `Body<X>` — true under any-propagation. `tsc` never relates
     /// an alias nominally (it substitutes the body), so `Async<any>` and
@@ -363,7 +755,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// body) otherwise degrades to a structural `then`-callable comparison that
     /// can spuriously fail for a deferred-conditional type argument. Returns
     /// `None` for every other shape so the caller keeps its historical
-    /// structural path; never returns `False`.
+    /// structural path. A proven `any`/`never` variance mismatch returns
+    /// `False`; every other non-accepting shape remains undecided.
     pub(super) fn try_pass_through_alias_any_unification(
         &mut self,
         s_app: &TypeApplication,
@@ -381,55 +774,184 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return None;
         }
 
-        // Source is the alias side: `Async<any>` vs `Promise<X>`.
-        if s_app.args.len() == 1
-            && s_app.args[0].is_any()
-            && t_app.args.len() == 1
-            && self.alias_body_forwards_to_single_arg_generic(s_def, t_def)
+        // Source is the alias side: `Alias<any, X>` vs `Body<Y, X>`.
+        if s_app.args.len() == t_app.args.len()
+            && s_app.args.iter().any(|arg| arg.is_any())
+            && s_app
+                .args
+                .iter()
+                .zip(t_app.args.iter())
+                .all(|(&source, &target)| source.is_any() || source == target)
+            && self.alias_body_forwards_positionally_to_generic(s_def, t_def)
         {
+            if s_app
+                .args
+                .iter()
+                .zip(t_app.args.iter())
+                .any(|(&source, &target)| source.is_any() && target == TypeId::NEVER)
+            {
+                let classification = self.classify_application_args_any_never_variance(
+                    t_def,
+                    &s_app.args,
+                    &t_app.args,
+                )?;
+                if classification.rejects {
+                    return Some(SubtypeResult::False);
+                }
+                return (!classification.has_unresolved_exceptional).then_some(SubtypeResult::True);
+            }
             return Some(SubtypeResult::True);
         }
-        // Target is the alias side: `Promise<X>` vs `Async<any>`.
-        if t_app.args.len() == 1
-            && t_app.args[0].is_any()
-            && s_app.args.len() == 1
-            && self.alias_body_forwards_to_single_arg_generic(t_def, s_def)
+        // Target is the alias side: `Body<X, Y>` vs `Alias<any, Y>`.
+        if t_app.args.len() == s_app.args.len()
+            && t_app.args.iter().any(|arg| arg.is_any())
+            && s_app
+                .args
+                .iter()
+                .zip(t_app.args.iter())
+                .all(|(&source, &target)| target.is_any() || source == target)
+            && self.alias_body_forwards_positionally_to_generic(t_def, s_def)
         {
+            if s_app
+                .args
+                .iter()
+                .zip(t_app.args.iter())
+                .any(|(&source, &target)| source == TypeId::NEVER && target.is_any())
+            {
+                let classification = self.classify_application_args_any_never_variance(
+                    s_def,
+                    &s_app.args,
+                    &t_app.args,
+                )?;
+                if classification.rejects {
+                    return Some(SubtypeResult::False);
+                }
+                return (!classification.has_unresolved_exceptional).then_some(SubtypeResult::True);
+            }
             return Some(SubtypeResult::True);
         }
         None
     }
 
-    /// Whether `alias_def`'s body is a single-argument `Application` whose base
-    /// canonically names `target_def`. "Pass-through" means the alias has one
-    /// type parameter forwarded as the body application's sole argument
-    /// (e.g. `Async<T> = Promise<T>`), so an `any` alias argument yields an
-    /// `any` body argument. An unresolvable alias body records the
+    /// Whether `alias_def`'s body is an `Application` whose base canonically
+    /// names `target_def` and whose parameters are forwarded exactly by
+    /// position (for example `Alias<X, Y> = Pair<X, Y>`). An unresolvable alias body records the
     /// undetermined-result event so the enclosing relation does not persist a
     /// registration-window verdict.
-    fn alias_body_forwards_to_single_arg_generic(
+    fn alias_body_forwards_positionally_to_generic(
         &self,
         alias_def: DefId,
         target_def: DefId,
     ) -> bool {
+        self.positional_pass_through_alias_body_def(alias_def)
+            .is_some_and(|body_def| {
+                self.resolver.canonical_def_id(body_def)
+                    == self.resolver.canonical_def_id(target_def)
+            })
+    }
+
+    /// Find the generic definition whose variance governs an `any`/`never`
+    /// application pair.
+    ///
+    /// TypeScript measures type-alias variance only for the alias body kinds
+    /// that support variance annotations: object, function/constructor,
+    /// callable, and mapped types. Those aliases own the variance decision.
+    /// An exact positional application alias forwards to its body's owner.
+    /// Normalizing transforms (union, tuple, conditional, `keyof`, indexed
+    /// access, and similar bodies) must expand instead. Unknown registration
+    /// state and cycles conservatively remain undecided.
+    pub(super) fn any_never_variance_owner_def(&self, mut def_id: DefId) -> Option<DefId> {
+        let mut seen = FxHashSet::default();
+        loop {
+            match self.resolver.get_def_kind(def_id) {
+                Some(crate::def::DefKind::TypeAlias) => {}
+                Some(_) => return Some(def_id),
+                None => {
+                    // Definition registration can be temporarily incomplete in
+                    // cross-file/re-entrant checks. Unknown kind is not proof
+                    // that this is a nominal generic: keep the relation
+                    // undecided so no transform-alias verdict is cached.
+                    self.note_unresolved_lazy_relation_event();
+                    return None;
+                }
+            }
+            if !seen.insert(def_id) {
+                return None;
+            }
+            let body = self.alias_body_for_variance_classification(def_id)?;
+            match self.interner.lookup(body) {
+                Some(
+                    TypeData::Object(_)
+                    | TypeData::ObjectWithIndex(_)
+                    | TypeData::Function(_)
+                    | TypeData::Callable(_)
+                    | TypeData::Mapped(_),
+                ) => return Some(def_id),
+                Some(TypeData::Application(_)) => {
+                    def_id = self.positional_pass_through_alias_body_def_from_body(def_id, body)?;
+                }
+                Some(_) => return None,
+                None => {
+                    self.note_unresolved_lazy_relation_event();
+                    return None;
+                }
+            }
+        }
+    }
+
+    fn positional_pass_through_alias_body_def(&self, alias_def: DefId) -> Option<DefId> {
         if self.resolver.get_def_kind(alias_def) != Some(crate::def::DefKind::TypeAlias) {
-            return false;
+            return None;
         }
-        let Some(body) = self.resolver.resolve_lazy(alias_def, self.interner) else {
+        let body = self.alias_body_for_variance_classification(alias_def)?;
+        self.positional_pass_through_alias_body_def_from_body(alias_def, body)
+    }
+
+    fn alias_body_for_variance_classification(&self, def_id: DefId) -> Option<TypeId> {
+        if let Some(body) = self.resolver.get_def_raw_body(def_id, self.interner) {
+            return Some(body);
+        }
+        let Some(body) = self.resolver.resolve_lazy(def_id, self.interner) else {
             self.note_unresolved_lazy_relation_event();
-            return false;
+            return None;
         };
-        let Some(body_app_id) = application_id(self.interner, body) else {
-            return false;
-        };
-        let body_app = self.interner.type_application(body_app_id);
-        if body_app.args.len() != 1 {
-            return false;
+        if matches!(self.interner.lookup(body), Some(TypeData::Lazy(body_def)) if body_def == def_id)
+        {
+            // A self wrapper means the alias body is not published yet. Treat
+            // the relation as registration-dependent so it cannot be cached.
+            self.note_unresolved_lazy_relation_event();
+            return None;
         }
-        let Some(body_def) = self.application_base_def_id(body_app.base) else {
-            return false;
+        Some(body)
+    }
+
+    fn positional_pass_through_alias_body_def_from_body(
+        &self,
+        alias_def: DefId,
+        body: TypeId,
+    ) -> Option<DefId> {
+        let body_app_id = application_id(self.interner, body)?;
+        let body_app = self.interner.type_application(body_app_id);
+        if body_app.args.is_empty() {
+            return None;
+        }
+        let Some(alias_params) = self.resolver.get_lazy_type_params(alias_def) else {
+            self.note_unresolved_lazy_relation_event();
+            return None;
         };
-        self.resolver.canonical_def_id(body_def) == self.resolver.canonical_def_id(target_def)
+        if alias_params.len() != body_app.args.len()
+            || !alias_params
+                .iter()
+                .zip(body_app.args.iter())
+                .all(|(&alias_param, &body_arg)| {
+                    crate::type_param_info(self.interner, body_arg) == Some(alias_param)
+                })
+        {
+            // Reordering, duplication, constants, and transforms are not
+            // pass-through. Only the exact positional binder leaves prove it.
+            return None;
+        }
+        self.application_base_def_id(body_app.base)
     }
 
     pub(super) fn recursive_mapped_alias_base_reaches_self(&self, base: TypeId) -> bool {

--- a/crates/tsz-solver/src/relations/variance.rs
+++ b/crates/tsz-solver/src/relations/variance.rs
@@ -31,6 +31,7 @@ use crate::caches::db::QueryDatabase;
 use crate::construction::TypeDatabase;
 use crate::def::DefId;
 use crate::def::resolver::TypeResolver;
+use crate::evaluation::session::{EffectiveVarianceCacheKey, EvaluationSession};
 use crate::types::{
     CallableShapeId, ConditionalTypeId, FunctionShapeId, IntrinsicKind, LiteralValue, MappedTypeId,
     ObjectShapeId, StringIntrinsicKind, SymbolRef, TemplateLiteralId, TemplateSpan, TupleListId,
@@ -241,6 +242,76 @@ pub fn contains_this_type_in_strict_contravariant_position_with_resolver(
     variance.has_direct_usage() && (variance.is_contravariant() || variance.is_invariant())
 }
 
+/// Compute the effective application variance of `def_id`.
+///
+/// Explicit `in`/`out` slots are authoritative, while unannotated slots in a
+/// partially annotated declaration are filled from the declaration body.
+/// Nested declarations follow the same rule recursively. Callback parameters
+/// are bivariant when `strict_function_types` is disabled; method and
+/// constructor parameters are bivariant in either mode.
+///
+/// Results use the owning `EvaluationSession` cache when one is available,
+/// keyed by declaration, strictness, database identity, and resolver
+/// identity/generation. A per-walk memo avoids duplicate recursion otherwise.
+pub struct EffectiveVarianceOutcome {
+    pub variances: Arc<[Variance]>,
+    /// The walk observed unresolved or opaque resolver state. The mask may be
+    /// reused to avoid repeated work, but it cannot settle a relation until the
+    /// owning checker has structurally retried under complete registration.
+    pub incomplete: bool,
+}
+
+pub fn compute_effective_type_param_variances_with_resolver_cached(
+    db: &dyn TypeDatabase,
+    resolver: &dyn TypeResolver,
+    evaluation_session: Option<&EvaluationSession>,
+    def_id: DefId,
+    strict_function_types: bool,
+    disable_method_bivariance: bool,
+) -> Option<EffectiveVarianceOutcome> {
+    let resolver_generation = resolver.resolver_generation();
+    let session_key = evaluation_session
+        .filter(|_| variance_cache_enabled())
+        .map(|_| {
+            EffectiveVarianceCacheKey::new(
+                def_id,
+                strict_function_types,
+                disable_method_bivariance,
+                db.type_database_identity(),
+                resolver.resolver_identity(),
+            )
+        });
+    if let (Some(session), Some(key)) = (evaluation_session, session_key)
+        && let Some((variances, incomplete)) =
+            session.effective_variance_get(key, resolver_generation)
+    {
+        return Some(EffectiveVarianceOutcome {
+            variances,
+            incomplete,
+        });
+    }
+    let mut computer = VarianceComputer::new_effective(
+        db,
+        resolver,
+        strict_function_types,
+        disable_method_bivariance,
+    );
+    let variances = computer.compute_def_variances(def_id)?;
+    let outcome = EffectiveVarianceOutcome {
+        variances,
+        incomplete: !computer.gap_log.is_empty() || computer.opaque_gaps != 0,
+    };
+    if let (Some(session), Some(key)) = (evaluation_session, session_key) {
+        session.effective_variance_put(
+            key,
+            resolver_generation,
+            outcome.variances.clone(),
+            outcome.incomplete,
+        );
+    }
+    Some(outcome)
+}
+
 /// Session-cached form of [`compute_type_param_variances_with_resolver`].
 ///
 /// Variance of a generic `DefId` is a pure function of that definition's
@@ -351,10 +422,54 @@ struct DefVarianceEntry {
 /// (per-walk reuse only).
 const MAX_GAP_FINGERPRINT: usize = 16;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum VarianceMode {
+    /// Honor declared masks exactly and use the ordinary shared/session cache.
+    Declared,
+    /// Ignore every declared mask and compute the raw structural variance.
+    Actual,
+    /// Merge declared slots with structural holes while applying the active
+    /// `strictFunctionTypes` callback rule.
+    Effective {
+        strict_function_types: bool,
+        disable_method_bivariance: bool,
+    },
+}
+
+impl VarianceMode {
+    const fn uses_declared_variance(self) -> bool {
+        !matches!(self, Self::Actual)
+    }
+
+    const fn is_effective(self) -> bool {
+        matches!(self, Self::Effective { .. })
+    }
+
+    const fn strict_function_types(self) -> Option<bool> {
+        match self {
+            Self::Effective {
+                strict_function_types,
+                ..
+            } => Some(strict_function_types),
+            Self::Declared | Self::Actual => None,
+        }
+    }
+
+    const fn effective_method_bivariance(self) -> bool {
+        matches!(
+            self,
+            Self::Effective {
+                disable_method_bivariance: false,
+                ..
+            }
+        )
+    }
+}
+
 struct VarianceComputer<'a> {
     db: &'a dyn TypeDatabase,
     resolver: &'a dyn TypeResolver,
-    use_declared_variance: bool,
+    mode: VarianceMode,
     /// In-flight defs on the recursion stack, mapped to their stack depth.
     active_defs: FxHashMap<DefId, usize>,
     /// Stack-ordered in-flight defs (`depth -> DefId`), parallel to
@@ -381,17 +496,16 @@ struct VarianceComputer<'a> {
     opaque_gaps: u64,
     /// Whether canonical, resolution-clean masks may be read from / written to
     /// the universe-shared interner store (`TypeDatabase::shared_def_variance`).
-    /// Only set for `use_declared_variance` computers (the store holds declared
-    /// masks, so the `new_actual` computer must never touch it) and disabled by
-    /// the `TSZ_DISABLE_VARIANCE_CACHE` kill switch.
+    /// Only declared-mode computers use it; effective masks are resolver- and
+    /// option-sensitive and stay in the evaluation-session cache.
     use_shared_store: bool,
     /// Optional session-persistent declared-variance cache.
     ///
     /// When present, `compute_def_variances` reads from and writes to this map
     /// for every def whose mask is canonical (see
     /// [`compute_type_param_variances_with_resolver_cached`]). Only wired in for
-    /// `use_declared_variance` computers: the map stores declared masks, so the
-    /// `new_actual` computer must never touch it.
+    /// declared computers: the map stores declared masks, so the actual and
+    /// effective computers must never touch it.
     session_cache: Option<&'a dyn QueryDatabase>,
 }
 
@@ -400,7 +514,7 @@ impl<'a> VarianceComputer<'a> {
         Self {
             db,
             resolver,
-            use_declared_variance: true,
+            mode: VarianceMode::Declared,
             active_defs: FxHashMap::default(),
             active_stack: Vec::new(),
             cached_def_variances: FxHashMap::default(),
@@ -416,7 +530,31 @@ impl<'a> VarianceComputer<'a> {
         Self {
             db,
             resolver,
-            use_declared_variance: false,
+            mode: VarianceMode::Actual,
+            active_defs: FxHashMap::default(),
+            active_stack: Vec::new(),
+            cached_def_variances: FxHashMap::default(),
+            min_inflight_dep: usize::MAX,
+            gap_log: Vec::new(),
+            opaque_gaps: 0,
+            use_shared_store: false,
+            session_cache: None,
+        }
+    }
+
+    fn new_effective(
+        db: &'a dyn TypeDatabase,
+        resolver: &'a dyn TypeResolver,
+        strict_function_types: bool,
+        disable_method_bivariance: bool,
+    ) -> Self {
+        Self {
+            db,
+            resolver,
+            mode: VarianceMode::Effective {
+                strict_function_types,
+                disable_method_bivariance,
+            },
             active_defs: FxHashMap::default(),
             active_stack: Vec::new(),
             cached_def_variances: FxHashMap::default(),
@@ -438,11 +576,36 @@ impl<'a> VarianceComputer<'a> {
         visitor.compute(type_id)
     }
 
-    fn compute_def_variances(&mut self, def_id: DefId) -> Option<Arc<[Variance]>> {
-        if self.use_declared_variance
-            && let Some(declared) = self.resolver.get_type_param_variance(def_id)
+    fn resolve_body_for_variance(&self, def_id: DefId) -> Option<TypeId> {
+        if self.mode.is_effective()
+            && self.resolver.get_def_kind(def_id) == Some(crate::def::DefKind::TypeAlias)
         {
-            return Some(declared);
+            if let Some(body) = self.resolver.get_def_raw_body(def_id, self.db) {
+                return Some(body);
+            }
+            let body = self.resolver.resolve_lazy(def_id, self.db)?;
+            if matches!(self.db.lookup(body), Some(TypeData::Lazy(body_def)) if body_def == def_id)
+            {
+                return None;
+            }
+            return Some(body);
+        }
+        self.resolver.resolve_lazy(def_id, self.db)
+    }
+
+    fn compute_def_variances(&mut self, def_id: DefId) -> Option<Arc<[Variance]>> {
+        let mut partial_declared = None;
+        let declared = self
+            .mode
+            .uses_declared_variance()
+            .then(|| self.resolver.get_type_param_variance(def_id))
+            .flatten();
+        if let Some(declared) = declared {
+            if self.mode.is_effective() && declared.iter().any(Variance::is_independent) {
+                partial_declared = Some(declared);
+            } else {
+                return Some(declared);
+            }
         }
 
         if let Some(entry) = self.cached_def_variances.get(&def_id) {
@@ -544,13 +707,13 @@ impl<'a> VarianceComputer<'a> {
         let gap_log_at_entry = self.gap_log.len();
         let opaque_at_entry = self.opaque_gaps;
 
-        let result: Option<Arc<[Variance]>> = (|| {
+        let mut result: Option<Arc<[Variance]>> = (|| {
             let params = self.resolver.get_lazy_type_params(def_id)?;
             if params.is_empty() {
                 return None;
             }
 
-            let body = self.resolver.resolve_lazy(def_id, self.db)?;
+            let body = self.resolve_body_for_variance(def_id)?;
             let mut variances = Vec::with_capacity(params.len());
             for param in &params {
                 variances.push(self.compute(body, param.name));
@@ -558,6 +721,23 @@ impl<'a> VarianceComputer<'a> {
             Some(Arc::from(variances))
         })();
 
+        if let (Some(declared), Some(actual)) = (partial_declared.as_ref(), result.as_ref()) {
+            result = (declared.len() == actual.len()).then(|| {
+                Arc::from(
+                    declared
+                        .iter()
+                        .zip(actual.iter())
+                        .map(|(&declared, &actual)| {
+                            if declared.is_independent() {
+                                actual
+                            } else {
+                                declared
+                            }
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            });
+        }
         // A `None` result means params or body did not resolve (or the def is
         // non-generic) — resolver-dependent territory either way. Record the
         // def itself as a fingerprintable gap: the parent's mask is valid for
@@ -624,11 +804,9 @@ impl<'a> VarianceComputer<'a> {
             && self.use_shared_store
             && let Some(variances) = result.as_ref()
         {
-            self.db.insert_shared_def_variance(
-                def_id,
-                variances.clone(),
-                shared_gaps.clone().unwrap_or_else(|| Arc::from([])),
-            );
+            let gaps = shared_gaps.clone().unwrap_or_else(|| Arc::from([]));
+            self.db
+                .insert_shared_def_variance(def_id, variances.clone(), gaps);
         }
 
         let dep = if canonical {
@@ -707,6 +885,11 @@ struct VarianceVisitor<'a, 'b> {
     /// (e.g. `{ container: C1<T> }` should remain bivariant when `C1` is
     /// bivariant).
     inside_unreliable_application: u32,
+    /// Depth below an option-aware method/constructor/callback parameter edge.
+    /// Such an occurrence is bivariant, not independent: ordinary argument
+    /// relations must expand structurally, while `any`/`never` may be accepted
+    /// in either orientation.
+    inside_effective_bivariant_param: u32,
     /// Completed type/context pairs within this target-param walk.
     ///
     /// The recursion guard only catches active cycles. Drizzle-like declaration
@@ -731,6 +914,7 @@ struct VarianceVisitKey {
     suppress_method_bivariance: bool,
     inside_mapped: bool,
     inside_unreliable_application: bool,
+    inside_effective_bivariant_param: bool,
 }
 
 impl<'a, 'b> VarianceVisitor<'a, 'b> {
@@ -759,6 +943,7 @@ impl<'a, 'b> VarianceVisitor<'a, 'b> {
             suppress_method_bivariance: false,
             strict_occurrence_seen: false,
             inside_unreliable_application: 0,
+            inside_effective_bivariant_param: 0,
             completed: FxHashSet::default(),
         }
     }
@@ -820,6 +1005,7 @@ impl<'a, 'b> VarianceVisitor<'a, 'b> {
         // occurrence does NOT make that rejection reliable.
         if self.strict_occurrence_seen && !self.seen_target_in_index_access {
             self.result.remove(Variance::REJECTION_UNRELIABLE);
+            self.result.remove(Variance::BIVARIANT_USAGE);
         }
         self.result
     }
@@ -878,6 +1064,7 @@ impl<'a, 'b> VarianceVisitor<'a, 'b> {
             suppress_method_bivariance: self.suppress_method_bivariance,
             inside_mapped: self.inside_mapped_depth > 0,
             inside_unreliable_application: self.inside_unreliable_application > 0,
+            inside_effective_bivariant_param: self.inside_effective_bivariant_param > 0,
         })
     }
 
@@ -886,9 +1073,30 @@ impl<'a, 'b> VarianceVisitor<'a, 'b> {
         *self.polarity_stack.last().unwrap_or(&true)
     }
 
+    fn visit_effective_bivariant_param(&mut self, type_id: TypeId, polarity: bool) {
+        self.inside_effective_bivariant_param += 1;
+        self.visit_with_polarity(type_id, polarity);
+        self.inside_effective_bivariant_param -= 1;
+    }
+
+    /// Visit after an inner invariant application has consumed an enclosing
+    /// bivariant parameter edge. Either orientation of the outer callback must
+    /// still satisfy the inner invariant generic, so its argument is measured
+    /// in both strict directions. A deeper bivariant generic can introduce a
+    /// fresh bivariant edge during these visits.
+    fn visit_below_inner_invariant(&mut self, type_id: TypeId, polarity: bool) {
+        let saved_depth = self.inside_effective_bivariant_param;
+        self.inside_effective_bivariant_param = 0;
+        self.visit_with_polarity(type_id, polarity);
+        self.visit_with_polarity(type_id, !polarity);
+        self.inside_effective_bivariant_param = saved_depth;
+    }
+
     /// Record an occurrence of the target parameter at the current polarity.
     fn add_occurrence(&mut self, polarity: bool) {
-        if self.method_bivariant_depth > 0 {
+        if self.inside_effective_bivariant_param > 0 {
+            self.result |= Variance::BIVARIANT_USAGE;
+        } else if self.method_bivariant_depth > 0 {
             // Inside method parameter types, always record as COVARIANT.
             // This matches tsc behavior: method bivariance makes T appear in
             // both co and contra positions (BIVARIANT), but tsc checks bivariant
@@ -911,7 +1119,10 @@ impl<'a, 'b> VarianceVisitor<'a, 'b> {
         // is one that's outside method bivariance AND outside an application
         // visit that already inherited unreliability. Such an occurrence pins
         // the variance signal — see `compute()` for how this is consumed.
-        if self.method_bivariant_depth == 0 && self.inside_unreliable_application == 0 {
+        if self.inside_effective_bivariant_param == 0
+            && self.method_bivariant_depth == 0
+            && self.inside_unreliable_application == 0
+        {
             self.strict_occurrence_seen = true;
         }
     }
@@ -1012,6 +1223,11 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
     fn visit_function(&mut self, shape_id: u32) {
         let shape = self.computer.db.function_shape(FunctionShapeId(shape_id));
         let current_polarity = self.get_current_polarity();
+        let effective_strict = self.computer.mode.strict_function_types();
+        let effective_method_bivariance = self.computer.mode.effective_method_bivariance();
+        let bound_len = self.bound_type_params.len();
+        self.bound_type_params
+            .extend(shape.type_params.iter().map(|param| param.name));
 
         let saved_method_depth = self.method_bivariant_depth;
 
@@ -1020,8 +1236,16 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
         // parameters. Treat those occurrences as covariant-first so generic
         // application checks do not classify Promise-like interfaces as
         // independent.
-        if shape.is_method {
-            if !self.suppress_method_bivariance {
+        if shape.is_method || (shape.is_constructor && effective_strict.is_some()) {
+            if effective_strict.is_some() && effective_method_bivariance {
+                for param in &shape.params {
+                    self.visit_effective_bivariant_param(param.type_id, !current_polarity);
+                }
+            } else if effective_strict.is_some() {
+                for param in &shape.params {
+                    self.visit_with_polarity(param.type_id, !current_polarity);
+                }
+            } else if !self.suppress_method_bivariance {
                 self.method_bivariant_depth = saved_method_depth + 1;
                 for param in &shape.params {
                     self.visit_with_polarity(param.type_id, !current_polarity);
@@ -1032,8 +1256,17 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
             // covariant position (matches tsc, where `interface C<T> { m():
             // T }` is COVARIANT).
             self.visit_with_polarity(shape.return_type, current_polarity);
+            if let Some(predicate_type) = shape.type_predicate.and_then(|pred| pred.type_id) {
+                self.visit_with_polarity(predicate_type, current_polarity);
+            }
             if let Some(this_ty) = shape.this_type {
-                self.visit_with_polarity(this_ty, current_polarity);
+                if effective_strict.is_some() && effective_method_bivariance {
+                    self.visit_effective_bivariant_param(this_ty, !current_polarity);
+                } else if effective_strict.is_some() {
+                    self.visit_with_polarity(this_ty, !current_polarity);
+                } else {
+                    self.visit_with_polarity(this_ty, current_polarity);
+                }
             }
         } else {
             // Nested non-method function: T occurrences inside its
@@ -1044,28 +1277,55 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
             // polarity (e.g. `Promise<T>.then(cb: (x: T) => T)` records the
             // return-position T as COVARIANT, not bivariant).
             self.method_bivariant_depth = 0;
-            for param in &shape.params {
-                self.visit_with_polarity(param.type_id, !current_polarity);
+            if effective_strict == Some(false) {
+                for param in &shape.params {
+                    self.visit_effective_bivariant_param(param.type_id, !current_polarity);
+                }
+            } else {
+                for param in &shape.params {
+                    self.visit_with_polarity(param.type_id, !current_polarity);
+                }
             }
             self.visit_with_polarity(shape.return_type, current_polarity);
+            if let Some(predicate_type) = shape.type_predicate.and_then(|pred| pred.type_id) {
+                self.visit_with_polarity(predicate_type, current_polarity);
+            }
             if let Some(this_ty) = shape.this_type {
-                self.visit_with_polarity(this_ty, !current_polarity);
+                if effective_strict == Some(false) {
+                    self.visit_effective_bivariant_param(this_ty, !current_polarity);
+                } else {
+                    self.visit_with_polarity(this_ty, !current_polarity);
+                }
             }
             self.method_bivariant_depth = saved_method_depth;
         }
+        self.bound_type_params.truncate(bound_len);
     }
 
     /// Callable types: same variance rules as functions.
     fn visit_callable(&mut self, shape_id: u32) {
         let callable = self.computer.db.callable_shape(CallableShapeId(shape_id));
         let current_polarity = self.get_current_polarity();
+        let effective_strict = self.computer.mode.strict_function_types();
+        let effective_method_bivariance = self.computer.mode.effective_method_bivariance();
         let saved_method_depth = self.method_bivariant_depth;
 
         // Call signatures
         for sig in &callable.call_signatures {
+            let bound_len = self.bound_type_params.len();
+            self.bound_type_params
+                .extend(sig.type_params.iter().map(|param| param.name));
             // For methods (see visit_function for full rationale).
             if sig.is_method {
-                if !self.suppress_method_bivariance {
+                if effective_strict.is_some() && effective_method_bivariance {
+                    for param in &sig.params {
+                        self.visit_effective_bivariant_param(param.type_id, !current_polarity);
+                    }
+                } else if effective_strict.is_some() {
+                    for param in &sig.params {
+                        self.visit_with_polarity(param.type_id, !current_polarity);
+                    }
+                } else if !self.suppress_method_bivariance {
                     self.method_bivariant_depth = saved_method_depth + 1;
                     for param in &sig.params {
                         self.visit_with_polarity(param.type_id, !current_polarity);
@@ -1074,23 +1334,46 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
                 }
                 // Method return type stays at the outer (saved) depth.
                 self.visit_with_polarity(sig.return_type, current_polarity);
+                if let Some(predicate_type) = sig.type_predicate.and_then(|pred| pred.type_id) {
+                    self.visit_with_polarity(predicate_type, current_polarity);
+                }
                 if let Some(this_ty) = sig.this_type {
-                    self.visit_with_polarity(this_ty, current_polarity);
+                    if effective_strict.is_some() && effective_method_bivariance {
+                        self.visit_effective_bivariant_param(this_ty, !current_polarity);
+                    } else if effective_strict.is_some() {
+                        self.visit_with_polarity(this_ty, !current_polarity);
+                    } else {
+                        self.visit_with_polarity(this_ty, current_polarity);
+                    }
                 }
             } else {
                 // Non-method call signature: reset method bivariance for the
                 // entire signature — parameters, return type, and `this` —
                 // matching `visit_function` for non-method shapes.
                 self.method_bivariant_depth = 0;
-                for param in &sig.params {
-                    self.visit_with_polarity(param.type_id, !current_polarity);
+                if effective_strict == Some(false) {
+                    for param in &sig.params {
+                        self.visit_effective_bivariant_param(param.type_id, !current_polarity);
+                    }
+                } else {
+                    for param in &sig.params {
+                        self.visit_with_polarity(param.type_id, !current_polarity);
+                    }
                 }
                 self.visit_with_polarity(sig.return_type, current_polarity);
+                if let Some(predicate_type) = sig.type_predicate.and_then(|pred| pred.type_id) {
+                    self.visit_with_polarity(predicate_type, current_polarity);
+                }
                 if let Some(this_ty) = sig.this_type {
-                    self.visit_with_polarity(this_ty, !current_polarity);
+                    if effective_strict == Some(false) {
+                        self.visit_effective_bivariant_param(this_ty, !current_polarity);
+                    } else {
+                        self.visit_with_polarity(this_ty, !current_polarity);
+                    }
                 }
                 self.method_bivariant_depth = saved_method_depth;
             }
+            self.bound_type_params.truncate(bound_len);
         }
 
         // Construct signatures follow the same rules. We deliberately do NOT
@@ -1101,13 +1384,30 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
         // behaviour. Changing this changed several `Partial<T>` /
         // `nongenericPartialInstantiations*` baselines without a clear win.
         for sig in &callable.construct_signatures {
-            for param in &sig.params {
-                self.visit_with_polarity(param.type_id, !current_polarity);
+            let bound_len = self.bound_type_params.len();
+            self.bound_type_params
+                .extend(sig.type_params.iter().map(|param| param.name));
+            if effective_strict.is_some() && effective_method_bivariance {
+                for param in &sig.params {
+                    self.visit_effective_bivariant_param(param.type_id, !current_polarity);
+                }
+            } else {
+                for param in &sig.params {
+                    self.visit_with_polarity(param.type_id, !current_polarity);
+                }
             }
             self.visit_with_polarity(sig.return_type, current_polarity);
-            if let Some(this_ty) = sig.this_type {
-                self.visit_with_polarity(this_ty, !current_polarity);
+            if let Some(predicate_type) = sig.type_predicate.and_then(|pred| pred.type_id) {
+                self.visit_with_polarity(predicate_type, current_polarity);
             }
+            if let Some(this_ty) = sig.this_type {
+                if effective_strict.is_some() && effective_method_bivariance {
+                    self.visit_effective_bivariant_param(this_ty, !current_polarity);
+                } else {
+                    self.visit_with_polarity(this_ty, !current_polarity);
+                }
+            }
+            self.bound_type_params.truncate(bound_len);
         }
 
         // Properties follow the same rules as regular objects
@@ -1115,14 +1415,11 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
             // Read type is always checked at current polarity
             self.visit_with_polarity(prop.type_id, current_polarity);
 
-            // CRITICAL FIX: Mutable properties are ALWAYS invariant
-            if !prop.readonly {
-                let write_ty = if prop.write_type != TypeId::NONE {
-                    prop.write_type
-                } else {
-                    prop.type_id
-                };
-                self.visit_with_polarity(write_ty, !current_polarity);
+            // Ordinary properties follow tsc's covariant inference even when
+            // mutable. Only a split accessor contributes an explicit write
+            // surface in the opposite direction.
+            if prop.has_split_accessor() {
+                self.visit_with_polarity(prop.write_type, !current_polarity);
             }
         }
     }
@@ -1153,6 +1450,10 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
         if let Some(ref idx) = shape.number_index {
             self.visit_with_polarity(idx.value_type, current_polarity);
         }
+
+        if let Some(ref idx) = shape.symbol_index {
+            self.visit_with_polarity(idx.value_type, current_polarity);
+        }
     }
 
     /// Object with index signatures: same variance rules as regular objects.
@@ -1162,7 +1463,8 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
 
     /// Type parameters: check if this is our target.
     fn visit_type_parameter(&mut self, info: &TypeParamInfo) {
-        if self.is_target_type_parameter(info) {
+        let is_bound = self.bound_type_params.contains(&info.name);
+        if !is_bound && self.is_target_type_parameter(info) {
             let current_polarity = self.get_current_polarity();
             self.add_occurrence(current_polarity);
         }
@@ -1170,7 +1472,6 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
         // Skip constraint/default for bound type parameters (mapped type iteration
         // variables like K in `{ [K in keyof S]: S[K] }`). Their constraints are
         // already accounted for by visit_mapped visiting mapped.constraint directly.
-        let is_bound = self.bound_type_params.contains(&info.name);
         if !is_bound {
             // Also check constraint (at current polarity).
             // Constraints affect structural shape: `<U extends T>` means T
@@ -1289,14 +1590,13 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
                 // Propagate NEEDS_STRUCTURAL_FALLBACK and REJECTION_UNRELIABLE
                 // from nested applications. If Required<T> needs structural fallback
                 // due to modifiers, then Foo<T> = { a: Required<T> } also needs it.
-                if base_param_variance.needs_structural_fallback() {
+                if base_param_variance.contains(Variance::NEEDS_STRUCTURAL_FALLBACK) {
                     self.result |= Variance::NEEDS_STRUCTURAL_FALLBACK;
                 }
                 let inherits_unreliable = base_param_variance.rejection_unreliable();
                 if inherits_unreliable {
                     self.result |= Variance::REJECTION_UNRELIABLE;
                 }
-
                 // Composition Rules:
                 // - Covariant base param: Argument inherits current polarity
                 // - Contravariant base param: Argument flips current polarity
@@ -1311,11 +1611,18 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
                 if inherits_unreliable {
                     self.inside_unreliable_application += 1;
                 }
-                if base_param_variance.contains(Variance::COVARIANT) {
-                    self.visit_with_polarity(arg, current_polarity);
-                }
-                if base_param_variance.contains(Variance::CONTRAVARIANT) {
-                    self.visit_with_polarity(arg, !current_polarity);
+                if self.inside_effective_bivariant_param > 0 && base_param_variance.is_invariant() {
+                    self.visit_below_inner_invariant(arg, current_polarity);
+                } else {
+                    if base_param_variance.contains(Variance::COVARIANT) {
+                        self.visit_with_polarity(arg, current_polarity);
+                    }
+                    if base_param_variance.contains(Variance::CONTRAVARIANT) {
+                        self.visit_with_polarity(arg, !current_polarity);
+                    }
+                    if base_param_variance.has_bivariant_usage() {
+                        self.visit_effective_bivariant_param(arg, current_polarity);
+                    }
                 }
                 if inherits_unreliable {
                     self.inside_unreliable_application -= 1;
@@ -1580,6 +1887,21 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
     fn visit_readonly_type(&mut self, inner_type: TypeId) {
         let current_polarity = self.get_current_polarity();
         self.visit_with_polarity(inner_type, current_polarity);
+    }
+
+    /// `NoInfer<T>` suppresses inference candidates but is transparent to the
+    /// relation surface, so it preserves the enclosing variance polarity.
+    fn visit_no_infer(&mut self, inner_type: TypeId) {
+        let current_polarity = self.get_current_polarity();
+        self.visit_with_polarity(inner_type, current_polarity);
+    }
+
+    /// A substitution type exposes its narrowed base on the type surface. The
+    /// implied constraint guides evaluation but does not replace the base's
+    /// variance occurrence.
+    fn visit_substitution(&mut self, base_type: TypeId, _constraint: TypeId) {
+        let current_polarity = self.get_current_polarity();
+        self.visit_with_polarity(base_type, current_polarity);
     }
 
     /// Infer types: declaration is not a usage.

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -1881,13 +1881,21 @@ bitflags::bitflags! {
         /// trusted because the direct usage provides a reliable variance signal
         /// that dominates over the unreliable mapped-type contribution.
         const DIRECT_USAGE = 1 << 4;
+        /// The parameter occurs below a method/constructor parameter or a
+        /// callback parameter governed by non-strict function checking. This
+        /// is not true independence: unrelated arguments must still compare
+        /// structurally, while the directional `any`/`never` exception accepts
+        /// either orientation.
+        const BIVARIANT_USAGE = 1 << 5;
     }
 }
 
 impl Variance {
     /// Check if this is an independent type parameter (not used in variance position).
     pub const fn is_independent(&self) -> bool {
-        !self.contains(Self::COVARIANT) && !self.contains(Self::CONTRAVARIANT)
+        !self.contains(Self::COVARIANT)
+            && !self.contains(Self::CONTRAVARIANT)
+            && !self.contains(Self::BIVARIANT_USAGE)
     }
 
     /// Check if this is covariant only.
@@ -1907,7 +1915,7 @@ impl Variance {
 
     /// Check if variance requires structural fallback (unreliable due to mapped type modifiers).
     pub const fn needs_structural_fallback(&self) -> bool {
-        self.contains(Self::NEEDS_STRUCTURAL_FALLBACK)
+        self.contains(Self::NEEDS_STRUCTURAL_FALLBACK) || self.contains(Self::BIVARIANT_USAGE)
     }
 
     /// Check if variance-based rejection is unreliable. When true, a variance
@@ -1925,7 +1933,21 @@ impl Variance {
         self.contains(Self::DIRECT_USAGE)
     }
 
-    /// Compose two variances (for nested generics).
+    /// Whether the effective variance walk found a bivariant parameter edge.
+    pub const fn has_bivariant_usage(&self) -> bool {
+        self.contains(Self::BIVARIANT_USAGE)
+    }
+
+    /// Whether bivariance is the only semantic occurrence in this mask.
+    pub const fn is_pure_bivariant_usage(&self) -> bool {
+        self.contains(Self::BIVARIANT_USAGE)
+            && !self.contains(Self::COVARIANT)
+            && !self.contains(Self::CONTRAVARIANT)
+            && !self.contains(Self::NEEDS_STRUCTURAL_FALLBACK)
+            && !self.contains(Self::REJECTION_UNRELIABLE)
+    }
+
+    /// Compose an outer variance (`self`) with a nested parameter variance.
     ///
     /// Rules:
     /// - Independent × anything = Independent
@@ -1933,13 +1955,24 @@ impl Variance {
     /// - Covariant × Contravariant = Contravariant
     /// - Contravariant × Covariant = Contravariant
     /// - Contravariant × Contravariant = Covariant
-    /// - Invariant × anything = Invariant
+    /// - Outer bivariant × inner invariant = Invariant
+    /// - Outer invariant × inner bivariant = Bivariant structural fallback
+    /// - Bivariant × directional = Bivariant structural fallback
     pub fn compose(&self, other: Self) -> Self {
-        if self.is_invariant() || other.is_invariant() {
-            return Self::COVARIANT | Self::CONTRAVARIANT;
-        }
         if self.is_independent() || other.is_independent() {
             return Self::empty();
+        }
+        if other.is_invariant() {
+            return Self::COVARIANT | Self::CONTRAVARIANT;
+        }
+        if other.has_bivariant_usage() {
+            return Self::BIVARIANT_USAGE;
+        }
+        if self.has_bivariant_usage() {
+            return Self::BIVARIANT_USAGE;
+        }
+        if self.is_invariant() {
+            return Self::COVARIANT | Self::CONTRAVARIANT;
         }
 
         // XOR for covariance composition

--- a/crates/tsz-solver/tests/types_tests.rs
+++ b/crates/tsz-solver/tests/types_tests.rs
@@ -606,3 +606,26 @@ fn typeparam_origin_layout_is_size_neutral() {
     );
     assert!(size_of::<(Atom, u32)>() <= size_of::<(u64, Option<Atom>)>());
 }
+
+#[test]
+fn bivariant_variance_composition_stays_structural() {
+    let bivariant = Variance::BIVARIANT_USAGE;
+    assert_eq!(
+        bivariant.compose(Variance::COVARIANT),
+        Variance::BIVARIANT_USAGE
+    );
+    assert_eq!(
+        Variance::CONTRAVARIANT.compose(bivariant),
+        Variance::BIVARIANT_USAGE
+    );
+    assert_eq!(Variance::empty().compose(bivariant), Variance::empty());
+}
+
+#[test]
+fn bivariant_and_invariant_composition_preserves_nesting_order() {
+    let bivariant = Variance::BIVARIANT_USAGE;
+    let invariant = Variance::COVARIANT | Variance::CONTRAVARIANT;
+
+    assert_eq!(invariant.compose(bivariant), Variance::BIVARIANT_USAGE);
+    assert_eq!(bivariant.compose(invariant), invariant);
+}


### PR DESCRIPTION
Goal: green

## Summary

- Accumulate interface overload families in O(n), compare the full derived/base signature sets when either side is overloaded, and keep return compatibility authoritative for tuple-union parameter coverage.
- Normalize determinate erased conditional returns through structural wrappers, while leaving deferred or distributive shapes on the ordinary solver relation.
- Apply option-aware effective variance only to exceptional `any`/`never` application arguments, including nested, callable, index, predicate, `NoInfer`, substitution, and exact positional alias shapes.
- Cache effective variance in the evaluation session with relation options and database/resolver identity in the key and definition generation in the entry; ordinary declared variance continues to use the shared interner cache.
- Keep the general N x M same-base fallback shallow: preserve the structural variance veto, but do not recursively relate an entire returned API before the existing correlation fallback can run.

## Structural rule

When an overloaded member is compared with another member, every target signature must be covered by a source signature whose parameters and return are compatible. Method-local erasure may select a determinate conditional branch, but a parameter-only shortcut cannot bypass a proven return mismatch. In the general same-base correlation fallback, the solver keeps the bounded structural variance veto and lets the established overload helper own conditional/fallback handling; it does not recursively expand the returned value before that helper. Exceptional `any`/`never` application arguments follow effective declared-plus-structural variance through solver-owned queries.

Owner: checker overload-family orchestration plus solver relation, normalization, variance, and evaluation-session cache boundaries.

Adjacent matrix: renamed binders; generic and concrete overloads; one-sided and two-sided overload sets; nested wrappers; callable properties; explicit method `this`; predicates; `NoInfer`; symbol indexes; N-ary aliases; strict/nonstrict callbacks; positive, negative, deferred, unrelated-wrapper, and void-return controls; depth over 32.

Fallback: unresolved, cyclic, incomplete, mapped/indexed transform, infer, deferred, or distributive shapes stay on the ordinary structural relation. No identifier, file, printer-output, or fixture-name predicates are used.

Performance: overload families are accumulated once instead of rebuilding growing callables; effective-variance traversal is cycle-safe and cached per evaluation session. The repaired general fallback removes a full recursive return relation from each source x target overload attempt while retaining the shallow paired variance walk, avoiding repeated expansion of recursive builder APIs.

## Verification

- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test class_implements_overloaded_method_ts2416_tests` — 79 passed on current `main`.
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(effective_variance_cache_partitions_options_replaces_generation_and_resets) | test(bivariant_variance_composition_stays_structural) | test(bivariant_and_invariant_composition_preserves_nesting_order)'` — 3 passed.
- Canonical embedded-lib Kysely compile-guard A/B against current `main` (`39865843d9`): 80 -> 72 primary diagnostics; the same eight false positives removed; zero additions.
- Direct exact Kysely tsconfig A/B against current `main` (embedded-libs env unset) (`39865843d9`): 78 -> 70 primary diagnostics; exactly eight false positives removed at `select-query-builder.ts` lines 2224, 2548, 2559, 2566, 2573, 2580, 2587, and 2624; zero additions. `tsc` reports none at those spans.
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver -p tsz-checker --all-targets -- -D warnings`.
- `cargo fmt --all -- --check` and `git diff --check`.

## Provenance

Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
