### PR TITLE
fix(checker): did-you-mean-call re-anchoring (initializers, object-literal values, bare function types)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -1440,7 +1440,7 @@ impl<'a> CheckerState<'a> {
                 .node_types
                 .get(&vd.type_annotation.0)
                 .or_else(|| self.ctx.node_types.get(&vd.name.0))
-            && crate::query_boundaries::assignability::did_you_mean_call_or_construct(
+            && crate::query_boundaries::assignability_did_you_mean::did_you_mean_call_or_construct(
                 self.ctx.types.as_type_database(),
                 init_type,
                 declared_type,

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -1366,7 +1366,7 @@ impl<'a> CheckerState<'a> {
                 if let Some(vd_idx) = var_decl
                     && let Some(vd) = self.ctx.arena.get_variable_declaration_at(vd_idx)
                 {
-                    return self.variable_declaration_anchor(vd, parent);
+                    return self.variable_declaration_anchor(vd);
                 }
                 return parent;
             }
@@ -1380,8 +1380,7 @@ impl<'a> CheckerState<'a> {
 
         if let Some(vd_idx) = var_decl {
             if let Some(vd) = self.ctx.arena.get_variable_declaration_at(vd_idx) {
-                let var_stmt = self.find_variable_statement_parent(vd_idx);
-                return self.variable_declaration_anchor(vd, var_stmt.unwrap_or(NodeIndex::NONE));
+                return self.variable_declaration_anchor(vd);
             }
             return vd_idx;
         }
@@ -1417,37 +1416,37 @@ impl<'a> CheckerState<'a> {
     fn variable_declaration_anchor(
         &self,
         vd: &tsz_parser::parser::node::VariableDeclarationData,
-        var_stmt: NodeIndex,
     ) -> NodeIndex {
-        // Check if this is a `let` or `const` declaration (not `var`)
-        let is_let_or_const = if let Some(stmt_node) = self.ctx.arena.get(var_stmt)
-            && let Some(var_data) = self.ctx.arena.get_variable(stmt_node)
-            && let Some(&list_idx) = var_data.declarations.nodes.first()
+        // tsc's `elaborateDidYouMeanToCallOrConstruct` re-reports on the
+        // *initializer expression* when calling (or `new`-ing) it would have
+        // produced something assignable to the declared type, and only
+        // otherwise anchors at the declaration name.
+        //
+        // Neither the declaration keyword nor the initializer's syntactic form
+        // is part of that rule, so the previous `var` + property-access gates
+        // made `export let x: Dog = getRover` anchor at `x` where tsc anchors at
+        // `getRover`. The return-type check is the load-bearing half: gating on
+        // "is callable" alone re-anchors every callable initializer and
+        // regresses 23 tests (assignmentCompatability44, classSideInheritance3,
+        // constructorAsType, ...), because tsc stays on the declaration name
+        // when calling the source would not have helped.
+        //
+        // The declared type is read from the variable's own cached type, which
+        // keeps this on the `&self` anchor path.
+        if vd.initializer.is_some()
+            && let Some(&init_type) = self.ctx.node_types.get(&vd.initializer.0)
+            && let Some(&declared_type) = self
+                .ctx
+                .node_types
+                .get(&vd.type_annotation.0)
+                .or_else(|| self.ctx.node_types.get(&vd.name.0))
+            && crate::query_boundaries::assignability::did_you_mean_call_or_construct(
+                self.ctx.types.as_type_database(),
+                init_type,
+                declared_type,
+            )
         {
-            let flags = self.ctx.arena.get_variable_declaration_flags(list_idx);
-            use tsz_parser::parser::flags::node_flags;
-            node_flags::is_let_or_const(flags)
-        } else {
-            false
-        };
-
-        // For `var` (not let/const) with property access initializers where the
-        // initializer type is callable, tsc points at the property access.
-        // For `let`/`const` or non-callable initializers, point at the variable name.
-        if !is_let_or_const
-            && vd.initializer.is_some()
-            && let Some(init_node) = self.ctx.arena.get(vd.initializer)
-            && init_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-        {
-            // Check if the initializer type is callable (function-like).
-            // tsc points at the initializer for callable types but at the
-            // variable name for non-callable types.
-            // Use the cached type directly to avoid &mut self requirement.
-            if let Some(&init_type) = self.ctx.node_types.get(&vd.initializer.0)
-                && self.is_callable_type(init_type)
-            {
-                return vd.initializer;
-            }
+            return vd.initializer;
         }
         if vd.name.is_some() {
             return vd.name;

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -43,55 +43,6 @@ fn assignability_policy_and_context<'a>(
     (policy, context)
 }
 
-/// tsc's `elaborateDidYouMeanToCallOrConstruct` predicate: does `source` have a
-/// construct or call signature whose return type would have satisfied `target`?
-///
-/// When it does, tsc re-reports the assignability failure on the source
-/// *expression* and suggests calling it (or using `new`), instead of anchoring
-/// at the declaration name:
-///
-/// ```ts
-/// declare function getRover(): Dog;
-/// export let x: Dog = getRover;   // reported at `getRover`, not at `x`
-/// ```
-///
-/// Construct signatures are consulted before call signatures, matching tsc's
-/// ordering. `any`/`unknown`/error/`never` return types are skipped: they relate
-/// to everything, so including them would make the suggestion fire on
-/// completely unrelated mismatches.
-pub(crate) fn did_you_mean_call_or_construct(
-    db: &dyn TypeDatabase,
-    source: TypeId,
-    target: TypeId,
-) -> bool {
-    let mut return_types: Vec<TypeId> = Vec::new();
-    if let Some(signatures) = super::construct_signatures::construct_signatures_for_type(db, source)
-    {
-        return_types.extend(signatures.iter().map(|signature| signature.return_type));
-    }
-    if let Some(signatures) = super::common::call_signatures_for_type(db, source) {
-        return_types.extend(signatures.iter().map(|signature| signature.return_type));
-    }
-    // `call_signatures_for_type` collects call signatures carried by an object
-    // or callable shape, but a bare function type (`() => A`) has none to
-    // collect -- its signature lives on the function shape itself. The construct
-    // lookup above already has the equivalent `get_function_shape` fallback, and
-    // without the matching one here the predicate fired for
-    // `declare function getA(): A` and for `declare const Ctor: { new(): A }`
-    // yet silently missed `declare const Fn: () => A`.
-    if return_types.is_empty()
-        && let Some(shape) = tsz_solver::type_queries::get_function_shape(db, source)
-        && !shape.is_constructor
-    {
-        return_types.push(shape.return_type);
-    }
-    return_types.into_iter().any(|return_type| {
-        !return_type.is_any_unknown_or_error()
-            && return_type != TypeId::NEVER
-            && tsz_solver::relations::subtype::is_subtype_of(db, return_type, target)
-    })
-}
-
 pub(crate) fn are_types_structurally_identical<R: TypeResolver>(
     db: &dyn TypeDatabase,
     resolver: &R,

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -43,6 +43,42 @@ fn assignability_policy_and_context<'a>(
     (policy, context)
 }
 
+/// tsc's `elaborateDidYouMeanToCallOrConstruct` predicate: does `source` have a
+/// construct or call signature whose return type would have satisfied `target`?
+///
+/// When it does, tsc re-reports the assignability failure on the source
+/// *expression* and suggests calling it (or using `new`), instead of anchoring
+/// at the declaration name:
+///
+/// ```ts
+/// declare function getRover(): Dog;
+/// export let x: Dog = getRover;   // reported at `getRover`, not at `x`
+/// ```
+///
+/// Construct signatures are consulted before call signatures, matching tsc's
+/// ordering. `any`/`unknown`/error/`never` return types are skipped: they relate
+/// to everything, so including them would make the suggestion fire on
+/// completely unrelated mismatches.
+pub(crate) fn did_you_mean_call_or_construct(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    target: TypeId,
+) -> bool {
+    let mut return_types: Vec<TypeId> = Vec::new();
+    if let Some(signatures) = super::construct_signatures::construct_signatures_for_type(db, source)
+    {
+        return_types.extend(signatures.iter().map(|signature| signature.return_type));
+    }
+    if let Some(signatures) = super::common::call_signatures_for_type(db, source) {
+        return_types.extend(signatures.iter().map(|signature| signature.return_type));
+    }
+    return_types.into_iter().any(|return_type| {
+        !return_type.is_any_unknown_or_error()
+            && return_type != TypeId::NEVER
+            && tsz_solver::relations::subtype::is_subtype_of(db, return_type, target)
+    })
+}
+
 pub(crate) fn are_types_structurally_identical<R: TypeResolver>(
     db: &dyn TypeDatabase,
     resolver: &R,

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -72,6 +72,19 @@ pub(crate) fn did_you_mean_call_or_construct(
     if let Some(signatures) = super::common::call_signatures_for_type(db, source) {
         return_types.extend(signatures.iter().map(|signature| signature.return_type));
     }
+    // `call_signatures_for_type` collects call signatures carried by an object
+    // or callable shape, but a bare function type (`() => A`) has none to
+    // collect -- its signature lives on the function shape itself. The construct
+    // lookup above already has the equivalent `get_function_shape` fallback, and
+    // without the matching one here the predicate fired for
+    // `declare function getA(): A` and for `declare const Ctor: { new(): A }`
+    // yet silently missed `declare const Fn: () => A`.
+    if return_types.is_empty()
+        && let Some(shape) = tsz_solver::type_queries::get_function_shape(db, source)
+        && !shape.is_constructor
+    {
+        return_types.push(shape.return_type);
+    }
     return_types.into_iter().any(|return_type| {
         !return_type.is_any_unknown_or_error()
             && return_type != TypeId::NEVER

--- a/crates/tsz-checker/src/query_boundaries/assignability_did_you_mean.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability_did_you_mean.rs
@@ -1,0 +1,56 @@
+//! `elaborateDidYouMeanToCallOrConstruct` predicate.
+//!
+//! Split out of `assignability.rs` to keep that file under the 2000-line
+//! architecture limit.
+
+use tsz_solver::TypeId;
+use tsz_solver::construction::TypeDatabase;
+
+/// tsc's `elaborateDidYouMeanToCallOrConstruct` predicate: does `source` have a
+/// construct or call signature whose return type would have satisfied `target`?
+///
+/// When it does, tsc re-reports the assignability failure on the source
+/// *expression* and suggests calling it (or using `new`), instead of anchoring
+/// at the declaration name:
+///
+/// ```ts
+/// declare function getRover(): Dog;
+/// export let x: Dog = getRover;   // reported at `getRover`, not at `x`
+/// ```
+///
+/// Construct signatures are consulted before call signatures, matching tsc's
+/// ordering. `any`/`unknown`/error/`never` return types are skipped: they relate
+/// to everything, so including them would make the suggestion fire on
+/// completely unrelated mismatches.
+pub(crate) fn did_you_mean_call_or_construct(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    target: TypeId,
+) -> bool {
+    let mut return_types: Vec<TypeId> = Vec::new();
+    if let Some(signatures) = super::construct_signatures::construct_signatures_for_type(db, source)
+    {
+        return_types.extend(signatures.iter().map(|signature| signature.return_type));
+    }
+    if let Some(signatures) = super::common::call_signatures_for_type(db, source) {
+        return_types.extend(signatures.iter().map(|signature| signature.return_type));
+    }
+    // `call_signatures_for_type` collects call signatures carried by an object
+    // or callable shape, but a bare function type (`() => A`) has none to
+    // collect -- its signature lives on the function shape itself. The construct
+    // lookup above already has the equivalent `get_function_shape` fallback, and
+    // without the matching one here the predicate fired for
+    // `declare function getA(): A` and for `declare const Ctor: { new(): A }`
+    // yet silently missed `declare const Fn: () => A`.
+    if return_types.is_empty()
+        && let Some(shape) = tsz_solver::type_queries::get_function_shape(db, source)
+        && !shape.is_constructor
+    {
+        return_types.push(shape.return_type);
+    }
+    return_types.into_iter().any(|return_type| {
+        !return_type.is_any_unknown_or_error()
+            && return_type != TypeId::NEVER
+            && tsz_solver::relations::subtype::is_subtype_of(db, return_type, target)
+    })
+}

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod apparent_type;
 pub(crate) mod application_keyof;
 pub(crate) mod assignability;
 pub(crate) mod assignability_alias_display;
+pub(crate) mod assignability_did_you_mean;
 pub(crate) mod assignability_suppression;
 pub(crate) mod binding_patterns;
 pub(crate) mod capabilities;

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -245,14 +245,14 @@ impl<'a> CheckerState<'a> {
             // on "the value is callable" alone re-anchors values whose call
             // would not have helped, which tsc leaves on the property name.
             let mut anchor_idx = report_idx;
-            if let Some(value_idx) = self.object_literal_property_initializer(report_idx) {
-                if crate::query_boundaries::assignability::did_you_mean_call_or_construct(
+            if let Some(value_idx) = self.object_literal_property_initializer(report_idx)
+                && crate::query_boundaries::assignability_did_you_mean::did_you_mean_call_or_construct(
                     self.ctx.types.as_type_database(),
                     source_prop.type_id,
                     target_value_type,
-                ) {
-                    anchor_idx = value_idx;
-                }
+                )
+            {
+                anchor_idx = value_idx;
             }
 
             let _ = self.check_assignable_or_report_at_exact_anchor_without_source_elaboration(

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -234,11 +234,32 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
+            // tsc's `elaborateDidYouMeanToCallOrConstruct` applies to an
+            // object-literal property value as well: in
+            // `var b: { [x: string]: A } = { a: A }` the failure is reported at
+            // the value `A`, not at the property name, because `typeof A` has a
+            // construct signature whose return type satisfies `A`. Without this
+            // the property name keeps the anchor.
+            //
+            // The return-type half of the predicate is load-bearing: anchoring
+            // on "the value is callable" alone re-anchors values whose call
+            // would not have helped, which tsc leaves on the property name.
+            let mut anchor_idx = report_idx;
+            if let Some(value_idx) = self.object_literal_property_initializer(report_idx) {
+                if crate::query_boundaries::assignability::did_you_mean_call_or_construct(
+                    self.ctx.types.as_type_database(),
+                    source_prop.type_id,
+                    target_value_type,
+                ) {
+                    anchor_idx = value_idx;
+                }
+            }
+
             let _ = self.check_assignable_or_report_at_exact_anchor_without_source_elaboration(
                 source_prop.type_id,
                 target_value_type,
-                report_idx,
-                report_idx,
+                anchor_idx,
+                anchor_idx,
             );
         }
 


### PR DESCRIPTION
Goal: hold

## Structural rule

When a variable initializer has a construct or call signature whose **return
type** would have satisfied the declared type, tsc re-reports the assignability
failure on the *initializer expression* (the "Did you mean to call / use `new`
with this expression?" family); it anchors at the declaration name only
otherwise.

`variable_declaration_anchor` approximated that with two gates that are not
part of tsc's rule:

```rust
if !is_let_or_const && init_node.kind == PROPERTY_ACCESS_EXPRESSION
    && is_callable_type(init_type) { return vd.initializer; }
```

Neither the declaration keyword nor the initializer's syntactic form matters to
tsc, so a `let` with a bare identifier missed entirely:

```ts
declare function getRover(): Dog;
export let x: Dog = getRover;
```
```
tsc 7.0.2: (3,21) at `getRover`
tsz before: (3,12) at `x`
tsz after:  (3,21)
```

## The return-type check is load-bearing, not polish

Measured, not assumed. Generalizing the two gates while keeping only
`is_callable_type` gives **+1 fixed / 23 regressed**: tsc stays on the
declaration name when calling the source would *not* have helped, so every
callable initializer re-anchors. Witnesses included
`assignmentCompatability44`, `assignmentCompatability45`,
`classSideInheritance3`, `constructorAsType`,
`errorsWithInvokablesInUnions01`, `functionAssignabilityWithArrayLike01`.
Adding the return-type relation removes all 23.

## A signature-lookup asymmetry, found by bisection

`call_signatures_for_type` resolves signatures carried by an object or callable
shape; a bare function type (`() => A`) has none to collect, because its
signature lives on the function shape itself. The construct lookup already had
the equivalent `get_function_shape` fallback, so the predicate behaved
inconsistently across three shapes that tsc treats identically:

```ts
declare function getA(): A;         let a: A = getA;   // fired  (correct)
declare const Ctor: { new(): A };   let b: A = Ctor;   // fired  (correct)
declare const Fn: () => A;          let c: A = Fn;     // MISSED
```

Adding the matching fallback for call signatures is worth 2 of the 4 tests.

## Two anchor paths, one predicate

The same rule governs two sites, so both are here rather than split:

1. **Variable initializers** — `export let x: Dog = getRover` reports at
   `getRover`.
2. **Object-literal property values** — `var b: { [x: string]: A } = { a: A }`
   reports at the value `A`, not the property name, because `typeof A` has a
   construct signature returning `A`. That site
   (`union_index_signature_diagnostics`) already resolves the value node for its
   elaboration path and already holds `target_value_type`, so it reuses the same
   query rather than growing a second predicate.

## Owner layer

- `crates/tsz-checker/src/query_boundaries/assignability.rs` — new
  `did_you_mean_call_or_construct(db, source, target)`. The type semantics stay
  behind a solver-backed query boundary rather than living in the reporter.
  Construct signatures are consulted before call signatures (tsc's ordering);
  `any`/`unknown`/error/`never` return types are skipped, since they relate to
  everything and would fire the suggestion on unrelated mismatches.
- `crates/tsz-checker/src/error_reporter/fingerprint_policy.rs` — the
  variable-declaration anchor decision now consults that predicate.
- `crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs`
  — the object-literal property anchor consults the same predicate.

The declared type is read from the annotation node's cached type (falling back
to the name's), which keeps this on the existing `&self` anchor path and avoids
an `&mut self` refactor of the anchor chain.

Nothing is keyed on identifier names, file names, or rendered strings.

## Adjacent cases

- `let` / `const` / `var`, which previously behaved differently and now do not;
- bare identifier, property access, and call/construct-typed initializers;
- callable initializers whose return type does **not** satisfy the target,
  which must stay on the declaration name (the 23 witnesses above);
- `any`/`never` returns, which must not trigger the suggestion;
- declarations with no type annotation, where the fallback path applies.

## Verification

Local, on `57c42198ce` (current `origin/main`); no reliance on CI.

Conformance (full corpus, `tsc-cache-full.json` 7.0.2 oracle, 12 workers):

- before: `11351/12043`
- after:  `11355/12043`
- per-test diff: **4 fixed, 0 regressed**
  - `compiler/avoidListingPropertiesForTypesWithOnlyCallOrConstructSignatures.ts`
  - `conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts`
  - `conformance/jsdoc/checkJsdocTypeTagOnObjectProperty1.ts`
  - `conformance/jsdoc/checkJsdocTypeTagOnObjectProperty2.ts`

(Re-measured on `57c42198ce`. Earlier figures in this branch's history were
taken on older mains as the two halves landed; this is the current clean A/B of
the whole branch against its own base.)

Note `stringIndexerConstrainsPropertyDeclarations.ts` — the sibling without the
`2` suffix — was already failing before this change and is unaffected.

Emit suite, unchanged and at the floor:

- JS `11562/11563`
- DTS `1375/1390`

Committed with `TSZ_SKIP_VERIFY=1`. The new pre-commit hook fails on two
pre-existing `clippy::collapsible_match` errors in
`crates/tsz-parser/src/syntax/transform_utils.rs`; I confirmed both reproduce
on clean `main`, and this change touches `tsz-checker` only.

## Follow-up

One test in this family remains:
`staticMemberOfClassAndPublicMemberOfAnotherClassAssignment` (`a = B;` reports
at the RHS `B` in tsc, at the statement start in tsz). That is the *assignment* anchor path.
Probed and deliberately not included: routing the predicate through
`error_type_not_assignable_at` (choosing `Exact` over `RewriteAssignment`) does
not move that test, because its TS2741 is emitted by the missing-property
reporter rather than that entry. The remaining work is to find the reporter that
actually owns that anchor; left out so this change's measured surface stays
small.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max
