### PR TITLE
fix(checker): TS2403 lib-global redeclaration materializes wrong-identity type

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1842,6 +1842,9 @@ path = "tests/optional_undefined_property_index_signature_tests.rs"
 name = "ts2403_enum_object_redeclaration_tests"
 path = "tests/ts2403_enum_object_redeclaration_tests.rs"
 [[test]]
+name = "ts2403_lib_global_redeclaration_tests"
+path = "tests/ts2403_lib_global_redeclaration_tests.rs"
+[[test]]
 name = "ts1262_multiple_await_declarations_tests"
 path = "tests/ts1262_multiple_await_declarations_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/flow/control_flow/assignment_compatibility.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_compatibility.rs
@@ -38,10 +38,10 @@ impl<'a> FlowAnalyzer<'a> {
                 option_sensitive_relation = assignment_started_provisional;
                 let rhs = self.skip_parens_and_assertions(bin.right);
                 if option_sensitive_relation
-                    && !self
+                    && self
                         .arena
                         .get(rhs)
-                        .is_some_and(|rhs_node| rhs_node.kind == syntax_kind_ext::CALL_EXPRESSION)
+                        .is_none_or(|rhs_node| rhs_node.kind != syntax_kind_ext::CALL_EXPRESSION)
                 {
                     // Reduced syntax-only surfaces keep the established flow path.
                     return Some(flow_type);

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -1287,23 +1287,85 @@ impl<'a> CheckerState<'a> {
                                 }
                                 for &lib_decl in &lib_sym.declarations {
                                     if lib_decl.is_some() {
-                                        let Some(cross_arena_guard) =
-                                            CheckerState::enter_cross_arena_delegation()
-                                        else {
+                                        // A merged symbol's `declarations` mixes its VALUE
+                                        // declarations with any same-named TYPE-space
+                                        // declarations (e.g. `declare var Array:
+                                        // ArrayConstructor` merged with `interface
+                                        // Array<T> { ... }`, both named `Array`) and, for a
+                                        // `declare namespace Reflect { ... }`-style global,
+                                        // a `MODULE_DECLARATION` whose synthesized "typeof
+                                        // namespace" value type this pass does not attempt
+                                        // to materialize. Only a plain value declaration can
+                                        // be a "prior declaration" for TS2403; a type-only
+                                        // declaration occupies a different declaration space
+                                        // (see the VALUE-flag check above) and a namespace
+                                        // declaration needs its own synthesis, so neither is
+                                        // materialized here.
+                                        use tsz_parser::parser::syntax_kind_ext;
+                                        if arena.get(lib_decl).is_some_and(|node| {
+                                            matches!(
+                                                node.kind,
+                                                syntax_kind_ext::INTERFACE_DECLARATION
+                                                    | syntax_kind_ext::TYPE_ALIAS_DECLARATION
+                                                    | syntax_kind_ext::MODULE_DECLARATION
+                                            )
+                                        }) {
                                             continue;
-                                        };
-                                        let mut lib_checker =
-                                            CheckerState::new_with_shared_def_store(
-                                                &arena,
-                                                &binder,
-                                                types,
-                                                "lib.d.ts".to_string(),
-                                                compiler_options.clone(),
-                                                definition_store.clone(),
-                                            );
-                                        lib_checker.ctx.lib_contexts = lib_contexts.clone();
-                                        let lib_type = lib_checker.get_type_of_node(lib_decl);
-                                        drop(cross_arena_guard);
+                                        }
+                                        // Resolve the lib global's type by reading its
+                                        // type annotation's referenced type BY NAME
+                                        // (`resolve_lib_type_by_name`) instead of
+                                        // materializing it with an ad-hoc child checker
+                                        // scoped to this one lib binder's own arena.
+                                        // Every lib binder's symbols share the u32::MAX
+                                        // declaration-file sentinel, so the child
+                                        // checker's raw-SymbolId resolution collides with
+                                        // whichever def a DIFFERENT lib binder registered
+                                        // under the same numeric id — the SymbolId-
+                                        // reinterpreted-as-DefId family also seen in
+                                        // #13862/#15778 (`Symbol` materializing as
+                                        // `blur`, `Array` as `CSSImportRule`, etc.).
+                                        // `resolve_lib_type_by_name` is the same
+                                        // collision-hardened, name-keyed route ordinary
+                                        // lib type references already resolve through.
+                                        // Declarations without a simple named type
+                                        // annotation (rare for `declare var` globals)
+                                        // fall back to the previous per-declaration
+                                        // child-checker materialization.
+                                        let lib_type = arena
+                                            .get(lib_decl)
+                                            .and_then(|node| arena.get_variable_declaration(node))
+                                            .filter(|vd| vd.type_annotation.is_some())
+                                            .and_then(|vd| arena.get(vd.type_annotation))
+                                            .and_then(|ann| arena.get_type_ref(ann))
+                                            .and_then(|type_ref| arena.get(type_ref.type_name))
+                                            .and_then(|name_node| arena.get_identifier(name_node))
+                                            .and_then(|ident| {
+                                                self.resolve_lib_type_by_name(
+                                                    ident.escaped_text.as_str(),
+                                                )
+                                            })
+                                            .unwrap_or_else(|| {
+                                                let Some(cross_arena_guard) =
+                                                    CheckerState::enter_cross_arena_delegation()
+                                                else {
+                                                    return TypeId::ERROR;
+                                                };
+                                                let mut lib_checker =
+                                                    CheckerState::new_with_shared_def_store(
+                                                        &arena,
+                                                        &binder,
+                                                        types,
+                                                        "lib.d.ts".to_string(),
+                                                        compiler_options.clone(),
+                                                        definition_store.clone(),
+                                                    );
+                                                lib_checker.ctx.lib_contexts = lib_contexts.clone();
+                                                let lib_type =
+                                                    lib_checker.get_type_of_node(lib_decl);
+                                                drop(cross_arena_guard);
+                                                lib_type
+                                            });
                                         if !is_in_namespace && !is_in_external_module {
                                             // TS2403 only applies to compatible global-scope vars.
                                             if !is_in_function_scope

--- a/crates/tsz-checker/tests/ts2403_lib_global_redeclaration_tests.rs
+++ b/crates/tsz-checker/tests/ts2403_lib_global_redeclaration_tests.rs
@@ -1,0 +1,113 @@
+//! Regression coverage for #15913: redeclaring a lib global whose symbol
+//! merges a VALUE declaration (`declare var X: XConstructor`) with a
+//! same-named TYPE declaration (`interface X { ... }`) must compare the
+//! new declaration's type against the *value* declaration's type — not
+//! materialize a garbage type by resolving the wrong declaration in the
+//! merged symbol's declaration list through a raw, colliding identity.
+//!
+//! `crates/tsz-checker/src/state/variable_checking/core.rs`'s TS2403 check
+//! looks up prior lib declarations by name across each lib file's own
+//! binder. Every lib binder's symbols share the `u32::MAX`
+//! declaration-file sentinel, so resolving such a symbol's type through an
+//! ad-hoc child checker scoped to one lib binder can collide with an
+//! unrelated def a *different* lib binder registered under the same raw
+//! `SymbolId` (same family as #13862/#15778). It also has to skip the
+//! TYPE-side (`interface`/`type alias`) and namespace declarations that
+//! share the merged symbol's declaration list, since only the VALUE
+//! declaration is a "prior declaration" for TS2403.
+//!
+//! `load_default_lib_files` + `check_source_with_libs` load each lib file
+//! into its own `LibFile` (own arena/binder), matching the multi-lib-context
+//! shape the CLI driver produces — `check_source`'s single merged-lib-file
+//! harness does not exercise this code path at all, so it cannot regression
+//! test this fix.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn ts2403_messages(source: &str) -> Vec<String> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs)
+        .iter()
+        .filter(|d| d.code == 2403)
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+/// `declare var Symbol: SymbolConstructor;` in lib. Redeclaring it with an
+/// incompatible type must report the real lib type, not an unrelated lib
+/// entity's name (the original bug: `must be of type 'blur'`).
+#[test]
+fn incompatible_redeclaration_of_symbol_reports_symbol_constructor() {
+    let messages = ts2403_messages("var Symbol: any;");
+    assert_eq!(messages.len(), 1, "Expected one TS2403: {messages:#?}");
+    assert!(
+        messages[0].contains("SymbolConstructor"),
+        "Expected the prior type to render as 'SymbolConstructor', got: {}",
+        messages[0]
+    );
+}
+
+/// `Array`, `Math`, and `JSON` are each a merged TYPE+VALUE lib symbol
+/// (`declare var Array: ArrayConstructor;` alongside `interface Array<T>
+/// {...}`, `Math`/`JSON` alongside their own same-named interfaces).
+/// Redeclaring each with its own correct value type must be a no-op — tsc
+/// emits nothing for the ordinary `declare var X: X` ambient-shim idiom.
+#[test]
+fn redeclaring_merged_lib_globals_with_correct_type_emits_no_ts2403() {
+    let messages = ts2403_messages(
+        r#"
+var Array: ArrayConstructor;
+var Math: Math;
+var JSON: JSON;
+var Promise: PromiseConstructor;
+"#,
+    );
+    assert!(
+        messages.is_empty(),
+        "declare var X: X for a merged lib global must not report TS2403: {messages:#?}"
+    );
+}
+
+/// The same merged lib globals, redeclared with an INCOMPATIBLE type, must
+/// still report TS2403 against their real value type (not a garbage
+/// unrelated lib entity — the collision family this fix removes).
+#[test]
+fn redeclaring_merged_lib_globals_with_wrong_type_reports_real_type() {
+    let cases: &[(&str, &str)] = &[
+        ("var Array: any;", "ArrayConstructor"),
+        ("var Math: any;", "Math"),
+        ("var JSON: any;", "JSON"),
+        ("var Promise: any;", "PromiseConstructor"),
+    ];
+    for (source, expected_type_name) in cases {
+        let messages = ts2403_messages(source);
+        assert_eq!(
+            messages.len(),
+            1,
+            "Expected one TS2403 for `{source}`: {messages:#?}"
+        );
+        assert!(
+            messages[0].contains(expected_type_name),
+            "Expected `{source}`'s prior type to render as '{expected_type_name}', got: {}",
+            messages[0]
+        );
+    }
+}
+
+/// `Reflect` is a `declare namespace Reflect { ... }` global (no
+/// `VariableDeclaration` at all), a different declaration-merging shape
+/// than the `interface`+`var` family above. This pass does not attempt to
+/// synthesize the namespace's "typeof Reflect" value type, so it must skip
+/// the declaration rather than materialize a garbage type for it.
+#[test]
+fn redeclaring_namespace_shaped_lib_global_emits_no_garbage_ts2403() {
+    let messages = ts2403_messages("var Reflect: any;");
+    assert!(
+        messages
+            .iter()
+            .all(|m| !m.contains("must be of type 'void'")),
+        "Must not report a collided placeholder type for a namespace-shaped \
+         lib global: {messages:#?}"
+    );
+}


### PR DESCRIPTION
When a lib global's symbol merges a VALUE declaration (`declare var X: XConstructor`) with a same-named TYPE declaration (`interface X {...}`) or a `declare namespace X {...}`, tsc compares a redeclaration's type against the value declaration's type. tsz materialized it through an ad-hoc child checker scoped to one lib binder's own arena, which (a) iterated every declaration in the merged symbol's list including the type-only/namespace ones, and (b) resolved raw `SymbolId`s that collide across lib binders sharing the `u32::MAX` declaration-file sentinel (#13862/#15778 family) — producing `must be of type 'blur'`/`'CSSImportRule'`/`'void'` instead of `SymbolConstructor`/`ArrayConstructor`/etc. The same garbage type also gated emission, so redeclaring a lib global with its own correct type (the `declare var X: X` ambient-shim idiom) falsely raised TS2403.

**Structural rule:** When a redeclared lib global's merged symbol has a VALUE declaration whose type annotation is a simple named type reference, tsc resolves the redeclaration's prior type from that value declaration; tsz now does the same through the checker's existing collision-hardened `resolve_lib_type_by_name` (owner: `crates/tsz-checker/src/state/variable_checking/core.rs`), instead of an ad-hoc per-lib-binder child checker whose raw `SymbolId` resolution collides across lib binders.

**Adjacent cases** (`ts2403_lib_global_redeclaration_tests.rs`):
- interface+var merge family (`Symbol`/`Array`/`Math`/`JSON`/`Promise`): incompatible redeclaration reports the real value type; compatible redeclaration (`declare var X: X`) emits no false TS2403.
- namespace-shaped family (`Reflect`, `declare namespace Reflect {...}`, no `VariableDeclaration` at all): skipped rather than materializing a colliding placeholder type — a strict improvement (no more false-positive-with-garbage-message), though this PR does not attempt to synthesize the namespace's own "typeof Reflect" value type.
- fallback path (child-checker materialization) preserved for any value declaration without a simple named type annotation.

Fixes #15913.

Also includes an unrelated one-line clippy fix (`flow/control_flow/assignment_compatibility.rs`, `nonminimal_bool`) applied mechanically from clippy's own suggestion: `main` currently fails `cargo clippy -p tsz-checker` (and this repo's pre-commit hook) without it, so no commit could otherwise land in this crate. Flagged on the coordination board for anyone who wants to split it out.

## Goal
Goal: hold

## Verification
- `cargo build -p tsz-cli --bin tsz` + manual repro via `tsz --project .` against the exact fixtures in #15913 (`var Symbol: any;`, `var Array: ArrayConstructor;`, `var Math: Math;`, `var JSON: JSON;`, `var Promise: any;`, `var Reflect: any;`, with `lib: ["es2015"]` and `["es2015","dom"]`): output now matches tsc's documented expected diagnostics exactly (before: `must be of type 'blur'/'CSSImportRule'/'void'`; after: `SymbolConstructor`/`ArrayConstructor`/no diagnostic/no diagnostic).
- `cargo test -p tsz-checker --test ts2403_lib_global_redeclaration_tests`: 4/4 new tests pass on this branch; all 4 fail on `main` (confirmed via `git stash`), reproducing the exact bug (e.g. `Variable 'Promise' must be of type 'parseInt'`).
- `cargo clippy -p tsz-checker --all-targets` (workspace lint config, warnings denied): clean.
- `cargo fmt --all -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: `Architecture guardrails passed.`
- Not run locally due to session time constraints: full `conformance.sh snapshot`, `scripts/emit/run.sh`, `scripts/fourslash/run-fourslash.sh`. The change is scoped to one checker code path (lib-global TS2403 redeclaration comparison); expected conformance effect is the 4 `ES5SymbolProperty3/4/5/7` tests named in #15913 turning from a message-only mismatch to exact match. Flagging for anyone who lands after — happy to run the broad suites on request or in a follow-up push.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_015nKRQnf7PY1mD5qF2ZLudQ)_