### PR TITLE
fix(checker): report TS2303 at the `export =` side of an alias cycle

### DIFF
--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1677,7 +1677,44 @@ impl<'a> CheckerState<'a> {
                 if self.get_node_span(error_node_idx).is_some() {
                     self.error_at_node(error_node_idx, &message, code);
                 } else if let Some((start, end)) = fallback_span {
-                    self.error(start, end.saturating_sub(start), message, code);
+                    self.error(start, end.saturating_sub(start), message.clone(), code);
+                }
+
+                // `export = X` does NOT create its own alias symbol: the binder
+                // records `"export="` in `file_locals` as a second KEY onto X's
+                // existing `SymbolId` (nodes/binding.rs, EXPORT_ASSIGNMENT arm),
+                // and never registers the `ExportAssignment` node as one of X's
+                // declarations. So the export side is unreachable from the
+                // symbol — neither by collecting more symbols nor by iterating
+                // `sym.declarations` — and the cycle could only ever be reported
+                // from the import side.
+                //
+                // tsc reports at EVERY alias declaration in the cycle, so when
+                // this file's `export =` targets the cyclic symbol, emit there
+                // too. Scanning only this file's statements preserves the
+                // current-file ownership the collection scan above is built on.
+                if self.ctx.binder.file_locals.get("export=") == Some(sym_id)
+                    && let Some(source_file) = self.ctx.arena.source_files.first()
+                {
+                    let export_equals_stmts: Vec<NodeIndex> = source_file
+                        .statements
+                        .nodes
+                        .iter()
+                        .copied()
+                        .filter(|&stmt_idx| {
+                            self.ctx.arena.get(stmt_idx).is_some_and(|stmt_node| {
+                                stmt_node.kind == syntax_kind_ext::EXPORT_ASSIGNMENT
+                                    && self
+                                        .ctx
+                                        .arena
+                                        .get_export_assignment(stmt_node)
+                                        .is_some_and(|assign| assign.is_export_equals)
+                            })
+                        })
+                        .collect();
+                    for stmt_idx in export_equals_stmts {
+                        self.error_at_node(stmt_idx, &message, code);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

tsc reports "Circular definition of import alias" at **every** alias declaration participating in the cycle — the emit block's own comment already states this. tsz only ever reported the import side.

The reason is that **`export = X` does not create an alias symbol.** The binder's `EXPORT_ASSIGNMENT` arm resolves the target to an *existing* `SymbolId` and records `"export="` in `file_locals` as a second **key** onto it (`crates/tsz-binder/src/nodes/binding.rs`; `crates/tsz-binder/src/modules/binding.rs` does the same for `module_exports`). So in

```ts
import self = require("./m");
export = self;
```

there is exactly one symbol, reachable under two keys.

## Two fixes that look obvious and are provably inert

Both were implemented and measured before arriving at this patch:

| attempt | result | why |
| --- | --- | --- |
| scan `binder.module_exports[file_name]` for ALIAS symbols in the collection loop | **inert** | contributes the import alias's own `SymbolId`; the existing `sort_unstable_by_key` + `dedup` at the end of the scan collapses it |
| scan `binder.file_locals` for ALIAS symbols | **inert** | same — the `"export="` entry is a second key onto the same id, not a second symbol |
| iterate `sym.declarations` instead of `primary_declaration()` at the emit site | **inert** (excluded by reading, not attempted) | the `ExportAssignment` node is never registered as a declaration of the target symbol |

Recording these because each is a natural first guess and none of them can work.

## The actual fix

The second anchor is reachable only from the AST. Once a cycle is detected for a symbol, scan the current file's top-level `export =` statements and report at each one when `file_locals["export="]` resolves to that symbol.

Scanning only this file's statements preserves the current-file ownership the collection scan is built on (see its comment at the top of `check_circular_import_aliases`), so it cannot reintroduce the cross-file duplicate emission that iterating the merged symbol arena would.

## Structural rule

When an import alias participates in a circular definition and the same file re-exports it with `export =`, tsc reports TS2303 at the export assignment as well as the import; tsz now does this from the AST, because the export assignment is not represented as a declaration of the alias symbol.

## Owner layer

Checker — `crates/tsz-checker/src/declarations/module_checker.rs`, inside `check_circular_import_aliases`'s existing `cycle_detected` block. No binder change, no new symbol, no change to cycle detection itself: only an additional anchor once a cycle has already been established.

## Scope

Flips `compiler/recursiveExportAssignmentAndFindAliasedType4/5/6.ts`.

**Explicitly not covered**, and left for follow-up:

- **types 1-3** nest `export = self` inside `declare module "moduleC" { ... }`, so the statement is not a top-level file statement and `file_locals["export="]` is not the relevant table. Needs container resolution — the enclosing module's own export table — which is a larger change.
- **`circular3` and `exportAsNamespaceConflict`** use `export type { A as B }` and `export as namespace N`, which **do** mint their own symbols. Those are a different defect: the symbol exists but is either not flagged `ALIAS`, filtered by `is_umd_export`, or reaching the loop and failing cycle detection. Not distinguishable by reading; wants a debugger session.

So the eight-test TS2303 family is really 6 + 2, and this PR closes 3 of the 6.

## Verification

Local, on this branch vs `main` at `c9fee7f6`:

- **Full conformance: +3 flips, 0 regressed, 0 changed-but-still-failing** (measured as part of a +16 run that also included my other open PRs' changes; the 3 attributable here are the `recursiveExportAssignmentAndFindAliasedType4/5/6` rows, each re-confirmed 1/1 individually on this branch after rebuilding on the clean base).
- **Full emit suite unchanged**: 11562/11563 JS, 1372/1390 DTS.
- Negative control from the audit that found this: `uniqueSymbolsPropertyNames`, which already *over*-reports TS2300 by 4, is unchanged.

## Note on test coverage

No checker unit test accompanies this. The cycle requires the import specifier to resolve back to the declaring file, and `tsz-checker`'s `check_source_diagnostics` harness does not perform module resolution — a self-import repro that reproduces correctly through the CLI (`import self = require("./test"); export = self;` in `test.ts`, both anchors reported) yields zero diagnostics in-process. I wrote the tests, found they could not express the shape, and removed them rather than leave a misleading always-passing file.

The regression lock is therefore the three conformance rows, which are a hard CI gate rather than an advisory artifact. If a reviewer wants an in-repo unit lock, the right home is a `tsz-cli` driver test with a real multi-file project.

Goal: hold

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
