### PR TITLE
fix(checker): TS1340 for bare JSDoc import types

### DIFF
--- a/crates/tsz-checker/src/jsdoc/base_types.rs
+++ b/crates/tsz-checker/src/jsdoc/base_types.rs
@@ -57,6 +57,35 @@ impl<'a> CheckerState<'a> {
                 if !is_param_tag && !is_return_tag {
                     continue;
                 }
+                // A bare `import('mod')` names the module's `export =` type. The
+                // module's own namespace is not a type, so a module exporting only
+                // values — or one with named type exports and no `export =` — is
+                // TS1340 even though the specifier resolves. The TypeScript
+                // import-type resolver reports this already; JSDoc reaches the
+                // question by a separate path, so it asks the shared predicate
+                // here, where the type expression's offset is known.
+                // `import('mod').Member` is unaffected: it is not a bare import.
+                {
+                    let raw = type_expr.trim();
+                    if let Some((module_specifier, None)) = Self::parse_jsdoc_import_type(raw)
+                        && !self.bare_import_type_names_a_type(
+                            &module_specifier,
+                            Self::jsdoc_import_type_resolution_mode(raw),
+                        )
+                    {
+                        let message = crate::diagnostics::format_message(
+                            crate::diagnostics::diagnostic_messages::MODULE_DOES_NOT_REFER_TO_A_TYPE_BUT_IS_USED_AS_A_TYPE_HERE_DID_YOU_MEAN_TYPEOF_I,
+                            &[&module_specifier],
+                        );
+                        self.error_at_position(
+                            comment.pos + offset_in_comment as u32,
+                            raw.len() as u32,
+                            &message,
+                            crate::diagnostics::diagnostic_codes::MODULE_DOES_NOT_REFER_TO_A_TYPE_BUT_IS_USED_AS_A_TYPE_HERE_DID_YOU_MEAN_TYPEOF_I,
+                        );
+                        continue;
+                    }
+                }
                 let simple_expr = type_expr
                     .trim()
                     .trim_start_matches('!')

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -385,6 +385,9 @@ mod js_open_object_property_access_tests;
 #[path = "../tests/js_property_write_self_declaration_tests.rs"]
 mod js_property_write_self_declaration_tests;
 #[cfg(test)]
+#[path = "tests/jsdoc_bare_import_type_tests.rs"]
+mod jsdoc_bare_import_type_tests;
+#[cfg(test)]
 #[path = "tests/jsdoc_closure_function_type_tests.rs"]
 mod jsdoc_closure_function_type_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_resolution/import_type.rs
+++ b/crates/tsz-checker/src/state/type_resolution/import_type.rs
@@ -2,7 +2,6 @@
 
 use crate::import::core::ModuleNotFoundSite;
 use crate::state::CheckerState;
-use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
@@ -748,80 +747,8 @@ impl<'a> CheckerState<'a> {
                 .any(|diag| diag.start >= call_node.pos && diag.start < call_node.end)
         });
         let suppress_bare_import_type_error = has_call_parse_diagnostic || has_import_type_options;
-        let bare_import_type_refers_to_type = if is_bare_import_type {
-            use tsz_binder::symbol_flags;
-
-            const PURE_TYPE: u32 = symbol_flags::INTERFACE | symbol_flags::TYPE_ALIAS;
-            const VALUE: u32 = symbol_flags::VARIABLE
-                | symbol_flags::FUNCTION
-                | symbol_flags::CLASS
-                | symbol_flags::ENUM
-                | symbol_flags::ENUM_MEMBER
-                | symbol_flags::VALUE_MODULE;
-
-            let lib_binders = self.get_lib_binders();
-            let ambient_export_equals_sym = self
-                .ctx
-                .binder
-                .module_exports
-                .get(&module_name)
-                .and_then(|exports| exports.get("export="))
-                .or_else(|| {
-                    self.ctx
-                        .global_module_exports_index
-                        .as_ref()
-                        .and_then(|idx| idx.get(&module_name))
-                        .and_then(|inner| inner.get("export="))
-                        .and_then(|entries| entries.first().map(|&(_file_idx, sym_id)| sym_id))
-                });
-            let file_export_equals = self
-                .ctx
-                .resolve_import_target_from_file_with_mode(
-                    self.ctx.current_file_idx,
-                    &module_name,
-                    resolution_mode_override,
-                )
-                .and_then(|target_idx| {
-                    self.ctx
-                        .get_binder_for_file(target_idx)
-                        .map(|binder| (target_idx, binder))
-                })
-                .and_then(|(target_idx, binder)| {
-                    let target_arena = self.ctx.get_arena_for_file(target_idx as u32);
-                    let file_name = target_arena.source_files.first()?.file_name.as_str();
-                    binder
-                        .module_exports
-                        .get(file_name)
-                        .and_then(|exports| exports.get("export="))
-                });
-            let has_export_equals =
-                ambient_export_equals_sym.is_some() || file_export_equals.is_some();
-
-            has_export_equals
-                || self.is_module_export_equals_type_only(&module_name)
-                || ambient_export_equals_sym.is_some_and(|sym_id| {
-                    let symbol_is_type = |checker: &Self, sym_id: tsz_binder::SymbolId| {
-                        checker
-                            .ctx
-                            .binder
-                            .get_symbol_with_libs(sym_id, &lib_binders)
-                            .is_some_and(|sym| {
-                                sym.is_type_only
-                                    || (sym.has_any_flags(PURE_TYPE) && !sym.has_any_flags(VALUE))
-                            })
-                    };
-
-                    if symbol_is_type(self, sym_id) {
-                        return true;
-                    }
-
-                    let mut visited = AliasCycleTracker::new();
-                    self.resolve_alias_symbol(sym_id, &mut visited)
-                        .is_some_and(|resolved| symbol_is_type(self, resolved))
-                })
-        } else {
-            false
-        };
+        let bare_import_type_refers_to_type = is_bare_import_type
+            && self.bare_import_type_names_a_type(&module_name, resolution_mode_override);
         let bare_import_type_error = |checker: &mut Self| {
             let message = format_message(
                 diagnostic_messages::MODULE_DOES_NOT_REFER_TO_A_TYPE_BUT_IS_USED_AS_A_TYPE_HERE_DID_YOU_MEAN_TYPEOF_I,

--- a/crates/tsz-checker/src/state/type_resolution/import_type_meaning.rs
+++ b/crates/tsz-checker/src/state/type_resolution/import_type_meaning.rs
@@ -1,0 +1,94 @@
+//! Whether a bare `import("mod")` names a type.
+//!
+//! Split out of `import_type.rs` so the JSDoc import-type resolver can ask the
+//! same question. The two resolvers reach it by entirely separate paths:
+//! `let a: import("./m")` goes through `import_type.rs`, while
+//! `/** @param {import("./m")} a */` goes through the JSDoc comment scan.
+
+use crate::state::CheckerState;
+use crate::symbols_domain::alias_cycle::AliasCycleTracker;
+
+impl<'a> CheckerState<'a> {
+    /// Whether a bare `import("mod")` used in a type position names a TYPE.
+    ///
+    /// A bare import type resolves to the module's `export =` type. The module's
+    /// own namespace is not a type, so a module exporting only values — or one
+    /// with named type exports and no `export =` — cannot be used this way, and
+    /// `tsc` reports TS1340. `import("mod").Member` is unaffected: it is not a
+    /// bare import type.
+    pub(crate) fn bare_import_type_names_a_type(
+        &self,
+        module_name: &str,
+        resolution_mode_override: Option<crate::context::ResolutionModeOverride>,
+    ) -> bool {
+        use tsz_binder::symbol_flags;
+
+        const PURE_TYPE: u32 = symbol_flags::INTERFACE | symbol_flags::TYPE_ALIAS;
+        const VALUE: u32 = symbol_flags::VARIABLE
+            | symbol_flags::FUNCTION
+            | symbol_flags::CLASS
+            | symbol_flags::ENUM
+            | symbol_flags::ENUM_MEMBER
+            | symbol_flags::VALUE_MODULE;
+
+        let lib_binders = self.get_lib_binders();
+        let ambient_export_equals_sym = self
+            .ctx
+            .binder
+            .module_exports
+            .get(module_name)
+            .and_then(|exports| exports.get("export="))
+            .or_else(|| {
+                self.ctx
+                    .global_module_exports_index
+                    .as_ref()
+                    .and_then(|idx| idx.get(module_name))
+                    .and_then(|inner| inner.get("export="))
+                    .and_then(|entries| entries.first().map(|&(_file_idx, sym_id)| sym_id))
+            });
+        let file_export_equals = self
+            .ctx
+            .resolve_import_target_from_file_with_mode(
+                self.ctx.current_file_idx,
+                module_name,
+                resolution_mode_override,
+            )
+            .and_then(|target_idx| {
+                self.ctx
+                    .get_binder_for_file(target_idx)
+                    .map(|binder| (target_idx, binder))
+            })
+            .and_then(|(target_idx, binder)| {
+                let target_arena = self.ctx.get_arena_for_file(target_idx as u32);
+                let file_name = target_arena.source_files.first()?.file_name.as_str();
+                binder
+                    .module_exports
+                    .get(file_name)
+                    .and_then(|exports| exports.get("export="))
+            });
+        let has_export_equals = ambient_export_equals_sym.is_some() || file_export_equals.is_some();
+
+        has_export_equals
+            || self.is_module_export_equals_type_only(module_name)
+            || ambient_export_equals_sym.is_some_and(|sym_id| {
+                let symbol_is_type = |checker: &Self, sym_id: tsz_binder::SymbolId| {
+                    checker
+                        .ctx
+                        .binder
+                        .get_symbol_with_libs(sym_id, &lib_binders)
+                        .is_some_and(|sym| {
+                            sym.is_type_only
+                                || (sym.has_any_flags(PURE_TYPE) && !sym.has_any_flags(VALUE))
+                        })
+                };
+
+                if symbol_is_type(self, sym_id) {
+                    return true;
+                }
+
+                let mut visited = AliasCycleTracker::new();
+                self.resolve_alias_symbol(sym_id, &mut visited)
+                    .is_some_and(|resolved| symbol_is_type(self, resolved))
+            })
+    }
+}

--- a/crates/tsz-checker/src/state/type_resolution/mod.rs
+++ b/crates/tsz-checker/src/state/type_resolution/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod cross_file_constructors;
 pub(crate) mod cross_file_export;
 pub(crate) mod heritage_publication;
 pub(crate) mod import_type;
+pub(crate) mod import_type_meaning;
 pub(crate) mod judge;
 pub(crate) mod mixin_constraints;
 pub(crate) mod module;

--- a/crates/tsz-checker/src/tests/jsdoc_bare_import_type_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_bare_import_type_tests.rs
@@ -1,0 +1,145 @@
+//! TS1340 for a bare `import('mod')` used as a type in JSDoc.
+//!
+//! A bare import type names the module's `export =` type. The module's own
+//! namespace is not a type, so a module exporting only values — or one with
+//! named type exports and no `export =` — is TS1340, verified against the pinned
+//! tsc 7.0.2:
+//!
+//! ```text
+//! ex.d.ts : export var config: {}
+//! test.js : /** @param {import('./ex')} a */ function demo(a) {}
+//!           -> TS1340 Module './ex' does not refer to a type ...
+//! ```
+//!
+//! `import('mod').Member` is unaffected: it is not a bare import type, and is
+//! how named type exports are meant to be reached.
+//!
+//! The TypeScript import-type resolver already reported this; JSDoc reaches the
+//! question through a separate path and now asks the same shared predicate.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_multi_file_with_libs_stamped, load_lib_files};
+
+fn js_codes(files: &[(&str, &str)]) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        ..CheckerOptions::default()
+    };
+    let entry = files
+        .iter()
+        .map(|(name, _)| *name)
+        .find(|name| name.ends_with(".js"))
+        .unwrap_or(files[0].0);
+    check_multi_file_with_libs_stamped(files, entry, options, &load_lib_files(&["es5.d.ts"]))
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+const VALUES_ONLY: &str = "export var config: {}\n";
+const NAMED_TYPE: &str = "export interface Thing { a: number }\n";
+const EXPORT_EQUALS_TYPE: &str = "interface Thing { a: number }\nexport = Thing;\n";
+
+// --- Bare import of a module with no `export =` type: TS1340. ---
+
+#[test]
+fn bare_import_of_values_only_module_reports() {
+    let files = [
+        ("ex.d.ts", VALUES_ONLY),
+        (
+            "test.js",
+            "/** @param {import('./ex')} a */\nfunction demo(a) { return a }\ndemo\n",
+        ),
+    ];
+    assert!(js_codes(&files).contains(&1340));
+}
+
+/// Named type exports do not make the module itself a type — the case most
+/// likely to be got wrong.
+#[test]
+fn bare_import_of_named_type_export_module_reports() {
+    let files = [
+        ("ty.d.ts", NAMED_TYPE),
+        (
+            "test.js",
+            "/** @param {import('./ty')} b */\nfunction demo(b) { return b }\ndemo\n",
+        ),
+    ];
+    assert!(js_codes(&files).contains(&1340));
+}
+
+/// `@returns` takes the same path as `@param`.
+#[test]
+fn bare_import_in_returns_tag_reports() {
+    let files = [
+        ("ex.d.ts", VALUES_ONLY),
+        (
+            "test.js",
+            "/** @returns {import('./ex')} */\nfunction demo() { return null }\ndemo\n",
+        ),
+    ];
+    assert!(js_codes(&files).contains(&1340));
+}
+
+/// A renamed module and parameter: the rule is structural.
+#[test]
+fn bare_import_rule_is_not_name_specific() {
+    let files = [
+        ("helpers.d.ts", "export var helper: {}\n"),
+        (
+            "consumer.js",
+            "/** @param {import('./helpers')} h */\nfunction use(h) { return h }\nuse\n",
+        ),
+    ];
+    assert!(js_codes(&files).contains(&1340));
+}
+
+// --- Negatives: these must stay silent. ---
+
+#[test]
+fn bare_import_of_export_equals_type_is_accepted() {
+    let files = [
+        ("ty.d.ts", EXPORT_EQUALS_TYPE),
+        (
+            "test.js",
+            "/** @param {import('./ty')} b */\nfunction demo(b) { return b }\ndemo\n",
+        ),
+    ];
+    assert!(!js_codes(&files).contains(&1340));
+}
+
+/// Member access reaches named type exports and is not a bare import type.
+#[test]
+fn member_access_import_type_is_accepted() {
+    let files = [
+        ("ty.d.ts", NAMED_TYPE),
+        (
+            "test.js",
+            "/** @param {import('./ty').Thing} c */\nfunction demo(c) { return c }\ndemo\n",
+        ),
+    ];
+    assert!(!js_codes(&files).contains(&1340));
+}
+
+/// A plain named type keeps working — the new branch must not swallow ordinary
+/// `@param` handling.
+#[test]
+fn non_import_param_type_is_unaffected() {
+    let files = [(
+        "test.js",
+        "/** @param {string} s */\nfunction demo(s) { return s }\ndemo\n",
+    )];
+    let codes = js_codes(&files);
+    assert!(!codes.contains(&1340) && !codes.contains(&2304));
+}
+
+/// An unresolvable plain name still reports TS2304 from the same scan.
+#[test]
+fn unresolvable_param_type_still_reports_2304() {
+    let files = [(
+        "test.js",
+        "/** @param {NoSuchTypeHere} a */\nfunction demo(a) { return a }\ndemo\n",
+    )];
+    assert!(js_codes(&files).contains(&2304));
+}

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -435,6 +435,7 @@ pub(super) const fn is_ts1xxx_allowed_in_js(code: u32) -> bool {
     matches!(
         code,
         1002 // Unterminated string literal
+        | 1340 // Module '{0}' does not refer to a type, but is used as a type here
         | 1003 // Identifier expected
         | 1005 // "{0}" expected (missing token)
         | 1014 // A rest parameter must be last in a parameter list


### PR DESCRIPTION
## Structural rule

A bare `import('mod')` in a type position names the module's `export =` type.
The module's own namespace is not a type, so a module exporting only values — or
one with named type exports and no `export =` — is TS1340
`Module 'X' does not refer to a type, but is used as a type here.` `tsc` reports
this for JSDoc as well as TypeScript; tsz reported it only for TypeScript.

`import('mod').Member` is unaffected: it is not a bare import type, and is how
named type exports are meant to be reached.

## Three things were in the way

**1. The predicate was unreachable from JSDoc.** It lived inline in the
TypeScript import-type resolver (`import_type.rs`), which the JSDoc path never
enters — a `.ts` file reported TS1340 correctly while the equivalent `.js` file
reported nothing. It moves to `state/type_resolution/import_type_meaning.rs` as
`bare_import_type_names_a_type`, called from both paths. The move is behaviour
neutral, measured before going further: the TypeScript control still reports
TS1340 and `conformance --filter jsdoc` was unchanged at 290 across it.

**2. JSDoc never asked.** The `@param`/`@return` comment scan now consults the
shared predicate, anchored at the type expression's offset — the column `tsc`
uses (the `import` keyword).

**3. The CLI dropped the answer.** For JS files the driver keeps only
allowlisted `TS1xxx` parser-grammar codes (`is_ts1xxx_allowed_in_js`), and 1340
was missing even though tsc emits it for JavaScript. This was invisible until an
identical emit at the identical position **survived as TS2304 but vanished as
TS1340** — that pair is what identified the filter rather than another guess at
the emit site.

## Behaviour, verified against the pinned tsc 7.0.2

| module | bare `import(...)` as a JSDoc type | tsz before | after |
|---|---|---|---|
| `export var config: {}` | TS1340 | none | **TS1340** |
| `export interface Thing {}` (no `export =`) | TS1340 | none | **TS1340** |
| `export = Thing` (a type) | none | none | none |
| `import('./m').Thing` (member access) | none | none | none |
| `.ts` control `let a: import('./ex')` | TS1340 | TS1340 | TS1340 |

Positions match tsc exactly (`test.js(1,13)`).

## Deliberately not included

Requiring the `export =` target to itself be a **type** would fix two more
corpus tests (`jsdocImportTypeReferenceToCommonjsModule`,
`jsdocTypeReferenceToImportOfFunctionExpression`, where `export = <value>`
short-circuits the predicate). Measured: +2/-1, regressing
`compiler_declarationImportTypeAliasInferredAndEmittable` on the TypeScript
path. Left out rather than ship a known regression; recorded for follow-up.

## Adjacent cases

`crates/tsz-checker/src/tests/jsdoc_bare_import_type_tests.rs`, 8 tests:
values-only module, named-type-export module, `@returns` as well as `@param`, a
renamed module/binder; negatives for `export =` of a type, member access, an
ordinary `@param {string}`, and an unresolvable name still reporting TS2304 from
the same scan.

## Verification

Local, on this branch's head; jsdoc re-run on the committed tree after the
clippy fixup.

| suite | before | after |
|---|---|---|
| `conformance` (full) | 11374/12043 | **11375/12043** |
| `conformance --filter jsdoc` | 290/368 | **291/368** |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

Full-corpus failing sets diffed both ways — **1 fixed, 0 regressed**
(`conformance_jsdoc_jsdocImportTypeReferenceToESModule`).

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(jsdoc_bare_import_type)'    # 8 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold