### PR TITLE
fix(checker): TS2309 — type-only exports don't conflict with export assignment

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/module_exports.rs
+++ b/crates/tsz-checker/src/declarations/import/core/module_exports.rs
@@ -109,6 +109,15 @@ impl<'a> CheckerState<'a> {
         let Some(clause_node) = self.ctx.arena.get(export_data.export_clause) else {
             return true;
         };
+        // Type-only exported declarations (`export interface`, `export type`)
+        // are not "other exported elements" for the export-assignment conflict
+        // (TS2309): tsc counts only value-meaning exports, so `export = X`
+        // coexisting with only an exported interface/type alias is not an error.
+        if clause_node.kind == syntax_kind_ext::INTERFACE_DECLARATION
+            || clause_node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+        {
+            return false;
+        }
         if clause_node.kind != syntax_kind_ext::NAMED_EXPORTS {
             return true;
         }


### PR DESCRIPTION
Exempt type-only exports (`export interface`, `export type`) from the export-assignment conflict diagnostic (TS2309).

## Structural rule
tsc emits TS2309 ("An export assignment cannot be used in a module with other exported elements") only when `export = X` coexists with a **value-meaning** other export. A type-only export — an exported interface or type alias — does not count. tsz parses `export interface X` as an `EXPORT_DECLARATION` whose clause is the interface, and `export_declaration_has_exported_elements` returned `true` for any non-`NAMED_EXPORTS` clause, so it counted the interface and emitted a spurious TS2309. The fix returns `false` for `INTERFACE_DECLARATION`/`TYPE_ALIAS_DECLARATION` clauses. Owner layer: checker (`module_exports.rs`). Diagnosed via a `TSZ_LOG` trace confirming the node kind (EXPORT_DECLARATION=279, not INTERFACE_DECLARATION), which revealed an earlier attempt was in the wrong match arm.

## Adjacent matrix
- `incompatibleExports1` (declare module "foo": `export interface x` + `export = y`): spurious TS2309 on foo → now suppressed; "baz" (namespace with a `var` value export + `export = c`) still correctly emits TS2309 → **PASS**.
- Value exports (`export class`, `export function`, `export enum`, `export import =`, value namespaces): unchanged — still count (verified: `exportAssignmentWithExports` `export class C` and `importDeclWithExportModifierAndExportAssignment` `export import a =` are untouched by the interface/type-alias-only check).

## Verification
Built `.target/debug/tsz`; ran the 122 single-file TS2309/TS2300 fixtures before/after against the pinned 7.0.2 oracle (`tsc-cache-full.json`): **72 → 73**, the diff being exactly `incompatibleExports1` FAIL→PASS with zero other changes. No TS2309 lost on value-export fixtures (the check matches only interface/type-alias clauses). Full regression owned by the merge_group.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Goal: hold
