### PR TITLE
fix(checker): a chained CommonJS export write declares, like a single one

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -661,28 +661,6 @@ impl<'a> CheckerState<'a> {
             left_type = jsdoc_left_type;
         }
 
-        let is_nested_assignment = self
-            .ctx
-            .arena
-            .get(expr_idx)
-            .and_then(|_| {
-                let expr_node = tsz_parser::parser::node::NodeView::new(self.ctx.arena, expr_idx)?;
-                let parent_idx = expr_node.parent();
-                (parent_idx != NodeIndex::NONE).then_some(parent_idx)
-            })
-            .and_then(|parent_idx| self.ctx.arena.get(parent_idx))
-            .filter(|parent_node| parent_node.kind == syntax_kind_ext::BINARY_EXPRESSION)
-            .and_then(|parent_node| self.ctx.arena.get_binary_expr(parent_node))
-            .is_some_and(|parent_binary| parent_binary.right == expr_idx);
-
-        let rhs_is_assignment_expression = self
-            .ctx
-            .arena
-            .get(right_idx)
-            .filter(|node| node.kind == syntax_kind_ext::BINARY_EXPRESSION)
-            .and_then(|node| self.ctx.arena.get_binary_expr(node))
-            .is_some_and(|binary| binary.operator_token == SyntaxKind::EqualsToken as u16);
-
         self.maybe_report_commonjs_export_implicit_any_assignment(left_idx, right_idx);
 
         if is_function_assignment {
@@ -766,10 +744,19 @@ impl<'a> CheckerState<'a> {
             // The type is inferred from the union of all assigned values, so individual
             // assignments should not be checked against the inferred type.
             //
-            // However, we still need to check concrete inferred targets. For example,
-            // `assignmentToVoidZero1` expects TS2322 on `exports.x = void 0` once later
-            // writes establish that `x` is `1`. Nested assignment chains should also
-            // stay checked so each step can report the concrete mismatch.
+            // A chain declares just as much as a single write does. `exports.y =
+            // exports.x = void 0` followed by `exports.x = 1; exports.y = 2` is
+            // silent in tsc 7.0.2 (`salsa/assignmentToVoidZero1`, upstream #38552):
+            // no assignment is checked against a type derived from a *different*
+            // assignment, so the inner write is not compared to `1` nor the outer
+            // to `2`. An earlier comment here claimed that test expects those two
+            // TS2322s; measured against the pinned tsc, it expects none, so the
+            // nested-assignment and assignment-RHS carve-outs are gone.
+            //
+            // Reads are unaffected: the declared type is still the union of all
+            // assignments, and both compilers type `exports.x` as `number` here.
+            // An explicit JSDoc `@type` still makes the declared type
+            // authoritative and keeps reporting, via `has_explicit_jsdoc_left_type`.
             //
             // TS7: when a bare `module.exports = X` is mixed with sibling property
             // exports (TS2309), the siblings are not declarations — resolve them as
@@ -777,11 +764,7 @@ impl<'a> CheckerState<'a> {
             let merge_suppressed = self
                 .resolve_js_export_surface(self.ctx.current_file_idx)
                 .suppresses_expando_merge();
-            if !merge_suppressed
-                && !has_explicit_jsdoc_left_type
-                && !is_nested_assignment
-                && !rhs_is_assignment_expression
-            {
+            if !merge_suppressed && !has_explicit_jsdoc_left_type {
                 return self.get_type_of_node(right_idx);
             }
         }

--- a/crates/tsz-checker/tests/commonjs_module_export_alias_tests.rs
+++ b/crates/tsz-checker/tests/commonjs_module_export_alias_tests.rs
@@ -947,3 +947,66 @@ c.chunk;
         "Expected no TS2339 for import-equals of CommonJS-exported class expression, got: {ts2339:#?}\nAll diagnostics: {diagnostics:#?}"
     );
 }
+
+// --- `exports.X = value` declares; chains declare too. ---
+//
+// The type of a CommonJS export property is the union of every assignment in the
+// module, so no write is checked against a type established by a *different*
+// write. That holds inside an assignment chain exactly as it does for a
+// standalone write. Verified against the pinned tsc 7.0.2, which reports nothing
+// for these sources (`salsa/assignmentToVoidZero1`, upstream #38552).
+
+fn assignment_mismatch_codes(source: &str) -> Vec<u32> {
+    check_commonjs_file("a.js", source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .filter(|code| *code == 2322)
+        .collect()
+}
+
+#[test]
+fn chained_export_write_declares_rather_than_assigning() {
+    let codes = assignment_mismatch_codes(
+        "exports.y = exports.x = void 0;\nexports.x = 1;\nexports.y = 2;\n",
+    );
+    assert!(
+        codes.is_empty(),
+        "a chained `exports.X =` write declares, so `void 0` is not checked against \
+         a literal from a later assignment; got TS2322 codes: {codes:?}"
+    );
+}
+
+/// Same shape under different property names — the rule is structural, not keyed
+/// to `x`/`y`.
+#[test]
+fn chained_export_write_declares_under_renamed_properties() {
+    let codes = assignment_mismatch_codes(
+        "exports.beta = exports.alpha = void 0;\nexports.alpha = 'str';\nexports.beta = true;\n",
+    );
+    assert!(
+        codes.is_empty(),
+        "renamed binders must behave identically; got TS2322 codes: {codes:?}"
+    );
+}
+
+/// A standalone write was already a declaration and stays one.
+#[test]
+fn standalone_export_write_declares() {
+    let codes = assignment_mismatch_codes("exports.x = void 0;\nexports.x = 1;\n");
+    assert!(
+        codes.is_empty(),
+        "a standalone `exports.X =` write declares; got TS2322 codes: {codes:?}"
+    );
+}
+
+/// Negative case: an explicit JSDoc `@type` makes the declared type
+/// authoritative, so the write IS checked and still reports.
+#[test]
+fn jsdoc_annotated_export_write_still_reports_mismatch() {
+    let codes = assignment_mismatch_codes("/** @type {number} */\nexports.x = \"hi\";\n");
+    assert!(
+        codes.contains(&2322),
+        "an explicit @type annotation keeps the assignability check; expected TS2322, \
+         got: {codes:?}"
+    );
+}


### PR DESCRIPTION
`exports.X = value` in a JS file is a **declaration**, not an assignment to an
already-declared type: the property's type is the union of every assignment in
the module, and no write is checked against a type derived from a *different*
write. tsz already encoded that rule, but carved chained forms out of it.

**Structural rule.** When a CommonJS export property write appears in an
assignment chain, it declares exactly as a standalone write does. tsz owns this
in the checker's assignment path; no solver behaviour changes.

### Measured, `--target es2015 --module commonjs --allowJs --checkJs`

```js
exports.y = exports.x = void 0;
exports.x = 1;
exports.y = 2;
```

tsc 7.0.2 reports **nothing**. tsz reported two false positives:

```
a.js(1,1)  TS2322 Type 'undefined' is not assignable to type '2'.
a.js(1,13) TS2322 Type 'undefined' is not assignable to type '1'.
```

Both compare a write against a literal established by a *different* assignment —
the inner write against `1`, the outer against `2`.

Witness: `conformance/salsa/assignmentToVoidZero1` (upstream #38552).

### Owner layer

`assignability/assignment_checker/assignment_ops.rs`, in the
`is_commonjs_exports_property_declaration` branch. Two carve-outs mapped
one-to-one onto the two diagnostics:

| carve-out | produced |
|---|---|
| `is_nested_assignment` | the 1:13 report |
| `rhs_is_assignment_expression` | the 1:1 report |

Both are removed and their now-unused computations deleted.

A comment at this site asserted that `assignmentToVoidZero1` *expects* those two
TS2322s "once later writes establish that `x` is `1`". Measured against the
pinned tsc 7.0.2 the test expects none — that premise predates the 7.0 pin, and
the carve-outs were engineering toward a TypeScript 6 baseline.

### Reads are unaffected

The declared type is still the union of all assignments. Appending
`/** @type {string} */ var probe = exports.x;` to the source above yields the
identical `Type 'number' is not assignable to type 'string'` in **both**
compilers, so only the write-side check moved.

### Adjacent-case matrix

| shape | before | after |
|---|---|---|
| `exports.y = exports.x = void 0` + later writes | 2x false TS2322 | silent, matches tsc |
| `exports.x = 1` standalone | silent | unchanged |
| `/** @type {number} */ exports.x = "hi"` | TS2322 | still TS2322 (`has_explicit_jsdoc_left_type`) |
| bare `module.exports = X` with sibling exports | ordinary assignment (TS2309/TS2339) | unchanged (`suppresses_expando_merge`) |

Pre-existing and **not** addressed here: in the JSDoc-annotated guard case tsz
renders the source type as the target (`Type 'number' is not assignable to type
'number'` where tsc says `Type 'string' ...`). The code path is unchanged by this
patch — `has_explicit_jsdoc_left_type` short-circuits before the edited branch in
both versions — and conformance shows no movement from it.

Goal: hold

## Verification

Controlled base/after with identical methodology, full local runs.

**Conformance** (`conformance.sh snapshot --workers 12 --force`):

| commit | passed | failing | salsa |
|---|---|---|---|
| parent `eb25b9f68f` | 11410 | 632 | 130/186 |
| this branch | **11411** | 631 | **131/186** |

Diffed by test name across the two baselines:

- newly passing (1): `assignmentToVoidZero1`
- **newly failing: 0**

**Emit** (`scripts/emit/run.sh`), run on both sides:

| commit | JS | DTS |
|---|---|---|
| parent `eb25b9f68f` | 11562/11563 | 1374/1390 |
| this branch | 11562/11563 | 1374/1390 |

The failing sets are **identical by name** (diffed, 17 entries each), so this
change moves emit by exactly zero.

Heads-up for a different lane: the parent — i.e. current `main` — is already at
DTS **1374**, one below the 1375 figure in `.claude/CLAUDE.md`. My own #15967
branch measured 1375 earlier today, so the drop happened on main in between;
`86964b896e "ci: reconcile known-failures baseline to r7"` edits the expected set
and is the likely cause. The newly-failing entry there is
`declarationEmitUsingTypeAlias2`, which contains no `exports.` assignment and no
`.js` file, so it cannot be reached by this patch. Flagging it because the
documented floor and reality now disagree.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

AgentName: M1FableArchitect
