### PR TITLE
fix(checker): CommonJS exports get a declaration-level type

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -193,6 +193,9 @@ mod class_property_typed_const_initializer_tests;
 #[path = "tests/comlink_row_regression_tests.rs"]
 mod comlink_row_regression_tests;
 #[cfg(test)]
+#[path = "tests/commonjs_export_declaration_level_type_tests.rs"]
+mod commonjs_export_declaration_level_type_tests;
+#[cfg(test)]
 #[path = "../tests/comparability_indexed_access_reduce_tests.rs"]
 mod comparability_indexed_access_reduce_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
@@ -430,6 +430,21 @@ impl<'a> CheckerState<'a> {
         Some(rhs_type)
     }
 
+    /// Declaration-level type of a CommonJS named export in the current file.
+    ///
+    /// `tsc` types `exports.x` from every assignment in the module, not only
+    /// those textually preceding the use. `exports.f = undefined; exports.f();
+    /// … exports.f = fn` reports nothing, because the declared type is `fn`, and
+    /// a call written before any assignment is likewise fine. Selecting with an
+    /// unbounded read position therefore takes the last assignment in the file
+    /// rather than the last one above the use.
+    pub(crate) fn current_file_commonjs_named_export_type(
+        &mut self,
+        property_name: &str,
+    ) -> Option<TypeId> {
+        self.current_file_commonjs_prior_named_export_type(property_name, u32::MAX)
+    }
+
     pub(crate) fn current_file_commonjs_prior_named_export_type(
         &mut self,
         property_name: &str,

--- a/crates/tsz-checker/src/tests/commonjs_export_declaration_level_type_tests.rs
+++ b/crates/tsz-checker/src/tests/commonjs_export_declaration_level_type_tests.rs
@@ -1,0 +1,93 @@
+//! CommonJS named exports are typed from every assignment, not the prior ones.
+//!
+//! `tsc` gives `exports.x` a declaration-level type: every assignment in the
+//! module contributes regardless of position. So a call written before the
+//! assignment is fine, and an early `= undefined` does not make the property
+//! possibly-undefined once a real value is assigned later.
+//!
+//! Verified against the pinned tsc 7.0.2 (`--allowJs --checkJs --strict`):
+//!
+//! ```text
+//! exports.f = undefined; exports.f(); … exports.f = a;  -> nothing
+//! exports.f(); … exports.f = a;                          -> nothing
+//! exports.f = undefined; exports.f();                    -> TS2722 (only contributor)
+//! ```
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn js_codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.js", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+const POSSIBLY_UNDEFINED_CALL: u32 = 2722;
+
+// --- A later assignment supplies the type. ---
+
+/// Witness `moduleExportDuplicateAlias`: the `undefined` assignment does not
+/// make the export possibly-undefined once a function is assigned later.
+#[test]
+fn undefined_then_function_is_not_possibly_undefined() {
+    let source = concat!(
+        "exports.apply = undefined;\n",
+        "function a() { }\n",
+        "exports.apply()\n",
+        "exports.apply = a;\n",
+        "exports.apply()\n",
+    );
+    assert!(!js_codes(source).contains(&POSSIBLY_UNDEFINED_CALL));
+}
+
+/// The same with a renamed export and helper, so the rule is structural.
+#[test]
+fn undefined_then_function_is_not_possibly_undefined_renamed() {
+    let source = concat!(
+        "exports.handler = undefined;\n",
+        "function h() { }\n",
+        "exports.handler()\n",
+        "exports.handler = h;\n",
+    );
+    assert!(!js_codes(source).contains(&POSSIBLY_UNDEFINED_CALL));
+}
+
+#[test]
+fn call_before_any_assignment_is_accepted() {
+    let source = "exports.f()\nfunction a() { }\nexports.f = a;\n";
+    assert!(!js_codes(source).contains(&POSSIBLY_UNDEFINED_CALL));
+}
+
+// --- `undefined` as the only contributor still reports. ---
+
+/// Nothing else is assigned, so the declared type really is `undefined` and tsc
+/// reports here too.
+#[test]
+fn undefined_as_sole_assignment_still_reports() {
+    let source = "exports.f = undefined;\nexports.f()\n";
+    assert!(js_codes(source).contains(&POSSIBLY_UNDEFINED_CALL));
+}
+
+// --- Ordinary shapes stay silent. ---
+
+#[test]
+fn assignment_before_use_is_silent() {
+    let source = "function a() { }\nexports.f = a;\nexports.f()\n";
+    assert!(!js_codes(source).contains(&POSSIBLY_UNDEFINED_CALL));
+}
+
+/// A genuinely non-callable export still reports its own error rather than being
+/// silenced by the declaration-level lookup.
+#[test]
+fn non_callable_export_still_reports() {
+    let source = "exports.n = 1;\nexports.n()\n";
+    let codes = js_codes(source);
+    assert!(codes.contains(&2349) || codes.contains(&2348));
+}

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -697,9 +697,7 @@ impl<'a> CheckerState<'a> {
             && !commonjs_named_props_disallowed
             && self.current_file_commonjs_exports_target_is_unshadowed(access.expression)
             && let Some(member_name) = static_member_name.as_deref()
-            && let Some(node) = self.ctx.arena.get(idx)
-            && let Some(prior_type) =
-                self.current_file_commonjs_prior_named_export_type(member_name, node.pos)
+            && let Some(prior_type) = self.current_file_commonjs_named_export_type(member_name)
         {
             return prior_type;
         }


### PR DESCRIPTION
## Structural rule

Reading `exports.x` used the last assignment **above** the use, so an early
`exports.f = undefined` made the property possibly-undefined even when a real
value was assigned later in the module.

`tsc` types a CommonJS named export from **every** assignment in the file,
regardless of position. `undefined` as the *sole* assignment still yields
`undefined`, which both compilers report — the property is genuinely undefined
then.

Owner layer: `current_file_commonjs_named_export_type` in
`state/type_analysis/computed_commonjs/exports_collection.rs`, consulted from the
in-file CommonJS read branch in `property_access_type/resolve.rs`. The wrapper
exists so the call site states the declaration-level intent instead of passing a
sentinel read position.

## Behaviour, verified against the pinned tsc 7.0.2

`--allowJs --checkJs --strict`:

| source | tsc | tsz before | after |
|---|---|---|---|
| `exports.f = undefined; exports.f(); … exports.f = a` | none | **TS2722** | none |
| `exports.f(); … exports.f = a` (call before any assignment) | none | **TS2722**/TS2565 | none |
| `exports.f = undefined; exports.f()` (sole assignment) | TS2722 | TS2722 | TS2722 |
| `exports.f = a; exports.f()` | none | none | none |

Witness: `moduleExportDuplicateAlias`, whose expected diagnostic set is **empty**
and which tsz failed with a single extra TS2722.

## Relationship to #15950

Same root observation — tsz is position-sensitive where tsc is not — but a
different code path. #15950 narrowed TS2565 to function/class expando receivers;
this one fixes the *type* a CommonJS export read resolves to. They were measured
independently against the same baseline and neither subsumes the other.

An earlier attempt at this defect patched `merge_property_info` in
`query_boundaries/js_exports.rs`; a sentinel returning `NUMBER` for every merge
changed nothing, proving that function builds the cross-file export surface and
is not on this single-file path.

## Adjacent cases

`crates/tsz-checker/src/tests/commonjs_export_declaration_level_type_tests.rs`,
6 tests: `undefined`-then-function (plus a renamed variant), call before any
assignment, `undefined` as sole assignment still reporting, ordinary
assignment-before-use, and a non-callable export still reporting its own error
rather than being silenced.

## Verification

Local, on this branch's head; salsa re-run on the committed tree after a clippy
fixup.

| suite | before (main @ a0a880d2b1) | after |
|---|---|---|
| `conformance` (full) | 11378/12043 | **11379/12043** |
| `conformance --filter salsa` | 122/186 | **123/186** |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

Full-corpus failing sets diffed both ways — **1 fixed, 0 regressed**
(`conformance_salsa_moduleExportDuplicateAlias`).

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(commonjs_export_declaration_level_type)'   # 6 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold