### PR TITLE
fix(checker): stop emitting retired JSDoc tag diagnostics TS8021/TS8022

### DIFF
--- a/crates/tsz-checker/src/jsdoc/diagnostics.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics.rs
@@ -383,20 +383,6 @@ impl<'a> CheckerState<'a> {
             .collect()
     }
 
-    fn jsdoc_typedef_has_inline_type(comment_text: &str, typedef_pos: usize) -> bool {
-        let after_typedef = typedef_pos + "@typedef".len();
-        comment_text[after_typedef..].trim_start().starts_with('{')
-    }
-
-    fn jsdoc_typedef_segment_has_child_type_tag(segment_text: &str) -> bool {
-        let before_template = Self::jsdoc_tag_offset(segment_text, "template")
-            .map(|template_pos| &segment_text[..template_pos])
-            .unwrap_or(segment_text);
-        ["property", "prop", "type", "member"]
-            .iter()
-            .any(|tag| Self::jsdoc_tag_offset(before_template, tag).is_some())
-    }
-
     fn jsdoc_type_tag_duplicate_anchor(comment_text: &str, type_tag_pos: usize) -> (usize, u32) {
         let after = type_tag_pos + "@type".len();
         let tag_text = &comment_text[after..];
@@ -419,20 +405,6 @@ impl<'a> CheckerState<'a> {
             None
         };
         anchor_offset.map_or((type_tag_pos, "@type".len() as u32), |offset| (offset, 0))
-    }
-
-    fn jsdoc_typedef_missing_type_name_span(
-        comment_text: &str,
-        typedef_pos: usize,
-        segment_end: usize,
-    ) -> (usize, usize) {
-        let after_typedef = typedef_pos + "@typedef".len();
-        let rest = &comment_text[after_typedef..segment_end];
-        let name_start = after_typedef + rest.find(|c: char| !c.is_whitespace()).unwrap_or(0);
-        let name_len = comment_text[name_start..segment_end]
-            .find(|c: char| c.is_whitespace() || c == '*' || c == '/')
-            .unwrap_or(segment_end - name_start);
-        (name_start, name_len)
     }
 
     fn jsdoc_typedef_is_import_alias(info: &crate::jsdoc::types::JsdocTypedefInfo) -> bool {
@@ -520,60 +492,6 @@ impl<'a> CheckerState<'a> {
                         diagnostic_codes::A_JSDOC_TYPEDEF_COMMENT_MAY_NOT_CONTAIN_MULTIPLE_TYPE_TAGS,
                     );
                 }
-            }
-        }
-    }
-
-    /// Check for `@typedef` tags that have neither a type annotation nor
-    /// `@property`/`@member` tags. Emits TS8021.
-    ///
-    /// Valid: `/** @typedef {Object} Foo */` or `/** @typedef Foo \n @property {string} name */`
-    /// Invalid: `/** @typedef T */` (no type, no properties)
-    pub(crate) fn check_typedef_missing_type(&mut self) {
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-        use tsz_common::comments::is_jsdoc_comment;
-
-        let Some(sf) = self.ctx.arena.source_files.first() else {
-            return;
-        };
-        let source_text: &str = &sf.text;
-        let comments = &sf.comments;
-
-        for comment in comments {
-            if !is_jsdoc_comment(comment, source_text) {
-                continue;
-            }
-
-            let comment_text = comment.get_text(source_text);
-
-            for (typedef_pos, segment_end) in Self::jsdoc_typedef_tag_spans(comment_text) {
-                let after_typedef = typedef_pos + "@typedef".len();
-                let segment_text = &comment_text[after_typedef..segment_end];
-                if Self::jsdoc_typedef_has_inline_type(comment_text, typedef_pos)
-                    || Self::jsdoc_typedef_segment_has_child_type_tag(segment_text)
-                {
-                    continue;
-                }
-
-                // Emit TS8021 at the typedef name position (TSC points at the name, not @typedef)
-                let (name_start, name_len) = Self::jsdoc_typedef_missing_type_name_span(
-                    comment_text,
-                    typedef_pos,
-                    segment_end,
-                );
-                let error_pos = comment.pos + name_start as u32;
-                let error_len = if name_len > 0 {
-                    name_len as u32
-                } else {
-                    "@typedef".len() as u32
-                };
-                self.ctx.error(
-                    error_pos,
-                    error_len,
-                    diagnostic_messages::JSDOC_TYPEDEF_TAG_SHOULD_EITHER_HAVE_A_TYPE_ANNOTATION_OR_BE_FOLLOWED_BY_PROPERT
-                        .to_string(),
-                    diagnostic_codes::JSDOC_TYPEDEF_TAG_SHOULD_EITHER_HAVE_A_TYPE_ANNOTATION_OR_BE_FOLLOWED_BY_PROPERT,
-                );
             }
         }
     }

--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -12,7 +12,6 @@
 //! - Type query resolution (`resolve_type_query_type`)
 //! - Generic constraint validation (`validate_jsdoc_generic_constraints_at_node`)
 //! - Metadata queries (`jsdoc_has_readonly_tag`, `jsdoc_access_level`)
-//! - Orphaned extends/augments detection (`find_orphaned_extends_tags_for_statements`)
 //! - Scoping helpers (`is_in_different_function_scope`, `find_function_body_end`)
 
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
@@ -25,11 +24,6 @@ use tsz_parser::parser::node::SourceFileData;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
-
-/// `(tag_name, Some((pos, len)))` for orphaned `@extends`/`@augments` tags.
-/// `None` means fully-dangling (no attached statement); `Some` gives the
-/// statement's source position and length for diagnostic anchoring.
-type OrphanedExtendsTag = (&'static str, Option<(u32, u32)>);
 
 // Above this size, a cheap textual typedef pre-scan avoids constructing a
 // cross-file child checker for every file that cannot contain the requested
@@ -1455,119 +1449,6 @@ impl<'a> CheckerState<'a> {
             }
         }
         None
-    }
-
-    /// Scan statements for `@extends`/`@augments` not on class declarations (TS8022).
-    ///
-    /// Each result is `(tag, Some((pos, len)))` when the orphan is the leading
-    /// JSDoc of a non-class statement (tsc reports these at the statement's
-    /// position), or `(tag, None)` when it is a fully-dangling JSDoc comment
-    /// not attached to any statement (tsc reports these at program level with
-    /// no file/position).
-    pub(crate) fn find_orphaned_extends_tags_for_statements(
-        &self,
-        statements: &[NodeIndex],
-    ) -> Vec<OrphanedExtendsTag> {
-        use tsz_parser::parser::syntax_kind_ext;
-        let Some(sf) = self.ctx.arena.source_files.first() else {
-            return Vec::new();
-        };
-        let source_text: &str = &sf.text;
-        let comments = &sf.comments;
-        let mut results = Vec::new();
-        let mut handled_comment_positions = Vec::new();
-        // Phase 1: Check each top-level statement's leading JSDoc
-        for &stmt_idx in statements {
-            let Some(node) = self.ctx.arena.get(stmt_idx) else {
-                continue;
-            };
-            if node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || node.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
-                // Always mark class declarations as handled so that any
-                // preceding `@extends`/`@augments` comment — even one
-                // separated from the class by blank lines or intermediate
-                // JSDoc comments — is not reported as orphaned.  tsc
-                // considers `@extends` on a class valid (possibly redundant)
-                // and never emits TS8022 for it.
-                handled_comment_positions.push(node.pos);
-                continue;
-            }
-            let Some(jsdoc) = self.try_leading_jsdoc(comments, node.pos, source_text) else {
-                continue;
-            };
-            let tag = if Self::jsdoc_contains_tag(&jsdoc, "augments") {
-                "augments"
-            } else if Self::jsdoc_contains_tag(&jsdoc, "extends") {
-                "extends"
-            } else {
-                continue;
-            };
-            handled_comment_positions.push(node.pos);
-            let (pos, len) = if node.kind == syntax_kind_ext::FUNCTION_DECLARATION {
-                if let Some(func) = self.ctx.arena.get_function(node)
-                    && let Some(name_node) = self.ctx.arena.get(func.name)
-                {
-                    (name_node.pos, name_node.end - name_node.pos)
-                } else {
-                    (node.pos, node.end - node.pos)
-                }
-            } else {
-                (node.pos, node.end - node.pos)
-            };
-            results.push((tag, Some((pos, len))));
-        }
-        // Phase 2: Check for dangling JSDoc comments not attached to any statement
-        use tsz_common::comments::{get_jsdoc_content, is_jsdoc_comment};
-        for comment in comments {
-            if !is_jsdoc_comment(comment, source_text) {
-                continue;
-            }
-            // Note: we intentionally do NOT skip comments simply because they
-            // appear before a handled class — tsc reports `@extends`/`@augments`
-            // as orphaned when another JSDoc comment is interposed between the
-            // tag and the class declaration (see extendsTag2). The
-            // is_leading_of_any_stmt check below is the sole gate.
-            let content = get_jsdoc_content(comment, source_text);
-            let tag = if Self::jsdoc_contains_tag(&content, "augments") {
-                "augments"
-            } else if Self::jsdoc_contains_tag(&content, "extends") {
-                "extends"
-            } else {
-                continue;
-            };
-            let is_leading_of_any_stmt = statements.iter().any(|&stmt_idx| {
-                if let Some(n) = self.ctx.arena.get(stmt_idx)
-                    && let Some((_, leading_pos)) =
-                        self.try_leading_jsdoc_with_pos(comments, n.pos, source_text)
-                {
-                    return leading_pos == comment.pos;
-                }
-                false
-            });
-            if is_leading_of_any_stmt {
-                continue;
-            }
-            // Dangling JSDoc comment. tsc distinguishes two cases:
-            //   * If there is any statement after the comment (even separated
-            //     by intervening JSDoc), tsc reports at program level with no
-            //     file/position — see `extendsTag2.ts`.
-            //   * If the comment is the last meaningful thing in the file, tsc
-            //     anchors the diagnostic at the position just after the
-            //     comment's closing `*/` — see `extendsTag4.ts`.
-            let any_stmt_after = statements.iter().any(|&stmt_idx| {
-                self.ctx
-                    .arena
-                    .get(stmt_idx)
-                    .is_some_and(|n| n.pos >= comment.end)
-            });
-            if any_stmt_after {
-                results.push((tag, None));
-            } else {
-                results.push((tag, Some((comment.end, 0))));
-            }
-        }
-        results
     }
 
     /// Check if two source positions are in different function scopes.

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -394,6 +394,9 @@ mod jsdoc_prototype_assignment_literal_display;
 #[path = "../tests/jsdoc_prototype_assignment_target_display.rs"]
 mod jsdoc_prototype_assignment_target_display;
 #[cfg(test)]
+#[path = "tests/jsdoc_retired_tag_diagnostics_tests.rs"]
+mod jsdoc_retired_tag_diagnostics_tests;
+#[cfg(test)]
 #[path = "../tests/jsdoc_this_arrow_tests.rs"]
 mod jsdoc_this_arrow_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/js_grammar.rs
+++ b/crates/tsz-checker/src/state/state_checking/js_grammar.rs
@@ -17,36 +17,6 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// TS8022: Check for orphaned `@extends`/`@augments` tags not attached to a class.
-    pub(crate) fn check_orphaned_extends_tags(&mut self, statements: &[NodeIndex]) {
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
-
-        let orphaned = self.find_orphaned_extends_tags_for_statements(statements);
-        for (tag_name, position) in orphaned {
-            let message = format_message(
-                diagnostic_messages::JSDOC_IS_NOT_ATTACHED_TO_A_CLASS,
-                &[tag_name],
-            );
-            match position {
-                Some((pos, len)) => {
-                    self.ctx.error(
-                        pos,
-                        len,
-                        message,
-                        diagnostic_codes::JSDOC_IS_NOT_ATTACHED_TO_A_CLASS,
-                    );
-                }
-                None => {
-                    // Fully-dangling JSDoc — tsc emits at program level.
-                    self.error_program_level(
-                        message,
-                        diagnostic_codes::JSDOC_IS_NOT_ATTACHED_TO_A_CLASS,
-                    );
-                }
-            }
-        }
-    }
-
     /// Check a single statement for TypeScript-only syntax in JS files.
     fn check_js_grammar_statement(&mut self, stmt_idx: NodeIndex) {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -639,9 +639,6 @@ impl CheckerState<'_> {
         if self.is_js_file() {
             self.check_js_grammar_statements(&sf.statements.nodes);
 
-            // TS8022: Check for orphaned @extends/@augments tags not attached to a class
-            self.check_orphaned_extends_tags(&sf.statements.nodes);
-
             // TS8033: Check for @typedef comments with multiple @type tags
             self.check_typedef_duplicate_type_tags();
 
@@ -668,9 +665,6 @@ impl CheckerState<'_> {
 
             // TS1110: unsupported multiline @typedef wrappers without leading `*`
             self.check_jsdoc_unwrapped_multiline_typedefs();
-
-            // TS8021: Check for @typedef without type or @property tags
-            self.check_typedef_missing_type();
 
             // TS8039: Check for @template tags after @typedef/@callback/@overload
             self.check_template_after_typedef_callback();

--- a/crates/tsz-checker/src/tests/jsdoc_retired_tag_diagnostics_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_retired_tag_diagnostics_tests.rs
@@ -1,0 +1,100 @@
+//! Two JSDoc tag diagnostics the pinned compiler no longer reports.
+//!
+//! TS8022 ("JSDoc '@extends'/'@augments' is not attached to a class") and
+//! TS8021 ("JSDoc '@typedef' tag should either have a type annotation or be
+//! followed by '@property' or '@member' tags") have zero expectations across
+//! the whole conformance corpus — including the tests written specifically to
+//! provoke them, `jsdocAugments_notAClass` and `extendsTag4`, which now expect
+//! no diagnostics at all. tsz kept emitting both.
+//!
+//! The sibling code TS8023 ("does not match the 'extends' clause") is still
+//! reported and is covered here as a positive control, so a regression that
+//! silences the whole `@augments` area would be caught.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn js_codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.js", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn augments_on_a_non_class_is_not_reported() {
+    for tag in ["augments", "extends"] {
+        // Attached to a function, an arrow, and a variable declaration.
+        for decl in [
+            "function b() {}",
+            "const b = () => {};",
+            "var b = 1;",
+            "class B {}",
+        ] {
+            let source = format!("class A {{}}\n/** @{tag} A */\n{decl}\n");
+            let codes = js_codes(&source);
+            assert!(
+                !codes.contains(&8022),
+                "@{tag} on `{decl}` must not report TS8022; got {codes:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn dangling_augments_comment_is_not_reported() {
+    // A JSDoc comment attached to nothing at all.
+    let codes = js_codes("class A {}\n\n/** @augments A */\n");
+    assert!(!codes.contains(&8022), "got {codes:?}");
+}
+
+#[test]
+fn augments_reporting_is_binder_name_independent() {
+    for (base, other) in [("A", "B"), ("Widget", "Gadget"), ("_x0", "_y1")] {
+        let source = format!("class {base} {{}}\n/** @augments {base} */\nfunction f() {{}}\n");
+        assert!(
+            !js_codes(&source).contains(&8022),
+            "base={base} must not report TS8022"
+        );
+        // Positive control: the mismatch diagnostic is a different code and
+        // must survive.
+        let mismatch = format!(
+            "class {base} {{}}\nclass {other} {{}}\n/** @augments {base} */\nclass C extends {other} {{}}\n"
+        );
+        assert!(
+            js_codes(&mismatch).contains(&8023),
+            "base={base} other={other}: TS8023 must still be reported"
+        );
+    }
+}
+
+#[test]
+fn typedef_without_type_or_properties_is_not_reported() {
+    for source in [
+        "/** @typedef T */\nvar x = 1;\n",
+        "/**\n * @typedef Foo\n */\nvar y = 2;\n",
+    ] {
+        let codes = js_codes(source);
+        assert!(!codes.contains(&8021), "got {codes:?} for {source:?}");
+    }
+}
+
+#[test]
+fn typedef_with_type_or_properties_still_resolves() {
+    // Positive control: well-formed typedefs keep working, so the removal did
+    // not disturb typedef handling itself.
+    let codes = js_codes(
+        "/** @typedef {{ name: string }} Person */\n\
+         /** @param {Person} p */\nfunction greet(p) { return p.name; }\n",
+    );
+    assert!(!codes.contains(&8021), "got {codes:?}");
+    assert!(
+        !codes.contains(&2304),
+        "Person should resolve; got {codes:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

## Problem

tsz emits two JSDoc tag diagnostics the pinned compiler no longer reports:

- **TS8022** — `JSDoc '@extends'/'@augments' is not attached to a class.`
- **TS8021** — `JSDoc '@typedef' tag should either have a type annotation or be followed by '@property' or '@member' tags.`

Both have **zero expectations across the entire conformance corpus** — including
the tests written specifically to provoke them. `jsdocAugments_notAClass.ts` is
literally `class A {} /** @augments A */ function b() {}` and now expects **no
diagnostics at all**; `extendsTag4.ts` likewise. The previous compiler version's
baselines record TS8022 at exactly those positions:

```
/b.js(3,10): error TS8022: JSDoc '@augments' is not attached to a class.
foo.js(11,1): error TS8022: JSDoc '@extends' is not attached to a class.
```

so this is a behaviour removal between the two versions, not a positioning or
wording difference.

## Structural rule

When a JSDoc `@extends`/`@augments` tag is not attached to a class, or a
`@typedef` tag carries neither a type annotation nor `@property`/`@member`
tags, tsc reports nothing; tsz now also reports nothing.

## How the scope was established

I audited **every** 8xxx code tsz emits against the oracle rather than reasoning
from the two failing tests. Only 8021 and 8022 have no expectation anywhere:

| code | tsc expects (whole corpus) | tsz emits |
| --- | --- | --- |
| TS8020 | 1 | 5 |
| **TS8021** | **0** | 1 |
| **TS8022** | **0** | 3 |
| TS8023 | 3 | 1 |
| TS8024 | 3 | 7 |
| TS8030 | 10 | 2 |
| TS8032 | 4 | 0 |
| TS8039 | 6 | 4 |

Every other 8xxx code still has expectations, so this removal is precisely
scoped to the two retired ones. Since a test cannot pass while emitting a code
that is never expected, removing them can only help — there is no test relying
on the current behaviour.

## Owner layer

Both were self-contained checks with a single caller each in
`state_checking/source_file.rs`. Removed along with the helpers that only served
them — `find_orphaned_extends_tags_for_statements`, the `OrphanedExtendsTag`
alias, and the three typedef-missing-type span helpers — so no dead code is left
behind.

**TS8023** (`does not match the 'extends' clause`) is a different code, still
expected 3× in the corpus, and is untouched. It is covered by an explicit
positive control so a future regression that silences the whole `@augments` area
would be caught rather than looking like a pass.

## Adjacent-case matrix

5 new tests in `tests/jsdoc_retired_tag_diagnostics_tests.rs`:

| Case | Expectation |
| --- | --- |
| `@augments` / `@extends` on a function, arrow, variable, or class | no TS8022 |
| Fully dangling JSDoc comment attached to nothing | no TS8022 |
| **Renamed binders** `A`/`Widget`/`_x0` × `B`/`Gadget`/`_y1` | identical, name-independent |
| Genuine `@augments A` on `class C extends B` | TS8023 **still reported** (positive control) |
| `@typedef T` with no type and no `@property` | no TS8021 |
| Well-formed `@typedef {{ name: string }} Person` used via `@param` | no TS8021, and `Person` still resolves (no TS2304) |

## Verification

All run locally; ground truth is the tsc 7.0.2 oracle in
`scripts/conformance/tsc-cache-full.json`, not the previous version's
`.errors.txt` baselines.

```
./scripts/conformance/conformance.sh run --workers 12
  before: 11308/12043      after: 11311/12043     (+3, zero regressions)

./scripts/conformance/conformance.sh run --filter conformance/jsdoc --workers 8
  before: 237/332          after: 239/332 (72.0%)

./scripts/emit/run.sh
  JS  11562/11563  (unchanged)
  DTS 1372/1390    (unchanged)

cargo nextest run -p tsz-checker --lib -E 'test(/jsdoc_retired_tag_diagnostics/)'
  5 passed

./scripts/arch/check-checker-boundaries.sh   passed
cargo clippy -p tsz-checker --lib            clean
```

Failing-set diff, derived per test from `expected_fingerprints` vs
`actual_fingerprints`:

```
FIXED: 2
  + extendsTag4.ts
  + jsdocAugments_notAClass.ts
REGRESSED: 0
```

The corpus-wide gain is +3: the third flip is outside `conformance/jsdoc`, which
is the point of auditing by code rather than by failing test.

Branched from `main`, independent of #15906 and #15908 (disjoint files).

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: xhigh
