### PR TITLE
fix(checker): TS4104 for readonly array/tuple in argument position

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -171,6 +171,30 @@ impl<'a> CheckerState<'a> {
         if self.try_elaborate_callback_body_diagnostics(idx, param_type) {
             return;
         }
+        // Promote a readonly-array/tuple → mutable-array/tuple argument mismatch to
+        // TS4104 ("The type 'X' is 'readonly' and cannot be assigned to the mutable
+        // type 'Y'"), matching the direct-assignment path
+        // (`check_assignable_or_report_at_with_options`) and tsc, which reports
+        // TS4104 rather than the generic TS2345 for this reason.
+        if let Some(reason) = self.readonly_to_mutable_array_or_tuple_reason(arg_type, param_type) {
+            let source_display = Some(self.format_type_for_diagnostic_role(
+                arg_type,
+                DiagnosticTypeDisplayRole::CallArgument {
+                    parameter: param_type,
+                    argument_idx: idx,
+                },
+            ));
+            let diag = self.render_failure_reason_with_source_display(
+                &reason,
+                arg_type,
+                param_type,
+                idx,
+                0,
+                source_display,
+            );
+            self.ctx.push_diagnostic(diag);
+            return;
+        }
         let analysis = self.analyze_assignability_failure(arg_type, param_type);
 
         // tsc promotes a sole missing-required-property failure to the PRIMARY

--- a/crates/tsz-checker/tests/readonly_array_alias_argument_display_tests.rs
+++ b/crates/tsz-checker/tests/readonly_array_alias_argument_display_tests.rs
@@ -1,18 +1,14 @@
-//! `TS2345` must render a `readonly` array / `readonly` tuple ARGUMENT by the
-//! non-generic type-alias name it was referenced through (its `aliasSymbol`),
-//! matching `tsc`, instead of the structurally-interned form
-//! (`readonly number[]`).
+//! `TS4104` ("The type 'X' is 'readonly' and cannot be assigned to the mutable
+//! type 'Y'") must render a `readonly` array / `readonly` tuple ARGUMENT by the
+//! source's alias name where `tsc` does (`Bag`, `Frozen<number>`), and
+//! structurally for an inline `readonly number[]` annotation (no alias).
 //!
-//! This is the argument-mismatch follow-up of #14483 (the `TS4104`
-//! readonly-to-mutable slice is handled separately). tsz interns array and
-//! `readonly` array/tuple types purely structurally, so a shared
-//! `readonly number[]` `TypeId` carries no per-reference alias; `tsc` recovers
-//! the name from the argument expression's declared annotation, and tsz must do
-//! the same. The rule is structural — it holds regardless of the alias name,
-//! element types, and tuple arity — and must NOT fire for an inline
-//! `readonly number[]` annotation (no alias) or repaint a generic alias
-//! application (which already keeps its name via the `Application` path).
-
+//! tsc reports readonly-to-mutable array/tuple ARGUMENTS as `TS4104`, not the
+//! generic `TS2345` (see the `readonlyTupleAndArrayElaboration` conformance
+//! fixture). tsz interns array and `readonly` array/tuple types purely
+//! structurally, so a shared `readonly number[]` `TypeId` carries no per-reference
+//! alias; the alias name is recovered from the source expression's declared
+//! annotation, else the structural display is used.
 use tsz_checker::test_utils::check_source_code_messages;
 
 fn messages(source: &str) -> Vec<(u32, String)> {
@@ -36,79 +32,79 @@ fn message_for(source: &str, code: u32) -> String {
 }
 
 #[test]
-fn ts2345_readonly_array_alias_argument_renders_alias_name() {
+fn ts4104_readonly_array_alias_argument_renders_alias_name() {
     let msg = message_for(
         "type Bag = readonly number[]; const b: Bag = []; function need(x: number[]) {} need(b);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Bag' is not assignable to parameter of type 'number[]'."
+        "The type 'Bag' is 'readonly' and cannot be assigned to the mutable type 'number[]'."
     );
 }
 
 #[test]
-fn ts2345_readonly_array_alias_argument_is_structural_not_name_keyed() {
+fn ts4104_readonly_array_alias_argument_is_structural_not_name_keyed() {
     // Renamed binder + different element type: proves the recovery is structural,
     // not keyed on the alias spelling `Bag` or the element type `number`.
     let msg = message_for(
         "type Grid = readonly string[]; const g: Grid = []; function need(x: string[]) {} need(g);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Grid' is not assignable to parameter of type 'string[]'."
+        "The type 'Grid' is 'readonly' and cannot be assigned to the mutable type 'string[]'."
     );
 }
 
 #[test]
-fn ts2345_readonly_tuple_alias_argument_renders_alias_name() {
+fn ts4104_readonly_tuple_alias_argument_renders_alias_name() {
     let msg = message_for(
         "type Pair = readonly [number, string]; const p: Pair = [1, 'a']; function need(x: [number, string]) {} need(p);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Pair' is not assignable to parameter of type '[number, string]'."
+        "The type 'Pair' is 'readonly' and cannot be assigned to the mutable type '[number, string]'."
     );
 }
 
 #[test]
-fn ts2345_readonly_tuple_alias_argument_arity_three_renders_alias_name() {
+fn ts4104_readonly_tuple_alias_argument_arity_three_renders_alias_name() {
     let msg = message_for(
         "type Triple = readonly [number, string, boolean]; const t: Triple = [1, 'a', true]; function need(x: [number, string, boolean]) {} need(t);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Triple' is not assignable to parameter of type '[number, string, boolean]'."
+        "The type 'Triple' is 'readonly' and cannot be assigned to the mutable type '[number, string, boolean]'."
     );
 }
 
 #[test]
-fn ts2345_inline_readonly_array_argument_keeps_structural_display() {
+fn ts4104_inline_readonly_array_argument_keeps_structural_display() {
     // No alias: the inline `readonly number[]` annotation must stay structural,
     // exactly as `tsc` renders it.
     let msg = message_for(
         "const ra: readonly number[] = []; function need(x: number[]) {} need(ra);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'readonly number[]' is not assignable to parameter of type 'number[]'."
+        "The type 'readonly number[]' is 'readonly' and cannot be assigned to the mutable type 'number[]'."
     );
 }
 
 #[test]
-fn ts2345_generic_readonly_array_alias_application_keeps_name() {
+fn ts4104_generic_readonly_array_alias_application_keeps_name() {
     // A generic alias survives as an `Application` and already renders by name;
     // the recovery must not interfere with it.
     let msg = message_for(
         "type Frozen<T> = readonly T[]; const f: Frozen<number> = []; function need(x: number[]) {} need(f);",
-        2345,
+        4104,
     );
     assert_eq!(
         msg,
-        "Argument of type 'Frozen<number>' is not assignable to parameter of type 'number[]'."
+        "The type 'Frozen<number>' is 'readonly' and cannot be assigned to the mutable type 'number[]'."
     );
 }

--- a/crates/tsz-checker/tests/readonly_tuple_to_array_constraint_tests.rs
+++ b/crates/tsz-checker/tests/readonly_tuple_to_array_constraint_tests.rs
@@ -99,7 +99,14 @@ fn readonly_tuple_satisfies_specific_mutable_element_constraint() {
 fn readonly_array_source_still_fails_against_mutable_array_constraint() {
     // tsc rejects a plain `readonly X[]` source at the constraint
     // boundary because its element list is unbounded; only tuples are
-    // loosened. tsz must mirror this rejection.
+    // loosened. tsz must mirror this rejection. Verified against the
+    // pinned tsc 7.0.2 oracle: the rejection's head diagnostic is TS4104
+    // ("The type 'readonly string[]' is 'readonly' and cannot be assigned
+    // to the mutable type 'unknown[]'."), not the generic TS2345 — tsc
+    // promotes the readonly-to-mutable reason to the head diagnostic here
+    // exactly as it does for a concretely-typed parameter, even though the
+    // constraint's mutable shape (`unknown[]`) was only reached through the
+    // type parameter's fallback.
     let source = r#"
         function processArray<T extends unknown[]>(arr: T): T[number] {
             return arr[0];
@@ -109,9 +116,10 @@ fn readonly_array_source_still_fails_against_mutable_array_constraint() {
     "#;
     let codes = error_codes(&check(source));
     assert!(
-        codes.contains(&2345),
+        codes.contains(&4104),
         "plain ReadonlyArray source must still be rejected at the \
-         constraint boundary; got error codes: {codes:?}"
+         constraint boundary, via TS4104 (matching tsc 7.0.2); got error \
+         codes: {codes:?}"
     );
 }
 


### PR DESCRIPTION
When a `readonly` array/tuple is passed as a call argument to a parameter whose type is a *mutable* array/tuple, `tsc` reports **TS4104** ("The type 'X' is 'readonly' and cannot be assigned to the mutable type 'Y'"), not the generic **TS2345**. tsz's direct-assignment path (`check_assignable_or_report_at_with_options`) already promotes this reason via the `readonly_to_mutable_array_or_tuple_reason` preflight, but the **call-argument** error path emitted the generic TS2345. This PR runs the same precise preflight (readonly source inner + mutable array/tuple target) in the argument path and, when it matches, renders the `ReadonlyToMutableAssignment` reason (TS4104) instead of falling through to the generic TS2345.

**Owner layer:** checker (`error_reporter/call_errors/error_emission.rs`). Reuses the existing solver reason and the existing renderer; no new relation logic.

## Supersedes #15880

This rescopes and corrects a prior attempt (#15880), which was parked as draft over a suspected over-application to type-parameter-constraint targets (`processArray<T extends unknown[]>(arr: T)` called with a plain `readonly string[]` argument, expected to fall back and reject via the constraint). That parking was based on an existing test (`readonly_tuple_to_array_constraint_tests::readonly_array_source_still_fails_against_mutable_array_constraint`) asserting the rejection must carry code TS2345 — but that assertion was never verified against the pinned oracle for this specific sub-case.

Verified directly against the pinned `tsc` 7.0.2 oracle (`scripts/node_modules/typescript@7.0.2`) for this exact scenario:

```
function processArray<T extends unknown[]>(arr: T): T[number] { return arr[0]; }
const ra: readonly string[] = ["a", "b"];
const out = processArray(ra);
```
tsc's actual output is bare **TS4104** ("The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type 'unknown[]'."), not TS2345 — the promotion is unconditional, including when the mutable target shape is only reached through a type parameter's constraint fallback. I also verified the promotion holds even when an *additional*, unrelated mismatch is present (readonly-ness plus a differing element type still yields bare TS4104, no TS2345). The "over-application" was a stale, unverified test expectation, not a real regression. The test now asserts TS4104 and documents the oracle verification.

## Structural rule

When a call argument's source type is a `readonly` array/tuple and the call's parameter type resolves (possibly through a type parameter's constraint) to a concretely mutable array/tuple, `tsc` reports TS4104 as the *sole* head diagnostic — never a wrapping TS2345 — regardless of any other structural mismatch between source and target. tsz's checker now mirrors this via the same `readonly_to_mutable_array_or_tuple_reason` preflight already used on the direct-assignment path.

## Adjacent-case matrix

- Direct assignment (`let y: number[] = a`) already emitted TS4104 — unchanged.
- Argument (`f(a)`, `arryFn2(a/b/c)` with `readonly number[]` / `Readonly<number[]>` / `ReadonlyArray<number>`, and a `readonly` tuple `as const` passed to `[number, number]`) now emits TS4104 — matches tsc.
- Generic call-site constraint fallback (`processArray<T extends unknown[]>(arr: T)` called with a plain readonly array) also emits TS4104 — matches tsc (verified above), fixing the stale test.
- Readonly-tuple-widening acceptance at generic constraint boundaries (`processArray([1, "two", true] as const)` against `T extends unknown[]`, issue #5804) is untouched — that's a separate acceptance rule, not an error-code rendering path.
- The preflight is precise (readonly source inner AND mutable array/tuple target), so non-readonly argument mismatches keep the generic TS2345.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test readonly_array_alias_argument_display_tests --test readonly_tuple_to_array_constraint_tests`: 11/11 passed.
- Targeted regression sweep: all 51 `readonly`/`tuple`/`4104`/`2345`-named test files under `crates/tsz-checker/tests/` (every one wired into `Cargo.toml`'s explicit `[[test]]` list): 100% pass, no regressions.
- Two-sided filtered conformance (`conformance.sh snapshot --workers 12 --force --filter readonly`, pinned tsc 7.0.2 oracle), branch `6c56dec` vs parent `99ddcc8`:
  - Before: 12/14 passed (85.7%) — `readonlyTupleAndArrayElaboration.ts` failing with extra TS2345.
  - After: 13/14 passed (92.9%) — `readonlyTupleAndArrayElaboration.ts` now matches exactly.
  - **+1 newly passing, 0 newly failing.** The one remaining failure (`readonlyMembers.ts`) is identical on both sides (same codes on both expected/actual — a pre-existing, unrelated mismatch).
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings`: clean.
- `./scripts/emit/run.sh`: JS 11562/11563 (unchanged from floor), DTS 1375/1390 (unchanged from floor) — no emit-visible regression, as expected since this change is confined to checker diagnostic-code selection in an already-erroring path.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4CksgsyY8E93KYhuYRMMD)_