### PR TITLE
fix(solver,checker): valibot canary false-negatives — one-sided TS2352 undefined-grace + silent unknown[key]

### DIFF
--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1585,6 +1585,24 @@ impl<'a> CheckerState<'a> {
             return TypeId::ERROR;
         }
 
+        // A non-literal index on an `unknown` object is TS18046 ("'x' is of
+        // type 'unknown'"), not TS7053 — `should_report_no_index_signature`
+        // rightly declines the TS7053 code for `unknown`, but tsc still
+        // rejects the access. The literal-key and property-access paths
+        // already route `unknown` receivers through the shared
+        // `unknown_object_access_result` gate (TS18046 under
+        // strictNullChecks, index-signature fallthrough otherwise); without
+        // this the general-index path was the one form that silently allowed
+        // `v[key]` on `unknown` — valibot guards exactly that with
+        // `@ts-expect-error`, which tsz then reported as unused (TS2578).
+        if use_index_signature_check
+            && !is_fresh_object_literal
+            && object_type_for_access == TypeId::UNKNOWN
+            && let Some(result) = self.unknown_object_access_result(access.expression)
+        {
+            return result;
+        }
+
         if use_index_signature_check
             && !is_fresh_object_literal
             && self.should_report_no_index_signature(

--- a/crates/tsz-solver/src/type_queries/assertion_overlap.rs
+++ b/crates/tsz-solver/src/type_queries/assertion_overlap.rs
@@ -127,7 +127,20 @@ pub(super) fn types_have_common_properties_relaxed(
         if let Some(source_entries) = source_by_name.get(target_name) {
             found_common = true;
             let any_comparable = source_entries.iter().any(|(source_ty, source_optional)| {
-                if (*source_optional || *target_optional)
+                // An optional property implicitly includes `undefined`, so an
+                // `undefined`-typed counterpart overlaps it at `undefined` —
+                // but only when BOTH effective property types contain
+                // `undefined`. A source `issues?: undefined` against a
+                // REQUIRED target `issues: [T, ...T[]]` shares no value: the
+                // source side holds only `undefined`, the target side holds
+                // none. tsc rejects that pair ("Type 'undefined' is not
+                // comparable to type '[T, ...]'"), which is what fires TS2352
+                // on valibot's `dataset as OutputDataset<...>`; this one-sided
+                // grace was the only reason tsz accepted it.
+                let source_holds_undefined = *source_ty == TypeId::UNDEFINED || *source_optional;
+                let target_holds_undefined = *target_ty == TypeId::UNDEFINED || *target_optional;
+                if source_holds_undefined
+                    && target_holds_undefined
                     && (*source_ty == TypeId::UNDEFINED || *target_ty == TypeId::UNDEFINED)
                 {
                     return true;

--- a/crates/tsz-solver/src/type_queries/flow/comparability.rs
+++ b/crates/tsz-solver/src/type_queries/flow/comparability.rs
@@ -1122,10 +1122,21 @@ fn types_have_common_properties(
         if let Some(source_entries) = source_by_name.get(target_name) {
             found_common = true;
             let any_comparable = source_entries.iter().any(|(source_ty, source_optional)| {
-                // If either property is optional, `undefined` is part of the type.
-                // E.g., `a?: string` effectively has type `string | undefined`,
-                // so `undefined` is comparable to it.
-                if (*source_optional || *target_optional)
+                // An optional property implicitly includes `undefined`
+                // (`a?: string` is effectively `string | undefined`), so an
+                // `undefined`-typed counterpart overlaps it at `undefined` —
+                // but only when BOTH effective types contain `undefined`.
+                // A source `issues?: undefined` against a REQUIRED target
+                // `issues: [T, ...T[]]` shares no value at all: the source
+                // side holds only `undefined` and the target side holds none.
+                // tsc rejects that pair ("Type 'undefined' is not comparable
+                // to type '[T, ...]'"), which is what fires TS2352 on
+                // valibot's `dataset as OutputDataset<...>`; the one-sided
+                // form of this grace was the only reason tsz accepted it.
+                let source_holds_undefined = *source_ty == TypeId::UNDEFINED || *source_optional;
+                let target_holds_undefined = *target_ty == TypeId::UNDEFINED || *target_optional;
+                if source_holds_undefined
+                    && target_holds_undefined
                     && (*source_ty == TypeId::UNDEFINED || *target_ty == TypeId::UNDEFINED)
                 {
                     return true;


### PR DESCRIPTION
Goal: grow

Two false-negative roots on the valibot canary row, found via its `@ts-expect-error` directives:
each unused-directive (TS2578) marks a place the source author expects an error that tsz fails to
report. Row TS2578: **124 → 59 (−52%)**; every other diagnostic count on the row is byte-identical
(each new error is consumed by its directive), zod row unchanged.

## 1. TS2352 property undefined-overlap grace was one-sided (solver)

Both property-overlap walks behind the assertion check (`type_queries/flow/comparability.rs`
`types_have_common_properties`, and `type_queries/assertion_overlap.rs`
`types_have_common_properties_relaxed` — the relaxed twin is the `.ts` as-expression path; fixing
only the first was measurably inert) accepted a shared property whenever **either** side was
optional and **either** type was `undefined`.

**Rule:** an optional property implicitly includes `undefined`, so an `undefined`-typed counterpart
overlaps it — but only when **both** effective property types contain `undefined`. A source
`issues?: undefined` holds only `undefined`; a required target `issues: [T, ...T[]]` holds none;
the pair shares no value and tsc rejects it.

```ts
interface UnknownDataset { typed?: false; value: unknown; issues?: undefined }
declare const d: UnknownDataset
d as FailureDataset<BaseIssue<unknown>>   // was accepted; now TS2352, matches tsc
```

tsz accepted exactly the `FailureDataset` member of `OutputDataset` (Success/Partial were already
rejected on the `typed` discriminant), so valibot's guarded `dataset as OutputDataset<...>` casts
were accepted and their directives went unused.

Adjacent matrix (tsz == tsc on all six): optional-undefined vs required tuple/array/primitive
(reject ×3), required `undefined` vs required tuple (reject), optional `string` vs required tuple
(reject), optional-undefined vs optional tuple (accept).

## 2. General-index element access on `unknown` reported nothing (checker)

Property access (`v.p`) and literal-key element access (`v["lit"]`) on an `unknown` receiver
already route through the shared `unknown_object_access_result` gate (TS18046 under
strictNullChecks). The general-index form (`v[key]`, non-literal key) was the one shape that
reported nothing: `should_report_no_index_signature` rightly declines the TS7053 code for
`unknown`, but nothing then reported the access at all — reads and writes through `unknown`
were silently allowed.

```ts
function x(v: unknown, key: string) { v[key] = 1; }        // now TS18046, matches tsc
function y(v: unknown, key: string) { const a = v[key]; }  // now TS18046, matches tsc
```

The general path now consults the same shared gate, byte-identical anchors to tsc. Controls:
narrowed receivers (typeof/instanceof), `as Record<...>` casts, property and literal-key forms all
unchanged.

## Verification

- Emit: **11562 JS / 1375 DTS** — exactly at floor, after both commits.
- Conformance, exact same-base A/B: base `b49ac71eb8` measured **11386**, this branch measured
  **11386**, and the per-test failing sets are **identical** (`comm` on the two baseline lists:
  0 fixed / 0 regressed). Both snapshots were clean runs with no mid-run rebuilds. An earlier draft
  of this body claimed "+4 vs 11382" — that was cross-base contamination (11382 predates the #15952
  merge); likewise the 66/22 churn vs the stale committed baseline was 100% nightly-lane drift.
  These fixes are precisely conformance-neutral: the corpus does not exercise these shapes, the
  canary corpus does.
- valibot row: TS2578 124 → 78 (fix 1) → 59 (fix 2); all other codes byte-identical
  (TS2344 59 / TS2322 47 / TS2345 34 / TS2353 23 / TS2339 10 / TS2394 5 / TS7006 2).
- zod row: 1 before, 1 after.
- Witness matrices vb1/vb2/uk1/uk2/as1: tsz == tsc position-for-position.

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-fable-5
Effort: xhigh

