### PR TITLE
fix(checker): validate JSDoc @type on nested variable statements

### DIFF
--- a/crates/tsz-checker/src/jsdoc/base_types.rs
+++ b/crates/tsz-checker/src/jsdoc/base_types.rs
@@ -509,6 +509,32 @@ impl<'a> CheckerState<'a> {
         // Inline expression-body casts like `value => /** @type {T} */(...)` should not
         // be treated as file-level tags; those are validated in the normal checker flow
         // where function-scoped `@template` params are available.
+        // A `@type` on a variable statement nested in a function body is just as
+        // much a real annotation as a top-level one, and `tsc` validates it —
+        // `function f() { /** @type {Missing} */ var y }` reports TS2304, and the
+        // same shape with a value name reports TS2749. Collect those leading
+        // comments so the scan below covers them too. Inline expression casts
+        // still fall through, because they lead no statement.
+        let nested_statement_jsdoc: rustc_hash::FxHashSet<u32> = {
+            let mut positions = rustc_hash::FxHashSet::default();
+            for raw_idx in 0..self.ctx.arena.len() {
+                let idx = tsz_parser::parser::NodeIndex(raw_idx as u32);
+                let Some((kind, pos)) = self.ctx.arena.get(idx).map(|node| (node.kind, node.pos))
+                else {
+                    continue;
+                };
+                if kind != tsz_parser::parser::syntax_kind_ext::VARIABLE_STATEMENT {
+                    continue;
+                }
+                if let Some((_, comment_pos)) =
+                    self.try_leading_jsdoc_with_pos(&comments, pos, &source_text)
+                {
+                    positions.insert(comment_pos);
+                }
+            }
+            positions
+        };
+
         for comment in &comments {
             if !is_jsdoc_comment(comment, &source_text) {
                 continue;
@@ -523,7 +549,9 @@ impl<'a> CheckerState<'a> {
                     })
                     .is_some_and(|(_, comment_pos)| comment_pos == comment.pos)
             });
-            if !is_top_level_leading_jsdoc {
+            let is_nested_statement_jsdoc =
+                !is_top_level_leading_jsdoc && nested_statement_jsdoc.contains(&comment.pos);
+            if !is_top_level_leading_jsdoc && !is_nested_statement_jsdoc {
                 continue;
             }
 
@@ -635,6 +663,17 @@ impl<'a> CheckerState<'a> {
                     || expr.contains('<')
                     || expr.contains('.')
                     || !unresolved
+                    // A `@typedef` written inside a function body is in scope for
+                    // that function's own `@type` tags (witness: typedefScope1,
+                    // where `B` is declared and used within `B1`). This scan does
+                    // not carry function scopes, so for a nested tag defer to any
+                    // `@typedef` of that name rather than report a false TS2304.
+                    // The top-level path is unaffected and still reports a
+                    // top-level use of a function-scoped typedef.
+                    || (is_nested_statement_jsdoc
+                        && Self::parse_jsdoc_typedefs(&source_text)
+                            .iter()
+                            .any(|(name, _)| name == expr))
                     // In JS files, `exports`, `module`, `require`, `global`
                     // are CommonJS built-ins that always resolve at runtime
                     // even if the checker's type system doesn't create a

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -394,6 +394,9 @@ mod jsdoc_import_type_constraints_relation_routing_arch_tests;
 #[path = "tests/jsdoc_lookup_constraints_relation_routing_arch_tests.rs"]
 mod jsdoc_lookup_constraints_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/jsdoc_nested_type_tag_validation_tests.rs"]
+mod jsdoc_nested_type_tag_validation_tests;
+#[cfg(test)]
 #[path = "../tests/jsdoc_postfix_nullable_type_tests.rs"]
 mod jsdoc_postfix_nullable_type_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/jsdoc_nested_type_tag_validation_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_nested_type_tag_validation_tests.rs
@@ -1,0 +1,123 @@
+//! Validation of JSDoc `@type` tags on variable statements inside function bodies.
+//!
+//! `tsc` validates a `@type` annotation wherever it appears, not only at the top
+//! level: `function f() { /** @type {Missing} */ var y }` reports TS2304, and the
+//! same shape naming a value reports TS2749. tsz's `@type` scan only visited
+//! comments leading top-level statements, so nested annotations went unchecked
+//! entirely — the corpus witnesses are `enumTag` and `jsDeclarationsEnumTag`,
+//! where `/** @type {Target} */` inside a function body should report TS2749
+//! (tsc 7.0.2 does not implement `@enum`, so `Target` is value-only).
+//!
+//! Inline expression casts (`value => /** @type {T} */(x)`) lead no statement and
+//! are deliberately still excluded.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn js_codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.js", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// --- Nested `@type` is now validated. ---
+
+#[test]
+fn nested_type_tag_reports_missing_name() {
+    let source = "function g() {\n    /** @type {NoSuchTypeAtAll} */\n    var z\n    return z\n}\n";
+    assert!(js_codes(source).contains(&2304));
+}
+
+#[test]
+fn nested_type_tag_reports_value_used_as_type() {
+    let source = "var v0 = 1\nfunction f() {\n    /** @type {v0} */\n    var y\n    return y\n}\n";
+    assert!(js_codes(source).contains(&2749));
+}
+
+/// The `enumTag` witness: `@enum` does not declare a type in tsc 7.0.2, so a
+/// nested `@type {Target}` is a value used as a type.
+#[test]
+fn nested_type_tag_reports_enum_tag_name_as_value() {
+    let source = concat!(
+        "/** @enum {string} */\n",
+        "const Target = { A: \"a\" }\n",
+        "function consume() {\n",
+        "    /** @type {Target} */\n",
+        "    var v = Target.A\n",
+        "    return v\n",
+        "}\n",
+    );
+    assert!(js_codes(source).contains(&2749));
+}
+
+/// A renamed binder in a differently named function: the rule is structural.
+#[test]
+fn nested_type_tag_rule_is_not_name_specific() {
+    let source = "var counter = 1\nfunction helper() {\n    /** @type {counter} */\n    var c\n    return c\n}\n";
+    assert!(js_codes(source).contains(&2749));
+}
+
+// --- Scope: a `@typedef` in the same function body is still in scope. ---
+
+/// Witness `typedefScope1`: `B` is declared and used inside `B1`, so the nested
+/// `@type {B}` must not report. This scan carries no function scopes, so it
+/// defers to the `@typedef` rather than emitting a false TS2304.
+#[test]
+fn nested_typedef_is_in_scope_for_nested_type_tag() {
+    let source = concat!(
+        "function B1() {\n",
+        "    /** @typedef {number} B */\n",
+        "    /** @type {B} */\n",
+        "    var ok1 = 0;\n",
+        "    return ok1;\n",
+        "}\n",
+    );
+    assert!(!js_codes(source).contains(&2304));
+}
+
+/// Two sibling functions each declaring their own `@typedef` of the same name
+/// stay silent, as they do in `typedefScope1`.
+#[test]
+fn sibling_function_typedefs_do_not_collide() {
+    let source = concat!(
+        "function B1() {\n",
+        "    /** @typedef {number} B */\n",
+        "    /** @type {B} */\n",
+        "    var ok1 = 0;\n",
+        "    return ok1;\n",
+        "}\n",
+        "function B2() {\n",
+        "    /** @typedef {string} B */\n",
+        "    /** @type {B} */\n",
+        "    var ok2 = 'hi';\n",
+        "    return ok2;\n",
+        "}\n",
+    );
+    assert!(!js_codes(source).contains(&2304));
+}
+
+// --- Top-level behaviour is unchanged. ---
+
+#[test]
+fn top_level_type_tag_still_reports_missing_name() {
+    assert!(js_codes("/** @type {NoSuchTypeAtAll} */\nvar z\n").contains(&2304));
+}
+
+#[test]
+fn top_level_type_tag_still_reports_value_used_as_type() {
+    assert!(js_codes("var v = 1\n/** @type {v} */\nvar y\n").contains(&2749));
+}
+
+/// A resolvable nested annotation stays silent.
+#[test]
+fn nested_type_tag_with_known_type_is_silent() {
+    let source = "function f() {\n    /** @type {string} */\n    var s = 'x'\n    return s\n}\n";
+    let codes = js_codes(source);
+    assert!(!codes.contains(&2304) && !codes.contains(&2749));
+}


### PR DESCRIPTION
## Structural rule

A JSDoc `@type` annotation is validated wherever it appears, not only at the top
level. `tsc` reports TS2304 for
`function f() { /** @type {Missing} */ var y }` and TS2749 for the same shape
naming a value. tsz's `@type` scan only visited comments leading **top-level**
statements, so nested annotations went unchecked entirely — neither diagnostic
fired.

Corpus witnesses: `enumTag` and `jsDeclarationsEnumTag`, where a nested
`/** @type {Target} */` should report TS2749 because tsc 7.0.2 does not
implement `@enum`, leaving `Target` value-only.

Owner layer: `jsdoc/base_types.rs::check_jsdoc_typedef_base_types`. Comments
leading a variable statement at any depth now join the scan. Inline expression
casts (`value => /** @type {T} */(x)`) still fall through, because they lead no
statement — the exclusion the original top-level gate was written for.

## Scope handling

A `@typedef` written inside a function body is in scope for that function's own
`@type` tags. `typedefScope1` is the witness: `B` is declared and used within
`B1`, and reporting there is wrong. This scan carries no function scopes, so a
**nested** tag defers to any `@typedef` of that name instead of emitting a false
TS2304. The top-level path is untouched, so a top-level use of a
function-scoped typedef is still reported.

That narrowing was added in response to a measured regression: the first version
fixed 2 and broke `typedefScope1`, which is what identified the scope rule.

## Behaviour, verified against the pinned tsc 7.0.2

| source (`--allowJs --checkJs`) | tsc | tsz before | tsz after |
|---|---|---|---|
| `function g(){ /** @type {NoSuchType} */ var z }` | TS2304 | none | TS2304 |
| `var v0=1; function f(){ /** @type {v0} */ var y }` | TS2749 | none | TS2749 |
| `@enum` name, nested `/** @type {Target} */` | TS2749 | none | TS2749 |
| `function B1(){ /** @typedef {number} B */ /** @type {B} */ var ok }` | none | none | none |
| top-level `/** @type {v} */` on a value | TS2749 | TS2749 | TS2749 |

## Adjacent cases

`crates/tsz-checker/src/tests/jsdoc_nested_type_tag_validation_tests.rs`,
9 tests: nested missing name, nested value-as-type, the `@enum` witness, a
renamed binder in a differently named function; the in-scope nested `@typedef`
and two sibling functions declaring the same typedef name; both top-level forms
unchanged; and a resolvable nested annotation staying silent.

## Verification

Local, on this branch's head (rebased onto `origin/main` @ 3f72da4fc4 and
re-measured there, not on the pre-rebase build).

| suite | before | after |
|---|---|---|
| `conformance` (full) | 11372/12043 | **11374/12043** |
| `conformance --filter jsdoc` | 288/368 | **290/368** |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

Full-corpus failing sets diffed both ways — **2 fixed, 0 regressed**:

```
conformance_jsdoc_enumTag
conformance_jsdoc_declarations_jsDeclarationsEnumTag
```

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(jsdoc_nested_type_tag_validation)'   # 9 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold