### PR TITLE
fix(checker): TS2804 — report static/instance private-name collision on both declarations

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/class_member_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/class_member_checks.rs
@@ -554,9 +554,15 @@ impl CheckerState<'_> {
         }
 
         // TS2804: static and instance members cannot share the same private name.
-        // Report on the later conflicting declaration only, matching tsc.
-        let mut seen_private_name_staticness: FxHashMap<String, (bool, bool)> =
-            FxHashMap::default();
+        // tsc reports on BOTH colliding declarations (the earlier and the current),
+        // not just the later one. Track the first instance and first static
+        // declaration's name node per private name, plus whether the pair has
+        // already been reported (so a 3rd colliding declaration does not
+        // re-report the earlier one).
+        let mut seen_private_name_staticness: FxHashMap<
+            String,
+            (Option<NodeIndex>, Option<NodeIndex>, bool),
+        > = FxHashMap::default();
         for &member_idx in members {
             let Some((name, name_idx, is_static)) = self.get_class_member_name_info(member_idx)
             else {
@@ -568,24 +574,39 @@ impl CheckerState<'_> {
 
             let seen = seen_private_name_staticness
                 .entry(name.clone())
-                .or_insert((false, false));
-            let has_opposite = if is_static { seen.0 } else { seen.1 };
-            if has_opposite {
-                let message = format_message(
-                    diagnostic_messages::DUPLICATE_IDENTIFIER_STATIC_AND_INSTANCE_ELEMENTS_CANNOT_SHARE_THE_SAME_PRIVATE,
-                    &[&name],
-                );
-                self.error_at_node(
-                    name_idx,
-                    &message,
-                    diagnostic_codes::DUPLICATE_IDENTIFIER_STATIC_AND_INSTANCE_ELEMENTS_CANNOT_SHARE_THE_SAME_PRIVATE,
-                );
+                .or_insert((None, None, false));
+            // The opposite-staticness declaration seen earlier, if any.
+            let opposite_idx = if is_static { seen.0 } else { seen.1 };
+            let already_reported = seen.2;
+            // First-wins per staticness.
+            if is_static {
+                seen.1.get_or_insert(name_idx);
+            } else {
+                seen.0.get_or_insert(name_idx);
+            }
+            if opposite_idx.is_some() {
+                seen.2 = true;
             }
 
-            if is_static {
-                seen.1 = true;
-            } else {
-                seen.0 = true;
+            if let Some(earlier_idx) = opposite_idx {
+                self.error_at_node(
+                    name_idx,
+                    &format_message(
+                        diagnostic_messages::DUPLICATE_IDENTIFIER_STATIC_AND_INSTANCE_ELEMENTS_CANNOT_SHARE_THE_SAME_PRIVATE,
+                        &[&name],
+                    ),
+                    diagnostic_codes::DUPLICATE_IDENTIFIER_STATIC_AND_INSTANCE_ELEMENTS_CANNOT_SHARE_THE_SAME_PRIVATE,
+                );
+                if !already_reported {
+                    self.error_at_node(
+                        earlier_idx,
+                        &format_message(
+                            diagnostic_messages::DUPLICATE_IDENTIFIER_STATIC_AND_INSTANCE_ELEMENTS_CANNOT_SHARE_THE_SAME_PRIVATE,
+                            &[&name],
+                        ),
+                        diagnostic_codes::DUPLICATE_IDENTIFIER_STATIC_AND_INSTANCE_ELEMENTS_CANNOT_SHARE_THE_SAME_PRIVATE,
+                    );
+                }
             }
         }
 

--- a/crates/tsz-core/tests/parallel_tests_parts/part_01.rs
+++ b/crates/tsz-core/tests/parallel_tests_parts/part_01.rs
@@ -1570,8 +1570,9 @@ class B {
 
     assert_eq!(
         ts2804_messages.len(),
-        2,
-        "Expected TS2804 on the later static/instance private-name conflicts only. Diagnostics: {:#?}",
+        4,
+        "Expected TS2804 on BOTH declarations of each static/instance private-name conflict \
+         (2 conflict pairs x 2 declarations). Diagnostics: {:#?}",
         file.diagnostics
     );
     assert!(


### PR DESCRIPTION
Report the static/instance private-name collision diagnostic (TS2804) on both colliding declarations, matching tsc.

## Structural rule
When a class declares the same private name (`#foo`) as both a static and an instance member, tsc reports TS2804 on **both** declarations. tsz's scan tracked only booleans for "an instance/static `#foo` was seen" and emitted on the later declaration only, so one of the two expected diagnostics was missing. Track each private name's first instance and first static declaration node; on collision, emit on the current declaration and (once) on the earlier one. Owner layer: checker (`class_member_checks.rs`).

## Adjacent matrix
- `privateNamesUnique-3` (`#foo` instance + `static #foo`): was 1 TS2804 (later only) → now 2 (both) → **PASS**.
- Single-collision pairs elsewhere: now report both, matching tsc.
- 3+ colliding declarations: a `reported` flag prevents re-reporting the earlier declaration once the pair is flagged.

## Verification
Built `.target/debug/tsz`; ran the 115 single-file private-name / TS2804 fixtures before/after against the pinned 7.0.2 oracle (`tsc-cache-full.json`): **103 → 104**, the diff being exactly `privateNamesUnique-3` FAIL→PASS with zero other changes (no over/under-emit regressions). Full regression owned by the merge_group.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Goal: hold
