### PR TITLE
fix(checker): TS8032 for unattached qualified JSDoc @param names

### DIFF
--- a/crates/tsz-checker/src/jsdoc/mod.rs
+++ b/crates/tsz-checker/src/jsdoc/mod.rs
@@ -32,6 +32,7 @@
 //! - Pure string parsing → `parsing.rs`
 //! - Type resolution (needs `&mut self`) → `resolution.rs`
 //! - Parameter handling / comment lookup → `params.rs`
+//! - Qualified (dotted) `@param` names and nesting → `params_qualified.rs`
 //! - Diagnostic emission → `diagnostics.rs`
 //! - New data structures → `types.rs`
 
@@ -45,6 +46,7 @@ pub(crate) mod lookup;
 pub(crate) mod params;
 pub(crate) mod params_comment_retrieval;
 pub(crate) mod params_generic_instantiation;
+pub(crate) mod params_qualified;
 pub(crate) mod params_type_strings;
 pub(crate) mod parsing;
 pub(crate) mod parsing_import_attributes;

--- a/crates/tsz-checker/src/jsdoc/params.rs
+++ b/crates/tsz-checker/src/jsdoc/params.rs
@@ -138,6 +138,8 @@ impl<'a> CheckerState<'a> {
             actual_params.push((name, is_binding_pattern));
         }
 
+        self.check_jsdoc_qualified_param_tags(jsdoc, &actual_params, func_idx);
+
         // Extract @param tag names from JSDoc (only top-level, non-dotted names)
         let jsdoc_params = Self::extract_jsdoc_param_names(jsdoc);
         let has_implicit_arguments_candidate =
@@ -393,7 +395,7 @@ impl<'a> CheckerState<'a> {
         )
     }
 
-    fn function_uses_implicit_arguments_object(&self, func_idx: NodeIndex) -> bool {
+    pub(super) fn function_uses_implicit_arguments_object(&self, func_idx: NodeIndex) -> bool {
         let Some(node) = self.ctx.arena.get(func_idx) else {
             return false;
         };
@@ -510,65 +512,6 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
         }
-    }
-
-    /// Find the byte offset of a parameter name after `@param` in source text.
-    ///
-    /// Given the text after `@param`, skips optional `{type}` and whitespace,
-    /// then checks if the next word matches `name`. Returns the byte offset
-    /// of the name relative to the start of the input.
-    fn find_param_name_in_source(after_param: &str, name: &str) -> Option<usize> {
-        let mut rest = after_param;
-        let mut offset = 0;
-        // Skip whitespace
-        let trimmed = rest.trim_start();
-        offset += rest.len() - trimmed.len();
-        rest = trimmed;
-        // Skip {type} if present
-        if rest.starts_with('{') {
-            let mut depth = 0usize;
-            for (i, ch) in rest.char_indices() {
-                match ch {
-                    '{' => depth += 1,
-                    '}' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            offset += i + 1;
-                            rest = &rest[i + 1..];
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            // Skip whitespace after type
-            let trimmed = rest.trim_start();
-            offset += rest.len() - trimmed.len();
-            rest = trimmed;
-        }
-        // Strip optional [ for optional params like [name] or [name=default]
-        if rest.starts_with('[') {
-            offset += 1;
-            rest = &rest[1..];
-        }
-        if name.is_empty() {
-            if let Some(after_star) = rest.strip_prefix('*') {
-                let ws_after_star = after_star.len() - after_star.trim_start().len();
-                if after_star.trim_start().starts_with('*') {
-                    return Some(offset + 1 + ws_after_star);
-                }
-            }
-            return (!rest.is_empty()).then_some(offset);
-        }
-        // Check if the next word is the name
-        if let Some(after_name) = rest.strip_prefix(name) {
-            // Verify it's a complete word (followed by non-alphanumeric or end)
-            if after_name.is_empty() || !after_name.chars().next().unwrap_or('\0').is_alphanumeric()
-            {
-                return Some(offset);
-            }
-        }
-        None
     }
 }
 

--- a/crates/tsz-checker/src/jsdoc/params_comment_retrieval.rs
+++ b/crates/tsz-checker/src/jsdoc/params_comment_retrieval.rs
@@ -584,4 +584,63 @@ impl<'a> CheckerState<'a> {
         self.try_jsdoc_with_ancestor_walk(idx, comments, source_text)
             .is_some_and(|content| Self::jsdoc_contains_tag(&content, "override"))
     }
+
+    /// Find the byte offset of a parameter name after `@param` in source text.
+    ///
+    /// Given the text after `@param`, skips optional `{type}` and whitespace,
+    /// then checks if the next word matches `name`. Returns the byte offset
+    /// of the name relative to the start of the input.
+    pub(super) fn find_param_name_in_source(after_param: &str, name: &str) -> Option<usize> {
+        let mut rest = after_param;
+        let mut offset = 0;
+        // Skip whitespace
+        let trimmed = rest.trim_start();
+        offset += rest.len() - trimmed.len();
+        rest = trimmed;
+        // Skip {type} if present
+        if rest.starts_with('{') {
+            let mut depth = 0usize;
+            for (i, ch) in rest.char_indices() {
+                match ch {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            offset += i + 1;
+                            rest = &rest[i + 1..];
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            // Skip whitespace after type
+            let trimmed = rest.trim_start();
+            offset += rest.len() - trimmed.len();
+            rest = trimmed;
+        }
+        // Strip optional [ for optional params like [name] or [name=default]
+        if rest.starts_with('[') {
+            offset += 1;
+            rest = &rest[1..];
+        }
+        if name.is_empty() {
+            if let Some(after_star) = rest.strip_prefix('*') {
+                let ws_after_star = after_star.len() - after_star.trim_start().len();
+                if after_star.trim_start().starts_with('*') {
+                    return Some(offset + 1 + ws_after_star);
+                }
+            }
+            return (!rest.is_empty()).then_some(offset);
+        }
+        // Check if the next word is the name
+        if let Some(after_name) = rest.strip_prefix(name) {
+            // Verify it's a complete word (followed by non-alphanumeric or end)
+            if after_name.is_empty() || !after_name.chars().next().unwrap_or('\0').is_alphanumeric()
+            {
+                return Some(offset);
+            }
+        }
+        None
+    }
 }

--- a/crates/tsz-checker/src/jsdoc/params_qualified.rs
+++ b/crates/tsz-checker/src/jsdoc/params_qualified.rs
@@ -1,0 +1,219 @@
+//! Qualified (dotted) `@param` tag names and tsc's nested-`@param` model.
+//!
+//! This module owns:
+//! - the nested-`@param` absorption model tsc implements in its parser
+//! - TS8032 `Qualified name '{0}' is not allowed without a leading '@param {object} {1}'`
+//!
+//! See also:
+//! - `params` — TS8024 `@param` name checking and tag syntax validation
+//! - `params_type_strings` — `@param {type}` text extraction and nested types
+
+use super::types::JsdocParamTagInfo;
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+
+impl<'a> CheckerState<'a> {
+    /// TS8032: a qualified `@param` name is only legal when an enclosing
+    /// `@param {object}` tag declares its parent.
+    pub(super) fn check_jsdoc_qualified_param_tags(
+        &mut self,
+        jsdoc: &str,
+        actual_params: &[(String, bool)],
+        func_idx: NodeIndex,
+    ) {
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+
+        // tsc skips the whole unmatched-parameter branch when the body reads
+        // `arguments`; the tags are matched against the implicit arguments
+        // object instead.
+        if self.function_uses_implicit_arguments_object(func_idx) {
+            return;
+        }
+
+        let unattached = Self::jsdoc_unattached_qualified_param_tags(jsdoc);
+        if unattached.is_empty() {
+            return;
+        }
+
+        let source_info = self
+            .get_jsdoc_comment_pos_for_function(func_idx)
+            .and_then(|pos| {
+                let sf = self.ctx.arena.source_files.first()?;
+                Some((pos, sf.text.clone()))
+            });
+
+        for (index, name, source_name) in unattached {
+            let Some((left, _)) = name.rsplit_once('.') else {
+                continue;
+            };
+            // Destructured parameters accept any tag name at their position.
+            if actual_params
+                .get(index)
+                .is_some_and(|(_, is_pattern)| *is_pattern)
+            {
+                continue;
+            }
+            let (name, source_name) = (name.as_str(), source_name.as_str());
+            let message = format_message(
+                diagnostic_messages::QUALIFIED_NAME_IS_NOT_ALLOWED_WITHOUT_A_LEADING_PARAM_OBJECT,
+                &[name, left],
+            );
+            let code =
+                diagnostic_codes::QUALIFIED_NAME_IS_NOT_ALLOWED_WITHOUT_A_LEADING_PARAM_OBJECT;
+            let start = source_info.as_ref().and_then(|(comment_pos, source_text)| {
+                Self::jsdoc_param_name_source_offset(source_text, *comment_pos, source_name)
+            });
+            match start {
+                Some(start) => {
+                    self.ctx
+                        .error(start, source_name.len() as u32, message, code);
+                }
+                None => self.error_at_node(func_idx, &message, code),
+            }
+        }
+    }
+
+    /// Replay tsc's nested-`@param` absorption and return the qualified tags it
+    /// leaves unattached — the TS8032 sites.
+    ///
+    /// tsc models nesting in the parser: `parseNestedTypeLiteral` lets a
+    /// `@param` tag whose type is `object`/`Object`/`object[]` absorb the
+    /// immediately following tags whose qualified name is exactly
+    /// `<parent>.<one segment>`. Absorbed tags become properties of the
+    /// parent's synthesized type literal and never reach the
+    /// unmatched-parameter check, so only tags that survive absorption are
+    /// reportable. tsz has no `JSDoc` AST, so the absorption is replayed as an
+    /// ordered scan over a stack of open object-typed parents, popped until one
+    /// of them is the direct parent of the current tag.
+    ///
+    /// Each entry is `(tag index, entity name, name as written in source)`. The
+    /// entity name has `[]` segments stripped, matching tsc's
+    /// `parseJSDocEntityName`, which accepts `y[]` but discards the brackets —
+    /// so `opts[].x` is the qualified name `opts.x` and nests under
+    /// `@param {Object[]} opts`. The source spelling is kept for anchoring.
+    pub(crate) fn jsdoc_unattached_qualified_param_tags(
+        jsdoc: &str,
+    ) -> Vec<(usize, String, String)> {
+        let tags = Self::extract_jsdoc_param_tag_entries(jsdoc);
+        let names: Vec<String> = tags
+            .iter()
+            .map(|(tag, _)| tag.name.replace("[]", ""))
+            .collect();
+
+        let mut open_parents: Vec<&str> = Vec::new();
+        let mut unattached = Vec::new();
+        for (index, (tag, _)) in tags.iter().enumerate() {
+            let name = names[index].as_str();
+            let parent = name.rsplit_once('.').map(|(left, _)| left);
+            while let Some(open) = open_parents.last() {
+                if parent == Some(*open) {
+                    break;
+                }
+                open_parents.pop();
+            }
+            // Plain identifiers are TS8024's business, not TS8032's.
+            if open_parents.is_empty() && parent.is_some() {
+                unattached.push((index, name.to_string(), tag.name.clone()));
+            }
+            if tag
+                .type_expr
+                .as_deref()
+                .is_some_and(Self::jsdoc_type_is_object_or_object_array)
+            {
+                open_parents.push(name);
+            }
+        }
+        unattached
+    }
+
+    /// Extract every `@param` tag from a `JSDoc` comment, keeping qualified
+    /// (dotted) names.
+    ///
+    /// `extract_jsdoc_param_names` drops dotted names because its callers only
+    /// care about tags that can name a real parameter. The nesting model needs
+    /// the dotted tags too, in source order, together with the tag type
+    /// expression, so this returns the parsed tag plus the byte offset of the
+    /// `@param` tag within `jsdoc`.
+    fn extract_jsdoc_param_tag_entries(jsdoc: &str) -> Vec<(JsdocParamTagInfo, usize)> {
+        let mut result = Vec::new();
+        let mut in_param = false;
+        let mut param_text = String::new();
+        let mut param_offset = 0usize;
+
+        let flush = |text: &str, offset: usize, out: &mut Vec<(JsdocParamTagInfo, usize)>| {
+            if let Some(tag) = Self::parse_jsdoc_param_tag(text) {
+                out.push((tag, offset));
+            }
+        };
+
+        for line in jsdoc.lines() {
+            let trimmed = line.trim();
+            let effective = Self::skip_backtick_quoted(trimmed);
+
+            if effective.starts_with('@') {
+                if in_param {
+                    flush(&param_text, param_offset, &mut result);
+                    param_text.clear();
+                }
+                if let Some((param_tag, rest)) = Self::strip_jsdoc_param_tag_prefix(effective) {
+                    in_param = true;
+                    if let Some(line_start) = jsdoc.find(line)
+                        && let Some(effective_pos) = line.find(effective)
+                        && let Some(tag_pos) = Self::jsdoc_tag_offset(effective, param_tag)
+                    {
+                        param_offset = line_start + effective_pos + tag_pos;
+                    }
+                    param_text = rest.to_string();
+                } else {
+                    in_param = false;
+                }
+            } else if in_param {
+                param_text.push(' ');
+                param_text.push_str(trimmed);
+            }
+        }
+        if in_param {
+            flush(&param_text, param_offset, &mut result);
+        }
+        result
+    }
+
+    /// Mirror of tsc's `isObjectOrObjectArrayTypeReference`: the only tag types
+    /// that can carry nested `@param` children.
+    ///
+    /// `object`, `Object` without type arguments, and any array of those.
+    fn jsdoc_type_is_object_or_object_array(type_expr: &str) -> bool {
+        let trimmed = type_expr.trim();
+        if let Some(element) = trimmed.strip_suffix("[]") {
+            return Self::jsdoc_type_is_object_or_object_array(element);
+        }
+        matches!(trimmed, "object" | "Object")
+    }
+
+    /// Byte offset of a `@param` tag's name within the source text, searching
+    /// from the start of the `JSDoc` comment at `comment_pos`.
+    fn jsdoc_param_name_source_offset(
+        source_text: &str,
+        comment_pos: u32,
+        name: &str,
+    ) -> Option<u32> {
+        let comment_start = comment_pos as usize;
+        let region = source_text.get(comment_start..)?;
+        let mut search_from = 0usize;
+        while let Some((at_param, param_tag)) =
+            Self::jsdoc_param_tag_offset(region.get(search_from..)?)
+        {
+            let after_param = search_from + at_param + Self::jsdoc_tag_source_len(param_tag);
+            if let Some(offset) = Self::find_param_name_in_source(region.get(after_param..)?, name)
+            {
+                return u32::try_from(comment_start + after_param + offset).ok();
+            }
+            search_from = after_param;
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/params_qualified_tests.rs"]
+mod tests;

--- a/crates/tsz-checker/src/jsdoc/tests/params_qualified_tests.rs
+++ b/crates/tsz-checker/src/jsdoc/tests/params_qualified_tests.rs
@@ -1,0 +1,170 @@
+use super::*;
+
+fn qualified_param_names(jsdoc: &str) -> Vec<String> {
+    CheckerState::jsdoc_unattached_qualified_param_tags(jsdoc)
+        .into_iter()
+        .map(|(_, name, _)| name)
+        .collect()
+}
+
+#[test]
+fn qualified_param_without_any_parent_tag_is_unattached() {
+    assert_eq!(
+        qualified_param_names(" * @param {number} xyz.p"),
+        vec!["xyz.p".to_string()]
+    );
+    // Two levels deep with no parent at all still reports the whole path.
+    assert_eq!(
+        qualified_param_names(" * @param {number} xyz.bar.p"),
+        vec!["xyz.bar.p".to_string()]
+    );
+}
+
+#[test]
+fn object_typed_parent_absorbs_direct_child_only() {
+    // Direct child: absorbed, so only the parent tag is unattached.
+    assert_eq!(
+        qualified_param_names(" * @param {object} xyz.bar\n * @param {number} xyz.bar.p"),
+        vec!["xyz.bar".to_string()]
+    );
+    // A grandchild skips a level, so it is not a direct child and stays
+    // unattached even though its root is object-typed.
+    assert_eq!(
+        qualified_param_names(" * @param {object} xyz\n * @param {number} xyz.bar.p"),
+        vec!["xyz.bar.p".to_string()]
+    );
+}
+
+#[test]
+fn absorption_is_name_independent() {
+    // Same shape under renamed binders — the rule is structural, not textual.
+    for (root, child) in [("xyz", "bar"), ("options", "nested"), ("_a1", "b2")] {
+        let jsdoc = format!(" * @param {{object}} {root}\n * @param {{string}} {root}.{child}");
+        assert!(
+            qualified_param_names(&jsdoc).is_empty(),
+            "{root}.{child} should be absorbed"
+        );
+        let skipped =
+            format!(" * @param {{object}} {root}\n * @param {{string}} {root}.{child}.deep");
+        assert_eq!(
+            qualified_param_names(&skipped),
+            vec![format!("{root}.{child}.deep")]
+        );
+    }
+}
+
+#[test]
+fn only_object_typed_parents_absorb() {
+    // `object`, `Object`, and arrays of either can carry children.
+    for parent_type in ["object", "Object", "object[]", "Object[]"] {
+        let jsdoc = format!(" * @param {{{parent_type}}} o\n * @param {{string}} o.x");
+        assert!(
+            qualified_param_names(&jsdoc).is_empty(),
+            "{parent_type} should absorb o.x"
+        );
+    }
+    // Any other parent type does not, so the child is reported.
+    for parent_type in ["string", "number", "Foo", "Object<string, number>"] {
+        let jsdoc = format!(" * @param {{{parent_type}}} o\n * @param {{string}} o.x");
+        assert_eq!(
+            qualified_param_names(&jsdoc),
+            vec!["o.x".to_string()],
+            "{parent_type} must not absorb o.x"
+        );
+    }
+}
+
+#[test]
+fn bracketed_array_element_paths_nest_like_plain_paths() {
+    // tsc's `parseJSDocEntityName` accepts `y[]` but discards the brackets.
+    assert!(
+        qualified_param_names(
+            " * @param {Object[]} opts2\n * @param {string} opts2[].anotherX\n\
+             * @param {string=} opts2[].anotherY"
+        )
+        .is_empty()
+    );
+    // Deep chain of array element paths, each level object-typed.
+    assert!(
+        qualified_param_names(
+            " * @param {object[]} o\n * @param {object} o[].what\n\
+             * @param {object[]} o[].what.bad\n * @param {string} o[].what.bad[].idea"
+        )
+        .is_empty()
+    );
+    // Optional and defaulted spellings still nest.
+    assert!(
+        qualified_param_names(
+            " * @param {Object} o\n * @param {string} [o.z]\n * @param {string} [o.w=\"hi\"]"
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn plain_identifier_tags_are_never_ts8032() {
+    // Unmatched plain names are TS8024's business.
+    assert!(qualified_param_names(" * @param {Object} a\n * @param {string} unrelated").is_empty());
+    assert!(qualified_param_names(" * @param {string} b").is_empty());
+}
+
+#[test]
+fn ts8032_reports_qualified_param_in_js_file() {
+    let diags = crate::test_utils::check_js_source_diagnostics(
+        "/**\n * @param {number} xyz.p\n */\nfunction g(xyz) { return xyz.p; }\n",
+    );
+    let ts8032: Vec<_> = diags.iter().filter(|d| d.code == 8032).collect();
+    assert_eq!(ts8032.len(), 1, "got: {diags:?}");
+    assert_eq!(
+        ts8032[0].message_text,
+        "Qualified name 'xyz.p' is not allowed without a leading '@param {object} xyz'."
+    );
+}
+
+#[test]
+fn ts8032_names_the_direct_parent_it_would_have_needed() {
+    let diags = crate::test_utils::check_js_source_diagnostics(
+        "/**\n * @param {object} xyz\n * @param {number} xyz.bar.p\n */\n\
+         function g(xyz) { return xyz.bar.p; }\n",
+    );
+    let ts8032: Vec<_> = diags.iter().filter(|d| d.code == 8032).collect();
+    assert_eq!(ts8032.len(), 1, "got: {diags:?}");
+    assert_eq!(
+        ts8032[0].message_text,
+        "Qualified name 'xyz.bar.p' is not allowed without a leading '@param {object} xyz.bar'."
+    );
+}
+
+#[test]
+fn ts8032_is_not_reported_in_typescript_files() {
+    let diags = crate::test_utils::check_source_diagnostics(
+        "/**\n * @param {number} xyz.p\n */\nfunction g(xyz: any) { return xyz.p; }\n",
+    );
+    assert!(
+        diags.iter().all(|d| d.code != 8032),
+        "TS8032 is JS-only; got: {diags:?}"
+    );
+}
+
+#[test]
+fn ts8032_is_suppressed_when_the_body_reads_arguments() {
+    let diags = crate::test_utils::check_js_source_diagnostics(
+        "/**\n * @param {number} xyz.p\n */\nfunction g() { return arguments.length; }\n",
+    );
+    assert!(
+        diags.iter().all(|d| d.code != 8032),
+        "tsc skips the unmatched-parameter branch when `arguments` is read; got: {diags:?}"
+    );
+}
+
+#[test]
+fn ts8032_absorbed_nested_params_report_nothing() {
+    let diags = crate::test_utils::check_js_source_diagnostics(
+        "/**\n * @param {object} opts\n * @param {string} opts.x\n */\n\
+         function g(opts) { return opts.x; }\n",
+    );
+    assert!(
+        diags.iter().all(|d| d.code != 8032),
+        "properly nested params must not report; got: {diags:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

## Problem

A JSDoc `@param` tag whose name is qualified (`xyz.p`) is only legal when an
enclosing `@param {object}` tag declares its direct parent. tsz dropped every
dotted `@param` name during tag extraction
(`extract_param_name_from_tag` returns `None` for names containing `.`), so
**TS8032 was never reported** — even though its message was already present in
the diagnostics table.

## Structural rule

When a JSDoc `@param` tag in a **JS file** has a qualified name whose direct
parent is not declared by an enclosing object-typed `@param` tag, tsc reports
TS8032 anchored at the name; tsz now does the same through the checker's
`jsdoc` module.

tsc models the nesting in its **parser**, not its checker:
`parseNestedTypeLiteral` (`src/compiler/parser.ts`) lets a `@param` tag whose
type is `object` / `Object` / `object[]` absorb the immediately following tags
whose qualified name is exactly `<parent>.<one segment>` — the
`escapedTextsEqual(name, child.name.left)` test in
`parseChildParameterOrPropertyTag`. Absorbed tags become properties of the
parent's synthesized type literal and never reach
`checkUnmatchedJSDocParameters`, so only the tags that *survive* absorption are
reportable. A surviving qualified name is TS8032, naming the parent it would
have needed.

That single mechanism explains all four corpus cases, including why
`@param {object} xyz` followed by `@param {number} xyz.bar.p` still errors (two
segments deeper, so not a direct child) while `@param {object} xyz.bar` followed
by `@param {number} xyz.bar.p` does not.

## Owner layer

tsz has no parse-time JSDoc AST — JSDoc types are extracted as strings at check
time — so the absorption is replayed as an ordered scan over a stack of open
object-typed parents, popped until one of them is the direct parent of the
current tag. This is JSDoc *tag structure*, not type semantics, so it stays in
the checker's `jsdoc` module and needs no solver involvement.

`[]` name segments are stripped before matching, mirroring tsc's
`parseJSDocEntityName`, which accepts `y[]` as a segment but discards the
brackets — so `opts[].x` is the qualified name `opts.x` and nests under
`@param {Object[]} opts`. Missing that rule was a real bug caught in
verification: it regressed `jsdocParamTagTypeLiteral` with 11 spurious TS8032s
before the fix.

New logic lives in `jsdoc/params_qualified.rs` rather than growing
`jsdoc/params.rs` past its size ratchet; the shared `find_param_name_in_source`
anchor helper moves to `jsdoc/params_comment_retrieval.rs`, whose stated concern
it is.

## Adjacent-case matrix

Covered by 11 new unit tests in `jsdoc/tests/params_qualified_tests.rs`:

| Case | Expectation |
| --- | --- |
| No parent tag at all (`xyz.p`, `xyz.bar.p`) | reported |
| Direct child under object-typed parent | absorbed, not reported |
| Grandchild skipping a level | reported, naming the direct parent |
| **Renamed binders** (`xyz`/`options`/`_a1` × `bar`/`nested`/`b2`) | identical structural outcome |
| Parent typed `object` / `Object` / `object[]` / `Object[]` | absorbs |
| Parent typed `string` / `number` / `Foo` / `Object<string, number>` | does **not** absorb |
| Array element paths `opts[].x`, deep `o[].what.bad[].idea` | absorbed |
| Optional / defaulted spellings `[o.z]`, `[o.w="hi"]` | absorbed |
| Plain identifier tags | never TS8032 (stays TS8024's job) |
| **TS file** | must not fire |
| Function body reads `arguments` | must not fire |

## Verification

All run locally on this branch; ground truth is the tsc 7.0.2 oracle in
`scripts/conformance/tsc-cache-full.json` (not the stale 6.0 `.errors.txt`
baselines).

```
./scripts/conformance/conformance.sh run --workers 12
  before: 11308/12043      after: 11312/12043     (+4, zero regressions)

./scripts/conformance/conformance.sh run --filter conformance/jsdoc --workers 8
  before: 237/332 (71.4%)  after: 241/332 (72.6%)

./scripts/conformance/conformance.sh run --filter conformance/salsa --workers 8
  before: 114/186          after: 114/186          (unchanged)

./scripts/emit/run.sh --skip-build
  JS  11562/11563  (unchanged)
  DTS 1372/1390    (unchanged)

cargo nextest run -p tsz-checker --lib -E 'test(/params_qualified/) or test(/ts8032/)'
  11 passed

./scripts/arch/check-checker-boundaries.sh   passed
cargo clippy -p tsz-checker --lib            clean
```

Failing-set diff computed per test from `--write-diff-artifacts`, comparing
`expected_fingerprints` against `actual_fingerprints`:

```
FIXED: 4
  + paramTagNestedWithoutTopLevelObject.ts
  + paramTagNestedWithoutTopLevelObject2.ts
  + paramTagNestedWithoutTopLevelObject3.ts
  + paramTagNestedWithoutTopLevelObject4.ts
REGRESSED: 0
```

Note for anyone using the runner's diff artifacts: the `missing_fingerprints` /
`extra_fingerprints` fields come out empty for tests whose code sets differ.
Derive the delta from `expected_fingerprints` vs `actual_fingerprints` instead.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: xhigh
