### PR TITLE
test(checker): align three readonly-argument expectations with TS4104

### DIFF
--- a/crates/tsz-checker/src/tests/dispatch_tests/part_01.rs
+++ b/crates/tsz-checker/src/tests/dispatch_tests/part_01.rs
@@ -1574,9 +1574,15 @@ var p3 = m3.Color.Blue;
 }
 
 #[test]
-fn ts2345_readonly_array_preserves_readonly_in_message() {
-    // When a readonly array is passed where a mutable array is expected,
-    // the TS2345 message should display 'readonly number[]' not 'number[]'.
+fn ts4104_readonly_array_preserves_readonly_in_message() {
+    // When a readonly array is passed where a mutable array is expected, the
+    // argument path reports the precise TS4104 rather than the generic TS2345
+    // (#16001), and the message must still display 'readonly number[]' rather
+    // than silently widening the source to 'number[]'.
+    //
+    // Verified against tsc 7.0.2, which emits exactly:
+    //   error TS4104: The type 'readonly number[]' is 'readonly' and cannot be
+    //   assigned to the mutable type 'number[]'.
     let diags = check_source_diagnostics(
         r#"
 declare const a: readonly number[];
@@ -1584,17 +1590,17 @@ declare function fn(x: number[]): void;
 fn(a);
 "#,
     );
-    let matching = diagnostics_with_code(&diags, 2345);
-    assert_eq!(matching.len(), 1, "Expected one TS2345, got: {diags:?}");
+    let matching = diagnostics_with_code(&diags, 4104);
+    assert_eq!(matching.len(), 1, "Expected one TS4104, got: {diags:?}");
 
     let msg = &matching[0].message_text;
     assert!(
         msg.contains("'readonly number[]'"),
-        "Expected 'readonly number[]' in TS2345 message, got: {msg}"
+        "Expected 'readonly number[]' in TS4104 message, got: {msg}"
     );
     assert!(
-        msg.contains("parameter of type 'number[]'"),
-        "Expected 'number[]' as target type, got: {msg}"
+        msg.contains("mutable type 'number[]'"),
+        "Expected 'number[]' as the mutable target type, got: {msg}"
     );
 }
 

--- a/crates/tsz-checker/src/tests/fresh_const_array_mutable_assignment_tests.rs
+++ b/crates/tsz-checker/src/tests/fresh_const_array_mutable_assignment_tests.rs
@@ -146,14 +146,18 @@ const r = concat([1, 2] as const, ['a', 'b'] as const);
 
 #[test]
 fn aliased_readonly_tuple_variable_still_rejected() {
-    // A variable is not fresh, so readonly stays binding (TS2345).
+    // A variable is not fresh, so readonly stays binding. The argument path
+    // reports the precise TS4104, not the generic TS2345 (#16001). Verified
+    // against tsc 7.0.2, which emits exactly:
+    //   error TS4104: The type 'readonly [1, 2]' is 'readonly' and cannot be
+    //   assigned to the mutable type '[number, number]'.
     let src = r#"
 declare function f(t: [number, number]): void;
 const a = [1, 2] as const;
 f(a);
 "#;
     assert!(
-        codes(src).contains(&2345),
+        codes(src).contains(&4104),
         "aliased readonly tuple must still be rejected against a mutable param"
     );
 }
@@ -161,13 +165,20 @@ f(a);
 #[test]
 fn readonly_array_source_still_rejected_for_variadic_generic() {
     // A readonly *array* (unbounded) is not a fresh fixed literal: rejected.
+    // The argument path reports the precise TS4104, not the generic TS2345
+    // (#16001). tsc 7.0.2 emits TS4104 here at the same position.
+    //
+    // Only the code is asserted, deliberately. tsz currently renders the target
+    // as '[...readonly unknown[]]' where tsc renders the instantiated
+    // 'number[]'; asserting the current rendering would freeze that divergence
+    // into a baseline. Tracked separately — see the PR that updated this test.
     let src = r#"
 declare function f<T extends readonly unknown[]>(t: [...T]): T;
 declare const arr: readonly number[];
 const r = f(arr);
 "#;
     assert!(
-        codes(src).contains(&2345),
+        codes(src).contains(&4104),
         "readonly array source must still be rejected against `[...T]`"
     );
 }


### PR DESCRIPTION
Fixes 3 of the 7 unbaselined failures currently on main. **I merged #16001, which introduced these, so I am fixing them.**

## Goal
Goal: hold

## Structural rule

When a `readonly` array/tuple is passed as a call argument to a parameter whose type is (or resolves to) a concrete mutable array/tuple, `tsc` reports **TS4104**, not the generic **TS2345**. #16001 correctly promoted tsz's call-argument error path to match. Three lib tests still asserted the pre-#16001 TS2345 and now fail.

**Owner layer:** test-only. No production code in this diff.

## How these were missed

#16001 updated the expectations it knew about in `crates/tsz-checker/tests/` (integration targets). These three live in `crates/tsz-checker/src/tests/` — they are **lib** tests, reached by `--lib`, not by `--test <target>`. That asymmetry is easy to fall into: `cargo nextest run -p tsz-checker --test <name>` cannot see them at all, and reports `no test target named ...`, which reads as "the test does not exist" rather than "you used the wrong selector."

I verified #16001 pre-merge against conformance (+1, 0 newly failing), emit, and fourslash — but not the checker unit suite, even though the change sits in the checker's diagnostic-emission path and these test names are transparently in its blast radius. That was my gap, not the author's; their filtered evidence was reasonable for what they could run in-container.

Surfaced by a full workspace signoff run at `79d9a4fd56` (#15999's method), which is now the standing check.

## Verification — oracle-first, not output-first

Each expectation was verified against the vendored `tsc` 7.0.2, **not** against tsz's current output. Updating a test to whatever the compiler happens to print is how a wrong expectation becomes a permanent baseline; that is the exact defect #16001 itself fixed, and it recurs across #15999 §2 and #16002.

```
$ node scripts/node_modules/typescript/lib/tsc.js --noEmit --strict --pretty false --lib es2015 repro.ts
```

| case | tsc 7.0.2 | tsz @ `79d9a4fd56` |
| --- | --- | --- |
| `f(a)`, `const a = [1,2] as const`, param `[number, number]` | `TS4104 ... mutable type '[number, number]'` | **byte-identical** |
| `fn(a)`, `a: readonly number[]`, param `number[]` | `TS4104 ... mutable type 'number[]'` | **byte-identical** |
| `f(arr)`, `f<T extends readonly unknown[]>(t: [...T])` | `TS4104 ... mutable type 'number[]'` | `TS4104 ... mutable type '[...readonly unknown[]]'` |

Same code and same position in all three.

### A divergence found, and deliberately not baked in

The third case renders a different target type: tsc shows the instantiated `number[]`, tsz shows the raw variadic `[...readonly unknown[]]`. This is a **pre-existing display gap, not caused by #16001** — the code and position already match.

That test therefore asserts **only the code**, with a comment explaining why. Asserting `'[...readonly unknown[]]'` would have made the test pass while permanently encoding a known parity divergence as expected behavior. Filing separately so it stays visible rather than silently correct-looking.

### Test results

```
cargo nextest run -p tsz-checker --lib -E '<the 3 rows>'
  3 tests run: 3 passed

cargo nextest run -p tsz-checker --lib -E 'test(fresh_const_array_mutable_assignment_tests) + test(dispatch_tests)'
  149 tests run: 149 passed        # full enclosing suites, no collateral damage
```

Pre-commit hook (fmt + `clippy -p tsz-checker` + arch guard) passed locally.

No conformance/emit/fourslash run: this diff contains no production code and cannot move them. For the record, main `20f2e877c5` measured conformance 11435/12043, emit 11562 JS / 1375 DTS, fourslash 6558/6562.

## Remaining after this

4 unbaselined failures stay on main — the `tsz-checker` rows bisected to `8493f99c30` (#15999 §1), a test-harness-only commit. They belong with the #15983 `lazy.rs` work and are not addressed here.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
AgentName: Quartz
