### PR TITLE
fix(checker): TS4104 for readonly array/tuple in argument position

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -159,6 +159,30 @@ impl<'a> CheckerState<'a> {
         if self.try_elaborate_callback_body_diagnostics(idx, param_type) {
             return;
         }
+        // Promote a readonly-array/tuple → mutable-array/tuple argument mismatch to
+        // TS4104 ("The type 'X' is 'readonly' and cannot be assigned to the mutable
+        // type 'Y'"), matching the direct-assignment path
+        // (`check_assignable_or_report_at_with_options`) and tsc, which reports
+        // TS4104 rather than the generic TS2345 for this reason.
+        if let Some(reason) = self.readonly_to_mutable_array_or_tuple_reason(arg_type, param_type) {
+            let source_display = Some(self.format_type_for_diagnostic_role(
+                arg_type,
+                DiagnosticTypeDisplayRole::CallArgument {
+                    parameter: param_type,
+                    argument_idx: idx,
+                },
+            ));
+            let diag = self.render_failure_reason_with_source_display(
+                &reason,
+                arg_type,
+                param_type,
+                idx,
+                0,
+                source_display,
+            );
+            self.ctx.push_diagnostic(diag);
+            return;
+        }
         let analysis = self.analyze_assignability_failure(arg_type, param_type);
 
         // tsc promotes a sole missing-required-property failure to the PRIMARY

--- a/crates/tsz-checker/tests/readonly_array_alias_argument_display_tests.rs
+++ b/crates/tsz-checker/tests/readonly_array_alias_argument_display_tests.rs
@@ -1,18 +1,14 @@
-//! `TS2345` must render a `readonly` array / `readonly` tuple ARGUMENT by the
-//! non-generic type-alias name it was referenced through (its `aliasSymbol`),
-//! matching `tsc`, instead of the structurally-interned form
-//! (`readonly number[]`).
+//! `TS4104` ("The type 'X' is 'readonly' and cannot be assigned to the mutable
+//! type 'Y'") must render a `readonly` array / `readonly` tuple ARGUMENT by the
+//! source's alias name where `tsc` does (`Bag`, `Frozen<number>`), and
+//! structurally for an inline `readonly number[]` annotation (no alias).
 //!
-//! This is the argument-mismatch follow-up of #14483 (the `TS4104`
-//! readonly-to-mutable slice is handled separately). tsz interns array and
-//! `readonly` array/tuple types purely structurally, so a shared
-//! `readonly number[]` `TypeId` carries no per-reference alias; `tsc` recovers
-//! the name from the argument expression's declared annotation, and tsz must do
-//! the same. The rule is structural — it holds regardless of the alias name,
-//! element types, and tuple arity — and must NOT fire for an inline
-//! `readonly number[]` annotation (no alias) or repaint a generic alias
-//! application (which already keeps its name via the `Application` path).
-
+//! tsc reports readonly-to-mutable array/tuple ARGUMENTS as `TS4104`, not the
+//! generic `TS2345` (see the `readonlyTupleAndArrayElaboration` conformance
+//! fixture). tsz interns array and `readonly` array/tuple types purely
+//! structurally, so a shared `readonly number[]` `TypeId` carries no per-reference
+//! alias; the alias name is recovered from the source expression's declared
+//! annotation, else the structural display is used.
 use tsz_checker::test_utils::check_source_code_messages;
 
 fn messages(source: &str) -> Vec<(u32, String)> {
@@ -36,79 +32,79 @@ fn message_for(source: &str, code: u32) -> String {
 }
 
 #[test]
-fn ts2345_readonly_array_alias_argument_renders_alias_name() {
+fn ts4104_readonly_array_alias_argument_renders_alias_name() {
     let msg = message_for(
         "type Bag = readonly number[]; const b: Bag = []; function need(x: number[]) {} need(b);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Bag' is not assignable to parameter of type 'number[]'."
+        "The type 'Bag' is 'readonly' and cannot be assigned to the mutable type 'number[]'."
     );
 }
 
 #[test]
-fn ts2345_readonly_array_alias_argument_is_structural_not_name_keyed() {
+fn ts4104_readonly_array_alias_argument_is_structural_not_name_keyed() {
     // Renamed binder + different element type: proves the recovery is structural,
     // not keyed on the alias spelling `Bag` or the element type `number`.
     let msg = message_for(
         "type Grid = readonly string[]; const g: Grid = []; function need(x: string[]) {} need(g);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Grid' is not assignable to parameter of type 'string[]'."
+        "The type 'Grid' is 'readonly' and cannot be assigned to the mutable type 'string[]'."
     );
 }
 
 #[test]
-fn ts2345_readonly_tuple_alias_argument_renders_alias_name() {
+fn ts4104_readonly_tuple_alias_argument_renders_alias_name() {
     let msg = message_for(
         "type Pair = readonly [number, string]; const p: Pair = [1, 'a']; function need(x: [number, string]) {} need(p);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Pair' is not assignable to parameter of type '[number, string]'."
+        "The type 'Pair' is 'readonly' and cannot be assigned to the mutable type '[number, string]'."
     );
 }
 
 #[test]
-fn ts2345_readonly_tuple_alias_argument_arity_three_renders_alias_name() {
+fn ts4104_readonly_tuple_alias_argument_arity_three_renders_alias_name() {
     let msg = message_for(
         "type Triple = readonly [number, string, boolean]; const t: Triple = [1, 'a', true]; function need(x: [number, string, boolean]) {} need(t);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Triple' is not assignable to parameter of type '[number, string, boolean]'."
+        "The type 'Triple' is 'readonly' and cannot be assigned to the mutable type '[number, string, boolean]'."
     );
 }
 
 #[test]
-fn ts2345_inline_readonly_array_argument_keeps_structural_display() {
+fn ts4104_inline_readonly_array_argument_keeps_structural_display() {
     // No alias: the inline `readonly number[]` annotation must stay structural,
     // exactly as `tsc` renders it.
     let msg = message_for(
         "const ra: readonly number[] = []; function need(x: number[]) {} need(ra);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'readonly number[]' is not assignable to parameter of type 'number[]'."
+        "The type 'readonly number[]' is 'readonly' and cannot be assigned to the mutable type 'number[]'."
     );
 }
 
 #[test]
-fn ts2345_generic_readonly_array_alias_application_keeps_name() {
+fn ts4104_generic_readonly_array_alias_application_keeps_name() {
     // A generic alias survives as an `Application` and already renders by name;
     // the recovery must not interfere with it.
     let msg = message_for(
         "type Frozen<T> = readonly T[]; const f: Frozen<number> = []; function need(x: number[]) {} need(f);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Frozen<number>' is not assignable to parameter of type 'number[]'."
+        "The type 'Frozen<number>' is 'readonly' and cannot be assigned to the mutable type 'number[]'."
     );
 }


### PR DESCRIPTION
Goal: hold

## Structural rule

When a `readonly` array/tuple is passed as an argument to a parameter whose type is a *mutable* array/tuple, tsc reports **TS4104** ("The type 'X' is 'readonly' and cannot be assigned to the mutable type 'Y'"), not the generic **TS2345** ("Argument of type … is not assignable to parameter …"). tsz's direct-assignment path (`check_assignable_or_report_at_with_options`) already promotes this reason via the `readonly_to_mutable_array_or_tuple_reason` preflight, but the **call-argument** error path emitted the generic TS2345.

Fix: in the argument error path, run the same precise preflight (readonly source inner + mutable array/tuple target) and, when it matches, render the `ReadonlyToMutableAssignment` reason — which already maps to the TS4104 message/code — instead of falling through to the generic TS2345.

**Owner layer:** checker (`error_reporter/call_errors/error_emission.rs`). Reuses the existing solver reason and the existing renderer; no new relation logic.

## Adjacent-case matrix

- Direct assignment (`let y: number[] = a`) already emitted TS4104 — unchanged.
- Argument (`f(a)`, `arryFn2(a/b/c)` with `readonly number[]` / `Readonly<number[]>` / `ReadonlyArray<number>`, and a `readonly` tuple `as const` passed to `[number, number]`) now emits TS4104 — matches tsc.
- The preflight is precise (readonly source inner AND mutable array/tuple target), so non-readonly argument mismatches keep the generic TS2345.

## Verification

Oracle: pinned `tsc` 7.0.2 (`scripts/conformance/tsc-cache-full.json`).

- **Flip (FAIL→PASS):** `compiler/readonlyTupleAndArrayElaboration.ts` (6 diagnostics: TS2345 → TS4104 at each readonly argument).
- **Regression sweep (before/after binary diff, distinct SHAs):** 385-test net (all oracle tests touching TS4104/TS2345 + readonly/tuple/as-const names) → **+1 fix, 0 regressions.**
- Broad unit + conformance suites run in `merge_group`.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
