### PR TITLE
fix(solver): scope TS2590 signals to producing workers

### DIFF
--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -1342,8 +1342,8 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // Snapshot the solver's `union_too_complex` flag before computing this
-        // array's element union. The flag is global and sticky: a recursive
+        // Snapshot the solver's worker-local complexity epoch before computing
+        // this array's element union. A recursive
         // type-alias evaluation triggered while computing the *contextual* element
         // type (e.g. `RecArray<T> = Array<T | RecArray<T>>` in a generic call
         // argument position) can set it, and an unrelated earlier expression can
@@ -1354,7 +1354,7 @@ impl<'a> CheckerState<'a> {
         // declaration/cache-order-dependent way. Mirror the evaluator
         // (`commit_closed_eval_writes`): attribute complexity only when this
         // array's own union computation newly trips the flag.
-        let union_too_complex_before = self.ctx.types.is_union_too_complex();
+        let union_complexity_checkpoint = self.ctx.types.union_complexity_checkpoint();
 
         // TS2590: Pre-check element count before BCT. tsc's removeSubtypes only
         // increments its cost counter for StructuredOrInstantiable source types —
@@ -1413,8 +1413,11 @@ impl<'a> CheckerState<'a> {
         // Only attribute the complexity to this array when its own union computation
         // newly tripped the flag — a flag inherited from contextual-type evaluation
         // or an earlier expression must not turn this array into `Array<error>`.
-        let union_too_complex_now = self.ctx.types.take_union_too_complex();
-        if union_too_complex_now && !union_too_complex_before {
+        if self
+            .ctx
+            .types
+            .take_union_too_complex_since(union_complexity_checkpoint)
+        {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
             self.error_at_node(
                 idx,

--- a/crates/tsz-checker/src/types/computation/object_literal_context.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_context.rs
@@ -499,15 +499,15 @@ impl<'a> CheckerState<'a> {
                 if common::is_callable_type(self.ctx.types, member) {
                     return Some(member);
                 }
-                let had_prior_complexity = self.ctx.types.take_union_too_complex();
+                let complexity_checkpoint = self.ctx.types.union_complexity_checkpoint();
                 let evaluated = self.evaluate_type_with_env(member);
                 let evaluated = self.resolve_lazy_type(evaluated);
                 let evaluated = self.evaluate_application_type(evaluated);
-                let produced_complexity = self.ctx.types.take_union_too_complex();
-                if had_prior_complexity || produced_complexity {
-                    self.ctx.types.mark_union_too_complex();
-                }
-                if produced_complexity {
+                if self
+                    .ctx
+                    .types
+                    .take_union_too_complex_since(complexity_checkpoint)
+                {
                     return None;
                 }
                 common::is_callable_type(self.ctx.types, evaluated).then_some(evaluated)

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
 
-pub use crate::caches::display_provenance::TypeDisplayProvenance;
+pub use crate::caches::display_provenance::{TypeDisplayProvenance, UnionComplexityCheckpoint};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum IntersectionMergeCacheEntry {

--- a/crates/tsz-solver/src/caches/display_provenance.rs
+++ b/crates/tsz-solver/src/caches/display_provenance.rs
@@ -4,6 +4,18 @@ use crate::intern::TypeInterner;
 use crate::types::{PropertyInfo, TypeId};
 use std::sync::Arc;
 
+/// Request-local snapshot of the exceptional `TS2590` side channel.
+///
+/// The concrete interner scopes the snapshot to both its own type universe and
+/// the current worker thread. Callers keep the token opaque and use the trait
+/// methods below to test, consume, or discard only events produced after it.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct UnionComplexityCheckpoint {
+    pub(crate) produced_epoch: u64,
+    pub(crate) interner_instance_id: u32,
+    pub(crate) pending_count: u32,
+}
+
 /// Diagnostic display and provenance hooks for interned types.
 ///
 /// These methods preserve source-facing type identities and display-only object
@@ -136,10 +148,10 @@ pub trait TypeDisplayProvenance {
         None
     }
 
-    /// Atomically read and clear the "union too complex" flag.
+    /// Read and clear the current worker's "union too complex" signal.
     ///
     /// Returns `true` if a union construction was aborted due to complexity
-    /// since the last call. The checker uses this to emit `TS2590`.
+    /// since its last call. The checker uses this to emit `TS2590`.
     fn take_union_too_complex(&self) -> bool {
         false
     }
@@ -151,6 +163,42 @@ pub trait TypeDisplayProvenance {
     /// re-evaluation. Default is `false`.
     fn is_union_too_complex(&self) -> bool {
         false
+    }
+
+    /// Snapshot the current worker's `TS2590` signal state.
+    fn union_complexity_checkpoint(&self) -> UnionComplexityCheckpoint {
+        UnionComplexityCheckpoint {
+            pending_count: if self.is_union_too_complex() { 1 } else { 0 },
+            ..UnionComplexityCheckpoint::default()
+        }
+    }
+
+    /// Return whether this worker produced a new complexity event after
+    /// `checkpoint`.
+    fn union_complexity_changed_since(&self, checkpoint: UnionComplexityCheckpoint) -> bool {
+        self.is_union_too_complex() && checkpoint.pending_count == 0
+    }
+
+    /// Consume a pending event only when it was produced after `checkpoint`,
+    /// preserving an event that was already pending for an outer owner.
+    fn take_union_too_complex_since(&self, checkpoint: UnionComplexityCheckpoint) -> bool {
+        if self.union_complexity_changed_since(checkpoint) {
+            if checkpoint.pending_count != 0 {
+                self.is_union_too_complex()
+            } else {
+                self.take_union_too_complex()
+            }
+        } else {
+            false
+        }
+    }
+
+    /// Discard events produced after `checkpoint` while preserving an event
+    /// that was already pending when the speculative operation began.
+    fn discard_union_too_complex_since(&self, checkpoint: UnionComplexityCheckpoint) {
+        if checkpoint.pending_count == 0 && self.union_complexity_changed_since(checkpoint) {
+            let _ = self.take_union_too_complex();
+        }
     }
 
     /// Mark the current operation as having produced a too-complex union.
@@ -256,6 +304,22 @@ impl TypeDisplayProvenance for TypeInterner {
 
     fn is_union_too_complex(&self) -> bool {
         Self::is_union_too_complex(self)
+    }
+
+    fn union_complexity_checkpoint(&self) -> UnionComplexityCheckpoint {
+        Self::union_complexity_checkpoint(self)
+    }
+
+    fn union_complexity_changed_since(&self, checkpoint: UnionComplexityCheckpoint) -> bool {
+        Self::union_complexity_changed_since(self, checkpoint)
+    }
+
+    fn take_union_too_complex_since(&self, checkpoint: UnionComplexityCheckpoint) -> bool {
+        Self::take_union_too_complex_since(self, checkpoint)
+    }
+
+    fn discard_union_too_complex_since(&self, checkpoint: UnionComplexityCheckpoint) {
+        Self::discard_union_too_complex_since(self, checkpoint);
     }
 
     fn mark_union_too_complex(&self) {

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -11,7 +11,7 @@ use crate::caches::db::{
     IntersectionMergeCacheEntry, QueryDatabase, TypeBuiltinAccess, TypeCompilerOptions,
     TypeContainsByIdCache, TypeDatabase, TypeDisplayProvenance, TypeExtractParamsCache,
     TypePruneUnionCache, TypeRawIntersectionConstruction, TypeSubstitutionConstruction,
-    TypeTupleLimitSignal, TypeWidenCache,
+    TypeTupleLimitSignal, TypeWidenCache, UnionComplexityCheckpoint,
 };
 use crate::caches::eval_dependency_index::{self, EvalDependencyIndex, EvalDependencyIndexState};
 use crate::caches::instantiation_cache::{InstantiationCache, InstantiationCacheKey};
@@ -806,6 +806,22 @@ impl TypeDisplayProvenance for QueryCache<'_> {
 
     fn is_union_too_complex(&self) -> bool {
         self.interner.is_union_too_complex()
+    }
+
+    fn union_complexity_checkpoint(&self) -> UnionComplexityCheckpoint {
+        self.interner.union_complexity_checkpoint()
+    }
+
+    fn union_complexity_changed_since(&self, checkpoint: UnionComplexityCheckpoint) -> bool {
+        self.interner.union_complexity_changed_since(checkpoint)
+    }
+
+    fn take_union_too_complex_since(&self, checkpoint: UnionComplexityCheckpoint) -> bool {
+        self.interner.take_union_too_complex_since(checkpoint)
+    }
+
+    fn discard_union_too_complex_since(&self, checkpoint: UnionComplexityCheckpoint) {
+        self.interner.discard_union_too_complex_since(checkpoint);
     }
 
     fn mark_union_too_complex(&self) {

--- a/crates/tsz-solver/src/evaluation/cache_stability.rs
+++ b/crates/tsz-solver/src/evaluation/cache_stability.rs
@@ -1,10 +1,10 @@
-use crate::construction::TypeDatabase;
+use crate::construction::{TypeDatabase, UnionComplexityCheckpoint};
 
 /// Snapshot for evaluation cache writes whose keys do not encode ambient limit
 /// state.
 #[derive(Clone, Copy)]
 pub(crate) struct EvaluationCacheLimitSnapshot {
-    union_too_complex: bool,
+    union_complexity: UnionComplexityCheckpoint,
 }
 
 /// Solver-owned verdict for cache writes gated by ambient evaluation limits.
@@ -23,12 +23,12 @@ impl EvaluationCacheLimitState {
 impl EvaluationCacheLimitSnapshot {
     pub(crate) fn capture(interner: &dyn TypeDatabase) -> Self {
         Self {
-            union_too_complex: interner.is_union_too_complex(),
+            union_complexity: interner.union_complexity_checkpoint(),
         }
     }
 
     pub(crate) fn state_after(self, interner: &dyn TypeDatabase) -> EvaluationCacheLimitState {
-        if interner.is_union_too_complex() && !self.union_too_complex {
+        if interner.union_complexity_changed_since(self.union_complexity) {
             EvaluationCacheLimitState::UnionComplexityNewlyExceeded
         } else {
             EvaluationCacheLimitState::Stable
@@ -69,5 +69,13 @@ mod tests {
             EvaluationCacheLimitState::Stable
         );
         assert!(pre_existing_snapshot.union_complexity_stayed_stable_after(&interner));
+
+        interner.set_union_too_complex();
+        assert_eq!(
+            pre_existing_snapshot.state_after(&interner),
+            EvaluationCacheLimitState::UnionComplexityNewlyExceeded,
+            "a second event must taint the cache even while the sticky signal was already pending"
+        );
+        assert!(interner.take_union_too_complex());
     }
 }

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -19,6 +19,7 @@ mod array_methods;
 
 use crate::caches::db::QueryDatabase;
 use crate::construction::TypeDatabase;
+use crate::construction::UnionComplexityCheckpoint;
 use crate::def::{DefId, DefKind};
 use crate::diagnostics::display_provenance::{
     self, AliasApplicationPriority, AliasApplicationProvenance,
@@ -245,11 +246,11 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// (issue #13097; see `evaluation::memo_audit`). 0 when perf counters
     /// are disabled.
     audit_evaluator_id: u64,
-    /// `is_union_too_complex` snapshot taken at construction. A memo
+    /// Union-complexity event checkpoint taken at construction. A memo
     /// write-through is suppressed while the flag is newly set relative to
     /// this snapshot, mirroring the top-level boundary drain's `TS2590`
     /// gate (a cached read must not swallow the diagnostic re-derivation).
-    union_complex_at_construction: bool,
+    union_complexity_at_construction: UnionComplexityCheckpoint,
     /// When true, nested `evaluate` nodes consult the persistent eval memo
     /// (`TypeApplicationEvalCache::lookup_eval_memo`) after a local-cache
     /// miss, so this
@@ -420,7 +421,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             closed_eval_writes_allowed: false,
             tainted: FxHashSet::default(),
             audit_evaluator_id: crate::evaluation::memo_audit::next_evaluator_id(),
-            union_complex_at_construction: interner.is_union_too_complex(),
+            union_complexity_at_construction: interner.union_complexity_checkpoint(),
             persistent_memo_reads: false,
             limited_resolver: false,
         }
@@ -1404,7 +1405,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             if self.persistent_memo_reads
                 && !type_id.is_intrinsic()
                 && (self.limit_epoch == 0 || crate::limits::limit_result_cache_enabled())
-                && (self.union_complex_at_construction || !self.interner.is_union_too_complex())
+                && !self
+                    .interner
+                    .union_complexity_changed_since(self.union_complexity_at_construction)
             {
                 self.interner
                     .insert_eval_memo(type_id, self.no_unchecked_indexed_access, result);

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_union_distribution.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_union_distribution.rs
@@ -51,14 +51,17 @@ pub(super) fn evaluate_index_union_distribution<R: TypeResolver>(
     // the whole union; the sticky `union_too_complex` flag then drives TS2590
     // in the checker. A nested distribution that already overflowed is detected
     // via the pre-loop flag snapshot so deeper keys are not re-expanded.
-    let union_complex_before_index = evaluator.interner().is_union_too_complex();
+    let union_complexity_checkpoint = evaluator.interner().union_complexity_checkpoint();
     let mut cumulative_members: usize = 0;
     let mut results = Vec::new();
     for &member in members {
         if evaluator.is_depth_exceeded() {
             return TypeId::ERROR;
         }
-        if !union_complex_before_index && evaluator.interner().is_union_too_complex() {
+        if evaluator
+            .interner()
+            .union_complexity_changed_since(union_complexity_checkpoint)
+        {
             break;
         }
         let result = evaluator.recurse_index_access(object_type, member);

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -619,7 +619,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // complexity that arose *inside* this evaluation (a nested key's
         // sub-evaluation), never to a flag a sibling type left set before this
         // mapped type was reached.
-        let union_complex_before_mapped = self.interner().is_union_too_complex();
+        let union_complexity_checkpoint = self.interner().union_complexity_checkpoint();
 
         for mapped_key in key_set.keys {
             // Check if depth was exceeded during previous iterations
@@ -630,7 +630,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // overflowed the union-complexity budget, so the whole mapped result
             // is too complex (TS2590). Stop before instantiating/evaluating the
             // remaining keys instead of re-paying the per-key cost for each.
-            if !union_complex_before_mapped && self.interner().is_union_too_complex() {
+            if self
+                .interner()
+                .union_complexity_changed_since(union_complexity_checkpoint)
+            {
                 break;
             }
             let key_name = mapped_key.name;

--- a/crates/tsz-solver/src/instantiation/instantiate/cache_stability.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/cache_stability.rs
@@ -1,8 +1,8 @@
-use crate::construction::TypeDatabase;
+use crate::construction::{TypeDatabase, UnionComplexityCheckpoint};
 
 #[derive(Clone, Copy)]
 pub(super) struct ProjectInstantiationCacheLimitSnapshot {
-    union_too_complex: bool,
+    union_complexity: UnionComplexityCheckpoint,
     tuple_too_large: bool,
     solver_frame_bail_count: u32,
 }
@@ -45,7 +45,7 @@ impl ProjectInstantiationCacheStability {
 impl ProjectInstantiationCacheLimitSnapshot {
     pub(super) fn capture(interner: &dyn TypeDatabase) -> Self {
         Self {
-            union_too_complex: interner.is_union_too_complex(),
+            union_complexity: interner.union_complexity_checkpoint(),
             tuple_too_large: interner.is_tuple_too_large(),
             solver_frame_bail_count: crate::recursion::solver_frame_bail_count(),
         }
@@ -62,7 +62,7 @@ impl ProjectInstantiationCacheLimitSnapshot {
         //  - solver-frame curtailment: a nested `evaluate_*` can return an
         //    under-evaluated form without flipping the instantiator's own
         //    `depth_exceeded`; the monotonic counter changing detects it.
-        let newly_too_complex = interner.is_union_too_complex() && !self.union_too_complex;
+        let newly_too_complex = interner.union_complexity_changed_since(self.union_complexity);
         let newly_tuple_too_large = interner.is_tuple_too_large() && !self.tuple_too_large;
         let frame_curtailed =
             crate::recursion::solver_frame_bail_count() != self.solver_frame_bail_count;
@@ -93,7 +93,11 @@ impl ProjectInstantiationCacheLimitSnapshot {
 
 #[cfg(test)]
 mod tests {
-    use super::{ProjectInstantiationCacheStability, ProjectInstantiationCacheTaint};
+    use super::{
+        ProjectInstantiationCacheLimitSnapshot, ProjectInstantiationCacheStability,
+        ProjectInstantiationCacheTaint,
+    };
+    use crate::intern::TypeInterner;
 
     #[test]
     fn stable_request_state_allows_project_cache_publication() {
@@ -150,5 +154,25 @@ mod tests {
                 ProjectInstantiationCacheTaint::UnionTooComplex
             )
         );
+    }
+
+    #[test]
+    fn second_union_event_taints_pre_existing_pending_snapshot() {
+        let interner = TypeInterner::new();
+        interner.set_union_too_complex();
+        let snapshot = ProjectInstantiationCacheLimitSnapshot::capture(&interner);
+
+        assert_eq!(
+            snapshot.request_state_stability_after(&interner),
+            ProjectInstantiationCacheStability::Stable,
+        );
+        interner.set_union_too_complex();
+        assert_eq!(
+            snapshot.request_state_stability_after(&interner),
+            ProjectInstantiationCacheStability::Unstable(
+                ProjectInstantiationCacheTaint::UnionTooComplex,
+            ),
+        );
+        assert!(interner.take_union_too_complex());
     }
 }

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -7,6 +7,7 @@
 //! - `display`: diagnostic display provenance (fresh-literal properties, alias
 //!   names, union member origin).
 //! - `cache`: the thread-local intern/lookup fast-path cache.
+//! - `union_complexity`: worker-local exceptional `TS2590` signaling.
 
 use crate::def::DefId;
 use crate::types::{
@@ -37,9 +38,22 @@ pub(super) struct DisplayUnionOrigin {
     pub(super) exact_rewrite_fallback: bool,
 }
 
+/// Per-worker state for the exceptional `TS2590` side channel.
+///
+/// The common state lives in fixed TLS slots keyed by `instance_id`; overflow
+/// lives on the owning interner only when one worker signals in more universes
+/// than those slots can hold.
+#[derive(Clone, Copy, Debug, Default)]
+struct UnionComplexityThreadState {
+    produced_epoch: u64,
+    instance_id: u32,
+    pending_count: u32,
+}
+
 mod cache;
 mod display;
 mod storage;
+mod union_complexity;
 mod variance_cache;
 
 pub use variance_cache::SharedDefVariance;
@@ -59,6 +73,13 @@ static NEXT_INTERNER_INSTANCE_ID: AtomicU32 = AtomicU32::new(1);
 /// from being returned for `TypeId` values that have been reused by a new interner.
 /// Without this, the lookup cache may return `TypeData` from a dropped interner,
 /// causing incorrect type resolution and panics.
+///
+/// This clears only the calling worker. Compilation sessions own and drop their
+/// `TypeInterner`, so fixed signal slots left on persistent Rayon workers are
+/// harmless: unique `instance_id`s prevent reuse, and a worker that eventually
+/// accumulates eight signaled universes uses the new interner's bounded-lifetime
+/// overflow map. That aging changes only an already-exceptional path, not signal
+/// ownership or cache correctness.
 pub fn clear_thread_local_cache() {
     cache::clear_thread_local_cache();
 }
@@ -501,11 +522,19 @@ pub struct TypeInterner {
     /// Key: the flattened Union `TypeId` returned to the checker.
     /// Value: the unflattened input member list, in the order the user wrote.
     pub(super) display_union_origin: DashMap<TypeId, DisplayUnionOrigin, FxBuildHasher>,
-    /// Flag set when union normalization detects that a union type is too complex
-    /// to represent (would require > 1M pairwise subtype comparisons during
-    /// reduction). Mirrors tsc's `removeSubtypes` complexity heuristic that
-    /// emits TS2590. The checker reads and clears this flag to emit the diagnostic.
-    pub(super) union_too_complex: AtomicBool,
+    /// Overflow for worker-scoped signals when a thread's fixed TLS slots are
+    /// full. Normal compilation uses TLS only; this map remains interner-owned
+    /// so fallback residency ends with the type universe.
+    union_complexity_overflow_by_thread:
+        OnceLock<DashMap<std::thread::ThreadId, UnionComplexityThreadState, FxBuildHasher>>,
+    /// Number of workers whose union-complexity signal is pending. The common
+    /// no-event path checks this with one relaxed load and avoids TLS, a
+    /// thread-id lookup, and `DashMap` access entirely.
+    union_complexity_pending_threads: AtomicUsize,
+    /// Monotonic ticket assigned to every union-complexity event in this type
+    /// universe. Cache snapshots compare this cheap atomic gate first, then
+    /// consult only the current worker's state if any event occurred.
+    union_complexity_event_epoch: AtomicU64,
     /// Flag set when tuple synthesis detects that a spread would produce a tuple
     /// with more than `MAX_REPRESENTABLE_TUPLE_LENGTH` elements. The checker reads
     /// and clears this to emit TS2799 instead of TS2589.
@@ -809,7 +838,9 @@ impl TypeInterner {
             global_this_surface_display: DashMap::with_hasher(FxBuildHasher),
             literal_object_annotations: DashMap::with_hasher(FxBuildHasher),
             display_union_origin: DashMap::with_hasher(FxBuildHasher),
-            union_too_complex: AtomicBool::new(false),
+            union_complexity_overflow_by_thread: OnceLock::new(),
+            union_complexity_pending_threads: AtomicUsize::new(0),
+            union_complexity_event_epoch: AtomicU64::new(0),
             tuple_too_large: AtomicBool::new(false),
             def_variance_masks: DashMap::with_hasher(FxBuildHasher),
             instance_id: NEXT_INTERNER_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
@@ -836,31 +867,6 @@ impl TypeInterner {
     pub fn set_exact_optional_property_types(&self, enabled: bool) {
         self.exact_optional_property_types
             .store(enabled, Ordering::Relaxed);
-    }
-
-    /// Atomically read and clear the "union too complex" flag.
-    ///
-    /// Returns `true` if a union construction was aborted due to complexity
-    /// since the last call to this method. The flag is cleared after reading.
-    /// The checker uses this to emit TS2590.
-    #[inline]
-    pub fn take_union_too_complex(&self) -> bool {
-        self.union_too_complex.swap(false, Ordering::Relaxed)
-    }
-
-    /// Mark that a union construction was aborted due to complexity.
-    /// Called from `reduce_union_subtypes` when pairwise comparisons would exceed 1M.
-    #[inline]
-    pub(crate) fn set_union_too_complex(&self) {
-        self.union_too_complex.store(true, Ordering::Relaxed);
-    }
-
-    /// Peek at the union-too-complex flag without clearing it (so the checker
-    /// still observes it). The evaluator uses this to skip caching an evaluation
-    /// that tripped the `TS2590` limit.
-    #[inline]
-    pub fn is_union_too_complex(&self) -> bool {
-        self.union_too_complex.load(Ordering::Relaxed)
     }
 
     /// Atomically read and clear the "tuple too large" flag.

--- a/crates/tsz-solver/src/intern/core/interner/cache.rs
+++ b/crates/tsz-solver/src/intern/core/interner/cache.rs
@@ -8,6 +8,7 @@
 //! add to the `inline_always` ratchet, and its backing array is sized to keep
 //! the per-thread allocation under the `large_stack_arrays` threshold.
 
+use super::UnionComplexityThreadState;
 use crate::types::{TypeData, TypeId};
 use std::cell::Cell;
 use tsz_common::interner::Atom;
@@ -122,6 +123,33 @@ struct TypeInternerCache {
     lookup: [Cell<LookupCacheEntry>; LOOKUP_CACHE_SIZE],
     intern: [Cell<InternCacheEntry>; INTERN_CACHE_SIZE],
     string: [Cell<StringCacheEntry>; STRING_CACHE_SIZE],
+    /// Exceptional `TS2590` state for the small number of type universes used
+    /// by this worker. Slots are assigned only when an event is produced and
+    /// remain stable until the compilation-session cache is cleared, so a
+    /// live checkpoint cannot lose its producer epoch through eviction.
+    union_complexity: [Cell<UnionComplexityThreadState>; UNION_COMPLEXITY_SLOT_COUNT],
+}
+
+/// A CLI worker normally sees one `TypeInterner`; extra slots cover nested
+/// test/project universes without allocating or hashing on the exceptional
+/// signal path. If all slots are occupied, the owning interner provides a
+/// bounded-lifetime overflow map keyed by worker thread.
+const UNION_COMPLEXITY_SLOT_COUNT: usize = 8;
+
+pub(super) enum UnionComplexityStateLookup {
+    Found(UnionComplexityThreadState),
+    /// At least one fixed slot is still empty, proving this worker has never
+    /// overflowed for the requested interner.
+    Absent,
+    /// All fixed slots are occupied, so the interner-owned overflow map may
+    /// contain this worker's state.
+    OverflowPossible,
+}
+
+pub(super) enum UnionComplexityPendingUpdate {
+    Updated(u32),
+    Absent,
+    OverflowPossible,
 }
 
 const EMPTY_LOOKUP_ENTRY: LookupCacheEntry = LookupCacheEntry {
@@ -145,6 +173,12 @@ const EMPTY_STRING_ENTRY: StringCacheEntry = StringCacheEntry {
     result: Atom::NONE,
 };
 
+const EMPTY_UNION_COMPLEXITY_STATE: UnionComplexityThreadState = UnionComplexityThreadState {
+    instance_id: 0,
+    produced_epoch: 0,
+    pending_count: 0,
+};
+
 #[allow(dead_code)]
 impl TypeInternerCache {
     #[allow(clippy::large_stack_arrays)]
@@ -153,6 +187,8 @@ impl TypeInternerCache {
             lookup: [const { Cell::new(EMPTY_LOOKUP_ENTRY) }; LOOKUP_CACHE_SIZE],
             intern: [const { Cell::new(EMPTY_INTERN_ENTRY) }; INTERN_CACHE_SIZE],
             string: [const { Cell::new(EMPTY_STRING_ENTRY) }; STRING_CACHE_SIZE],
+            union_complexity: [const { Cell::new(EMPTY_UNION_COMPLEXITY_STATE) };
+                UNION_COMPLEXITY_SLOT_COUNT],
         }
     }
 
@@ -259,12 +295,92 @@ impl TypeInternerCache {
             result,
         });
     }
+
+    /// Record a new event in this worker's fixed signal slots.
+    ///
+    /// Returns the previous pending state, or `None` when all slots belong to
+    /// other live/checkpointed interner instances and the caller must use its
+    /// interner-owned overflow map.
+    fn mark_union_complexity(&self, instance_id: u32, produced_epoch: u64) -> Option<bool> {
+        let mut empty_slot = None;
+        for slot in &self.union_complexity {
+            let state = slot.get();
+            if state.instance_id == instance_id {
+                let previous_pending_count = state.pending_count;
+                slot.set(UnionComplexityThreadState {
+                    produced_epoch,
+                    pending_count: previous_pending_count.saturating_add(1),
+                    ..state
+                });
+                return Some(previous_pending_count != 0);
+            }
+            if state.instance_id == 0 && empty_slot.is_none() {
+                empty_slot = Some(slot);
+            }
+        }
+
+        let slot = empty_slot?;
+        slot.set(UnionComplexityThreadState {
+            instance_id,
+            produced_epoch,
+            pending_count: 1,
+        });
+        Some(false)
+    }
+
+    fn union_complexity_state(&self, instance_id: u32) -> UnionComplexityStateLookup {
+        let mut has_empty_slot = false;
+        for slot in &self.union_complexity {
+            let state = slot.get();
+            if state.instance_id == instance_id {
+                return UnionComplexityStateLookup::Found(state);
+            }
+            has_empty_slot |= state.instance_id == 0;
+        }
+        if has_empty_slot {
+            UnionComplexityStateLookup::Absent
+        } else {
+            UnionComplexityStateLookup::OverflowPossible
+        }
+    }
+
+    /// Change the pending-event count in an already assigned fixed slot,
+    /// returning its previous value while distinguishing a proven absence
+    /// from a possible overflow entry.
+    fn set_union_complexity_pending_count(
+        &self,
+        instance_id: u32,
+        pending_count: u32,
+    ) -> UnionComplexityPendingUpdate {
+        let mut has_empty_slot = false;
+        for slot in &self.union_complexity {
+            let mut state = slot.get();
+            if state.instance_id == instance_id {
+                let previous = state.pending_count;
+                state.pending_count = pending_count;
+                slot.set(state);
+                return UnionComplexityPendingUpdate::Updated(previous);
+            }
+            has_empty_slot |= state.instance_id == 0;
+        }
+        if has_empty_slot {
+            UnionComplexityPendingUpdate::Absent
+        } else {
+            UnionComplexityPendingUpdate::OverflowPossible
+        }
+    }
 }
 
 thread_local! {
     static TL_CACHE: TypeInternerCache = const { TypeInternerCache::new() };
 }
 
+/// Clear caches owned by the calling worker only.
+///
+/// Persistent Rayon workers can retain fixed union-complexity slots across
+/// compilation sessions. Those slots are instance-tagged and never reused for
+/// another universe; after all eight are occupied, a later signaled universe
+/// takes its interner-owned overflow path instead.
 pub(super) fn clear_thread_local_cache() {
     TL_CACHE.with(|cache| {
         for cell in &cache.lookup {
@@ -276,7 +392,28 @@ pub(super) fn clear_thread_local_cache() {
         for cell in &cache.string {
             cell.set(EMPTY_STRING_ENTRY);
         }
+        for cell in &cache.union_complexity {
+            cell.set(EMPTY_UNION_COMPLEXITY_STATE);
+        }
     });
+}
+
+#[inline]
+pub(super) fn mark_union_complexity(instance_id: u32, produced_epoch: u64) -> Option<bool> {
+    TL_CACHE.with(|cache| cache.mark_union_complexity(instance_id, produced_epoch))
+}
+
+#[inline]
+pub(super) fn union_complexity_state(instance_id: u32) -> UnionComplexityStateLookup {
+    TL_CACHE.with(|cache| cache.union_complexity_state(instance_id))
+}
+
+#[inline]
+pub(super) fn set_union_complexity_pending_count(
+    instance_id: u32,
+    pending_count: u32,
+) -> UnionComplexityPendingUpdate {
+    TL_CACHE.with(|cache| cache.set_union_complexity_pending_count(instance_id, pending_count))
 }
 
 #[inline(always)]

--- a/crates/tsz-solver/src/intern/core/interner/union_complexity.rs
+++ b/crates/tsz-solver/src/intern/core/interner/union_complexity.rs
@@ -1,0 +1,222 @@
+//! Worker-local exceptional signal for union-complexity bailouts (`TS2590`).
+
+use super::{TypeInterner, UnionComplexityThreadState, cache};
+use crate::caches::display_provenance::UnionComplexityCheckpoint;
+use dashmap::DashMap;
+use rustc_hash::FxBuildHasher;
+use std::sync::atomic::Ordering;
+
+impl TypeInterner {
+    /// Read and clear the current worker's "union too complex" signal.
+    #[inline]
+    pub fn take_union_too_complex(&self) -> bool {
+        if self
+            .union_complexity_pending_threads
+            .load(Ordering::Relaxed)
+            == 0
+        {
+            return false;
+        }
+        let Some(previous_pending_count) = self.replace_union_complexity_pending_count(0) else {
+            return false;
+        };
+        if previous_pending_count == 0 {
+            return false;
+        }
+        self.decrement_union_complexity_pending_threads();
+        true
+    }
+
+    /// Mark that a union construction was aborted due to complexity.
+    /// Called from `reduce_union_subtypes` when pairwise comparisons would exceed 1M.
+    #[inline]
+    pub(crate) fn set_union_too_complex(&self) {
+        let produced_epoch = self
+            .union_complexity_event_epoch
+            .fetch_add(1, Ordering::Relaxed)
+            .wrapping_add(1);
+        debug_assert_ne!(produced_epoch, 0, "union complexity epoch exhausted");
+
+        let was_pending = if let Some(previous) =
+            cache::mark_union_complexity(self.instance_id, produced_epoch)
+        {
+            previous
+        } else {
+            let thread_id = std::thread::current().id();
+            let overflow = self
+                .union_complexity_overflow_by_thread
+                .get_or_init(|| DashMap::with_hasher(FxBuildHasher));
+            let mut state = overflow
+                .entry(thread_id)
+                .or_insert(UnionComplexityThreadState {
+                    instance_id: self.instance_id,
+                    produced_epoch: 0,
+                    pending_count: 0,
+                });
+            let previous = state.pending_count != 0;
+            state.produced_epoch = produced_epoch;
+            state.pending_count = state.pending_count.saturating_add(1);
+            previous
+        };
+        if !was_pending {
+            self.union_complexity_pending_threads
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Peek at the union-too-complex signal without clearing it.
+    ///
+    /// The evaluator uses this to skip caching an evaluation that tripped the
+    /// `TS2590` limit.
+    #[inline]
+    pub fn is_union_too_complex(&self) -> bool {
+        if self
+            .union_complexity_pending_threads
+            .load(Ordering::Relaxed)
+            == 0
+        {
+            return false;
+        }
+        self.current_union_complexity_state().pending_count != 0
+    }
+
+    /// Snapshot the current worker's union-complexity event epoch and pending
+    /// state. Before this interner has produced any exceptional event, this is
+    /// one relaxed load and does not enter TLS or a concurrent map.
+    #[inline]
+    pub fn union_complexity_checkpoint(&self) -> UnionComplexityCheckpoint {
+        let produced_epoch = self.union_complexity_event_epoch.load(Ordering::Relaxed);
+        let pending_count = if produced_epoch != 0
+            && self
+                .union_complexity_pending_threads
+                .load(Ordering::Relaxed)
+                != 0
+        {
+            self.current_union_complexity_state().pending_count
+        } else {
+            0
+        };
+        UnionComplexityCheckpoint {
+            interner_instance_id: self.instance_id,
+            produced_epoch,
+            pending_count,
+        }
+    }
+
+    /// Return whether the current worker produced another complexity event
+    /// after `checkpoint`, including a second event while one was already
+    /// pending.
+    #[inline]
+    pub fn union_complexity_changed_since(&self, checkpoint: UnionComplexityCheckpoint) -> bool {
+        if checkpoint.interner_instance_id != self.instance_id {
+            return false;
+        }
+        if self.union_complexity_event_epoch.load(Ordering::Relaxed) == checkpoint.produced_epoch {
+            return false;
+        }
+        self.current_union_complexity_state().produced_epoch > checkpoint.produced_epoch
+    }
+
+    /// Consume a pending event only when this worker produced it after the
+    /// supplied checkpoint.
+    pub fn take_union_too_complex_since(&self, checkpoint: UnionComplexityCheckpoint) -> bool {
+        if checkpoint.interner_instance_id != self.instance_id
+            || !self.union_complexity_changed_since(checkpoint)
+        {
+            return false;
+        }
+        let state = self.current_union_complexity_state();
+        if state.pending_count <= checkpoint.pending_count {
+            return false;
+        }
+        let Some(previous_pending_count) =
+            self.replace_union_complexity_pending_count(checkpoint.pending_count)
+        else {
+            return false;
+        };
+        debug_assert_eq!(previous_pending_count, state.pending_count);
+        if checkpoint.pending_count == 0 {
+            self.decrement_union_complexity_pending_threads();
+        }
+        true
+    }
+
+    /// Discard events produced by the current worker after `checkpoint` while
+    /// restoring a signal that was already pending before the discarded work.
+    pub fn discard_union_too_complex_since(&self, checkpoint: UnionComplexityCheckpoint) {
+        if checkpoint.interner_instance_id != self.instance_id
+            || !self.union_complexity_changed_since(checkpoint)
+        {
+            return;
+        }
+        let Some(previous_pending_count) =
+            self.replace_union_complexity_pending_count(checkpoint.pending_count)
+        else {
+            return;
+        };
+        match (previous_pending_count != 0, checkpoint.pending_count != 0) {
+            (false, true) => {
+                self.union_complexity_pending_threads
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            (true, false) => self.decrement_union_complexity_pending_threads(),
+            _ => {}
+        }
+    }
+
+    fn decrement_union_complexity_pending_threads(&self) {
+        let previous = self
+            .union_complexity_pending_threads
+            .fetch_sub(1, Ordering::Relaxed);
+        debug_assert!(previous > 0, "union complexity pending count underflow");
+    }
+
+    /// Replace this worker's pending-event count without producing a new event.
+    /// A proven TLS absence returns `None` without consulting the overflow map.
+    fn replace_union_complexity_pending_count(&self, pending_count: u32) -> Option<u32> {
+        match cache::set_union_complexity_pending_count(self.instance_id, pending_count) {
+            cache::UnionComplexityPendingUpdate::Updated(previous) => Some(previous),
+            cache::UnionComplexityPendingUpdate::Absent => None,
+            cache::UnionComplexityPendingUpdate::OverflowPossible => {
+                let thread_id = std::thread::current().id();
+                let mut state = self
+                    .union_complexity_overflow_by_thread
+                    .get()?
+                    .get_mut(&thread_id)?;
+                let previous = state.pending_count;
+                state.pending_count = pending_count;
+                Some(previous)
+            }
+        }
+    }
+
+    /// Read only this worker's interner-scoped state. TLS owns the common
+    /// fixed-slot path; the concurrent map is reached only after this worker
+    /// has filled all of its bounded signal slots with other interner ids.
+    #[inline]
+    fn current_union_complexity_state(&self) -> UnionComplexityThreadState {
+        match cache::union_complexity_state(self.instance_id) {
+            cache::UnionComplexityStateLookup::Found(state) => return state,
+            cache::UnionComplexityStateLookup::Absent => {
+                return UnionComplexityThreadState {
+                    instance_id: self.instance_id,
+                    produced_epoch: 0,
+                    pending_count: 0,
+                };
+            }
+            cache::UnionComplexityStateLookup::OverflowPossible => {}
+        }
+        self.union_complexity_overflow_by_thread
+            .get()
+            .and_then(|overflow| {
+                overflow
+                    .get(&std::thread::current().id())
+                    .map(|state| *state)
+            })
+            .unwrap_or(UnionComplexityThreadState {
+                instance_id: self.instance_id,
+                produced_epoch: 0,
+                pending_count: 0,
+            })
+    }
+}

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -252,7 +252,7 @@ pub mod observability {
 pub mod construction {
     pub use crate::caches::db::{
         QueryDatabase, TypeBuiltinAccess, TypeDatabase, TypeRawIntersectionConstruction,
-        TypeSubstitutionConstruction,
+        TypeSubstitutionConstruction, UnionComplexityCheckpoint,
     };
     pub use crate::caches::query_cache::{QueryCache, RelationCacheProbe, SharedQueryCache};
     pub use crate::caches::query_cache_statistics::{QueryCacheStatistics, RelationCacheStats};

--- a/crates/tsz-solver/tests/concurrent_tests.rs
+++ b/crates/tsz-solver/tests/concurrent_tests.rs
@@ -8,8 +8,8 @@ use crate::{
     TypeInterner, TypeParamInfo, Visibility,
 };
 use rayon::prelude::*;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
 use tsz_common::interner::Atom;
 
 #[test]
@@ -451,5 +451,115 @@ fn test_concurrent_template_literal_creation() {
         assert_ne!(type_id, TypeId::ERROR);
         assert!(interner.lookup(type_id).is_some());
     }
+}
+
+#[test]
+fn union_complexity_signal_cannot_be_taken_by_another_worker() {
+    let interner = Arc::new(TypeInterner::new());
+    let observer_checkpoint = interner.union_complexity_checkpoint();
+    let producer_ready = Arc::new(Barrier::new(2));
+    let thief_checked = Arc::new(Barrier::new(2));
+
+    let producer = {
+        let interner = Arc::clone(&interner);
+        let producer_ready = Arc::clone(&producer_ready);
+        let thief_checked = Arc::clone(&thief_checked);
+        std::thread::spawn(move || {
+            let checkpoint = interner.union_complexity_checkpoint();
+            interner.set_union_too_complex();
+            producer_ready.wait();
+            thief_checked.wait();
+
+            assert!(interner.is_union_too_complex());
+            assert!(interner.take_union_too_complex_since(checkpoint));
+            assert!(!interner.is_union_too_complex());
+        })
+    };
+
+    producer_ready.wait();
+    assert!(
+        !interner.union_complexity_changed_since(observer_checkpoint),
+        "another worker's event must not taint this worker's cache snapshot"
+    );
+    assert!(!interner.is_union_too_complex());
+    assert!(!interner.take_union_too_complex());
+    thief_checked.wait();
+    producer.join().expect("producer worker should finish");
+}
+
+#[test]
+fn union_complexity_fixed_slots_overflow_without_losing_ownership() {
+    let interners: Vec<_> = (0..9).map(|_| TypeInterner::new()).collect();
+    for interner in &interners {
+        interner.set_union_too_complex();
+    }
+
+    for interner in &interners {
+        assert!(interner.is_union_too_complex());
+        assert!(interner.take_union_too_complex());
+        assert!(!interner.is_union_too_complex());
+    }
+}
+
+#[test]
+fn union_complexity_checkpoint_cannot_cross_interner_universes() {
+    let first = TypeInterner::new();
+    let second = TypeInterner::new();
+    let foreign_checkpoint = first.union_complexity_checkpoint();
+
+    second.set_union_too_complex();
+    assert!(!second.union_complexity_changed_since(foreign_checkpoint));
+    second.discard_union_too_complex_since(foreign_checkpoint);
+    assert!(
+        second.take_union_too_complex(),
+        "a foreign checkpoint must not consume this interner's signal"
+    );
+}
+
+#[test]
+fn union_complexity_checkpoints_preserve_prior_and_nested_ownership() {
+    let interner = TypeInterner::new();
+
+    let outer = interner.union_complexity_checkpoint();
+    interner.set_union_too_complex();
+    let nested = interner.union_complexity_checkpoint();
+    interner.set_union_too_complex();
+
+    assert!(interner.union_complexity_changed_since(outer));
+    assert!(interner.union_complexity_changed_since(nested));
+    assert!(interner.take_union_too_complex_since(nested));
+    assert!(
+        !interner.take_union_too_complex_since(nested),
+        "a checkpoint must attribute its newer events only once"
+    );
+    assert!(
+        interner.take_union_too_complex_since(outer),
+        "the nested owner must preserve the event pending for its outer owner"
+    );
+    assert!(!interner.is_union_too_complex());
+
+    interner.set_union_too_complex();
+    let pre_existing = interner.union_complexity_checkpoint();
+    interner.set_union_too_complex();
+    interner.discard_union_too_complex_since(pre_existing);
+    assert!(
+        interner.is_union_too_complex(),
+        "discard must preserve the event pending before its checkpoint"
+    );
+    assert!(interner.take_union_too_complex());
+
+    let clean = interner.union_complexity_checkpoint();
+    interner.set_union_too_complex();
+    interner.discard_union_too_complex_since(clean);
+    assert!(!interner.is_union_too_complex());
+    assert!(
+        interner.union_complexity_changed_since(clean),
+        "an encompassing cache snapshot remains tainted after discarded work"
+    );
+    let after_discard = interner.union_complexity_checkpoint();
+    assert!(
+        !interner.union_complexity_changed_since(after_discard),
+        "a fresh checkpoint after discard must start stable"
+    );
 }
 use crate::types::PropertyLookup;


### PR DESCRIPTION
Goal: hold

## Summary

Structural rule: when concurrent checker workers share one type universe, a union-complexity event belongs to the worker and request that produced it. TSZ now carries that rule through solver-owned worker-local signal state and opaque request checkpoints exposed at the query boundary.

- replace the universe-wide sticky flag with eight fixed TLS slots per worker plus an interner-owned overflow map
- preserve nested and pre-existing event ownership while allowing request-local take/discard operations
- make evaluation and instantiation cache stability compare event epochs, including a second event while one is already pending
- keep checker consumers on the solver-backed signal API

Owner layer: solver interner and cache-stability boundaries. Checker call sites only snapshot and consume opaque checkpoints.

Adjacent matrix: cross-worker theft, fixed-slot overflow across nine universes, foreign checkpoint rejection, nested ownership, discard with and without a prior event, second-event cache taint, and exact-rewrite no-event control.

Fallback and performance: the no-event path is one relaxed atomic load. Signaled workers scan eight fixed TLS slots; only workers that have filled all slots use the interner-owned hash map. The common path remains O(1), exceptional fixed-slot work is bounded O(8), and overflow residency ends with the interner.

## Verification

- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(/union_complexity/) | test(/second_union_event/)'` (7 passed)
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py`
- ready-review CI owns broad conformance, emit, fourslash, and unit suites

## Provenance

Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
