### PR TITLE
fix(checker): don't merge named exports from a re-entrant export surface

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -196,6 +196,9 @@ mod comlink_row_regression_tests;
 #[path = "tests/commonjs_export_declaration_level_type_tests.rs"]
 mod commonjs_export_declaration_level_type_tests;
 #[cfg(test)]
+#[path = "tests/commonjs_reentrant_surface_tests.rs"]
+mod commonjs_reentrant_surface_tests;
+#[cfg(test)]
 #[path = "tests/commonjs_require_binding_type_meaning_tests.rs"]
 mod commonjs_require_binding_type_meaning_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
@@ -527,9 +527,24 @@ impl<'a> CheckerState<'a> {
         // Use the cached JsExportSurface for typed exports instead of
         // re-scanning the AST with augment_namespace_props_with_commonjs_exports_for_file.
         let current_file_idx = self.ctx.current_file_idx;
+        // While this file's own export surface is still being computed,
+        // `resolve_js_export_surface` hands back a re-entrancy placeholder
+        // rather than the file's surface. That placeholder reports no
+        // `module.exports = X`, which makes the merge test below vacuously
+        // true and lets the deep scan synthesize a namespace containing every
+        // `module.exports.<name>` in the file. A property write typed inside
+        // that window then resolves against a namespace that *has* the member,
+        // so its missing-property diagnostic is lost — while a sibling write
+        // typed after the window resolves against the real export type and
+        // reports correctly. Suppress the merge inside the window so both
+        // resolve against the same thing.
+        let surface_is_reentrant_placeholder = self
+            .ctx
+            .js_export_surface_resolution_set
+            .contains(&current_file_idx);
         let surface = self.resolve_js_export_surface(current_file_idx);
-        let can_merge_named_exports =
-            js_exports_query::commonjs_export_surface_can_merge_named_exports(
+        let can_merge_named_exports = !surface_is_reentrant_placeholder
+            && js_exports_query::commonjs_export_surface_can_merge_named_exports(
                 self.ctx.types,
                 &surface,
             );

--- a/crates/tsz-checker/src/tests/commonjs_reentrant_surface_tests.rs
+++ b/crates/tsz-checker/src/tests/commonjs_reentrant_surface_tests.rs
@@ -1,0 +1,93 @@
+//! Property writes on a function-typed `module.exports` are checked consistently.
+//!
+//! While a file's JS export surface is being computed, `resolve_js_export_surface`
+//! hands re-entrant callers a placeholder surface that reports no
+//! `module.exports = X`. Consumers then synthesised a namespace containing every
+//! `module.exports.<name>` in the file, and a property write typed inside that
+//! window resolved against a namespace that *had* the member — losing its
+//! missing-property diagnostic — while a sibling write typed after the window
+//! resolved against the real export type and reported.
+//!
+//! The window is entered only for RHSs that need the checker: a function
+//! expression re-enters, a numeric literal short-circuits. That is why
+//! `module.exports.f = function () {}` was silent while
+//! `module.exports.g = 1` reported, in one file, against one receiver.
+//!
+//! tsc reports both (verified against the pinned tsc 7.0.2).
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn js_codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.js", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+const MISSING_PROPERTY: u32 = 2339;
+
+fn missing_property_count(source: &str) -> usize {
+    js_codes(source)
+        .into_iter()
+        .filter(|c| *c == MISSING_PROPERTY)
+        .count()
+}
+
+#[test]
+fn function_and_value_writes_are_both_reported() {
+    let source = concat!(
+        "module.exports = function () { }\n",
+        "module.exports.f = function (a) { };\n",
+        "module.exports.g = 1;\n",
+    );
+    assert_eq!(missing_property_count(source), 2);
+}
+
+/// The function-expression write alone — the case that used to be silent.
+#[test]
+fn function_expression_write_is_reported() {
+    let source = "module.exports = function () { }\nmodule.exports.f = function (a) { };\n";
+    assert!(js_codes(source).contains(&MISSING_PROPERTY));
+}
+
+/// Renamed export and helper: the rule is structural.
+#[test]
+fn function_expression_write_is_reported_renamed() {
+    let source = "module.exports = function () { }\nmodule.exports.handler = function (q) { };\n";
+    assert!(js_codes(source).contains(&MISSING_PROPERTY));
+}
+
+/// An arrow RHS also re-enters and must report.
+#[test]
+fn arrow_write_is_reported() {
+    let source = "module.exports = function () { }\nmodule.exports.f = (a) => a;\n";
+    assert!(js_codes(source).contains(&MISSING_PROPERTY));
+}
+
+// --- Files without a whole-module export are unaffected. ---
+
+/// Plain named exports with no `module.exports = X` keep working: the members
+/// are the module's exports, so reading them is fine.
+#[test]
+fn named_exports_without_whole_module_export_are_unaffected() {
+    let source = concat!(
+        "exports.a = function () { };\n",
+        "exports.b = 1;\n",
+        "exports.a;\n",
+        "exports.b;\n",
+    );
+    assert_eq!(missing_property_count(source), 0);
+}
+
+/// A whole-module object-literal export still exposes its own members.
+#[test]
+fn object_literal_whole_module_export_keeps_its_members() {
+    let source = "module.exports = { a: 1 };\nmodule.exports.a;\n";
+    assert_eq!(missing_property_count(source), 0);
+}


### PR DESCRIPTION
## Structural rule

`module.exports = function () { }` followed by
`module.exports.f = function (a) { }` reported nothing, while the sibling
`module.exports.g = 1` reported TS2339 — **same file, same receiver**. tsc
reports both, because a JS module whose whole-module export is `X` has type `X`
and no `module.exports.<name> = …` contributes a member.

## Mechanism

While a file's export surface is being computed, `resolve_js_export_surface`
hands re-entrant callers a placeholder that reports no `module.exports = X`
(`js_exports.rs`, the `js_export_surface_resolution_set` guard). That makes
`commonjs_export_surface_can_merge_named_exports` vacuously true, so the deep
scan in `current_file_commonjs_namespace_type_with_display_extension`
synthesises a namespace containing every `module.exports.<name>` in the file.

A property write typed **inside** that window resolves against a namespace that
*has* the member and loses its diagnostic; a sibling typed **after** the window
resolves against the real export type (`() => void`) and reports.

Only RHSs that need the checker enter the window: a function expression
re-enters via `get_type_of_node`, while a numeric literal short-circuits in
`literal_type_from_initializer`. That asymmetry is the entire bug — it is why
the two writes in one file disagreed.

The fix suppresses the merge while the placeholder is in play, so both writes
resolve against the same receiver.

## How it was established

Temporary probes (all reverted), in order:

1. `#[track_caller]` on `error_property_not_exist_at` named the emitter as
   `identifier_resolution.rs:1758`.
2. All 44 `return`s in `resolve_identifier_property_access` instrumented: none
   fire for either property; neither missing-property guard fires for `f`.
3. Receiver types printed on entry: `f` gets `typeof import("s")`, `g` gets
   `() => void` — so the divergence is upstream.
4. Sequence-numbered probes on the surface guard proved the nesting:
   `seq=0 compute-begin`, `seq=1 guard-hit`, `seq=2 compute-end`.

Step 4 matters: the diagnostics all sit at 1:1, so display order is not
emission order — an unsequenced probe made the guard look like it fired *after*
the compute.

Also ruled out along the way, so they are not re-suspected:
`commonjs_direct_export_supports_named_props` (the write-target block computes
`can_add_named_props = false` for **both** properties, probed), and every caller
of `is_expando_function_assignment` / `is_js_expando_object_assignment`
(disabled simultaneously — no change).

## Behaviour, verified against the pinned tsc 7.0.2

| source (`--allowJs --checkJs`) | tsc | tsz before | after |
|---|---|---|---|
| `module.exports = function(){}` + `.f = function(a){}` | TS2339 | **none** | TS2339 |
| same + `.g = 1` | TS2339 | TS2339 | TS2339 |
| `.f = (a) => a` (arrow RHS) | TS2339 | **none** | TS2339 |
| `exports.a = fn; exports.b = 1; exports.a; exports.b` (no whole-module export) | none | none | none |
| `module.exports = { a: 1 }; module.exports.a` | none | none | none |

## Adjacent cases

`crates/tsz-checker/src/tests/commonjs_reentrant_surface_tests.rs`, 6 tests:
both writes reported together, the function-expression write alone, a renamed
export, an arrow RHS; and two negatives — named exports with no whole-module
export, and an object-literal whole-module export keeping its own members.

## Known remaining

`moduleExportAlias2` (`exports = module.exports = C` + `exports.f = n => n + 1`)
still misses its TS2339. It reaches the namespace helper through a different
entry, so it needs its own investigation rather than a widened change here.

## Verification

Local, on this branch's head; salsa re-run on the committed tree. Baseline
measured from a clean `main` checkout at 3873c93d97.

| suite | before | after |
|---|---|---|
| `conformance` (full) | 11384/12043 | **11385/12043** |
| `conformance --filter salsa` | 125/186 | **126/186** |
| `conformance --filter jsdoc` | 294/368 | 294/368 |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

Full-corpus failing sets diffed both ways — **1 fixed, 0 regressed**
(`conformance_salsa_moduleExportWithExportPropertyAssignment`).

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(commonjs_reentrant_surface)'   # 6 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold