### PR TITLE
fix(checker): don't late-bind non-literal computed accessor names

### DIFF
--- a/crates/tsz-checker/src/checkers/accessor_checker.rs
+++ b/crates/tsz-checker/src/checkers/accessor_checker.rs
@@ -306,6 +306,18 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
 
+            // tsc only pairs get/set accessors when the name is late-bindable
+            // (a string/numeric-literal or unique-symbol computed name, or a
+            // plain identifier). A computed name whose expression type is
+            // non-literal (`[1 << 6]` -> `number`, `[s]` -> `string`) is *not*
+            // late-bound, so tsc never merges the pair and runs no getter/setter
+            // type-compatibility check. `is_late_bound_member_name` returns true
+            // exactly for those non-determinable computed names; skip them so we
+            // don't synthesize a spurious pair (and TS2322/TS2741).
+            if self.is_late_bound_member_name(accessor.name) {
+                continue;
+            }
+
             if node.kind == syntax_kind_ext::GET_ACCESSOR {
                 pairs.entry(name).or_default().0 =
                     Some((accessor.name, accessor.body, accessor.type_annotation));

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -302,9 +302,16 @@ impl<'a> CheckerState<'a> {
             // Duplicate properties are an error in object literals.
             // TS1118 for duplicate get/set accessors, TS1117 for other duplicates.
             // Skip for computed property names — tsc only checks static names.
+            //
+            // A computed name whose expression type is non-literal (`[1 + 1]` ->
+            // `number`) is *not* late-bound, so tsc never resolves it to a static
+            // key and never treats two such accessors as the same property. Even
+            // though `get_property_name_resolved` constant-folds `1 + 1` to `"2"`
+            // for us, we must not raise a duplicate/clash diagnostic for it.
             if !skip_duplicate_check
                 && explicit_property_names.contains(&name_atom)
                 && !is_complementary_pair
+                && !self.is_late_bound_member_name(accessor.name)
                 && !self.ctx.has_parse_errors
                 && (!self.is_js_file() || self.ctx.js_strict_mode_diagnostics_enabled())
             {


### PR DESCRIPTION
## Summary

A computed member name whose expression **type** is non-literal (e.g. `[1 << 6]` → `number`, `[1 + 1]` → `number`) is **not late-bound** in `tsc`: it never resolves to a static property key. `tsz` was constant-folding such names to a key and then over-applying two late-bound-only checks.

**Structural rule:** When a get/set accessor pair (or two same-kind accessors) share a computed name whose expression type is non-literal, `tsc` does not merge them into one property, so it runs neither the getter/setter type-compatibility check nor same-name duplicate detection. `tsz` must gate accessor pairing on the name being statically determinable.

Owner layer: **checker** (class accessor pairing + object-literal accessor duplicate detection).

Two spurious-diagnostic families fixed:
- **TS2741/TS2322** — get/set accessors sharing a non-literal computed name (`[1 << 6]`) were merged and type-compatibility-checked (`computedPropertyNames38/39`).
- **TS1118 + TS2300** — two object-literal accessors with the same non-literal computed name (`[1 + 1]`) were flagged as duplicates (`computedPropertyNames49/50`).

Both sites now gate on `is_late_bound_member_name`, which is true exactly for non-determinable computed names.

## Adjacent-case matrix
- **String/numeric-literal computed names** (`["get1"]`, `[0]`) — still paired/checked (gate false). `computedPropertyNames36/40/42/43/45` remain green.
- **Const-enum computed names** (`[E.A]`) — literal-typed → still paired (preserves the reason the class path uses `get_property_name_resolved`).
- **Plain identifiers** (`get x` / `set x`) — `is_late_bound_member_name` returns false for non-computed names → duplicate/compat detection unchanged (`twoAccessorsWithSameName`, `duplicateObjectLiteralProperty` behave identically; both are pre-existing baseline fails on identifier accessors, provably untouched).
- **Named-accessor type mismatch** (`divergentAccessorsTypes2/4/5/6/8`) — still emit TS2322.
- **Computed-name duplicates that ARE literal** (`duplicateObjectLiteralProperty_computedName1/2`) — still flagged.

## Verification
- Oracle harness (pinned `tsc` 7.0.2 fingerprints in `scripts/conformance/tsc-cache-full.json`) over the full `es6/computedProperties` directory: **137 pass / 4 fail** (was 133/8 → **+8 flips**: 38/39/49/50 × ES5/ES6). Remaining 4: `computedPropertyNames44` (separate TS2411 derived-index, covered by #15863) and `computedPropertyNamesDeclarationEmit1` (emit-harness, out of scope).
- Regression set, all green post-fix: `divergentAccessorsTypes{2,4,5,6,8}`, `duplicateObjectLiteralProperty_computedName{1,2}`, `objectLiteralErrors`, `typeParametersInStaticAccessors`.
- Broad regression gate: native `merge_group` CI.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Goal: hold
