### PR TITLE
fix(checker): TS2423 — report accessor/method kind mismatch once per member

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -1109,6 +1109,19 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
+            // Accessor-pair dedup for the kind-mismatch diagnostics: a `get x` /
+            // `set x` pair is one overriding member, but the loop visits both
+            // declarations. The getter's iteration already reports the member's
+            // method/accessor KIND mismatch (TS2423/2425/2426), so skip the setter
+            // of the same pair — otherwise a getter+setter overriding a base
+            // method double-reports TS2423. (Mirrors the type-compat setter skip
+            // below.)
+            if is_setter
+                && derived_accessor_pair_types.contains_key(&(member_name.clone(), is_static))
+            {
+                continue;
+            }
+
             // TS2423/TS2425/TS2426: Check for method/property/accessor kind mismatch (INSTANCE members only)
             // Static members use TS2417 instead
             if !is_static {


### PR DESCRIPTION
Report the class member override kind-mismatch diagnostic (TS2423/2425/2426) once per member instead of once per accessor declaration.

## Structural rule
A `get x` / `set x` pair is a single overriding member, but the derived-member loop in `class_checker.rs` visits both declarations. The accessor-pair dedup that already prevents a duplicate TS2416 (type-compat) was positioned *after* the kind-mismatch emit, so when a getter+setter pair overrides a base **method**, TS2423 fired twice — at the getter and again at the setter. The getter's iteration already reports the member's method/accessor kind mismatch once; hoisting the setter-of-a-pair skip ahead of the kind-mismatch block removes the duplicate. Owner layer: checker. A lone setter (no paired getter) is not in `derived_accessor_pair_types`, so it still reports.

## Adjacent matrix
- `inheritanceMemberAccessorOverridingMethod` (base method `x`; derived `get x`/`set x`): was TS2423 ×2 (getter+setter) → now ×1 (getter) → **PASS**.
- Lone-setter / lone-getter overrides: unaffected (not a dedup-eligible pair).
- TS2425/2426 (property↔method, accessor→method) and TS2416 type-compat: unchanged.

## Verification
Built `.target/debug/tsz`; ran the single-file kind-mismatch fixtures (TS2423/2425/2426) before/after against the pinned 7.0.2 oracle: 6/7 → **7/7**, the diff being exactly `inheritanceMemberAccessorOverridingMethod` FAIL→PASS. Wider accessor-override family (TS2416/2610/2611/2423/2425/2426, 64 fixtures): **no over-suppression** — zero expected kind-mismatch diagnostics lost. Full regression owned by the merge_group.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Goal: hold
