### PR TITLE
fix(checker): anchor parameter diagnostics at the parameter, not its name

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2516,3 +2516,6 @@ path = "tests/js_number_string_semantics_tests.rs"
 [[test]]
 name = "compound_assignment_operator_anchor_tests"
 path = "tests/compound_assignment_operator_anchor_tests.rs"
+[[test]]
+name = "parameter_property_anchor_tests"
+path = "tests/parameter_property_anchor_tests.rs"

--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -919,12 +919,19 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
 
-            // If parameter has an initializer in an ambient function, emit TS2371
-            // TSC anchors the error at the parameter name, not the initializer.
+            // If parameter has an initializer in an ambient function, emit
+            // TS2371. tsc anchors at the PARAMETER, not the initializer and not
+            // the name: `getErrorSpanForNode` has no `SyntaxKind.Parameter`
+            // case, so the span is the parameter's own. For a plain parameter
+            // that is the name (the node starts there), but a parameter
+            // property starts at its accessibility modifier — `declare class C
+            // { constructor(public c = 10); }` anchors at `public`. Reporting
+            // on `param_idx` lets `normalized_anchor_span` narrow to the name
+            // only in the modifier-less case.
             let name = param.name;
             if param.initializer.is_some() {
                 self.error_at_node(
-                    name,
+                    param_idx,
                     "A parameter initializer is only allowed in a function or constructor implementation.",
                     2371, // TS2371
                 );

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -1112,14 +1112,26 @@ impl<'a> CheckerState<'a> {
             return self.normalized_anchor_span(prop.name, name_start, name_len);
         }
 
+        // tsc's `getErrorSpanForNode` has no `SyntaxKind.Parameter` case, so a
+        // parameter keeps its own span rather than narrowing to its name. For a
+        // plain parameter the two coincide (the node starts at the name), but a
+        // **parameter property** starts at its accessibility modifier, and tsc
+        // anchors there: `constructor(public x: string = 1)` reports TS2322 at
+        // `public`, not at `x`. Narrowing unconditionally lost that.
         if node.kind == syntax_kind_ext::PARAMETER
             && let Some(param) = self.ctx.arena.get_parameter(node)
             && param.name.is_some()
             && let Some(name_node) = self.ctx.arena.get(param.name)
         {
-            let name_start = name_node.pos;
-            let name_len = name_node.end.saturating_sub(name_start);
-            return self.normalized_anchor_span(param.name, name_start, name_len);
+            let has_modifiers = param
+                .modifiers
+                .as_ref()
+                .is_some_and(|modifiers| !modifiers.nodes.is_empty());
+            if !has_modifiers {
+                let name_start = name_node.pos;
+                let name_len = name_node.end.saturating_sub(name_start);
+                return self.normalized_anchor_span(param.name, name_start, name_len);
+            }
         }
 
         // tsc's `getErrorSpanForNode` narrows a *named* function or class

--- a/crates/tsz-checker/tests/parameter_property_anchor_tests.rs
+++ b/crates/tsz-checker/tests/parameter_property_anchor_tests.rs
@@ -1,0 +1,85 @@
+//! Parameter diagnostics anchor at the PARAMETER, not at its name.
+//!
+//! Structural rule: tsc's `getErrorSpanForNode` has no `SyntaxKind.Parameter`
+//! case, so a parameter keeps its own span. For a plain parameter that span
+//! starts at the name and the distinction is invisible; for a **parameter
+//! property** it starts at the accessibility modifier, and tsc anchors there.
+//!
+//! Pins `conformance/classes/constructorDeclarations/constructorParameters/
+//! constructorImplementationWithDefaultValues2.ts` (TS2322 at `public`) and
+//! `compiler/varBlock.ts` (TS2371 at `public`).
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn starts_for(source: &str, code: u32) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == code)
+        .map(|d| d.start)
+        .collect()
+}
+
+fn offset_of(source: &str, needle: &str) -> u32 {
+    u32::try_from(source.find(needle).expect("needle present")).expect("fits u32")
+}
+
+#[test]
+fn parameter_property_default_mismatch_anchors_at_the_modifier() {
+    let source = "class C {\n    constructor(public x: string = 1) {}\n}\n";
+    assert_eq!(
+        starts_for(source, 2322),
+        vec![offset_of(source, "public")],
+        "TS2322 on a parameter property must anchor at `public`, not at the name"
+    );
+}
+
+/// The modifier-less sibling: the parameter node starts at the name, so the
+/// answer is unchanged. This is the case the old unconditional narrowing was
+/// written for, and it must keep working.
+#[test]
+fn plain_parameter_default_mismatch_still_anchors_at_the_name() {
+    let source = "class C {\n    constructor(x: string = 1) {}\n}\n";
+    assert_eq!(
+        starts_for(source, 2322),
+        vec![offset_of(source, "x: string")],
+        "TS2322 on a plain parameter must still anchor at the name"
+    );
+}
+
+/// Renamed binders and a different modifier keyword, so the fix cannot be a
+/// match on `public` or on a fixed column.
+#[test]
+fn parameter_property_anchor_survives_renamed_binders_and_other_modifiers() {
+    for modifier in ["private", "protected", "readonly"] {
+        let source = format!(
+            "class Holder {{\n    constructor({modifier} someValue: string = 1) {{}}\n}}\n"
+        );
+        assert_eq!(
+            starts_for(&source, 2322),
+            vec![offset_of(&source, modifier)],
+            "TS2322 must anchor at `{modifier}`"
+        );
+    }
+}
+
+/// TS2371 (`A parameter initializer is only allowed in a function or
+/// constructor implementation`) takes the same rule.
+#[test]
+fn ambient_parameter_property_initializer_anchors_at_the_modifier() {
+    let source = "declare class C {\n    constructor(public c = 10);\n}\n";
+    assert_eq!(
+        starts_for(source, 2371),
+        vec![offset_of(source, "public")],
+        "TS2371 on a parameter property must anchor at `public`"
+    );
+}
+
+#[test]
+fn ambient_plain_parameter_initializer_still_anchors_at_the_name() {
+    let source = "declare function f(c = 10): void;\n";
+    assert_eq!(
+        starts_for(source, 2371),
+        vec![offset_of(source, "c = 10")],
+        "TS2371 on a plain parameter must still anchor at the name"
+    );
+}


### PR DESCRIPTION
## Summary

tsc's `getErrorSpanForNode` has no `SyntaxKind.Parameter` case, so a parameter keeps its own span rather than narrowing to its name. For a plain parameter the two coincide — the node starts at the name — so the distinction is invisible. For a **parameter property** the node starts at its accessibility modifier, and that is where tsc anchors:

```ts
constructor(public x: string = 1)                 // TS2322 at `public`, not at `x`
declare class C { constructor(public c = 10); }   // TS2371 at `public`, not at `c`
```

Two sites narrowed unconditionally, both carrying a comment asserting the name is correct:

- **`error_reporter/fingerprint_policy.rs`** — `normalized_anchor_span` rewrote any `PARAMETER` anchor to `param.name`. It now does so only when the parameter carries no modifiers, which leaves the modifier-less case byte-identical.
- **`checkers/parameter_checker.rs`** — TS2371 was emitted directly on `param.name` (`// TSC anchors the error at the parameter name, not the initializer`). It now reports on the parameter node and lets `normalized_anchor_span` apply the rule.

## Structural rule

When a diagnostic anchors on a parameter, tsc uses the parameter's own span — which begins at its first modifier when it is a parameter property, and at its name otherwise; tsz now applies that through the checker's shared anchor-normalization path rather than narrowing to the name unconditionally.

## Owner layer

Checker, diagnostic anchoring only. No condition changes and no type computation, so no diagnostic can newly fire or stop firing — only spans move, and only for parameters that have modifiers.

## Verification

Local, on this branch vs `main` at `821458f6`:

- **Full conformance: 11308 -> 11321 passed (722 failed), +14 fixed, 0 regressed, 0 changed-but-still-failing.** The two flips attributable to this PR are `conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues2.ts` and `compiler/varBlock.ts`; the other 12 come from #15907/#15909/#15911/#15912, which are in this branch's history.
- **Full emit suite unchanged**: 11562/11563 JS, 1372/1390 DTS.
- 5/5 new checker tests pass.

Both flipped tests were partially correct already, which is what pins the rule rather than a coincidence: `constructorImplementationWithDefaultValues2` emits 4 TS2322 and **two were always at the right column** — precisely the two whose parameters carry no modifiers (`x: T = 1`, and the `Date` case) — while the two parameter properties were off by the modifier's width. Likewise `varBlock`'s TS2369 was already correct at the modifier and only its TS2371 was not.

## Tests

`crates/tsz-checker/tests/parameter_property_anchor_tests.rs` (new), covering both directions at both codes:

- parameter property anchors at the modifier (TS2322, TS2371);
- plain parameter still anchors at the name (TS2322, TS2371) — the case the old unconditional narrowing existed for;
- `private` / `protected` / `readonly` with renamed binders, so the rule cannot be satisfied by matching on `public` or on a fixed column.

Assertions compare against `source.find(...)` rather than hard-coded offsets.

## Provenance note on the diagnosis

I initially dropped this item, having reproduced the test by hand and seen only 2 of the 4 expected TS2322 — which read as a missing-diagnostic gap rather than an anchoring one. That was a misconfigured repro: I invoked the binary without the test's `// @` option header, so `strict` took tsz's default of **true** (the TS7 default) and suppressed the other two. A teammate's fingerprint-delta balance check (oracle count vs missing/extra: 4 vs m=2/x=2, i.e. balanced) contradicted my reading and was correct. Replaying the header reproduced all four.

Worth recording because the failure mode is asymmetric: a missing option that *removes* diagnostics looks like a coverage gap and is easy to act on wrongly, whereas one that *adds* them is self-announcing.

Goal: hold

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
