### PR TITLE
ci(unit): cover tsz-cli and tsz-conformance, guard baseline-package drift

### DIFF
--- a/scripts/ci/full-ci.sh
+++ b/scripts/ci/full-ci.sh
@@ -446,6 +446,12 @@ run_lint() {
   fi
 }
 
+# Every workspace crate whose tests the unit lane adjudicates. A crate absent
+# here is covered by no lane at all: its failures reach no junit, so
+# known-failures-check.mjs can neither fail on them nor ratchet them down, and
+# any baseline entry naming it is inert (#15999 §3). The
+# `known_failure_packages_are_in_the_unit_lane` contract test in
+# scripts/ci/test_full_ci_unit_gate.py holds that invariant.
 _UNIT_TEST_PACKAGES=(
   tsz-common
   tsz-scanner
@@ -456,6 +462,8 @@ _UNIT_TEST_PACKAGES=(
   tsz-emitter
   tsz-lsp
   tsz-core
+  tsz-cli
+  tsz-conformance
 )
 
 # The `tsz-checker` lib-test target can exceed hosted runner memory even with
@@ -480,7 +488,10 @@ unit_test_packages() {
     printf '%s\n' "${_UNIT_TEST_PACKAGES[@]}"
     return
   fi
-  local known=" tsz-common tsz-scanner tsz-parser tsz-binder tsz-solver tsz-checker tsz-emitter tsz-lsp tsz-core "
+  # Derived from _UNIT_TEST_PACKAGES rather than hand-copied: a second literal
+  # list drifts silently, and a crate missing from it is rejected as "unknown"
+  # even though the full lane runs it.
+  local known=" ${_UNIT_TEST_PACKAGES[*]} "
   local crate
   for crate in $override; do
     if [[ "$known" != *" $crate "* ]]; then

--- a/scripts/ci/test_full_ci_unit_gate.py
+++ b/scripts/ci/test_full_ci_unit_gate.py
@@ -147,5 +147,114 @@ class UnitGateWiringTests(unittest.TestCase):
         self.assertEqual(rc, 7)
 
 
+KNOWN_FAILURES = ROOT / "scripts" / "ci" / "known-failures.txt"
+CRATES_DIR = ROOT / "crates"
+
+
+def _baseline_packages():
+    """Packages named by `scripts/ci/known-failures.txt` entries.
+
+    A baseline line is `binary-id::test-name`, and nextest's binary-id always
+    starts with the package name, so the first `::` segment is the owner.
+    """
+    packages = set()
+    for line in KNOWN_FAILURES.read_text(encoding="utf-8").splitlines():
+        entry = line.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        packages.add(entry.split("::", 1)[0])
+    return packages
+
+
+def _workspace_packages():
+    names = set()
+    for manifest in CRATES_DIR.glob("*/Cargo.toml"):
+        for line in manifest.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("name"):
+                _, _, value = stripped.partition("=")
+                names.add(value.strip().strip('"'))
+                break
+    return names
+
+
+class UnitLaneCoverageTests(unittest.TestCase):
+    """The lane must actually adjudicate every package the baseline names.
+
+    #15999 §3: `tsz-cli` and `tsz-conformance` sat in no unit lane, so the six
+    `tsz-cli` baseline entries were inert — CI never ran that package, its
+    tests reached no junit, and known-failures-check.mjs treated them as
+    neither a new failure nor a shrink. They read like coverage and were not.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        script = FULL_CI.read_text(encoding="utf-8")
+        start = script.index("_UNIT_TEST_PACKAGES=(")
+        end = script.index("\n}", script.index("unit_test_packages() {")) + 2
+        cls.packages_fn = script[start:end]
+
+    def _resolve(self, env_line="", expect_rc=0):
+        harness = textwrap.dedent(
+            f"""#!/usr/bin/env bash
+            set -Eeuo pipefail
+            {env_line}
+            {self.packages_fn}
+            set +e
+            unit_test_packages
+            echo "RC=$?"
+            """
+        )
+        proc = subprocess.run(["bash", "-c", harness], capture_output=True, text=True)
+        lines = proc.stdout.splitlines()
+        rc_lines = [ln for ln in lines if ln.startswith("RC=")]
+        self.assertEqual(len(rc_lines), 1, msg=f"missing RC line:\n{proc.stdout}")
+        rc = int(rc_lines[0][len("RC=") :])
+        self.assertEqual(rc, expect_rc, msg=proc.stdout + proc.stderr)
+        return [ln for ln in lines if not ln.startswith("RC=")]
+
+    def test_known_failure_packages_are_in_the_unit_lane(self):
+        lane = set(self._resolve())
+        uncovered = sorted(_baseline_packages() - lane)
+        self.assertEqual(
+            uncovered,
+            [],
+            msg=(
+                "known-failures.txt names packages the unit lane never runs: "
+                f"{uncovered}. Their entries can never fail the gate nor "
+                "ratchet down. Add them to _UNIT_TEST_PACKAGES in "
+                "scripts/ci/full-ci.sh, or drop the entries."
+            ),
+        )
+
+    def test_lane_packages_exist_in_the_workspace(self):
+        workspace = _workspace_packages()
+        unknown = sorted(set(self._resolve()) - workspace)
+        self.assertEqual(
+            unknown,
+            [],
+            msg=f"_UNIT_TEST_PACKAGES names non-workspace crates: {unknown}",
+        )
+
+    def test_override_accepts_every_lane_package(self):
+        # The validator's `known` list is derived from _UNIT_TEST_PACKAGES; a
+        # hand-copied second literal drifts and rejects lane crates as unknown.
+        lane = self._resolve()
+        for crate in lane:
+            with self.subTest(crate=crate):
+                self.assertEqual(
+                    self._resolve(
+                        env_line=f"export _TSZ_CI_UNIT_PACKAGES_OVERRIDE='{crate}'"
+                    ),
+                    [crate],
+                )
+
+    def test_override_still_rejects_an_unknown_crate(self):
+        self._resolve(
+            env_line="export _TSZ_CI_UNIT_PACKAGES_OVERRIDE='tsz-not-a-crate'",
+            expect_rc=2,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes the structural half of #15999 (§3): two workspace packages that the unit lane never ran.

**Structural rule.** When a package's tests are absent from `_UNIT_TEST_PACKAGES`, no lane produces a junit for them, so `known-failures-check.mjs` — which adjudicates strictly from junit — can classify them as neither a new failure nor a shrink. Any baseline entry naming such a package is therefore **inert**: it can never fail the gate and can never ratchet down. It reads like coverage and is not. The gate must adjudicate every package its own baseline names; that invariant is now owned by a contract test in the cheap per-merge lane rather than by whoever last remembered to edit two lists together.

**What was wrong**

`_UNIT_TEST_PACKAGES` (`scripts/ci/full-ci.sh`) listed 9 crates and omitted `tsz-cli` and `tsz-conformance`. Consequences Quartz measured in #15999 and I re-derived from a clean read:

| package | in unit lane | baseline entries | status |
|---|---|---|---|
| `tsz-cli` | **no** | 6 | entries inert — CI never ran the package |
| `tsz-conformance` | **no** | 0 | covered by no lane at all |

The 6 `tsz-cli` entries were added deliberately in the `r8` re-reconcile (`known-failures.txt:59-61`, "pre-existing cli-lane drift first surfaced when a push touched tsz-cli") — i.e. they were reconciled from an ad-hoc scoped run, into a baseline the standing lane cannot evaluate. That is exactly the failure mode the guard now blocks.

**What changed**

1. `tsz-cli` and `tsz-conformance` join `_UNIT_TEST_PACKAGES`. No runner change needed: `unit-nextest.sh:229-238` routes every non-`tsz-checker` package through a plain `-p <pkg>` on the general pass, and only `tsz-checker` needs the batched `[[test]]` enumeration. Note the `--workspace-minus-checker` mode (`--workspace --exclude tsz-checker`) *already* included both packages, so the two runner modes disagreed about the lane's contents until now.
2. New `UnitLaneCoverageTests` in `scripts/ci/test_full_ci_unit_gate.py`, run by `scripts/ci/check-unit-gate-contracts.sh` — which both `ci.yml`'s cheap-guards step and `full-ci.sh run_lint` invoke, so this is enforced on **every merge**, not nightly:
   - `known_failure_packages_are_in_the_unit_lane` — the invariant above. Parses baseline entries (the first `::` segment of a `binary-id::test-name` is always the package) and diffs against the lane resolved by executing the real `unit_test_packages` out of `full-ci.sh`.
   - `lane_packages_exist_in_the_workspace` — a typo'd crate name in the array is a config error, not a silent skip.
   - `override_accepts_every_lane_package` / `override_still_rejects_an_unknown_crate` — pins the `_TSZ_CI_UNIT_PACKAGES_OVERRIDE` validator to the lane in both directions.
3. `unit_test_packages`'s override-validation list is now derived (`" ${_UNIT_TEST_PACKAGES[*]} "`) instead of a hand-copied literal. It was a second drift source with a worse failure mode than the first: a crate present in the array but missing from the literal is rejected as "unknown crate" even though the full lane runs it — so adding `tsz-cli` to the array alone would have broken narrow-override runs.

**Anti-hardcoding.** No compiler-layer change; nothing here reads identifiers, rendered types, or printer output. The package names in `_UNIT_TEST_PACKAGES` are cargo package names validated against `crates/*/Cargo.toml`, and the guard derives its expectation from `known-failures.txt` rather than from a second hand-maintained list.

## Goal
Goal: hold

## Verification

Both gates are pure `bash`/`node`/`python3` and run in ~2s — no cargo round-trip.

```
$ bash scripts/ci/check-unit-gate-contracts.sh
check_known_failures_growth      ... Ran 14 tests   OK
test_unit_nextest.py             ... OK
test_full_ci_unit_gate.py        ... Ran 11 tests   OK     (was 7 before; +4)
test-known-failures-check.mjs    ... All 15 known-failures-check tests passed
```

**Negative control — the guard reproduces the bug it fixes.** Reverting only the two-package addition and re-running:

```
FAIL: test_known_failure_packages_are_in_the_unit_lane
AssertionError: Lists differ: ['tsz-cli'] != []
  known-failures.txt names packages the unit lane never runs: ['tsz-cli'].
  Their entries can never fail the gate nor ratchet down.
```

Restored → 11/11 OK. So the guard fails for the real reason, not incidentally.

Also run:
- `bash -n scripts/ci/full-ci.sh` — clean.
- `python3 scripts/lib/check-sh-portability.py` — rc=0.
- Both touched files stay well under the 2000-line shard ceiling (`full-ci.sh` 1198, `test_full_ci_unit_gate.py` 260).

**Not claimed here**, deliberately:
- No cargo suite was run in this container (cold, no `.target`, 4 cores). This diff contains no Rust and cannot change any test's result — it only changes *which* packages the lane executes. The new coverage's first real verdict lands on the next nightly `unit` run.
- **Merge-order note:** `tsz-conformance` currently has 2 failing tests (#15999 §1), fixed in **#16002**. That PR should land first, or the first nightly unit run after this one reports them as new failures. They are genuinely-failing tests that were invisible, which is the point of the change — but sequencing avoids a spurious red.
- The clippy half of §3 (`cargo clippy --workspace --exclude tsz-conformance`, `ci.yml:61` / `full-ci.sh:432`) is **not** touched. It is a different gate with a different justification (#13453) and a much larger blast radius on the per-merge lane, and I could not finish a local clippy run on `tsz-conformance` to verify it in this session. Quartz reported it clean at `99ddcc8` (#15994, 21:15Z); that wants its own PR with a fresh exact-head run behind it.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Cinder

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPzUumjY91NwkUH5q3akP3)_