### PR TITLE
fix(checker): TS1340 for a bare import as a @typedef base

### DIFF
--- a/crates/tsz-checker/src/jsdoc/base_types.rs
+++ b/crates/tsz-checker/src/jsdoc/base_types.rs
@@ -487,6 +487,36 @@ impl<'a> CheckerState<'a> {
                     if expr == "Object" || expr == "object" || expr.is_empty() {
                         continue;
                     }
+                    // A bare `import('mod')` as a typedef base follows the same
+                    // rule as in `@param`/`@return`: it names the module's
+                    // exported type, and a module without one is TS1340.
+                    // Witness: jsdocTypeReferenceToImportOfFunctionExpression,
+                    // whose module exports a plain function.
+                    let typedef_comment_text = comment.get_text(&source_text);
+                    // Only a real `@typedef` base. An `@import` tag also carries a
+                    // module specifier but is a value import, not a type
+                    // reference, and must not be flagged (witness: importTag2/3/9/…).
+                    if Self::jsdoc_tag_offset(typedef_comment_text, "typedef").is_some()
+                        && let Some(offset_in_comment) = typedef_comment_text.find(expr)
+                        && let Some((module_specifier, None)) = Self::parse_jsdoc_import_type(expr)
+                        && !self.bare_import_type_names_a_type(
+                            &module_specifier,
+                            Self::jsdoc_import_type_resolution_mode(expr),
+                        )
+                    {
+                        let anchor = comment.pos + offset_in_comment as u32;
+                        let message = crate::diagnostics::format_message(
+                            crate::diagnostics::diagnostic_messages::MODULE_DOES_NOT_REFER_TO_A_TYPE_BUT_IS_USED_AS_A_TYPE_HERE_DID_YOU_MEAN_TYPEOF_I,
+                            &[&module_specifier],
+                        );
+                        self.error_at_position(
+                            anchor,
+                            expr.len() as u32,
+                            &message,
+                            crate::diagnostics::diagnostic_codes::MODULE_DOES_NOT_REFER_TO_A_TYPE_BUT_IS_USED_AS_A_TYPE_HERE_DID_YOU_MEAN_TYPEOF_I,
+                        );
+                        continue;
+                    }
                     // TS2344: Check constraint satisfaction for import type refs with generics.
                     // e.g., @typedef {import('./file1').Foo<T>} Bar
                     if expr.starts_with("import(")

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -427,6 +427,9 @@ mod jsdoc_template_reference_scope_tests;
 #[path = "../tests/jsdoc_this_arrow_tests.rs"]
 mod jsdoc_this_arrow_tests;
 #[cfg(test)]
+#[path = "tests/jsdoc_typedef_bare_import_tests.rs"]
+mod jsdoc_typedef_bare_import_tests;
+#[cfg(test)]
 #[path = "../tests/jsx_component_attribute_tests.rs"]
 mod jsx_component_attribute_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/js_exports_named_class.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports_named_class.rs
@@ -102,6 +102,70 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Whether the target module assigns a **class** to `module.exports`
+    /// (or bare `exports`) as a whole-module export.
+    ///
+    /// A JS module has no TypeScript `export =`, so this is how
+    /// `module.exports = class {}` / `class C {} module.exports = C` gives the
+    /// module a type meaning for a bare `import('./m')`. A function export does
+    /// not: TS7 dropped constructor-function inference, and `tsc` reports
+    /// TS1340 for `@typedef {import('./m')}` when the module exports a plain
+    /// function.
+    pub(crate) fn commonjs_whole_module_export_assigns_a_class(
+        &self,
+        module_name: &str,
+        source_file_idx: Option<usize>,
+    ) -> bool {
+        let Some(target_file_idx) = source_file_idx
+            .and_then(|file_idx| {
+                self.ctx
+                    .resolve_import_target_from_file(file_idx, module_name)
+            })
+            .or_else(|| self.ctx.resolve_import_target(module_name))
+        else {
+            return false;
+        };
+        let target_arena = self.ctx.get_arena_for_file(target_file_idx as u32);
+        let Some(source_file) = target_arena.source_files.first() else {
+            return false;
+        };
+
+        let mut assigns_class = false;
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = target_arena.get(stmt_idx) else {
+                continue;
+            };
+            if stmt_node.kind != syntax_kind_ext::EXPRESSION_STATEMENT {
+                continue;
+            }
+            let Some(stmt) = target_arena.get_expression_statement(stmt_node) else {
+                continue;
+            };
+            let Some(expr_node) = target_arena.get(stmt.expression) else {
+                continue;
+            };
+            if expr_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+                continue;
+            }
+            let Some(binary) = target_arena.get_binary_expr(expr_node) else {
+                continue;
+            };
+            if binary.operator_token != SyntaxKind::EqualsToken as u16 {
+                continue;
+            }
+            let targets_whole_module =
+                Self::is_module_exports_target_in_arena(target_arena, binary.left)
+                    || target_arena
+                        .get_identifier_at(binary.left)
+                        .is_some_and(|ident| ident.escaped_text == "exports");
+            if !targets_whole_module {
+                continue;
+            }
+            assigns_class = Self::commonjs_export_rhs_is_class_in_arena(target_arena, binary.right);
+        }
+        assigns_class
+    }
+
     /// Whether an `exports.X = <rhs>` right-hand side is a class: a class
     /// expression, or a bare identifier naming a class declared in the same
     /// file. A property access (`NS.K`) is deliberately excluded.

--- a/crates/tsz-checker/src/state/type_resolution/import_type_meaning.rs
+++ b/crates/tsz-checker/src/state/type_resolution/import_type_meaning.rs
@@ -76,6 +76,15 @@ impl<'a> CheckerState<'a> {
         // type meaning alongside its value meaning, so `class Conn {}
         // export = Conn` is a valid bare import type. A plain `var` or
         // `function` export does not, and tsc reports TS1340 for it.
+        // A JS module has no `export =`; `module.exports = class {}` is how it
+        // supplies a type for a bare `import('./m')`.
+        if self.commonjs_whole_module_export_assigns_a_class(
+            module_name,
+            Some(self.ctx.current_file_idx),
+        ) {
+            return true;
+        }
+
         file_export_equals.unwrap_or(false)
             || self.is_module_export_equals_type_only(module_name)
             || ambient_export_equals_sym.is_some_and(|sym_id| {

--- a/crates/tsz-checker/src/tests/jsdoc_typedef_bare_import_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_typedef_bare_import_tests.rs
@@ -1,0 +1,83 @@
+//! TS1340 for a bare `import('mod')` as a `@typedef` base.
+//!
+//! A bare import type names the module's exported type. A TypeScript module
+//! supplies one through `export =`; a JS module does so by assigning a class to
+//! `module.exports`. A module that exports a plain function or a value does not,
+//! and `tsc` reports TS1340.
+//!
+//! `@import` tags also carry a module specifier but are value imports, not type
+//! references, and must never be flagged.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_multi_file_with_libs_stamped, load_lib_files};
+
+fn js_codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        ..CheckerOptions::default()
+    };
+    check_multi_file_with_libs_stamped(files, entry, options, &load_lib_files(&["es5.d.ts"]))
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+const MODULE_IS_NOT_A_TYPE: u32 = 1340;
+
+const TYPEDEF_USE: &str =
+    "/** @typedef {import('./mod.js')} M */\n/** @param {M} m */\nfunction f(m) { return m }\nf\n";
+
+fn reports(module_src: &str) -> bool {
+    js_codes(&[("mod.js", module_src), ("use.js", TYPEDEF_USE)], "use.js")
+        .contains(&MODULE_IS_NOT_A_TYPE)
+}
+
+// --- A JS module exporting a class supplies a type. ---
+
+#[test]
+fn module_exports_class_expression_is_a_type() {
+    assert!(!reports("module.exports = class { m() { } };\n"));
+}
+
+#[test]
+fn module_exports_class_declaration_is_a_type() {
+    assert!(!reports("class C { m() { } }\nmodule.exports = C;\n"));
+}
+
+// --- A function or value export does not. ---
+
+/// Witness `jsdocTypeReferenceToImportOfFunctionExpression`.
+#[test]
+fn module_exports_function_expression_is_not_a_type() {
+    assert!(reports("module.exports = function MC() { };\n"));
+}
+
+#[test]
+fn module_exports_value_is_not_a_type() {
+    assert!(reports("module.exports = 1;\n"));
+}
+
+// --- `@import` tags are value imports and must not be flagged. ---
+
+#[test]
+fn import_tag_is_never_flagged() {
+    let files = [
+        ("types.js", "module.exports = 1;\n"),
+        (
+            "use.js",
+            "/** @import { Thing } from './types.js' */\nvar x = 1;\nx\n",
+        ),
+    ];
+    assert!(!js_codes(&files, "use.js").contains(&MODULE_IS_NOT_A_TYPE));
+}
+
+/// A typedef whose base is not an import is unaffected.
+#[test]
+fn non_import_typedef_base_is_unaffected() {
+    let files = [(
+        "use.js",
+        "/** @typedef {number} Num */\n/** @param {Num} n */\nfunction f(n) { return n }\nf\n",
+    )];
+    assert!(!js_codes(&files, "use.js").contains(&MODULE_IS_NOT_A_TYPE));
+}


### PR DESCRIPTION
## Structural rule

`@typedef {import('./m')}` was never checked, so a module that does not export a
type went unreported. `tsc` reports TS1340 there, exactly as it does for the
same bare import in `@param`/`@return` (fixed in #15942/#15943).

## Two things had to be right first

**A JS module has no TypeScript `export =`.** `bare_import_type_names_a_type`
was written around that declaration, so it rejected *every* JS module —
including those that genuinely supply a type via `module.exports = class {}`.
It now also accepts that shape, through
`commonjs_whole_module_export_assigns_a_class`, preserving the asymmetry tsc
has: a **class** export supplies a type, a **function** export does not.

This is why the earlier attempt at the typedef path measured +2/-11: it flagged
`jsdocTypeReferenceToImportOfClassExpression` and friends, whose modules export
classes.

**The branch must fire only for a real `@typedef`.** An `@import` tag also
carries a module specifier but is a value import, not a type reference. Without
that gate it flagged eight `importTag*` tests, anchored at column 1 because the
expression was not found in the comment — the tell that the tag was the wrong
kind.

## Behaviour, verified against the pinned tsc 7.0.2

Consumer: `/** @typedef {import('./mod.js')} M */ /** @param {M} m */`

| module | tsc | tsz before | after |
|---|---|---|---|
| `module.exports = class {}` | none | none | none |
| `class C {} module.exports = C` | none | none | none |
| `module.exports = function MC() {}` | TS1340 | **none** | TS1340 |
| `module.exports = 1` | TS1340 | **none** | TS1340 |
| `/** @import { T } from './m' */` | none | none | none |

Witnesses: `jsdocTypeReferenceToImportOfFunctionExpression` and
`jsDeclarationsParameterTagReusesInputNodeInEmit1`.

## Adjacent cases

`crates/tsz-checker/src/tests/jsdoc_typedef_bare_import_tests.rs`, 6 tests:
class-expression and class-declaration whole-module exports accepted;
function-expression and value exports reporting; an `@import` tag never flagged;
and a non-import `@typedef` base unaffected.

## Verification

Local, on this branch's head; jsdoc re-run on the committed tree after a clippy
fixup. Baseline measured from a clean `main` checkout rather than a stash.

| suite | before (main @ 2a78147d88) | after |
|---|---|---|
| `conformance` (full) | 11383/12043 | **11385/12043** |
| `conformance --filter jsdoc` | 293/368 | **295/368** |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

Full-corpus failing sets diffed both ways — **2 fixed, 0 regressed**:

```
conformance_jsdoc_jsdocTypeReferenceToImportOfFunctionExpression
conformance_jsdoc_declarations_jsDeclarationsParameterTagReusesInputNodeInEmit1
```

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(jsdoc_typedef_bare_import)'   # 6 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold