### PR TITLE
fix(solver): materialize dependent operand constraints

### DIFF
--- a/crates/tsz-cli/tests/driver_tests.rs
+++ b/crates/tsz-cli/tests/driver_tests.rs
@@ -105,3 +105,4 @@ include!("driver_tests_parts/part_10.rs");
 include!("driver_tests_parts/part_11.rs");
 include!("driver_tests_parts/part_12.rs");
 include!("driver_tests_parts/part_13.rs");
+include!("driver_tests_parts/part_14.rs");

--- a/crates/tsz-cli/tests/driver_tests_parts/part_14.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_14.rs
@@ -1,0 +1,359 @@
+/// Cross-file dependent constraints must materialize imported alias
+/// applications before reducing the mapped/indexed/conditional types that
+/// contain them. The same `InputValue` node is shared by the scalar and
+/// readonly-array union arms, exercising request-local memoization as well as
+/// literal-array recovery.
+#[test]
+fn cross_file_dependent_operand_aliases_accept_scalars_and_literal_arrays() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+
+    write_file(
+        &base.join("column.ts"),
+        r#"export interface StorageType<Read, Write, Change> {
+  readonly read: Read
+  readonly write: Write
+  readonly change: Change
+}
+export type OutputType<T> = T extends StorageType<infer Read, any, any>
+  ? Read
+  : T
+"#,
+    );
+    write_file(
+        &base.join("expression.ts"),
+        r#"export interface Expr<T> {
+  readonly expressionType: T | undefined
+}
+export interface ScalarBuilder<Output> extends Expr<Output> {
+  readonly scalar: true
+}
+export interface ExprScope<DB, TB extends keyof DB> {
+  readonly database: DB
+  readonly tables: TB
+}
+export type ScalarOperand<T> = Expr<T> | ScalarBuilder<Record<string, T>>
+export type ExprFactory<DB, TB extends keyof DB, T> =
+  (scope: ExprScope<DB, TB>) => ScalarOperand<T>
+export type ExprOrFactory<DB, TB extends keyof DB, T> =
+  ScalarOperand<T> | ExprFactory<DB, TB, T>
+"#,
+    );
+    write_file(
+        &base.join("reference.ts"),
+        r#"import type { OutputType } from './column.js'
+import type { Expr, ExprOrFactory, ScalarBuilder } from './expression.js'
+
+export type PlainField<DB, TB extends keyof DB> = {
+  [Table in TB]: keyof DB[Table]
+}[TB] & string
+export type QualifiedField<DB, TB extends keyof DB> = {
+  [Table in TB]: `${Table & string}.${keyof DB[Table] & string}`
+}[TB]
+export type FieldRef<DB, TB extends keyof DB> =
+  PlainField<DB, TB> | QualifiedField<DB, TB> | ExprOrFactory<DB, TB, any>
+export type FieldLookup<DB, TB extends keyof DB, Name> = {
+  [Table in TB]: Name extends keyof DB[Table] ? DB[Table][Name] : never
+}[TB]
+export type RawFieldOutput<DB, TB extends keyof DB, Ref> = Ref extends string
+  ? Ref extends `${infer Schema}.${infer Table}.${infer Name}`
+    ? `${Schema}.${Table}` extends TB
+      ? Name extends keyof DB[`${Schema}.${Table}`]
+        ? DB[`${Schema}.${Table}`][Name]
+        : never
+      : never
+    : Ref extends `${infer Table}.${infer Name}`
+      ? Table extends TB
+        ? Name extends keyof DB[Table] ? DB[Table][Name] : never
+        : never
+      : Ref extends PlainField<DB, TB>
+        ? FieldLookup<DB, TB, Ref>
+        : unknown
+  : Ref extends ScalarBuilder<infer Output>
+    ? Output[keyof Output] | null
+    : Ref extends (scope: any) => ScalarBuilder<infer Output>
+      ? Output[keyof Output] | null
+      : Ref extends Expr<infer Output>
+        ? Output
+        : Ref extends (scope: any) => Expr<infer Output> ? Output : unknown
+export type FieldOutput<DB, TB extends keyof DB, Ref> =
+  OutputType<RawFieldOutput<DB, TB, Ref>>
+"#,
+    );
+    write_file(
+        &base.join("value.ts"),
+        r#"import type { ExprOrFactory } from './expression.js'
+import type { FieldOutput } from './reference.js'
+
+export type InputValue<DB, TB extends keyof DB, Value> =
+  Value | ExprOrFactory<DB, TB, Value>
+export type InputValueOrList<DB, TB extends keyof DB, Value> =
+  InputValue<DB, TB, Value> | ReadonlyArray<InputValue<DB, TB, Value>>
+export type DependentOperand<DB, TB extends keyof DB, Ref> =
+  InputValueOrList<DB, TB, FieldOutput<DB, TB, Ref> | null>
+"#,
+    );
+    write_file(
+        &base.join("api.ts"),
+        r#"import type { Expr, ExprOrFactory } from './expression.js'
+import type { FieldRef } from './reference.js'
+import type { DependentOperand } from './value.js'
+
+export type CompareOp = 'in' | 'not like' | '!=' | Expr<unknown>
+export interface Filter<DB, TB extends keyof DB> {
+  where<Ref extends FieldRef<DB, TB>, Value extends DependentOperand<DB, TB, Ref>>(
+    lhs: Ref, operator: CompareOp, rhs: Value,
+  ): Filter<DB, TB>
+  where<Predicate extends ExprOrFactory<DB, TB, boolean>>(
+    predicate: Predicate,
+  ): Filter<DB, TB>
+}
+export interface LayeredBuilder<DB, TB extends keyof DB, Output>
+  extends Filter<DB, TB>, Expr<Output> {
+  where<Ref extends FieldRef<DB, TB>, Value extends DependentOperand<DB, TB, Ref>>(
+    lhs: Ref, operator: CompareOp, rhs: Value,
+  ): LayeredBuilder<DB, TB, Output>
+  where<Predicate extends ExprOrFactory<DB, TB, boolean>>(
+    predicate: Predicate,
+  ): LayeredBuilder<DB, TB, Output>
+}
+export type Chosen<DB, TB extends keyof DB, Table extends keyof DB & string> =
+  [Table] extends [keyof DB] ? LayeredBuilder<DB, TB | Table, {}> : never
+export declare class LayeredCreator<DB> {
+  selectFrom<Table extends keyof DB & string>(table: Table): Chosen<DB, never, Table>
+}
+export declare class LayeredExtended<DB> extends LayeredCreator<DB> {
+  readonly extra: true
+}
+"#,
+    );
+    let usage = r#"import type { LayeredCreator, LayeredExtended } from './api.js'
+
+interface RegistryRow {
+  title: string
+  category: 'one' | 'two' | 'three' | 'four'
+}
+interface Registry { entries: RegistryRow }
+declare const origin: LayeredCreator<Registry> | LayeredExtended<Registry>
+
+const result = origin
+  .selectFrom('entries')
+  .where('category', 'in', ['one', 'two'])
+  .where('title', 'not like', 'internal_%')
+  .where('title', '!=', 'migration')
+  .where('title', '!=', 'lock')
+
+result.where('category', '!=', 'wrong')
+result.where('category', 'in', ['one', 'wrong'])
+const wrongTitles: number[] = [1, 2]
+result.where('title', 'in', wrongTitles)
+"#;
+    write_file(&base.join("use.ts"), usage);
+
+    let args = parse_args(&[
+        "tsz",
+        "--noEmit",
+        "--strict",
+        "--skipLibCheck",
+        "--target",
+        "es2022",
+        "--module",
+        "esnext",
+        "--moduleResolution",
+        "bundler",
+        "column.ts",
+        "expression.ts",
+        "reference.ts",
+        "value.ts",
+        "api.ts",
+        "use.ts",
+    ]);
+    let result = compile(&args, base).expect("compile should succeed");
+    let actual: Vec<(u32, u32)> = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.code, diagnostic.start))
+        .collect();
+    let expected = vec![
+        (2345, usage.find("'wrong'").expect("wrong operand") as u32),
+        (
+            2345,
+            usage
+                .find("['one', 'wrong']")
+                .expect("wrong mixed-list operand") as u32,
+        ),
+        (
+            2345,
+            usage.rfind("wrongTitles").expect("wrong list operand") as u32,
+        ),
+    ];
+    assert_eq!(
+        actual, expected,
+        "only the three deliberately invalid dependent operands may fail: {:#?}",
+        result.diagnostics
+    );
+    assert!(
+        result.diagnostics[0].message_text.contains("DependentOperand")
+            && result.diagnostics[0].message_text.contains("category")
+            && result.diagnostics[1].message_text.contains("DependentOperand")
+            && result.diagnostics[1].message_text.contains("category")
+            && result.diagnostics[2].message_text.contains("DependentOperand")
+            && result.diagnostics[2].message_text.contains("title"),
+        "dependent-constraint diagnostics must retain their selected field: {:#?}",
+        result.diagnostics
+    );
+}
+
+/// A recursive imported alias must terminate through the active-node guard.
+/// Its valid nested readonly-list form remains accepted, while a wrong leaf is
+/// still rejected.
+#[test]
+fn cross_file_dependent_operand_recursive_alias_terminates() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+    write_file(
+        &base.join("recursive.ts"),
+        r#"export type RecursiveInput<T> = T | ReadonlyArray<RecursiveInput<T>>
+export type Selected<Model, Key extends keyof Model> = {
+  [Name in Key]: Model[Name]
+}[Key]
+"#,
+    );
+    let usage = r#"import type { RecursiveInput, Selected } from './recursive.js'
+interface Model { kind: 'alpha' | 'beta' }
+declare function accept<
+  Key extends keyof Model,
+  Value extends RecursiveInput<Selected<Model, Key>>,
+>(key: Key, value: Value): void
+
+accept('kind', ['alpha', ['beta']])
+const wrongTree: readonly (string | readonly string[])[] = ['alpha', ['wrong']]
+accept('kind', wrongTree)
+"#;
+    write_file(&base.join("use.ts"), usage);
+    let args = parse_args(&[
+        "tsz",
+        "--noEmit",
+        "--strict",
+        "--module",
+        "esnext",
+        "--moduleResolution",
+        "bundler",
+        "recursive.ts",
+        "use.ts",
+    ]);
+    let result = compile(&args, base).expect("compile should terminate");
+    let actual: Vec<(u32, u32)> = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.code, diagnostic.start))
+        .collect();
+    assert_eq!(
+        actual,
+        [(
+            2345,
+            usage.rfind("wrongTree").expect("wrong recursive operand") as u32,
+        )],
+        "recursive dependent alias accepts only the valid nested list: {:#?}",
+        result.diagnostics
+    );
+}
+
+/// The fallback for template conditionals must not reinterpret a legitimate
+/// `never` true branch as a failed template match.
+#[test]
+fn dependent_constraint_template_match_with_never_true_branch_stays_rejected() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+    write_file(
+        &base.join("constraint.ts"),
+        "export type RejectTemplateMatch<Text> = Text extends `${infer Whole}` ? never : Text\n",
+    );
+    let usage = r#"import type { RejectTemplateMatch } from './constraint.js'
+declare function reject<
+  Text extends string,
+  Value extends RejectTemplateMatch<Text>,
+>(text: Text, value: Value): void
+reject('matched', 'matched')
+"#;
+    write_file(&base.join("use.ts"), usage);
+    let args = parse_args(&[
+        "tsz",
+        "--noEmit",
+        "--strict",
+        "--module",
+        "esnext",
+        "--moduleResolution",
+        "bundler",
+        "constraint.ts",
+        "use.ts",
+    ]);
+    let result = compile(&args, base).expect("compile should succeed");
+    let actual: Vec<(u32, u32)> = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.code, diagnostic.start))
+        .collect();
+    assert_eq!(
+        actual,
+        [(
+            2345,
+            usage.rfind("'matched'").expect("rejected matched value") as u32,
+        )],
+        "a matching template whose true branch is `never` must remain rejected: {:#?}",
+        result.diagnostics
+    );
+}
+
+/// A chain longer than the materialization fuel must fail conservatively and
+/// terminate. The generated source keeps the hand-authored Rust shard small.
+#[test]
+fn dependent_constraint_alias_materialization_is_bounded() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+    let mut aliases = String::from("export type Level0<T> = T\n");
+    for level in 1..=96 {
+        aliases.push_str(&format!(
+            "export type Level{level}<T> = Level{}<T>\n",
+            level - 1
+        ));
+    }
+    aliases.push_str("export type Deep<T> = Level96<T>\n");
+    write_file(&base.join("deep.ts"), &aliases);
+    let usage = r#"import type { Deep } from './deep.js'
+interface Model { kind: 'alpha' | 'beta' }
+declare function accept<
+  Key extends keyof Model,
+  Value extends Deep<Model[Key]>,
+>(key: Key, value: Value): void
+accept('kind', 'alpha')
+accept('kind', 'wrong')
+"#;
+    write_file(&base.join("use.ts"), usage);
+    let args = parse_args(&[
+        "tsz",
+        "--noEmit",
+        "--strict",
+        "--module",
+        "esnext",
+        "--moduleResolution",
+        "bundler",
+        "deep.ts",
+        "use.ts",
+    ]);
+    let result = compile(&args, base).expect("compile should terminate at bounded fuel");
+    let actual: Vec<(u32, u32)> = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.code, diagnostic.start))
+        .collect();
+    assert_eq!(
+        actual,
+        [(
+            2345,
+            usage.rfind("'wrong'").expect("wrong deep operand") as u32,
+        )],
+        "deep alias materialization accepts the valid leaf and rejects the invalid one: {:#?}",
+        result.diagnostics
+    );
+}

--- a/crates/tsz-solver/src/operations/generic_call/resolve/constraint_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve/constraint_helpers.rs
@@ -2,6 +2,73 @@
 
 use super::*;
 
+/// Bound resolver-backed alias materialization during dependent constraint
+/// validation. This path only runs after the ordinary relation rejects the
+/// inferred candidate, so keeping it request-local and bounded avoids turning
+/// deeply recursive aliases into unbounded generic-call work.
+const MAX_RAW_CONSTRAINT_MATERIALIZATION_STEPS: usize = 64;
+
+#[inline]
+fn enter_raw_constraint_materialization(
+    constraint: TypeId,
+    active: &mut FxHashSet<TypeId>,
+    steps: &mut usize,
+) -> bool {
+    if *steps >= MAX_RAW_CONSTRAINT_MATERIALIZATION_STEPS || !active.insert(constraint) {
+        return false;
+    }
+    *steps += 1;
+    true
+}
+
+#[cfg(test)]
+mod raw_constraint_materialization_guard_tests {
+    use super::*;
+
+    #[test]
+    fn fuel_stops_before_the_sixty_fifth_unique_node() {
+        let mut active = FxHashSet::default();
+        let mut steps = 0;
+        for offset in 0..MAX_RAW_CONSTRAINT_MATERIALIZATION_STEPS {
+            assert!(enter_raw_constraint_materialization(
+                TypeId(1_000 + offset as u32),
+                &mut active,
+                &mut steps,
+            ));
+        }
+        assert!(!enter_raw_constraint_materialization(
+            TypeId(2_000),
+            &mut active,
+            &mut steps,
+        ));
+        assert_eq!(steps, MAX_RAW_CONSTRAINT_MATERIALIZATION_STEPS);
+    }
+
+    #[test]
+    fn cycle_guard_is_path_scoped_for_shared_nodes() {
+        let shared = TypeId(1_000);
+        let mut active = FxHashSet::default();
+        let mut steps = 0;
+        assert!(enter_raw_constraint_materialization(
+            shared,
+            &mut active,
+            &mut steps,
+        ));
+        assert!(!enter_raw_constraint_materialization(
+            shared,
+            &mut active,
+            &mut steps,
+        ));
+        active.remove(&shared);
+        assert!(enter_raw_constraint_materialization(
+            shared,
+            &mut active,
+            &mut steps,
+        ));
+        assert_eq!(steps, 2);
+    }
+}
+
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     pub(super) fn object_constraint_properties_are_any(&self, constraint: TypeId) -> bool {
         let Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) =
@@ -18,6 +85,33 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     }
 
     fn raw_instantiated_constraint_may_satisfy(&self, constraint: TypeId) -> bool {
+        if matches!(
+            self.interner.lookup(constraint),
+            Some(
+                TypeData::Application(_)
+                    | TypeData::IndexAccess(_, _)
+                    | TypeData::KeyOf(_)
+                    | TypeData::Mapped(_)
+                    | TypeData::StringIntrinsic { .. }
+            )
+        ) {
+            return true;
+        }
+        let mut visited = FxHashSet::default();
+        let mut steps = 0;
+        self.raw_instantiated_constraint_may_satisfy_inner(constraint, &mut visited, &mut steps)
+    }
+
+    fn raw_instantiated_constraint_may_satisfy_inner(
+        &self,
+        constraint: TypeId,
+        visited: &mut FxHashSet<TypeId>,
+        steps: &mut usize,
+    ) -> bool {
+        if *steps >= MAX_RAW_CONSTRAINT_MATERIALIZATION_STEPS || !visited.insert(constraint) {
+            return false;
+        }
+        *steps += 1;
         match self.interner.lookup(constraint) {
             Some(
                 TypeData::Application(_)
@@ -26,32 +120,483 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 | TypeData::Mapped(_)
                 | TypeData::StringIntrinsic { .. },
             ) => true,
-            Some(TypeData::Union(members) | TypeData::Intersection(members)) => self
-                .interner
-                .type_list(members)
-                .iter()
-                .any(|&member| self.raw_instantiated_constraint_may_satisfy(member)),
+            Some(TypeData::Conditional(id)) => {
+                let conditional = self.interner.get_conditional(id);
+                [
+                    conditional.check_type,
+                    conditional.extends_type,
+                    conditional.true_type,
+                    conditional.false_type,
+                ]
+                .into_iter()
+                .any(|part| {
+                    self.raw_instantiated_constraint_may_satisfy_inner(part, visited, steps)
+                })
+            }
+            Some(TypeData::Union(members) | TypeData::Intersection(members)) => {
+                self.interner.type_list(members).iter().any(|&member| {
+                    self.raw_instantiated_constraint_may_satisfy_inner(member, visited, steps)
+                })
+            }
             Some(
                 TypeData::Array(inner) | TypeData::ReadonlyType(inner) | TypeData::NoInfer(inner),
-            ) => self.raw_instantiated_constraint_may_satisfy(inner),
+            ) => self.raw_instantiated_constraint_may_satisfy_inner(inner, visited, steps),
             _ => false,
         }
+    }
+
+    fn raw_instantiated_constraint_root_may_need_materialization(
+        &self,
+        constraint: TypeId,
+    ) -> bool {
+        matches!(
+            self.interner.lookup(constraint),
+            Some(
+                TypeData::Application(_)
+                    | TypeData::Conditional(_)
+                    | TypeData::IndexAccess(_, _)
+                    | TypeData::KeyOf(_)
+                    | TypeData::Mapped(_)
+                    | TypeData::StringIntrinsic { .. }
+                    | TypeData::Union(_)
+                    | TypeData::Intersection(_)
+                    | TypeData::Array(_)
+                    | TypeData::ReadonlyType(_)
+                    | TypeData::NoInfer(_)
+            )
+        )
     }
 
     pub(super) fn satisfies_raw_instantiated_constraint(
         &mut self,
         source: TypeId,
         constraint: TypeId,
+        already_checked_constraint: TypeId,
     ) -> bool {
-        if !self.raw_instantiated_constraint_may_satisfy(constraint) {
+        if !self.raw_instantiated_constraint_root_may_need_materialization(constraint)
+            || !self.raw_instantiated_constraint_may_satisfy(constraint)
+        {
             return false;
         }
-        if self.checker.is_assignable_to(source, constraint) {
+        if constraint != already_checked_constraint
+            && self.checker.is_assignable_to(source, constraint)
+        {
             return true;
         }
-        self.checker
-            .expand_type_alias_application(constraint)
-            .is_some_and(|expanded| self.checker.is_assignable_to(source, expanded))
+
+        // Imported aliases can remain as a chain of applications after the
+        // instantiated constraint is evaluated. A single expansion is not
+        // enough for shapes such as `ValueOrList<FieldOutput<...>>`, where
+        // the conditional's check type, a union arm, and its array element are
+        // aliases declared in other modules. Expand applications before asking
+        // the ordinary evaluator to reduce their containing meta-types; doing
+        // that in the opposite order can commit a still-opaque conditional to
+        // `never`.
+        let mut memo = FxHashMap::default();
+        let mut active = FxHashSet::default();
+        let mut steps = 0;
+        let materialized = self.materialize_raw_instantiated_constraint(
+            constraint,
+            &mut memo,
+            &mut active,
+            &mut steps,
+        );
+        if materialized == TypeId::ERROR || materialized == constraint {
+            return false;
+        }
+        if self.checker.is_assignable_to(source, materialized) {
+            return true;
+        }
+
+        // Relations over a freshly rebuilt readonly-array/union surface can
+        // still retain opaque provenance on a nested member. Preserve the
+        // ordinary union and container rules while comparing their already
+        // materialized leaves. This is also what lets an un-widened array
+        // literal element union satisfy a dependent readonly-list arm.
+        let mut relation_memo = FxHashMap::default();
+        let mut relation_active = FxHashSet::default();
+        let mut relation_steps = 0;
+        self.source_satisfies_materialized_container(
+            source,
+            materialized,
+            &mut relation_memo,
+            &mut relation_active,
+            &mut relation_steps,
+        )
+    }
+
+    fn source_satisfies_materialized_container(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        memo: &mut FxHashMap<(TypeId, TypeId), bool>,
+        active: &mut FxHashSet<(TypeId, TypeId)>,
+        steps: &mut usize,
+    ) -> bool {
+        let pair = (source, target);
+        if let Some(&satisfied) = memo.get(&pair) {
+            return satisfied;
+        }
+        if *steps >= MAX_RAW_CONSTRAINT_MATERIALIZATION_STEPS || !active.insert(pair) {
+            return false;
+        }
+        *steps += 1;
+        let satisfied = if self.checker.is_assignable_to(source, target) {
+            true
+        } else if let Some(TypeData::Union(members)) = self.interner.lookup(source) {
+            let members = self.interner.type_list(members).to_vec();
+            !members.is_empty()
+                && members.into_iter().all(|member| {
+                    self.source_satisfies_materialized_container(
+                        member, target, memo, active, steps,
+                    )
+                })
+        } else {
+            match self.interner.lookup(target) {
+                Some(TypeData::Union(members)) => self
+                    .interner
+                    .type_list(members)
+                    .to_vec()
+                    .into_iter()
+                    .any(|member| {
+                        self.source_satisfies_materialized_container(
+                            source, member, memo, active, steps,
+                        )
+                    }),
+                Some(TypeData::Intersection(members)) => {
+                    let members = self.interner.type_list(members).to_vec();
+                    !members.is_empty()
+                        && members.into_iter().all(|member| {
+                            self.source_satisfies_materialized_container(
+                                source, member, memo, active, steps,
+                            )
+                        })
+                }
+                Some(TypeData::NoInfer(inner)) => {
+                    self.source_satisfies_materialized_container(source, inner, memo, active, steps)
+                }
+                Some(TypeData::ReadonlyType(_)) => {
+                    let db = self.interner.as_type_database();
+                    let Some(source_element) =
+                        crate::type_queries::get_array_element_type(db, source)
+                    else {
+                        active.remove(&pair);
+                        memo.insert(pair, false);
+                        return false;
+                    };
+                    let Some(target_element) =
+                        crate::type_queries::get_array_element_type(db, target)
+                    else {
+                        active.remove(&pair);
+                        memo.insert(pair, false);
+                        return false;
+                    };
+                    self.source_satisfies_materialized_container(
+                        source_element,
+                        target_element,
+                        memo,
+                        active,
+                        steps,
+                    )
+                }
+                Some(TypeData::Array(target_element)) => {
+                    let Some(TypeData::Array(source_element)) = self.interner.lookup(source) else {
+                        active.remove(&pair);
+                        memo.insert(pair, false);
+                        return false;
+                    };
+                    self.source_satisfies_materialized_container(
+                        source_element,
+                        target_element,
+                        memo,
+                        active,
+                        steps,
+                    )
+                }
+                _ => false,
+            }
+        };
+        active.remove(&pair);
+        memo.insert(pair, satisfied);
+        satisfied
+    }
+
+    /// Return true only when static template text proves that a concrete string
+    /// literal cannot match. Interpolated spans are treated as arbitrary-width
+    /// wildcards, so this cannot reject a possible match.
+    fn string_literal_definitely_misses_template(
+        &self,
+        literal_type: TypeId,
+        template_type: TypeId,
+    ) -> bool {
+        let Some(literal_atom) =
+            crate::visitors::visitor_extract::literal_string(self.interner, literal_type)
+        else {
+            return false;
+        };
+        let Some(TypeData::TemplateLiteral(spans_id)) = self.interner.lookup(template_type) else {
+            return false;
+        };
+        let literal = self.interner.resolve_atom_ref(literal_atom);
+        let spans = self.interner.template_list(spans_id);
+        let mut remaining = literal.as_ref();
+
+        for span in spans.iter() {
+            let crate::types::TemplateSpan::Text(text_atom) = span else {
+                continue;
+            };
+            let text = self.interner.resolve_atom_ref(*text_atom);
+            if text.is_empty() {
+                continue;
+            }
+            let Some(offset) = remaining.find(text.as_ref()) else {
+                return true;
+            };
+            remaining = &remaining[offset + text.len()..];
+        }
+        false
+    }
+
+    fn materialize_raw_instantiated_constraint(
+        &mut self,
+        constraint: TypeId,
+        memo: &mut FxHashMap<TypeId, TypeId>,
+        active: &mut FxHashSet<TypeId>,
+        steps: &mut usize,
+    ) -> TypeId {
+        if constraint.is_intrinsic() {
+            return constraint;
+        }
+        if let Some(&materialized) = memo.get(&constraint) {
+            return materialized;
+        }
+        if !enter_raw_constraint_materialization(constraint, active, steps) {
+            return constraint;
+        }
+
+        let materialized = if let Some(expanded) =
+            self.checker.expand_type_alias_application(constraint)
+            && expanded != constraint
+            && expanded != TypeId::ERROR
+        {
+            self.materialize_raw_instantiated_constraint(expanded, memo, active, steps)
+        } else {
+            match self.interner.lookup(constraint) {
+                Some(TypeData::Union(members)) => {
+                    let members = self.interner.type_list(members).to_vec();
+                    let materialized = members
+                        .iter()
+                        .map(|&member| {
+                            self.materialize_raw_instantiated_constraint(
+                                member, memo, active, steps,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    if materialized == members {
+                        constraint
+                    } else {
+                        self.interner.union(materialized)
+                    }
+                }
+                Some(TypeData::Intersection(members)) => {
+                    let members = self.interner.type_list(members).to_vec();
+                    let materialized = members
+                        .iter()
+                        .map(|&member| {
+                            self.materialize_raw_instantiated_constraint(
+                                member, memo, active, steps,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    if materialized == members {
+                        constraint
+                    } else {
+                        self.interner.intersection(materialized)
+                    }
+                }
+                Some(TypeData::NoInfer(inner)) => {
+                    let materialized =
+                        self.materialize_raw_instantiated_constraint(inner, memo, active, steps);
+                    if materialized == inner {
+                        constraint
+                    } else {
+                        self.interner.no_infer(materialized)
+                    }
+                }
+                Some(TypeData::Array(inner)) => {
+                    let materialized =
+                        self.materialize_raw_instantiated_constraint(inner, memo, active, steps);
+                    if materialized == inner {
+                        constraint
+                    } else {
+                        self.interner.array(materialized)
+                    }
+                }
+                Some(TypeData::ReadonlyType(inner)) => {
+                    let materialized =
+                        self.materialize_raw_instantiated_constraint(inner, memo, active, steps);
+                    if materialized == inner {
+                        constraint
+                    } else {
+                        self.interner.readonly_type(materialized)
+                    }
+                }
+                Some(TypeData::Conditional(id)) => {
+                    let conditional = self.interner.get_conditional(id);
+                    let check_type = self.materialize_raw_instantiated_constraint(
+                        conditional.check_type,
+                        memo,
+                        active,
+                        steps,
+                    );
+                    let extends_type = self.materialize_raw_instantiated_constraint(
+                        conditional.extends_type,
+                        memo,
+                        active,
+                        steps,
+                    );
+                    let rebuilt = if check_type == conditional.check_type
+                        && extends_type == conditional.extends_type
+                    {
+                        constraint
+                    } else {
+                        self.interner.conditional(crate::types::ConditionalType {
+                            check_type,
+                            extends_type,
+                            ..conditional
+                        })
+                    };
+                    let concrete_scalar_check =
+                        crate::visitors::visitor_predicates::is_primitive_type(
+                            self.interner.as_type_database(),
+                            check_type,
+                        ) && !matches!(
+                            check_type,
+                            TypeId::ANY | TypeId::UNKNOWN | TypeId::NEVER | TypeId::ERROR
+                        ) && !crate::visitors::visitor_predicates::contains_infer_types(
+                            self.interner.as_type_database(),
+                            extends_type,
+                        ) && !crate::type_queries::contains_type_parameters_db(
+                            self.interner.as_type_database(),
+                            extends_type,
+                        );
+                    if concrete_scalar_check {
+                        let branch = if self.checker.is_assignable_to(check_type, extends_type) {
+                            conditional.true_type
+                        } else {
+                            conditional.false_type
+                        };
+                        self.materialize_raw_instantiated_constraint(branch, memo, active, steps)
+                    } else {
+                        let evaluated = self.checker.evaluate_type(rebuilt);
+                        // The conditional evaluator can conservatively yield
+                        // `never` for a concrete literal checked against a
+                        // template containing `infer`. Select the false branch
+                        // only when the template's static text proves a
+                        // mismatch; a template such as `${infer T}` remains
+                        // undecided because its true branch may legitimately
+                        // evaluate to `never`.
+                        let literal_misses_template = self
+                            .string_literal_definitely_misses_template(check_type, extends_type);
+                        let check_is_primitive_compound_for_object =
+                            crate::type_queries::is_literal_or_primitive_or_compound_of_those(
+                                self.interner.as_type_database(),
+                                check_type,
+                            ) && crate::visitors::visitor_predicates::is_object_like_type(
+                                self.interner.as_type_database(),
+                                extends_type,
+                            );
+                        let concrete_primitive_false_branch = evaluated == TypeId::NEVER
+                            && (literal_misses_template || check_is_primitive_compound_for_object)
+                            && !self.checker.is_assignable_to(check_type, extends_type);
+                        if concrete_primitive_false_branch {
+                            self.materialize_raw_instantiated_constraint(
+                                conditional.false_type,
+                                memo,
+                                active,
+                                steps,
+                            )
+                        } else if evaluated == rebuilt || evaluated == TypeId::ERROR {
+                            rebuilt
+                        } else {
+                            self.materialize_raw_instantiated_constraint(
+                                evaluated, memo, active, steps,
+                            )
+                        }
+                    }
+                }
+                Some(TypeData::Mapped(id)) => {
+                    let mapped = self.interner.get_mapped(id);
+                    let mapped_constraint = self.materialize_raw_instantiated_constraint(
+                        mapped.constraint,
+                        memo,
+                        active,
+                        steps,
+                    );
+                    let template = self.materialize_raw_instantiated_constraint(
+                        mapped.template,
+                        memo,
+                        active,
+                        steps,
+                    );
+                    let name_type = mapped.name_type.map(|name_type| {
+                        self.materialize_raw_instantiated_constraint(name_type, memo, active, steps)
+                    });
+                    if mapped_constraint == mapped.constraint
+                        && template == mapped.template
+                        && name_type == mapped.name_type
+                    {
+                        constraint
+                    } else {
+                        self.interner.mapped(crate::types::MappedType {
+                            constraint: mapped_constraint,
+                            template,
+                            name_type,
+                            ..mapped
+                        })
+                    }
+                }
+                Some(TypeData::IndexAccess(object, index)) => {
+                    let object =
+                        self.materialize_raw_instantiated_constraint(object, memo, active, steps);
+                    let index =
+                        self.materialize_raw_instantiated_constraint(index, memo, active, steps);
+                    let rebuilt = self.interner.index_access(object, index);
+                    let evaluated = self.checker.evaluate_type(rebuilt);
+                    if evaluated == rebuilt || evaluated == TypeId::ERROR {
+                        rebuilt
+                    } else {
+                        self.materialize_raw_instantiated_constraint(evaluated, memo, active, steps)
+                    }
+                }
+                Some(TypeData::KeyOf(inner)) => {
+                    let inner =
+                        self.materialize_raw_instantiated_constraint(inner, memo, active, steps);
+                    let rebuilt = self.interner.keyof(inner);
+                    let evaluated = self.checker.evaluate_type(rebuilt);
+                    if evaluated == rebuilt || evaluated == TypeId::ERROR {
+                        rebuilt
+                    } else {
+                        self.materialize_raw_instantiated_constraint(evaluated, memo, active, steps)
+                    }
+                }
+                Some(TypeData::StringIntrinsic { kind, type_arg }) => {
+                    let type_arg =
+                        self.materialize_raw_instantiated_constraint(type_arg, memo, active, steps);
+                    let rebuilt = self.interner.string_intrinsic(kind, type_arg);
+                    let evaluated = self.checker.evaluate_type(rebuilt);
+                    if evaluated == rebuilt || evaluated == TypeId::ERROR {
+                        rebuilt
+                    } else {
+                        self.materialize_raw_instantiated_constraint(evaluated, memo, active, steps)
+                    }
+                }
+                _ => constraint,
+            }
+        };
+        active.remove(&constraint);
+        memo.insert(constraint, materialized);
+        materialized
     }
 
     pub(crate) fn top_rest_any_callable_constraint(&self, constraint: TypeId) -> bool {

--- a/crates/tsz-solver/src/operations/generic_call/resolve/constraint_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve/constraint_helpers.rs
@@ -21,54 +21,6 @@ fn enter_raw_constraint_materialization(
     true
 }
 
-#[cfg(test)]
-mod raw_constraint_materialization_guard_tests {
-    use super::*;
-
-    #[test]
-    fn fuel_stops_before_the_sixty_fifth_unique_node() {
-        let mut active = FxHashSet::default();
-        let mut steps = 0;
-        for offset in 0..MAX_RAW_CONSTRAINT_MATERIALIZATION_STEPS {
-            assert!(enter_raw_constraint_materialization(
-                TypeId(1_000 + offset as u32),
-                &mut active,
-                &mut steps,
-            ));
-        }
-        assert!(!enter_raw_constraint_materialization(
-            TypeId(2_000),
-            &mut active,
-            &mut steps,
-        ));
-        assert_eq!(steps, MAX_RAW_CONSTRAINT_MATERIALIZATION_STEPS);
-    }
-
-    #[test]
-    fn cycle_guard_is_path_scoped_for_shared_nodes() {
-        let shared = TypeId(1_000);
-        let mut active = FxHashSet::default();
-        let mut steps = 0;
-        assert!(enter_raw_constraint_materialization(
-            shared,
-            &mut active,
-            &mut steps,
-        ));
-        assert!(!enter_raw_constraint_materialization(
-            shared,
-            &mut active,
-            &mut steps,
-        ));
-        active.remove(&shared);
-        assert!(enter_raw_constraint_materialization(
-            shared,
-            &mut active,
-            &mut steps,
-        ));
-        assert_eq!(steps, 2);
-    }
-}
-
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     pub(super) fn object_constraint_properties_are_any(&self, constraint: TypeId) -> bool {
         let Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) =
@@ -793,5 +745,53 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         if changed {
             instantiated_rest_param.type_id = self.interner.tuple(elements);
         }
+    }
+}
+
+#[cfg(test)]
+mod raw_constraint_materialization_guard_tests {
+    use super::*;
+
+    #[test]
+    fn fuel_stops_before_the_sixty_fifth_unique_node() {
+        let mut active = FxHashSet::default();
+        let mut steps = 0;
+        for offset in 0..MAX_RAW_CONSTRAINT_MATERIALIZATION_STEPS {
+            assert!(enter_raw_constraint_materialization(
+                TypeId(1_000 + offset as u32),
+                &mut active,
+                &mut steps,
+            ));
+        }
+        assert!(!enter_raw_constraint_materialization(
+            TypeId(2_000),
+            &mut active,
+            &mut steps,
+        ));
+        assert_eq!(steps, MAX_RAW_CONSTRAINT_MATERIALIZATION_STEPS);
+    }
+
+    #[test]
+    fn cycle_guard_is_path_scoped_for_shared_nodes() {
+        let shared = TypeId(1_000);
+        let mut active = FxHashSet::default();
+        let mut steps = 0;
+        assert!(enter_raw_constraint_materialization(
+            shared,
+            &mut active,
+            &mut steps,
+        ));
+        assert!(!enter_raw_constraint_materialization(
+            shared,
+            &mut active,
+            &mut steps,
+        ));
+        active.remove(&shared);
+        assert!(enter_raw_constraint_materialization(
+            shared,
+            &mut active,
+            &mut steps,
+        ));
+        assert_eq!(steps, 2);
     }
 }

--- a/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
@@ -714,22 +714,26 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             self.interner,
                             contextual_ty,
                         );
-                        let ty_satisfies_raw = constraint_ty_raw != constraint_ty
+                        let ty_satisfies_constraint =
+                            self.checker.is_assignable_to(ty_for_check, constraint_ty);
+                        let ty_satisfies_raw = !ty_satisfies_constraint
                             && self.satisfies_raw_instantiated_constraint(
                                 ty_for_check,
                                 constraint_ty_raw,
+                                constraint_ty,
                             );
-                        let contextual_satisfies_raw = constraint_ty_raw != constraint_ty
+                        let contextual_satisfies_constraint = self
+                            .checker
+                            .is_assignable_to(contextual_for_check, constraint_ty);
+                        let contextual_satisfies_raw = !contextual_satisfies_constraint
                             && self.satisfies_raw_instantiated_constraint(
                                 contextual_for_check,
                                 constraint_ty_raw,
+                                constraint_ty,
                             );
-                        let ty_satisfies_constraint = ty_satisfies_raw
-                            || self.checker.is_assignable_to(ty_for_check, constraint_ty);
-                        let contextual_satisfies_constraint = contextual_satisfies_raw
-                            || self
-                                .checker
-                                .is_assignable_to(contextual_for_check, constraint_ty);
+                        let ty_satisfies_constraint = ty_satisfies_constraint || ty_satisfies_raw;
+                        let contextual_satisfies_constraint =
+                            contextual_satisfies_constraint || contextual_satisfies_raw;
                         !ty_satisfies_constraint && contextual_satisfies_constraint
                     } else {
                         false
@@ -901,10 +905,18 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 // Strip freshness before constraint check: inferred types should not
                 // trigger excess property checking against type parameter constraints.
                 let ty_for_check = crate::relations::freshness::widen_freshness(self.interner, ty);
-                let raw_constraint_satisfied = constraint_ty_raw != constraint_ty
-                    && self.satisfies_raw_instantiated_constraint(ty_for_check, constraint_ty_raw);
                 let constraint_satisfied =
                     self.arg_satisfies_type_parameter_constraint(ty_for_check, constraint_ty);
+                // Resolver-backed alias expansion is also needed when ordinary
+                // evaluation leaves a cross-file application unchanged. Keep
+                // it strictly behind the normal relation so passing calls pay
+                // none of the bounded materialization cost.
+                let raw_constraint_satisfied = !constraint_satisfied
+                    && self.satisfies_raw_instantiated_constraint(
+                        ty_for_check,
+                        constraint_ty_raw,
+                        constraint_ty,
+                    );
                 if !constraint_satisfied
                     && !raw_constraint_satisfied
                     && !self.callable_satisfies_top_rest_any_constraint(ty_for_check, constraint_ty)
@@ -970,7 +982,51 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     }
                     // Try to recover using un-widened literal candidates when widening
                     // caused the violation (e.g., "b" widened to string violates keyof O).
-                    let un_widened = infer_ctx.get_literal_candidates(var);
+                    let mut un_widened = infer_ctx.get_literal_candidates(var);
+                    // Direct array literals enter inference as tuples or arrays
+                    // with literal-union elements, then widen during
+                    // finalization. If that widening is the only reason a
+                    // dependent constraint fails, retry the original container
+                    // just as we retry scalar literal evidence.
+                    // Some direct array literals are represented as an `Array`
+                    // whose element is still the un-widened literal union, so
+                    // include changed array bounds too, but only when widening
+                    // their element literals produces the finalized element.
+                    // This keeps unrelated array lower bounds out of the
+                    // recovery tournament.
+                    let widened_container_element = crate::type_queries::get_array_element_type(
+                        self.interner.as_type_database(),
+                        ty_for_check,
+                    );
+                    if let Some(constraints) = infer_ctx.get_constraints(var) {
+                        for lower_bound in constraints.lower_bounds {
+                            let lower_bound_widens_to_candidate = widened_container_element
+                                .is_some_and(|widened_element| {
+                                    crate::type_queries::get_array_element_type(
+                                        self.interner.as_type_database(),
+                                        lower_bound,
+                                    )
+                                    .is_some_and(
+                                        |lower_element| {
+                                            lower_element != widened_element
+                                                && crate::operations::widening::widen_literal_type(
+                                                    self.interner.as_type_database(),
+                                                    lower_element,
+                                                ) == widened_element
+                                        },
+                                    )
+                                });
+                            if lower_bound_widens_to_candidate
+                                && matches!(
+                                    self.interner.lookup(lower_bound),
+                                    Some(TypeData::Array(_) | TypeData::Tuple(_))
+                                )
+                                && !un_widened.contains(&lower_bound)
+                            {
+                                un_widened.push(lower_bound);
+                            }
+                        }
+                    }
                     let candidate_type = if !un_widened.is_empty() {
                         Some(if un_widened.len() == 1 {
                             un_widened[0]
@@ -981,14 +1037,15 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         None
                     };
                     let recovered = if let Some(candidate_type) = candidate_type {
-                        let candidate_satisfies_raw = constraint_ty_raw != constraint_ty
+                        let candidate_satisfies_constraint =
+                            self.checker.is_assignable_to(candidate_type, constraint_ty);
+                        let candidate_satisfies_raw = !candidate_satisfies_constraint
                             && self.satisfies_raw_instantiated_constraint(
                                 candidate_type,
                                 constraint_ty_raw,
+                                constraint_ty,
                             );
-                        if self.checker.is_assignable_to(candidate_type, constraint_ty)
-                            || candidate_satisfies_raw
-                        {
+                        if candidate_satisfies_constraint || candidate_satisfies_raw {
                             Some(candidate_type)
                         } else {
                             None


### PR DESCRIPTION
Goal: green

## Structural rule

When ordinary constraint assignability rejects an inferred candidate against a concrete dependent constraint, generic-call resolution materializes nested resolver-backed imported alias applications before reducing their containing conditional, mapped, indexed-access, union, and array shapes. The rebuilt structural constraint is then checked through assignability; a successful ordinary relation still returns before this fallback.

Owner: solver generic-call constraint finalization. Checker and CLI remain consumers of the solver result.

## Adjacent matrix

- Cross-file dependent field constraints accept valid scalar and readonly-list operands.
- Invalid scalar, mixed-literal list, and wrong-element arrays still report TS2345 at the operand.
- Recursive imported list aliases terminate while preserving valid nested lists and rejecting wrong leaves.
- Template conditionals with a legitimate never true branch remain rejected.
- Renamed binders, primitive aliases, generic keyof aliases, and conditional-union constraints retain their existing behavior.
- A chain beyond the materialization budget terminates conservatively.

## Fallback and performance

The normal relation runs first, and the fallback has an O(1) root-shape gate. Materialization is request-local with memoized TypeId results, an active-path cycle set, and a hard 64-step fuel cap. Container relation recovery has its own request-local pair memo and the same cap. Array literal recovery is limited to lower-bound containers whose element literal widening exactly produces the finalized element.

No source text, user identifier, alias name, property name, file name, diagnostic string, or rendered type is used as a semantic predicate. Exceeding fuel or encountering an unresolved cycle returns the existing conservative rejection. Rebuilt interned types have project lifetime, while per-invocation work and retained request state remain bounded.

## Verification

- cargo fmt --all -- --check
- git diff --check
- cargo nextest run -p tsz-solver -p tsz-cli -E "focused six raw-materialization and dependent-operand cases" (6/6)
- cargo nextest run -p tsz-cli -E "test(/cross_module_generic_method_constraint_cli_tests::/)" (4/4)
- cargo nextest run -p tsz-cli --test cross_module_conditional_constraint_union_param_cli_tests (2/2)
- cargo nextest run -p tsz-solver --test architecture_guards (13/13)
- cargo clippy -p tsz-solver --lib -- -D warnings
- cargo clippy -p tsz-cli --lib --tests -- -D warnings
- Repeated the 12 targeted tests after rebasing onto main with #15852.
- Exact Kysely was not run concurrently with debugger-owned compiler processes; the six-file shared-alias matrix exercises the isolated failing scalar/list path.

## Provenance

Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high