### PR TITLE
test(checker): retire the TS8021/TS8022 assertions with the codes

### DIFF
--- a/crates/tsz-checker/tests/jsdoc_readonly_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_readonly_tests.rs
@@ -86,17 +86,16 @@ f.y = 12
 
 /// @augments on a function declaration → TS8022
 #[test]
-fn test_jsdoc_augments_on_function_emits_ts8022() {
+fn test_jsdoc_augments_on_function_reports_no_ts8022() {
     let source = r#"
 class A {}
 /** @augments A */
 function b() {}
 "#;
     let diagnostics = check_js_source_diagnostics(source);
-    let ts8022 = diagnostics.iter().filter(|d| d.code == 8022).count();
     assert!(
-        ts8022 >= 1,
-        "Expected TS8022 for @augments on function, got: {:?}",
+        diagnostics.iter().all(|d| d.code != 8022),
+        "TS8022 is retired and must not be reported, got: {:?}",
         diagnostic_codes(&diagnostics)
     );
 }
@@ -106,7 +105,7 @@ function b() {}
 /// the @extends tag's attachment, making it orphaned. Confirmed via
 /// conformance/jsdoc/extendsTag2.ts fingerprint (code 8022, file="").
 #[test]
-fn test_jsdoc_extends_interposed_jsdoc_emits_ts8022() {
+fn test_jsdoc_extends_interposed_jsdoc_reports_no_ts8022() {
     let source = r#"
 class A {
     constructor() {}
@@ -120,17 +119,16 @@ class B extends A {
 }
 "#;
     let diagnostics = check_js_source_diagnostics(source);
-    let ts8022 = diagnostics.iter().filter(|d| d.code == 8022).count();
     assert!(
-        ts8022 >= 1,
-        "Expected TS8022 for @extends separated from class by interposed JSDoc, got: {:?}",
+        diagnostics.iter().all(|d| d.code != 8022),
+        "TS8022 is retired and must not be reported, got: {:?}",
         diagnostic_codes(&diagnostics)
     );
 }
 
-/// Dangling @extends at end of file → TS8022
+/// Dangling @extends at end of file: TS8022 is retired, so nothing is reported.
 #[test]
-fn test_jsdoc_dangling_extends_at_eof_emits_ts8022() {
+fn test_jsdoc_dangling_extends_at_eof_reports_no_ts8022() {
     let source = r#"
 class A {
     constructor() {}
@@ -139,26 +137,24 @@ class A {
 /** @extends {A} */
 "#;
     let diagnostics = check_js_source_diagnostics(source);
-    let ts8022 = diagnostics.iter().filter(|d| d.code == 8022).count();
     assert!(
-        ts8022 >= 1,
-        "Expected TS8022 for dangling @extends at EOF, got: {:?}",
+        diagnostics.iter().all(|d| d.code != 8022),
+        "TS8022 is retired and must not be reported, got: {:?}",
         diagnostic_codes(&diagnostics)
     );
 }
 
-/// @typedef without type or @property → TS8021
+/// @typedef without type or @property: TS8021 is retired, so nothing is reported.
 #[test]
-fn test_jsdoc_typedef_missing_type_emits_ts8021() {
+fn test_jsdoc_typedef_missing_type_reports_no_ts8021() {
     let source = r#"
 /** @typedef T */
 const t = 0;
 "#;
     let diagnostics = check_js_source_diagnostics(source);
-    let ts8021 = diagnostics.iter().filter(|d| d.code == 8021).count();
     assert!(
-        ts8021 >= 1,
-        "Expected TS8021 for @typedef without type, got: {:?}",
+        diagnostics.iter().all(|d| d.code != 8021),
+        "TS8021 is retired and must not be reported, got: {:?}",
         diagnostic_codes(&diagnostics)
     );
 }
@@ -366,7 +362,7 @@ const person = { name: "" };
 }
 
 #[test]
-fn test_jsdoc_multiple_typedefs_missing_second_type_emits_ts8021() {
+fn test_jsdoc_multiple_typedefs_missing_second_type_reports_no_ts8021() {
     let source = r#"
 // @ts-check
 /**
@@ -375,10 +371,9 @@ fn test_jsdoc_multiple_typedefs_missing_second_type_emits_ts8021() {
  */
 "#;
     let diagnostics = check_js_source_diagnostics(source);
-    let ts8021 = diagnostics.iter().filter(|d| d.code == 8021).count();
-    assert_eq!(
-        ts8021, 1,
-        "Expected exactly one TS8021 for the second @typedef, got: {diagnostics:?}"
+    assert!(
+        diagnostics.iter().all(|d| d.code != 8021),
+        "TS8021 is retired and must not be reported, got: {diagnostics:?}"
     );
 }
 

--- a/crates/tsz-checker/tests/jsdoc_reference_kernel_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_reference_kernel_tests.rs
@@ -332,15 +332,15 @@ const identity = x => x;
 
 /// Bare @typedef with no type annotation and no @property tags should emit TS8021.
 #[test]
-fn bare_typedef_emits_ts8021() {
+fn bare_typedef_reports_no_ts8021() {
     let codes = check_js(
         r#"
 /** @typedef T */
 "#,
     );
     assert!(
-        codes.contains(&8021),
-        "Expected TS8021 for bare @typedef, got: {codes:?}"
+        !codes.contains(&8021),
+        "TS8021 is retired and must not be reported, got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Goal: hold

## Problem

#15910 stopped emitting TS8021 and TS8022, because the pinned compiler reports neither
anywhere in the conformance corpus — including in the tests written specifically to
provoke them. `jsdocAugments_notAClass.ts` is literally
`class A {} /** @augments A */ function b() {}` and expects **no diagnostics at all**;
`extendsTag4.ts` likewise.

Six unit tests still asserted the codes *were* emitted, and have been failing on `main`
ever since:

```
jsdoc_readonly_tests::test_jsdoc_augments_on_function_emits_ts8022
jsdoc_readonly_tests::test_jsdoc_extends_interposed_jsdoc_emits_ts8022
jsdoc_readonly_tests::test_jsdoc_dangling_extends_at_eof_emits_ts8022
jsdoc_readonly_tests::test_jsdoc_typedef_missing_type_emits_ts8021
jsdoc_readonly_tests::test_jsdoc_multiple_typedefs_missing_second_type_emits_ts8021
jsdoc_reference_kernel_tests::bare_typedef_emits_ts8021
```

**That was my miss.** I verified #15910 with a filtered test selection
(`-E 'test(/jsdoc_retired_tag_diagnostics/)'`) rather than the full checker lib suite, and
CI's unit lane had already moved to schedule/dispatch, so nothing caught it before it
landed.

## Change

Invert them rather than delete them. Each keeps its fixture and becomes a guard that the
retired code *stays* retired — worth more than the absence of a test, and it means a
future change that resurrects TS8021/TS8022 fails loudly instead of silently disagreeing
with the oracle.

## Verification

```
cargo nextest run -p tsz-checker --lib
  before: 13 distinct failures
  after:   7 distinct failures
```

The remaining 7 are pre-existing and unrelated to this change or to #15910:

```
architecture_contract_tests_src::part_01::test_solver_imports_go_through_query_boundaries
assignability_domain::assignment_checker::tests::discriminated_union_object_literal_expands_literal_alias_property_target
flow_assignment_relation_routing_arch_tests::flow_assignment_and_predicate_exclusion_use_relation_outcome_boundary
return_context_type_param_shadowing_tests::async_return_of_generic_call_with_shadowed_param_async_callback_is_clean
state_type_environment_relation_routing_arch_tests::impossible_intersection_pruning_uses_subtype_outcome_boundary
ts2303_tests::recursive_export_assignment_self_import_reports_ts2303
zod_type_query_regression_tests::generic_promise_then_flattens_promise_return_from_callback
```

Worth noting one of those: `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`
fails on `main` today. I previously attributed a merge_group failure of that same test to
the CI unit-job split in #15919 and said so in a comment there. That attribution was
wrong — the test is red on main independently. The split was obsolete for other reasons,
so reverting it was still correct.

Also verified: clippy and the architecture guard, via the pre-commit gate landed in #15919.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: xhigh
