### PR TITLE
fix(checker): recover awaited enclosing class declarations

### DIFF
--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -562,10 +562,12 @@ impl<'a> CheckerState<'a> {
         } else {
             resolved_type
         };
-        let Some(then_type) = query::thenable_property_type(self.ctx.types, receiver_type) else {
+        let then_type = self
+            .enclosing_class_application_then_declared_type(type_id)
+            .or_else(|| query::thenable_property_type(self.ctx.types, receiver_type));
+        let Some(then_type) = then_type else {
             return ThenableAwaitInfo::default();
         };
-
         if check_this_context
             && let (
                 tsz_solver::operations::CallResult::ThisTypeMismatch { expected_this, .. },
@@ -624,6 +626,62 @@ impl<'a> CheckerState<'a> {
             rejected_this_type,
             has_callable_then: true,
         }
+    }
+
+    /// Recover the actual `then` declaration for an application of the
+    /// enclosing class. Deferred class publication exposes a rest-`any`
+    /// placeholder until later methods have been checked; `await` needs the
+    /// fulfillment callback parameter now.
+    ///
+    /// The recovery is deliberately narrow: exact enclosing-class identity, a
+    /// direct non-static method declaration, and an exact
+    /// class-binder/application-argument substitution. Ordinary structural
+    /// lookup remains the fallback and `implements` clauses are not used as
+    /// evidence of thenability.
+    fn enclosing_class_application_then_declared_type(
+        &mut self,
+        type_id: TypeId,
+    ) -> Option<TypeId> {
+        let (class_idx, class_type_parameter_arity) = {
+            let enclosing = self.ctx.enclosing_class.as_ref()?;
+            (
+                enclosing.class_idx,
+                enclosing.class_type_parameter_ids.len(),
+            )
+        };
+        let app = query::promise_application_parts(self.ctx.types, type_id)?;
+        if class_type_parameter_arity != app.args().len() {
+            return None;
+        }
+        let base_sym_id = query::promise_base_symbol_id(self.ctx.types, app.base(), |def_id| {
+            self.ctx.def_to_symbol_id(def_id)
+        })?;
+        let base_sym_id = self
+            .resolve_alias_symbol(base_sym_id, &mut AliasCycleTracker::new())
+            .unwrap_or(base_sym_id);
+
+        if self.get_class_declaration_from_symbol(base_sym_id)? != class_idx {
+            return None;
+        }
+
+        let then_type = self.direct_enclosing_class_method_declared_type("then")?;
+        let class_type_parameter_ids = self
+            .ctx
+            .enclosing_class
+            .as_ref()
+            .filter(|enclosing| enclosing.class_idx == class_idx)?
+            .class_type_parameter_ids
+            .clone();
+        if class_type_parameter_ids.is_empty() {
+            return Some(then_type);
+        }
+        crate::query_boundaries::exact_rewrite::start_session(
+            self.ctx.types,
+            then_type,
+            &class_type_parameter_ids,
+            app.args(),
+        )
+        .map(|(rewritten, _)| rewritten)
     }
 
     /// Extract type argument from a Promise-like base type.

--- a/crates/tsz-checker/src/checkers/signature_builder.rs
+++ b/crates/tsz-checker/src/checkers/signature_builder.rs
@@ -139,6 +139,19 @@ impl<'a> CheckerState<'a> {
         self.call_signature_from_method_with_this(method, None, method_idx)
     }
 
+    /// Build only a method's declared parameter surface.
+    ///
+    /// Early class-construction queries sometimes need a later method's
+    /// parameters before its body is checked. Inferring that body's return type
+    /// would recurse into work that class publication intentionally deferred.
+    pub(crate) fn call_signature_parameter_surface_from_method(
+        &mut self,
+        method: &tsz_parser::parser::node::MethodDeclData,
+        method_idx: NodeIndex,
+    ) -> tsz_solver::CallSignature {
+        self.call_signature_from_method_internal(method, None, method_idx, true)
+    }
+
     /// Build a `CallSignature` from a method declaration with an explicit `this` type.
     /// This is used for static methods where `this` refers to the constructor type.
     pub(crate) fn call_signature_from_method_with_this(
@@ -146,6 +159,16 @@ impl<'a> CheckerState<'a> {
         method: &tsz_parser::parser::node::MethodDeclData,
         explicit_this_type: Option<TypeId>,
         method_idx: NodeIndex,
+    ) -> tsz_solver::CallSignature {
+        self.call_signature_from_method_internal(method, explicit_this_type, method_idx, false)
+    }
+
+    fn call_signature_from_method_internal(
+        &mut self,
+        method: &tsz_parser::parser::node::MethodDeclData,
+        explicit_this_type: Option<TypeId>,
+        method_idx: NodeIndex,
+        parameter_surface_only: bool,
     ) -> tsz_solver::CallSignature {
         let enclosing_updates = self.push_enclosing_type_parameters(method_idx);
         self.exclude_params_for_type_param_constraints(&method.parameters);
@@ -200,30 +223,31 @@ impl<'a> CheckerState<'a> {
                 }
             }
         }
-        let (mut return_type, mut type_predicate) =
-            if method.type_annotation.is_none() && method.body.is_some() {
-                // Infer return type from body when there's no annotation
-                // Push the this type for proper resolution
-                let pushed_this = if let Some(this_ty) = explicit_this_type {
-                    self.ctx.this_type_stack.push(this_ty);
-                    true
-                } else {
-                    false
-                };
-                let inferred = self.infer_return_type_from_body(method_idx, method.body, None);
-                if pushed_this {
-                    self.ctx.this_type_stack.pop();
-                }
-                (inferred, None)
+        let (mut return_type, mut type_predicate) = if parameter_surface_only {
+            (TypeId::ANY, None)
+        } else if method.type_annotation.is_none() && method.body.is_some() {
+            // Infer return type from body when there's no annotation
+            // Push the this type for proper resolution
+            let pushed_this = if let Some(this_ty) = explicit_this_type {
+                self.ctx.this_type_stack.push(this_ty);
+                true
             } else {
-                self.return_type_and_predicate(method.type_annotation, &params)
+                false
             };
+            let inferred = self.infer_return_type_from_body(method_idx, method.body, None);
+            if pushed_this {
+                self.ctx.this_type_stack.pop();
+            }
+            (inferred, None)
+        } else {
+            self.return_type_and_predicate(method.type_annotation, &params)
+        };
 
         // Check JSDoc @returns for type predicates on class methods.
         // Mirrors the logic in get_type_of_function (function_type.rs) for standalone
         // functions. In JS files, method return type predicates like
         // `@return {this is Entry}` are specified via JSDoc instead of syntax.
-        if type_predicate.is_none() {
+        if !parameter_surface_only && type_predicate.is_none() {
             if let Some(pred) = self.extract_jsdoc_return_type_predicate(&method_jsdoc, &params) {
                 return_type = if pred.asserts {
                     TypeId::VOID
@@ -242,7 +266,8 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        if type_predicate.is_none()
+        if !parameter_surface_only
+            && type_predicate.is_none()
             && method.type_annotation.is_none()
             && matches!(return_type, TypeId::BOOLEAN | TypeId::UNKNOWN)
             && method.body.is_some()
@@ -258,7 +283,7 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        if method.type_annotation.is_none() {
+        if !parameter_surface_only && method.type_annotation.is_none() {
             return_type = self.maybe_evaluate_inferred_return_contribution(return_type, None);
         }
 
@@ -267,7 +292,7 @@ impl<'a> CheckerState<'a> {
         let is_generator = method.asterisk_token;
         let is_async = self.has_async_modifier(&method.modifiers);
 
-        if !has_annotation && is_generator {
+        if !parameter_surface_only && !has_annotation && is_generator {
             let gen_name = if is_async {
                 "AsyncGenerator"
             } else {
@@ -285,7 +310,7 @@ impl<'a> CheckerState<'a> {
                     .factory()
                     .application(base, vec![TypeId::ANY, TypeId::VOID, TypeId::UNKNOWN]);
             }
-        } else if !has_annotation && is_async {
+        } else if !parameter_surface_only && !has_annotation && is_async {
             if let Some(inner) = self.unwrap_promise_type(return_type) {
                 return_type = inner;
             }

--- a/crates/tsz-checker/src/types/property_access_type/class_recovery.rs
+++ b/crates/tsz-checker/src/types/property_access_type/class_recovery.rs
@@ -9,6 +9,82 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// Returns the actual declared callable surface for a named instance method
+    /// on the class currently being built.
+    ///
+    /// Phase-2 class publication intentionally gives deferred methods a cheap
+    /// rest-`any` placeholder. Semantic consumers that need a method's parameter
+    /// surface before final publication can use this bounded symbol-table lookup
+    /// instead of scanning the provisional object or the whole class body.
+    pub(crate) fn direct_enclosing_class_method_declared_type(
+        &mut self,
+        property_name: &str,
+    ) -> Option<TypeId> {
+        let (class_idx, member_sym_id, declarations) = {
+            let class_idx = self.ctx.enclosing_class.as_ref()?.class_idx;
+            let class_sym_id = self.ctx.binder.get_node_symbol(class_idx)?;
+            let class_symbol = self.ctx.binder.get_symbol(class_sym_id)?;
+            let member_sym_id = class_symbol.members.as_ref()?.get(property_name)?;
+            let declarations = self
+                .ctx
+                .binder
+                .get_symbol(member_sym_id)?
+                .declarations
+                .clone();
+            (class_idx, member_sym_id, declarations)
+        };
+
+        let mut overload_signatures = Vec::new();
+        let mut implementation_signatures = Vec::new();
+        let mut overload_optional = false;
+        let mut implementation_optional = false;
+        for member_idx in declarations {
+            if !self
+                .ctx
+                .declaration_is_local_to_current_arena(member_sym_id, member_idx)
+                || self.nearest_enclosing_class(member_idx) != Some(class_idx)
+            {
+                continue;
+            }
+            let Some(member_node) = self.ctx.arena.get(member_idx) else {
+                continue;
+            };
+            if member_node.kind != syntax_kind_ext::METHOD_DECLARATION {
+                continue;
+            }
+            let Some(method) = self.ctx.arena.get_method_decl(member_node) else {
+                continue;
+            };
+            if self.has_static_modifier(&method.modifiers) {
+                continue;
+            }
+            let signature = self.call_signature_parameter_surface_from_method(method, member_idx);
+            if method.body.is_none() {
+                overload_optional |= method.question_token;
+                overload_signatures.push(signature);
+            } else {
+                implementation_optional |= method.question_token;
+                implementation_signatures.push(signature);
+            }
+        }
+        let (signatures, optional) = if overload_signatures.is_empty() {
+            (implementation_signatures, implementation_optional)
+        } else {
+            (overload_signatures, overload_optional)
+        };
+        if signatures.is_empty() {
+            return None;
+        }
+
+        let method_type =
+            class_type_boundary::class_method_callable_type(self.ctx.types, signatures);
+        Some(class_type_boundary::optional_class_member_type(
+            self.ctx.types,
+            method_type,
+            optional,
+        ))
+    }
+
     /// Recover a bare-`this` member whose syntactically nearest class is only a
     /// class-header evaluation boundary, not the owner of lexical `this`.
     ///

--- a/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
@@ -1412,3 +1412,133 @@ fn cli_override_retracts_chain_effective_removed_value() {
         result.diagnostics
     );
 }
+
+#[test]
+fn compile_project_awaits_later_generic_then_through_barrel_after_static_overload() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "es2015",
+            "module": "esnext",
+            "strict": false,
+            "noImplicitAny": true,
+            "strictNullChecks": true,
+            "strictFunctionTypes": true,
+            "lib": ["dom", "es2018"],
+            "skipLibCheck": true,
+            "noEmit": true,
+            "types": [],
+            "moduleResolution": "bundler"
+          },
+          "include": ["src/**/*.ts"]
+        }"#,
+    );
+    write_file(
+        &base.join("src/result.ts"),
+        r#"
+import { Deferred } from './';
+
+export type Outcome<T, E> = Good<T, E> | Bad<T, E>;
+
+interface OutcomeLike<T, E> {
+    isErr(): this is Bad<T, E>;
+    andThen<F>(make: (value: T) => Deferred<unknown, F>): Deferred<unknown, E | F>;
+}
+
+export class Good<T, E> implements OutcomeLike<T, E> {
+    constructor(readonly value: T) {}
+    isErr(): this is Bad<T, E> { return false; }
+    andThen<F>(make: (value: T) => Deferred<unknown, F>): Deferred<unknown, E | F> {
+        return make(this.value);
+    }
+}
+
+export class Bad<T, E> implements OutcomeLike<T, E> {
+    constructor(readonly error: E) {}
+    isErr(): this is Bad<T, E> { return true; }
+    andThen<F>(_make: (value: T) => Deferred<unknown, F>): Deferred<unknown, E | F> {
+        throw new Error();
+    }
+}
+"#,
+    );
+    write_file(
+        &base.join("src/index.ts"),
+        r#"
+export { Outcome, Good, Bad } from './result';
+export { Deferred } from './result-async';
+"#,
+    );
+    write_file(
+        &base.join("src/result-async.ts"),
+        r#"
+import { Outcome, Good, Bad } from './';
+
+export class Deferred<T, E> {
+    private promise: Promise<Outcome<T, E>>;
+
+    constructor(promise: Promise<Outcome<T, E>>) {
+        this.promise = promise;
+    }
+
+    static wrap(value: number): number;
+    static wrap(value: number): number {
+        return value;
+    }
+
+    map<A>(make: (value: T) => A | Promise<A>): Deferred<A, E> {
+        return new Deferred<A, E>(
+            this.promise.then(async (outcome: Outcome<T, E>) => {
+                if (outcome.isErr()) {
+                    return new Bad<A, E>(outcome.error);
+                }
+                return new Good<A, E>(await make(outcome.value));
+            }),
+        );
+    }
+
+    andThrough<F>(
+        make: (value: T) => Outcome<unknown, F> | Deferred<unknown, F>,
+    ): Deferred<T, E | F> {
+        return new Deferred<T, E | F>(
+            this.promise.then(async (outcome: Outcome<T, E>) => {
+                if (outcome.isErr()) {
+                    return new Bad<T, E>(outcome.error);
+                }
+
+                const result = await make(outcome.value);
+                if (result.isErr()) {
+                    return new Bad<T, F>(result.error);
+                }
+
+                return new Good<T, F>(outcome.value);
+            }),
+        );
+    }
+
+    then<A>(
+        onfulfilled?: (value: Outcome<T, E>) => A | PromiseLike<A>,
+    ): PromiseLike<A>;
+    then(
+        onfulfilled?:
+            | ((value: Outcome<T, E>) => unknown)
+            | ((value: string) => unknown),
+    ): PromiseLike<unknown> {
+        throw new Error();
+    }
+}
+"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    assert!(
+        result.diagnostics.is_empty(),
+        "the applied class must expose its later declared then surface: {:#?}",
+        result.diagnostics
+    );
+}


### PR DESCRIPTION
Goal: green

## Structural rule

When an await operand still carries the exact generic application of the class currently being published, and the evaluated receiver exposes only the deferred rest-`any` method placeholder, recover the actual direct non-static `then` declaration, select exposed overloads over the implementation, substitute only the enclosing class binders, and feed that callable surface through the existing thenable validation. The actual declaration is authoritative; `implements` clauses are not evidence of thenability.

Owner: checker class-construction orchestration plus existing solver-backed promise/signature/exact-rewrite query boundaries. Ordinary evaluated structural lookup and `this` validation remain unchanged.

Adjacent matrix: circular barrel imports, an earlier static overload group that triggers deferred publication, generic class and method binders, no `implements PromiseLike` clause, exposed `then` overload versus a deliberately broader implementation callback, positive callback payload lookup, and exact project-corpus verification with Neverthrow's real correct `implements` surface.

Fallback: non-applications, arity/base/class identity mismatches, static/property-only members, foreign declarations, missing direct `then`, and aborted exact rewrites return to the existing evaluated structural lookup. The recovery never infers the later method body.

Performance: outside a class this adds one O(1) context check. Inside a class it performs O(1) application/arity/base identity checks; only an exact self-application builds O(overload parameter surface) signatures and performs the bounded exact binder rewrite. No class-body scan, formatted-type predicate, or fixture-name path.

## Verification

- `scripts/safe-run.sh --limit 50% -- cargo nextest run -p tsz-cli --lib compile_project_awaits_later_generic_then_through_barrel_after_static_overload --no-fail-fast` — 1/1 passed on rebased head
- disabled-path control — same focused test failed with TS2339; restored recovery passed
- `scripts/safe-run.sh --limit 50% -- cargo clippy -p tsz-checker -p tsz-cli --lib -- -D warnings` — passed
- `scripts/safe-run.sh --limit 50% -- cargo build --profile dist-fast -p tsz-cli --bin tsz` — passed
- final Neverthrow project compile — TSZ-only diagnostics reduced 6 → 5; `result-async.ts:109 TS2339` removed
- `/opt/homebrew/bin/tsc --project .target/project-compile-guard/neverthrow/tsconfig.tsz-guard.json --pretty false` — clean
- `scripts/architecture-check.sh --quick` — no LOC or cross-layer violations; existing diagnostic-leak baseline warning only
- `cargo fmt --all -- --check` and `git diff --check` — passed

## Provenance

Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high