### PR TITLE
fix(checker): report TS2300 at every duplicate class member

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2519,3 +2519,6 @@ path = "tests/compound_assignment_operator_anchor_tests.rs"
 [[test]]
 name = "parameter_property_anchor_tests"
 path = "tests/parameter_property_anchor_tests.rs"
+[[test]]
+name = "duplicate_class_member_all_declarations_tests"
+path = "tests/duplicate_class_member_all_declarations_tests.rs"

--- a/crates/tsz-checker/src/state/state_checking_members/class_member_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/class_member_checks.rs
@@ -545,9 +545,12 @@ impl CheckerState<'_> {
                     // Already handled above via accessor_plain_names
                     continue;
                 }
-                let start = if info.is_private { 0 } else { 1 };
+                // tsc reports TS2300 at EVERY duplicate declaration, not just
+                // the subsequent ones — `class C { get x() {...} get x() {...} }`
+                // is two diagnostics. The private-name case already reported all
+                // of them; the public case skipped the first.
                 let name_source = info.indices[0];
-                for &idx in info.indices.iter().skip(start) {
+                for &idx in &info.indices {
                     self.report_duplicate_class_member_ts2300(idx, name_source);
                 }
             }
@@ -729,10 +732,16 @@ impl CheckerState<'_> {
                         .max()
                         .unwrap_or(0);
 
-                    let public_pair_before_member =
-                        has_valid_pair && last_accessor_pos < first_member_pos;
+                    // A public get+set pair declared before a conflicting
+                    // property does NOT establish the member for tsc: it reports
+                    // every declaration. `class C { get x() {...} set x(v) {...}
+                    // x: any }` is three diagnostics, and compiler/
+                    // duplicateClassElements.ts pins that for both its `x2` and
+                    // `z2` groups. The private-name variant is untouched here —
+                    // no oracle row contradicts it.
+                    let _ = (has_valid_pair, last_accessor_pos, first_member_pos);
 
-                    if (is_private && field_strictly_after_accessor) || public_pair_before_member {
+                    if is_private && field_strictly_after_accessor {
                         // Accessor(s) established the member first — flag only
                         // the later property/method declarations.
                         for &idx in &member_info.indices {

--- a/crates/tsz-checker/tests/duplicate_class_member_all_declarations_tests.rs
+++ b/crates/tsz-checker/tests/duplicate_class_member_all_declarations_tests.rs
@@ -1,0 +1,107 @@
+//! TS2300 "Duplicate identifier" is reported at EVERY conflicting class-member
+//! declaration, not only the subsequent ones.
+//!
+//! Two sites in `class_member_checks.rs` under-reported:
+//!
+//!   1. same-kind duplicate accessors skipped the first declaration for public
+//!      names (`start = if info.is_private { 0 } else { 1 }`) — private names
+//!      already reported all of them;
+//!   2. a public `get`+`set` pair declared *before* a conflicting
+//!      property/method suppressed the accessors, on the theory that the pair
+//!      "established" the member. The oracle for `compiler/duplicateClassElements.ts`
+//!      disproves that: tsc reports the getter, the setter and the property.
+//!
+//! The private-name variant of (2) is deliberately untouched — no oracle row
+//! contradicts it.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn ts2300_count(source: &str) -> usize {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == 2300)
+        .count()
+}
+
+#[test]
+fn duplicate_public_accessors_report_every_declaration() {
+    assert_eq!(
+        ts2300_count("class C { get x() { return 1; } get x() { return 1; } }"),
+        2,
+        "both getters must be flagged, not just the second"
+    );
+    assert_eq!(
+        ts2300_count("class C { set x(v: number) {} set x(v: number) {} }"),
+        2,
+        "both setters must be flagged, not just the second"
+    );
+}
+
+#[test]
+fn accessor_pair_before_conflicting_property_reports_all_three() {
+    assert_eq!(
+        ts2300_count("class C { get x() { return 1; } set x(v: number) {} x: any; }"),
+        3,
+        "a get+set pair does not establish the member; all three are duplicates"
+    );
+}
+
+/// The mirrored order was already correct and must stay so.
+#[test]
+fn property_before_accessor_pair_still_reports_all_three() {
+    assert_eq!(
+        ts2300_count("class C { x: any; get x() { return 1; } set x(v: number) {} }"),
+        3
+    );
+}
+
+/// Duplicate accessors *plus* a property: three declarations, three diagnostics.
+#[test]
+fn duplicate_accessors_with_conflicting_property_report_all_three() {
+    assert_eq!(
+        ts2300_count("class C { get x() { return 1; } get x() { return 1; } x: any; }"),
+        3
+    );
+}
+
+/// Adjacent cases that were already correct — guards against over-reporting.
+#[test]
+fn single_accessor_and_plain_duplicates_are_unchanged() {
+    assert_eq!(
+        ts2300_count("class C { get x() { return 1; } x: any; }"),
+        2,
+        "one accessor plus one property is two duplicates"
+    );
+    assert_eq!(ts2300_count("class C { x: any; x: any; }"), 2);
+}
+
+/// Object literals route through a different path and must not shift.
+#[test]
+fn object_literal_duplicate_accessors_unchanged() {
+    assert_eq!(
+        ts2300_count("var o = { get x() { return 1; }, get x() { return 1; } };"),
+        2
+    );
+}
+
+/// A valid get/set pair with no conflict is not a duplicate at all.
+#[test]
+fn valid_accessor_pair_reports_nothing() {
+    assert_eq!(
+        ts2300_count("class C { get x(): number { return 1; } set x(v: number) {} }"),
+        0,
+        "a matched getter/setter pair is legal"
+    );
+}
+
+/// Renamed binders and a static group, so the rule is not tied to a name or to
+/// instance members.
+#[test]
+fn rule_holds_for_renamed_binders_and_static_members() {
+    assert_eq!(
+        ts2300_count(
+            "class Holder { static get someValue() { return 1; } static get someValue() { return 1; } }"
+        ),
+        2
+    );
+}


### PR DESCRIPTION
## Summary

tsc reports TS2300 "Duplicate identifier" at **each** conflicting declaration. Two sites in `crates/tsz-checker/src/state/state_checking_members/class_member_checks.rs` under-reported.

### 1. Same-kind duplicate accessors skipped the first declaration

```rust
let start = if info.is_private { 0 } else { 1 };
```

Private names already reported all of them — the rule had been found and applied to only one branch. `class C { get x() {...} get x() {...} }` is two diagnostics in tsc, one in tsz.

### 2. A public `get`+`set` pair before a conflicting property suppressed the accessors

The guard carried its rationale in a comment:

> *Public names with a valid get+set pair: when a getter and setter are declared BEFORE a conflicting property/method, tsc treats the accessor pair as establishing the member — only the later property/method is flagged.*

The oracle disproves it. `compiler/duplicateClassElements.ts` declares `get x2` (29), `set x2` (32), `public x2` (34) and tsc reports **all three** — 29:9, 32:9, 34:12. tsz reported only 34:12. Identical for its `z2` group (36/39/41).

The **private-name** half of that branch (`is_private && field_strictly_after_accessor`) is deliberately left alone — no oracle row contradicts it, so it is not in scope here.

## Structural rule

When several class-member declarations share a name, tsc reports TS2300 at every one of them; a getter/setter pair does not establish the member and exempt itself. tsz now does this in the checker's class-member duplicate pass, by removing two special cases rather than adding machinery.

## Owner layer

Checker, diagnostic coverage. No solver involvement and no type computation — only which declarations get flagged.

## Adjacent-case matrix

All eight verified against tsc; the six that were already correct still are:

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `class C { get x(){} get x(){} }` | 2 | 1 | **2** |
| `class C { set x(v){} set x(v){} }` | 2 | 1 | **2** |
| `class C { get x(){} set x(v){} x: any }` | 3 | 1 | **3** |
| `class C { x: any; get x(){} set x(v){} }` | 3 | 3 | 3 |
| `class C { get x(){} get x(){} x: any }` | 3 | 3 | 3 |
| `class C { get x(){} x: any }` | 2 | 2 | 2 |
| `class C { x: any; x: any }` | 2 | 2 | 2 |
| `var o = { get x(){}, get x(){} }` | 2 | 2 | 2 |

Object literals route through a different path and are unaffected; a valid unpaired `get`/`set` still reports nothing.

## Verification

Local, on this branch vs `main` at `0b91224b`:

- **Full conformance: 11308 -> 11327 passed (716 failed), +19 fixed, 0 regressed, 0 changed-but-still-failing.** The **5** attributable to this PR: `duplicateClassElements`, `gettersAndSettersErrors`, `twoAccessorsWithSameName`, `twoAccessorsWithSameName2`, `symbolProperty44`. The other 14 come from #15907/#15909/#15911/#15912/#15914 in this branch's history.
- **Full emit suite unchanged**: 11562/11563 JS, 1372/1390 DTS.
- 8/8 new checker tests pass, covering both directions plus the six must-not-move cases above and a static/renamed-binder variant.

`gettersAndSettersErrors` is a bonus: it was classified as a *detection failure* (missing **both** declarations of its groups) rather than skip-the-first, and was expected not to ride along. Reporting every declaration fixed it too.

## Scope note

This is the cheap, oracle-verified half of a larger duplicate-identifier gap. A survey of the 26 tests touching TS2300/2303/2699/2687/2393 found 24 under-reporting, splitting into at least five families. Deliberately **not** bundled here: the TS2303 circular-import-alias family (8 tests, and its direction is inconsistent — one row keeps the first declaration, another keeps the second), TS2699 `staticPropertyNameConflicts` (1 test but 58 fingerprints), the duplicate-**parameter** family (3 tests), and TS2687. Each wants its own investigation.

One unverified interaction worth flagging for review: `class C { x; x }` already reported both declarations even though other TS2300 emitters (`duplicate_property_modifiers.rs`, `duplicate_identifiers_followup.rs`, `statement_callback_bridge.rs`) carry "subsequent only" comments, so at least one other site participates in that shape. The full-corpus run shows no regression from this change, but a reviewer familiar with those sites may want to confirm there is no double-reporting path I have not exercised.

Goal: hold

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
