### PR TITLE
fix(checker): JS anonymous object receivers are open under implicit any

### DIFF
--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -1179,6 +1179,10 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        if self.js_open_object_receiver_under_implicit_any(type_id) {
+            return;
+        }
+
         // Suppress error if type is ERROR/ANY or an Error type wrapper.
         // This prevents cascading errors when accessing properties on error types.
         // NOTE: We do NOT suppress for UNKNOWN — accessing properties on unknown should error (TS2339).

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -379,6 +379,9 @@ mod interface_heritage_property_index_relation_routing_arch_tests;
 #[path = "../tests/isolated_declarations_unannotated_param_tests.rs"]
 mod isolated_declarations_unannotated_param_tests;
 #[cfg(test)]
+#[path = "tests/js_open_object_property_access_tests.rs"]
+mod js_open_object_property_access_tests;
+#[cfg(test)]
 #[path = "../tests/js_property_write_self_declaration_tests.rs"]
 mod js_property_write_self_declaration_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/js_open_object_property_access_tests.rs
+++ b/crates/tsz-checker/src/tests/js_open_object_property_access_tests.rs
@@ -1,0 +1,121 @@
+//! Unknown property access on an anonymous object shape in a JS file.
+//!
+//! In a JS file `tsc` treats a value whose type is an *anonymous* object shape
+//! as open — JS code routinely builds such containers up by property assignment,
+//! often across files — so an unknown property access is an implicit `any` and
+//! is reported only under `noImplicitAny`. Verified against the pinned tsc
+//! 7.0.2:
+//!
+//! ```text
+//! // a.js, --allowJs --checkJs
+//! var o = {}; o.nope        // noImplicitAny off: silent | on: TS2339
+//! var s = "x"; s.nope       // TS2339 either way ('string')
+//! class K {}; new K().nope  // TS2339 either way ('K')
+//! var a = [1]; a.nope       // TS2339 either way ('number[]')
+//! ```
+//!
+//! The discriminator is the shape's nominal `symbol`: class instances and
+//! interfaces carry one, anonymous literals do not. Arrays and primitives have
+//! no object shape at all.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn js_codes_with(source: &str, no_implicit_any: bool) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        no_implicit_any,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.js", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn ts_codes(source: &str) -> Vec<u32> {
+    check_source(source, "test.ts", CheckerOptions::default())
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn js_reports_2339(source: &str) -> bool {
+    js_codes_with(source, false).contains(&2339)
+}
+
+// --- Open anonymous containers: silent when noImplicitAny is off. ---
+
+#[test]
+fn empty_object_literal_receiver_is_open() {
+    assert!(!js_reports_2339("var o = {}\no.nope\n"));
+}
+
+#[test]
+fn non_empty_object_literal_receiver_is_open() {
+    assert!(!js_reports_2339("var o = { a: 1 }\no.nope\n"));
+}
+
+/// A renamed binder and a different property, so the rule is structural rather
+/// than tied to any particular spelling.
+#[test]
+fn open_container_rule_is_not_name_specific() {
+    assert!(!js_reports_2339(
+        "var registry = { first: 1 }\nregistry.second\n"
+    ));
+}
+
+/// The container shape JS code actually builds: a nested object extended by
+/// property assignment, as in the `typeFromPropertyAssignment` corpus tests.
+#[test]
+fn nested_assigned_container_is_open() {
+    let source = "var N = {}\nN.commands = {}\nN.commands.a = 1\nN.commands.b\n";
+    assert!(!js_reports_2339(source));
+}
+
+#[test]
+fn writes_to_an_open_container_are_also_silent() {
+    assert!(!js_reports_2339("var o = {}\no.nope = 1\n"));
+}
+
+// --- noImplicitAny restores the diagnostic. ---
+
+#[test]
+fn no_implicit_any_reports_on_open_container() {
+    assert!(js_codes_with("var o = {}\no.nope\n", true).contains(&2339));
+}
+
+// --- Declared shapes keep reporting, with or without noImplicitAny. ---
+
+/// Witness `typeFromPropertyAssignment28`: a class instance carries a nominal
+/// symbol, so it is not an open container.
+#[test]
+fn class_instance_receiver_still_reports() {
+    let source = "class C { constructor() { this.p = 1 } }\nvar c = new C()\nc.nope\n";
+    assert!(js_reports_2339(source));
+    assert!(js_codes_with(source, true).contains(&2339));
+}
+
+#[test]
+fn string_receiver_still_reports() {
+    assert!(js_reports_2339("var s = \"x\"\ns.nope\n"));
+}
+
+#[test]
+fn array_receiver_still_reports() {
+    assert!(js_reports_2339("var a = [1, 2]\na.nope\n"));
+}
+
+// --- TypeScript files are unaffected. ---
+
+#[test]
+fn typescript_object_literal_receiver_still_reports() {
+    assert!(ts_codes("var o = {}\no.nope\n").contains(&2339));
+}
+
+#[test]
+fn typescript_annotated_object_receiver_still_reports() {
+    let source = "const p: { a: number } = { a: 1 };\np.b;\n";
+    assert!(ts_codes(source).contains(&2339));
+}

--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -1746,4 +1746,27 @@ impl<'a> CheckerState<'a> {
             || ((self.is_js_file() && self.ctx.compiler_options.check_js)
                 && self.is_js_prototype_read_root(object_expr_idx, property_name))
     }
+
+    /// Whether an unknown property on `type_id` is an implicit `any` rather than
+    /// a `TS2339`, because the receiver is an *open* JS object container.
+    ///
+    /// In a JS file a value whose type is an anonymous object shape is open: JS
+    /// code routinely builds such containers up by property assignment, often
+    /// across files (`var N = {}` in one file, `N.commands.a = 1` in another), so
+    /// `tsc` types the access as an implicit `any` and reports it only under
+    /// `noImplicitAny`.
+    ///
+    /// The shape's nominal `symbol` separates an open container from a declared
+    /// shape: class instance types carry it so distinct classes do not intern
+    /// structurally, and interfaces carry their declaration's symbol. So
+    /// `Event.prototype.removeChildren = ...` and `new C().q` keep reporting
+    /// TS2339. Arrays and primitives have no object shape at all and are
+    /// excluded before the `symbol` test is reached.
+    pub(crate) fn js_open_object_receiver_under_implicit_any(&self, type_id: TypeId) -> bool {
+        self.is_js_file()
+            && self.ctx.compiler_options.check_js
+            && !self.ctx.no_implicit_any()
+            && crate::query_boundaries::common::object_shape_for_type(self.ctx.types, type_id)
+                .is_some_and(|shape| shape.symbol.is_none())
+    }
 }


### PR DESCRIPTION
## Structural rule

In a JS file, a value whose type is an **anonymous object shape** is *open*: JS
code routinely builds such containers up by property assignment, often across
files. `tsc` therefore types an unknown property access on one as an implicit
`any` and reports TS2339 only under `noImplicitAny`. tsz reported it
unconditionally.

The shape's nominal `symbol` is what separates an open container from a declared
shape: class instance types carry it so distinct classes do not intern
structurally, and interfaces carry their declaration's symbol. Arrays and
primitives have no object shape at all and never reach the test.

Owner layer: `js_open_object_receiver_under_implicit_any` in the JS expando
helpers, consulted from `error_property_not_exist_at` — the single entry point
every TS2339 caller funnels through, so reads and writes are covered by one
gate. No identifier/file-name literals, no rendered-text predicates.

## Behaviour, verified against the pinned tsc 7.0.2

Run the native binary directly (`node tsc` fails).

| source (`--allowJs --checkJs`) | noImplicitAny off | on |
|---|---|---|
| `var o = {}; o.nope` | silent | TS2339 |
| `var o = {a:1}; o.nope` | silent | TS2339 |
| `var N = {}; N.commands = {}; N.commands.b` | silent | TS2339 |
| `var s = "x"; s.nope` | TS2339 `'string'` | TS2339 |
| `class K {}; new K().nope` | TS2339 `'K'` | TS2339 |
| `var a = [1]; a.nope` | TS2339 `'number[]'` | TS2339 |
| `.ts` `var o = {}; o.nope` | TS2339 | TS2339 |

tsz now matches every row; before, it reported TS2339 in all of them.

## How the discriminator was chosen

The first attempt gated on `is_object_like_type` alone and measured **+5/-2**:
it wrongly suppressed `typeFromPropertyAssignment21` (receiver `Event`, a DOM
interface) and `typeFromPropertyAssignment28` (receiver `C`, a class instance).
Adding `lazy_def_id`/`application_id` emptiness changed nothing — both types are
materialised shapes by that point. The nominal `symbol` is the field that
actually distinguishes them, and it also picked up `expandoOnAlias`, which the
broad version missed.

## Adjacent cases

`crates/tsz-checker/src/tests/js_open_object_property_access_tests.rs`, 11 tests:
empty and non-empty literals, a renamed binder with a different property, the
nested cross-assignment container shape from the corpus, and a write; against
class-instance, string and array receivers; `noImplicitAny` on restoring the
diagnostic; and two TypeScript-file cases that must be unaffected.

## Verification

Local, this branch's head.

| suite | before | after |
|---|---|---|
| `conformance` (full) | 11363/12043 | **11372/12043** |
| `conformance --filter salsa` | 116/186 | **122/186** |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

Full-corpus failing sets diffed in both directions — **9 fixed, 0 regressed**
(679 -> 670 failing):

```
conformance_salsa_expandoOnAlias
conformance_salsa_privateIdentifierExpando
conformance_salsa_propertyAssignmentOnImportedSymbol
conformance_salsa_typeFromPropertyAssignment18
conformance_salsa_typeFromPropertyAssignment34
conformance_salsa_typeFromPropertyAssignment37
compiler_functionExpressionNames
compiler_objectPropertyAsClass
conformance_types_thisType_contextualThisTypeInJavascript
```

salsa was re-run on the committed tree after the predicate was extracted into a
helper (a size-ratchet split), confirming 122/186 for the code actually shipped
rather than for the pre-refactor build.

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(js_open_object_property_access)'   # 11 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold