### PR TITLE
fix(checker): TS1454 anchors at the attributes clause, TS1092 at the @template tag

### DIFF
--- a/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
@@ -176,15 +176,20 @@ impl<'a> CheckerState<'a> {
         // Step 6: a valid `resolution-mode` override on a NON-type-only
         // declaration gets tsc's dedicated TS1454 at the attribute name
         // ("`resolution-mode` can only be set for type-only imports.").
+        // tsc anchors this at the whole attributes clause (the `with`/`assert`
+        // keyword through the closing brace), not at the attribute name.
+        //
+        // The single-element guard is load-bearing and mirrors tsc's
+        // `getResolutionModeOverride`, which bails when the clause carries more
+        // than one attribute; the resolution-mode lookup itself already
+        // resolves the element, so no per-element node is needed here.
         if !declaration_is_type_only
             && self.get_resolution_mode_override(attributes_idx).is_some()
             && attrs_data.elements.nodes.len() == 1
-            && let Some(&elem_idx) = attrs_data.elements.nodes.first()
-            && let Some(elem_node) = self.ctx.arena.get(elem_idx)
-            && let Some(attr) = self.ctx.arena.get_import_attribute_data(elem_node)
         {
-            self.error_at_node(
-                attr.name,
+            self.error_at_position(
+                node_pos,
+                node_len,
                 diagnostic_messages::RESOLUTION_MODE_CAN_ONLY_BE_SET_FOR_TYPE_ONLY_IMPORTS,
                 diagnostic_codes::RESOLUTION_MODE_CAN_ONLY_BE_SET_FOR_TYPE_ONLY_IMPORTS,
             );

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_constructor_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_constructor_checks.rs
@@ -371,12 +371,11 @@ impl<'a> CheckerState<'a> {
 
         // TS1092: Check for @template tag on constructor
         if let Some(template_offset) = Self::jsdoc_tag_offset(raw_comment, "template") {
-            let rest = &raw_comment[template_offset + "@template".len()..];
-            let trimmed = rest.trim_start();
-            // tsc points at the first type parameter name after @template
-            let ws_len = rest.len() - trimmed.len();
-            let error_offset = template_offset + "@template".len() + ws_len;
-            let abs_pos = comment_pos + error_offset as u32;
+            // tsc anchors at the `@` of the `@template` tag itself, not at what
+            // follows it. Skipping to the text after the tag also mis-landed on
+            // `{` for a typed form like `@template {string} T`, which is wrong
+            // under either rule.
+            let abs_pos = comment_pos + template_offset as u32;
             self.ctx.error(
                 abs_pos,
                 0,


### PR DESCRIPTION
Goal: hold

## Structural rule

Two diagnostic anchors that tsz inherited from TypeScript 6 and that TypeScript
7 moved. Both rules were derived by **running tsc 7.0.2 directly**, not from the
checked-in `.errors.txt` baselines, which are stale 6.0 artifacts.

**TS1454** — When an import/export declaration is not exclusively type-only but
its attributes clause carries exactly one valid `resolution-mode` entry, tsc
anchors at the whole `ImportAttributes` clause (the `with`/`assert` keyword
through the closing brace); tsz anchored at the attribute *name*, landing 7
columns late.

**TS1092** — When a constructor in a JS file carries a JSDoc `@template` tag,
tsc anchors at the `@` of that tag; tsz skipped past the tag and its trailing
whitespace to the type-parameter name.

## Owner layer

- `crates/tsz-checker/src/declarations/import/declaration_attributes.rs` —
  the clause span was already computed upstream as `node_pos`/`node_len`, so
  this uses it instead of `attr.name`.
- `crates/tsz-checker/src/state/state_checking_members/ambient_constructor_checks.rs`
  — drops the `+ "@template".len() + ws_len` offset.

Checker diagnostic anchoring only. No solver or emitter changes. Both anchors
come from AST/structural facts; nothing is keyed on identifier names, file
names, or rendered strings.

The single-element guard in the TS1454 path is **kept deliberately**: it mirrors
tsc's `getResolutionModeOverride`, which bails when the clause holds more than
one attribute. The resolution-mode lookup already resolves the element, so the
per-element node lookups it guarded were dead weight and are removed.

## Adjacent cases

- `with { "resolution-mode": "import" }` on a non-type-only import (the bug) vs
  on a type-only import, which is accepted and must stay silent;
- an attributes clause with more than one attribute, where tsc bails and no
  TS1454 is reported;
- `assert { ... }` as well as `with { ... }`, since the anchor is the clause
  node either way;
- `@template T` vs `@template {string} T` — the old code landed on `{` for the
  typed form, wrong under either version's rule;
- real (non-JSDoc) type parameters on a constructor, which report TS1093 and
  must not move.

## Verification

Local, on `a18434bd88` (current `origin/main`); no reliance on CI.

Conformance (full corpus, `tsc-cache-full.json` 7.0.2 oracle, 12 workers):

- before: `11332/12043`
- after:  `11335/12043`
- per-test diff: **3 fixed, 0 regressed**
  - `compiler/jsdocIllegalTags.ts` (TS1092)
  - `conformance/node/nodeModulesImportAttributesModeDeclarationEmit2.ts` (TS1454 ×2)
  - `conformance/node/nodeModulesImportModeDeclarationEmit2.ts` (TS1454 ×2)

Emit suite (`./scripts/emit/run.sh --skip-build`), unchanged and at the floor:

- JS `11562/11563`
- DTS `1372/1390`

Direct oracle check for TS1092:

```
class C { /** @template T */ constructor(x) { this.x = x; } }

tsc 7.0.2: a.js(3,6): error TS1092: Type parameters cannot appear on a constructor declaration.
tsz:       a.js(3,6): error TS1092: Type parameters cannot appear on a constructor declaration.
```
(tsz previously reported `3,16`.)

## Follow-up filed separately

`ImportAttributes.end` swallows the following token, because
`crates/tsz-parser/src/parser/state_declarations_modules.rs` reads `token_end()`
*after* `parse_expected(CloseBraceToken)`. That affects the caret **length**
only — conformance-inert, since length is not part of the diagnostic
fingerprint — but it is visible in `--pretty` output and in the LSP. Kept out of
this change rather than mixed into an anchor fix; the same read-after-consume
pattern appears at two other sites in that file.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max
