### PR TITLE
fix(checker): an invalid jsxFactory resolves no name at all

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/runtime.rs
+++ b/crates/tsz-checker/src/checkers/jsx/runtime.rs
@@ -715,6 +715,20 @@ impl<'a> CheckerState<'a> {
             && !pragma_overrides_config
         {
             let jsx_factory = self.ctx.compiler_options.jsx_factory.clone();
+            // tsc parses `jsxFactory` with `parseIsolatedEntityName`, which
+            // yields `undefined` for a value that is not an identifier or
+            // qualified name. No `_jsxFactoryEntity` then exists, so tsc
+            // resolves no factory name and reports nothing per tag — the
+            // invalid value is already reported once as TS5067 by option
+            // validation. Splitting on '.' regardless makes the whole invalid
+            // string the root identifier (`"id1 id2"` stays `"id1 id2"`),
+            // which fails resolution and yields a spurious TS2304 at every tag.
+            //
+            // Returning here rather than clearing the flag is deliberate: the
+            // fall-through path below would emit the retired TS2874 instead.
+            if !tsz_scanner::is_ecmascript_entity_name(&jsx_factory) {
+                return;
+            }
             let jsx_root = jsx_factory
                 .split('.')
                 .next()

--- a/crates/tsz-scanner/src/lib.rs
+++ b/crates/tsz-scanner/src/lib.rs
@@ -611,6 +611,34 @@ pub fn is_ecmascript_identifier_part(ch: char) -> bool {
     scanner_impl::is_identifier_part(ch as u32)
 }
 
+/// Returns `true` if `s` is a valid ECMAScript identifier: a non-empty string
+/// whose first character is an identifier start and whose remainder are all
+/// identifier parts.
+#[must_use]
+pub fn is_ecmascript_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => {
+            is_ecmascript_identifier_start(first) && chars.all(is_ecmascript_identifier_part)
+        }
+        None => false,
+    }
+}
+
+/// Returns `true` if `s` is a valid entity name: one or more identifiers joined
+/// by dots (`A`, `A.B`, `A.B.C`).
+///
+/// This is tsz's equivalent of tsc's `parseIsolatedEntityName`, which returns
+/// `undefined` for anything that does not parse. Callers that consume a
+/// user-supplied entity name from compiler options — `jsxFactory`,
+/// `jsxFragmentFactory`, `reactNamespace` — must treat a `false` here the way
+/// tsc treats that `undefined`: resolve nothing and report nothing, leaving the
+/// option-validation diagnostic (TS5067) as the only complaint.
+#[must_use]
+pub fn is_ecmascript_entity_name(s: &str) -> bool {
+    !s.is_empty() && s.split('.').all(is_ecmascript_identifier)
+}
+
 // =============================================================================
 // Keyword Text Mapping
 // =============================================================================

--- a/crates/tsz-scanner/tests/entity_name_validity_tests.rs
+++ b/crates/tsz-scanner/tests/entity_name_validity_tests.rs
@@ -1,0 +1,81 @@
+//! `is_ecmascript_entity_name` is tsz's equivalent of tsc's
+//! `parseIsolatedEntityName`: it decides whether a user-supplied compiler-option
+//! value (`jsxFactory`, `jsxFragmentFactory`, `reactNamespace`) names something
+//! resolvable at all.
+//!
+//! Callers must treat `false` the way tsc treats `parseIsolatedEntityName`
+//! returning `undefined` — resolve nothing, report nothing — leaving TS5067
+//! from option validation as the only complaint. Getting this predicate wrong in
+//! the permissive direction produces a spurious TS2304 at every JSX tag.
+
+use tsz_scanner::{is_ecmascript_entity_name, is_ecmascript_identifier};
+
+#[test]
+fn plain_identifiers_are_entity_names() {
+    for s in [
+        "h",
+        "React",
+        "_",
+        "$",
+        "createElement",
+        "_private",
+        "$dollar",
+        "a1",
+    ] {
+        assert!(is_ecmascript_identifier(s), "{s} should be an identifier");
+        assert!(is_ecmascript_entity_name(s), "{s} should be an entity name");
+    }
+}
+
+#[test]
+fn dotted_qualified_names_are_entity_names() {
+    for s in [
+        "React.createElement",
+        "a.b.c",
+        "Element.createElement",
+        "_.$.x",
+    ] {
+        assert!(is_ecmascript_entity_name(s), "{s} should be an entity name");
+        assert!(
+            !is_ecmascript_identifier(s),
+            "{s} is qualified, not a bare identifier"
+        );
+    }
+}
+
+/// The case that produced the spurious TS2304: a space-separated pair has no
+/// dot, so splitting on '.' yields the whole invalid string as the "root".
+#[test]
+fn space_separated_pair_is_not_an_entity_name() {
+    assert!(!is_ecmascript_entity_name("id1 id2"));
+    assert!(!is_ecmascript_identifier("id1 id2"));
+}
+
+#[test]
+fn malformed_values_are_rejected() {
+    for s in [
+        "",      // empty
+        ".",     // bare dot
+        "a.",    // trailing dot -> empty segment
+        ".a",    // leading dot -> empty segment
+        "a..b",  // empty interior segment
+        "1abc",  // starts with a digit
+        "a-b",   // hyphen is not an identifier part
+        "a b",   // space
+        "a+b",   // operator
+        "a.b c", // valid head, invalid tail
+        "(a)",   // punctuation
+        "a=>b",  // arrow
+    ] {
+        assert!(!is_ecmascript_entity_name(s), "{s:?} must be rejected");
+    }
+}
+
+/// Unicode identifiers are legal in ECMAScript and must not be rejected — the
+/// predicate delegates to the same tables the scanner uses.
+#[test]
+fn unicode_identifiers_are_accepted() {
+    for s in ["café", "naïve", "Ωmega", "日本語", "_ø.café"] {
+        assert!(is_ecmascript_entity_name(s), "{s} should be accepted");
+    }
+}


### PR DESCRIPTION
## Summary

`check_jsx_factory_in_scope` took the configured `jsxFactory`, split it on `'.'`, and resolved the first segment as a value name. For a value that is not a valid entity name that split is a **no-op** — `"id1 id2"` contains no dot, so the whole invalid string becomes the "root identifier", fails resolution, and produces a spurious TS2304 at every JSX tag:

```
compiler/jsxFactoryNotIdentifierOrQualifiedName2.ts
  oracle: [TS5067]
  tsz:    [TS5067, TS2304, TS2304]   "Cannot find name 'id1 id2'."
```

tsc parses the option with `parseIsolatedEntityName`, which returns `undefined` when the value does not parse. No `_jsxFactoryEntity` exists, so tsc resolves no factory name and reports nothing per tag — the invalid value is already reported once, as TS5067, by option validation.

## Structural rule

When `jsxFactory` is not a valid identifier or qualified name, tsc resolves no factory entity and reports nothing at the tag sites; tsz now returns early from the factory-in-scope check, leaving TS5067 from option validation as the only diagnostic.

## Owner layer

Checker — `crates/tsz-checker/src/checkers/jsx/runtime.rs`, in the `jsx_factory_from_config` branch, before the `'.'` split.

The predicate goes in `tsz-scanner` as `is_ecmascript_entity_name` (with `is_ecmascript_identifier`), beside the existing `is_ecmascript_identifier_start` / `_part` that it delegates to, so "parses as an entity name" uses the same Unicode tables the scanner uses to accept identifiers. `crates/tsz-core/src/config/mod.rs`'s `is_valid_identifier_or_qualified_name` (used for TS5067) is a character-for-character duplicate of this logic and should delegate to the new helper — left for a follow-up to keep this diff focused.

## Why an early `return` rather than clearing the flag

Setting `jsx_factory_from_config = false` is **not** equivalent. It falls through to the branch below, which emits the retired TS8074/TS2874 instead of nothing. The return is load-bearing.

## Adjacent cases

- `compiler/jsxFactoryNotIdentifierOrQualifiedName.ts` (the sibling) passed before only because its root `Element` happens to be imported — i.e. it passed by luck, not by rule. It still passes.
- `--filter jsxFactory` is 13/14. The remaining failure, `jsxFactoryIdentifierWithAbsentParameter`, is unrelated to entity-name validity.

## Verification

Local, on this branch vs `main` at `572c8bd330`:

- **Full conformance: 11353 -> 11354 passed (689 failed), +1 fixed, 0 regressed, 0 changed-but-still-failing.**
- **Full emit suite unchanged**: 11562/11563 JS, 1375/1390 DTS.
- 5 new `tsz-scanner` tests covering plain identifiers, dotted qualified names, the space-separated pair that caused this, twelve malformed shapes (empty, bare/leading/trailing/interior dots, leading digit, hyphen, operators, punctuation), and Unicode identifiers (`café`, `Ωmega`, `日本語`) which must keep being accepted.

Goal: hold

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
