### PR TITLE
fix(checker): TS8030 on object-literal method shorthands

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -652,6 +652,10 @@ impl CheckerState<'_> {
             // does not accept in any tag position.
             self.check_jsdoc_closure_function_types();
 
+            // TS8030 on object-literal method shorthands, which the
+            // function-declaration callback never reaches.
+            self.check_jsdoc_type_tag_callable_on_object_methods();
+
             // TS1069: `@template {Constraint}` with no following type-parameter name
             self.check_jsdoc_template_brace_syntax();
 

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -78,50 +78,12 @@ impl<'a> CheckerState<'a> {
             checker.check_function_declaration(func_idx);
         }
 
-        // TS8030: in JS files, a function declaration whose `@type` tag does not
-        // resolve to a callable type. tsc points the error at the type
-        // expression inside the tag (e.g. at "MyClass" in `@type {MyClass}`).
-        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-            && self.is_js_file()
-            && let Some(jsdoc) = self.get_jsdoc_for_function(func_idx)
-            && let Some(type_expr) = Self::jsdoc_extract_type_tag_expr(&jsdoc)
-            // Skip types that are syntactically callable (arrow functions, function types,
-            // or generic signatures) — these may not resolve but are valid function types.
-            && !Self::is_syntactically_callable_type(&type_expr)
-            && self
-                .jsdoc_callable_type_annotation_for_function(func_idx)
-                .is_none()
-        {
-            // Find the position of the type expression inside the JSDoc comment
-            if let Some(sf) = self.source_file_data_for_node(func_idx) {
-                let source_text = sf.text.to_string();
-                let comments = sf.comments.clone();
-                if let Some((_, jsdoc_start)) =
-                    self.try_jsdoc_with_ancestor_walk_and_pos(func_idx, &comments, &source_text)
-                {
-                    // Find "@type {expr}" in the source text starting from jsdoc_start
-                    let jsdoc_text = &source_text[jsdoc_start as usize..];
-                    if let Some(type_tag_off) = jsdoc_text.find("@type") {
-                        let after_type = &jsdoc_text[type_tag_off + 5..];
-                        if let Some(brace_off) = after_type.find('{') {
-                            let expr_start =
-                                jsdoc_start + type_tag_off as u32 + 5 + brace_off as u32 + 1;
-                            // Find matching close brace
-                            let after_brace = &after_type[brace_off + 1..];
-                            let expr_end = after_brace
-                                .find('}')
-                                .map_or(type_expr.len() as u32, |i| i as u32);
-                            self.ctx.error(
-                                expr_start,
-                                expr_end,
-                                crate::diagnostics::diagnostic_messages::THE_TYPE_OF_A_FUNCTION_DECLARATION_MUST_MATCH_THE_FUNCTIONS_SIGNATURE
-                                    .to_string(),
-                                crate::diagnostics::diagnostic_codes::THE_TYPE_OF_A_FUNCTION_DECLARATION_MUST_MATCH_THE_FUNCTIONS_SIGNATURE,
-                            );
-                        }
-                    }
-                }
-            }
+        // TS8030: in JS files, a `@type` tag on a function whose type supplies
+        // no callable signature. Object-literal methods are checked by
+        // `check_jsdoc_type_tag_callable_on_object_methods`, which this path
+        // does not reach.
+        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION {
+            self.check_jsdoc_type_tag_supplies_callable(func_idx);
         }
 
         // Re-get node after DeclarationChecker borrows ctx
@@ -1427,6 +1389,107 @@ impl<'a> CheckerState<'a> {
             }
             syntax_kind_ext::THROW_STATEMENT => Some((false, false)),
             _ => None,
+        }
+    }
+
+    /// TS8030 for one function-like node: its `@type` tag must supply a
+    /// callable signature. tsc points the error at the type expression inside
+    /// the tag (e.g. at "MyClass" in `@type {MyClass}`).
+    pub(crate) fn check_jsdoc_type_tag_supplies_callable(&mut self, idx: NodeIndex) {
+        if !self.is_js_file() {
+            return;
+        }
+        let Some(jsdoc) = self.get_jsdoc_for_function(idx) else {
+            return;
+        };
+        let Some(type_expr) = Self::jsdoc_extract_type_tag_expr(&jsdoc) else {
+            return;
+        };
+        // Skip types that are syntactically callable (arrow functions or
+        // generic signatures) — these may not resolve but are valid function
+        // types. The Closure `function(...)` spelling is deliberately not among
+        // them; TypeScript 7 rejects it, so it earns no skip.
+        if Self::is_syntactically_callable_type(&type_expr) {
+            return;
+        }
+        if self
+            .jsdoc_callable_type_annotation_for_function(idx)
+            .is_some()
+        {
+            return;
+        }
+        let Some(sf) = self.source_file_data_for_node(idx) else {
+            return;
+        };
+        let source_text = sf.text.to_string();
+        let comments = sf.comments.clone();
+        let Some((_, jsdoc_start)) =
+            self.try_jsdoc_with_ancestor_walk_and_pos(idx, &comments, &source_text)
+        else {
+            return;
+        };
+        let jsdoc_text = &source_text[jsdoc_start as usize..];
+        let Some(type_tag_off) = jsdoc_text.find("@type") else {
+            return;
+        };
+        let after_type = &jsdoc_text[type_tag_off + 5..];
+        let Some(brace_off) = after_type.find('{') else {
+            return;
+        };
+        let expr_start = jsdoc_start + type_tag_off as u32 + 5 + brace_off as u32 + 1;
+        let after_brace = &after_type[brace_off + 1..];
+        let expr_end = after_brace
+            .find('}')
+            .map_or(type_expr.len() as u32, |i| i as u32);
+        self.ctx.error(
+            expr_start,
+            expr_end,
+            crate::diagnostics::diagnostic_messages::THE_TYPE_OF_A_FUNCTION_DECLARATION_MUST_MATCH_THE_FUNCTIONS_SIGNATURE
+                .to_string(),
+            crate::diagnostics::diagnostic_codes::THE_TYPE_OF_A_FUNCTION_DECLARATION_MUST_MATCH_THE_FUNCTIONS_SIGNATURE,
+        );
+    }
+
+    /// TS8030 for object-literal method shorthands.
+    ///
+    /// tsc runs this check from `checkFunctionOrMethodDeclaration`, which covers
+    /// method declarations; tsz's function-declaration callback is only reached
+    /// from the statement bridge, so object-literal methods never see it. The
+    /// witness is `conformance/jsdoc/checkJsdocTypeTagOnObjectProperty1.ts`,
+    /// whose oracle reports TS8030 for `method1(n1) {}` under a
+    /// `@type {function(number): number}` tag.
+    ///
+    /// Restricted to methods directly inside an object literal. A property with
+    /// a function or arrow *initializer* is an expression, not a method
+    /// declaration, and the same oracle reports nothing for `arrowFunc: (num)
+    /// => ...` under an identical tag.
+    pub(crate) fn check_jsdoc_type_tag_callable_on_object_methods(&mut self) {
+        if !self.is_js_file() {
+            return;
+        }
+        let mut methods = Vec::new();
+        for raw in 0..self.ctx.arena.len() {
+            let idx = NodeIndex(raw as u32);
+            let Some(node) = self.ctx.arena.get(idx) else {
+                continue;
+            };
+            if node.kind != syntax_kind_ext::METHOD_DECLARATION {
+                continue;
+            }
+            let Some(ext) = self.ctx.arena.get_extended(idx) else {
+                continue;
+            };
+            if self
+                .ctx
+                .arena
+                .get(ext.parent)
+                .is_some_and(|p| p.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION)
+            {
+                methods.push(idx);
+            }
+        }
+        for idx in methods {
+            self.check_jsdoc_type_tag_supplies_callable(idx);
         }
     }
 }

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -1394,7 +1394,7 @@ impl<'a> CheckerState<'a> {
 
     /// TS8030 for one function-like node: its `@type` tag must supply a
     /// callable signature. tsc points the error at the type expression inside
-    /// the tag (e.g. at "MyClass" in `@type {MyClass}`).
+    /// the tag (e.g. at `MyClass` in `@type {MyClass}`).
     pub(crate) fn check_jsdoc_type_tag_supplies_callable(&mut self, idx: NodeIndex) {
         if !self.is_js_file() {
             return;

--- a/crates/tsz-checker/src/tests/jsdoc_closure_function_type_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_closure_function_type_tests.rs
@@ -167,3 +167,38 @@ fn a_resolvable_callable_type_does_not_report_ts8030() {
     let codes = js_codes("/** @type {() => number} */\nfunction f() { return 1; }\n");
     assert!(!codes.contains(&8030), "got {codes:?}");
 }
+
+#[test]
+fn closure_type_on_an_object_literal_method_reports_ts8030() {
+    // tsc runs the TS8030 check from `checkFunctionOrMethodDeclaration`, which
+    // covers method declarations. `checkJsdocTypeTagOnObjectProperty1`'s oracle
+    // reports it for the method shorthand.
+    let codes = js_codes(
+        "const obj = {\n  /** @type {function(number): number} */\n  method1(n1) { return n1; }\n};\n",
+    );
+    assert!(codes.contains(&8030), "got {codes:?}");
+}
+
+#[test]
+fn closure_type_on_an_arrow_initialized_property_reports_no_ts8030() {
+    // A property with a function or arrow *initializer* is an expression, not a
+    // method declaration. The same oracle reports no TS8030 for `arrowFunc`
+    // under an identical tag — only the TS1005 for the type itself.
+    let codes = js_codes(
+        "const obj = {\n  /** @type {function(number): number} */\n  arrowFunc: (num) => num\n};\n",
+    );
+    assert!(
+        codes.contains(&1005),
+        "the type is still rejected: {codes:?}"
+    );
+    assert!(!codes.contains(&8030), "got {codes:?}");
+}
+
+#[test]
+fn class_methods_are_left_alone() {
+    // The pass is restricted to methods directly inside an object literal;
+    // there is no corpus witness for class methods, so it must not fire there.
+    let codes =
+        js_codes("class C {\n  /** @type {function(number): number} */\n  m(n) { return n; }\n}\n");
+    assert!(!codes.contains(&8030), "got {codes:?}");
+}

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -96,10 +96,15 @@ fi
 
 echo "Verifying:${PKG_FLAGS}"
 
+# `-D warnings` matches what CI's lint lane runs (full-ci.sh: `cargo clippy
+# --workspace --all-targets -- -D warnings`). Without it this gate passes code
+# that CI then rejects — clippy::doc_markdown in particular is warn-level by
+# default and only becomes an error under `-D warnings`.
+#
 # Redirect rather than pipe: `cmd | tail` reports tail's exit status, not the
 # compiler's, which would let a failing build through the gate entirely.
 if ! cargo clippy --profile dist-fast --target-dir .target $PKG_FLAGS --lib \
-    >/tmp/tsz-clippy.log 2>&1; then
+    -- -D warnings >/tmp/tsz-clippy.log 2>&1; then
     echo ""
     echo "ERROR: clippy failed:"
     tail -40 /tmp/tsz-clippy.log


### PR DESCRIPTION
Goal: hold

## Structural rule

When a `@type` tag on an object-literal **method shorthand** in a JS file supplies no
callable signature, tsc reports TS8030; tsz now does too.

tsc runs this from `checkFunctionOrMethodDeclaration`, which covers method declarations.
tsz's equivalent lives in `check_function_declaration_callback`, reached only from the
statement bridge (`statement_callback_bridge.rs:92`), so a method inside an object literal
never saw it.

## The split, which the oracle draws sharply

`conformance/jsdoc/checkJsdocTypeTagOnObjectProperty1.ts` carries the *same* tag on two
members and expects different outcomes:

```js
const obj = {
  /** @type {function(number): number} */
  method1(n1) { return n1 + 42; },        // oracle: TS8030 at 8:14
  /** @type {function(number): number} */
  arrowFunc: (num) => num + 42            // oracle: no TS8030
}
```

A property with a function or arrow *initializer* is an expression, not a method
declaration. So the new pass is restricted to methods directly inside an object literal,
and a test pins each side.

## Owner layer

Extracts the existing per-node TS8030 logic into
`check_jsdoc_type_tag_supplies_callable`, so the function-declaration path and the new
object-method pass share one implementation rather than duplicating both the condition and
the anchor search.

Class methods are deliberately untouched — there is no corpus witness for them, and a
third test pins that they stay silent. Widening to class methods without evidence would be
guessing at tsc.

## Adjacent cases

Three tests added to `tests/jsdoc_closure_function_type_tests.rs`:

| Case | Expectation |
| --- | --- |
| `@type {function(number): number}` on an object-literal method shorthand | TS8030 |
| Same tag on a property with an arrow initializer | **no** TS8030 (TS1005 for the type still fires) |
| Same tag on a class method | **no** TS8030 |

## Verification

Measured on merged `main` (`57c42198ce`), against the tsc 7.0.2 oracle:

```
./scripts/conformance/conformance.sh run --workers 12
  before: 11351/12043    after: 11353/12043    (+2, zero regressions)

./scripts/conformance/conformance.sh run --filter conformance/jsdoc --workers 8
  before: 253/332        after: 255/332

./scripts/conformance/conformance.sh run --filter conformance/salsa --workers 8
  116/186 unchanged

./scripts/emit/run.sh
  JS 11562/11563, DTS 1375/1390 — both unchanged

cargo nextest run -p tsz-checker --lib      zero new failures vs the branch base
./scripts/arch/check-checker-boundaries.sh  passed
```

Flips: `checkJsdocTypeTagOnObjectProperty1`, `checkJsdocTypeTagOnObjectProperty2`.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: xhigh
