### PR TITLE
fix(config): match tsc 7.0 TS5052 option-dependency rule

### DIFF
--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -487,6 +487,34 @@ fn option_key_present_or_invalidated(
     compiler_opts.contains_key(key) || invalidated_options.iter().any(|k| k == key)
 }
 
+/// tsc's `getStrictOptionValue`: a strict-family member's effective value is
+/// its own explicit value when it has one, and the `strict` umbrella's value
+/// otherwise. An invalidated (TS5024) member is treated like an absent one, so
+/// it still inherits `strict` — matching tsc, where a rejected option value
+/// simply leaves the field `undefined`.
+///
+/// `strict` itself defaults to **true** in TypeScript 7 (it was false in 6.x),
+/// which is what makes a lone `strictPropertyInitialization: true` legal:
+/// `strictNullChecks` is absent, so it inherits an enabled `strict`, and the
+/// TS5052 dependency is satisfied. `CheckerOptions`'s own defaults carry the
+/// same `strict: true`.
+///
+/// This differs from [`option_is_effectively_enabled`], which reports the raw
+/// per-key value and never consults `strict`. Option-consistency checks need
+/// both: tsc tests the raw value of the *dependent* option and the strict-aware
+/// value of the option it *depends on*.
+fn strict_option_value(
+    compiler_opts: &serde_json::Map<String, serde_json::Value>,
+    invalidated_options: &[String],
+    key: &str,
+) -> bool {
+    let explicit = |k: &str| {
+        (compiler_opts.contains_key(k) && !invalidated_options.iter().any(|i| i == k))
+            .then(|| option_is_truthy(compiler_opts.get(k)))
+    };
+    explicit(key).or_else(|| explicit("strict")).unwrap_or(true)
+}
+
 /// Check if a string is a valid TypeScript identifier or qualified name.
 /// A qualified name is one or more identifiers separated by dots: `A.B.C`.
 /// Used to validate `jsxFactory` option values (TS5067).
@@ -514,14 +542,70 @@ fn is_valid_identifier(s: &str) -> bool {
 /// Find the byte offset of a JSON key within the source text.
 /// Searches for `"key"` after `compilerOptions`.
 fn find_key_offset_in_source(source: &str, key: &str) -> u32 {
+    find_key_offset_in_source_opt(source, key).unwrap_or(0)
+}
+
+/// Like [`find_key_offset_in_source`], but distinguishes "key absent" from
+/// "key at offset 0" so callers can choose between several candidate keys.
+fn find_key_offset_in_source_opt(source: &str, key: &str) -> Option<u32> {
     let search = format!("\"{key}\"");
     // Look for the key after "compilerOptions" to avoid matching in other sections
     let compiler_opts_pos = source.find("compilerOptions").unwrap_or(0);
-    if let Some(pos) = source[compiler_opts_pos..].find(&search) {
+    source[compiler_opts_pos..]
+        .find(&search)
         // Point at the opening quote of the key, matching tsc behavior
-        (compiler_opts_pos + pos) as u32
-    } else {
-        0
+        .map(|pos| (compiler_opts_pos + pos) as u32)
+}
+
+/// Report a TS5052 "Option '{0}' cannot be specified without specifying option
+/// '{1}'" pair.
+///
+/// tsc walks the `compilerOptions` object literal looking for either name and
+/// anchors on the **first one it encounters in source order**, emitting a
+/// single diagnostic — so a config listing `allowJs` above `checkJs` anchors at
+/// `allowJs` even though the rule is "about" `checkJs`. The message always
+/// names the pair in dependency order regardless of which key is pointed at.
+/// If neither key is written out (both are implied), tsc falls back to the
+/// enclosing `compilerOptions` key.
+fn push_option_dependency_diagnostic(
+    diagnostics: &mut Vec<Diagnostic>,
+    file_path: &str,
+    stripped: &str,
+    dependent: &str,
+    required: &str,
+) {
+    let message = format_message(
+        diagnostic_messages::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION,
+        &[dependent, required],
+    );
+    let code = diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION;
+
+    let anchor = [dependent, required]
+        .into_iter()
+        .filter_map(|key| find_key_offset_in_source_opt(stripped, key).map(|off| (off, key)))
+        .min_by_key(|(off, _)| *off);
+
+    match anchor {
+        Some((start, key)) => {
+            diagnostics.push(Diagnostic::error(
+                file_path,
+                start,
+                key.len() as u32 + 2, // include surrounding quotes
+                message,
+                code,
+            ));
+        }
+        None => {
+            let search = "\"compilerOptions\"";
+            let start = stripped.find(search).map(|p| p as u32).unwrap_or(0);
+            diagnostics.push(Diagnostic::error(
+                file_path,
+                start,
+                search.len() as u32,
+                message,
+                code,
+            ));
+        }
     }
 }
 

--- a/crates/tsz-core/src/config/parse.rs
+++ b/crates/tsz-core/src/config/parse.rs
@@ -821,54 +821,54 @@ pub fn parse_tsconfig_with_diagnostics_deferred(
         }
 
         // TS5052: Option '{0}' cannot be specified without specifying option '{1}'.
-        // `checkJs` implies `allowJs` unless `allowJs` is explicitly disabled.
+        //
+        // `strictPropertyInitialization` and `exactOptionalPropertyTypes` each
+        // require `strictNullChecks`. tsc (`verifyCompilerOptions`) tests the
+        // *raw* value of the dependent option but the *strict-aware* effective
+        // value of `strictNullChecks`, so a bare `strict: true` is fine while
+        // `strict: true` with an explicit `strictNullChecks: false` is an error.
+        for (dependent, required) in [
+            ("strictPropertyInitialization", "strictNullChecks"),
+            ("exactOptionalPropertyTypes", "strictNullChecks"),
+        ] {
+            if option_is_effectively_enabled(compiler_opts, &ts5024_keys, dependent)
+                && !strict_option_value(compiler_opts, &ts5024_keys, required)
+            {
+                push_option_dependency_diagnostic(
+                    &mut diagnostics,
+                    file_path,
+                    &stripped,
+                    dependent,
+                    required,
+                );
+            }
+        }
+
+        // TS5052: `checkJs` implies `allowJs` unless `allowJs` is explicitly
+        // disabled.
         if option_is_truthy(compiler_opts.get("checkJs"))
             && !option_is_effectively_enabled(compiler_opts, &ts5024_keys, "allowJs")
             && option_key_present_or_invalidated(compiler_opts, &ts5024_keys, "allowJs")
         {
-            let msg = format_message(
-                diagnostic_messages::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION,
-                &["checkJs", "allowJs"],
-            );
-
-            // Always emit at the checkJs key.
-            push_key_diagnostic(
+            push_option_dependency_diagnostic(
                 &mut diagnostics,
                 file_path,
                 &stripped,
                 "checkJs",
-                msg.clone(),
-                diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION,
+                "allowJs",
             );
-
-            // If allowJs is explicitly present, emit at allowJs too (tsc parity).
-            if compiler_opts.contains_key("allowJs") {
-                push_key_diagnostic(
-                    &mut diagnostics,
-                    file_path,
-                    &stripped,
-                    "allowJs",
-                    msg,
-                    diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION,
-                );
-            }
         }
 
         // TS5052: emitDecoratorMetadata requires experimentalDecorators.
         if option_is_truthy(compiler_opts.get("emitDecoratorMetadata"))
             && !option_is_effectively_enabled(compiler_opts, &ts5024_keys, "experimentalDecorators")
         {
-            let msg = format_message(
-                diagnostic_messages::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION,
-                &["emitDecoratorMetadata", "experimentalDecorators"],
-            );
-            push_key_diagnostic(
+            push_option_dependency_diagnostic(
                 &mut diagnostics,
                 file_path,
                 &stripped,
                 "emitDecoratorMetadata",
-                msg,
-                diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION,
+                "experimentalDecorators",
             );
         }
 

--- a/crates/tsz-core/src/config/tests/module_resolution.rs
+++ b/crates/tsz-core/src/config/tests/module_resolution.rs
@@ -1223,13 +1223,157 @@ fn test_ts5052_not_emitted_when_check_js_implies_allow_js() {
 }
 
 #[test]
-fn test_ts5052_check_js_with_allow_js_false_reports_both_sites() {
+fn test_ts5052_check_js_with_allow_js_false_anchors_at_first_key_in_source_order() {
+    // tsc reports one TS5052 and anchors it at whichever of the two named
+    // options it reaches first while walking the compilerOptions object, so
+    // `allowJs` listed above `checkJs` takes the anchor even though the rule
+    // is stated about `checkJs`. The conformance oracle for
+    // compiler/checkJsFiles6.ts pins exactly this (single diagnostic, anchored
+    // at the `allowJs` line).
     let source = r#"{"compilerOptions":{"allowJs":false,"checkJs":true}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let hits: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5052)
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "Expected exactly one TS5052 diagnostic, got: {:?}",
+        parsed.diagnostics
+    );
+    assert_eq!(
+        hits[0].start as usize,
+        source.find(r#""allowJs""#).unwrap(),
+        "TS5052 should anchor at the earlier key (allowJs), got: {:?}",
+        hits[0]
+    );
+}
+
+#[test]
+fn test_ts5052_check_js_with_invalid_allow_js_reports_once() {
+    // An invalid `allowJs` value is still a property assignment in the object
+    // literal, so it is still eligible to take the anchor — and there is still
+    // only one diagnostic.
+    let source = r#"{"compilerOptions":{"allowJs":"nope","checkJs":true}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let hits: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5052)
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "Expected exactly one TS5052 diagnostic, got: {:?}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
+fn test_ts5052_strict_property_initialization_requires_strict_null_checks() {
+    // `strict: true` fans out to strictPropertyInitialization, so an explicit
+    // `strictNullChecks: false` leaves the dependent option on with its
+    // prerequisite off — tsc's verifyCompilerOptions reports TS5052.
+    let source = r#"{"compilerOptions":{"strict":true,"strictNullChecks":false,"strictPropertyInitialization":true}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let msgs: Vec<&str> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5052)
+        .map(|d| d.message_text.as_str())
+        .collect();
+    assert_eq!(
+        msgs,
+        vec![
+            "Option 'strictPropertyInitialization' cannot be specified without specifying option 'strictNullChecks'."
+        ],
+        "got: {:?}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
+fn test_ts5052_exact_optional_property_types_requires_strict_null_checks() {
+    let source =
+        r#"{"compilerOptions":{"exactOptionalPropertyTypes":true,"strictNullChecks":false}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let msgs: Vec<&str> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5052)
+        .map(|d| d.message_text.as_str())
+        .collect();
+    assert_eq!(
+        msgs,
+        vec![
+            "Option 'exactOptionalPropertyTypes' cannot be specified without specifying option 'strictNullChecks'."
+        ],
+        "got: {:?}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
+fn test_ts5052_strict_family_pair_silent_when_strict_umbrella_is_absent() {
+    // TypeScript 7 defaults `strict` to true, so an absent `strictNullChecks`
+    // inherits an *enabled* prerequisite and a lone strict-family member is
+    // legal. Pins compiler/optionsStrictPropertyInitializationStrictNullChecks.ts,
+    // whose oracle expects no diagnostics at all.
+    for source in [
+        r#"{"compilerOptions":{"strictPropertyInitialization":true,"target":"es2015"}}"#,
+        r#"{"compilerOptions":{"exactOptionalPropertyTypes":true}}"#,
+    ] {
+        let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+        let has_5052 = parsed.diagnostics.iter().any(|d| d.code == 5052);
+        assert!(
+            !has_5052,
+            "strict defaults to true in TS7, so no TS5052 is due for {source}, got: {:?}",
+            parsed.diagnostics
+        );
+    }
+}
+
+#[test]
+fn test_ts5052_strict_family_pair_fires_when_strict_umbrella_is_explicitly_off() {
+    // The converse: an explicit `strict: false` really does leave
+    // strictNullChecks off, so the dependency is unmet.
+    let source = r#"{"compilerOptions":{"strict":false,"strictPropertyInitialization":true}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let count = parsed.diagnostics.iter().filter(|d| d.code == 5052).count();
     assert_eq!(
-        count, 2,
-        "Expected two TS5052 diagnostics (allowJs/checkJs), got: {:?}",
+        count, 1,
+        "explicit strict: false leaves strictNullChecks off, got: {:?}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
+fn test_ts5052_strict_family_pair_silent_when_prerequisite_inherited_from_strict() {
+    // strictNullChecks is absent, so it inherits `strict: true` and the
+    // prerequisite is satisfied. Nothing to report.
+    let source = r#"{"compilerOptions":{"strict":true,"strictPropertyInitialization":true,"exactOptionalPropertyTypes":true}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let has_5052 = parsed.diagnostics.iter().any(|d| d.code == 5052);
+    assert!(
+        !has_5052,
+        "strictNullChecks inherits strict: true, so no TS5052 is due, got: {:?}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
+fn test_ts5052_strict_family_pair_silent_when_dependent_option_absent() {
+    // A bare `strict: true` never names strictPropertyInitialization, and tsc
+    // tests the raw option there rather than the strict-aware value, so an
+    // umbrella-only config with strictNullChecks off stays quiet.
+    let source = r#"{"compilerOptions":{"strict":true,"strictNullChecks":false}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let has_5052 = parsed.diagnostics.iter().any(|d| d.code == 5052);
+    assert!(
+        !has_5052,
+        "no dependent option is specified, so no TS5052 is due, got: {:?}",
         parsed.diagnostics
     );
 }


### PR DESCRIPTION
## Summary

Three fixes to TS5052 `Option '{0}' cannot be specified without specifying option '{1}'`, all in the tsconfig option-consistency checker. Net **+7 conformance, 0 regressions**.

Two of the three are places where the vendored `TypeScript/` submodule is actively misleading — it is a **6.0 checkout**, and 7.0.2 disagrees with it on both an anchoring behavior and a default value. The oracle (`scripts/conformance/tsc-cache-full.json`, generated at 7.0.2) is the authority used here.

### 1. Two strict-family dependencies were never implemented

`strictPropertyInitialization` and `exactOptionalPropertyTypes` each require `strictNullChecks`. tsz implemented only the `checkJs`/`allowJs` and `emitDecoratorMetadata`/`experimentalDecorators` pairs.

tsc's `verifyCompilerOptions` tests the **raw** value of the dependent option but the **strict-aware** effective value of the prerequisite:

```ts
if (options.strictPropertyInitialization && !getStrictOptionValue(options, "strictNullChecks"))
```

So a bare `strict: true` is silent (the dependent option is `undefined`), while `strict: true` + explicit `strictNullChecks: false` + a specified dependent option is an error. tsz had only the raw reader (`option_is_effectively_enabled`); this adds `strict_option_value` alongside it rather than changing the existing helper's meaning, because the rule genuinely needs both readings.

### 2. `strict` defaults to true in TypeScript 7

An absent `strictNullChecks` therefore inherits an *enabled* prerequisite, which is what makes a lone `strictPropertyInitialization: true` legal (`compiler/optionsStrictPropertyInitializationStrictNullChecks.ts`, oracle: no diagnostics). `CheckerOptions` already carries `strict: true`; the config diagnostic layer did not. The submodule's 6.0 `getStrictOptionValue` defaults it to false.

### 3. One diagnostic, anchored at the first key in source order

tsc 7.0.2 emits exactly **one** TS5052, anchored at whichever of the two named options appears **first** in the `compilerOptions` object literal — which is often the prerequisite rather than the option the message is about. 6.0's `forEachPropertyAssignment(objLit, key1, cb, key2)` visits both and emits two; tsz followed that, and additionally anchored at a fixed key.

All eight TS5052 cases in the oracle are single-anchored this way:

| test | first of the pair in config | oracle anchor |
| --- | --- | --- |
| `compiler/checkJsFiles6.ts` | `allowJs` line 3 | 3:5 — not `checkJs` |
| `compiler/declarationEmitCastReusesTypeNode1.ts` | `strictNullChecks` line 10 | 10:5 — not `strictPropertyInitialization` |
| `compiler/declarationEmitCastReusesTypeNode4.ts` | `strictNullChecks` line 12 | 12:5 |
| `compiler/regexpExecAndMatchTypeUsages.ts` | `exactOptionalPropertyTypes` line 3 | 3:5 |
| `conformance/esDecorators/esDecorators-emitDecoratorMetadata.ts` | `emitDecoratorMetadata` line 3 | 3:5 |

`checkJsFiles6` was failing purely from tsz's extra duplicate, so it flips as part of this.

## Structural rule

When a tsconfig specifies an option whose prerequisite option is effectively disabled, tsc reports exactly one TS5052 anchored at whichever member of the pair is written first in the `compilerOptions` object; tsz now does this through a single `push_option_dependency_diagnostic` helper in the config layer, shared by all three option pairs.

## Owner layer

`tsz-core` config parsing/validation — option consistency is program-level validation, not type checking, so nothing in checker/solver/emitter is touched.

- `config/mod.rs`: new `strict_option_value` (tsc's `getStrictOptionValue`, with the TS7 `true` default) and `push_option_dependency_diagnostic` (single-emit, first-key anchoring, falling back to the enclosing `compilerOptions` key when neither name is written out). `find_key_offset_in_source_opt` distinguishes "key absent" from "key at offset 0" so the anchor can be chosen.
- `config/parse.rs`: adds the two strict-family pairs and routes all three pairs through the shared helper, replacing three ad-hoc emit sites.

## Scope / over-fire safety

Before writing the patch I scanned all 12,585 corpus tests for configs matching the proposed trigger and cross-checked each against the oracle — every structural match expects the diagnostic, no counterexamples. The full-corpus run then caught the one case the static scan could not (the TS7 `strict` default), which is fixed here and pinned by a test.

## Verification

All local, on this branch vs `main` at `5d7264e6`:

- **Full conformance: 11308 -> 11315 passed (728 failed), +7 fixed, 0 regressed, 0 changed-but-still-failing.** Fixed: `checkJsFiles6`, `declarationEmitCastReusesTypeNode1`-`5`, `regexpExecAndMatchTypeUsages`.
- **Full emit suite unchanged**: 11562/11563 JS, 1372/1390 DTS (identical to base).
- **19 `tsz-core` config unit tests pass**, including 6 new ones pinning both directions of each rule: fires on explicit `strict: false`, silent when `strict` is absent (TS7 default), silent when the dependent option is absent, single-emit and first-key anchoring for `checkJs`/`allowJs`, and the invalid-value (TS5024) path.
- `cargo clippy -p tsz-core --lib --all-features`: clean.

Goal: hold

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
