### PR TITLE
fix(checker): check object-literal method bodies outside classes

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -499,6 +499,9 @@ mod nuia_write_index_signature_emits_ts2322_tests;
 #[path = "tests/nullish_union_indexed_access_missing_property_tests.rs"]
 mod nullish_union_indexed_access_missing_property_tests;
 #[cfg(test)]
+#[path = "tests/object_literal_method_body_check_tests.rs"]
+mod object_literal_method_body_check_tests;
+#[cfg(test)]
 #[path = "../tests/optional_param_display_tests.rs"]
 mod optional_param_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
@@ -329,7 +329,14 @@ impl<'a> CheckerState<'a> {
             // `commonjs_export_rhs_symbol_type`: for `exports = module.exports
             // = C` the latter answers with C's *instance* type, while tsc
             // reports the callable `() => void`.
-            if ty == TypeId::ERROR {
+            // The degenerate value differs by path: the chain types as an error
+            // when only the ambient declaration is in play, and as `any` once
+            // the surrounding method bodies are checked. Both mean the same
+            // thing here — the intermediate target's declaration won, not the
+            // module's real export — so rescue either.
+            if ty == TypeId::ERROR
+                || crate::query_boundaries::assignability::is_any_type(self.ctx.types, ty)
+            {
                 let inner = self.commonjs_export_rhs_through_assignment_chain(rhs_expr);
                 if inner != rhs_expr {
                     let inner_ty = self.get_type_of_node(inner);

--- a/crates/tsz-checker/src/tests/object_literal_method_body_check_tests.rs
+++ b/crates/tsz-checker/src/tests/object_literal_method_body_check_tests.rs
@@ -1,0 +1,110 @@
+//! Method bodies of an object literal outside a class are checked.
+//!
+//! `skip_body_check` in `function_type.rs` is keyed on the node kind alone. Its
+//! comment justifies skipping method bodies during type-environment building
+//! because `check_class_member` re-checks them later with the class context
+//! established. An object-literal method is also a `METHOD_DECLARATION` and gets
+//! no such second pass, so its body was never checked — every diagnostic inside
+//! `X.prototype = { m() { … } }` was dropped.
+//!
+//! Verified against the pinned tsc 7.0.2: it reports inside all of these.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn js_codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.js", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+const NOT_ASSIGNABLE: u32 = 2322;
+
+/// The regressing shape: a whole-prototype object-literal assignment.
+#[test]
+fn prototype_object_literal_method_body_is_checked() {
+    let source = concat!(
+        "function M() { };\n",
+        "M.prototype = {\n",
+        "    m() {\n",
+        "        /** @type {string} */\n",
+        "        var s = 1;\n",
+        "        return s;\n",
+        "    }\n",
+        "};\n",
+        "M;\n",
+    );
+    assert!(js_codes(source).contains(&NOT_ASSIGNABLE));
+}
+
+/// A renamed constructor and method: the rule is structural.
+#[test]
+fn prototype_object_literal_method_body_is_checked_renamed() {
+    let source = concat!(
+        "function Widget() { };\n",
+        "Widget.prototype = {\n",
+        "    render() {\n",
+        "        /** @type {number} */\n",
+        "        var n = 'x';\n",
+        "        return n;\n",
+        "    }\n",
+        "};\n",
+        "Widget;\n",
+    );
+    assert!(js_codes(source).contains(&NOT_ASSIGNABLE));
+}
+
+/// An object literal assigned to a plain variable already worked; keep it.
+#[test]
+fn plain_object_literal_method_body_is_still_checked() {
+    let source = concat!(
+        "var o = {\n",
+        "    m() {\n",
+        "        /** @type {string} */\n",
+        "        var s = 1;\n",
+        "        return s;\n",
+        "    }\n",
+        "};\n",
+        "o;\n",
+    );
+    assert!(js_codes(source).contains(&NOT_ASSIGNABLE));
+}
+
+/// A function expression assigned to a prototype member already worked too.
+#[test]
+fn prototype_member_function_expression_is_still_checked() {
+    let source = concat!(
+        "function M() { };\n",
+        "M.prototype.m = function () {\n",
+        "    /** @type {string} */\n",
+        "    var s = 1;\n",
+        "    return s;\n",
+        "};\n",
+        "M;\n",
+    );
+    assert!(js_codes(source).contains(&NOT_ASSIGNABLE));
+}
+
+/// A class method still reports through its own later pass — the narrowed skip
+/// must not disturb the class path.
+#[test]
+fn class_method_body_is_still_checked() {
+    let source = concat!(
+        "class K {\n",
+        "    m() {\n",
+        "        /** @type {string} */\n",
+        "        var s = 1;\n",
+        "        return s;\n",
+        "    }\n",
+        "}\n",
+        "new K();\n",
+    );
+    assert!(js_codes(source).contains(&NOT_ASSIGNABLE));
+}

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1836,7 +1836,18 @@ impl<'a> CheckerState<'a> {
                 // properly checked later during check_class_member with correct context.
                 // The method's return type is already computed above (from annotation
                 // or infer_return_type_from_body which snapshots/restores).
-                let skip_body_check = !self.ctx.is_checking_statements && is_method_or_constructor;
+                let is_class_member = self
+                    .ctx
+                    .arena
+                    .get_extended(idx)
+                    .map(|ext| ext.parent)
+                    .and_then(|parent| self.ctx.arena.get(parent))
+                    .is_some_and(|parent| {
+                        parent.kind == syntax_kind_ext::CLASS_DECLARATION
+                            || parent.kind == syntax_kind_ext::CLASS_EXPRESSION
+                    });
+                let skip_body_check =
+                    !self.ctx.is_checking_statements && is_method_or_constructor && is_class_member;
                 // Save outer generator's yield collection state (for nested generators)
                 let saved_yield_collection =
                     std::mem::take(&mut self.ctx.generator_yield_operand_types);


### PR DESCRIPTION
## Structural rule

`X.prototype = { m() { … } }` never had its method bodies checked, so **every**
diagnostic inside one was silently dropped.

`skip_body_check` (`types/function_type.rs`) is keyed on the node kind alone:

```rust
let skip_body_check = !self.ctx.is_checking_statements && is_method_or_constructor;
```

Its comment justifies the skip by saying class methods are re-checked later by
`check_class_member` once the class context exists. An object-literal method is
also a `METHOD_DECLARATION`, is typed during type-environment building, and has
**no** such second pass — so nothing ever checked it. Those methods also need no
class context, so checking them in place is correct. The skip now applies only
when the method's parent really is a class.

## The second half, and why both are needed

Checking those bodies changes which degenerate type a chained
`exports = module.exports = C` collapses to when an ambient
`declare var module: { exports: any }` is present: `TypeId::ERROR` before, `any`
once the bodies run. The rescue added in #15960 keys on `ERROR`, so on its own
this change **regressed `moduleExportAlias2`** (measured: salsa 127 -> 126).
Widening the rescue to cover `any` as well keeps it passing.

An earlier hypothesis — that the extra body check opened a new export-surface
re-entrancy window — was **refuted** by probe: with the body fix applied, the
sequenced surface probe shows a clean `compute-begin` / `compute-end` and no
`guard-hit`.

## Scope

This closes the "body never checked" hole. It does **not** fix
`typeFromPrototypeAssignment3`, whose `this` inside the now-checked method is
still `any` — that is a separate defect, recorded for follow-up.

## Isolation

| form | RHS kind | body checked before | after |
|---|---|---|---|
| `var o = { m(){} }` | object literal in a variable initializer | yes | yes |
| `X.prototype.m = function(){}` | function expression in an assignment | yes | yes |
| `X.prototype = { m(){} }` | object literal in an assignment | **no** | yes |
| `class K { m(){} }` | class member | yes (later pass) | yes |

## Adjacent cases

`crates/tsz-checker/src/tests/object_literal_method_body_check_tests.rs`,
5 tests: the prototype-literal form (plus a renamed constructor/method), and the
three neighbouring forms that already worked and must keep working — including
the class method, which the narrowed skip must not disturb.

## Verification

Local. Baseline measured from a clean `main` checkout at this branch's base
(`1fb69092aa`).

| suite | baseline | after |
|---|---|---|
| `conformance` (full) | 11403/12043 | **11404/12043** |
| `conformance --filter salsa` | 127/186 | 127/186 |
| `conformance --filter jsdoc` | 296/368 | 296/368 |
| `scripts/emit/run.sh` | 11562 JS / 1375 DTS | **11562 JS / 1375 DTS** |

Full-corpus failing sets diffed both ways — **1 fixed, 0 regressed**
(`compiler_functionLikeInParameterInitializer`). Emit failing-test names diffed
against main: identical sets, none new.

Note on the emit numbers: an earlier run of this suite on this branch was killed
at a 10-minute timeout and reported 11554/1368. That was a truncated run, not a
regression — fewer tests executed, so fewer passed, with the same 16 failing
names. The figures above are from a run that completed.

```
cargo nextest run --target-dir .target -p tsz-checker --lib \
  -E 'test(object_literal_method_body_check)'   # 5 passed
./scripts/conformance/conformance.sh run --workers 8
./scripts/emit/run.sh
```

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: max

Goal: hold