### PR TITLE
fix(checker): Closure function types no longer earn the TS8030 skip

### DIFF
--- a/crates/tsz-checker/src/jsdoc/params_type_strings.rs
+++ b/crates/tsz-checker/src/jsdoc/params_type_strings.rs
@@ -1431,10 +1431,12 @@ impl<'a> CheckerState<'a> {
         if trimmed.contains("=>") {
             return true;
         }
-        // function(...): ... type
-        if trimmed.starts_with("function") {
-            return true;
-        }
+        // Deliberately NOT the Closure `function(...)` spelling. Its only
+        // caller is the TS8030 check, which skips syntactically-callable types
+        // because they may fail to resolve while still being valid function
+        // types. TypeScript 7 rejects the Closure form outright, so it is not a
+        // valid function type and must not earn that skip — the oracle for
+        // jsdocFunction_missingReturn expects TS8030 for exactly that shape.
         // Generic signature: <T>(...) => ...
         if trimmed.starts_with('<') {
             return true;

--- a/crates/tsz-checker/src/tests/jsdoc_closure_function_type_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_closure_function_type_tests.rs
@@ -148,3 +148,22 @@ fn ordinary_jsdoc_function_types_are_unaffected() {
         assert!(!codes.contains(&1005), "got {codes:?} for {source}");
     }
 }
+
+#[test]
+fn closure_type_on_a_function_declaration_reports_ts8030() {
+    // The Closure form yields no call signature, so a `@type` tag carrying it
+    // on a function declaration fails the "must have a signature with the
+    // correct number of arguments" check. `jsdocFunction_missingReturn`'s
+    // oracle is exactly TS1005 + TS8030 for this shape.
+    let codes = js_codes("/** @type {function(): number} */\nfunction f() {}\n");
+    assert!(codes.contains(&1005), "got {codes:?}");
+    assert!(codes.contains(&8030), "got {codes:?}");
+}
+
+#[test]
+fn a_resolvable_callable_type_does_not_report_ts8030() {
+    // Control: the arrow form still supplies a signature, so the TS8030 skip
+    // that the Closure form no longer earns must remain in place for it.
+    let codes = js_codes("/** @type {() => number} */\nfunction f() { return 1; }\n");
+    assert!(!codes.contains(&8030), "got {codes:?}");
+}


### PR DESCRIPTION
Goal: hold

## Structural rule

The TS8030 check skips types that are *syntactically callable*, on the reasoning that such
a type may fail to resolve while still being a valid function type. That skip covered the
Closure `function(...)` spelling.

TypeScript 7 rejects that spelling outright (#15926 reports TS1005, #15928 gives it no
type), so it is not a valid function type and must not earn the skip. The oracle for
`conformance/jsdoc/jsdocFunction_missingReturn.ts` is exactly **TS1005 + TS8030** for
`@type {function(): number}` on a function declaration — tsz was emitting only the TS1005.

## Owner layer

`is_syntactically_callable_type` has exactly one caller — the TS8030 check in
`function_declaration_checks.rs` — so dropping the Closure branch is contained. The arrow,
generic-signature and parenthesized forms still earn the skip.

This is a follow-up to #15928: it was verified there but pushed after that PR had been
queued with a pinned head, so it did not ride along.

## Adjacent cases

Two tests added to `tests/jsdoc_closure_function_type_tests.rs`:

| Case | Expectation |
| --- | --- |
| `@type {function(): number}` on a function declaration | TS1005 **and** TS8030 |
| `@type {() => number}` on a function declaration that returns | no TS8030 — control that the skip still works for resolvable callables |

## Verification

Measured on top of merged `main` (`f5f921d20e`), against the tsc 7.0.2 oracle:

```
./scripts/conformance/conformance.sh run --workers 12
  before: 11349/12043    after: 11351/12043    (+2, zero regressions)

./scripts/conformance/conformance.sh run --filter conformance/jsdoc --workers 8
  before: 251/332        after: 253/332

./scripts/conformance/conformance.sh run --filter conformance/salsa --workers 8
  116/186 unchanged

./scripts/emit/run.sh
  JS 11562/11563, DTS 1375/1390 — both unchanged

cargo nextest run -p tsz-checker --lib
  zero new failures against the branch base
```

Flips: `jsdocFunction_missingReturn`, `jsdocThisType`.

The two remaining single-delta TS8030 tests (`checkJsdocTypeTagOnObjectProperty1`/`2`)
need the check to cover `@type` on an object-literal *method*, which the current gate on
`FUNCTION_DECLARATION` excludes. Separate change.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: xhigh
