### PR TITLE
fix(checker): require-imported names are types only for direct class exports

### DIFF
--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -1535,11 +1535,13 @@ impl<'a> CheckerState<'a> {
         })
     }
 
-    fn resolve_jsdoc_commonjs_binding_element_type(
+    /// The `(module specifier, export name)` a destructured `require` binding
+    /// reads, e.g. `const { K: Local } = require("./mod")` -> `("./mod", "K")`.
+    fn jsdoc_require_binding_export_origin(
         &mut self,
         value_decl: NodeIndex,
         local_name: &str,
-    ) -> Option<TypeId> {
+    ) -> Option<(String, String)> {
         let node = self.ctx.arena.get(value_decl)?;
         if node.kind != SyntaxKind::Identifier as u16 {
             return None;
@@ -1571,6 +1573,43 @@ impl<'a> CheckerState<'a> {
         } else {
             local_name.to_string()
         };
+        Some((module_specifier, export_name))
+    }
+
+    /// Whether a destructured `require` binding names something usable as a
+    /// bare JSDoc **type**.
+    ///
+    /// `tsc` allows it only when the module's `exports.X = …` assigns a class
+    /// directly. A plain value (`exports.v = 1`), a function, or a value reached
+    /// through another object (`var NS = {}; NS.K = class {}; exports.K = NS.K`)
+    /// carries only a value meaning, and using the imported name as a type is
+    /// TS2749. The discriminator has to be syntactic: the direct and indirect
+    /// class exports above resolve to the *same* type, yet tsc accepts only the
+    /// direct one.
+    fn jsdoc_require_binding_supplies_type(
+        &mut self,
+        value_decl: NodeIndex,
+        local_name: &str,
+    ) -> bool {
+        let Some((module_specifier, export_name)) =
+            self.jsdoc_require_binding_export_origin(value_decl, local_name)
+        else {
+            return true;
+        };
+        self.commonjs_named_export_assigns_a_class(
+            &module_specifier,
+            &export_name,
+            Some(self.ctx.current_file_idx),
+        )
+    }
+
+    fn resolve_jsdoc_commonjs_binding_element_type(
+        &mut self,
+        value_decl: NodeIndex,
+        local_name: &str,
+    ) -> Option<TypeId> {
+        let (module_specifier, export_name) =
+            self.jsdoc_require_binding_export_origin(value_decl, local_name)?;
 
         // TS7: `module.exports = { X }` object-literal members carry only value
         // meaning. A require-destructured binding of such a member is not a type
@@ -1744,14 +1783,18 @@ impl<'a> CheckerState<'a> {
                     symbol.escaped_name.as_str(),
                 )
             {
-                // TS7 dropped constructor-function inference: a binding whose
-                // resolved export is a plain function (call signatures — a
-                // class constructor type has only construct signatures) has
-                // no meaning as a bare JSDoc type; failing here routes the
-                // reference to the TS2749 value-used-as-type terminal.
+                // A `require()`-imported binding names a TYPE only when the
+                // module assigns a class directly to that export. TS7 also
+                // dropped constructor-function inference, so an expando-exported
+                // plain function is a value too. Failing here routes the
+                // reference to the TS2749 value-used-as-type terminal;
                 // `typeof` queries (ValuePosition) still get the value type.
                 if mode == JsdocNameMode::BareTypeReference
-                    && self.jsdoc_value_is_plain_callable(instance_type)
+                    && (self.jsdoc_value_is_plain_callable(instance_type)
+                        || !self.jsdoc_require_binding_supplies_type(
+                            symbol.value_declaration,
+                            symbol.escaped_name.as_str(),
+                        ))
                 {
                     return TypeId::ERROR;
                 }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -196,6 +196,9 @@ mod comlink_row_regression_tests;
 #[path = "tests/commonjs_export_declaration_level_type_tests.rs"]
 mod commonjs_export_declaration_level_type_tests;
 #[cfg(test)]
+#[path = "tests/commonjs_require_binding_type_meaning_tests.rs"]
+mod commonjs_require_binding_type_meaning_tests;
+#[cfg(test)]
 #[path = "../tests/comparability_indexed_access_reduce_tests.rs"]
 mod comparability_indexed_access_reduce_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/js_exports_named_class.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports_named_class.rs
@@ -1,0 +1,137 @@
+//! Does a CommonJS named export assign a class?
+//!
+//! Split out of `js_exports.rs` to keep that file under the 2000-line cap. The
+//! question is syntactic on purpose: a direct `exports.K = class {}` and an
+//! indirect `exports.K = NS.K` resolve to the same type, yet only the direct
+//! form gives the export a type meaning in `tsc`.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
+use tsz_scanner::SyntaxKind;
+
+impl<'a> CheckerState<'a> {
+    /// Whether the target module assigns a **class** directly to
+    /// `exports.<export_name>` (or `module.exports.<export_name>`).
+    ///
+    /// Only that gives the export a type meaning for a bare JSDoc reference:
+    /// `exports.K = class {}` and `class K {} … exports.K = K` do, while
+    /// `exports.v = 1`, `exports.f = function () {}` and an indirect
+    /// `exports.K = NS.K` do not — `tsc` reports TS2749 for those. The check is
+    /// syntactic because the direct and indirect class exports resolve to the
+    /// same type.
+    ///
+    /// Returns `true` when no such assignment is found, leaving other resolution
+    /// paths (`module.exports = …`, re-exports, `.d.ts` targets) untouched.
+    pub(crate) fn commonjs_named_export_assigns_a_class(
+        &self,
+        module_name: &str,
+        export_name: &str,
+        source_file_idx: Option<usize>,
+    ) -> bool {
+        let Some(target_file_idx) = source_file_idx
+            .and_then(|file_idx| {
+                self.ctx
+                    .resolve_import_target_from_file(file_idx, module_name)
+            })
+            .or_else(|| self.ctx.resolve_import_target(module_name))
+        else {
+            return true;
+        };
+        let target_arena = self.ctx.get_arena_for_file(target_file_idx as u32);
+        let Some(source_file) = target_arena.source_files.first() else {
+            return true;
+        };
+
+        let mut found_assignment = false;
+        let mut assigns_class = false;
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = target_arena.get(stmt_idx) else {
+                continue;
+            };
+            if stmt_node.kind != syntax_kind_ext::EXPRESSION_STATEMENT {
+                continue;
+            }
+            let Some(stmt) = target_arena.get_expression_statement(stmt_node) else {
+                continue;
+            };
+            let Some(expr_node) = target_arena.get(stmt.expression) else {
+                continue;
+            };
+            if expr_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+                continue;
+            }
+            let Some(binary) = target_arena.get_binary_expr(expr_node) else {
+                continue;
+            };
+            if binary.operator_token != SyntaxKind::EqualsToken as u16 {
+                continue;
+            }
+            // `exports.<name>` / `module.exports.<name>`
+            let Some(lhs_node) = target_arena.get(binary.left) else {
+                continue;
+            };
+            if lhs_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+                continue;
+            }
+            let Some(lhs) = target_arena.get_access_expr(lhs_node) else {
+                continue;
+            };
+            if target_arena
+                .get_identifier_at(lhs.name_or_argument)
+                .is_none_or(|ident| ident.escaped_text != export_name)
+            {
+                continue;
+            }
+            // Either `exports.X = …` (bare identifier) or `module.exports.X = …`.
+            let receiver_is_exports = target_arena
+                .get_identifier_at(lhs.expression)
+                .is_some_and(|ident| ident.escaped_text == "exports")
+                || Self::is_module_exports_target_in_arena(target_arena, lhs.expression);
+            if !receiver_is_exports {
+                continue;
+            }
+
+            found_assignment = true;
+            assigns_class = Self::commonjs_export_rhs_is_class_in_arena(target_arena, binary.right);
+        }
+
+        if found_assignment {
+            assigns_class
+        } else {
+            true
+        }
+    }
+
+    /// Whether an `exports.X = <rhs>` right-hand side is a class: a class
+    /// expression, or a bare identifier naming a class declared in the same
+    /// file. A property access (`NS.K`) is deliberately excluded.
+    fn commonjs_export_rhs_is_class_in_arena(
+        arena: &tsz_parser::parser::node::NodeArena,
+        rhs_idx: NodeIndex,
+    ) -> bool {
+        let Some(rhs) = arena.get(rhs_idx) else {
+            return false;
+        };
+        if rhs.kind == syntax_kind_ext::CLASS_EXPRESSION {
+            return true;
+        }
+        if rhs.kind != SyntaxKind::Identifier as u16 {
+            return false;
+        }
+        let Some(name) = arena.get_identifier(rhs).map(|i| i.escaped_text.clone()) else {
+            return false;
+        };
+        let Some(source_file) = arena.source_files.first() else {
+            return false;
+        };
+        source_file.statements.nodes.iter().any(|&stmt_idx| {
+            arena.get(stmt_idx).is_some_and(|stmt| {
+                stmt.kind == syntax_kind_ext::CLASS_DECLARATION
+                    && arena
+                        .get_class(stmt)
+                        .and_then(|class| arena.get_identifier_at(class.name))
+                        .is_some_and(|ident| ident.escaped_text == name)
+            })
+        })
+    }
+}

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -49,6 +49,7 @@ pub(crate) mod interface_merge;
 pub(crate) mod intersection_display;
 pub(crate) mod js_exports;
 mod js_exports_json;
+pub(crate) mod js_exports_named_class;
 pub(crate) mod jsdoc_construction;
 pub(crate) mod key_constraints;
 pub(crate) mod lib_augmentations;

--- a/crates/tsz-checker/src/tests/commonjs_require_binding_type_meaning_tests.rs
+++ b/crates/tsz-checker/src/tests/commonjs_require_binding_type_meaning_tests.rs
@@ -1,0 +1,85 @@
+//! When a `require()`-imported binding may be used as a JSDoc **type**.
+//!
+//! `tsc` allows it only when the module assigns a class directly to that
+//! export. A plain value, a function, or a value reached through another object
+//! carries only a value meaning, and using the imported name as a type is
+//! TS2749.
+//!
+//! The discriminator has to be **syntactic**: `exports.K = class {}` and
+//! `var NS = {}; NS.K = class {}; exports.K = NS.K` resolve to the *same* type,
+//! yet tsc accepts only the first. Verified against the pinned tsc 7.0.2.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_multi_file_with_libs_stamped, load_lib_files};
+
+fn js_codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        ..CheckerOptions::default()
+    };
+    check_multi_file_with_libs_stamped(files, entry, options, &load_lib_files(&["es5.d.ts"]))
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+const VALUE_USED_AS_TYPE: u32 = 2749;
+
+const USE: &str =
+    "const { K } = require('./mod.js');\n/** @param {K} k */\nfunction f(k) { return k }\nf\n";
+
+fn reports(module_src: &str) -> bool {
+    js_codes(&[("mod.js", module_src), ("use.js", USE)], "use.js").contains(&VALUE_USED_AS_TYPE)
+}
+
+// --- Direct class export: usable as a type. ---
+
+#[test]
+fn direct_class_expression_export_is_a_type() {
+    assert!(!reports("exports.K = class { m() { } };\n"));
+}
+
+#[test]
+fn direct_class_declaration_export_is_a_type() {
+    assert!(!reports("class K { m() { } }\nexports.K = K;\n"));
+}
+
+#[test]
+fn module_exports_receiver_is_also_accepted() {
+    assert!(!reports("class K { m() { } }\nmodule.exports.K = K;\n"));
+}
+
+// The indirect shapes (`var NS = {}; NS.K = class {}; exports.K = NS.K`) are
+// covered by the conformance witness `commonJSImportNestedClassTypeReference`
+// and by direct CLI verification against tsc; this multi-file unit harness does
+// not resolve that cross-file expando chain, so asserting it here would pass
+// vacuously.
+
+// --- Non-class exports are value-only however they are written. ---
+
+#[test]
+fn direct_value_export_is_value_only() {
+    assert!(reports("exports.K = 1;\n"));
+}
+
+#[test]
+fn indirect_value_export_is_value_only() {
+    assert!(reports("var NS = {}\nNS.K = 1;\nexports.K = NS.K;\n"));
+}
+
+#[test]
+fn function_export_is_value_only() {
+    assert!(reports("exports.K = function () { };\n"));
+}
+
+// --- A renamed binding element resolves through its property name. ---
+
+/// The direct form still resolves under a renamed binding.
+#[test]
+fn renamed_binding_element_accepts_a_direct_class() {
+    let module_src = "exports.K = class { m() { } };\n";
+    let use_src = "const { K: Local } = require('./mod.js');\n/** @param {Local} k */\nfunction f(k) { return k }\nf\n";
+    let codes = js_codes(&[("mod.js", module_src), ("use.js", use_src)], "use.js");
+    assert!(!codes.contains(&VALUE_USED_AS_TYPE));
+}


### PR DESCRIPTION
## Structural rule

A `require()`-imported binding used as a **bare JSDoc type** resolved to the
value's type, so `const { v } = require('./m'); /** @param {v} x */` silently
meant `typeof v`. `tsc` reports TS2749 there — the name carries a value meaning
only.

An export names a TYPE only when the module assigns a class **directly**:
`exports.K = class {}`, or `class K {} … exports.K = K`. A plain value, a
function, or a value reached through another object
(`var NS = {}; NS.K = class {}; exports.K = NS.K`) does not.

## Why the check is syntactic

The direct and indirect class exports resolve to the **same type**, yet tsc
accepts only the direct one — so no type-based predicate can separate them. A
first attempt keyed on `has_construct_signatures` fixed all four value/indirect
cases but rejected `exports.K = class {}`, which tsc accepts (the helper returns
the class *instance* type, which has no construct signatures).

`commonjs_named_export_assigns_a_class` therefore walks the target module for
`exports.X = <rhs>` / `module.exports.X = <rhs>` and requires `<rhs>` to be a
class expression or an identifier naming a class declared in that file. When no
such assignment exists it answers `true`, leaving `module.exports = …`,
re-exports and `.d.ts` targets untouched.

## Behaviour, verified against the pinned tsc 7.0.2

Consumer in every row: `const { K } = require('./mod'); /** @param {K} k */`

| module | tsc | tsz before | after |
|---|---|---|---|
| `exports.K = class {}` | none | none | none |
| `class K {} … exports.K = K` | none | none | none |
| `var NS={}; NS.K = class {}; exports.K = NS.K` | TS2749 | **none** | TS2749 |
| `class K {} … NS.K = K; exports.K = NS.K` | TS2749 | **none** | TS2749 |
| `var NS={}; NS.v = 1; exports.v = NS.v` | TS2749 | **none** | TS2749 |
| `exports.v = 1` | TS2749 | **none** | TS2749 |

All six now match. Witness: `commonJSImportNestedClassTypeReference`.

## Adjacent cases

`crates/tsz-checker/src/tests/commonjs_require_binding_type_meaning_tests.rs`,
7 tests: direct class expression / class declaration / `module.exports.K`
receiver accepted; direct value, indirect value and function export reporting;
and a renamed binding element (`{ K: Local }`) resolving through its property
name.

The two indirect **class** shapes are covered by the conformance witness and by
the CLI verification above rather than here: this multi-file unit harness does
not resolve that cross-file expando chain, so asserting it would pass vacuously.
The harness does resolve direct exports — `direct_value_export_is_value_only`
genuinely reports — so the direct-class negatives are meaningful.

## Verification

Local, on this branch's head; salsa and the two decisive repros re-run on the
committed tree after the module split. Baseline rebuilt from this branch's merge
base rather than reused, since main moved.

| suite | before | after |
|---|---|---|
| `conformance` (full) | 11382/12043 | **11383/12043** |
| `conformance --filter salsa` | 124/186 | **125/186** |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

Full-corpus failing sets diffed both ways — **1 fixed, 0 regressed**
(`conformance_salsa_commonJSImportNestedClassTypeReference`).

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(commonjs_require_binding_type_meaning)'   # 7 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold