### PR TITLE
fix(solver): preserve any in conditional extraction

### DIFF
--- a/crates/tsz-checker/tests/raw_builder_return_context_inference_tests.rs
+++ b/crates/tsz-checker/tests/raw_builder_return_context_inference_tests.rs
@@ -123,6 +123,74 @@ fn argument_inference_outranks_conflicting_return_context() {
 }
 
 #[test]
+fn nested_generic_extraction_uses_outer_apparent_constraint() {
+    assert_clean(
+        r#"
+interface ContextualBox<Scope, Key extends keyof Scope, Value> {
+  readonly expressionType: Value | undefined
+}
+
+type ReferenceInput<Scope, Key extends keyof Scope> =
+  | (keyof Scope & string)
+  | ContextualBox<Scope, Key, any>
+
+type ExtractReferenceValue<Scope, Key extends keyof Scope, Ref> =
+  Ref extends ContextualBox<any, any, infer Value> ? Value : unknown
+
+function wrapUnary<
+  Scope,
+  Key extends keyof Scope,
+  Ref extends ReferenceInput<Scope, Key>,
+>(expr: Ref): ContextualBox<Scope, Key, boolean> {
+  function unary<Ref extends ReferenceInput<Scope, Key>>(
+    value: Ref,
+  ): ContextualBox<Scope, Key, ExtractReferenceValue<Scope, Key, Ref>> {
+    return {} as any
+  }
+
+  return unary(expr)
+}
+"#,
+        "same-spelled nested generic extraction",
+    );
+}
+
+#[test]
+fn renamed_sibling_type_parameter_keeps_the_same_apparent_constraint() {
+    assert_clean(
+        r#"
+interface ContextualBox<Scope, Key extends keyof Scope, Value> {
+  readonly expressionType: Value | undefined
+}
+
+type ReferenceInput<Scope, Key extends keyof Scope> =
+  | (keyof Scope & string)
+  | ContextualBox<Scope, Key, any>
+
+type ExtractReferenceValue<Scope, Key extends keyof Scope, Ref> =
+  Ref extends ContextualBox<any, any, infer Value> ? Value : unknown
+
+function makeOperations<Scope, Key extends keyof Scope>() {
+  function unary<Ref extends ReferenceInput<Scope, Key>>(
+    value: Ref,
+  ): ContextualBox<Scope, Key, ExtractReferenceValue<Scope, Key, Ref>> {
+    return {} as any
+  }
+
+  function renamed<OuterRef extends ReferenceInput<Scope, Key>>(
+    expr: OuterRef,
+  ): ContextualBox<Scope, Key, boolean> {
+    return unary(expr)
+  }
+
+  return { renamed }
+}
+"#,
+        "renamed sibling binder passed to a generic helper",
+    );
+}
+
+#[test]
 fn different_base_and_ambiguous_union_do_not_pin_the_tag() {
     let source = format!(
         r#"{PRELUDE}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
@@ -683,7 +683,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 for &source_member in source_members.iter() {
                     let mut matched = false;
                     for &non_infer in &non_infer_pattern_members {
-                        if checker.is_subtype_of(source_member, non_infer)
+                        // `any` is mutually assignable with fixed members such
+                        // as `undefined`, but that compatibility is not an
+                        // exact union-member match. Keep it in the residual so
+                        // `any` against `infer V | undefined` infers `V = any`.
+                        if !source_member.is_any()
+                            && checker.is_subtype_of(source_member, non_infer)
                             && checker.is_subtype_of(non_infer, source_member)
                         {
                             matched = true;
@@ -720,7 +725,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             _ => {
                 // Source is not a union - check if source matches any non-infer pattern member
                 for &non_infer in &non_infer_pattern_members {
-                    if checker.is_subtype_of(source, non_infer)
+                    if !source.is_any()
+                        && checker.is_subtype_of(source, non_infer)
                         && checker.is_subtype_of(non_infer, source)
                     {
                         // Source is exactly a non-infer member, so infer gets never

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -448,6 +448,9 @@ mod computed_prop_name_tests;
 #[path = "../tests/conditional_comprehensive_tests.rs"]
 mod conditional_comprehensive_tests;
 #[cfg(test)]
+#[path = "../tests/conditional_infer_apparent_constraint_tests.rs"]
+mod conditional_infer_apparent_constraint_tests;
+#[cfg(test)]
 #[path = "../tests/conditional_infer_callable_arity_tests.rs"]
 mod conditional_infer_callable_arity_tests;
 #[cfg(test)]

--- a/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
@@ -494,11 +494,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 let instantiated = instantiate_type(self.interner, cond_type_id, &sub);
                 if instantiated != cond_type_id {
                     let evaluated = self.evaluate_type(instantiated);
-                    // A `never` distributive constraint (e.g. `ZeroOf<{}>`, where
-                    // no branch matches) is legitimately assignable to any target,
-                    // so it is kept here rather than guarded out — `never <: T`
-                    // holds and matches tsc's acceptance of such relations.
-                    if evaluated != cond_type_id && self.check_subtype(evaluated, target).is_true()
+                    // A `never` infer-extraction result means there is no
+                    // distributive constraint, so that path falls back to the
+                    // default constraint. For non-infer conditionals such as
+                    // `ZeroOf<T extends {}>`, `never` remains a legitimate
+                    // subtype witness.
+                    if evaluated != cond_type_id
+                        && (!extends_is_inference_pattern || evaluated != TypeId::NEVER)
+                        && self.check_subtype(evaluated, target).is_true()
                     {
                         return SubtypeResult::True;
                     }
@@ -541,18 +544,30 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         {
             return None;
         }
-        // Checker-owned relations carry a query database, so they can rewrite
-        // the exact check-binder identity without touching same-named foreign
-        // binders. Standalone TypeDatabase-only relations retain the legacy
-        // instantiation fallback.
+        // The shallow base query intentionally preserves resolver-owned alias
+        // applications. Expose that application before substitution so a
+        // distributive extraction sees each constraint member rather than an
+        // opaque alias that later collapses to `unknown` as one whole check.
+        let raw_constraint =
+            crate::type_queries::get_base_constraint_of_type(self.interner, cond.check_type);
+        if raw_constraint == cond.check_type {
+            return None;
+        }
+        let exposed_constraint = self.evaluate_type(raw_constraint);
+        // Checker-owned relations use the query-backed exact rewriter so a
+        // same-named sibling binder is not replaced. Standalone
+        // TypeDatabase-only relations retain the legacy name-based fallback.
         let substituted = if let Some(query_db) = self.query_db {
-            crate::type_queries::conditional_check_type_substituted_constraint_exact(
-                query_db, type_id,
+            crate::type_queries::conditional_check_type_substituted_with_constraint_exact(
+                query_db,
+                type_id,
+                exposed_constraint,
             )
         } else {
-            crate::type_queries::conditional_check_type_substituted_constraint(
+            crate::type_queries::conditional_check_type_substituted_with_constraint(
                 self.interner,
                 type_id,
+                exposed_constraint,
             )
         }?;
         let evaluated = self.evaluate_type(substituted);

--- a/crates/tsz-solver/src/type_queries/data/conditional_constraint.rs
+++ b/crates/tsz-solver/src/type_queries/data/conditional_constraint.rs
@@ -17,6 +17,24 @@ pub fn conditional_check_type_substituted_constraint_exact(
     let type_db = db.as_type_database();
     let cond_id = crate::type_queries::get_conditional_type_id(type_db, type_id)?;
     let cond = type_db.conditional_type(cond_id);
+    let constraint = crate::type_queries::get_base_constraint_of_type(type_db, cond.check_type);
+    conditional_check_type_substituted_with_constraint_exact(db, type_id, constraint)
+}
+
+/// Query-backed exact-identity substitution using an explicitly exposed
+/// constraint.
+///
+/// This composes resolver-owned constraint exposure with the exact rewriter:
+/// only the conditional's check-parameter `TypeId` is replaced, while sibling
+/// binders with the same spelling remain unchanged.
+pub fn conditional_check_type_substituted_with_constraint_exact(
+    db: &dyn QueryDatabase,
+    type_id: TypeId,
+    constraint: TypeId,
+) -> Option<TypeId> {
+    let type_db = db.as_type_database();
+    let cond_id = crate::type_queries::get_conditional_type_id(type_db, type_id)?;
+    let cond = type_db.conditional_type(cond_id);
     if !matches!(
         type_db.lookup(cond.check_type),
         Some(TypeData::TypeParameter(_))
@@ -24,8 +42,7 @@ pub fn conditional_check_type_substituted_constraint_exact(
         return None;
     }
 
-    let constraint = crate::type_queries::get_base_constraint_of_type(type_db, cond.check_type);
-    if constraint == cond.check_type {
+    if constraint == cond.check_type || constraint == TypeId::ERROR {
         return None;
     }
     let substituted = crate::instantiation::instantiate::substitute_exact_type(

--- a/crates/tsz-solver/src/type_queries/data/mod.rs
+++ b/crates/tsz-solver/src/type_queries/data/mod.rs
@@ -13,6 +13,7 @@ mod content_predicate_guards;
 mod content_predicates;
 #[cfg(test)]
 mod free_param_cache_tests;
+mod nominal_and_base;
 mod signatures_and_advanced;
 #[cfg(test)]
 mod tests;
@@ -22,5 +23,6 @@ pub use accessors::*;
 pub use conditional_constraint::*;
 pub use conditional_distribution::*;
 pub use content_predicates::*;
+pub use nominal_and_base::*;
 pub use signatures_and_advanced::*;
 pub use type_id_list::{TypeIdList, TypeIdListIter};

--- a/crates/tsz-solver/src/type_queries/data/nominal_and_base.rs
+++ b/crates/tsz-solver/src/type_queries/data/nominal_and_base.rs
@@ -1,0 +1,231 @@
+//! Nominal shape metadata and heritage-base validity queries.
+
+use super::content_predicates::contains_type_parameters_db;
+use crate::construction::TypeDatabase;
+use crate::types::{IntrinsicKind, TypeData, TypeId};
+
+/// Find the private brand name for a type.
+///
+/// Private members in TypeScript classes use a "brand" property for nominal typing.
+/// The brand is a property named like `__private_brand_#className`.
+///
+/// Returns the full brand property name (e.g., `"__private_brand_#Foo"`) if found,
+/// or None if the type has no private brand.
+pub fn get_private_brand_name(db: &dyn TypeDatabase, type_id: TypeId) -> Option<String> {
+    // Fast path: intrinsics aren't `Object` / `ObjectWithIndex` / `Callable`.
+    if type_id.is_intrinsic() {
+        return None;
+    }
+    match db.lookup(type_id)? {
+        TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
+            let shape = db.object_shape(shape_id);
+            for prop in &shape.properties {
+                let name = db.resolve_atom(prop.name);
+                if name.starts_with("__private_brand_") {
+                    return Some(name);
+                }
+            }
+            None
+        }
+        TypeData::Callable(shape_id) => {
+            let shape = db.callable_shape(shape_id);
+            for prop in &shape.properties {
+                let name = db.resolve_atom(prop.name);
+                if name.starts_with("__private_brand_") {
+                    return Some(name);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Find the private field name from a type's properties.
+///
+/// Given a type with private members, returns the name of the first private field
+/// (a property starting with `#` that is not a brand marker).
+///
+/// Returns `Some(field_name)` (e.g., `"#foo"`) if found, None otherwise.
+pub fn get_private_field_name(db: &dyn TypeDatabase, type_id: TypeId) -> Option<String> {
+    // Fast path: intrinsics aren't `Object` / `ObjectWithIndex` / `Callable`.
+    if type_id.is_intrinsic() {
+        return None;
+    }
+    match db.lookup(type_id)? {
+        TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
+            let shape = db.object_shape(shape_id);
+            for prop in &shape.properties {
+                let name = db.resolve_atom(prop.name);
+                if name.starts_with('#') && !name.starts_with("__private_brand_") {
+                    return Some(name);
+                }
+            }
+            None
+        }
+        TypeData::Callable(shape_id) => {
+            let shape = db.callable_shape(shape_id);
+            for prop in &shape.properties {
+                let name = db.resolve_atom(prop.name);
+                if name.starts_with('#') && !name.starts_with("__private_brand_") {
+                    return Some(name);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Get the symbol associated with a type's shape.
+///
+/// Checks object, object-with-index, and callable shapes for their `symbol` field.
+/// Returns the first `SymbolId` found, or None if the type has no shape with a symbol.
+pub fn get_type_shape_symbol(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<tsz_binder::SymbolId> {
+    // Fast path: intrinsics aren't `Object` / `ObjectWithIndex` / `Callable`.
+    if type_id.is_intrinsic() {
+        return None;
+    }
+    match db.lookup(type_id)? {
+        TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
+            db.object_shape(shape_id).symbol
+        }
+        TypeData::Callable(shape_id) => db.callable_shape(shape_id).symbol,
+        _ => None,
+    }
+}
+
+/// Get the `DefId` from an Enum type.
+///
+/// Returns None if the type is not an Enum type.
+pub fn get_enum_def_id(db: &dyn TypeDatabase, type_id: TypeId) -> Option<crate::def::DefId> {
+    // Fast path: intrinsics aren't `Enum(_)`.
+    if type_id.is_intrinsic() {
+        return None;
+    }
+    match db.lookup(type_id) {
+        Some(TypeData::Enum(def_id, _)) => Some(def_id),
+        _ => None,
+    }
+}
+
+/// Get the structural member type from an Enum type.
+///
+/// Returns None if the type is not an Enum type.
+pub fn get_enum_member_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
+    // Fast path: intrinsics aren't `Enum(_)`.
+    if type_id.is_intrinsic() {
+        return None;
+    }
+    match db.lookup(type_id) {
+        Some(TypeData::Enum(_, member_type)) => Some(member_type),
+        _ => None,
+    }
+}
+
+/// Check if a type is a valid base type for a class `extends` clause.
+///
+/// In TypeScript, a valid base type must be:
+/// - An object type (with properties/signatures) that is not a generic mapped type
+/// - The `object` intrinsic (`NonPrimitive`)
+/// - `any`
+/// - An intersection where every member is a valid base type
+/// - A union where every member is a valid base type (e.g. from overloaded constructors)
+/// - A type parameter
+///
+/// Primitives, `never`, `void`, `undefined`, `null`, `unknown`, and literals
+/// are NOT valid base types. Used for TS2509 checking.
+pub fn is_valid_base_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    // Fast path: only `any` and `object` intrinsics are valid base types;
+    // all other intrinsics (including `BOOLEAN_TRUE` / `BOOLEAN_FALSE`,
+    // which lookup as `Literal(Boolean)` and don't match the `Literal` arm)
+    // fall through to `_ => false`. Skip `lookup` for these.
+    if type_id.is_intrinsic() {
+        return type_id == TypeId::ANY
+            || type_id == TypeId::OBJECT
+            || type_id == TypeId::PROMISE_BASE;
+    }
+    match db.lookup(type_id) {
+        // Object-like types, callables, arrays/tuples, type params, and
+        // lazy/application/mapped refs are all valid class base types.
+        Some(
+            TypeData::Intrinsic(IntrinsicKind::Any | IntrinsicKind::Object)
+            | TypeData::Object(_)
+            | TypeData::ObjectWithIndex(_)
+            | TypeData::Callable(_)
+            | TypeData::Function(_)
+            | TypeData::Array(_)
+            | TypeData::Tuple(_)
+            | TypeData::TypeParameter(_)
+            | TypeData::Lazy(_)
+            | TypeData::Application(_)
+            | TypeData::Mapped(_),
+        ) => true,
+        Some(TypeData::Intersection(list_id)) => {
+            let members = db.type_list(list_id);
+            members.iter().all(|&m| is_valid_base_type(db, m))
+        }
+        Some(TypeData::Union(list_id)) => {
+            // Union can arise from construct-signature return-type merging
+            // (get_construct_return_type_union). All members must be valid base types.
+            let members = db.type_list(list_id);
+            !members.is_empty() && members.iter().all(|&m| is_valid_base_type(db, m))
+        }
+        Some(TypeData::ReadonlyType(inner)) => is_valid_base_type(db, inner),
+        // Intrinsics (never, void, null, etc.), literals, None => not valid base types
+        _ => false,
+    }
+}
+
+/// Check if a type is a valid base type for an interface `extends` clause.
+///
+/// Interface heritage is narrower than class heritage: the base must be an
+/// object type or an intersection of object types with statically known
+/// members. Unions and type parameters are rejected with TS2312.
+pub fn is_valid_interface_base_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if type_id.is_intrinsic() {
+        return type_id == TypeId::ANY || type_id == TypeId::OBJECT;
+    }
+
+    match db.lookup(type_id) {
+        Some(
+            TypeData::Intrinsic(IntrinsicKind::Any | IntrinsicKind::Object)
+            | TypeData::Object(_)
+            | TypeData::ObjectWithIndex(_)
+            | TypeData::Callable(_)
+            | TypeData::Function(_)
+            | TypeData::Array(_)
+            | TypeData::Tuple(_)
+            | TypeData::Lazy(_)
+            | TypeData::Application(_),
+        ) => true,
+        Some(TypeData::Intersection(list_id)) => {
+            let members = db.type_list(list_id);
+            !members.is_empty()
+                && members
+                    .iter()
+                    .all(|&member| is_valid_interface_base_type(db, member))
+        }
+        Some(TypeData::Mapped(mapped_id)) => {
+            let mapped = db.mapped_type(mapped_id);
+            !contains_type_parameters_db(db, mapped.constraint)
+                && !mapped
+                    .name_type
+                    .is_some_and(|name_type| contains_type_parameters_db(db, name_type))
+        }
+        Some(TypeData::ReadonlyType(inner)) => is_valid_interface_base_type(db, inner),
+        // tsc `isValidBaseType`: a type parameter is a valid interface base iff
+        // its base constraint is a valid base type. Members are inherited from
+        // the constraint's statically-known object shape (e.g.
+        // `interface I<T extends { k: string }> extends T {}` inherits `k`). An
+        // unconstrained parameter resolves to itself and is rejected (TS2312).
+        Some(TypeData::TypeParameter(_) | TypeData::Infer(_)) => {
+            let constraint = crate::type_queries::get_base_constraint_or_type(db, type_id);
+            constraint != type_id && is_valid_interface_base_type(db, constraint)
+        }
+        _ => false,
+    }
+}

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -12,7 +12,7 @@ use crate::evaluation::evaluate::{TypeEvaluator, evaluate_index_access, evaluate
 use crate::evaluation::evaluate_rules::infer_pattern::InferPatternVisited;
 use crate::instantiation::instantiate::instantiate_type_params_to_constraints_uncached;
 use crate::relations::subtype::SubtypeChecker;
-use crate::types::{CallSignature, ConditionalType, IntrinsicKind, LiteralValue, TypeData, TypeId};
+use crate::types::{CallSignature, ConditionalType, LiteralValue, TypeData, TypeId};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
 use tsz_common::Atom;
@@ -372,11 +372,31 @@ pub fn conditional_check_type_substituted_constraint(
 ) -> Option<TypeId> {
     let cond_id = crate::type_queries::get_conditional_type_id(db, type_id)?;
     let cond = db.conditional_type(cond_id);
+    let constraint = get_base_constraint_of_type(db, cond.check_type);
+    conditional_check_type_substituted_with_constraint(db, type_id, constraint)
+}
+
+/// Substitute an explicitly exposed constraint for a deferred conditional's
+/// naked check parameter.
+///
+/// This is the resolver-aware companion to
+/// [`conditional_check_type_substituted_constraint`]. Callers that own a
+/// resolver can first expose an alias/reference constraint, then use this
+/// construction helper so the instantiator sees the resulting union and keeps
+/// distributive conditional semantics. The supplied constraint is used only
+/// for the check parameter owned by `type_id`; evaluation remains the caller's
+/// responsibility.
+pub fn conditional_check_type_substituted_with_constraint(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    constraint: TypeId,
+) -> Option<TypeId> {
+    let cond_id = crate::type_queries::get_conditional_type_id(db, type_id)?;
+    let cond = db.conditional_type(cond_id);
     let TypeData::TypeParameter(info) = db.lookup(cond.check_type)? else {
         return None;
     };
-    let constraint = get_base_constraint_of_type(db, cond.check_type);
-    if constraint == cond.check_type {
+    if constraint == cond.check_type || constraint == TypeId::ERROR {
         return None;
     }
     let subst = crate::instantiation::instantiate::TypeSubstitution::single(info.name, constraint);
@@ -1911,230 +1931,4 @@ fn resolve_concrete_conditional_result(
             cond.false_type
         },
     )
-}
-
-/// Find the private brand name for a type.
-///
-/// Private members in TypeScript classes use a "brand" property for nominal typing.
-/// The brand is a property named like `__private_brand_#className`.
-///
-/// Returns the full brand property name (e.g., `"__private_brand_#Foo"`) if found,
-/// or None if the type has no private brand.
-pub fn get_private_brand_name(db: &dyn TypeDatabase, type_id: TypeId) -> Option<String> {
-    // Fast path: intrinsics aren't `Object` / `ObjectWithIndex` / `Callable`.
-    if type_id.is_intrinsic() {
-        return None;
-    }
-    match db.lookup(type_id)? {
-        TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
-            let shape = db.object_shape(shape_id);
-            for prop in &shape.properties {
-                let name = db.resolve_atom(prop.name);
-                if name.starts_with("__private_brand_") {
-                    return Some(name);
-                }
-            }
-            None
-        }
-        TypeData::Callable(shape_id) => {
-            let shape = db.callable_shape(shape_id);
-            for prop in &shape.properties {
-                let name = db.resolve_atom(prop.name);
-                if name.starts_with("__private_brand_") {
-                    return Some(name);
-                }
-            }
-            None
-        }
-        _ => None,
-    }
-}
-
-/// Find the private field name from a type's properties.
-///
-/// Given a type with private members, returns the name of the first private field
-/// (a property starting with `#` that is not a brand marker).
-///
-/// Returns `Some(field_name)` (e.g., `"#foo"`) if found, None otherwise.
-pub fn get_private_field_name(db: &dyn TypeDatabase, type_id: TypeId) -> Option<String> {
-    // Fast path: intrinsics aren't `Object` / `ObjectWithIndex` / `Callable`.
-    if type_id.is_intrinsic() {
-        return None;
-    }
-    match db.lookup(type_id)? {
-        TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
-            let shape = db.object_shape(shape_id);
-            for prop in &shape.properties {
-                let name = db.resolve_atom(prop.name);
-                if name.starts_with('#') && !name.starts_with("__private_brand_") {
-                    return Some(name);
-                }
-            }
-            None
-        }
-        TypeData::Callable(shape_id) => {
-            let shape = db.callable_shape(shape_id);
-            for prop in &shape.properties {
-                let name = db.resolve_atom(prop.name);
-                if name.starts_with('#') && !name.starts_with("__private_brand_") {
-                    return Some(name);
-                }
-            }
-            None
-        }
-        _ => None,
-    }
-}
-
-/// Get the symbol associated with a type's shape.
-///
-/// Checks object, object-with-index, and callable shapes for their `symbol` field.
-/// Returns the first `SymbolId` found, or None if the type has no shape with a symbol.
-pub fn get_type_shape_symbol(
-    db: &dyn TypeDatabase,
-    type_id: TypeId,
-) -> Option<tsz_binder::SymbolId> {
-    // Fast path: intrinsics aren't `Object` / `ObjectWithIndex` / `Callable`.
-    if type_id.is_intrinsic() {
-        return None;
-    }
-    match db.lookup(type_id)? {
-        TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
-            db.object_shape(shape_id).symbol
-        }
-        TypeData::Callable(shape_id) => db.callable_shape(shape_id).symbol,
-        _ => None,
-    }
-}
-
-/// Get the `DefId` from an Enum type.
-///
-/// Returns None if the type is not an Enum type.
-pub fn get_enum_def_id(db: &dyn TypeDatabase, type_id: TypeId) -> Option<crate::def::DefId> {
-    // Fast path: intrinsics aren't `Enum(_)`.
-    if type_id.is_intrinsic() {
-        return None;
-    }
-    match db.lookup(type_id) {
-        Some(TypeData::Enum(def_id, _)) => Some(def_id),
-        _ => None,
-    }
-}
-
-/// Get the structural member type from an Enum type.
-///
-/// Returns None if the type is not an Enum type.
-pub fn get_enum_member_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
-    // Fast path: intrinsics aren't `Enum(_)`.
-    if type_id.is_intrinsic() {
-        return None;
-    }
-    match db.lookup(type_id) {
-        Some(TypeData::Enum(_, member_type)) => Some(member_type),
-        _ => None,
-    }
-}
-
-/// Check if a type is a valid base type for a class `extends` clause.
-///
-/// In TypeScript, a valid base type must be:
-/// - An object type (with properties/signatures) that is not a generic mapped type
-/// - The `object` intrinsic (`NonPrimitive`)
-/// - `any`
-/// - An intersection where every member is a valid base type
-/// - A union where every member is a valid base type (e.g. from overloaded constructors)
-/// - A type parameter
-///
-/// Primitives, `never`, `void`, `undefined`, `null`, `unknown`, and literals
-/// are NOT valid base types. Used for TS2509 checking.
-pub fn is_valid_base_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    // Fast path: only `any` and `object` intrinsics are valid base types;
-    // all other intrinsics (including `BOOLEAN_TRUE` / `BOOLEAN_FALSE`,
-    // which lookup as `Literal(Boolean)` and don't match the `Literal` arm)
-    // fall through to `_ => false`. Skip `lookup` for these.
-    if type_id.is_intrinsic() {
-        return type_id == TypeId::ANY
-            || type_id == TypeId::OBJECT
-            || type_id == TypeId::PROMISE_BASE;
-    }
-    match db.lookup(type_id) {
-        // Object-like types, callables, arrays/tuples, type params, and
-        // lazy/application/mapped refs are all valid class base types.
-        Some(
-            TypeData::Intrinsic(IntrinsicKind::Any | IntrinsicKind::Object)
-            | TypeData::Object(_)
-            | TypeData::ObjectWithIndex(_)
-            | TypeData::Callable(_)
-            | TypeData::Function(_)
-            | TypeData::Array(_)
-            | TypeData::Tuple(_)
-            | TypeData::TypeParameter(_)
-            | TypeData::Lazy(_)
-            | TypeData::Application(_)
-            | TypeData::Mapped(_),
-        ) => true,
-        Some(TypeData::Intersection(list_id)) => {
-            let members = db.type_list(list_id);
-            members.iter().all(|&m| is_valid_base_type(db, m))
-        }
-        Some(TypeData::Union(list_id)) => {
-            // Union can arise from construct-signature return-type merging
-            // (get_construct_return_type_union). All members must be valid base types.
-            let members = db.type_list(list_id);
-            !members.is_empty() && members.iter().all(|&m| is_valid_base_type(db, m))
-        }
-        Some(TypeData::ReadonlyType(inner)) => is_valid_base_type(db, inner),
-        // Intrinsics (never, void, null, etc.), literals, None => not valid base types
-        _ => false,
-    }
-}
-
-/// Check if a type is a valid base type for an interface `extends` clause.
-///
-/// Interface heritage is narrower than class heritage: the base must be an
-/// object type or an intersection of object types with statically known
-/// members. Unions and type parameters are rejected with TS2312.
-pub fn is_valid_interface_base_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    if type_id.is_intrinsic() {
-        return type_id == TypeId::ANY || type_id == TypeId::OBJECT;
-    }
-
-    match db.lookup(type_id) {
-        Some(
-            TypeData::Intrinsic(IntrinsicKind::Any | IntrinsicKind::Object)
-            | TypeData::Object(_)
-            | TypeData::ObjectWithIndex(_)
-            | TypeData::Callable(_)
-            | TypeData::Function(_)
-            | TypeData::Array(_)
-            | TypeData::Tuple(_)
-            | TypeData::Lazy(_)
-            | TypeData::Application(_),
-        ) => true,
-        Some(TypeData::Intersection(list_id)) => {
-            let members = db.type_list(list_id);
-            !members.is_empty()
-                && members
-                    .iter()
-                    .all(|&member| is_valid_interface_base_type(db, member))
-        }
-        Some(TypeData::Mapped(mapped_id)) => {
-            let mapped = db.mapped_type(mapped_id);
-            !contains_type_parameters_db(db, mapped.constraint)
-                && !mapped
-                    .name_type
-                    .is_some_and(|name_type| contains_type_parameters_db(db, name_type))
-        }
-        Some(TypeData::ReadonlyType(inner)) => is_valid_interface_base_type(db, inner),
-        // tsc `isValidBaseType`: a type parameter is a valid interface base iff
-        // its base constraint is a valid base type. Members are inherited from
-        // the constraint's statically-known object shape (e.g.
-        // `interface I<T extends { k: string }> extends T {}` inherits `k`). An
-        // unconstrained parameter resolves to itself and is rejected (TS2312).
-        Some(TypeData::TypeParameter(_) | TypeData::Infer(_)) => {
-            let constraint = crate::type_queries::get_base_constraint_or_type(db, type_id);
-            constraint != type_id && is_valid_interface_base_type(db, constraint)
-        }
-        _ => false,
-    }
 }

--- a/crates/tsz-solver/tests/conditional_infer_apparent_constraint_tests.rs
+++ b/crates/tsz-solver/tests/conditional_infer_apparent_constraint_tests.rs
@@ -1,0 +1,406 @@
+//! Apparent-constraint coverage for deferred distributive extraction conditionals.
+//!
+//! A constrained check parameter may point at a resolver-owned alias application.
+//! The relation must expose that alias before substituting the constraint into the
+//! conditional, otherwise the evaluator sees the application as one opaque check
+//! and loses distribution over the alias body's union.
+
+use crate::def::{DefId, DefKind};
+use crate::evaluation::evaluate::evaluate_type_with_resolver;
+use crate::intern::TypeInterner;
+use crate::relations::subtype::{SubtypeChecker, TypeEnvironment};
+use crate::types::{ConditionalType, PropertyInfo, TypeId, TypeParamInfo, Variance};
+use std::sync::Arc;
+
+fn register_input_alias(
+    interner: &TypeInterner,
+    env: &mut TypeEnvironment,
+    def_id: DefId,
+    argument: TypeId,
+) -> TypeId {
+    // `type Input<Payload> = string | { value: Payload }`.
+    let payload = TypeParamInfo::simple(interner.intern_string("Payload"));
+    let payload_type = interner.type_param(payload);
+    let value_name = interner.intern_string("value");
+    let carrier = interner.object(vec![PropertyInfo::new(value_name, payload_type)]);
+    let body = interner.union2(TypeId::STRING, carrier);
+
+    env.insert_def_with_params(def_id, body, vec![payload]);
+    env.insert_def_kind(def_id, DefKind::TypeAlias);
+    interner.application(interner.lazy(def_id), vec![argument])
+}
+
+fn register_never_alias(
+    interner: &TypeInterner,
+    env: &mut TypeEnvironment,
+    def_id: DefId,
+) -> TypeId {
+    // Keep this generic so the constraint remains an alias Application rather
+    // than simplifying to the intrinsic before the resolver-backed path runs.
+    let unused = TypeParamInfo::simple(interner.intern_string("Unused"));
+    env.insert_def_with_params(def_id, TypeId::NEVER, vec![unused]);
+    env.insert_def_kind(def_id, DefKind::TypeAlias);
+    interner.application(interner.lazy(def_id), vec![TypeId::ANY])
+}
+
+fn constrained_subject(interner: &TypeInterner, name: &str, constraint: TypeId) -> TypeId {
+    let mut subject = TypeParamInfo::simple(interner.intern_string(name));
+    subject.constraint = Some(constraint);
+    interner.type_param(subject)
+}
+
+fn extraction_conditional(interner: &TypeInterner, constraint: TypeId) -> TypeId {
+    // `Subject extends { value: infer Extracted } ? Extracted : unknown`.
+    let subject = constrained_subject(interner, "Subject", constraint);
+    let extracted = interner.infer(TypeParamInfo::simple(interner.intern_string("Extracted")));
+    let pattern = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("value"),
+        extracted,
+    )]);
+    interner.conditional(ConditionalType {
+        check_type: subject,
+        extends_type: pattern,
+        true_type: extracted,
+        false_type: TypeId::UNKNOWN,
+        is_distributive: true,
+    })
+}
+
+fn optional_value_extraction_conditional(interner: &TypeInterner, constraint: TypeId) -> TypeId {
+    // `Subject extends { value: infer Extracted | undefined }
+    //   ? Extracted : unknown`.
+    let subject = constrained_subject(interner, "OptionalSubject", constraint);
+    let extracted = interner.infer(TypeParamInfo::simple(interner.intern_string("Extracted")));
+    let pattern = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("value"),
+        interner.union2(extracted, TypeId::UNDEFINED),
+    )]);
+    interner.conditional(ConditionalType {
+        check_type: subject,
+        extends_type: pattern,
+        true_type: extracted,
+        false_type: TypeId::UNKNOWN,
+        is_distributive: true,
+    })
+}
+
+#[test]
+fn resolver_exposed_any_alias_constraint_is_apparently_any() {
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+    let constraint = register_input_alias(&interner, &mut env, DefId(158_560), TypeId::ANY);
+    let conditional = extraction_conditional(&interner, constraint);
+    let mut checker = SubtypeChecker::with_resolver(&interner, &env);
+
+    assert_eq!(
+        checker.infer_extraction_conditional_constraint(conditional),
+        Some(TypeId::ANY),
+        "Input<any> must expose `string | {{ value: any }}`, distribute the extraction, and reduce `unknown | any` to any"
+    );
+    for target in [
+        TypeId::BOOLEAN,
+        TypeId::STRING,
+        TypeId::NUMBER,
+        TypeId::OBJECT,
+        TypeId::UNKNOWN,
+    ] {
+        assert!(
+            checker.is_subtype_of(conditional, target),
+            "an extraction with apparent constraint any must be assignable to {target:?}"
+        );
+    }
+    assert!(
+        !checker.is_subtype_of(conditional, TypeId::NEVER),
+        "any remains unassignable to never"
+    );
+}
+
+#[test]
+fn any_remains_infer_evidence_next_to_a_fixed_union_member() {
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+    let constraint = register_input_alias(&interner, &mut env, DefId(158_569), TypeId::ANY);
+    let conditional = optional_value_extraction_conditional(&interner, constraint);
+    let mut checker = SubtypeChecker::with_resolver(&interner, &env);
+
+    assert_eq!(
+        checker.infer_extraction_conditional_constraint(conditional),
+        Some(TypeId::ANY),
+        "`any` is residual evidence for `infer V | undefined`, not an exact `undefined` match"
+    );
+    assert!(checker.is_subtype_of(conditional, TypeId::BOOLEAN));
+}
+
+#[test]
+fn resolver_exposed_number_alias_constraint_is_apparently_unknown() {
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+    let constraint = register_input_alias(&interner, &mut env, DefId(158_561), TypeId::NUMBER);
+    let conditional = extraction_conditional(&interner, constraint);
+    let mut checker = SubtypeChecker::with_resolver(&interner, &env);
+
+    assert_eq!(
+        checker.infer_extraction_conditional_constraint(conditional),
+        Some(TypeId::UNKNOWN),
+        "Input<number> must distribute to `unknown | number`, whose apparent type is unknown"
+    );
+    assert!(checker.is_subtype_of(conditional, TypeId::UNKNOWN));
+    for target in [
+        TypeId::BOOLEAN,
+        TypeId::STRING,
+        TypeId::NUMBER,
+        TypeId::OBJECT,
+        TypeId::NEVER,
+    ] {
+        assert!(
+            !checker.is_subtype_of(conditional, target),
+            "an extraction with apparent constraint unknown must not be assignable to {target:?}"
+        );
+    }
+}
+
+#[test]
+fn infer_free_alias_predicate_keeps_the_default_constraint() {
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+    let constraint = register_input_alias(&interner, &mut env, DefId(158_562), TypeId::ANY);
+    let subject = constrained_subject(&interner, "PredicateSubject", constraint);
+    let pattern = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("value"),
+        TypeId::ANY,
+    )]);
+    let conditional = interner.conditional(ConditionalType {
+        check_type: subject,
+        extends_type: pattern,
+        true_type: TypeId::NUMBER,
+        false_type: TypeId::UNKNOWN,
+        is_distributive: true,
+    });
+    let mut checker = SubtypeChecker::with_resolver(&interner, &env);
+
+    assert_eq!(
+        checker.infer_extraction_conditional_constraint(conditional),
+        None,
+        "an infer-free predicate must stay behind the ordinary determinism gate"
+    );
+    assert!(checker.is_subtype_of(conditional, TypeId::UNKNOWN));
+    assert!(
+        !checker.is_subtype_of(conditional, TypeId::NUMBER),
+        "the predicate's true branch is not a sound apparent constraint"
+    );
+}
+
+#[test]
+fn resolver_exposed_never_constraint_falls_back_to_default_unknown() {
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+    let constraint = register_never_alias(&interner, &mut env, DefId(158_563));
+    let conditional = extraction_conditional(&interner, constraint);
+    let mut checker = SubtypeChecker::with_resolver(&interner, &env);
+
+    assert_eq!(
+        checker.infer_extraction_conditional_constraint(conditional),
+        None,
+        "tsc discards a distributive constraint that instantiates to never"
+    );
+    assert!(checker.is_subtype_of(conditional, TypeId::UNKNOWN));
+    assert!(!checker.is_subtype_of(conditional, TypeId::BOOLEAN));
+    assert!(
+        !checker.is_subtype_of(conditional, TypeId::NEVER),
+        "discarding the never constraint must preserve the default apparent constraint unknown"
+    );
+}
+
+#[test]
+fn non_infer_zeroof_empty_constraint_keeps_never_subtype_witness() {
+    let interner = TypeInterner::new();
+    let empty_object = interner.object(vec![]);
+    let subject = constrained_subject(&interner, "Value", empty_object);
+    let zero = interner.literal_number(0.0);
+    let empty_string = interner.literal_string("");
+    let branch = |extends_type, true_type, false_type| {
+        interner.conditional(ConditionalType {
+            check_type: subject,
+            extends_type,
+            true_type,
+            false_type,
+            is_distributive: true,
+        })
+    };
+
+    // `type ZeroOf<T> =
+    //   T extends null ? null :
+    //   T extends undefined ? undefined :
+    //   T extends string ? "" :
+    //   T extends number ? 0 :
+    //   T extends boolean ? false :
+    //   never`.
+    let boolean_case = branch(TypeId::BOOLEAN, TypeId::BOOLEAN_FALSE, TypeId::NEVER);
+    let number_case = branch(TypeId::NUMBER, zero, boolean_case);
+    let string_case = branch(TypeId::STRING, empty_string, number_case);
+    let undefined_case = branch(TypeId::UNDEFINED, TypeId::UNDEFINED, string_case);
+    let zero_of = branch(TypeId::NULL, TypeId::NULL, undefined_case);
+    let target = interner.union(vec![empty_string, zero, TypeId::BOOLEAN_FALSE]);
+    let mut checker = SubtypeChecker::new(&interner);
+
+    assert!(
+        checker.is_subtype_of(zero_of, target),
+        "`ZeroOf<T>` for `T extends {{}}` evaluates its distributive constraint to `never`, which remains a valid subtype witness"
+    );
+}
+
+fn assert_reference_extraction_relation(outer_name: &str) {
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+    let input = register_input_alias(&interner, &mut env, DefId(158_564), TypeId::ANY);
+
+    // `type ExtractReferenceValue<Reference> =
+    //   Reference extends { value: infer Value } ? Value : unknown`.
+    let alias_param = TypeParamInfo::simple(interner.intern_string("Reference"));
+    let alias_param_type = interner.type_param(alias_param);
+    let extracted = interner.infer(TypeParamInfo::simple(interner.intern_string("Value")));
+    let pattern = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("value"),
+        extracted,
+    )]);
+    let body = interner.conditional(ConditionalType {
+        check_type: alias_param_type,
+        extends_type: pattern,
+        true_type: extracted,
+        false_type: TypeId::UNKNOWN,
+        is_distributive: true,
+    });
+    let extract_def = DefId(158_565);
+    env.insert_def_with_params(extract_def, body, vec![alias_param]);
+    env.insert_def_kind(extract_def, DefKind::TypeAlias);
+
+    let argument = constrained_subject(&interner, outer_name, input);
+    let application = interner.application(interner.lazy(extract_def), vec![argument]);
+    let evaluated = evaluate_type_with_resolver(&interner, &env, application);
+    assert!(
+        crate::visitor::conditional_type_id(&interner, evaluated).is_some(),
+        "a generic extraction remains deferred until its relation is queried"
+    );
+    let source_value = interner.union2(evaluated, TypeId::UNDEFINED);
+    let application_source_value = interner.union2(application, TypeId::UNDEFINED);
+    let target_value = interner.union2(TypeId::BOOLEAN, TypeId::UNDEFINED);
+    let value_name = interner.intern_string("expressionType");
+    let source_box = interner.object(vec![PropertyInfo::new(value_name, source_value)]);
+    let target_box = interner.object(vec![PropertyInfo::new(value_name, target_value)]);
+
+    let mut checker = SubtypeChecker::with_resolver(&interner, &env);
+    assert_eq!(
+        checker.infer_extraction_conditional_constraint(evaluated),
+        Some(TypeId::ANY)
+    );
+    assert!(
+        checker.is_subtype_of(evaluated, TypeId::BOOLEAN),
+        "the resolver-exposed Input<any> constraint makes the extraction apparently any"
+    );
+    assert!(
+        checker.is_subtype_of(application, TypeId::BOOLEAN),
+        "the application expansion path must reach the extraction's apparent constraint"
+    );
+    assert!(
+        checker.is_subtype_of(source_value, target_value),
+        "the apparent extraction constraint must survive union member comparison"
+    );
+    assert!(
+        checker.is_subtype_of(application_source_value, target_value),
+        "an unevaluated extraction application must survive union member comparison"
+    );
+    assert!(
+        checker.is_subtype_of(source_box, target_box),
+        "the apparent extraction constraint must survive object property comparison"
+    );
+}
+
+#[test]
+fn application_extraction_uses_the_caller_constraint_in_relations() {
+    assert_reference_extraction_relation("Reference");
+    assert_reference_extraction_relation("OuterReference");
+}
+
+#[test]
+fn generic_container_relation_exposes_nested_extraction_constraint() {
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+
+    // `interface ContextualBox<Scope, Key, Value> {
+    //   expressionType: Value | undefined
+    // }`.
+    let scope = TypeParamInfo::simple(interner.intern_string("Scope"));
+    let key = TypeParamInfo::simple(interner.intern_string("Key"));
+    let value = TypeParamInfo::simple(interner.intern_string("Value"));
+    let scope_type = interner.type_param(scope);
+    let key_type = interner.type_param(key);
+    let value_type = interner.type_param(value);
+    let expression_name = interner.intern_string("expressionType");
+    let box_def = DefId(158_566);
+    let box_body = interner.object(vec![PropertyInfo::readonly(
+        expression_name,
+        interner.union2(value_type, TypeId::UNDEFINED),
+    )]);
+    env.insert_def_with_params(box_def, box_body, vec![scope, key, value]);
+    env.insert_def_kind(box_def, DefKind::Interface);
+    env.insert_declared_variances(
+        box_def,
+        Arc::from([
+            Variance::empty(),
+            Variance::empty(),
+            Variance::COVARIANT | Variance::DIRECT_USAGE,
+        ]),
+    );
+
+    // `type ReferenceInput<S, K> = string | ContextualBox<S, K, any>`.
+    let input_def = DefId(158_567);
+    let input_box = interner.application(
+        interner.lazy(box_def),
+        vec![scope_type, key_type, TypeId::ANY],
+    );
+    let input_body = interner.union2(TypeId::STRING, input_box);
+    env.insert_def_with_params(input_def, input_body, vec![scope, key]);
+    env.insert_def_kind(input_def, DefKind::TypeAlias);
+
+    // `type ExtractValue<S, K, Ref> =
+    //   Ref extends ContextualBox<any, any, infer V> ? V : unknown`.
+    let reference = TypeParamInfo::simple(interner.intern_string("Reference"));
+    let reference_type = interner.type_param(reference);
+    let extracted = interner.infer(TypeParamInfo::simple(interner.intern_string("Extracted")));
+    let extract_pattern = interner.application(
+        interner.lazy(box_def),
+        vec![TypeId::ANY, TypeId::ANY, extracted],
+    );
+    let extract_body = interner.conditional(ConditionalType {
+        check_type: reference_type,
+        extends_type: extract_pattern,
+        true_type: extracted,
+        false_type: TypeId::UNKNOWN,
+        is_distributive: true,
+    });
+    let extract_def = DefId(158_568);
+    env.insert_def_with_params(extract_def, extract_body, vec![scope, key, reference]);
+    env.insert_def_kind(extract_def, DefKind::TypeAlias);
+
+    let outer_input = interner.application(interner.lazy(input_def), vec![scope_type, key_type]);
+    let outer_reference = constrained_subject(&interner, "OuterReference", outer_input);
+    let extraction = interner.application(
+        interner.lazy(extract_def),
+        vec![scope_type, key_type, outer_reference],
+    );
+    let source = interner.application(
+        interner.lazy(box_def),
+        vec![scope_type, key_type, extraction],
+    );
+    let target = interner.application(
+        interner.lazy(box_def),
+        vec![scope_type, key_type, TypeId::BOOLEAN],
+    );
+
+    let mut checker = SubtypeChecker::with_resolver(&interner, &env);
+    assert!(checker.is_subtype_of(extraction, TypeId::BOOLEAN));
+    assert!(
+        checker.is_subtype_of(source, target),
+        "same-base generic variance must use the nested extraction's resolver-backed apparent constraint"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
- expose resolver-owned alias constraints before substituting deferred infer-extraction conditionals
- keep `any` as residual evidence when matching `infer V | undefined`, instead of consuming it as an exact `undefined` member
- treat infer-pattern `never` as missing distributive evidence while preserving `never` as a valid witness for non-infer conditionals
- split nominal/base queries so every touched hand-authored shard stays below 2,000 lines

## Structural rule
When a distributive infer-extraction checks a constrained type parameter, tsc substitutes the resolver-exposed constraint and distributes over its members. An `any` source is compatibility evidence, not an exact match for a fixed union member, so it remains available to the `infer` binder. A `never` result from infer extraction falls back to the default constraint, while a non-infer distributive conditional keeps `never` as a valid subtype witness. The solver evaluator owns infer-pattern matching; the subtype conditional relation owns apparent-constraint selection.

Adjacent matrix: alias constraints resolving to `any`, `number`, and `never`; infer-free predicates; direct and application-wrapped conditionals; union, object-property, and same-base generic-container relations; same-spelled nested and renamed caller binders; non-infer `ZeroOf<T>` controls.

Fallback: unresolved or no-op constraints remain deferred and use the ordinary default or branch constraint. No identifier, file, or rendered-type predicate participates in semantics.

Performance: the common infer-union loop adds one intrinsic `any` check. Resolver evaluation remains behind the existing type-parameter and infer-pattern gates and uses existing evaluation caches.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high

## Verification
- `CARGO_TARGET_DIR=.target-private scripts/safe-run.sh --limit 16384 -- cargo nextest run -p tsz-solver --lib -E test(conditional_infer_apparent_constraint_tests)` (8 passed)
- focused existing `ZeroOf` distributive-constraint controls (2 passed)
- focused existing infer-pattern controls (4 passed)
- focused `raw_builder_return_context_inference_tests` Kysely-shaped matrix (9 passed)
- `cargo clippy -p tsz-solver --lib --tests -- -D warnings`
- `cargo clippy -p tsz-checker --test raw_builder_return_context_inference_tests -- -D warnings`
- `cargo fmt --all -- --check`
- architecture guard and checker-boundary guards passed; `test_arch_guard.py` retains two unrelated `origin/main` baseline failures

The exact Kysely process was not duplicated locally because another agent owns paused debugger processes for that fixture; ready-review CI owns the broad canary suite.