### PR TITLE
fix(checker): TS2370 non-strict rest + TS2537 any-sourced destructuring default

### DIFF
--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -1369,7 +1369,13 @@ impl<'a> CheckerState<'a> {
                 let should_emit = if is_callable_type {
                     true
                 } else if is_arrow_or_expr {
-                    param.type_annotation.is_none() && param.initializer.is_none()
+                    // An unannotated rest param on an arrow/function expression is
+                    // implicitly `any[]` — a valid array type — so TS2370 only fires
+                    // under noImplicitAny (tsc reports the implicit-any/rest grammar
+                    // separately otherwise). Gate to match.
+                    self.ctx.no_implicit_any()
+                        && param.type_annotation.is_none()
+                        && param.initializer.is_none()
                 } else {
                     false
                 };

--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -573,17 +573,25 @@ impl<'a> CheckerState<'a> {
                     self.get_type_of_node_with_request(element_data.initializer, &request);
                 self.ctx.preserve_literal_types = prev_preserve;
 
-                if element_type == TypeId::ANY || element_type == TypeId::UNKNOWN {
-                    element_type = init_type;
-                } else if !self
-                    .destructuring_relation_outcome(init_type, element_type)
-                    .related
-                {
-                    element_type = binding_patterns::binding_pattern_initializer_union_type(
-                        self.ctx.types,
-                        element_type,
-                        init_type,
-                    );
+                // When the destructuring SOURCE is genuinely `any`, every element is
+                // `any` and stays `any` (tsc's `isTypeAny(parentType)` short-circuit):
+                // do NOT fold the default initializer's type onto it, or a nested
+                // computed-key would then be checked against the init type and fire a
+                // spurious TS2537. The initializer is still evaluated above for its own
+                // checks; only the type override is skipped.
+                if parent_type != TypeId::ANY {
+                    if element_type == TypeId::ANY || element_type == TypeId::UNKNOWN {
+                        element_type = init_type;
+                    } else if !self
+                        .destructuring_relation_outcome(init_type, element_type)
+                        .related
+                    {
+                        element_type = binding_patterns::binding_pattern_initializer_union_type(
+                            self.ctx.types,
+                            element_type,
+                            init_type,
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
Goal: hold

Two conformance false-positives surfaced by a parallel FP-tractability audit (diagnose → adversarial-verify → synthesize over the current 49-FP landscape). Both are the campaign's proven "right predicate / missing gate, wrong context" shape.

## Structural rules

**TS2370** ("A rest parameter must be of an array type"): an *unannotated* rest parameter on an arrow / function-expression is implicitly `any[]` — a valid array type — so tsc reports TS2370 for it only under `noImplicitAny`. tsz emitted it unconditionally for the `is_arrow_or_expr` case. Fix: gate that arm of `should_emit` on `self.ctx.no_implicit_any()`. The annotated branch (non-array annotations → TS2370 regardless) and the callable-type-alias branch are untouched.

**TS2537** ("Type 'X' has no matching index signature…"): when a destructuring *source* type is genuinely `any`, tsc's `isTypeAny(parentType)` short-circuit keeps every element (and nested element) `any`. tsz instead folded a default initializer's type onto the `any` element, so a *nested computed key* was then checked against that init type and fired a spurious TS2537. Fix: skip the initializer type-override when `parent_type == TypeId::ANY` (the initializer is still evaluated for its own checks; only the type assignment is skipped).

**Owner layer:** checker. No solver/relation change.

## Adjacent-case matrix

- TS2370 positive (still fires): unannotated optional rest under `--strict` (`var f = (...a?) => 1`) → TS2370; non-array *annotated* rest (`restParametersOfNonArrayTypes`, `nonArrayRestArgs`) → TS2370 regardless of strictness; callable-type context (`parserParameterList10/11`) unaffected. Negative (now suppressed): unannotated rest under non-strict.
- TS2537 positive (still fires): a genuine non-`any` source with an invalid computed key still reports. Negative (now suppressed): any-sourced element with a default initializer.

## Verification

Oracle: pinned `tsc` 7.0.2 (`scripts/conformance/tsc-cache-full.json`).

- **Flips (FAIL→PASS):** `compiler/fatarrowfunctionsOptionalArgsErrors1.ts` (TS2370), `compiler/objectRestSpread.ts` (TS2537).
- **Regression sweeps (before/after binary diff, distinct SHAs):** a 1035-test destructuring/binding/index net → **0 regressions**; a 196-test TS2370/rest-param net → **0 regressions**. Each net independently confirms its flip.
- `cargo clippy -p tsz-checker --lib` clean; touched files under the 2000-LOC limit (destructuring.rs 1478, parameter_checker.rs 1985). Broad unit/conformance/emit run in `merge_group`.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
