### PR TITLE
[WIP] fix(checker): gate cross-file owner answers on contested SymbolIds (measured no-op — closed)

### DIFF
--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -197,6 +197,7 @@ protected_constructor_types = { lifetime = "FileLocalReset", capability = "FileT
 private_constructor_types = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 cross_file_symbol_targets = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 global_symbol_file_index = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
+contested_symbol_ids = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
 all_arenas = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
 all_binders = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
 global_file_locals_index = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -442,6 +442,7 @@ impl<'a> CheckerContext<'a> {
             private_constructor_types: FxHashSet::default(),
             cross_file_symbol_targets: RefCell::new(super::SymbolFileTargetsOverlay::default()),
             global_symbol_file_index: None,
+            contested_symbol_ids: None,
             all_arenas: None,
             all_binders: None,
             global_file_locals_index: None,

--- a/crates/tsz-checker/src/context/contested_symbols.rs
+++ b/crates/tsz-checker/src/context/contested_symbols.rs
@@ -1,0 +1,47 @@
+//! Cross-binder raw-`SymbolId` ambiguity.
+//!
+//! `SymbolId` is a per-arena handle. Whether it is globally unique depends on
+//! how the program was assembled: the production driver hands the checker
+//! globally-remapped ids, but any assembly that binds files independently
+//! leaves each binder numbering its own symbols from `0`. In that second case
+//! the *same* raw id names a different declaration in every binder, so a
+//! `SymbolId -> file_idx` answer is meaningless — there is no single owner to
+//! name.
+//!
+//! A contested id must therefore resolve to "unknown" and let callers take
+//! their local/name-based fallback, never to an arbitrary last-writer file.
+//! Resolving one anyway is the `#15983` false-`TS2538` family: an import
+//! alias whose own raw id happens to collide with an unrelated symbol in
+//! another binder materializes as *that* symbol's type.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::sync::Arc;
+
+use tsz_binder::{BinderState, SymbolId};
+
+/// Raw `SymbolId`s declared by two or more of `binders`.
+///
+/// An empty set means every id names exactly one declaration program-wide,
+/// which is the normal state after the driver's global remap — so gating on
+/// this set costs nothing where ids are already unique and only bites where
+/// they genuinely collide.
+#[must_use]
+pub fn build_contested_symbol_ids(binders: &[Arc<BinderState>]) -> FxHashSet<SymbolId> {
+    let mut owner: FxHashMap<SymbolId, usize> = FxHashMap::default();
+    let mut contested = FxHashSet::default();
+    for (file_idx, binder) in binders.iter().enumerate() {
+        for symbol in binder.symbols.iter() {
+            match owner.entry(symbol.id) {
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(file_idx);
+                }
+                std::collections::hash_map::Entry::Occupied(slot) => {
+                    if *slot.get() != file_idx {
+                        contested.insert(symbol.id);
+                    }
+                }
+            }
+        }
+    }
+    contested
+}

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -184,8 +184,12 @@ impl<'a> CheckerContext<'a> {
     ///
     /// Checks the layered `cross_file_symbol_targets` overlay first, then falls
     /// back to the shared `global_symbol_file_index` base map.
-    /// Returns `None` if the symbol has no known cross-file owner.
+    /// Returns `None` if the symbol has no known cross-file owner, including
+    /// when the raw id is contested (see [`Self::symbol_id_is_contested`]).
     pub fn resolve_symbol_file_index(&self, sym_id: SymbolId) -> Option<usize> {
+        if self.symbol_id_is_contested(sym_id) {
+            return None;
+        }
         if let Some(idx) = self.resolve_dynamic_symbol_file_index(sym_id) {
             return Some(idx);
         }
@@ -201,7 +205,43 @@ impl<'a> CheckerContext<'a> {
 
     /// Resolve only dynamically-discovered `SymbolId` ownership.
     pub fn resolve_dynamic_symbol_file_index(&self, sym_id: SymbolId) -> Option<usize> {
+        if self.symbol_id_is_contested(sym_id) {
+            return None;
+        }
         self.cross_file_symbol_targets.borrow().get(sym_id)
+    }
+
+    /// Whether a foreign owner for `sym_id` would contradict the checking
+    /// file's own symbol table.
+    ///
+    /// True only when the raw id is declared by two or more binders *and* the
+    /// file being checked is one of them. That conjunction is what makes the
+    /// answer knowably wrong rather than merely unproven: the id names a real
+    /// local declaration here, so pointing it at another file claims foreign
+    /// ownership of this file's own local or import alias — the `#15983`
+    /// false-`TS2538` mechanism.
+    ///
+    /// Contested ids the checking file does *not* declare are left alone. It
+    /// has no competing claim to make, and refusing those too strands
+    /// legitimate cross-file resolutions on their name-based fallback.
+    ///
+    /// The rule has to hold for the dynamically discovered overlay as well as
+    /// the static index: the overlay is consulted first, so one dynamic
+    /// registration would otherwise defeat a static index that had correctly
+    /// dropped the id as ambiguous.
+    #[must_use]
+    pub fn symbol_id_is_contested(&self, sym_id: SymbolId) -> bool {
+        if !self
+            .contested_symbol_ids
+            .as_ref()
+            .is_some_and(|ids| ids.contains(&sym_id))
+        {
+            return false;
+        }
+        self.all_binders
+            .as_ref()
+            .and_then(|binders| binders.get(self.current_file_idx))
+            .is_some_and(|binder| binder.symbols.get(sym_id).is_some())
     }
 
     /// Resolve a `SymbolId` to its *declaring* file index from the shared,
@@ -221,6 +261,9 @@ impl<'a> CheckerContext<'a> {
     /// (e.g. ambient-module exports discovered only during resolution); callers
     /// fall back to the dynamic overlay in that case.
     pub fn resolve_symbol_declaring_file_index(&self, sym_id: SymbolId) -> Option<usize> {
+        if self.symbol_id_is_contested(sym_id) {
+            return None;
+        }
         self.global_symbol_file_index
             .as_ref()
             .and_then(|map| map.get(&sym_id).copied())
@@ -354,6 +397,15 @@ impl<'a> CheckerContext<'a> {
     /// into the local `cross_file_symbol_targets` overlay.
     pub fn set_global_symbol_file_index(&mut self, index: Arc<FxHashMap<SymbolId, usize>>) {
         self.global_symbol_file_index = Some(index);
+    }
+
+    /// Install the shared set of raw `SymbolId`s declared in more than one
+    /// binder, so cross-file owner queries can refuse to answer for them.
+    ///
+    /// Pre-installing this before [`Self::set_all_binders`] keeps the O(symbols)
+    /// scan at the driver level instead of paying it once per file checker.
+    pub fn set_contested_symbol_ids(&mut self, ids: Arc<FxHashSet<SymbolId>>) {
+        self.contested_symbol_ids = Some(ids);
     }
 
     /// Set lib contexts for global type resolution.
@@ -671,6 +723,16 @@ impl<'a> CheckerContext<'a> {
     /// `set_declared_modules_from_skeleton`), the declared-modules binder scan
     /// is skipped — the skeleton-derived data is used instead.
     pub fn set_all_binders(&mut self, binders: Arc<Vec<Arc<BinderState>>>) {
+        // Raw `SymbolId`s only name a unique declaration program-wide after the
+        // driver's global remap. Callers that assemble binders themselves (the
+        // test harnesses, and any pre-merge path) leave each binder numbering
+        // from 0, so record which ids collide before anything can resolve one
+        // to an owning file. `ProgramContext` pre-installs this, which is what
+        // keeps the scan off the per-file fast path below.
+        if self.contested_symbol_ids.is_none() {
+            self.contested_symbol_ids = Some(Arc::new(super::build_contested_symbol_ids(&binders)));
+        }
+
         // If the 5 name-based global indices are already pre-populated (from ProgramContext),
         // skip the O(N) binder scans entirely. This is the fast path for multi-file
         // checking where ProgramContext::build_global_indices was called once at the driver level.

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -65,6 +65,7 @@ mod module_entity;
 mod package_resolution;
 mod program_context;
 pub use program_context::ProgramContext;
+mod contested_symbols;
 mod request_cache;
 mod resolver;
 mod source_file_symbol_type_cache_scope;
@@ -78,6 +79,7 @@ use crate::diagnostics::Diagnostic;
 use crate::query_boundaries::common::{QueryDatabase, TypeEnvironment};
 pub use aliases::*;
 pub use analysis_state_types::*;
+pub use contested_symbols::build_contested_symbol_ids;
 pub(crate) use diagnostic_indices::DiagnosticIndices;
 pub use request_cache::{RequestCacheCounters, RequestCacheKey};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1563,6 +1565,15 @@ pub struct CheckerContext<'a> {
     /// of `cross_file_symbol_targets`. Read sites use `resolve_symbol_file_index()`
     /// which checks the local overlay first, then this shared base.
     pub global_symbol_file_index: Option<Arc<FxHashMap<SymbolId, usize>>>,
+
+    /// Raw `SymbolId`s declared by two or more binders in this program.
+    ///
+    /// Such an id names a different declaration in each binder, so it has no
+    /// single owning file. `resolve_symbol_file_index()` and friends answer
+    /// `None` for these instead of picking whichever binder wrote last, which
+    /// sends callers down their local/name-based fallback. Empty (and so
+    /// free) once the driver's global `SymbolId` remap has run.
+    pub contested_symbol_ids: Option<Arc<FxHashSet<SymbolId>>>,
 
     /// All arenas for cross-file resolution (indexed by `file_idx` from `Symbol.decl_file_idx`).
     /// Set during multi-file type checking to allow resolving declarations across files.

--- a/crates/tsz-checker/src/context/program_context.rs
+++ b/crates/tsz-checker/src/context/program_context.rs
@@ -94,6 +94,12 @@ pub struct ProgramContext {
     /// Read sites fall back to this base map when the local
     /// `cross_file_symbol_targets` overlay has no entry.
     pub global_symbol_file_index: Option<Arc<FxHashMap<SymbolId, usize>>>,
+    /// Raw `SymbolId`s declared by two or more of `all_binders`.
+    ///
+    /// Built once by `build_global_indices()` and shared with every checker so
+    /// the O(symbols) scan is not repeated per file. Cross-file owner queries
+    /// answer `None` for these ids instead of naming an arbitrary binder.
+    pub contested_symbol_ids: Option<Arc<FxHashSet<SymbolId>>>,
     /// Pre-computed global `file_locals` index: name -> Vec<(`file_idx`, SymbolId)>.
     /// Built once from all binders; shared across all checkers via `Arc`.
     pub global_file_locals_index: Option<GlobalFileLocalsIndex>,
@@ -189,6 +195,7 @@ impl Default for ProgramContext {
             skeleton_module_exports_index: None,
             symbol_file_targets: Arc::new(vec![]),
             global_symbol_file_index: None,
+            contested_symbol_ids: None,
             global_file_locals_index: None,
             global_module_exports_index: None,
             global_module_augmentations_index: None,
@@ -280,6 +287,9 @@ impl ProgramContext {
         }
         // Pre-install remaining global indices before set_all_binders so it
         // can skip re-computing them. This avoids O(N) binder scans per checker.
+        if let Some(ref ids) = self.contested_symbol_ids {
+            ctx.set_contested_symbol_ids(Arc::clone(ids));
+        }
         if let Some(ref idx) = self.global_file_locals_index {
             ctx.global_file_locals_index = Some(Arc::clone(idx));
         }
@@ -375,6 +385,13 @@ impl ProgramContext {
     /// When these fields are `Some`, `set_all_binders` skips re-computing them.
     pub fn build_global_indices(&mut self) {
         self.source_file_symbol_type_cache_scope = next_source_file_symbol_type_cache_scope();
+
+        // Which raw `SymbolId`s name a declaration in more than one binder.
+        // Computed here, once per program, so every checker shares the answer
+        // and `set_all_binders` never has to scan symbols per file.
+        self.contested_symbol_ids = Some(Arc::new(super::build_contested_symbol_ids(
+            &self.all_binders,
+        )));
 
         // Phase 2 step 2: when the driver pre-built
         // `skeleton_module_augmentations_index` from `SkeletonIndex`, skip the

--- a/crates/tsz-checker/tests/program_context_tests.rs
+++ b/crates/tsz-checker/tests/program_context_tests.rs
@@ -27,6 +27,7 @@ fn empty_program_context() -> ProgramContext {
         skeleton_module_exports_index: None,
         symbol_file_targets: Arc::new(vec![]),
         global_symbol_file_index: None,
+        contested_symbol_ids: None,
         global_file_locals_index: None,
         global_module_exports_index: None,
         global_module_augmentations_index: None,


### PR DESCRIPTION
**Not landable as-is — net `+2 / -2` on the #15983 family.** Opened so the
mechanism and the measured deltas survive the container, and so the next
session starts from a working chokepoint instead of re-deriving one. See the
WIP comment below for the blocker and next action.

## Goal

Goal: hold

## Structural rule

When a raw `SymbolId` is declared by two or more binders **and the file being
checked is one of them**, `tsc` resolves the name against the checking file's
own scope; tsz must answer "no cross-file owner" through the checker's
cross-file symbol-resolution chokepoint (`CheckerContext::resolve_symbol_file_index`
and friends) rather than name whichever binder registered the id last.

`SymbolId` is a per-arena handle. It names a unique declaration program-wide
only after the driver's global remap; any assembly that binds files
independently leaves each binder numbering from `0`, so the same raw id names a
different declaration in every binder. The static symbol-file index already
knew this — `test_utils/multi_file.rs:39-49` drops ambiguous ids — but the
dynamically discovered `cross_file_symbol_targets` overlay had no such rule and
is consulted **first** (`context/core.rs:188`), so one dynamic registration
defeated the filter built to prevent exactly this.

Owner layer: checker cross-file symbol resolution. The gate sits above all 205
`resolve_symbol_file_index` / `resolve_dynamic_symbol_file_index` raw-id
readers, which is why it moves witnesses that per-reader guards could not.

## What changed

- `context/contested_symbols.rs` (new): `build_contested_symbol_ids` — raw ids
  declared by ≥2 binders.
- `ProgramContext::build_global_indices` computes the set once per program and
  `configure_checker` installs it **before** `set_all_binders`, so the
  O(symbols) scan never lands on the per-file fast path. `set_all_binders`
  computes it only on the fallback path (harnesses, pre-merge callers).
- `resolve_symbol_file_index`, `resolve_dynamic_symbol_file_index` and
  `resolve_symbol_declaring_file_index` answer `None` for a contested id the
  checking file also declares.

The set is **empty** wherever ids are already globally unique, so the gate is
inert on the production driver path and bites only where binders genuinely
collide.

## Verification

`cargo fmt --all` clean. CI's exact clippy invocation clean:

```
cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings
→ no errors, no warnings
```

Per-target unit runs, parent `99ddcc8` vs this head. `cargo-nextest` is not
installable in this container (agent proxy 403s `get.nexte.st`), so these are
`cargo test --test <target>` runs.

| target | parent | this head | delta |
| --- | --- | --- | --- |
| `reexported_symbol_keyed_member_tests` | 3 pass / 1 fail | 3 / 1 | witness **moved** but still red (see below) |
| `cross_file_recursive_alias_intersection_tests` | 2 / 3 | 2 / 3 | unchanged |
| `kysely_callback_context_tests` | 7 / 2 | 8 / 1 | **+2 fixed, −1 regressed** |
| `object_assign_identity_tests` | 2 / 1 | 1 / 2 | **−1 regressed** |
| `order_independent_alias_resolution_tests` | 3 / 1 | 3 / 1 | unchanged |

**Fixed** (both were in `scripts/ci/known-failures.txt`):
- `kysely_callback_context_tests::imported_conditional_builder_alias_materializes_callback_context`
- `kysely_callback_context_tests::imported_conditional_builder_alias_uses_declaring_file_for_duplicate_helper_names`

**Regressed** (neither is in `known-failures.txt`, so both pass on main):
- `kysely_callback_context_tests::imported_select_callback_alias_contextually_types_array_expression_factory`
- `object_assign_identity_tests::builtin_object_assign_still_reports_nonportable_default_export`

**Witness movement.** `direct_import_symbol_keyed_member_is_clean` reported
`["TS2538@104"]` on main across four prior sessions and every ablation any of
them tried. With this gate it reports `["TS2456@92", "TS2536@96"]` — the
poisoned `SymbolConstructor` materialization is gone; what is left is the
fallback failing to re-resolve the alias, which is a different defect.

Not run: conformance snapshot, emit, fourslash. Deliberate — the change is
`-2` on unit tests and cannot land regardless, so spending the corpus time
would not have changed the outcome. Any future revision of this branch needs
all three before it goes near the queue.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Dune

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1GCB5BpXNabUri4aTkzSt)_