### PR TITLE
fix(solver): preserve normalized object union origins

### DIFF
--- a/crates/tsz-solver/src/operations/expression_ops.rs
+++ b/crates/tsz-solver/src/operations/expression_ops.rs
@@ -457,6 +457,12 @@ fn fresh_literal_shape(
     Some((*shape).clone())
 }
 
+#[derive(Clone, Copy)]
+struct ContextPropertyOrigin {
+    name: Atom,
+    order: u32,
+}
+
 pub(crate) fn normalize_fresh_object_literal_union_members(
     interner: &dyn TypeDatabase,
     members: &[TypeId],
@@ -477,33 +483,61 @@ pub(crate) fn normalize_fresh_object_literal_union_members(
         return None;
     }
 
-    // Collect property names in source order. shape.properties is Atom-sorted
-    // (canonical form for hashing), so iterating it directly leaks Atom-allocation
-    // order into `names`, producing non-source-order display strings on the
-    // resulting normalized objects. Sort by `declaration_order` so the first
-    // missing-property fill-in for an empty `{}` literal stays in the order tsc
-    // reports.
-    let mut names: Vec<Atom> = Vec::new();
+    // Collect each property's stable sibling-relative declaration origin.
+    // `shape.properties` is Atom-sorted for canonical hashing, so first recover
+    // each sibling's source order from `declaration_order`. A repeated name
+    // overwrites its context prototype, matching tsc's `getPropertiesOfContext`
+    // Map: a missing optional property inherits the declaration of the *last*
+    // sibling that supplied that name.
+    //
+    // The rank is display-only. It is monotonic across the ordered sibling
+    // list, so it reproduces the source-position comparison tsc applies to the
+    // original and inherited declarations without changing property semantics.
+    let mut context_properties: Vec<ContextPropertyOrigin> = Vec::new();
+    let mut context_property_indices: FxHashMap<Atom, usize> = FxHashMap::default();
+    let mut member_property_origins: Vec<FxHashMap<Atom, u32>> =
+        Vec::with_capacity(object_members.len());
+    let mut next_origin_order = 1_u32;
+
     for (_, shape) in &object_members {
         let mut props_by_decl: Vec<&PropertyInfo> = shape.properties.iter().collect();
         props_by_decl.sort_by_key(|p| p.declaration_order);
+        let mut origins = FxHashMap::default();
         for prop in props_by_decl {
-            if !names.contains(&prop.name) {
-                names.push(prop.name);
+            let origin_order = next_origin_order;
+            next_origin_order = next_origin_order.saturating_add(1);
+            origins.insert(prop.name, origin_order);
+
+            if let Some(&index) = context_property_indices.get(&prop.name) {
+                context_properties[index].order = origin_order;
+            } else {
+                context_property_indices.insert(prop.name, context_properties.len());
+                context_properties.push(ContextPropertyOrigin {
+                    name: prop.name,
+                    order: origin_order,
+                });
             }
         }
+        member_property_origins.push(origins);
     }
 
-    if names.is_empty() {
+    if context_properties.is_empty() {
         return None;
     }
 
     let mut changed = false;
     let mut normalized = Vec::with_capacity(object_members.len());
-    for (original_type, shape) in object_members {
-        let completed = add_missing_optional_properties(&shape.properties, &names);
+    for ((original_type, shape), mut display_origins) in
+        object_members.into_iter().zip(member_property_origins)
+    {
+        let mut completed = add_missing_optional_properties(&shape.properties, &context_properties);
         if completed != shape.properties {
             changed = true;
+            for property in &context_properties {
+                display_origins
+                    .entry(property.name)
+                    .or_insert(property.order);
+            }
             // Capture source-order display properties before interning sorts the
             // canonical shape by Atom. Without this, the canonical shape may
             // dedupe to a previously-interned twin whose `declaration_order` is
@@ -512,8 +546,22 @@ pub(crate) fn normalize_fresh_object_literal_union_members(
             // source-written property order tsc preserves. Existing properties
             // keep their display-only literal types so normalized unions don't
             // repaint `{ c: true }` as `{ c: boolean }`.
+            for prop in &mut completed {
+                if let Some(&origin_order) = display_origins.get(&prop.name) {
+                    prop.declaration_order = origin_order;
+                }
+            }
+            crate::types::normalize_display_property_order(&mut completed);
+
             let display_props = normalized_display_properties(interner, original_type, &completed);
-            let new_type_id = interner.object_with_flags(completed, shape.flags);
+            // A normalized member can have the same semantic property shape in
+            // multiple BCT contexts but a different inherited source order.
+            // Give that order context-owned identity so a later partial
+            // normalization cannot repaint another context's display side
+            // table entry. Relations remain structural; the flag affects only
+            // interning identity and diagnostics.
+            let flags = shape.flags | ObjectFlags::PRESERVE_DECLARATION_ORDER;
+            let new_type_id = interner.object_with_flags(completed, flags);
             interner.store_display_properties(new_type_id, display_props);
             normalized.push(new_type_id);
         } else {
@@ -524,22 +572,18 @@ pub(crate) fn normalize_fresh_object_literal_union_members(
     changed.then_some(normalized)
 }
 
-fn add_missing_optional_properties(existing: &[PropertyInfo], names: &[Atom]) -> Vec<PropertyInfo> {
+fn add_missing_optional_properties(
+    existing: &[PropertyInfo],
+    context_properties: &[ContextPropertyOrigin],
+) -> Vec<PropertyInfo> {
     let mut out: Vec<PropertyInfo> = existing.to_vec();
-    let mut next_order = out
-        .iter()
-        .map(|p| p.declaration_order)
-        .max()
-        .unwrap_or(0)
-        .saturating_add(1);
 
-    for &name in names {
-        if out.iter().any(|p| p.name == name) {
+    for property in context_properties {
+        if out.iter().any(|p| p.name == property.name) {
             continue;
         }
-        let mut prop = PropertyInfo::opt(name, TypeId::UNDEFINED);
-        prop.declaration_order = next_order;
-        next_order = next_order.saturating_add(1);
+        let mut prop = PropertyInfo::opt(property.name, TypeId::UNDEFINED);
+        prop.declaration_order = property.order;
         out.push(prop);
     }
     out

--- a/crates/tsz-solver/tests/expression_ops_tests.rs
+++ b/crates/tsz-solver/tests/expression_ops_tests.rs
@@ -330,6 +330,136 @@ fn test_normalize_fresh_object_literal_union_members_preserves_source_order_for_
 }
 
 #[test]
+fn test_normalize_fresh_object_literal_union_members_inherits_last_sibling_origin() {
+    use crate::diagnostics::format::TypeFormatter;
+    use crate::operations::expression_ops::normalize_fresh_object_literal_union_members;
+
+    let interner = TypeInterner::new();
+    // Allocate names out of source order so canonical Atom sorting cannot
+    // accidentally satisfy the display assertion.
+    let later = interner.intern_string("later");
+    let shared = interner.intern_string("shared");
+    let earlier = interner.intern_string("earlier");
+
+    let mut first_shared = PropertyInfo::new(shared, TypeId::NUMBER);
+    first_shared.declaration_order = 1;
+    let mut first_earlier = PropertyInfo::new(earlier, TypeId::BOOLEAN);
+    first_earlier.declaration_order = 2;
+    let first = interner.object_with_flags(
+        vec![first_shared, first_earlier],
+        ObjectFlags::FRESH_LITERAL,
+    );
+
+    let mut second_shared = PropertyInfo::new(shared, TypeId::NUMBER);
+    second_shared.declaration_order = 1;
+    let mut second_later = PropertyInfo::new(later, TypeId::STRING);
+    second_later.declaration_order = 2;
+    let second = interner.object_with_flags(
+        vec![second_shared, second_later],
+        ObjectFlags::FRESH_LITERAL,
+    );
+
+    let opposite = normalize_fresh_object_literal_union_members(&interner, &[second, first])
+        .expect("the reversed context should normalize the same semantic shape");
+    let mut formatter = TypeFormatter::new(&interner).with_display_properties();
+    assert_eq!(
+        formatter.format(opposite[1]).as_ref(),
+        "{ later?: undefined; shared: number; earlier: boolean; }",
+        "the cold context deliberately primes the same semantic shape in the opposite order",
+    );
+
+    let normalized = normalize_fresh_object_literal_union_members(&interner, &[first, second])
+        .expect("disjoint fresh-literal properties should be normalized");
+
+    assert_ne!(
+        opposite[1], normalized[0],
+        "display-order-sensitive normalized members need context-owned identities",
+    );
+    assert_eq!(
+        formatter.format(normalized[0]).as_ref(),
+        "{ shared: number; earlier: boolean; later?: undefined; }",
+        "a missing property supplied by the later sibling follows this member's own declarations",
+    );
+    assert_eq!(
+        formatter.format(normalized[1]).as_ref(),
+        "{ earlier?: undefined; shared: number; later: string; }",
+        "a missing property inherits its earlier sibling declaration origin",
+    );
+
+    let bct = compute_best_common_type::<NoopResolver>(&interner, &[first, second], None);
+    assert_eq!(
+        formatter.format(bct).as_ref(),
+        "{ shared: number; earlier: boolean; later?: undefined; } | { earlier?: undefined; shared: number; later: string; }",
+        "the BCT union surface must retain the per-member inherited origins",
+    );
+
+    normalize_fresh_object_literal_union_members(&interner, &[normalized[1], first])
+        .expect("a partial normalized context should still complete the original member");
+    assert_eq!(
+        formatter.format(normalized[0]).as_ref(),
+        "{ shared: number; earlier: boolean; later?: undefined; }",
+        "re-entry with a completed sibling must not repaint an identical display surface",
+    );
+}
+
+#[test]
+fn test_normalize_fresh_object_literal_union_members_orders_empty_from_last_origins() {
+    use crate::diagnostics::format::TypeFormatter;
+    use crate::operations::expression_ops::normalize_fresh_object_literal_union_members;
+
+    let interner = TypeInterner::new();
+    let first_name = interner.intern_string("firstName");
+    let carried_name = interner.intern_string("carriedName");
+
+    let mut first_a = PropertyInfo::new(first_name, TypeId::NUMBER);
+    first_a.declaration_order = 1;
+    let mut first_b = PropertyInfo::new(carried_name, TypeId::NUMBER);
+    first_b.declaration_order = 2;
+    let both = interner.object_with_flags(vec![first_a, first_b], ObjectFlags::FRESH_LITERAL);
+
+    let mut later_a = PropertyInfo::new(first_name, TypeId::STRING);
+    later_a.declaration_order = 1;
+    let only_a = interner.object_with_flags(vec![later_a.clone()], ObjectFlags::FRESH_LITERAL);
+    let empty = interner.object_with_flags(Vec::new(), ObjectFlags::FRESH_LITERAL);
+
+    let normalized =
+        normalize_fresh_object_literal_union_members(&interner, &[both, only_a, empty])
+            .expect("mixed-shape fresh literals should be normalized");
+
+    let mut formatter = TypeFormatter::new(&interner).with_display_properties();
+    assert_eq!(
+        formatter.format(normalized[1]).as_ref(),
+        "{ carriedName?: undefined; firstName: string; }",
+    );
+    assert_eq!(
+        formatter.format(normalized[2]).as_ref(),
+        "{ carriedName?: undefined; firstName?: undefined; }",
+        "the empty member follows the declarations cloned from the last name suppliers",
+    );
+    let bct = compute_best_common_type::<NoopResolver>(&interner, &[both, only_a, empty], None);
+    assert_eq!(
+        formatter.format(bct).as_ref(),
+        "{ firstName: number; carriedName: number; } | { carriedName?: undefined; firstName: string; } | { carriedName?: undefined; firstName?: undefined; }",
+    );
+
+    // Equal display order re-interns, while the same semantic properties in
+    // the opposite order retain a distinct diagnostic surface.
+    later_a.declaration_order = 2;
+    let mut missing_b = PropertyInfo::opt(carried_name, TypeId::UNDEFINED);
+    missing_b.declaration_order = 1;
+    let display_flags = ObjectFlags::FRESH_LITERAL | ObjectFlags::PRESERVE_DECLARATION_ORDER;
+    let same_display_shape =
+        interner.object_with_flags(vec![later_a.clone(), missing_b.clone()], display_flags);
+    assert_eq!(normalized[1], same_display_shape);
+
+    later_a.declaration_order = 1;
+    missing_b.declaration_order = 2;
+    let opposite_display_shape =
+        interner.object_with_flags(vec![later_a, missing_b], display_flags);
+    assert_ne!(normalized[1], opposite_display_shape);
+}
+
+#[test]
 fn test_normalize_fresh_object_literal_union_members_preserves_member_order() {
     // Ensure the resulting union of normalized fresh object literal members
     // preserves source-written member order even when the canonical union


### PR DESCRIPTION
Goal: hold

## Structural rule

When a fresh object-literal union is normalized and a property is supplied by a sibling branch, `tsc` carries the supplying declaration origin into diagnostic display order. TSZ now applies that rule in solver expression normalization by assigning stable sibling-relative origins to completed properties and preserving the resulting declaration-order identity. Assignability remains structural.

## Owner layer

The solver owns fresh object-literal union normalization and display provenance. The checker and printer do not infer semantics from names or rendered output.

## Adjacent-case matrix

- Repeated names inherit the last supplying sibling origin.
- Atom allocation is deliberately adversarial to source order.
- Cold normalization in the opposite order retains a distinct display identity.
- Partial normalized re-entry cannot repaint an existing diagnostic surface.
- Empty members inherit the complete context order.
- Equal display order re-interns; opposite display order stays distinct.
- Five official inference witnesses now match `tsc`.

## Fallback and performance

The rule is limited to changed fresh object-literal union members. Non-fresh objects and unchanged members keep the existing path. The result carries `PRESERVE_DECLARATION_ORDER` only when normalization completes missing properties, preventing a global display-side-table overwrite. Context origin collection is linear in supplied properties with hash lookup; the existing missing-property completion scan is unchanged in scope. No new persistent cache or residency surface is introduced.

## Verification

- `cargo nextest run -p tsz-solver --test expression_ops_tests`: 52/52 passed.
- `cargo clippy -p tsz-solver --lib -- -D warnings`: passed.
- Architecture guard, checker boundary check, and diff check: passed.
- Official targeted conformance witnesses: 5/5 passed.
- Full fresh-worker conformance against current-main baseline: 11422 -> 11427 passed; failures 621 -> 616; fingerprint-only 187 -> 182; no added artifacts, crashes, or timeouts. The only common-failure semantic delta fixes one property-order fingerprint in `typeArgumentInferenceConstructSignatures` while that case remains failing for unrelated output.
- `./scripts/emit/run.sh --skip-build`: JS 11562/11563, DTS 1375/1390, exact repository floor.
- `cargo build --release -p tsz-cli --bin tsz-server`: passed.
- `./scripts/fourslash/run-fourslash.sh --skip-build`: 6558/6562, exact repository floor.

## Provenance

Machine: m4
Assistant: codex
Model: gpt-5.6-sol
Effort: xhigh