### PR TITLE
fix(checker): scope JSDoc @template to its own declaration

### DIFF
--- a/crates/tsz-checker/src/jsdoc/base_types.rs
+++ b/crates/tsz-checker/src/jsdoc/base_types.rs
@@ -69,7 +69,11 @@ impl<'a> CheckerState<'a> {
                         simple_expr,
                     )
                     .is_some()
-                    || self.source_file_declares_jsdoc_template(simple_expr)
+                    || self.jsdoc_template_in_scope_for_reference(
+                        simple_expr,
+                        &content,
+                        comment.pos,
+                    )
                     || Self::parse_jsdoc_typedefs(&source_text)
                         .iter()
                         .any(|(name, _)| name == simple_expr)

--- a/crates/tsz-checker/src/jsdoc/diagnostics_templates.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics_templates.rs
@@ -401,42 +401,94 @@ impl<'a> CheckerState<'a> {
     /// scope contains the reference at `ref_pos`.
     pub(crate) fn source_file_declares_jsdoc_template_at(&self, name: &str, ref_pos: u32) -> bool {
         use tsz_common::comments::{get_jsdoc_content, is_jsdoc_comment};
-        use tsz_parser::parser::syntax_kind_ext;
+        use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 
         let Some(sf) = self.ctx.arena.source_files.first() else {
             return false;
         };
         let source_text: &str = &sf.text;
 
-        for &stmt_idx in &sf.statements.nodes {
-            let Some(stmt_node) = self.ctx.arena.get(stmt_idx) else {
+        // Locate the innermost class enclosing the reference. Scanning the arena
+        // rather than the top-level statement list is what makes `export class
+        // Foo` work: the parser wraps that class in an `EXPORT_DECLARATION`, so
+        // the class is not itself a top-level statement and a statement-list
+        // scan would miss its `@template`.
+        let mut host_pos: Option<u32> = None;
+        for raw_idx in 0..self.ctx.arena.len() {
+            let idx = NodeIndex(raw_idx as u32);
+            let Some(node) = self.ctx.arena.get(idx) else {
                 continue;
             };
-            if stmt_node.kind != syntax_kind_ext::CLASS_DECLARATION
-                && stmt_node.kind != syntax_kind_ext::CLASS_EXPRESSION
+            if node.kind != syntax_kind_ext::CLASS_DECLARATION
+                && node.kind != syntax_kind_ext::CLASS_EXPRESSION
             {
                 continue;
             }
-            if !(ref_pos >= stmt_node.pos && ref_pos < stmt_node.end) {
+            if !(ref_pos >= node.pos && ref_pos < node.end) {
                 continue;
             }
-            for comment in &sf.comments {
-                if !is_jsdoc_comment(comment, source_text) {
-                    continue;
-                }
-                if comment.end > stmt_node.pos {
-                    continue;
-                }
-                let content = get_jsdoc_content(comment, source_text);
-                if Self::jsdoc_template_type_params(&content)
-                    .into_iter()
-                    .any(|(decl_name, _, _)| decl_name == name)
-                {
-                    return true;
-                }
+            // The JSDoc sits before the `export` keyword, so anchor the comment
+            // search at the wrapping export when there is one.
+            let mut anchor = node.pos;
+            if let Some(ext) = self.ctx.arena.get_extended(idx)
+                && ext.parent.is_some()
+                && let Some(parent) = self.ctx.arena.get(ext.parent)
+                && parent.kind == syntax_kind_ext::EXPORT_DECLARATION
+            {
+                anchor = parent.pos;
+            }
+            // Innermost wins: a later, tighter class shadows an outer one.
+            if host_pos.is_none_or(|prev| anchor >= prev) {
+                host_pos = Some(anchor);
+            }
+        }
+        let Some(host_pos) = host_pos else {
+            return false;
+        };
+
+        for comment in &sf.comments {
+            if !is_jsdoc_comment(comment, source_text) {
+                continue;
+            }
+            if comment.end > host_pos {
+                continue;
+            }
+            let content = get_jsdoc_content(comment, source_text);
+            if Self::jsdoc_template_type_params(&content)
+                .into_iter()
+                .any(|(decl_name, _, _)| decl_name == name)
+            {
+                return true;
             }
         }
         false
+    }
+
+    /// True when `name` is declared by an `@template` tag that is actually in
+    /// scope for a JSDoc type reference at `ref_pos`.
+    ///
+    /// `tsc` scopes `@template` to the declaration its comment is attached to,
+    /// plus — for a class — that class's members. A `@template` written on some
+    /// other declaration in the same file is not in scope, so a reference to it
+    /// is a genuine `TS2304`. The case that matters most in practice is a JS
+    /// constructor function: `@template K` on `function M() {}` does not reach a
+    /// separate JSDoc comment on `M.prototype.get`, and `tsc` reports
+    /// "Cannot find name 'K'" there.
+    pub(crate) fn jsdoc_template_in_scope_for_reference(
+        &self,
+        name: &str,
+        own_comment_content: &str,
+        ref_pos: u32,
+    ) -> bool {
+        // The reference's own comment: `@template T` alongside `@param {T}`.
+        if Self::jsdoc_template_type_params(own_comment_content)
+            .into_iter()
+            .any(|(decl_name, _is_const, _default)| decl_name == name)
+        {
+            return true;
+        }
+        // An enclosing class declaration's `@template`, in scope for members.
+        self.source_file_declares_jsdoc_template_at(name, ref_pos)
     }
 
     pub(crate) fn source_file_declares_jsdoc_template(&self, name: &str) -> bool {

--- a/crates/tsz-checker/src/jsdoc/diagnostics_templates.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics_templates.rs
@@ -491,26 +491,6 @@ impl<'a> CheckerState<'a> {
         self.source_file_declares_jsdoc_template_at(name, ref_pos)
     }
 
-    pub(crate) fn source_file_declares_jsdoc_template(&self, name: &str) -> bool {
-        use tsz_common::comments::{get_jsdoc_content, is_jsdoc_comment};
-        let Some(sf) = self.ctx.arena.source_files.first() else {
-            return false;
-        };
-        let source_text: &str = &sf.text;
-        for comment in &sf.comments {
-            if !is_jsdoc_comment(comment, source_text) {
-                continue;
-            }
-            let content = get_jsdoc_content(comment, source_text);
-            for (decl_name, _is_const, _default) in Self::jsdoc_template_type_params(&content) {
-                if decl_name == name {
-                    return true;
-                }
-            }
-        }
-        false
-    }
-
     /// TS1069: `@template {Constraint}` with no type-parameter name following
     /// the constraint braces (e.g. `@template {T}`). TypeScript's JSDoc parser
     /// reports "Unexpected token. A type parameter name was expected without

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -400,6 +400,9 @@ mod jsdoc_prototype_assignment_target_display;
 #[path = "tests/jsdoc_retired_tag_diagnostics_tests.rs"]
 mod jsdoc_retired_tag_diagnostics_tests;
 #[cfg(test)]
+#[path = "tests/jsdoc_template_reference_scope_tests.rs"]
+mod jsdoc_template_reference_scope_tests;
+#[cfg(test)]
 #[path = "../tests/jsdoc_this_arrow_tests.rs"]
 mod jsdoc_this_arrow_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/jsdoc_template_reference_scope_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_template_reference_scope_tests.rs
@@ -1,0 +1,205 @@
+//! Scope of JSDoc `@template` names for `@param`/`@returns` type references.
+//!
+//! `tsc` scopes a `@template` tag to the declaration its comment is attached
+//! to, plus — for a class — that class's members. A `@template` written on some
+//! other declaration in the same file is not in scope, and a reference to it is
+//! a genuine TS2304 `Cannot find name`.
+//!
+//! tsz used to suppress TS2304 whenever the name appeared in *any* `@template`
+//! tag anywhere in the file, which silently accepted references that `tsc`
+//! rejects. The corpus witness is `jsdocTemplateTag4`, where `@template K`/`V`
+//! on a constructor function do not reach a separate JSDoc comment written on
+//! `Multimap.prototype.get`.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn js_codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.js", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn cannot_find_name_count(source: &str) -> usize {
+    js_codes(source).into_iter().filter(|c| *c == 2304).count()
+}
+
+// --- Positive cases: the template is out of scope, so TS2304 is correct. ---
+
+#[test]
+fn template_on_unrelated_function_is_not_in_scope() {
+    let source = r"
+/**
+ * @template Q
+ * @param {Q} x
+ */
+function unrelated(x) { return x; }
+
+/**
+ * @param {Q} y
+ */
+function standalone(y) { return y; }
+";
+    assert_eq!(cannot_find_name_count(source), 1);
+}
+
+/// Same shape, different binder names: the rule is structural, not keyed on
+/// any particular type-parameter spelling.
+#[test]
+fn template_on_unrelated_function_is_not_in_scope_renamed() {
+    let source = r"
+/**
+ * @template Element
+ * @param {Element} x
+ */
+function unrelated(x) { return x; }
+
+/**
+ * @param {Element} y
+ */
+function standalone(y) { return y; }
+";
+    assert_eq!(cannot_find_name_count(source), 1);
+}
+
+/// The `jsdocTemplateTag4` witness: a constructor function's `@template` does
+/// not reach a separate JSDoc comment on one of its prototype methods.
+#[test]
+fn constructor_template_is_not_in_scope_for_prototype_method() {
+    let source = r"
+/**
+ * @template K
+ */
+function Multimap() { }
+
+/**
+ * @param {K} key
+ */
+Multimap.prototype.get = function (key) { return key; };
+";
+    assert_eq!(cannot_find_name_count(source), 1);
+}
+
+/// The prototype owner having no `@template` at all makes the reference
+/// unambiguously file-wide, which is what the old suppression allowed.
+#[test]
+fn unrelated_template_does_not_reach_prototype_method() {
+    let source = r"
+/** @template K */
+function HasTemplate() { }
+
+function Owner() { }
+
+/**
+ * @param {K} a
+ */
+Owner.prototype.get = function (a) { return a; };
+";
+    assert_eq!(cannot_find_name_count(source), 1);
+}
+
+// --- Negative cases: the template IS in scope, so TS2304 must not fire. ---
+
+#[test]
+fn template_on_the_same_comment_is_in_scope() {
+    let source = r"
+/**
+ * @template T
+ * @param {T} x
+ * @returns {T}
+ */
+function id(x) { return x; }
+";
+    assert_eq!(cannot_find_name_count(source), 0);
+}
+
+#[test]
+fn enclosing_class_template_is_in_scope_for_members() {
+    let source = r"
+/**
+ * @template T
+ */
+class Box {
+  /**
+   * @param {T} v
+   */
+  set(v) { this.v = v; }
+}
+new Box();
+";
+    assert_eq!(cannot_find_name_count(source), 0);
+}
+
+/// `export class` wraps the class in an export declaration, so the JSDoc sits
+/// before the `export` keyword. The class-host lookup has to see through that
+/// wrapper or every member reference becomes a false TS2304.
+#[test]
+fn exported_class_template_is_in_scope_for_members() {
+    let source = r"
+/**
+ * @template T
+ */
+export class Foo {
+  /**
+   * @param {T} value
+   */
+  bar(value) { }
+}
+";
+    assert_eq!(cannot_find_name_count(source), 0);
+}
+
+/// A method nested inside a class expression assigned to a variable: the host
+/// is found by range containment, not by being a top-level statement.
+#[test]
+fn class_expression_template_is_in_scope_for_members() {
+    let source = r"
+/**
+ * @template T
+ */
+const Holder = class {
+  /**
+   * @param {T} v
+   */
+  put(v) { this.v = v; }
+};
+Holder;
+";
+    assert_eq!(cannot_find_name_count(source), 0);
+}
+
+/// Multiple templates on the same comment all stay in scope together.
+#[test]
+fn multiple_templates_on_same_comment_are_in_scope() {
+    let source = r"
+/**
+ * @template K
+ * @template V
+ * @param {K} k
+ * @param {V} v
+ */
+function pair(k, v) { return [k, v]; }
+";
+    assert_eq!(cannot_find_name_count(source), 0);
+}
+
+/// A genuinely undefined name is still reported when a template is in scope —
+/// the in-scope template must not suppress unrelated missing names.
+#[test]
+fn in_scope_template_does_not_suppress_other_missing_names() {
+    let source = r"
+/**
+ * @template T
+ * @param {T} x
+ * @param {NoSuchType} y
+ */
+function mix(x, y) { return x; }
+";
+    assert_eq!(cannot_find_name_count(source), 1);
+}


### PR DESCRIPTION
## Structural rule

When a JSDoc type name resolves to no declaration and the only `@template`
declaring it sits on an unrelated declaration, `tsc` reports TS2304
`Cannot find name`; tsz now does too, through
`jsdoc_template_in_scope_for_reference` in the JSDoc diagnostics layer.

`tsc` scopes `@template` to the declaration its comment is attached to, plus —
for a class — that class's members. tsz suppressed TS2304 whenever the name
appeared in *any* `@template` tag anywhere in the file
(`source_file_declares_jsdoc_template`, no position argument), so a reference
to a type parameter declared on a completely unrelated function was accepted.

Corpus witness `jsdocTemplateTag4`: `@template K`/`V` on a constructor function
do not reach a separate JSDoc comment written on `Multimap.prototype.get`, and
the oracle expects six `Cannot find name` diagnostics there.

## Owner layer

JSDoc diagnostics (`jsdoc/diagnostics_templates.rs`, `jsdoc/base_types.rs`).
This is a scope predicate over declarations and comment ranges — no type
semantics, no identifier/file-name literals, no reading of rendered output.

## The export-wrapper half

Narrowing the suppression alone measured +1/−2. Both regressions were
`export class`: the class-host lookup scanned top-level statements for a
`CLASS_DECLARATION`, but the parser wraps an exported class in an
`EXPORT_DECLARATION`, so the class is not itself a statement and its
`@template` was missed — a latent bug the file-wide suppression had been
masking. The lookup now finds the innermost class enclosing the reference by
range and anchors the comment search at the wrapping export, which also covers
class expressions and nesting.

## Adjacent cases

`crates/tsz-checker/src/tests/jsdoc_template_reference_scope_tests.rs`, 10 tests:

- positive — template on an unrelated function; the same shape with a renamed
  binder (`Element` rather than `Q`), so the rule is structural rather than
  keyed on a spelling; constructor `@template` vs. a prototype-method comment;
  owner with no `@template` at all
- negative — `@template` on the reference's own comment; enclosing class;
  `export class`; class expression assigned to a variable; several templates on
  one comment
- fallback — an in-scope `@template` must not suppress an unrelated genuinely
  missing name

## Verification

Local, on this branch's head.

| suite | before | after |
|---|---|---|
| `conformance --filter jsdoc` | 286/368 | **287/368** |
| `conformance` (full) | 11353/12043 | **11354/12043** |
| `conformance --filter salsa` | 116/186 | 116/186 |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

Flips measured by diffing per-test diff artifacts in both directions, not by
comparing pass counts:

- fixed: `jsdocOuterTypeParameters2`
- regressed: none

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(jsdoc_template_reference_scope)'    # 10 passed
./scripts/conformance/conformance.sh run --filter jsdoc --workers 8
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold