### PR TITLE
fix(checker): TS2411 — skip inherited-property index check when a class inherits its index

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -1307,10 +1307,24 @@ impl<'a> CheckerState<'a> {
 
             // Skip properties already covered by a base that owns the string index sig.
             // A template-literal pattern key constrains only matching names.
+            //
+            // When the derived type declares no OWN string index signature
+            // (`string_index_sig_node` is None) the string index is itself
+            // inherited; for a class (single `extends`) the inherited property and
+            // the inherited index necessarily share the same base, which already
+            // validated the property when it was checked. Re-reporting here
+            // duplicates that diagnostic at the derived class name, so restrict the
+            // inherited-property check to derived types that own the index.
+            let derived_owns_string_index = string_index_sig_node.is_some()
+                || !matches!(
+                    self.ctx.arena.get(iface_node).map(|n| n.kind),
+                    Some(k) if k == syntax_kind_ext::CLASS_DECLARATION
+                );
             if let Some((string_key_type, string_value_type)) = index_info
                 .string_index
                 .as_ref()
                 .map(|s| (s.key_type, s.value_type))
+                && derived_owns_string_index
                 && !string_index_covered.contains(&prop_name)
                 && self.property_name_matches_index_key(&prop_name, string_key_type)
                 && !self.property_type_assignable_to_index_type(prop_type, string_value_type)


### PR DESCRIPTION
Restrict the inherited-property-vs-index-signature TS2411 check to derived types that own their index signature.

## Structural rule
When a class declares no own string index signature, it inherits one from its base; the base already validated its own (now-inherited) properties against that index when the base was checked. tsc reports each such property once, in its declaring type. tsz re-ran `check_inherited_properties_against_index_signatures` on the derived class and re-emitted TS2411 at the derived class name — a duplicate tsc does not produce. Owner layer: checker (`index_signature_checks.rs`). Interfaces (which may extend multiple bases, so property and index origins can differ) are explicitly excluded, preserving their behavior.

## Adjacent matrix
- `computedPropertyNames44_ES5/ES6` (class C has index+getter, D extends C): spurious duplicate at D's name — now suppressed → **PASS**.
- `computedPropertyNames43_ES5/ES6` (index in base, accessors in derived): own-member path, unaffected → stays PASS.
- `computedPropertyNames45_ES5/ES6` (derived owns the index): still emitted (correct); unrelated name-rendering gap tracked separately.
- Interfaces: excluded by construction; no change across the TS2411 interface fixtures.

## Verification
Built `.target/debug/tsz` and ran every `computedPropertyNames*` + the TS2411 fingerprint fixtures against the pinned 7.0.2 oracle (`scripts/conformance/tsc-cache-full.json`), before vs after: **127 → 129 pass**, the diff being exactly `computedPropertyNames44_{ES5,ES6}` FAIL→PASS with **zero** other changes. Full conformance/emit/unit regression is owned by the merge_group.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Goal: hold
