### PR TITLE
fix(checker): a JSDoc @template scopes over its function's body

### DIFF
--- a/crates/tsz-checker/src/jsdoc/diagnostics_templates.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics_templates.rs
@@ -419,6 +419,49 @@ impl<'a> CheckerState<'a> {
             let Some(node) = self.ctx.arena.get(idx) else {
                 continue;
             };
+            // A function-like host scopes its own `@template` over its entire
+            // source range, so a JSDoc annotation written inside the body sees it
+            // — `function F(){ /** @type {V} */ this.p = {} }` where `V` comes
+            // from `@template V` on `F`. tsc 7.0.2 accepts that; tsz reported a
+            // false TS2304 because only class hosts were modelled here.
+            //
+            // Unlike the class arm below, this consults ONLY the host's own
+            // leading JSDoc. Falling through to the loose `comment.end <=
+            // host_pos` scan would turn the false positive into a false
+            // negative, letting a *sibling* function's `@template T` satisfy a
+            // reference that tsc correctly rejects.
+            //
+            // Every containing function is visited, not just the innermost, so an
+            // outer `@template` reaches a nested function's body.
+            if matches!(
+                node.kind,
+                syntax_kind_ext::FUNCTION_DECLARATION
+                    | syntax_kind_ext::FUNCTION_EXPRESSION
+                    | syntax_kind_ext::ARROW_FUNCTION
+                    | syntax_kind_ext::METHOD_DECLARATION
+                    | syntax_kind_ext::CONSTRUCTOR
+            ) {
+                if !(ref_pos >= node.pos && ref_pos < node.end) {
+                    continue;
+                }
+                let mut anchor = node.pos;
+                if let Some(ext) = self.ctx.arena.get_extended(idx)
+                    && ext.parent.is_some()
+                    && let Some(parent) = self.ctx.arena.get(ext.parent)
+                    && parent.kind == syntax_kind_ext::EXPORT_DECLARATION
+                {
+                    anchor = parent.pos;
+                }
+                if let Some((content, _)) =
+                    self.try_leading_jsdoc_with_pos(&sf.comments, anchor, source_text)
+                    && Self::jsdoc_template_type_params(&content)
+                        .into_iter()
+                        .any(|(decl_name, _, _)| decl_name == name)
+                {
+                    return true;
+                }
+                continue;
+            }
             if node.kind != syntax_kind_ext::CLASS_DECLARATION
                 && node.kind != syntax_kind_ext::CLASS_EXPRESSION
             {


### PR DESCRIPTION
A JSDoc `@template` declared on a function was not in scope for a JSDoc
annotation written inside that function's body, producing a false TS2304.

**Structural rule.** When `@template N` is declared on the leading JSDoc of a
function-like declaration D, tsc 7.0.2 scopes `N` over D's entire source range —
D's own signature tags and every JSDoc comment lexically inside D's body at any
nesting depth — and nowhere outside it. tsz should do the same through the
checker's JSDoc scope oracle `source_file_declares_jsdoc_template_at`, which
modelled class hosts only.

### Measured, `--target es2015 --allowJs --checkJs`

```js
/**
 * @template V
 * @param {string} ik
 */
function Multimap(ik, iv) {
    /** @type {{ [s: string]: V }} */
    this._map = {};
}
```

tsc reports nothing; tsz reported `TS2304: Cannot find name 'V'`. `@param {V}` on
the signature already resolved — only body-level annotations failed, and that
asymmetry is the tell.

**Diagnostic-only.** The body walk already resolved `V` correctly: for
`/** @type {V} */ var x = 123` tsz emits the right TS2322 ("'V' could be
instantiated with an arbitrary type") *alongside* the bogus TS2304. So
`type_parameter_scope` / `check_function_body` are not involved, despite the
stale root cause named in the test file's header comment.

### Owner layer

`jsdoc/diagnostics_templates.rs` — a function-host arm added to the arena walk in
`source_file_declares_jsdoc_template_at`. One fix covers all three TS2304
emitters, since they funnel through this predicate (`jsdoc/base_types.rs:927`,
`jsdoc/base_types.rs:101` -> `jsdoc_template_in_scope_for_reference`, and
`jsdoc/params_generic_instantiation.rs:392`).

Three load-bearing choices:

- consults **only** the host's own leading JSDoc, never the loose
  `comment.end <= host_pos` scan the class arm falls back to. Reusing that scan
  turns this false positive into a false negative, letting a *sibling* function's
  `@template T` satisfy a reference tsc correctly rejects.
- visits **every** containing function, not just the innermost, so an outer
  `@template` reaches a nested function's body.
- leaves the class arm byte-identical.

### Adjacent-case matrix (tsc 7.0.2 oracle)

Now matching tsc (previously false TS2304):

| shape | |
|---|---|
| body `@type {{ [s: string]: V }}` on `this.p` | corpus witness |
| body `@type {T}` on an expression statement / variable statement | the two unit tests |
| nested function body `@type {T}` | needs the ancestor walk |
| `export function` host | needs the EXPORT_DECLARATION anchor hop |
| nested function's own `@param {T}` | routes via `base_types.rs:101` |
| body-level `@typedef` / `@property {T}` | |

Still reporting, verified unchanged (guard rails):

| shape | |
|---|---|
| sibling function's `@template T` used in another function's body | TS2304, tsc agrees |
| genuinely unknown names (`{Nope}`, `{{[s:string]: Nope2}}`) | TS2304, tsc agrees |
| `Multimap.prototype.get`'s `@param {K}` outside any host | TS2304, tsc agrees |
| `jsdoc_template_reference_scope_tests` (5 negative cases) | unchanged |

Not addressed here, both pre-existing and unrelated: a top-level
`/** @template T @type {T} */ var x` reports TS2304 at tsz's own anchor (2,14)
rather than tsc's (3,11) — a position difference, the diagnostic is present; and
a class-arm over-suppression where an unrelated function's `@template Q` reaches
a plain class member (tsc errors, tsz silent).

Goal: hold

## Verification

Controlled base/after, identical methodology, full local runs. Base is the branch
point `7f3d9b7f74`.

**Conformance** (`conformance.sh snapshot --workers 12 --force`): 631 failing
before and after. Diffed by test name: **0 newly failing, 0 newly passing.**

This fix intentionally flips **no** corpus row. `propertiesOfGenericConstructorFunctions`
is the one changed fingerprint — its delta drops 3 -> 2 (the false TS2304 is gone;
the two remaining missing TS2339s are the separate `X.prototype = { m(){} }`
receiver-typing cluster). The row will flip when that lands.

**Unit** (`cargo nextest run -p tsz-checker -j 6`, 18835 tests): **49 -> 47
failures**, 0 new. The two tests that flip are
`jsdoc_template_in_body_scope_tests::jsdoc_template_param_visible_in_body_jsdoc_type_annotation`
and `::jsdoc_template_param_does_not_emit_unrelated_diagnostics`; both were
already failing on main (its unit lane runs nightly and carries 49) and their
assertions are correct as written — verified against tsc 7.0.2 rather than
against tsz's new output.

**Emit** (`scripts/emit/run.sh`): JS 11562/11563, DTS 1375/1390 — at the parity
floor, failing set identical by name to the pre-change measurement.

**Clippy**: `cargo clippy -p tsz-checker --all-targets` clean.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

AgentName: M1FableArchitect
