### PR TITLE
fix(checker,solver): three canary-corpus inference and literal-shape fixes

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -672,11 +672,26 @@ impl<'a> CheckerState<'a> {
                     TypeId::UNDEFINED
                 } else if base_is_actual_lib_iterator && param_index == 2 {
                     TypeId::UNKNOWN
+                } else if let Some(default) = param.default {
+                    // A default may reference an EARLIER type parameter, as in
+                    // `class ZodType<Output, Def = ZodTypeDef, Input = Output>`.
+                    // Pushing it raw binds `Input` to the *parameter* `Output`
+                    // rather than to the supplied argument, so the inherited
+                    // member keeps type `=> Output` and no concrete override can
+                    // satisfy it (zod's `ZodNativeEnum` TS2416).
+                    //
+                    // Instantiate the default under the arguments bound so far.
+                    // `from_args` does this for genuinely-unsupplied parameters,
+                    // but pre-filling here makes every argument look explicit, so
+                    // that path never runs.
+                    let partial = TypeSubstitution::from_args(
+                        self.ctx.types,
+                        &base_type_params[..param_index],
+                        &type_args,
+                    );
+                    instantiate_type(self.ctx.types, default, &partial)
                 } else {
-                    param
-                        .default
-                        .or(param.constraint)
-                        .unwrap_or(TypeId::UNKNOWN)
+                    param.constraint.unwrap_or(TypeId::UNKNOWN)
                 };
                 type_args.push(fallback);
             }

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -1101,15 +1101,31 @@ impl<'a> CheckerState<'a> {
                 // For non-tuple spreads in array context, use element type.
                 // For tuple context, use the spread type itself. A `never` source
                 // is array-like with element type `never`.
+                // The literal's final shape is built from `tuple_elements` whenever
+                // any `force_tuple_*` flag is set, not only when `tuple_context`
+                // is present. Gating this push on `tuple_context` alone sent a
+                // spread into `element_types` while the shape was read back from
+                // an empty `tuple_elements`, so `let b: A | B = [...two]` (with
+                // `two: A | B` a union of tuples) typed as `[]`. The elided-hole
+                // path above already gates on the full flag set.
+                let force_tuple_shape = tuple_context.is_some()
+                    || force_tuple_for_union_context
+                    || force_tuple_for_mapped
+                    || force_tuple_for_constraint_hint
+                    || force_tuple_for_array_length_intersection
+                    || force_tuple_for_tuple_like;
+                // A forced-tuple shape keeps the spread source itself as the rest
+                // element (so a union of tuples stays a union), while the array
+                // path wants the iterated element type.
                 let elem_type = if spread_is_never {
                     TypeId::NEVER
-                } else if tuple_context.is_some() {
+                } else if force_tuple_shape {
                     spread_expr_type
                 } else {
                     self.for_of_element_type(spread_expr_type, false)
                 };
 
-                if tuple_context.is_some() || self.ctx.in_const_assertion {
+                if force_tuple_shape || self.ctx.in_const_assertion {
                     let rest_type = if self.ctx.in_const_assertion && tuple_context.is_none() {
                         array_surfaces::array_type(self.ctx.types, elem_type)
                     } else {

--- a/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
@@ -182,7 +182,24 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             // parameters like `T` must still count as usable evidence.
             let has_constraints = matches!(&constraints, Some(c) if !c.is_empty())
                 || infer_ctx.has_usable_contra_candidates(var, self.interner.as_type_database());
+            // A defaulted parameter prefers its default over bounds that were merely
+            // DECLARED on it (`<T extends A | B = B>` resolves to `B`, not to the
+            // constraint) — but only bounds the declaration actually introduced count.
+            // Requiring `tp.constraint.is_some()` is what makes the name honest: with no
+            // `extends` clause there are no declared upper bounds, so any upper bound
+            // present is real inference evidence and must not be discarded.
+            //
+            // `declare function mk<U = void>(f: (r: U) => void): Array<U>` used as
+            // `const p: Array<string> = mk((r) => ...)` seeds U from the contextual RETURN
+            // type (normalization.rs:976, `InferencePriority::ReturnType`). For a callback
+            // parameter position that candidate lands in UPPER bounds with no lower bound
+            // and no usable contra-candidate, so without this conjunct the whole candidate
+            // path was skipped and U silently became `void`. Dropping ` = void` made the
+            // same call resolve correctly, which is exactly the asymmetry this fixes.
+            // (`mk<U = void>(x?: U)` was already correct: a direct parameter position
+            // yields a LOWER bound, so the gate never fired for it.)
             let has_only_declared_upper_bounds = tp.default.is_some()
+                && tp.constraint.is_some()
                 && !infer_ctx.has_usable_contra_candidates(var, self.interner.as_type_database())
                 && constraints
                     .as_ref()


### PR DESCRIPTION
Goal: green

Three canary-corpus compiler fixes. Each is a distinct semantic operation with its own
minimal repro where `tsc` is clean and `tsz` errors; all three were found by shrinking a
canary row's diagnostic until a single token flipped the behaviour.

## 1. Heritage type-argument defaults are instantiated, not used raw

`extends` clauses pre-filled missing type arguments with `param.default` **verbatim**, which
made every argument look explicitly supplied, so `TypeSubstitution::from_args`'s defaulting
loop never ran. A default referencing an earlier parameter then leaked the raw parameter:

```ts
class ZodType<Output, Def = ZodTypeDef, Input = Output> {}
class Sub extends ZodType<string> {}   // Input leaked as the bare parameter `Output`
```

**Rule:** when a heritage clause omits a type argument whose declared default references an
earlier parameter, `tsc` instantiates that default against the arguments resolved so far;
`tsz` now does the same in `class_checker.rs` by building a partial substitution.

## 2. Array-literal spread respects every forced-tuple shape flag

The elided-hole path gated on the full `force_tuple_*` set, but the spread path checked only
`tuple_context`. With a **union** contextual type `tuple_context` is `None` while
`force_tuple_for_union_context` is set, so the spread pushed into `element_types` while the
final shape was read back from an empty `tuple_elements`:

```ts
type A = [x: 'set', n: number]; type B = [x: 'del', s: string]
declare const two: A | B
let b: A | B = [...two]      // was TS2322 "Type '[]' ..."; now clean
```

Two sites needed it — the push gate *and* the `elem_type` selection. Fixing only the gate
moved the result from `[]` to `string | number`, since a forced-tuple spread was still taking
its *iterated element* type.

## 3. A defaulted type parameter only prefers its default over DECLARED upper bounds

`has_only_declared_upper_bounds` (`generic_call/resolve/finalize.rs:185`) skipped the entire
inference-candidate path whenever a parameter had a default, had no usable contra-candidates,
and its constraint set held only upper bounds — but it never checked that a *declaration*
introduced those bounds. A candidate seeded from the call's contextual **return** type
(`normalization.rs:976`, `InferencePriority::ReturnType`) lands in upper bounds for a callback
parameter position, so genuine inference evidence was discarded in favour of the default:

```ts
declare function mk<U = void>(f: (r: U) => void): Array<U>;
const p: Array<string> = mk((r) => { const s: string = r; });
//  was: TS2322 'void[]' is not assignable to 'string[]'   now: clean (tsc agrees)
```

**Rule:** with no `extends` clause there are no declared upper bounds, so any upper bound
present is real evidence. Adding `tp.constraint.is_some()` makes the predicate mean its name.
`<T extends A | B = B>` still prefers `B` over its constraint — `normalization.rs:1241`
documents that case and **xstate** depends on it.

### Known limitation, deliberately not papered over

Fix 3 is **partial**. It covers contextual types that are concrete (`Array<string>`). When the
contextual type mentions an **outer type parameter** (`Array<T>`) the parameter still resolves
to `void`, which covers the real `new Promise` canary witness. The mechanism is identified:
`single_concrete_upper_bound` (`inference_helpers_higher_order.rs:232`) filters out any upper
bound where `contains_type_parameters` is true, so the bound `T` is rejected and the default
takes over; with no default the fallback is the open `__infer_N` placeholder instead, which is
why the no-default form is clean. That second layer is tracked with repros and is **not**
addressed here — so **no canary row goes green from this PR**.

## Verification

Run locally on this branch; conformance compared against a **same-base** baseline (a cross-base
comparison earlier in this work manufactured a phantom +15 that was entirely upstream JSDoc work).

- `./scripts/conformance/conformance.sh snapshot --workers 12 --force` — **11378 passed, 0 fixed /
  0 regressed**. Per-test churn checked via the tracked `conformance-baseline.txt` diff: all 54
  changed lines are JSDoc/salsa drift against a stale committed baseline; **nothing in
  generic-call inference moved**.
- `./scripts/emit/run.sh --skip-build` — **11562 JS / 1375 DTS**, exactly at floor.
- Targeted repros, each `tsc`-verified (run **individually** — two of these files together share a
  global scope and emit spurious TS2393/TS2403):
  - positives now clean: defaulted-param + concrete contextual type, union-of-tuples spread,
    heritage default referencing an earlier parameter
  - controls unchanged: no-default form; direct-parameter position (yields a *lower* bound, so the
    gate never fired); no-contextual-type defaults `<T = "off">` and `<U = string>` where the
    default must still win; non-union spread; union-of-arrays

**Re-verified after rebase.** The branch was rebased onto current `main` (3 upstream commits, clean
rebase, no conflicts) and everything above was re-run against that head: conformance **11382 passed**
and every repro/control behaves identically. The delta from the pre-rebase 11378 is the three
upstream commits, not this branch — these three fixes remain 0 fixed / 0 regressed, which is the
expected result for changes that fix shapes the conformance corpus does not exercise but the canary
corpus does.

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

