### PR TITLE
fix(checker): validate JSDoc @type on nested expression statements

### DIFF
--- a/crates/tsz-checker/src/jsdoc/base_types.rs
+++ b/crates/tsz-checker/src/jsdoc/base_types.rs
@@ -552,7 +552,16 @@ impl<'a> CheckerState<'a> {
                 else {
                     continue;
                 };
-                if kind != tsz_parser::parser::syntax_kind_ext::VARIABLE_STATEMENT {
+                // Variable statements carry most nested annotations, but a JS
+                // class routinely declares its fields as `/** @type {T} */
+                // this.x = ...` inside the constructor — an *expression*
+                // statement. tsc validates that annotation too (witness:
+                // jsDeclarationsReferenceToClassInstanceCrossFile).
+                if !matches!(
+                    kind,
+                    tsz_parser::parser::syntax_kind_ext::VARIABLE_STATEMENT
+                        | tsz_parser::parser::syntax_kind_ext::EXPRESSION_STATEMENT
+                ) {
                     continue;
                 }
                 if let Some((_, comment_pos)) =

--- a/crates/tsz-checker/src/tests/jsdoc_nested_type_tag_validation_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_nested_type_tag_validation_tests.rs
@@ -121,3 +121,68 @@ fn nested_type_tag_with_known_type_is_silent() {
     let codes = js_codes(source);
     assert!(!codes.contains(&2304) && !codes.contains(&2749));
 }
+
+// --- Expression statements carry annotations too. ---
+
+/// A JS class declares its fields as `/** @type {T} */ this.x = ...` inside the
+/// constructor — an *expression* statement, not a variable statement. tsc
+/// validates that annotation (witness:
+/// `jsDeclarationsReferenceToClassInstanceCrossFile`).
+#[test]
+fn nested_type_tag_on_this_assignment_reports_missing_name() {
+    let source = concat!(
+        "class Render {\n",
+        "  constructor() {\n",
+        "    /** @type {NoSuchTypeAtAll} */\n",
+        "    this.objects = [];\n",
+        "  }\n",
+        "}\n",
+        "new Render()\n",
+    );
+    assert!(js_codes(source).contains(&2304));
+}
+
+/// The array suffix does not change the rule — the element name is still checked.
+#[test]
+fn nested_type_tag_on_this_assignment_checks_array_element() {
+    let source = concat!(
+        "class Render {\n",
+        "  constructor() {\n",
+        "    /** @type {NoSuchTypeAtAll[]} */\n",
+        "    this.objects = [];\n",
+        "  }\n",
+        "}\n",
+        "new Render()\n",
+    );
+    assert!(js_codes(source).contains(&2304));
+}
+
+/// A plain expression statement outside a class behaves the same.
+#[test]
+fn nested_type_tag_on_plain_expression_statement_reports() {
+    let source = concat!(
+        "var o = {};\n",
+        "function f() {\n",
+        "  /** @type {NoSuchTypeAtAll} */\n",
+        "  o.field = 1;\n",
+        "}\n",
+        "f\n",
+    );
+    assert!(js_codes(source).contains(&2304));
+}
+
+/// A resolvable annotation on an expression statement stays silent.
+#[test]
+fn nested_type_tag_on_this_assignment_with_known_type_is_silent() {
+    let source = concat!(
+        "class Render {\n",
+        "  constructor() {\n",
+        "    /** @type {string[]} */\n",
+        "    this.names = [];\n",
+        "  }\n",
+        "}\n",
+        "new Render()\n",
+    );
+    let codes = js_codes(source);
+    assert!(!codes.contains(&2304) && !codes.contains(&2749));
+}


### PR DESCRIPTION
## Structural rule

A JSDoc `@type` annotation is validated wherever it appears. The nested-`@type`
scan added in #15941 collected leading JSDoc of **variable** statements only, so
`/** @type {T} */ this.x = ...` — the standard way a JS class declares its
fields inside the constructor — went unchecked. That is an *expression*
statement, and tsc validates its annotation like any other.

Owner layer: `jsdoc/base_types.rs::check_jsdoc_typedef_base_types`, the same
statement-kind collection. Inline expression casts
(`value => /** @type {T} */(x)`) still fall through, because they lead no
statement.

Witness: `jsDeclarationsReferenceToClassInstanceCrossFile`, where
`/** @type {Rectangle[]} */ this.objects = []` should report TS2749 —
`Rectangle` arrives via `module.exports = { Rectangle }`, so it is a value, not
a type.

## Behaviour, verified against the pinned tsc 7.0.2

| source (`--allowJs --checkJs`) | tsc | tsz before | after |
|---|---|---|---|
| `class R { constructor(){ /** @type {Rectangle[]} */ this.objects = [] } }` | TS2749 | none | **TS2749** |
| same shape with an unresolvable name | TS2304 | none | **TS2304** |
| `/** @type {string[]} */ this.names = []` | none | none | none |
| top-level and variable-statement forms | unchanged | unchanged | unchanged |

## How it was found

The corpus test's missing diagnostic sits at the `@type` inside a constructor,
not at the `@param`/`@returns` tags. Reduced repros of the *same* test using
`@param`, `@returns`, and a top-level `@type` all already matched tsc — only the
`this.x = ...` shape reproduced the gap. Worth noting because three
simplifications of that test passed before the fourth reproduced it.

## Adjacent cases

`jsdoc_nested_type_tag_validation_tests.rs` grows to 13 tests; the four new ones
cover `this.x` with an unresolvable name, the same with an array suffix, a plain
(non-class) expression statement, and a resolvable annotation staying silent.

## Verification

Local, on this branch's head. Baseline rebuilt from this branch's merge base
rather than taken from a previous run, since main moved.

| suite | before | after |
|---|---|---|
| `conformance` (full) | 11377/12043 | **11378/12043** |
| `conformance --filter jsdoc` | 292/368 | **293/368** |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

Full-corpus failing sets diffed both ways — **1 fixed, 0 regressed**
(`conformance_jsdoc_declarations_jsDeclarationsReferenceToClassInstanceCrossFile`).

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(jsdoc_nested_type_tag_validation)'   # 13 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold