### PR TITLE
fix(checker): TS2420 — keep one diagnostic per interface a class incorrectly implements

### DIFF
--- a/crates/tsz-checker/src/context/diagnostic_push.rs
+++ b/crates/tsz-checker/src/context/diagnostic_push.rs
@@ -102,6 +102,16 @@ impl<'a> CheckerContext<'a> {
             || code == 4094
         {
             (start ^ fold_u32(message), code)
+        } else if code == 2420 {
+            // TS2420 ("Class 'C' incorrectly implements interface 'I'") anchors
+            // every instance at the class name, so a class implementing several
+            // interfaces incorrectly yields multiple diagnostics at one position
+            // differing only in the interface name (the first message line). Fold
+            // just that first line so distinct interfaces stay distinct, while
+            // per-member sub-message variants of the SAME interface still collapse
+            // to a single diagnostic.
+            let first_line = message.split('\n').next().unwrap_or(message);
+            (start ^ fold_u32(first_line), code)
         } else if code == 2869 || code == 2871 {
             // The `??` operand checks classify the left operand syntactically
             // (`getSyntacticNullishnessSemantics`), recursing through nested


### PR DESCRIPTION
Keep one TS2420 per interface a class incorrectly implements (dedup collapsed multiple interfaces into one).

## Structural rule
TS2420 ("Class 'C' incorrectly implements interface 'I'") is anchored at the class name node. When a class incorrectly implements several interfaces (`class C implements I1, I2`), tsc emits one TS2420 per failing interface — all at the same class-name position, differing only in the interface name on the first message line. tsz's diagnostic dedup keyed on `(start, code)`, so the second interface's TS2420 collided with the first and was dropped. Fold the first message line into the dedup key for TS2420: distinct interfaces (distinct first lines) stay distinct, while per-member sub-message variants of the *same* interface (same first line) still collapse to one. Owner layer: checker (`diagnostic_push.rs`). Diagnosed via a `TSZ_LOG` trace confirming both `(I1, iFn)` and `(I2, iFn)` reach the check — the loss was in the dedup, not the emit.

## Adjacent matrix
- `interfaceImplementation1` (`C1 implements I1, I2`, both violated by private members): was 1 TS2420 (I1 only) → now 2 (I1 + I2) → **PASS**.
- Single-interface fixtures with per-member sub-message variants (`implementingAnInterfaceExtendingClassWithPrivates`, `mergedInterfacesWithInheritedPrivates`, `recursiveInheritance3`, …): same first line → still collapse to one → unchanged (a naive full-message fold regressed these; the first-line fold does not).
- TS2416 and the other message-folded codes: untouched.

## Verification
Built `.target/debug/tsz`; ran the 32 single-file TS2420 fixtures before/after against the pinned 7.0.2 oracle (`tsc-cache-full.json`): **26 → 27**, the diff being exactly `interfaceImplementation1` FAIL→PASS with zero other changes (the 7 fixtures a full-message fold would have regressed all stay passing). Full regression owned by the merge_group.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Goal: hold
