### PR TITLE
fix(solver): gate optional-member undefined on strictNullChecks (TS2349)

### DIFF
--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -158,6 +158,11 @@ impl<'a> CheckerContext<'a> {
             types.set_no_unchecked_indexed_access(compiler_options.no_unchecked_indexed_access);
             types.set_exact_optional_property_types(compiler_options.exact_optional_property_types);
         }
+        // Wire strictNullChecks unconditionally: it gates whether optional-member
+        // access/call/inference types carry `| undefined` (tsc's addOptionality is
+        // strictNullChecks-gated). The interner defaults to `true`, so this must run
+        // for a non-strict compilation to actually strip the synthetic `undefined`.
+        types.set_strict_null_checks(compiler_options.strict_null_checks);
         let capabilities =
             crate::query_boundaries::capabilities::EnvironmentCapabilities::from_options(
                 &compiler_options,

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -842,6 +842,10 @@ impl TypeCompilerOptions for TypeInterner {
     fn exact_optional_property_types(&self) -> bool {
         TypeInterner::exact_optional_property_types(self)
     }
+
+    fn strict_null_checks(&self) -> bool {
+        TypeInterner::strict_null_checks(self)
+    }
 }
 
 impl TypeApplicationEvalCache for TypeInterner {
@@ -1533,6 +1537,8 @@ pub trait QueryDatabase:
 
     fn set_exact_optional_property_types(&self, _enabled: bool) {}
 
+    fn set_strict_null_checks(&self, _enabled: bool) {}
+
     fn contextual_property_type(&self, expected: TypeId, prop_name: &str) -> Option<TypeId> {
         let ctx = crate::computation::ContextualTypeContext::with_expected(
             self.as_type_database(),
@@ -1920,6 +1926,10 @@ impl QueryDatabase for TypeInterner {
 
     fn set_exact_optional_property_types(&self, enabled: bool) {
         TypeInterner::set_exact_optional_property_types(self, enabled);
+    }
+
+    fn set_strict_null_checks(&self, enabled: bool) {
+        TypeInterner::set_strict_null_checks(self, enabled);
     }
 
     fn get_type_param_variance(&self, _def_id: DefId) -> Option<Arc<[Variance]>> {

--- a/crates/tsz-solver/src/caches/db_base_traits.rs
+++ b/crates/tsz-solver/src/caches/db_base_traits.rs
@@ -271,4 +271,14 @@ pub trait TypeCompilerOptions {
     fn exact_optional_property_types(&self) -> bool {
         false
     }
+
+    /// Whether `strictNullChecks` is enabled.
+    ///
+    /// Gates whether an optional member's access/call/inference type carries
+    /// `| undefined` (tsc's `addOptionality` is strictNullChecks-gated). The
+    /// default is `true` so a backend without wired options never wrongly
+    /// strips `undefined` in strict code.
+    fn strict_null_checks(&self) -> bool {
+        true
+    }
 }

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -305,6 +305,7 @@ pub struct QueryCache<'a> {
     subtype_reduction_cache_stats: CacheCounter,
     no_unchecked_indexed_access: Cell<bool>,
     exact_optional_property_types: Cell<bool>,
+    strict_null_checks: Cell<bool>,
     /// Optional shared cross-file cache for multi-file project checking.
     /// When present, local cache misses fall through to the shared `DashMap` cache,
     /// and local cache inserts are also written to the shared cache.
@@ -382,6 +383,7 @@ impl<'a> QueryCache<'a> {
             subtype_reduction_cache_stats: CacheCounter::new(),
             no_unchecked_indexed_access: Cell::new(interner.no_unchecked_indexed_access()),
             exact_optional_property_types: Cell::new(interner.exact_optional_property_types()),
+            strict_null_checks: Cell::new(interner.strict_null_checks()),
             shared,
             definition_store: None,
         }
@@ -842,6 +844,10 @@ impl TypeCompilerOptions for QueryCache<'_> {
 
     fn exact_optional_property_types(&self) -> bool {
         self.exact_optional_property_types.get()
+    }
+
+    fn strict_null_checks(&self) -> bool {
+        self.strict_null_checks.get()
     }
 }
 
@@ -1821,6 +1827,10 @@ impl QueryDatabase for QueryCache<'_> {
 
     fn set_exact_optional_property_types(&self, enabled: bool) {
         self.exact_optional_property_types.set(enabled);
+    }
+
+    fn set_strict_null_checks(&self, enabled: bool) {
+        self.strict_null_checks.set(enabled);
     }
 
     fn get_type_param_variance(&self, def_id: DefId) -> Option<Arc<[Variance]>> {

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -433,6 +433,12 @@ pub struct TypeInterner {
     pub(super) no_unchecked_indexed_access: AtomicBool,
     /// Effective value for `exactOptionalPropertyTypes` used by query-boundary helpers.
     pub(super) exact_optional_property_types: AtomicBool,
+    /// Effective value for `strictNullChecks`. Gates whether an optional
+    /// member's access/call/inference type carries `| undefined` (see
+    /// `utils::optional_property_type`). Defaults to `true` so an un-wired
+    /// interner never wrongly strips `undefined` in strict code; each
+    /// compilation wires the real value from compiler options.
+    pub(super) strict_null_checks: AtomicBool,
     /// Monotonic invalidation generation for diagnostic and semantic provenance
     /// side tables. Exact graph-rewrite sessions compare this before replaying
     /// retained source provenance, making unchanged cache hits `O(1)`.
@@ -829,6 +835,7 @@ impl TypeInterner {
             poisoned: std::sync::atomic::AtomicBool::new(false),
             no_unchecked_indexed_access: AtomicBool::new(false),
             exact_optional_property_types: AtomicBool::new(false),
+            strict_null_checks: AtomicBool::new(true),
             display_provenance_generation: AtomicU64::new(0),
             display_properties: DashMap::with_hasher(FxBuildHasher),
             display_alias: DashMap::with_hasher(FxBuildHasher),
@@ -867,6 +874,16 @@ impl TypeInterner {
     pub fn set_exact_optional_property_types(&self, enabled: bool) {
         self.exact_optional_property_types
             .store(enabled, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn strict_null_checks(&self) -> bool {
+        self.strict_null_checks.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub fn set_strict_null_checks(&self, enabled: bool) {
+        self.strict_null_checks.store(enabled, Ordering::Relaxed);
     }
 
     /// Atomically read and clear the "tuple too large" flag.

--- a/crates/tsz-solver/src/utils/mod.rs
+++ b/crates/tsz-solver/src/utils/mod.rs
@@ -368,7 +368,12 @@ pub(crate) fn find_common_base_type(
 ///
 /// Note: `SubtypeChecker` has its own version that respects `exactOptionalPropertyTypes`.
 pub(crate) fn optional_property_type(db: &dyn TypeDatabase, prop: &PropertyInfo) -> TypeId {
-    if prop.optional {
+    // tsc's `addOptionality` only adds `| undefined` under `strictNullChecks`;
+    // in non-strict an optional member's access/call/inference type is just `T`.
+    // Without this gate, `interface I { m?(): T } i.m()` in non-strict wrongly
+    // reports TS2349 (`undefined` not callable). The SubtypeChecker keeps its own
+    // strictNullChecks/exactOptionalPropertyTypes-gated copy for the relation.
+    if prop.optional && db.strict_null_checks() {
         db.union2(prop.type_id, TypeId::UNDEFINED)
     } else {
         prop.type_id


### PR DESCRIPTION
## Summary
In non-strict mode, tsc's `addOptionality` does NOT add `| undefined` to an optional member's type (it's gated on `strictNullChecks`). tsz added it unconditionally, so an optional member's access/call/inference type was `T | undefined` even in non-strict — and calling such a member (`i.m()` where `m?(): T`) reported a spurious **TS2349** ("not callable, `undefined` has no call signatures"):

```ts
// @strict: false
interface I { m?(): number; }
declare var i: I;
i.m();   // tsz wrongly: TS2349; tsc: ok (m is () => number, not | undefined)
```

## Structural rule
When a property/method member is optional, tsc includes `| undefined` in its type only under `strictNullChecks`. tsz now gates the shared read-side helper `tsz_solver::utils::optional_property_type` on `strictNullChecks`, so in non-strict an optional member reads as `T`. (The `SubtypeChecker` already gated its own copy — this closes the access/call/inference side.)

## Owner layer
Solver. The compiler option is threaded exactly like `exactOptionalPropertyTypes`:
- `TypeInterner`: new `strict_null_checks: AtomicBool` (**init `true`** — safe default so an un-wired backend never wrongly strips `undefined` in strict code) + getter/setter (`intern/core/interner.rs`).
- `TypeCompilerOptions::strict_null_checks` (default `true`) + `QueryDatabase::{strict_null_checks, set_strict_null_checks}` (`caches/db_base_traits.rs`, `caches/db.rs`).
- **`QueryCache`**: mirrors its `exact_optional_property_types` `Cell<bool>` — field + init-from-interner + getter + setter (`caches/query_cache.rs`). This was the operative piece: the checker context's db is a `QueryCache`, so without forwarding, `set_strict_null_checks` hit the trait no-op default and the gate read the interner's `true` default (the bug this fixes).
- Wired from options at `tsz_checker` context construction (`context/constructors.rs`), beside `set_exact_optional_property_types`.
- Gate: `utils::optional_property_type` — `if prop.optional && db.strict_null_checks()`.

## Scope / over-fire safety
- Gated on **non-strict** only; strict mode is unchanged (`init true` + wiring keep strict correct — verified: strict `i.m()` still TS2722).
- Init-`true` default means any interner path that isn't wired keeps the current (undefined-preserving) behavior — safe against un-wired backends.
- The subtype relation keeps its own `strictNullChecks`/`exactOptionalPropertyTypes`-gated copy, so assignability is unaffected.

## Verification
- `compiler/fixingTypeParametersRepeatedly3.ts`: FAIL on base (spurious TS2349 on `d.toBase()`, optional method) → **PASS** (oracle `[]`), before/after binary diff, distinct SHAs.
- Broad regression net (5737 optional / interface / property / member / access / call / class / nullable fixtures, **strict and non-strict**), before vs after: **0 regressions** (+ genuine flip of the target fixture, confirmed by before/after binary diff with distinct SHAs).
- Edge probes: non-strict optional-method call now clean; strict optional-method call still TS2722; `exactOptionalPropertyTypes` unaffected.

Goal: hold

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
