### PR TITLE
test(conformance): fix stale noTypesAndSymbols tsconfig-threading assertions

### DIFF
--- a/crates/conformance/tests/tsz_wrapper.rs
+++ b/crates/conformance/tests/tsz_wrapper.rs
@@ -503,7 +503,12 @@ import { styles } from "package-a";
 }
 
 #[test]
-fn test_prepare_test_dir_threads_no_types_and_symbols_into_generated_tsconfig() {
+fn test_prepare_test_dir_excludes_no_types_and_symbols_from_generated_tsconfig() {
+    // `noTypesAndSymbols` is a harness-only test directive (HARNESS_ONLY_DIRECTIVES):
+    // tsc's own compiler-options schema has no such flag, so threading it into the
+    // written tsconfig would hand the tsz/tsc binary a fabricated option. Its real
+    // effect — excluding `@types` packages from the root `files` list — is exercised
+    // separately in `test_prepare_test_dir_no_types_and_symbols_excludes_at_types_from_root_files`.
     let content = "";
     let filenames = vec![("usage.ts".to_string(), "export {};".to_string())];
     let options: HashMap<String, String> =
@@ -515,17 +520,22 @@ fn test_prepare_test_dir_threads_no_types_and_symbols_into_generated_tsconfig() 
     let tsconfig_json: serde_json::Value = serde_json::from_str(&tsconfig_raw).unwrap();
     let compiler_options = tsconfig_json
         .get("compilerOptions")
-        .and_then(serde_json::Value::as_object)
-        .expect("compilerOptions object should exist");
+        .and_then(serde_json::Value::as_object);
 
-    assert_eq!(
-        compiler_options.get("noTypesAndSymbols"),
-        Some(&serde_json::Value::Bool(true))
+    let has_no_types_and_symbols =
+        compiler_options.is_some_and(|opts| opts.contains_key("noTypesAndSymbols"));
+    assert!(
+        !has_no_types_and_symbols,
+        "noTypesAndSymbols is harness-only and must not appear in the generated tsconfig's \
+         compilerOptions, got {compiler_options:?}"
     );
 }
 
 #[test]
-fn test_prepare_test_dir_threads_no_types_and_symbols_into_root_tsconfig_merge() {
+fn test_prepare_test_dir_excludes_no_types_and_symbols_from_root_tsconfig_merge() {
+    // Same harness-only exclusion as above, but merging directives into an
+    // authored root tsconfig.json rather than generating one from scratch —
+    // real directive options (`module`) still merge in.
     let content = "";
     let filenames = vec![
         (
@@ -550,9 +560,10 @@ fn test_prepare_test_dir_threads_no_types_and_symbols_into_root_tsconfig_merge()
         compiler_options.get("module"),
         Some(&serde_json::Value::String("commonjs".to_string()))
     );
-    assert_eq!(
-        compiler_options.get("noTypesAndSymbols"),
-        Some(&serde_json::Value::Bool(true))
+    assert!(
+        !compiler_options.contains_key("noTypesAndSymbols"),
+        "noTypesAndSymbols is harness-only and must not appear in the merged tsconfig's \
+         compilerOptions, got {compiler_options:?}"
     );
 }
 

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -87,7 +87,12 @@ CHANGED_CRATES=$(echo "$CHANGED_RS" | sed -n 's|^crates/\([^/]*\)/.*|\1|p' | sor
 PKG_FLAGS=""
 for crate in $CHANGED_CRATES; do
     if [ -f "crates/$crate/Cargo.toml" ]; then
-        PKG_FLAGS="$PKG_FLAGS -p $crate"
+        # The crate directory name does not always match the Cargo package
+        # name (e.g. crates/conformance -> package "tsz-conformance"), and
+        # `cargo -p <dir-name>` fails with "did not match any packages" when
+        # they diverge. Read the real package name from Cargo.toml.
+        pkg_name=$(sed -n 's/^name *= *"\([^"]*\)"/\1/p' "crates/$crate/Cargo.toml" | head -1)
+        PKG_FLAGS="$PKG_FLAGS -p ${pkg_name:-$crate}"
     fi
 done
 if [ -z "$PKG_FLAGS" ]; then


### PR DESCRIPTION
## Goal
Goal: hold

## Structural rule

`noTypesAndSymbols` is a TypeScript-harness-only test directive (no such flag
exists in `tsc`'s real `CompilerOptions`), and `crates/conformance` correctly
classifies it in `HARNESS_ONLY_DIRECTIVES` (`compiler_options.rs:13`) so
`directives_to_tsconfig` strips it before the harness writes `tsconfig.json`.
Its only real effect is excluding `@types/*` packages from the generated
project's root `files` list (`tsz_wrapper.rs:382-393`, `no_types_and_symbols`
local) — never threading the flag itself into `compilerOptions`. **Owner
layer:** conformance harness (`crates/conformance`), test-only; no production
compiler behavior changes.

## What was actually wrong

Two unit tests in `crates/conformance/tests/tsz_wrapper.rs` asserted the
opposite of the rule above:
`test_prepare_test_dir_threads_no_types_and_symbols_into_generated_tsconfig`
and `..._into_root_tsconfig_merge` asserted that
`compilerOptions.noTypesAndSymbols == true` appears in the written
`tsconfig.json`. If tsz/tsc actually consumed that generated config, a
fabricated `noTypesAndSymbols` compiler option would end up on the command
line. Filed as #15999 §1 ("harness fixture setup... cheap to fix, worth doing
before they distort conformance results"); neither test runs in any CI lane
today (`tsz-conformance` has no unit-test lane per #15999 §3), so the
contradiction with the production code's `HARNESS_ONLY_DIRECTIVES`
classification went unnoticed.

Renamed both tests to `test_prepare_test_dir_excludes_no_types_and_symbols_*`
and inverted the assertion to match the actual, correct harness behavior —
the flag must **not** appear in `compilerOptions`. The
already-passing sibling test
(`test_prepare_test_dir_no_types_and_symbols_excludes_at_types_from_root_files`)
already covers the directive's real, intended effect, so this PR doesn't
duplicate that coverage.

## Adjacent fix: `scripts/githooks/pre-commit` package-name bug

While committing, the pre-commit hook failed local verification with:

```
error: package ID specification `conformance` did not match any packages
```

The hook derives the cargo package name from the crate's directory name
(`crates/$crate` → `-p $crate`), but `crates/conformance`'s actual package
name is `tsz-conformance` (`crates/conformance/Cargo.toml`) — the only
directory/package-name mismatch in the workspace (verified by diffing every
`crates/*/Cargo.toml` `name` against its directory). That means **every**
commit touching `crates/conformance` failed local pre-commit verification.
Fixed the hook to read the real package name from `Cargo.toml` instead of
assuming it matches the directory.

## Verification

- `cargo test -p tsz-conformance --lib`: 186/186 passed (was 184/186 before
  the fix — the 2 renamed tests are the delta; confirmed failing under their
  old names/assertions before this change, per #15999).
- `cargo clippy -p tsz-conformance --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-conformance -- --check`: clean.
- Local pre-commit hook (post-fix) ran clippy + arch-guard on `tsz-conformance`
  and passed.
- No production compiler code touched; conformance/emit/fourslash suites
  unaffected by construction (test-only + CI-tooling change).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KK7aBgRRAp7fG3BM53BTzn)_