### PR TITLE
fix(checker): reuse active class type parameter identities

### DIFF
--- a/crates/tsz-checker/src/tests/cross_file_type_param_decl_identity_tests.rs
+++ b/crates/tsz-checker/src/tests/cross_file_type_param_decl_identity_tests.rs
@@ -28,7 +28,7 @@
 //! #13137 hit). The identity invariant is therefore pinned directly at the
 //! scope-push unit level, plus single-file behavioral controls.
 
-use crate::context::CheckerOptions;
+use crate::context::{CheckerOptions, EnclosingClassInfo};
 use crate::diagnostics::{Diagnostic, diagnostic_codes};
 use crate::state::CheckerState;
 use crate::test_utils::{check_multi_file_with_libs, load_lib_files};
@@ -36,7 +36,7 @@ use tsz_binder::BinderState;
 use tsz_common::common::ModuleKind;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, ParserState};
-use tsz_solver::construction::TypeInterner;
+use tsz_solver::{TypeId, construction::TypeInterner};
 
 fn check(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
     check_multi_file_with_libs(
@@ -166,6 +166,110 @@ class Box<Alpha, Beta extends keyof Alpha> {
         direct_first, direct_second,
         "repeated direct pushes must reuse the declaration's TypeIds"
     );
+}
+
+/// An active class owns the canonical identity and recovery state of its type
+/// parameters. Reconstructing a method signature must reuse those exact
+/// binders instead of re-resolving an invalid constraint and minting a cleaner
+/// but distinct type parameter for the same declaration.
+#[test]
+fn active_class_enclosing_push_reuses_error_constrained_binder_identity() {
+    let source = r#"
+class Box<Element extends MissingConstraint> {
+  read(): Element {
+    return null as any;
+  }
+}
+"#;
+    let mut parser = ParserState::new("box.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let arena = parser.get_arena().clone();
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        &arena,
+        &binder,
+        &types,
+        "box.ts".to_string(),
+        CheckerOptions {
+            no_lib: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let source_file = arena.get_source_file_at(root).expect("source file data");
+    let class_idx = source_file
+        .statements
+        .nodes
+        .iter()
+        .copied()
+        .find(|&idx| {
+            arena
+                .get(idx)
+                .is_some_and(|n| n.kind == syntax_kind_ext::CLASS_DECLARATION)
+        })
+        .expect("class declaration");
+    let class_data = arena
+        .get(class_idx)
+        .and_then(|n| arena.get_class(n))
+        .expect("class data");
+    let method_idx = class_data
+        .members
+        .nodes
+        .iter()
+        .copied()
+        .find(|&idx| {
+            arena
+                .get(idx)
+                .is_some_and(|n| n.kind == syntax_kind_ext::METHOD_DECLARATION)
+        })
+        .expect("method declaration");
+
+    let (class_type_parameters, class_updates) =
+        checker.push_type_parameters(&class_data.type_parameters);
+    let class_type_parameter_ids = checker
+        .exact_type_parameter_ids_in_scope(&class_type_parameters)
+        .expect("canonical class parameter identities");
+    let direct_id = class_type_parameter_ids[0];
+    let direct_info = crate::query_boundaries::common::type_param_info(&types, direct_id)
+        .expect("class parameter info");
+    assert_eq!(
+        direct_info.constraint,
+        Some(TypeId::ERROR),
+        "the canonical class binder must retain its invalid-constraint recovery state"
+    );
+
+    checker.ctx.enclosing_class = Some(EnclosingClassInfo {
+        name: "Box".to_string(),
+        class_idx,
+        member_nodes: class_data.members.nodes.clone(),
+        in_constructor: false,
+        is_declared: false,
+        in_static_property_initializer: false,
+        in_static_member: false,
+        has_super_call_in_current_constructor: false,
+        cached_instance_this_type: None,
+        type_param_names: vec!["Element".to_string()],
+        class_type_parameters,
+        class_type_parameter_ids,
+    });
+
+    let enclosing_updates = checker.push_enclosing_type_parameters(method_idx);
+    assert_eq!(
+        checker.ctx.type_parameter_scope.get("Element").copied(),
+        Some(direct_id),
+        "a method signature must close over the active class's exact binder"
+    );
+    checker.pop_type_parameters(enclosing_updates);
+    assert_eq!(
+        checker.ctx.type_parameter_scope.get("Element").copied(),
+        Some(direct_id),
+        "popping the reconstructed scope must restore the active class binder"
+    );
+
+    checker.ctx.enclosing_class = None;
+    checker.pop_type_parameters(class_updates);
 }
 
 /// Single-file behavioral control for the kysely `whereRef` shape (tsc 5.9.3

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -1378,7 +1378,7 @@ impl<'a> CheckerState<'a> {
     ) -> Vec<(String, Option<TypeId>, bool)> {
         use tsz_parser::parser::syntax_kind_ext;
 
-        let mut enclosing_param_indices: Vec<Vec<NodeIndex>> = Vec::new();
+        let mut enclosing_param_indices: Vec<(Vec<NodeIndex>, Option<Vec<TypeId>>)> = Vec::new();
         let mut current = func_idx;
         while let Some(ext) = self.ctx.arena.get_extended(current) {
             let parent_idx = ext.parent;
@@ -1425,7 +1425,29 @@ impl<'a> CheckerState<'a> {
             };
 
             if let Some(indices) = type_param_nodes {
-                enclosing_param_indices.push(indices);
+                // A method signature built while its class is being checked must
+                // close over the class binders already installed by
+                // `push_effective_class_type_parameters`. Re-resolving the same
+                // declarations here can observe a different transient recovery
+                // state (for example, `None` versus `Some(ERROR)` constraints)
+                // and mint a second `TypeId` for the same binder.
+                let exact_class_type_parameter_ids = if matches!(
+                    parent.kind,
+                    k if k == syntax_kind_ext::CLASS_DECLARATION
+                        || k == syntax_kind_ext::CLASS_EXPRESSION
+                ) {
+                    self.ctx
+                        .enclosing_class
+                        .as_ref()
+                        .filter(|info| {
+                            info.class_idx == parent_idx
+                                && info.class_type_parameter_ids.len() == indices.len()
+                        })
+                        .map(|info| info.class_type_parameter_ids.clone())
+                } else {
+                    None
+                };
+                enclosing_param_indices.push((indices, exact_class_type_parameter_ids));
             }
 
             current = parent_idx;
@@ -1439,8 +1461,10 @@ impl<'a> CheckerState<'a> {
         let mut added_params: Vec<(NodeIndex, bool)> = Vec::new();
 
         // Pass 1: Add all type parameters to scope WITHOUT constraints
-        for param_indices in enclosing_param_indices.into_iter().rev() {
-            for param_idx in param_indices {
+        for (param_indices, exact_class_type_parameter_ids) in
+            enclosing_param_indices.into_iter().rev()
+        {
+            for (param_position, param_idx) in param_indices.into_iter().enumerate() {
                 let Some(node) = self.ctx.arena.get(param_idx) else {
                     continue;
                 };
@@ -1457,6 +1481,17 @@ impl<'a> CheckerState<'a> {
                         || "T".to_string(),
                         |id_data| id_data.escaped_text.to_string(),
                     );
+
+                if let Some(type_id) = exact_class_type_parameter_ids
+                    .as_ref()
+                    .and_then(|ids| ids.get(param_position))
+                    .copied()
+                {
+                    let previous = self.ctx.type_parameter_scope.insert(name.clone(), type_id);
+                    updates.push((name, previous, false));
+                    continue;
+                }
+
                 let atom = self.ctx.types.intern_string(&name);
 
                 let is_const = self

--- a/crates/tsz-checker/tests/abstract_method_overload_ts2416_tests.rs
+++ b/crates/tsz-checker/tests/abstract_method_overload_ts2416_tests.rs
@@ -1,5 +1,5 @@
 use tsz_checker::context::CheckerOptions;
-use tsz_checker::test_utils::check_source;
+use tsz_checker::test_utils::{check_multi_file, check_source};
 
 /// Structural rule: when a derived class implements abstract overload
 /// signatures from a base class with matching overload declarations plus
@@ -269,5 +269,150 @@ class Derived extends Mid {
     assert!(
         ts2416_on_derived.is_empty(),
         "Expected no TS2416 — Derived covers all of Mid's overloads, got: {diags:#?}"
+    );
+}
+
+/// Zod's `ZodNativeEnum<T>` specializes an abstract method through an indexed
+/// access and returns the same generic union alias as its instantiated base.
+/// Parameter names are irrelevant, and the identical return applications must
+/// remain related in the ordinary single-signature override path.
+#[test]
+fn non_overloaded_indexed_access_return_alias_is_related_to_itself() {
+    let source = r#"
+type Rejected = { valid: false };
+type Accepted<Value> = { valid: true; value: Value };
+type SyncMaybe<Value> = Accepted<Value> | Rejected;
+type AsyncMaybe<Value> = Promise<SyncMaybe<Value>>;
+type MaybeAsync<Value> = SyncMaybe<Value> | AsyncMaybe<Value>;
+
+type EnumShape = {
+  [key: string]: string | number;
+  [index: number]: string;
+};
+
+abstract class Parser<Output> {
+  abstract parse(
+    _context: object,
+    _data: any,
+    _kind: string
+  ): MaybeAsync<Output>;
+}
+
+class AnyParser extends Parser<any> {
+  parse(
+    context: object,
+    data: any,
+    kind: string
+  ): MaybeAsync<any> {
+    return null as any;
+  }
+}
+
+class NativeParser<Table extends EnumShape>
+  extends Parser<Table[keyof Table]> {
+  parse(
+    context: object,
+    data: any,
+    kind: string
+  ): MaybeAsync<Table[keyof Table]> {
+    return null as any;
+  }
+}
+"#;
+    let diags = check_source(source, "test.ts", CheckerOptions::default());
+    let ts2416: Vec<_> = diags.iter().filter(|d| d.code == 2416).collect();
+    assert!(
+        ts2416.is_empty(),
+        "An instantiated abstract method returning the same generic union alias must not emit TS2416: {diags:#?}"
+    );
+}
+
+#[test]
+fn non_overloaded_imported_indexed_access_return_alias_is_related_to_itself() {
+    let files = [
+        (
+            "result.ts",
+            r#"
+export type Rejected = { valid: false };
+export type Accepted<Value> = { valid: true; value: Value };
+export type SyncMaybe<Value> = Accepted<Value> | Rejected;
+export type AsyncMaybe<Value> = Promise<SyncMaybe<Value>>;
+export type MaybeAsync<Value> = SyncMaybe<Value> | AsyncMaybe<Value>;
+export type ParsedKind = "text" | "number" | "object";
+"#,
+        ),
+        (
+            "parser.ts",
+            r#"
+import { MaybeAsync, ParsedKind } from "./result";
+
+interface Definition {}
+type EnumShape = {
+  [key: string]: string | number;
+  [index: number]: string;
+};
+interface NativeDefinition<Table extends EnumShape = EnumShape>
+  extends Definition {
+  values: Table;
+}
+
+abstract class Parser<
+  Output,
+  Def extends Definition = Definition,
+  Input = Output
+> {
+  abstract parse(
+    _context: object,
+    _data: any,
+    _kind: ParsedKind
+  ): MaybeAsync<Output>;
+}
+
+class NativeParser<Table extends EnumShape>
+  extends Parser<Table[keyof Table], NativeDefinition<Table>> {
+  parse(
+    context: object,
+    data: any,
+    kind: ParsedKind
+  ): MaybeAsync<Table[keyof Table]> {
+    return null as any;
+  }
+}
+"#,
+        ),
+    ];
+    let diags = check_multi_file(&files, "parser.ts", CheckerOptions::default());
+    let ts2416: Vec<_> = diags.iter().filter(|d| d.code == 2416).collect();
+    assert!(
+        ts2416.is_empty(),
+        "Cross-file alias identity must not make an otherwise identical abstract override incompatible: {diags:#?}"
+    );
+}
+
+/// Invalid constraints retain an internal recovery sentinel on the canonical
+/// class binder. A method signature must reuse that binder, while the missing
+/// name still reports normally; reconstructing a second unconstrained binder
+/// made `Element` spuriously incompatible with itself.
+#[test]
+fn unresolved_class_constraint_preserves_override_binder_identity() {
+    let source = r#"
+abstract class Reader<Output> {
+  abstract read(): Output;
+}
+
+class Box<Element extends MissingConstraint> extends Reader<Element> {
+  read(): Element {
+    return null as any;
+  }
+}
+"#;
+    let diags = check_source(source, "test.ts", CheckerOptions::default());
+    assert!(
+        diags.iter().any(|d| d.code == 2304),
+        "the unresolved constraint must still report TS2304: {diags:#?}"
+    );
+    assert!(
+        diags.iter().all(|d| d.code != 2416),
+        "the same declared Element binder must not be incompatible with itself: {diags:#?}"
     );
 }


### PR DESCRIPTION
Goal: green

Fixes #15883

## Structural rule

When a method signature is built lexically inside an active generic class, `tsc` uses the one canonical binder identity for each class type-parameter declaration. The checker now reuses `EnclosingClassInfo.class_type_parameter_ids` in declaration order instead of rebuilding the same binders through a second constraint-resolution pass.

Owner layer: checker type-parameter scope orchestration in `push_enclosing_type_parameters`. Solver relations, overload variance policy, and diagnostics remain unchanged.

Fallback: class expressions use the same exact-ID path; foreign classes, inactive classes, malformed arity, method/function parameters, and interfaces retain the existing two-pass reconstruction behavior.

## Root cause

Zod heritage instantiation used canonical `T { constraint: Some(ERROR) }`, while method signature construction transiently rebuilt the same declaration as `T { constraint: None }`. The resulting `T[keyof T]` graphs rendered identically but had different identities, producing a false TS2416 on `ZodNativeEnum<T>._parse`. Globally discarding `ERROR` fixed that symptom but caused three recovery regressions, so this change preserves the canonical recovery state and only eliminates the duplicate binder.

## Adjacent cases

- renamed class binders and local/indexed-access return aliases
- imported alias and multi-parameter base-class forms
- unresolved-constraint recovery keeps TS2304 without splitting identity
- overloaded any/never positive and genuine-mismatch controls
- method-level shadowing, nested closures, and defaulted parameters remain covered by existing focused suites

## Verification

- Before: pinned Zod guard emitted one false TS2416 at `src/types.ts:3012`; after: exit 0 with no diagnostics.
- `cargo nextest run -p tsz-checker --lib cross_file_type_param_decl_identity_tests` — 4 passed.
- `cargo nextest run -p tsz-checker --lib enclosing_type_param_default_scope_tests` — 10 passed.
- `cargo nextest run -p tsz-checker --lib lexical_identity_scope_tests` — 3 passed.
- `cargo nextest run -p tsz-checker --test abstract_method_overload_ts2416_tests` — 13 passed.
- `cargo clippy -p tsz-checker --lib` and targeted integration-test Clippy — passed.
- Local pre-commit gate — formatting, Clippy, and architecture guard passed.
- Fresh-worker full conformance comparison (`--workers 12 --max-compilations-per-worker 1`): base `aab57598d4` and behavior head `e7d14a39c0` both passed 11,419/12,043 with 624 failures and 189 fingerprint-only failures; all 624 canonicalized per-test artifacts were semantically identical (0 added, 0 removed, 0 changed).
- `TSZ_BIN="$PWD/.target/dist-fast/tsz" ./scripts/emit/run.sh --skip-build` — held JS 11,562/11,563 and DTS 1,375/1,390.
- `./scripts/fourslash/run-fourslash.sh --skip-build` against the exact dist-fast server — held 6,558/6,562 with the same four known failures.
- Rebased onto queued-and-merged #15976; `git range-diff aab57598d4..e7d14a39c0 origin/main..cd6aa89494` reports the Zod patch unchanged.

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5.6-sol
Effort: xhigh
