### PR TITLE
fix(checker): a chained module.exports assignment keeps its export type

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -193,6 +193,9 @@ mod class_property_typed_const_initializer_tests;
 #[path = "tests/comlink_row_regression_tests.rs"]
 mod comlink_row_regression_tests;
 #[cfg(test)]
+#[path = "tests/commonjs_export_assignment_chain_tests.rs"]
+mod commonjs_export_assignment_chain_tests;
+#[cfg(test)]
 #[path = "tests/commonjs_export_declaration_level_type_tests.rs"]
 mod commonjs_export_declaration_level_type_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
@@ -282,6 +282,34 @@ impl<'a> CheckerState<'a> {
         );
     }
 
+    /// Follow an assignment chain to the value actually exported.
+    ///
+    /// `exports = module.exports = C` assigns through an intermediate target.
+    /// An assignment expression takes its target's declared type, so an ambient
+    /// `declare var module: { exports: any }` — what node typings and
+    /// hand-written shims provide — makes the chain resolve to an error type
+    /// rather than to `C`. tsc collects the assigned value, keeping the real
+    /// export type, so every `exports.<name>` is still checked against it.
+    fn commonjs_export_rhs_through_assignment_chain(&self, rhs_expr: NodeIndex) -> NodeIndex {
+        let mut current = rhs_expr;
+        for _ in 0..8 {
+            let Some(node) = self.ctx.arena.get(current) else {
+                break;
+            };
+            if node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+                break;
+            }
+            let Some(binary) = self.ctx.arena.get_binary_expr(node) else {
+                break;
+            };
+            if binary.operator_token != SyntaxKind::EqualsToken as u16 {
+                break;
+            }
+            current = binary.right;
+        }
+        current
+    }
+
     pub(crate) fn infer_commonjs_export_rhs_type(
         &mut self,
         target_file_idx: usize,
@@ -293,6 +321,23 @@ impl<'a> CheckerState<'a> {
                 .literal_type_from_initializer(rhs_expr)
                 .or_else(|| self.commonjs_export_rhs_symbol_type(rhs_expr))
                 .unwrap_or_else(|| self.get_type_of_node(rhs_expr));
+            // An error type here means the chain's intermediate target carried
+            // an ambient declaration, not that the module exports nothing
+            // usable — the error renders as `any`, which then accepts every
+            // property access silently. Recover the assigned value's type.
+            // Deliberately re-typing the node rather than consulting
+            // `commonjs_export_rhs_symbol_type`: for `exports = module.exports
+            // = C` the latter answers with C's *instance* type, while tsc
+            // reports the callable `() => void`.
+            if ty == TypeId::ERROR {
+                let inner = self.commonjs_export_rhs_through_assignment_chain(rhs_expr);
+                if inner != rhs_expr {
+                    let inner_ty = self.get_type_of_node(inner);
+                    if inner_ty != TypeId::ERROR {
+                        ty = inner_ty;
+                    }
+                }
+            }
             ty = self.upgrade_commonjs_export_constructor_type(rhs_expr, ty);
             ty = self.augment_commonjs_export_type_with_expandos(target_file_idx, expando_root, ty);
             ty = self.widen_fresh_object_literal_properties_for_display(ty);

--- a/crates/tsz-checker/src/tests/commonjs_export_assignment_chain_tests.rs
+++ b/crates/tsz-checker/src/tests/commonjs_export_assignment_chain_tests.rs
@@ -1,0 +1,86 @@
+//! A chained `exports = module.exports = X` keeps the real export type.
+//!
+//! An assignment expression takes its target's declared type, so an ambient
+//! `declare var module: { exports: any }` — what node typings and hand-written
+//! `node.d.ts` shims provide — makes the chain resolve to an error type. That
+//! renders as `any`, and every property access on the module is then silently
+//! accepted.
+//!
+//! tsc collects the assigned value instead, so the module keeps its real export
+//! type and `exports.<name>` is still checked against it. Verified against the
+//! pinned tsc 7.0.2.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_multi_file_with_libs_stamped, load_lib_files};
+
+fn js_diags(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        ..CheckerOptions::default()
+    };
+    check_multi_file_with_libs_stamped(files, entry, options, &load_lib_files(&["es5.d.ts"]))
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect()
+}
+
+const MISSING_PROPERTY: u32 = 2339;
+
+const NODE_SHIM: &str = concat!(
+    "declare function require(name: string): any;\n",
+    "declare var exports: any;\n",
+    "declare var module: { exports: any };\n",
+);
+
+const CHAIN_SRC: &str = concat!(
+    "exports = module.exports = C\n",
+    "exports.f = n => n + 1\n",
+    "function C() {\n",
+    "    this.p = 1\n",
+    "}\n",
+);
+
+// The ambient-shim variant (`node.d.ts` + `semver.js`, witness
+// `moduleExportAlias2`) is covered by the conformance corpus and by direct
+// CLI verification against tsc: this multi-file unit harness does not apply
+// the ambient declaration the way the driver does, so asserting it here
+// would not exercise the rescue.
+
+/// The same file without the ambient shim already worked; it must keep working,
+/// and must keep naming the callable type rather than the instance type `C`.
+#[test]
+fn chain_without_ambient_shim_still_reports_the_callable_type() {
+    let diags = js_diags(&[("alias.js", CHAIN_SRC)], "alias.js");
+    assert!(
+        diags.iter().any(|(code, msg)| *code == MISSING_PROPERTY
+            && msg.contains("'f'")
+            && msg.contains("() => void")),
+        "expected TS2339 on '() => void', got: {diags:?}"
+    );
+}
+
+/// A plain (unchained) whole-module export is untouched by the rescue.
+#[test]
+fn unchained_whole_module_export_is_unaffected() {
+    let src = "module.exports = function () { }\nmodule.exports.f = function (a) { };\n";
+    let diags = js_diags(&[("mod.js", src)], "mod.js");
+    assert!(
+        diags
+            .iter()
+            .any(|(code, msg)| *code == MISSING_PROPERTY && msg.contains("() => void")),
+        "expected TS2339 on '() => void', got: {diags:?}"
+    );
+}
+
+/// A chain exporting an object literal keeps its members — the rescue must not
+/// turn a legitimate member access into an error.
+#[test]
+fn chain_exporting_an_object_literal_keeps_its_members() {
+    let src = "exports = module.exports = { a: 1 }\nexports.a;\n";
+    let diags = js_diags(&[("node.d.ts", NODE_SHIM), ("obj.js", src)], "obj.js");
+    assert!(
+        !diags.iter().any(|(code, _)| *code == MISSING_PROPERTY),
+        "expected no TS2339, got: {diags:?}"
+    );
+}


### PR DESCRIPTION
## Structural rule

`exports = module.exports = C` assigns through an intermediate target, and an
assignment expression takes that target's **declared** type. With an ambient
`declare var module: { exports: any }` — what node typings and hand-written
`node.d.ts` shims provide — the chain resolves to an error type, which renders
as `any`, so every property access on the module is silently accepted.

`tsc` collects the assigned **value**, so the module keeps its real export type
and `exports.f = …` is still checked against it.

## Why three earlier guards missed

The collapsed type *renders* as `any` but is **`TypeId::ERROR`**
(`raw=1, data=Some(Error)`, established by probe). So both
`ty == TypeId::ANY` and `is_any_type(ty)` are false, and two attempts keyed on
those did nothing at all. Reading the actual `TypeData` rather than the
displayed name is what settled it.

## Why it re-types the node instead of using the symbol path

The rescue calls `get_type_of_node` on the chain's innermost value. Routing
through `commonjs_export_rhs_symbol_type` instead answers with `C`'s *instance*
type, which

- names the wrong type in the message (`'C'` where tsc says `'() => void'`), and
- **regressed the shim-free case**, which already reported correctly.

That was measured, not assumed.

## Behaviour, verified against the pinned tsc 7.0.2

| source (`--allowJs --checkJs`) | tsc | tsz before | after |
|---|---|---|---|
| `node.d.ts` shim + `exports = module.exports = C` + `exports.f = n => n+1` | TS2339 on `() => void` | **none** | TS2339 on `() => void` |
| same chain, no ambient shim | TS2339 on `() => void` | TS2339 | TS2339 |
| `module.exports = function(){}` + `.f = function(a){}` (unchained) | TS2339 | TS2339 | TS2339 |
| `exports = module.exports = { a: 1 }` + `exports.a` | none | none | none |

Witness: `moduleExportAlias2`.

## Adjacent cases

`crates/tsz-checker/src/tests/commonjs_export_assignment_chain_tests.rs`,
3 tests: the shim-free chain still naming the callable type, an unchained
whole-module export unaffected, and a chain exporting an object literal keeping
its members.

The ambient-shim variant itself is covered by the conformance witness and by CLI
verification against tsc: this multi-file unit harness does not apply the
ambient declaration the way the driver does, so asserting it there would not
exercise the rescue. Noted in the test file rather than left as a passing
decoration.

## Verification

Local. Baseline measured from a clean `main` checkout at the same HEAD this
branch is based on (`b15d22d2fe`), not reused from an earlier run.

| suite | baseline | after |
|---|---|---|
| `conformance` (full) | 11387/12043 | **11388/12043** |
| `conformance --filter salsa` | 126/186 | **127/186** |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | 11562 JS / 1375 DTS |

Same-HEAD failing-set diff by lane: salsa 60 -> 59 failing (**1 fixed**), jsdoc
72 -> 72 (**unchanged**), **0 regressed**.

Reporting +1 deliberately. The whole-corpus set diff also lists
`typeArgumentInferenceWithConstraints` as fixed, but the artifact counts do not
reconcile exactly with the pass counts in either run (655 artifacts vs 656
failures at baseline), so some failures do not emit artifacts and the set diff
can overstate. The pass count is the number I stand behind.

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(commonjs_export_assignment_chain)'   # 3 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold