### PR TITLE
fix(emit): gate the DTS identity-call literal on callee genericity

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/literal_initializers.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/literal_initializers.rs
@@ -344,6 +344,35 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
 
+        // Name equality alone is not the rule. tsc only lets the argument's
+        // literal type survive when the returned parameter is typed by one of
+        // the callee's OWN type parameters — a real identity signature
+        // `<T>(x: T) => T`. With a concrete parameter type the call's type is
+        // the signature's return type, so `function f(x: number) { return x; }`
+        // called as `f(10)` is `number`, not `10`.
+        //
+        // Only the `import x = ns.fn` resolver path reaches this heuristic, so
+        // the miss was confined to aliased callees with an INFERRED return type
+        // (an annotated one is answered by an earlier branch). Witness:
+        // compiler/internalAliasFunction.ts, whose baseline is `var bVal: number`.
+        let first_param_annotation = func
+            .parameters
+            .nodes
+            .first()
+            .copied()
+            .and_then(|param_idx| self.arena.get(param_idx))
+            .and_then(|param_node| self.arena.get_parameter(param_node))
+            .map(|param| param.type_annotation)?;
+        let annotation_name =
+            self.simple_type_node_name_from_arena(self.arena, first_param_annotation)?;
+        if !super::generic_call_literal::function_declares_type_parameter(
+            self.arena,
+            func,
+            &annotation_name,
+        ) {
+            return None;
+        }
+
         let mut text = self.const_literal_initializer_text_deep_guarded(args.nodes[0], guard)?;
         if text.starts_with('-') {
             while text.ends_with(')') {


### PR DESCRIPTION
## Summary

`const_literal_identity_call_text` returns the **argument's literal source text** whenever the callee's body is `return <first-parameter>`, decided by name equality alone with no test that the callee is generic. An aliased call to a concrete-typed identity function therefore emitted the literal:

```ts
namespace a { export function foo(x: number) { return x; } }
namespace c {
    import b = a.foo;
    export var bVal = b(10);   // baseline: `var bVal: number;`   tsz: `var bVal: 10;`
}
```

tsc only lets the argument's literal type survive when the returned parameter is typed by one of the callee's **own type parameters** — a real identity signature `<T>(x: T) => T`. With a concrete parameter type, the call's type is the signature's return type.

## This is emit-only, and specifically *not* a type query

The checker already computes `number` for the same declaration — `const probe: string = c.bVal` reports `TS2322: Type 'number' is not assignable to type 'string'`. So two type paths disagreed and the DTS one was wrong.

The decisive evidence that it is **source-text extraction** rather than an impure or mis-scoped type query:

```ts
export var castArg = b(10 as number);   // tsz: 10   tsc: number
```

`10 as number` has type `number`. No type query, pure or otherwise, returns `10` from it — only copying the literal token can. That ruled out an earlier hypothesis (a purity problem in the binding-initializer type path) and relocated the fix to the emitter's own text-inference heuristic.

## Why the blast radius is small

Only the `import x = ns.fn` resolver path reaches this heuristic — `a.foo(10)` and `const q = a.foo; q(10)` both already printed `number`. And an *annotated* return is answered by an earlier branch (`variable_decl.rs` gates the fallback on `preferred_expression_type_text(initializer).is_none()`, which resolves from the annotation text). That is why the miss was confined to aliased callees with an **inferred** return type.

Differential probe, tsz vs tsc 7.0.2, after the fix:

| declaration | call | tsc | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| `f1(x: number) { return x }` | `g1(10)` | `number` | `10` | **`number`** |
| `f2(x: number) { return x + 0 }` | `g2(10)` | `number` | `number` | `number` |
| `f3(x: string) { return x }` | `g3("hi")` | `string` | `"hi"` | **`string`** |
| `f4<T>(x: T) { return x }` | `g4(10)` | `number` | `number` | `number` |
| `f1` via `const` | `c1 = g1(10)` | `number` | `10` | **`number`** |

The generic case (`f4`) is the one that must keep working, and does.

## Structural rule

When a declaration-emit initializer is a call whose callee body returns its own first parameter, tsc's declared type is the callee signature's return type; the argument's literal type may only survive when that parameter is typed by one of the callee's type parameters. tsz now applies this in the declaration emitter's literal-initializer path.

## Owner layer

Emitter only — `crates/tsz-emitter/src/declaration_emitter/helpers/literal_initializers.rs`, in `const_literal_identity_call_text` immediately after the existing name-equality check.

The gate is composed from two existing helpers, `simple_type_node_name_from_arena` and `generic_call_literal::function_declares_type_parameter`, rather than adding a third variant of the same predicate. Strictly narrowing: it can only turn a literal answer into a fall-through to the next branch, never the reverse.

## Verification

Local, on this branch vs `main` at `08a46207` (measured on a clean base, not alongside my other open PRs):

- **Emit DTS: 1372 -> 1375 (15 failing).** Flips `internalAliasFunction`, `internalAliasFunctionInsideLocalModuleWithExport`, `internalAliasFunctionInsideTopLevelModuleWithoutExport`.
- **Emit JS unchanged**: 11562/11563.
- **Full conformance unchanged**: no flips and no regressions attributable to this change.

## Note on the remaining DTS failures

An audit of all 18 grouped them into five root causes. Two of the remaining 15 have **stale checked-in baselines** and should not be chased: `jsdocDisallowedInTypescript` (tsz matches tsc 7.0.2 byte-for-byte on the `var g` region; the baseline is 6.0 — though tsz also diverges from 7.0.2 on `hof`/`hof2`, so the test is unflippable in both directions and `TSZ_CI_JS_ACCEPTED_FLOOR` should stay at 11562) and `lateBoundAssignmentCandidateJS1` (baseline stale on three counts: `export const` vs `export declare const`, setter-before-getter, and the `[kBar]` position). Four more are the known union-display-ordering campaign.

Goal: hold

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
