### PR TITLE
chore(ci): split CI into a fast per-merge lane and a nightly heavy lane

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -56,8 +56,19 @@ Hard rules:
   2000 physical lines. Split instead of adding local allowlists or ceilings.
 
 ## Testing And Commands
-- Never run full conformance, emit, or fourslash locally. Use narrow filters;
-  ready-review CI owns broad suites.
+- Local runs are the source of truth. CI's per-merge lane is only `clippy` +
+  `arch-size`; conformance, emit, fourslash and unit run nightly and on
+  `workflow_dispatch`, so a broad suite you did not run locally did not run.
+- Before pushing a behavior change, run the suites it can affect and record
+  the before/after in the PR body:
+  - `./scripts/conformance/conformance.sh snapshot --workers 12 --force`
+    (~8 min; diff `conformance-detail.json` against a saved baseline)
+  - `./scripts/emit/run.sh --skip-build` (~25s, must hold 11562 JS / 1375 DTS)
+  - `./scripts/fourslash/run-fourslash.sh --skip-build` (~2 min, needs
+    `cargo build --release -p tsz-cli --bin tsz-server`)
+- Never run two `conformance.sh` invocations concurrently: it cleans the shared
+  `TypeScript/tests/cases` tree on entry, so parallel runs corrupt each other
+  silently and one dies producing no output.
 - Use `cargo nextest run`, not `cargo test`.
 - Wrap long or memory-heavy commands with `scripts/safe-run.sh`.
 - Prefer not to checkout the full TypeScript submodule unless the specific
@@ -86,8 +97,9 @@ Hard rules:
 - Every PR serves one of the four roadmap goals: `green` (benchmark rows
   compile like `tsc`), `fast` (green rows 2x faster than `tsgo`), `grow`
   (new corpus projects), `hold` (conformance/emit/fourslash parity floor).
-- The `pr-body-gate` CI job greps the remote body for exact field formats;
-  match them or the job fails. Required lines, each with a non-empty value:
+- PR bodies follow a review convention, not an enforced gate: no
+  `pr-body-gate` job exists in `.github/workflows/`. Write these because
+  reviewers and future sessions read them. Each line takes a non-empty value:
   - `Goal: <green|fast|grow|hold>`
   - A `## Provenance` block with `Machine: <m1|m4|studio|cloud|hostname>`,
     `Assistant: <claude-code|codex>`, `Model: <model id>`, and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # Nightly heavy lane. Local runs are the per-merge source of truth for
+    # conformance/emit/fourslash/unit; this is the automated drift detector.
+    - cron: '0 4 * * *'
   workflow_dispatch:
     inputs:
       refresh_tsc_cache:
@@ -20,13 +24,15 @@ permissions:
   actions: read
 
 concurrency:
-  group: ci-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  # Event is part of the group so a long nightly cannot queue behind (or
+  # block) push-to-main runs: both resolve github.ref to refs/heads/main.
+  group: ci-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   clippy:
     name: clippy
-    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.refresh_tsc_cache != true) }}
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.refresh_tsc_cache != true }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -57,7 +63,7 @@ jobs:
 
   unit:
     name: unit
-    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.refresh_tsc_cache != true) }}
+    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && inputs.refresh_tsc_cache != true }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -69,7 +75,7 @@ jobs:
 
   conformance:
     name: conformance-${{ matrix.shard }}
-    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.refresh_tsc_cache != true) }}
+    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && inputs.refresh_tsc_cache != true }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
@@ -98,7 +104,7 @@ jobs:
             ci-metrics/conformance-failures-*.txt
             ci-metrics/conformance-timings-*.json
           if-no-files-found: warn
-          retention-days: 1
+          retention-days: 14
 
   conformance-aggregate:
     name: conformance-aggregate
@@ -125,7 +131,7 @@ jobs:
 
   emit:
     name: emit-${{ matrix.shard }}
-    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.refresh_tsc_cache != true) }}
+    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && inputs.refresh_tsc_cache != true }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
@@ -153,7 +159,7 @@ jobs:
             ci-metrics/emit-detail-${{ matrix.shard }}.json
             .ci-logs/emit/*.log
           if-no-files-found: warn
-          retention-days: 1
+          retention-days: 14
 
   emit-aggregate:
     name: emit-aggregate
@@ -179,7 +185,7 @@ jobs:
 
   fourslash:
     name: fourslash-${{ matrix.shard }}
-    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.refresh_tsc_cache != true) }}
+    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && inputs.refresh_tsc_cache != true }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
@@ -212,7 +218,7 @@ jobs:
             ci-metrics/fourslash-shard-${{ matrix.shard }}.json
             .ci-logs/fourslash/*.log
           if-no-files-found: warn
-          retention-days: 1
+          retention-days: 14
 
   fourslash-aggregate:
     name: fourslash-aggregate
@@ -238,7 +244,7 @@ jobs:
 
   arch-size:
     name: arch-size
-    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.refresh_tsc_cache != true) }}
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.refresh_tsc_cache != true }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -446,17 +452,24 @@ jobs:
               "arch-size",
           }
 
-          # On pull_request the heavy jobs are intentionally skipped: the merge
-          # campaign validates PRs via local delta-verified trains, and the full
-          # suite still runs on merge_group / push-to-main / workflow_dispatch.
-          # So "skipped" counts as a pass ONLY for pull_request; a real failure or
-          # cancellation still fails, and every non-PR event stays strict.
-          allow_skipped = os.environ.get("EVENT_NAME") == "pull_request"
-          passing = {"success", "skipped"} if allow_skipped else {"success"}
+          # Two lanes. `fast` runs on every event and must always succeed.
+          # `heavy` runs only on schedule / workflow_dispatch, because local
+          # runs are the per-merge source of truth for conformance, emit,
+          # fourslash and unit; on every other event those jobs are skipped BY
+          # DESIGN and skipping must count as passing, or nothing can merge.
+          #
+          # A real failure or cancellation still fails in both lanes, and on the
+          # events where the heavy jobs actually run they are strictly required.
+          fast = {"clippy", "arch-size"}
+          heavy_lane_event = os.environ.get("EVENT_NAME") in {"schedule", "workflow_dispatch"}
 
           failures = []
           for name in sorted(required):
               result = needs.get(name, {}).get("result")
+              if name in fast or heavy_lane_event:
+                  passing = {"success"}
+              else:
+                  passing = {"success", "skipped"}
               if result not in passing:
                   failures.append(f"{name}: {result}")
 
@@ -466,8 +479,13 @@ jobs:
                   print(f"  - {failure}")
               sys.exit(1)
 
-          if allow_skipped:
-              print("PR event: heavy jobs skipped by design; core gate passes.")
+          if heavy_lane_event:
+              print("Heavy lane: clippy, unit, conformance, emit and fourslash all passed.")
           else:
-              print("Clippy, unit, conformance, emit, and fourslash checks passed.")
+              print(
+                  "Fast lane: clippy and arch-size passed. Conformance, emit, "
+                  "fourslash and unit are skipped by design on this event — they "
+                  "run nightly and on workflow_dispatch, and local runs are the "
+                  "per-merge source of truth. See docs/CONTRIBUTING.md."
+              )
           PY

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -75,8 +75,11 @@ python3 scripts/conformance/query-conformance.py --dashboard
 Every PR body must include a `Goal: <green|fast|grow|hold>` line, a
 `## Verification` section, and a `## Provenance` block with `Machine:`,
 `Assistant:`, `Model:`, and `Effort:` lines reporting your actual runtime
-values; the `pr-body-gate` CI job enforces these. Use the PR body for
-scope, invariants, findings, and verification.
+values. Use the PR body for scope, invariants, findings, and verification.
+
+These fields are a review convention, not an enforced gate: no `pr-body-gate`
+job exists in `.github/workflows/`. Write them because reviewers and future
+sessions read them, not because CI will stop you.
 
 When adding or re-adding WIP state, leave a PR comment with the reason WIP
 state changed, the current blocker or work, and the next action, signed with

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -134,9 +134,12 @@ These survive any goal reshuffle:
 5. **Cache/order honesty.** Cache-enabled and cache-disabled runs agree;
    reordered declarations produce stable diagnostics; `T` not assignable to
    `T` is a cache/keying bug until proven otherwise.
-6. **Local verification.** Never run full conformance/emit/fourslash locally;
-   use narrow filters and `cargo nextest run`; ready-review CI owns broad
-   suites. Wrap heavy commands in `scripts/safe-run.sh`.
+6. **Local verification.** Local runs are the source of truth. CI's per-merge
+   lane is `clippy` + `arch-size` only; conformance, emit, fourslash and unit
+   run nightly and on `workflow_dispatch`. Run the suites a change can affect
+   before pushing and record before/after in the PR body. Wrap heavy commands
+   in `scripts/safe-run.sh`, and never run two `conformance.sh` invocations
+   concurrently — it cleans the shared corpus tree on entry.
 
 ## Coordination
 

--- a/scripts/ci/test_full_ci_conformance_artifacts.py
+++ b/scripts/ci/test_full_ci_conformance_artifacts.py
@@ -46,7 +46,11 @@ class ConformanceArtifactHandoffTests(unittest.TestCase):
         upload_block = self.workflow[
             self.workflow.index("name: conformance-shard-${{ matrix.shard }}") :
         ]
-        upload_block = upload_block[: upload_block.index("retention-days: 1")]
+        # Match the key, not a value prefix: "retention-days: 14".index(
+        # "retention-days: 1") is 0, which silently truncates the block to ""
+        # and makes the assertion below vacuous, and any value not starting
+        # with "1" would raise ValueError here instead.
+        upload_block = upload_block[: upload_block.index("retention-days:")]
         self.assertNotIn("include-hidden-files", upload_block)
 
     def test_shard_writes_failure_list_before_artifact_handoff(self):


### PR DESCRIPTION
## Summary

Local runs become the source of truth for conformance, emit, fourslash and unit. CI keeps a fast correctness gate on every event and moves the heavy suites to a nightly schedule plus `workflow_dispatch`.

**Per landed PR: ~1720 → ~100 timeout-minutes (95% less.)** The heavy suite runs once a day instead of twice per landing.

| lane | jobs | events |
| --- | --- | --- |
| **fast** | `clippy`, `arch-size`, `CI Summary` | pull_request, merge_group, push→main, schedule, workflow_dispatch |
| **heavy** | `unit`, `conformance`×4, `conformance-aggregate`, `emit`×4, `emit-aggregate`, `fourslash`×6, `fourslash-aggregate` | schedule (04:00 UTC), workflow_dispatch |

## Why no job is deleted

**No job is deleted or renamed — only the `if:` predicates change.** A `needs:` entry pointing at a nonexistent job makes the whole workflow unparseable, so *no* checks report and nothing can ever merge. `CI Summary` is the only required check on `main` and it `needs:` all nine heavy jobs, so keeping every job defined removes that failure mode by construction.

Verified: 11 jobs, **zero dangling `needs:`**, `CI Summary` still reports on every event.

## The gate logic had to change with it

`ci-summary` previously allowed skipped jobs only on `pull_request`. With the heavy jobs now skipped on `merge_group` and `push` too, that would have **hard-blocked every merge**. It now splits by lane: fast jobs must succeed on every event; heavy jobs must succeed only on the events where they actually run.

Simulated across all 9 event/result combinations:

| event | fast | heavy | verdict |
| --- | --- | --- | --- |
| pull_request / merge_group / push | success | skipped | PASS |
| schedule / workflow_dispatch | success | success | PASS |
| merge_group | **failure** | skipped | FAIL |
| schedule | success | **failure** | FAIL |
| schedule | success | **skipped** | FAIL |

That last row matters: a nightly that fires but does not execute its suites reports red rather than a false green.

## Two departures from the obvious plan

Both forced by cross-references, not preference:

1. **`push: main` stays.** Deleting it breaks `gh-pages.yml`, which deploys on `workflow_run` gated at `head_branch == main` — a `merge_group` run's head_branch is `gh-readonly-queue/main/pr-…`, never `main`. It would also blind `check-main-red.mjs` to admin/out-of-band merges. The push run now costs 50 minutes instead of 860, capturing ~97% of the lever.
2. **The fast lane turns ON for `pull_request`,** where nothing ran before. A net safety increase, and it stops `CI Summary` from being an unconditional green on PR heads.

## What this deliberately does NOT do

An earlier version of this change also added `schedule` to `check-main-red.mjs`'s `MAIN_EVENTS` so a red nightly would file a sentinel issue. **Adversarial review killed it, with measurements from the live repo:**

- `check-main-red.mjs` takes the *newest conclusive run* as its verdict and **closes** the sentinel on any non-red. After this split, push→main is an 8-minute green run arriving every ~22 minutes, so a red nightly would be superseded and auto-closed with "✅ main is green again". Its 60-run lookback also spans only ~4 hours, so a 04:00 nightly is out of the input by ~09:30 regardless.
- GitHub is **dropping ~80% of this repo's cron firings** — `ci-health.yml` requests 96/day and receives ~20, with an observed 3h23m gap spanning exactly the 04:00 window. A *missed* nightly is currently indistinguishable from a passing one.

Rather than ship a sentinel that reports green when nothing ran, the sentinel is left watching what actually runs. **Follow-up worth doing:** a freshness check for the nightly, modelled on the existing `check-latest-freshness.mjs --file-issue --max-age-hours 9` pattern in `ci-health.yml`, which exists for precisely this failure mode.

## Also fixed

- Artifact retention `1` → `14` days. At nightly cadence a 1-day artifact naming the regressed tests expired at roughly the moment the next nightly began.
- `test_full_ci_conformance_artifacts.py` slices on `retention-days:` rather than `retention-days: 1`. The old form matched `"14"` by prefix, truncating the block to `""` and making its `assertNotIn` vacuous; any value not starting with `1` would have raised `ValueError` and killed `full-ci.sh lint`.

## Docs corrected, including two statements that were already false

- **`pr-body-gate` does not exist.** It is referenced in `.claude/CLAUDE.md`, `docs/CONTRIBUTING.md`, `docs/plan/LSP_ROADMAP.md` and a design spec, and is defined in no workflow. Now described as a review convention.
- **"Never run full conformance/emit/fourslash locally; ready-review CI owns broad suites"** is now exactly backwards. `CLAUDE.md` and `ROADMAP.md` now say local runs are the source of truth, with the commands and their expected numbers, plus the hazard that two concurrent `conformance.sh` invocations corrupt each other silently (it cleans the shared corpus tree on entry).

## Verification

- YAML parses; 11 jobs; zero dangling `needs:`; `CI Summary` present with its full `needs:` list intact.
- Gate logic simulated across all 9 event/result combinations (table above).
- CI self-tests: `test_full_ci_conformance_artifacts.py`, `test_full_ci_emit_metrics.py`, `test_full_ci_summary.py`, `test_full_ci_unit_gate.py`, `test_suite_metadata.py`, `test_unit_nextest.py`, `test_ci_resources.py`, `test_check_known_failures_growth.py`, `test-pr-ready-state.mjs` — all pass. (`test_bench_shard_prelude.py` fails identically on clean `main`: a `dict | None` annotation under this Python; pre-existing and unrelated.)
- `scripts/agents/llm-context-audit.py`: 2 findings before and after, both pre-existing `rust-debugger/SKILL.md` budget overruns.

## Known follow-up

`scripts/conformance/conformance-snapshot.json` records 11019 passing; `main` now measures **11342** locally. Refreshing it matters more under a nightly gate, but is deliberately not bundled here: there is a documented Linux/macOS delta (~43 tests) and pinning a macOS-measured number could make the nightly permanently red. It wants a Linux-measured refresh.

Goal: hold

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high