### PR TITLE
fix(checker): an inaccessible constructor still yields the instance type

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2522,3 +2522,6 @@ path = "tests/parameter_property_anchor_tests.rs"
 [[test]]
 name = "duplicate_class_member_all_declarations_tests"
 path = "tests/duplicate_class_member_all_declarations_tests.rs"
+[[test]]
+name = "inaccessible_constructor_instance_type_tests"
+path = "tests/inaccessible_constructor_instance_type_tests.rs"

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -630,6 +630,21 @@ impl<'a> CheckerState<'a> {
         // When the constructor is inaccessible, tsc only emits the accessibility
         // error and suppresses subsequent arg-count/type-mismatch diagnostics.
         if self.check_constructor_accessibility_for_new(idx, constructor_type) {
+            // tsc suppresses the *call's* subsequent arg-count/type-mismatch
+            // diagnostics, but the new-expression still has the instance type.
+            // Returning `any` here instead poisons everything downstream:
+            // `var c = new C()` on a private constructor made `c` `any`, so
+            // `var r: () => void = c.constructor` silently passed where tsc
+            // reports TS2322 (`c.constructor` is `Function`).
+            if let Some(signatures) =
+                crate::query_boundaries::construct_signatures::construct_signatures_for_type(
+                    self.ctx.types,
+                    constructor_type,
+                )
+                && let Some(first) = signatures.first()
+            {
+                return first.return_type;
+            }
             return TypeId::ANY;
         }
 

--- a/crates/tsz-checker/tests/inaccessible_constructor_instance_type_tests.rs
+++ b/crates/tsz-checker/tests/inaccessible_constructor_instance_type_tests.rs
@@ -1,0 +1,94 @@
+//! An inaccessible constructor still yields the instance type.
+//!
+//! tsc's `resolveNewExpression` reports TS2673/TS2674 for a private/protected
+//! constructor and suppresses the *call's* subsequent arg-count and
+//! type-mismatch diagnostics — but the new-expression's type is still the
+//! instance type. tsz returned `any` instead, which poisoned everything
+//! downstream: `var c = new C()` made `c` `any`, so any later misuse of `c`
+//! silently passed.
+//!
+//! Pins `conformance/types/members/typesWithPrivateConstructor.ts` and
+//! `typesWithProtectedConstructor.ts`, whose oracle expects the accessibility
+//! error AND a TS2322 on `var r: () => void = c.constructor` (an instance's
+//! `.constructor` is `Function`, which is not assignable to a specific
+//! function type).
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut c: Vec<u32> = check_source_diagnostics(source)
+        .iter()
+        .map(|d| d.code)
+        .collect();
+    c.sort_unstable();
+    c
+}
+
+#[test]
+fn private_constructor_keeps_instance_type_for_downstream_checks() {
+    let source = "class C { private constructor() { } }\n\
+                  var c = new C();\n\
+                  var r: () => void = c.constructor;\n";
+    assert_eq!(
+        codes(source),
+        vec![2322, 2673],
+        "expected the accessibility error AND the downstream assignability error"
+    );
+}
+
+#[test]
+fn protected_constructor_keeps_instance_type_for_downstream_checks() {
+    let source = "class C { protected constructor() { } }\n\
+                  var c = new C();\n\
+                  var r: () => void = c.constructor;\n";
+    assert_eq!(codes(source), vec![2322, 2674]);
+}
+
+/// The instance type must be the class, not `any` — a genuinely wrong member
+/// access on it still has to be caught.
+#[test]
+fn inaccessible_constructor_instance_still_reports_unknown_members() {
+    let source = "class C { private constructor() { } x: number = 1; }\n\
+                  var c = new C();\n\
+                  c.notAMember;\n";
+    assert_eq!(
+        codes(source),
+        vec![2339, 2673],
+        "the instance must still be typed `C`, so TS2339 fires"
+    );
+}
+
+/// ...and a correct member access on it must NOT error.
+#[test]
+fn inaccessible_constructor_instance_allows_real_members() {
+    let source = "class C { private constructor() { } x: number = 1; }\n\
+                  var c = new C();\n\
+                  var n: number = c.x;\n";
+    assert_eq!(
+        codes(source),
+        vec![2673],
+        "only the accessibility error is due"
+    );
+}
+
+/// The public-constructor path was already correct and must not shift.
+#[test]
+fn public_constructor_is_unchanged() {
+    let source = "class C { constructor() { } }\n\
+                  var c = new C();\n\
+                  var r: () => void = c.constructor;\n";
+    assert_eq!(codes(source), vec![2322]);
+}
+
+/// Renamed binders, so the rule is not keyed to a particular class name.
+#[test]
+fn rule_holds_for_renamed_binders() {
+    let source = "class Holder { private constructor() { } value: string = \"\"; }\n\
+                  var held = new Holder();\n\
+                  var n: number = held.value;\n";
+    assert_eq!(
+        codes(source),
+        vec![2322, 2673],
+        "instance type survives, so string-to-number is still caught"
+    );
+}


### PR DESCRIPTION
## Summary

`new C()` on a private or protected constructor returned `TypeId::ANY` after reporting TS2673/TS2674. That poisons everything downstream:

```ts
class C { private constructor() { } }
var c = new C();                      // TS2673 — and c became `any`
var r: () => void = c.constructor;    // tsc: TS2322     tsz: silent
```

An instance's `.constructor` is `Function`, which is not assignable to a specific function type. tsz gets that relation right in isolation:

```ts
declare var f: Function;
const a: () => void = f;   // tsz already reports TS2322 correctly
```

and gets the whole thing right when the constructor is **public**. It only went quiet because `c` was `any`.

## Structural rule

When a `new` expression targets an inaccessible constructor, tsc reports the accessibility error and suppresses the *call's* subsequent arg-count and type-mismatch diagnostics, but the expression still has the instance type; tsz now returns that instance type instead of `any`.

The existing comment at the call site already stated this rule — *"tsc only emits the accessibility error and suppresses subsequent arg-count/type-mismatch diagnostics"* — and the code then returned `any` anyway. The suppression is about the call's own diagnostics, not about the resulting type.

## Owner layer

Checker, `crates/tsz-checker/src/types/computation/complex.rs`, in the `check_constructor_accessibility_for_new` branch. Uses the existing `query_boundaries::construct_signatures::construct_signatures_for_type` boundary to take the first construct signature's return type, falling back to `any` only when no construct signature is available — so nothing regresses for targets that genuinely have none.

## Adjacent-case matrix

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| private ctor, `c.constructor` → `() => void` | 2673, 2322 | 2673 | **2673, 2322** |
| protected ctor, same | 2674, 2322 | 2674 | **2674, 2322** |
| private ctor, `c.notAMember` | 2673, 2339 | 2673 | **2673, 2339** |
| private ctor, correct member access | 2673 | 2673 | 2673 |
| **public** ctor, `c.constructor` → `() => void` | 2322 | 2322 | 2322 |

The third and fourth rows are the ones that matter for scope: the instance type has to be good enough to still catch an unknown member, *and* to not invent errors on a correct one.

## Verification

Local, on this branch vs `main` at `04de3102`:

- **Full conformance: 11377 -> 11379 passed (664 failed), +2 fixed, 0 regressed, 0 changed-but-still-failing.** Flips `conformance/types/members/typesWithPrivateConstructor.ts` and `typesWithProtectedConstructor.ts`.
- **Full emit suite unchanged**: 11562/11563 JS, 1375/1390 DTS.
- 6/6 new checker tests, including the public-constructor control and a renamed-binder case.

This sits on a hot path (every `new` expression), so the full-corpus run rather than the two target tests is the real evidence here.

Goal: hold

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high