### PR TITLE
fix(checker): resolve lib-global TS2403 types through the canonical lib def query

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/assignment_compatibility.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_compatibility.rs
@@ -38,10 +38,10 @@ impl<'a> FlowAnalyzer<'a> {
                 option_sensitive_relation = assignment_started_provisional;
                 let rhs = self.skip_parens_and_assertions(bin.right);
                 if option_sensitive_relation
-                    && !self
+                    && self
                         .arena
                         .get(rhs)
-                        .is_some_and(|rhs_node| rhs_node.kind == syntax_kind_ext::CALL_EXPRESSION)
+                        .is_none_or(|rhs_node| rhs_node.kind != syntax_kind_ext::CALL_EXPRESSION)
                 {
                     // Reduced syntax-only surfaces keep the established flow path.
                     return Some(flow_type);

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -15,6 +15,7 @@ use tsz_solver::TypeId;
 
 mod annotation_context;
 mod async_jsdoc_return;
+mod lib_decl_arena;
 mod precheck_helpers;
 mod prior_value;
 
@@ -1287,23 +1288,60 @@ impl<'a> CheckerState<'a> {
                                 }
                                 for &lib_decl in &lib_sym.declarations {
                                     if lib_decl.is_some() {
-                                        let Some(cross_arena_guard) =
-                                            CheckerState::enter_cross_arena_delegation()
-                                        else {
+                                        // A merged binder's symbol keeps
+                                        // declaration indices from every file
+                                        // that contributed to it, and
+                                        // `NodeIndex` is arena-local. Reading
+                                        // one against the wrong arena resolves
+                                        // to an unrelated node instead of
+                                        // failing, so the child checker below
+                                        // would materialize (and compare
+                                        // against) a foreign lib member's type.
+                                        if !lib_decl_arena::lib_declaration_belongs_to_arena(
+                                            &binder, &arena, lib_sym_id, lib_decl, &name,
+                                        ) {
                                             continue;
-                                        };
-                                        let mut lib_checker =
-                                            CheckerState::new_with_shared_def_store(
-                                                &arena,
-                                                &binder,
-                                                types,
-                                                "lib.d.ts".to_string(),
-                                                compiler_options.clone(),
-                                                definition_store.clone(),
-                                            );
-                                        lib_checker.ctx.lib_contexts = lib_contexts.clone();
-                                        let lib_type = lib_checker.get_type_of_node(lib_decl);
-                                        drop(cross_arena_guard);
+                                        }
+                                        // A lib global's annotation is a bare
+                                        // reference to a lib type (`declare var
+                                        // Symbol: SymbolConstructor;`). Resolve
+                                        // it through the canonical,
+                                        // name-verified lib def query. The
+                                        // child-checker fallback lowers the
+                                        // same annotation through the raw
+                                        // `SymbolId -> DefId` map, which is
+                                        // first-writer-wins across lib binders
+                                        // and answers with an unrelated lib
+                                        // entity's def.
+                                        let lib_type =
+                                            match lib_decl_arena::lib_global_annotation_type(
+                                                &self.ctx, &arena, lib_decl,
+                                            ) {
+                                                Some(annotation_type) => annotation_type,
+                                                None => {
+                                                    let Some(cross_arena_guard) =
+                                                        CheckerState::enter_cross_arena_delegation(
+                                                        )
+                                                    else {
+                                                        continue;
+                                                    };
+                                                    let mut lib_checker =
+                                                        CheckerState::new_with_shared_def_store(
+                                                            &arena,
+                                                            &binder,
+                                                            types,
+                                                            "lib.d.ts".to_string(),
+                                                            compiler_options.clone(),
+                                                            definition_store.clone(),
+                                                        );
+                                                    lib_checker.ctx.lib_contexts =
+                                                        lib_contexts.clone();
+                                                    let materialized =
+                                                        lib_checker.get_type_of_node(lib_decl);
+                                                    drop(cross_arena_guard);
+                                                    materialized
+                                                }
+                                            };
                                         if !is_in_namespace && !is_in_external_module {
                                             // TS2403 only applies to compatible global-scope vars.
                                             if !is_in_function_scope

--- a/crates/tsz-checker/src/state/variable_checking/core/lib_decl_arena.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core/lib_decl_arena.rs
@@ -1,0 +1,129 @@
+//! Cross-arena declaration ownership guard for the TS2403 lib-global lookup.
+//!
+//! A merged binder's symbol carries declaration `NodeIndex` values from *every*
+//! file that contributed to it. `NodeIndex` is an arena-local offset, so reading
+//! one against a different arena silently yields an unrelated node rather than
+//! failing. The TS2403 prior-declaration scan walks every `LibContext` and, for
+//! each one, materializes `lib_sym.declarations` against *that* context's arena
+//! — so a `Symbol` declaration that really lives in `lib.es2015.symbol.d.ts`
+//! got materialized against `lib.dom.d.ts` and produced the type of whatever
+//! member happened to sit at that index (`blur`, `parseInt`, `CSSImportRule`).
+//!
+//! That value is not only rendered in the message, it also gates emission
+//! through `are_var_decl_types_compatible`, so redeclaring a lib global with its
+//! own correct type (`declare var Symbol: SymbolConstructor;`, the ordinary
+//! ambient-shim shape) reported a false TS2403.
+//!
+//! The intra-file arm of the same scan already guards this way by comparing the
+//! declaration's name text; these helpers give the lib arm the same guard plus
+//! the binder's recorded per-declaration arena provenance.
+
+use crate::context::CheckerContext;
+use tsz_binder::{BinderState, SymbolId};
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::{NodeAccess, NodeArena};
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
+
+/// True when `decl_idx` is a declaration of `name` that genuinely lives in
+/// `arena`, and is therefore safe to materialize through a child checker built
+/// over `arena`.
+///
+/// Two independent checks, both required:
+///
+/// 1. **Recorded provenance.** When the binder recorded arenas for this
+///    `(symbol, declaration)` pair, `arena` must be one of them.
+/// 2. **Name agreement.** The node at `decl_idx` *in `arena`* must be a
+///    declaration whose name is `name`. This is the check that survives
+///    `NodeIndex` collisions, where `declaration_arenas` legitimately records
+///    several arenas for one index because two files declare something at the
+///    same offset.
+pub(super) fn lib_declaration_belongs_to_arena(
+    binder: &BinderState,
+    arena: &NodeArena,
+    lib_sym_id: SymbolId,
+    decl_idx: NodeIndex,
+    name: &str,
+) -> bool {
+    if let Some(arenas) = binder.declaration_arenas.get(&(lib_sym_id, decl_idx))
+        && !arenas
+            .iter()
+            .any(|recorded| std::ptr::eq(recorded.as_ref(), arena))
+    {
+        return false;
+    }
+
+    declaration_name_text_in_arena(arena, decl_idx).is_some_and(|text| text == name)
+}
+
+/// Declared type of a lib global whose annotation is a bare type reference
+/// (`declare var Symbol: SymbolConstructor;`), resolved through the *parent*
+/// checker's canonical, name-verified lib def query.
+///
+/// The alternative — running a child `CheckerState` over the lib arena and
+/// asking it for the declaration's type — lowers that annotation through the
+/// raw `SymbolId -> DefId` map. Every lib binder's symbols carry the `u32::MAX`
+/// declaration-file sentinel, so that map is first-writer-wins across lib
+/// binders and a per-lib `SymbolId` resolves to whichever def another lib binder
+/// registered at the same raw index. `SymbolConstructor` came back as `blur`
+/// (lib.dom) or `parseInt` (lib.es5) depending only on the lib set — the
+/// `SymbolId`-reinterpreted-as-`DefId` collision family.
+///
+/// `actual_lib_def_id_for_bare_name` is the hardened query the rest of the
+/// checker already uses for exactly this: it canonicalizes the symbol and then
+/// verifies the elected def's recorded name against the requested name, so a
+/// collided identity can never be committed.
+///
+/// Returns `None` for anything that is not a bare, non-generic type reference;
+/// the caller keeps its existing materialization for those.
+pub(super) fn lib_global_annotation_type(
+    ctx: &CheckerContext<'_>,
+    arena: &NodeArena,
+    decl_idx: NodeIndex,
+) -> Option<TypeId> {
+    let node = arena.get(decl_idx)?;
+    if node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
+        return None;
+    }
+    let annotation_idx = arena.get_variable_declaration(node)?.type_annotation;
+    if annotation_idx.is_none() {
+        return None;
+    }
+    let annotation = arena.get(annotation_idx)?;
+    if annotation.kind != syntax_kind_ext::TYPE_REFERENCE {
+        return None;
+    }
+    let type_ref = arena.get_type_ref(annotation)?;
+    if type_ref.type_arguments.is_some() {
+        return None;
+    }
+    let annotation_name = arena.get_identifier_text(type_ref.type_name)?;
+    let def_id = ctx.actual_lib_def_id_for_bare_name(annotation_name)?;
+    Some(ctx.types.lazy(def_id))
+}
+
+/// Name text of the declaration at `decl_idx`, read from `arena` rather than
+/// from the checker's own arena.
+///
+/// Covers the declaration kinds a value global can take (`var`/`function`/
+/// `class`/`enum`/`namespace`, plus parameters, which the same scan also
+/// compares against). Anything else has no bare name to verify and is treated
+/// as unverifiable.
+fn declaration_name_text_in_arena(arena: &NodeArena, decl_idx: NodeIndex) -> Option<String> {
+    let node = arena.get(decl_idx)?;
+    let name_idx = match node.kind {
+        k if k == tsz_scanner::SyntaxKind::Identifier as u16 => decl_idx,
+        syntax_kind_ext::VARIABLE_DECLARATION => arena.get_variable_declaration(node)?.name,
+        syntax_kind_ext::FUNCTION_DECLARATION => arena.get_function(node)?.name,
+        syntax_kind_ext::CLASS_DECLARATION => arena.get_class(node)?.name,
+        syntax_kind_ext::ENUM_DECLARATION => arena.get_enum(node)?.name,
+        syntax_kind_ext::MODULE_DECLARATION => arena.get_module(node)?.name,
+        syntax_kind_ext::PARAMETER => arena.get_parameter(node)?.name,
+        _ => return None,
+    };
+    let name_node = arena.get(name_idx)?;
+    if let Some(ident) = arena.get_identifier(name_node) {
+        return Some(ident.escaped_text.to_string());
+    }
+    arena.get_literal(name_node).map(|lit| lit.text.clone())
+}


### PR DESCRIPTION
Fixes #15913.

**Structural rule.** When a global-scope `var` redeclares a lib global, `tsc`
compares against the lib declaration's declared type, so `declare var Symbol:
SymbolConstructor;` is identical and emits nothing. tsz now does the same
through the checker's canonical lib def query (`CheckerContext::
actual_lib_def_id_for_bare_name`) instead of an ad-hoc child `CheckerState`
built over a lib arena.

## What was wrong

`variable_checking/core.rs` materialized the lib declaration's type by spinning
up a child `CheckerState` over the lib arena and calling `get_type_of_node`.
That child lowers the declaration's annotation through the raw
`SymbolId -> DefId` map. Every lib binder's symbols carry the `u32::MAX`
declaration-file sentinel, so that map is first-writer-wins across lib binders
and a per-lib `SymbolId` resolves to whichever def a *different* lib binder
registered at the same raw index — the `SymbolId`-reinterpreted-as-`DefId`
collision family already documented in `def/resolver_tests.rs` (#13862) and
`context/def_mapping.rs` (#15778).

The answer varied with the lib set, not the source:

| libs | `var Symbol: any;` reported prior type |
| --- | --- |
| `["es2015"]` | `parseInt` (lib.es5) |
| `["es2015","dom"]` | `blur` (lib.dom) |

That value is not only rendered in the message — it is also fed to
`are_var_decl_types_compatible`, which gates emission. So redeclaring a lib
global with its own correct type, the ordinary ambient-shim / polyfill shape in
hand-written `.d.ts`, raised a **false TS2403**. `tsc` emits nothing for any of
these; tsz emitted four:

```ts
declare var Symbol: SymbolConstructor;  // TS2403 "must be of type 'blur'"
declare var Array: ArrayConstructor;    // TS2403 "must be of type 'CSSImportRule'"
declare var Math: Math;                 // TS2403 "must be of type 'void'"
declare var JSON: JSON;                 // TS2403 "must be of type 'void'"
```

`Math`/`JSON` reporting `void` is the tell for the second half of the defect:
`void` is not a lib entity name, it is a low `TypeId`.

## The fix

Both changes are at the owning site, `crates/tsz-checker/src/state/variable_checking/`.

1. **Annotation resolution** (`core/lib_decl_arena.rs`,
   `lib_global_annotation_type`). A lib global's annotation is a bare reference
   to a lib type. Resolve it through `actual_lib_def_id_for_bare_name` — the
   hardened query the rest of the checker already uses, which canonicalizes the
   symbol and then verifies the elected def's *recorded name* against the
   requested name, so a collided identity can never be committed. The child
   checker remains the fallback for annotations that are not bare, non-generic
   type references.

2. **Cross-arena declaration ownership** (`lib_declaration_belongs_to_arena`). A
   merged binder's symbol keeps declaration `NodeIndex` values from every file
   that contributed to it, and `NodeIndex` is an arena-local offset — reading
   one against a different arena silently yields an unrelated node rather than
   failing. The scan walks every `LibContext` and read each index against *that*
   context's arena. The guard requires both the binder's recorded
   per-declaration arena provenance and name agreement with the symbol (the
   latter is what survives the legitimate `NodeIndex` collisions
   `declaration_arenas` records as several arenas for one index). The intra-file
   arm of this same scan already guarded exactly this way; the lib arm did not.

No identifier, alias, property, or file-name literal drives any decision, and
nothing reads rendered printer output.

## Goal
Goal: hold

## Verification

Baseline binary = `origin/main` at `00a4c6d`; fixed binary = this branch. Both
release profile, same pinned lib set.

**Message variant** — `var Symbol: any;`, `target: es2015`, no `strict`:

| lib set | before | after | `tsc` 6.0.3 |
| --- | --- | --- | --- |
| default (es2015 + dom) | `must be of type 'blur'` | `must be of type 'SymbolConstructor'` | `SymbolConstructor` |
| `["es2015"]` | `must be of type 'parseInt'` | `must be of type 'SymbolConstructor'` | `SymbolConstructor` |

Two lib sets on purpose: the wrong answer was lib-set dependent, so a single-lib
check would pass against a fix that merely reorders the first-writer race.

**False-positive variant** — the four `declare var X: X` shapes above:

- before: 4 × TS2403
- after: **no diagnostics**, matching `tsc`

**Negative control** — must still error. `declare var {Math,JSON,Symbol,Array}:
number;`:

| | before | after |
| --- | --- | --- |
| `Math` | TS2403 `must be of type 'resizeBy'` | TS2403 `must be of type 'Math'` |
| `JSON` | TS2403 `must be of type 'atob'` | TS2403 `must be of type 'JSON'` |
| `Symbol` | TS2403 `must be of type 'blur'` | TS2403 `must be of type 'SymbolConstructor'` |
| `Array` | TS2403 `must be of type 'CSSImportRule'` | TS2403 `must be of type 'ArrayConstructor'` |

All four still fire — the fix corrects the identity, it does not silence the
diagnostic.

**Conformance** — `./scripts/conformance/conformance.sh run --filter
ES5SymbolProperty --workers 4`:

```
FINAL RESULTS: 16/16 passed (100.0%)
  Candidates: 16   Runnable: 16   Known failures: 0   Crashed: 0   Timeout: 0
```

This includes `ES5SymbolProperty3/4/5/7`, the four rows #15913 records as
failing on main on the rendered type name.

**Lint** — `cargo fmt --all`; `cargo clippy --workspace --all-targets --
-D warnings` clean. Note that `-D warnings` was **already failing on main** on
the current toolchain (`nonminimal_bool` in
`flow/control_flow/assignment_compatibility.rs:41`, untouched by this fix);
this PR includes the one-line simplification so the per-merge lane can pass.

**Not run this session:** the full conformance snapshot, emit, and fourslash
suites. The change is confined to the TS2403 lib-global prior-declaration scan
and does not touch emit; the targeted conformance filter above covers the rows
the issue names.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Aster


---
_Generated by [Claude Code](https://claude.ai/code/session_015DghnWVPsRTz5hgZnBmmoK)_