### PR TITLE
fix(checker): annotated receivers do not take expando properties

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -244,6 +244,9 @@ mod enum_recursion_tests;
 #[path = "../tests/environment_capabilities_tests.rs"]
 mod environment_capabilities_tests;
 #[cfg(test)]
+#[path = "tests/expando_annotated_receiver_tests.rs"]
+mod expando_annotated_receiver_tests;
+#[cfg(test)]
 #[path = "tests/flow_assignment_relation_routing_arch_tests.rs"]
 mod flow_assignment_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/expando_annotated_receiver_tests.rs
+++ b/crates/tsz-checker/src/tests/expando_annotated_receiver_tests.rs
@@ -1,0 +1,114 @@
+//! Expando property assignment onto an explicitly annotated receiver.
+//!
+//! `tsc` accepts `fn.prop = value` as an expando *declaration* only when the
+//! receiver's type is inferred from a function declaration or function-valued
+//! initializer. An explicit type annotation makes the declared type
+//! authoritative, so the assignment is an ordinary property write and reports
+//! TS2339 when the property is absent — verified against the pinned tsc 7.0.2:
+//!
+//! ```text
+//! const a1 = () => {};            a1.f = 1;   // accepted (inferred)
+//! const a2: () => void = () => {}; a2.f = 1;  // TS2339
+//! declare const a3: () => void;    a3.f = 1;  // TS2339
+//! ```
+//!
+//! tsz previously ignored the annotation whenever an initializer was present,
+//! so `a2.f = 1` silently created a property on `() => void`.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn ts_codes(source: &str) -> Vec<u32> {
+    check_source(source, "test.ts", CheckerOptions::default())
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn js_codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.js", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// --- Annotated receivers: the declared type wins, so TS2339. ---
+
+#[test]
+fn annotated_function_typed_const_rejects_expando_write() {
+    let source = "const a2: () => void = () => {};\na2.f = 1;\n";
+    assert!(ts_codes(source).contains(&2339));
+}
+
+/// Same rule with a different binder name and a different function type, so the
+/// behaviour is structural rather than tied to a spelling.
+#[test]
+fn annotated_function_typed_const_rejects_expando_write_renamed() {
+    let source = "const handler: (n: number) => string = n => String(n);\nhandler.cache = 1;\n";
+    assert!(ts_codes(source).contains(&2339));
+}
+
+#[test]
+fn annotated_declare_without_initializer_still_rejects() {
+    let source = "declare const a3: () => void;\na3.f = 1;\n";
+    assert!(ts_codes(source).contains(&2339));
+}
+
+/// A function expression initializer does not rescue an annotated receiver.
+#[test]
+fn annotated_receiver_with_function_expression_initializer_rejects() {
+    let source = "const a4: () => void = function () {};\na4.f = 1;\n";
+    assert!(ts_codes(source).contains(&2339));
+}
+
+// --- Inferred receivers: the expando pattern still works. ---
+
+#[test]
+fn inferred_arrow_still_accepts_expando_write() {
+    let source = "const a1 = () => {};\na1.f = 1;\na1.f;\n";
+    assert!(!ts_codes(source).contains(&2339));
+}
+
+#[test]
+fn function_declaration_still_accepts_expando_write() {
+    let source = "function C() {}\nC.f = 1;\nC.f;\n";
+    assert!(!ts_codes(source).contains(&2339));
+}
+
+#[test]
+fn function_expression_initializer_still_accepts_expando_write() {
+    let source = "const h = function () {};\nh.f = 1;\nh.f;\n";
+    assert!(!ts_codes(source).contains(&2339));
+}
+
+/// The JS expando pattern is unaffected: a JS function declaration still takes
+/// properties, which is what `checkJs` sources rely on.
+#[test]
+fn js_function_declaration_still_accepts_expando_write() {
+    let source = "function C() {}\nC.f = 1;\nC.f;\n";
+    assert!(!js_codes(source).contains(&2339));
+}
+
+/// An annotated receiver whose declared type *does* have the property stays
+/// silent — the guard rejects unknown properties, not every annotated write.
+#[test]
+fn annotated_receiver_with_declared_property_is_accepted() {
+    let source = concat!(
+        "interface Callable { (): void; f: number }\n",
+        "declare const c: Callable;\n",
+        "c.f = 1;\n",
+    );
+    assert!(!ts_codes(source).contains(&2339));
+}
+
+/// An annotated object receiver was already checked; keep it that way.
+#[test]
+fn annotated_object_receiver_still_rejects_unknown_property() {
+    let source = "const p: { a: number } = { a: 1 };\np.b = 1;\n";
+    assert!(ts_codes(source).contains(&2339));
+}

--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -374,6 +374,17 @@ impl<'a> CheckerState<'a> {
             .resolve_identifier_symbol(symbol_target_expr)
             .or_else(|| self.resolve_qualified_symbol(symbol_target_expr));
 
+        // An explicit type annotation makes the declared type authoritative, so
+        // the write is an ordinary property assignment and must report TS2339
+        // when the property is absent. `const f: () => void = () => {}` takes no
+        // expando properties even though its initializer is a function, while
+        // the inferred `const f = () => {}` still does.
+        if let Some(sym_id) = sym_id
+            && self.expando_root_symbol_has_type_annotation(sym_id)
+        {
+            return false;
+        }
+
         if let Some(sym_id) = sym_id
             && let Some(symbol) = self
                 .get_cross_file_symbol(sym_id)


### PR DESCRIPTION
## Structural rule

When a property assignment targets a property access whose receiver has an
**explicit type annotation**, the declared type is authoritative: the write is
an ordinary property assignment and reports TS2339 if the property is absent.
The expando pattern (`fn.prop = value` contributing to `fn`'s type) applies only
when the receiver's type is *inferred* from a function declaration or a
function-valued initializer.

tsz ignored the annotation whenever an initializer was present. Owner layer is
`is_expando_function_assignment` in
`types/property_access_helpers/expando.rs`, which now consults the existing
`expando_root_symbol_has_type_annotation` helper — previously used only when
computing a declared expando property's type, not when deciding whether the
write *is* an expando declaration.

## Behaviour, verified against the pinned tsc 7.0.2

Run directly (`scripts/node_modules/@typescript/typescript-darwin-arm64/lib/tsc`
is a native binary; `node tsc` fails).

| source | tsc | tsz before | tsz after |
|---|---|---|---|
| `const a1 = () => {}; a1.f = 1` | accepted | accepted | accepted |
| `function C() {} C.f = 1` | accepted | accepted | accepted |
| `const h = function () {}; h.f = 1` | accepted | accepted | accepted |
| `const a2: () => void = () => {}; a2.f = 1` | **TS2339** | accepted | **TS2339** |
| `const a4: () => void = function () {}; a4.f = 1` | **TS2339** | accepted | **TS2339** |
| `declare const a3: () => void; a3.f = 1` | TS2339 | TS2339 | TS2339 |
| `const p: { a: number } = { a: 1 }; p.b = 1` | TS2339 | TS2339 | TS2339 |

The old behaviour was also a false negative on *reads*: the phantom property
suppressed TS2339 on a later `a2.f`, so
`const a2: () => void = () => {}; a2.f = 1; a2.f;` produced no diagnostic at all
where tsc produces two.

## Known residual

tsc reports TS2339 at both the write and the following read; tsz now reports the
write. The read stays silent, so this closes the write half of the gap only. The
remaining half is the expando property still being registered for the annotated
root; it is recorded for follow-up rather than fixed here.

## Adjacent cases

`crates/tsz-checker/src/tests/expando_annotated_receiver_tests.rs`, 10 tests:
annotated const / annotated with function-expression initializer / `declare`
without initializer / a renamed binder with a different function type
(`(n: number) => string`), against inferred arrow, function declaration,
function expression, and the JS `checkJs` function-declaration expando. Plus two
fallbacks: an annotated *callable interface* receiver whose declared type does
have the property stays silent, and an annotated object receiver still reports.

## Verification

Local, this branch's head.

| suite | before | after |
|---|---|---|
| `conformance` (full) | 11363/12043 | 11363/12043 |
| `conformance --filter salsa` | 116/186 | 116/186 |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

**Conformance is unchanged — this PR flips no corpus test.** Failing-test sets
were diffed in both directions across the full 12043-test corpus: zero fixed,
zero regressed (679 failing before and after). It lands on parity grounds: the
old behaviour is a confirmed false negative against tsc, and the corpus simply
has no case with an annotated function-typed receiver taking an expando write.

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(expando_annotated_receiver)'      # 10 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold