### PR TITLE
fix(config): classify enum option values in TS5024

### DIFF
--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -471,7 +471,7 @@ fn option_is_effectively_enabled(
     invalidated_options: &[String],
     key: &str,
 ) -> bool {
-    if compiler_option_expected_type(key) == "boolean"
+    if compiler_option_expected_type(key) == Some(CompilerOptionValueType::Boolean)
         && invalidated_options.iter().any(|k| k == key)
     {
         return false;
@@ -786,9 +786,41 @@ const fn is_rooted_path_mapping_substitution(specifier: &str) -> bool {
     }
 }
 
-/// Return the expected JSON value type for a compiler option.
-/// Returns "" for unknown/unvalidated options.
-fn compiler_option_expected_type(key: &str) -> &'static str {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CompilerOptionValueType {
+    Boolean,
+    String,
+    Enum,
+    Number,
+    Array,
+    Object,
+}
+
+impl CompilerOptionValueType {
+    const fn diagnostic_name(self) -> &'static str {
+        match self {
+            Self::Boolean => "boolean",
+            Self::String => "string",
+            Self::Enum => "enum",
+            Self::Number => "number",
+            Self::Array => "Array",
+            Self::Object => "object",
+        }
+    }
+
+    fn accepts(self, value: &serde_json::Value) -> bool {
+        match self {
+            Self::Boolean => value.is_boolean(),
+            Self::String | Self::Enum => value.is_string(),
+            Self::Number => value.is_number(),
+            Self::Array => value.is_array(),
+            Self::Object => value.is_object(),
+        }
+    }
+}
+
+/// Return the expected JSON value type for a recognized compiler option.
+fn compiler_option_expected_type(key: &str) -> Option<CompilerOptionValueType> {
     match key {
         // Boolean options
         "allowArbitraryExtensions"
@@ -863,36 +895,35 @@ fn compiler_option_expected_type(key: &str) -> &'static str {
         | "traceResolution"
         | "useDefineForClassFields"
         | "useUnknownInCatchVariables"
-        | "verbatimModuleSyntax" => "boolean",
+        | "verbatimModuleSyntax" => Some(CompilerOptionValueType::Boolean),
+        // Enum options are encoded as strings in JSON, but tsc identifies
+        // their map-backed value domain as `enum` in TS5024.
+        "jsx" | "module" | "moduleDetection" | "moduleResolution" | "newLine" | "target" => {
+            Some(CompilerOptionValueType::Enum)
+        }
         // String options
         "baseUrl"
         | "declarationDir"
-        | "jsx"
         | "jsxFactory"
         | "jsxFragmentFactory"
         | "jsxImportSource"
         | "mapRoot"
-        | "module"
-        | "moduleDetection"
-        | "moduleResolution"
-        | "newLine"
         | "outDir"
         | "outFile"
         | "reactNamespace"
         | "rootDir"
         | "sourceRoot"
-        | "target"
         | "tsBuildInfoFile"
         | "ignoreDeprecations"
-        | "typesVersionsCompilerVersion" => "string",
+        | "typesVersionsCompilerVersion" => Some(CompilerOptionValueType::String),
         // Number options
-        "maxNodeModuleJsDepth" => "number",
+        "maxNodeModuleJsDepth" => Some(CompilerOptionValueType::Number),
         // List options (arrays)
         "lib" | "types" | "typeRoots" | "rootDirs" | "moduleSuffixes" | "customConditions"
-        | "plugins" => "Array",
+        | "plugins" => Some(CompilerOptionValueType::Array),
         // Object options
-        "paths" => "object",
-        _ => "",
+        "paths" => Some(CompilerOptionValueType::Object),
+        _ => None,
     }
 }
 

--- a/crates/tsz-core/src/config/parse.rs
+++ b/crates/tsz-core/src/config/parse.rs
@@ -250,29 +250,19 @@ pub fn parse_tsconfig_with_diagnostics_deferred(
         let mut bad_keys: Vec<String> = Vec::new();
         let mut ts5024_keys: Vec<String> = Vec::new();
         for key in &keys_after_rename {
-            let expected_type = compiler_option_expected_type(key);
-            if expected_type.is_empty() {
+            let Some(expected_type) = compiler_option_expected_type(key) else {
                 continue; // Unknown option or no type constraint
-            }
+            };
             let Some(value) = compiler_opts.get(key) else {
                 continue;
             };
-            let type_ok = value.is_null()
-                || match expected_type {
-                    "boolean" => value.is_boolean(),
-                    "string" => value.is_string(),
-                    "number" => value.is_number(),
-                    "Array" => value.is_array(),
-                    "string or Array" => value.is_string() || value.is_array(),
-                    "object" => value.is_object(),
-                    _ => true,
-                };
+            let type_ok = value.is_null() || expected_type.accepts(value);
             if !type_ok {
                 let start = find_value_offset_in_source(&stripped, key);
                 let value_len = estimate_json_value_len(value);
                 let msg = format_message(
                     diagnostic_messages::COMPILER_OPTION_REQUIRES_A_VALUE_OF_TYPE,
-                    &[key, expected_type],
+                    &[key, expected_type.diagnostic_name()],
                 );
                 diagnostics.push(Diagnostic::error(
                     file_path,

--- a/crates/tsz-core/src/config/tests/options_parsing.rs
+++ b/crates/tsz-core/src/config/tests/options_parsing.rs
@@ -307,6 +307,12 @@ fn test_ts5024_emitted_for_recognized_options_with_invalid_value_types() {
         ("plugins", r#""not-an-array""#, "Array"),
         ("maxNodeModuleJsDepth", r#""not-a-number""#, "number"),
         ("traceResolution", r#""yes""#, "boolean"),
+        ("jsx", "42", "enum"),
+        ("module", "42", "enum"),
+        ("moduleDetection", "42", "enum"),
+        ("moduleResolution", "42", "enum"),
+        ("newLine", "42", "enum"),
+        ("target", "42", "enum"),
     ] {
         let source = format!(
             r#"{{
@@ -334,6 +340,28 @@ fn test_ts5024_emitted_for_recognized_options_with_invalid_value_types() {
             "Expected {option} TS5024 to mention {expected_type}, got: {diagnostic:?}"
         );
     }
+}
+
+#[test]
+fn test_enum_compiler_options_accept_string_values() {
+    let source = r#"{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "module": "esnext",
+    "moduleDetection": "auto",
+    "moduleResolution": "bundler",
+    "newLine": "lf",
+    "target": "esnext"
+  }
+}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    assert!(
+        !parsed.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == diagnostic_codes::COMPILER_OPTION_REQUIRES_A_VALUE_OF_TYPE
+        }),
+        "valid enum strings must not emit TS5024: {:?}",
+        parsed.diagnostics
+    );
 }
 
 #[test]

--- a/crates/tsz-core/src/config/tests/strict_lib_extends.rs
+++ b/crates/tsz-core/src/config/tests/strict_lib_extends.rs
@@ -1182,6 +1182,61 @@ fn test_extends_base_invalid_allowjs_string_emits_ts5024_anchored_at_base() {
     );
 }
 
+#[test]
+fn test_extends_child_invalid_enum_option_reports_enum_and_keeps_base_value() {
+    let temp = tempdir().expect("create temp dir");
+    let base_path = temp.path().join("base.json");
+    std::fs::write(
+        &base_path,
+        r#"{"compilerOptions":{"module":"esnext","moduleResolution":"bundler"}}"#,
+    )
+    .expect("write base");
+
+    let child_source =
+        r#"{"extends":"./base.json","files":["a.ts"],"compilerOptions":{"moduleResolution":42}}"#;
+    let child_path = temp.path().join("tsconfig.json");
+    std::fs::write(&child_path, child_source).expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load child");
+    let diagnostic = parsed
+        .diagnostics
+        .iter()
+        .find(|diagnostic| {
+            diagnostic.code == diagnostic_codes::COMPILER_OPTION_REQUIRES_A_VALUE_OF_TYPE
+                && diagnostic.message_text.contains("moduleResolution")
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected TS5024 for child moduleResolution, got: {:?}",
+                parsed.diagnostics
+            )
+        });
+    assert_eq!(
+        diagnostic.message_text,
+        "Compiler option 'moduleResolution' requires a value of type enum."
+    );
+    assert_eq!(
+        std::path::Path::new(&diagnostic.file)
+            .file_name()
+            .and_then(|name| name.to_str()),
+        Some("tsconfig.json"),
+        "the invalid child value must own the diagnostic"
+    );
+    assert_eq!(
+        diagnostic.start,
+        child_source.find("42").expect("invalid child value") as u32
+    );
+    assert_eq!(
+        parsed
+            .config
+            .compiler_options
+            .as_ref()
+            .and_then(|options| options.module_resolution.as_deref()),
+        Some("bundler"),
+        "the invalid child value must not erase the valid inherited option"
+    );
+}
+
 /// A valid base config must not produce spurious TS5024 just because the
 /// child loader now recurses through the diagnostic path. Regression guard
 /// for the happy path of #3589's fix.


### PR DESCRIPTION
Goal: green

Fixes #15824.

## Structural rule

When a recognized compiler option has a map-backed enum value domain, an invalid JSON value type produces TS5024 with expected type `enum`; the config layer still accepts JSON strings for both enum and free-form string options. `tsz-core::config` owns the value-domain descriptor, validation, and diagnostic label.

The six current TypeScript 7 enum options are covered as a structural matrix: `jsx`, `module`, `moduleDetection`, `moduleResolution`, `newLine`, and `target`. A free-form `baseUrl` oracle control remains `string`; valid enum strings remain accepted; an invalid child override preserves the valid inherited base value and anchors TS5024 in the child config.

Validation remains one O(1) descriptor lookup and JSON-kind check per config key, with no new allocation, scan, cache, or residency change.

## Verification

- `scripts/safe-run.sh --limit 50% -- cargo nextest run -p tsz-core --lib -E 'test(config::tests::options_parsing) | test(config::tests::strict_lib_extends::test_extends)'` (39/39 passed)
- `scripts/safe-run.sh --limit 50% -- cargo clippy -p tsz-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/architecture-check.sh --quick` (0 LOC violations, 0 cross-layer imports; inherited baseline: 557 direct solver imports and 1 diagnostic leak)
- Pinned `scripts/node_modules/.bin/tsc` 7.0.2 oracle via `/dev/stdin` for all six enum options plus `baseUrl` string control

## Provenance

Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
