### PR TITLE
fix(checker): render TS8030 with its table message

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -688,6 +688,9 @@ mod ts7053_index_reason_chain_tests;
 #[path = "../tests/ts7057_yield_implicit_any.rs"]
 mod ts7057_yield_implicit_any;
 #[cfg(test)]
+#[path = "tests/ts8030_jsdoc_type_tag_message_tests.rs"]
+mod ts8030_jsdoc_type_tag_message_tests;
+#[cfg(test)]
 #[path = "../tests/tuple_index_access_tests.rs"]
 mod tuple_index_access_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -78,19 +78,19 @@ impl<'a> CheckerState<'a> {
             checker.check_function_declaration(func_idx);
         }
 
-        // TS8030: In JS files, if a function declaration has a @type tag that doesn't
-        // resolve to a callable type, emit "The type of a function declaration must match
-        // the function's signature." TSC points the error at the type expression inside
-        // the @type tag (e.g. at "MyClass" in `@type {MyClass}`).
-        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION && self.is_js_file()
+        // TS8030: in JS files, a function declaration whose `@type` tag does not
+        // resolve to a callable type. tsc points the error at the type
+        // expression inside the tag (e.g. at "MyClass" in `@type {MyClass}`).
+        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
+            && self.is_js_file()
             && let Some(jsdoc) = self.get_jsdoc_for_function(func_idx)
-                && let Some(type_expr) = Self::jsdoc_extract_type_tag_expr(&jsdoc)
-                // Skip types that are syntactically callable (arrow functions, function types,
-                // or generic signatures) — these may not resolve but are valid function types.
-                && !Self::is_syntactically_callable_type(&type_expr)
-                && self
-                    .jsdoc_callable_type_annotation_for_function(func_idx)
-                    .is_none()
+            && let Some(type_expr) = Self::jsdoc_extract_type_tag_expr(&jsdoc)
+            // Skip types that are syntactically callable (arrow functions, function types,
+            // or generic signatures) — these may not resolve but are valid function types.
+            && !Self::is_syntactically_callable_type(&type_expr)
+            && self
+                .jsdoc_callable_type_annotation_for_function(func_idx)
+                .is_none()
         {
             // Find the position of the type expression inside the JSDoc comment
             if let Some(sf) = self.source_file_data_for_node(func_idx) {
@@ -112,11 +112,12 @@ impl<'a> CheckerState<'a> {
                                 .find('}')
                                 .map_or(type_expr.len() as u32, |i| i as u32);
                             self.ctx.error(
-                                    expr_start,
-                                    expr_end,
-                                    "The type of a function declaration must match the function's signature.".to_string(),
-                                    8030,
-                                );
+                                expr_start,
+                                expr_end,
+                                crate::diagnostics::diagnostic_messages::THE_TYPE_OF_A_FUNCTION_DECLARATION_MUST_MATCH_THE_FUNCTIONS_SIGNATURE
+                                    .to_string(),
+                                crate::diagnostics::diagnostic_codes::THE_TYPE_OF_A_FUNCTION_DECLARATION_MUST_MATCH_THE_FUNCTIONS_SIGNATURE,
+                            );
                         }
                     }
                 }

--- a/crates/tsz-checker/src/tests/ts8030_jsdoc_type_tag_message_tests.rs
+++ b/crates/tsz-checker/src/tests/ts8030_jsdoc_type_tag_message_tests.rs
@@ -1,0 +1,82 @@
+//! TS8030 wording for a JS function declaration whose `@type` tag is not callable.
+//!
+//! The message text moved with the compiler version this corpus is pinned to:
+//! it used to read "The type of a function declaration must match the
+//! function's signature." and now reads "A JSDoc '@type' tag on a function must
+//! have a signature with the correct number of arguments." tsz had the current
+//! wording in its diagnostics table but the emission site carried a hardcoded
+//! copy of the old string, so every TS8030 rendered stale.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source, check_source_diagnostics};
+
+const EXPECTED: &str =
+    "A JSDoc '@type' tag on a function must have a signature with the correct number of arguments.";
+
+fn js_diagnostics(source: &str) -> Vec<(u32, String)> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.js", options)
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect()
+}
+
+fn ts8030_messages(source: &str) -> Vec<String> {
+    js_diagnostics(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 8030)
+        .map(|(_, message)| message)
+        .collect()
+}
+
+#[test]
+fn non_callable_type_tag_uses_current_wording() {
+    let messages = ts8030_messages("/** @type {number} */\nfunction f() { return 1; }\n");
+    assert_eq!(messages, vec![EXPECTED.to_string()]);
+}
+
+#[test]
+fn wording_is_binder_name_independent() {
+    // Same structural situation under renamed binders and different
+    // non-callable annotations.
+    for (name, annotation) in [
+        ("f", "number"),
+        ("compute", "string"),
+        ("_handler0", "boolean"),
+    ] {
+        let source =
+            format!("/** @type {{{annotation}}} */\nfunction {name}() {{ return undefined; }}\n");
+        assert_eq!(
+            ts8030_messages(&source),
+            vec![EXPECTED.to_string()],
+            "name={name} annotation={annotation}"
+        );
+    }
+}
+
+#[test]
+fn callable_type_tag_reports_nothing() {
+    // Positive control: a callable annotation must stay silent, so the wording
+    // change cannot be masking a condition change.
+    for annotation in ["(a: number) => number", "() => void"] {
+        let source = format!("/** @type {{{annotation}}} */\nfunction f(a) {{ return a; }}\n");
+        assert!(
+            ts8030_messages(&source).is_empty(),
+            "annotation={annotation} must not report TS8030"
+        );
+    }
+}
+
+#[test]
+fn ts8030_is_not_reported_in_typescript_files() {
+    let diags =
+        check_source_diagnostics("/** @type {number} */\nfunction f(): number { return 1; }\n");
+    assert!(
+        diags.iter().all(|d| d.code != 8030),
+        "TS8030 is JS-only; got: {diags:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

## Problem

The TS8030 emission site in `function_declaration_checks.rs` carried a
**hardcoded copy** of the message string instead of reading the diagnostics
table, so every TS8030 rendered the previous compiler version's wording:

```
tsz: The type of a function declaration must match the function's signature.
tsc: A JSDoc '@type' tag on a function must have a signature with the correct number of arguments.
```

The table already held the current text (`part_002.rs:465`, code 8030) — only
the emission site was stale.

## Structural rule

When a diagnostic is emitted, its text comes from the diagnostics table; the
table is the single source of truth for wording. This site is now the same
shape as every other emission site.

The mismatch was unconditional: **all 10** TS8030 diagnostics across the entire
tsc oracle use the current wording, so no call site wanted the old string.
`typeTagCircularReferenceOnConstructorFunction` was already reporting TS8030 at
the correct position (`bug27346.js:2:11`) and failed purely on the text.

## Scope note — what this deliberately does not change

The **firing condition** is untouched. tsc's `checkFunctionOrMethodDeclaration`
asks `getContextualCallSignature`, which drops the signatures that are
arity-smaller than the declaration and reports when none survive — so tsc also
reports TS8030 for e.g. `/** @type {(a: number) => number} */ function add1(a, b)`.
tsz reports only the "not callable at all" case.

I implemented and measured that arity condition, then backed it out: for these
JSDoc annotations `call_signatures_for_type` yields no readable signatures (the
type is callable through a function/callable shape instead), so the check could
not fire on any corpus test, and a version that guessed instead produced three
false positives (`assertionsAndNonReturningFunctions`, `callbackTagNamespace`,
`returnTagTypeGuard`). Every corpus test that needs the arity case
(`checkJsdocTypeTag5`/`6`, `checkJsdocTypeTagOnObjectProperty1`/`2`) is *also*
blocked on the JSDoc `function(...)` syntax family and on JSDoc function-type
parameters being marked optional (`(x?: number)` where tsc has `(x: number)`),
so none would flip. It belongs with that work, not here.

## Adjacent-case matrix

4 new tests in `tests/ts8030_jsdoc_type_tag_message_tests.rs`:

| Case | Expectation |
| --- | --- |
| Non-callable `@type {number}` on a JS function declaration | current wording |
| **Renamed binders** `f`/`compute`/`_handler0` × `number`/`string`/`boolean` | identical, name-independent |
| Callable `@type {(a: number) => number}`, `@type {() => void}` | silent — positive control that the condition did not shift |
| TS file | must not fire |

## Verification

All run locally; ground truth is the tsc 7.0.2 oracle in
`scripts/conformance/tsc-cache-full.json`.

```
./scripts/conformance/conformance.sh run --workers 12
  before: 11312/12043      after: 11313/12043     (+1, zero regressions)

./scripts/conformance/conformance.sh run --filter conformance/jsdoc --workers 8
  before: 241/332          after: 242/332 (72.9%)

./scripts/emit/run.sh
  JS  11562/11563  (unchanged)
  DTS 1372/1390    (unchanged)

cargo nextest run -p tsz-checker --lib -E 'test(/ts8030_jsdoc_type_tag_message/)'
  4 passed

./scripts/arch/check-checker-boundaries.sh   passed
cargo clippy -p tsz-checker --lib            clean
```

Failing-set diff, derived per test from `expected_fingerprints` vs
`actual_fingerprints`:

```
FIXED: 1
  + typeTagCircularReferenceOnConstructorFunction.ts
REGRESSED: 0
```

Baseline here is the tip of #15906; the two changes are independent and touch
disjoint files.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: xhigh
