### PR TITLE
fix(checker): allow genuine any as a destructuring computed-key index

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -1078,7 +1078,20 @@ impl<'a> CheckerState<'a> {
                     } else {
                         self.resolve_lazy_type(key_type)
                     };
-                    let is_invalid = crate::query_boundaries::type_checking_utilities::get_invalid_index_type_member_strict(self.ctx.types, check_key);
+                    // A genuine `any` is a valid index type for a value-position
+                    // destructuring computed key: `{ [k]: v } = obj` desugars to
+                    // `v = obj[k]`, and element access permits an `any` index.
+                    // Only the strict type-level `isValidIndexType` (keyof/mapped/
+                    // `T[K]`) rejects `any`; that helper must not gate this
+                    // value-position check. But an ERROR key (e.g. `[foo()]` where
+                    // `foo` is not callable) is remapped to ANY above precisely so
+                    // it still reports TS2538 (tsc does too) — so exempt only when
+                    // the ORIGINAL key type is `any`, never the ERROR remap.
+                    let is_invalid = if key_type == TypeId::ANY && check_key == TypeId::ANY {
+                        None
+                    } else {
+                        crate::query_boundaries::type_checking_utilities::get_invalid_index_type_member_strict(self.ctx.types, check_key)
+                    };
                     // Symbol types pass the general validity check but can't
                     // index into objects through string/number index signatures,
                     // UNLESS the parent type (or its constraint for generics)


### PR DESCRIPTION
Goal: hold

## Structural rule

When a value-position destructuring pattern uses a computed key — `{ [k]: v } = obj` — it desugars to element access `v = obj[k]`. Element access permits an `any` index (`any` indexes anything), so tsc emits **no** TS2538 for an `any`-typed computed key. tsz routed the destructuring computed key through the **strict** type-level `isValidIndexType` (`get_invalid_index_type_member_strict`, the helper for `keyof` / mapped-type constraints / `T[K]`), which rejects `any`, producing a false TS2538 ("Type 'any' cannot be used as an index type").

TypeScript has two distinct index-type predicates: the strict `isValidIndexType` (type-level, rejects `any`/`unknown`) and the permissive element-access check (`obj[k]`, allows `any`). A value-position destructuring key must use the permissive one. This is a "right predicate, wrong context" bug.

**Owner layer:** checker (`state/variable_checking/destructuring.rs`). Fix: exempt a genuine `any` key from the strict check.

## Adjacent-case matrix

- Positive (still fires TS2538): a genuinely invalid key type — `boolean`, `void`, symbol without a matching property — still reports (verified: `let k = true; let [{ [k]: y }] = [{}]` → TS2538/TS2536).
- **ERROR-origin keys still fire** (matches tsc): `[foo()]` where `foo` is a `string` (not callable) is remapped ERROR→`any` upstream precisely so it still reports TS2538. The exemption checks the ORIGINAL `key_type == ANY`, never the ERROR remap — so `computedPropertiesInDestructuring1{,_ES6}.ts` keep their expected TS2538 at those sites.
- Fixed: a genuine `any` key (`order(1)` where `order: (n:any)=>any`) is exempt.

## Verification

Oracle: pinned `tsc` 7.0.2 (`scripts/conformance/tsc-cache-full.json`).

- **Flip (FAIL→PASS):** `conformance/es6/destructuring/destructuringEvaluationOrder.ts`.
- **Regression sweep (before/after binary diff, distinct SHAs):** 537-test destructuring/index-type net (all oracle tests touching TS2538/2536/2537 + destructuring/computed-property/index-signature names) → **+1 fix, 0 regressions.** An initial over-broad version (exempting the ERROR remap too) regressed 4 tests (`computedPropertiesInDestructuring1{,_ES6}`, `blockScopedBindingUsedBeforeDef`, `for-of-excess-declarations`); narrowing the exemption to genuine `any` restored all 4 while keeping the flip.
- Broad unit + conformance suites run in `merge_group`.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
