### PR TITLE
fix(solver): require definite narrowing subtype proofs

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2528,3 +2528,6 @@ path = "tests/inaccessible_constructor_instance_type_tests.rs"
 [[test]]
 name = "nullish_non_strict_assignability_tests"
 path = "tests/nullish_non_strict_assignability_tests.rs"
+[[test]]
+name = "instanceof_promise_recursive_narrowing_tests"
+path = "tests/instanceof_promise_recursive_narrowing_tests.rs"

--- a/crates/tsz-checker/tests/instanceof_promise_recursive_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/instanceof_promise_recursive_narrowing_tests.rs
@@ -1,0 +1,106 @@
+//! Regression coverage for Promise `instanceof` narrowing when the non-Promise
+//! union member expands through recursive generic result types.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs, load_default_lib_files};
+use tsz_common::common::{ModuleKind, ScriptTarget};
+
+fn diagnostics(source: &str) -> Vec<(u32, String)> {
+    let libs = load_default_lib_files();
+    if libs.is_empty() {
+        return Vec::new();
+    }
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ESNext,
+            module: ModuleKind::CommonJS,
+            strict: true,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| (diagnostic.code, diagnostic.message_text))
+    .collect()
+}
+
+#[test]
+fn recursive_iterator_result_union_is_definitely_narrowed_by_promise() {
+    let source = r#"
+type Result<T, E> = Ok<T, E> | Err<T, E>;
+type InferOk<R> = R extends Result<infer T, unknown> ? T : never;
+type InferErr<R> = R extends Result<unknown, infer E> ? E : never;
+
+class Ok<T, E> {
+  constructor(readonly value: T) {}
+  andThen<R extends Result<unknown, unknown>>(f: (value: T) => R): Result<InferOk<R>, InferErr<R> | E>;
+  andThen<U, F>(f: (value: T) => Result<U, F>): Result<U, E | F>;
+  andThen(f: (value: T) => Result<unknown, unknown>): Result<unknown, unknown> { return f(this.value); }
+}
+
+class Err<T, E> {
+  constructor(readonly error: E) {}
+  andThen<R extends Result<unknown, unknown>>(_f: (value: T) => R): Result<InferOk<R>, InferErr<R> | E>;
+  andThen<U, F>(_f: (value: T) => Result<U, F>): Result<U, E | F>;
+  andThen(_f: (value: T) => Result<unknown, unknown>): Result<never, E> { return new Err<never, E>(this.error); }
+}
+
+function probe<T, E>(
+  body: (() => Generator<Err<never, E>, Err<T, E>>) | (() => AsyncGenerator<Err<never, E>, Err<T, E>>),
+) {
+  const next = body().next();
+  if (next instanceof Promise) {
+    return next.then((result) => result.value);
+  }
+  return next.value;
+}
+"#;
+
+    let diags = diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "Promise must be the sole true-branch member and the iterator result the sole false-branch member: {diags:#?}",
+    );
+}
+
+#[test]
+fn recursive_promise_narrowing_is_independent_of_user_binder_names() {
+    let source = r#"
+type Outcome<Value, Fault> = Pass<Value, Fault> | Fail<Value, Fault>;
+type Passed<R> = R extends Outcome<infer Value, unknown> ? Value : never;
+type Failed<R> = R extends Outcome<unknown, infer Fault> ? Fault : never;
+
+class Pass<Value, Fault> {
+  constructor(readonly value: Value) {}
+  chain<R extends Outcome<unknown, unknown>>(f: (value: Value) => R): Outcome<Passed<R>, Failed<R> | Fault>;
+  chain<Next, Other>(f: (value: Value) => Outcome<Next, Other>): Outcome<Next, Fault | Other>;
+  chain(f: (value: Value) => Outcome<unknown, unknown>): Outcome<unknown, unknown> { return f(this.value); }
+}
+
+class Fail<Value, Fault> {
+  constructor(readonly error: Fault) {}
+  chain<R extends Outcome<unknown, unknown>>(_f: (value: Value) => R): Outcome<Passed<R>, Failed<R> | Fault>;
+  chain<Next, Other>(_f: (value: Value) => Outcome<Next, Other>): Outcome<Next, Fault | Other>;
+  chain(_f: (value: Value) => Outcome<unknown, unknown>): Outcome<never, Fault> { return new Fail<never, Fault>(this.error); }
+}
+
+function inspect<Value, Fault>(
+  factory: (() => Generator<Fail<never, Fault>, Fail<Value, Fault>>) | (() => AsyncGenerator<Fail<never, Fault>, Fail<Value, Fault>>),
+) {
+  const step = factory().next();
+  if (step instanceof Promise) {
+    return step.then((entry) => entry.value);
+  }
+  return step.value;
+}
+"#;
+
+    let diags = diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "renamed classes, methods, values, and generic binders must preserve the structural narrowing rule: {diags:#?}",
+    );
+}

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -669,17 +669,24 @@ impl<'a> QueryCache<'a> {
             Some(RelationCacheValue::LimitTrue { .. }) | None => {}
         }
 
-        let result = query_relation(
+        let relation_result = query_relation(
             self.as_type_database(),
             source,
             target,
             relation.relation_kind(),
             policy,
             RelationContext::default(),
-        )
-        .related;
+        );
+        let result = relation_result.related;
 
-        self.insert_policy_relation_cache(relation, key, result);
+        // Keep request-local relation answers out of this outer boolean cache.
+        // The typed stability signal includes local depth/iteration overflow,
+        // global fuel and shared solver-frame limits, truncated evaluation,
+        // and unresolved semantic references; not all of those appear in the
+        // diagnostic termination channel.
+        if relation_result.is_cacheable() {
+            self.insert_policy_relation_cache(relation, key, result);
+        }
         if let Some(query_id) = trace_query_id {
             query_trace::relation_end(query_id, trace_op, result, false);
         }

--- a/crates/tsz-solver/src/evaluation/evaluate/compound_simplification.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/compound_simplification.rs
@@ -149,6 +149,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // redundant. Termination is unaffected: the recursion guard still fires;
         // only the returned verdict changes from optimistic-true to not-related.
         checker.assume_related_on_cycle = false;
+        checker.assume_related_on_depth = false;
         checker.max_depth = MAX_SUBTYPE_DEPTH;
         checker.no_unchecked_indexed_access = self.no_unchecked_indexed_access;
         checker.exact_optional_property_types = self.exact_optional_property_types;
@@ -300,6 +301,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
 
         let lazy_events_at_entry = checker.unresolved_lazy_relation_event_count();
+        let budget_events_at_entry = checker.incomplete_evaluation_relation_event_count();
         let weak_sensitivity_at_entry = crate::limits::weak_type_sensitivity_count();
         let result = checker.check_subtype(source, target);
         let related = result.is_true();
@@ -312,6 +314,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             && !checker.depth_exceeded()
             && !checker.iteration_exceeded()
             && checker.unresolved_lazy_relation_event_count() == lazy_events_at_entry
+            && checker.incomplete_evaluation_relation_event_count() == budget_events_at_entry
             && crate::limits::weak_type_sensitivity_count() == weak_sensitivity_at_entry
         {
             if let Some(session) = session {
@@ -641,6 +644,7 @@ mod tests {
     use crate::construction::TypeInterner;
     use crate::def::DefId;
     use crate::evaluation::session::EvaluationSession;
+    use crate::recursion::{MAX_SOLVER_STACK_FRAMES, try_enter_solver_frame};
     use crate::relations::subtype::{MAX_SUBTYPE_DEPTH, SubtypeChecker};
     use crate::types::{IndexSignature, ObjectShape, PropertyInfo, TupleElement, TypeId};
 
@@ -661,6 +665,7 @@ mod tests {
         // member removal only acts on definitive verdicts, so the probe key must
         // carry the same not-coinductive relation mode.
         checker.assume_related_on_cycle = false;
+        checker.assume_related_on_depth = false;
         checker.max_depth = MAX_SUBTYPE_DEPTH;
         checker.exact_optional_property_types = exact_optional_property_types;
         checker
@@ -1042,6 +1047,43 @@ mod tests {
             vec![present_undefined, optional_number],
             "a legacy-mode seeded verdict must not be read by an exact-mode compound probe",
         );
+    }
+
+    #[test]
+    fn compound_subtype_cache_skips_shared_budget_failure() {
+        crate::limits::reset_subtype_thread_local_state();
+        let interner = TypeInterner::new();
+        let value = interner.intern_string("value");
+        let extra = interner.intern_string("extra");
+        let source = interner.object(vec![
+            PropertyInfo::new(value, TypeId::STRING),
+            PropertyInfo::new(extra, TypeId::NUMBER),
+        ]);
+        let target = interner.object(vec![PropertyInfo::new(value, TypeId::STRING)]);
+        let mut checker = compound_probe_checker(&interner, false);
+        let mut evaluator = TypeEvaluator::new(&interner);
+
+        let mut held_frames = Vec::new();
+        for _ in 0..MAX_SOLVER_STACK_FRAMES {
+            held_frames.push(try_enter_solver_frame().expect("solver frame budget has headroom"));
+        }
+        assert!(!evaluator.compound_subtype_cached(&mut checker, source, target));
+        assert_eq!(
+            evaluator.cache_statistics().compound_subtype_entries,
+            0,
+            "a strict shared-budget failure must not enter the compound memo",
+        );
+
+        drop(held_frames);
+        crate::limits::reset_subtype_thread_local_state();
+        checker.reset();
+        assert!(evaluator.compound_subtype_cached(&mut checker, source, target));
+        assert_eq!(
+            evaluator.cache_statistics().compound_subtype_entries,
+            1,
+            "a fresh-budget structural proof should be memoized",
+        );
+        crate::limits::reset_subtype_thread_local_state();
     }
 
     #[test]

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -759,9 +759,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 } else {
                     let mut strict_checker = self.conditional_subtype_checker();
                     let verdict = strict_checker.is_subtype_of(check_type, extends_type);
-                    // A walk that exhausted its own depth/iteration budget returned
-                    // a conservative verdict; mark it un-publishable.
-                    if strict_checker.depth_exceeded() || strict_checker.iteration_exceeded() {
+                    // Any request-local relation answer is un-publishable. The
+                    // typed stability signal also covers global fuel, shared
+                    // solver frames, and truncated evaluation, which do not
+                    // necessarily trip this checker's local recursion guard.
+                    if !strict_checker.relation_result_cacheable() {
                         cache_stability.mark_budget_bounded();
                     }
                     verdict

--- a/crates/tsz-solver/src/narrowing/cache.rs
+++ b/crates/tsz-solver/src/narrowing/cache.rs
@@ -191,6 +191,10 @@ pub struct NarrowingCache {
     /// Memo for the narrowing-boundary subtype check keyed by
     /// `(source, target, resolver_generation)`.
     pub(crate) narrow_subtype_cache: RefCell<GenerationMemo<NarrowExcludingStableKey, bool>>,
+    /// Monotonic count of strict relation-limit rejections observed while
+    /// computing narrowing answers. Parent memo boundaries snapshot this value
+    /// and avoid publishing results that depend on the ambient relation budget.
+    pub(crate) narrow_relation_budget_events: Cell<u64>,
     /// Re-entrancy depth of the exclusion-narrowing families.
     pub(crate) narrow_excluding_depth: Cell<u32>,
     /// Remaining cumulative work for the current outermost exclusion-narrowing
@@ -297,6 +301,7 @@ impl NarrowingCache {
             narrow_excluding_visiting: RefCell::new(FxHashSet::default()),
             narrow_assignable_cache: RefCell::new(GenerationMemo::default()),
             narrow_subtype_cache: RefCell::new(GenerationMemo::default()),
+            narrow_relation_budget_events: Cell::new(0),
             narrow_excluding_depth: Cell::new(0),
             narrow_excluding_fuel: Cell::new(0),
             narrow_excluding_budget: Cell::new(0),
@@ -467,6 +472,17 @@ impl NarrowingCache {
             fuel: &self.narrow_excluding_fuel,
             prior,
         }
+    }
+
+    #[inline]
+    pub(in crate::narrowing) fn note_relation_budget_event(&self) {
+        self.narrow_relation_budget_events
+            .set(self.narrow_relation_budget_events.get().wrapping_add(1));
+    }
+
+    #[inline]
+    pub(in crate::narrowing) const fn relation_budget_event_count(&self) -> u64 {
+        self.narrow_relation_budget_events.get()
     }
 
     pub(in crate::narrowing) fn charge_exclusion_work(&self) -> bool {

--- a/crates/tsz-solver/src/narrowing/compound.rs
+++ b/crates/tsz-solver/src/narrowing/compound.rs
@@ -19,7 +19,7 @@ pub enum NullishFilter {
     /// Exclude the nullish part, keeping everything else.
     ExcludeNullish,
 }
-use crate::relations::subtype::{SubtypeChecker, is_subtype_of};
+use crate::relations::subtype::SubtypeChecker;
 use crate::type_queries::{UnionMembersKind, classify_for_union_members};
 use crate::types::{LiteralValue, TypeData, TypeId};
 use crate::visitor::{
@@ -644,7 +644,7 @@ impl<'a> NarrowingContext<'a> {
             tracing::debug_span!("narrow", ty = type_id.0, narrower = narrower.0,).entered();
 
         // Fast path: already a subtype
-        if is_subtype_of(self.db, type_id, narrower) {
+        if self.is_subtype_for_narrowing(type_id, narrower) {
             return type_id;
         }
 
@@ -652,9 +652,16 @@ impl<'a> NarrowingContext<'a> {
         let mut visitor = NarrowingVisitor {
             db: self.db,
             narrower,
-            checker: SubtypeChecker::new(self.db.as_type_database()),
+            checker: SubtypeChecker::new(self.db.as_type_database())
+                .with_query_db(self.db)
+                .with_assume_related_on_depth(false),
+            budget_dependent: false,
         };
-        visitor.visit_type(self.db, type_id)
+        let result = visitor.visit_type(self.db, type_id);
+        if visitor.budget_dependent {
+            self.cache.note_relation_budget_event();
+        }
+        result
     }
 
     /// Narrow a type to only array-like types.
@@ -718,7 +725,7 @@ impl<'a> NarrowingContext<'a> {
                     let resolved_member = self.resolve_type(member);
                     if !self.is_array_like(resolved_member)
                         && (self.is_any_array_compat(resolved_member)
-                            || is_subtype_of(self.db, any_array, resolved_member))
+                            || self.is_subtype_for_narrowing(any_array, resolved_member))
                     {
                         has_any_compat = true;
                         return Some(any_array);
@@ -799,7 +806,9 @@ impl<'a> NarrowingContext<'a> {
         // interface — i.e. `any[] <: source`. Without the supertype case these
         // object-like guards narrowed to `never`, producing false TS2339 on every
         // member access in the true branch.
-        if self.is_any_array_compat(source_type) || is_subtype_of(self.db, any_array, source_type) {
+        if self.is_any_array_compat(source_type)
+            || self.is_subtype_for_narrowing(any_array, source_type)
+        {
             return any_array;
         }
 

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -728,16 +728,12 @@ impl<'a> NarrowingContext<'a> {
                     // Reverse subtype check: target <: member.
                     // Handles narrowing \`string | number\` by \`"hello"\` where
                     // \`"hello" <: string\` so the member should be kept.
-                    // Guard: only use the bare is_subtype_of_with_db (which lacks a
-                    // TypeResolver) for primitive/literal types. For interface/class
-                    // Lazy(DefId) types, the global subtype cache can contain stale
-                    // results that cause false positives.
+                    // Guard: this reverse proof only applies when either side
+                    // has primitive/literal semantics. The narrowing boundary
+                    // still owns the relation so budget exhaustion cannot prove
+                    // membership and resolver-backed aliases stay authoritative.
                     if (self.is_js_primitive(target_type) || self.is_js_primitive(member))
-                        && crate::relations::subtype::is_subtype_of_with_db(
-                            self.db,
-                            target_type,
-                            member,
-                        )
+                        && self.is_subtype_for_narrowing(target_type, member)
                     {
                         // Keep a wide `symbol` member over a `unique symbol`
                         // value; resolved target also catches aliases.
@@ -1087,12 +1083,15 @@ impl<'a> NarrowingContext<'a> {
         let Some(_visit_guard) = self.cache.narrow_excluding_visit_guard(key) else {
             return source_type;
         };
+        let relation_budget_events = self.cache.relation_budget_event_count();
         let result = self.narrow_excluding_type_uncached(source_type, excluded_type);
         // Only memoize when the whole subtree stayed within budget. A result that
         // bottomed out the fuel is truncated and request-local, so caching it
         // would poison a later, fully-budgeted request with the conservative
         // answer.
-        if self.cache.exclusion_within_budget() {
+        if self.cache.exclusion_within_budget()
+            && self.cache.relation_budget_event_count() == relation_budget_events
+        {
             self.cache.narrow_excluding_cache.borrow_mut().insert(
                 stable_key,
                 resolver_generation,
@@ -1431,12 +1430,15 @@ impl<'a> NarrowingContext<'a> {
         if let Some(cached) = self.cache.narrow_type_cache.borrow().get(&key, generation) {
             return cached;
         }
+        let relation_budget_events = self.cache.relation_budget_event_count();
         let narrowed =
             self.narrow_type_uncached(request.source_type(), request.guard(), request.sense());
-        self.cache
-            .narrow_type_cache
-            .borrow_mut()
-            .insert(key, generation, narrowed);
+        if self.cache.relation_budget_event_count() == relation_budget_events {
+            self.cache
+                .narrow_type_cache
+                .borrow_mut()
+                .insert(key, generation, narrowed);
+        }
         narrowed
     }
 

--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -840,11 +840,14 @@ impl<'a> NarrowingContext<'a> {
         {
             return cached;
         }
+        let budget_events = self.cache.relation_budget_event_count();
         let result = self.is_assignable_to_uncached(source, target);
-        self.cache
-            .narrow_assignable_cache
-            .borrow_mut()
-            .insert(key, generation, result);
+        if self.cache.relation_budget_event_count() == budget_events {
+            self.cache
+                .narrow_assignable_cache
+                .borrow_mut()
+                .insert(key, generation, result);
+        }
         result
     }
 
@@ -987,17 +990,35 @@ impl<'a> NarrowingContext<'a> {
         {
             return cached;
         }
-        let result = if let Some(resolver) = self.resolver {
+        let (result, cacheable) = if let Some(resolver) = self.resolver {
             let mut checker = SubtypeChecker::with_resolver(self.db.as_type_database(), &resolver)
-                .with_query_db(self.db);
-            checker.is_subtype_of(source, target)
+                .with_query_db(self.db)
+                .with_assume_related_on_depth(false);
+            let budget_events = checker.incomplete_evaluation_relation_event_count();
+            let result = checker.is_subtype_of(source, target);
+            (
+                result,
+                checker.incomplete_evaluation_relation_event_count() == budget_events,
+            )
         } else {
-            crate::relations::subtype::is_subtype_of_with_db(self.db, source, target)
+            let mut checker = SubtypeChecker::new(self.db.as_type_database())
+                .with_query_db(self.db)
+                .with_assume_related_on_depth(false);
+            let budget_events = checker.incomplete_evaluation_relation_event_count();
+            let result = checker.is_subtype_of(source, target);
+            (
+                result,
+                checker.incomplete_evaluation_relation_event_count() == budget_events,
+            )
         };
-        self.cache
-            .narrow_subtype_cache
-            .borrow_mut()
-            .insert(key, generation, result);
+        if cacheable {
+            self.cache
+                .narrow_subtype_cache
+                .borrow_mut()
+                .insert(key, generation, result);
+        } else {
+            self.cache.note_relation_budget_event();
+        }
         result
     }
 
@@ -1109,11 +1130,7 @@ impl<'a> NarrowingContext<'a> {
                 sp.name == t_prop.name
                     // Optional source can't satisfy required target
                     && (!sp.optional || t_prop.optional)
-                    && crate::relations::subtype::is_subtype_of_with_db(
-                        self.db,
-                        sp.type_id,
-                        t_prop.type_id,
-                    )
+                    && self.is_subtype_for_narrowing(sp.type_id, t_prop.type_id)
             });
             if !found {
                 return false;

--- a/crates/tsz-solver/src/narrowing/instanceof.rs
+++ b/crates/tsz-solver/src/narrowing/instanceof.rs
@@ -198,12 +198,18 @@ impl<'a> NarrowingContext<'a> {
                 let members = self.db.type_list(members_id);
                 // PERF: Reuse a single SubtypeChecker across all member checks
                 // instead of allocating 4 hash sets per is_subtype_of call.
-                let mut checker = SubtypeChecker::new(self.db.as_type_database());
+                let mut checker = SubtypeChecker::new(self.db.as_type_database())
+                    .with_query_db(self.db)
+                    .with_assume_related_on_depth(false);
                 let mut filtered_members: SmallVec<[TypeId; 4]> = SmallVec::new();
                 for &member in &*members {
                     // Check if member is assignable to instance type
                     checker.reset();
-                    if checker.is_subtype_of(member, instance_type) {
+                    let member_is_subtype = checker.is_subtype_of(member, instance_type);
+                    if checker.incomplete_evaluation_relation_event_count() != 0 {
+                        self.cache.note_relation_budget_event();
+                    }
+                    if member_is_subtype {
                         trace!(
                             "Union member {} is assignable to instance type {}, keeping",
                             member.0, instance_type.0
@@ -215,7 +221,11 @@ impl<'a> NarrowingContext<'a> {
                     // Check if instance type is assignable to member (subclass case)
                     // If we have a Dog and instanceof Animal, Dog is an instance of Animal
                     checker.reset();
-                    if checker.is_subtype_of(instance_type, member) {
+                    let instance_is_subtype = checker.is_subtype_of(instance_type, member);
+                    if checker.incomplete_evaluation_relation_event_count() != 0 {
+                        self.cache.note_relation_budget_event();
+                    }
+                    if instance_is_subtype {
                         trace!(
                             "Instance type {} is assignable to union member {} (subclass), narrowing to instance type",
                             instance_type.0, member.0
@@ -353,12 +363,18 @@ impl<'a> NarrowingContext<'a> {
             if let Some(members_id) = union_list_id(self.db, resolved_source) {
                 let members = self.db.type_list(members_id);
                 // PERF: Reuse a single SubtypeChecker across all member checks
-                let mut checker = SubtypeChecker::new(self.db.as_type_database());
+                let mut checker = SubtypeChecker::new(self.db.as_type_database())
+                    .with_query_db(self.db)
+                    .with_assume_related_on_depth(false);
                 let mut filtered_members: SmallVec<[TypeId; 4]> = SmallVec::new();
                 for &member in &*members {
                     // Exclude members that are definitely subtypes of the instance type
                     checker.reset();
-                    if !checker.is_subtype_of(member, instance_type) {
+                    let member_is_subtype = checker.is_subtype_of(member, instance_type);
+                    if checker.incomplete_evaluation_relation_event_count() != 0 {
+                        self.cache.note_relation_budget_event();
+                    }
+                    if !member_is_subtype {
                         filtered_members.push(member);
                     }
                 }
@@ -464,17 +480,9 @@ impl<'a> NarrowingContext<'a> {
                         );
                         continue;
                     }
-                    if crate::relations::subtype::is_subtype_of_with_db(
-                        self.db,
-                        member,
-                        instance_type,
-                    ) {
+                    if self.is_subtype_for_narrowing(member, instance_type) {
                         result.push(member);
-                    } else if crate::relations::subtype::is_subtype_of_with_db(
-                        self.db,
-                        instance_type,
-                        member,
-                    ) {
+                    } else if self.is_subtype_for_narrowing(instance_type, member) {
                         result.push(instance_type);
                     }
                 }
@@ -980,6 +988,8 @@ impl<'a> NarrowingContext<'a> {
         let resolved_source = self.resolve_type(source);
         let resolved_instance = self.resolve_type(instance_type);
 
+        // Overlap is intentionally conservative: budget uncertainty must keep
+        // the possible intersection instead of proving it uninhabitable.
         let mut checker = SubtypeChecker::new(self.db.as_type_database()).with_query_db(self.db);
         checker.are_types_overlapping(resolved_source, resolved_instance)
     }
@@ -1116,11 +1126,7 @@ impl<'a> NarrowingContext<'a> {
         // and primitives) have no private constructor identity. `tsc` keeps the
         // source iff it is a subtype of the constructor's instance type.
         let resolved_member = self.resolve_type(member);
-        crate::relations::subtype::is_subtype_of_with_db(
-            self.db,
-            resolved_member,
-            resolved_instance,
-        )
+        self.is_subtype_for_narrowing(resolved_member, resolved_instance)
     }
 
     /// Narrow by `x.constructor !== SomeClass` (false branch).

--- a/crates/tsz-solver/src/narrowing/utils.rs
+++ b/crates/tsz-solver/src/narrowing/utils.rs
@@ -16,6 +16,16 @@ pub(crate) struct NarrowingVisitor<'a> {
     pub(crate) narrower: TypeId,
     /// PERF: Reusable `SubtypeChecker` to avoid per-call hash allocations
     pub(crate) checker: SubtypeChecker<'a>,
+    pub(crate) budget_dependent: bool,
+}
+
+impl NarrowingVisitor<'_> {
+    fn is_definite_subtype(&mut self, source: TypeId, target: TypeId) -> bool {
+        self.checker.reset();
+        let result = self.checker.is_subtype_of(source, target);
+        self.budget_dependent |= self.checker.incomplete_evaluation_relation_event_count() != 0;
+        result
+    }
 }
 
 impl<'a> TypeVisitor for NarrowingVisitor<'a> {
@@ -49,14 +59,12 @@ impl<'a> TypeVisitor for NarrowingVisitor<'a> {
                 TypeData::Object(_) => {
                     // Case 1: type_id is subtype of narrower (e.g., { a: "foo" } narrowed by { a: string })
                     // Result: type_id (keep the more specific type)
-                    self.checker.reset();
-                    if self.checker.is_subtype_of(type_id, self.narrower) {
+                    if self.is_definite_subtype(type_id, self.narrower) {
                         return type_id;
                     }
                     // Case 2: narrower is subtype of type_id (e.g., { a: string } narrowed by { a: "foo" })
                     // Result: narrower (narrow down to the more specific type)
-                    self.checker.reset();
-                    if self.checker.is_subtype_of(self.narrower, type_id) {
+                    if self.is_definite_subtype(self.narrower, type_id) {
                         return self.narrower;
                     }
                     // Case 3: Both are object types but not directly related
@@ -71,13 +79,11 @@ impl<'a> TypeVisitor for NarrowingVisitor<'a> {
                 // Function types: check subtype relationships
                 TypeData::Function(_) => {
                     // Case 1: type_id is subtype of narrower (keep specific)
-                    self.checker.reset();
-                    if self.checker.is_subtype_of(type_id, self.narrower) {
+                    if self.is_definite_subtype(type_id, self.narrower) {
                         return type_id;
                     }
                     // Case 2: narrower is subtype of type_id (narrow down)
-                    self.checker.reset();
-                    if self.checker.is_subtype_of(self.narrower, type_id) {
+                    if self.is_definite_subtype(self.narrower, type_id) {
                         return self.narrower;
                     }
                     // Case 3: Disjoint function types
@@ -113,15 +119,13 @@ impl<'a> TypeVisitor for NarrowingVisitor<'a> {
 
                 // Case 1: narrower is subtype of type_id (e.g., narrow(string, "foo"))
                 // Result: narrower
-                self.checker.reset();
-                if self.checker.is_subtype_of(self.narrower, type_id) {
+                if self.is_definite_subtype(self.narrower, type_id) {
                     self.narrower
                 }
                 // Case 2: type_id is subtype of narrower (e.g., narrow("foo", string))
                 // Result: type_id (the original)
                 else {
-                    self.checker.reset();
-                    if self.checker.is_subtype_of(type_id, self.narrower) {
+                    if self.is_definite_subtype(type_id, self.narrower) {
                         type_id
                     }
                     // Case 3: Disjoint types (e.g., narrow(string, number))

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -785,6 +785,13 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         }
     }
 
+    pub fn set_assume_related_on_depth(&mut self, assume: bool) {
+        if self.subtype.assume_related_on_depth != assume {
+            self.subtype.assume_related_on_depth = assume;
+            self.clear_operation_caches();
+        }
+    }
+
     /// Enable generic erasure for function subtype checks.
     ///
     /// When true, non-generic functions can match generic targets by erasing
@@ -883,8 +890,16 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return cached;
         }
 
+        let unresolved_events = self.subtype.unresolved_lazy_relation_event_count();
+        let incomplete_events = self.subtype.incomplete_evaluation_relation_event_count();
+        let relation_limit_events = self.subtype.relation_limit_event_count();
         let result = self.is_assignable_impl(source, target, self.strict_function_types);
-        self.cache.insert(key, result);
+        if self.subtype.unresolved_lazy_relation_event_count() == unresolved_events
+            && self.subtype.incomplete_evaluation_relation_event_count() == incomplete_events
+            && self.subtype.relation_limit_event_count() == relation_limit_events
+        {
+            self.cache.insert(key, result);
+        }
         result
     }
 

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -56,6 +56,9 @@ pub struct RelationPolicy {
     pub any_propagation_mode: AnyPropagationMode,
     /// Whether recursive relation cycles should be treated as assumed-related.
     pub assume_related_on_cycle: bool,
+    /// Whether relation depth/iteration exhaustion should be treated as
+    /// assumed-related. This is independent of valid recursive cycles.
+    pub assume_related_on_depth: bool,
     /// Skip weak type checks (TS2559) during assignability.
     ///
     /// In tsc, `isTypeAssignableTo` does NOT include the weak type check.
@@ -80,6 +83,7 @@ impl Default for RelationPolicy {
             strict_any_propagation: false,
             any_propagation_mode: AnyPropagationMode::All,
             assume_related_on_cycle: true,
+            assume_related_on_depth: true,
             skip_weak_type_checks: false,
             erase_generics: true,
         }
@@ -99,6 +103,7 @@ impl RelationPolicy {
             strict_any_propagation: false,
             any_propagation_mode: AnyPropagationMode::All,
             assume_related_on_cycle: true,
+            assume_related_on_depth: true,
             skip_weak_type_checks: false,
             erase_generics: true,
         }
@@ -137,6 +142,7 @@ impl RelationPolicy {
             strict_any_propagation: flags.contains(RelationFlags::STRICT_ANY_PROPAGATION),
             any_propagation_mode: AnyPropagationMode::All,
             assume_related_on_cycle: true,
+            assume_related_on_depth: true,
             skip_weak_type_checks: flags.contains(RelationFlags::SKIP_WEAK_TYPE_CHECKS),
             erase_generics,
         }
@@ -164,6 +170,11 @@ impl RelationPolicy {
 
     pub const fn with_assume_related_on_cycle(mut self, assume: bool) -> Self {
         self.assume_related_on_cycle = assume;
+        self
+    }
+
+    pub const fn with_assume_related_on_depth(mut self, assume: bool) -> Self {
+        self.assume_related_on_depth = assume;
         self
     }
 
@@ -270,6 +281,7 @@ impl RelationPolicy {
             .union(RelationFlags::STRICT_ANY_PROPAGATION)
             .union(RelationFlags::SKIP_WEAK_TYPE_CHECKS)
             .union(RelationFlags::ASSUME_RELATED_ON_CYCLE)
+            .union(RelationFlags::ASSUME_RELATED_ON_DEPTH)
             .union(RelationFlags::NO_ERASE_GENERICS);
         let mut bits =
             RelationFlags::from_bits_retain(self.flags.bits() & !field_owned_bits.bits());
@@ -284,6 +296,9 @@ impl RelationPolicy {
         }
         if self.assume_related_on_cycle {
             bits = bits.union(RelationFlags::ASSUME_RELATED_ON_CYCLE);
+        }
+        if self.assume_related_on_depth {
+            bits = bits.union(RelationFlags::ASSUME_RELATED_ON_DEPTH);
         }
         // `erase_generics=false` maps to NO_ERASE_GENERICS bit. The typed
         // `flags` field may already carry this bit; merging here keeps explicit
@@ -325,6 +340,7 @@ pub struct RelationResult {
     pub kind: RelationKind,
     pub related: bool,
     termination: RelationTermination,
+    cacheable: bool,
 }
 
 /// Whether a relation query completed or stopped at a relation budget.
@@ -370,6 +386,7 @@ impl RelationResult {
             kind,
             related,
             termination: RelationTermination::Complete,
+            cacheable: true,
         }
     }
 
@@ -378,11 +395,13 @@ impl RelationResult {
         related: bool,
         depth_exceeded: bool,
         iteration_exceeded: bool,
+        cacheable: bool,
     ) -> Self {
         Self {
             kind,
             related,
             termination: RelationTermination::from_flags(depth_exceeded, iteration_exceeded),
+            cacheable,
         }
     }
 
@@ -405,6 +424,15 @@ impl RelationResult {
     pub const fn iteration_exceeded(self) -> bool {
         self.termination.iteration_exceeded()
     }
+
+    /// Whether this answer is stable enough for an outer boolean relation
+    /// cache. Kept separate from diagnostic termination because global fuel,
+    /// unresolved semantic references, and shared solver-frame limits can make
+    /// a verdict request-local without tripping the local recursion guard.
+    #[inline]
+    pub(crate) const fn is_cacheable(self) -> bool {
+        self.cacheable
+    }
 }
 
 const fn relation_result_from_compat_checker<R: TypeResolver>(
@@ -417,6 +445,7 @@ const fn relation_result_from_compat_checker<R: TypeResolver>(
         related,
         checker.depth_exceeded(),
         checker.iteration_exceeded(),
+        checker.subtype.relation_result_cacheable(),
     )
 }
 
@@ -430,6 +459,7 @@ const fn relation_result_from_subtype_checker<R: TypeResolver>(
         related,
         checker.depth_exceeded(),
         checker.iteration_exceeded(),
+        checker.relation_result_cacheable(),
     )
 }
 
@@ -562,6 +592,7 @@ where
         related,
         checker.depth_exceeded(),
         checker.iteration_exceeded(),
+        checker.subtype.relation_result_cacheable(),
     );
 
     // The failure analysis runs on the same `checker`, so its relation cache is
@@ -713,6 +744,7 @@ pub fn query_relation_with_overrides<
         related = result.related,
         depth_exceeded = result.depth_exceeded(),
         iteration_exceeded = result.iteration_exceeded(),
+        cacheable = result.is_cacheable(),
         "query_relation result"
     );
 
@@ -738,6 +770,7 @@ pub fn query_erased_overload_params_with_matching_return_base<'a, R: TypeResolve
         related,
         checker.depth_exceeded(),
         checker.iteration_exceeded(),
+        checker.relation_result_cacheable(),
     )
 }
 
@@ -825,6 +858,7 @@ fn configure_compat_checker_policy<R: TypeResolver>(
         AnyPropagationMode::AnySourceNotRelated
     ));
     checker.set_assume_related_on_cycle(policy.assume_related_on_cycle);
+    checker.set_assume_related_on_depth(policy.assume_related_on_depth);
     checker.set_skip_weak_type_checks(policy.skip_weak_type_checks);
     checker.set_erase_generics(policy.erase_generics);
 }
@@ -851,6 +885,7 @@ const fn configure_subtype_checker_policy<'a, R: TypeResolver>(
     configure_subtype_checker_policy_bits(checker, policy)
         .with_any_propagation_mode(policy.any_propagation_mode)
         .with_assume_related_on_cycle(policy.assume_related_on_cycle)
+        .with_assume_related_on_depth(policy.assume_related_on_depth)
 }
 
 const fn configure_subtype_checker_policy_bits<'a, R: TypeResolver>(

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -69,6 +69,8 @@ pub(crate) struct MaybeRelationEntry {
 /// - the checker-local guard-truncated evaluation counter (#14346 verdict
 ///   consumption: a meta-type evaluation bailed on a depth/fuel/stack budget,
 ///   so the verdict is a budget artifact);
+/// - the checker-local relation-limit counter (a child `DepthExceeded` may be
+///   consumed through `.is_true()` and collapse into a parent `True`);
 /// - the thread-local weak-type sensitivity counter (the verdict depended on
 ///   TS2559 enforcement state the flag-agnostic key does not encode).
 ///
@@ -78,6 +80,7 @@ pub(crate) struct MaybeRelationEntry {
 pub(crate) struct RelationTaintSnapshot {
     unresolved_lazy_events: u64,
     incomplete_evaluation_events: u64,
+    relation_limit_events: u64,
     weak_sensitivity: u64,
 }
 
@@ -438,7 +441,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                                 && remaining_global_subtype_fuel() <= fuel_band =>
                         {
                             tsz_common::perf_counters::record_relation_limit_cache_hit();
-                            return SubtypeResult::DepthExceeded;
+                            return self.depth_result();
                         }
                         Some(RelationCacheValue::LimitTrue { .. }) | None => {}
                     }
@@ -523,13 +526,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         //   feeding this verdict was cut short by a depth/fuel/stack budget, so
         //   the verdict is an artifact of the ambient budget state rather than
         //   a pure function of the pair.
+        // - The relation-limit snapshot records `DepthExceeded` even under the
+        //   optimistic policy, where an ancestor may collapse it through
+        //   `.is_true()` into an otherwise-definitive success.
         // - The weak-type-sensitivity snapshot: if it changes, the result
         //   depended on weak-type enforcement state (TS2559), which the
         //   flag-agnostic `RelationCacheKey` does not encode. Caching it would
         //   let a result computed under one enforcement state be served to a
         //   sibling check under another.
         //
-        // The three counters travel as one `RelationTaintSnapshot`.
+        // The four counters travel as one `RelationTaintSnapshot`.
         let frame_entry = crate::limits::enter_subtype_frame();
         let global_depth = frame_entry.global_depth;
         let fuel = frame_entry.fuel;
@@ -1312,19 +1318,30 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         RelationTaintSnapshot {
             unresolved_lazy_events: self.unresolved_lazy_relation_event_count(),
             incomplete_evaluation_events: self.incomplete_evaluation_relation_event_count(),
+            relation_limit_events: self.relation_limit_event_count(),
             weak_sensitivity,
         }
     }
 
-    /// Whether any taint counter moved since `snapshot` was taken — i.e. the
-    /// in-flight relation verdict depended on an unresolved `Lazy` body, a
-    /// guard-truncated meta-type evaluation, or weak-type enforcement state,
-    /// and must not be published as a pure function of its cache key.
-    pub(crate) fn relation_taint_changed_since(&self, snapshot: RelationTaintSnapshot) -> bool {
+    fn relation_nonlimit_taint_changed_since(&self, snapshot: RelationTaintSnapshot) -> bool {
         self.unresolved_lazy_relation_event_count() != snapshot.unresolved_lazy_events
             || self.incomplete_evaluation_relation_event_count()
                 != snapshot.incomplete_evaluation_events
             || crate::limits::weak_type_sensitivity_count() != snapshot.weak_sensitivity
+    }
+
+    const fn relation_limit_changed_since(&self, snapshot: RelationTaintSnapshot) -> bool {
+        self.relation_limit_event_count() != snapshot.relation_limit_events
+    }
+
+    /// Whether any taint counter moved since `snapshot` was taken — i.e. the
+    /// in-flight relation verdict depended on an unresolved `Lazy` body, a
+    /// guard-truncated meta-type evaluation, a relation-limit result consumed
+    /// by an ancestor, or weak-type enforcement state, and must not be
+    /// published as a pure function of its cache key.
+    pub(crate) fn relation_taint_changed_since(&self, snapshot: RelationTaintSnapshot) -> bool {
+        self.relation_nonlimit_taint_changed_since(snapshot)
+            || self.relation_limit_changed_since(snapshot)
     }
 
     /// Record a definitive subtype verdict for later reuse.
@@ -1347,7 +1364,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// promotion path.
     ///
     /// This mirrors the discipline of the former `cache_definitive!` macro. The
-    /// unresolved-`Lazy` and guard-truncated-evaluation snapshots are
+    /// unresolved-`Lazy` and budget-dependent-relation snapshots are
     /// checker-local, so only events observed by this relation checker suppress
     /// this frame's write; fresh/nested checker probes only propagate when
     /// their verdict contributes to the outer relation. The weak-type
@@ -1414,12 +1431,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ///   (`guard.depth() == 0`), surviving entries are promoted on overall
     ///   success — cycle entries to definitive `true` (the coinductive
     ///   assumption set is self-consistent), fuel entries to band-conditional
-    ///   `LimitTrue` — or discarded on failure. Promotion is additionally
-    ///   gated on the frame's [`RelationTaintSnapshot`] (checker-local
-    ///   unresolved-`Lazy` and guard-truncated-evaluation counters plus the
-    ///   thread-local weak-type-sensitivity counter) having been stable across
-    ///   the whole outermost window, the same discipline
-    ///   `record_definitive_verdict` applies to definitive writes.
+    ///   `LimitTrue` — or discarded on failure. A moved relation-limit counter
+    ///   suppresses definitive cycle promotion while the explicitly banded
+    ///   outer `DepthExceeded` entry remains eligible for `LimitTrue`; every
+    ///   other [`RelationTaintSnapshot`] counter suppresses all promotion. This
+    ///   preserves the same cache-honesty discipline as definitive writes
+    ///   without discarding the typed limit protocol itself.
     fn finish_relation_frame(
         &mut self,
         result: SubtypeResult,
@@ -1454,13 +1471,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if self.guard.depth() == 0 && !self.maybe_keys.is_empty() {
             let entries = std::mem::take(&mut self.maybe_keys);
             if result.is_true()
-                && !self.relation_taint_changed_since(frame.taint_at_entry)
+                && !self.relation_nonlimit_taint_changed_since(frame.taint_at_entry)
                 && let Some(db) = self.query_db
             {
+                let limit_moved = self.relation_limit_changed_since(frame.taint_at_entry);
                 for entry in entries {
                     match entry.fuel_band {
-                        None => db.promote_subtype_cache_true(entry.key),
-                        Some(band) => db.insert_subtype_limit_true(entry.key, band),
+                        None if !limit_moved => db.promote_subtype_cache_true(entry.key),
+                        Some(band) if matches!(result, SubtypeResult::DepthExceeded) => {
+                            db.insert_subtype_limit_true(entry.key, band);
+                        }
+                        None | Some(_) => continue,
                     }
                     tsz_common::perf_counters::record_relation_maybe_promotion();
                 }
@@ -1799,6 +1820,19 @@ mod tests {
             },
             None,
             "a contributing subchecker truncation must keep the outer frame non-cacheable",
+        );
+    }
+
+    #[test]
+    fn relation_cache_write_skips_consumed_subchecker_limit_event() {
+        assert_definitive_write_gate(
+            |checker, subchecker| {
+                let entry = subchecker.relation_limit_event_count();
+                let _ = subchecker.depth_result();
+                checker.absorb_relation_limit_events_from(subchecker, entry);
+            },
+            None,
+            "a consumed subchecker Maybe verdict must keep the outer frame non-cacheable",
         );
     }
 

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -382,9 +382,10 @@ mod relation_evaluation_result_tests {
 ///
 /// One instance per taint source
 /// ([`SubtypeChecker::unresolved_lazy_relation_events`],
-/// [`SubtypeChecker::incomplete_evaluation_relation_events`]). Scoped to one
-/// [`SubtypeChecker`]: fresh unrelated checkers keep their own counters, and a
-/// contributing subchecker's events are propagated by the `absorb_*` methods.
+/// [`SubtypeChecker::incomplete_evaluation_relation_events`], and
+/// [`SubtypeChecker::relation_limit_events`]). Scoped to one [`SubtypeChecker`]:
+/// fresh unrelated checkers keep their own counters, and contributing
+/// subchecker taint is propagated by the `absorb_*` methods.
 #[derive(Debug)]
 pub(crate) struct RelationEventCounter(Cell<u64>);
 
@@ -631,9 +632,14 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// flag is set per strict target construct signature and consumed (reset)
     /// on entry to `check_function_subtype`, so nested comparisons start fresh.
     pub(crate) force_strict_construct_params: bool,
-    /// Whether recursive relation cycles and overflow should be treated as
+    /// Whether valid recursive relation cycles should be treated as
     /// assumed-related (`true`) or definitive failure (`false`).
     pub assume_related_on_cycle: bool,
+    /// Whether relation depth, iteration, or shared solver-frame exhaustion
+    /// should be treated as assumed-related (`true`) or definitive failure
+    /// (`false`). Kept separate from cycle handling so proof-oriented callers
+    /// can reject budget exhaustion while retaining coinductive recursion.
+    pub assume_related_on_depth: bool,
     /// When `true`, DefId-level cycle detection compares Application type
     /// arguments before assuming related. This prevents false identity matches
     /// for recursive generic interfaces like `IPromise<T>` vs `Promise<T>`
@@ -692,9 +698,11 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// caches and conditional branch selection, but relation cache writes are
     /// gated only by this scoped counter.
     pub(crate) unresolved_lazy_relation_events: RelationEventCounter,
-    /// Monotonic count of guard-truncated meta-type evaluations
-    /// ([`crate::evaluation::result::Termination::Incomplete`]) consumed while
-    /// computing relation answers for this checker.
+    /// Monotonic count of budget-dependent events consumed while computing
+    /// relation answers for this checker. This includes guard-truncated
+    /// meta-type evaluations
+    /// ([`crate::evaluation::result::Termination::Incomplete`]) and relation
+    /// limit hits converted to `False` by a strict depth policy.
     ///
     /// First verdict-aware consumer of the #14346 typed termination channel:
     /// a relation verdict computed from a budget-truncated evaluation is a
@@ -704,6 +712,12 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// skip the write (the pair is recomputed later), never publish the
     /// approximation.
     pub(crate) incomplete_evaluation_relation_events: RelationEventCounter,
+    /// Monotonic count of relation depth, iteration, global-fuel, or shared
+    /// solver-frame limit hits. Unlike `incomplete_evaluation_relation_events`,
+    /// this records both optimistic and strict depth policies so outer query
+    /// caches can distinguish a budget-dependent answer from a stable verdict
+    /// without disabling the subtype checker's banded `LimitTrue` protocol.
+    pub(crate) relation_limit_events: RelationEventCounter,
     /// Instance-local fallback memo for definitive relation verdicts that the
     /// cross-checker shared cache must skip (issue #13828).
     ///
@@ -810,6 +824,7 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             in_callable_property_check: false,
             force_strict_construct_params: false,
             assume_related_on_cycle: true,
+            assume_related_on_depth: true,
             identity_cycle_check: false,
             bypass_evaluation: false,
             max_depth: MAX_SUBTYPE_DEPTH,
@@ -821,6 +836,7 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             maybe_keys: Vec::new(),
             unresolved_lazy_relation_events: RelationEventCounter::new(),
             incomplete_evaluation_relation_events: RelationEventCounter::new(),
+            relation_limit_events: RelationEventCounter::new(),
             local_relation_cache: FxHashMap::default(),
             explain_budget: super::explain::EXPLAIN_EVAL_BUDGET,
             explain_eval_fuel: None,
@@ -868,6 +884,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             in_callable_property_check: false,
             force_strict_construct_params: false,
             assume_related_on_cycle: true,
+            assume_related_on_depth: true,
             identity_cycle_check: false,
             bypass_evaluation: false,
             max_depth: MAX_SUBTYPE_DEPTH,
@@ -879,6 +896,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             maybe_keys: Vec::new(),
             unresolved_lazy_relation_events: RelationEventCounter::new(),
             incomplete_evaluation_relation_events: RelationEventCounter::new(),
+            relation_limit_events: RelationEventCounter::new(),
             local_relation_cache: FxHashMap::default(),
             explain_budget: super::explain::EXPLAIN_EVAL_BUDGET,
             explain_eval_fuel: None,
@@ -951,9 +969,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
     }
 
-    /// Record that a meta-type evaluation consumed by this relation checker was
-    /// cut short by an evaluation guard
-    /// ([`crate::evaluation::result::Termination::Incomplete`]).
+    /// Record that a verdict consumed by this relation checker depended on a
+    /// budget limit, either through a guard-truncated meta-type evaluation or a
+    /// strict relation-depth policy converting overflow to `False`.
     ///
     /// The checker-local counter gates definitive relation cache writes and
     /// maybe-key promotion the same way the unresolved-`Lazy` counter does: a
@@ -964,10 +982,44 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.incomplete_evaluation_relation_events.note();
     }
 
-    /// Current checker-local guard-truncated evaluation event count.
+    /// Current checker-local budget-dependent relation event count.
     #[inline]
     pub(crate) const fn incomplete_evaluation_relation_event_count(&self) -> u64 {
         self.incomplete_evaluation_relation_events.count()
+    }
+
+    /// Current checker-local relation-limit event count.
+    #[inline]
+    pub(crate) const fn relation_limit_event_count(&self) -> u64 {
+        self.relation_limit_events.count()
+    }
+
+    /// Propagate a contributing subchecker's relation-limit event after its
+    /// ternary result was consumed as a boolean. The outer checker can no
+    /// longer preserve that subchecker's `Maybe`/`LimitTrue` protocol, so the
+    /// event also taints definitive cache writes as budget-dependent.
+    #[inline]
+    pub(crate) fn absorb_relation_limit_events_from<S: TypeResolver>(
+        &self,
+        subchecker: &SubtypeChecker<'_, S>,
+        subchecker_events_at_entry: u64,
+    ) {
+        if subchecker.relation_limit_event_count() != subchecker_events_at_entry {
+            self.relation_limit_events.note();
+            self.note_incomplete_evaluation_relation_event();
+        }
+    }
+
+    /// Whether the current top-level relation answer is stable enough for an
+    /// outer boolean query cache. Diagnostic termination remains a separate
+    /// channel: global fuel and shared solver-frame limits do not necessarily
+    /// trip the local recursion guard, but still make the answer budget-bound.
+    #[inline]
+    pub(crate) const fn relation_result_cacheable(&self) -> bool {
+        !self.depth_exceeded()
+            && self.unresolved_lazy_relation_event_count() == 0
+            && self.incomplete_evaluation_relation_event_count() == 0
+            && self.relation_limit_event_count() == 0
     }
 
     /// Propagate guard-truncated evaluation events from a subchecker whose
@@ -997,6 +1049,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self
     }
 
+    /// Configure whether relation budget exhaustion is assumed related.
+    pub const fn with_assume_related_on_depth(mut self, assume: bool) -> Self {
+        self.assume_related_on_depth = assume;
+        self
+    }
+
     /// Override the failure-explanation work budget (issue #13243).
     ///
     /// Lowering the budget bounds the elaboration the explain pass performs
@@ -1018,10 +1076,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
     }
 
-    pub(crate) const fn depth_result(&self) -> SubtypeResult {
-        if self.assume_related_on_cycle {
+    pub(crate) fn depth_result(&self) -> SubtypeResult {
+        self.relation_limit_events.note();
+        if self.assume_related_on_depth {
             SubtypeResult::DepthExceeded
         } else {
+            // A limit-derived `False` is correct for this proof-oriented query,
+            // but it is not a pure function of the relation key: a fresh query
+            // with more budget may prove the relation. Taint every ancestor so
+            // no definitive shared-cache entry is published from this result.
+            self.note_incomplete_evaluation_relation_event();
             SubtypeResult::False
         }
     }
@@ -1096,6 +1160,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.maybe_keys.clear();
         self.unresolved_lazy_relation_events.reset();
         self.incomplete_evaluation_relation_events.reset();
+        self.relation_limit_events.reset();
         self.local_relation_cache.clear();
         self.explain_eval_fuel = None;
     }
@@ -1353,12 +1418,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// The shared cross-operation [`crate::recursion::with_solver_frame`] breaker
     /// bounds the combined `evaluate -> subtype -> instantiate -> evaluate` cycle
     /// that no per-instance guard can see (issue #7574). When that budget is
-    /// exhausted we bail with [`SubtypeResult::DepthExceeded`], which is treated
-    /// as `true` (tsc's `Ternary.Maybe` overflow behavior) and so cannot
-    /// introduce a spurious assignability error.
+    /// exhausted we use the caller's depth policy: ordinary relations return
+    /// [`SubtypeResult::DepthExceeded`] (tsc's `Ternary.Maybe` behavior), while
+    /// proof-oriented relations may make exhaustion a definitive failure.
     pub(crate) fn check_subtype_inner(&mut self, source: TypeId, target: TypeId) -> SubtypeResult {
         crate::recursion::with_solver_frame(|| self.check_subtype_inner_impl(source, target))
-            .unwrap_or(SubtypeResult::DepthExceeded)
+            .unwrap_or_else(|| self.depth_result())
     }
 
     pub(crate) fn readonly_application_or_display_alias_inner(

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -429,6 +429,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if self.assume_related_on_cycle {
             flags |= RelationFlags::ASSUME_RELATED_ON_CYCLE;
         }
+        if self.assume_related_on_depth {
+            flags |= RelationFlags::ASSUME_RELATED_ON_DEPTH;
+        }
         // The class-symbol classifier is behavior-affecting (it can make a
         // no-`DefId` class-flagged symbol nominal), so discriminate verdicts
         // computed with it active from class-agnostic ones (issue #13828). The
@@ -441,6 +444,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         RelationPolicy::from_relation_flags(flags)
             .with_any_propagation_mode(self.any_propagation)
             .with_assume_related_on_cycle(self.assume_related_on_cycle)
+            .with_assume_related_on_depth(self.assume_related_on_depth)
     }
 
     /// Resolve depth-sensitive `any` propagation to the cache-key mode.

--- a/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
@@ -16,6 +16,17 @@ use crate::visitor::{
 use super::super::{AnyPropagationMode, SubtypeChecker, SubtypeResult, TypeResolver};
 
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
+    fn conditional_identity_fallback_checker(&self) -> SubtypeChecker<'a, R> {
+        let mut fallback = SubtypeChecker::with_resolver(self.interner, self.resolver)
+            .with_any_propagation_mode(AnyPropagationMode::IdenticalOnly)
+            .with_assume_related_on_cycle(self.assume_related_on_cycle)
+            .with_assume_related_on_depth(self.assume_related_on_depth);
+        if let Some(db) = self.query_db {
+            fallback = fallback.with_query_db(db);
+        }
+        fallback
+    }
+
     /// Conditional extends-types use a stricter equivalence than ordinary
     /// assignability. Two extends-types are equivalent only when their full
     /// per-property modifier shape matches, even when individual differences
@@ -66,13 +77,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return false;
         }
 
-        let mut fallback = SubtypeChecker::with_resolver(self.interner, self.resolver)
-            .with_any_propagation_mode(AnyPropagationMode::IdenticalOnly);
-        if let Some(db) = self.query_db {
-            fallback = fallback.with_query_db(db);
-        }
+        let mut fallback = self.conditional_identity_fallback_checker();
         let fallback_events_at_entry = fallback.unresolved_lazy_relation_event_count();
         let fallback_incomplete_at_entry = fallback.incomplete_evaluation_relation_event_count();
+        let fallback_limits_at_entry = fallback.relation_limit_event_count();
         let equivalent = fallback.check_subtype(left_eval, right_eval).is_true()
             && fallback.check_subtype(right_eval, left_eval).is_true();
         self.absorb_unresolved_lazy_relation_events_from(&fallback, fallback_events_at_entry);
@@ -80,6 +88,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             &fallback,
             fallback_incomplete_at_entry,
         );
+        self.absorb_relation_limit_events_from(&fallback, fallback_limits_at_entry);
         equivalent
     }
 
@@ -760,5 +769,24 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         } else {
             SubtypeResult::False
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::construction::TypeInterner;
+
+    #[test]
+    fn conditional_identity_fallback_inherits_cycle_and_depth_policies() {
+        let interner = TypeInterner::new();
+        let checker = SubtypeChecker::new(&interner)
+            .with_assume_related_on_cycle(false)
+            .with_assume_related_on_depth(false);
+
+        let fallback = checker.conditional_identity_fallback_checker();
+
+        assert!(!fallback.assume_related_on_cycle);
+        assert!(!fallback.assume_related_on_depth);
     }
 }

--- a/crates/tsz-solver/src/types/relation_cache.rs
+++ b/crates/tsz-solver/src/types/relation_cache.rs
@@ -35,8 +35,8 @@ bitflags::bitflags! {
     /// Bits `0..=8` are preserved from the original packed `u16` layout so
     /// legacy callers (e.g. checker boundary helpers that import the
     /// `FLAG_*` constants) continue to interoperate byte-for-byte. Bits
-    /// `9..=15` are new and encode previously-missing Lawyer-layer options
-    /// that were silently missing from the cache key.
+    /// Bits `9` and above encode previously-missing Lawyer-layer and
+    /// operation-policy options that were silently absent from the cache key.
     #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Default)]
     pub struct RelationFlags: u32 {
         /// `strictNullChecks` compiler option.
@@ -102,6 +102,11 @@ bitflags::bitflags! {
         /// class-context verdicts live in the cross-checker shared cache without
         /// poisoning the class-agnostic regime (issue #13828).
         const CLASS_CHECK_CONTEXT           = 1 << 16;
+        /// Treat relation depth/iteration exhaustion as assumed-related. This
+        /// is independent of valid coinductive cycle handling so callers that
+        /// need a definitive proof can reject overflow without rejecting
+        /// recursive structural types.
+        const ASSUME_RELATED_ON_DEPTH       = 1 << 17;
     }
 }
 

--- a/crates/tsz-solver/tests/compat_tests_parts/part_03.rs
+++ b/crates/tsz-solver/tests/compat_tests_parts/part_03.rs
@@ -1705,3 +1705,32 @@ fn test_analyze_weak_and_explain_matches_assignable() {
     assert_eq!(format!("{reason:?}"), format!("{expected_reason:?}"));
     assert!(reason.is_none(), "assignable pair has no reason");
 }
+#[test]
+fn reusable_compat_cache_skips_global_fuel_failure() {
+    crate::limits::reset_subtype_thread_local_state();
+    let interner = TypeInterner::new();
+    let value = interner.intern_string("value");
+    let extra = interner.intern_string("extra");
+    let source = interner.object(vec![
+        PropertyInfo::new(value, TypeId::STRING),
+        PropertyInfo::new(extra, TypeId::NUMBER),
+    ]);
+    let target = interner.object(vec![PropertyInfo::new(value, TypeId::STRING)]);
+    let mut checker = CompatChecker::new(&interner);
+    checker.set_assume_related_on_depth(false);
+
+    for _ in 0..crate::relations::subtype::cache::MAX_GLOBAL_SUBTYPE_FUEL {
+        let _ = crate::limits::enter_subtype_frame();
+    }
+    assert!(
+        !checker.is_assignable(source, target),
+        "strict proof mode rejects a request whose global relation fuel is exhausted",
+    );
+
+    crate::limits::reset_subtype_thread_local_state();
+    assert!(
+        checker.is_assignable(source, target),
+        "the reusable compat cache must recompute under a fresh budget",
+    );
+    crate::limits::reset_subtype_thread_local_state();
+}

--- a/crates/tsz-solver/tests/limit_relation_cache_tests.rs
+++ b/crates/tsz-solver/tests/limit_relation_cache_tests.rs
@@ -19,10 +19,15 @@ use crate::construction::RelationCacheProbe;
 use crate::def::DefId;
 use crate::evaluation::evaluate::TypeEvaluator;
 use crate::intern::TypeInterner;
+use crate::recursion::RecursionGuard;
+use crate::relations::relation_queries::{
+    RelationContext, RelationKind, RelationPolicy, query_relation,
+};
 use crate::relations::subtype::cache::MAX_GLOBAL_SUBTYPE_FUEL;
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
 use crate::types::{
-    MappedType, PropertyInfo, RelationCacheValue, SymbolRef, TypeId, TypeParamInfo,
+    MappedType, PropertyInfo, RelationCacheKey, RelationCacheValue, SymbolRef, TypeId,
+    TypeParamInfo,
 };
 
 /// Maps a fixed set of `DefId`s to recursive bodies.
@@ -86,6 +91,133 @@ fn recursive_pair(
         defs: vec![(s_def, body_s), (t_def, body_t)],
     };
     (resolver, lazy_s, lazy_t, arr_s, arr_t)
+}
+
+#[test]
+fn strict_depth_overflow_does_not_poison_fresh_cycle_query() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let (resolver, source, target, _, _) = recursive_pair(
+        &interner,
+        "next",
+        "tag",
+        TypeId::STRING,
+        TypeId::STRING,
+        DefId(90),
+        DefId(91),
+    );
+
+    let mut low_budget = SubtypeChecker::with_resolver(&interner, &resolver)
+        .with_query_db(&db)
+        .with_assume_related_on_depth(false);
+    low_budget.guard = RecursionGuard::new(1, 100_000);
+    let key = low_budget.debug_cache_key_for(source, target);
+    assert!(!low_budget.is_subtype_of(source, target));
+    assert!(low_budget.guard.is_exceeded());
+    assert_eq!(
+        db.lookup_subtype_cache(key),
+        None,
+        "strict limit-derived failure must not be published as definitive",
+    );
+
+    let mut fresh = SubtypeChecker::with_resolver(&interner, &resolver)
+        .with_query_db(&db)
+        .with_assume_related_on_depth(false);
+    assert!(
+        fresh.is_subtype_of(source, target),
+        "a fresh-budget query must retain valid coinductive recursion",
+    );
+    assert_eq!(db.lookup_subtype_cache(key), Some(true));
+}
+
+#[test]
+fn outer_query_cache_skips_global_relation_fuel_failure() {
+    crate::limits::reset_subtype_thread_local_state();
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let value = interner.intern_string("value");
+    let extra = interner.intern_string("extra");
+    let source = interner.object(vec![
+        PropertyInfo::new(value, TypeId::STRING),
+        PropertyInfo::new(extra, TypeId::NUMBER),
+    ]);
+    let target = interner.object(vec![PropertyInfo::new(value, TypeId::STRING)]);
+    let policy = RelationPolicy::default().with_assume_related_on_depth(false);
+    let key = RelationCacheKey::for_subtype(source, target, policy.cache_config());
+
+    for _ in 0..MAX_GLOBAL_SUBTYPE_FUEL {
+        let _ = crate::limits::enter_subtype_frame();
+    }
+
+    let limited = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Subtype,
+        policy,
+        RelationContext::default(),
+    );
+    assert!(!limited.is_related());
+    assert!(
+        !limited.depth_exceeded(),
+        "global relation fuel is separate from diagnostic depth termination",
+    );
+    assert!(
+        !limited.is_cacheable(),
+        "the typed stability channel must expose non-local relation fuel",
+    );
+    assert!(!db.is_subtype_of_with_policy(source, target, policy));
+    assert_eq!(
+        db.lookup_subtype_cache(key),
+        None,
+        "the outer boolean cache must not publish a global-fuel failure",
+    );
+
+    crate::limits::reset_subtype_thread_local_state();
+    assert!(
+        db.is_subtype_of_with_policy(source, target, policy),
+        "a fresh-budget query must prove the structural subtype",
+    );
+    assert_eq!(db.lookup_subtype_cache(key), Some(true));
+    crate::limits::reset_subtype_thread_local_state();
+}
+
+#[test]
+fn parent_relation_cache_skips_optimistic_child_fuel_limit() {
+    crate::limits::reset_subtype_thread_local_state();
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let property = interner.intern_string("property");
+    let nested = interner.intern_string("nested");
+    let source_inner = interner.object(vec![PropertyInfo::new(nested, TypeId::NUMBER)]);
+    let target_inner = interner.object(vec![PropertyInfo::new(nested, TypeId::STRING)]);
+    let source = interner.object(vec![PropertyInfo::new(property, source_inner)]);
+    let target = interner.object(vec![PropertyInfo::new(property, target_inner)]);
+
+    for _ in 0..MAX_GLOBAL_SUBTYPE_FUEL - 1 {
+        let _ = crate::limits::enter_subtype_frame();
+    }
+
+    let mut limited = SubtypeChecker::new(&interner).with_query_db(&db);
+    let key = limited.debug_cache_key_for(source, target);
+    assert!(
+        limited.is_subtype_of(source, target),
+        "the default relation policy conservatively accepts a child fuel limit",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(key),
+        None,
+        "a parent True that consumed child DepthExceeded must not be definitive",
+    );
+
+    crate::limits::reset_subtype_thread_local_state();
+    let mut fresh = SubtypeChecker::new(&interner).with_query_db(&db);
+    assert!(
+        !fresh.is_subtype_of(source, target),
+        "fresh fuel must reveal the incompatible nested property",
+    );
+    assert_eq!(db.lookup_subtype_cache(key), Some(false));
+    crate::limits::reset_subtype_thread_local_state();
 }
 
 // =============================================================================

--- a/crates/tsz-solver/tests/relation_cache_config_tests.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests.rs
@@ -184,6 +184,7 @@ fn each_relation_flag_bit_produces_a_distinct_key() {
         RelationFlags::STRICT_ANY_PROPAGATION,
         RelationFlags::SKIP_WEAK_TYPE_CHECKS,
         RelationFlags::ASSUME_RELATED_ON_CYCLE,
+        RelationFlags::ASSUME_RELATED_ON_DEPTH,
         // Transient flags set during checker execution — they reach the cache
         // via packed `u16` flags rather than a typed builder field, but they
         // must still partition the cache to keep distinct relation passes in
@@ -758,6 +759,15 @@ fn assume_related_on_cycle_partitions_cache_entries() {
 }
 
 #[test]
+fn assume_related_on_depth_partitions_cache_entries() {
+    assert_subtype_partitions(
+        "assume_related_on_depth",
+        RelationPolicy::default().with_assume_related_on_depth(true),
+        RelationPolicy::default().with_assume_related_on_depth(false),
+    );
+}
+
+#[test]
 fn subtype_cache_assume_related_on_cycle_policy_matches_uncached_relation_query() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);
@@ -780,8 +790,12 @@ fn subtype_cache_assume_related_on_cycle_policy_matches_uncached_relation_query(
     env.insert_def_kind(left_def, DefKind::TypeAlias);
     env.insert_def_kind(right_def, DefKind::TypeAlias);
 
-    let assume = RelationPolicy::default().with_assume_related_on_cycle(true);
-    let reject = RelationPolicy::default().with_assume_related_on_cycle(false);
+    let assume = RelationPolicy::default()
+        .with_assume_related_on_cycle(true)
+        .with_assume_related_on_depth(false);
+    let reject = RelationPolicy::default()
+        .with_assume_related_on_cycle(false)
+        .with_assume_related_on_depth(false);
     let context = RelationContext {
         query_db: Some(&db),
         ..RelationContext::default()
@@ -810,7 +824,7 @@ fn subtype_cache_assume_related_on_cycle_policy_matches_uncached_relation_query(
 
     assert!(
         assume_uncached,
-        "recursive aliases with the same shape should rely on the cycle assumption",
+        "recursive aliases should remain coinductively related when only depth overflow is strict",
     );
     assert!(
         !reject_uncached,

--- a/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests/cache_agreement.rs
@@ -166,6 +166,7 @@ fn policy_cache_config_preserves_typed_extended_bits() {
         | RelationFlags::STRICT_ANY_PROPAGATION
         | RelationFlags::SKIP_WEAK_TYPE_CHECKS
         | RelationFlags::ASSUME_RELATED_ON_CYCLE
+        | RelationFlags::ASSUME_RELATED_ON_DEPTH
         | RelationFlags::IN_CALLBACK_PARAM_CHECK
         | RelationFlags::STRICT_READONLY_IDENTITY;
 
@@ -182,6 +183,11 @@ fn policy_cache_config_preserves_typed_extended_bits() {
         config
             .flags
             .contains(RelationFlags::ASSUME_RELATED_ON_CYCLE)
+    );
+    assert!(
+        config
+            .flags
+            .contains(RelationFlags::ASSUME_RELATED_ON_DEPTH)
     );
     assert!(
         config

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/cache_agreement.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/cache_agreement.rs
@@ -426,7 +426,7 @@ fn assignability_cache_strict_null_checks_matches_uncached_relation_policy() {
 }
 
 #[test]
-fn assignability_cache_assume_related_on_cycle_matches_uncached_depth_policy() {
+fn assignability_cache_assume_related_on_depth_matches_uncached_depth_policy() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);
 
@@ -437,8 +437,8 @@ fn assignability_cache_assume_related_on_cycle_matches_uncached_depth_policy() {
         target = interner.array(target);
     }
 
-    let assume_related = RelationPolicy::default().with_assume_related_on_cycle(true);
-    let reject_overflow = RelationPolicy::default().with_assume_related_on_cycle(false);
+    let assume_related = RelationPolicy::default().with_assume_related_on_depth(true);
+    let reject_overflow = RelationPolicy::default().with_assume_related_on_depth(false);
     let assume_key =
         RelationCacheKey::for_assignability(source, target, assume_related.cache_config());
     let reject_key =
@@ -446,7 +446,7 @@ fn assignability_cache_assume_related_on_cycle_matches_uncached_depth_policy() {
 
     assert_ne!(
         assume_key, reject_key,
-        "cycle/depth-overflow policies must occupy distinct assignability cache slots",
+        "depth-overflow policies must occupy distinct assignability cache slots",
     );
 
     let assume_uncached = query_relation(
@@ -490,8 +490,8 @@ fn assignability_cache_assume_related_on_cycle_matches_uncached_depth_policy() {
     );
     assert_eq!(
         db.lookup_assignability_cache(assume_key),
-        Some(assume_uncached.is_related()),
-        "assume-related result must be stored in its own assignability slot",
+        None,
+        "budget-dependent assume-related success must not become a definitive cache entry",
     );
     assert_eq!(
         db.lookup_assignability_cache(reject_key),
@@ -506,13 +506,13 @@ fn assignability_cache_assume_related_on_cycle_matches_uncached_depth_policy() {
     );
     assert_eq!(
         db.lookup_assignability_cache(reject_key),
-        Some(reject_uncached.is_related()),
-        "non-assuming result must be stored in its own assignability slot",
+        None,
+        "budget-dependent strict-depth failure must not become a definitive cache entry",
     );
     assert_eq!(
         db.lookup_assignability_cache(assume_key),
-        Some(assume_uncached.is_related()),
-        "assume-related slot must remain intact after the non-assuming lookup",
+        None,
+        "neither overflow policy may publish a definitive outer-cache entry",
     );
 }
 

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/effective_any_mode_policy_bits.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/effective_any_mode_policy_bits.rs
@@ -28,6 +28,7 @@ fn effective_cached_any_mode_projection_preserves_policy_bits() {
         | RelationFlags::STRICT_SUBTYPE_CHECKING
         | RelationFlags::STRICT_ANY_PROPAGATION
         | RelationFlags::ASSUME_RELATED_ON_CYCLE
+        | RelationFlags::ASSUME_RELATED_ON_DEPTH
         | RelationFlags::SKIP_WEAK_TYPE_CHECKS
         | RelationFlags::NO_ERASE_GENERICS;
 
@@ -66,6 +67,7 @@ fn effective_cached_any_mode_projection_honors_builder_overrides() {
         .with_strict_any_propagation(false)
         .with_any_propagation_mode(AnyPropagationMode::TopLevelOnly)
         .with_assume_related_on_cycle(false)
+        .with_assume_related_on_depth(false)
         .with_skip_weak_type_checks(false)
         .with_erase_generics(true);
 

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/policy_config.rs
@@ -35,6 +35,11 @@ fn relation_policy_cache_config_unifies_equivalent_flag_and_builder_bits() {
             RelationPolicy::unflagged_compatibility().with_assume_related_on_cycle(true),
         ),
         (
+            "assume related on depth",
+            RelationPolicy::from_relation_flags(RelationFlags::ASSUME_RELATED_ON_DEPTH),
+            RelationPolicy::unflagged_compatibility().with_assume_related_on_depth(true),
+        ),
+        (
             "disable generic erasure",
             RelationPolicy::from_relation_flags(RelationFlags::NO_ERASE_GENERICS),
             RelationPolicy::unflagged_compatibility().with_erase_generics(false),
@@ -85,6 +90,12 @@ fn relation_policy_builder_overrides_remove_prior_flag_bits_from_cache_config() 
             RelationFlags::ASSUME_RELATED_ON_CYCLE,
         ),
         (
+            "assume related on depth",
+            RelationPolicy::from_relation_flags(RelationFlags::ASSUME_RELATED_ON_DEPTH)
+                .with_assume_related_on_depth(false),
+            RelationFlags::ASSUME_RELATED_ON_DEPTH,
+        ),
+        (
             "generic erasure",
             RelationPolicy::from_relation_flags(RelationFlags::NO_ERASE_GENERICS)
                 .with_erase_generics(true),
@@ -126,6 +137,10 @@ fn relation_policy_behavior_builders_partition_cache_config() {
             base.with_assume_related_on_cycle(false).cache_config(),
         ),
         (
+            "reject depth overflow instead of assuming related",
+            base.with_assume_related_on_depth(false).cache_config(),
+        ),
+        (
             "skip weak type checks",
             base.with_skip_weak_type_checks(true).cache_config(),
         ),
@@ -162,6 +177,7 @@ fn relation_policy_builder_cache_matrix_covers_current_behavior_builders() {
             "with_strict_any_propagation",
             "with_any_propagation_mode",
             "with_assume_related_on_cycle",
+            "with_assume_related_on_depth",
             "with_skip_weak_type_checks",
         ],
         "new behavior-affecting RelationPolicy builders must update the cache-config partition matrix",

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/subtype_policy_projection.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/subtype_policy_projection.rs
@@ -32,7 +32,8 @@ fn subtype_cache_key_matches_equivalent_relation_policy_projection() {
     let target = TypeId::NUMBER;
     let mut checker = SubtypeChecker::new(&interner)
         .with_any_propagation_mode(AnyPropagationMode::TopLevelOnly)
-        .with_assume_related_on_cycle(false);
+        .with_assume_related_on_cycle(false)
+        .with_assume_related_on_depth(false);
     checker.strict_null_checks = true;
     checker.strict_function_types = true;
     checker.exact_optional_property_types = true;
@@ -60,7 +61,8 @@ fn subtype_cache_key_matches_equivalent_relation_policy_projection() {
         | RelationFlags::STRICT_READONLY_IDENTITY;
     let expected_policy = RelationPolicy::from_relation_flags(expected_flags)
         .with_any_propagation_mode(AnyPropagationMode::TopLevelOnly)
-        .with_assume_related_on_cycle(false);
+        .with_assume_related_on_cycle(false)
+        .with_assume_related_on_depth(false);
 
     let key = checker.debug_cache_key_for(source, target);
 

--- a/crates/tsz-solver/tests/relation_queries_tests.rs
+++ b/crates/tsz-solver/tests/relation_queries_tests.rs
@@ -507,6 +507,7 @@ fn relation_policy_fields_are_exhaustively_partitioned_in_cache_keys() {
         strict_any_propagation,
         any_propagation_mode,
         assume_related_on_cycle,
+        assume_related_on_depth,
         skip_weak_type_checks,
         erase_generics,
     } = policy;
@@ -547,6 +548,11 @@ fn relation_policy_fields_are_exhaustively_partitioned_in_cache_keys() {
     assert_subtype_partitions(
         "assume_related_on_cycle",
         policy.with_assume_related_on_cycle(!assume_related_on_cycle),
+        policy,
+    );
+    assert_subtype_partitions(
+        "assume_related_on_depth",
+        policy.with_assume_related_on_depth(!assume_related_on_depth),
         policy,
     );
     assert_assignability_partitions(

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_00.rs
@@ -1360,6 +1360,43 @@ fn test_recursion_depth_limit_provisional_subtyping() {
     let result = checker.check_subtype(deep_string, deep_number);
     assert!(matches!(result, SubtypeResult::DepthExceeded));
     assert!(checker.guard.is_exceeded());
+
+    let mut strict_depth_checker =
+        SubtypeChecker::new(&interner).with_assume_related_on_depth(false);
+    let strict_result = strict_depth_checker.check_subtype(deep_string, deep_number);
+    assert!(matches!(strict_result, SubtypeResult::False));
+    assert!(strict_depth_checker.guard.is_exceeded());
+}
+
+#[test]
+fn strict_depth_policy_rejects_nested_union_member_overflow() {
+    let interner = TypeInterner::new();
+
+    fn nest_array(interner: &TypeInterner, base: TypeId, depth: usize) -> TypeId {
+        let mut ty = base;
+        for _ in 0..depth {
+            ty = interner.array(ty);
+        }
+        ty
+    }
+
+    let deep_string = nest_array(&interner, TypeId::STRING, 120);
+    let deep_boolean = nest_array(&interner, TypeId::BOOLEAN, 120);
+    let deep_number = nest_array(&interner, TypeId::NUMBER, 120);
+    let source_union = interner.union(vec![deep_string, deep_boolean]);
+
+    let mut ordinary = SubtypeChecker::new(&interner);
+    assert!(matches!(
+        ordinary.check_subtype(source_union, deep_number),
+        SubtypeResult::True
+    ));
+
+    let mut strict = SubtypeChecker::new(&interner).with_assume_related_on_depth(false);
+    assert!(matches!(
+        strict.check_subtype(source_union, deep_number),
+        SubtypeResult::False
+    ));
+    assert!(strict.guard.is_exceeded());
 }
 
 #[test]

--- a/crates/tsz-solver/tests/union_simplification_generic_member_tests.rs
+++ b/crates/tsz-solver/tests/union_simplification_generic_member_tests.rs
@@ -195,6 +195,7 @@ fn compound_simplification_checker(
     // member removal only acts on definitive verdicts, so the probe key must
     // carry the same not-coinductive relation mode.
     checker.assume_related_on_cycle = false;
+    checker.assume_related_on_depth = false;
     checker.max_depth = MAX_SUBTYPE_DEPTH;
     checker
 }


### PR DESCRIPTION
Goal: green

## Summary
- split coinductive cycle handling from depth, iteration, global-fuel, and shared-frame exhaustion
- require definite subtype proof at narrowing boundaries while retaining conservative overlap checks
- keep budget-derived results out of subtype, compatibility, compound, conditional, narrowing, and outer query caches
- remove the three Promise/iterator narrowing diagnostics from the pinned Neverthrow row, reducing the parent-head delta from 4 TSZ-only diagnostics to 1

Structural rule: When union membership is tested for narrowing, tsc requires a completed subtype proof; TSZ now rejects budget exhaustion as proof while preserving valid recursive-cycle equivalence.

Owner layer: solver relation policy, subtype cache stability, and narrowing query boundaries.

Adjacent matrix: direct and renamed recursive Result classes; Promise true branch and iterator false branch; optimistic and strict depth policies; genuine recursive cycles; local depth, global fuel, shared solver frames, compound probes, conditional fallback, outer query caches, and reusable CompatChecker caches.

Fallback: overlap checks remain conservative on uncertainty. Ordinary relations retain assumed-related DepthExceeded and banded LimitTrue behavior; only proof-oriented narrowing opts into strict depth handling.

Performance: no additional type traversal or rendered-type inspection. Policy and cache partitioning are O(1); extra counter snapshots are scalar Cell reads, and cache suppression occurs only on actual unstable or budget-limited paths. Focused release/canary evidence follows in CI.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p tsz-solver -p tsz-checker --tests`
- `cargo clippy -p tsz-solver -p tsz-checker --tests -- -D warnings`
- `cargo nextest run -p tsz-solver --lib` with 69 focused relation-limit, policy-cache, compound, conditional, and compat regressions: 69 passed
- `cargo nextest run -p tsz-checker --test instanceof_promise_recursive_narrowing_tests --test array_isarray_mutual_subtype_narrowing_tests --test instanceof_loop_generic_any_fill_tests --test ts2345_instanceof_narrowed_union_display_tests`: 27 passed
- `scripts/architecture-check.sh --quick`: 0 LOC violations, 0 cross-layer violations; 1 pre-existing diagnostic leak warning
- standalone recursive Promise/IteratorResult oracle: tsc clean and TSZ clean
- pinned `neverthrow-project` canary with tsc oracle: 1 TSZ-only diagnostic, down from 4 on the parent head

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high