### PR TITLE
fix(checker): a bare `exports.X =` write gives its function no receiver `this`

### DIFF
--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -926,6 +926,29 @@ impl<'a> CheckerState<'a> {
         // `M.prototype.m = function () { ... }` takes the ordinary
         // assignment-receiver `this` (the type of `M.prototype`) like any other
         // `obj.m = function () { ... }`.
+        // A depth-1 write to the CommonJS `exports` object gives its RHS function
+        // no receiver `this`: tsc reports
+        // `TS2683 'this' implicitly has type 'any'` for
+        // `exports.A = function () { this.x = 1 }`. Reading `typeof exports`
+        // here instead pushes a `this` type, which suppresses TS2683 entirely.
+        //
+        // Deliberately keyed on the bare unshadowed `exports` identifier, NOT on
+        // an exports-rooted access: tsc *does* give `module.exports.A = ...` a
+        // receiver `this` (it reports `Property 'x' does not exist on type
+        // 'typeof import(...)'`), and depth-2 `exports.ns.A = ...` likewise keeps
+        // it. Both access kinds are covered — tsc treats `exports["A"] = ...`
+        // the same as `exports.A = ...`.
+        if self.is_js_file()
+            && !self.current_source_file_has_esm_syntax()
+            && self
+                .ctx
+                .arena
+                .get(access.expression)
+                .is_some_and(|n| n.kind == SyntaxKind::Identifier as u16)
+            && self.is_unshadowed_commonjs_exports_identifier(access.expression)
+        {
+            return None;
+        }
         let receiver = self.get_type_of_node(access.expression);
         (receiver != TypeId::ERROR).then_some(receiver)
     }


### PR DESCRIPTION
    exports.A = function () { this.x = 1 };

tsc 7.0.2 reports `TS2683: 'this' implicitly has type 'any'`. tsz was silent.

**Structural rule.** When a function expression is the RHS of `<recv>.<k> =` or
`<recv>[<k>] =` in a CommonJS (non-ESM) JS file and `<recv>` is the bare,
unshadowed `exports` binding, the function gets no receiver `this`. tsz owns this
in `this_type_from_assignment_left`.

The site read `typeof exports` as the assignment receiver and pushed it as a
contextual `this`, which suppresses TS2683 entirely — the diagnostic was never
reachable, so this is an upstream-gate defect rather than a missing emitter.

Proven on-path by controlled experiment: varying only the ambient declaration in
`node.d.ts` while holding the JS file fixed —

| ambient decl | tsz |
|---|---|
| `declare var exports: any` | silent |
| `declare var exports: { readonly zz: number }` | silent |
| **no `exports` decl at all** | **TS2683 (matches tsc)** |

The second row rules out a contextual-signature explanation: `{readonly zz}` has
no property `A`, so there is no contextual `this` to find, yet tsz stays silent.

### Why the bare identifier, not an exports-rooted access

`is_exports_rooted_access` looks like the natural predicate and is **wrong** here:

- `module.exports.A = function(){ this.x }` — tsc DOES give receiver `this`; it
  reports `Property 'x' does not exist on type 'typeof import(...)'`
- depth-2 `exports.ns.A = ...` likewise keeps receiver `this`

Both access kinds are covered, since tsc treats `exports["A"] =` like
`exports.A =`.

### The three guards are load-bearing

Each verified against tsc; dropping any one causes a regression:

| guard | without it |
|---|---|
| `is_js_file()` | a `.ts` file with `declare var exports` loses a TS2339 and gains a bogus TS2683 |
| `!current_source_file_has_esm_syntax()` | an ESM `.js` file gains a spurious TS2683 |
| bare-identifier kind check | property-access receivers leave the general path |

`exports` is the CommonJS builtin, resolved through the existing
`is_unshadowed_commonjs_exports_identifier` predicate, so no new user-name
literal enters a decision path. `var exports = {...}` shadowing keeps the
ordinary receiver `this` via that predicate's unshadowed check.

### Adjacent cases (tsc 7.0.2 oracle)

| shape | after |
|---|---|
| `exports.A = function(){ this.x = 1 }` | **matches** (TS2683) |
| `exports["A"] = function(){ this.x = 1 }` | **matches** (TS2683) |
| `.ts` + `declare var exports` | unchanged |
| ESM `.js` (`export const k = 1`) | unchanged |
| `var bag = {q:1}; bag.A = function(){ this.zzz }` | unchanged — general receiver `this` preserved |
| `module.exports.A = function(){ this.x }` | unchanged |

Out of scope, still missing: `module.exports = function(){ this.x }` needs a
separate `module` branch, which cannot gate on
`current_file_has_commonjs_export_assignment` (that accepts a `module`-rooted
assignment as its indicator, so a lone `module.A = ...` — which tsc leaves silent
— would wrongly qualify).

Goal: hold

## Verification

Controlled base/after against the exact parent commit, full local runs.

**Conformance**: **11422 -> 11424 (+2)**, diffed by test name — newly passing
`typeFromParamTagForFunction` and `commonjsAccessExports`; **0 newly failing**.

**Emit** (`scripts/emit/run.sh`): JS 11562/11563, DTS 1375/1390 — at the parity
floor.

**Unit** (`cargo nextest run -p tsz-checker -j 6`, 18849 tests): **47 failures,
identical to main's baseline**, 0 new. (main's unit lane runs nightly and already
carries 47.)

**Clippy**: pre-commit `-p tsz-checker` clean; arch guard passed.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

AgentName: M1FableArchitect
