### PR TITLE
fix(checker): resolve default class heritage by exact owner

### DIFF
--- a/crates/tsz-checker/src/types/interface_heritage_class.rs
+++ b/crates/tsz-checker/src/types/interface_heritage_class.rs
@@ -1,0 +1,90 @@
+//! Class-declaration recovery for interface heritage.
+//!
+//! Keeps owner-aware import/default-export resolution out of the interface
+//! shape-merging shard while preserving the checker/solver boundary.
+
+use crate::state::CheckerState;
+use crate::symbols_domain::alias_cycle::AliasCycleTracker;
+use tsz_binder::{SymbolId, symbol_flags};
+
+impl CheckerState<'_> {
+    /// Resolve an interface-heritage base symbol to the underlying `class`
+    /// symbol — directly, through an import alias, or through a cross-file
+    /// re-export — or `None` when the base is not a class. Used to route a
+    /// class base through the class-instance resolver (so instance members are
+    /// inherited) instead of the symbol's constructor type.
+    pub(super) fn heritage_base_class_symbol(&mut self, base_sym_id: SymbolId) -> Option<SymbolId> {
+        let symbol_is_class = |this: &Self, sym: SymbolId| {
+            this.get_cross_file_symbol(sym)
+                .or_else(|| this.ctx.binder.get_symbol(sym))
+                .is_some_and(|symbol| symbol.has_any_flags(symbol_flags::CLASS))
+        };
+
+        if symbol_is_class(self, base_sym_id) {
+            return Some(base_sym_id);
+        }
+
+        // A default import of `class Base; export default Base` resolves first
+        // to the exporting file's synthetic `default` symbol. That symbol is an
+        // alias/value surface, not the local class declaration, so the ordinary
+        // alias paths below cannot classify it as a class and heritage falls
+        // through to `get_type_of_symbol` (the constructor/static side).
+        //
+        // Recover the exact declaration named by the explicit default-export
+        // clause before that fallback. The target is resolved from the
+        // export-clause identifier through its owning binder, which avoids raw
+        // cross-binder `SymbolId` collisions and also preserves class/namespace
+        // merges. Property-access defaults, re-exports, `export =`, and
+        // non-class defaults remain on their existing paths.
+        if let Some(target) = self.explicit_default_import_class_symbol(base_sym_id) {
+            return Some(target);
+        }
+
+        let mut visited_aliases = AliasCycleTracker::new();
+        if let Some(target) = self
+            .resolve_alias_symbol(base_sym_id, &mut visited_aliases)
+            .filter(|&target| target != base_sym_id)
+            && symbol_is_class(self, target)
+        {
+            return Some(target);
+        }
+
+        self.resolve_import_alias_cross_file(base_sym_id)
+            .filter(|&target| target != base_sym_id && symbol_is_class(self, target))
+    }
+
+    /// Resolve the local class named by an explicit
+    /// `export default <identifier>` reached through a requester-local default
+    /// import.
+    fn explicit_default_import_class_symbol(&self, base_sym_id: SymbolId) -> Option<SymbolId> {
+        let alias_symbol = self.local_import_alias(base_sym_id)?;
+        if alias_symbol.import_name()? != "default" {
+            return None;
+        }
+        let module_specifier = alias_symbol.import_module()?;
+        let source_file_idx = if alias_symbol.decl_file_idx == u32::MAX {
+            self.ctx.current_file_idx
+        } else {
+            alias_symbol.decl_file_idx as usize
+        };
+        let target_file_idx = self
+            .ctx
+            .resolve_import_target_from_file(source_file_idx, module_specifier)?;
+        let target_binder = self.ctx.get_binder_for_file(target_file_idx)?;
+        let target_arena = self.ctx.get_arena_for_file(target_file_idx as u32);
+        let target_file_name = &target_arena.source_files.first()?.file_name;
+        let exports = self
+            .ctx
+            .module_exports_for_module(target_binder, target_file_name)?;
+        if exports.get("export=").is_some() {
+            return None;
+        }
+        let default_sym_id = exports.get("default")?;
+        let target_sym_id =
+            self.default_export_identifier_target_in_file(default_sym_id, target_file_idx)?;
+        target_binder
+            .get_symbol(target_sym_id)
+            .filter(|symbol| symbol.has_any_flags(symbol_flags::CLASS))
+            .map(|_| target_sym_id)
+    }
+}

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -10,7 +10,6 @@
 //! - Type parameter instantiation for generic bases
 
 use crate::state::CheckerState;
-use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use crate::types_domain::type_node_helpers::type_node_includes_explicit_undefined;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
@@ -173,40 +172,6 @@ impl<'a> CheckerState<'a> {
             // declaring file is checked through cross-arena delegation,
             // making results depend on root-file order.
             .or_else(|| self.ctx.binder.program_global_type(normalized))
-    }
-
-    /// Resolve an interface-heritage base symbol to the underlying `class`
-    /// symbol — directly, through an import alias, or through a cross-file
-    /// re-export — or `None` when the base is not a class. Used to route a
-    /// class base through the class-instance resolver (so instance members are
-    /// inherited) instead of the symbol's constructor type.
-    fn heritage_base_class_symbol(
-        &mut self,
-        base_sym_id: tsz_binder::SymbolId,
-    ) -> Option<tsz_binder::SymbolId> {
-        use tsz_binder::symbol_flags;
-
-        let symbol_is_class = |this: &Self, sym: tsz_binder::SymbolId| {
-            this.get_cross_file_symbol(sym)
-                .or_else(|| this.ctx.binder.get_symbol(sym))
-                .is_some_and(|symbol| symbol.has_any_flags(symbol_flags::CLASS))
-        };
-
-        if symbol_is_class(self, base_sym_id) {
-            return Some(base_sym_id);
-        }
-
-        let mut visited_aliases = AliasCycleTracker::new();
-        if let Some(target) = self
-            .resolve_alias_symbol(base_sym_id, &mut visited_aliases)
-            .filter(|&t| t != base_sym_id)
-            && symbol_is_class(self, target)
-        {
-            return Some(target);
-        }
-
-        self.resolve_import_alias_cross_file(base_sym_id)
-            .filter(|&t| t != base_sym_id && symbol_is_class(self, t))
     }
 
     /// Get the type of an interface declaration.

--- a/crates/tsz-checker/src/types/mod.rs
+++ b/crates/tsz-checker/src/types/mod.rs
@@ -6,6 +6,7 @@ pub mod function_type;
 pub(crate) mod function_type_circular;
 pub(crate) mod function_type_helpers;
 pub(crate) mod function_type_signature_display;
+mod interface_heritage_class;
 pub mod interface_type;
 pub mod module_augmentation;
 mod module_augmentation_prime;

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -548,10 +548,7 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        if self
-            .default_export_identifier_value_target(member_id)
-            .is_some()
-        {
+        if self.default_export_identifier_target(member_id).is_some() {
             return self.get_validated_member_type(member_id, property_name);
         }
 
@@ -673,9 +670,7 @@ impl<'a> CheckerState<'a> {
         if self.symbol_member_is_type_only(resolved_member_id, Some(property_name)) {
             return None;
         }
-        if let Some(target_member_id) =
-            self.default_export_identifier_value_target(resolved_member_id)
-        {
+        if let Some(target_member_id) = self.default_export_identifier_target(resolved_member_id) {
             let wrapper_type = self.get_type_of_symbol(resolved_member_id);
             if !matches!(wrapper_type, TypeId::UNKNOWN | TypeId::ERROR) {
                 return Some(wrapper_type);
@@ -813,10 +808,22 @@ impl<'a> CheckerState<'a> {
         Some(self.get_type_of_symbol(resolved_member_id))
     }
 
-    fn default_export_identifier_value_target(&self, sym_id: SymbolId) -> Option<SymbolId> {
-        let symbol = self
-            .get_cross_file_symbol(sym_id)
-            .or_else(|| self.ctx.binder.get_symbol(sym_id))?;
+    /// Resolve the owner-local declaration named by a synthetic
+    /// `export default <identifier>` symbol.
+    pub(crate) fn default_export_identifier_target(&self, sym_id: SymbolId) -> Option<SymbolId> {
+        let target_file_idx = self.ctx.resolve_symbol_file_index(sym_id)?;
+        self.default_export_identifier_target_in_file(sym_id, target_file_idx)
+    }
+
+    /// Resolve the owner-local declaration named by a synthetic
+    /// `export default <identifier>` symbol with an exact owning file.
+    pub(crate) fn default_export_identifier_target_in_file(
+        &self,
+        sym_id: SymbolId,
+        target_file_idx: usize,
+    ) -> Option<SymbolId> {
+        let target_binder = self.ctx.get_binder_for_file(target_file_idx)?;
+        let symbol = target_binder.get_symbol(sym_id)?;
         if !symbol.has_any_flags(symbol_flags::ALIAS)
             || symbol.import_module().is_some()
             || !(symbol.escaped_name == "default" || symbol.import_name() == Some("default"))
@@ -824,10 +831,8 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         let decl_idx = symbol.primary_declaration()?;
-        let target_file_idx = self.ctx.resolve_symbol_file_index(sym_id)?;
         let target_arena = self.ctx.get_arena_for_file(target_file_idx as u32);
         let ident = target_arena.get_identifier_at(decl_idx)?;
-        let target_binder = self.ctx.get_binder_for_file(target_file_idx)?;
         let target_sym_id = target_binder.file_locals.get(&ident.escaped_text)?;
         if target_sym_id == sym_id {
             return None;

--- a/crates/tsz-checker/tests/class_interface_namespace_merge_tests.rs
+++ b/crates/tsz-checker/tests/class_interface_namespace_merge_tests.rs
@@ -149,6 +149,149 @@ const b: B = new B(B.b);
 }
 
 #[test]
+fn default_export_identifier_class_namespace_interface_heritage_uses_instance_type() {
+    let diags = check_multi_file(
+        &[
+            (
+                "vessel.ts",
+                r#"
+class Vessel<Payload = unknown> {
+    value!: Payload;
+    static #hidden = 0;
+    static make<Shape extends Vessel>(): Shape {
+        return null as any;
+    }
+}
+namespace Vessel {
+    export type Core<Payload = unknown> = Vessel<Payload>;
+    export const label = "vessel";
+}
+export default Vessel;
+"#,
+            ),
+            (
+                "cargo.ts",
+                r#"
+import Vessel from "./vessel";
+
+interface Cargo extends Vessel<number> {
+    kind: "cargo";
+}
+
+const cargo: Cargo = Vessel.make<Cargo>();
+const value: number = cargo.value;
+const label: string = Vessel.label;
+"#,
+            ),
+        ],
+        "cargo.ts",
+        CheckerOptions {
+            module: tsz_common::common::ModuleKind::CommonJS,
+            target: tsz_common::common::ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect::<Vec<_>>();
+
+    assert!(
+        diags.is_empty(),
+        "default-exported class+namespace heritage should be tsc-clean: {diags:?}"
+    );
+}
+
+#[test]
+fn default_export_identifier_class_without_namespace_interface_heritage_uses_instance_type() {
+    let diags = check_multi_file(
+        &[
+            (
+                "crate.ts",
+                r#"
+class Crate<Item = unknown> {
+    item!: Item;
+    static #token = 0;
+    static create<Shape extends Crate>(): Shape {
+        return null as any;
+    }
+}
+export default Crate;
+"#,
+            ),
+            (
+                "shipment.ts",
+                r#"
+import Crate from "./crate";
+
+interface Shipment extends Crate<string> {
+    ready: true;
+}
+
+const shipment: Shipment = Crate.create<Shipment>();
+const item: string = shipment.item;
+"#,
+            ),
+        ],
+        "shipment.ts",
+        CheckerOptions {
+            module: tsz_common::common::ModuleKind::CommonJS,
+            target: tsz_common::common::ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect::<Vec<_>>();
+
+    assert!(
+        diags.is_empty(),
+        "default-exported class heritage should be tsc-clean without a namespace: {diags:?}"
+    );
+}
+
+#[test]
+fn named_export_class_value_side_stays_available() {
+    let diags = check_multi_file(
+        &[
+            (
+                "repository.ts",
+                r#"
+export class Repository<Entry = unknown> {
+    entry!: Entry;
+    static open<Shape extends Repository>(): Shape {
+        return null as any;
+    }
+}
+"#,
+            ),
+            (
+                "record.ts",
+                r#"
+import { Repository } from "./repository";
+
+const record: Repository<boolean> = Repository.open<Repository<boolean>>();
+const entry: boolean = record.entry;
+"#,
+            ),
+        ],
+        "record.ts",
+        CheckerOptions {
+            module: tsz_common::common::ModuleKind::CommonJS,
+            target: tsz_common::common::ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect::<Vec<_>>();
+
+    assert!(
+        diags.is_empty(),
+        "named-import class type/value control should remain tsc-clean: {diags:?}"
+    );
+}
+
+#[test]
 fn interface_class_namespace_declaration_order_sees_class_member() {
     // Declaration order swapped: interface first, then class, then namespace.
     // (tsc reports TS2434 for namespace-before-class — that's expected and


### PR DESCRIPTION
Goal: green

## Provenance

Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high

## Structural rule

When an interface heritage base is a requester-local default import whose target file explicitly exports a class identifier, including a class/namespace merge, resolve the identifier in that exact owner binder and merge the class instance type. The synthetic `default` export and constructor/static side must not become the interface base.

Owner layer: the checker resolves the owner-qualified import/export symbol chain and routes the existing class-instance query; solver type construction and value-side class/namespace behavior remain unchanged.

## Adjacent matrix

- renamed generic classes with and without a namespace merge
- inherited instance properties plus static private/generic factory controls
- named-import class type/value behavior remains green
- existing property-access default exports remain on their prior path
- `export =`, re-exports, non-class defaults, and anonymous/inline defaults remain on fallback
- the independently red named-import interface-heritage family is intentionally not hidden or bundled

## Performance

The new path performs bounded module/export-table and owner-binder lookups only for unresolved default-import heritage bases. It adds no type-shape recursion, broad scan, rendered-type predicate, or new semantic cache.

## Verification

- `CARGO_TARGET_DIR=/Users/mohsen/code/.target-codex-runtypes-default-class-heritage-20260723 scripts/safe-run.sh --limit 12288 -- cargo nextest run -p tsz-checker --test class_interface_namespace_merge_tests` (14 passed)
- `CARGO_TARGET_DIR=/Users/mohsen/code/.target-codex-runtypes-default-class-heritage-20260723 scripts/safe-run.sh --limit 12288 -- cargo clippy -p tsz-checker --test class_interface_namespace_merge_tests -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/architecture-check.sh --quick`
- `git diff --check`
- touched source/test shards: 1965, 90, 1826, 439, and 63 physical lines
