### PR TITLE
fix(checker): exports/module used as a JSDoc type are values

### DIFF
--- a/crates/tsz-checker/src/jsdoc/base_types.rs
+++ b/crates/tsz-checker/src/jsdoc/base_types.rs
@@ -717,8 +717,17 @@ impl<'a> CheckerState<'a> {
                     // even if the checker's type system doesn't create a
                     // user-land binding for them.  tsc does not flag them
                     // as "Cannot find name" in JSDoc @type contexts.
+                    // `exports`, `module`, `require`, `global` are CommonJS
+                    // built-ins that resolve at runtime even without a
+                    // user-land binding, so tsc does not flag them as
+                    // "Cannot find name". It does report `exports`/`module`
+                    // as TS2749 once the file assigns to them — they are the
+                    // module object, a value — so let those reach the emitter,
+                    // which picks TS2749 for a value used as a type.
                     || (self.ctx.is_js_file()
-                        && matches!(expr, "exports" | "module" | "require" | "global"));
+                        && (matches!(expr, "require" | "global")
+                            || (matches!(expr, "exports" | "module")
+                                && !self.current_file_has_commonjs_export_assignment())));
                 if !skip_cannot_find_name {
                     self.emit_jsdoc_cannot_find_name(expr, comment.pos, comment.end, &source_text);
                 } else if !Self::is_simple_type_name(expr) && !expr.is_empty() {
@@ -900,7 +909,15 @@ impl<'a> CheckerState<'a> {
 
         // A name that resolves to a value (function, variable, …) but not a type
         // is a "value used as a type" error (TS2749), not a missing name (TS2304).
-        if self.jsdoc_name_refers_to_value_only(name) {
+        //
+        // `exports`/`module` are values in a file that assigns to them — the
+        // module object. Their symbol carries the MODULE flag, which
+        // `jsdoc_name_refers_to_value_only` deliberately excludes, so name them
+        // here rather than loosening that predicate for real namespaces.
+        let is_commonjs_module_value = self.is_js_file()
+            && matches!(name, "exports" | "module")
+            && self.current_file_has_commonjs_export_assignment();
+        if is_commonjs_module_value || self.jsdoc_name_refers_to_value_only(name) {
             let code = diagnostic_codes::REFERS_TO_A_VALUE_BUT_IS_BEING_USED_AS_A_TYPE_HERE_DID_YOU_MEAN_TYPEOF;
             let template = tsz_common::diagnostics::get_message_template(code)
                 .unwrap_or("'{0}' refers to a value, but is being used as a type here. Did you mean 'typeof {0}'?");

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -397,6 +397,9 @@ mod jsdoc_bare_import_type_tests;
 #[path = "tests/jsdoc_closure_function_type_tests.rs"]
 mod jsdoc_closure_function_type_tests;
 #[cfg(test)]
+#[path = "tests/jsdoc_commonjs_globals_as_type_tests.rs"]
+mod jsdoc_commonjs_globals_as_type_tests;
+#[cfg(test)]
 #[path = "tests/jsdoc_import_type_constraints_relation_routing_arch_tests.rs"]
 mod jsdoc_import_type_constraints_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
@@ -11,6 +11,67 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// Whether the current file gives `exports` / `module.exports` a value
+    /// meaning by assigning to them.
+    ///
+    /// `tsc` reports `/** @type {exports} */` as TS2749 (a value used as a
+    /// type) once such an assignment exists, and as TS2304 (cannot find name)
+    /// when it does not — the CommonJS globals only become values in a module
+    /// that actually exports.
+    pub(crate) fn current_file_has_commonjs_export_assignment(&self) -> bool {
+        use tsz_parser::parser::syntax_kind_ext;
+        use tsz_scanner::SyntaxKind;
+
+        let Some(source_file) = self.ctx.arena.source_files.first() else {
+            return false;
+        };
+        let arena = &self.ctx.arena;
+        let names_exports_root = |idx: tsz_parser::parser::NodeIndex| -> bool {
+            arena.get_identifier_at(idx).is_some_and(|ident| {
+                ident.escaped_text == "exports" || ident.escaped_text == "module"
+            })
+        };
+        source_file.statements.nodes.iter().any(|&stmt_idx| {
+            let Some(stmt_node) = arena.get(stmt_idx) else {
+                return false;
+            };
+            if stmt_node.kind != syntax_kind_ext::EXPRESSION_STATEMENT {
+                return false;
+            }
+            let Some(stmt) = arena.get_expression_statement(stmt_node) else {
+                return false;
+            };
+            let Some(expr_node) = arena.get(stmt.expression) else {
+                return false;
+            };
+            if expr_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+                return false;
+            }
+            let Some(binary) = arena.get_binary_expr(expr_node) else {
+                return false;
+            };
+            if binary.operator_token != SyntaxKind::EqualsToken as u16 {
+                return false;
+            }
+            // `exports = …`, `module.exports = …`, `exports.X = …`,
+            // `module.exports.X = …` — walk the assignment target to its root.
+            let mut root = binary.left;
+            for _ in 0..4 {
+                let Some(node) = arena.get(root) else {
+                    return false;
+                };
+                if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+                    break;
+                }
+                let Some(access) = arena.get_access_expr(node) else {
+                    return false;
+                };
+                root = access.expression;
+            }
+            names_exports_root(root)
+        })
+    }
+
     pub(crate) fn current_source_file_has_esm_syntax(&self) -> bool {
         self.source_file_idx_has_esm_syntax(self.ctx.current_file_idx)
     }

--- a/crates/tsz-checker/src/tests/jsdoc_commonjs_globals_as_type_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_commonjs_globals_as_type_tests.rs
@@ -1,0 +1,72 @@
+//! `exports` / `module` used as a JSDoc type in a CommonJS file.
+//!
+//! Those names are the module object — a value — in a file that assigns to
+//! them, so `tsc` reports TS2749 "refers to a value, but is being used as a
+//! type here". Without any export assignment they are not values either, and
+//! tsc reports a cannot-find-name variant instead; tsz leaves that case alone.
+//!
+//! Verified against the pinned tsc 7.0.2 (`--allowJs --checkJs`):
+//!
+//! ```text
+//! module.exports = {}   /** @type {exports} */ var x   -> TS2749
+//! module.exports = {}   /** @type {module}  */ var x   -> TS2749
+//! ```
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn js_codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.js", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+const VALUE_USED_AS_TYPE: u32 = 2749;
+
+#[test]
+fn exports_as_a_type_reports_when_the_file_exports() {
+    let source = "module.exports = {}\n/**\n * @type {exports}\n */\nvar x\n";
+    assert!(js_codes(source).contains(&VALUE_USED_AS_TYPE));
+}
+
+#[test]
+fn module_as_a_type_reports_when_the_file_exports() {
+    let source = "module.exports = {}\n/**\n * @type {module}\n */\nvar x\n";
+    assert!(js_codes(source).contains(&VALUE_USED_AS_TYPE));
+}
+
+/// A named export assignment counts as well as a whole-module one.
+#[test]
+fn named_export_assignment_also_makes_exports_a_value() {
+    let source = "exports.a = 1\n/**\n * @type {exports}\n */\nvar x\n";
+    assert!(js_codes(source).contains(&VALUE_USED_AS_TYPE));
+}
+
+/// Without an export assignment the names are not values; this path is left to
+/// the existing cannot-find-name handling and must not report TS2749.
+#[test]
+fn exports_without_an_export_assignment_is_not_value_used_as_type() {
+    let source = "/**\n * @type {exports}\n */\nvar x\n";
+    assert!(!js_codes(source).contains(&VALUE_USED_AS_TYPE));
+}
+
+/// An ordinary local value used as a type keeps reporting — the new branch must
+/// not shadow the general predicate.
+#[test]
+fn local_value_used_as_a_type_still_reports() {
+    let source = "var v = 1\n/**\n * @type {v}\n */\nvar y\n";
+    assert!(js_codes(source).contains(&VALUE_USED_AS_TYPE));
+}
+
+/// A real type is still accepted in the same file shape.
+#[test]
+fn a_genuine_type_is_still_accepted() {
+    let source = "module.exports = {}\n/**\n * @typedef {number} Num\n */\n/**\n * @type {Num}\n */\nvar x\n";
+    assert!(!js_codes(source).contains(&VALUE_USED_AS_TYPE));
+}


### PR DESCRIPTION
## Structural rule

`/** @type {exports} */` produced no diagnostic. In a file that assigns to
`exports` or `module.exports`, those names are the module object — a **value** —
and `tsc` reports TS2749 "refers to a value, but is being used as a type here".

## Two blockers

**The CommonJS skip list.** `jsdoc/base_types.rs` treated all four built-ins
(`exports`, `module`, `require`, `global`) as never-reportable, justified by "tsc
does not flag them as Cannot find name". That is true, and it is also
incomplete: tsc reports the first two as TS2749. The list now lets
`exports`/`module` reach the emitter once the file actually exports.

**The value-only predicate.** `jsdoc_name_refers_to_value_only` requires
`VALUE && !(TYPE | MODULE)`, and the `exports` symbol carries MODULE, so the
emitter fell through to TS2304. The new branch names `exports`/`module`
directly rather than loosening that predicate, which would also have changed
behaviour for real namespaces.

`current_file_has_commonjs_export_assignment` supplies the "does this file
export" test by walking assignment targets to their root, covering
`exports = …`, `module.exports = …`, `exports.X = …` and `module.exports.X = …`.

## Behaviour, verified against the pinned tsc 7.0.2

| source (`--allowJs --checkJs`) | tsc | tsz before | after |
|---|---|---|---|
| `module.exports = {}` + `@type {exports}` | TS2749 | **none** | TS2749 |
| `module.exports = {}` + `@type {module}` | TS2749 | **none** | TS2749 |
| `exports.a = 1` + `@type {exports}` | TS2749 | **none** | TS2749 |
| local `var v = 1` + `@type {v}` | TS2749 | TS2749 | TS2749 |

Witness: `jsdocTypeReferenceExports`.

## Deliberately not addressed

tsc reports cannot-find-name variants that tsz still does not emit, and this
change does not touch them:

| source | tsc | tsz |
|---|---|---|
| `@type {require}` | TS2552 (did you mean `Required`?) | none |
| `@type {global}` | TS2304 | none |
| `@type {exports}`, no export assignment | TS2304 | none |
| `@type {module}`, no export assignment | TS2591 (`@types/node`) | none |

They keep the existing skip-list behaviour rather than being widened here; the
measured table is recorded for follow-up.

## Adjacent cases

`crates/tsz-checker/src/tests/jsdoc_commonjs_globals_as_type_tests.rs`, 6 tests:
`exports` and `module` reporting with a whole-module assignment, a named export
assignment also counting, the no-export-assignment case explicitly NOT reporting
TS2749, an ordinary local value still reporting, and a genuine `@typedef` still
accepted in the same file shape.

## Verification

Local, on this branch's head; jsdoc re-run on the committed tree. Baseline
rebuilt from this branch's merge base rather than reused, since main moved.

| suite | before | after |
|---|---|---|
| `conformance` (full) | 11382/12043 | **11383/12043** |
| `conformance --filter jsdoc` | 293/368 | **294/368** |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

Full-corpus failing sets diffed both ways — **1 fixed, 0 regressed**
(`conformance_jsdoc_jsdocTypeReferenceExports`).

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(jsdoc_commonjs_globals_as_type)'   # 6 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold