### PR TITLE
fix(solver): preserve sibling binder identity in conditional constraints

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
@@ -541,10 +541,20 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         {
             return None;
         }
-        let substituted = crate::type_queries::conditional_check_type_substituted_constraint(
-            self.interner,
-            type_id,
-        )?;
+        // Checker-owned relations carry a query database, so they can rewrite
+        // the exact check-binder identity without touching same-named foreign
+        // binders. Standalone TypeDatabase-only relations retain the legacy
+        // instantiation fallback.
+        let substituted = if let Some(query_db) = self.query_db {
+            crate::type_queries::conditional_check_type_substituted_constraint_exact(
+                query_db, type_id,
+            )
+        } else {
+            crate::type_queries::conditional_check_type_substituted_constraint(
+                self.interner,
+                type_id,
+            )
+        }?;
         let evaluated = self.evaluate_type(substituted);
         (evaluated != TypeId::NEVER).then_some(evaluated)
     }

--- a/crates/tsz-solver/src/type_queries/data/conditional_constraint.rs
+++ b/crates/tsz-solver/src/type_queries/data/conditional_constraint.rs
@@ -1,0 +1,38 @@
+//! Exact-identity construction for deferred conditional constraints.
+
+use crate::construction::QueryDatabase;
+use crate::types::{TypeData, TypeId};
+
+/// Query-backed variant of
+/// [`super::conditional_check_type_substituted_constraint`] that replaces only
+/// the exact check-parameter identity.
+///
+/// The full exact rewriter traverses mapped and other deferred nodes and keeps
+/// same-named foreign binders unchanged. Callers without a query database use
+/// the legacy `TypeDatabase`-only helper instead.
+pub fn conditional_check_type_substituted_constraint_exact(
+    db: &dyn QueryDatabase,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    let type_db = db.as_type_database();
+    let cond_id = crate::type_queries::get_conditional_type_id(type_db, type_id)?;
+    let cond = type_db.conditional_type(cond_id);
+    if !matches!(
+        type_db.lookup(cond.check_type),
+        Some(TypeData::TypeParameter(_))
+    ) {
+        return None;
+    }
+
+    let constraint = crate::type_queries::get_base_constraint_of_type(type_db, cond.check_type);
+    if constraint == cond.check_type {
+        return None;
+    }
+    let substituted = crate::instantiation::instantiate::substitute_exact_type(
+        db,
+        type_id,
+        cond.check_type,
+        constraint,
+    );
+    (substituted != type_id).then_some(substituted)
+}

--- a/crates/tsz-solver/src/type_queries/data/mod.rs
+++ b/crates/tsz-solver/src/type_queries/data/mod.rs
@@ -5,6 +5,7 @@
 //! a stable API for querying type properties without matching on `TypeData` directly.
 
 mod accessors;
+mod conditional_constraint;
 mod conditional_distribution;
 #[cfg(test)]
 mod construct_return_union_tests;
@@ -18,6 +19,7 @@ mod tests;
 mod type_id_list;
 
 pub use accessors::*;
+pub use conditional_constraint::*;
 pub use conditional_distribution::*;
 pub use content_predicates::*;
 pub use signatures_and_advanced::*;

--- a/crates/tsz-solver/tests/conditional_deferred_return_tests.rs
+++ b/crates/tsz-solver/tests/conditional_deferred_return_tests.rs
@@ -1,9 +1,9 @@
 //! Regression tests for deferred conditional evaluation through the public solver API.
 
-use tsz_solver::computation::evaluate_conditional;
+use tsz_solver::computation::{evaluate_conditional, evaluate_type};
 use tsz_solver::construction::TypeInterner;
 use tsz_solver::query::conditional_type_id;
-use tsz_solver::type_handles::{ConditionalType, PropertyInfo, TypeId, TypeParamInfo};
+use tsz_solver::type_handles::{ConditionalType, PropertyInfo, TypeData, TypeId, TypeParamInfo};
 
 fn type_param(interner: &TypeInterner, name: &str) -> TypeId {
     interner.type_param(TypeParamInfo {
@@ -23,6 +23,92 @@ fn infer_param(interner: &TypeInterner, name: &str) -> TypeId {
         is_const: false,
         origin: tsz_solver::TypeParamOrigin::User,
     })
+}
+
+fn constrained_type_param(interner: &TypeInterner, name: &str, constraint: TypeId) -> TypeId {
+    interner.type_param(TypeParamInfo {
+        name: interner.intern_string(name),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+        origin: tsz_solver::TypeParamOrigin::User,
+    })
+}
+
+fn evaluated_exact_constraint_substitution(
+    interner: &TypeInterner,
+    check_type: TypeId,
+    branch_type: TypeId,
+) -> TypeId {
+    let conditional = interner.conditional(ConditionalType {
+        check_type,
+        extends_type: TypeId::UNKNOWN,
+        true_type: branch_type,
+        false_type: TypeId::NEVER,
+        is_distributive: true,
+    });
+    let substituted =
+        tsz_solver::type_queries::conditional_check_type_substituted_constraint_exact(
+            interner,
+            conditional,
+        )
+        .expect("the constrained check type should be substituted");
+    evaluate_type(interner, substituted)
+}
+
+fn object_property_type(interner: &TypeInterner, object: TypeId, name: &str) -> TypeId {
+    let shape_id = match interner.lookup(object) {
+        Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => shape_id,
+        other => panic!("expected object result, got {other:?}"),
+    };
+    let name = interner.intern_string(name);
+    interner
+        .object_shape(shape_id)
+        .properties
+        .iter()
+        .find(|property| property.name == name)
+        .map(|property| property.type_id)
+        .expect("expected result property")
+}
+
+#[test]
+fn conditional_constraint_substitution_preserves_same_named_foreign_parameter() {
+    let interner = TypeInterner::new();
+    let owned = constrained_type_param(&interner, "Ref", TypeId::BOOLEAN);
+    let foreign = constrained_type_param(&interner, "Ref", TypeId::STRING);
+    let branch = interner.object(vec![
+        PropertyInfo::new(interner.intern_string("owned"), owned),
+        PropertyInfo::new(interner.intern_string("foreign"), foreign),
+    ]);
+
+    assert_ne!(
+        owned, foreign,
+        "the declarations must have distinct identities"
+    );
+    let result = evaluated_exact_constraint_substitution(&interner, owned, branch);
+    assert_eq!(
+        object_property_type(&interner, result, "owned"),
+        TypeId::BOOLEAN,
+        "the conditional-owned binder must still be substituted with its constraint",
+    );
+    assert_eq!(
+        object_property_type(&interner, result, "foreign"),
+        foreign,
+        "substituting the conditional's check binder must not rewrite a same-named sibling binder",
+    );
+}
+
+#[test]
+fn conditional_constraint_substitution_keeps_renamed_foreign_parameter() {
+    let interner = TypeInterner::new();
+    let owned = constrained_type_param(&interner, "Ref", TypeId::BOOLEAN);
+    let foreign = constrained_type_param(&interner, "OuterRef", TypeId::STRING);
+
+    assert_eq!(
+        evaluated_exact_constraint_substitution(&interner, owned, foreign),
+        foreign,
+        "renaming a foreign binder must not change conditional constraint substitution",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Goal: hold

## Structural rule

When a deferred infer-extraction conditional replaces its constrained check parameter, only the exact `TypeId` owned by that conditional is substituted. A distinct sibling binder with the same spelling remains foreign and must not be rewritten or distributed through the check parameter's constraint.

Owner: solver conditional relation/query boundary. The checker supplies the query-backed type database; the shared exact rewriter owns graph traversal, memoization, provenance, and fuel.

## Adjacent matrix

- The conditional-owned binder is still replaced inside branch structure.
- A distinct same-named sibling binder keeps its exact identity.
- A renamed sibling behaves identically to the same-named sibling.
- Exact rewriting continues through mapped/deferred fields via the existing comprehensive walker.
- Standalone `TypeDatabase`-only relation callers retain the existing legacy substitution fallback.

## Fallback and performance

The exact path is reached only after the existing cheap gates prove a constrained type-parameter check and an infer-bearing extends type. It performs one memoized, solver-frame-bounded graph walk and then uses the existing resolver evaluation path. No identifier, alias, property, file-name, rendered-type, or source-text predicate is added. The no-query-database fallback is unchanged.

## Verification

- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test conditional_deferred_return_tests` (6/6)
- Focused same-named and renamed conditional constraint tests (2/2)
- Exact rewrite identity and mapped-field adjacency tests (2/2; 7,538 skipped)
- `scripts/safe-run.sh cargo clippy -p tsz-solver --lib --tests -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- Pre-fix witness: same-named sibling evaluated to `boolean`; renamed control preserved the foreign binder.

## Provenance

Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
