### PR TITLE
fix(checker): a bare import type needs export= to supply a type

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/import_type_meaning.rs
+++ b/crates/tsz-checker/src/state/type_resolution/import_type_meaning.rs
@@ -23,13 +23,12 @@ impl<'a> CheckerState<'a> {
     ) -> bool {
         use tsz_binder::symbol_flags;
 
-        const PURE_TYPE: u32 = symbol_flags::INTERFACE | symbol_flags::TYPE_ALIAS;
-        const VALUE: u32 = symbol_flags::VARIABLE
-            | symbol_flags::FUNCTION
+        /// Symbol kinds whose `export =` gives the module a type meaning.
+        /// Classes and enums qualify: they declare a type as well as a value.
+        const TYPE_PROVIDING: u32 = symbol_flags::INTERFACE
+            | symbol_flags::TYPE_ALIAS
             | symbol_flags::CLASS
-            | symbol_flags::ENUM
-            | symbol_flags::ENUM_MEMBER
-            | symbol_flags::VALUE_MODULE;
+            | symbol_flags::ENUM;
 
         let lib_binders = self.get_lib_binders();
         let ambient_export_equals_sym = self
@@ -61,14 +60,23 @@ impl<'a> CheckerState<'a> {
             .and_then(|(target_idx, binder)| {
                 let target_arena = self.ctx.get_arena_for_file(target_idx as u32);
                 let file_name = target_arena.source_files.first()?.file_name.as_str();
-                binder
+                let sym_id = binder
                     .module_exports
                     .get(file_name)
-                    .and_then(|exports| exports.get("export="))
+                    .and_then(|exports| exports.get("export="))?;
+                Some(
+                    binder
+                        .get_symbol(sym_id)
+                        .is_some_and(|sym| sym.is_type_only || sym.has_any_flags(TYPE_PROVIDING)),
+                )
             });
-        let has_export_equals = ambient_export_equals_sym.is_some() || file_export_equals.is_some();
 
-        has_export_equals
+        // The module is usable as a bare import type only when its `export =`
+        // target actually supplies a TYPE. A class or enum does — it carries a
+        // type meaning alongside its value meaning, so `class Conn {}
+        // export = Conn` is a valid bare import type. A plain `var` or
+        // `function` export does not, and tsc reports TS1340 for it.
+        file_export_equals.unwrap_or(false)
             || self.is_module_export_equals_type_only(module_name)
             || ambient_export_equals_sym.is_some_and(|sym_id| {
                 let symbol_is_type = |checker: &Self, sym_id: tsz_binder::SymbolId| {
@@ -76,10 +84,7 @@ impl<'a> CheckerState<'a> {
                         .ctx
                         .binder
                         .get_symbol_with_libs(sym_id, &lib_binders)
-                        .is_some_and(|sym| {
-                            sym.is_type_only
-                                || (sym.has_any_flags(PURE_TYPE) && !sym.has_any_flags(VALUE))
-                        })
+                        .is_some_and(|sym| sym.is_type_only || sym.has_any_flags(TYPE_PROVIDING))
                 };
 
                 if symbol_is_type(self, sym_id) {

--- a/crates/tsz-checker/src/tests/jsdoc_bare_import_type_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_bare_import_type_tests.rs
@@ -143,3 +143,55 @@ fn unresolvable_param_type_still_reports_2304() {
     )];
     assert!(js_codes(&files).contains(&2304));
 }
+
+// --- `export =` must supply a TYPE, not merely exist. ---
+
+/// `declare var config: {...}; export = config` exports a VALUE, so the module
+/// is not usable as a bare import type (witness:
+/// `jsdocImportTypeReferenceToCommonjsModule`).
+#[test]
+fn bare_import_of_export_equals_value_reports() {
+    let files = [
+        (
+            "ex.d.ts",
+            "declare var config: { fix: boolean }\nexport = config;\n",
+        ),
+        (
+            "test.js",
+            "/** @param {import('./ex')} a */\nfunction demo(a) { return a }\ndemo\n",
+        ),
+    ];
+    assert!(js_codes(&files).contains(&1340));
+}
+
+/// A class carries a type meaning alongside its value meaning, so
+/// `class Conn {} export = Conn` IS a valid bare import type. This is the case
+/// that a naive "export = must be a pure type" rule gets wrong — it regressed
+/// `declarationImportTypeAliasInferredAndEmittable` until classes were counted.
+#[test]
+fn bare_import_of_export_equals_class_is_accepted() {
+    let files = [
+        (
+            "foo.d.ts",
+            "declare class Conn { item: number }\nexport = Conn;\n",
+        ),
+        (
+            "test.js",
+            "/** @param {import('./foo')} c */\nfunction demo(c) { return c }\ndemo\n",
+        ),
+    ];
+    assert!(!js_codes(&files).contains(&1340));
+}
+
+/// An enum likewise declares a type.
+#[test]
+fn bare_import_of_export_equals_enum_is_accepted() {
+    let files = [
+        ("e.d.ts", "declare enum E { A, B }\nexport = E;\n"),
+        (
+            "test.js",
+            "/** @param {import('./e')} e */\nfunction demo(e) { return e }\ndemo\n",
+        ),
+    ];
+    assert!(!js_codes(&files).contains(&1340));
+}


### PR DESCRIPTION
## Structural rule

A bare `import('mod')` used as a type resolves to the module's `export =`
**type**. `bare_import_type_names_a_type` accepted the mere *presence* of an
`export =`, so a module exporting a value that way was wrongly treated as a
type. `declare var config; export = config` exports a value, so a bare
`import('./mod')` in a type position is TS1340.

Follow-up to #15942, which noted this and deliberately left it out.

## The part that makes it safe

Classes and enums **do** supply a type — they declare one alongside their value
— so `class Conn {} export = Conn` remains a valid bare import type.

A naive "the `export =` must be a pure type" rule gets this wrong. #15942
measured exactly that: restricting to `INTERFACE | TYPE_ALIAS` gave +2/-1,
regressing `compiler_declarationImportTypeAliasInferredAndEmittable`, whose
module is `class Conn { … } export = Conn`. Counting classes and enums as
type-providing is what turns that into +1/-0 here.

Two concrete gaps are closed:

- the file-backed `export =` path never inspected the symbol at all; only the
  ambient path did
- the ambient check required the symbol NOT to be a value
  (`has_any_flags(PURE_TYPE) && !has_any_flags(VALUE)`), which excluded classes
  and enums by construction

Both now use one `TYPE_PROVIDING` set: `INTERFACE | TYPE_ALIAS | CLASS | ENUM`.

## Behaviour, verified against the pinned tsc 7.0.2

| module | bare `import(...)` as a type | tsz before | after |
|---|---|---|---|
| `declare var config; export = config` | TS1340 | none | **TS1340** |
| `class Conn {} export = Conn` | none | none | none |
| `declare enum E {} export = E` | none | none | none |
| `interface Thing {} export = Thing` | none | none | none |

## Adjacent cases

`jsdoc_bare_import_type_tests.rs` grows to 11 tests; the three new ones cover
`export =` of a value (reports), of a class (accepted), and of an enum
(accepted) — the class case being the regression witness from #15942.

## Verification

Local, on this branch's head.

| suite | before (main @ adad15a1ab) | after |
|---|---|---|
| `conformance` (full) | 11375/12043 | **11376/12043** |
| `conformance --filter jsdoc` | 291/368 | **292/368** |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

Full-corpus failing sets diffed both ways — **1 fixed, 0 regressed**
(`conformance_jsdoc_jsdocImportTypeReferenceToCommonjsModule`). In particular
`compiler_declarationImportTypeAliasInferredAndEmittable`, which the earlier
attempt broke, still passes.

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(jsdoc_bare_import_type)'    # 11 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold