### PR TITLE
chore(cli): place checker diagnostic tests last

### DIFF
--- a/crates/tsz-cli/src/driver/checker_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/checker_diagnostics.rs
@@ -61,24 +61,6 @@ pub(super) fn keep_checker_diagnostic_when_program_has_real_syntax_errors(code: 
         || is_reserved_type_name_declaration_diagnostic(code)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::keep_checker_diagnostic_when_program_has_real_syntax_errors;
-
-    #[test]
-    fn real_syntax_errors_suppress_semantic_ts1xxx_but_keep_parse_diagnostics() {
-        assert!(!keep_checker_diagnostic_when_program_has_real_syntax_errors(1064));
-        assert!(!keep_checker_diagnostic_when_program_has_real_syntax_errors(1315));
-        assert!(keep_checker_diagnostic_when_program_has_real_syntax_errors(
-            1005
-        ));
-        assert!(keep_checker_diagnostic_when_program_has_real_syntax_errors(
-            2427
-        ));
-        assert!(!keep_checker_diagnostic_when_program_has_real_syntax_errors(2322));
-    }
-}
-
 /// `TS1xxx` codes that tsc routes through `getSemanticDiagnostics`. They are in
 /// the parser-grammar range numerically but are emitted from the checker, so
 /// unchecked JS files (no `checkJs`, or `// @ts-nocheck`) must not see them
@@ -277,5 +259,23 @@ pub(super) fn post_process_checker_diagnostics(
                 dist <= MAX_CASCADE_DISTANCE
             })
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::keep_checker_diagnostic_when_program_has_real_syntax_errors;
+
+    #[test]
+    fn real_syntax_errors_suppress_semantic_ts1xxx_but_keep_parse_diagnostics() {
+        assert!(!keep_checker_diagnostic_when_program_has_real_syntax_errors(1064));
+        assert!(!keep_checker_diagnostic_when_program_has_real_syntax_errors(1315));
+        assert!(keep_checker_diagnostic_when_program_has_real_syntax_errors(
+            1005
+        ));
+        assert!(keep_checker_diagnostic_when_program_has_real_syntax_errors(
+            2427
+        ));
+        assert!(!keep_checker_diagnostic_when_program_has_real_syntax_errors(2322));
     }
 }


### PR DESCRIPTION
Goal: hold

## Summary

Move the existing `#[cfg(test)]` module in `checker_diagnostics.rs` below all production items. The test body is unchanged; this restores `clippy::items_after_test_module` compliance without an allowlist and keeps runtime behavior unchanged.

## Invariant

Rust test modules stay after production items, so the workspace all-target Clippy lane can compile the lib-test target without `items_after_test_module` violations.

## Verification

- `CARGO_PROFILE_DEV_DEBUG=0 cargo nextest run -p tsz-cli --lib real_syntax_errors_suppress_semantic_ts1xxx_but_keep_parse_diagnostics` — 1 passed; 1,616 skipped.
- `CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p tsz-cli --all-targets -- -D warnings` — passed.
- `python3 scripts/arch/arch_guard.py` — passed.
- `CARGO_PROFILE_DEV_DEBUG=0 scripts/safe-run.sh scripts/githooks/pre-commit` — formatting, scoped Clippy, and architecture guard passed.

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5.6-sol
Effort: xhigh