### PR TITLE
fix(checker): classify default-export declaration merges

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2531,3 +2531,6 @@ path = "tests/nullish_non_strict_assignability_tests.rs"
 [[test]]
 name = "instanceof_promise_recursive_narrowing_tests"
 path = "tests/instanceof_promise_recursive_narrowing_tests.rs"
+[[test]]
+name = "default_export_merge_diagnostics_tests"
+path = "tests/default_export_merge_diagnostics_tests.rs"

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -470,8 +470,16 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            // TS2395
-            let mut has_ts2395 = false;
+            // TS2652 / TS2395
+            //
+            // Default exports are a third visibility class, distinct from ordinary
+            // exported declarations. A merged declaration whose default-exported
+            // type/value/namespace space intersects any non-default declaration
+            // reports TS2652. Only ordinary exported-vs-local intersections report
+            // TS2395, and a declaration claimed by TS2652 must not also report
+            // TS2395.
+            let mut ts2652_error_nodes: Vec<NodeIndex> = Vec::new();
+            let mut ts2395_error_nodes: Vec<NodeIndex> = Vec::new();
 
             // Skip TS2395 when all local declarations are in a `declare namespace`
             // (identifier-named ambient namespace). In these contexts, the
@@ -480,137 +488,154 @@ impl<'a> CheckerState<'a> {
             // However, `declare module "..."` (string-literal-named module
             // declarations) SHOULD still emit TS2395 — tsc treats these as
             // module scopes where export consistency matters.
-            let all_ambient = declarations
+            let suppress_ts2395_for_ambient = declarations
                 .iter()
                 .filter(|(_, _, is_local, _, _)| *is_local)
                 .all(|(decl_idx, _, _, _, _)| self.is_in_ambient_namespace_not_module(*decl_idx));
 
-            if !all_ambient {
-                {
-                    const SPACE_TYPE: u32 = 1;
-                    const SPACE_VALUE: u32 = 2;
-                    const SPACE_NAMESPACE: u32 = 4;
+            const SPACE_TYPE: u32 = 1;
+            const SPACE_VALUE: u32 = 2;
+            const SPACE_NAMESPACE: u32 = 4;
 
-                    let mut error_nodes: Vec<NodeIndex> = Vec::new();
-
+            let decl_info: Vec<(NodeIndex, u32, u32, bool, bool, NodeIndex)> = declarations
+                .iter()
+                .filter(|&(_, _, is_local, _, _)| *is_local)
+                .map(|&(decl_idx, flags, _, exported, _)| {
+                    let space = if (flags & symbol_flags::INTERFACE) != 0
+                        || (flags & symbol_flags::TYPE_ALIAS) != 0
                     {
-                        let decl_info: Vec<(NodeIndex, u32, u32, bool, NodeIndex)> = declarations
-                            .iter()
-                            .filter(|&(_, _, is_local, _, _)| *is_local)
-                            .map(|&(decl_idx, flags, _, exported, _)| {
-                                let space = if (flags & symbol_flags::INTERFACE) != 0
-                                    || (flags & symbol_flags::TYPE_ALIAS) != 0
-                                {
-                                    SPACE_TYPE
-                                } else if (flags
-                                    & (symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE))
-                                    != 0
-                                {
-                                    if self.is_namespace_declaration_instantiated(decl_idx) {
-                                        SPACE_NAMESPACE | SPACE_VALUE
-                                    } else {
-                                        SPACE_NAMESPACE
-                                    }
-                                } else if (flags & symbol_flags::CLASS) != 0
-                                    || (flags
-                                        & (symbol_flags::REGULAR_ENUM | symbol_flags::CONST_ENUM))
-                                        != 0
-                                {
-                                    SPACE_TYPE | SPACE_VALUE
-                                } else if (flags & symbol_flags::VARIABLE) != 0
-                                    || (flags & symbol_flags::FUNCTION) != 0
-                                {
-                                    SPACE_VALUE
-                                } else if (flags & symbol_flags::ALIAS) != 0 {
-                                    // Import-equals declarations (`import Foo = X`) occupy both
-                                    // type and value space, so they trigger TS2395 against an
-                                    // exported type/value alias of the same name.
-                                    //
-                                    // Other alias forms (`import * as X`, `import { X }`,
-                                    // `import X from`) collide with local declarations as TS2440
-                                    // (Import declaration conflicts with local declaration of X)
-                                    // — tsc does not double-report TS2395 for them. Skip space
-                                    // contribution for those by limiting to ImportEqualsDeclaration.
-                                    if self.ctx.arena.get(decl_idx).is_some_and(|n| {
-                                        n.kind == tsz_parser::parser::syntax_kind_ext::IMPORT_EQUALS_DECLARATION
-                                    }) {
-                                        SPACE_VALUE | SPACE_TYPE
-                                    } else {
-                                        0
-                                    }
-                                } else {
-                                    0
-                                };
-                                let scope = self.get_enclosing_namespace(decl_idx);
-                                (decl_idx, flags, space, exported, scope)
-                            })
-                            .collect();
-
-                        type ScopeGroupEntry = (NodeIndex, u32, u32, bool);
-                        // At most one distinct scope per declaration (#11617).
-                        let mut scope_groups: FxHashMap<NodeIndex, Vec<ScopeGroupEntry>> =
-                            FxHashMap::with_capacity_and_hasher(
-                                decl_info.len(),
-                                Default::default(),
-                            );
-                        for &(decl_idx, flags, space, exported, scope) in &decl_info {
-                            scope_groups
-                                .entry(scope)
-                                .or_default()
-                                .push((decl_idx, flags, space, exported));
+                        SPACE_TYPE
+                    } else if (flags
+                        & (symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE))
+                        != 0
+                    {
+                        if self.is_namespace_declaration_instantiated(decl_idx) {
+                            SPACE_NAMESPACE | SPACE_VALUE
+                        } else {
+                            SPACE_NAMESPACE
                         }
-
-                        for group in scope_groups.values() {
-                            if group.len() <= 1 {
-                                continue;
-                            }
-                            let all_functions = group
-                                .iter()
-                                .all(|&(_, flags, _, _)| (flags & symbol_flags::FUNCTION) != 0);
-                            if all_functions {
-                                continue;
-                            }
-                            let mut exported_spaces: u32 = 0;
-                            let mut non_exported_spaces: u32 = 0;
-                            for &(_, _, space, exported) in group {
-                                if exported {
-                                    exported_spaces |= space;
-                                } else {
-                                    non_exported_spaces |= space;
-                                }
-                            }
-                            let common_spaces = exported_spaces & non_exported_spaces;
-                            let _ = (exported_spaces, non_exported_spaces, common_spaces);
-                            if common_spaces != 0 {
-                                has_ts2395 = true;
-                                for &(decl_idx, _, space, _) in group {
-                                    if (space & common_spaces) != 0 {
-                                        let error_node = self
-                                            .get_declaration_name_node(decl_idx)
-                                            .unwrap_or(decl_idx);
-                                        error_nodes.push(error_node);
-                                    }
-                                }
-                            }
+                    } else if (flags & symbol_flags::CLASS) != 0
+                        || (flags & (symbol_flags::REGULAR_ENUM | symbol_flags::CONST_ENUM)) != 0
+                    {
+                        SPACE_TYPE | SPACE_VALUE
+                    } else if (flags & symbol_flags::VARIABLE) != 0
+                        || (flags & symbol_flags::FUNCTION) != 0
+                    {
+                        SPACE_VALUE
+                    } else if (flags & symbol_flags::ALIAS) != 0 {
+                        // Import-equals declarations (`import Foo = X`) occupy both
+                        // type and value space, so they trigger TS2395 against an
+                        // exported type/value alias of the same name.
+                        //
+                        // Other alias forms (`import * as X`, `import { X }`,
+                        // `import X from`) collide with local declarations as TS2440
+                        // (Import declaration conflicts with local declaration of X)
+                        // — tsc does not double-report TS2395 for them. Skip space
+                        // contribution for those by limiting to ImportEqualsDeclaration.
+                        if self.ctx.arena.get(decl_idx).is_some_and(|n| {
+                            n.kind == tsz_parser::parser::syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+                        }) {
+                            SPACE_VALUE | SPACE_TYPE
+                        } else {
+                            0
                         }
-                    }
+                    } else {
+                        0
+                    };
+                    let default_exported = exported
+                        && self.declaration_participates_in_default_export_conflict(decl_idx);
+                    let scope = self.get_enclosing_namespace(decl_idx);
+                    (decl_idx, flags, space, exported, default_exported, scope)
+                })
+                .collect();
 
-                    if has_ts2395 {
-                        let name = symbol.escaped_name.clone();
-                        let message = format_message(
-                        diagnostic_messages::INDIVIDUAL_DECLARATIONS_IN_MERGED_DECLARATION_MUST_BE_ALL_EXPORTED_OR_ALL_LOCAL,
-                        &[&name],
-                    );
-                        for error_node in error_nodes {
-                            self.error_at_node(
-                            error_node,
-                            &message,
-                            diagnostic_codes::INDIVIDUAL_DECLARATIONS_IN_MERGED_DECLARATION_MUST_BE_ALL_EXPORTED_OR_ALL_LOCAL,
-                        );
-                        }
+            type ScopeGroupEntry = (NodeIndex, u32, u32, bool, bool);
+            // At most one distinct scope per declaration (#11617).
+            let mut scope_groups: FxHashMap<NodeIndex, Vec<ScopeGroupEntry>> =
+                FxHashMap::with_capacity_and_hasher(decl_info.len(), Default::default());
+            for &(decl_idx, flags, space, exported, default_exported, scope) in &decl_info {
+                scope_groups.entry(scope).or_default().push((
+                    decl_idx,
+                    flags,
+                    space,
+                    exported,
+                    default_exported,
+                ));
+            }
+
+            for group in scope_groups.values() {
+                if group.len() <= 1 {
+                    continue;
+                }
+                let all_functions = group
+                    .iter()
+                    .all(|&(_, flags, _, _, _)| (flags & symbol_flags::FUNCTION) != 0);
+                let mut default_exported_spaces: u32 = 0;
+                let mut exported_spaces: u32 = 0;
+                let mut non_exported_spaces: u32 = 0;
+                for &(_, _, space, exported, default_exported) in group {
+                    if default_exported {
+                        default_exported_spaces |= space;
+                    } else if exported {
+                        exported_spaces |= space;
+                    } else {
+                        non_exported_spaces |= space;
                     }
                 }
-            } // end if !all_ambient
+                let non_default_spaces = exported_spaces | non_exported_spaces;
+                let default_conflict_spaces = default_exported_spaces & non_default_spaces;
+                let export_local_conflict_spaces = if all_functions || suppress_ts2395_for_ambient {
+                    0
+                } else {
+                    exported_spaces & non_exported_spaces
+                };
+
+                if default_conflict_spaces == 0 && export_local_conflict_spaces == 0 {
+                    continue;
+                }
+
+                for &(decl_idx, _, space, _, _) in group {
+                    let error_node = self.get_declaration_name_node(decl_idx).unwrap_or(decl_idx);
+                    if (space & default_conflict_spaces) != 0 {
+                        ts2652_error_nodes.push(error_node);
+                    } else if (space & export_local_conflict_spaces) != 0 {
+                        ts2395_error_nodes.push(error_node);
+                    }
+                }
+            }
+
+            let has_merge_visibility_diagnostic =
+                !ts2652_error_nodes.is_empty() || !ts2395_error_nodes.is_empty();
+
+            if !ts2652_error_nodes.is_empty() {
+                let name = symbol.escaped_name.clone();
+                let message = format_message(
+                    diagnostic_messages::MERGED_DECLARATION_CANNOT_INCLUDE_A_DEFAULT_EXPORT_DECLARATION_CONSIDER_ADDING_A,
+                    &[&name],
+                );
+                for error_node in ts2652_error_nodes {
+                    self.error_at_node(
+                        error_node,
+                        &message,
+                        diagnostic_codes::MERGED_DECLARATION_CANNOT_INCLUDE_A_DEFAULT_EXPORT_DECLARATION_CONSIDER_ADDING_A,
+                    );
+                }
+            }
+
+            if !ts2395_error_nodes.is_empty() {
+                let name = symbol.escaped_name.clone();
+                let message = format_message(
+                    diagnostic_messages::INDIVIDUAL_DECLARATIONS_IN_MERGED_DECLARATION_MUST_BE_ALL_EXPORTED_OR_ALL_LOCAL,
+                    &[&name],
+                );
+                for error_node in ts2395_error_nodes {
+                    self.error_at_node(
+                        error_node,
+                        &message,
+                        diagnostic_codes::INDIVIDUAL_DECLARATIONS_IN_MERGED_DECLARATION_MUST_BE_ALL_EXPORTED_OR_ALL_LOCAL,
+                    );
+                }
+            }
 
             // TS2428 only applies to merged interface declarations. Mixed
             // class+interface merges are handled separately by
@@ -1626,7 +1651,7 @@ impl<'a> CheckerState<'a> {
                     diagnostic_codes::ENUM_DECLARATIONS_CAN_ONLY_MERGE_WITH_NAMESPACE_OR_OTHER_ENUM_DECLARATIONS,
                 )
             } else {
-                if has_ts2395 {
+                if has_merge_visibility_diagnostic {
                     continue;
                 }
 

--- a/crates/tsz-checker/tests/default_export_merge_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/default_export_merge_diagnostics_tests.rs
@@ -1,0 +1,195 @@
+//! Focused coverage for merged-declaration default export diagnostics.
+//!
+//! A default-exported declaration is distinct from an ordinary exported
+//! declaration. Its declaration space may not overlap any non-default
+//! declaration space (TS2652). Ordinary exported/local intersections that are
+//! not claimed by TS2652 continue to report TS2395.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+use tsz_common::common::ModuleKind;
+
+const TS2300: u32 = 2300;
+const TS2323: u32 = 2323;
+const TS2395: u32 = 2395;
+const TS2451: u32 = 2451;
+const TS2652: u32 = 2652;
+
+fn relevant_diagnostics(source: &str) -> Vec<(u32, u32)> {
+    let mut diagnostics: Vec<_> = check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .filter(|diagnostic| matches!(diagnostic.code, TS2300 | TS2323 | TS2395 | TS2451 | TS2652))
+    .map(|diagnostic| (diagnostic.code, diagnostic.start))
+    .collect();
+    diagnostics.sort_unstable_by_key(|&(code, start)| (start, code));
+    diagnostics
+}
+
+fn assert_merge_diagnostics(source: &str, declaration_name: &str, expected: &[(u32, usize)]) {
+    let name_starts: Vec<u32> = source
+        .match_indices(declaration_name)
+        .map(|(start, _)| start as u32)
+        .collect();
+    let mut expected: Vec<(u32, u32)> = expected
+        .iter()
+        .map(|&(code, occurrence)| (code, name_starts[occurrence]))
+        .collect();
+    expected.sort_unstable_by_key(|&(code, start)| (start, code));
+
+    assert_eq!(
+        relevant_diagnostics(source),
+        expected,
+        "unexpected merged-declaration diagnostics"
+    );
+}
+
+#[test]
+fn default_function_conflicts_only_with_instantiated_namespace_space() {
+    // `defaultExportsCannotMerge01`: functions occupy value space, interfaces
+    // type space, and this namespace is instantiated by its exported value.
+    let source = r#"
+export default function Decl() {}
+export interface Decl {
+    property: number;
+}
+export namespace Decl {
+    export const value = 1;
+}
+"#;
+
+    assert_merge_diagnostics(source, "Decl", &[(TS2652, 0), (TS2652, 2)]);
+}
+
+#[test]
+fn default_class_conflicts_with_interface_but_not_type_only_namespace() {
+    // `defaultExportsCannotMerge02`: classes occupy type and value space; the
+    // non-instantiated namespace contributes namespace space only.
+    let source = r#"
+export default class Entity {}
+export interface Entity {
+    property: number;
+}
+export namespace Entity {
+    interface Nested {}
+}
+"#;
+
+    assert_merge_diagnostics(source, "Entity", &[(TS2652, 0), (TS2652, 1)]);
+}
+
+#[test]
+fn default_class_and_local_interface_use_ts2652_not_ts2395() {
+    // `defaultExportsCannotMerge03`: the class and local interface overlap in
+    // type space, so the default/non-default rule takes precedence over the
+    // ordinary export/local rule.
+    let source = r#"
+export default class Model {}
+interface Model {
+    property: number;
+}
+namespace Model {
+    interface Nested {}
+}
+"#;
+
+    assert_merge_diagnostics(source, "Model", &[(TS2652, 0), (TS2652, 1)]);
+}
+
+#[test]
+fn default_conflicts_and_export_local_conflicts_are_partitioned_by_space() {
+    // `defaultExportsCannotMerge04`: value-space contributors receive TS2652,
+    // while the disjoint exported/local type-space contributors retain TS2395.
+    let source = r#"
+export default function Factory() {}
+namespace Factory {
+    export const value = 1;
+}
+interface Factory {}
+export interface Factory {}
+"#;
+
+    assert_merge_diagnostics(
+        source,
+        "Factory",
+        &[(TS2652, 0), (TS2652, 1), (TS2395, 2), (TS2395, 3)],
+    );
+}
+
+#[test]
+fn disjoint_default_function_and_interface_spaces_are_allowed() {
+    let source = r#"
+export default function Callable() {}
+export interface Callable {
+    property: number;
+}
+"#;
+
+    assert_merge_diagnostics(source, "Callable", &[]);
+}
+
+#[test]
+fn default_class_and_non_instantiated_namespace_spaces_are_allowed() {
+    let source = r#"
+export default class Container {}
+namespace Container {
+    interface Nested {}
+}
+"#;
+
+    assert_merge_diagnostics(source, "Container", &[]);
+}
+
+#[test]
+fn separate_default_export_does_not_reclassify_local_merge_declarations() {
+    let source = r#"
+function Separate() {}
+namespace Separate {
+    export const value = 1;
+}
+export default Separate;
+"#;
+
+    assert_merge_diagnostics(source, "Separate", &[]);
+}
+
+#[test]
+fn ordinary_function_overloads_keep_existing_ts2395_suppression() {
+    let source = r#"
+export function overload(value: string): void;
+function overload(value: number): void;
+function overload(value: string | number): void {}
+"#;
+
+    assert_merge_diagnostics(source, "overload", &[]);
+}
+
+#[test]
+fn all_function_group_still_reports_default_non_default_overlap() {
+    // The all-function exception suppresses ordinary TS2395 overload noise,
+    // not the default/non-default declaration-space invariant.
+    let source = r#"
+export default function Execute(): void;
+function Execute(): void;
+"#;
+
+    assert_merge_diagnostics(source, "Execute", &[(TS2652, 0), (TS2652, 1)]);
+}
+
+#[test]
+fn ambient_namespace_merge_keeps_existing_ts2395_suppression() {
+    let source = r#"
+declare namespace Ambient {
+    export interface Entry {}
+    interface Entry {}
+}
+"#;
+
+    assert_merge_diagnostics(source, "Entry", &[]);
+}


### PR DESCRIPTION
Goal: hold

## Summary

- When a default-exported declaration space intersects any non-default declaration space in the same merged symbol and scope, `tsc` reports TS2652 on the contributing declarations.
- The checker duplicate-declaration pass now partitions default-exported, ordinary exported, and local type/value/namespace spaces before selecting TS2652 or TS2395.
- TS2652 takes precedence only in intersecting spaces; disjoint ordinary exported/local intersections retain TS2395, and generic duplicate fallbacks do not double-report.

## Structural rule

When default-export and non-default declaration spaces overlap within one scope group, `tsc` emits TS2652 through checker-owned merged-declaration classification. Ordinary exported/local overlaps outside those spaces continue through TS2395. The implementation uses parser/binder flags and declaration-space intersections only; no source names, file names, rendered types, or fixture predicates affect behavior.

## Adjacent matrix

- Official shapes: default function plus instantiated namespace; default class plus interface; default class plus local interface; partitioned TS2652 and TS2395 spaces.
- Legal controls: disjoint function/interface spaces, class plus non-instantiated namespace, and a separate `export default Identifier` declaration.
- Fallback controls: ordinary function overload suppression, default/non-default function overlap, ambient namespace suppression, and existing TS2300/TS2428/TS2440 families.

## Performance

The pass remains linear in declarations plus scope-group contributors for each symbol and reuses the existing scope map. It adds no semantic cache, global scan, or rendered-type dependency.

## Verification

- `cargo nextest run -p tsz-checker --test default_export_merge_diagnostics_tests` — 10/10 passed.
- `cargo nextest run -p tsz-checker --lib ts2440_tests ts2428_tests` — 60/60 passed.
- `cargo nextest run -p tsz-checker --test ambient_default_namespace_export_dup_tests --test ts2300_tests` — 74/74 passed.
- `./scripts/conformance/conformance.sh run --filter defaultExportsCannotMerge0 --workers 4 --verbose` — TS2652 fingerprints match in all four cases; case 04 now passes, while cases 01-03 retain only separate import/member-resolution mismatches.
- Exact fresh-process full conformance (`--all --workers 12 --no-batch`): current main 11421/12043; branch 11422/12043. Canonical structured-artifact comparison: 0 added, case 04 removed, only cases 01-03 changed, with precisely the intended TS2652 additions and TS2395 removal. Zero crashes. The same heavy inference case exceeded 90 seconds on both runs and failed identically when rerun alone with a 300-second timeout.
- `cargo clippy -p tsz-checker --lib --test default_export_merge_diagnostics_tests -- -D warnings` — passed.
- `./scripts/arch/check-checker-boundaries.sh` and the commit-hook architecture guard — passed; changed production shard is 1866 lines.
- `TSZ_BIN=$PWD/.target/dist-fast/tsz ./scripts/emit/run.sh --skip-build` — held 11562/11563 JS and 1375/1390 DTS.
- `./scripts/fourslash/run-fourslash.sh --skip-build` against the exact dist-fast server — held 6558/6562 with the established four failures.

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5.6-sol
Effort: xhigh