### PR TITLE
fix(checker): binding-pattern parameter with default takes initializer type

### DIFF
--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -855,8 +855,22 @@ impl<'a> CheckerState<'a> {
                         && *cached_param_type != TypeId::UNKNOWN
                         && *cached_param_type != TypeId::ERROR
                 });
+                // A binding-pattern parameter with a default value and no type
+                // annotation takes the *initializer's* widened type, not the
+                // reconstructed pattern tuple (tsc `getTypeForVariableLikeDeclaration`:
+                // annotation -> contextual -> initializer -> pattern). Here
+                // `type_id` already holds the initializer's widened type (it was
+                // computed from `param.initializer` when no contextual type
+                // applied), so preserve it. Without this, `[a, b] = new Iter`
+                // reconstructs `[T, T]` and rejects a non-tuple iterable default
+                // via a false TS2345/TS2740.
+                let has_meaningful_initializer_type = param.initializer.is_some()
+                    && type_id != TypeId::ANY
+                    && type_id != TypeId::UNKNOWN
+                    && type_id != TypeId::ERROR;
                 let mut type_id = if let Some(pattern_type) = element_type_from_pattern {
                     if param.type_annotation.is_some()
+                        || has_meaningful_initializer_type
                         || ((has_contextual_type || has_external_binding_context)
                             && type_id != TypeId::ANY
                             && type_id != TypeId::UNKNOWN)


### PR DESCRIPTION
## Summary

A destructuring/binding-pattern parameter with a **default value and no type annotation** must take the **initializer's widened type** as its parameter type — not the tuple/object reconstructed from the pattern.

**Structural rule (confirmed against `checker.ts` `getTypeForVariableLikeDeclaration`):** for an un-annotated binding-pattern parameter the precedence is **annotation → contextual type → initializer → pattern-reconstruction**. `tsz` implemented annotation and contextual but skipped the *initializer* rung, jumping to pattern-reconstruction.

Owner layer: **checker** (`types/function_type.rs`). `type_id` already holds the initializer's widened type when no contextual type applies; the fix preserves it (instead of falling through to the reconstructed `pattern_type`) when the parameter has a meaningful initializer type.

## Why the bug hid
Pattern-reconstruction only coincidentally matched for **array-literal defaults** (`[a,b] = [1,2]` → `[number,number]`, which the array argument satisfies). For a **non-tuple iterable default** it broke: `function fun([a, b] = new FooIterator) {}` reconstructed `[Foo, Foo]`, so `fun(new FooIterator)` (an iterable, not a tuple) produced a false **TS2345**/**TS2740**.

## Verification
- Flips `iterableArrayPattern11`, `iterableArrayPattern12`.
- **Before/after diff over 419 destructuring-related conformance tests: +2 flips, 0 regressions** (built the pre-change binary and diffed FAIL sets).
- `iterableArrayPattern4` (assignment-target form `[a, ...b] = new FooIterator`) is a separate mechanism and is intentionally unchanged.
- Broad regression gate: native `merge_group` CI.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Goal: hold
