### PR TITLE
fix(solver): make method variance target-driven

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -333,6 +333,9 @@ path = "tests/block_body_callback_literal_widening_tests.rs"
 name = "return_literal_union_widening_tests"
 path = "tests/return_literal_union_widening_tests.rs"
 [[test]]
+name = "method_inference_bivariance_tests"
+path = "tests/method_inference_bivariance_tests.rs"
+[[test]]
 name = "conditional_branch_array_literal_widening_tests"
 path = "tests/conditional_branch_array_literal_widening_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/signature_builder.rs
+++ b/crates/tsz-checker/src/checkers/signature_builder.rs
@@ -410,7 +410,7 @@ impl<'a> CheckerState<'a> {
             this_type,
             instance_type,
             None,
-            false,
+            true,
         )
     }
 

--- a/crates/tsz-checker/src/types/class_type/constructor_parts/rough_partial.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor_parts/rough_partial.rs
@@ -153,7 +153,7 @@ impl<'a> CheckerState<'a> {
                                     sig.this_type,
                                     rough_sig_return_type,
                                     sig.type_predicate,
-                                    false,
+                                    sig.is_method,
                                 )
                             })
                             .collect(),

--- a/crates/tsz-checker/tests/construct_signature_param_variance_tests.rs
+++ b/crates/tsz-checker/tests/construct_signature_param_variance_tests.rs
@@ -142,6 +142,57 @@ fn class_constructor_params_stay_bivariant_both_directions() {
     );
 }
 
+#[test]
+fn class_source_does_not_loosen_strict_construct_target() {
+    let source = "
+        class Animal { animal = true; }
+        class Dog extends Animal { dog = true; }
+        class DogCtor { constructor(value: Dog) {} }
+        class AnimalCtor { constructor(value: Animal) {} }
+        const strictTarget: new (value: Animal) => DogCtor = DogCtor;
+        const classTarget: typeof AnimalCtor = DogCtor;
+    ";
+    assert_eq!(
+        count(source, TS2322),
+        1,
+        "variance is selected from the target declaration kind",
+    );
+}
+
+#[test]
+fn class_extending_construct_typed_value_preserves_strict_provenance() {
+    let source = "
+        declare const Base: new (value: 1) => object;
+        class Derived extends Base {}
+        const strictTarget: new (value: number) => object = Derived;
+    ";
+    assert_eq!(
+        count(source, TS2322),
+        1,
+        "inherited construct-signature types stay strict",
+    );
+}
+
+#[test]
+fn inherited_constructor_target_retains_declaration_provenance() {
+    let source = "
+        class Animal { animal = true; }
+        class Dog extends Animal { dog = true; }
+        declare const StrictBase: new (value: Animal) => object;
+        class StrictDerived extends StrictBase {}
+        class RealBase { constructor(value: Animal) {} }
+        class RealDerived extends RealBase {}
+        class DogCtor { constructor(value: Dog) {} }
+        const strictTarget: typeof StrictDerived = DogCtor;
+        const bivariantTarget: typeof RealDerived = DogCtor;
+    ";
+    assert_eq!(
+        count(source, TS2322),
+        1,
+        "inherited constructor signatures retain their original declaration kind",
+    );
+}
+
 // ---------------------------------------------------------------------------
 // CALL-signature literals already contravariant — guards the shared path.
 // ---------------------------------------------------------------------------

--- a/crates/tsz-checker/tests/method_inference_bivariance_tests.rs
+++ b/crates/tsz-checker/tests/method_inference_bivariance_tests.rs
@@ -1,0 +1,360 @@
+//! Source-level coverage for method-target inference bivariance.
+//!
+//! TypeScript walks method and constructor parameters in the usual
+//! contravariant direction, but candidates reached below that target signature
+//! are ordinary inference candidates. Function-valued properties retain strict
+//! contravariant candidate collection. These tests exercise the full
+//! parser/binder/lowering pipeline so the `is_method` distinction cannot be
+//! synthesized only in solver tests.
+
+use tsz_checker::test_utils::{check_source_strict, diagnostic_codes};
+
+#[test]
+fn kysely_style_method_contextually_infers_generic_new_return() {
+    let source = r#"
+interface ExpressionBuilder<DB, TB extends keyof DB> {
+  readonly database: DB;
+  readonly table: TB;
+}
+
+interface QueryBuilder<DB, TB extends keyof DB, O> {
+  limit(
+    value: number | ((eb: ExpressionBuilder<DB, TB>) => number),
+  ): QueryBuilder<DB, TB, O>;
+}
+
+class Impl<DB, TB extends keyof DB, O> implements QueryBuilder<DB, TB, O> {
+  constructor(_props: {}) {}
+
+  limit(
+    value: number | ((eb: ExpressionBuilder<DB, TB>) => number),
+  ): QueryBuilder<DB, TB, O> {
+    return new Impl({});
+  }
+}
+"#;
+
+    let diagnostics = check_source_strict(source);
+    assert!(
+        diagnostics.is_empty(),
+        "method-only type parameters should contextually infer for generic `new`: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
+#[test]
+fn renamed_kysely_style_method_contextually_infers_generic_new_return() {
+    let source = r#"
+interface Expr<Schema, Scope extends keyof Schema> {
+  readonly schema: Schema;
+  readonly scope: Scope;
+}
+
+interface Builder<Schema, Scope extends keyof Schema, Result> {
+  take(
+    value: number | ((ctx: Expr<Schema, Scope>) => number),
+  ): Builder<Schema, Scope, Result>;
+}
+
+class Renamed<Schema, Scope extends keyof Schema, Result>
+  implements Builder<Schema, Scope, Result> {
+  constructor(_state: {}) {}
+
+  take(
+    value: number | ((ctx: Expr<Schema, Scope>) => number),
+  ): Builder<Schema, Scope, Result> {
+    return new Renamed({});
+  }
+}
+"#;
+
+    let diagnostics = check_source_strict(source);
+    assert!(
+        diagnostics.is_empty(),
+        "renamed method-only binders should contextually infer: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
+#[test]
+fn function_valued_property_inference_remains_contravariant() {
+    let source = r#"
+interface PropertyBuilder<Value> {
+  readonly output: Value;
+  whereRef: (reference: Value) => PropertyBuilder<Value>;
+}
+
+type InferredValue<Source> =
+  Source extends PropertyBuilder<infer Value> ? Value : never;
+
+type ConcreteBuilder = {
+  readonly output: number;
+  whereRef: (reference: string) => PropertyBuilder<string>;
+};
+
+declare const candidate: string | number;
+const rejected: InferredValue<ConcreteBuilder> = candidate;
+"#;
+
+    let diagnostics = check_source_strict(source);
+    assert_eq!(
+        diagnostic_codes(&diagnostics),
+        vec![2322],
+        "function-valued properties must keep contravariant inference"
+    );
+}
+
+#[test]
+fn generic_call_inference_distinguishes_method_and_property_targets() {
+    let source = r#"
+declare function inferMethod<T>(
+  argument: { value: T; use(entry: T): void },
+): T;
+declare const methodInput: {
+  value: string;
+  use(entry: number): void;
+};
+const methodResult: string = inferMethod(methodInput);
+
+declare function inferProperty<T>(
+  argument: { value: T; use: (entry: T) => void },
+): T;
+declare const propertyInput: {
+  value: string;
+  use: (entry: number) => void;
+};
+const propertyResult: number = inferProperty(propertyInput);
+"#;
+
+    let diagnostics = check_source_strict(source);
+    assert_eq!(
+        diagnostic_codes(&diagnostics),
+        vec![2345, 2345],
+        "generic calls infer from target declaration kind"
+    );
+}
+
+#[test]
+fn relation_variance_uses_target_declaration_kind_with_explicit_this() {
+    let source = r#"
+class Animal { animal = true; }
+class Dog extends Animal { dog = true; }
+
+interface MethodSource {
+  use(this: unknown, entry: Dog): void;
+}
+interface PropertyTarget {
+  use: (this: unknown, entry: Animal) => void;
+}
+declare const methodSource: MethodSource;
+const rejected: PropertyTarget = methodSource;
+
+interface PropertySource {
+  use: (this: unknown, entry: Animal) => void;
+}
+interface MethodTarget {
+  use(this: unknown, entry: Dog): void;
+}
+declare const propertySource: PropertySource;
+const accepted: MethodTarget = propertySource;
+
+interface ThisMethodSource {
+  use(this: Dog): void;
+}
+interface ThisPropertyTarget {
+  use: (this: Animal) => void;
+}
+declare const thisMethodSource: ThisMethodSource;
+const rejectedThis: ThisPropertyTarget = thisMethodSource;
+
+interface ThisPropertySource {
+  use: (this: Animal) => void;
+}
+interface ThisMethodTarget {
+  use(this: Dog): void;
+}
+declare const thisPropertySource: ThisPropertySource;
+const acceptedThis: ThisMethodTarget = thisPropertySource;
+"#;
+
+    let diagnostics = check_source_strict(source);
+    assert_eq!(
+        diagnostic_codes(&diagnostics),
+        vec![2322, 2322],
+        "only the target declaration grants method bivariance"
+    );
+}
+
+#[test]
+fn method_source_does_not_loosen_index_signature_target() {
+    let source = r#"
+class Animal { animal = true; }
+class Dog extends Animal { dog = true; }
+const methods = { use(entry: Dog): void {} };
+const rejected: { [key: string]: (entry: Animal) => void } = methods;
+declare const symbolKey: unique symbol;
+const symbolMethods = { [symbolKey](entry: Dog): void {} };
+const rejectedSymbol: { [key: symbol]: (entry: Animal) => void } = symbolMethods;
+"#;
+
+    let diagnostics = check_source_strict(source);
+    assert_eq!(diagnostic_codes(&diagnostics), vec![2322, 2322]);
+}
+
+#[test]
+fn overloaded_method_source_does_not_loosen_property_target() {
+    let source = r#"
+class Animal { animal = true; }
+class Dog extends Animal { dog = true; }
+interface OverloadedSource {
+  use(entry: Dog): void;
+  use(entry: Dog, count?: number): void;
+}
+interface PropertyTarget {
+  use: (entry: Animal) => void;
+}
+declare const methods: OverloadedSource;
+const rejected: PropertyTarget = methods;
+"#;
+
+    let diagnostics = check_source_strict(source);
+    assert_eq!(diagnostic_codes(&diagnostics), vec![2322]);
+}
+
+#[test]
+fn overload_tuple_rest_shortcut_uses_target_declaration_kind() {
+    let source = r#"
+interface PropertyOverloads {
+  set: {
+    (value: { [key: string]: unknown }): void;
+    (name: string, value: unknown): void;
+  };
+}
+interface MethodTarget {
+  set(...args:
+    | [{ [key: string]: unknown }]
+    | [string, unknown]
+    | [string]
+  ): void;
+}
+interface PropertyTarget {
+  set: (...args:
+    | [{ [key: string]: unknown }]
+    | [string, unknown]
+    | [string]
+  ) => void;
+}
+declare const source: PropertyOverloads;
+const accepted: MethodTarget = source;
+const rejected: PropertyTarget = source;
+
+class ThisA { a = true; }
+class ThisB { b = true; }
+class ThisOverloads {
+  set(this: ThisA, value: { [key: string]: unknown }): void;
+  set(this: ThisA, name: string, value: unknown): void;
+  set(this: ThisA, ..._args: any[]): void {}
+}
+interface ThisTarget {
+  set(this: ThisB, ...args:
+    | [{ [key: string]: unknown }]
+    | [string, unknown]
+    | [string]
+  ): void;
+}
+declare const thisSource: ThisOverloads;
+const rejectedThis: ThisTarget = thisSource;
+
+class PredicateA { a = true; }
+class PredicateB { b = true; }
+interface PredicateOverloads {
+  set: {
+    (value: PredicateA | PredicateB): value is PredicateA;
+    (value: PredicateA | PredicateB, name: string): value is PredicateA;
+  };
+}
+interface BooleanOverloads {
+  set: {
+    (value: PredicateA | PredicateB): boolean;
+    (value: PredicateA | PredicateB, name: string): boolean;
+  };
+}
+interface MatchingPredicateOverloads {
+  set: {
+    (value: PredicateA | PredicateB): value is PredicateB;
+    (value: PredicateA | PredicateB, name: string): value is PredicateB;
+  };
+}
+interface PredicateTarget {
+  set(
+    value: PredicateA | PredicateB,
+    ...args: [] | [string]
+  ): value is PredicateB;
+}
+declare const predicateSource: PredicateOverloads;
+declare const booleanSource: BooleanOverloads;
+declare const matchingPredicateSource: MatchingPredicateOverloads;
+const rejectedPredicate: PredicateTarget = predicateSource;
+const rejectedBoolean: PredicateTarget = booleanSource;
+const acceptedPredicate: PredicateTarget = matchingPredicateSource;
+"#;
+
+    let diagnostics = check_source_strict(source);
+    assert_eq!(diagnostic_codes(&diagnostics), vec![2322, 2322, 2322, 2322]);
+}
+
+#[test]
+fn callback_mode_only_relaxes_explicit_this_parameter() {
+    let source = r#"
+class Animal { animal = true; }
+class Dog extends Animal { dog = true; }
+type MethodThisDog = { use(this: Dog): void }["use"];
+type PropertyThisAnimal = (this: Animal) => void;
+declare const thisForward: (callback: PropertyThisAnimal) => void;
+const acceptedThisForward: (callback: MethodThisDog) => void = thisForward;
+declare const thisReverse: (callback: MethodThisDog) => void;
+const acceptedThisReverse: (callback: PropertyThisAnimal) => void = thisReverse;
+
+type MethodParamDog = { use(entry: Dog): void }["use"];
+type PropertyParamAnimal = (entry: Animal) => void;
+declare const paramForward: (callback: PropertyParamAnimal) => void;
+const rejectedParam: (callback: MethodParamDog) => void = paramForward;
+declare const paramReverse: (callback: MethodParamDog) => void;
+const acceptedParam: (callback: PropertyParamAnimal) => void = paramReverse;
+"#;
+
+    let diagnostics = check_source_strict(source);
+    assert_eq!(diagnostic_codes(&diagnostics), vec![2322]);
+}
+
+#[test]
+fn contextual_generic_retry_preserves_callback_variance_mode() {
+    let source = r#"
+class Animal { animal = true; }
+class Dog extends Animal { dog = true; }
+type Mapped<Result extends string, Fallback = any> =
+  Result extends "ok" ? number : Fallback;
+interface Box<Value> { data?: Value; }
+
+type MethodThis = {
+  use<Value = any, Result extends string = "ok">(this: Dog): Box<Value>;
+}["use"];
+type PropertyThis =
+  <Value = any, Result extends string = "ok">(this: Animal) =>
+    Box<Mapped<Result, Value>>;
+declare const thisSource: (callback: PropertyThis) => void;
+const acceptedThis: (callback: MethodThis) => void = thisSource;
+
+type MethodParam = {
+  use<Value = any, Result extends string = "ok">(entry: Dog): Box<Value>;
+}["use"];
+type PropertyParam =
+  <Value = any, Result extends string = "ok">(entry: Animal) =>
+    Box<Mapped<Result, Value>>;
+declare const paramSource: (callback: PropertyParam) => void;
+const rejectedParam: (callback: MethodParam) => void = paramSource;
+"#;
+
+    let diagnostics = check_source_strict(source);
+    assert_eq!(diagnostic_codes(&diagnostics), vec![2322]);
+}

--- a/crates/tsz-lowering/src/lower/core/signature_members.rs
+++ b/crates/tsz-lowering/src/lower/core/signature_members.rs
@@ -73,7 +73,7 @@ impl<'a> TypeLowering<'a> {
                     return_type,
                     type_predicate: None,
                     is_constructor: true,
-                    is_method: false,
+                    is_method: true,
                 })
             }
             k if k == syntax_kind_ext::FUNCTION_DECLARATION => {

--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -241,6 +241,22 @@ impl InferenceContextCacheStatistics {
     }
 }
 
+/// Algorithmic parameter-recovery mode for constraint walks that deliberately
+/// reverse source and target independently of structural variance.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum ParameterRecoveryMode {
+    #[default]
+    None,
+    /// Placeholder-free dependency recovery. A source inference placeholder is
+    /// recorded as a candidate even when the live structural polarity is covariant.
+    StandaloneReverse,
+    /// A complex target containing a call-local placeholder. Recovery walks
+    /// retain the live structural polarity so nested contravariant edges can
+    /// toggle candidate routing back to covariance.
+    ComplexPlaceholder,
+}
+
 /// Type inference context for a single function call or expression.
 pub(crate) struct InferenceContext<'a> {
     pub(crate) interner: &'a dyn TypeDatabase,
@@ -276,6 +292,27 @@ pub(crate) struct InferenceContext<'a> {
     /// contra-candidates are resolved via intersection and are only used
     /// when no covariant candidates exist.
     pub(crate) in_contra_mode: bool,
+    /// Whether inference is currently below at least one contravariant
+    /// structural edge. TSZ uses this sticky state separately from
+    /// `in_contra_mode`: nested contravariant edges toggle candidate polarity
+    /// back to covariance, but the structural matcher must still treat source-side
+    /// inference placeholders as parameter-inference evidence instead of hard bounds.
+    pub(crate) in_variance_walk: bool,
+    /// Algorithmic parameter-recovery state, separate from structural variance.
+    pub(crate) parameter_recovery_mode: ParameterRecoveryMode,
+    /// Whether the current contravariant signature walk was entered through a
+    /// target signature whose declaration origin grants parameter bivariance.
+    /// TypeScript still walks those parameters in the contravariant direction,
+    /// but records every inference reached beneath them as an ordinary
+    /// candidate. The mode is scoped to one inference request and restored
+    /// before return-type inference.
+    pub(crate) in_bivariant_mode: bool,
+    /// Method metadata carried by an object property until its top-level
+    /// function/callable signature is reached. `PropertyInfo::is_method` can
+    /// survive structural transformations even when a rebuilt function shape
+    /// has lost its declaration-kind bit, so inference consumes this one-level
+    /// hint at the signature boundary.
+    pub(crate) pending_target_method: bool,
     /// Properties accumulated during reverse mapped type inference.
     /// When a homomorphic mapped type `{ [K in keyof T]: Template<T[K]> }`
     /// is matched against a source object, we accumulate (`key_atom`, `value_type`)
@@ -294,10 +331,11 @@ pub(crate) struct InferenceContext<'a> {
     /// interface hierarchies (e.g., `ArrayIterator<T>` which has
     /// `[Symbol.iterator](): ArrayIterator<T>` returning itself).
     pub(crate) infer_depth: u32,
-    /// Visited (source, target) pairs during structural inference.
-    /// Prevents re-visiting the same pair, breaking cycles in
-    /// self-referential type hierarchies.
-    pub(crate) infer_visited: FxHashSet<(TypeId, TypeId)>,
+    /// Visited `(source, target, mode)` states during structural inference.
+    /// The request-local mode packs polarity, sticky variance-walk, bivariant,
+    /// pending-method, and one three-state parameter-recovery mode; each affects
+    /// how nested placeholders are recorded.
+    pub(crate) infer_visited: FxHashSet<(TypeId, TypeId, u8)>,
     /// Inference variables whose corresponding type parameter appears at the
     /// top level of the signature's return type and has not yet been "fixed".
     ///
@@ -366,6 +404,29 @@ impl<'a> InferenceContext<'a> {
     /// recursion during structural property inference.
     pub(crate) const MAX_INFER_DEPTH: u32 = 20;
 
+    /// Run one nested inference operation without leaking its variance/member
+    /// routing modes into the next operation on this context.
+    #[inline]
+    pub(crate) fn with_restored_inference_modes<R>(
+        &mut self,
+        operation: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let saved = (
+            self.in_contra_mode,
+            self.in_variance_walk,
+            self.parameter_recovery_mode,
+            self.in_bivariant_mode,
+            self.pending_target_method,
+        );
+        let result = operation(self);
+        self.in_contra_mode = saved.0;
+        self.in_variance_walk = saved.1;
+        self.parameter_recovery_mode = saved.2;
+        self.in_bivariant_mode = saved.3;
+        self.pending_target_method = saved.4;
+        result
+    }
+
     pub fn new(interner: &'a dyn TypeDatabase) -> Self {
         InferenceContext {
             interner,
@@ -379,6 +440,10 @@ impl<'a> InferenceContext<'a> {
             literal_preserving_declared_constraints: FxHashSet::default(),
             app_expansion_depth: 0,
             in_contra_mode: false,
+            in_variance_walk: false,
+            parameter_recovery_mode: ParameterRecoveryMode::None,
+            in_bivariant_mode: false,
+            pending_target_method: false,
             reverse_mapped_properties: FxHashMap::default(),
             source_is_type_annotation: false,
             infer_depth: 0,
@@ -406,6 +471,10 @@ impl<'a> InferenceContext<'a> {
             literal_preserving_declared_constraints: FxHashSet::default(),
             app_expansion_depth: 0,
             in_contra_mode: false,
+            in_variance_walk: false,
+            parameter_recovery_mode: ParameterRecoveryMode::None,
+            in_bivariant_mode: false,
+            pending_target_method: false,
             reverse_mapped_properties: FxHashMap::default(),
             source_is_type_annotation: false,
             infer_depth: 0,
@@ -1439,7 +1508,7 @@ impl<'a> InferenceContext<'a> {
         // otherwise the leaked bare parameter becomes a contra-candidate that
         // overrides a legitimate covariant inference. Covariant routing keeps its
         // existing behavior (handled by `discard_self_referential_candidates`).
-        if self.in_contra_mode && self.type_is_own_original_type_param(var, ty) {
+        if self.collects_contra_candidates() && self.type_is_own_original_type_param(var, ty) {
             return;
         }
         let root = self.table.find(var);
@@ -1467,7 +1536,7 @@ impl<'a> InferenceContext<'a> {
             from_array_element: self.in_array_element_context,
             from_readonly_source: self.candidate_is_from_readonly_source(ty),
         };
-        if self.in_contra_mode {
+        if self.collects_contra_candidates() {
             // In contravariant context (e.g., callback parameter structural
             // decomposition), route to contra_candidates so they are resolved
             // via intersection and only used when no covariant candidates exist.
@@ -1487,6 +1556,33 @@ impl<'a> InferenceContext<'a> {
                 },
             );
         }
+    }
+
+    /// Whether candidates at the current point use TypeScript's
+    /// contravariant candidate set. A target signature whose declaration
+    /// origin grants parameter bivariance preserves the contravariant traversal
+    /// direction while deliberately suppressing this routing.
+    pub(crate) const fn collects_contra_candidates(&self) -> bool {
+        self.in_contra_mode && !self.in_bivariant_mode
+    }
+
+    /// Compact behavior mode for the hot structural-matcher cycle key.
+    pub(crate) const fn inference_visit_mode(&self) -> u8 {
+        (self.in_contra_mode as u8)
+            | ((self.in_variance_walk as u8) << 1)
+            | ((self.in_bivariant_mode as u8) << 2)
+            | ((self.pending_target_method as u8) << 3)
+            | ((self.parameter_recovery_mode as u8) << 4)
+    }
+
+    /// Compact behavior mode for the constraint-walker cycle key. The sticky
+    /// matcher-only variance bit is deliberately omitted so it cannot duplicate
+    /// constraint work or consume the shared step budget.
+    pub(crate) const fn constraint_visit_mode(&self) -> u8 {
+        (self.in_contra_mode as u8)
+            | ((self.in_bivariant_mode as u8) << 1)
+            | ((self.pending_target_method as u8) << 2)
+            | ((self.parameter_recovery_mode as u8) << 3)
     }
 
     fn candidate_is_from_readonly_source(&self, ty: TypeId) -> bool {

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -21,11 +21,9 @@ use crate::types::{
 use rustc_hash::FxHashMap;
 use tsz_common::interner::Atom;
 
-use super::infer::{InferenceContext, InferenceError, InferenceVar};
+use super::infer::{InferenceContext, InferenceError};
 use super::infer_matching_guard_state as guard_state;
 use super::infer_matching_helpers::constraint_is_nullable_union;
-use super::template_anchor::{find_leftmost_occurrence, find_next_anchor_alternatives};
-use super::template_segment_prefix::match_template_segment_prefix;
 
 impl<'a> InferenceContext<'a> {
     /// Perform structural type inference from a source type to a target type.
@@ -68,8 +66,10 @@ impl<'a> InferenceContext<'a> {
         target: TypeId,
         priority: InferencePriority,
     ) -> Result<(), InferenceError> {
-        let inserted_visit =
-            self.infer_depth < Self::MAX_INFER_DEPTH && self.infer_visited.insert((source, target));
+        let inserted_visit = self.infer_depth < Self::MAX_INFER_DEPTH
+            && self
+                .infer_visited
+                .insert((source, target, self.inference_visit_mode()));
         match guard_state::infer_match_entry_state(
             self.infer_depth,
             Self::MAX_INFER_DEPTH,
@@ -122,13 +122,10 @@ impl<'a> InferenceContext<'a> {
         if let Some(TypeData::TypeParameter(ref param_info)) = source_key
             && let Some(var) = self.find_type_param(param_info.name)
         {
-            // When in contra_mode (function parameter inference), add as a contra-candidate
-            // instead of an upper bound. This matches tsc's behavior where inference from
-            // function parameter types (contravariant position) produces contra-candidates
-            // that are resolved via intersection/most-specific, NOT hard upper bounds that
-            // must each individually be satisfied. Without this, decomposing a union target
-            // (e.g., matching {kind: T} against {kind:'a'} | {kind:'b'}) produces separate
-            // upper bounds 'a' and 'b', causing false TS2345 errors.
+            // Beneath a structural variance walk, route through the ordinary candidate
+            // entrypoint. Its live polarity selects regular versus contra-candidates, while
+            // method bivariance can suppress contra classification. Outside such a walk this
+            // remains a hard upper bound.
             self.add_source_type_param_candidate(var, target, priority);
             return Ok(());
         }
@@ -505,7 +502,11 @@ impl<'a> InferenceContext<'a> {
                 // Use partially inferable type to prevent implicit `any` from
                 // flowing contravariantly into inference. Matches tsc behavior.
                 let inferable_type = self.get_partially_inferable_type(source_prop.type_id);
-                self.infer_from_types(inferable_type, target_prop.type_id, priority)?;
+                let was_pending_method = self.pending_target_method;
+                self.pending_target_method |= target_prop.is_method;
+                let result = self.infer_from_types(inferable_type, target_prop.type_id, priority);
+                self.pending_target_method = was_pending_method;
+                result?;
             }
         }
 
@@ -1015,6 +1016,17 @@ impl<'a> InferenceContext<'a> {
         target_func: FunctionShapeId,
         priority: InferencePriority,
     ) -> Result<(), InferenceError> {
+        self.with_restored_inference_modes(|ctx| {
+            ctx.infer_functions_scoped(source_func, target_func, priority)
+        })
+    }
+
+    fn infer_functions_scoped(
+        &mut self,
+        source_func: FunctionShapeId,
+        target_func: FunctionShapeId,
+        priority: InferencePriority,
+    ) -> Result<(), InferenceError> {
         let source_sig = self.interner.function_shape(source_func);
         let target_sig = self.interner.function_shape(target_func);
 
@@ -1029,7 +1041,18 @@ impl<'a> InferenceContext<'a> {
         // (after direction swap) are recorded as contra-candidates rather than hard
         // upper bounds. This matches tsc's handling of function parameter inference.
         let was_contra = self.in_contra_mode;
-        self.in_contra_mode = true;
+        let was_variance_walk = self.in_variance_walk;
+        let was_bivariant = self.in_bivariant_mode;
+        let was_pending_method = self.pending_target_method;
+        self.in_contra_mode = !was_contra;
+        self.in_variance_walk = true;
+        self.in_bivariant_mode |=
+            target_sig.is_method || (was_pending_method && !target_sig.is_constructor);
+        self.pending_target_method = false;
+        if let (Some(source_this), Some(target_this)) = (source_sig.this_type, target_sig.this_type)
+        {
+            self.infer_from_types(target_this, source_this, priority)?;
+        }
         let mut source_params = source_sig.params.iter().peekable();
         let mut target_params = target_sig.params.iter().peekable();
 
@@ -1166,20 +1189,13 @@ impl<'a> InferenceContext<'a> {
             }
         }
 
-        // Restore contra mode before covariant inference (return type, type predicates).
+        // Restore variance modes before covariant inference (return type, type predicates).
         self.in_contra_mode = was_contra;
+        self.in_variance_walk = was_variance_walk;
+        self.in_bivariant_mode = was_bivariant;
 
         // Return type is covariant: normal order
         self.infer_from_types(source_sig.return_type, target_sig.return_type, priority)?;
-
-        // This type is contravariant
-        if let (Some(source_this), Some(target_this)) = (source_sig.this_type, target_sig.this_type)
-        {
-            let was_contra2 = self.in_contra_mode;
-            self.in_contra_mode = true;
-            self.infer_from_types(target_this, source_this, priority)?;
-            self.in_contra_mode = was_contra2;
-        }
 
         // Type predicates are covariant
         if let (Some(source_pred), Some(target_pred)) =
@@ -1207,6 +1223,7 @@ impl<'a> InferenceContext<'a> {
             }
         }
 
+        self.pending_target_method = was_pending_method;
         Ok(())
     }
 
@@ -1217,25 +1234,52 @@ impl<'a> InferenceContext<'a> {
         target_id: CallableShapeId,
         priority: InferencePriority,
     ) -> Result<(), InferenceError> {
+        self.with_restored_inference_modes(|ctx| {
+            ctx.infer_callables_scoped(source_id, target_id, priority)
+        })
+    }
+
+    fn infer_callables_scoped(
+        &mut self,
+        source_id: CallableShapeId,
+        target_id: CallableShapeId,
+        priority: InferencePriority,
+    ) -> Result<(), InferenceError> {
         let source = self.interner.callable_shape(source_id);
         let target = self.interner.callable_shape(target_id);
+        let was_pending_method = self.pending_target_method;
+        self.pending_target_method = false;
 
         // For each call signature in the target, try to find a compatible one in the source
         for target_sig in &target.call_signatures {
             for source_sig in &source.call_signatures {
                 if source_sig.params.len() == target_sig.params.len() {
                     let was_contra = self.in_contra_mode;
-                    self.in_contra_mode = true;
+                    let was_variance_walk = self.in_variance_walk;
+                    let was_bivariant = self.in_bivariant_mode;
+                    self.in_contra_mode = !was_contra;
+                    self.in_variance_walk = true;
+                    self.in_bivariant_mode |= was_pending_method || target_sig.is_method;
+                    if let (Some(source_this), Some(target_this)) =
+                        (source_sig.this_type, target_sig.this_type)
+                    {
+                        self.infer_from_types(target_this, source_this, priority)?;
+                    }
                     for (s_param, t_param) in source_sig.params.iter().zip(target_sig.params.iter())
                     {
                         let result =
                             self.infer_from_types(t_param.type_id, s_param.type_id, priority);
                         if result.is_err() {
                             self.in_contra_mode = was_contra;
+                            self.in_variance_walk = was_variance_walk;
+                            self.in_bivariant_mode = was_bivariant;
+                            self.pending_target_method = was_pending_method;
                             return result;
                         }
                     }
                     self.in_contra_mode = was_contra;
+                    self.in_variance_walk = was_variance_walk;
+                    self.in_bivariant_mode = was_bivariant;
                     self.infer_from_types(
                         source_sig.return_type,
                         target_sig.return_type,
@@ -1251,17 +1295,31 @@ impl<'a> InferenceContext<'a> {
             for source_sig in &source.construct_signatures {
                 if source_sig.params.len() == target_sig.params.len() {
                     let was_contra = self.in_contra_mode;
-                    self.in_contra_mode = true;
+                    let was_variance_walk = self.in_variance_walk;
+                    let was_bivariant = self.in_bivariant_mode;
+                    self.in_contra_mode = !was_contra;
+                    self.in_variance_walk = true;
+                    self.in_bivariant_mode |= target_sig.is_method;
+                    if let (Some(source_this), Some(target_this)) =
+                        (source_sig.this_type, target_sig.this_type)
+                    {
+                        self.infer_from_types(target_this, source_this, priority)?;
+                    }
                     for (s_param, t_param) in source_sig.params.iter().zip(target_sig.params.iter())
                     {
                         let result =
                             self.infer_from_types(t_param.type_id, s_param.type_id, priority);
                         if result.is_err() {
                             self.in_contra_mode = was_contra;
+                            self.in_variance_walk = was_variance_walk;
+                            self.in_bivariant_mode = was_bivariant;
+                            self.pending_target_method = was_pending_method;
                             return result;
                         }
                     }
                     self.in_contra_mode = was_contra;
+                    self.in_variance_walk = was_variance_walk;
+                    self.in_bivariant_mode = was_bivariant;
                     self.infer_from_types(
                         source_sig.return_type,
                         target_sig.return_type,
@@ -1279,7 +1337,12 @@ impl<'a> InferenceContext<'a> {
                 .iter()
                 .find(|p| p.name == target_prop.name)
             {
-                self.infer_from_types(source_prop.type_id, target_prop.type_id, priority)?;
+                let child_pending_method = self.pending_target_method;
+                self.pending_target_method |= target_prop.is_method;
+                let result =
+                    self.infer_from_types(source_prop.type_id, target_prop.type_id, priority);
+                self.pending_target_method = child_pending_method;
+                result?;
             }
         }
 
@@ -1293,31 +1356,60 @@ impl<'a> InferenceContext<'a> {
             self.infer_from_types(source_idx.value_type, target_idx.value_type, priority)?;
         }
 
+        self.pending_target_method = was_pending_method;
         Ok(())
     }
 
     /// Infer from a Function shape against a Callable's call signature.
-    /// Bridges Function ↔ Callable for cross-type inference.
+    /// Bridges Function ↔ Callable for cross-type inference. Only call
+    /// signatures reach this bridge; construct signatures are paired by
+    /// `infer_callables` above.
     fn infer_function_vs_signature(
         &mut self,
         source_func: FunctionShapeId,
         target_sig: &crate::types::CallSignature,
         priority: InferencePriority,
     ) -> Result<(), InferenceError> {
+        self.with_restored_inference_modes(|ctx| {
+            ctx.infer_function_vs_signature_scoped(source_func, target_sig, priority)
+        })
+    }
+
+    fn infer_function_vs_signature_scoped(
+        &mut self,
+        source_func: FunctionShapeId,
+        target_sig: &crate::types::CallSignature,
+        priority: InferencePriority,
+    ) -> Result<(), InferenceError> {
         let source = self.interner.function_shape(source_func);
+        let was_pending_method = self.pending_target_method;
+        let was_bivariant = self.in_bivariant_mode;
+        self.pending_target_method = false;
         // Parameters are contravariant
         let was_contra = self.in_contra_mode;
-        self.in_contra_mode = true;
+        let was_variance_walk = self.in_variance_walk;
+        self.in_contra_mode = !was_contra;
+        self.in_variance_walk = true;
+        self.in_bivariant_mode |= was_pending_method || target_sig.is_method;
+        if let (Some(source_this), Some(target_this)) = (source.this_type, target_sig.this_type) {
+            self.infer_from_types(target_this, source_this, priority)?;
+        }
         for (s_param, t_param) in source.params.iter().zip(target_sig.params.iter()) {
             let result = self.infer_from_types(t_param.type_id, s_param.type_id, priority);
             if result.is_err() {
                 self.in_contra_mode = was_contra;
+                self.in_variance_walk = was_variance_walk;
+                self.in_bivariant_mode = was_bivariant;
+                self.pending_target_method = was_pending_method;
                 return result;
             }
         }
         self.in_contra_mode = was_contra;
+        self.in_variance_walk = was_variance_walk;
+        self.in_bivariant_mode = was_bivariant;
         // Return type is covariant
         self.infer_from_types(source.return_type, target_sig.return_type, priority)?;
+        self.pending_target_method = was_pending_method;
         Ok(())
     }
 
@@ -1329,20 +1421,47 @@ impl<'a> InferenceContext<'a> {
         target_func: FunctionShapeId,
         priority: InferencePriority,
     ) -> Result<(), InferenceError> {
+        self.with_restored_inference_modes(|ctx| {
+            ctx.infer_signature_vs_function_scoped(source_sig, target_func, priority)
+        })
+    }
+
+    fn infer_signature_vs_function_scoped(
+        &mut self,
+        source_sig: &crate::types::CallSignature,
+        target_func: FunctionShapeId,
+        priority: InferencePriority,
+    ) -> Result<(), InferenceError> {
         let target = self.interner.function_shape(target_func);
+        let was_pending_method = self.pending_target_method;
+        let was_bivariant = self.in_bivariant_mode;
+        self.pending_target_method = false;
         // Parameters are contravariant
         let was_contra = self.in_contra_mode;
-        self.in_contra_mode = true;
+        let was_variance_walk = self.in_variance_walk;
+        self.in_contra_mode = !was_contra;
+        self.in_variance_walk = true;
+        self.in_bivariant_mode |=
+            target.is_method || (was_pending_method && !target.is_constructor);
+        if let (Some(source_this), Some(target_this)) = (source_sig.this_type, target.this_type) {
+            self.infer_from_types(target_this, source_this, priority)?;
+        }
         for (s_param, t_param) in source_sig.params.iter().zip(target.params.iter()) {
             let result = self.infer_from_types(t_param.type_id, s_param.type_id, priority);
             if result.is_err() {
                 self.in_contra_mode = was_contra;
+                self.in_variance_walk = was_variance_walk;
+                self.in_bivariant_mode = was_bivariant;
+                self.pending_target_method = was_pending_method;
                 return result;
             }
         }
         self.in_contra_mode = was_contra;
+        self.in_variance_walk = was_variance_walk;
+        self.in_bivariant_mode = was_bivariant;
         // Return type is covariant
         self.infer_from_types(source_sig.return_type, target.return_type, priority)?;
+        self.pending_target_method = was_pending_method;
         Ok(())
     }
 
@@ -1636,9 +1755,13 @@ impl<'a> InferenceContext<'a> {
                     // candidates are recorded as contra-candidates (via in_contra_mode)
                     // or equivalently, infer in the reverse direction.
                     let was_contra = self.in_contra_mode;
+                    let was_variance_walk = self.in_variance_walk;
                     self.in_contra_mode = !was_contra;
-                    self.infer_from_types(*source_arg, *target_arg, priority)?;
+                    self.in_variance_walk = true;
+                    let result = self.infer_from_types(*source_arg, *target_arg, priority);
                     self.in_contra_mode = was_contra;
+                    self.in_variance_walk = was_variance_walk;
+                    result?;
                 } else {
                     self.infer_from_types(*source_arg, *target_arg, priority)?;
                 }
@@ -1798,85 +1921,5 @@ impl<'a> InferenceContext<'a> {
             Some(TypeData::Literal(LiteralValue::String(s))) => Some(self.interner.resolve_atom(s)),
             _ => None,
         }
-    }
-
-    /// Match a source string against a template pattern, extracting infer variable bindings.
-    ///
-    /// # Arguments
-    ///
-    /// * `source` - The source string to match (e.g., `"user_123"`)
-    /// * `spans` - The template spans (e.g., `[Text("user_"), Type(ID), Text("_")]`)
-    ///
-    /// # Returns
-    ///
-    /// * `Some(bindings)` - Mapping from inference variables to captured strings
-    /// * `None` - The source doesn't match the pattern
-    fn match_template_pattern(
-        &self,
-        source: &str,
-        spans: &[TemplateSpan],
-    ) -> Option<Vec<(InferenceVar, String)>> {
-        let mut bindings = Vec::with_capacity(spans.len());
-        let mut pos = 0;
-
-        for (i, span) in spans.iter().enumerate() {
-            let is_last = i == spans.len() - 1;
-
-            match span {
-                TemplateSpan::Text(text_atom) => {
-                    // Match literal text at current position
-                    let text = self.interner.resolve_atom(*text_atom).to_string();
-                    if !source.get(pos..)?.starts_with(&text) {
-                        return None; // Text doesn't match
-                    }
-                    pos += text.len();
-                }
-
-                TemplateSpan::Type(type_id) => {
-                    // Match both `infer T` (conditional) and generic `T` (type parameter).
-                    // Intrinsics are never Infer or TypeParameter.
-                    if !type_id.is_intrinsic()
-                        && let Some(
-                            TypeData::Infer(param_info) | TypeData::TypeParameter(param_info),
-                        ) = self.interner.lookup(*type_id)
-                        && let Some(var) = self.find_type_param(param_info.name)
-                    {
-                        if is_last {
-                            // Last span: capture all remaining text (greedy)
-                            let captured = source[pos..].to_string();
-                            bindings.push((var, captured));
-                            pos = source.len();
-                        } else if let Some(alternatives) =
-                            find_next_anchor_alternatives(self.interner, spans, i, |type_id| {
-                                if type_id.is_intrinsic() {
-                                    return false;
-                                }
-                                matches!(
-                                    self.interner.lookup(type_id),
-                                    Some(
-                                        TypeData::Infer(param_info)
-                                            | TypeData::TypeParameter(param_info)
-                                    ) if self.find_type_param(param_info.name).is_some()
-                                )
-                            })
-                        {
-                            let capture_end = find_leftmost_occurrence(source, pos, &alternatives)?;
-                            let captured = source[pos..capture_end].to_string();
-                            bindings.push((var, captured));
-                            pos = capture_end;
-                        } else {
-                            bindings.push((var, String::new()));
-                        }
-                    } else {
-                        let next_pos =
-                            match_template_segment_prefix(self.interner, source, pos, *type_id)?;
-                        pos = next_pos;
-                    }
-                }
-            }
-        }
-
-        // Must have consumed the entire source string
-        (pos == source.len()).then_some(bindings)
     }
 }

--- a/crates/tsz-solver/src/inference/infer_matching_helpers.rs
+++ b/crates/tsz-solver/src/inference/infer_matching_helpers.rs
@@ -1,7 +1,9 @@
 use crate::caches::db::TypeDatabase;
-use crate::types::{InferencePriority, TypeData, TypeId};
+use crate::types::{InferencePriority, TemplateSpan, TypeData, TypeId};
 
 use super::infer::{InferenceContext, InferenceVar};
+use super::template_anchor::{find_leftmost_occurrence, find_next_anchor_alternatives};
+use super::template_segment_prefix::match_template_segment_prefix;
 
 impl InferenceContext<'_> {
     pub(super) fn add_source_type_param_candidate(
@@ -14,11 +16,95 @@ impl InferenceContext<'_> {
             return;
         }
 
-        if self.in_contra_mode {
-            self.add_contra_candidate(var, target, priority);
+        if self.in_variance_walk {
+            // Contravariant traversal swaps source and target in TSZ. Route the
+            // recovered concrete type through the ordinary candidate entrypoint
+            // so nested polarity and method/constructor bivariance can select
+            // the candidate bucket without changing traversal direction.
+            self.add_candidate(var, target, priority);
         } else {
             self.add_upper_bound(var, target);
         }
+    }
+
+    /// Match a source string against a template pattern, extracting infer variable bindings.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - The source string to match (e.g., `"user_123"`)
+    /// * `spans` - The template spans (e.g., `[Text("user_"), Type(ID), Text("_")]`)
+    ///
+    /// # Returns
+    ///
+    /// * `Some(bindings)` - Mapping from inference variables to captured strings
+    /// * `None` - The source doesn't match the pattern
+    pub(super) fn match_template_pattern(
+        &self,
+        source: &str,
+        spans: &[TemplateSpan],
+    ) -> Option<Vec<(InferenceVar, String)>> {
+        let mut bindings = Vec::with_capacity(spans.len());
+        let mut pos = 0;
+
+        for (i, span) in spans.iter().enumerate() {
+            let is_last = i == spans.len() - 1;
+
+            match span {
+                TemplateSpan::Text(text_atom) => {
+                    // Match literal text at current position
+                    let text = self.interner.resolve_atom(*text_atom).to_string();
+                    if !source.get(pos..)?.starts_with(&text) {
+                        return None; // Text doesn't match
+                    }
+                    pos += text.len();
+                }
+
+                TemplateSpan::Type(type_id) => {
+                    // Match both `infer T` (conditional) and generic `T` (type parameter).
+                    // Intrinsics are never Infer or TypeParameter.
+                    if !type_id.is_intrinsic()
+                        && let Some(
+                            TypeData::Infer(param_info) | TypeData::TypeParameter(param_info),
+                        ) = self.interner.lookup(*type_id)
+                        && let Some(var) = self.find_type_param(param_info.name)
+                    {
+                        if is_last {
+                            // Last span: capture all remaining text (greedy)
+                            let captured = source[pos..].to_string();
+                            bindings.push((var, captured));
+                            pos = source.len();
+                        } else if let Some(alternatives) =
+                            find_next_anchor_alternatives(self.interner, spans, i, |type_id| {
+                                if type_id.is_intrinsic() {
+                                    return false;
+                                }
+                                matches!(
+                                    self.interner.lookup(type_id),
+                                    Some(
+                                        TypeData::Infer(param_info)
+                                            | TypeData::TypeParameter(param_info)
+                                    ) if self.find_type_param(param_info.name).is_some()
+                                )
+                            })
+                        {
+                            let capture_end = find_leftmost_occurrence(source, pos, &alternatives)?;
+                            let captured = source[pos..capture_end].to_string();
+                            bindings.push((var, captured));
+                            pos = capture_end;
+                        } else {
+                            bindings.push((var, String::new()));
+                        }
+                    } else {
+                        let next_pos =
+                            match_template_segment_prefix(self.interner, source, pos, *type_id)?;
+                        pos = next_pos;
+                    }
+                }
+            }
+        }
+
+        // Must have consumed the entire source string
+        (pos == source.len()).then_some(bindings)
     }
 }
 

--- a/crates/tsz-solver/src/operations/constraints/signatures.rs
+++ b/crates/tsz-solver/src/operations/constraints/signatures.rs
@@ -3,7 +3,7 @@
 //! Contains methods for constraining object properties, function signatures,
 //! call signatures, tuple types, and index signatures during type inference.
 
-use crate::inference::infer::InferenceContext;
+use crate::inference::infer::{InferenceContext, ParameterRecoveryMode};
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::operations::{AssignabilityChecker, CallEvaluator};
 use crate::types::{
@@ -21,6 +21,13 @@ struct SignatureSide<'a> {
     this_type: Option<TypeId>,
     return_type: TypeId,
     type_predicate: Option<&'a TypePredicate>,
+}
+
+#[derive(Clone, Copy)]
+struct SignatureConstraintMode {
+    is_constructor: bool,
+    target_is_constructor: bool,
+    target_is_bivariant: bool,
 }
 
 // Reusable scratch `FxHashSet<TypeId>` for `type_contains_placeholder` calls
@@ -100,6 +107,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             source_is_fresh,
                         );
                     } else {
+                        let was_pending_method = ctx.pending_target_method;
+                        ctx.pending_target_method |= target.is_method;
                         self.constrain_types(
                             ctx,
                             var_map,
@@ -107,6 +116,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             target.type_id,
                             priority,
                         );
+                        ctx.pending_target_method = was_pending_method;
                     }
                     // Constrain write type for mutable targets.
                     // Note: readonly source → writable target is allowed during
@@ -314,7 +324,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     }
 
     /// Shared body for `constrain_{function,call_signature}_to_{call_signature,function}`.
-    /// Applies the four-step inference constraint: params → optional `this` → return →
+    /// Applies the four-step inference constraint: optional `this` → params → return →
     /// type predicates. The three public wrappers differ only in their source/target
     /// struct types; those structs expose the same inference-relevant fields.
     ///
@@ -338,17 +348,29 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         source: &SignatureSide<'_>,
         target: &SignatureSide<'_>,
         priority: crate::types::InferencePriority,
-        is_constructor: bool,
+        mode: SignatureConstraintMode,
     ) {
-        self.constrain_params_with_rest(ctx, var_map, source.params, target.params, priority);
+        let was_contra = ctx.in_contra_mode;
+        let was_variance_walk = ctx.in_variance_walk;
+        let was_bivariant = ctx.in_bivariant_mode;
+        let was_pending_method = ctx.pending_target_method;
+        ctx.pending_target_method = false;
+        ctx.in_contra_mode = !was_contra;
+        ctx.in_variance_walk = true;
+        ctx.in_bivariant_mode |=
+            mode.target_is_bivariant || (was_pending_method && !mode.target_is_constructor);
         if let (Some(s_this), Some(t_this)) = (source.this_type, target.this_type) {
             self.constrain_parameter_types(ctx, var_map, s_this, t_this, priority);
         }
+        self.constrain_params_with_rest(ctx, var_map, source.params, target.params, priority);
+        ctx.in_contra_mode = was_contra;
+        ctx.in_variance_walk = was_variance_walk;
+        ctx.in_bivariant_mode = was_bivariant;
         // Return types must never be inferred at NakedTypeVariable priority — cap
         // at ReturnType so direct-arg inferences always win. Mirrors the same
         // invariant enforced in the Function→Function path in walker.rs.
         // Skip the cap for construct signatures (see doc comment above).
-        let return_priority = if is_constructor {
+        let return_priority = if mode.is_constructor {
             priority
         } else {
             priority.max(crate::types::InferencePriority::ReturnType)
@@ -370,6 +392,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             target.type_predicate,
             return_priority,
         );
+        ctx.pending_target_method = was_pending_method;
     }
 
     pub(super) fn constrain_function_to_call_signature(
@@ -379,6 +402,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         source: &FunctionShape,
         target: &CallSignature,
         priority: crate::types::InferencePriority,
+        target_is_constructor: bool,
     ) {
         trace!(
             source_has_predicate = source.type_predicate.is_some(),
@@ -401,7 +425,11 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 type_predicate: target.type_predicate.as_ref(),
             },
             priority,
-            source.is_constructor,
+            SignatureConstraintMode {
+                is_constructor: source.is_constructor,
+                target_is_constructor,
+                target_is_bivariant: target.is_method,
+            },
         );
     }
 
@@ -429,7 +457,11 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 type_predicate: target.type_predicate.as_ref(),
             },
             priority,
-            target.is_constructor,
+            SignatureConstraintMode {
+                is_constructor: target.is_constructor,
+                target_is_constructor: target.is_constructor,
+                target_is_bivariant: target.is_method,
+            },
         );
     }
 
@@ -458,7 +490,11 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 type_predicate: target.type_predicate.as_ref(),
             },
             priority,
-            is_constructor,
+            SignatureConstraintMode {
+                is_constructor,
+                target_is_constructor: is_constructor,
+                target_is_bivariant: target.is_method,
+            },
         );
     }
 
@@ -500,7 +536,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return_type: sig.return_type,
             type_predicate: sig.type_predicate,
             is_constructor,
-            is_method: false,
+            is_method: sig.is_method,
         })
     }
 
@@ -981,7 +1017,11 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // contravariant inferences go to `contraCandidates` and are resolved
         // via intersection (not union).
         if let Some(&var) = var_map.get(&target_param) {
-            ctx.add_contra_candidate(var, source_param, priority);
+            if ctx.collects_contra_candidates() {
+                ctx.add_contra_candidate(var, source_param, priority);
+            } else {
+                ctx.add_candidate(var, source_param, priority);
+            }
             // Do not feed a bare placeholder target back into source-side type parameters.
             // For higher-order generic callbacks like `callr(sn, f16)`, that reverse edge
             // creates recursive source-placeholder candidates (`A = T`, `T = [A, B]`) and
@@ -996,35 +1036,47 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 // instead of a hard upper bound. This matches the behavior
                 // of the complex-type branch below and prevents upper bounds
                 // from overriding correct covariant inference.
-                let was_contra = ctx.in_contra_mode;
-                ctx.in_contra_mode = true;
                 self.constrain_types(ctx, var_map, target_param, source_param, priority);
-                ctx.in_contra_mode = was_contra;
             }
         } else {
             // The target parameter is a complex type containing type variables
-            // (e.g., `{ kind: T }`, not just `T` directly). In tsc, callback
-            // parameter inference in this case goes to `contraCandidates` because
-            // function parameters are contravariant. We set `in_contra_mode` for
-            // BOTH directions so that:
-            // - Forward (source→target): candidates are routed to contra_candidates
-            // - Reverse (target→source): type parameters in source position add
-            //   contra-candidates instead of hard upper bounds
-            // Without contra mode on the reverse direction, decomposing a union
-            // target (e.g., {kind:T} vs {kind:'a'}|{kind:'b'}) creates separate
-            // upper bounds 'a' and 'b', causing false TS2345 when the covariant
-            // result ('a') fails to satisfy upper bound 'b'.
+            // (e.g., `{ kind: T }`, not just `T` directly). Candidate routing
+            // follows the live signature polarity: one parameter edge is
+            // contravariant, while a nested second edge toggles back to
+            // covariance. Preserve that polarity for both recovery directions.
+            // At the ordinary single-edge depth this still keeps the reverse
+            // walk contravariant, preventing union decomposition from creating
+            // hard upper bounds that override the inferred candidate.
             let target_has_placeholder = with_signatures_visited(|visited| {
                 self.type_contains_placeholder(target_param, var_map, visited)
             });
             if target_has_placeholder {
-                let was_contra = ctx.in_contra_mode;
-                ctx.in_contra_mode = true;
-                self.constrain_types(ctx, var_map, source_param, target_param, priority);
-                self.constrain_types(ctx, var_map, target_param, source_param, priority);
-                ctx.in_contra_mode = was_contra;
+                ctx.with_restored_inference_modes(|ctx| {
+                    ctx.in_variance_walk = true;
+                    ctx.parameter_recovery_mode = ParameterRecoveryMode::ComplexPlaceholder;
+                    self.constrain_types(ctx, var_map, source_param, target_param, priority);
+                    self.constrain_types(ctx, var_map, target_param, source_param, priority);
+                });
             } else {
-                self.constrain_types(ctx, var_map, target_param, source_param, priority);
+                // This helper explicitly reverses source and target for
+                // dependency recovery. A standalone reverse cancels ambient
+                // signature contravariance but keeps source-placeholder evidence;
+                // a reverse nested beneath complex-placeholder inference stays
+                // contravariant in both directions.
+                ctx.with_restored_inference_modes(|ctx| {
+                    let nested_complex =
+                        ctx.parameter_recovery_mode == ParameterRecoveryMode::ComplexPlaceholder;
+                    if !nested_complex {
+                        ctx.in_contra_mode = false;
+                    }
+                    ctx.in_variance_walk = true;
+                    ctx.parameter_recovery_mode = if nested_complex {
+                        ParameterRecoveryMode::ComplexPlaceholder
+                    } else {
+                        ParameterRecoveryMode::StandaloneReverse
+                    };
+                    self.constrain_types(ctx, var_map, target_param, source_param, priority);
+                });
             }
         }
     }

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -1,4 +1,4 @@
-use crate::inference::infer::InferenceContext;
+use crate::inference::infer::{InferenceContext, ParameterRecoveryMode};
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::operations::constraints::walker_guard_state::with_placeholder_visited;
 use crate::operations::{AssignabilityChecker, CallEvaluator};
@@ -31,14 +31,14 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return;
         }
 
-        // If source is an inference placeholder, add upper bound: var <: target.
-        // In contra_mode (function parameter inference), add as contra-candidate instead
-        // of upper bound. This matches tsc where inference from contravariant positions
-        // produces contra-candidates resolved via intersection/most-specific, not hard
-        // upper bounds that must each be individually satisfied.
+        // Source placeholders become upper bounds outside contravariant
+        // inference. Placeholder-free parameter dependency recovery can opt in
+        // to candidate routing for its explicit reverse edge.
         if let Some(&var) = var_map.get(&source) {
-            if ctx.in_contra_mode {
-                ctx.add_contra_candidate(var, target, priority);
+            if ctx.in_contra_mode
+                || ctx.parameter_recovery_mode == ParameterRecoveryMode::StandaloneReverse
+            {
+                ctx.add_candidate(var, target, priority);
             } else {
                 ctx.add_upper_bound(var, target);
             }
@@ -180,12 +180,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             // infers T = { a: any } & { b: any }.
             (_, Some(TypeData::KeyOf(keyof_inner))) => {
                 if let Some(&var) = var_map.get(&keyof_inner) {
-                    // Reverse keyof inference: source <: keyof T → T has property source.
-                    // Construct an object `{ [source]: any }` and add it as a contra
-                    // candidate — contra candidates combine via intersection, matching
-                    // tsc's behavior where `bar<T>(x: keyof T, y: keyof T)` called with
-                    // `('a', 'b')` infers T = { a: any } & { b: any }.
-                    //
+                    // Reverse keyof inference synthesizes `{ [source]: any }`.
                     // Use `LiteralKeyof` priority (strictly worse than `NakedTypeVariable`)
                     // so a co-occurring naked `obj: T` argument always outranks the
                     // synthesised key shape. Mirrors tsc's `inferToKeyof` (checker.ts
@@ -198,11 +193,15 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     if let Some(key_atom) = key_atom {
                         let prop = PropertyInfo::new(key_atom, TypeId::ANY);
                         let obj = self.interner.object(vec![prop]);
-                        ctx.add_contra_candidate(
-                            var,
-                            obj,
-                            crate::types::InferencePriority::LiteralKeyof,
-                        );
+                        ctx.with_restored_inference_modes(|ctx| {
+                            ctx.in_contra_mode = !ctx.in_contra_mode;
+                            ctx.in_variance_walk = true;
+                            ctx.add_candidate(
+                                var,
+                                obj,
+                                crate::types::InferencePriority::LiteralKeyof,
+                            );
+                        });
                     } else if let Some(TypeData::Union(source_members)) =
                         self.interner.lookup(source)
                     {
@@ -1088,20 +1087,25 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     has_t_pred = t_fn.type_predicate.is_some(),
                     "constrain_types_impl: Function"
                 );
-
+                let was_pending_method = std::mem::take(&mut ctx.pending_target_method);
+                let pending_is_method = was_pending_method && !t_fn.is_constructor;
                 if s_fn.type_params.is_empty() {
                     // Non-generic source function - direct comparison
-                    self.constrain_params_with_rest(
-                        ctx,
-                        var_map,
-                        &s_fn.params,
-                        &t_fn.params,
-                        priority,
-                    );
-
-                    if let (Some(s_this), Some(t_this)) = (s_fn.this_type, t_fn.this_type) {
-                        self.constrain_parameter_types(ctx, var_map, s_this, t_this, priority);
-                    }
+                    ctx.with_restored_inference_modes(|ctx| {
+                        ctx.in_contra_mode = !ctx.in_contra_mode;
+                        ctx.in_variance_walk = true;
+                        ctx.in_bivariant_mode |= pending_is_method || t_fn.is_method;
+                        if let (Some(s_this), Some(t_this)) = (s_fn.this_type, t_fn.this_type) {
+                            self.constrain_parameter_types(ctx, var_map, s_this, t_this, priority);
+                        }
+                        self.constrain_params_with_rest(
+                            ctx,
+                            var_map,
+                            &s_fn.params,
+                            &t_fn.params,
+                            priority,
+                        );
+                    });
                     // Covariant return: source_return <: target_return
                     // Return types must never be inferred at NakedTypeVariable priority
                     // (which is reserved for direct value arguments). Cap at ReturnType so
@@ -1243,7 +1247,6 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         .chain(source_var_map.iter())
                         .map(|(k, v)| (*k, *v))
                         .collect();
-
                     // Unpack tuple rest parameters for proper generic inference.
                     // In TypeScript, `(...args: [A, B]) => R` should match `(a: X, b: Y) => R`
                     // and infer the tuple type. We unpack tuple rest params into fixed params.
@@ -1257,37 +1260,38 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         .iter()
                         .flat_map(|p| unpack_tuple_rest_parameter(self.interner, p))
                         .collect();
-
-                    // Contravariant parameters: target_param <: instantiated_source_param
-                    for (s_p, t_p) in instantiated_params_unpacked
-                        .iter()
-                        .zip(target_params_unpacked.iter())
-                    {
-                        self.constrain_parameter_types(
+                    ctx.with_restored_inference_modes(|ctx| {
+                        ctx.in_contra_mode = !ctx.in_contra_mode;
+                        ctx.in_variance_walk = true;
+                        ctx.in_bivariant_mode |= pending_is_method || t_fn.is_method;
+                        if let (Some(s_this), Some(t_this)) = (instantiated_this, t_fn.this_type) {
+                            self.constrain_parameter_types(
+                                ctx,
+                                &combined_var_map,
+                                s_this,
+                                t_this,
+                                priority,
+                            );
+                        }
+                        for (s_p, t_p) in instantiated_params_unpacked
+                            .iter()
+                            .zip(target_params_unpacked.iter())
+                        {
+                            self.constrain_parameter_types(
+                                ctx,
+                                &combined_var_map,
+                                s_p.type_id,
+                                t_p.type_id,
+                                priority,
+                            );
+                        }
+                        self.infer_rest_param_tuple_candidate(
                             ctx,
                             &combined_var_map,
-                            s_p.type_id,
-                            t_p.type_id,
-                            priority,
+                            &instantiated_params_unpacked,
+                            &target_params_unpacked,
                         );
-                    }
-
-                    self.infer_rest_param_tuple_candidate(
-                        ctx,
-                        &combined_var_map,
-                        &instantiated_params_unpacked,
-                        &target_params_unpacked,
-                    );
-
-                    if let (Some(s_this), Some(t_this)) = (instantiated_this, t_fn.this_type) {
-                        self.constrain_parameter_types(
-                            ctx,
-                            &combined_var_map,
-                            s_this,
-                            t_this,
-                            priority,
-                        );
-                    }
+                    });
                     // Covariant return: instantiated_source_return <: target_return
                     //
                     // Keep source and target placeholders distinct. `constrain_types`
@@ -1320,25 +1324,31 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         return_priority,
                     );
                 }
+                ctx.pending_target_method = was_pending_method;
             }
             (Some(TypeData::Function(s_fn_id)), Some(TypeData::Callable(t_callable_id))) => {
                 let s_fn = self.interner.function_shape(s_fn_id);
                 let t_callable = self.interner.callable_shape(t_callable_id);
                 for sig in &t_callable.call_signatures {
-                    self.constrain_function_to_call_signature(ctx, var_map, &s_fn, sig, priority);
+                    self.constrain_function_to_call_signature(
+                        ctx, var_map, &s_fn, sig, priority, false,
+                    );
                 }
+                let was_pending_method = std::mem::take(&mut ctx.pending_target_method);
                 if s_fn.is_constructor && t_callable.construct_signatures.len() == 1 {
                     let sig = &t_callable.construct_signatures[0];
                     if sig.type_params.is_empty() {
                         self.constrain_function_to_call_signature(
-                            ctx, var_map, &s_fn, sig, priority,
+                            ctx, var_map, &s_fn, sig, priority, true,
                         );
                     }
                 }
+                ctx.pending_target_method = was_pending_method;
             }
             (Some(TypeData::Callable(s_callable_id)), Some(TypeData::Callable(t_callable_id))) => {
                 let s_callable = self.interner.callable_shape(s_callable_id);
                 let t_callable = self.interner.callable_shape(t_callable_id);
+                let was_pending_method = ctx.pending_target_method;
                 self.constrain_matching_signatures(
                     ctx,
                     var_map,
@@ -1347,6 +1357,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     false,
                     priority,
                 );
+                ctx.pending_target_method = false;
                 self.constrain_matching_signatures(
                     ctx,
                     var_map,
@@ -1385,6 +1396,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         priority,
                     );
                 }
+                ctx.pending_target_method = was_pending_method;
             }
             (Some(TypeData::Callable(s_callable_id)), Some(TypeData::Function(t_fn_id))) => {
                 let s_callable = self.interner.callable_shape(s_callable_id);
@@ -1407,7 +1419,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             return_type: sig.return_type,
                             type_predicate: sig.type_predicate,
                             is_constructor: false,
-                            is_method: false,
+                            is_method: sig.is_method,
                         });
                         self.constrain_types(ctx, var_map, func_type, target, priority);
                     }

--- a/crates/tsz-solver/src/operations/constraints/walker_guard_state.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker_guard_state.rs
@@ -60,11 +60,12 @@ pub(super) enum ConstraintPairVisitState {
 }
 
 pub(super) fn constraint_pair_visit_state(
-    pairs: &mut FxHashSet<(TypeId, TypeId)>,
+    pairs: &mut FxHashSet<(TypeId, TypeId, u8)>,
     source: TypeId,
     target: TypeId,
+    inference_mode: u8,
 ) -> ConstraintPairVisitState {
-    if pairs.insert((source, target)) {
+    if pairs.insert((source, target, inference_mode)) {
         ConstraintPairVisitState::Entered
     } else {
         ConstraintPairVisitState::AlreadyVisited
@@ -108,7 +109,12 @@ impl<C: AssignabilityChecker> CallEvaluator<'_, C> {
         }
 
         if matches!(
-            constraint_pair_visit_state(&mut self.constraint_pairs.borrow_mut(), source, target),
+            constraint_pair_visit_state(
+                &mut self.constraint_pairs.borrow_mut(),
+                source,
+                target,
+                ctx.constraint_visit_mode(),
+            ),
             ConstraintPairVisitState::AlreadyVisited
         ) {
             return;
@@ -148,13 +154,32 @@ mod tests {
     fn constraint_pair_visit_state_enters_once_then_reports_revisit() {
         let mut pairs = FxHashSet::default();
         assert_eq!(
-            constraint_pair_visit_state(&mut pairs, TypeId::STRING, TypeId::NUMBER),
+            constraint_pair_visit_state(&mut pairs, TypeId::STRING, TypeId::NUMBER, 0),
             ConstraintPairVisitState::Entered
         );
         assert_eq!(
-            constraint_pair_visit_state(&mut pairs, TypeId::STRING, TypeId::NUMBER),
+            constraint_pair_visit_state(&mut pairs, TypeId::STRING, TypeId::NUMBER, 0),
             ConstraintPairVisitState::AlreadyVisited
         );
+    }
+
+    #[test]
+    fn constraint_pair_guard_distinguishes_modes_in_either_order() {
+        for modes in [[0, 0b010], [0b010, 0]] {
+            let mut pairs = FxHashSet::default();
+            assert_eq!(
+                constraint_pair_visit_state(&mut pairs, TypeId::STRING, TypeId::NUMBER, modes[0],),
+                ConstraintPairVisitState::Entered
+            );
+            assert_eq!(
+                constraint_pair_visit_state(&mut pairs, TypeId::STRING, TypeId::NUMBER, modes[1],),
+                ConstraintPairVisitState::Entered
+            );
+            assert_eq!(
+                constraint_pair_visit_state(&mut pairs, TypeId::STRING, TypeId::NUMBER, modes[1],),
+                ConstraintPairVisitState::AlreadyVisited
+            );
+        }
     }
 
     #[test]

--- a/crates/tsz-solver/src/operations/constraints/walker_helpers.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker_helpers.rs
@@ -111,9 +111,12 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 .unwrap_or(Variance::COVARIANT);
             if variance.is_contravariant() {
                 let was_contra = ctx.in_contra_mode;
+                let was_variance_walk = ctx.in_variance_walk;
                 ctx.in_contra_mode = !was_contra;
+                ctx.in_variance_walk = true;
                 self.constrain_types(ctx, var_map, *s_arg, *t_arg, priority);
                 ctx.in_contra_mode = was_contra;
+                ctx.in_variance_walk = was_variance_walk;
             } else {
                 self.constrain_types(ctx, var_map, *s_arg, *t_arg, priority);
             }
@@ -247,13 +250,16 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         });
         let source_tuple = self.interner.tuple(tuple_elements);
         if needs_regular_candidate {
-            ctx.add_candidate(
-                var,
-                source_tuple,
-                crate::types::InferencePriority::NakedTypeVariable,
-            );
+            ctx.with_restored_inference_modes(|ctx| {
+                ctx.in_contra_mode = !ctx.in_contra_mode;
+                ctx.add_candidate(
+                    var,
+                    source_tuple,
+                    crate::types::InferencePriority::NakedTypeVariable,
+                );
+            });
         } else {
-            ctx.add_contra_candidate(
+            ctx.add_candidate(
                 var,
                 source_tuple,
                 crate::types::InferencePriority::NakedTypeVariable,
@@ -337,7 +343,10 @@ mod tests {
     use crate::def::DefId;
     use crate::intern::TypeInterner;
     use crate::relations::subtype::{TypeEnvironment, TypeResolver};
-    use crate::types::{InferencePriority, PropertyInfo, SymbolRef, TypeParamInfo};
+    use crate::types::{
+        CallSignature, CallableShape, FunctionShape, IndexSignature, InferencePriority, ParamInfo,
+        PropertyInfo, SymbolRef, TypeParamInfo, TypePredicate, TypePredicateTarget,
+    };
 
     struct ResolverBackedChecker<'a> {
         resolver: &'a dyn TypeResolver,
@@ -371,6 +380,452 @@ mod tests {
         fn defs_are_equivalent(&self, a: DefId, b: DefId) -> bool {
             a == b || (a == self.left && b == self.right) || (a == self.right && b == self.left)
         }
+    }
+
+    fn unary_signature(interner: &TypeInterner, ty: TypeId, is_method: bool) -> CallSignature {
+        let mut signature = CallSignature::new(
+            vec![ParamInfo {
+                name: Some(interner.intern_string("value")),
+                type_id: ty,
+                optional: false,
+                rest: false,
+            }],
+            TypeId::UNKNOWN,
+        );
+        signature.is_method = is_method;
+        signature
+    }
+
+    fn assert_signature_candidate_routing(
+        is_construct: bool,
+        target_is_method: bool,
+        use_explicit_this: bool,
+    ) {
+        let interner = TypeInterner::new();
+        let cache = QueryCache::new(&interner);
+        let resolver = TypeEnvironment::new();
+        let mut checker = ResolverBackedChecker {
+            resolver: &resolver,
+            assignable: true,
+        };
+        let mut evaluator = CallEvaluator::new(&cache, &mut checker);
+        let t_param = TypeParamInfo::simple(interner.intern_string("Slot"));
+        let t_type = interner.type_param(t_param);
+        let mut ctx = InferenceContext::new(&interner);
+        let var = ctx.fresh_type_param(t_param.name, false);
+        let mut var_map = FxHashMap::default();
+        var_map.insert(t_type, var);
+        let signature = |ty, is_method| {
+            if use_explicit_this {
+                let mut signature = CallSignature::new(Vec::new(), TypeId::UNKNOWN);
+                signature.this_type = Some(ty);
+                signature.is_method = is_method;
+                signature
+            } else {
+                unary_signature(&interner, ty, is_method)
+            }
+        };
+        let source_sig = signature(TypeId::STRING, true);
+        let target_sig = signature(t_type, target_is_method);
+        let callable = |signature: CallSignature| CallableShape {
+            call_signatures: (!is_construct)
+                .then_some(signature.clone())
+                .into_iter()
+                .collect(),
+            construct_signatures: is_construct.then_some(signature).into_iter().collect(),
+            ..CallableShape::default()
+        };
+        let source = interner.callable(callable(source_sig));
+        let target = interner.callable(callable(target_sig));
+
+        evaluator.constrain_types(
+            &mut ctx,
+            &var_map,
+            source,
+            target,
+            InferencePriority::NakedTypeVariable,
+        );
+
+        let regular = ctx
+            .get_constraints(var)
+            .map(|constraints| constraints.lower_bounds)
+            .unwrap_or_default();
+        let contra = ctx.get_contra_candidate_types(var);
+        if target_is_method {
+            assert_eq!(regular, vec![TypeId::STRING]);
+            assert!(contra.is_empty());
+        } else {
+            assert!(regular.is_empty());
+            assert_eq!(contra, vec![TypeId::STRING]);
+        }
+    }
+
+    fn assert_method_hint_does_not_loosen_constructor_bridge(bridge: u8) {
+        let interner = TypeInterner::new();
+        let cache = QueryCache::new(&interner);
+        let resolver = TypeEnvironment::new();
+        let mut checker = ResolverBackedChecker {
+            resolver: &resolver,
+            assignable: true,
+        };
+        let mut evaluator = CallEvaluator::new(&cache, &mut checker);
+        let t_param = TypeParamInfo::simple(interner.intern_string("Constructed"));
+        let t_type = interner.type_param(t_param);
+        let constructor = |ty, is_method| {
+            let mut shape = FunctionShape::new(
+                unary_signature(&interner, ty, false).params,
+                TypeId::UNKNOWN,
+            );
+            shape.is_constructor = true;
+            shape.is_method = is_method;
+            interner.function(shape)
+        };
+        let callable = |ty, is_method| {
+            interner.callable(CallableShape {
+                call_signatures: vec![CallSignature::new(Vec::new(), TypeId::UNKNOWN)],
+                construct_signatures: vec![unary_signature(&interner, ty, is_method)],
+                ..CallableShape::default()
+            })
+        };
+        let (source, target) = match bridge {
+            0 => (
+                constructor(TypeId::STRING, true),
+                constructor(t_type, false),
+            ),
+            1 => (constructor(TypeId::STRING, true), callable(t_type, false)),
+            _ => (callable(TypeId::STRING, true), callable(t_type, false)),
+        };
+        let mut ctx = InferenceContext::new(&interner);
+        ctx.pending_target_method = true;
+        let var = ctx.fresh_type_param(t_param.name, false);
+        let mut var_map = FxHashMap::default();
+        var_map.insert(t_type, var);
+
+        evaluator.constrain_types(
+            &mut ctx,
+            &var_map,
+            source,
+            target,
+            InferencePriority::NakedTypeVariable,
+        );
+
+        assert!(
+            ctx.get_constraints(var)
+                .map(|constraints| constraints.lower_bounds.is_empty())
+                .unwrap_or(true)
+        );
+        assert_eq!(ctx.get_contra_candidate_types(var), vec![TypeId::STRING]);
+        assert!(ctx.pending_target_method);
+    }
+
+    #[test]
+    fn signature_constraint_variance_uses_target_declaration_kind() {
+        for is_construct in [false, true] {
+            for use_explicit_this in [false, true] {
+                assert_signature_candidate_routing(is_construct, true, use_explicit_this);
+                assert_signature_candidate_routing(is_construct, false, use_explicit_this);
+            }
+        }
+    }
+
+    #[test]
+    fn method_property_hint_does_not_loosen_constructor_bridges() {
+        for bridge in 0..3 {
+            assert_method_hint_does_not_loosen_constructor_bridge(bridge);
+        }
+    }
+
+    #[test]
+    fn nested_strict_signature_toggles_back_to_covariant_candidates() {
+        let interner = TypeInterner::new();
+        let cache = QueryCache::new(&interner);
+        let resolver = TypeEnvironment::new();
+        let mut checker = ResolverBackedChecker {
+            resolver: &resolver,
+            assignable: true,
+        };
+        let mut evaluator = CallEvaluator::new(&cache, &mut checker);
+        let t_param = TypeParamInfo::simple(interner.intern_string("Nested"));
+        let t_type = interner.type_param(t_param);
+        let inner = |ty| {
+            interner.function(FunctionShape::new(
+                unary_signature(&interner, ty, false).params,
+                TypeId::UNKNOWN,
+            ))
+        };
+        let source = interner.callable(CallableShape {
+            call_signatures: vec![unary_signature(&interner, inner(TypeId::STRING), false)],
+            ..CallableShape::default()
+        });
+        let target = interner.callable(CallableShape {
+            call_signatures: vec![unary_signature(&interner, inner(t_type), false)],
+            ..CallableShape::default()
+        });
+        let mut ctx = InferenceContext::new(&interner);
+        let var = ctx.fresh_type_param(t_param.name, false);
+        let mut var_map = FxHashMap::default();
+        var_map.insert(t_type, var);
+
+        evaluator.constrain_types(
+            &mut ctx,
+            &var_map,
+            source,
+            target,
+            InferencePriority::NakedTypeVariable,
+        );
+
+        assert_eq!(
+            ctx.get_constraints(var)
+                .expect("double contravariance must produce a regular candidate")
+                .lower_bounds,
+            vec![TypeId::STRING]
+        );
+        assert!(ctx.get_contra_candidate_types(var).is_empty());
+    }
+
+    #[test]
+    fn triple_nested_strict_signature_routes_to_contravariant_candidates() {
+        let interner = TypeInterner::new();
+        let cache = QueryCache::new(&interner);
+        let resolver = TypeEnvironment::new();
+        let mut checker = ResolverBackedChecker {
+            resolver: &resolver,
+            assignable: true,
+        };
+        let mut evaluator = CallEvaluator::new(&cache, &mut checker);
+        let t_param = TypeParamInfo::simple(interner.intern_string("TripleNested"));
+        let t_type = interner.type_param(t_param);
+        let inner = |ty| {
+            interner.function(FunctionShape::new(
+                unary_signature(&interner, ty, false).params,
+                TypeId::UNKNOWN,
+            ))
+        };
+        let source = interner.callable(CallableShape {
+            call_signatures: vec![unary_signature(
+                &interner,
+                inner(inner(TypeId::STRING)),
+                false,
+            )],
+            ..CallableShape::default()
+        });
+        let target = interner.callable(CallableShape {
+            call_signatures: vec![unary_signature(&interner, inner(inner(t_type)), false)],
+            ..CallableShape::default()
+        });
+        let mut ctx = InferenceContext::new(&interner);
+        let var = ctx.fresh_type_param(t_param.name, false);
+        let mut var_map = FxHashMap::default();
+        var_map.insert(t_type, var);
+
+        evaluator.constrain_types(
+            &mut ctx,
+            &var_map,
+            source,
+            target,
+            InferencePriority::NakedTypeVariable,
+        );
+
+        assert!(
+            ctx.get_constraints(var)
+                .map(|constraints| constraints.lower_bounds.is_empty())
+                .unwrap_or(true)
+        );
+        assert_eq!(ctx.get_contra_candidate_types(var), vec![TypeId::STRING]);
+    }
+
+    #[test]
+    fn method_property_metadata_reaches_rebuilt_constraint_signature() {
+        let interner = TypeInterner::new();
+        let cache = QueryCache::new(&interner);
+        let resolver = TypeEnvironment::new();
+        let mut checker = ResolverBackedChecker {
+            resolver: &resolver,
+            assignable: true,
+        };
+        let mut evaluator = CallEvaluator::new(&cache, &mut checker);
+        let t_param = TypeParamInfo::simple(interner.intern_string("Rebuilt"));
+        let t_type = interner.type_param(t_param);
+        let function = |ty| {
+            interner.function(FunctionShape::new(
+                unary_signature(&interner, ty, false).params,
+                TypeId::UNKNOWN,
+            ))
+        };
+        let member = interner.intern_string("consume");
+        let source = interner.object(vec![PropertyInfo::new(member, function(TypeId::STRING))]);
+        let mut target_property = PropertyInfo::new(member, function(t_type));
+        target_property.is_method = true;
+        let target = interner.object(vec![target_property]);
+        let mut ctx = InferenceContext::new(&interner);
+        let var = ctx.fresh_type_param(t_param.name, false);
+        let mut var_map = FxHashMap::default();
+        var_map.insert(t_type, var);
+
+        evaluator.constrain_types(
+            &mut ctx,
+            &var_map,
+            source,
+            target,
+            InferencePriority::NakedTypeVariable,
+        );
+
+        assert_eq!(
+            ctx.get_constraints(var)
+                .expect("property method metadata must reach the signature boundary")
+                .lower_bounds,
+            vec![TypeId::STRING]
+        );
+        assert!(ctx.get_contra_candidate_types(var).is_empty());
+    }
+
+    #[test]
+    fn method_property_metadata_does_not_reach_callable_number_index() {
+        let interner = TypeInterner::new();
+        let cache = QueryCache::new(&interner);
+        let resolver = TypeEnvironment::new();
+        let mut checker = ResolverBackedChecker {
+            resolver: &resolver,
+            assignable: true,
+        };
+        let mut evaluator = CallEvaluator::new(&cache, &mut checker);
+        let t_param = TypeParamInfo::simple(interner.intern_string("Indexed"));
+        let t_type = interner.type_param(t_param);
+        let function = |ty| {
+            interner.function(FunctionShape::new(
+                unary_signature(&interner, ty, false).params,
+                TypeId::UNKNOWN,
+            ))
+        };
+        let callable = |value_type| {
+            interner.callable(CallableShape {
+                number_index: Some(IndexSignature {
+                    key_type: TypeId::NUMBER,
+                    value_type,
+                    readonly: false,
+                    param_name: None,
+                }),
+                ..CallableShape::default()
+            })
+        };
+        let source = callable(function(TypeId::STRING));
+        let target = callable(function(t_type));
+        let mut ctx = InferenceContext::new(&interner);
+        ctx.pending_target_method = true;
+        let var = ctx.fresh_type_param(t_param.name, false);
+        let mut var_map = FxHashMap::default();
+        var_map.insert(t_type, var);
+
+        evaluator.constrain_types(
+            &mut ctx,
+            &var_map,
+            source,
+            target,
+            InferencePriority::NakedTypeVariable,
+        );
+
+        assert!(
+            ctx.get_constraints(var)
+                .map(|constraints| constraints.lower_bounds.is_empty())
+                .unwrap_or(true)
+        );
+        assert_eq!(ctx.get_contra_candidate_types(var), vec![TypeId::STRING]);
+        assert!(ctx.pending_target_method);
+    }
+
+    #[test]
+    fn method_property_metadata_does_not_reach_type_predicate() {
+        let interner = TypeInterner::new();
+        let cache = QueryCache::new(&interner);
+        let resolver = TypeEnvironment::new();
+        let mut checker = ResolverBackedChecker {
+            resolver: &resolver,
+            assignable: true,
+        };
+        let mut evaluator = CallEvaluator::new(&cache, &mut checker);
+        let t_param = TypeParamInfo::simple(interner.intern_string("Predicate"));
+        let t_type = interner.type_param(t_param);
+        let predicate_name = interner.intern_string("value");
+        let predicate = |ty| TypePredicate {
+            asserts: false,
+            target: TypePredicateTarget::Identifier(predicate_name),
+            type_id: Some(interner.function(FunctionShape::new(
+                unary_signature(&interner, ty, false).params,
+                TypeId::BOOLEAN,
+            ))),
+            parameter_index: Some(0),
+        };
+        let signature = |ty| {
+            let mut signature = CallSignature::new(Vec::new(), TypeId::BOOLEAN);
+            signature.type_predicate = Some(predicate(ty));
+            signature
+        };
+        let mut ctx = InferenceContext::new(&interner);
+        ctx.pending_target_method = true;
+        let var = ctx.fresh_type_param(t_param.name, false);
+        let mut var_map = FxHashMap::default();
+        var_map.insert(t_type, var);
+
+        evaluator.constrain_call_signature_to_call_signature(
+            &mut ctx,
+            &var_map,
+            &signature(TypeId::STRING),
+            &signature(t_type),
+            InferencePriority::ReturnType,
+            false,
+        );
+
+        assert!(
+            ctx.get_constraints(var)
+                .map(|constraints| constraints.lower_bounds.is_empty())
+                .unwrap_or(true)
+        );
+        assert_eq!(ctx.get_contra_candidate_types(var), vec![TypeId::STRING]);
+        assert!(ctx.pending_target_method);
+    }
+
+    #[test]
+    fn method_property_metadata_does_not_reach_return_signature() {
+        let interner = TypeInterner::new();
+        let cache = QueryCache::new(&interner);
+        let resolver = TypeEnvironment::new();
+        let mut checker = ResolverBackedChecker {
+            resolver: &resolver,
+            assignable: true,
+        };
+        let mut evaluator = CallEvaluator::new(&cache, &mut checker);
+        let t_param = TypeParamInfo::simple(interner.intern_string("Returned"));
+        let t_type = interner.type_param(t_param);
+        let function = |ty| {
+            interner.function(FunctionShape::new(
+                unary_signature(&interner, ty, false).params,
+                TypeId::BOOLEAN,
+            ))
+        };
+        let source = CallSignature::new(Vec::new(), function(TypeId::STRING));
+        let target = CallSignature::new(Vec::new(), function(t_type));
+        let mut ctx = InferenceContext::new(&interner);
+        ctx.pending_target_method = true;
+        let var = ctx.fresh_type_param(t_param.name, false);
+        let mut var_map = FxHashMap::default();
+        var_map.insert(t_type, var);
+
+        evaluator.constrain_call_signature_to_call_signature(
+            &mut ctx,
+            &var_map,
+            &source,
+            &target,
+            InferencePriority::ReturnType,
+            false,
+        );
+
+        assert!(
+            ctx.get_constraints(var)
+                .map(|constraints| constraints.lower_bounds.is_empty())
+                .unwrap_or(true)
+        );
+        assert_eq!(ctx.get_contra_candidate_types(var), vec![TypeId::STRING]);
+        assert!(ctx.pending_target_method);
     }
 
     #[test]

--- a/crates/tsz-solver/src/operations/constructors.rs
+++ b/crates/tsz-solver/src/operations/constructors.rs
@@ -132,7 +132,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 type_params: sig.type_params.clone(),
                 type_predicate: sig.type_predicate,
                 is_constructor: true,
-                is_method: false,
+                is_method: sig.is_method,
             };
             return self.resolve_function_call(&func, arg_types);
         }
@@ -165,7 +165,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 type_params: sig.type_params.clone(),
                 type_predicate: sig.type_predicate,
                 is_constructor: true,
-                is_method: false,
+                is_method: sig.is_method,
             };
 
             match self.resolve_function_call(&func, arg_types) {

--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -219,8 +219,8 @@ pub struct CallEvaluator<'a, C: AssignabilityChecker> {
     pub(crate) constraint_recursion_depth: Cell<usize>,
     /// Total constrain-types steps for the current inference pass.
     pub(crate) constraint_step_count: Cell<usize>,
-    /// Visited (source, target) pairs during constraint collection.
-    pub(crate) constraint_pairs: RefCell<FxHashSet<(TypeId, TypeId)>>,
+    /// Visited (source, target, inference-mode) keys during constraint collection.
+    pub(crate) constraint_pairs: RefCell<FxHashSet<(TypeId, TypeId, u8)>>,
     /// Memoized fixed members for target union types during one inference pass.
     /// Keyed by the union `TypeId` used as the target in constrain-types.
     pub(crate) constraint_fixed_union_members: RefCell<FxHashMap<TypeId, FxHashSet<TypeId>>>,

--- a/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
@@ -791,11 +791,14 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     // the inferred type must stand and the error surface at the
                     // call/assignment site (#14792). The evidence check is the second
                     // `&&` operand so it only runs once the cheap override gate passes.
+                    // Callback-parameter-only bounds are contextual feedback; explicit
+                    // annotations are still validated by the final argument check.
                     if ((can_apply && should_use) || indirect_narrowing_override)
-                        && !self.contextual_substitution_contradicts_evidence(
-                            &lower_bounds,
-                            contextual_ty,
-                        )
+                        && (callback_param_only_vars.contains(&var)
+                            || !self.contextual_substitution_contradicts_evidence(
+                                &lower_bounds,
+                                contextual_ty,
+                            ))
                     {
                         contextual_ty
                     } else {

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -626,14 +626,10 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// When `true`, the immediate construct-signature comparison about to start
     /// must compare its parameters **strictly** (contravariantly under
     /// `strict_function_types`), suppressing constructor-parameter bivariance.
-    /// `tsc` applies constructor-parameter bivariance only to class-derived
-    /// constructor functions (`typeof Class`, declaration kind `Constructor`);
-    /// standalone `new (...) => T` type literals and interface construct
-    /// signatures (declaration kind `ConstructSignature`) compare parameters
-    /// like call-signature literals. This flag is set by `check_callable_subtype`
-    /// per construct-signature comparison when the target callable is not a
-    /// class, and is consumed (reset) on entry to `check_function_subtype` so
-    /// nested function comparisons start fresh.
+    /// `tsc` grants constructor-parameter bivariance only when the target
+    /// signature has constructor-declaration provenance (`is_method`). This
+    /// flag is set per strict target construct signature and consumed (reset)
+    /// on entry to `check_function_subtype`, so nested comparisons start fresh.
     pub(crate) force_strict_construct_params: bool,
     /// Whether recursive relation cycles and overflow should be treated as
     /// assumed-related (`true`) or definitive failure (`false`).

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1711,7 +1711,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // TS2327 before this check would hide that root mismatch.
                 let source_type = self.optional_property_type(sp);
                 let target_type = self.optional_property_type(t_prop);
-                let allow_bivariant = sp.is_method || t_prop.is_method;
+                let allow_bivariant = t_prop.is_method;
                 if !self
                     .check_subtype_with_method_variance(source_type, target_type, allow_bivariant)
                     .is_true()

--- a/crates/tsz-solver/src/relations/subtype/explain_function.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_function.rs
@@ -65,7 +65,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         } else {
             target.params.len()
         };
-        let allow_bivariant_param_count = self.allows_bivariant_param_count(source.is_method);
+        // Parameter variance follows the target declaration kind. Explicit
+        // class constructors carry `is_method`; construct-signature types do not.
+        let is_method_or_ctor = target.is_method;
+        let allow_bivariant_param_count = self.allows_bivariant_param_count(is_method_or_ctor);
         // When the target has a rest parameter (e.g., ...args: number[]),
         // it can absorb unlimited arguments — skip the too-many check entirely
         // so we fall through to per-parameter type checking.
@@ -88,9 +91,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             source.params.len()
         };
         let fixed_compare_count = std::cmp::min(source_fixed_count, target_fixed_count);
-        // Constructor and method signatures are bivariant even with strictFunctionTypes
-        let is_method_or_ctor =
-            source.is_method || target.is_method || source.is_constructor || target.is_constructor;
         for i in 0..fixed_compare_count {
             let s_param = &source.params[i];
             let t_param = &target.params[i];

--- a/crates/tsz-solver/src/relations/subtype/explain_indexes.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_indexes.rs
@@ -28,7 +28,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             } else {
                 prop.type_id
             };
-            let allow_bivariant = prop.is_method;
+            let allow_bivariant = false;
 
             if let Some(number_idx) = number_index {
                 let is_numeric = utils::is_numeric_property_name(self.interner, prop.name);

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -43,15 +43,25 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // literal or interface construct signature (`ConstructSignature`) is
         // compared strictly like a call-signature literal.
         let force_strict_construct_params = std::mem::take(&mut self.force_strict_construct_params);
-        let allow_constructor_bivariance = !force_strict_construct_params
-            && !Self::constructor_signatures_need_strict_params(source, target);
+        let allow_constructor_bivariance = target.is_constructor && target.is_method;
+        debug_assert!(
+            !force_strict_construct_params || !allow_constructor_bivariance,
+            "explicit class-constructor targets must not request strict construct variance"
+        );
+        let callback_modes = (
+            self.in_callback_param_check,
+            self.in_bivariant_callback_return_check,
+        );
         let result = self.check_function_subtype_impl(source, target, allow_constructor_bivariance);
         if result.is_true() {
             return result;
         }
-        if let Some(retry) =
-            self.retry_generic_signature_with_context_instantiation(source, target, result)
-        {
+        if let Some(retry) = self.retry_generic_signature_with_context_instantiation(
+            source,
+            target,
+            result,
+            callback_modes,
+        ) {
             return retry;
         }
         result
@@ -207,6 +217,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         target: &FunctionShape,
         allow_constructor_bivariance: bool,
     ) -> SubtypeResult {
+        // Capture and reset the callback-param-check flags at function entry so
+        // every terminal path consumes the one-shot mode and nested sub-checks
+        // cannot steal it before the parameter comparison below.
+        let in_callback_param_check = self.in_callback_param_check;
+        let in_bivariant_callback_return_check = self.in_bivariant_callback_return_check;
+        self.in_callback_param_check = false;
+        self.in_bivariant_callback_return_check = false;
+
         // Constructor vs non-constructor
         if source.is_constructor != target.is_constructor {
             return SubtypeResult::False;
@@ -216,20 +234,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let mut target_instantiated = target.clone();
         // Track type param equivalences scope for cleanup at end of function.
         let equiv_start = self.type_param_equivalences.len();
-
-        // Capture and reset the callback-param-check flag at function entry so
-        // it cannot be prematurely consumed by intermediate sub-checks (return
-        // type, this/type-predicate, generic constraint checks, recursive
-        // signature comparisons) that occur before the parameter comparison
-        // below. Without this early capture, a nested call into
-        // `check_function_subtype_impl` would steal the flag and the outer
-        // signature would lose method-bivariance suppression for its callback
-        // parameters. Resetting to `false` here also matches tsc, where
-        // level-3+ recursions start fresh without the Callback bit.
-        let in_callback_param_check = self.in_callback_param_check;
-        let in_bivariant_callback_return_check = self.in_bivariant_callback_return_check;
-        self.in_callback_param_check = false;
-        self.in_bivariant_callback_return_check = false;
 
         if self.erase_generics
             && source_instantiated.type_params.is_empty()
@@ -931,7 +935,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if !self.are_this_parameters_compatible(
             source_instantiated.this_type,
             target_instantiated.this_type,
-            source_instantiated.is_method || target_instantiated.is_method,
+            in_callback_param_check || target_instantiated.is_method,
         ) {
             self.type_param_equivalences.truncate(equiv_start);
             return SubtypeResult::False;
@@ -943,8 +947,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return SubtypeResult::False;
         }
 
-        // Method/constructor bivariance: strictFunctionTypes only applies to function
-        // type literals, not to methods or construct signatures (new (...) => T).
+        // Target methods and explicit class constructors are bivariant;
+        // function properties and construct-signature types remain strict.
         //
         // tsc's StrictCallback/BivariantCallback override: when the immediately-
         // enclosing comparison was a callback parameter check, methods do *not*
@@ -952,12 +956,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // captured and cleared at the top of this function (see above) so that
         // nested sub-checks performed before this point cannot consume it; we
         // read the captured local here.
-        let constructor_param_bivariance = allow_constructor_bivariance
-            && (source_instantiated.is_constructor || target_instantiated.is_constructor);
+        let constructor_param_bivariance =
+            allow_constructor_bivariance && target_instantiated.is_constructor;
         let is_method = !in_callback_param_check
-            && (source_instantiated.is_method
-                || target_instantiated.is_method
-                || constructor_param_bivariance);
+            && (target_instantiated.is_method || constructor_param_bivariance);
 
         // The lib iterator/generator declarations encode `next(value?)` as a single
         // rest parameter with tuple-list type `[] | [TNext]`. Compare that whole
@@ -1600,7 +1602,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         for t_sig in &target.call_signatures {
             let mut found_match = false;
             if source.call_signatures.len() > 1
-                && (t_sig.is_method || source.call_signatures.iter().any(|sig| sig.is_method))
+                && t_sig.is_method
                 && self
                     .method_overloads_cover_tuple_union_rest_target(&source.call_signatures, t_sig)
             {
@@ -1656,9 +1658,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // `compareSignaturesRelated`, so it is computed from the target callable.
         // Short-circuit on the empty case so a callable with only call
         // signatures pays no resolver lookup.
-        let force_strict = !target.construct_signatures.is_empty()
-            && !self.callable_target_is_class_constructor(target);
         for t_sig in &target.construct_signatures {
+            let force_strict = !t_sig.is_method;
             let mut found_match = false;
             for s_sig in &source.construct_signatures {
                 self.force_strict_construct_params = force_strict;

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/call_signatures.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/call_signatures.rs
@@ -81,9 +81,8 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
     /// (e.g. partially constructed programs). The closure can only witness
     /// classes, so a positive fallback resolves to [`DefKind::Class`].
     ///
-    /// Shared by the relation layer's nominal-kind checks
-    /// (`callable_target_is_class_constructor`,
-    /// `requires_explicit_declared_index_signature`).
+    /// Shared by the relation layer's nominal-kind checks, including
+    /// `requires_explicit_declared_index_signature`.
     pub(crate) fn symbol_def_kind(
         &self,
         symbol_ref: crate::SymbolRef,
@@ -94,74 +93,6 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
         self.is_class_symbol.and_then(|is_class_symbol| {
             is_class_symbol(symbol_ref).then_some(crate::def::DefKind::Class)
         })
-    }
-
-    /// Whether a callable's construct signatures originate from a class
-    /// declaration (`typeof Class`), which `tsc` compares with constructor-
-    /// parameter bivariance (declaration kind `Constructor`).
-    ///
-    /// A `new (...) => T` construct-signature **type literal** carries no
-    /// nominal symbol, and an **interface** construct signature carries an
-    /// interface symbol; both compare parameters strictly (contravariantly
-    /// under `strict_function_types`), exactly like call-signature literals
-    /// (declaration kind `ConstructSignature`). Detection is the same nominal
-    /// `symbol -> DefKind` lookup the rest of the relation layer uses, narrowed
-    /// to `DefKind::Class` so interface construct signatures stay strict.
-    pub(crate) fn callable_target_is_class_constructor(
-        &self,
-        target: &crate::types::CallableShape,
-    ) -> bool {
-        // `new (...) => T` type literal: no nominal class identity.
-        let Some(sym_id) = target.symbol else {
-            return false;
-        };
-        matches!(
-            self.symbol_def_kind(crate::SymbolRef(sym_id.0)),
-            Some(crate::def::DefKind::Class)
-        )
-    }
-
-    pub(crate) fn constructor_signatures_need_strict_params(
-        source: &FunctionShape,
-        target: &FunctionShape,
-    ) -> bool {
-        if !(source.is_constructor || target.is_constructor) {
-            return false;
-        }
-
-        let source_generic = !source.type_params.is_empty();
-        let target_generic = !target.type_params.is_empty();
-        if !source_generic && !target_generic {
-            // Non-generic constructors need strict params when there's an
-            // optionality mismatch between corresponding parameters. This
-            // matches tsc where property-typed constructor types like
-            // `new (x?: number) => number` use strict comparison, not
-            // constructor bivariance.
-            return source
-                .params
-                .iter()
-                .zip(target.params.iter())
-                .any(|(sp, tp)| sp.optional != tp.optional);
-        }
-
-        if source_generic && !target_generic {
-            let has_optionality_mismatch = source
-                .params
-                .iter()
-                .zip(target.params.iter())
-                .any(|(sp, tp)| sp.optional != tp.optional);
-            return has_optionality_mismatch
-                || source.type_params.iter().any(|tp| tp.constraint.is_some());
-        }
-
-        source.type_params.len() != target.type_params.len()
-            || source
-                .type_params
-                .iter()
-                .chain(target.type_params.iter())
-                .any(|tp| tp.constraint.is_some())
-            || source.params.len() != 1
-            || target.params.len() != 1
     }
 
     /// Check call signature subtype to function shape.

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/context_instantiation.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/context_instantiation.rs
@@ -43,6 +43,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: &FunctionShape,
         target: &FunctionShape,
         direct_result: SubtypeResult,
+        callback_modes: (bool, bool),
     ) -> Option<SubtypeResult> {
         if direct_result.is_true() {
             return None;
@@ -82,10 +83,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             .infer_source_type_param_substitution(&source_for_inference, &target_for_inference)
             .ok()?;
         let inferred_source = self.instantiate_function_shape(&source_for_inference, &substitution);
-        let allow_constructor_bivariance = !Self::constructor_signatures_need_strict_params(
-            &inferred_source,
-            &target_for_inference,
-        );
+        let allow_constructor_bivariance =
+            target_for_inference.is_constructor && target_for_inference.is_method;
+        self.in_callback_param_check = callback_modes.0;
+        self.in_bivariant_callback_return_check = callback_modes.1;
         let retry = self.check_function_subtype_impl(
             &inferred_source,
             &target_for_inference,

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
@@ -1040,27 +1040,30 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     };
                     self.check_function_subtype(&source_fn, &variant_fn)
                         .is_true()
-                        || self.method_overload_prefix_covers_variant(source_sig, &variant_params)
+                        || self.method_overload_prefix_covers_variant(&source_fn, &variant_fn)
                 })
         })
     }
 
     fn method_overload_prefix_covers_variant(
         &mut self,
-        source_sig: &CallSignature,
-        variant_params: &[ParamInfo],
+        source: &FunctionShape,
+        target: &FunctionShape,
     ) -> bool {
-        if !source_sig.is_method || variant_params.is_empty() {
+        if target.params.is_empty() {
             return false;
         }
-        if source_sig.params.len() < variant_params.len() {
+        if source.params.len() < target.params.len()
+            || !self.are_this_parameters_compatible(source.this_type, target.this_type, true)
+            || !self.are_type_predicates_compatible(source, target)
+        {
             return false;
         }
-        source_sig
+        source
             .params
             .iter()
-            .zip(variant_params.iter())
-            .take(variant_params.len())
+            .zip(target.params.iter())
+            .take(target.params.len())
             .all(|(source_param, target_param)| {
                 let (source_type, target_type) =
                     self.effective_param_type_pair(source_param, target_param);

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
@@ -1295,13 +1295,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
             if !self.is_uninformative_contextual_inference_input(t_effective) {
                 let was_contra = infer_ctx.in_contra_mode;
+                let was_variance_walk = infer_ctx.in_variance_walk;
                 infer_ctx.in_contra_mode = true;
+                infer_ctx.in_variance_walk = true;
                 let _ = infer_ctx.infer_from_types(
                     s_effective,
                     t_effective,
                     InferencePriority::NakedTypeVariable,
                 );
                 infer_ctx.in_contra_mode = was_contra;
+                infer_ctx.in_variance_walk = was_variance_walk;
             }
         }
 
@@ -1315,25 +1318,31 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 .skip(target_fixed_count)
             {
                 let was_contra = infer_ctx.in_contra_mode;
+                let was_variance_walk = infer_ctx.in_variance_walk;
                 infer_ctx.in_contra_mode = true;
+                infer_ctx.in_variance_walk = true;
                 let _ = infer_ctx.infer_from_types(
                     s_param.type_id,
                     rest_elem_type,
                     InferencePriority::NakedTypeVariable,
                 );
                 infer_ctx.in_contra_mode = was_contra;
+                infer_ctx.in_variance_walk = was_variance_walk;
             }
 
             if source_has_rest && let Some(s_rest_param) = source_params_unpacked.last() {
                 let s_rest_elem = self.get_array_element_type(s_rest_param.type_id);
                 let was_contra = infer_ctx.in_contra_mode;
+                let was_variance_walk = infer_ctx.in_variance_walk;
                 infer_ctx.in_contra_mode = true;
+                infer_ctx.in_variance_walk = true;
                 let _ = infer_ctx.infer_from_types(
                     s_rest_elem,
                     rest_elem_type,
                     InferencePriority::NakedTypeVariable,
                 );
                 infer_ctx.in_contra_mode = was_contra;
+                infer_ctx.in_variance_walk = was_variance_walk;
             }
         }
 
@@ -1346,13 +1355,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             {
                 if !self.is_uninformative_contextual_inference_input(t_param.type_id) {
                     let was_contra = infer_ctx.in_contra_mode;
+                    let was_variance_walk = infer_ctx.in_variance_walk;
                     infer_ctx.in_contra_mode = true;
+                    infer_ctx.in_variance_walk = true;
                     let _ = infer_ctx.infer_from_types(
                         rest_elem_type,
                         t_param.type_id,
                         InferencePriority::NakedTypeVariable,
                     );
                     infer_ctx.in_contra_mode = was_contra;
+                    infer_ctx.in_variance_walk = was_variance_walk;
                 }
             }
         }

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -697,7 +697,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             self.bind_property_receiver_this(source_receiver, self.optional_property_type(source));
         let target_read =
             self.bind_property_receiver_this(target_receiver, self.optional_property_type(target));
-        let allow_bivariant = source.is_method || target.is_method;
+        let allow_bivariant = target.is_method;
 
         // Mark that we're inside a property comparison so nested weak type checks
         // apply to recursive structural comparisons of property types.
@@ -1333,7 +1333,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     let target_value =
                         self.bind_property_receiver_this(target_receiver, t_number_idx.value_type);
                     if !self
-                        .check_subtype_with_method_variance(prop_type, target_value, prop.is_method)
+                        .check_subtype_with_method_variance(prop_type, target_value, false)
                         .is_true()
                     {
                         return SubtypeResult::False;
@@ -1511,7 +1511,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     target_receiver,
                     self.optional_property_type(t_prop),
                 );
-                let allow_bivariant = sp.is_method || t_prop.is_method;
+                let allow_bivariant = t_prop.is_method;
                 if !self
                     .check_subtype_with_method_variance(source_type, target_type, allow_bivariant)
                     .is_true()
@@ -1658,7 +1658,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             } else {
                 string_prop_type
             };
-            let allow_bivariant = prop.is_method;
+            let allow_bivariant = false;
 
             if let Some(number_idx) = number_index {
                 let is_numeric = utils::is_numeric_property_name(self.interner, prop.name);

--- a/crates/tsz-solver/tests/compat_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/compat_tests_parts/part_00.rs
@@ -921,6 +921,37 @@ fn test_explain_failure_parameter_mismatch_strict() {
     ));
 }
 
+#[test]
+fn strict_construct_target_explains_extra_class_constructor_parameter() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+    checker.set_strict_function_types(true);
+    let mut source_shape = FunctionShape::new(
+        vec![
+            ParamInfo::unnamed(TypeId::STRING),
+            ParamInfo::unnamed(TypeId::NUMBER),
+        ],
+        TypeId::VOID,
+    );
+    source_shape.is_constructor = true;
+    source_shape.is_method = true;
+    let mut target_shape = FunctionShape::new(
+        vec![ParamInfo::unnamed(TypeId::STRING)],
+        TypeId::VOID,
+    );
+    target_shape.is_constructor = true;
+    let source = interner.function(source_shape);
+    let target = interner.function(target_shape);
+
+    assert!(matches!(
+        checker.explain_failure(source, target),
+        Some(SubtypeFailureReason::TooManyParameters {
+            source_count: 2,
+            target_count: 1,
+        })
+    ));
+}
+
 /// When the outer parameter mismatch is *itself* a callable, the
 /// `inner_reason` should describe how the inner contravariant subtype
 /// check (`target_param <: source_param`) failed. This is what lets

--- a/crates/tsz-solver/tests/matching_tests.rs
+++ b/crates/tsz-solver/tests/matching_tests.rs
@@ -7,7 +7,7 @@
 use super::*;
 use crate::construction::TypeDatabase;
 use crate::def::DefId;
-use crate::inference::infer::InferenceContext;
+use crate::inference::infer::{InferenceContext, InferenceError, ParameterRecoveryMode};
 use crate::intern::TypeInterner;
 use crate::relations::subtype::TypeResolver;
 use crate::types::{
@@ -29,6 +29,77 @@ fn make_type_param(interner: &TypeInterner, name: &str) -> (tsz_common::interner
         origin: crate::types::TypeParamOrigin::User,
     }));
     (atom, ty)
+}
+
+fn unary_function(
+    interner: &TypeInterner,
+    parameter_type: TypeId,
+    is_method: bool,
+    is_constructor: bool,
+) -> TypeId {
+    interner.function(FunctionShape {
+        type_params: Vec::new(),
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("value")),
+            type_id: parameter_type,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: TypeId::VOID,
+        type_predicate: None,
+        is_constructor,
+        is_method,
+    })
+}
+
+fn unary_call_signature(
+    interner: &TypeInterner,
+    parameter_type: TypeId,
+    is_method: bool,
+) -> CallSignature {
+    CallSignature {
+        type_params: Vec::new(),
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("entry")),
+            type_id: parameter_type,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: TypeId::VOID,
+        type_predicate: None,
+        is_method,
+    }
+}
+
+fn function_with_this(interner: &TypeInterner, this_type: TypeId, is_method: bool) -> TypeId {
+    interner.function(FunctionShape {
+        type_params: Vec::new(),
+        params: Vec::new(),
+        this_type: Some(this_type),
+        return_type: TypeId::VOID,
+        type_predicate: None,
+        is_constructor: false,
+        is_method,
+    })
+}
+
+fn assert_candidate_partition(
+    context: &mut InferenceContext<'_>,
+    variable: crate::inference::infer::InferenceVar,
+    expected_regular: &[TypeId],
+    expected_contra: &[TypeId],
+) {
+    let regular = context
+        .get_constraints(variable)
+        .map(|constraints| constraints.lower_bounds)
+        .unwrap_or_default();
+    assert_eq!(regular, expected_regular);
+    assert_eq!(
+        context.get_contra_candidate_types(variable),
+        expected_contra
+    );
 }
 
 struct CanonicalApplicationResolver {
@@ -811,6 +882,333 @@ fn test_match_contravariant_parameter() {
     // (because infer_functions swaps target and source for params)
     let result = ctx.resolve_with_constraints(var_t).unwrap();
     assert_eq!(result, TypeId::STRING);
+}
+
+#[test]
+fn test_method_target_parameter_records_regular_candidate_with_renamed_binders() {
+    for binder in ["Payload", "RenamedItem"] {
+        let interner = TypeInterner::new();
+        let mut context = InferenceContext::new(&interner);
+        let (parameter_name, parameter_type) = make_type_param(&interner, binder);
+        let variable = context.fresh_type_param(parameter_name, false);
+
+        let source = unary_function(&interner, TypeId::STRING, false, false);
+        let target = unary_function(&interner, parameter_type, true, false);
+        context
+            .infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+            .unwrap();
+
+        assert_candidate_partition(&mut context, variable, &[TypeId::STRING], &[]);
+    }
+}
+
+#[test]
+fn test_constructor_inference_uses_target_declaration_kind() {
+    for (binder, target_is_class, regular, contra) in [
+        ("ClassConstructor", true, &[TypeId::NUMBER][..], &[][..]),
+        ("ConstructType", false, &[][..], &[TypeId::NUMBER][..]),
+    ] {
+        let interner = TypeInterner::new();
+        let mut context = InferenceContext::new(&interner);
+        let (parameter_name, parameter_type) = make_type_param(&interner, binder);
+        let variable = context.fresh_type_param(parameter_name, false);
+        let source = unary_function(&interner, TypeId::NUMBER, true, true);
+        let target = unary_function(&interner, parameter_type, target_is_class, true);
+
+        context
+            .infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+            .unwrap();
+
+        assert_candidate_partition(&mut context, variable, regular, contra);
+    }
+}
+
+#[test]
+fn test_method_property_hint_does_not_loosen_strict_constructor_target() {
+    let interner = TypeInterner::new();
+    let (name, target_param) = make_type_param(&interner, "Constructed");
+    let source = unary_function(&interner, TypeId::STRING, true, true);
+    let target = unary_function(&interner, target_param, false, true);
+    let mut context = InferenceContext::new(&interner);
+    let variable = context.fresh_type_param(name, false);
+    context.pending_target_method = true;
+
+    context
+        .infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .expect("constructor inference should complete");
+
+    assert_candidate_partition(&mut context, variable, &[], &[TypeId::STRING]);
+    assert!(context.pending_target_method);
+}
+
+#[test]
+fn test_method_property_hint_does_not_reach_returned_signature() {
+    let interner = TypeInterner::new();
+    let (name, target_param) = make_type_param(&interner, "Returned");
+    let source_return = unary_function(&interner, TypeId::STRING, false, false);
+    let target_return = unary_function(&interner, target_param, false, false);
+    let source = interner.function(FunctionShape::new(Vec::new(), source_return));
+    let target = interner.function(FunctionShape::new(Vec::new(), target_return));
+    let mut context = InferenceContext::new(&interner);
+    let variable = context.fresh_type_param(name, false);
+    context.pending_target_method = true;
+
+    context
+        .infer_from_types(source, target, InferencePriority::ReturnType)
+        .expect("nested return inference should complete");
+
+    assert_candidate_partition(&mut context, variable, &[], &[TypeId::STRING]);
+    assert!(context.pending_target_method);
+}
+
+#[test]
+fn test_method_property_metadata_reaches_rebuilt_function_signature() {
+    let interner = TypeInterner::new();
+    let mut context = InferenceContext::new(&interner);
+    let (parameter_name, parameter_type) = make_type_param(&interner, "Element");
+    let variable = context.fresh_type_param(parameter_name, false);
+    let member_name = interner.intern_string("consume");
+
+    let source_member = unary_function(&interner, TypeId::BOOLEAN, false, false);
+    let target_member = unary_function(&interner, parameter_type, false, false);
+    let source = interner.object(vec![PropertyInfo::new(member_name, source_member)]);
+    let mut target_property = PropertyInfo::new(member_name, target_member);
+    target_property.is_method = true;
+    let target = interner.object(vec![target_property]);
+
+    context
+        .infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    assert_candidate_partition(&mut context, variable, &[TypeId::BOOLEAN], &[]);
+}
+
+#[test]
+fn test_method_bivariant_mode_persists_through_nested_callback_signature() {
+    let interner = TypeInterner::new();
+    let mut context = InferenceContext::new(&interner);
+    let (parameter_name, parameter_type) = make_type_param(&interner, "NestedValue");
+    let variable = context.fresh_type_param(parameter_name, false);
+
+    let source_callback = unary_function(&interner, TypeId::STRING, false, false);
+    let target_callback = unary_function(&interner, parameter_type, false, false);
+    let source_method = unary_function(&interner, source_callback, false, false);
+    let target_method = unary_function(&interner, target_callback, true, false);
+
+    context
+        .infer_from_types(
+            source_method,
+            target_method,
+            InferencePriority::NakedTypeVariable,
+        )
+        .unwrap();
+
+    assert_candidate_partition(&mut context, variable, &[TypeId::STRING], &[]);
+}
+
+#[test]
+fn test_nested_strict_function_parameters_toggle_back_to_covariance() {
+    let interner = TypeInterner::new();
+    let mut context = InferenceContext::new(&interner);
+    let (parameter_name, parameter_type) = make_type_param(&interner, "DoubleContra");
+    let variable = context.fresh_type_param(parameter_name, false);
+    let source_inner = unary_function(&interner, TypeId::STRING, false, false);
+    let target_inner = unary_function(&interner, parameter_type, false, false);
+    let source = unary_function(&interner, source_inner, false, false);
+    let target = unary_function(&interner, target_inner, false, false);
+
+    context
+        .infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    assert_candidate_partition(&mut context, variable, &[TypeId::STRING], &[]);
+}
+
+#[test]
+fn test_nested_variance_walk_keeps_source_placeholder_as_regular_candidate() {
+    let interner = TypeInterner::new();
+    let mut context = InferenceContext::new(&interner);
+    let (parameter_name, parameter_type) = make_type_param(&interner, "NestedSource");
+    let variable = context.fresh_type_param(parameter_name, false);
+    let source_inner = unary_function(&interner, parameter_type, false, false);
+    let target_inner = unary_function(&interner, TypeId::STRING, false, false);
+    let source = unary_function(&interner, source_inner, false, false);
+    let target = unary_function(&interner, target_inner, false, false);
+
+    context
+        .infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    let constraints = context
+        .get_constraints(variable)
+        .expect("nested source placeholder should remain inference evidence");
+    assert_eq!(constraints.lower_bounds, vec![TypeId::STRING]);
+    assert!(constraints.upper_bounds.is_empty());
+    assert!(context.get_contra_candidate_types(variable).is_empty());
+}
+
+#[test]
+fn test_explicit_this_uses_target_method_variance() {
+    for (binder, is_method, regular, contra) in [
+        ("MethodThis", true, &[TypeId::STRING][..], &[][..]),
+        ("PropertyThis", false, &[][..], &[TypeId::STRING][..]),
+    ] {
+        let interner = TypeInterner::new();
+        let mut context = InferenceContext::new(&interner);
+        let (parameter_name, parameter_type) = make_type_param(&interner, binder);
+        let variable = context.fresh_type_param(parameter_name, false);
+        let source = function_with_this(&interner, TypeId::STRING, false);
+        let target = function_with_this(&interner, parameter_type, is_method);
+
+        context
+            .infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+            .unwrap();
+
+        assert_candidate_partition(&mut context, variable, regular, contra);
+    }
+}
+
+#[test]
+fn test_function_valued_property_parameter_remains_contravariant() {
+    let interner = TypeInterner::new();
+    let mut context = InferenceContext::new(&interner);
+    let (parameter_name, parameter_type) = make_type_param(&interner, "OrdinaryProperty");
+    let variable = context.fresh_type_param(parameter_name, false);
+    let member_name = interner.intern_string("callback");
+
+    let source_member = unary_function(&interner, TypeId::NUMBER, false, false);
+    let target_member = unary_function(&interner, parameter_type, false, false);
+    let source = interner.object(vec![PropertyInfo::new(member_name, source_member)]);
+    let target = interner.object(vec![PropertyInfo::new(member_name, target_member)]);
+
+    context
+        .infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    assert_candidate_partition(&mut context, variable, &[], &[TypeId::NUMBER]);
+}
+
+#[test]
+fn test_callable_signature_inference_uses_target_declaration_kind() {
+    for (binder, use_construct_signature, target_is_method) in [
+        ("MethodArg", false, true),
+        ("ClassCtorArg", true, true),
+        ("ConstructTypeArg", true, false),
+    ] {
+        let interner = TypeInterner::new();
+        let mut context = InferenceContext::new(&interner);
+        let (parameter_name, parameter_type) = make_type_param(&interner, binder);
+        let variable = context.fresh_type_param(parameter_name, false);
+
+        let source_signature = unary_call_signature(&interner, TypeId::STRING, false);
+        let target_signature = unary_call_signature(&interner, parameter_type, target_is_method);
+        let (source_calls, source_constructs, target_calls, target_constructs) =
+            if use_construct_signature {
+                (
+                    Vec::new(),
+                    vec![source_signature],
+                    Vec::new(),
+                    vec![target_signature],
+                )
+            } else {
+                (
+                    vec![source_signature],
+                    Vec::new(),
+                    vec![target_signature],
+                    Vec::new(),
+                )
+            };
+        let source = interner.callable(CallableShape {
+            call_signatures: source_calls,
+            construct_signatures: source_constructs,
+            ..CallableShape::default()
+        });
+        let target = interner.callable(CallableShape {
+            call_signatures: target_calls,
+            construct_signatures: target_constructs,
+            ..CallableShape::default()
+        });
+
+        context
+            .infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+            .unwrap();
+
+        if target_is_method {
+            assert_candidate_partition(&mut context, variable, &[TypeId::STRING], &[]);
+        } else {
+            assert_candidate_partition(&mut context, variable, &[], &[TypeId::STRING]);
+        }
+    }
+}
+
+#[test]
+fn test_inference_modes_restore_after_error() {
+    let interner = TypeInterner::new();
+    let mut context = InferenceContext::new(&interner);
+    let failed: Result<(), InferenceError> = context.with_restored_inference_modes(|ctx| {
+        ctx.in_contra_mode = true;
+        ctx.in_variance_walk = true;
+        ctx.parameter_recovery_mode = ParameterRecoveryMode::ComplexPlaceholder;
+        ctx.in_bivariant_mode = true;
+        ctx.pending_target_method = true;
+        Err(InferenceError::Conflict(TypeId::STRING, TypeId::NUMBER))
+    });
+
+    assert!(matches!(failed, Err(InferenceError::Conflict(..))));
+    assert!(!context.in_contra_mode);
+    assert!(!context.in_variance_walk);
+    assert_eq!(context.parameter_recovery_mode, ParameterRecoveryMode::None);
+    assert!(!context.in_bivariant_mode);
+    assert!(!context.pending_target_method);
+}
+
+#[test]
+fn test_constraint_visit_mode_omits_matcher_only_variance_state() {
+    let interner = TypeInterner::new();
+    let mut context = InferenceContext::new(&interner);
+    let base_constraint_mode = context.constraint_visit_mode();
+    let base_matching_mode = context.inference_visit_mode();
+
+    context.in_variance_walk = true;
+    assert_eq!(context.constraint_visit_mode(), base_constraint_mode);
+    assert_ne!(context.inference_visit_mode(), base_matching_mode);
+
+    context.parameter_recovery_mode = ParameterRecoveryMode::StandaloneReverse;
+    assert_ne!(context.constraint_visit_mode(), base_constraint_mode);
+}
+
+#[test]
+fn test_inference_visited_distinguishes_method_property_mode() {
+    let interner = TypeInterner::new();
+    let mut context = InferenceContext::new(&interner);
+    let (parameter_name, parameter_type) = make_type_param(&interner, "VisitedMode");
+    let variable = context.fresh_type_param(parameter_name, false);
+    let ordinary_name = interner.intern_string("ordinary");
+    let method_name = interner.intern_string("method");
+
+    let source_member = unary_function(&interner, TypeId::BOOLEAN, false, false);
+    let target_member = unary_function(&interner, parameter_type, false, false);
+    let source = interner.object(vec![
+        PropertyInfo::new(ordinary_name, source_member),
+        PropertyInfo::new(method_name, source_member),
+    ]);
+    let mut method_property = PropertyInfo::new(method_name, target_member);
+    method_property.is_method = true;
+    let target = interner.object(vec![
+        PropertyInfo::new(ordinary_name, target_member),
+        method_property,
+    ]);
+
+    context
+        .infer_from_types(source, target, InferencePriority::NakedTypeVariable)
+        .unwrap();
+
+    assert_candidate_partition(
+        &mut context,
+        variable,
+        &[TypeId::BOOLEAN],
+        &[TypeId::BOOLEAN],
+    );
 }
 
 // =============================================================================

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_01.rs
@@ -1321,7 +1321,7 @@ fn test_named_object_without_number_index_does_not_satisfy_number_index_target()
 }
 
 #[test]
-fn test_number_index_signature_method_bivariant_property() {
+fn test_number_index_signature_method_property_is_strict() {
     let interner = TypeInterner::new();
     let mut checker = SubtypeChecker::new(&interner);
 
@@ -1383,7 +1383,7 @@ fn test_number_index_signature_method_bivariant_property() {
     };
     let target = interner.object_with_index(target_shape);
 
-    assert!(checker.is_subtype_of(source_method, target));
+    assert!(!checker.is_subtype_of(source_method, target));
     assert!(!checker.is_subtype_of(source_prop, target));
 }
 
@@ -1476,7 +1476,7 @@ fn test_namespace_object_can_satisfy_string_index_structurally() {
 }
 
 #[test]
-fn test_string_index_signature_method_bivariant_property() {
+fn test_string_index_signature_method_property_is_strict() {
     let interner = TypeInterner::new();
     let mut checker = SubtypeChecker::new(&interner);
 
@@ -1538,7 +1538,7 @@ fn test_string_index_signature_method_bivariant_property() {
     };
     let target = interner.object_with_index(target_shape);
 
-    assert!(checker.is_subtype_of(source_method, target));
+    assert!(!checker.is_subtype_of(source_method, target));
     assert!(!checker.is_subtype_of(source_prop, target));
 }
 
@@ -1806,4 +1806,3 @@ fn test_object_with_index_properties_match_target_index() {
 
     assert!(checker.is_subtype_of(source, target));
 }
-

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_02.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_02.rs
@@ -884,7 +884,7 @@ fn test_method_bivariant_required_param() {
 }
 
 #[test]
-fn test_method_source_bivariant_against_function_property() {
+fn test_method_source_is_strict_against_function_property() {
     let interner = TypeInterner::new();
     let mut checker = SubtypeChecker::new(&interner);
     let name = interner.intern_string("m");
@@ -954,7 +954,7 @@ fn test_method_source_bivariant_against_function_property() {
         single_quoted_name: false, non_widening: false,
     }]);
 
-    assert!(checker.is_subtype_of(source, target));
+    assert!(!checker.is_subtype_of(source, target));
 }
 
 #[test]
@@ -1318,7 +1318,7 @@ fn test_variance_optional_rest_function_rest_with_this_contravariant() {
 }
 
 #[test]
-fn test_variance_optional_rest_constructor_optional_bivariant() {
+fn test_variance_optional_rest_construct_signature_optional_strict() {
     let interner = TypeInterner::new();
     let mut checker = SubtypeChecker::new(&interner);
 
@@ -1356,12 +1356,13 @@ fn test_variance_optional_rest_constructor_optional_bivariant() {
     });
 
     assert!(checker.is_subtype_of(wide_ctor, narrow_ctor));
-    // Constructor signatures are bivariant (like methods), not contravariant
-    assert!(checker.is_subtype_of(narrow_ctor, wide_ctor));
+    // A construct-signature type is strict. Only a class constructor declaration
+    // carries the method-like provenance that grants bivariance.
+    assert!(!checker.is_subtype_of(narrow_ctor, wide_ctor));
 }
 
 #[test]
-fn test_variance_optional_rest_constructor_rest_bivariant() {
+fn test_variance_optional_rest_construct_signature_rest_strict() {
     let interner = TypeInterner::new();
     let mut checker = SubtypeChecker::new(&interner);
 
@@ -1401,8 +1402,9 @@ fn test_variance_optional_rest_constructor_rest_bivariant() {
     });
 
     assert!(checker.is_subtype_of(wide_ctor, narrow_ctor));
-    // Constructor signatures are bivariant (like methods), not contravariant
-    assert!(checker.is_subtype_of(narrow_ctor, wide_ctor));
+    // A construct-signature type is strict. Only a class constructor declaration
+    // carries the method-like provenance that grants bivariance.
+    assert!(!checker.is_subtype_of(narrow_ctor, wide_ctor));
 }
 
 #[test]
@@ -1804,4 +1806,3 @@ fn test_this_parameter_variance() {
     assert!(checker.is_subtype_of(union_this_fn, string_this_fn));
     assert!(!checker.is_subtype_of(string_this_fn, union_this_fn));
 }
-

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_03.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_03.rs
@@ -67,7 +67,7 @@ fn test_this_parameter_function_property_contravariant() {
 }
 
 #[test]
-fn test_this_parameter_method_source_bivariant_against_function_property() {
+fn test_this_parameter_method_source_is_strict_against_function_property() {
     let interner = TypeInterner::new();
     let mut checker = SubtypeChecker::new(&interner);
     let name = interner.intern_string("m");
@@ -127,7 +127,7 @@ fn test_this_parameter_method_source_bivariant_against_function_property() {
         single_quoted_name: false, non_widening: false,
     }]);
 
-    assert!(checker.is_subtype_of(source, target));
+    assert!(!checker.is_subtype_of(source, target));
 }
 
 #[test]
@@ -1806,4 +1806,3 @@ fn test_mapped_type_key_remap_optional_remove_subtyping() {
     assert!(checker.is_subtype_of(mapped, required_b));
     assert!(checker.is_subtype_of(mapped, optional_b));
 }
-


### PR DESCRIPTION
Goal: green

## Structural rule

When a function or construct signature is related or used for inference, parameter variance follows the target declaration kind. Target MethodDeclaration, MethodSignature, and explicit class Constructor declarations grant method-style bivariance; function properties, call-signature types, and construct-signature types remain strict even when the source came from a method or class constructor.

When placeholder-free parameter dependency recovery reverses a constraint edge, that standalone reverse cancels ambient signature contravariance while preserving source-placeholder evidence. When a complex target contains a call-local placeholder, both recovery directions preserve the live structural polarity: each nested strict signature parameter edge toggles it, so occurrences beneath an even number of parameter edges feed regular candidates and occurrences beneath an odd number feed `contraCandidates`; proven method/class-constructor provenance suppresses contra routing without changing traversal direction. TSZ owns this in solver inference/constraint modes, which remain request-local and are restored after every scoped walk.

Owner: solver inference, constraint collection, and subtype relation. Checker and lowering preserve declaration-origin metadata only.

## Adjacent matrix

- Method targets accept bivariant parameter candidates; property targets collect strict contravariant candidates.
- Real class constructor targets stay bivariant; new-signature type literals and interface construct signatures stay strict.
- Source methods and class constructors do not loosen strict property, index-signature, or construct-signature targets.
- Explicit this, overload tuple-rest shortcuts, predicates, nested callbacks, generic contextual-instantiation retries, and reverse-keyof recovery follow the same target-driven rule.
- Standalone and complex-placeholder recovery retain distinct modes; double- and triple-nested strict-signature controls prove even/odd polarity routing.
- Method metadata is consumed at the immediate signature boundary and does not leak into returns, predicates, indexes, nested construct signatures, or later comparisons.
- Renamed-binder and positive/negative controls prevent fixture-name dependence.

## Fallback and performance

No source text, identifier, alias, property, or file-name predicate is used. The existing FunctionShape and CallSignature is_method bit is the declaration-origin signal.

Inference keeps allocation-free request-local state in compact u8 cycle keys. The structural matcher key includes polarity, sticky variance, bivariance, pending-method state, and a three-state recovery mode; its theoretical space is 48 combinations. The constraint-walker key deliberately omits matcher-only sticky variance, limiting its theoretical space to 24 and preventing duplicate constraint work from consuming the shared step budget. The correction preserves existing state and visited-key dimensions, so it adds no residency or step-budget cost. Conservative strict behavior remains the fallback without proven method provenance.

## Verification

- cargo fmt --all -- --check
- git diff --check
- Exact callback-marker, actor, rest, self-constrained-pipe, and reverse-keyof merge regressions (7/7)
- cargo nextest run -p tsz-checker --test method_inference_bivariance_tests --test construct_signature_param_variance_tests (19/19)
- Focused solver variance, mode-restoration, visited-key, rest, keyof, and template-helper matrix (21/21)
- cargo nextest run -p tsz-solver --lib -E test(test_constraint_visit_mode_omits_matcher_only_variance_state) (1/1)
- cargo nextest run -p tsz-solver --test architecture_guards (13/13)
- cargo clippy -p tsz-solver -p tsz-checker -p tsz-lowering --lib -- -D warnings
- Post-rebase double/triple nested strict-signature polarity controls (2/2)
- TypeScript 6.0.0-dev probes confirm optional/rest construct-signature strictness and overload predicate directionality.

## Provenance

Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high