### PR TITLE
fix(ci): add use_define_for_class_fields to tsz-core test initializers

### DIFF
--- a/crates/tsz-core/tests/checker_state_tests_parts/part_16.rs
+++ b/crates/tsz-core/tests/checker_state_tests_parts/part_16.rs
@@ -33,6 +33,7 @@ class Foo {
             jsx_factory_from_config: false,
             jsx_fragment_factory: "React.Fragment".to_string(),
             jsx_fragment_factory_from_config: false,
+            use_define_for_class_fields: None,
             strict: true,
             ..Default::default()
         },
@@ -83,6 +84,7 @@ class Foo {
             jsx_factory_from_config: false,
             jsx_fragment_factory: "React.Fragment".to_string(),
             jsx_fragment_factory_from_config: false,
+            use_define_for_class_fields: None,
             strict: true,
             ..Default::default()
         },
@@ -137,6 +139,7 @@ class Foo {
             jsx_factory_from_config: false,
             jsx_fragment_factory: "React.Fragment".to_string(),
             jsx_fragment_factory_from_config: false,
+            use_define_for_class_fields: None,
             strict: true,
             ..Default::default()
         },
@@ -196,6 +199,7 @@ class Foo {
             jsx_factory_from_config: false,
             jsx_fragment_factory: "React.Fragment".to_string(),
             jsx_fragment_factory_from_config: false,
+            use_define_for_class_fields: None,
             strict: true,
             ..Default::default()
         },
@@ -244,6 +248,7 @@ class Foo {
             jsx_factory_from_config: false,
             jsx_fragment_factory: "React.Fragment".to_string(),
             jsx_fragment_factory_from_config: false,
+            use_define_for_class_fields: None,
             strict: true,
             strict_null_checks: true,
             strict_property_initialization: false,
@@ -294,6 +299,7 @@ class Foo {
             jsx_factory_from_config: false,
             jsx_fragment_factory: "React.Fragment".to_string(),
             jsx_fragment_factory_from_config: false,
+            use_define_for_class_fields: None,
             strict: true,
             strict_null_checks: false,
             strict_property_initialization: true,
@@ -340,6 +346,7 @@ fn test_tier_2_type_checker_accuracy_fixes() {
             jsx_factory_from_config: false,
             jsx_fragment_factory: "React.Fragment".to_string(),
             jsx_fragment_factory_from_config: false,
+            use_define_for_class_fields: None,
             strict: true,
             no_implicit_any: true,
             no_implicit_returns: false,


### PR DESCRIPTION
`use_define_for_class_fields` was added to `CheckerOptions` (`tsz-common/src/options/checker.rs:53`) without updating the struct literals in `crates/tsz-core/tests/checker_state_tests_parts/part_16.rs`, so the CI `clippy` lane fails to compile on **main itself**:

```
error[E0063]: missing field `use_define_for_class_fields` in initializer of `tsz_common::CheckerOptions`
   --> crates/tsz-core/../tests/checker_state_tests_parts/part_16.rs:338:9
error: could not compile `tsz-core` (lib test) due to 1 previous error
```

`clippy` is a required check, and cargo aborts at the first failing crate, so this fails **every open PR regardless of its content** — it is what is currently blocking #15965.

Seven initializers in that file needed the field. Each gets `None`, matching the `CheckerOptions` default at `options/checker.rs:251`, so no test behaviour changes.

### Why the local hook missed it

The pre-commit gate scopes clippy to the crates a commit touches (`-p <crate>`). The commit that added the field did not touch `tsz-core`, and `tsz-core` only fails under `--all-targets` (it is a *test* initializer), so neither the author's scoped run nor a normal `cargo build` saw it. CI runs `--workspace --all-targets`, which does.

Goal: hold

## Verification

- `cargo clippy --workspace --all-targets` — clean (the CI lane's exact invocation).
- Before the fix, the same command reproduces the `E0063` above on a clean `main` checkout, confirming the breakage is main-side and not introduced by any open PR.
- Field-only change to a test initializer; no non-test code touched.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

AgentName: M1FableArchitect