### PR TITLE
fix(checker): only function/class expandos have ordered declarations

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -379,6 +379,9 @@ mod interface_heritage_property_index_relation_routing_arch_tests;
 #[path = "../tests/isolated_declarations_unannotated_param_tests.rs"]
 mod isolated_declarations_unannotated_param_tests;
 #[cfg(test)]
+#[path = "tests/js_expando_order_sensitivity_tests.rs"]
+mod js_expando_order_sensitivity_tests;
+#[cfg(test)]
 #[path = "tests/js_open_object_property_access_tests.rs"]
 mod js_open_object_property_access_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/js_expando_order_sensitivity_tests.rs
+++ b/crates/tsz-checker/src/tests/js_expando_order_sensitivity_tests.rs
@@ -1,0 +1,102 @@
+//! Which JS expando receivers have *ordered* property declarations.
+//!
+//! `tsc` reports TS2565 "used before being assigned" only when the receiver is a
+//! function or class declaration — there the expando property is a declaration
+//! on that object, so a use preceding the assignment is an error. A plain object
+//! (`var o = {}`) or a CommonJS `exports` object is not ordered: `tsc` types
+//! those from every assignment in the program regardless of position, so a use
+//! written before the assignment is fine.
+//!
+//! Verified against the pinned tsc 7.0.2 (`--allowJs --checkJs --strict`):
+//!
+//! ```text
+//! function C() {} C.f(); C.f = a;   -> TS2565   (ordered)
+//! var o = {};     o.f(); o.f = a;   -> nothing  (not ordered)
+//! exports.f();           exports.f = a; -> nothing (not ordered)
+//! ```
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn js_codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.js", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+const USED_BEFORE_ASSIGNED: u32 = 2565;
+
+// --- Ordered receivers keep reporting. ---
+
+#[test]
+fn function_declaration_expando_is_ordered() {
+    let source = "function C() { }\nC.f()\nfunction a() { }\nC.f = a;\n";
+    assert!(js_codes(source).contains(&USED_BEFORE_ASSIGNED));
+}
+
+/// A different binder name and property, so the rule is structural.
+#[test]
+fn function_declaration_expando_is_ordered_renamed() {
+    let source = "function Widget() { }\nWidget.render()\nfunction r() { }\nWidget.render = r;\n";
+    assert!(js_codes(source).contains(&USED_BEFORE_ASSIGNED));
+}
+
+#[test]
+fn class_declaration_expando_is_ordered() {
+    let source = "class K { }\nK.f()\nfunction a() { }\nK.f = a;\n";
+    assert!(js_codes(source).contains(&USED_BEFORE_ASSIGNED));
+}
+
+/// A `const` initialised with a function expression is a function declaration in
+/// all but syntax, and stays ordered.
+#[test]
+fn function_expression_binding_is_ordered() {
+    let source = "const C = function () { };\nC.f()\nfunction a() { }\nC.f = a;\n";
+    assert!(js_codes(source).contains(&USED_BEFORE_ASSIGNED));
+}
+
+// --- Unordered receivers must not report. ---
+
+#[test]
+fn plain_object_expando_is_not_ordered() {
+    let source = "var o = {}\no.f()\nfunction a() { }\no.f = a;\n";
+    assert!(!js_codes(source).contains(&USED_BEFORE_ASSIGNED));
+}
+
+#[test]
+fn commonjs_exports_is_not_ordered() {
+    let source = "exports.f()\nfunction a() { }\nexports.f = a;\n";
+    assert!(!js_codes(source).contains(&USED_BEFORE_ASSIGNED));
+}
+
+/// Witness `typeFromPropertyAssignment17`: a property assigned later in the file
+/// and used earlier through the module object.
+#[test]
+fn exports_property_assigned_after_use_is_not_ordered() {
+    let source = concat!(
+        "exports.helper = undefined;\n",
+        "exports.helper()\n",
+        "function h() { }\n",
+        "exports.helper = h;\n",
+    );
+    assert!(!js_codes(source).contains(&USED_BEFORE_ASSIGNED));
+}
+
+/// The ordinary in-order case stays silent everywhere.
+#[test]
+fn assignment_before_use_is_silent_for_every_receiver() {
+    for source in [
+        "function C() { }\nfunction a() { }\nC.f = a;\nC.f()\n",
+        "var o = {}\nfunction a() { }\no.f = a;\no.f()\n",
+        "function a() { }\nexports.f = a;\nexports.f()\n",
+    ] {
+        assert!(!js_codes(source).contains(&USED_BEFORE_ASSIGNED));
+    }
+}

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -68,6 +68,44 @@ impl<'a> CheckerState<'a> {
     /// late-attaching a JSDoc-typed prototype property is a declaration; for
     /// `class C {}` the prototype shape is the class instance type and a
     /// late attachment is genuinely "used before assigned".
+    /// Whether an expando receiver is a declaration whose property assignments
+    /// `tsc` treats as **ordered**.
+    ///
+    /// `function C() {} C.f(); C.f = a;` reports TS2565 in tsc: the expando is a
+    /// declaration on the function, so using it before the assignment is an
+    /// error. A plain object (`var o = {}`) or a CommonJS `exports` object is
+    /// not ordered — tsc types those from every assignment in the program
+    /// regardless of position and reports nothing, so a use that textually
+    /// precedes the assignment is fine.
+    pub(crate) fn expando_root_has_ordered_declarations(&mut self, access_expr: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(access_expr) else {
+            return false;
+        };
+        if node.kind != SyntaxKind::Identifier as u16 {
+            return false;
+        }
+        let Some(sym_id) = self.resolve_identifier_symbol(access_expr) else {
+            return false;
+        };
+        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+            return false;
+        };
+        let decl_idx = symbol.value_declaration;
+        let Some(decl) = self.ctx.arena.get(decl_idx) else {
+            return false;
+        };
+        match decl.kind {
+            syntax_kind_ext::FUNCTION_DECLARATION | syntax_kind_ext::CLASS_DECLARATION => true,
+            syntax_kind_ext::VARIABLE_DECLARATION => self
+                .ctx
+                .arena
+                .get_variable_declaration(decl)
+                .and_then(|var_decl| self.ctx.arena.get(var_decl.initializer))
+                .is_some_and(|init| init.is_function_expression_or_arrow()),
+            _ => false,
+        }
+    }
+
     pub(crate) fn expando_receiver_is_function_constructor(&self, access_expr: NodeIndex) -> bool {
         let Some(node) = self.ctx.arena.get(access_expr) else {
             return false;

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -760,7 +760,13 @@ impl<'a> CheckerState<'a> {
                         .enclosing_expression_statement(idx)
                         .and_then(|stmt_idx| self.js_statement_declared_type(stmt_idx))
                         .is_some();
-                if !suppress_for_jsdoc_type_decl {
+                // Only a function/class declaration's expando properties are
+                // ordered in tsc. On a plain object or a CommonJS `exports`
+                // object the property type comes from every assignment in the
+                // program, so a use before the assignment is not an error.
+                let receiver_is_ordered =
+                    self.expando_root_has_ordered_declarations(access.expression);
+                if !suppress_for_jsdoc_type_decl && receiver_is_ordered {
                     use crate::diagnostics::format_message;
                     use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                     self.error_at_node(


### PR DESCRIPTION
## Structural rule

TS2565 "Property is used before being assigned" fired for **any** JS expando
property used before its assignment. `tsc` reports it only when the receiver is
a **function or class declaration**, where the expando property is a declaration
on that object. A plain object or a CommonJS `exports` object is not ordered:
`tsc` types those from every assignment in the program regardless of position,
so a use written before the assignment is fine.

Owner layer: `expando_root_has_ordered_declarations` in
`property_access_helpers/access_semantics.rs`, consulted at the TS2565 emission
in `property_access_type/resolve.rs`. It resolves the receiver identifier to its
value declaration and accepts a function declaration, a class declaration, or a
binding initialised with a function expression. No name or file-name literals.

## Behaviour, verified against the pinned tsc 7.0.2

`--allowJs --checkJs --strict`, each with the use written *before* the assignment:

| receiver | tsc | tsz before | after |
|---|---|---|---|
| `function C() {}` | TS2565 | TS2565 | TS2565 |
| `class K {}` | TS2565 | TS2565 | TS2565 |
| `const C = function () {}` | TS2565 | TS2565 | TS2565 |
| `var o = {}` | none | **TS2565** | none |
| `exports.f` | none | **TS2565** | none |
| any receiver, assignment first | none | none | none |

Witness: `typeFromPropertyAssignment17`, where `M.defaults = function …` is
assigned after a cross-file use.

## How the boundary was found

Probing receivers one at a time against tsc showed position-sensitivity is
*correct* for function/class roots and wrong only for object/`exports` roots —
so this is a narrowing, not a removal. An earlier framing of the same defect
("an `undefined` assignment should not survive the union") was a symptom: I
patched `merge_property_info` in `query_boundaries/js_exports.rs`, saw no change,
and a sentinel returning `NUMBER` for *every* merge also changed nothing, proving
that function is not on this path (it builds the cross-file export surface, while
the repro is single-file).

## Known remaining

The sibling TS2722 over-report (`exports.f = undefined; exports.f(); … = a`)
comes from `current_file_commonjs_prior_named_export_type` in `resolve.rs`
typing the read from *prior* assignments only. Same root cause, different code
path; left for a follow-up rather than widened into this change.

## Adjacent cases

`crates/tsz-checker/src/tests/js_expando_order_sensitivity_tests.rs`, 8 tests:
function declaration (plus a renamed binder), class declaration, and
function-expression binding all still reporting; plain object, `exports`, and the
`typeFromPropertyAssignment17` shape all silent; and assignment-before-use silent
for every receiver kind.

## Verification

Local, on this branch's head; salsa re-run on the committed tree. Baseline
rebuilt from this branch's merge base rather than reused, since main moved.

| suite | before | after |
|---|---|---|
| `conformance` (full) | 11378/12043 | **11379/12043** |
| `conformance --filter salsa` | 122/186 | **123/186** |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

Full-corpus failing sets diffed both ways — **1 fixed, 0 regressed**
(`conformance_salsa_typeFromPropertyAssignment17`).

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(js_expando_order_sensitivity)'   # 8 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold