### PR TITLE
fix(solver): union literal members sort by value under TS7 stableTypeOrdering

### DIFF
--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_00.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_00.rs
@@ -412,7 +412,7 @@ fn format_number_literal_uses_scientific_notation_above_1e21() {
 }
 
 #[test]
-fn number_literal_union_uses_tsc_allocation_order() {
+fn number_literal_union_uses_tsc_numeric_order() {
     let db = TypeInterner::new();
     let one = db.literal_number(1.0);
     let minus_one = db.literal_number(-1.0);
@@ -421,20 +421,24 @@ fn number_literal_union_uses_tsc_allocation_order() {
 
     let union = db.union(vec![minus_one, zero, one, two]);
 
+    // TypeScript 7 runs with `stableTypeOrdering`, whose `compareTypes` orders
+    // numeric literal types by value, so allocation order does not leak into
+    // the rendered union. Negative values sort ahead of zero.
     let mut fmt = TypeFormatter::new(&db);
-    assert_eq!(fmt.format(union), "0 | 1 | -1 | 2");
+    assert_eq!(fmt.format(union), "-1 | 0 | 1 | 2");
 }
 
 #[test]
-fn number_literal_union_is_not_numeric_sorted() {
+fn number_literal_union_is_numeric_sorted_regardless_of_allocation_order() {
     let db = TypeInterner::new();
+    // Intern `2` first so allocation order disagrees with numeric order.
     let two = db.literal_number(2.0);
     let one = db.literal_number(1.0);
 
     let union = db.union(vec![one, two]);
 
     let mut fmt = TypeFormatter::new(&db);
-    assert_eq!(fmt.format(union), "2 | 1");
+    assert_eq!(fmt.format(union), "1 | 2");
 }
 
 #[test]

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
@@ -1187,21 +1187,20 @@ fn store_union_origin_overrides_canonical_anon_object_sort() {
 fn store_union_origin_preserves_source_order_for_number_literal_union() {
     let db = TypeInterner::new();
 
-    // Force a non-source allocation order: intern `2` before `1` so the
-    // canonical sort's alloc-order fallback puts `2` ahead of `1`.
     let two = db.literal_number(2.0);
     let one = db.literal_number(1.0);
     let zero = db.literal_number(0.0);
 
-    // Build the union in source-written order: `0 | 1 | 2`.
-    let origin = vec![zero, one, two];
+    // Build the union in a source-written order that disagrees with TS7's
+    // canonical numeric order: `2 | 1 | 0`.
+    let origin = vec![two, one, zero];
     let union_id = db.union(origin.clone());
 
-    // Pre-condition: without an origin, the canonical sort produces
-    // `0 | 2 | 1` because alloc_order(2) < alloc_order(1).
+    // Pre-condition: without an origin, `compareTypes` sorts numeric literal
+    // types by value, producing `0 | 1 | 2`.
     {
         let mut fmt = TypeFormatter::new(&db);
-        assert_eq!(fmt.format(union_id), "0 | 2 | 1");
+        assert_eq!(fmt.format(union_id), "0 | 1 | 2");
     }
 
     // Store the origin. Length is unchanged (3 in / 3 out) and there are no
@@ -1210,7 +1209,7 @@ fn store_union_origin_preserves_source_order_for_number_literal_union() {
     db.store_union_origin(union_id, origin);
 
     let mut fmt = TypeFormatter::new(&db);
-    assert_eq!(fmt.format(union_id), "0 | 1 | 2");
+    assert_eq!(fmt.format(union_id), "2 | 1 | 0");
 }
 
 #[test]
@@ -1278,15 +1277,16 @@ fn formatter_can_ignore_union_origin_for_canonical_number_literal_display() {
     let two = db.literal_number(2.0);
     let one = db.literal_number(1.0);
     let zero = db.literal_number(0.0);
-    let origin = vec![zero, one, two];
+    // Source order `2 | 1 | 0` disagrees with TS7's canonical numeric order.
+    let origin = vec![two, one, zero];
     let union_id = db.union(origin.clone());
     db.store_union_origin(union_id, origin);
 
     let mut source_order = TypeFormatter::new(&db);
-    assert_eq!(source_order.format(union_id), "0 | 1 | 2");
+    assert_eq!(source_order.format(union_id), "2 | 1 | 0");
 
     let mut canonical_order = TypeFormatter::new(&db).with_ignore_union_origins();
-    assert_eq!(canonical_order.format(union_id), "0 | 2 | 1");
+    assert_eq!(canonical_order.format(union_id), "0 | 1 | 2");
 }
 
 // Negative case: a number-literal-only union whose canonical order already

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -658,33 +658,24 @@ impl TypeInterner {
                         .string_literal_text
                         .as_deref()
                         .expect("string literal union member must cache resolved text");
-                    let a_short = str_a.len() <= 2;
-                    let b_short = str_b.len() <= 2;
-                    match (a_short, b_short) {
-                        (true, true) => {
-                            let cmp = str_a.cmp(str_b);
-                            if cmp != Ordering::Equal {
-                                return cmp;
-                            }
-                        }
-                        (true, false) => return Ordering::Less,
-                        (false, true) => return Ordering::Greater,
-                        (false, false) => {}
+                    // TypeScript 7 runs with `stableTypeOrdering` enabled, so
+                    // `compareTypes` orders string literal types by their value
+                    // rather than by creation order.
+                    let cmp = str_a.cmp(str_b);
+                    if cmp != Ordering::Equal {
+                        return cmp;
                     }
                 }
                 (
                     TypeData::Literal(LiteralValue::Number(na)),
                     TypeData::Literal(LiteralValue::Number(nb)),
                 ) => {
-                    // TypeScript orders union members by type id, not numeric value.
-                    // Its checker creates the `0` literal eagerly (`zeroType`), while
-                    // other number literals keep first-use order.
-                    let a_zero = na.0 == 0.0;
-                    let b_zero = nb.0 == 0.0;
-                    match (a_zero, b_zero) {
-                        (true, false) => return Ordering::Less,
-                        (false, true) => return Ordering::Greater,
-                        _ => {}
+                    // TypeScript 7 runs with `stableTypeOrdering` enabled, so
+                    // `compareTypes` orders numeric literal types by their value
+                    // rather than by creation order.
+                    let cmp = na.0.total_cmp(&nb.0);
+                    if cmp != Ordering::Equal {
+                        return cmp;
                     }
                 }
                 (TypeData::Lazy(d1), TypeData::Lazy(d2))

--- a/crates/tsz-solver/src/tests/type_queries_property_names_tests.rs
+++ b/crates/tsz-solver/src/tests/type_queries_property_names_tests.rs
@@ -142,13 +142,15 @@ fn keyof_object_properties_excludes_non_public_members() {
 }
 
 #[test]
-fn keyof_object_properties_preserves_declaration_order() {
-    // Object shapes are stored sorted by atom for hash consistency, but
-    // `keyof T`'s union must reflect source declaration order so that the
-    // type printer matches tsc (e.g., `{ foo, bar }` -> `"foo" | "bar"`,
-    // not the alphabetical `"bar" | "foo"`). This test uses property names
-    // that sort opposite to declaration order ("xyz" before "abc" in source,
-    // but "abc" sorts before "xyz" alphabetically).
+fn keyof_object_properties_uses_string_literal_value_order() {
+    // `keyof T` builds a union of string literal types, and TypeScript 7 runs
+    // with `stableTypeOrdering`, whose `compareTypes` orders string literal
+    // types by value. So the union is alphabetical regardless of declaration
+    // order -- e.g. `Omit<this, "getter" | "method" | "setter">` in the
+    // destructuringUnspreadableIntoRest conformance oracle, whose class
+    // declares those members in a different order. This test uses property
+    // names that sort opposite to declaration order ("xyz" before "abc" in
+    // source, but "abc" sorts before "xyz" alphabetically).
     let interner = TypeInterner::new();
     // Intern atoms in declaration order so `Atom` IDs alone are not enough
     // to recover declaration order via the storage sort.
@@ -189,7 +191,7 @@ fn keyof_object_properties_preserves_declaration_order() {
             other => panic!("expected string literal member, got {other:?}"),
         })
         .collect();
-    assert_eq!(names, vec!["xyzunique1", "abcunique2"]);
+    assert_eq!(names, vec!["abcunique2", "xyzunique1"]);
 }
 
 #[test]

--- a/crates/tsz-solver/tests/intern_tests.rs
+++ b/crates/tsz-solver/tests/intern_tests.rs
@@ -1756,11 +1756,10 @@ fn test_union_application_types_same_base_sort_by_args() {
 }
 
 #[test]
-fn test_union_member_order_uses_allocation_order() {
-    // Short string literals (1-2 chars) are sorted by content to match tsc's
-    // lib.d.ts pre-allocation order. tsc pre-creates common short string
-    // literals during lib processing in roughly alphabetical order.
-    // Longer strings use allocation order (source encounter order).
+fn test_union_member_order_uses_string_literal_value_order() {
+    // TypeScript 7 runs with `stableTypeOrdering`, whose `compareTypes` orders
+    // string literal types by their value, independent of interning order and
+    // independent of string length.
     let interner = TypeInterner::new();
 
     // Create short string literals in a specific order (d, c, a)
@@ -1768,7 +1767,6 @@ fn test_union_member_order_uses_allocation_order() {
     let lit_c = interner.literal_string("c");
     let lit_a = interner.literal_string("a");
 
-    // Short strings should sort by content (alphabetical), matching tsc lib ordering
     let union_id = interner.union(vec![lit_a, lit_c, lit_d]);
 
     if let Some(TypeData::Union(list_id)) = interner.lookup(union_id) {
@@ -1791,7 +1789,7 @@ fn test_union_member_order_uses_allocation_order() {
         panic!("Expected Union type");
     }
 
-    // Longer strings should preserve allocation order (source encounter order)
+    // Longer strings sort by value too: interning order must not leak through.
     let lit_foo = interner.literal_string("foo");
     let lit_bar = interner.literal_string("bar");
 
@@ -1800,14 +1798,14 @@ fn test_union_member_order_uses_allocation_order() {
     if let Some(TypeData::Union(list_id)) = interner.lookup(union_id2) {
         let members = interner.type_list(list_id);
         assert_eq!(members.len(), 2);
-        // Allocation order: foo was interned first, then bar
+        // Value order: "bar" < "foo", even though "foo" was interned first.
         assert_eq!(
-            members[0], lit_foo,
-            "First member should be 'foo' (interned first)"
+            members[0], lit_bar,
+            "First member should be 'bar' (alphabetically first)"
         );
         assert_eq!(
-            members[1], lit_bar,
-            "Second member should be 'bar' (interned second)"
+            members[1], lit_foo,
+            "Second member should be 'foo' (alphabetically second)"
         );
     } else {
         panic!("Expected Union type");


### PR DESCRIPTION
Goal: hold

## Structural rule

When a union contains string- or numeric-literal members, tsc orders those
members by their **value**; tsz does this through the interner's canonical
union comparator (`compare_cached_members`).

TypeScript 7 runs with `stableTypeOrdering` enabled by default
(`TypeScript/src/compiler/checker.ts:1545`). Under that flag
`insertType` / `addTypeToUnion` / `containsType` (`checker.ts:18068-18100`)
binary-search the member list with `compareTypes` (`checker.ts:53856`) instead
of by creation-order `type.id`. `compareTypes` orders string literal types by
value (`checker.ts:53968`) and numeric literal types by value
(`checker.ts:53975`).

tsz's comparator predated that flag and approximated *creation* order with two
heuristics that are now wrong:

- string literals: a `len <= 2` "short strings first" bucket, with longer
  strings falling through to allocation order;
- number literals: only the `0` literal was hoisted (modelling tsc's eagerly
  created `zeroType`), everything else fell through to allocation order.

Both are replaced by an unconditional value comparison. Ordering stays at
interning time, where it belongs: in tsc the member order is part of type
*identity* (the binary search above), not a display concern, so `A | B` and
`B | A` intern to one type.

## Owner layer

`crates/tsz-solver/src/intern/core/constructors.rs` — solver interner. No
checker/emitter changes; no printer output is read.

## Scope note

This lands only the *literal* tiebreak stages of `compareTypes`. The
`compareTypeNames` stage (`checker.ts:53867`) is deliberately **not** included:
the interner holds no binder symbol arena, so it cannot resolve a symbol to a
name, and `Cb[]` is a `TypeData::Array` with no name source at all (tsc sees it
as a `TypeReference` to `Array`). That stage therefore belongs at a layer that
already takes a name resolver — the diagnostic formatter's
`order_union_members_by_source` / `ts7_sort_name_source`, which is where the
remaining `Cb[] | Cb`, `Cover[] | Cover`, `any[] | Record<string, any>` and
`Bar | Foo` orderings should be fixed. Filed separately rather than forced into
the interner.

## Adjacent cases

- string literals shorter and longer than the old 2-char bucket, in both
  interning orders;
- numeric literals including negatives and zero, interned out of value order;
- `keyof` over an object whose declaration order is the reverse of value order;
- unions carrying a stored display origin, which must still render in source
  order while the canonical order stays value-sorted;
- mixed literal/non-literal unions, where the flag-rank stage still dominates.

## Verification

Local, on `a18434bd88` (current `origin/main`); no reliance on CI.

Conformance (full corpus, `tsc-cache-full.json` 7.0.2 oracle, 12 workers):

- before: `11332/12043` passed
- after:  `11333/12043` passed
- per-test diff: **1 fixed, 0 regressed** — `compiler/mappedTypeIndexedAccess.ts`

Emit suite (`./scripts/emit/run.sh --skip-build`), unchanged in both
directions and at/above the required floor:

- JS `11562/11563` (the one failure, `jsdocDisallowedInTypescript`, is
  pre-existing and in another lane)
- DTS `1372/1390`

Unit tests: `cargo nextest run -p tsz-solver` -> **7612 passed, 1 skipped, 0 failed**.

Six tests asserted the pre-`stableTypeOrdering` model and were updated to the
TS7 rule rather than deleted; the two union-origin tests kept their mechanism
and only changed vehicle, since their source order now has to disagree with
value order to be meaningful:

- `number_literal_union_uses_tsc_allocation_order` -> `..._uses_tsc_numeric_order`
- `number_literal_union_is_not_numeric_sorted` -> `..._is_numeric_sorted_regardless_of_allocation_order`
- `store_union_origin_preserves_source_order_for_number_literal_union`
- `formatter_can_ignore_union_origin_for_canonical_number_literal_display`
- `test_union_member_order_uses_allocation_order` -> `..._uses_string_literal_value_order`
- `keyof_object_properties_preserves_declaration_order` -> `..._uses_string_literal_value_order`

The `keyof` rename is oracle-backed: `destructuringUnspreadableIntoRest`
expects `Omit<this, "getter" | "method" | "publicProp" | "setter">` while the
class declares those members in a different order.

`cargo clippy -p tsz-solver` reports no new findings; its three existing ones
are in `operations/expression_ops.rs` and `operations/widening.rs`, untouched
here.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max
