### PR TITLE
fix(solver): array union members sort under the global "Array" name

### DIFF
--- a/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
@@ -537,6 +537,17 @@ impl<'a> TypeFormatter<'a> {
                 TypeData::TypeParameter(param) => {
                     return Some(self.atom(param.name).to_string());
                 }
+                // tsc has no distinct array type: `T[]` is a `TypeReference` to
+                // the global `Array` interface, so `compareTypeNames`
+                // (checker.ts:53867) orders it under the name "Array". tsz
+                // models arrays as their own `TypeData`, which would otherwise
+                // have no name to compare and sort after every named member.
+                // Reporting the global's own name keeps ordering agreement --
+                // e.g. `Cb[] | Cb` and `any[] | Record<string, any>`, where
+                // "Array" precedes "Cb" and "Record".
+                TypeData::Array(_) => {
+                    return Some("Array".to_string());
+                }
                 _ => return None,
             }
         }

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
@@ -1424,12 +1424,27 @@ fn typeof_prefix_for_namespace_and_class_constructor_defs() {
     assert_eq!(fmt.format(class_instance_obj), "Bar");
 }
 
-/// Regression: `T[]` (modeled as `TypeData::Array(T)`) should inherit its
-/// element type's source position when sorting union members. Without this,
-/// `Cover[]` falls through to the tier-2 sentinel and a union written as
-/// `Cover | Cover[]` displays out of order.
+/// `T[]` is a `TypeReference` to the global `Array` in tsc, so under TS7's
+/// `stableTypeOrdering` it sorts under the name "Array" via `compareTypeNames`
+/// (`checker.ts:53867`) -- ahead of any named member sorting after "Array",
+/// regardless of the order the union was written in.
+///
+/// Verified against tsc 7.0.2:
+/// ```text
+/// interface Cover { color: string; }
+/// declare function f(c: Cover | Cover[]): void;
+/// f({ color: "red", couleur: "rouge" });
+/// // error TS2353: ... does not exist in type 'Cover[] | Cover'.
+/// ```
+/// Note the source is written `Cover | Cover[]` and tsc still renders
+/// `Cover[] | Cover`. The conformance oracle agrees
+/// (`compiler/objectLiteralExcessProperties.ts`).
+///
+/// The element-source-position inheritance this test originally pinned is still
+/// the tie-break for arrays whose names compare equal; it is simply no longer
+/// the deciding key when the names differ.
 #[test]
-fn union_array_inherits_element_source_position() {
+fn union_array_sorts_under_the_array_name() {
     let db = TypeInterner::new();
     let def_store = crate::def::DefinitionStore::new();
 
@@ -1450,8 +1465,8 @@ fn union_array_inherits_element_source_position() {
     let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
     assert_eq!(
         fmt.format(union_id),
-        "Cover | Cover[]",
-        "Array(T) should inherit T's position so `Cover | Cover[]` stays in source order"
+        "Cover[] | Cover",
+        "`Cover[]` sorts under the global name \"Array\", which precedes \"Cover\""
     );
 }
 


### PR DESCRIPTION
Goal: hold

## Structural rule

When a union contains an array member alongside named object members, tsc
orders the array under the name **`Array`**; tsz does this through the
diagnostic formatter's union member ordering.

tsc has no distinct array type — `T[]` is a `TypeReference` to the global
`Array` interface. Under TS7's `stableTypeOrdering`, `compareTypes` reaches
`compareTypeNames` (`checker.ts:53867`) once two members share an object sort
rank, so the array is compared by the name `Array`.

tsz models arrays as their own `TypeData::Array`. `stable_order_type_name`
(`crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs`)
handled `Application`, `Lazy`, `Enum`, `Object`, `ObjectWithIndex`, `Callable`
and `TypeParameter`, but fell through to `None` for arrays — and the comparator
sorts unnamed members after every named one. So `Cover[] | Cover` rendered as
`Cover | Cover[]`.

Verified directly against tsc 7.0.2. Note the source is written
`Cover | Cover[]` and tsc still renders the array first, so this is an ordering
rule, not source-order preservation:

```ts
interface Cover { color: string; }
declare function f(c: Cover | Cover[]): void;
f({ color: "red", couleur: "rouge" });
// error TS2353: ... does not exist in type 'Cover[] | Cover'.
```

## Owner layer

`crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs` — the
formatter's ordering name resolution. The printer reads types; no type reads
printer output.

On the anti-hardcoding gate: this produces the canonical name of a **true
built-in** for ordering, which the gate explicitly permits ("use binder/global
builtin ids for true built-ins"). It is not a branch on a user-chosen
identifier, and no rendered string is used as a predicate.

This stage deliberately does **not** live in the interner comparator: a
`CachedUnionMember` carries only a raw `SymbolId`, the interner holds no binder
symbol arena, and an array has no symbol at all — so the name is simply not
available there.

## Adjacent cases

- array vs a named type sorting after `Array` (`Cover[] | Cover`) and vs one
  sorting before it, which must not move;
- array of an intrinsic against a named alias
  (`any[] | Record<string, any>`), covered by the fixed conformance tests;
- two arrays whose element names differ, where the `Array` names tie and the
  existing element-source-position tie-break still decides;
- arrays inside unions carrying a stored display origin, which still render in
  origin order.

## Verification

Local, on `a18434bd88` (current `origin/main`); no reliance on CI.

Conformance (full corpus, `tsc-cache-full.json` 7.0.2 oracle, 12 workers):

- before: `11332/12043`
- after:  `11334/12043`
- per-test diff: **2 fixed, 0 regressed**
  - `compiler/narrowingMutualSubtypes.ts` (`any[] | Record<string, any>`)
  - `compiler/objectLiteralExcessProperties.ts` (`Cover[] | Cover`)

Emit suite (`./scripts/emit/run.sh --skip-build`), unchanged and at the floor:

- JS `11562/11563`
- DTS `1372/1390`

Unit tests: `cargo nextest run -p tsz-solver` -> **7612 passed, 1 skipped, 0 failed**.

One test (`union_array_inherits_element_source_position`) pinned the opposite
order, asserting `Cover | Cover[]` "stays in source order". That is the
pre-`stableTypeOrdering` rule and is contradicted by both the tsc 7.0.2 run
above and the conformance oracle, so it is updated and renamed
`union_array_sorts_under_the_array_name`. The element-source-position
inheritance it originally covered is still the tie-break when names compare
equal; it is simply no longer the deciding key when the names differ.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max
