### PR TITLE
fix(checker): drop stale JS prototype instance `this` typing

### DIFF
--- a/crates/tsz-checker/src/tests/dispatch_tests/part_01.rs
+++ b/crates/tsz-checker/src/tests/dispatch_tests/part_01.rs
@@ -259,8 +259,17 @@ id2(E);
     );
 }
 
+/// TypeScript 7 dropped JS constructor-function inference, so `@class` /
+/// `@template` no longer synthesize an instance type, and a method of an object
+/// literal assigned to `.prototype` is an ordinary object-literal method: its
+/// `this` is the literal. Verified against the pinned tsc 7.0.2, which reports
+/// `Property 'x' does not exist on type '{ m1(): any; m2(): any; }'` — naming
+/// the literal, not `Cp`.
+///
+/// This test previously asserted the opposite (instance `this`, no TS2339/7023),
+/// which was TypeScript 6 behaviour.
 #[test]
-fn jsdoc_generic_constructor_prototype_object_literal_methods_use_instance_this() {
+fn jsdoc_generic_constructor_prototype_object_literal_methods_use_object_literal_this() {
     let diags = check_js_source_diagnostics(
         r#"
 /**
@@ -288,14 +297,18 @@ var n = cp.m1();
 var n = cp.m2();
 "#,
     );
-    let relevant: Vec<_> = diags
-        .iter()
-        .filter(|d| matches!(d.code, 2339 | 7023))
-        .collect();
-    assert_eq!(
-        relevant.len(),
-        0,
-        "Expected generic JS constructor prototype object literal methods to use instance `this`, got: {relevant:?}"
+    let ts2339: Vec<_> = diags.iter().filter(|d| d.code == 2339).collect();
+    assert!(
+        !ts2339.is_empty(),
+        "`this` in a prototype object-literal method is the literal, which has no \
+         `x`/`y`/`z`, so TS2339 is expected; got: {diags:?}"
+    );
+    assert!(
+        ts2339
+            .iter()
+            .all(|d| d.message_text.contains("m1(): any") && !d.message_text.contains("Cp")),
+        "the receiver must be reported as the object literal, not the constructor \
+         `Cp`; got: {ts2339:?}"
     );
 }
 

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -1549,12 +1549,26 @@ impl<'a> CheckerState<'a> {
                                 *property_idx,
                             );
                         }
-                        use crate::diagnostics::diagnostic_codes;
-                        self.error_at_node_msg(
-                            method.name,
-                            diagnostic_codes::IMPLICITLY_HAS_RETURN_TYPE_ANY_BECAUSE_IT_DOES_NOT_HAVE_A_RETURN_TYPE_ANNOTATION,
-                            &[&name],
-                        );
+                        // A JSDoc `@returns` is a return type annotation, so there is
+                        // nothing implicit to report: the return type never depended
+                        // on the body, and the circularity this refinement works
+                        // around cannot arise. `jsdoc_declared_type` does not cover
+                        // this — it holds a `@type` tag on the element, not `@returns`.
+                        // The refinement itself is kept either way; it produces the
+                        // corrected `this` display used by the TS2339s just above.
+                        let has_jsdoc_return_annotation = self
+                            .get_jsdoc_for_function(elem_idx)
+                            .as_deref()
+                            .and_then(Self::jsdoc_returns_type_expression)
+                            .is_some();
+                        if jsdoc_declared_type.is_none() && !has_jsdoc_return_annotation {
+                            use crate::diagnostics::diagnostic_codes;
+                            self.error_at_node_msg(
+                                method.name,
+                                diagnostic_codes::IMPLICITLY_HAS_RETURN_TYPE_ANY_BECAUSE_IT_DOES_NOT_HAVE_A_RETURN_TYPE_ANNOTATION,
+                                &[&name],
+                            );
+                        }
                         method_type = refined_method_type;
                     }
 

--- a/crates/tsz-checker/src/types/computation/object_literal/computation_request_facts.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation_request_facts.rs
@@ -165,18 +165,16 @@ impl<'a> CheckerState<'a> {
             }
             self.ctx.this_type_stack.push(this_type);
         }
-        let prototype_owner_this_type = if self.is_js_file() {
-            self.js_prototype_owner_expression_for_node(idx)
-                .and_then(|owner_expr| self.js_prototype_owner_function_target(owner_expr))
-                .and_then(|owner_target| {
-                    self.synthesize_js_constructor_instance_type(owner_target, TypeId::ANY, &[])
-                })
-        } else {
-            None
-        };
-        let contextual_receiver_this_type = prototype_owner_this_type.or_else(|| {
-            self.contextual_object_receiver_this_type(contextual_type, marker_this_type)
-        });
+        // TypeScript 7 dropped JS constructor-function inference, so an object
+        // literal assigned to `M.prototype` no longer borrows `M`'s synthesized
+        // instance type as the `this` of its methods. Such a method is an
+        // ordinary object-literal method: its `this` is the literal itself, the
+        // same as `var o = { m() { ... } }`. tsc 7.0.2 reports
+        // `Property '_map' does not exist on type '{ get(key: any): any; }'`
+        // for `M.prototype = { get(key) { return this._map[key] } }`, naming the
+        // literal rather than `M`.
+        let contextual_receiver_this_type =
+            self.contextual_object_receiver_this_type(contextual_type, marker_this_type);
         let base_request = request.contextual_opt(contextual_type);
         let partial_initializer_stack_index = self
             .object_literal_variable_initializer_symbol(idx)

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -318,10 +318,14 @@ impl<'a> CheckerState<'a> {
         // `@type {new () => T}` annotations and real classes still supply construct
         // signatures through separate paths. Prototype-method `this` typing (the
         // `X.prototype.m = function () { ... }` receiver) is preserved below.
+        // The same removal covers the prototype-method receiver: with no
+        // synthesized instance type for `M`, `this` inside
+        // `M.prototype.m = function () { ... }` is implicitly `any`, so
+        // `this.whatever` is accepted rather than checked against a synthesized
+        // instance shape. Verified against tsc 7.0.2, which reports only TS2683
+        // on the constructor body for that form.
         let js_constructor_instance_type: Option<TypeId> = None;
-        let js_prototype_owner_instance_type = prototype_owner_target.and_then(|owner_target| {
-            self.synthesize_js_constructor_instance_type(owner_target, TypeId::ANY, &[])
-        });
+        let js_prototype_owner_instance_type: Option<TypeId> = None;
 
         // Check if this closure is inside a decorator expression.
         // Decorator arrow functions like `@((t, c) => {})` should not emit TS7006

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -921,9 +921,11 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         let access = self.ctx.arena.get_access_expr(left_node)?;
-        if let Some(instance_type) = self.prototype_assignment_instance_type(access.expression) {
-            return Some(instance_type);
-        }
+        // No prototype special case: TypeScript 7 dropped JS constructor-function
+        // inference, so `M.prototype` does not name a synthesized instance type.
+        // `M.prototype.m = function () { ... }` takes the ordinary
+        // assignment-receiver `this` (the type of `M.prototype`) like any other
+        // `obj.m = function () { ... }`.
         let receiver = self.get_type_of_node(access.expression);
         (receiver != TypeId::ERROR).then_some(receiver)
     }

--- a/crates/tsz-checker/tests/js_constructor_property_more_tests.rs
+++ b/crates/tsz-checker/tests/js_constructor_property_more_tests.rs
@@ -714,7 +714,7 @@ Installer.prototype.second = function () {
         );
     }
     assert!(
-        codes.iter().any(|&code| code == 2683),
+        codes.contains(&2683),
         "expected TS2683 for each implicitly-`any` constructor `this`, got: {diagnostics:?}"
     );
 }

--- a/crates/tsz-checker/tests/js_constructor_property_more_tests.rs
+++ b/crates/tsz-checker/tests/js_constructor_property_more_tests.rs
@@ -331,13 +331,33 @@ var cpn = cp.m4()
         .iter()
         .filter(|(code, _)| *code == 2403)
         .collect();
+    // TypeScript 7 dropped JS constructor-function inference, so `@class` /
+    // `@template` no longer synthesize an instance type carrying the
+    // constructor's `this.<prop>` writes. A new `this.<prop>` inside a method of
+    // the literal assigned to `Cp.prototype` is therefore a missing member, which
+    // this test previously asserted must be *allowed*.
     assert!(
-        ts2339.is_empty(),
-        "Expected generic constructor prototype methods to allow new `this` properties, got: {diagnostics:?}"
+        ts2339.iter().any(|(_, message)| message.contains("'y'")),
+        "`this.y` is not a member once constructor inference is gone; expected \
+         TS2339, got: {diagnostics:?}"
+    );
+    // KNOWN RESIDUAL, pinned so it stays visible: tsc 7.0.2 names the object
+    // literal as the receiver —
+    //     TS2339 Property 'y' does not exist on type '{ m4(): any; }'
+    // — while tsz still names `Cp`, because `Cp.prototype` retains a synthesized
+    // instance type from other `synthesize_js_constructor_instance_type` callers
+    // and that becomes the literal's contextual type, outranking the literal's own
+    // receiver `this`. tsc also reports TS2526 for the method's `@return {this}`,
+    // which tsz does not. Both are follow-on TS7 cleanups beyond the three
+    // prototype-`this` sites fixed here.
+    assert!(
+        ts2339.iter().all(|(_, message)| message.contains("'Cp'")),
+        "residual pin: tsz reports the receiver as `Cp`; if this now names the \
+         object literal, the residual is fixed — update this test, got: {ts2339:?}"
     );
     assert!(
         ts2403.is_empty(),
-        "Expected JSDoc generic constructor instance types to stay stable across prototype methods, got: {diagnostics:?}"
+        "Expected no subsequent-variable-declaration conflicts, got: {diagnostics:?}"
     );
 }
 
@@ -677,50 +697,25 @@ Installer.prototype.second = function () {
             ..CheckerOptions::default()
         },
     );
+    // TypeScript 7 dropped JS constructor-function inference. `Installer` gains
+    // no synthesized instance type, so every `this.<prop>` here is a member of an
+    // implicitly-`any` receiver: the assignment mismatches (TS2322), the
+    // nullability check (TS2531) and the implicit-member reports (TS7008) this
+    // test was written against can no longer arise. Verified against the pinned
+    // tsc 7.0.2, which reports TS2683 on each constructor-body `this` and
+    // nothing else for this source.
     let codes: Vec<u32> = diagnostics.iter().map(|(code, _)| *code).collect();
-    assert_eq!(
-        codes.iter().filter(|&&code| code == 2322).count(),
-        5,
-        "Expected closed constructor properties to report the same assignment mismatches as tsc, got: {diagnostics:?}"
-    );
-    assert_eq!(
-        codes.iter().filter(|&&code| code == 2531).count(),
-        1,
-        "Expected unchecked nullable constructor property access to report TS2531 once, got: {diagnostics:?}"
-    );
-    let ts7008_messages: Vec<_> = diagnostics
-        .iter()
-        .filter(|(code, _)| *code == 7008)
-        .map(|(_, msg)| msg.as_str())
-        .collect();
+    for stale in [2322u32, 2531, 7008] {
+        assert_eq!(
+            codes.iter().filter(|&&code| code == stale).count(),
+            0,
+            "TS{stale} depends on constructor-function inference, which TS7 removed; \
+             got: {diagnostics:?}"
+        );
+    }
     assert!(
-        ts7008_messages
-            .iter()
-            .any(|msg| msg.contains("Member 'twices' implicitly has an 'any[]' type.")),
-        "Expected a constructor-origin TS7008 for twices, got: {diagnostics:?}"
-    );
-    assert!(
-        ts7008_messages
-            .iter()
-            .all(|msg| !msg.contains("Member 'unknown' implicitly has an 'any' type.")),
-        "Expected prototype writes to suppress the stale constructor TS7008 for unknown, got: {diagnostics:?}"
-    );
-    assert!(
-        ts7008_messages
-            .iter()
-            .all(|msg| !msg.contains("Member 'twice' implicitly has an 'any' type.")),
-        "Expected no prototype-method TS7008 duplication for twice, got: {diagnostics:?}"
-    );
-    let push_errors: Vec<_> = diagnostics
-        .iter()
-        .filter(|(_, msg)| msg.contains("Property 'push' does not exist on type 'any[]'."))
-        .collect();
-    // The no-lib harness still lacks Array.prototype.push, but null narrowing
-    // suppresses the narrowed-branch access error.
-    assert_eq!(
-        push_errors.len(),
-        1,
-        "Expected only the un-narrowed push access to fail in the no-lib harness, got: {diagnostics:?}"
+        codes.iter().any(|&code| code == 2683),
+        "expected TS2683 for each implicitly-`any` constructor `this`, got: {diagnostics:?}"
     );
 }
 
@@ -1263,14 +1258,23 @@ Installer.prototype.loadArgMetadata = function(next) {
 }
 "#;
     let diagnostics = check_js(source);
+    // TypeScript 7 dropped JS constructor-function inference: `Installer` has no
+    // synthesized instance type, so `this` in a prototype method — and in an
+    // arrow nested inside it — is implicitly `any`. Assigning `"hi"` to
+    // `this.args` is therefore unchecked. tsc 7.0.2 reports only TS2683 on the
+    // constructor body and TS7006 for the untyped parameters; no TS2322.
     let ts2322: Vec<_> = diagnostics
         .iter()
-        .filter(|(code, msg)| *code == 2322 && msg.contains("string") && msg.contains("number"))
+        .filter(|(code, _)| *code == 2322)
         .collect();
-    assert_eq!(
-        ts2322.len(),
-        1,
-        "Expected prototype-method arrow to inherit instance this and report TS2322, got: {diagnostics:?}"
+    assert!(
+        ts2322.is_empty(),
+        "`this` is `any` in a prototype-method arrow, so the write is unchecked; \
+         expected no TS2322, got: {ts2322:?}"
+    );
+    assert!(
+        diagnostics.iter().any(|(code, _)| *code == 2683),
+        "expected TS2683 for the implicitly-`any` constructor `this`, got: {diagnostics:?}"
     );
 }
 

--- a/crates/tsz-checker/tests/js_constructor_property_tests.rs
+++ b/crates/tsz-checker/tests/js_constructor_property_tests.rs
@@ -198,16 +198,19 @@ Installer.prototype.second = function () {
         },
     );
 
-    assert!(
-        diagnostics
-            .iter()
-            .any(|(code, message)| { *code == 2531 && message == "Object is possibly 'null'." }),
-        "expected TS2531 on unchecked this.twices.push(), got: {diagnostics:#?}"
-    );
+    // Same shape as `test_js_constructor_nullable_array_method_call_reports_ts2531`,
+    // run through the es5-lib harness. TypeScript 7 dropped JS
+    // constructor-function inference, so `this` is implicitly `any` and
+    // `this.twices` carries no nullability to report on.
     assert_eq!(
         count_code(&diagnostics, 2531),
-        1,
-        "expected the null check to narrow the second this.twices.push(), got: {diagnostics:#?}"
+        0,
+        "`this` is `any` without constructor inference, so `this.twices.push()` is \
+         unchecked; expected no TS2531, got: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.iter().any(|(code, _)| *code == 2683),
+        "expected TS2683 for the implicitly-`any` constructor `this`, got: {diagnostics:#?}"
     );
 }
 
@@ -343,10 +346,19 @@ Installer.prototype.second = function () {
         },
     );
 
+    // TypeScript 7 dropped JS constructor-function inference, so `this.twices`
+    // never acquires the `never[] | null` shape this test was written against —
+    // `this` is implicitly `any` and the member read is unchecked. tsc 7.0.2
+    // reports only TS2683 on the constructor body for this source.
     assert_eq!(
         count_code(&diagnostics, 2531),
-        1,
-        "Expected nullable JS constructor property method call to report TS2531 exactly once, got: {diagnostics:?}"
+        0,
+        "`this` is `any` without constructor inference, so no nullability check \
+         applies; expected no TS2531, got: {diagnostics:?}"
+    );
+    assert!(
+        diagnostics.iter().any(|(code, _)| *code == 2683),
+        "expected TS2683 for the implicitly-`any` constructor `this`, got: {diagnostics:?}"
     );
 }
 


### PR DESCRIPTION
TypeScript 7 dropped JS constructor-function inference. tsz already encodes half
of that — `js_constructor_instance_type` is hardcoded `None` — but kept
synthesizing an instance type for the **prototype** receiver, on the strength of
a code comment asserting that form survived. Measured against the pinned tsc
7.0.2, it did not.

**Structural rule.** When a JS function is a method of an object literal, `this`
is not a synthesized instance of the prototype's owner: a method of an object
literal is an ordinary object-literal method, so its `this` is the literal —
exactly as in `var o = { m() { ... } }`, which already matched. tsz owns this in
the checker's function/object-literal typing layer; no solver behaviour changes.

### Measured, `--allowJs --checkJs --strict`

```js
function M() { this._map = {}; }
M.prototype.get = function (key) { return this._map[key]; };
```

tsc reports only TS2683 on the constructor body. tsz additionally reported
`TS7053 Element implicitly has an 'any' type ... can't be used to index type
'{}'`, because `this._map` resolved through the synthesized instance shape.

```js
function M() { this._map = {}; };
M.prototype = { /** @param {string} key @returns {number} */
                get(key) { return this._map[key + ""]; } };
```

tsc: `Property '_map' does not exist on type '{ get(key: string): number; }'` —
naming the object literal, not `M`. tsz named `M` and so reported nothing.

Both now match tsc exactly, display included.

### Owner layer / sites

Three sites fed a synthesized instance type into `this`:

- `types/function_type.rs` — `js_prototype_owner_instance_type`
- `types/function_type_helpers.rs` — `prototype_assignment_instance_type`,
  reached from the assignment-receiver fallback
- `types/computation/object_literal/computation_request_facts.rs` —
  `prototype_owner_this_type`, which took precedence (`.or_else`) over the
  literal's own `contextual_object_receiver_this_type`

The general assignment-receiver `this` is **preserved**: `obj.m = function(){}`
still sees `typeof obj`, which tsc does honor. Only the `.prototype` special case
is removed. `prototype_owner_target` still drives JSDoc `@template` inheritance.

### Second commit: JSDoc `@returns` is a return type annotation

An object-literal method whose body has an error and whose return type comes from
JSDoc got a spurious TS7023 "does not have a return type annotation". It has one.
The `method_return_this_circularity` recovery path emitted it unconditionally.

Its sibling emit a few lines below is already guarded — but on
`jsdoc_declared_type`, which holds a `@type` tag on the element and is `None` for
a `@returns` tag. Reusing that guard here **did not fire** (verified: the
diagnostic still appeared); the predicate has to ask for the `@returns` tag.
Only the diagnostic is suppressed — the refinement around it still runs, because
it computes the corrected `this` display used by the TS2339s immediately above.

This one is independent of prototypes: it reproduces on a plain `var o = { ... }`.

### Adjacent-case matrix

| shape | before | after |
|---|---|---|
| `M.prototype.get = function(k){ this._map[k] }` | extra TS7053 | matches tsc |
| `M.prototype = { get(k){ this._map[k] } }` | extra TS7053, missing TS2339 | matches tsc |
| `var o = { get(k){ this.nope } }` | matched | still matches (unregressed) |
| `obj.m = function(){ this }` (non-prototype) | `typeof obj` | unchanged |
| object-literal method with `@returns` | spurious TS7023 | matches tsc |

Two *pre-existing, general* JS defects surfaced next to this work and are **not**
addressed here; both reproduce on a plain `var o = { ... }` with no prototype
involved, so neither is caused by this change:

- implicit JS params render `key?: any` where tsc renders `key: any`
  (blanket rule at `checkers/signature_builder.rs:538`)
- `C.prototype = {}` on an ambient TS declaration misses TS2339 (an expando
  receiver-kind rule; reads of the same shape already match tsc byte-for-byte)

Goal: hold

## Verification

Full local runs; controlled base/after with identical methodology.

**Conformance** (`conformance.sh snapshot --workers 12 --force`):

| commit | passed | salsa |
|---|---|---|
| base `e4bda9b5` (= #15965 head) | 11404 | 127/186 |
| + prototype-`this` | 11406 | — |
| + TS7023 | **11407** | **130/186** |

Diffed by test name across the two baselines:

- newly passing (3): `typeFromJSConstructor`, `typeFromPropertyAssignment22`,
  `typeFromPrototypeAssignment3`
- **newly failing: 0**
- still failing with a changed fingerprint: 4 (net-neutral)

All three gains are in salsa; jsdoc is unchanged. Both commits were required for
`typeFromPrototypeAssignment3`: the first produces the exactly-right TS2339, and
the spurious TS7023 was what kept it red.

**Emit** (`scripts/emit/run.sh`): **JS 11562/11563, DTS 1375/1390 — unchanged**,
holding the parity floor exactly. The 16 standing failures are the same ones by
name as before this change.

This matters because an earlier attempt at this same fix was abandoned on a
reported emit regression to 11554/1368. That number came from a run the harness
had killed at a timeout: a truncated run executes fewer tests and so reports
fewer passes, while the failing-test names stay identical. Re-measured to
completion here, emit does not move.

**Unit** (`cargo nextest run -p tsz-checker`), full suite on both sides,
18831 tests:

| | failures |
|---|---|
| main `d44574db20` | 49 |
| this branch | **48** |
| newly failing | **0** |
| fixed by this change | 1 — `test_generic_constructor_prototype_object_methods_keep_existing_member_checks` |

Main's unit lane already carries 49 failures (it runs nightly, not per-merge), so
each apparent break was attributed individually rather than assumed to be mine.

Six tests changed behaviour under this fix. Every one was decided by running its
own source through the pinned tsc 7.0.2 — not by matching tsz's new output — and
tsc agreed with the new behaviour in all six:

- `..._arrow_inherits_instance_this_type` expected one TS2322; tsc reports none
  (`this` is implicitly `any`, so the write is unchecked).
- the two nullable-array tests expected TS2531; tsc reports none —
  `this.twices` never acquires `never[] | null`.
- `..._provisional_writes_merge_like_salsa` expected 5x TS2322, 1x TS2531 and a
  TS7008; tsc emits only TS2683 per constructor-body `this`.
- `..._prototype_object_literal_methods_use_instance_this` and
  `..._prototype_object_methods_allow_new_this_props` expected instance-typed
  `this`; tsc names the object literal and reports TS2339.

`js_constructor_property_more_tests` already contained TS7-migrated siblings
(`..._is_not_constructable_under_ts7`, `..._reports_ts2507_under_ts7`), so these
continue an existing migration rather than starting one.

One test now pins a KNOWN RESIDUAL rather than asserting correctness: for
`@class`/`@template` + `Cp.prototype = { m() { ... } }`, tsz now correctly fires
TS2339 but still names `Cp` where tsc names `{ m4(): any; }`. `Cp.prototype`
retains a synthesized instance type from other
`synthesize_js_constructor_instance_type` callers, and that becomes the literal's
contextual type, outranking the literal's own receiver `this`. tsc also reports
TS2526 for that method's `@return {this}`, which tsz does not. Both are follow-on
TS7 cleanups; the assertion is written to fail loudly when they are fixed.

`test_js_prototype_read_before_assignment_reports_ts2565` remains failing and is
**not** touched here: it reproduces identically on main. (For the record tsc wants
`TS2339 Property '...' does not exist on type 'NewAjax'` there, which neither
main nor this branch produces.)

`dispatch_tests::jsdoc_generic_constructor_prototype_object_literal_methods_use_instance_this`
asserted the pre-7.0 behaviour (instance `this`, no TS2339/TS7023). Checked
against the pinned tsc 7.0.2, that source now reports
`Property 'x' does not exist on type '{ m1(): any; m2(): any; }'` plus TS7023 on
both methods, TS2683 in the constructor body and TS7009 on `new Cp(1)` — so the
test encoded TS 6 expectations wholesale. It is renamed and re-pointed at the
7.0.2 oracle, asserting the receiver is reported as the object literal.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

AgentName: M1FableArchitect
