### PR TITLE
fix(checker): recover generic call assignment flow

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -221,6 +221,9 @@ path = "tests/recursive_lib_type_relation_tests.rs"
 name = "assignment_branch_merge_narrowing_tests"
 path = "tests/assignment_branch_merge_narrowing_tests.rs"
 [[test]]
+name = "generic_call_assignment_flow_tests"
+path = "tests/generic_call_assignment_flow_tests.rs"
+[[test]]
 name = "mapped_remapped_excess_function_property_tests"
 path = "tests/mapped_remapped_excess_function_property_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/context/core_module_resolution.rs
+++ b/crates/tsz-checker/src/context/core_module_resolution.rs
@@ -389,6 +389,82 @@ impl CheckerContext<'_> {
             })
     }
 
+    /// Owner-carrying form of [`Self::resolve_export_in_target_file`]. Raw
+    /// `SymbolId`s are binder-relative, so callers that feed a resolved export
+    /// into an owner-keyed cache must keep the declaring file attached instead
+    /// of recovering it from the mutable symbol-target overlay afterward.
+    pub fn resolve_export_in_target_file_with_owner(
+        &self,
+        target_idx: usize,
+        export_name: &str,
+        visited: &mut FxHashSet<usize>,
+        remaining_steps: &mut usize,
+    ) -> Option<(tsz_binder::SymbolId, usize)> {
+        let next = remaining_steps.checked_sub(1)?;
+        *remaining_steps = next;
+        if !visited.insert(target_idx) {
+            return None;
+        }
+        let target_binder = self.get_binder_for_file(target_idx)?;
+        let target_arena = self.get_arena_for_file(target_idx as u32);
+        let file_name = target_arena.source_files.first()?.file_name.clone();
+
+        // Direct exports (program-aware).
+        if let Some(exports) = self.module_exports_for_module(target_binder, &file_name)
+            && let Some(sym_id) = exports.get(export_name)
+            && target_binder.get_symbol(sym_id).is_some()
+        {
+            self.register_symbol_file_target(sym_id, target_idx);
+            return Some((sym_id, target_idx));
+        }
+
+        // Named re-exports: `export { foo } from './other'` (and `as` renames).
+        if let Some(reexports) = self.reexports_for_file(target_binder, &file_name)
+            && let Some((source_module, original_name)) = reexports.get(export_name)
+        {
+            let name = original_name.as_deref().unwrap_or(export_name);
+            if let Some(source_idx) =
+                self.resolve_import_target_from_file(target_idx, source_module)
+                && let Some(resolved) = self.resolve_export_in_target_file_with_owner(
+                    source_idx,
+                    name,
+                    visited,
+                    remaining_steps,
+                )
+            {
+                return Some(resolved);
+            }
+        }
+
+        // Wildcard re-exports: `export * from './other'`.
+        if let Some(source_modules) = self.wildcard_reexports_for_file(target_binder, &file_name) {
+            let source_modules = source_modules.clone();
+            for (source_module, _is_type_only) in &source_modules {
+                if let Some(source_idx) =
+                    self.resolve_import_target_from_file(target_idx, source_module)
+                    && let Some(resolved) = self.resolve_export_in_target_file_with_owner(
+                        source_idx,
+                        export_name,
+                        visited,
+                        remaining_steps,
+                    )
+                {
+                    return Some(resolved);
+                }
+            }
+        }
+
+        // Fallback: the target binder's own re-export resolution for
+        // single-file / ambient-module binders whose local tables are
+        // populated (e.g. `declare module "x" { ... }`).
+        target_binder
+            .resolve_import_with_reexports_type_only(&file_name, export_name)
+            .map(|(sym_id, _)| {
+                self.register_symbol_file_target(sym_id, target_idx);
+                (sym_id, target_idx)
+            })
+    }
+
     /// When `alias_id` is a *named* import bound to an `export * as NS from '<m>'`
     /// namespace re-export, return the file index of the re-exported module `<m>`
     /// — the backing module whose exports are the anchor's members. Returns

--- a/crates/tsz-checker/src/context/import_alias_resolution.rs
+++ b/crates/tsz-checker/src/context/import_alias_resolution.rs
@@ -6,9 +6,17 @@
 //! `SymbolId`s, so each hop is read from the binder of the file that declares
 //! it and pinned into the cross-file target overlay for cross-arena delegation.
 
+use smallvec::SmallVec;
 use tsz_binder::{BinderState, SymbolId};
 
 use super::CheckerContext;
+
+/// Total owner-carrying alias/re-export steps allowed for one flow fallback.
+///
+/// This budget is shared by direct alias hops and recursive named/wildcard
+/// barrel traversal so a wide or deeply nested project cannot turn the
+/// conservative recovery path into an unbounded walk.
+const MAX_OWNER_ALIAS_RESOLUTION_STEPS: usize = 64;
 
 /// Look up `import_name` among a binder's exports for `file_name`, falling back
 /// to its file-local declarations. Shared by the single-hop and chain import
@@ -127,6 +135,98 @@ impl CheckerContext<'_> {
         None
     }
 
+    /// Resolve one import hop and carry the target binder index with the raw
+    /// symbol id. The overlay registration remains for legacy consumers, but
+    /// owner-aware callers never need to read that lossy raw-id map back.
+    fn resolve_import_alias_with_owner_and_register(
+        &self,
+        sym_id: tsz_binder::SymbolId,
+        remaining_steps: &mut usize,
+    ) -> Option<(tsz_binder::SymbolId, usize)> {
+        let symbol = self.binder.symbols.get(sym_id).or_else(|| {
+            self.all_binders
+                .as_ref()
+                .and_then(|bs| bs.iter().find_map(|b| b.symbols.get(sym_id)))
+        })?;
+
+        if (symbol.flags & tsz_binder::symbol_flags::ALIAS) == 0 {
+            return None;
+        }
+
+        let source_file_idx = if self
+            .binder
+            .get_symbol(sym_id)
+            .is_some_and(|local| local.flags & tsz_binder::symbol_flags::ALIAS != 0)
+        {
+            self.current_file_idx
+        } else {
+            symbol.decl_file_idx as usize
+        };
+        self.resolve_import_alias_from_file_with_owner_and_register(
+            sym_id,
+            source_file_idx,
+            remaining_steps,
+        )
+    }
+
+    /// Resolve one alias hop from the binder that owns `sym_id`, carrying the
+    /// resolved export's owner through direct, named, wildcard, and ambient
+    /// module paths.
+    fn resolve_import_alias_from_file_with_owner_and_register(
+        &self,
+        sym_id: tsz_binder::SymbolId,
+        source_file_idx: usize,
+        remaining_steps: &mut usize,
+    ) -> Option<(tsz_binder::SymbolId, usize)> {
+        let source_binder = self.get_binder_for_file(source_file_idx)?;
+        let symbol = source_binder.get_symbol(sym_id)?;
+        if (symbol.flags & tsz_binder::symbol_flags::ALIAS) == 0 {
+            return None;
+        }
+        let module_specifier = symbol.import_module()?;
+        let import_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
+
+        if let Some(target_idx) =
+            self.resolve_import_target_from_file(source_file_idx, module_specifier)
+        {
+            let target_binder = self.get_binder_for_file(target_idx)?;
+            let target_arena = self.get_arena_for_file(target_idx as u32);
+            let file_name = &target_arena.source_files.first()?.file_name;
+            let resolved = if let Some(result) =
+                binder_named_export_or_local(target_binder, file_name, import_name)
+            {
+                let next = remaining_steps.checked_sub(1)?;
+                *remaining_steps = next;
+                (result, target_idx)
+            } else {
+                let mut visited = rustc_hash::FxHashSet::default();
+                self.resolve_export_in_target_file_with_owner(
+                    target_idx,
+                    import_name,
+                    &mut visited,
+                    remaining_steps,
+                )?
+            };
+            self.register_symbol_file_target(resolved.0, resolved.1);
+            return Some(resolved);
+        }
+
+        // Fallback: check ambient module exports (declare module "X" { ... }).
+        // These are keyed by the module specifier in binder.module_exports.
+        // For ambient modules, the symbol lives in the same binder that declared
+        // the module, so we also register it in cross_file_symbol_targets with
+        // the declaring file's index for proper cross-arena delegation.
+        if let Some((result, file_idx)) =
+            self.resolve_import_from_ambient_module_with_file_idx(module_specifier, import_name)
+        {
+            let next = remaining_steps.checked_sub(1)?;
+            *remaining_steps = next;
+            self.register_symbol_file_target(result, file_idx);
+            return Some((result, file_idx));
+        }
+        None
+    }
+
     /// Follow an import-alias / re-export chain to its terminal target symbol,
     /// registering every hop's owning file so cross-arena delegation can locate
     /// it.
@@ -197,6 +297,47 @@ impl CheckerContext<'_> {
             current = next;
         }
         Some(current)
+    }
+
+    /// Follow an import/re-export chain while carrying the terminal symbol's
+    /// binder-relative owner as part of the result. Consumers must prefer this
+    /// over re-reading the mutable raw-id ownership overlay.
+    pub fn resolve_import_alias_chain_with_owner_and_register(
+        &self,
+        sym_id: tsz_binder::SymbolId,
+    ) -> Option<(tsz_binder::SymbolId, usize)> {
+        // Resolve the first hop with its owner attached. Re-reading the raw-id
+        // overlay here would be ambiguous when two target binders minted the
+        // same `SymbolId`.
+        let mut remaining_steps = MAX_OWNER_ALIAS_RESOLUTION_STEPS;
+        let (mut current, mut current_file_idx) =
+            self.resolve_import_alias_with_owner_and_register(sym_id, &mut remaining_steps)?;
+        let mut seen = SmallVec::<[(usize, SymbolId); 4]>::new();
+        loop {
+            let owned_symbol = (current_file_idx, current);
+            if seen.contains(&owned_symbol) {
+                return None;
+            }
+            seen.push(owned_symbol);
+            // Read the intermediate from the binder that actually owns it.
+            let binder = self.get_binder_for_file(current_file_idx)?;
+            let symbol = binder.get_symbol(current)?;
+            if (symbol.flags & tsz_binder::symbol_flags::ALIAS) == 0 {
+                return Some((current, current_file_idx));
+            }
+            let (next, target_idx) = self.resolve_import_alias_from_file_with_owner_and_register(
+                current,
+                current_file_idx,
+                &mut remaining_steps,
+            )?;
+            // Raw ids are binder-relative. Equal ids in different owner files
+            // are a forward alias hop, not a re-export cycle.
+            if next == current && target_idx == current_file_idx {
+                return None;
+            }
+            current = next;
+            current_file_idx = target_idx;
+        }
     }
 
     /// Resolve an import name from ambient module exports (`declare module "X" { ... }`).

--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -26,7 +26,7 @@ struct DestructuringSource {
 }
 
 impl<'a> FlowAnalyzer<'a> {
-    fn assignment_relation_outcome(
+    pub(super) fn assignment_relation_outcome(
         &self,
         source: TypeId,
         target: TypeId,
@@ -65,7 +65,7 @@ impl<'a> FlowAnalyzer<'a> {
             .is_some_and(|node| node.kind == syntax_kind_ext::CONDITIONAL_EXPRESSION)
     }
 
-    fn assigned_type_respecting_access_read_surface(
+    pub(super) fn assigned_type_respecting_access_read_surface(
         &self,
         assignment_node: NodeIndex,
         target: NodeIndex,
@@ -140,83 +140,6 @@ impl<'a> FlowAnalyzer<'a> {
         self.assignment_relation_outcome(assigned_type, target_type, false)
             .related
             .then_some(assigned_type)
-    }
-
-    /// Validate the whole RHS before flow; literal initializers are handled earlier.
-    fn compatible_simple_assignment_type(
-        &self,
-        assignment_node: NodeIndex,
-        target: NodeIndex,
-        assigned_type: TypeId,
-        compatibility_target_fallback: Option<TypeId>,
-        assignment_type_is_provisional: &mut bool,
-        preserve_declared_assignment_flow: &mut bool,
-    ) -> Option<TypeId> {
-        let Some(flow_type) = self.assigned_type_respecting_access_read_surface(
-            assignment_node,
-            target,
-            assigned_type,
-        ) else {
-            *preserve_declared_assignment_flow = true;
-            return None;
-        };
-        let node = self.arena.get(assignment_node)?;
-        let (value_declaration, compatibility_node) =
-            if node.kind == syntax_kind_ext::BINARY_EXPRESSION {
-                let bin = self.arena.get_binary_expr(node)?;
-                if bin.operator_token != SyntaxKind::EqualsToken as u16
-                    || !self.is_matching_reference(bin.left, target)
-                {
-                    return Some(flow_type);
-                }
-                (
-                    self.binder
-                        .resolve_identifier(self.arena, bin.left)
-                        .and_then(|sym| self.binder.get_symbol(sym))
-                        .map(|sym| sym.value_declaration)
-                        .filter(|decl| decl.is_some()),
-                    bin.left,
-                )
-            } else if node.kind == syntax_kind_ext::VARIABLE_DECLARATION
-                && self.is_var_decl_with_type_annotation(assignment_node)
-            {
-                (Some(assignment_node), target)
-            } else {
-                return Some(flow_type);
-            };
-        let node_types = self.node_types;
-        let declared_target_type = value_declaration
-            .and_then(|declaration| {
-                let (type_id, provisional) =
-                    self.declared_type_from_value_declaration_with_stability(declaration);
-                *assignment_type_is_provisional |= provisional;
-                type_id
-            })
-            .or_else(|| node_types.and_then(|types| types.get(&compatibility_node.0).copied()))
-            .or(compatibility_target_fallback.filter(|&type_id| type_id != TypeId::ERROR));
-        if declared_target_type.is_none() && *assignment_type_is_provisional {
-            *preserve_declared_assignment_flow = true;
-            return None;
-        }
-        let env = self.type_environment.map(std::cell::RefCell::borrow);
-        let relation_flags = self.checker_context.map_or(
-            crate::query_boundaries::assignability::RelationFlags::STRICT_NULL_CHECKS,
-            |ctx| ctx.pack_relation_flags(),
-        );
-        if let Some(lhs_type) = declared_target_type
-            && !crate::query_boundaries::flow_analysis::whole_assignment_rhs_is_compatible(
-                self.interner,
-                env.as_deref(),
-                self.concrete_this_type,
-                assigned_type,
-                lhs_type,
-                relation_flags,
-            )
-        {
-            *preserve_declared_assignment_flow = true;
-            return None;
-        }
-        Some(flow_type)
     }
 
     fn access_reference_split_read_write_type(

--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -142,6 +142,83 @@ impl<'a> FlowAnalyzer<'a> {
             .then_some(assigned_type)
     }
 
+    /// Validate the whole RHS before flow; literal initializers are handled earlier.
+    fn compatible_simple_assignment_type(
+        &self,
+        assignment_node: NodeIndex,
+        target: NodeIndex,
+        assigned_type: TypeId,
+        compatibility_target_fallback: Option<TypeId>,
+        assignment_type_is_provisional: &mut bool,
+        preserve_declared_assignment_flow: &mut bool,
+    ) -> Option<TypeId> {
+        let Some(flow_type) = self.assigned_type_respecting_access_read_surface(
+            assignment_node,
+            target,
+            assigned_type,
+        ) else {
+            *preserve_declared_assignment_flow = true;
+            return None;
+        };
+        let node = self.arena.get(assignment_node)?;
+        let (value_declaration, compatibility_node) =
+            if node.kind == syntax_kind_ext::BINARY_EXPRESSION {
+                let bin = self.arena.get_binary_expr(node)?;
+                if bin.operator_token != SyntaxKind::EqualsToken as u16
+                    || !self.is_matching_reference(bin.left, target)
+                {
+                    return Some(flow_type);
+                }
+                (
+                    self.binder
+                        .resolve_identifier(self.arena, bin.left)
+                        .and_then(|sym| self.binder.get_symbol(sym))
+                        .map(|sym| sym.value_declaration)
+                        .filter(|decl| decl.is_some()),
+                    bin.left,
+                )
+            } else if node.kind == syntax_kind_ext::VARIABLE_DECLARATION
+                && self.is_var_decl_with_type_annotation(assignment_node)
+            {
+                (Some(assignment_node), target)
+            } else {
+                return Some(flow_type);
+            };
+        let node_types = self.node_types;
+        let declared_target_type = value_declaration
+            .and_then(|declaration| {
+                let (type_id, provisional) =
+                    self.declared_type_from_value_declaration_with_stability(declaration);
+                *assignment_type_is_provisional |= provisional;
+                type_id
+            })
+            .or_else(|| node_types.and_then(|types| types.get(&compatibility_node.0).copied()))
+            .or(compatibility_target_fallback.filter(|&type_id| type_id != TypeId::ERROR));
+        if declared_target_type.is_none() && *assignment_type_is_provisional {
+            *preserve_declared_assignment_flow = true;
+            return None;
+        }
+        let env = self.type_environment.map(std::cell::RefCell::borrow);
+        let relation_flags = self.checker_context.map_or(
+            crate::query_boundaries::assignability::RelationFlags::STRICT_NULL_CHECKS,
+            |ctx| ctx.pack_relation_flags(),
+        );
+        if let Some(lhs_type) = declared_target_type
+            && !crate::query_boundaries::flow_analysis::whole_assignment_rhs_is_compatible(
+                self.interner,
+                env.as_deref(),
+                self.concrete_this_type,
+                assigned_type,
+                lhs_type,
+                relation_flags,
+            )
+        {
+            *preserve_declared_assignment_flow = true;
+            return None;
+        }
+        Some(flow_type)
+    }
+
     fn access_reference_split_read_write_type(
         &self,
         target: NodeIndex,
@@ -296,15 +373,15 @@ impl<'a> FlowAnalyzer<'a> {
         assignment_node: NodeIndex,
         target: NodeIndex,
         widen_literals_for_destructuring: bool,
+        compatibility_target_fallback: Option<TypeId>,
+        assignment_type_is_provisional: &mut bool,
+        preserve_declared_assignment_flow: &mut bool,
     ) -> Option<TypeId> {
         let node = self.arena.get(assignment_node)?;
 
-        // CRITICAL FIX: Handle compound assignments (+=, -=, *=, etc.)
-        // Compound assignments compute the result of a binary operation and assign it back.
-        // Example: x += 1 where x: string | number should narrow x to number after assignment.
+        // Compound assignments compute a binary result and assign it back.
         if node.kind == syntax_kind_ext::BINARY_EXPRESSION {
             let bin = self.arena.get_binary_expr(node)?;
-            // Check if this is an assignment to our target reference
             if self.is_matching_reference(bin.left, target) {
                 if bin.operator_token == SyntaxKind::QuestionQuestionToken as u16
                     || bin.operator_token == SyntaxKind::BarBarToken as u16
@@ -385,7 +462,6 @@ impl<'a> FlowAnalyzer<'a> {
                         return None;
                     }
 
-                    // When node_types is not available, use heuristics for flow narrowing
                     if self.node_types.is_none() {
                         return fallback_compound_assignment_result(
                             self.interner,
@@ -431,10 +507,8 @@ impl<'a> FlowAnalyzer<'a> {
         }
 
         if let Some(rhs) = self.assignment_rhs_for_reference(assignment_node, target) {
-            // Unannotated declaration initializers `let/var/const x = []` should flow as
-            // evolving-any arrays so immediate writes like `x.push(...)` are permitted.
-            // Keep this scoped to declaration assignments to avoid changing expression-level
-            // `[]` behavior (e.g. generic inference with `id([])`).
+            // Unannotated declaration `[]` initializers create evolving arrays;
+            // expression-level empty arrays retain ordinary inference.
             let is_unannotated_decl_init = (self
                 .is_mutable_var_decl_without_annotation(assignment_node)
                 || (self.is_const_variable_declaration(assignment_node)
@@ -454,9 +528,7 @@ impl<'a> FlowAnalyzer<'a> {
                 );
             }
 
-            // Also handle `let x; x = []` — assignment of empty array to an
-            // unannotated variable declared without initializer. This should
-            // also create an evolving array (any[]) matching tsc's behavior.
+            // `let x; x = []` also creates an evolving array.
             let is_rhs_empty_array = self.arena.get(rhs).is_some_and(|rhs_node| {
                 rhs_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
                     && self
@@ -475,32 +547,18 @@ impl<'a> FlowAnalyzer<'a> {
                 );
             }
 
-            // For flow narrowing, prefer literal types from AST nodes over the type checker's widened types
-            // This ensures that `x = 42` narrows to literal 42.0, not just NUMBER
-            // This matches TypeScript's behavior where control flow analysis preserves literal types
+            // Prefer AST literal types so flow preserves literal assignment values.
             if let Some(literal_type) = self.literal_type_from_node(rhs) {
-                // For destructuring contexts, return the literal type as-is.
-                // narrow_assignment (using one-way assignability) handles the
-                // correct narrowing: `[b] = [0]` with `b: 0|1|9` narrows to `0`,
-                // while `[c] = [0]` with `c: string|number` narrows to `number`.
+                // Destructuring reduction owns any required literal widening.
                 if widen_literals_for_destructuring {
                     return Some(literal_type);
                 }
-                // For mutable variable declarations (let/var) without type annotations,
-                // widen literal types to their base types to match TypeScript behavior.
-                // Example: let x = "hi" -> string (not "hi"), let x = 42 -> number (not 42)
+                // Mutable unannotated declarations widen literals to primitives.
                 if self.is_mutable_var_decl_without_annotation(assignment_node) {
                     return Some(widen_literal_to_primitive(self.interner, literal_type));
                 }
-                // For const variable declarations with type annotations, if the literal
-                // type (null or undefined) is not assignable to the declared annotation
-                // type, return None (use the declared type). This prevents TS18047 false
-                // positives like `const x: IAsyncEnumerator<number> = null` where
-                // subsequent uses of x should see IAsyncEnumerator<number>, not null.
-                // Note: annotation type is keyed by annotation node index in node_types,
-                // not by the variable declaration node index.
-                // We use strict null check mode (flags=1) because the question is whether
-                // null semantically belongs to the declared type — a strict-mode concept.
+                // An excluded annotated nullish literal keeps the declared type;
+                // its cache entry is keyed by the annotation node.
                 if (literal_type == TypeId::NULL || literal_type == TypeId::UNDEFINED)
                     && let Some(annotation_type) =
                         self.annotation_type_from_assignment_node(assignment_node, target)
@@ -514,21 +572,9 @@ impl<'a> FlowAnalyzer<'a> {
                     literal_type,
                 );
             }
-            // Narrow a variable declaration's declared type by its initializer,
-            // as tsc's `getAssignmentReducedType` does. (Primitive-literal
-            // initializers are handled by the `literal_type_from_node` branch
-            // above; this block covers object/array literals and non-literal
-            // initializers such as `new C()` or another reference.)
-            //
-            // `const` always narrows; a `let`/`var` narrows only when it is
-            // never reassigned — an effectively constant reference, mirroring
-            // tsc's `isConstantReference`. A reassigned mutable local keeps its
-            // declared type so the loop fixed-point machinery owns its
-            // evolution: narrowing a loop-reassigned initializer would evaluate
-            // the loop body's first fixed-point pass against the narrowed entry
-            // type and surface spurious diagnostics (the #8513 `Optional<r>`
-            // repro). A never-reassigned local can never sit on a loop
-            // back-edge, so narrowing it is always safe.
+            // Match tsc's `getAssignmentReducedType` for annotated initializers.
+            // `const` always narrows; mutable locals narrow only when effectively
+            // constant, leaving loop-reassigned evolution to fixed-point flow.
             if self.is_var_decl_with_type_annotation(assignment_node) {
                 if self.var_decl_redeclares_parameter_for_reference(assignment_node, target) {
                     return None;
@@ -581,8 +627,7 @@ impl<'a> FlowAnalyzer<'a> {
                 // killing-definition `narrow_assignment` reduces the declared
                 // union — identical to the `const` path.
             }
-            // `undefined` identifier (not a keyword) as initializer: if the variable
-            // has a type annotation that doesn't include undefined, use the declared type.
+            // Reject `undefined` initializers excluded by an annotation.
             if let Some(nullish_type) = self.nullish_literal_type(rhs) {
                 if let Some(annotation_type) =
                     self.annotation_type_from_assignment_node(assignment_node, target)
@@ -610,57 +655,15 @@ impl<'a> FlowAnalyzer<'a> {
                     rhs_type
                 );
                 if rhs_type == TypeId::ERROR {
-                    // Loop fixed-point often caches an ERROR placeholder for recursive calls
-                    // before the callee has been fully checked. Fall through to the AST-based
-                    // fallback instead of short-circuiting on the placeholder.
+                    // Retry an `ERROR` loop placeholder through the AST fallback.
                 } else {
-                    // Only apply assignment-based "killing definition" narrowing when
-                    // the write itself is compatible. For invalid assignments, TypeScript
-                    // reports the assignment error but keeps subsequent reads at the
-                    // variable's declared type.
-                    if node.kind == syntax_kind_ext::BINARY_EXPRESSION
-                        && let Some(bin) = self.arena.get_binary_expr(node)
-                        && bin.operator_token == SyntaxKind::EqualsToken as u16
-                        && self.is_matching_reference(bin.left, target)
-                    {
-                        // For divergent accessors, the assignment target type can be the
-                        // setter parameter type while later reads must still use the
-                        // getter surface. If the RHS isn't assignable to the read type of
-                        // a property/element access, don't narrow future reads to the RHS.
-                        self.assigned_type_respecting_access_read_surface(
-                            assignment_node,
-                            target,
-                            rhs_type,
-                        )?;
-
-                        let declared_target_type = self
-                            .binder
-                            .resolve_identifier(self.arena, bin.left)
-                            .and_then(|sym| self.binder.get_symbol(sym))
-                            .map(|sym| sym.value_declaration)
-                            .filter(|decl| decl.is_some())
-                            .and_then(|decl| {
-                                // Prefer explicit type annotations when available.
-                                // `node_types[decl]` can hold a flow-initialized value type
-                                // (e.g. `undefined`) instead of the declared annotation type,
-                                // which would incorrectly block assignment-based narrowing.
-                                self.annotation_type_from_var_decl_node(decl)
-                                    .or_else(|| node_types.get(&decl.0).copied())
-                            })
-                            .or_else(|| node_types.get(&bin.left.0).copied());
-
-                        if let Some(lhs_type) = declared_target_type
-                            && !self
-                                .assignment_relation_outcome(rhs_type, lhs_type, false)
-                                .related
-                        {
-                            return None;
-                        }
-                    }
-                    return self.assigned_type_respecting_access_read_surface(
+                    return self.compatible_simple_assignment_type(
                         assignment_node,
                         target,
                         rhs_type,
+                        compatibility_target_fallback,
+                        assignment_type_is_provisional,
+                        preserve_declared_assignment_flow,
                     );
                 }
             }
@@ -670,19 +673,26 @@ impl<'a> FlowAnalyzer<'a> {
                     "get_assigned_type: node_types MISS for rhs; trying syntactic fallback"
                 );
             }
+            *assignment_type_is_provisional = true;
             let fallback_rhs_type = self.fallback_assigned_type_from_expression(rhs);
             if let Some(rhs_type) = fallback_rhs_type {
-                return self.assigned_type_respecting_access_read_surface(
+                return self.compatible_simple_assignment_type(
                     assignment_node,
                     target,
                     rhs_type,
+                    compatibility_target_fallback,
+                    assignment_type_is_provisional,
+                    preserve_declared_assignment_flow,
                 );
             }
             if let Some(rhs_type) = cached_rhs_type {
-                return self.assigned_type_respecting_access_read_surface(
+                return self.compatible_simple_assignment_type(
                     assignment_node,
                     target,
                     rhs_type,
+                    compatibility_target_fallback,
+                    assignment_type_is_provisional,
+                    preserve_declared_assignment_flow,
                 );
             }
             return None;

--- a/crates/tsz-checker/src/flow/control_flow/assignment_compatibility.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_compatibility.rs
@@ -1,0 +1,110 @@
+//! Whole-RHS compatibility validation for assignment-flow fallbacks.
+
+use super::FlowAnalyzer;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
+use tsz_scanner::SyntaxKind;
+use tsz_solver::TypeId;
+
+impl<'a> FlowAnalyzer<'a> {
+    /// Validate the whole RHS before flow; literal initializers are handled earlier.
+    pub(super) fn compatible_simple_assignment_type(
+        &self,
+        assignment_node: NodeIndex,
+        target: NodeIndex,
+        assigned_type: TypeId,
+        compatibility_target_fallback: Option<TypeId>,
+        assignment_type_is_provisional: &mut bool,
+        preserve_declared_assignment_flow: &mut bool,
+    ) -> Option<TypeId> {
+        let assignment_started_provisional = *assignment_type_is_provisional;
+        let Some(flow_type) = self.assigned_type_respecting_access_read_surface(
+            assignment_node,
+            target,
+            assigned_type,
+        ) else {
+            *preserve_declared_assignment_flow = true;
+            return None;
+        };
+        let node = self.arena.get(assignment_node)?;
+        let option_sensitive_relation;
+        let (value_declaration, compatibility_node) =
+            if node.kind == syntax_kind_ext::BINARY_EXPRESSION {
+                let bin = self.arena.get_binary_expr(node)?;
+                if bin.operator_token != SyntaxKind::EqualsToken as u16
+                    || !self.is_matching_reference(bin.left, target)
+                {
+                    return Some(flow_type);
+                }
+                option_sensitive_relation = assignment_started_provisional;
+                let rhs = self.skip_parens_and_assertions(bin.right);
+                if option_sensitive_relation
+                    && !self
+                        .arena
+                        .get(rhs)
+                        .is_some_and(|rhs_node| rhs_node.kind == syntax_kind_ext::CALL_EXPRESSION)
+                {
+                    // Reduced syntax-only surfaces keep the established flow path.
+                    return Some(flow_type);
+                }
+                let declaration = self
+                    .binder
+                    .resolve_identifier(self.arena, bin.left)
+                    .and_then(|sym| self.binder.get_symbol(sym))
+                    .map(|sym| sym.value_declaration)
+                    .filter(|decl| decl.is_some());
+                (declaration, bin.left)
+            } else if node.kind == syntax_kind_ext::VARIABLE_DECLARATION
+                && self.is_var_decl_with_type_annotation(assignment_node)
+            {
+                option_sensitive_relation = true;
+                (Some(assignment_node), target)
+            } else {
+                return Some(flow_type);
+            };
+        let node_types = self.node_types;
+        let declared_target_type = value_declaration
+            .and_then(|declaration| {
+                if option_sensitive_relation {
+                    let (type_id, provisional) =
+                        self.declared_type_from_value_declaration_with_stability(declaration);
+                    *assignment_type_is_provisional |= provisional;
+                    type_id
+                } else {
+                    self.annotation_type_from_var_decl_node(declaration)
+                        .or_else(|| node_types.and_then(|types| types.get(&declaration.0).copied()))
+                }
+            })
+            .or_else(|| node_types.and_then(|types| types.get(&compatibility_node.0).copied()))
+            .or(compatibility_target_fallback.filter(|&type_id| type_id != TypeId::ERROR));
+        if declared_target_type.is_none() && *assignment_type_is_provisional {
+            *preserve_declared_assignment_flow = true;
+            return None;
+        }
+        if let Some(lhs_type) = declared_target_type {
+            let related = if option_sensitive_relation {
+                let env = self.type_environment.map(std::cell::RefCell::borrow);
+                let relation_flags = self.checker_context.map_or(
+                    crate::query_boundaries::assignability::RelationFlags::STRICT_NULL_CHECKS,
+                    |ctx| ctx.pack_relation_flags(),
+                );
+                crate::query_boundaries::flow_analysis::whole_assignment_rhs_is_compatible(
+                    self.interner,
+                    env.as_deref(),
+                    self.concrete_this_type,
+                    assigned_type,
+                    lhs_type,
+                    relation_flags,
+                )
+            } else {
+                // Cached assignments retain their established relation path.
+                self.assignment_relation_outcome(assigned_type, lhs_type, false)
+                    .related
+            };
+            if !related {
+                *preserve_declared_assignment_flow = true;
+                return None;
+            }
+        }
+        Some(flow_type)
+    }
+}

--- a/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
@@ -310,23 +310,17 @@ impl<'a> FlowAnalyzer<'a> {
                 // Without this, generic new expressions with type parameter arguments
                 // fail the fallback path, losing the type argument information.
                 if (symbol.flags & tsz_binder::symbol_flags::TYPE_PARAMETER) != 0 {
-                    return symbol
-                        .declarations
-                        .iter()
-                        .copied()
-                        .find_map(|decl| {
-                            self.node_types
-                                .and_then(|nt| nt.get(&decl.0).copied())
-                                .filter(|&ty| ty != TypeId::ERROR)
-                        })
-                        .or_else(|| self.fallback_cached_stable_symbol_type(sym_id));
+                    return symbol.declarations.iter().copied().find_map(|decl| {
+                        self.node_types
+                            .and_then(|nt| nt.get(&decl.0).copied())
+                            .filter(|&ty| ty != TypeId::ERROR)
+                    });
                 }
                 let base_type = symbol
                     .declarations
                     .iter()
                     .copied()
-                    .find_map(|decl| self.fallback_named_type_declaration_type(decl))
-                    .or_else(|| self.fallback_cached_stable_symbol_type(sym_id));
+                    .find_map(|decl| self.fallback_named_type_declaration_type(decl));
                 // For generic type references with type arguments (e.g., Box<K>),
                 // apply the type arguments to the base type.
                 if let Some(base) = base_type
@@ -788,7 +782,11 @@ impl<'a> FlowAnalyzer<'a> {
                 // concrete declared/contextual type before manufacturing a Lazy
                 // fallback, whose body is not registered during the provisional
                 // walk and cannot participate in structural argument inference.
-                self.fallback_cached_stable_symbol_type(sym_id)
+                self.arena
+                    .get(decl)
+                    .is_some_and(|node| node.kind == syntax_kind_ext::PARAMETER)
+                    .then(|| self.fallback_cached_stable_symbol_type(sym_id))
+                    .flatten()
             })
             .or_else(|| {
                 self.resolve_symbol_to_lazy(SymbolRef(sym_id.0))

--- a/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
@@ -12,9 +12,11 @@ use crate::query_boundaries::flow_analysis::{
     is_promise_like_type, literal_value, optional_flow_property, union_members_for_type,
     unwrap_promise_type_argument, widen_literal_to_primitive,
 };
+use crate::query_boundaries::operator_wrappers::is_equality_comparison_operator;
 use crate::types_domain::queries::lib_resolution::{
     keyword_name_to_type_id, keyword_syntax_to_type_id,
 };
+use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
@@ -170,6 +172,17 @@ impl<'a> FlowAnalyzer<'a> {
             k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION => {
                 self.fallback_object_literal_type_from_syntax(expr)
             }
+            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
+                self.fallback_property_access_type(expr)
+            }
+            k if k == syntax_kind_ext::BINARY_EXPRESSION => {
+                let binary = self.arena.get_binary_expr(expr_node)?;
+                self.fallback_binary_expression_type(
+                    binary.left,
+                    binary.right,
+                    binary.operator_token,
+                )
+            }
             k if k == syntax_kind_ext::NEW_EXPRESSION => self.fallback_new_expression_type(expr),
             _ => None,
         }
@@ -297,17 +310,23 @@ impl<'a> FlowAnalyzer<'a> {
                 // Without this, generic new expressions with type parameter arguments
                 // fail the fallback path, losing the type argument information.
                 if (symbol.flags & tsz_binder::symbol_flags::TYPE_PARAMETER) != 0 {
-                    return symbol.declarations.iter().copied().find_map(|decl| {
-                        self.node_types
-                            .and_then(|nt| nt.get(&decl.0).copied())
-                            .filter(|&ty| ty != TypeId::ERROR)
-                    });
+                    return symbol
+                        .declarations
+                        .iter()
+                        .copied()
+                        .find_map(|decl| {
+                            self.node_types
+                                .and_then(|nt| nt.get(&decl.0).copied())
+                                .filter(|&ty| ty != TypeId::ERROR)
+                        })
+                        .or_else(|| self.fallback_cached_stable_symbol_type(sym_id));
                 }
                 let base_type = symbol
                     .declarations
                     .iter()
                     .copied()
-                    .find_map(|decl| self.fallback_named_type_declaration_type(decl));
+                    .find_map(|decl| self.fallback_named_type_declaration_type(decl))
+                    .or_else(|| self.fallback_cached_stable_symbol_type(sym_id));
                 // For generic type references with type arguments (e.g., Box<K>),
                 // apply the type arguments to the base type.
                 if let Some(base) = base_type
@@ -498,6 +517,64 @@ impl<'a> FlowAnalyzer<'a> {
 
     fn fallback_call_expression_type(&self, call_expr: NodeIndex) -> Option<TypeId> {
         self.reject_unresolved_generic_result(self.fallback_call_expression_type_inner(call_expr))
+            .or_else(|| self.fallback_instantiated_generic_call_type(call_expr))
+    }
+
+    /// Recover a concrete return for the one unambiguous generic-call shape.
+    /// Call selection, inference, constraints, and return instantiation stay in
+    /// the solver's canonical call resolver; flow only supplies cached argument
+    /// types and fails closed for explicit type arguments or spread syntax.
+    fn fallback_instantiated_generic_call_type(&self, call_expr: NodeIndex) -> Option<TypeId> {
+        let call_node = self.arena.get(call_expr)?;
+        if call_node.kind != syntax_kind_ext::CALL_EXPRESSION || call_node.is_optional_chain() {
+            return None;
+        }
+
+        let call = self.arena.get_call_expr(call_node)?;
+        let callee = self.skip_parens_and_assertions(call.expression);
+        let callee_type = self
+            .fallback_cached_callable_reference_type(callee)
+            .or_else(|| self.fallback_type_for_reference(callee))
+            .or_else(|| self.fallback_expression_type_from_syntax(callee))
+            .map(|ty| self.resolve_lazy_via_env(ty))?;
+        if call.type_arguments.is_some() {
+            return None;
+        }
+
+        let arguments = call
+            .arguments
+            .as_ref()
+            .map_or(&[][..], |arguments| arguments.nodes.as_slice());
+        let node_types = self.node_types?;
+        let mut argument_types = Vec::with_capacity(arguments.len());
+        for argument in arguments.iter().copied() {
+            let argument_node = self.arena.get(argument)?;
+            if argument_node.kind == syntax_kind_ext::SPREAD_ELEMENT {
+                return None;
+            }
+            let stripped_argument = self.skip_parens_and_assertions(argument);
+            let argument_type = node_types
+                .get(&argument.0)
+                .or_else(|| node_types.get(&stripped_argument.0))
+                .copied()
+                .filter(|&ty| ty != TypeId::ERROR)
+                .or_else(|| self.fallback_expression_type_from_syntax(stripped_argument))
+                .filter(|&ty| ty != TypeId::ERROR)
+                .map(|ty| self.resolve_lazy_via_env(ty))?;
+            argument_types.push(argument_type);
+        }
+
+        let ctx = self.checker_context?;
+        let env = self.type_environment?.borrow();
+        let return_type =
+            crate::query_boundaries::checkers::call::resolve_single_non_rest_generic_call_with_context(
+                self.interner,
+                ctx,
+                &env,
+                callee_type,
+                &argument_types,
+            )?;
+        self.reject_unresolved_generic_result((return_type != TypeId::ERROR).then_some(return_type))
     }
 
     fn fallback_call_expression_type_inner(&self, call_expr: NodeIndex) -> Option<TypeId> {
@@ -705,6 +782,15 @@ impl<'a> FlowAnalyzer<'a> {
                     .filter(|&ty| ty != TypeId::ERROR)
             })
             .or_else(|| {
+                // Contextually typed callback parameters are published on their
+                // symbol before deferred body flow runs, even when speculative
+                // return inference has rolled back the per-node cache. Reuse that
+                // concrete declared/contextual type before manufacturing a Lazy
+                // fallback, whose body is not registered during the provisional
+                // walk and cannot participate in structural argument inference.
+                self.fallback_cached_stable_symbol_type(sym_id)
+            })
+            .or_else(|| {
                 self.resolve_symbol_to_lazy(SymbolRef(sym_id.0))
                     .map(|ty| self.resolve_lazy_via_env(ty))
             });
@@ -736,6 +822,83 @@ impl<'a> FlowAnalyzer<'a> {
         declared_type.or_else(|| self.fallback_declaration_type(decl))
     }
 
+    /// Read a stable declared/contextual symbol type already published by the
+    /// checker. Semantic `any` is usable here once symbol resolution has
+    /// completed: TypeScript infers through it and a non-null generic result still
+    /// kills `undefined`. In-flight entries, `unknown`, error sentinels, unresolved
+    /// lazy refs, and free parameters are incomplete evidence.
+    fn fallback_cached_stable_symbol_type(&self, sym_id: SymbolId) -> Option<TypeId> {
+        let ctx = self.checker_context?;
+        if ctx.symbol_resolution_set.contains(&sym_id) {
+            return None;
+        }
+        let ty = ctx.symbol_types.get(&sym_id)?;
+        let ty = self.resolve_lazy_via_env(ty);
+        (!matches!(ty, TypeId::ERROR | TypeId::UNKNOWN)
+            && !self.is_unresolved_lazy_type(ty)
+            && !contains_free_type_parameters(self.interner, ty))
+        .then_some(ty)
+    }
+
+    /// Read a callable symbol type without rejecting its signature-scoped type
+    /// parameters as free. Imported generic functions have no local function
+    /// declaration for the syntax fallback, but their checked alias symbol type
+    /// is stable and carries the call signature needed for ordinary inference.
+    fn fallback_cached_callable_reference_type(&self, reference: NodeIndex) -> Option<TypeId> {
+        let reference = self.skip_parenthesized(reference);
+        // Preserve the raw symbol bound in this file before `reference_symbol`
+        // follows imports. Per-file binders mint colliding raw `SymbolId`s, so a
+        // terminal foreign id must never be inspected through the current binder.
+        let local_sym_id = self.binder.get_node_symbol(reference).or_else(|| {
+            self.binder
+                .resolve_identifier_with_filter(self.arena, reference, &[], |_| true)
+        });
+        let sym_id = self.reference_symbol(reference)?;
+        let ctx = self.checker_context?;
+        let local_is_alias = local_sym_id
+            .and_then(|local| self.binder.get_symbol(local))
+            .is_some_and(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS));
+        let (target, target_file_idx) = if local_is_alias {
+            let (target, owner) = local_sym_id
+                .and_then(|local| ctx.resolve_import_alias_chain_with_owner_and_register(local))?;
+            (target, Some(owner))
+        } else {
+            let owner = if local_sym_id == Some(sym_id) {
+                Some(ctx.current_file_idx)
+            } else {
+                ctx.resolve_dynamic_symbol_file_index(sym_id)
+                    .or_else(|| ctx.resolve_symbol_file_index_stable(sym_id))
+            };
+            (sym_id, owner)
+        };
+        let cross_file = target_file_idx
+            .and_then(|file_idx| ctx.cached_cross_file_symbol_type(target, file_idx as u32));
+        // Interactive/LSP contexts intentionally disable persistent owner-cache
+        // sharing. Their cross-arena checker still publishes the canonical
+        // declaration body through the owner-keyed `DefId` environment, which
+        // is safe to read here without consulting any raw-`SymbolId` cache.
+        let owner_def_type = target_file_idx
+            .and_then(|file_idx| {
+                ctx.definition_store
+                    .lookup_by_symbol(target.0, file_idx as u32)
+            })
+            .and_then(|def_id| {
+                self.type_environment
+                    .and_then(|env| env.borrow().get_def(def_id))
+            });
+        let target_env_type = self
+            .type_environment
+            .and_then(|env| env.borrow().get(SymbolRef(target.0)));
+        let target_is_current = target_file_idx == Some(ctx.current_file_idx);
+        let ty = cross_file
+            .map(|(ty, _)| ty)
+            .or(owner_def_type)
+            .or_else(|| target_is_current.then_some(target_env_type).flatten())?;
+        let ty = self.resolve_lazy_via_env(ty);
+        (!matches!(ty, TypeId::ERROR | TypeId::UNKNOWN) && !self.is_unresolved_lazy_type(ty))
+            .then_some(ty)
+    }
+
     /// True when `ty` is a `Lazy(DefId)` that no `TypeEnvironment` resolution has
     /// collapsed to a concrete type. Such a type carries no structural shape, so
     /// flow narrowing (`narrow_assignment`, truthiness filtering) cannot reduce a
@@ -750,7 +913,7 @@ impl<'a> FlowAnalyzer<'a> {
     /// `Lazy(DefId)` can leak unresolved during inferred-return inference. Returns
     /// `None` when the declaration has no annotation or the annotation syntax is
     /// not one the syntactic resolver understands (callers then keep the `Lazy`).
-    fn fallback_declared_annotation_type(&self, decl: NodeIndex) -> Option<TypeId> {
+    pub(super) fn fallback_declared_annotation_type(&self, decl: NodeIndex) -> Option<TypeId> {
         let node = self.arena.get(decl)?;
         let annotation = match node.kind {
             k if k == syntax_kind_ext::PARAMETER => self.arena.get_parameter(node)?.type_annotation,
@@ -913,6 +1076,13 @@ impl<'a> FlowAnalyzer<'a> {
         right: NodeIndex,
         operator: u16,
     ) -> Option<TypeId> {
+        // Equality expressions always have boolean result type. Operand checking
+        // and any comparison diagnostic remain owned by the ordinary checker;
+        // flow only needs the structural result while reconstructing an uncached
+        // object-literal argument.
+        if is_equality_comparison_operator(operator) {
+            return Some(TypeId::BOOLEAN);
+        }
         if operator == SyntaxKind::QuestionQuestionToken as u16 {
             // x ?? y -> NonNullable<typeof x> | typeof y
             let left_type = self.resolve_operand_type(left)?;
@@ -1066,5 +1236,46 @@ impl<'a> FlowAnalyzer<'a> {
             );
         }
         resolved
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FlowAnalyzer;
+    use crate::state::CheckerState;
+    use tsz_binder::BinderState;
+    use tsz_parser::parser::ParserState;
+    use tsz_solver::{TypeId, construction::TypeInterner};
+
+    #[test]
+    fn stable_symbol_fallback_rejects_in_flight_any_sentinel() {
+        let mut parser = ParserState::new("test.ts".to_string(), "const payload = 1;".to_string());
+        let root = parser.parse_source_file();
+        let arena = parser.get_arena();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(arena, root);
+        let symbol = binder.file_locals.get("payload").expect("payload symbol");
+        let types = TypeInterner::new();
+        let mut checker = CheckerState::new(
+            arena,
+            &binder,
+            &types,
+            "test.ts".to_string(),
+            crate::context::CheckerOptions::default(),
+        );
+
+        checker.ctx.symbol_types.insert(symbol, TypeId::ANY);
+        assert_eq!(
+            FlowAnalyzer::from_ctx(&checker.ctx).fallback_cached_stable_symbol_type(symbol),
+            Some(TypeId::ANY),
+            "resolved semantic any remains valid generic inference evidence"
+        );
+
+        checker.ctx.symbol_resolution_set.insert(symbol);
+        assert_eq!(
+            FlowAnalyzer::from_ctx(&checker.ctx).fallback_cached_stable_symbol_type(symbol),
+            None,
+            "an in-flight any sentinel must not become current-pass flow evidence"
+        );
     }
 }

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -543,13 +543,37 @@ impl<'a> FlowAnalyzer<'a> {
                             // contribute that result; otherwise fall back to the
                             // antecedent type until expression checking catches up.
                             let is_destructuring = self.is_destructuring_assignment(flow.node);
-                            let raw_assigned =
-                                self.get_assigned_type(flow.node, reference, is_destructuring);
+                            let mut assignment_type_is_provisional = false;
+                            let mut preserve_declared_assignment_flow = false;
+                            let raw_assigned = self.get_assigned_type(
+                                flow.node,
+                                reference,
+                                is_destructuring,
+                                Some(initial_type),
+                                &mut assignment_type_is_provisional,
+                                &mut preserve_declared_assignment_flow,
+                            );
+                            if assignment_type_is_provisional || preserve_declared_assignment_flow {
+                                cache_policy.mark_provisional();
+                            }
                             if let Some(assigned_type) =
                                 raw_assigned.filter(|&t| t != TypeId::ERROR)
                             {
                                 cache_policy.mark_provisional();
                                 assigned_type
+                            } else if preserve_declared_assignment_flow
+                                || assignment_type_is_provisional
+                            {
+                                symbol_id
+                                    .and_then(|sid| self.binder.get_symbol(sid))
+                                    .filter(|sym| sym.value_declaration.is_some())
+                                    .and_then(|sym| {
+                                        self.declared_type_from_value_declaration_with_stability(
+                                            sym.value_declaration,
+                                        )
+                                        .0
+                                    })
+                                    .unwrap_or(initial_type)
                             } else if let Some(&ant) = flow.antecedent.first() {
                                 if let Some(&ant_type) = results.get(&ant) {
                                     ant_type
@@ -597,8 +621,19 @@ impl<'a> FlowAnalyzer<'a> {
                             // `len(x)`'s result to determine x's loop type). ERROR is "subtype of
                             // everything" so narrow_assignment would keep all union members,
                             // incorrectly returning the full declared type.
-                            let raw_assigned =
-                                self.get_assigned_type(flow.node, reference, is_destructuring);
+                            let mut assignment_type_is_provisional = false;
+                            let mut preserve_declared_assignment_flow = false;
+                            let raw_assigned = self.get_assigned_type(
+                                flow.node,
+                                reference,
+                                is_destructuring,
+                                Some(initial_type),
+                                &mut assignment_type_is_provisional,
+                                &mut preserve_declared_assignment_flow,
+                            );
+                            if assignment_type_is_provisional || preserve_declared_assignment_flow {
+                                cache_policy.mark_provisional();
+                            }
                             if let Some(assigned_type) =
                                 raw_assigned.filter(|&t| t != TypeId::ERROR)
                             {
@@ -689,12 +724,12 @@ impl<'a> FlowAnalyzer<'a> {
                                         .and_then(|sid| self.binder.get_symbol(sid))
                                         .filter(|sym| sym.value_declaration.is_some())
                                         .and_then(|sym| {
-                                            self.node_types.and_then(|nt| {
+                                            self.node_types.and_then(|types| {
                                                 self.annotation_type_from_var_decl_node(
                                                     sym.value_declaration,
                                                 )
                                                 .or_else(|| {
-                                                    nt.get(&sym.value_declaration.0).copied()
+                                                    types.get(&sym.value_declaration.0).copied()
                                                 })
                                             })
                                         });
@@ -750,7 +785,20 @@ impl<'a> FlowAnalyzer<'a> {
                                 cache_policy.mark_provisional();
                                 // If we can't resolve the RHS type, conservatively return declared type
                                 // The value HAS changed, so we can't continue to antecedent
-                                if self.is_await_assignment_for_reference(flow.node, reference) {
+                                if preserve_declared_assignment_flow {
+                                    symbol_id
+                                        .and_then(|sid| self.binder.get_symbol(sid))
+                                        .filter(|sym| sym.value_declaration.is_some())
+                                        .and_then(|sym| {
+                                            self.declared_type_from_value_declaration_with_stability(
+                                                sym.value_declaration,
+                                            )
+                                            .0
+                                        })
+                                        .unwrap_or(initial_type)
+                                } else if self
+                                    .is_await_assignment_for_reference(flow.node, reference)
+                                {
                                     // `x = await expr` assigns a realized value. When RHS typing
                                     // isn't available yet, keep this sound by at least excluding
                                     // `undefined` from the assignment base.
@@ -758,14 +806,10 @@ impl<'a> FlowAnalyzer<'a> {
                                         .and_then(|sid| self.binder.get_symbol(sid))
                                         .filter(|sym| sym.value_declaration.is_some())
                                         .and_then(|sym| {
-                                            self.node_types.and_then(|nt| {
-                                                self.annotation_type_from_var_decl_node(
-                                                    sym.value_declaration,
-                                                )
-                                                .or_else(|| {
-                                                    nt.get(&sym.value_declaration.0).copied()
-                                                })
-                                            })
+                                            self.declared_type_from_value_declaration_with_stability(
+                                                sym.value_declaration,
+                                            )
+                                            .0
                                         })
                                         .unwrap_or(initial_type);
                                     flow_boundary::narrow_destructuring_default(
@@ -783,26 +827,32 @@ impl<'a> FlowAnalyzer<'a> {
                                     // `null`/`undefined` from the declared union so the killing
                                     // definition matches tsc's `getAssignmentReducedType`
                                     // instead of leaving a false TS18048 on a later read.
-                                    let declared_type =
-                                        symbol_id
-                                            .and_then(|sid| self.binder.get_symbol(sid))
-                                            .filter(|sym| sym.value_declaration.is_some())
-                                            .and_then(|sym| {
-                                                self.annotation_type_from_var_decl_node(
-                                                    sym.value_declaration,
-                                                )
-                                                .or_else(|| {
-                                                    self.node_types.and_then(|nt| {
-                                                        nt.get(&sym.value_declaration.0).copied()
-                                                    })
-                                                })
-                                            })
-                                            .unwrap_or(initial_type);
+                                    let declared_type = symbol_id
+                                        .and_then(|sid| self.binder.get_symbol(sid))
+                                        .filter(|sym| sym.value_declaration.is_some())
+                                        .and_then(|sym| {
+                                            self.declared_type_from_value_declaration_with_stability(
+                                                sym.value_declaration,
+                                            )
+                                            .0
+                                        })
+                                        .unwrap_or(initial_type);
                                     flow_boundary::narrow_destructuring_default(
                                         self.interner.as_type_database(),
                                         declared_type,
                                         true,
                                     )
+                                } else if assignment_type_is_provisional {
+                                    symbol_id
+                                        .and_then(|sid| self.binder.get_symbol(sid))
+                                        .filter(|sym| sym.value_declaration.is_some())
+                                        .and_then(|sym| {
+                                            self.declared_type_from_value_declaration_with_stability(
+                                                sym.value_declaration,
+                                            )
+                                            .0
+                                        })
+                                        .unwrap_or(initial_type)
                                 } else {
                                     current_type
                                 }

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -553,27 +553,11 @@ impl<'a> FlowAnalyzer<'a> {
                                 &mut assignment_type_is_provisional,
                                 &mut preserve_declared_assignment_flow,
                             );
-                            if assignment_type_is_provisional || preserve_declared_assignment_flow {
-                                cache_policy.mark_provisional();
-                            }
                             if let Some(assigned_type) =
                                 raw_assigned.filter(|&t| t != TypeId::ERROR)
                             {
                                 cache_policy.mark_provisional();
                                 assigned_type
-                            } else if preserve_declared_assignment_flow
-                                || assignment_type_is_provisional
-                            {
-                                symbol_id
-                                    .and_then(|sid| self.binder.get_symbol(sid))
-                                    .filter(|sym| sym.value_declaration.is_some())
-                                    .and_then(|sym| {
-                                        self.declared_type_from_value_declaration_with_stability(
-                                            sym.value_declaration,
-                                        )
-                                        .0
-                                    })
-                                    .unwrap_or(initial_type)
                             } else if let Some(&ant) = flow.antecedent.first() {
                                 if let Some(&ant_type) = results.get(&ant) {
                                     ant_type
@@ -631,9 +615,6 @@ impl<'a> FlowAnalyzer<'a> {
                                 &mut assignment_type_is_provisional,
                                 &mut preserve_declared_assignment_flow,
                             );
-                            if assignment_type_is_provisional || preserve_declared_assignment_flow {
-                                cache_policy.mark_provisional();
-                            }
                             if let Some(assigned_type) =
                                 raw_assigned.filter(|&t| t != TypeId::ERROR)
                             {
@@ -783,22 +764,9 @@ impl<'a> FlowAnalyzer<'a> {
                                 // for the RHS yet. Do not publish the declared-type result into the
                                 // shared flow cache or later reads will reuse a stale answer.
                                 cache_policy.mark_provisional();
-                                // If we can't resolve the RHS type, conservatively return declared type
-                                // The value HAS changed, so we can't continue to antecedent
-                                if preserve_declared_assignment_flow {
-                                    symbol_id
-                                        .and_then(|sid| self.binder.get_symbol(sid))
-                                        .filter(|sym| sym.value_declaration.is_some())
-                                        .and_then(|sym| {
-                                            self.declared_type_from_value_declaration_with_stability(
-                                                sym.value_declaration,
-                                            )
-                                            .0
-                                        })
-                                        .unwrap_or(initial_type)
-                                } else if self
-                                    .is_await_assignment_for_reference(flow.node, reference)
-                                {
+                                // Preserve specialized sound fallbacks; otherwise keep the
+                                // current branch type until canonical RHS typing catches up.
+                                if self.is_await_assignment_for_reference(flow.node, reference) {
                                     // `x = await expr` assigns a realized value. When RHS typing
                                     // isn't available yet, keep this sound by at least excluding
                                     // `undefined` from the assignment base.
@@ -806,10 +774,14 @@ impl<'a> FlowAnalyzer<'a> {
                                         .and_then(|sid| self.binder.get_symbol(sid))
                                         .filter(|sym| sym.value_declaration.is_some())
                                         .and_then(|sym| {
-                                            self.declared_type_from_value_declaration_with_stability(
-                                                sym.value_declaration,
-                                            )
-                                            .0
+                                            self.node_types.and_then(|types| {
+                                                self.annotation_type_from_var_decl_node(
+                                                    sym.value_declaration,
+                                                )
+                                                .or_else(|| {
+                                                    types.get(&sym.value_declaration.0).copied()
+                                                })
+                                            })
                                         })
                                         .unwrap_or(initial_type);
                                     flow_boundary::narrow_destructuring_default(
@@ -827,32 +799,26 @@ impl<'a> FlowAnalyzer<'a> {
                                     // `null`/`undefined` from the declared union so the killing
                                     // definition matches tsc's `getAssignmentReducedType`
                                     // instead of leaving a false TS18048 on a later read.
-                                    let declared_type = symbol_id
-                                        .and_then(|sid| self.binder.get_symbol(sid))
-                                        .filter(|sym| sym.value_declaration.is_some())
-                                        .and_then(|sym| {
-                                            self.declared_type_from_value_declaration_with_stability(
-                                                sym.value_declaration,
-                                            )
-                                            .0
-                                        })
-                                        .unwrap_or(initial_type);
+                                    let declared_type =
+                                        symbol_id
+                                            .and_then(|sid| self.binder.get_symbol(sid))
+                                            .filter(|sym| sym.value_declaration.is_some())
+                                            .and_then(|sym| {
+                                                self.annotation_type_from_var_decl_node(
+                                                    sym.value_declaration,
+                                                )
+                                                .or_else(|| {
+                                                    self.node_types.and_then(|types| {
+                                                        types.get(&sym.value_declaration.0).copied()
+                                                    })
+                                                })
+                                            })
+                                            .unwrap_or(initial_type);
                                     flow_boundary::narrow_destructuring_default(
                                         self.interner.as_type_database(),
                                         declared_type,
                                         true,
                                     )
-                                } else if assignment_type_is_provisional {
-                                    symbol_id
-                                        .and_then(|sid| self.binder.get_symbol(sid))
-                                        .filter(|sym| sym.value_declaration.is_some())
-                                        .and_then(|sym| {
-                                            self.declared_type_from_value_declaration_with_stability(
-                                                sym.value_declaration,
-                                            )
-                                            .0
-                                        })
-                                        .unwrap_or(initial_type)
                                 } else {
                                     current_type
                                 }

--- a/crates/tsz-checker/src/flow/control_flow/mod.rs
+++ b/crates/tsz-checker/src/flow/control_flow/mod.rs
@@ -20,6 +20,7 @@
 
 pub(crate) mod alias_narrowing;
 pub(crate) mod assignment;
+mod assignment_compatibility;
 mod assignment_fallback;
 mod call_condition_narrowing;
 mod comparison_types;

--- a/crates/tsz-checker/src/flow/control_flow/var_utils.rs
+++ b/crates/tsz-checker/src/flow/control_flow/var_utils.rs
@@ -1366,6 +1366,31 @@ impl<'a> FlowAnalyzer<'a> {
         }
     }
 
+    /// Recover the declared type for any value declaration used as a flow
+    /// target, including parameters whose annotation is not represented by a
+    /// `VARIABLE_DECLARATION` node.
+    pub(crate) fn declared_type_from_value_declaration_with_stability(
+        &self,
+        declaration: NodeIndex,
+    ) -> (Option<TypeId>, bool) {
+        let cached = self
+            .annotation_type_from_var_decl_node(declaration)
+            .filter(|&type_id| type_id != TypeId::ERROR)
+            .or_else(|| {
+                self.node_types
+                    .and_then(|types| types.get(&declaration.0).copied())
+                    .filter(|&type_id| type_id != TypeId::ERROR)
+            });
+        if cached.is_some() {
+            return (cached, false);
+        }
+        (
+            self.fallback_declared_annotation_type(declaration)
+                .filter(|&type_id| type_id != TypeId::ERROR),
+            true,
+        )
+    }
+
     pub(crate) fn annotation_type_from_assignment_node(
         &self,
         assignment_node: NodeIndex,

--- a/crates/tsz-checker/src/query_boundaries/checkers/call.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/call.rs
@@ -526,6 +526,22 @@ pub(crate) fn resolve_call<C: AssignabilityChecker>(
     )
 }
 
+pub(crate) fn resolve_single_non_rest_generic_call_with_context(
+    db: &dyn QueryDatabase,
+    ctx: &crate::context::CheckerContext<'_>,
+    env: &TypeEnvironment,
+    func_type: TypeId,
+    arg_types: &[TypeId],
+) -> Option<TypeId> {
+    tsz_solver::operations::resolve_single_non_rest_generic_call_with_compat_checker(
+        db,
+        env,
+        func_type,
+        arg_types,
+        |checker| ctx.configure_compat_checker(checker),
+    )
+}
+
 pub(crate) struct CallArgSourceOptions<'a> {
     pub(crate) force_bivariant_callbacks: bool,
     pub(crate) contextual_type: Option<TypeId>,

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -1041,6 +1041,54 @@ pub(crate) fn flow_assignability_outcome(
     )
 }
 
+/// Validate a whole assignment source against its target.
+///
+/// Flow reduction intentionally uses existential overlap when selecting the
+/// surviving members of a declared union. The validity gate for the write is
+/// stricter: every member of a union RHS must be assignable to the LHS before
+/// that reduction may run.
+pub(crate) fn whole_assignment_rhs_is_compatible(
+    db: &dyn QueryDatabase,
+    env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
+    concrete_this_type: Option<TypeId>,
+    source: TypeId,
+    target: TypeId,
+    flags: u16,
+) -> bool {
+    let source = substitute_flow_this_type(db, concrete_this_type, source);
+    let target = substitute_flow_this_type(db, concrete_this_type, target);
+    let db = db.as_type_database();
+    let policy = relation_policy::from_checker_flags_u16(flags);
+    let related = |source| {
+        if let Some(env) = env {
+            tsz_solver::relations::relation_queries::query_relation_with_resolver(
+                db,
+                env,
+                source,
+                target,
+                tsz_solver::relations::relation_queries::RelationKind::Assignable,
+                policy,
+                tsz_solver::relations::relation_queries::RelationContext::default(),
+            )
+            .is_related()
+        } else {
+            tsz_solver::relations::relation_queries::query_relation(
+                db,
+                source,
+                target,
+                tsz_solver::relations::relation_queries::RelationKind::Assignable,
+                policy,
+                tsz_solver::relations::relation_queries::RelationContext::default(),
+            )
+            .is_related()
+        }
+    };
+    if let Some(members) = union_members_for_type(db, source) {
+        return !members.is_empty() && members.iter().copied().all(related);
+    }
+    related(source)
+}
+
 fn substitute_flow_this_type(
     db: &dyn QueryDatabase,
     concrete_this_type: Option<TypeId>,

--- a/crates/tsz-checker/src/tests/flow_assignment_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_assignment_relation_routing_arch_tests.rs
@@ -54,6 +54,17 @@ fn flow_assignment_and_predicate_exclusion_use_relation_outcome_boundary() {
         .chars()
         .filter(|c| !c.is_whitespace())
         .collect();
+    let whole_rhs_start = boundary_source
+        .find("pub(crate) fn whole_assignment_rhs_is_compatible(")
+        .expect("whole-RHS relation boundary must exist");
+    let whole_rhs_tail = &boundary_source[whole_rhs_start..];
+    let whole_rhs_end = whole_rhs_tail
+        .find("\nfn substitute_flow_this_type(")
+        .expect("whole-RHS relation boundary must end before the next helper");
+    let compact_whole_rhs: String = whole_rhs_tail[..whole_rhs_end]
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
 
     assert!(
         compact_boundary.contains("fnflow_assignability_outcome(")
@@ -100,10 +111,19 @@ fn flow_assignment_and_predicate_exclusion_use_relation_outcome_boundary() {
                 .contains("assignment_relation_outcome(assigned_type,write_type,true)")
             && compact_assignment
                 .contains("assignment_relation_outcome(assigned_type,target_type,false)")
-            && compact_assignment.contains("assignment_relation_outcome(rhs_type,lhs_type,false)")
+            && compact_assignment.contains("whole_assignment_rhs_is_compatible(")
+            && compact_assignment.contains("ctx.pack_relation_flags()")
             && compact_assignment
                 .contains("assignment_relation_outcome(nullish_type,annotation_type,true)"),
         "flow assignment guards should consume outcome-shaped relation truth"
+    );
+    assert!(
+        compact_whole_rhs.contains("fnwhole_assignment_rhs_is_compatible(")
+            && compact_whole_rhs.contains("relation_policy::from_checker_flags_u16(flags)")
+            && compact_whole_rhs.contains("query_relation_with_resolver(")
+            && compact_whole_rhs.contains("query_relation(")
+            && compact_whole_rhs.contains("members.iter().copied().all(related)"),
+        "whole-RHS assignment validity must apply the complete checker relation policy through resolver and no-resolver paths"
     );
     assert!(
         !compact_assignment.contains("self.is_assignable_to(")

--- a/crates/tsz-checker/tests/generic_call_assignment_flow_tests.rs
+++ b/crates/tsz-checker/tests/generic_call_assignment_flow_tests.rs
@@ -1,0 +1,1044 @@
+//! Flow fallback coverage for generic call results assigned inside deferred closures.
+//!
+//! Structural rule: when a missed call-result cache entry has one generic signature
+//! whose ordinary arguments determine a fully concrete return type, assignment flow
+//! may use that instantiated return. Ambiguous, spread, underconstrained, and
+//! nullable results remain conservative.
+
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_checker::test_utils::{
+    check_multi_file_with_libs_stamped, check_source_with_libs, diagnostic_codes, load_lib_files,
+    strict_checker_options,
+};
+use tsz_parser::parser::{NodeIndex, ParserState};
+use tsz_solver::construction::TypeInterner;
+
+const TS18048: u32 = 18048;
+const TS2322: u32 = 2322;
+const TS2339: u32 = 2339;
+const TS2344: u32 = 2344;
+const TS2349: u32 = 2349;
+const TS7006: u32 = 7006;
+
+fn codes(source: &str) -> Vec<u32> {
+    codes_with_options(source, strict_checker_options())
+}
+
+fn codes_with_options(source: &str, options: CheckerOptions) -> Vec<u32> {
+    let libs = load_lib_files(&["es5.d.ts", "es2015.core.d.ts"]);
+    let mut codes = diagnostic_codes(&check_source_with_libs(source, "test.ts", options, &libs));
+    // These tests pin the complete diagnostic multiset from the TypeScript 7.0.2
+    // oracle. Checker discovery order is not a source-order API guarantee.
+    codes.sort_unstable();
+    codes
+}
+
+fn multi_codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    let libs = load_lib_files(&["es5.d.ts", "es2015.core.d.ts"]);
+    let mut codes = diagnostic_codes(&check_multi_file_with_libs_stamped(
+        files,
+        entry,
+        strict_checker_options(),
+        &libs,
+    ));
+    codes.sort_unstable();
+    codes
+}
+
+fn resolve_generated_reexport_chain(
+    barrel_count: usize,
+    wildcard: bool,
+) -> (
+    Option<(tsz_binder::SymbolId, usize)>,
+    tsz_binder::SymbolId,
+    usize,
+) {
+    assert!(barrel_count > 0);
+    let mut files = Vec::with_capacity(barrel_count + 2);
+    files.push((
+        "consumer.ts".to_string(),
+        "import { seal } from './barrel0.js';\nseal({ value: 1 });".to_string(),
+    ));
+    for index in 0..barrel_count {
+        let target = if index + 1 == barrel_count {
+            "provider".to_string()
+        } else {
+            format!("barrel{}", index + 1)
+        };
+        let source = if wildcard {
+            format!("export * from './{target}.js';")
+        } else {
+            format!("export {{ seal }} from './{target}.js';")
+        };
+        files.push((format!("barrel{index}.ts"), source));
+    }
+    files.push((
+        "provider.ts".to_string(),
+        "export function seal<Value>(value: Value): Value { return value; }".to_string(),
+    ));
+
+    let mut arenas = Vec::with_capacity(files.len());
+    let mut binders = Vec::with_capacity(files.len());
+    for (file_idx, (name, source)) in files.iter().enumerate() {
+        let mut parser = ParserState::new(name.clone(), source.clone());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.set_file_idx(file_idx as u32);
+        binder.bind_source_file(parser.get_arena(), root);
+        arenas.push(Arc::new(parser.get_arena().clone()));
+        binders.push(Arc::new(binder));
+    }
+
+    let local_alias = binders[0]
+        .file_locals
+        .get("seal")
+        .expect("consumer import alias");
+    let provider_idx = files.len() - 1;
+    let terminal = binders[provider_idx]
+        .file_locals
+        .get("seal")
+        .expect("provider export");
+    let file_names = files
+        .iter()
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    let (resolved_module_paths, resolved_modules) =
+        tsz_checker::module_resolution::build_module_resolution_maps(&file_names);
+    let arenas = Arc::new(arenas);
+    let binders = Arc::new(binders);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        arenas[0].as_ref(),
+        binders[0].as_ref(),
+        &types,
+        file_names[0].clone(),
+        strict_checker_options(),
+    );
+    checker.ctx.set_all_arenas(Arc::clone(&arenas));
+    checker.ctx.set_all_binders(Arc::clone(&binders));
+    checker.ctx.set_current_file_idx(0);
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+    checker.ctx.set_resolved_modules(resolved_modules);
+
+    (
+        checker
+            .ctx
+            .resolve_import_alias_chain_with_owner_and_register(local_alias),
+        terminal,
+        provider_idx,
+    )
+}
+
+#[test]
+fn inferred_generic_result_narrows_inside_reduce_arrow() {
+    let diagnostics = codes(
+        r#"
+interface Bucket {
+    readonly name: string;
+    readonly values: string[];
+}
+declare function freeze<T>(value: T): Readonly<T>;
+
+function collect(names: string[]): Bucket[] {
+    return names.reduce<Bucket[]>((buckets, name) => {
+        let bucket = buckets.find((item) => item.name === name);
+        if (!bucket) {
+            bucket = freeze({ name, values: [] });
+            buckets.push(bucket);
+        }
+        bucket.values.push(name);
+        return buckets;
+    }, []);
+}
+"#,
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "a fully inferred generic call result must kill undefined in the reducer closure: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn imported_generic_result_narrows_inside_reduce_arrow() {
+    let diagnostics = multi_codes(
+        &[
+            (
+                "object-utils.ts",
+                r#"
+export function freeze<T>(value: T): Readonly<T> {
+    return value;
+}
+"#,
+            ),
+            (
+                "mysql-introspector.ts",
+                r#"
+import { freeze } from './object-utils.js';
+
+interface TableMetadata {
+    readonly name: string;
+    readonly isView: boolean;
+    readonly columns: ColumnMetadata[];
+    readonly schema?: string;
+}
+interface ColumnMetadata { readonly name: string; }
+
+interface RawColumnMetadata {
+    readonly tableName: string;
+    readonly tableType: string;
+    readonly columnName: string;
+}
+
+export function collect(columns: RawColumnMetadata[]): TableMetadata[] {
+    return columns.reduce<TableMetadata[]>((tables, item) => {
+        let table = tables.find((candidate) => candidate.name === item.tableName);
+        if (!table) {
+            table = freeze({
+                name: item.tableName,
+                isView: item.tableType === "VIEW",
+                schema: undefined,
+                columns: [],
+            });
+            tables.push(table);
+        }
+        table.columns.push({ name: item.columnName });
+        return tables;
+    }, []);
+}
+"#,
+            ),
+        ],
+        "mysql-introspector.ts",
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "an imported generic callee must publish the same concrete deferred result: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn reexported_generic_result_narrows_inside_deferred_function() {
+    let diagnostics = multi_codes(
+        &[
+            (
+                "object-utils.ts",
+                r#"
+export function seal<Value>(value: Value): Readonly<Value> {
+    return value;
+}
+"#,
+            ),
+            (
+                "index.ts",
+                r#"
+export { seal as preserve } from "./object-utils.js";
+"#,
+            ),
+            (
+                "consumer.ts",
+                r#"
+import { preserve } from "./index.js";
+
+interface Entry {
+    readonly key: string;
+    readonly values: string[];
+}
+
+export function callback(entry: Entry | undefined, key: string) {
+    return function (): void {
+        if (!entry) {
+            entry = preserve({ key, values: [] });
+        }
+        entry.values.push(key);
+    };
+}
+"#,
+            ),
+        ],
+        "consumer.ts",
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "a re-export alias must reach the terminal generic signature without retaining undefined: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn named_alias_to_wildcard_reexport_tracks_owner_when_raw_symbol_ids_repeat() {
+    let files = [
+        (
+            "consumer.ts",
+            "type Local0 = 0;\ntype Local1 = 1;\nimport { poison } from './decoy.js';\nimport { preserve } from './bridge.js';\npreserve({ value: poison });",
+        ),
+        (
+            "bridge.ts",
+            "type Pad0 = 0;\ntype Pad1 = 1;\nimport { seal as preserve } from './barrel.js';\nexport { preserve };",
+        ),
+        ("barrel.ts", "export * from './object-utils.js';"),
+        (
+            "object-utils.ts",
+            "type Pad0 = 0;\ntype Pad1 = 1;\nexport function seal<Value>(value: Value): Value { return value; }",
+        ),
+        ("decoy.ts", "export const poison = 1;"),
+    ];
+    let mut arenas = Vec::new();
+    let mut binders = Vec::new();
+    for (file_idx, (name, source)) in files.iter().enumerate() {
+        let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.set_file_idx(file_idx as u32);
+        binder.bind_source_file(parser.get_arena(), root);
+        arenas.push(Arc::new(parser.get_arena().clone()));
+        binders.push(Arc::new(binder));
+    }
+
+    let local_alias = binders[0]
+        .file_locals
+        .get("preserve")
+        .expect("consumer import alias");
+    let terminal = binders[3]
+        .file_locals
+        .get("seal")
+        .expect("terminal generic function");
+    let unrelated_local_alias = binders[0]
+        .file_locals
+        .get("poison")
+        .expect("unrelated local import alias");
+    assert_ne!(
+        local_alias, terminal,
+        "the actual import binding must differ from the foreign terminal id"
+    );
+    assert_eq!(
+        unrelated_local_alias, terminal,
+        "foreign terminal must collide with an unrelated current-file alias"
+    );
+    assert!(
+        binders[0]
+            .get_symbol(terminal)
+            .is_some_and(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)),
+        "the colliding current-file symbol must be the decoy alias"
+    );
+    assert!(
+        binders[3]
+            .get_symbol(terminal)
+            .is_some_and(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::FUNCTION)),
+        "the foreign owner must classify the same raw id as the terminal function"
+    );
+    let preserve_use = arenas[0]
+        .nodes
+        .iter()
+        .enumerate()
+        .filter_map(|(index, node)| {
+            arenas[0]
+                .get_identifier(node)
+                .filter(|identifier| identifier.escaped_text == "preserve")
+                .map(|_| NodeIndex(index as u32))
+        })
+        .next_back()
+        .expect("preserve call identifier");
+    assert_eq!(
+        binders[0].resolve_identifier_with_filter(arenas[0].as_ref(), preserve_use, &[], |_| true,),
+        Some(local_alias),
+        "unfollowed scope lookup must return the actual local import binding"
+    );
+
+    let file_names = files
+        .iter()
+        .map(|(name, _)| (*name).to_string())
+        .collect::<Vec<_>>();
+    let (resolved_module_paths, resolved_modules) =
+        tsz_checker::module_resolution::build_module_resolution_maps(&file_names);
+    let arenas = Arc::new(arenas);
+    let binders = Arc::new(binders);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        arenas[0].as_ref(),
+        binders[0].as_ref(),
+        &types,
+        file_names[0].clone(),
+        strict_checker_options(),
+    );
+    checker.ctx.set_all_arenas(Arc::clone(&arenas));
+    checker.ctx.set_all_binders(Arc::clone(&binders));
+    checker.ctx.set_current_file_idx(0);
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+    checker.ctx.set_resolved_modules(resolved_modules);
+
+    let resolved = checker
+        .ctx
+        .resolve_import_alias_chain_with_owner_and_register(local_alias);
+    assert_eq!(resolved, Some((terminal, 3)));
+    assert_eq!(
+        checker.ctx.resolve_dynamic_symbol_file_index(terminal),
+        Some(3)
+    );
+}
+
+#[test]
+fn owner_carried_reexport_walk_has_one_shared_step_budget() {
+    for wildcard in [false, true] {
+        let (at_cap, terminal, provider_idx) = resolve_generated_reexport_chain(63, wildcard);
+        assert_eq!(
+            at_cap,
+            Some((terminal, provider_idx)),
+            "a supported named/wildcard chain must resolve at the 64-step cap"
+        );
+
+        let (over_cap, _, _) = resolve_generated_reexport_chain(64, wildcard);
+        assert_eq!(
+            over_cap, None,
+            "a 65-step named/wildcard chain must fail closed"
+        );
+    }
+}
+
+#[test]
+fn colliding_generic_terminals_keep_flow_diagnostics_clean_across_file_orders() {
+    const LEFT: &str = r#"
+export function retain<Value>(value: Value): Readonly<Value> {
+    return value;
+}
+"#;
+    const RIGHT: &str = r#"
+export function enclose<Item>(value: Item): { payload: Item } {
+    return { payload: value };
+}
+"#;
+    const CONSUMER: &str = r#"
+import { retain } from "./left.js";
+import { enclose } from "./right.js";
+
+interface LeftValue { readonly name: string; readonly values: string[]; }
+interface RightValue { readonly payload: { readonly count: number }; }
+
+export function deferred(leftValues: LeftValue[], rightValues: RightValue[]) {
+    return (): void => {
+        let left = leftValues.find((candidate) => candidate.name === "missing");
+        let right = rightValues.find((candidate) => candidate.payload.count === -1);
+        if (!left) left = retain({ name: "left", values: [] });
+        if (!right) right = enclose({ count: 1 });
+        left.values.push(left.name);
+        right.payload.count.toFixed();
+    };
+}
+"#;
+
+    let terminal_ids = [("left.ts", LEFT, "retain"), ("right.ts", RIGHT, "enclose")].map(
+        |(name, source, export)| {
+            let mut parser = ParserState::new(name.to_string(), source.to_string());
+            let root = parser.parse_source_file();
+            let mut binder = BinderState::new();
+            binder.bind_source_file(parser.get_arena(), root);
+            binder.file_locals.get(export).expect("terminal export")
+        },
+    );
+    assert_eq!(
+        terminal_ids[0], terminal_ids[1],
+        "the diagnostic witness requires colliding binder-relative terminal ids"
+    );
+
+    for files in [
+        [
+            ("left.ts", LEFT),
+            ("right.ts", RIGHT),
+            ("consumer.ts", CONSUMER),
+        ],
+        [
+            ("right.ts", RIGHT),
+            ("left.ts", LEFT),
+            ("consumer.ts", CONSUMER),
+        ],
+    ] {
+        let libs = load_lib_files(&["es5.d.ts", "es2015.core.d.ts"]);
+        let diagnostics = check_multi_file_with_libs_stamped(
+            &files,
+            "consumer.ts",
+            strict_checker_options(),
+            &libs,
+        );
+        assert!(
+            diagnostics.is_empty(),
+            "terminal owner identity must not depend on provider order: {diagnostics:#?}"
+        );
+    }
+}
+
+#[test]
+fn inferred_generic_result_narrows_inside_function_expression() {
+    let diagnostics = codes(
+        r#"
+interface Group {
+    readonly id: string;
+    readonly members: string[];
+}
+declare function retain<T>(value: T): Readonly<T>;
+
+function callback(groups: Group[]) {
+    return function (id: string): void {
+        let group = groups.find((candidate) => candidate.id === id);
+        if (!group) {
+            group = retain({ id, members: [] });
+        }
+        group.members.push(id);
+    };
+}
+"#,
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "renamed binders in a deferred function expression must use the same structural rule: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn concrete_factory_assignment_remains_narrowed() {
+    let diagnostics = codes(
+        r#"
+interface Item {
+    key: string;
+    values: string[];
+}
+declare function makeItem(key: string): Item;
+
+function callback(items: Item[]) {
+    return (key: string): void => {
+        let item = items.find((candidate) => candidate.key === key);
+        if (!item) {
+            item = makeItem(key);
+        }
+        item.values.push(key);
+    };
+}
+"#,
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "the existing concrete-call flow path must remain narrowed: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn ordinary_function_generic_assignment_remains_narrowed() {
+    let diagnostics = codes(
+        r#"
+interface Row {
+    key: string;
+    values: string[];
+}
+declare function preserve<T>(value: T): Readonly<T>;
+
+function append(rows: Row[], key: string): void {
+    let row = rows.find((candidate) => candidate.key === key);
+    if (!row) {
+        row = preserve({ key, values: [] });
+    }
+    row.values.push(key);
+}
+"#,
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "ordinary-function generic assignment flow must remain clean: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn defaulted_generic_result_narrows_after_implicit_inference() {
+    let diagnostics = codes(
+        r#"
+interface BoxValue {
+    label: string;
+    values: string[];
+}
+declare function preserve<T, U = T>(value: T): Readonly<U>;
+
+function callback(box: BoxValue | undefined) {
+    return function (label: string): void {
+        if (!box) {
+            box = preserve({ label, values: [] });
+        }
+        box.values.push(label);
+    };
+}
+"#,
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "an uninferred parameter with a concrete default must instantiate before flow: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn constrained_generic_result_narrows_when_argument_satisfies_constraint() {
+    let diagnostics = codes(
+        r#"
+interface BoxValue {
+    label: string;
+    values: string[];
+}
+declare function preserve<T extends BoxValue>(value: T): Readonly<T>;
+
+function callback(box: BoxValue | undefined) {
+    return function (label: string): void {
+        if (!box) {
+            box = preserve({ label, values: [] });
+        }
+        box.values.push(label);
+    };
+}
+"#,
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "a satisfied generic constraint must retain its concrete non-null result: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn nullable_generic_result_stays_possibly_undefined() {
+    let diagnostics = codes(
+        r#"
+interface Slot {
+    name: string;
+    values: string[];
+}
+declare function maybePreserve<T>(value: T): Readonly<T> | undefined;
+
+function callback(slots: Slot[]) {
+    return (name: string): void => {
+        let slot = slots.find((candidate) => candidate.name === name);
+        if (!slot) {
+            slot = maybePreserve({ name, values: [] });
+        }
+        slot.values.push(name);
+    };
+}
+"#,
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![TS18048],
+        "a nullable generic return must remain nullable after assignment"
+    );
+}
+
+#[test]
+fn call_without_assignment_does_not_kill_undefined() {
+    let diagnostics = codes(
+        r#"
+interface Queue {
+    name: string;
+    values: string[];
+}
+declare function preserve<T>(value: T): Readonly<T>;
+
+function callback(queues: Queue[]) {
+    return (name: string): void => {
+        let queue = queues.find((candidate) => candidate.name === name);
+        if (!queue) {
+            preserve({ name, values: [] });
+        }
+        queue.values.push(name);
+    };
+}
+"#,
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![TS18048],
+        "a non-assignment call must not kill undefined"
+    );
+}
+
+#[test]
+fn underconstrained_generic_result_keeps_conservative_flow() {
+    let diagnostics = codes(
+        r#"
+interface Cell {
+    label: string;
+    values: string[];
+}
+declare function project<T, U>(value: T): U;
+
+function callback(cells: Cell[]) {
+    return (label: string): void => {
+        let cell = cells.find((candidate) => candidate.label === label);
+        if (!cell) {
+            cell = project({ label, values: [] });
+        }
+        cell.values.push(label);
+    };
+}
+"#,
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![TS18048],
+        "an uninferred return parameter must not become a killing definition"
+    );
+}
+
+#[test]
+fn implicit_any_argument_still_narrows_non_nullable_result() {
+    let diagnostics = codes(
+        r#"
+interface BoxValue {
+    label: string;
+    values: string[];
+}
+
+declare function preserve<T>(value: T): Readonly<T>;
+
+function callback(box: BoxValue | undefined) {
+    return function (label) {
+        if (!box) {
+            box = preserve({ label, values: [] });
+        }
+        box.values.push("x");
+    };
+}
+"#,
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![TS7006],
+        "semantic any still infers a definitely non-null generic call result"
+    );
+}
+
+#[test]
+fn free_argument_parameter_does_not_publish_killing_definition() {
+    let diagnostics = codes(
+        r#"
+interface BoxValue {
+    label: string;
+    values: string[];
+}
+
+declare function preserve<T>(value: T): Readonly<T>;
+
+function callback<K>(box: BoxValue | undefined) {
+    return function (label: K): void {
+        if (!box) {
+            box = preserve({ label, values: [] });
+        }
+        box.values.push("x");
+    };
+}
+"#,
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![TS2322, TS18048],
+        "a free argument parameter must not become a fully concrete provisional result"
+    );
+}
+
+#[test]
+fn incompatible_generic_result_keeps_possibly_undefined_flow() {
+    let diagnostics = codes(
+        r#"
+interface BoxValue {
+    label: string;
+    values: string[];
+}
+declare function preserve<T>(value: T): Readonly<T>;
+
+function callback(box: BoxValue | undefined) {
+    return function (): void {
+        if (!box) {
+            box = preserve({ label: 1, values: [] });
+        }
+        box.values.push("x");
+    };
+}
+"#,
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![TS2322, TS18048],
+        "a concrete but incompatible return must not become a killing definition"
+    );
+}
+
+#[test]
+fn violated_constraint_uses_the_constrained_non_null_result() {
+    let diagnostics = codes(
+        r#"
+interface BoxValue {
+    label: string;
+    values: string[];
+}
+declare function preserve<T extends BoxValue>(value: T): Readonly<T>;
+
+function callback(box: BoxValue | undefined) {
+    return function (): void {
+        if (!box) {
+            box = preserve({ label: 1, values: [] });
+        }
+        box.values.push("x");
+    };
+}
+"#,
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![TS2322],
+        "failed argument inference must fall back to the signature constraint"
+    );
+}
+
+#[test]
+fn dependent_constraint_fallback_narrows_the_return() {
+    let diagnostics = codes(
+        r#"
+interface BoxValue {
+    label: string;
+    values: string[];
+}
+declare function preserve<T extends U, U extends BoxValue>(value: T): Readonly<T>;
+
+function callback(box: BoxValue | undefined) {
+    return function (): void {
+        if (!box) {
+            box = preserve({ label: 1, values: [] });
+        }
+        box.values.push("x");
+    };
+}
+"#,
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![TS2322],
+        "dependent constraints must be instantiated after all candidates are known"
+    );
+}
+
+#[test]
+fn dependent_default_constraint_fallback_narrows_the_return() {
+    let diagnostics = codes(
+        r#"
+interface BoxValue {
+    label: string;
+    values: string[];
+}
+declare function preserve<T extends U, U extends BoxValue = BoxValue>(value: T): Readonly<T>;
+
+function callback(box: BoxValue | undefined) {
+    return function (): void {
+        if (!box) {
+            box = preserve({ label: 1, values: [] });
+        }
+        box.values.push("x");
+    };
+}
+"#,
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![TS2322],
+        "a later default must be available while validating a dependent constraint"
+    );
+}
+
+#[test]
+fn invalid_default_uses_the_constraint_for_call_flow() {
+    let diagnostics = codes(
+        r#"
+declare function choose<T extends string = number>(): T;
+
+function callback(value: string | undefined) {
+    return function (): void {
+        if (!value) {
+            value = choose();
+        }
+        value.toUpperCase();
+    };
+}
+"#,
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![TS2344],
+        "an invalid default diagnoses its declaration but the call uses the constraint"
+    );
+}
+
+#[test]
+fn overloaded_and_spread_nullable_calls_keep_conservative_flow() {
+    let overloaded = codes(
+        r#"
+interface NodeValue { name: string; values: string[]; }
+declare function maybeCopy<T>(value: T): Readonly<T> | undefined;
+declare function maybeCopy<T>(value: T, marker: boolean): Readonly<T> | undefined;
+
+function callback(nodes: NodeValue[]) {
+    return (name: string): void => {
+        let node = nodes.find((candidate) => candidate.name === name);
+        if (!node) node = maybeCopy({ name, values: [] });
+        node.values.push(name);
+    };
+}
+"#,
+    );
+    assert_eq!(
+        overloaded,
+        vec![TS18048],
+        "flow fallback must not select among overloaded generic signatures"
+    );
+
+    let spread = codes(
+        r#"
+interface NodeValue { name: string; values: string[]; }
+declare function maybeCopy<T>(...values: [T]): Readonly<T> | undefined;
+
+function callback(nodes: NodeValue[]) {
+    return (name: string): void => {
+        let node = nodes.find((candidate) => candidate.name === name);
+        const args: [{ name: string; values: string[] }] = [{ name, values: [] }];
+        if (!node) node = maybeCopy(...args);
+        node.values.push(name);
+    };
+}
+"#,
+    );
+    assert_eq!(
+        spread,
+        vec![TS18048],
+        "flow fallback must not infer through a spread argument"
+    );
+}
+
+#[test]
+fn partially_overlapping_generic_result_does_not_narrow_invalid_assignment() {
+    let diagnostics = codes(
+        r#"
+declare function preserve<T>(value: T): T | boolean;
+
+function callback(value: string | undefined) {
+    return function (): void {
+        if (value === undefined) {
+            value = preserve("x");
+        }
+        value.toUpperCase();
+    };
+}
+"#,
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![TS2322, TS18048],
+        "one compatible union member must not hide an invalid whole-RHS assignment"
+    );
+}
+
+#[test]
+fn annotated_initializer_whole_rhs_respects_strict_null_checks() {
+    let source = r#"
+declare const source: { value: string } | null;
+const target: { value: string } | { other: number } = source;
+target.value.toUpperCase();
+"#;
+    let strict = strict_checker_options();
+    assert_eq!(
+        codes_with_options(source, strict.clone()),
+        vec![TS2322, TS2339]
+    );
+
+    let mut loose = strict;
+    loose.strict_null_checks = false;
+    assert!(codes_with_options(source, loose).is_empty());
+}
+
+#[test]
+fn annotated_initializer_whole_rhs_respects_strict_function_types() {
+    let source = r#"
+interface Animal { animal: true }
+interface Dog extends Animal { dog: true }
+declare const source: (value: Dog) => void;
+const target: ((value: Animal) => void) | { other: number } = source;
+target({ animal: true });
+"#;
+    let strict = strict_checker_options();
+    assert_eq!(
+        codes_with_options(source, strict.clone()),
+        vec![TS2322, TS2349]
+    );
+
+    let mut loose = strict;
+    loose.strict_function_types = false;
+    assert!(codes_with_options(source, loose).is_empty());
+}
+
+#[test]
+fn annotated_initializer_whole_rhs_respects_exact_optional_properties() {
+    let source = r#"
+declare const source: { value: string; optional: undefined };
+const target: { value: string; optional?: string } | { other: number } = source;
+target.value.toUpperCase();
+"#;
+    let mut exact = strict_checker_options();
+    exact.exact_optional_property_types = true;
+    assert_eq!(codes_with_options(source, exact), vec![TS2322, TS2339]);
+
+    let loose = strict_checker_options();
+    assert!(codes_with_options(source, loose).is_empty());
+}
+
+#[test]
+fn provisional_generic_fallback_does_not_poison_canonical_rhs_flow() {
+    let diagnostics = codes(
+        r#"
+interface ExactBox {
+    kind: "fixed";
+    values: string[];
+}
+declare function preserve<T>(value: T): Readonly<T>;
+
+function callback(box: ExactBox | undefined) {
+    return function (): number {
+        if (box === undefined) {
+            box = preserve({ kind: "fixed", values: [] }) as unknown;
+        }
+        return box.values.length;
+    };
+}
+"#,
+    );
+
+    assert_eq!(
+        diagnostics,
+        vec![TS2322, TS18048],
+        "an early syntactic fallback must not outlive the canonical unknown RHS type"
+    );
+}

--- a/crates/tsz-cli/tests/kysely_cross_file_callback_context_cli_tests.rs
+++ b/crates/tsz-cli/tests/kysely_cross_file_callback_context_cli_tests.rs
@@ -11,11 +11,16 @@
 //! against tsc 7.0.2 (both clean) before migration.
 
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, ExitStatus};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 struct TempDir {
     path: PathBuf,
+}
+
+struct TszOutput {
+    status: ExitStatus,
+    diagnostics: String,
 }
 
 impl TempDir {
@@ -52,8 +57,8 @@ fn find_tsz_binary() -> Option<PathBuf> {
 
 /// Write `files` (relative path, contents) into a temp dir and run `tsz` over
 /// them (in listed order) with strict cross-file bundler options, returning
-/// combined stdout+stderr.
-fn run_tsz_files(name: &str, files: &[(&str, &str)]) -> Option<String> {
+/// process status and combined stdout+stderr.
+fn run_tsz_files(name: &str, files: &[(&str, &str)]) -> Option<TszOutput> {
     let tsz_bin = find_tsz_binary()?;
     let temp = TempDir::new(name).expect("temp dir");
     let mut args: Vec<String> = Vec::new();
@@ -87,16 +92,23 @@ fn run_tsz_files(name: &str, files: &[(&str, &str)]) -> Option<String> {
         .expect("run tsz");
     let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
     text.push_str(&String::from_utf8_lossy(&output.stderr));
-    Some(text)
+    Some(TszOutput {
+        status: output.status,
+        diagnostics: text,
+    })
 }
 
-fn assert_lacks_codes(out: &str, codes: &[&str], context: &str) {
-    for code in codes {
-        assert!(
-            !out.contains(code),
-            "{context} (tsc 7.0.2 is clean); got {code}:\n{out}"
-        );
-    }
+fn assert_clean_tsc_oracle(out: &TszOutput, context: &str) {
+    assert!(
+        out.status.success(),
+        "{context} (tsc 7.0.2 is clean) must exit successfully:\n{}",
+        out.diagnostics
+    );
+    assert!(
+        out.diagnostics.trim().is_empty(),
+        "{context} (tsc 7.0.2 is clean) must be diagnostic-free:\n{}",
+        out.diagnostics
+    );
 }
 
 const EXPRESSION_BUILDER: &str = r#"
@@ -171,9 +183,8 @@ db.selectFrom("user").select((eb) => [
         println!("tsz binary not found; skipping");
         return;
     };
-    assert_lacks_codes(
+    assert_clean_tsc_oracle(
         &out,
-        &["TS2339", "TS7006", "TS2347"],
         "cross-file Kysely subclass should inherit the generic builder callback context",
     );
 }
@@ -284,9 +295,143 @@ fn kysely_schemable_identifier_factory_preserves_nested_imported_literal_kind() 
         println!("tsz binary not found; skipping");
         return;
     };
-    assert_lacks_codes(
+    assert_clean_tsc_oracle(
         &out,
-        &["TS2322"],
         "Kysely nested imported factory should keep literal node kinds",
     );
+}
+
+const DATABASE_INTROSPECTOR: &str = r#"
+export interface TableMetadata {
+  readonly name: string;
+  readonly isView: boolean;
+  readonly columns: ColumnMetadata[];
+  readonly schema?: string;
+}
+
+export interface ColumnMetadata {
+  readonly name: string;
+}
+"#;
+
+const MYSQL_INTROSPECTOR: &str = r#"
+import type { TableMetadata } from "../database-introspector.js";
+import { freeze } from "../../util/object-utils.js";
+
+interface RawColumnMetadata {
+  readonly tableName: string;
+  readonly tableType: string;
+  readonly columnName: string;
+}
+
+declare function findTable(
+  tables: TableMetadata[],
+  name: string,
+): TableMetadata | undefined;
+
+export function collect(columns: RawColumnMetadata[]): TableMetadata[] {
+  return columns.reduce<TableMetadata[]>((tables, item) => {
+    let table = findTable(tables, item.tableName);
+
+    if (!table) {
+      table = freeze({
+        name: item.tableName,
+        isView: item.tableType === "VIEW",
+        schema: undefined,
+        columns: [],
+      });
+      tables.push(table);
+    }
+
+    table.columns.push({ name: item.columnName });
+    return tables;
+  }, []);
+}
+"#;
+
+/// A generic call assigned to an imported interface union inside a deferred
+/// reducer callback is a killing definition when its instantiated return is
+/// compatible with that interface. Both the callee and the declared assignment
+/// surface cross file boundaries here, matching the `MySQL` introspector shape
+/// that exposed the false TS18048. tsc 7.0.2 is clean.
+#[test]
+fn kysely_imported_generic_assignment_narrows_deferred_reducer_local() {
+    let Some(out) = run_tsz_files(
+        "imported_generic_assignment_flow",
+        &[
+            ("util/object-utils.ts", OBJECT_UTILS),
+            ("dialect/database-introspector.ts", DATABASE_INTROSPECTOR),
+            ("dialect/mysql/mysql-introspector.ts", MYSQL_INTROSPECTOR),
+        ],
+    ) else {
+        println!("tsz binary not found; skipping");
+        return;
+    };
+    assert_clean_tsc_oracle(
+        &out,
+        "an imported generic assignment compatible with an imported interface",
+    );
+}
+
+/// The owner-keyed callable cache must distinguish equal binder-relative
+/// terminal ids. The checker-level companion proves the ids collide; this
+/// production CLI path proves diagnostics are independent of provider order.
+#[test]
+fn colliding_generic_terminal_owners_are_clean_across_provider_orders() {
+    const LEFT: &str = r#"
+export function retain<Value>(value: Value): Readonly<Value> {
+  return value;
+}
+"#;
+    const RIGHT: &str = r#"
+export function enclose<Item>(value: Item): { payload: Item } {
+  return { payload: value };
+}
+"#;
+    const CONSUMER: &str = r#"
+import { retain } from "./left.js";
+import { enclose } from "./right.js";
+
+interface LeftValue { readonly name: string; readonly values: string[]; }
+interface RightValue { readonly payload: { readonly count: number }; }
+
+export function deferred(leftValues: LeftValue[], rightValues: RightValue[]) {
+  return (): void => {
+    let left = leftValues.find((candidate) => candidate.name === "missing");
+    let right = rightValues.find((candidate) => candidate.payload.count === -1);
+    if (!left) left = retain({ name: "left", values: [] });
+    if (!right) right = enclose({ count: 1 });
+    left.values.push(left.name);
+    right.payload.count.toFixed();
+  };
+}
+"#;
+
+    for (name, files) in [
+        (
+            "generic_terminal_owner_left_first",
+            [
+                ("left.ts", LEFT),
+                ("right.ts", RIGHT),
+                ("consumer.ts", CONSUMER),
+            ],
+        ),
+        (
+            "generic_terminal_owner_right_first",
+            [
+                ("right.ts", RIGHT),
+                ("left.ts", LEFT),
+                ("consumer.ts", CONSUMER),
+            ],
+        ),
+    ] {
+        let Some(out) = run_tsz_files(name, &files) else {
+            println!("tsz binary not found; skipping");
+            return;
+        };
+        assert_clean_tsc_oracle(
+            &out,
+            "colliding terminal owners must compile in either provider order",
+        );
+    }
 }

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -1826,6 +1826,7 @@ pub fn resolve_call_with_checker<C: AssignabilityChecker>(
         },
     )
 }
+
 pub fn resolve_call_with_checker_and_arg_sources<C: AssignabilityChecker>(
     interner: &dyn QueryDatabase,
     checker: &mut C,

--- a/crates/tsz-solver/src/operations/core/flow_call_fallback.rs
+++ b/crates/tsz-solver/src/operations/core/flow_call_fallback.rs
@@ -1,0 +1,317 @@
+//! Conservative canonical call resolution for checker flow fallback.
+
+use super::{AssignabilityChecker, CallResult, resolve_call_with_checker};
+use crate::construction::QueryDatabase;
+use crate::{IntrinsicKind, TypeData, TypeId};
+use rustc_hash::FxHashSet;
+
+/// Maximum total type nodes inspected while proving that a fallback target
+/// has exactly one supported generic call signature.
+///
+/// This is a conservative recovery path, so exhaustion must reject the
+/// fallback rather than publish a result derived from a partial walk. A total
+/// node budget (rather than only a recursion-depth cap) also bounds wide
+/// intersections and shared acyclic graphs that revisit a child after it has
+/// left the active cycle-detection set.
+const MAX_SINGLE_GENERIC_CALL_WALK_STEPS: usize = 100;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SignatureGate {
+    NonCallable,
+    One(TypeId),
+    Unsupported,
+}
+
+fn single_non_rest_generic_call<C: AssignabilityChecker>(
+    db: &dyn QueryDatabase,
+    checker: &mut C,
+    type_id: TypeId,
+    seen: &mut FxHashSet<TypeId>,
+    remaining_steps: &mut usize,
+) -> SignatureGate {
+    if *remaining_steps == 0 {
+        return SignatureGate::Unsupported;
+    }
+    *remaining_steps -= 1;
+
+    if !seen.insert(type_id) {
+        return SignatureGate::Unsupported;
+    }
+
+    let evaluated = checker.evaluate_type(type_id);
+    let result = if evaluated != type_id {
+        single_non_rest_generic_call(db, checker, evaluated, seen, remaining_steps)
+    } else if let Some(expanded) = checker.expand_type_alias_application(type_id)
+        && expanded != type_id
+    {
+        single_non_rest_generic_call(db, checker, expanded, seen, remaining_steps)
+    } else {
+        match db.lookup(type_id) {
+            Some(TypeData::Function(shape_id)) => {
+                let shape = db.function_shape(shape_id);
+                if shape.is_constructor {
+                    SignatureGate::NonCallable
+                } else if !shape.type_params.is_empty()
+                    && !shape.params.iter().any(|param| param.rest)
+                {
+                    SignatureGate::One(type_id)
+                } else {
+                    SignatureGate::Unsupported
+                }
+            }
+            Some(TypeData::Callable(shape_id)) => {
+                let shape = db.callable_shape(shape_id);
+                match shape.call_signatures.as_slice() {
+                    [signature]
+                        if !signature.type_params.is_empty()
+                            && !signature.params.iter().any(|param| param.rest) =>
+                    {
+                        SignatureGate::One(type_id)
+                    }
+                    [] => SignatureGate::NonCallable,
+                    _ => SignatureGate::Unsupported,
+                }
+            }
+            Some(TypeData::Intersection(list_id)) => {
+                let mut found = None;
+                let mut unsupported = false;
+                for &member in db.type_list(list_id).iter() {
+                    match single_non_rest_generic_call(db, checker, member, seen, remaining_steps) {
+                        SignatureGate::NonCallable => {}
+                        SignatureGate::One(call_type) if found.is_none() => {
+                            found = Some(call_type);
+                        }
+                        _ => {
+                            unsupported = true;
+                            break;
+                        }
+                    }
+                }
+                if unsupported {
+                    SignatureGate::Unsupported
+                } else if let Some(call_type) = found {
+                    SignatureGate::One(call_type)
+                } else {
+                    SignatureGate::NonCallable
+                }
+            }
+            Some(TypeData::TypeParameter(info)) => {
+                info.constraint
+                    .map_or(SignatureGate::Unsupported, |constraint| {
+                        single_non_rest_generic_call(db, checker, constraint, seen, remaining_steps)
+                    })
+            }
+            Some(TypeData::Application(_) | TypeData::Conditional(_) | TypeData::Union(_)) => {
+                SignatureGate::Unsupported
+            }
+            Some(
+                TypeData::Intrinsic(
+                    IntrinsicKind::Never
+                    | IntrinsicKind::Void
+                    | IntrinsicKind::Null
+                    | IntrinsicKind::Undefined
+                    | IntrinsicKind::Boolean
+                    | IntrinsicKind::Number
+                    | IntrinsicKind::String
+                    | IntrinsicKind::Bigint
+                    | IntrinsicKind::Symbol,
+                )
+                | TypeData::Literal(_)
+                | TypeData::Object(_)
+                | TypeData::ObjectWithIndex(_)
+                | TypeData::Array(_)
+                | TypeData::Tuple(_)
+                | TypeData::Enum(_, _)
+                | TypeData::TemplateLiteral(_)
+                | TypeData::UniqueSymbol(_),
+            ) => SignatureGate::NonCallable,
+            // Anything still deferred after evaluation may reveal another call
+            // signature. Intersections may ignore only proven non-callable leaves.
+            _ => SignatureGate::Unsupported,
+        }
+    };
+    seen.remove(&type_id);
+    result
+}
+
+/// Resolve the one generic call shape that flow fallback can recover without
+/// performing overload selection or spread expansion.
+pub fn resolve_single_non_rest_generic_call_with_compat_checker<'a, R, F>(
+    db: &'a dyn QueryDatabase,
+    resolver: &'a R,
+    func_type: TypeId,
+    arg_types: &[TypeId],
+    configure_checker: F,
+) -> Option<TypeId>
+where
+    R: crate::relations::subtype::TypeResolver,
+    F: FnOnce(&mut crate::relations::compat::CompatChecker<'a, R>),
+{
+    let mut checker = crate::relations::compat::CompatChecker::with_resolver(db, resolver);
+    configure_checker(&mut checker);
+    let mut remaining_steps = MAX_SINGLE_GENERIC_CALL_WALK_STEPS;
+    let SignatureGate::One(call_type) = single_non_rest_generic_call(
+        db,
+        &mut checker,
+        func_type,
+        &mut FxHashSet::default(),
+        &mut remaining_steps,
+    ) else {
+        return None;
+    };
+
+    let (result, _, _) =
+        resolve_call_with_checker(db, &mut checker, call_type, arg_types, false, None, None);
+    match result {
+        CallResult::Success(return_type) => Some(return_type),
+        CallResult::ArgumentTypeMismatch {
+            fallback_return, ..
+        }
+        | CallResult::NoOverloadMatch {
+            fallback_return, ..
+        } if fallback_return != TypeId::ERROR => Some(fallback_return),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::computation::TypeEnvironment;
+    use crate::intern::TypeInterner;
+    use crate::{DefId, FunctionShape, ParamInfo, TypeParamInfo, TypeParamOrigin};
+
+    fn generic_identity(db: &TypeInterner, name: &str) -> TypeId {
+        let parameter = TypeParamInfo {
+            name: db.intern_string(name),
+            constraint: None,
+            default: None,
+            is_const: false,
+            origin: TypeParamOrigin::User,
+        };
+        let parameter_type = db.type_param(parameter);
+        db.function(FunctionShape {
+            type_params: vec![parameter],
+            params: vec![ParamInfo {
+                name: None,
+                type_id: parameter_type,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: parameter_type,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    }
+
+    fn constrained_chain(db: &TypeInterner, terminal: TypeId, links: usize) -> TypeId {
+        (0..links).fold(terminal, |constraint, index| {
+            db.type_param(TypeParamInfo {
+                name: db.intern_string(&format!("Wrapper{index}")),
+                constraint: Some(constraint),
+                default: None,
+                is_const: false,
+                origin: TypeParamOrigin::User,
+            })
+        })
+    }
+
+    #[test]
+    fn resolves_one_generic_signature_through_an_intersection_wrapper() {
+        let db = TypeInterner::new();
+        let callable = generic_identity(&db, "T");
+        let wrapped = db.intersection2(callable, db.object(Vec::new()));
+        let result = resolve_single_non_rest_generic_call_with_compat_checker(
+            &db,
+            &TypeEnvironment::new(),
+            wrapped,
+            &[TypeId::STRING],
+            |_| {},
+        );
+        assert_eq!(result, Some(TypeId::STRING));
+    }
+
+    #[test]
+    fn rejects_an_intersection_with_two_generic_call_signatures() {
+        let db = TypeInterner::new();
+        let overloaded = db.intersection2(generic_identity(&db, "T"), generic_identity(&db, "U"));
+        let result = resolve_single_non_rest_generic_call_with_compat_checker(
+            &db,
+            &TypeEnvironment::new(),
+            overloaded,
+            &[TypeId::STRING],
+            |_| {},
+        );
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn ignores_a_construct_only_member_in_an_intersection_wrapper() {
+        let db = TypeInterner::new();
+        let callable = generic_identity(&db, "T");
+        let constructor = db.function(FunctionShape {
+            type_params: Vec::new(),
+            params: Vec::new(),
+            this_type: None,
+            return_type: TypeId::UNKNOWN,
+            type_predicate: None,
+            is_constructor: true,
+            is_method: false,
+        });
+        let wrapped = db.intersection2(callable, constructor);
+        let result = resolve_single_non_rest_generic_call_with_compat_checker(
+            &db,
+            &TypeEnvironment::new(),
+            wrapped,
+            &[TypeId::STRING],
+            |_| {},
+        );
+        assert_eq!(result, Some(TypeId::STRING));
+    }
+
+    #[test]
+    fn rejects_an_intersection_with_an_unresolved_member() {
+        let db = TypeInterner::new();
+        let wrapped = db.intersection2(generic_identity(&db, "T"), db.lazy(DefId(17)));
+        let result = resolve_single_non_rest_generic_call_with_compat_checker(
+            &db,
+            &TypeEnvironment::new(),
+            wrapped,
+            &[TypeId::STRING],
+            |_| {},
+        );
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn accepts_an_acyclic_constraint_chain_at_the_walk_cap() {
+        let db = TypeInterner::new();
+        let callable = generic_identity(&db, "Value");
+        let wrapped = constrained_chain(&db, callable, MAX_SINGLE_GENERIC_CALL_WALK_STEPS - 1);
+        let result = resolve_single_non_rest_generic_call_with_compat_checker(
+            &db,
+            &TypeEnvironment::new(),
+            wrapped,
+            &[TypeId::STRING],
+            |_| {},
+        );
+        assert_eq!(result, Some(TypeId::STRING));
+    }
+
+    #[test]
+    fn rejects_an_acyclic_constraint_chain_over_the_walk_cap() {
+        let db = TypeInterner::new();
+        let callable = generic_identity(&db, "Element");
+        let wrapped = constrained_chain(&db, callable, MAX_SINGLE_GENERIC_CALL_WALK_STEPS);
+        let result = resolve_single_non_rest_generic_call_with_compat_checker(
+            &db,
+            &TypeEnvironment::new(),
+            wrapped,
+            &[TypeId::STRING],
+            |_| {},
+        );
+        assert_eq!(result, None);
+    }
+}

--- a/crates/tsz-solver/src/operations/core/mod.rs
+++ b/crates/tsz-solver/src/operations/core/mod.rs
@@ -11,8 +11,10 @@ mod call_inference_shape;
 mod call_resolution;
 #[cfg(test)]
 mod call_resolution_tests;
+mod flow_call_fallback;
 mod union_signatures;
 
 pub(crate) use call_evaluator::MAX_CONSTRAINT_STEPS;
 pub use call_evaluator::*;
 pub use call_resolution::*;
+pub use flow_call_fallback::*;

--- a/crates/tsz-solver/src/operations/mod.rs
+++ b/crates/tsz-solver/src/operations/mod.rs
@@ -67,6 +67,7 @@ pub use self::core::{
     get_contextual_signature_with_compat_checker, infer_call_signature, infer_generic_function,
     overload_failure_return_type, resolve_call_with_checker,
     resolve_call_with_checker_and_arg_sources, resolve_new_with_checker,
+    resolve_single_non_rest_generic_call_with_compat_checker,
 };
 
 pub use generic_call::{GenericCallRequest, GenericCallResult};


### PR DESCRIPTION
Goal: green

## Summary

- Structural rule: when a deferred assignment has no authoritative cached RHS type and the callee exposes exactly one non-rest generic call signature whose ordinary arguments determine a concrete return, TypeScript uses that instantiated return as the assignment's killing definition. TSZ obtains that result through the solver's canonical call resolver and accepts it only when the complete RHS is compatible with the declared assignment surface.
- Whole-assignment validity uses the complete packed checker relation policy (strict null checks, strict function types, exact optional properties, and unchecked indexed access) on both resolver-backed and resolver-free query paths. The gate covers binary assignments and non-literal annotated initializers; existing literal-initializer reduction remains owned by its dedicated path.
- Cross-file import and re-export aliases carry `(owner file, binder-relative symbol)` identity through every flow-only alias hop, including named local aliases that continue through wildcard barrels. Flow consumes the returned owner directly instead of re-reading the mutable raw-`SymbolId` overlay; incomplete and cyclic walks fail closed.
- Direct alias hops and recursive named/wildcard traversal share one 64-step budget. A supported result at the cap is accepted; the 65th step fails closed without deeper recursion or a partial result.
- Batch checks read the existing owner-keyed cross-file type cache. Interactive/gate-off checks read the canonical owner-specific `DefId` body already merged into the type environment, so no request-wide successful-result cache or raw-`SymbolId` fallback is introduced.
- Cached contextual symbol types are eligible only after that symbol has left `symbol_resolution_set`; this preserves genuine semantic `any` while preventing an in-flight `ANY` sentinel or provisional circular function type from becoming current-pass flow evidence.
- The generic-call shape proof has a per-resolution 100-node budget. At the cap it still resolves a supported signature; exhaustion fails closed without publishing a partial fallback result.

## Adjacent matrix

- Positive: local, imported, and re-exported generic functions; named alias through wildcard barrel; reducer arrows and ordinary function expressions; concrete factories; defaults, constraints, dependent constraints, and resolved semantic `any`; renamed binders and colliding terminal ids across provider-file order.
- Assignment policy: strict-null, strict-function, and exact-optional invalid initializers report the assignment diagnostic and retain declared flow; disabling the corresponding option restores the valid narrowed flow.
- Conservative fallback: nullable and underconstrained returns, free type parameters, overload sets, spread calls, unresolved intersection members, partial-union overlap, incompatible assignments, provisional assertion-wrapped RHS values, and in-flight symbol sentinels do not become killing definitions.
- Traversal bounds: 64-step named and wildcard barrels resolve while 65 steps reject; a 100-node acyclic constraint wrapper resolves while 101 nodes reject the generic-call shape proof.

## Performance and cache behavior

- Whole-RHS checking performs linear per-union-member validation with a behavior-complete `RelationPolicy`; its existing relation cache is partitioned by `RelationPolicy::cache_config()`.
- Alias-cycle tracking keeps the common four owned-symbol hops inline with `SmallVec`; direct and recursive traversal spend one decrement/branch per visited hop under a shared 64-step cap and add no persistent state.
- Generic signature classification spends one decrement/branch per visited node, is capped at 100 total nodes (including wide/revisited DAG work), and adds no cache or checker-global state.
- Provisional fallback evidence still prevents flow-cache publication, so evaluation order cannot make recovery authoritative. No fixture names, user identifiers, rendered types, or diagnostic strings drive compiler behavior.

## Verification

- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test generic_call_assignment_flow_tests` (27 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib stable_symbol_fallback_rejects_in_flight_any_sentinel` (passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(~flow_call_fallback)'` (6 passed on the same semantic patch)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(~flow_assignment_relation_routing_arch_tests)'` (passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test assignment_branch_merge_narrowing_tests --test let_var_initializer_assignment_reduced_type_tests --test accessor_assignment_read_surface_tests --test closure_boundary_property_narrowing_tests` (37 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test order_independent_alias_resolution_tests` (3 passed; `non_generic_reexport_reports_ts2315_in_every_order` failed identically on the untouched pre-change base with the same `[hub.ts, site.ts, decl.ts]` missing-TS2315 permutation)
- `scripts/safe-run.sh cargo nextest run -p tsz-cli --test kysely_cross_file_callback_context_cli_tests` (4 passed; every canary requires exit status 0 and empty diagnostics)
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver -p tsz-checker --all-targets -- -D warnings` (passed on the semantic patch; refreshed head is in CI)
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-cli --test kysely_cross_file_callback_context_cli_tests -- -D warnings` (passed)
- `cargo fmt --all -- --check` (passed)
- `git diff origin/main...HEAD --check` (passed)
- `python3 scripts/arch/arch_guard.py` (passed)
- `scripts/arch/check-checker-boundaries.sh` (passed)

## Provenance

Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
