### PR TITLE
fix(solver): infer aligned contextual return arguments

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -161,6 +161,9 @@ path = "tests/assertion_source_literal_display_tests.rs"
 name = "return_context_identity_wrapper_literal_tests"
 path = "tests/return_context_identity_wrapper_literal_tests.rs"
 [[test]]
+name = "raw_builder_return_context_inference_tests"
+path = "tests/raw_builder_return_context_inference_tests.rs"
+[[test]]
 name = "nested_generic_union_callback_return_tests"
 path = "tests/nested_generic_union_callback_return_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/raw_builder_return_context_inference_tests.rs
+++ b/crates/tsz-checker/tests/raw_builder_return_context_inference_tests.rs
@@ -1,0 +1,165 @@
+//! Return-context inference for zero-evidence generic tags and calls.
+//!
+//! Kysely's `sql<T = unknown>` tag is returned from a generic helper as
+//! `RawBuilder<Simplify<ShallowDehydrateObject<O>> | null>`. The contextual
+//! return is the only inference source. When the declared and contextual
+//! results are aligned applications of the same `RawBuilder` definition,
+//! `tsc` binds the tag's tracked `T` to that whole composite outer type.
+
+use tsz_checker::test_utils::{
+    DiagnosticShape, assert_diagnostic_shapes_exactly, check_source_diagnostics,
+    diagnostic_code_message_refs,
+};
+
+const PRELUDE: &str = r#"
+interface TemplateStringsArray {
+  readonly raw: readonly string[]
+}
+
+interface Promise<Value> {
+  catch<Result = never>(
+    onrejected: (reason: unknown) => Result
+  ): Promise<Value | Result>
+}
+
+interface RawBuilder<Output> {
+  readonly expressionType: Output | undefined
+  readonly isRawBuilder: true
+}
+
+interface SqlTag {
+  <Tagged = unknown>(parts: TemplateStringsArray, ...values: unknown[]): RawBuilder<Tagged>
+}
+
+declare const sql: SqlTag
+declare function rawCall<Result = unknown>(): RawBuilder<Result>
+declare function fromValue<Result = unknown>(value: Result): RawBuilder<Result>
+
+type DrainOuterGeneric<T> = [T] extends [unknown] ? T : never
+type Simplify<T> = DrainOuterGeneric<{ [K in keyof T]: T[K] } & {}>
+type ShallowDehydrateObject<T> = { [K in keyof T]: T[K] }
+"#;
+
+fn check(body: &str) -> Vec<tsz_common::diagnostics::Diagnostic> {
+    check_source_diagnostics(&format!("{PRELUDE}\n{body}"))
+}
+
+fn assert_clean(body: &str, context: &str) {
+    let diagnostics = check(body);
+    assert!(
+        diagnostics.is_empty(),
+        "{context}: expected no diagnostics, got {:#?}",
+        diagnostic_code_message_refs(&diagnostics),
+    );
+}
+
+#[test]
+fn generic_tag_uses_composite_outer_return_context() {
+    assert_clean(
+        r#"
+function jsonObjectFrom<Row>(value: Row): RawBuilder<
+  Simplify<ShallowDehydrateObject<Row>> | null
+> {
+  return sql`json(${value})`
+}
+"#,
+        "generic tag with mapped/union/null outer context",
+    );
+}
+
+#[test]
+fn ordinary_zero_evidence_call_uses_outer_return_context() {
+    assert_clean(
+        r#"
+function buildRecord<Entity>(): RawBuilder<Simplify<Entity> | null> {
+  return rawCall()
+}
+"#,
+        "ordinary call with renamed outer binder",
+    );
+}
+
+#[test]
+fn direct_substitution_and_explicit_type_argument_stay_clean() {
+    assert_clean(
+        r#"
+function direct<Value>(): RawBuilder<Value> {
+  return sql``
+}
+
+function explicit<Value>(): RawBuilder<Simplify<Value> | null> {
+  return sql<Simplify<Value> | null>``
+}
+"#,
+        "direct and explicit contextual return bindings",
+    );
+}
+
+#[test]
+fn no_context_keeps_default_unknown() {
+    let source =
+        format!("{PRELUDE}\nconst inferred = sql``\nconst bad: RawBuilder<string> = inferred\n");
+    let diagnostics = check_source_diagnostics(&source);
+    assert_diagnostic_shapes_exactly(
+        &source,
+        &diagnostics,
+        &[DiagnosticShape::code(2322).with_message_fragment(
+            "RawBuilder<unknown>' is not assignable to type 'RawBuilder<string>",
+        )],
+    );
+}
+
+#[test]
+fn argument_inference_outranks_conflicting_return_context() {
+    let source = format!("{PRELUDE}\nconst bad: RawBuilder<string> = fromValue(123)\n");
+    let diagnostics = check_source_diagnostics(&source);
+    assert_diagnostic_shapes_exactly(
+        &source,
+        &diagnostics,
+        &[DiagnosticShape::code(2322).with_message_fragment(
+            "RawBuilder<number>' is not assignable to type 'RawBuilder<string>",
+        )],
+    );
+}
+
+#[test]
+fn different_base_and_ambiguous_union_do_not_pin_the_tag() {
+    let source = format!(
+        r#"{PRELUDE}
+interface OtherBuilder<T> {{ readonly other: T }}
+declare function other<Result = unknown>(): OtherBuilder<Result>
+
+function wrongBase<Outer>(): RawBuilder<Outer> {{
+  return other()
+}}
+
+function ambiguous(): RawBuilder<string> | RawBuilder<number> {{
+  return sql``
+}}
+"#
+    );
+    let diagnostics = check_source_diagnostics(&source);
+    let codes: Vec<_> = diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect();
+    assert_eq!(
+        codes,
+        vec![2739, 2322],
+        "unexpected diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn nested_promise_catch_generic_does_not_escape_into_outer_result() {
+    assert_clean(
+        r#"
+declare function makePromise<Value = unknown>(): Promise<Value>
+
+function recover<Outer>(): Promise<Outer> {
+  return makePromise().catch((reason): never => { throw reason })
+}
+"#,
+        "nested Promise.catch generic control",
+    );
+}

--- a/crates/tsz-solver/src/operations/generic_call/return_context.rs
+++ b/crates/tsz-solver/src/operations/generic_call/return_context.rs
@@ -408,6 +408,110 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         self.interner.evaluate_type(type_id)
     }
 
+    fn return_context_application_base_def_id(&self, base: TypeId) -> Option<crate::def::DefId> {
+        let resolver = self
+            .checker
+            .type_resolver()
+            .unwrap_or_else(|| self.interner.as_type_resolver());
+        match self.interner.lookup(base)? {
+            TypeData::Lazy(def_id) => Some(resolver.canonical_def_id(def_id)),
+            TypeData::TypeQuery(symbol) => resolver
+                .symbol_to_def_id(symbol)
+                .map(|def_id| resolver.canonical_def_id(def_id)),
+            _ => None,
+        }
+    }
+
+    fn return_context_application_bases_match(&self, source: TypeId, target: TypeId) -> bool {
+        if source == target {
+            return true;
+        }
+
+        let Some(source_def) = self.return_context_application_base_def_id(source) else {
+            return false;
+        };
+        let Some(target_def) = self.return_context_application_base_def_id(target) else {
+            return false;
+        };
+        let resolver = self
+            .checker
+            .type_resolver()
+            .unwrap_or_else(|| self.interner.as_type_resolver());
+        resolver.defs_are_equivalent(source_def, target_def)
+    }
+
+    /// Match direct, same-base return applications before any structural
+    /// expansion can expose foreign type parameters from nested members.
+    ///
+    /// For `G<TCall>` against the contextual `G<X>`, `X` is the whole aligned
+    /// return argument. It may legitimately contain free parameters from the
+    /// enclosing declaration, so the ordinary nested/member contamination
+    /// guard must not reject it. Other tracked call parameters remain blocked,
+    /// and nested structural matching continues through the guarded fallback.
+    fn collect_aligned_return_application_substitution(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        tracked_type_params: &FxHashSet<tsz_common::Atom>,
+        substitution: &mut TypeSubstitution,
+        visited: &mut FxHashSet<(TypeId, TypeId)>,
+    ) -> bool {
+        let Some((source_base, source_args)) =
+            crate::type_queries::get_application_info(self.interner.as_type_database(), source)
+        else {
+            return false;
+        };
+        let Some((target_base, target_args)) =
+            crate::type_queries::get_application_info(self.interner.as_type_database(), target)
+        else {
+            return false;
+        };
+        if source_args.len() != target_args.len()
+            || !self.return_context_application_bases_match(source_base, target_base)
+        {
+            return false;
+        }
+
+        let has_aligned_tracked_param = source_args.iter().any(|&source_arg| {
+            matches!(
+                self.interner.lookup(source_arg),
+                Some(TypeData::TypeParameter(tp))
+                    if substitution.domain_contains_type_parameter(&tp, tracked_type_params)
+            )
+        });
+        if !has_aligned_tracked_param {
+            return false;
+        }
+
+        for (&source_arg, &target_arg) in source_args.iter().zip(&target_args) {
+            if let Some(TypeData::TypeParameter(tp)) = self.interner.lookup(source_arg)
+                && substitution.domain_contains_type_parameter(&tp, tracked_type_params)
+            {
+                if substitution.get(tp.name).is_none()
+                    && !target_arg.is_any_unknown_or_error()
+                    && !self.type_references_other_tracked_params(
+                        target_arg,
+                        &tp,
+                        tracked_type_params,
+                        substitution,
+                    )
+                {
+                    substitution.insert(tp.name, target_arg);
+                }
+                continue;
+            }
+
+            self.collect_return_context_substitution(
+                source_arg,
+                target_arg,
+                tracked_type_params,
+                substitution,
+                visited,
+            );
+        }
+        true
+    }
+
     fn collect_return_context_substitution(
         &mut self,
         source: TypeId,
@@ -1216,13 +1320,21 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         }
 
         let mut visited = FxHashSet::default();
-        self.collect_return_context_substitution(
+        if !self.collect_aligned_return_application_substitution(
             func.return_type,
             contextual_type,
             &tracked_type_params,
             &mut substitution,
             &mut visited,
-        );
+        ) {
+            self.collect_return_context_substitution(
+                func.return_type,
+                contextual_type,
+                &tracked_type_params,
+                &mut substitution,
+                &mut visited,
+            );
+        }
         substitution
     }
 
@@ -1246,6 +1358,10 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         self.resolve_with_request(GenericCallRequest::new(func, arg_types))
     }
 }
+
+#[cfg(test)]
+#[path = "return_context/aligned_application_tests.rs"]
+mod aligned_application_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/tsz-solver/src/operations/generic_call/return_context/aligned_application_tests.rs
+++ b/crates/tsz-solver/src/operations/generic_call/return_context/aligned_application_tests.rs
@@ -1,0 +1,187 @@
+use crate::TypeInterner;
+use crate::caches::query_cache_evaluation::StoreOnlyResolver;
+use crate::construction::QueryDatabase;
+use crate::def::{DefId, DefinitionStore};
+use crate::instantiation::instantiate::TypeSubstitution;
+use crate::operations::{AssignabilityChecker, CallEvaluator};
+use crate::relations::subtype::TypeResolver;
+use crate::types::{FunctionShape, PropertyInfo, TypeId, TypeParamInfo};
+use tsz_common::interner::Atom;
+
+const fn tp(name: u32) -> TypeParamInfo {
+    TypeParamInfo {
+        name: Atom(name),
+        constraint: Some(TypeId::UNKNOWN),
+        default: Some(TypeId::ERROR),
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    }
+}
+
+struct ReturnContextChecker<'a> {
+    resolver: &'a dyn TypeResolver,
+}
+
+impl AssignabilityChecker for ReturnContextChecker<'_> {
+    fn is_assignable_to(&mut self, _source: TypeId, _target: TypeId) -> bool {
+        true
+    }
+
+    fn type_resolver(&self) -> Option<&dyn TypeResolver> {
+        Some(self.resolver)
+    }
+}
+
+fn substitution(
+    interner: &TypeInterner,
+    resolver: &dyn TypeResolver,
+    type_params: Vec<TypeParamInfo>,
+    return_type: TypeId,
+    contextual_type: TypeId,
+) -> TypeSubstitution {
+    let func = FunctionShape {
+        type_params,
+        params: Vec::new(),
+        this_type: None,
+        return_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    };
+    CallEvaluator::new(interner, &mut ReturnContextChecker { resolver })
+        .compute_return_context_substitution(&func, Some(contextual_type))
+}
+
+fn foreign_composite(interner: &TypeInterner, outer: TypeParamInfo) -> TypeId {
+    let mapped_alias = interner.lazy(DefId(90_002));
+    let mapped = interner.application(mapped_alias, vec![interner.type_param(outer)]);
+    interner.union(vec![mapped, TypeId::NULL])
+}
+
+#[test]
+fn same_base_aligned_return_argument_keeps_foreign_composite_whole() {
+    let interner = TypeInterner::new();
+    let resolver = interner.as_type_resolver();
+    let call_param = tp(11);
+    let target_arg = foreign_composite(&interner, tp(12));
+    let base = interner.lazy(DefId(90_001));
+
+    let result = substitution(
+        &interner,
+        resolver,
+        vec![call_param],
+        interner.application(base, vec![interner.type_param(call_param)]),
+        interner.application(base, vec![target_arg]),
+    );
+
+    assert_eq!(result.get(call_param.name), Some(target_arg));
+}
+
+#[test]
+fn canonical_base_definitions_align_return_arguments() {
+    let interner = TypeInterner::new();
+    let store = DefinitionStore::new();
+    let alias_base = DefId(90_010);
+    let declared_base = DefId(90_011);
+    store.set_alias_forward(alias_base, declared_base);
+    let resolver = StoreOnlyResolver::new(&store);
+    let call_param = tp(21);
+    let target_arg = foreign_composite(&interner, tp(22));
+
+    let result = substitution(
+        &interner,
+        &resolver,
+        vec![call_param],
+        interner.application(
+            interner.lazy(alias_base),
+            vec![interner.type_param(call_param)],
+        ),
+        interner.application(interner.lazy(declared_base), vec![target_arg]),
+    );
+
+    assert_eq!(result.get(call_param.name), Some(target_arg));
+}
+
+#[test]
+fn aligned_return_argument_rejects_invalid_and_other_tracked_targets() {
+    let interner = TypeInterner::new();
+    let resolver = interner.as_type_resolver();
+    let first = tp(31);
+    let second = tp(32);
+    let base = interner.lazy(DefId(90_020));
+    let source = interner.application(base, vec![interner.type_param(first)]);
+
+    for invalid in [TypeId::ANY, TypeId::UNKNOWN, TypeId::ERROR] {
+        let result = substitution(
+            &interner,
+            resolver,
+            vec![first],
+            source,
+            interner.application(base, vec![invalid]),
+        );
+        assert_eq!(result.get(first.name), None, "invalid target {invalid:?}");
+    }
+
+    let target_with_other = interner.application(
+        interner.lazy(DefId(90_021)),
+        vec![interner.type_param(second)],
+    );
+    let result = substitution(
+        &interner,
+        resolver,
+        vec![first, second],
+        source,
+        interner.application(base, vec![target_with_other]),
+    );
+    assert_eq!(result.get(first.name), None);
+}
+
+#[test]
+fn different_base_and_nested_member_paths_keep_untracked_guard() {
+    let interner = TypeInterner::new();
+    let resolver = interner.as_type_resolver();
+    let call_param = tp(41);
+    let target_arg = foreign_composite(&interner, tp(42));
+    let source_base = interner.lazy(DefId(90_030));
+    let target_base = interner.lazy(DefId(90_031));
+    let source_app = interner.application(source_base, vec![interner.type_param(call_param)]);
+    let target_app = interner.application(target_base, vec![target_arg]);
+
+    let different_base = substitution(
+        &interner,
+        resolver,
+        vec![call_param],
+        source_app,
+        target_app,
+    );
+    assert_eq!(different_base.get(call_param.name), None);
+
+    let member = Atom(90_032);
+    let nested = substitution(
+        &interner,
+        resolver,
+        vec![call_param],
+        interner.object(vec![PropertyInfo::new(member, source_app)]),
+        interner.object(vec![PropertyInfo::new(
+            member,
+            interner.application(source_base, vec![target_arg]),
+        )]),
+    );
+    assert_eq!(nested.get(call_param.name), None);
+}
+
+#[test]
+fn union_context_with_disagreeing_same_base_arms_stays_ambiguous() {
+    let interner = TypeInterner::new();
+    let resolver = interner.as_type_resolver();
+    let call_param = tp(51);
+    let base = interner.lazy(DefId(90_040));
+    let source = interner.application(base, vec![interner.type_param(call_param)]);
+    let contextual = interner.union(vec![
+        interner.application(base, vec![TypeId::STRING]),
+        interner.application(base, vec![TypeId::NUMBER]),
+    ]);
+
+    let result = substitution(&interner, resolver, vec![call_param], source, contextual);
+    assert_eq!(result.get(call_param.name), None);
+}


### PR DESCRIPTION
Goal: green

## Summary
- infer a direct contextual return placeholder from the matching argument of the same canonical generic application
- preserve composite outer types whole instead of recursively rejecting their free type parameters
- keep different-base, nested-member, ambiguous-union, and conflicting argument-inference paths on the guarded fallback

## Structural Rule
When a generic call returns `G<T_call>` and its contextual target is the same canonical declaration `G<X>`, `tsc` infers the direct return placeholder from the whole aligned argument `X`; TSZ now performs that inference in the solver's generic-call return-context owner.

## Owner Layer
`tsz-solver::operations::generic_call::return_context`; checker coverage exercises the public source path without checker-side type-shape recursion.

## Adjacent Matrix
- same-base applications with local and canonicalized definitions
- composite foreign outer type parameters
- ordinary zero-evidence calls and explicit/direct substitutions
- argument evidence outranking conflicting return context
- different generic bases, nested member paths, and disagreeing union arms
- invalid/other tracked targets and nested Promise/catch escape control

## Performance
The direct path is root-only and O(generic arity), adds no cache, and falls back immediately for non-aligned shapes.

## Verification
- `cargo nextest run -p tsz-solver aligned_application_tests` (5 passed)
- `cargo nextest run -p tsz-checker --test raw_builder_return_context_inference_tests` (7 passed)
- existing Promise/shadowing and ambiguity/callback/identity controls (28 passed before rebase)
- architecture guards and `git diff --check`
- isolated `dist-fast` build
- Kysely guard on current main, repeated identically: 72 diagnostics -> 66; four RawBuilder TS2322 and two related TS2590 removed, zero additions

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
