### PR TITLE
fix(checker): emit TS2350 for non-void `new` calls

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -1611,8 +1611,21 @@ impl<'a> CheckerState<'a> {
         );
     }
 
-    /// TS2350 was removed in tsc 6.0 — no longer emitted.
-    pub const fn error_non_void_function_called_with_new_at(&mut self, _idx: NodeIndex) {}
+    /// Report TS2350: "Only a void function can be called with the 'new' keyword."
+    ///
+    /// `new f()` where `f`'s apparent type has call signatures but no construct
+    /// signatures resolves as a plain call returning `any`. tsc
+    /// (`resolveNewExpression`) reports this only when the resolved signature's
+    /// return type is not `void` **and `noImplicitAny` is off** — with
+    /// `noImplicitAny` on, the implicit-`any` result is reported as TS7009
+    /// instead, so the two are mutually exclusive and callers gate on that.
+    pub fn error_non_void_function_called_with_new_at(&mut self, idx: NodeIndex) {
+        self.error_at_node(
+            idx,
+            diagnostic_messages::ONLY_A_VOID_FUNCTION_CAN_BE_CALLED_WITH_THE_NEW_KEYWORD,
+            diagnostic_codes::ONLY_A_VOID_FUNCTION_CAN_BE_CALLED_WITH_THE_NEW_KEYWORD,
+        );
+    }
 
     /// Report TS2721/TS2722/TS2723: "Cannot invoke an object which is possibly 'null'/'undefined'/'null or undefined'."
     /// Emitted when strictNullChecks is on and the callee type includes null/undefined.

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -899,10 +899,15 @@ impl<'a> CheckerState<'a> {
                     is_optional_chain,
                 )
             }
-            CallResult::NonVoidFunctionCalledWithNew | CallResult::VoidFunctionCalledWithNew => {
-                self.error_non_void_function_called_with_new_at(callee_expr);
+            CallResult::NonVoidFunctionCalledWithNew => {
+                // TS2350 only fires when `noImplicitAny` is off; with it on the
+                // implicit-`any` result is reported as TS7009 instead.
+                if !self.ctx.no_implicit_any() {
+                    self.error_non_void_function_called_with_new_at(callee_expr);
+                }
                 TypeId::ANY
             }
+            CallResult::VoidFunctionCalledWithNew => TypeId::ANY,
             CallResult::NotCallable { .. } => {
                 if is_super_call {
                     // Emit TS2346 when the super() call target has no signatures

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1636,13 +1636,17 @@ impl<'a> CheckerState<'a> {
                 // function (the old `isJSConstructor` inference was dropped), so
                 // `new f()` gains no synthesized instance type and is not exempt
                 // from the missing-construct-signature check. Under noImplicitAny
-                // the result is `any` and reported as TS7009.
+                // the result is `any` and reported as TS7009; with it off, a
+                // non-`void` return is TS2350 instead. tsc's resolveNewExpression
+                // gates both on `noImplicitAny`, so they never co-occur.
                 if self.ctx.no_implicit_any() {
                     self.error_at_node(
                         idx,
                         crate::diagnostics::diagnostic_messages::NEW_EXPRESSION_WHOSE_TARGET_LACKS_A_CONSTRUCT_SIGNATURE_IMPLICITLY_HAS_AN_ANY_TY,
                         crate::diagnostics::diagnostic_codes::NEW_EXPRESSION_WHOSE_TARGET_LACKS_A_CONSTRUCT_SIGNATURE_IMPLICITLY_HAS_AN_ANY_TY,
                     );
+                } else if matches!(result, CallResult::NonVoidFunctionCalledWithNew) {
+                    self.error_non_void_function_called_with_new_at(idx);
                 }
                 TypeId::ANY
             }


### PR DESCRIPTION
## Summary

`new f()` where `f`'s apparent type has call signatures but no construct signatures resolves as a plain call returning `any`. tsc reports **TS2350** "Only a void function can be called with the 'new' keyword" when the resolved signature's return type is not `void` — but **only when `noImplicitAny` is off**, because with it on the implicit-`any` result is reported as TS7009 instead. The two are mutually exclusive halves of one branch in `resolveNewExpression`:

```ts
if (!noImplicitAny) {
    if (signature.declaration && !isJSConstructor(signature.declaration)
        && getReturnTypeOfSignature(signature) !== voidType) {
        error(node, Diagnostics.Only_a_void_function_can_be_called_with_the_new_keyword);
    }
    ...
}
```

tsz implemented only the TS7009 half, so in non-strict code `new r()` on `r: () => string` was silent.

The semantics were already correct in the solver — `resolve_callable_new` / the `TypeData::Function` path in `operations/constructors.rs` distinguish `CallResult::NonVoidFunctionCalledWithNew` from `VoidFunctionCalledWithNew`. The information was discarded at the reporting boundary:

```rust
/// TS2350 was removed in tsc 6.0 — no longer emitted.
pub const fn error_non_void_function_called_with_new_at(&mut self, _idx: NodeIndex) {}
```

That claim does not hold for the pinned 7.0.2 oracle, which expects TS2350 in five corpus tests (`compiler/bigintWithLib.ts`, `conformance/es6/Symbols/symbolType14.ts`, `conformance/jsdoc/declarations/jsDeclarationsFunctionLikeClasses2.ts`, `conformance/salsa/constructorFunctions.ts` — 8 occurrences — and `conformance/types/specifyingTypes/typeLiterals/arrayTypeOfFunctionTypes.ts`).

Both call sites additionally merged the two variants into a single match arm, so simply un-stubbing the reporter would have fired on legal `void`-returning constructor calls. This splits them.

## Structural rule

When `new f()` targets a type with call signatures but no construct signatures and the resolved call signature returns something other than `void`, tsc reports TS2350 if and only if `noImplicitAny` is off; tsz now does this through the checker's call-result reporting boundary, with the void variant staying silent and TS7009 unchanged for the `noImplicitAny`-on case.

## Owner layer

Checker (diagnostic selection only). No solver change — the relation/call verdict was already right.

- `error_reporter/call_errors/error_emission.rs`: `error_non_void_function_called_with_new_at` now emits `ONLY_A_VOID_FUNCTION_CAN_BE_CALLED_WITH_THE_NEW_KEYWORD` instead of being an empty stub.
- `types/computation/call_result.rs`: splits `NonVoidFunctionCalledWithNew | VoidFunctionCalledWithNew`; only the non-void arm reports, gated on `!no_implicit_any()`.
- `types/computation/complex.rs`: same split on the JS/expando `new` path, as the `else` branch of the existing TS7009 gate so the two can never co-occur.

## Scope / over-fire safety

- Gated on `!noImplicitAny` at both sites, so strict-mode behavior is unchanged and TS7009 keeps its exclusive ownership of the `noImplicitAny`-on case.
- The `VoidFunctionCalledWithNew` variant reports nothing, preserving the legal `new f()`-on-a-void-function case.
- Corpus-wide check: exactly five oracle tests expect TS2350 and the full run shows no test gaining an unexpected one.

## Known remaining gap (not addressed here)

`conformance/salsa/constructorFunctions.ts` now emits 6 of its 8 expected TS2350s and still fails. The two misses are both a self-reference inside a function expression assigned to a var:

```js
var C2 = function () {
    if (!(this instanceof C2)) return new C2();   // tsz silent
    this.x = 1;
};
```

The equivalent inside a function *declaration* (`function C1() { ... return new C1(); }`) reports correctly, so the callee resolves to `any` when it is the very var being initialized by the function expression whose body is being checked. That is a circular-initializer resolution gap, independent of this diagnostic, and is left for separate work.

## Verification

All local, on this branch vs `main` at `e2b2161e`:

- **Full conformance: 11308 -> 11310 passed (733 failed), +2 fixed, 0 regressed.** Fixed: `conformance/es6/Symbols/symbolType14.ts`, `conformance/types/specifyingTypes/typeLiterals/arrayTypeOfFunctionTypes.ts`. Three further tests changed diagnostics without flipping (`bigintWithLib` now emits its TS2350 and fails only on an unrelated TS2769 column; `constructorFunctions` / `constructorFunctionsStrict` per the gap noted above).
- **Full emit suite unchanged**: 11562/11563 JS, 1372/1390 DTS (identical to base).
- Measured in isolation on a branch based on main *without* my other open PR (#15907), so this +2 is attributable to this change alone.

Goal: hold

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
