### PR TITLE
fix(config): apply the first-key anchor rule to TS5053 and TS5091

### DIFF
--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -557,30 +557,29 @@ fn find_key_offset_in_source_opt(source: &str, key: &str) -> Option<u32> {
         .map(|pos| (compiler_opts_pos + pos) as u32)
 }
 
-/// Report a TS5052 "Option '{0}' cannot be specified without specifying option
-/// '{1}'" pair.
+/// Report an option-interaction diagnostic that names two compiler options.
 ///
 /// tsc walks the `compilerOptions` object literal looking for either name and
 /// anchors on the **first one it encounters in source order**, emitting a
-/// single diagnostic — so a config listing `allowJs` above `checkJs` anchors at
-/// `allowJs` even though the rule is "about" `checkJs`. The message always
-/// names the pair in dependency order regardless of which key is pointed at.
-/// If neither key is written out (both are implied), tsc falls back to the
-/// enclosing `compilerOptions` key.
-fn push_option_dependency_diagnostic(
+/// single diagnostic — regardless of which of the two the message names first.
+/// A config listing `allowJs` above `checkJs` anchors at `allowJs` even though
+/// TS5052 is "about" `checkJs`; a config listing `inlineSourceMap` above
+/// `sourceMap` anchors at `inlineSourceMap` even though TS5053's message names
+/// `sourceMap` first. If neither key is written out (both are implied), tsc
+/// falls back to the enclosing `compilerOptions` key.
+///
+/// Shared by TS5052, TS5053 and TS5091, which previously each pushed a
+/// diagnostic at *both* keys — a tsc 6.0 behavior
+/// (`forEachPropertyAssignment` visiting both) that 7.0.2 no longer has.
+fn push_first_key_anchored_diagnostic(
     diagnostics: &mut Vec<Diagnostic>,
     file_path: &str,
     stripped: &str,
-    dependent: &str,
-    required: &str,
+    keys: [&str; 2],
+    message: impl Into<String>,
+    code: u32,
 ) {
-    let message = format_message(
-        diagnostic_messages::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION,
-        &[dependent, required],
-    );
-    let code = diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION;
-
-    let anchor = [dependent, required]
+    let anchor = keys
         .into_iter()
         .filter_map(|key| find_key_offset_in_source_opt(stripped, key).map(|off| (off, key)))
         .min_by_key(|(off, _)| *off);
@@ -607,6 +606,29 @@ fn push_option_dependency_diagnostic(
             ));
         }
     }
+}
+
+/// TS5052 "Option '{0}' cannot be specified without specifying option '{1}'".
+/// The message always names the pair in dependency order; the anchor is chosen
+/// by [`push_first_key_anchored_diagnostic`].
+fn push_option_dependency_diagnostic(
+    diagnostics: &mut Vec<Diagnostic>,
+    file_path: &str,
+    stripped: &str,
+    dependent: &str,
+    required: &str,
+) {
+    push_first_key_anchored_diagnostic(
+        diagnostics,
+        file_path,
+        stripped,
+        [dependent, required],
+        format_message(
+            diagnostic_messages::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION,
+            &[dependent, required],
+        ),
+        diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION,
+    );
 }
 
 /// Push an error diagnostic anchored at a tsconfig key, spanning the key text

--- a/crates/tsz-core/src/config/parse.rs
+++ b/crates/tsz-core/src/config/parse.rs
@@ -744,8 +744,9 @@ pub fn parse_tsconfig_with_diagnostics_deferred(
             );
         }
 
-        // TS5091: preserveConstEnums cannot be disabled when isolatedModules is enabled.
-        // tsc emits this at both key positions; we emit once per enabler.
+        // TS5091: preserveConstEnums cannot be disabled when isolatedModules is
+        // enabled. One diagnostic per enabler, anchored at whichever of the pair
+        // comes first in the config source.
         if matches!(
             compiler_opts.get("preserveConstEnums"),
             Some(serde_json::Value::Bool(false))
@@ -753,25 +754,15 @@ pub fn parse_tsconfig_with_diagnostics_deferred(
             let enablers: &[&str] = &["isolatedModules", "isolatedDeclarations"];
             for enabler in enablers {
                 if option_is_effectively_enabled(compiler_opts, &ts5024_keys, enabler) {
-                    let msg = format_message(
-                        diagnostic_messages::OPTION_PRESERVECONSTENUMS_CANNOT_BE_DISABLED_WHEN_IS_ENABLED,
-                        &[enabler],
-                    );
-                    push_key_diagnostic(
+                    push_first_key_anchored_diagnostic(
                         &mut diagnostics,
                         file_path,
                         &stripped,
-                        "preserveConstEnums",
-                        msg.clone(),
-                        diagnostic_codes::OPTION_PRESERVECONSTENUMS_CANNOT_BE_DISABLED_WHEN_IS_ENABLED,
-                    );
-                    // tsc also emits at the enabler key position
-                    push_key_diagnostic(
-                        &mut diagnostics,
-                        file_path,
-                        &stripped,
-                        enabler,
-                        msg,
+                        ["preserveConstEnums", enabler],
+                        format_message(
+                            diagnostic_messages::OPTION_PRESERVECONSTENUMS_CANNOT_BE_DISABLED_WHEN_IS_ENABLED,
+                            &[enabler],
+                        ),
                         diagnostic_codes::OPTION_PRESERVECONSTENUMS_CANNOT_BE_DISABLED_WHEN_IS_ENABLED,
                     );
                 }
@@ -908,27 +899,19 @@ pub fn parse_tsconfig_with_diagnostics_deferred(
                 };
                 let key_a = resolve(opt_a);
                 let key_b = resolve(opt_b);
-                // Emit at the resolved-key position (issue #3732 anchors at
-                // `checkJs` when allowJs is implied).
-                let msg = format_message(
-                    diagnostic_messages::OPTION_CANNOT_BE_SPECIFIED_WITH_OPTION,
-                    &[opt_a, opt_b],
-                );
-                push_key_diagnostic(
+                // One diagnostic, anchored at whichever key comes first in the
+                // config source — which is often not the option the message
+                // names first (`sourceMap`/`inlineSourceMap` anchors at
+                // `inlineSourceMap`).
+                push_first_key_anchored_diagnostic(
                     &mut diagnostics,
                     file_path,
                     &stripped,
-                    key_a,
-                    msg.clone(),
-                    diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITH_OPTION,
-                );
-                // Emit at opt_b's position (same message, different location)
-                push_key_diagnostic(
-                    &mut diagnostics,
-                    file_path,
-                    &stripped,
-                    key_b,
-                    msg,
+                    [key_a, key_b],
+                    format_message(
+                        diagnostic_messages::OPTION_CANNOT_BE_SPECIFIED_WITH_OPTION,
+                        &[opt_a, opt_b],
+                    ),
                     diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITH_OPTION,
                 );
             }

--- a/crates/tsz-core/src/config/tests/module_resolution.rs
+++ b/crates/tsz-core/src/config/tests/module_resolution.rs
@@ -1139,11 +1139,67 @@ fn test_ts5053_sourcemap_with_inline_sourcemap() {
         codes.contains(&5053),
         "Expected TS5053 for sourceMap with inlineSourceMap, got: {codes:?}"
     );
-    // tsc emits twice (at each key position)
-    let count = codes.iter().filter(|&&c| c == 5053).count();
+    // One diagnostic, anchored at whichever key comes first in the source —
+    // here `sourceMap`, even though the harness-generated configs in the
+    // conformance corpus sort `inlineSourceMap` above it and anchor there.
+    let hits: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5053)
+        .collect();
     assert_eq!(
-        count, 2,
-        "Expected 2 TS5053 diagnostics (one per key), got: {count}"
+        hits.len(),
+        1,
+        "Expected exactly one TS5053 diagnostic, got: {:?}",
+        parsed.diagnostics
+    );
+    assert_eq!(
+        hits[0].start as usize,
+        source.find(r#""sourceMap""#).unwrap(),
+        "TS5053 should anchor at the earlier key, got: {:?}",
+        hits[0]
+    );
+}
+
+#[test]
+fn test_ts5053_anchors_at_second_named_option_when_it_comes_first() {
+    // The message names `sourceMap` first but `inlineSourceMap` is written
+    // first, so that is where tsc anchors. Pins the corpus oracle for
+    // compiler/optionsInlineSourceMapSourcemap.ts.
+    let source = r#"{"compilerOptions":{"inlineSourceMap":true,"sourceMap":true}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let hits: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5053)
+        .collect();
+    assert_eq!(hits.len(), 1, "got: {:?}", parsed.diagnostics);
+    assert_eq!(
+        hits[0].start as usize,
+        source.find(r#""inlineSourceMap""#).unwrap(),
+        "TS5053 should anchor at inlineSourceMap, got: {:?}",
+        hits[0]
+    );
+}
+
+#[test]
+fn test_ts5091_reports_once_anchored_at_first_key() {
+    // preserveConstEnums: false with isolatedModules on. `isolatedModules` is
+    // written first, so it takes the anchor even though the message is about
+    // `preserveConstEnums`. Pins compiler/isolatedModulesRequiresPreserveConstEnum.ts.
+    let source = r#"{"compilerOptions":{"isolatedModules":true,"preserveConstEnums":false}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let hits: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5091)
+        .collect();
+    assert_eq!(hits.len(), 1, "got: {:?}", parsed.diagnostics);
+    assert_eq!(
+        hits[0].start as usize,
+        source.find(r#""isolatedModules""#).unwrap(),
+        "TS5091 should anchor at isolatedModules, got: {:?}",
+        hits[0]
     );
 }
 


### PR DESCRIPTION
## Summary

TS5053 (`Option '{0}' cannot be specified with option '{1}'`) and TS5091 (`Option 'preserveConstEnums' cannot be disabled when '{0}' is enabled`) carried the **same duplicate-anchor bug** #15907 fixes for TS5052, complete with the same now-disproven comments:

```rust
// Emit at opt_b's position (same message, different location)
// tsc emits this at both key positions; we emit once per enabler
```

tsc 7.0.2 emits **one** diagnostic per option pair, anchored at whichever of the two named options appears **first in the `compilerOptions` object** — frequently *not* the option the message names first. tsz emitted at both keys, so every one of these tests failed with a spurious extra fingerprint.

All six corpus oracle rows for these two codes are single-anchored, verified against the harness-generated tsconfig for each:

| test | message names first | config order | oracle anchor |
| --- | --- | --- | --- |
| `optionsInlineSourceMapSourcemap.ts` | `sourceMap` | `inlineSourceMap` L3, `sourceMap` L4 | **3:5** = `inlineSourceMap` |
| `optionsInlineSourceMapMapRoot.ts` | `mapRoot` | `inlineSourceMap` L3 | **3:5** = `inlineSourceMap` |
| `jsxFactoryAndReactNamespace.ts` | `reactNamespace` | `jsxFactory` L4, `reactNamespace` L7 | **4:5** = `jsxFactory` |
| `isolatedModulesRequiresPreserveConstEnum.ts` | `preserveConstEnums` | `isolatedModules` L3, `preserveConstEnums` L5 | **3:5** = `isolatedModules` |
| `arrayIterationLibES5TargetDifferent.ts` | `lib` | — | 3:5 |
| `isolatedDeclarationsAllowJs.ts` | `allowJs` | — | 3:5 |

In three of the four flipped tests the anchor is the option the message names **second**, which is why a "anchor at option1" rule would not have worked.

## Structural rule

When a tsconfig triggers an option-interaction diagnostic naming two compiler options, tsc reports it once, anchored at whichever of the two is written first in the `compilerOptions` object, regardless of the order the message names them; tsz now does this for TS5052, TS5053 and TS5091 through one shared helper in the config layer.

## Owner layer

`tsz-core` config validation — same layer as #15907, no checker/solver/emitter involvement.

- `config/mod.rs`: generalizes #15907's `push_option_dependency_diagnostic` into `push_first_key_anchored_diagnostic`, which takes the option pair plus an already-formatted message and code. `push_option_dependency_diagnostic` becomes a thin TS5052 wrapper over it.
- `config/parse.rs`: the TS5053 conflicting-pairs loop and the TS5091 per-enabler loop each drop their second `push_key_diagnostic` and route through the shared helper.

## Scope / over-fire safety

Strictly reduces the number of diagnostics emitted — no new condition is introduced, so nothing can newly fire. The two remaining TS5053 oracle rows (`arrayIterationLibES5TargetDifferent`, `isolatedDeclarationsAllowJs`) still fail on unrelated grounds and are unaffected by this change.

## Tests

- Replaces `test_ts5053_sourcemap_with_inline_sourcemap`'s `count == 2` assertion — which encoded the tsc 6.0 behavior — with a single-diagnostic + anchor-position assertion.
- Adds `test_ts5053_anchors_at_second_named_option_when_it_comes_first`, pinning the case where the message's second-named option is written first.
- Adds `test_ts5091_reports_once_anchored_at_first_key`.

## Verification

Local, measured on this branch vs `main` at `0446331019` (before #15907 merged; this branch has since been rebased onto `821458f6`, which contains it):

- **Full conformance: 11308 -> 11319 passed (724 failed), +11 fixed, 0 regressed, 0 changed-but-still-failing.** Measured before #15907 landed, so that total includes its 7; the 4 attributable to this PR are `isolatedModulesRequiresPreserveConstEnum`, `jsxFactoryAndReactNamespace`, `optionsInlineSourceMapMapRoot`, `optionsInlineSourceMapSourcemap`.
- **Full emit suite unchanged**: 11562/11563 JS, 1372/1390 DTS.
- **20 `tsz-core` config unit tests pass** (`ts5052` / `ts5053` / `ts5091` / `check_js` filters).

Credit: the second and third instances of this pattern were found by a corpus-wide fingerprint audit that bucketed all 217 "fingerprint-only" conformance failures by whether tsz picked the wrong *node* versus the wrong *offset*; these four surfaced as an anchor-selection cluster with the two emission sites named directly.

Goal: hold

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
