### PR TITLE
fix(checker): preserve selected lib alias identity

### DIFF
--- a/crates/tsz-checker/src/types/queries/lib_augmentations.rs
+++ b/crates/tsz-checker/src/types/queries/lib_augmentations.rs
@@ -193,14 +193,43 @@ impl<'a> CheckerState<'a> {
     ///      unconditionally clears type evaluation caches for the def,
     ///      which is wasted work on repeated lookups.
     pub(crate) fn register_finalized_lib_body(&mut self, name: &str, ty: TypeId) {
+        self.register_finalized_lib_body_for_def(name, ty, None);
+    }
+
+    /// Finalize against the exact lib definition selected while lowering.
+    /// Falling back to the name index preserves callers that do not carry a
+    /// symbol-owned `DefId` (notably post-resolution global augmentations).
+    pub(crate) fn register_finalized_lib_body_for_def(
+        &mut self,
+        name: &str,
+        ty: TypeId,
+        selected_def_id: Option<tsz_solver::DefId>,
+    ) {
+        // A selected per-arena definition is authoritative only for deciding
+        // whether lowering returned that definition's public `Lazy(DefId)`
+        // identity. Final structural bodies still publish through the stable
+        // canonical name entry: parallel source-file checkers can select
+        // equivalent lib declarations from different arenas, and letting that
+        // selection choose the finalized body makes cross-file consumers depend
+        // on worker completion order.
+        if selected_def_id.is_some_and(|def_id| {
+            crate::query_boundaries::lib_augmentations::is_lazy_def_identity(
+                self.ctx.types,
+                ty,
+                def_id,
+            )
+        }) {
+            return;
+        }
         let name_atom = self.ctx.types.intern_string(name);
-        let Some(defs) = self.ctx.definition_store.find_defs_by_name(name_atom) else {
+        let def_id = self
+            .ctx
+            .definition_store
+            .find_defs_by_name(name_atom)
+            .and_then(|defs| defs.first().copied());
+        let Some(def_id) = def_id else {
             return;
         };
-        let Some(&def_id) = defs.first() else {
-            return;
-        };
-        self.ctx.definition_store.register_type_to_def(ty, def_id);
         if crate::query_boundaries::lib_augmentations::is_lazy_def_identity(
             self.ctx.types,
             ty,
@@ -208,6 +237,7 @@ impl<'a> CheckerState<'a> {
         ) {
             return;
         }
+        self.ctx.definition_store.register_type_to_def(ty, def_id);
         let existing_body = self.ctx.definition_store.get_body(def_id);
         if existing_body == Some(ty) {
             return;
@@ -336,5 +366,121 @@ impl<'a> CheckerState<'a> {
             self.ctx.types,
             type_id,
         )
+    }
+}
+
+#[cfg(test)]
+mod finalized_lib_body_identity_tests {
+    use super::*;
+    use crate::context::CheckerOptions;
+    use tsz_binder::BinderState;
+    use tsz_solver::construction::TypeInterner;
+    use tsz_solver::def::DefinitionInfo;
+
+    #[test]
+    fn selected_same_name_lazy_identity_does_not_rewrite_or_bump_generation() {
+        let arena = NodeArena::default();
+        let binder = BinderState::new();
+        let types = TypeInterner::new();
+        let mut checker = CheckerState::new(
+            &arena,
+            &binder,
+            &types,
+            "identity.ts".to_string(),
+            CheckerOptions::default(),
+        );
+        let name = types.intern_string("AliasToken");
+        let canonical = checker
+            .ctx
+            .definition_store
+            .register(DefinitionInfo::type_alias(name, Vec::new(), TypeId::STRING));
+        let sibling = checker
+            .ctx
+            .definition_store
+            .register(DefinitionInfo::type_alias(name, Vec::new(), TypeId::NUMBER));
+
+        let sibling_ref = types.lazy(sibling);
+        let generation = checker.ctx.definition_store.generation();
+        checker.register_finalized_lib_body_for_def("AliasToken", sibling_ref, Some(sibling));
+
+        assert_eq!(checker.ctx.definition_store.generation(), generation);
+        assert_eq!(
+            checker.ctx.definition_store.get_body(canonical),
+            Some(TypeId::STRING),
+            "a same-name sibling wrapper is its own public identity, not a body for the first def",
+        );
+        assert_eq!(
+            checker.ctx.definition_store.get_body(sibling),
+            Some(TypeId::NUMBER),
+            "finalization must preserve the sibling's already-published structural body",
+        );
+    }
+
+    #[test]
+    fn selected_same_name_structural_body_still_finalizes_canonical_definition() {
+        let arena = NodeArena::default();
+        let binder = BinderState::new();
+        let types = TypeInterner::new();
+        let mut checker = CheckerState::new(
+            &arena,
+            &binder,
+            &types,
+            "structural.ts".to_string(),
+            CheckerOptions::default(),
+        );
+        let name = types.intern_string("AliasToken");
+        let canonical = checker
+            .ctx
+            .definition_store
+            .register(DefinitionInfo::type_alias(name, Vec::new(), TypeId::STRING));
+        let sibling = checker
+            .ctx
+            .definition_store
+            .register(DefinitionInfo::type_alias(name, Vec::new(), TypeId::NUMBER));
+
+        checker.register_finalized_lib_body_for_def("AliasToken", TypeId::BOOLEAN, Some(sibling));
+
+        assert_eq!(
+            checker.ctx.definition_store.get_body(canonical),
+            Some(TypeId::BOOLEAN),
+            "structural lib bodies must publish through the stable canonical name entry",
+        );
+        assert_eq!(
+            checker.ctx.definition_store.get_body(sibling),
+            Some(TypeId::NUMBER),
+            "a worker-local selected sibling must not become the structural finalization target",
+        );
+    }
+
+    #[test]
+    fn same_basename_distinct_lazy_target_remains_a_real_alias_chain() {
+        let arena = NodeArena::default();
+        let binder = BinderState::new();
+        let types = TypeInterner::new();
+        let mut checker = CheckerState::new(
+            &arena,
+            &binder,
+            &types,
+            "same-basename-chain.ts".to_string(),
+            CheckerOptions::default(),
+        );
+        let name = types.intern_string("AliasToken");
+        let source = checker
+            .ctx
+            .definition_store
+            .register(DefinitionInfo::type_alias(name, Vec::new(), TypeId::STRING));
+        let target = checker
+            .ctx
+            .definition_store
+            .register(DefinitionInfo::type_alias(name, Vec::new(), TypeId::NUMBER));
+        let target_ref = types.lazy(target);
+
+        checker.register_finalized_lib_body_for_def("AliasToken", target_ref, Some(source));
+
+        assert_eq!(
+            checker.ctx.definition_store.get_body(source),
+            Some(target_ref),
+            "a same-basename but distinct lazy target is a valid alias chain",
+        );
     }
 }

--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -843,6 +843,7 @@ impl<'a> CheckerState<'a> {
         let mut heritage_incomplete = false;
         let factory = self.ctx.types.factory();
         let mut symbol_has_interface = false;
+        let mut selected_lib_def_id = None;
 
         let lib_contexts = self.ctx.lib_contexts.clone();
         // Collect lowered types from the symbol's declarations.
@@ -1109,7 +1110,7 @@ impl<'a> CheckerState<'a> {
                             // If lowering succeeded (not ERROR), use the result
                             if ty != TypeId::ERROR {
                                 // Register DefId, type params, and body in one step.
-                                register_selected_lib_def_resolved(
+                                let def_id = register_selected_lib_def_resolved(
                                     &self.ctx,
                                     name,
                                     sym_id,
@@ -1117,6 +1118,7 @@ impl<'a> CheckerState<'a> {
                                     ty,
                                     params,
                                 );
+                                selected_lib_def_id.get_or_insert(def_id);
 
                                 lib_types.push(ty);
                             }
@@ -1144,6 +1146,7 @@ impl<'a> CheckerState<'a> {
                                         ty,
                                         params,
                                     );
+                                    selected_lib_def_id.get_or_insert(def_id);
 
                                     // CRITICAL: Return Lazy(DefId) instead of the structural body.
                                     // Application types only expand when the base is Lazy, not when
@@ -1252,9 +1255,26 @@ impl<'a> CheckerState<'a> {
             // display "Date" instead of expanding all members. The initial
             // registration uses the pre-merge TypeId which changes after heritage
             // merging and global augmentations add more members.
+            let selected_is_identity = selected_lib_def_id.is_some_and(|def_id| {
+                crate::query_boundaries::lib_augmentations::is_lazy_def_identity(
+                    self.ctx.types,
+                    ty,
+                    def_id,
+                )
+            });
             let name_atom = self.ctx.types.intern_string(name);
-            if let Some(defs) = self.ctx.definition_store.find_defs_by_name(name_atom)
-                && let Some(&def_id) = defs.first()
+            let canonical_def_id = self
+                .ctx
+                .definition_store
+                .find_defs_by_name(name_atom)
+                .and_then(|defs| defs.first().copied());
+            if let Some(def_id) = canonical_def_id
+                && !selected_is_identity
+                && !crate::query_boundaries::lib_augmentations::is_lazy_def_identity(
+                    self.ctx.types,
+                    ty,
+                    def_id,
+                )
             {
                 self.ctx.definition_store.register_type_to_def(ty, def_id);
             }
@@ -1371,7 +1391,7 @@ impl<'a> CheckerState<'a> {
         if let Some(ty) = lib_type_id
             && !heritage_incomplete
         {
-            self.register_finalized_lib_body(name, ty);
+            self.register_finalized_lib_body_for_def(name, ty, selected_lib_def_id);
             // Update the symbol_types cache for the INTERFACE type position.
             // compute_type_of_symbol may have cached a DIFFERENT TypeId
             // when has_local_interface_decl was a false positive (NodeIndex


### PR DESCRIPTION
Goal: green

## Summary
- carry the exact standard-library `DefId` selected during lowering far enough to recognize its public lazy identity
- keep finalized structural lib bodies on the stable canonical name entry so parallel file workers cannot choose the publication target by completion order
- preserve legitimate same-basename alias chains and the existing name-index fallback for callers without symbol-owned identity

## Structural rule
When standard-library lowering returns `Lazy(selected DefId)`, TSZ treats it as the selected definition identity and never publishes that wrapper as a body. When lowering returns a structural body, checker lib finalization publishes through the canonical same-name definition so equivalent per-arena selections cannot make cross-file results order-dependent.

## Adjacent matrix
- same-name sibling lazy identity: no body rewrite and no generation bump
- same-basename distinct lazy target: alias chain remains published
- selected same-name structural body: canonical definition is finalized and the worker-local sibling is unchanged
- primitive, generic, and interface lib aliases: both project root orders remain green
- parallel Zod IssueData cross-file spread: 60/60 repeated runs stay green after the merge-queue regression reproduced at 1/12 on the prior head
- exact Kysely `hasOwnProperty.call` witness: false TS2345 for `PropertyKey` is removed; unrelated missing Node `Buffer` globals remain

## Performance
The hot path carries one `Option<DefId>` and performs O(1) lazy-identity checks. Exact identity skips redundant reverse registration and shared resolver-generation invalidation; structural publication retains the prior canonical path. One warm exact-file comparison was 1.37s before and 1.43s after, within single-run noise.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py --size-only`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E test(finalized_lib_body_identity_tests)` (3 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test lib_primitive_alias_materialization_tests` (1 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-core --lib -E test(test_check_files_parallel_zod_issue_data_cross_file_spread)` (1 passed), followed by 60 direct exact repetitions (60 passed)
- exact Kysely `src/query-builder/no-result-error.ts` compile with ES2022 and DOM libs: baseline false TS2345 removed; only unrelated TS2552 Buffer diagnostics remain because Node globals are absent

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high