### PR TITLE
emit: add a TypeScript 7 baseline overlay and generator

### DIFF
--- a/scripts/emit/baselines-ts7/README.md
+++ b/scripts/emit/baselines-ts7/README.md
@@ -1,0 +1,85 @@
+# TypeScript 7 emit baselines (overlay)
+
+Baselines regenerated against **TypeScript 7.0.2** — the same compiler version the
+conformance oracle (`scripts/conformance/tsc-cache-full.json`) is pinned to.
+
+## Why this directory exists
+
+`scripts/emit/run.sh` compares tsz's JS and `.d.ts` output against the baselines
+checked into the `TypeScript/` submodule. Those are TypeScript 6.0-era artifacts,
+so the emit suite and the conformance suite were pinned to *different* compiler
+versions. That inconsistency is not cosmetic: TS 7.0.2 rejects Closure-style
+`function(...)` JSDoc types with TS1005 and emits `Function` for them, while the
+6.0 baselines still expect a reconstructed `(this: Object, ...args: any[]) => any`
+signature. Matching one suite meant failing the other.
+
+The submodule is read-only — `scripts/githooks/pre-commit` rejects any commit that
+touches it — so regenerated baselines live here instead.
+
+## How it works
+
+`scripts/emit/src/runner.ts` prefers a file in this directory over the submodule
+copy of the same name, and falls back to the submodule for everything else. Names
+match the submodule exactly, including option suffixes such as
+`foo(target=es2015).js`. The overlay may only *replace* baselines, never add or
+remove them — the runner hard-fails on an overlay name with no submodule
+counterpart, because a new name would change the pass-count denominator and
+re-slice the emit shards.
+
+## Regenerating
+
+    node scripts/emit/dist/regen-baseline.js --filter=<substring> [--dry-run] [--verify]
+
+The generator splices: it copies the existing baseline's header and input-echo
+sections byte-for-byte and replaces only the emitted output sections. That avoids
+having to re-derive the harness's echo format (BOM handling, unit ordering,
+trailing-newline conventions), which is where faithful regeneration is hardest.
+
+Validation rule: a regenerated baseline whose content TS6 and TS7 agree on must
+come out byte-identical to the submodule copy. If a generator cannot reproduce
+the agreement cases exactly, its disagreement cases mean nothing.
+
+## Status: mechanism landed, first slice held
+
+The overlay is empty on purpose. The first slice is generated and verified, but
+landing it would publish a regression, so it is held until the tsz-side emit gaps
+below are fixed.
+
+Reproduce the slice with:
+
+    npx tsc -p scripts/emit/tsconfig.json
+    node scripts/emit/dist/regen-baseline.js --filter=jsDeclarationsRestArgs --verify
+    node scripts/emit/dist/regen-baseline.js --filter=jsDeclarationsMissingTypeParameters --verify
+    node scripts/emit/dist/regen-baseline.js --filter=jsDeclarationsReusesExistingNodesMappingJSDocTypes --verify
+
+Measured effect (full emit run, with those five files present):
+
+    JS  11562 / 11563   unchanged — every JS section regenerates byte-identically
+    DTS  1372 -> 1369 / 1390
+
+The three DTS rows that move are the three retargeted tests. They fail because tsz
+still emits the TS 6.0 shape, not because the new baselines are wrong. Those are
+real gaps that the stale baselines were masking:
+
+| test | TS 6.0 baseline (what tsz emits) | TypeScript 7.0.2 |
+| --- | --- | --- |
+| `jsDeclarationsRestArgsWithThisTypeInJSDocFunction` | `export class` + `(this: Object, ...args: any[]) => any` | `export declare class` + `Function` |
+| `jsDeclarationsMissingTypeParameters` | `func: (arg0: any[]) => any` | `func: Function` |
+| `jsDeclarationsReusesExistingNodesMappingJSDocTypes` | `export const`, `unknown`, callable types, `{[x: string]: number}` | `export declare const`, `any \| null`, `Function`, `Record<string, number>` |
+
+So the tsz-side work is: emit `declare` in JS declaration output, render an
+unparseable Closure `function(...)` JSDoc type as `Function`, render `?` as
+`any | null`, and render `Object.<K, V>` as `Record<K, V>`. Land those together
+with the slice so no published number goes backwards — `scripts/refresh-readme.py`
+deliberately refuses to lower the README emit metrics.
+
+## Do not
+
+- Write into `TypeScript/` or bump the submodule pointer; the pre-commit hook
+  blocks both, and moving the pointer would change the test population and both
+  pass-count denominators.
+- Regenerate the whole corpus in one change. An independent census puts the
+  change set near 286 tests, worth roughly JS -69 and DTS -199 currently-passing
+  rows. That is a gated campaign that needs tsz fixes first, not a baseline swap.
+- Repoint `build-baseline-blob.ts` at this directory. The blob is a read cache of
+  submodule bytes; correctness comes from the runner checking the overlay first.

--- a/scripts/emit/src/regen-baseline.ts
+++ b/scripts/emit/src/regen-baseline.ts
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+/**
+ * Regenerate emit baselines against TypeScript 7.0.2.
+ *
+ * The baselines checked into the TypeScript submodule are TS 6.0-era, while the
+ * conformance oracle is TS 7.0.2. This produces TS7 replacements into
+ * `scripts/emit/baselines-ts7/`, which `runner.ts` prefers over the submodule.
+ * The submodule itself is read-only (`scripts/githooks/pre-commit` blocks it).
+ *
+ * DESIGN: splice, do not rebuild.
+ *
+ * The generator copies the existing baseline verbatim from byte 0 through the
+ * end of the input-echo sections, and replaces only the emitted output
+ * sections. Re-deriving the echo would mean reproducing the TS harness's own
+ * formatting — BOM and UTF-16 inputs, unit ordering, trailing-newline
+ * conventions, `@fullEmitPaths` markers — and every one of those is a way to
+ * corrupt 11.5k currently-passing rows. Splicing makes them structurally
+ * impossible to get wrong.
+ *
+ * VALIDATION RULE: a baseline whose content TS6 and TS7 agree on must
+ * regenerate byte-identically. `--verify` asserts that for the JS sections,
+ * which today agree for every slice-1 test. A generator that cannot reproduce
+ * the agreement cases exactly tells you nothing about its disagreement cases.
+ *
+ * Usage:
+ *   node scripts/emit/dist/regen-baseline.js --filter=<substr> [--dry-run] [--verify] [--repeat=2]
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { parseBaseline } from './baseline-parser.js';
+import { parseDirectiveLine } from './directives.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, '../../..');
+const TS_DIR = path.join(ROOT_DIR, 'TypeScript');
+const BASELINES_DIR = path.join(TS_DIR, 'tests/baselines/reference');
+const OVERLAY_DIR = path.join(__dirname, '../baselines-ts7');
+const TSC = path.join(ROOT_DIR, 'scripts/node_modules/typescript/bin/tsc');
+
+/** Output sections are the emitted artifacts; everything else is input echo. */
+const OUTPUT_EXT_RE = /\.(js|jsx|mjs|cjs|d\.ts|d\.mts|d\.cts)$/;
+
+interface Section {
+  name: string;
+  /** Byte offset of the `//// [name]` marker line. */
+  markerStart: number;
+}
+
+/** Locate every `//// [name]` section marker, in order. */
+function findSections(content: string): Section[] {
+  const out: Section[] = [];
+  const re = /^\/\/\/\/ \[([^\]]+)\]( \/\/\/\/)?\s*$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    // The first marker carries a trailing ` ////` and names the test path, not a file.
+    if (m[2]) continue;
+    out.push({ name: m[1], markerStart: m.index });
+  }
+  return out;
+}
+
+/**
+ * Split a corpus test into its units, honouring `@filename` directives.
+ * Directive lines are dropped from the emitted unit content, matching the
+ * harness.
+ */
+function splitUnits(source: string): { name: string; content: string }[] {
+  const units: { name: string; content: string }[] = [];
+  let current: { name: string; content: string[] } | null = null;
+  for (const line of source.split('\n')) {
+    const directive = parseDirectiveLine(line);
+    if (directive && directive.key === 'filename') {
+      if (current) units.push({ name: current.name, content: current.content.join('\n') });
+      current = { name: directive.value, content: [] };
+      continue;
+    }
+    if (directive) continue; // other directives are options, not content
+    if (current) current.content.push(line);
+    else current = { name: '', content: [line] };
+  }
+  if (current) units.push({ name: current.name, content: current.content.join('\n') });
+  return units.filter(u => u.name !== '' || u.content.trim() !== '');
+}
+
+/** Collect `// @key: value` options, lowercased keys, first variant value only. */
+function collectOptions(source: string): Map<string, string> {
+  const opts = new Map<string, string>();
+  for (const line of source.split('\n')) {
+    const d = parseDirectiveLine(line);
+    if (!d || d.key === 'filename') continue;
+    opts.set(d.key, d.value);
+  }
+  return opts;
+}
+
+interface RegenResult {
+  baselineName: string;
+  outputs: Map<string, string>;
+  diagnostics: string;
+}
+
+/**
+ * Run tsc 7.0.2 over a test's units and return its emitted files.
+ *
+ * `newLine: "crlf"` is mandatory: the harness writes baselines with CRLF, so
+ * dropping it makes every emitted line differ. The `--verify` byte-exact JS
+ * assertion is what catches it if it is ever lost.
+ */
+function runTsc7(
+  units: { name: string; content: string }[],
+  opts: Map<string, string>,
+  variantOverrides: Map<string, string>,
+): RegenResult['outputs'] & { __diagnostics?: string } {
+  const work = fs.mkdtempSync(path.join(os.tmpdir(), 'tsz-regen-'));
+  try {
+    for (const unit of units) {
+      const file = path.join(work, unit.name || 'input.ts');
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, unit.content);
+    }
+    const co: Record<string, unknown> = {
+      newLine: 'crlf',
+      outDir: 'out',
+      declaration: true,
+    };
+    const passthrough = [
+      'target', 'module', 'lib', 'strict', 'allowjs', 'checkjs', 'declaration',
+      'esmoduleinterop', 'jsx', 'moduleresolution', 'noimplicitany', 'emitdeclarationonly',
+      'downleveliteration', 'usedefineforclassfields', 'experimentaldecorators', 'alwaysstrict',
+    ];
+    const camel: Record<string, string> = {
+      allowjs: 'allowJs', checkjs: 'checkJs', esmoduleinterop: 'esModuleInterop',
+      moduleresolution: 'moduleResolution', noimplicitany: 'noImplicitAny',
+      emitdeclarationonly: 'emitDeclarationOnly', downleveliteration: 'downlevelIteration',
+      usedefineforclassfields: 'useDefineForClassFields',
+      experimentaldecorators: 'experimentalDecorators', alwaysstrict: 'alwaysStrict',
+    };
+    for (const key of passthrough) {
+      const raw = variantOverrides.get(key) ?? opts.get(key);
+      if (raw === undefined) continue;
+      const name = camel[key] ?? key;
+      const first = raw.split(',')[0].trim();
+      if (key === 'lib') co[name] = raw.split(',').map(s => s.trim()).filter(Boolean);
+      else if (first === 'true' || first === 'false') co[name] = first === 'true';
+      else co[name] = first;
+    }
+    fs.writeFileSync(
+      path.join(work, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: co, include: ['**/*'] }, null, 2),
+    );
+    let diagnostics = '';
+    try {
+      execFileSync(process.execPath, [TSC, '--project', work, '--pretty', 'false'], {
+        encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      // tsc exits nonzero when the program has errors; it still emits.
+      diagnostics = String((err as { stdout?: string }).stdout ?? '');
+    }
+    const outputs = new Map<string, string>();
+    const outDir = path.join(work, 'out');
+    if (fs.existsSync(outDir)) {
+      const walk = (dir: string) => {
+        for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+          const p = path.join(dir, e.name);
+          if (e.isDirectory()) walk(p);
+          else outputs.set(path.relative(outDir, p), fs.readFileSync(p, 'utf-8'));
+        }
+      };
+      walk(outDir);
+    }
+    (outputs as RegenResult['outputs'] & { __diagnostics?: string }).__diagnostics = diagnostics;
+    return outputs as RegenResult['outputs'] & { __diagnostics?: string };
+  } finally {
+    fs.rmSync(work, { recursive: true, force: true });
+  }
+}
+
+/** Variant options encoded in a baseline filename, e.g. `foo(target=es2015).js`. */
+function variantFromName(baselineName: string): Map<string, string> {
+  const out = new Map<string, string>();
+  const m = /\(([^)]*)\)\.js$/.exec(baselineName);
+  if (!m) return out;
+  for (const part of m[1].split(',')) {
+    const [k, v] = part.split('=');
+    if (k && v) out.set(k.trim().toLowerCase(), v.trim());
+  }
+  return out;
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const filter = (args.find(a => a.startsWith('--filter=')) ?? '').slice('--filter='.length);
+  const dryRun = args.includes('--dry-run');
+  const verify = args.includes('--verify');
+  if (!filter) {
+    console.error('usage: regen-baseline --filter=<substring> [--dry-run] [--verify]');
+    process.exit(2);
+  }
+
+  const names = fs.readdirSync(BASELINES_DIR)
+    .filter(n => n.endsWith('.js') && n.toLowerCase().includes(filter.toLowerCase()))
+    .sort();
+
+  let changed = 0;
+  let identical = 0;
+  let refused = 0;
+
+  for (const name of names) {
+    const existing = fs.readFileSync(path.join(BASELINES_DIR, name), 'utf-8');
+    const parsed = parseBaseline(existing);
+    if (!parsed.testPath) { refused++; continue; }
+    const testFile = path.join(TS_DIR, parsed.testPath);
+    if (!fs.existsSync(testFile)) { refused++; continue; }
+
+    const sections = findSections(existing);
+    const firstOutput = sections.find(s => OUTPUT_EXT_RE.test(s.name)
+      && !parsed.sourceFiles.some(f => f.name === s.name));
+    if (!firstOutput) { refused++; continue; }
+
+    const source = fs.readFileSync(testFile, 'utf-8').replace(/^﻿/, '');
+    const units = splitUnits(source);
+    // A test with no `@filename` directive is a single unit named after the
+    // test file itself. Emitting it as `input.ts` would make every output name
+    // fail to match the baseline's section names.
+    if (units.length > 0 && units[0].name === '') {
+      units[0].name = path.basename(parsed.testPath);
+    }
+    const opts = collectOptions(source);
+    const outputs = runTsc7(units, opts, variantFromName(name));
+
+    // Splice: keep everything before the first output section verbatim, then
+    // substitute each output section's CONTENT in place while preserving the
+    // original marker lines and inter-section separators byte-for-byte.
+    //
+    // Reconstructing those separators is not worth attempting: the harness
+    // writes input echo with the source file's own line endings but output
+    // sections with CRLF, and the blank-line runs between sections vary. Any
+    // mismatch there would corrupt every regenerated baseline while looking
+    // like a real diff. Preserving the original bytes makes it impossible.
+    const outSections = sections.filter(s => s.markerStart >= firstOutput.markerStart);
+    let result = existing.slice(0, firstOutput.markerStart);
+    let missing = false;
+    for (let i = 0; i < outSections.length; i++) {
+      const s = outSections[i];
+      const emitted = outputs.get(s.name);
+      if (emitted === undefined) { missing = true; break; }
+
+      const markerLineEnd = existing.indexOf('\n', s.markerStart) + 1;
+      const regionEnd = i + 1 < outSections.length
+        ? outSections[i + 1].markerStart
+        : existing.length;
+      const region = existing.slice(markerLineEnd, regionEnd);
+      // Whatever terminates the original region — its own newline plus any
+      // blank-line separator before the next marker — is reused verbatim.
+      const trailing = /(?:\r?\n)*$/.exec(region)?.[0] ?? '';
+
+      result += existing.slice(s.markerStart, markerLineEnd);
+      result += emitted.replace(/(?:\r?\n)*$/, '') + trailing;
+    }
+    if (missing) {
+      // tsc did not produce one of the sections the baseline declares. Losing a
+      // section would change the pass-count denominator, so refuse rather than
+      // write a partial baseline.
+      console.log(`  refuse  ${name} (tsc did not emit every declared section)`);
+      refused++;
+      continue;
+    }
+
+    const regenerated = result;
+    if (regenerated === existing) {
+      identical++;
+      if (verify) console.log(`  same    ${name}`);
+      continue;
+    }
+    changed++;
+    console.log(`  CHANGED ${name}`);
+    if (verify) {
+      // The JS sections must agree; only .d.ts is expected to move in slice 1.
+      const before = parseBaseline(existing);
+      const after = parseBaseline(regenerated);
+      if (before.js !== after.js) {
+        console.log(`    !! JS section moved — investigate before trusting the .d.ts diff`);
+      } else {
+        console.log(`    JS byte-identical; .d.ts differs (expected)`);
+      }
+    }
+    if (!dryRun) {
+      fs.mkdirSync(OVERLAY_DIR, { recursive: true });
+      fs.writeFileSync(path.join(OVERLAY_DIR, name), regenerated);
+    }
+  }
+
+  console.log(`\n${changed} changed, ${identical} identical, ${refused} refused`);
+}
+
+main();

--- a/scripts/emit/src/runner.ts
+++ b/scripts/emit/src/runner.ts
@@ -30,7 +30,34 @@ const TS_DIR = path.join(ROOT_DIR, 'TypeScript');
 const BASELINES_DIR = path.join(TS_DIR, 'tests/baselines/reference');
 const CACHE_DIR = path.join(__dirname, '../.cache');
 const DTS_DISCOVERY_CACHE = path.join(CACHE_DIR, 'dts-baseline-index.json');
-const DTS_DISCOVERY_CACHE_VERSION = 2;
+// Bumped to 3 for the TS7 baseline overlay: the cache is keyed on the bare
+// baseline filename plus mtime/size, so a pre-overlay entry would otherwise
+// answer `hasDts` from the submodule copy of an overlaid name.
+const DTS_DISCOVERY_CACHE_VERSION = 3;
+
+// ============================================================================
+// TypeScript 7 baseline overlay
+// ============================================================================
+//
+// The baselines checked into the TypeScript submodule are TS 6.0-era, while
+// the conformance oracle (scripts/conformance/tsc-cache-full.json) is TS 7.0.2.
+// Baselines regenerated against 7.0.2 live here instead, because the submodule
+// is read-only — scripts/githooks/pre-commit rejects any commit that touches
+// it. Names are identical to the submodule's, including option suffixes like
+// "foo(target=es2015).js", and the submodule remains the fallback for every
+// baseline not yet regenerated, so the migration is incremental.
+const OVERLAY_DIR = process.env.TSZ_EMIT_BASELINES_OVERLAY
+  ?? path.join(__dirname, '../baselines-ts7');
+
+const overlayNames: Set<string> = fs.existsSync(OVERLAY_DIR)
+  ? new Set(fs.readdirSync(OVERLAY_DIR).filter(e => e.endsWith('.js')))
+  : new Set();
+
+function resolveBaselinePath(name: string): string {
+  return overlayNames.has(name)
+    ? path.join(OVERLAY_DIR, name)
+    : path.join(BASELINES_DIR, name);
+}
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -529,7 +556,7 @@ async function filterToDtsBaselines(jsFiles: string[]): Promise<string[]> {
   const readLimit = pLimit(64);
 
   const checks = await Promise.all(jsFiles.map(file => statLimit(async () => {
-    const fullPath = path.join(BASELINES_DIR, file);
+    const fullPath = resolveBaselinePath(file);
     const stat = await fs.promises.stat(fullPath);
     const entry = cached[file];
     if (entry && entry.version === DTS_DISCOVERY_CACHE_VERSION && entry.mtimeMs === stat.mtimeMs && entry.size === stat.size) {
@@ -580,6 +607,12 @@ async function readBaselineFile(
   blob: BaselineBlobReader | null,
   name: string,
 ): Promise<string> {
+  // The overlay must win before the blob: the blob is baked from the submodule
+  // directory, so consulting it first would silently serve TS6 bytes for an
+  // overlaid name whenever TSZ_EMIT_BLOB is set.
+  if (overlayNames.has(name)) {
+    return await fs.promises.readFile(path.join(OVERLAY_DIR, name), 'utf-8');
+  }
   if (blob && blob.has(name)) {
     const buf = await blob.readBaseline(name);
     if (buf) return buf.toString('utf-8');
@@ -599,7 +632,21 @@ async function findTestCases(filter: string, maxTests: number, dtsOnly: boolean)
     console.log(pc.dim(`  Baseline blob: ${stats.entries} entries (loaded in 1 open() call)`));
   }
 
-  const entries = fs.readdirSync(BASELINES_DIR);
+  const submoduleEntries = fs.readdirSync(BASELINES_DIR);
+  // An overlay baseline replaces a submodule one; it must never introduce a new
+  // test. A new name would grow jsTotal/dtsTotal and re-slice every emit shard
+  // (the shards are --max/--offset windows over this sorted list), which would
+  // make before/after pass counts incomparable. Fail loudly instead.
+  const submoduleNames = new Set(submoduleEntries);
+  const orphanOverlays = [...overlayNames].filter(n => !submoduleNames.has(n));
+  if (orphanOverlays.length > 0) {
+    console.error(
+      `Overlay baselines with no submodule counterpart: ${orphanOverlays.join(', ')}\n` +
+      `The overlay replaces baselines name-for-name; it must not add tests.`,
+    );
+    process.exit(1);
+  }
+  const entries = submoduleEntries;
   let jsFiles = entries.filter(e => e.endsWith('.js')).sort();
 
   // Apply filter before reading any files


### PR DESCRIPTION
Goal: hold

## Problem

The two suites are pinned to different compiler versions.

- `scripts/emit/run.sh` compares tsz's JS and `.d.ts` output against baselines checked
  into the `TypeScript/` submodule — **TS 6.0-era artifacts**.
- `scripts/conformance/conformance.sh` compares diagnostics against
  `scripts/conformance/tsc-cache-full.json` — a **TS 7.0.2** oracle.

That is not cosmetic. TS 7.0.2 rejects Closure-style `function(...)` JSDoc types with
TS1005 and emits `Function` for them; the 6.0 baselines still expect a reconstructed
`(this: Object, ...args: any[]) => any`. Matching one suite meant failing the other, which
is what blocked the largest remaining jsdoc conformance family (21 tests).

## What this adds

**An overlay.** Baselines regenerated against 7.0.2 live in `scripts/emit/baselines-ts7/`.
The submodule is read-only — `scripts/githooks/pre-commit` rejects any commit touching it
— so they cannot go in-place. `runner.ts` prefers an overlay file over the submodule copy
of the same name and falls back for everything else, so the migration is incremental.

**A denominator guard.** The overlay may only *replace* baselines, never add them. A new
name would grow `jsTotal`/`dtsTotal` and re-slice every emit shard (shards are
`--max/--offset` windows over the sorted discovery list), making before/after pass counts
incomparable. The runner hard-fails on an overlay name with no submodule counterpart.

**A generator** (`scripts/emit/src/regen-baseline.ts`) that **splices rather than rebuilds**:
it copies each baseline's header and input-echo sections byte-for-byte and substitutes only
the emitted output sections, preserving the original marker lines and separators.
Re-deriving the echo would mean reproducing the harness's own formatting — BOM and UTF-16
inputs, unit ordering, the LF-echo/CRLF-output convention — and each of those is a way to
corrupt 11.5k currently-passing rows. Splicing makes them structurally impossible to hit.

## The validation rule, and the two bugs it caught

**A baseline whose content TS6 and TS7 agree on must regenerate byte-identically.** A
generator that cannot reproduce the *agreement* cases exactly tells you nothing about its
*disagreement* cases. `--verify` enforces it, and it earned its keep twice:

1. Tests with no `@filename` directive were written as `input.ts`, so no emitted output name
   ever matched a baseline section — the generator silently refused six baselines instead of
   regenerating them.
2. The splice normalised CRLF to LF. Output sections require CRLF (input echo keeps the
   source's own endings), so every regenerated line differed while looking like a real diff.

Both showed up as `2dArrays` failing to round-trip, even though I had separately proven
tsc 7.0.2 reproduces that baseline byte-for-byte. After the fixes it reports `same`.

## Why the overlay ships empty

The first slice is generated and verified, but held. With those five files present:

```
JS  11562 / 11563   unchanged — every JS section regenerates byte-identically
DTS  1372 -> 1369 / 1390
```

The three DTS rows that move are exactly the three retargeted tests. They fail because tsz
still emits the TS 6.0 shape, **not** because the new baselines are wrong — the stale
baselines were masking real gaps:

| test | what tsz emits (TS 6.0 shape) | TypeScript 7.0.2 |
| --- | --- | --- |
| `jsDeclarationsRestArgsWithThisTypeInJSDocFunction` | `export class` + `(this: Object, ...args: any[]) => any` | `export declare class` + `Function` |
| `jsDeclarationsMissingTypeParameters` | `func: (arg0: any[]) => any` | `func: Function` |
| `jsDeclarationsReusesExistingNodesMappingJSDocTypes` | `export const`, `unknown`, callable types, `{[x: string]: number}` | `export declare const`, `any \| null`, `Function`, `Record<string, number>` |

`scripts/refresh-readme.py` deliberately refuses to publish a lower emit number, which is
the repo agreeing that the retarget should land *with* its compensating tsz fix rather than
before it. `scripts/emit/baselines-ts7/README.md` records the slice, the exact commands to
reproduce it, and the four tsz emit gaps it exposes.

## Verification

All run locally.

```
./scripts/emit/run.sh                       JS 11562/11563, DTS 1372/1390 — unchanged
                                            (zero-delta proof: overlay present but empty)

# overlay proven live, all three read paths
identical copy in overlay                   -> row passes  (no false change)
altered copy in overlay                     -> row fails   (overlay IS read)
TSZ_EMIT_BLOB=1 with altered copy           -> row fails   (overlay wins over the blob)

# generator, validation rule
regen --filter=2dArrays --verify                                    same (byte-identical)
regen --filter=internalAliasFunctionInsideTopLevelModuleWithoutExport --verify   same
regen --filter=jsDeclarationsRestArgs --verify        CHANGED, JS byte-identical, d.ts differs
regen --filter=jsDeclarationsMissingTypeParameters --verify                    likewise
regen --filter=jsDeclarationsReusesExistingNodesMappingJSDocTypes --verify     likewise

# denominator stability, with the slice applied
emit-detail row-key set before vs after     IDENTICAL (11564 rows both sides)
jsTotal 11563 / dtsTotal 1390               unchanged

python3 scripts/emit/test_query_emit_families.py     101 passed
npx tsc --noEmit -p scripts/emit/tsconfig.json       clean
git -C TypeScript status --porcelain                 empty (submodule untouched)
```

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: xhigh
