### PR TITLE
fix(checker): only a JS constructor's prototype is closed by its literal

### DIFF
--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -464,6 +464,10 @@ impl<'a> CheckerState<'a> {
                         read_pos,
                     )
                     .is_some_and(|declares| !declares)
+                // Mirrors the TS2339 site: only a JS constructor's prototype is
+                // closed by its object literal. On a plain function the write
+                // stays an expando declaration.
+                && self.js_prototype_owner_is_js_constructor(prototype_root_expr)
             {
                 return false;
             }

--- a/crates/tsz-checker/src/types/property_access_helpers/expando_prototype_writes.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando_prototype_writes.rs
@@ -408,4 +408,34 @@ impl<'a> CheckerState<'a> {
             elem_prop_name.is_some_and(|name| name == property_name)
         }))
     }
+
+    /// Whether the owner of a `X.prototype` expression is a JS *constructor*,
+    /// in tsc's `isJSConstructor` sense: the function carries a `@constructor`
+    /// (`@class`) JSDoc tag, or its symbol has members — which for a JS
+    /// function means the body performs `this.x = ...` assignments.
+    ///
+    /// This is what separates a closed prototype from an open one. For a JS
+    /// constructor, `X.prototype = { ... }` establishes the complete prototype
+    /// and a later `X.prototype.y = ...` writing an undeclared property is
+    /// TS2339. For a plain function it is an ordinary prototype-property
+    /// declaration that merges with the literal, and reporting it is a false
+    /// positive.
+    pub(in crate::types_domain) fn js_prototype_owner_is_js_constructor(
+        &mut self,
+        prototype_root_expr: NodeIndex,
+    ) -> bool {
+        let Some(owner_target) = self.js_prototype_owner_function_target(prototype_root_expr)
+        else {
+            return false;
+        };
+        if self
+            .get_jsdoc_for_function(owner_target)
+            .is_some_and(|jsdoc| Self::jsdoc_contains_tag(&jsdoc, "constructor"))
+        {
+            return true;
+        }
+        self.resolve_identifier_symbol(prototype_root_expr)
+            .or_else(|| self.resolve_qualified_symbol(prototype_root_expr))
+            .is_some_and(|sym_id| self.symbol_has_js_constructor_evidence(sym_id))
+    }
 }

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -725,6 +725,11 @@ impl<'a> CheckerState<'a> {
                         read_pos,
                     )
                     .is_some_and(|declares| !declares)
+                // Only a JS *constructor*'s prototype is closed by its object
+                // literal. On a plain function, `X.prototype.y = ...` is an
+                // ordinary prototype-property declaration that merges with the
+                // literal, and reporting it is a false positive.
+                && self.js_prototype_owner_is_js_constructor(prototype_access.expression)
             {
                 let type_display = self
                     .prior_js_prototype_object_literal_assignment_display(

--- a/crates/tsz-checker/tests/jsdoc_prototype_assignment_literal_display.rs
+++ b/crates/tsz-checker/tests/jsdoc_prototype_assignment_literal_display.rs
@@ -95,14 +95,19 @@ fn ts2339_nested_iife_prototype_property_assignment_uses_literal_shape() {
     assert_prototype_addon_message_is_structural(&diags);
 }
 
-/// A different iteration variable name — `K`/`P`/`X` instead of the
+/// A different iteration variable name — `one`/`two`/`three` instead of the
 /// idiomatic `set`/`get` — must produce the same structural display: the
 /// rule is about the receiver shape, not about specific identifier names.
+///
+/// `C` has to be a JS *constructor* for the prototype to be closed at all;
+/// `this._m = {}` supplies the symbol members that make it one. A plain
+/// `function C() {}` owner is an open prototype and correctly reports
+/// nothing — see `ts2339_plain_function_prototype_write_is_not_reported`.
 #[test]
 fn ts2339_renamed_prototype_methods_use_literal_shape() {
     let diags = diagnostics_for_js(
         r#"
-function C() {}
+function C() { this._m = {}; }
 C.prototype = {
     one: function() {},
     two() {}
@@ -126,6 +131,95 @@ C.prototype.three = function () {};
         assert!(
             !msg.contains("type 'prototype'"),
             "TS2339 must not display as 'prototype'; got: {msg:?}",
+        );
+    }
+}
+
+// =========================================================================
+// Only a JS *constructor*'s prototype is closed by its object literal
+// =========================================================================
+//
+// tsc's `isJSConstructor`: the owner function carries a `@constructor`
+// (`@class`) JSDoc tag, or its symbol has members — which for a JS function
+// means the body performs `this.x = ...` assignments. For such an owner,
+// `X.prototype = { ... }` establishes the complete prototype and a later
+// `X.prototype.y = ...` writing an undeclared property is TS2339. For a plain
+// function the write is an ordinary prototype-property declaration that merges
+// with the literal, and reporting it is a false positive
+// (`typeFromPropertyAssignment11`/`13` expect no diagnostics at all).
+
+fn ts2339_names(source: &str) -> Vec<String> {
+    diagnostics_for_js(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2339)
+        .map(|(_, message)| message)
+        .collect()
+}
+
+#[test]
+fn ts2339_plain_function_prototype_write_is_not_reported() {
+    // Empty-bodied function owner: open prototype, the write declares `j`.
+    for owner in ["function I() {}", "var I = function() {};"] {
+        let source = format!("{owner}\nI.prototype = {{ m() {{}} }};\nI.prototype.j = 2;\n");
+        assert!(
+            ts2339_names(&source).is_empty(),
+            "owner={owner} must not report TS2339; got {:?}",
+            ts2339_names(&source)
+        );
+    }
+}
+
+#[test]
+fn ts2339_plain_function_prototype_write_is_name_independent() {
+    // Same shape under renamed binders and a nested owner.
+    for (ctor, prop) in [("I", "j"), ("Widget", "extra"), ("_a0", "_b1")] {
+        let source = format!(
+            "var {ctor} = function() {{}};\n{ctor}.prototype = {{ m() {{}} }};\n{ctor}.prototype.{prop} = 2;\n"
+        );
+        assert!(
+            ts2339_names(&source).is_empty(),
+            "ctor={ctor} prop={prop} must not report TS2339"
+        );
+    }
+    let nested = "var O = {};\nO.Inner = function() {};\nO.Inner.prototype = { m() {} };\nO.Inner.prototype.j = 2;\n";
+    assert!(
+        ts2339_names(nested).is_empty(),
+        "nested owner must not report TS2339"
+    );
+}
+
+#[test]
+fn ts2339_js_constructor_prototype_write_is_still_reported() {
+    // Both disjuncts of `isJSConstructor` keep the prototype closed.
+    let via_tag = "/** @constructor */\nvar M = function() {};\nM.prototype = { set: function() {} };\nM.prototype.addon = function () {};\n";
+    let via_members = "var M = function() { this._map = {}; };\nM.prototype = { set: function() {} };\nM.prototype.addon = function () {};\n";
+    for (label, source) in [
+        ("@constructor tag", via_tag),
+        ("this.x members", via_members),
+    ] {
+        let messages = ts2339_names(source);
+        assert!(
+            messages.iter().any(|m| m.contains("'addon'")),
+            "{label}: a JS constructor's prototype stays closed; got {messages:?}"
+        );
+    }
+}
+
+#[test]
+fn ts2339_prototype_write_is_not_reported_when_the_literal_declares_it() {
+    // Control: a write of a property the literal already declares is fine on
+    // either owner kind.
+    for owner in [
+        "var M = function() { this._map = {}; };",
+        "var M = function() {};",
+    ] {
+        let source = format!(
+            "{owner}\nM.prototype = {{ set: function() {{}} }};\nM.prototype.set = function () {{}};\n"
+        );
+        assert!(
+            ts2339_names(&source).is_empty(),
+            "owner={owner} redeclaring `set` must not report; got {:?}",
+            ts2339_names(&source)
         );
     }
 }


### PR DESCRIPTION
Goal: hold

## Problem

`X.prototype = { ... }` followed by `X.prototype.y = ...` reported TS2339 on the
write for **every** owner:

```js
var Inner = function() {}
Inner.prototype = { m() { }, i: 1 }
Inner.prototype.j = 2        // tsz: TS2339 'j' does not exist on '{ m(): void; i: number; }'
                             // tsc: nothing — the write declares `j`
```

## Structural rule

When the owner of a `X.prototype` expression is a JS **constructor**, tsc treats
`X.prototype = { ... }` as establishing the complete prototype and reports
TS2339 for a later write of an undeclared property; when the owner is a plain
function the write is an ordinary prototype-property declaration that merges
with the literal and tsc reports nothing. tsz now does the same, through a new
`js_prototype_owner_is_js_constructor` predicate in the checker's
`property_access_helpers`.

"JS constructor" is tsc's `isJSConstructor`, and the predicate is built from its
two disjuncts:
1. the owner function carries a `@constructor` / `@class` JSDoc tag, or
2. its symbol has members — which for a JS function means the body performs
   `this.x = ...` assignments.

## How the discriminator was found

Not from the reported witness. I enumerated **every** corpus test that combines
a prototype object literal with a later prototype write, and matched the written
property names against the property names in the oracle's TS2339 messages. All
six separate exactly on that predicate:

| test | owner | oracle |
| --- | --- | --- |
| `typeFromPropertyAssignment11` | plain function | no diagnostics |
| `typeFromPropertyAssignment13` | plain function (nested `Outer.Inner`) | no diagnostics |
| `contextualTyping` | plain function | no diagnostics |
| `targetTypeTest1` | plain function | no diagnostics |
| `typeFromPrototypeAssignment` | `@constructor` + `this.x =` | **TS2339 on the write** |
| `typeFromPrototypeAssignment2` | `@constructor` + `this.x =` | **TS2339 on the write** |

The two positive cases satisfy *both* disjuncts, so the corpus alone cannot
separate them — which is expected, since they are two halves of one predicate in
tsc. Both are covered by tests here.

## A rejected simpler fix

Removing the check outright was implemented and measured first. It fixes the
same two tests with no pass-count regression anywhere — and is still wrong: it
silently drops a genuine TS2339 from `typeFromPrototypeAssignment` and
`typeFromPrototypeAssignment2`, each going from 6 to 7 missing fingerprints.
**The pass count hides this**, because both tests were already failing for other
reasons. Worth noting for anyone measuring parity work by pass count alone; I
now diff per-test fingerprint multisets, not just the pass/fail bit.

## Adjacent-case matrix

`tests/jsdoc_prototype_assignment_literal_display.rs`, 4 new tests plus the 3
existing display tests still passing:

| Case | Expectation |
| --- | --- |
| `function I() {}` and `var I = function(){}` owners | no TS2339 |
| **Renamed binders** `I`/`Widget`/`_a0` × `j`/`extra`/`_b1` | no TS2339, name-independent |
| Nested owner `O.Inner.prototype.j` | no TS2339 |
| Owner with `@constructor` tag | TS2339 **still reported** |
| Owner with `this.x =` members | TS2339 **still reported** |
| Write of a property the literal already declares, either owner kind | no TS2339 |
| Receiver display is the literal's structural shape, never `'prototype'` | unchanged (3 existing tests) |

`ts2339_renamed_prototype_methods_use_literal_shape` used a plain
`function C() {}` owner — a shape tsc reports nothing for, so it was asserting
the old behaviour. Its subject is the receiver *display* being name-independent,
so its fixture becomes a real JS constructor and the original intent is kept.

## Verification

All run locally; ground truth is the tsc 7.0.2 oracle in
`scripts/conformance/tsc-cache-full.json`.

```
./scripts/conformance/conformance.sh run --workers 12
  before: 11308/12043      after: 11310/12043     (+2, zero regressions)

./scripts/conformance/conformance.sh run --filter conformance/salsa --workers 8
  before: 114/186 (61.3%)  after: 116/186 (62.4%)

./scripts/emit/run.sh
  JS  11562/11563  (unchanged)
  DTS 1372/1390    (unchanged)

cargo nextest run -p tsz-checker --lib
  8273 run, 6 failed — the same 6 that fail on main untouched
  (architecture_contract, assignability_domain, flow_assignment_relation_routing,
   return_context_type_param_shadowing, state_type_environment_relation_routing,
   zod_type_query_regression). Verified by stashing and re-running.

./scripts/arch/check-checker-boundaries.sh   passed
cargo clippy -p tsz-checker --lib            clean
```

Per-test fingerprint deltas:

```
FIXED: 2
  + typeFromPropertyAssignment11.ts
  + typeFromPropertyAssignment13.ts
REGRESSED: 0
typeFromPrototypeAssignment:  missing 6 -> 6, newly-missing []
typeFromPrototypeAssignment2: missing 6 -> 6, newly-missing []
```

Branched from `main`; independent of #15906, #15908 and #15910.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: xhigh
