### PR TITLE
fix(checker): preserve materialized lib alias bodies

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping/body_publication.rs
+++ b/crates/tsz-checker/src/context/def_mapping/body_publication.rs
@@ -1,19 +1,80 @@
 use crate::context::CheckerContext;
 use tsz_solver::TypeId;
-use tsz_solver::def::DefId;
+use tsz_solver::def::{DefId, DefKind};
 
 impl CheckerContext<'_> {
+    /// Whether `body` is only a registration-window placeholder for a
+    /// non-program type alias, rather than progress beyond that alias's public
+    /// identity.
+    ///
+    /// Standard-library alias lowering returns `Lazy(DefId)` while publishing
+    /// the structural body as a side effect. A later cross-file lookup can
+    /// recover `UNKNOWN` or that self-lazy identity from its local symbol
+    /// state. Neither candidate may be mirrored back into the shared
+    /// `DefId -> body` slot: doing so makes publication non-monotone and turns
+    /// already-materialized utility aliases opaque again.
+    ///
+    /// The candidate, kind, and origin gates are O(1). Ordinary program aliases
+    /// (including program `.d.ts` inputs whose body genuinely is `unknown`) are
+    /// deliberately excluded, and no name lookup or cache is added.
+    pub(crate) fn is_non_progress_non_program_alias_body(
+        &self,
+        def_id: DefId,
+        body: TypeId,
+    ) -> bool {
+        if body != TypeId::UNKNOWN
+            && !crate::query_boundaries::definition_identity::is_lazy_def_identity(
+                self.types, body, def_id,
+            )
+        {
+            return false;
+        }
+        self.definition_store.get_kind(def_id) == Some(DefKind::TypeAlias)
+            && self.definition_store.def_is_non_program(def_id)
+    }
+
+    /// Select the body that a checker-owned environment bridge may register.
+    ///
+    /// A cross-file symbol lookup can still return a non-progress placeholder
+    /// after the canonical alias body was materialized. Keep the symbol result
+    /// intact, but make its `DefId` cache monotone by reusing the published body.
+    /// If materialization has not completed yet, defer the `DefId` write.
+    pub(crate) fn definition_body_for_env_registration(
+        &self,
+        def_id: DefId,
+        candidate: TypeId,
+    ) -> Option<TypeId> {
+        if !self.is_non_progress_non_program_alias_body(def_id, candidate) {
+            return Some(candidate);
+        }
+
+        self.definition_store.get_body(def_id).filter(|&body| {
+            body != TypeId::ERROR && !self.is_non_progress_non_program_alias_body(def_id, body)
+        })
+    }
+
+    /// Publish `body` and its dependency set when it is canonical progress.
+    /// Returns `false` when the candidate is a rejected registration-window
+    /// placeholder or the store does not retain that exact body.
     pub(crate) fn publish_definition_body(&self, def_id: DefId, body: TypeId) -> bool {
+        if self.is_non_progress_non_program_alias_body(def_id, body) {
+            return false;
+        }
         self.definition_store.set_body(def_id, body);
         self.record_definition_body_dependencies_if_published(def_id, body)
     }
 
+    /// Parameterized counterpart of [`Self::publish_definition_body`], with
+    /// the same exact-publication return contract.
     pub(crate) fn publish_definition_body_with_params(
         &self,
         def_id: DefId,
         body: TypeId,
         params: Vec<tsz_solver::TypeParamInfo>,
     ) -> bool {
+        if self.is_non_progress_non_program_alias_body(def_id, body) {
+            return false;
+        }
         self.definition_store
             .set_body_with_params(def_id, body, Some(params));
         self.record_definition_body_dependencies_if_published(def_id, body)

--- a/crates/tsz-checker/src/context/def_mapping/env_registration.rs
+++ b/crates/tsz-checker/src/context/def_mapping/env_registration.rs
@@ -16,6 +16,9 @@ impl CheckerContext<'_> {
     /// Register a non-generic definition body in **both** type environments.
     #[track_caller]
     pub fn register_def_in_envs(&self, def_id: DefId, body: TypeId) {
+        let Some(body) = self.definition_body_for_env_registration(def_id, body) else {
+            return;
+        };
         let prev_body = self.definition_store.get_body(def_id);
         let body_changed = prev_body != Some(body);
         self.publish_definition_body(def_id, body);
@@ -74,6 +77,9 @@ impl CheckerContext<'_> {
         body: TypeId,
         params: Vec<tsz_solver::TypeParamInfo>,
     ) {
+        let Some(body) = self.definition_body_for_env_registration(def_id, body) else {
+            return;
+        };
         let prev_body = self.definition_store.get_body(def_id);
         let body_changed = prev_body != Some(body);
         let params_changed = self

--- a/crates/tsz-checker/src/context/def_mapping_tests.rs
+++ b/crates/tsz-checker/src/context/def_mapping_tests.rs
@@ -968,6 +968,116 @@ fn augmented_def_registration_deferred_mirror_preserves_params() {
     );
 }
 
+/// Cross-file reads of a standard-library alias can temporarily recover the
+/// alias's public identity (`Lazy(def)`) or its pre-materialization placeholder
+/// (`UNKNOWN`). Once the structural body is published, neither result may
+/// rewrite the shared body or either evaluator environment. Program aliases
+/// remain outside this guard because `type Local = unknown` is meaningful.
+#[test]
+fn non_program_alias_placeholders_do_not_rewrite_materialized_bodies() {
+    use tsz_solver::TypeId;
+    use tsz_solver::def::{DefinitionInfo, DefinitionStore};
+
+    let (arena, binder, types) = minimal_checker_ctx();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    let type_param = tsz_solver::TypeParamInfo::simple(types.intern_string("Element"));
+    let type_params = vec![type_param];
+    let mut lib_alias = DefinitionInfo::type_alias(
+        types.intern_string("SelectKeys"),
+        type_params.clone(),
+        TypeId::STRING,
+    );
+    lib_alias.file_id = Some(DefinitionStore::NON_PROGRAM_FILE_SENTINEL);
+    let lib_def = ctx.definition_store.register(lib_alias);
+    ctx.register_def_with_params_in_envs(lib_def, TypeId::STRING, type_params.clone());
+
+    let store_generation = ctx.definition_store.generation();
+    let eval_generation = ctx.type_env.borrow().generation();
+    let flow_generation = ctx.type_environment.borrow().generation();
+    let self_identity = types.lazy(lib_def);
+
+    ctx.register_def_with_params_in_envs(lib_def, TypeId::UNKNOWN, type_params.clone());
+    ctx.register_def_with_params_in_envs(lib_def, self_identity, type_params.clone());
+    assert_eq!(
+        ctx.definition_body_for_env_registration(lib_def, TypeId::UNKNOWN),
+        Some(TypeId::STRING),
+    );
+    assert_eq!(
+        ctx.definition_body_for_env_registration(lib_def, self_identity),
+        Some(TypeId::STRING),
+    );
+    assert!(!ctx.publish_definition_body(lib_def, TypeId::UNKNOWN));
+    assert!(!ctx.publish_definition_body_with_params(lib_def, self_identity, type_params.clone(),));
+
+    assert_eq!(ctx.definition_store.get_body(lib_def), Some(TypeId::STRING));
+    assert_eq!(
+        ctx.definition_store.get_type_params(lib_def),
+        Some(type_params.clone()),
+    );
+    assert_eq!(ctx.type_env.borrow().get_def(lib_def), Some(TypeId::STRING));
+    assert_eq!(
+        ctx.type_environment.borrow().get_def(lib_def),
+        Some(TypeId::STRING),
+    );
+    assert_eq!(
+        ctx.definition_store.generation(),
+        store_generation,
+        "rejected placeholders must not invalidate shared definition readers",
+    );
+    assert_eq!(
+        ctx.type_env.borrow().generation(),
+        eval_generation,
+        "rejected placeholders must not invalidate evaluator caches",
+    );
+    assert_eq!(
+        ctx.type_environment.borrow().generation(),
+        flow_generation,
+        "rejected placeholders must not invalidate flow caches",
+    );
+
+    // A different file checker can share the canonical store while starting
+    // with empty local evaluator environments. Replaying its placeholder must
+    // seed those environments with the structural body, not merely avoid the
+    // shared-store rewrite.
+    *ctx.type_env.borrow_mut() = TypeEnvironment::new();
+    *ctx.type_environment.borrow_mut() = TypeEnvironment::new();
+    ctx.register_def_with_params_in_envs(lib_def, TypeId::UNKNOWN, type_params.clone());
+    assert_eq!(ctx.type_env.borrow().get_def(lib_def), Some(TypeId::STRING));
+    assert_eq!(
+        ctx.type_env.borrow().get_def_params(lib_def),
+        Some(type_params.as_slice()),
+    );
+    assert_eq!(
+        ctx.type_environment.borrow().get_def(lib_def),
+        Some(TypeId::STRING),
+    );
+    assert_eq!(
+        ctx.type_environment.borrow().get_def_params(lib_def),
+        Some(type_params.as_slice()),
+    );
+
+    let mut local_alias = DefinitionInfo::type_alias(
+        types.intern_string("LocalUnknown"),
+        Vec::new(),
+        TypeId::STRING,
+    );
+    local_alias.file_id = Some(0);
+    let local_def = ctx.definition_store.register(local_alias);
+    ctx.register_def_in_envs(local_def, TypeId::UNKNOWN);
+    assert_eq!(
+        ctx.definition_store.get_body(local_def),
+        Some(TypeId::UNKNOWN),
+        "program aliases must retain genuine `unknown` bodies",
+    );
+}
+
 /// Companion for the shared-store path: a cross-file checker can observe a
 /// generic def whose params live only in `DefinitionStore`, not in its local
 /// `TypeEnvironment`. Replaying an augmentation merge must still re-insert the

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1697,7 +1697,8 @@ impl CheckerState<'_> {
             // resolution even after the real instance type is finished.
             && !class_instance_resolution_in_flight
         {
-            self.publish_symbol_result_to_type_envs(sym_id, result, &type_params);
+            let definition_body_is_progress =
+                self.publish_symbol_result_to_type_envs(sym_id, result, &type_params);
 
             // Register TypeId -> DefId reverse mapping for TYPE ALIASES only.
             // This enables diagnostics to display type alias names (e.g., "ExoticAnimal")
@@ -1717,7 +1718,7 @@ impl CheckerState<'_> {
                 .get(&sym_id)
                 .copied()
                 .filter(|_| self.symbol_is_type_alias(sym_id));
-            if let Some(def_id) = alias_def_id {
+            if definition_body_is_progress && let Some(def_id) = alias_def_id {
                 self.ctx
                     .definition_store
                     .register_type_to_def(result, def_id);

--- a/crates/tsz-checker/src/state/type_analysis/symbol_env_registration.rs
+++ b/crates/tsz-checker/src/state/type_analysis/symbol_env_registration.rs
@@ -11,7 +11,7 @@ impl CheckerState<'_> {
         sym_id: SymbolId,
         result: TypeId,
         type_params: &[TypeParamInfo],
-    ) {
+    ) -> bool {
         // For class symbols, cache BOTH the constructor type (for value position)
         // and the instance type (for type position with typeof/TypeQuery resolution).
         let class_env_entry = self.ctx.binder.get_symbol(sym_id).and_then(|symbol| {
@@ -40,14 +40,23 @@ impl CheckerState<'_> {
         self.ctx
             .register_symbol_type_in_envs(symbol_ref, result, env_params.clone());
 
-        if let Some(def_id) = def_id {
+        let definition_body_is_progress = def_id.is_none_or(|def_id| {
+            !self
+                .ctx
+                .is_non_progress_non_program_alias_body(def_id, result)
+        });
+        let definition_body = def_id.and_then(|def_id| {
+            self.ctx
+                .definition_body_for_env_registration(def_id, result)
+        });
+        if let (Some(def_id), Some(definition_body)) = (def_id, definition_body) {
             let def_params = if class_env_entry.is_some() {
                 type_params.to_vec()
             } else {
                 env_params
             };
             self.ctx
-                .register_def_auto_params_in_envs(def_id, result, def_params);
+                .register_def_auto_params_in_envs(def_id, definition_body, def_params);
 
             if let Some((instance_type, _instance_params)) = &class_env_entry {
                 self.ctx
@@ -82,5 +91,6 @@ impl CheckerState<'_> {
         {
             self.ctx.register_def_symbol_mapping_in_envs(def_id, sym_id);
         }
+        definition_body_is_progress
     }
 }

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -1443,6 +1443,17 @@ impl CheckerState<'_> {
 
         let symbol_ref = SymbolRef(sym_id.0);
         let def_id = current_def_id;
+        // A symbol lookup for a materialized standard-library alias can still
+        // observe its registration-window `UNKNOWN` result. The symbol cache
+        // may retain that result, but the `DefId` cache must keep the structural
+        // body already published by alias lowering. Otherwise this direct env
+        // bridge makes definition publication non-monotone and `keyof` sees an
+        // opaque alias again.
+        let definition_body = def_id.and_then(|def_id| {
+            self.ctx
+                .definition_body_for_env_registration(def_id, resolved)
+        });
+        let definition_registration = def_id.zip(definition_body);
 
         // Reuse cached params already in the environment when available.
         let mut cached_env_params: Option<Vec<tsz_solver::TypeParamInfo>> = None;
@@ -1451,8 +1462,8 @@ impl CheckerState<'_> {
         if let Ok(env) = self.ctx.type_env.try_borrow() {
             symbol_already_registered = env.contains(symbol_ref);
             cached_env_params = env.get_params(symbol_ref).map(|s| s.to_vec());
-            if let Some(def_id) = def_id {
-                def_already_registered = env.contains_def(def_id);
+            if let Some((def_id, body)) = definition_registration {
+                def_already_registered = env.get_def(def_id) == Some(body);
             }
         }
         let had_env_params = cached_env_params.is_some();
@@ -1498,8 +1509,8 @@ impl CheckerState<'_> {
             if type_params.is_empty() {
                 self.ctx
                     .insert_symbol_type_and_mirror(&mut env, symbol_ref, resolved, Vec::new());
-                if let Some(def_id) = def_id {
-                    env.insert_def(def_id, resolved);
+                if let Some((def_id, body)) = definition_registration {
+                    env.insert_def(def_id, body);
                 }
             } else {
                 self.ctx.insert_symbol_type_and_mirror(
@@ -1508,19 +1519,21 @@ impl CheckerState<'_> {
                     resolved,
                     type_params.clone(),
                 );
-                if let Some(def_id) = def_id {
-                    env.insert_def_with_params(def_id, resolved, type_params.clone());
+                if let Some((def_id, body)) = definition_registration {
+                    env.insert_def_with_params(def_id, body, type_params.clone());
                 }
             }
             drop(env);
-            self.mirror_application_def_resolution(def_id, resolved, &type_params);
-            true
+            if let Some((def_id, body)) = definition_registration {
+                self.mirror_application_def_resolution(Some(def_id), body, &type_params);
+            }
+            def_id.is_none() || definition_registration.is_some()
         } else {
             self.ctx
                 .register_symbol_type_in_envs(symbol_ref, resolved, type_params.clone());
-            if let Some(def_id) = def_id {
+            if let Some((def_id, body)) = definition_registration {
                 self.ctx
-                    .register_def_auto_params_in_envs(def_id, resolved, type_params);
+                    .register_def_auto_params_in_envs(def_id, body, type_params);
             }
             false
         }

--- a/crates/tsz-cli/src/driver/cross_file_keyof_utility_alias_tests.rs
+++ b/crates/tsz-cli/src/driver/cross_file_keyof_utility_alias_tests.rs
@@ -8,14 +8,11 @@
 //! resolution — the in-crate single-context checker harness conflates per-file
 //! `SymbolId`/`DefId` namespaces and cannot host them.
 //!
-//! Scope: this guard pins the cross-file `keyof`/utility-alias behavior tsz
-//! already gets right (value-position `keyof Omit<…>`, bare `keyof I`, identity
-//! and `keyof` aliases) so future cross-arena identity work (#14344) cannot
-//! silently regress them. The one shape that does NOT yet match `tsc` — a
-//! generic-call constraint `T extends keyof Omit<ImportedIface, K>`, where the
-//! consumer never names the utility alias so its structural body is never
-//! lowered locally and collapses to `never` — is captured as an `#[ignore]`d
-//! witness (kysely `AlterColumnNode.create`, #10663) pending that work.
+//! Scope: this guard pins value-position aliases, generic-call constraints,
+//! private/exported aliases, nested utility wrappers, and both project file
+//! orders. In particular, a consumer that never names `Omit` must not replace
+//! its already-materialized standard-library body with a registration-window
+//! `unknown`/self-lazy placeholder (kysely `AlterColumnNode.create`, #10663).
 //!
 //! Binder names vary across cases so the guard follows the structural shape
 //! rather than any identifier (anti-hardcoding).
@@ -76,6 +73,10 @@ fn constraint_errors(diags: &[Diagnostic]) -> Vec<(u32, String)> {
         .filter(|d| d.code == 2322 || d.code == 2345 || d.code == 2344)
         .map(|d| (d.code, d.message_text.clone()))
         .collect()
+}
+
+fn diagnostic_codes(diags: &[Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|diag| diag.code).collect()
 }
 
 // ---- Cases tsz already matches `tsc` on (parity floor) ----
@@ -501,21 +502,16 @@ export function run() { make('extra'); }
     );
 }
 
-// ---- Known gap: cross-arena utility-alias identity (#10663 / #14344) ----
+// ---- Cross-file utility-alias publication regression (#10663) ----
 
-// kysely `AlterColumnNode.create` witness: the utility alias and the generic
-// method live in the SAME module, the interface backs the alias, and the call
-// is in a DIFFERENT module that never names the alias. The consumer resolves
-// the lib `Omit` def through the shared store's `unknown` placeholder (the
-// structural body is keyed to the declaring arena, #14344), so `keyof Omit<…>`
-// collapses to `never` and a valid key is rejected. tsc is clean.
+// Kysely `AlterColumnNode.create` witness: the utility alias and generic method
+// live in the same module, while the caller never names the alias. Both root
+// orders must retain the structural `Omit` body and accept the surviving key.
 #[test]
-#[ignore = "cross-arena utility-alias identity (#10663/#14344): consumer resolves the lib Omit def to the unknown placeholder, collapsing keyof Omit<…> to never"]
 fn constraint_keyof_omit_imported_alias_inferred_arg() {
-    let diags = compile_project(&[
-        (
-            "node.ts",
-            r#"
+    let provider = (
+        "node.ts",
+        r#"
 export interface AlterColumnNode {
     readonly kind: 'AlterColumnNode'
     readonly column: string
@@ -526,18 +522,163 @@ export declare const AlterColumnNode: {
     create<T extends keyof AlterColumnNodeProps>(prop: T): void
 }
 "#,
-        ),
-        (
-            "builder.ts",
-            r#"
+    );
+    let consumer = (
+        "builder.ts",
+        r#"
 import { AlterColumnNode } from "./node";
 export function f() { AlterColumnNode.create('dropDefault'); }
+"#,
+    );
+
+    for roots in [[provider, consumer], [consumer, provider]] {
+        let diags = compile_project(&roots);
+        assert_eq!(
+            diagnostic_codes(&diags),
+            Vec::<u32>::new(),
+            "keyof Omit<AlterColumnNode, …> must include 'dropDefault' when {} is the first project root",
+            roots[0].0,
+        );
+    }
+}
+
+// Negative companion for the exact exported-alias architecture: publication
+// must preserve the reduced key set, not merely widen it enough for survivors.
+#[test]
+fn constraint_keyof_omit_imported_alias_rejects_omitted_key() {
+    let diags = compile_project(&[
+        (
+            "change.ts",
+            r#"
+export interface ChangeNode {
+    readonly kind: 'ChangeNode'
+    readonly column: string
+    readonly clearValue?: true
+}
+export type ChangeProps = Omit<ChangeNode, 'kind' | 'column'>
+export declare const Changes: {
+    create<Name extends keyof ChangeProps>(name: Name): void
+}
+"#,
+        ),
+        (
+            "consumer.ts",
+            r#"
+import { Changes } from "./change";
+Changes.create('column');
 "#,
         ),
     ]);
     assert_eq!(
-        constraint_errors(&diags),
-        Vec::<(u32, String)>::new(),
-        "keyof Omit<AlterColumnNode, …> over a cross-module alias must include 'dropDefault'"
+        diagnostic_codes(&diags),
+        vec![2345],
+        "the key removed by the imported Omit alias must still be rejected",
+    );
+}
+
+// The alias need not be exported itself. A callable's public type can be the
+// only path that carries `keyof` of the private mapped alias to the consumer.
+#[test]
+fn constraint_keyof_private_omit_alias_in_exported_callable_is_precise() {
+    let diags = compile_project(&[
+        (
+            "mutations.ts",
+            r#"
+export interface MutationShape {
+    readonly tag: 'MutationShape'
+    readonly value: string
+    readonly reset?: true
+}
+type MutableNames = Omit<MutationShape, 'tag'>
+export declare const Mutations: {
+    apply<Slot extends keyof MutableNames>(slot: Slot): void
+}
+"#,
+        ),
+        (
+            "run.ts",
+            r#"
+import { Mutations } from "./mutations";
+Mutations.apply('reset');
+Mutations.apply('tag');
+"#,
+        ),
+    ]);
+    assert_eq!(
+        diagnostic_codes(&diags),
+        vec![2345],
+        "the private alias must accept its survivor and reject its removed key",
+    );
+}
+
+// Nested standard-library aliases exercise the same publication invariant for
+// more than a direct `keyof Omit<…>` body.
+#[test]
+fn constraint_keyof_nested_utility_aliases_is_precise() {
+    let diags = compile_project(&[
+        (
+            "preferences.ts",
+            r#"
+export interface Preferences {
+    readonly discriminator: 'Preferences'
+    readonly theme: string
+    readonly retries?: number
+}
+type EditablePreferences = Required<Readonly<Omit<Preferences, 'discriminator'>>>
+export declare function edit<Field extends keyof EditablePreferences>(field: Field): void
+"#,
+        ),
+        (
+            "screen.ts",
+            r#"
+import { edit } from "./preferences";
+edit('theme');
+edit('retries');
+edit('discriminator');
+"#,
+        ),
+    ]);
+    assert_eq!(
+        diagnostic_codes(&diags),
+        vec![2345],
+        "nested aliases must accept surviving keys and reject the removed key",
+    );
+}
+
+// A renamed generic wrapper and its concrete alias must both evaluate through
+// the canonical utility body; neither may depend on binder spelling.
+#[test]
+fn constraint_keyof_generic_and_concrete_omit_wrappers_are_precise() {
+    let diags = compile_project(&[
+        (
+            "envelope.ts",
+            r#"
+interface Envelope {
+    readonly kind: 'Envelope'
+    readonly secret: string
+    readonly payload: Uint8Array
+}
+type Without<Model, Hidden extends keyof Model> = Omit<Model, Hidden>
+type EnvelopeFields = Without<Envelope, 'kind' | 'secret'>
+export declare const Lens: {
+    generic<Name extends keyof Without<Envelope, 'kind' | 'secret'>>(name: Name): void
+    concrete<Name extends keyof EnvelopeFields>(name: Name): void
+}
+"#,
+        ),
+        (
+            "reader.ts",
+            r#"
+import { Lens } from "./envelope";
+Lens.generic('payload');
+Lens.concrete('payload');
+Lens.generic('secret');
+"#,
+        ),
+    ]);
+    assert_eq!(
+        diagnostic_codes(&diags),
+        vec![2345],
+        "generic and concrete wrappers must retain the same precise key set",
     );
 }


### PR DESCRIPTION
Goal: green

## Summary
- Preserve a materialized standard-library alias body when a later cross-file symbol lookup yields its registration-window `unknown` or exact self-`Lazy(DefId)` placeholder.
- Seed fresh per-file evaluator environments from the canonical published body and parameters without attaching reverse provenance to the stale symbol result.
- Turn the Kysely `keyof Omit<…>` witness into a passing two-root-order guard and add precise private/exported, nested, generic/concrete, survivor, and removed-key companions.

## Structural Rule
When a non-program type alias already has a structural body and a later cross-file lookup produces only `unknown` or that alias's exact self-lazy identity, `tsc` retains the structural alias semantics. TSZ now enforces that through the checker-owned definition-publication/environment bridge: the stale candidate cannot replace the shared body, local environments reuse the canonical body and params, and reverse display provenance is recorded only for real progress.

Owner layer: checker definition publication and solver-backed type-environment registration.

Adjacent matrix: both project root orders; exported and private aliases; direct and nested utility aliases; generic and concrete wrappers; accepted surviving keys; rejected omitted keys; real program `type X = unknown`; fresh local environments; body/parameter and cache-generation stability.

Fallback: before canonical materialization, placeholder publication is deferred and the application remains opaque for later resolution.

Performance: O(1) DefId kind/origin/body lookups per publication bridge; no name checks, type walks, new caches, or cache-residency growth.

## Verification
- `cargo nextest run -p tsz-checker --lib non_program_alias_placeholders_do_not_rewrite_materialized_bodies --no-capture` (1 passed)
- `cargo nextest run -p tsz-cli --lib cross_file_keyof_utility_alias_tests --no-capture` (14 passed)
- `cargo nextest run -p tsz-checker --lib test_lazy_type_env_symbol_publication_uses_context_authority_on_contention --no-capture` (1 passed)
- `cargo fmt --all -- --check`
- `python3 scripts/arch/arch_guard.py --size-only`
- `git diff --check`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
