### PR TITLE
fix(checker): preserve shadowed binders in nested closures

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -672,23 +672,8 @@ impl CheckerState<'_> {
             // shadowing; require an enclosing declaration in the AST before
             // opting into the exact domain. Record the name node so every
             // refinement pass reuses the same origin.
-            let needs_identity_scope = self
-                .ctx
-                .type_parameter_scope
-                .get(&name)
-                .copied()
-                .and_then(|active| {
-                    common_query::type_param_info(self.ctx.types, active)
-                        .map(|active_info| (active, active_info))
-                })
-                .is_some_and(|(active, active_info)| {
-                    super::lexical_type_param_scope::is_lexical_type_parameter_shadow(
-                        self,
-                        active,
-                        active_info,
-                        data.name,
-                    )
-                });
+            let needs_identity_scope =
+                self.type_parameter_decl_needs_identity_scope(&name, data.name);
             if needs_identity_scope {
                 identity_scoped_param_names.push(data.name.0);
             }
@@ -1008,7 +993,7 @@ impl CheckerState<'_> {
         self.intern_type_param_for_decl_stamped_with_identity(name_node, info, false)
     }
 
-    fn intern_type_param_for_decl_stamped_with_identity(
+    pub(crate) fn intern_type_param_for_decl_stamped_with_identity(
         &mut self,
         name_node: tsz_parser::parser::NodeIndex,
         mut info: tsz_solver::TypeParamInfo,

--- a/crates/tsz-checker/src/state/type_analysis/lexical_identity_scope_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/lexical_identity_scope_tests.rs
@@ -3,7 +3,7 @@
 
 use crate::context::CheckerOptions;
 use crate::state::CheckerState;
-use tsz_parser::parser::ParserState;
+use tsz_parser::parser::{NodeIndex, ParserState, syntax_kind_ext};
 use tsz_solver::construction::TypeInterner;
 use tsz_solver::{TypeParamInfo, TypeParamOrigin};
 
@@ -99,4 +99,76 @@ fn same_name_lexical_owner_stamps_nested_declaration() {
 
     checker.pop_type_parameters(inner_updates);
     checker.pop_type_parameters(outer_updates);
+}
+
+#[test]
+fn shadowed_declaration_id_is_stable_across_nested_closure_reentry() {
+    let source = r#"
+class Container<Token> {
+  static wrap<Token>(value: Token) {
+    const callback = () => value
+    return callback()
+  }
+}
+"#;
+    let mut parser = ParserState::new("closure-reentry.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.get_arena();
+    let class_idx = arena
+        .get_source_file_at(root)
+        .expect("source file")
+        .statements
+        .nodes[0];
+    let class = arena
+        .get_class(arena.get(class_idx).expect("class node"))
+        .expect("class data");
+    let class_params = class
+        .type_parameters
+        .clone()
+        .expect("class type parameters");
+    let method_idx = class.members.nodes[0];
+    let method_params = arena
+        .get_method_decl(arena.get(method_idx).expect("method node"))
+        .and_then(|method| method.type_parameters.clone())
+        .expect("method type parameters");
+    let arrow_idx = arena
+        .nodes
+        .iter()
+        .position(|node| node.kind == syntax_kind_ext::ARROW_FUNCTION)
+        .map(|idx| NodeIndex(idx as u32))
+        .expect("nested arrow");
+
+    let mut binder = tsz_binder::BinderState::new();
+    binder.bind_source_file(arena, root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        arena,
+        &binder,
+        &types,
+        "closure-reentry.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    let (_, class_updates) = checker.push_type_parameters(&Some(class_params));
+    let (_, method_updates) = checker.push_type_parameters(&Some(method_params));
+    let direct = checker.ctx.type_parameter_scope["Token"];
+    checker.pop_type_parameters(method_updates);
+    checker.pop_type_parameters(class_updates);
+
+    let reentry_updates = checker.push_enclosing_type_parameters(arrow_idx);
+    let reentered = checker.ctx.type_parameter_scope["Token"];
+    checker.pop_type_parameters(reentry_updates);
+
+    let repeated_updates = checker.push_enclosing_type_parameters(arrow_idx);
+    let repeated = checker.ctx.type_parameter_scope["Token"];
+    checker.pop_type_parameters(repeated_updates);
+
+    assert_eq!(
+        direct, reentered,
+        "canonical method push and nested closure re-entry must reuse one declaration TypeId"
+    );
+    assert_eq!(
+        direct, repeated,
+        "repeated nested closure re-entry must keep the declaration TypeId stable"
+    );
 }

--- a/crates/tsz-checker/src/state/type_analysis/lexical_type_param_scope.rs
+++ b/crates/tsz-checker/src/state/type_analysis/lexical_type_param_scope.rs
@@ -35,3 +35,30 @@ pub(super) fn is_lexical_type_parameter_shadow(
 
     !belongs_to_current_decl
 }
+
+impl CheckerState<'_> {
+    /// Whether this declaration needs exact identity because it shadows an
+    /// active same-named parameter from a lexically enclosing generic owner.
+    ///
+    /// Keep the active-scope check paired with binder ancestry: an unrelated
+    /// re-entrant scratch entry must not opt a declaration into the exact
+    /// domain, while every scope-reconstruction path must make the same
+    /// decision as [`Self::push_type_parameters`].
+    pub(crate) fn type_parameter_decl_needs_identity_scope(
+        &self,
+        name: &str,
+        name_node: NodeIndex,
+    ) -> bool {
+        self.ctx
+            .type_parameter_scope
+            .get(name)
+            .copied()
+            .and_then(|active| {
+                crate::query_boundaries::common::type_param_info(self.ctx.types, active)
+                    .map(|active_info| (active, active_info))
+            })
+            .is_some_and(|(active, active_info)| {
+                is_lexical_type_parameter_shadow(self, active, active_info, name_node)
+            })
+    }
+}

--- a/crates/tsz-checker/src/tests/enclosing_type_param_default_scope_tests.rs
+++ b/crates/tsz-checker/src/tests/enclosing_type_param_default_scope_tests.rs
@@ -11,6 +11,14 @@
 //! `resolve_unbound_property_member_defaults` then treats the parameter as
 //! dangling and collapses an application member read (`Box<R>.get`) to the
 //! parameter's declared default (tsc keeps `R`; zustand Family B witness).
+//!
+//! The same re-entry path must preserve selective declaration identity when an
+//! enclosing generic declaration shadows a same-named lexical owner. The
+//! canonical declaration push stamps that rare binder as `DeclScoped`; a
+//! nested closure must re-push the exact same identity in both its initial and
+//! constraint/default refinement passes. Otherwise a captured value keeps the
+//! method binder while a type annotation inside the closure resolves to a
+//! newly minted same-named binder (`E` not assignable to `E`).
 
 use crate::test_utils::check_source_diagnostics;
 
@@ -119,5 +127,138 @@ class Der extends Base {
             .iter()
             .any(|d| d.contains("2322") && d.contains("'string'")),
         "omitted base arg must fill to its default 'string', got: {diags:?}"
+    );
+}
+
+/// A nested arrow re-enters both the class and the shadowing method scopes.
+/// The method parameter annotation and captured value must keep one identity.
+#[test]
+fn shadowed_method_param_keeps_identity_in_nested_arrow() {
+    let diags = diagnostics(
+        r#"
+class Container<Token> {
+  static wrap<Token>(value: Token) {
+    const callback = () => {
+      const copy: Token = value
+      return copy
+    }
+    return callback()
+  }
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "the captured method binder must keep its identity in an arrow, got: {diags:?}"
+    );
+}
+
+/// Function expressions use the same enclosing-scope reconstruction path.
+/// Vary the binder name so the fix cannot depend on the Neverthrow spelling.
+#[test]
+fn shadowed_method_param_keeps_identity_in_function_expression() {
+    let diags = diagnostics(
+        r#"
+class Envelope<Failure> {
+  static wrap<Failure>(value: Failure) {
+    const callback = function () {
+      const copy: Failure = value
+      return copy
+    }
+    return callback()
+  }
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "the captured method binder must keep its identity in a function expression, got: {diags:?}"
+    );
+}
+
+/// The refined pass must preserve the same identity when the shadowing binder
+/// carries both a constraint and a default.
+#[test]
+fn constrained_defaulted_shadow_keeps_identity_in_nested_arrow() {
+    let diags = diagnostics(
+        r#"
+class Wrapper<Item> {
+  static map<Item extends { tag: string } = { tag: string }>(value: Item) {
+    const callback = () => {
+      const copy: Item = value
+      return copy.tag
+    }
+    return callback()
+  }
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "constraint/default refinement must reuse the shadowing binder identity, got: {diags:?}"
+    );
+}
+
+/// Reduced Neverthrow shape: a static overload implementation shadows its
+/// generic class binders, Promise callbacks reconstruct that method scope, and
+/// the resulting application is passed to the enclosing generic constructor.
+#[test]
+fn shadowed_static_overload_promise_chain_keeps_constructor_argument_identity() {
+    let diags = diagnostics(
+        r#"
+interface PromiseLike<Value> {
+  then<Next>(onfulfilled: (value: Value) => Next): Promise<Next>
+}
+interface Promise<Value> extends PromiseLike<Value> {
+  catch<Next>(onrejected: (reason: unknown) => Next): Promise<Value | Next>
+}
+class Outcome<Value, Failure> {
+  value!: Value
+  failure!: Failure
+}
+class AsyncOutcome<Value, Failure> {
+  constructor(promise: Promise<Outcome<Value, Failure>>) {}
+
+  static from<Value, Failure>(
+    promise: PromiseLike<Value>,
+    errorFn: (reason: unknown) => Failure,
+  ): AsyncOutcome<Value, Failure>
+  static from<Value, Failure>(
+    promise: Promise<Value>,
+    errorFn: (reason: unknown) => Failure,
+  ): AsyncOutcome<Value, Failure> {
+    const transformed = promise
+      .then((value) => new Outcome<Value, Failure>())
+      .catch((reason) => new Outcome<Value, Failure>())
+    return new AsyncOutcome(transformed)
+  }
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "static overload callbacks must keep the implementation binders, got: {diags:?}"
+    );
+}
+
+/// A genuinely distinct nested binder with the same display name must remain
+/// distinct; declaration identity is not a name-based compatibility escape.
+#[test]
+fn genuinely_nested_same_name_binder_still_reports_mismatch() {
+    let diags = diagnostics(
+        r#"
+class Outer<T> {
+  static wrap<T>(value: T) {
+    return <T>(other: T) => {
+      const wrong: T = value
+      return [other, wrong]
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        diags.iter().any(|diag| diag.contains("2719")),
+        "distinct nested binders must remain incompatible, got: {diags:?}"
     );
 }

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -1434,7 +1434,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let mut updates = Vec::new();
-        let mut added_params: Vec<NodeIndex> = Vec::new();
+        let mut added_params: Vec<(NodeIndex, bool)> = Vec::new();
 
         // Pass 1: Add all type parameters to scope WITHOUT constraints
         for param_indices in enclosing_param_indices.into_iter().rev() {
@@ -1463,6 +1463,8 @@ impl<'a> CheckerState<'a> {
                     .has_modifier(&data.modifiers, tsz_scanner::SyntaxKind::ConstKeyword);
                 let info =
                     signature_building_boundary::user_type_param_info(atom, None, None, is_const);
+                let needs_identity_scope =
+                    self.type_parameter_decl_needs_identity_scope(&name, data.name);
                 // Mint through the declaration-scoped cache (not a structural
                 // `factory.type_param` intern) so the enclosing parameter
                 // resolves to the SAME `TypeId` here as under
@@ -1471,11 +1473,17 @@ impl<'a> CheckerState<'a> {
                 // parameter than the one the `implements`-clause type
                 // arguments resolve to, breaking the alias-application
                 // identity fast path (false TS2416, #13044).
-                let type_id = self.intern_type_param_for_decl(data.name, info);
+                let type_id = self
+                    .intern_type_param_for_decl_stamped_with_identity(
+                        data.name,
+                        info,
+                        needs_identity_scope,
+                    )
+                    .0;
 
                 let previous = self.ctx.type_parameter_scope.insert(name.clone(), type_id);
                 updates.push((name, previous, false));
-                added_params.push(param_idx);
+                added_params.push((param_idx, needs_identity_scope));
             }
         }
 
@@ -1490,7 +1498,7 @@ impl<'a> CheckerState<'a> {
         // treats the enclosing parameter as unbound and collapses e.g.
         // `Box<R>.get`'s `R` to its declared default inside nested-function
         // bodies (`f<R = unknown>(box: Box<R>) { () => box.get() }`).
-        for param_idx in added_params {
+        for (param_idx, needs_identity_scope) in added_params {
             let Some(node) = self.ctx.arena.get(param_idx) else {
                 continue;
             };
@@ -1527,7 +1535,13 @@ impl<'a> CheckerState<'a> {
             let info = signature_building_boundary::user_type_param_info(
                 atom, constraint, default, is_const,
             );
-            let refined_type_id = self.intern_type_param_for_decl(data.name, info);
+            let refined_type_id = self
+                .intern_type_param_for_decl_stamped_with_identity(
+                    data.name,
+                    info,
+                    needs_identity_scope,
+                )
+                .0;
             self.ctx.type_parameter_scope.insert(name, refined_type_id);
         }
 


### PR DESCRIPTION
Goal: green

## Summary

- Structural rule: when a nested function reconstructs enclosing generic scopes and an inner declaration lexically shadows a same-named outer binder, the re-entered scope must reuse the inner declaration's exact type-parameter identity in both the placeholder and constraint/default refinement passes.
- Owner layer: checker scope reconstruction now shares the canonical selective `DeclScoped` decision and declaration mint used by `push_type_parameters`; solver assignability remains strict and unchanged.
- Neverthrow's `ResultAsync<T, E>` static overload implementation now keeps its method `E` through `.then`/`.catch` closures, removing the false `E`-to-`E` TS2345 at `result-async.ts:40`. The exact pinned row improves from five TSZ-only diagnostics to four, with the remaining diagnostics unchanged.
- Adjacent coverage includes arrows, function expressions, renamed binders, constrained/defaulted binders, the static-overload Promise-chain constructor shape, direct `TypeId` stability across repeated re-entry, and a genuine third same-named binder that must still report TS2719.
- No identifier, property, alias, file-name, or rendered-type string drives the semantic decision.

## Fallback and performance

- Non-generic nested functions remain unchanged. Each enclosing type parameter adds one O(1) active-scope lookup; binder ancestry is consulted only for an active same-name candidate.
- The existing parameter vector carries one additional boolean per enclosing binder. Only rare lexical collisions enter the bounded ancestry walk; common unstamped binders retain `User` identity and existing allocation order.
- Reusing the canonical `DeclScoped` entry avoids minting and caching a second `User` variant for the same shadowing declaration.

## Dependency

- This PR is stacked on #15856 so its diff contains only this scope-reentry fix. Retarget to `main` immediately after #15856 lands.

## Verification

- `scripts/safe-run.sh env CARGO_TARGET_DIR=/Users/mohsen/code/tsz-jsdoc-ts7-triage/.target cargo nextest run -p tsz-checker --lib -E 'test(~enclosing_type_param_default_scope_tests) | test(~lexical_identity_scope_tests) | test(cross_file_type_param_decl_identity_tests::enclosing_and_direct_scope_pushes_mint_identical_type_param_ids)'` (14 passed)
- `scripts/safe-run.sh env CARGO_TARGET_DIR=/Users/mohsen/code/tsz-jsdoc-ts7-triage/.target cargo clippy -p tsz-checker --lib -- -D warnings`
- `scripts/safe-run.sh env CARGO_TARGET_DIR=/Users/mohsen/code/tsz-jsdoc-ts7-triage/.target cargo build --profile dist-fast -p tsz-cli --bin tsz`
- Exact pinned Neverthrow TSZ compile: 5 -> 4 TSZ-only diagnostics; `result-async.ts:40 TS2345` removed and remaining multiset unchanged.
- `/opt/homebrew/bin/tsc --pretty false -p /Users/mohsen/code/tsz-jsdoc-ts7-triage/.target/project-compile-guard/neverthrow/tsconfig.tsz-guard.json` (clean)
- `scripts/architecture-check.sh --quick` (0 LOC violations, 0 cross-layer violations; existing diagnostic-leak warning)
- `cargo fmt --all -- --check`
- `git diff --check`

## Provenance

Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
