### PR TITLE
fix(checker): materialize actual-lib alias bodies on demand

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -753,6 +753,9 @@ path = "tests/interface_call_signature_typeof_param_tests.rs"
 name = "lib_conditional_alias_return_consumer_first_tests"
 path = "tests/lib_conditional_alias_return_consumer_first_tests.rs"
 [[test]]
+name = "lib_primitive_alias_materialization_tests"
+path = "tests/lib_primitive_alias_materialization_tests.rs"
+[[test]]
 name = "lib_merge_indexed_access_no_cascade_tests"
 path = "tests/lib_merge_indexed_access_no_cascade_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -1128,6 +1128,69 @@ impl CheckerState<'_> {
         self.resolve_lazy_type_inner(type_id, &mut visited)
     }
 
+    /// Read a definition body only when it represents progress beyond the
+    /// unresolved alias placeholder.
+    fn registered_alias_body(&self, def_id: tsz_solver::DefId) -> Option<TypeId> {
+        let is_usable = |body: TypeId| {
+            body != TypeId::ERROR
+                && body != TypeId::UNKNOWN
+                && lazy_def_id(self.ctx.types, body) != Some(def_id)
+        };
+
+        if let Ok(env) = self.ctx.type_env.try_borrow()
+            && let Some(body) = TypeResolver::resolve_lazy(&*env, def_id, self.ctx.types)
+            && is_usable(body)
+        {
+            return Some(body);
+        }
+
+        self.ctx
+            .definition_store
+            .get_body(def_id)
+            .filter(|&body| is_usable(body))
+    }
+
+    /// Materialize a canonical standard-library type-alias body on demand.
+    ///
+    /// Lib alias lowering deliberately returns `Lazy(DefId)` so generic
+    /// applications retain their alias identity, while publishing the actual
+    /// body into the definition store and both type environments as a side
+    /// effect. On-demand interface forcing does not own alias lowering, so a
+    /// consumer that first reaches a member's alias-typed result must trigger
+    /// that publication through the mutable checker boundary and then re-read
+    /// the body for the same canonical `DefId`.
+    fn materialize_actual_lib_alias_body(&mut self, def_id: tsz_solver::DefId) -> Option<TypeId> {
+        if !self.ctx.has_lib_loaded()
+            // This helper runs from relation-readiness hot paths. Reject ordinary
+            // program aliases before resolving their names or scanning lib binders;
+            // the canonical actual-lib identity check below remains authoritative
+            // for non-program ambient definitions.
+            || !self.ctx.definition_store.def_is_non_program(def_id)
+            || self.ctx.definition_store.get_kind(def_id)
+                != Some(tsz_solver::def::DefKind::TypeAlias)
+        {
+            return None;
+        }
+
+        let name_atom = self.ctx.definition_store.get_name(def_id)?;
+        let name = self.ctx.types.resolve_atom(name_atom);
+        if self.ctx.actual_lib_def_id_for_bare_name(&name) != Some(def_id) {
+            return None;
+        }
+
+        if let Some(body) = self.registered_alias_body(def_id) {
+            return Some(body);
+        }
+        if self.lib_name_resolution_in_progress(&name) {
+            return None;
+        }
+
+        // The return value is intentionally the public Lazy wrapper for type
+        // aliases. The structural body is the side effect read below.
+        let _ = self.resolve_lib_type_by_name(&name);
+        self.registered_alias_body(def_id)
+    }
+
     /// For union types whose members are Lazy(DefId) references, resolve each
     /// member so that downstream consumers (e.g., the solver's `this` type
     /// checking in union call resolution) can inspect their callable shapes.
@@ -1250,7 +1313,7 @@ impl CheckerState<'_> {
                 }
             }
 
-            // Fourth fallback: resolve lib interface types by name.
+            // Fourth fallback: resolve actual-lib aliases and interfaces by name.
             //
             // When a lib interface (e.g., ProxyConstructor) is referenced in a type
             // annotation (e.g., `declare var Proxy: ProxyConstructor`), the Lazy(DefId)
@@ -1258,15 +1321,15 @@ impl CheckerState<'_> {
             // checker context didn't propagate them to the main context. The
             // DefinitionStore still has the name, so we can materialize the interface
             // type through the lib type resolution system.
+            if let Some(body) = self.materialize_actual_lib_alias_body(def_id) {
+                return self.resolve_lazy_type_inner(body, visited);
+            }
             if self.ctx.has_lib_loaded()
-                && let Some(def_info) = self.ctx.definition_store.get(def_id)
-                && matches!(
-                    def_info.kind,
-                    tsz_solver::def::DefKind::Interface | tsz_solver::def::DefKind::TypeAlias
-                )
+                && self.ctx.definition_store.get_kind(def_id)
+                    == Some(tsz_solver::def::DefKind::Interface)
+                && let Some(name_atom) = self.ctx.definition_store.get_name(def_id)
             {
-                let name = self.ctx.types.resolve_atom(def_info.name);
-                drop(def_info);
+                let name = self.ctx.types.resolve_atom(name_atom);
                 if let Some(lib_type) = self.resolve_lib_type_by_name(&name)
                     && lib_type != type_id
                     && lib_type != TypeId::ERROR
@@ -1463,6 +1526,11 @@ impl CheckerState<'_> {
         &mut self,
         def_id: tsz_solver::DefId,
     ) -> Option<TypeId> {
+        if let Some(body) = self.materialize_actual_lib_alias_body(def_id) {
+            self.try_insert_def_in_type_env(def_id, body);
+            return Some(body);
+        }
+
         let lib_name = self.ctx.definition_store.get(def_id).and_then(|info| {
             (info.file_id == Some(u32::MAX)).then(|| self.ctx.types.resolve_atom(info.name))
         });

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -1321,7 +1321,15 @@ impl CheckerState<'_> {
             // checker context didn't propagate them to the main context. The
             // DefinitionStore still has the name, so we can materialize the interface
             // type through the lib type resolution system.
-            if let Some(body) = self.materialize_actual_lib_alias_body(def_id) {
+            // Keep the actual-lib forcing path completely out of no-lib and
+            // ordinary program resolution. Besides avoiding shared-store work
+            // on a hot fallback, this preserves the existing cross-file
+            // program-definition ordering when no library can contribute the
+            // requested alias.
+            if self.ctx.has_lib_loaded()
+                && self.ctx.definition_store.def_is_non_program(def_id)
+                && let Some(body) = self.materialize_actual_lib_alias_body(def_id)
+            {
                 return self.resolve_lazy_type_inner(body, visited);
             }
             if self.ctx.has_lib_loaded()
@@ -1526,7 +1534,13 @@ impl CheckerState<'_> {
         &mut self,
         def_id: tsz_solver::DefId,
     ) -> Option<TypeId> {
-        if let Some(body) = self.materialize_actual_lib_alias_body(def_id) {
+        // Most relation-readiness calls resolve program definitions. Do not
+        // enter the actual-lib materializer unless both structural preconditions
+        // already hold; the helper repeats the checks as its authority guard.
+        if self.ctx.has_lib_loaded()
+            && self.ctx.definition_store.def_is_non_program(def_id)
+            && let Some(body) = self.materialize_actual_lib_alias_body(def_id)
+        {
             self.try_insert_def_in_type_env(def_id, body);
             return Some(body);
         }

--- a/crates/tsz-checker/tests/lib_primitive_alias_materialization_tests.rs
+++ b/crates/tsz-checker/tests/lib_primitive_alias_materialization_tests.rs
@@ -1,0 +1,119 @@
+//! Standard-library aliases reached through lazy interface members must expose
+//! their structural bodies to relation and operation consumers.
+//!
+//! The custom lib keeps binder names unrelated to the project witness and
+//! covers primitive aliases, alias chains, generic applications, aliases to
+//! interfaces, and a module-local shadow. The producer/consumer order is
+//! reversed to exercise both cross-file `DefId` layouts.
+
+use std::sync::Arc;
+
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_multi_file_with_libs_stamped, load_lib_files};
+use tsz_common::common::ModuleKind;
+
+const LIB_SOURCE: &str = r#"
+type ClockTick = NumericTick;
+type NumericTick = number;
+type CaptionTick = string;
+type Parcel<T> = { value: T };
+
+interface DisplayFace {
+    label: string;
+}
+type DisplayAlias = DisplayFace;
+
+interface Chronometer {
+    now(): ClockTick;
+    caption(): CaptionTick;
+    parcel<T>(value: T): Parcel<T>;
+    display(): DisplayAlias;
+}
+
+declare const chronometer: Chronometer;
+"#;
+
+const PRODUCER: &str = r#"
+export const marker = 1;
+"#;
+
+const CONSUMER: &str = r#"
+import { marker } from "./producer";
+
+declare const selectClock: boolean;
+declare function needsNumber(value: number): void;
+
+void marker;
+const clockValue = selectClock ? chronometer.now() : 0;
+needsNumber(clockValue);
+const elapsed = clockValue - 1;
+
+const captionOk: string = chronometer.caption();
+const captionWrong: number = chronometer.caption();
+const captionMath = chronometer.caption() - 1;
+
+const boxedOk: number = chronometer.parcel(1).value;
+const boxedWrong: string = chronometer.parcel(1).value;
+
+const labelOk: string = chronometer.display().label;
+
+type ClockTick = string;
+const localTick: ClockTick = "local";
+const localTickWrong: number = localTick;
+"#;
+
+fn options() -> CheckerOptions {
+    CheckerOptions {
+        module: ModuleKind::ESNext,
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn diagnostics(files: &[(&str, &str)]) -> Vec<(u32, String, u32, String)> {
+    let mut libs = load_lib_files(&["es5.d.ts"]);
+    assert_eq!(
+        libs.len(),
+        1,
+        "es5 lib is required for this regression test"
+    );
+    libs.push(Arc::new(LibFile::from_source(
+        "lib.clockwork.d.ts".to_string(),
+        LIB_SOURCE.to_string(),
+    )));
+    check_multi_file_with_libs_stamped(files, "consumer.ts", options(), &libs)
+        .into_iter()
+        .map(|diagnostic| {
+            (
+                diagnostic.code,
+                diagnostic.file,
+                diagnostic.start,
+                diagnostic.message_text,
+            )
+        })
+        .collect()
+}
+
+fn assert_expected_diagnostics(files: &[(&str, &str)], order: &str) {
+    let diagnostics = diagnostics(files);
+    let codes: Vec<u32> = diagnostics.iter().map(|(code, ..)| *code).collect();
+    assert_eq!(
+        codes,
+        vec![2322, 2362, 2322, 2322],
+        "primitive/generic/lib-interface aliases must materialize while genuine string and shadow mismatches remain ({order}); got {diagnostics:#?}",
+    );
+}
+
+#[test]
+fn lazy_lib_alias_bodies_are_materialized_in_both_root_orders() {
+    assert_expected_diagnostics(
+        &[("producer.ts", PRODUCER), ("consumer.ts", CONSUMER)],
+        "producer first",
+    );
+    assert_expected_diagnostics(
+        &[("consumer.ts", CONSUMER), ("producer.ts", PRODUCER)],
+        "consumer first",
+    );
+}

--- a/crates/tsz-checker/tests/lib_primitive_alias_materialization_tests.rs
+++ b/crates/tsz-checker/tests/lib_primitive_alias_materialization_tests.rs
@@ -48,6 +48,7 @@ void marker;
 const clockValue = selectClock ? chronometer.now() : 0;
 needsNumber(clockValue);
 const elapsed = clockValue - 1;
+const clockWrong: string = chronometer.now();
 
 const captionOk: string = chronometer.caption();
 const captionWrong: number = chronometer.caption();
@@ -57,6 +58,7 @@ const boxedOk: number = chronometer.parcel(1).value;
 const boxedWrong: string = chronometer.parcel(1).value;
 
 const labelOk: string = chronometer.display().label;
+const labelWrong: number = chronometer.display().label;
 
 type ClockTick = string;
 const localTick: ClockTick = "local";
@@ -101,7 +103,7 @@ fn assert_expected_diagnostics(files: &[(&str, &str)], order: &str) {
     let codes: Vec<u32> = diagnostics.iter().map(|(code, ..)| *code).collect();
     assert_eq!(
         codes,
-        vec![2322, 2362, 2322, 2322],
+        vec![2322, 2322, 2362, 2322, 2322, 2322],
         "primitive/generic/lib-interface aliases must materialize while genuine string and shadow mismatches remain ({order}); got {diagnostics:#?}",
     );
 }

--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -82,6 +82,9 @@ path = "tests/instanceof_class_value_rhs_tests.rs"
 name = "lib_alias_ref_def_identity_tests"
 path = "tests/lib_alias_ref_def_identity_tests.rs"
 [[test]]
+name = "lib_primitive_alias_on_demand_cli_tests"
+path = "tests/lib_primitive_alias_on_demand_cli_tests.rs"
+[[test]]
 name = "zod_cross_file_partial_omit_tests"
 path = "tests/zod_cross_file_partial_omit_tests.rs"
 [[test]]

--- a/crates/tsz-cli/tests/lib_primitive_alias_on_demand_cli_tests.rs
+++ b/crates/tsz-cli/tests/lib_primitive_alias_on_demand_cli_tests.rs
@@ -1,0 +1,140 @@
+//! Real-DOM regression for a primitive lib alias returned from a lazily
+//! materialized interface member.
+//!
+//! Each run uses a separate CLI process because the on-demand forcing switch
+//! is process-cached. Default forcing must agree byte-for-byte with the legacy
+//! eager kill switch in both root orders.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new() -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_lib_primitive_alias_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+struct RunResult {
+    status: ExitStatus,
+    output: String,
+}
+
+fn run_tsz(tsz: &Path, dir: &TempDir, roots: &[&str], eager: bool) -> RunResult {
+    let mut command = Command::new(tsz);
+    command
+        .args([
+            "--ignoreConfig",
+            "--noEmit",
+            "--strict",
+            "--pretty",
+            "false",
+            "--target",
+            "es2022",
+            "--lib",
+            "es2022,dom,dom.iterable",
+        ])
+        .args(roots)
+        .current_dir(&dir.path);
+    if eager {
+        command.env("TSZ_DISABLE_ON_DEMAND_FORCING", "1");
+    } else {
+        command.env_remove("TSZ_DISABLE_ON_DEMAND_FORCING");
+    }
+    let result = command.output().expect("run tsz");
+    let mut output = String::from_utf8_lossy(&result.stdout).into_owned();
+    output.push_str(&String::from_utf8_lossy(&result.stderr));
+    RunResult {
+        status: result.status,
+        output,
+    }
+}
+
+fn assert_default_matches_eager(tsz: &Path, dir: &TempDir, roots: &[&str]) {
+    let default = run_tsz(tsz, dir, roots, false);
+    let eager = run_tsz(tsz, dir, roots, true);
+
+    assert!(
+        default.status.success(),
+        "default on-demand forcing must accept root order {roots:?}; got:\n{}",
+        default.output,
+    );
+    assert!(
+        eager.status.success(),
+        "legacy eager forcing must accept root order {roots:?}; got:\n{}",
+        eager.output,
+    );
+    assert_eq!(
+        default.output, eager.output,
+        "default and eager forcing must agree for root order {roots:?}",
+    );
+}
+
+#[test]
+fn dom_primitive_alias_return_matches_eager_forcing_in_both_root_orders() {
+    let Some(tsz) = find_tsz_binary() else {
+        println!("tsz binary not found; skipping");
+        return;
+    };
+    let dir = TempDir::new().expect("temp dir");
+    std::fs::write(
+        dir.path.join("clock.ts"),
+        r#"
+function isCallable(value: unknown): value is (...args: never[]) => unknown {
+    return typeof value === "function";
+}
+
+export function clockValue() {
+    if (typeof performance !== "undefined" && isCallable(performance.now)) {
+        return performance.now();
+    }
+    return Date.now();
+}
+"#,
+    )
+    .expect("write producer");
+    std::fs::write(
+        dir.path.join("consumer.ts"),
+        r#"
+import { clockValue } from "./clock.js";
+
+declare function needsNumber(value: number): void;
+needsNumber(clockValue());
+export const elapsed = clockValue() - 1;
+"#,
+    )
+    .expect("write consumer");
+
+    assert_default_matches_eager(&tsz, &dir, &["clock.ts", "consumer.ts"]);
+    assert_default_matches_eager(&tsz, &dir, &["consumer.ts", "clock.ts"]);
+}

--- a/crates/tsz-cli/tests/lib_primitive_alias_on_demand_cli_tests.rs
+++ b/crates/tsz-cli/tests/lib_primitive_alias_on_demand_cli_tests.rs
@@ -3,7 +3,8 @@
 //!
 //! Each run uses a separate CLI process because the on-demand forcing switch
 //! is process-cached. Default forcing must agree byte-for-byte with the legacy
-//! eager kill switch in both root orders.
+//! eager kill switch in both root orders, including a negative assignment that
+//! proves the alias remained `number` rather than degrading to `any`.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
@@ -84,19 +85,28 @@ fn assert_default_matches_eager(tsz: &Path, dir: &TempDir, roots: &[&str]) {
     let default = run_tsz(tsz, dir, roots, false);
     let eager = run_tsz(tsz, dir, roots, true);
 
-    assert!(
-        default.status.success(),
-        "default on-demand forcing must accept root order {roots:?}; got:\n{}",
-        default.output,
-    );
-    assert!(
-        eager.status.success(),
-        "legacy eager forcing must accept root order {roots:?}; got:\n{}",
-        eager.output,
-    );
+    assert!(!default.status.success());
+    assert!(!eager.status.success());
     assert_eq!(
         default.output, eager.output,
         "default and eager forcing must agree for root order {roots:?}",
+    );
+    let diagnostics: Vec<_> = default
+        .output
+        .lines()
+        .filter(|line| line.contains("error TS"))
+        .collect();
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected one negative-control diagnostic for root order {roots:?}; got:\n{}",
+        default.output,
+    );
+    assert!(
+        diagnostics[0].contains("error TS2322:")
+            && diagnostics[0].contains("Type 'number' is not assignable to type 'string'."),
+        "DOM primitive alias must materialize as number for root order {roots:?}; got:\n{}",
+        default.output,
     );
 }
 
@@ -131,6 +141,7 @@ import { clockValue } from "./clock.js";
 declare function needsNumber(value: number): void;
 needsNumber(clockValue());
 export const elapsed = clockValue() - 1;
+export const wrong: string = clockValue();
 "#,
     )
     .expect("write consumer");


### PR DESCRIPTION
Goal: green

## Summary

- Materialize a missing actual-standard-library alias body only when a lazy consumer reaches it, then re-read the body through the canonical definition environment.
- Keep the public `Lazy(DefId)` alias identity while exposing primitive, chained, generic-object, and interface-backed bodies to relation and operation consumers.
- Restrict the fallback to proven non-program actual-lib definitions and preserve ordinary program aliases and module-local shadows.
- Prefilter both hot-path callers before entering actual-lib materialization, so no-lib and ordinary program resolution retain their existing ordering and avoid shared-store work.

## Structural Rule

When a lazy alias is proven by canonical `DefId` ownership to come from the actual standard library and its published body is not yet visible to a consumer, `tsc` evaluates that alias declaration before applying relations or operations. TSZ now triggers the existing lib lowering through the checker lazy type-environment boundary, re-reads the same definition body, and leaves unrelated or in-progress aliases deferred. When no library is loaded or the definition belongs to the program, resolution never enters this forcing path.

## Owner Layer

This is checker-side relation-readiness and environment publication (`state/type_environment/lazy.rs`). Existing lib alias lowering still owns construction of the body, and solver relation/operation semantics are unchanged.

## Adjacent Matrix

- primitive alias chains reached through interface method returns;
- numeric union, argument, and arithmetic consumers;
- negative assignments prove primitive chains do not degrade to `any`;
- genuine string-alias assignment and arithmetic failures remain diagnostics;
- generic alias applications expose their members, with a negative member assignment;
- aliases to interfaces expose interface members, with a negative member assignment;
- module-local aliases with the same spelling remain local;
- producer-first and consumer-first root orders;
- no-lib cross-file Zod discriminants retain their existing program-definition resolution;
- real DOM `performance.now()` agrees with legacy eager forcing in both root orders, and a TS2322 negative control proves `DOMHighResTimeStamp` remains `number` rather than `any`.

## Performance And Residency

No eager lib walk or new cache is introduced. Both callers first require a loaded lib and a non-program definition, so ordinary relation-readiness misses do not enter the materializer. The fallback then requires canonical actual-lib `DefId` identity and respects the existing in-progress cycle guard. Publication remains bounded to the existing per-checker definition store/type environments. No timing claim is made while the Kysely row is not yet green.

## Project Corpus Impact

- Row: Kysely
- Failure family: lazy standard-library primitive alias results remained opaque to downstream relations and operations.
- Full local Kysely compilation was deliberately not run concurrently on the shared machine; exact-head project CI and the coordinated row comparison own broad evidence.

## Verification

- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test lib_primitive_alias_materialization_tests --no-fail-fast` — 1 passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-cli --test lib_primitive_alias_on_demand_cli_tests --no-fail-fast` — 1 passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test lib_conditional_alias_return_consumer_first_tests --no-fail-fast` — 3 passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-cli --test lib_alias_ref_def_identity_tests --no-fail-fast` — 2 passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-core --lib test_check_files_parallel_zod_issue_data_cross_file_spread` — passed after rebase onto current `main`; 20 additional repetitions passed with `RAYON_NUM_THREADS=4`.
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings`.
- `cargo fmt --all -- --check` and `git diff --check`.
- Exact-head ready-review CI owns broad conformance, emit, and project gates.

## Provenance

Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
