### PR TITLE
fix(checker): TS4104 for readonly array/tuple in argument position

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -171,6 +171,30 @@ impl<'a> CheckerState<'a> {
         if self.try_elaborate_callback_body_diagnostics(idx, param_type) {
             return;
         }
+        // Promote a readonly-array/tuple → mutable-array/tuple argument mismatch to
+        // TS4104 ("The type 'X' is 'readonly' and cannot be assigned to the mutable
+        // type 'Y'"), matching the direct-assignment path
+        // (`check_assignable_or_report_at_with_options`) and tsc, which reports
+        // TS4104 rather than the generic TS2345 for this reason.
+        if let Some(reason) = self.readonly_to_mutable_array_or_tuple_reason(arg_type, param_type) {
+            let source_display = Some(self.format_type_for_diagnostic_role(
+                arg_type,
+                DiagnosticTypeDisplayRole::CallArgument {
+                    parameter: param_type,
+                    argument_idx: idx,
+                },
+            ));
+            let diag = self.render_failure_reason_with_source_display(
+                &reason,
+                arg_type,
+                param_type,
+                idx,
+                0,
+                source_display,
+            );
+            self.ctx.push_diagnostic(diag);
+            return;
+        }
         let analysis = self.analyze_assignability_failure(arg_type, param_type);
 
         // tsc promotes a sole missing-required-property failure to the PRIMARY

--- a/crates/tsz-checker/tests/readonly_array_alias_argument_display_tests.rs
+++ b/crates/tsz-checker/tests/readonly_array_alias_argument_display_tests.rs
@@ -1,18 +1,14 @@
-//! `TS2345` must render a `readonly` array / `readonly` tuple ARGUMENT by the
-//! non-generic type-alias name it was referenced through (its `aliasSymbol`),
-//! matching `tsc`, instead of the structurally-interned form
-//! (`readonly number[]`).
+//! `TS4104` ("The type 'X' is 'readonly' and cannot be assigned to the mutable
+//! type 'Y'") must render a `readonly` array / `readonly` tuple ARGUMENT by the
+//! source's alias name where `tsc` does (`Bag`, `Frozen<number>`), and
+//! structurally for an inline `readonly number[]` annotation (no alias).
 //!
-//! This is the argument-mismatch follow-up of #14483 (the `TS4104`
-//! readonly-to-mutable slice is handled separately). tsz interns array and
-//! `readonly` array/tuple types purely structurally, so a shared
-//! `readonly number[]` `TypeId` carries no per-reference alias; `tsc` recovers
-//! the name from the argument expression's declared annotation, and tsz must do
-//! the same. The rule is structural — it holds regardless of the alias name,
-//! element types, and tuple arity — and must NOT fire for an inline
-//! `readonly number[]` annotation (no alias) or repaint a generic alias
-//! application (which already keeps its name via the `Application` path).
-
+//! tsc reports readonly-to-mutable array/tuple ARGUMENTS as `TS4104`, not the
+//! generic `TS2345` (see the `readonlyTupleAndArrayElaboration` conformance
+//! fixture). tsz interns array and `readonly` array/tuple types purely
+//! structurally, so a shared `readonly number[]` `TypeId` carries no per-reference
+//! alias; the alias name is recovered from the source expression's declared
+//! annotation, else the structural display is used.
 use tsz_checker::test_utils::check_source_code_messages;
 
 fn messages(source: &str) -> Vec<(u32, String)> {
@@ -36,79 +32,79 @@ fn message_for(source: &str, code: u32) -> String {
 }
 
 #[test]
-fn ts2345_readonly_array_alias_argument_renders_alias_name() {
+fn ts4104_readonly_array_alias_argument_renders_alias_name() {
     let msg = message_for(
         "type Bag = readonly number[]; const b: Bag = []; function need(x: number[]) {} need(b);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Bag' is not assignable to parameter of type 'number[]'."
+        "The type 'Bag' is 'readonly' and cannot be assigned to the mutable type 'number[]'."
     );
 }
 
 #[test]
-fn ts2345_readonly_array_alias_argument_is_structural_not_name_keyed() {
+fn ts4104_readonly_array_alias_argument_is_structural_not_name_keyed() {
     // Renamed binder + different element type: proves the recovery is structural,
     // not keyed on the alias spelling `Bag` or the element type `number`.
     let msg = message_for(
         "type Grid = readonly string[]; const g: Grid = []; function need(x: string[]) {} need(g);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Grid' is not assignable to parameter of type 'string[]'."
+        "The type 'Grid' is 'readonly' and cannot be assigned to the mutable type 'string[]'."
     );
 }
 
 #[test]
-fn ts2345_readonly_tuple_alias_argument_renders_alias_name() {
+fn ts4104_readonly_tuple_alias_argument_renders_alias_name() {
     let msg = message_for(
         "type Pair = readonly [number, string]; const p: Pair = [1, 'a']; function need(x: [number, string]) {} need(p);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Pair' is not assignable to parameter of type '[number, string]'."
+        "The type 'Pair' is 'readonly' and cannot be assigned to the mutable type '[number, string]'."
     );
 }
 
 #[test]
-fn ts2345_readonly_tuple_alias_argument_arity_three_renders_alias_name() {
+fn ts4104_readonly_tuple_alias_argument_arity_three_renders_alias_name() {
     let msg = message_for(
         "type Triple = readonly [number, string, boolean]; const t: Triple = [1, 'a', true]; function need(x: [number, string, boolean]) {} need(t);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Triple' is not assignable to parameter of type '[number, string, boolean]'."
+        "The type 'Triple' is 'readonly' and cannot be assigned to the mutable type '[number, string, boolean]'."
     );
 }
 
 #[test]
-fn ts2345_inline_readonly_array_argument_keeps_structural_display() {
+fn ts4104_inline_readonly_array_argument_keeps_structural_display() {
     // No alias: the inline `readonly number[]` annotation must stay structural,
     // exactly as `tsc` renders it.
     let msg = message_for(
         "const ra: readonly number[] = []; function need(x: number[]) {} need(ra);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'readonly number[]' is not assignable to parameter of type 'number[]'."
+        "The type 'readonly number[]' is 'readonly' and cannot be assigned to the mutable type 'number[]'."
     );
 }
 
 #[test]
-fn ts2345_generic_readonly_array_alias_application_keeps_name() {
+fn ts4104_generic_readonly_array_alias_application_keeps_name() {
     // A generic alias survives as an `Application` and already renders by name;
     // the recovery must not interfere with it.
     let msg = message_for(
         "type Frozen<T> = readonly T[]; const f: Frozen<number> = []; function need(x: number[]) {} need(f);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Frozen<number>' is not assignable to parameter of type 'number[]'."
+        "The type 'Frozen<number>' is 'readonly' and cannot be assigned to the mutable type 'number[]'."
     );
 }

--- a/crates/tsz-checker/tests/readonly_tuple_to_array_constraint_tests.rs
+++ b/crates/tsz-checker/tests/readonly_tuple_to_array_constraint_tests.rs
@@ -99,7 +99,10 @@ fn readonly_tuple_satisfies_specific_mutable_element_constraint() {
 fn readonly_array_source_still_fails_against_mutable_array_constraint() {
     // tsc rejects a plain `readonly X[]` source at the constraint
     // boundary because its element list is unbounded; only tuples are
-    // loosened. tsz must mirror this rejection.
+    // loosened. Verified against tsc 7.0.2: it reports TS4104 here (not
+    // the generic TS2345), the same code as the direct-assignment case,
+    // because the constraint-check falls back to comparing the argument
+    // against the constraint's own concrete mutable-array shape.
     let source = r#"
         function processArray<T extends unknown[]>(arr: T): T[number] {
             return arr[0];
@@ -109,9 +112,9 @@ fn readonly_array_source_still_fails_against_mutable_array_constraint() {
     "#;
     let codes = error_codes(&check(source));
     assert!(
-        codes.contains(&2345),
+        codes.contains(&4104),
         "plain ReadonlyArray source must still be rejected at the \
-         constraint boundary; got error codes: {codes:?}"
+         constraint boundary, matching tsc's TS4104; got error codes: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Picks up PR #15880 (parked in draft since 2026-07-22 by @mohsen1), which was held back over a suspected over-application to the generic-constraint case. Investigation found the fix itself was already correct — the regression test it shipped alongside had the wrong expected diagnostic code, unverified against a real `tsc` run. This PR carries #15880's original two commits (reset to my authorship for signing; content unchanged) plus a one-file test fix.

## Goal
Goal: hold

## Structural rule

When a `readonly` array/tuple is passed as a call argument to a parameter whose type is (or resolves to, via a failed generic-constraint check) a *concrete mutable* array/tuple, `tsc` reports **TS4104** ("The type 'X' is 'readonly' and cannot be assigned to the mutable type 'Y'"), not the generic **TS2345**. This holds uniformly for:
- a directly-typed mutable parameter, and
- a generic parameter `T extends C` whose argument fails the constraint check `C` — `tsc` falls back to comparing the argument against `C`'s own concrete shape, and TS4104 fires there too if `C` is a mutable array/tuple.

tsz's direct-assignment path already promoted this via the `readonly_to_mutable_array_or_tuple_reason` preflight. The call-argument path emitted the generic TS2345 in both of the above cases; #15880 added the same preflight to the argument-error path. **Owner layer:** checker (`error_reporter/call_errors/error_emission.rs`) — reuses the existing solver reason (`SubtypeFailureReason::ReadonlyToMutableAssignment`) and renderer; no new relation logic.

## What was actually wrong

`readonly_tuple_to_array_constraint_tests.rs::readonly_array_source_still_fails_against_mutable_array_constraint` asserted that `processArray(ra)` (with `ra: readonly string[]`, `processArray<T extends unknown[]>`) reports the generic **TS2345**. Checked against the vendored `tsc` 7.0.2 oracle directly:

```
$ node scripts/node_modules/typescript/lib/tsc.js --noEmit --strict --pretty false --lib es2015 repro.ts
repro.ts(5,26): error TS4104: The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type 'unknown[]'.
```

tsz (with #15880's fix applied) already produces `CODE=4104 MSG=The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type 'unknown[]'.` — a byte-for-byte match. The test's TS2345 expectation was never verified against a real `tsc` run; it assumed the generic code without checking. This PR corrects the test to assert TS4104 and documents why. No production code changes beyond #15880's original two commits.

## Adjacent-case matrix (unchanged behavior, re-verified)

- Direct assignment (`let y: number[] = a`) — TS4104, unchanged.
- Argument against a concrete mutable parameter (`f(a)` with `readonly number[]` / `Readonly<number[]>` / `ReadonlyArray<number>`, readonly tuple `as const` to `[number, number]`) — TS4104, matches tsc (#15880's original flip: `readonlyTupleAndArrayElaboration.ts`).
- Argument against a generic constraint `T extends unknown[]` with a plain `readonly X[]` source — **TS4104** (this PR's fix), matches tsc.
- Argument against a generic constraint with a `readonly` **tuple** source (`[1, "two", true] as const`) — issue #5804's constraint-widening rule accepts it with **zero errors** (tuples have a fixed element list checkable against the constraint element-wise); renaming the type parameter doesn't change this. Unaffected by this PR — verified against tsc, still zero diagnostics.

## Verification

Oracle: pinned `tsc` 7.0.2 (`scripts/conformance/tsc-cache-full.json`) plus direct `node scripts/node_modules/typescript/lib/tsc.js` spot checks for every case in the matrix above.

- `cargo test -p tsz-checker --test readonly_tuple_to_array_constraint_tests --test readonly_array_alias_argument_display_tests`: 11/11 passed (previously 10/11, one failure — now fixed to match tsc).
- `./scripts/conformance/conformance.sh run --filter readonly --workers 12`: 13/14 passed on today's main baseline (1 pre-existing unrelated fingerprint-only mismatch, `readonlyMembers.ts`, TS2540/TS2542 position — untouched by this diff). `readonlyTupleAndArrayElaboration.ts` (#15880's original flip target) passes.
- `./scripts/conformance/conformance.sh run --filter tuple --workers 12`: 30/37 passed; all 7 failures are pre-existing and unrelated (noImplicitAny TS7005/TS7031, labeled-tuple-element syntax TS5085/5086/5087, tuple-widening TS2322/TS7005) — none touch readonly/TS4104/TS2345.
- `./scripts/emit/run.sh`: JS 11562/11563, DTS 1375/1390 — exact ROADMAP floor, unchanged.
- Fourslash: not run — this container's TypeScript harness isn't built (`hereby tests --no-bundle` prerequisite missing), and the change is confined to a checker diagnostic-emission path, not LSP surface. Flagging for whoever next has a built harness to spot-check.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzDsm8BQv1yDq3qA9Xy1VU)_