### PR TITLE
fix(checker): TS2384 takes canonical overload flags from the implementation

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -231,6 +231,10 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
             let mut func_decls_for_2384 = Vec::new();
+            // The implementation is excluded from the overload list but is still
+            // needed: tsc's `getCanonicalOverload` may take the canonical flags
+            // from it. See the TS2384 report below.
+            let mut implementation_for_2384: Option<NodeIndex> = None;
             let mut has_ambient_func = false;
             let mut has_non_ambient_func = false;
             for &(decl_idx, flags, is_local, _, _) in &declarations {
@@ -239,6 +243,9 @@ impl<'a> CheckerState<'a> {
                     // Skip implementations (declarations with bodies) — a non-ambient
                     // implementation following ambient overloads is valid.
                     if self.function_has_body(decl_idx) {
+                        if implementation_for_2384.is_none() {
+                            implementation_for_2384 = Some(decl_idx);
+                        }
                         continue;
                     }
                     func_decls_for_2384.push(decl_idx);
@@ -250,7 +257,28 @@ impl<'a> CheckerState<'a> {
                 }
             }
             if has_ambient_func && has_non_ambient_func {
-                let ref_is_ambient = self.is_ambient_declaration(func_decls_for_2384[0]);
+                // tsc's `getCanonicalOverload` (checker.ts:43088) takes the
+                // canonical set of flags from the *implementation* when it
+                // shares a container with the first overload, and only
+                // otherwise from the first overload. The container check is
+                // what keeps lib.d.ts overloads from being blamed for a local
+                // implementation. Reading the flags off the first overload
+                // unconditionally blames the wrong declaration whenever the
+                // implementation is the one the majority agrees with.
+                let first_overload = func_decls_for_2384[0];
+                let first_parent = self
+                    .ctx
+                    .arena
+                    .get_extended(first_overload)
+                    .map(|ext| ext.parent);
+                let canonical = implementation_for_2384
+                    .filter(|&impl_idx| {
+                        first_parent.is_some()
+                            && self.ctx.arena.get_extended(impl_idx).map(|ext| ext.parent)
+                                == first_parent
+                    })
+                    .unwrap_or(first_overload);
+                let ref_is_ambient = self.is_ambient_declaration(canonical);
                 for &decl_idx in &func_decls_for_2384 {
                     if self.is_ambient_declaration(decl_idx) != ref_is_ambient {
                         let error_node =


### PR DESCRIPTION
Goal: hold

## Structural rule

When overload signatures disagree on ambient-ness, tsc takes the canonical set
of modifier flags from the **implementation** if it shares a container with the
first overload, and only otherwise from the first overload; tsz always used the
first overload, which blames the wrong declaration.

Oracle — `TypeScript/src/compiler/checker.ts:43088` `getCanonicalOverload`:

```ts
// The caveat is that if some overloads are defined in lib.d.ts, we don't want to
// report the errors on those. To achieve this, we will say that the implementation is
// the canonical signature only if it is in the same container as the first overload
const implementationSharesContainerWithFirstOverload =
    implementation !== undefined && implementation.parent === overloads[0].parent;
return implementationSharesContainerWithFirstOverload ? implementation : overloads[0];
```

tsz excludes implementations from `func_decls_for_2384` — correctly, since they
are not overload signatures — and then used `func_decls_for_2384[0]` as the
reference for ambient-ness. That is wrong exactly when the implementation is the
declaration the majority agrees with:

```ts
declare function bar();            // ambient
export function bar(s: string);    // non-ambient
function bar(s?: string) { }       // implementation, non-ambient
```

Canonical is the implementation (non-ambient), so the single deviation is the
**ambient** overload on line 1. tsz took line 1 as the reference, concluded it
agreed with itself, and reported line 2 instead.

```
tsc 7.0.2:  ov.ts(1,18): error TS2384: Overload signatures must all be ambient or non-ambient.
tsz before: ov.ts(2,17)
tsz after:  ov.ts(1,18)
```

The container check is preserved, so overloads declared in `lib.d.ts` are still
never blamed for a local implementation.

## Owner layer

`crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs` — checker
diagnostic reporting. The implementation node is captured while scanning
declarations (it was already being skipped there) and the container comparison
uses `get_extended(idx).map(|ext| ext.parent)`, an AST fact. Nothing is keyed on
identifier names, file names, or rendered strings.

## Adjacent cases

- implementation in the same container as the first overload (the bug) vs a
  different container, where the first overload must remain canonical;
- overloads with no implementation at all, which must keep using the first
  overload;
- the reverse polarity: a single non-ambient overload among ambient ones, where
  the non-ambient one must be blamed;
- class method overloads, which reach the same code path;
- multiple implementations (error recovery), where the first is taken.

## Verification

Local, on `910c990faf` (current `origin/main`); no reliance on CI.

Conformance (full corpus, `tsc-cache-full.json` 7.0.2 oracle, 12 workers):

- before: `11342/12043`
- after:  `11343/12043`
- per-test diff: **1 fixed, 0 regressed** —
  `compiler/overloadModifiersMustAgree.ts`

Baseline discipline for this measurement (all four traps checked): the tree was
committed before any branch switch; the rebuild was forced with
`git diff --name-only main...HEAD | grep '\.rs$' | xargs -r touch` and confirmed
against a minimal repro that distinguishes the two sides; no concurrent
`conformance.sh` was running; `main` was freshly fast-forwarded to `origin/main`.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max
