### PR TITLE
refactor(checker): drop the name-keyed `bind` overload-anchor override

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -839,7 +839,7 @@ impl<'a> CheckerState<'a> {
                     == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
             })
             .collect();
-        let mut literal_anchor = self.overload_literal_argument_anchor(idx, failures);
+        let literal_anchor = self.overload_literal_argument_anchor(idx, failures);
         let shared_argument_anchor = self
             .shared_overload_argument_anchor_from_spans(idx, &argument_failures)
             .or_else(|| self.shared_overload_argument_anchor(idx, &argument_failures));
@@ -1018,46 +1018,6 @@ impl<'a> CheckerState<'a> {
             .and_then(|call_expr| call_expr.arguments.as_ref())
             .is_some_and(|args| args.nodes.len() == 1);
         let is_new_call = self.is_new_expression(idx);
-        let is_bind_method_call = self
-            .ctx
-            .arena
-            .get(idx)
-            .and_then(|call_node| self.ctx.arena.get_call_expr(call_node))
-            .is_some_and(|call_expr| {
-                let is_bind = self
-                    .ctx
-                    .arena
-                    .get(call_expr.expression)
-                    .and_then(|callee| {
-                        if callee.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-                            self.ctx.arena.get_access_expr(callee)
-                        } else {
-                            None
-                        }
-                    })
-                    .and_then(|access| self.ctx.arena.get(access.name_or_argument))
-                    .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                    .is_some_and(|ident| ident.escaped_text == "bind");
-                if !is_bind {
-                    return false;
-                }
-
-                // tsc anchors callback.bind(2)-style failures at `bind`, but
-                // keeps first-argument anchoring for `bind(undefined)` mismatches.
-                let first_arg_is_undefined = call_expr
-                    .arguments
-                    .as_ref()
-                    .and_then(|args| args.nodes.first().copied())
-                    .and_then(|arg_idx| self.ctx.arena.get(arg_idx))
-                    .and_then(|arg_node| self.ctx.arena.get_identifier(arg_node))
-                    .is_some_and(|ident| ident.escaped_text == "undefined");
-                !first_arg_is_undefined
-            });
-        if is_bind_method_call {
-            // For `callback.bind(2)`-style overload failures, tsc anchors TS2769
-            // at `bind`, not at the argument literal.
-            literal_anchor = None;
-        }
         let allow_callback_argument_anchor = argument_anchor_is_callback
             && single_callback_argument
             && all_failures_are_argument_mismatches
@@ -1068,7 +1028,6 @@ impl<'a> CheckerState<'a> {
             && !self.is_weak_collection_constructor_new(idx);
         let anchor_first_argument = (!is_new_call || allow_new_argument_anchor)
             && (!argument_anchor_is_callback || allow_callback_argument_anchor)
-            && !is_bind_method_call
             && (identical_argument_failures
                 && !remaining_failures.is_empty()
                 && remaining_failures_are_count_mismatches
@@ -1123,10 +1082,9 @@ impl<'a> CheckerState<'a> {
         // so tsc anchors on the member expression, not the explicit argument);
         // leave those to the existing `OverloadPrimary` handling rather than
         // redirecting them to the positional argument.
-        let indexed_argument_anchor =
-            (matches!(anchor_kind, DiagnosticAnchorKind::OverloadPrimary) && !is_bind_method_call)
-                .then(|| self.indexed_overload_argument_anchor(idx, &argument_failures))
-                .flatten();
+        let indexed_argument_anchor = matches!(anchor_kind, DiagnosticAnchorKind::OverloadPrimary)
+            .then(|| self.indexed_overload_argument_anchor(idx, &argument_failures))
+            .flatten();
         let Some(anchor) = callback_body_failure_span
             .or(indexed_argument_anchor)
             .or_else(|| self.resolve_diagnostic_anchor(anchor_idx, anchor_kind))


### PR DESCRIPTION
Goal: hold

## Structural rule

Overload-failure anchoring must be decided from AST structure, never from a
callee's spelling. `report_overload_failure` decided it from two identifier
strings.

`crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs` computed
`is_bind_method_call` by testing the callee's property name against the literal
`"bind"`, and then the first argument's identifier against `"undefined"`:

```rust
.is_some_and(|ident| ident.escaped_text == "bind");
.is_some_and(|ident| ident.escaped_text == "undefined");
```

That is a user-facing identifier driving compiler logic, which the
anti-hardcoding gate forbids ("no new user-name/file-name literals driving
compiler logic"). Any user function named `bind` hit it.

It also encoded the *pre-TS7* answer. Its comment claims tsc anchors
`callback.bind(2)` failures at `bind`; TS7 anchors that case at the
this-argument (`callback`), because the failing relation is the this-argument
relation. So the override actively forced the wrong anchor for exactly the case
TypeScript 7 changed.

## Owner layer

`crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs` —
checker diagnostic anchoring. No solver or emitter changes.

Removing the flag also drops the now-unused `mut` on `literal_anchor` and
simplifies the two conditions that were gated on it (`anchor_first_argument`
and `indexed_argument_anchor`).

## Why this is a prerequisite, not a cleanup

The TS2769 overload-anchor bucket is the largest remaining location-only
cluster (10 conformance tests). It cannot be done correctly while a name-keyed
override pins the Strada anchor for the very shape TS7 moved — any structural
rule would be silently overridden whenever the callee happens to be spelled
`bind`. This change unblocks that work.

## Adjacent cases

- `x.bind(...)` on a user-defined method named `bind` (previously caught by the
  string test purely by name collision);
- `f.bind(undefined, ...)`, the case the second string test carved out;
- overload failures on callees not named `bind`, which must be unchanged;
- `new` expressions and callback-argument anchoring, both of which share the
  `anchor_first_argument` condition the flag gated.

## Verification

Local, on `a18434bd88` (current `origin/main`); no reliance on CI.

Measured **before** removing, in two stages. First the flag was neutralized
(forced to `false`) and the corpus re-run; then the code was deleted and the
corpus re-run again. Both stages are byte-identical to main:

- conformance `11332/12043` — **0 fixed, 0 regressed**
- emit JS `11562/11563`, DTS `1372/1390` — unchanged, at the required floor

So the override was inert on the entire corpus: it was dead weight guarding
nothing, while still violating the gate.

Unit tests: `cargo nextest run -p tsz-checker -E 'binary(~overload) or
binary(~call)'` -> **890 tests run, 890 passed, 0 failed**.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max
