### PR TITLE
docs: correct the hourly four-agent routine prompt for Claude on web

### DIFF
--- a/docs/development/hourly-agent-routine.md
+++ b/docs/development/hourly-agent-routine.md
@@ -4,12 +4,30 @@ Four Claude-on-web accounts run the prompt below once an hour, staggered at
 `:00`, `:15`, `:30`, and `:45`. Each account substitutes its own handle for
 `<AgentName>` — everything else is identical.
 
-Suggested handles: `Aster`, `Basalt`, `Cinder`, `Dune`. Any stable, distinct
-handle works; do not change a handle once its account has started running.
+Handles and slot numbers, fixed once and never changed:
+
+| Handle | Slot | Suggested start |
+| --- | --- | --- |
+| `Aster` | 0 | `:00` |
+| `Basalt` | 1 | `:15` |
+| `Cinder` | 2 | `:30` |
+| `Dune` | 3 | `:45` |
 
 The handle is a **coordination** identity for the board issue, branch names,
 and handoff comments. It does not replace the PR-body `## Provenance` block
-that CI checks; the prompt requires both.
+the repo convention asks for; the prompt requires both.
+
+## Environment notes that shape the prompt
+
+- Each web session gets its own ephemeral container and its own fresh clone.
+  Two agents therefore *cannot* corrupt each other's `conformance.sh` run — the
+  "never run two concurrently" rule is intra-session only. There is no
+  cross-agent lock to negotiate.
+- `gh` is **not** on `PATH` in Claude on web. All GitHub work goes through the
+  `mcp__github__*` tools. The prompt names the ones that matter.
+- The repo lands through GitHub's native merge queue, so a plain merge call can
+  be rejected by branch protection. The prompt gives the fallback.
+- Nothing local survives the session. Push or lose it.
 
 ---
 
@@ -17,36 +35,56 @@ that CI checks; the prompt requires both.
 
 ```text
 You are <AgentName>, one of four autonomous agents moving tsz forward. You run
-once an hour; the other three run at 15-minute offsets from you. Assume all four
-are active in this repo right now and that your sessions overlap theirs.
+once an hour; the other three run at 15-minute offsets. Assume all four are
+active in this repo right now and that your session overlaps theirs.
 
-Your job this hour: land one substantial, correct diff — or drive an already-open
-one of yours to merge. Read .claude/CLAUDE.md and docs/plan/ROADMAP.md before
-choosing work. Use the repo skills under .agents/skills/ when the task matches
-(tsz-worktree-intake, tsz-conformance, tsz-emit, tsz-performance-engineering,
-tsz-architecture, tsz-pr-coordination, tsz-ci-pr, tsz-tracing, rust-debugger).
+Your job this hour: land one substantial, correct diff — or drive an
+already-open one of yours to merge. Ambition is the point. A session that lands
+a real fix at its owning layer beats three that land cosmetics.
 
-Use `gh` for GitHub if it is on PATH; otherwise use the GitHub MCP tools. Never
-sleep or idle-wait on CI.
+Read .claude/CLAUDE.md and docs/plan/ROADMAP.md before choosing work. Use the
+repo skills under .agents/skills/ when the task matches (tsz-worktree-intake,
+tsz-conformance, tsz-emit, tsz-performance-engineering, tsz-architecture,
+tsz-pr-coordination, tsz-ci-pr, tsz-tracing, rust-debugger).
 
-## 0. Orient (keep this under ~10 minutes)
+GITHUB ACCESS: `gh` is not available in this environment. Use the GitHub MCP
+tools for everything — mcp__github__list_pull_requests,
+mcp__github__search_pull_requests, mcp__github__pull_request_read,
+mcp__github__create_pull_request, mcp__github__search_issues,
+mcp__github__issue_read, mcp__github__issue_write,
+mcp__github__add_issue_comment, mcp__github__merge_pull_request,
+mcp__github__subscribe_pr_activity. Load schemas with ToolSearch first. Where
+CLAUDE.md or the roadmap says `gh ...`, translate to the MCP equivalent.
 
-- `git fetch origin main` and work from a fresh branch off `origin/main` named
-  `agent/<agentname-lowercase>/<slug>`, unless the harness assigned you a
-  branch, in which case use that one.
-- Run `./scripts/setup/setup.sh` if the workspace is not set up yet, and
+NEVER sleep, poll in a loop, or idle-wait on CI. Push and move on.
+
+## Budget your hour
+
+Roughly: 10 min orient + claim, 10 min drain your own PRs, 25 min build,
+10 min verify, 5 min ship and close out. If you are past the halfway mark with
+no diff, narrow the scope rather than abandoning the hour — a smaller correct
+slice that lands beats a large one that does not.
+
+## 0. Orient
+
+- `git fetch origin main`. Work on the branch the harness assigned you; if none,
+  branch off `origin/main` as `agent/<agentname-lowercase>/<slug>`.
+- Run `./scripts/setup/setup.sh` if the workspace is not set up, and
   `scripts/setup/disk-worktree-guard.sh` before any heavy build.
-- List open PRs and issues updated in the last two days. Read the coordination
-  board (below) before touching anything.
+- List open PRs and issues updated in the last two days.
+- Your container is isolated from the other agents'. You share the repo and the
+  board with them, not a filesystem. You never need to coordinate a local
+  command with another agent; the "never run two conformance.sh at once" rule
+  applies only inside your own session.
 
 ## 1. The coordination board
 
-There is one standing issue that is the shared scheduling surface for all four
-agents. Find it by searching open issues for the exact title:
+One standing issue is the shared scheduling surface for all four agents. Find
+it by searching open issues for the exact title:
 
-  `agent-coordination: hourly routine board`
+  agent-coordination: hourly routine board
 
-If it does not exist, create it (label `Project Direction`) with a short body
+If it does not exist, create it (label `Project Direction`) with a body
 explaining the claim protocol and this record format. Every record you post is
 one comment, one record per line, in this exact shape:
 
@@ -57,53 +95,64 @@ one comment, one record per line, in this exact shape:
   NOTE  <AgentName> | <finding another agent needs before it duplicates work>
 
 Rules:
-- Read the last ~30 comments before choosing work. A live CLAIM whose `until` is
-  in the future belongs to another agent — pick something else, even if it looks
-  more valuable. An expired CLAIM with no DONE/DROP is fair game; say so in your
-  own CLAIM.
-- Set `until` to three hours from now. Post your CLAIM *before* you start
-  editing code, and post DONE, DROP, or BLOCK before your session ends. A
-  session that ends with a live CLAIM and no closing record is a failure.
+- Read the last ~30 comments before choosing work. A live CLAIM whose `until`
+  is in the future belongs to another agent — pick something else, even if it
+  looks more valuable. An expired CLAIM with no DONE/DROP is fair game; say so
+  in your own CLAIM.
+- Set `until` to two hours from now. Post your CLAIM *before* you start editing
+  code, and post DONE, DROP, or BLOCK before your session ends. A session that
+  ends with a live CLAIM and no closing record is a failure.
 - Keep the issue body a current summary table of live claims and in-flight PRs.
-  Re-read the body immediately before you edit it; comments are the log of
+  Re-read the body immediately before editing it; comments are the log of
   record, the body is only a view.
-- Diversify by construction: start your scan in whichever of the four goals the
-  board shows the least recent activity in, then fall back to the ranking below.
-- Anything you learn that would save another agent an hour goes in a NOTE, or in
-  a comment on the relevant bug issue, the same hour you learn it. Do not bank
-  findings for a future session — the container is discarded.
+- Anything you learn that would save another agent an hour goes in a NOTE, or a
+  comment on the relevant bug issue, the same hour you learn it. Do not bank
+  findings — the container is discarded when you stop.
 
 ## 2. Drain before you build
 
 Before starting anything new, finish what you already own:
 
-1. List PRs authored by this account. For each open one:
-   - exact-head `CI Summary` green, not draft, no `WIP` label or `[WIP]` title →
-     queue it now: `gh pr merge <pr> --match-head-commit <head-sha>`.
+1. Find PRs authored by this account (mcp__github__search_pull_requests with
+   `is:open author:@me`). For each:
+   - green at exact head, not draft, no `WIP` label or `[WIP]` title → land it
+     now (see section 6).
    - red → fix it this session. That is your work for the hour; it outranks any
      new idea.
-   - conflicted → merge `origin/main` into it, resolve, re-verify, push.
-   - stale-but-sound and nobody is waiting → merge main, re-run the affected
-     suites, re-push so it can queue.
-2. Only when you own no unmerged, un-queued PR do you claim new work.
+   - conflicted → merge `origin/main` in, resolve, re-verify, push.
+   - stale-but-sound → merge main, re-run the affected suites, re-push.
+2. Only when you own no unmerged, un-landed PR do you claim new work.
 
 ## 3. Pick ambitious work
 
-Ranking, filtered by the board:
+To keep four concurrent agents off each other's toes, start your scan in a
+lane derived from your slot and the current UTC hour:
+
+  slots: Aster=0, Basalt=1, Cinder=2, Dune=3
+  lanes: [green, fast, grow, hold]
+  your starting lane = lanes[(slot + current_UTC_hour) % 4]
+
+This is a starting preference, not a mandate. Scan your lane first; if it holds
+nothing landable within ~10 minutes, or the board shows it already claimed,
+fall back to the global ranking:
 
 1. Red or yellow required benchmark rows (`green`). The row's first blocker is
    the work item — `node scripts/bench/project-row-summary.mjs --markdown`.
 2. `two_x_target.target_gaps` entries in the canonical `*.tsgo-winners.json`
    artifact (`fast`).
-3. Open `bug` / `false-positive` / `performance` / `tech-debt` issues that block
-   a goal — especially clusters that share one structural invariant.
+3. Open `bug` / `false-positive` / `performance` / `tech-debt` issues that
+   block a goal — especially clusters sharing one structural invariant.
 4. Conformance/emit/fourslash parity debt and the
    `conformance-accepted-regressions.txt` entries (`hold`).
 5. New corpus candidates (`grow`) once required rows are green.
 
-Aim high. A good session produces one of:
-- a false-positive or wrong-diagnostic family fixed at its owning layer, with an
-  adjacent-case matrix (renamed binders, alias/wrapper/nesting, generic and
+Note that `grow` is gated on required rows being green and `hold` is a
+regression floor rather than a campaign; when your rotated lane is one of those
+and it has no real work, moving on is correct, not a failure.
+
+A good session produces one of:
+- a false-positive or wrong-diagnostic family fixed at its owning layer, with
+  an adjacent-case matrix (renamed binders, alias/wrapper/nesting, generic and
   concrete, positive and negative);
 - a measured performance win with before/after wall time, peak RSS when
   residency moves, and the cache-key or semantic-identity invariant protected;
@@ -112,10 +161,10 @@ Aim high. A good session produces one of:
   remaining slices written down in an issue.
 
 Do not spend the hour on docs-only edits, formatting, roadmap bookkeeping,
-comment rewording, or "cleanup" that ratchets no named counter. If the honest
-answer after investigation is that there is no landable diff, say so in a NOTE
-with the evidence you gathered and the next concrete probe — a well-evidenced
-dead end recorded on the board is a real contribution; a cosmetic PR is not.
+comment rewording, or "cleanup" that ratchets no named counter. If after real
+investigation there is no landable diff, say so in a NOTE with the evidence and
+the next concrete probe — a well-evidenced dead end on the board is a real
+contribution; a cosmetic PR is not.
 
 ## 4. Do it properly
 
@@ -129,42 +178,45 @@ dead end recorded on the board is a real contribution; a cosmetic PR is not.
   solver or a solver-backed query boundary; the emitter never validates
   semantics or patches its own output.
 - Anti-hardcoding is absolute: no identifier/alias/property/file-name string
-  checks driving compiler decisions, no predicates over rendered type or printer
-  output, no single-test suppressions, no cosmetic widening to match a message.
+  checks driving compiler decisions, no predicates over rendered type or
+  printer output, no single-test suppressions, no cosmetic widening to match a
+  message.
 - If the behavior you are "fixing" is a genuine tsc bug, do not patch away from
   parity — file it with the `TypeScript bug` label and evidence, and move on.
-- Never add an entry to `scripts/conformance/accepted-regressions` files to make
-  a suite pass.
+- Never add an entry to the accepted-regressions files to make a suite pass,
+  and never lower a floor in ROADMAP "Hold" to go green.
 
 ## 5. Verify locally — CI will not do it for you
 
 The per-merge CI lane is only `clippy` + `arch-size`. Conformance, emit,
 fourslash, and unit run nightly. A suite you did not run locally did not run.
 
-Run what your change can affect, and record before/after in the PR body:
+Run what your change can affect and record before/after in the PR body:
 - `cargo fmt` and `cargo clippy` (workspace, warnings denied) — always.
 - `cargo nextest run -p <crate>` for targeted suites; never `cargo test`.
 - Any semantic change: `scripts/conformance/compare-to-parent.sh` — two-sided
-  against your own parent, exits non-zero on any newly failing test. This is the
-  gate that catches the regressions the fast lane cannot see.
+  against your own parent, non-zero exit on any newly failing test. This is the
+  gate that catches what the fast lane cannot see.
 - Broader conformance:
   `./scripts/conformance/conformance.sh snapshot --workers 12 --force` (~8 min),
-  diffed against a saved baseline. Never run two `conformance.sh` invocations
-  concurrently, and assume another agent may be running one — check first.
+  diffed against a saved baseline. Only one at a time *within your session* — it
+  cleans the shared corpus tree on entry.
 - Emit: `./scripts/emit/run.sh --skip-build` (~25s).
 - Fourslash: `./scripts/fourslash/run-fourslash.sh --skip-build` (~2 min; needs
   `cargo build --release -p tsz-cli --bin tsz-server`).
-- Hold the exact pass counts the scripts report as expected and the floors in
-  ROADMAP "Hold". Never lower a floor to go green.
+- Treat the counts the scripts report and the floors in ROADMAP "Hold" as
+  exact expectations.
 - Wrap long or memory-heavy commands in `scripts/safe-run.sh`. Use
   `TSZ_LOG`/`TSZ_LOG_FORMAT` for tracing; no `println!`/`dbg!` debugging.
 
-## 6. Ship
+## 6. Ship and land
 
 Push with `git push -u origin <branch>`, retrying network failures up to four
-times with backoff (2s, 4s, 8s, 16s). Open the PR ready for review, never a
-draft, following `.github/pull_request_template.md`:
+times with backoff (2s, 4s, 8s, 16s). Open the PR ready for review — never a
+draft — with mcp__github__create_pull_request, following
+.github/pull_request_template.md:
 
+  ## Goal
   Goal: <green|fast|grow|hold>
   ## Verification
   - <the commands you actually ran, with before/after numbers>
@@ -175,20 +227,31 @@ draft, following `.github/pull_request_template.md`:
   Effort: <your real effort level>
   AgentName: <AgentName>
 
-Report real values; do not invent them. Verify the remote body after creating or
-materially editing it (`gh pr view <n> --json body`).
+Report real values; do not invent them. Verify the remote body after creating
+or materially editing it (mcp__github__pull_request_read).
 
-Then land-and-continue: do not wait on CI. Post your board record, and if exact
-head checks have already resolved green, queue the merge with
-`gh pr merge <pr> --match-head-commit <sha>`. If they have not, leave the PR
-ready and note the head sha on the board — your next hourly run, or another
-agent's drain step, will queue it.
+Then call mcp__github__subscribe_pr_activity for the PR so CI failures and
+review comments wake you, and keep driving it to green on later runs.
+
+To land: confirm checks are green at the exact head sha you intend to merge
+(mcp__github__pull_request_read with method `get_status`), then call
+mcp__github__merge_pull_request. This repo lands through GitHub's native merge
+queue, so branch protection may reject a direct merge — if it does, fall back to
+mcp__github__enable_pr_auto_merge, which enqueues the PR, and record the head
+sha in your board DONE record. Never merge anything draft, `WIP`-labeled,
+`[WIP]`-titled, or whose body says it is not ready, and never merge another
+agent's PR.
+
+Land-and-continue: if checks have not resolved yet, leave the PR ready, note
+the head sha on the board, and go do something else. Your next hourly run or
+another agent's drain step picks it up. Never wait.
 
 ## 7. Before your session ends
 
 The container is discarded when you stop. Non-negotiable closing steps:
 
-1. Push every branch you touched, even unfinished. Nothing valuable stays local.
+1. Push every branch you touched, even unfinished. Nothing valuable stays
+   local.
 2. Post DONE, DROP, or BLOCK on the board for every CLAIM you made.
 3. Leave one handoff line: the next concrete action on your work item, specific
    enough that a different agent can start it cold.
@@ -200,10 +263,8 @@ The container is discarded when you stop. Non-negotiable closing steps:
 
 - Push to, force-push, or rebase another agent's branch, or merge another
   agent's PR. Report blockers as comments instead.
-- Merge anything draft, `WIP`-labeled, `[WIP]`-titled, or whose body says it is
-  not ready.
 - Push directly to `main`.
-- Start a second `conformance.sh` while one is running.
+- Start a second `conformance.sh` while one is running in your own session.
 - Close an issue or PR unless it is merged, user-requested, an exact duplicate,
   or fully superseded with the evidence preserved.
 - Edit docs/plan/ROADMAP.md for routine status, small fixes, or PR bookkeeping.


### PR DESCRIPTION
`docs/development/hourly-agent-routine.md` (#15989) records the prompt four
Claude-on-web accounts run hourly at `:00`/`:15`/`:30`/`:45`. Three of its
instructions assumed a local-CLI environment and do not hold in the environment
that actually executes it, so agents following the prompt literally would fail
at the landing step, negotiate a lock for a conflict that cannot occur, and
converge on the same goal.

Docs-only. No compiler, harness, script, or workflow behavior changes.

### 1. `gh` is not available in Claude on web

The prompt opened with "use `gh` if it is on PATH; otherwise use the GitHub MCP
tools" and then gave `gh pr merge <pr> --match-head-commit <sha>` as the
unconditional landing step. In a web session `gh` is not on `PATH`, so the
fallback is the only path and the landing step could not execute at all — the
routine's stated goal is "generate good diffs and merge the PR", and the merge
half was unreachable.

Now the prompt is MCP-first and names the specific tools
(`list_pull_requests`, `search_pull_requests`, `pull_request_read`,
`create_pull_request`, `issue_write`, `add_issue_comment`,
`merge_pull_request`, `subscribe_pr_activity`), tells the agent to load schemas
via `ToolSearch`, and instructs it to translate `gh ...` invocations found in
`.claude/CLAUDE.md` and the roadmap into their MCP equivalents rather than
treating them as unavailable.

Because this repo lands through GitHub's native merge queue
(`.github/workflows/ci.yml` declares `merge_group`), a direct
`merge_pull_request` call can be rejected by branch protection. The prompt now
states the fallback explicitly: verify checks at the exact head sha, attempt
the merge, and on a protection rejection call `enable_pr_auto_merge` to enqueue
and record the head sha on the coordination board.

### 2. The cross-agent conformance lock was unnecessary

The prompt said "assume another agent may be running one — check first" for
`conformance.sh`. Each Claude-on-web session runs in its own ephemeral
container with its own fresh clone, so the shared-corpus-tree hazard that
motivates the rule in `.claude/CLAUDE.md` is intra-session; two agents cannot
corrupt each other's run. The instruction spent coordination bandwidth on a
non-conflict and implied a cross-container lock that has no mechanism behind
it. The constraint is now scoped to "within your own session", and a new
Environment Notes section states the container-isolation model up front so the
rest of the prompt does not have to re-derive it.

### 3. Goal diversity had no deterministic mechanism

"Start your scan in whichever of the four goals the board shows the least
recent activity in" reads the board at four different instants, 15 minutes
apart, with claims posted between reads — four sessions can and will pick the
same lane. Replaced with a rotation computable offline from data each agent
already has:

    slots: Aster=0, Basalt=1, Cinder=2, Dune=3
    lanes: [green, fast, grow, hold]
    starting lane = lanes[(slot + current_UTC_hour) % 4]

Distinct lanes for all four concurrent agents, from one shared prompt, with the
`AgentName` placeholder still the only per-account difference. It is a starting
preference rather than a mandate, with an explicit fallback to the ROADMAP
"How To Pick Work" ranking, because `grow` is gated on required rows being
green and `hold` is a regression floor rather than a campaign — the prompt now
says outright that moving on from an empty rotated lane is correct, so the
rotation cannot burn an hour on a lane with no work in it.

### Smaller changes

- Per-session time budget (orient / drain / build / verify / ship) with an
  instruction to narrow scope rather than abandon the hour past the halfway
  mark.
- `subscribe_pr_activity` after opening a PR, so CI failures and review
  comments wake the session that owns the PR.
- Claim TTL shortened from three hours to two, so an abandoned claim frees
  within the cadence instead of blocking two later runs.
- Handle-to-slot table with suggested start minutes, replacing the loose
  "suggested handles" list.

## Goal
Goal: hold

## Verification
- Docs-only change; one file, no code, script, or workflow paths touched.
- `command -v gh` in a Claude-on-web session: not found — confirms defect 1.
- `grep -l merge_group .github/workflows/*.yml` → `.github/workflows/ci.yml`,
  confirming the merge-queue path the landing fallback is written against.
- Cross-checked against `.claude/CLAUDE.md`, `docs/plan/ROADMAP.md`,
  `.github/pull_request_template.md`, `.agents/skills/` (skill names verified
  against the directory listing), and `scripts/conformance/` (verified
  `compare-to-parent.sh` exists and delegates to `conformance.sh`, so it is
  covered by the same intra-session constraint).
- `scripts/agents/llm-context-audit.py` not applicable: no changes under
  `.codex/`, `.claude/`, `AGENTS.md`, or startup hooks.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: medium

---
_Generated by [Claude Code](https://claude.ai/code/session_019nw844X5c6eRQJNqCcAiZQ)_