### PR TITLE
fix(checker): no TS2690 mapped-type suggestion for typeof type-query operand

### DIFF
--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -464,6 +464,19 @@ impl<'a> CheckerState<'a> {
                     | syntax_kind_ext::METHOD_SIGNATURE
                     | syntax_kind_ext::INDEX_SIGNATURE
             ) {
+                // Only a KEY-position identifier is a computed property name. When
+                // the identifier sits in the member's TYPE position — e.g.
+                // `prop: typeof string`, where `string` is the operand of a
+                // `typeof` type query — it is not a computed key and must get the
+                // plain TS2693, not the TS2690 mapped-type suggestion.
+                if self
+                    .ctx
+                    .arena
+                    .get_signature(parent)
+                    .is_some_and(|sig| sig.type_annotation == current)
+                {
+                    return false;
+                }
                 return true;
             }
             if matches!(


### PR DESCRIPTION
Goal: hold

## Structural rule

TS2690 ("'X' only refers to a type, but is being used as a value here. Did you mean to use 'K in X'?") is the **computed-property-key** variant of the type-used-as-value error — it suggests mapped-type syntax and only applies when a type is used as a *computed key* (`{ [K]: T }`). tsz's computed-key detector (`is_computed_property_in_type_member`) walked up the AST and returned `true` as soon as it reached a `PROPERTY_SIGNATURE`/`METHOD_SIGNATURE` ancestor, without checking that the identifier was in the member's **key** position. So an identifier in the member's **type** position — e.g. `prop: typeof string`, where `string` is the operand of a `typeof` type query — was misclassified as a computed key and got a spurious TS2690 (with a garbled "'s in string'" suggestion) in addition to the correct TS2693.

Fix: when the walk reaches a signature member, return `false` if the identifier sits in the member's type node (`signature.type_annotation == current`). Type-position operands then get the plain TS2693; genuine computed keys still get TS2690.

**Owner layer:** checker (`error_reporter/type_value.rs`, diagnostic selection). No type-system change.

## Adjacent-case matrix

- Type position (`prop: typeof string`) → TS2693 only (fixed; was TS2693 + spurious TS2690).
- Genuine computed key (`type T = { [K]: number }` with `type K = string`) → still TS2690 with the mapped-type suggestion (verified).
- The `[number]` primitive-keyword computed-key recovery path (the reason the signature-ancestor shortcut exists) is unaffected — its identifier is in key position, not `type_annotation`.

## Verification

Oracle: pinned `tsc` 7.0.2 (`scripts/conformance/tsc-cache-full.json`).

- **Flip (FAIL→PASS):** `compiler/interfacedeclWithIndexerErrors.ts` (drops the spurious TS2690 at the `typeof string` operand; keeps the oracle's TS2693/TS2411/TS2693/TS2840).
- **Regression sweep (before/after binary diff, distinct SHAs):** 492-test net (all oracle tests touching TS2690/TS2693 + typeof/computed-property/mapped-type names) → **+1 fix, 0 regressions.**
- Broad unit + conformance suites run in `merge_group`.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
