### PR TITLE
ci(lint): drop stale tsz-conformance exclusion from the deny-warnings clippy gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run cargo clippy
         run: |
           scripts/safe-run.sh --limit 88% -- \
-            cargo clippy --profile ci-lint --workspace --exclude tsz-conformance \
+            cargo clippy --profile ci-lint --workspace \
               --all-targets -- -D warnings
 
   unit:

--- a/scripts/ci/full-ci.sh
+++ b/scripts/ci/full-ci.sh
@@ -426,10 +426,12 @@ run_lint() {
   # — separate cache key from .target/debug so dev incrementals on a
   # contributor's machine aren't poisoned by CI-shaped fingerprints, and
   # vice versa.
-  # tsz-conformance is excluded: it pre-dates workspace lint inheritance and
-  # has existing violations that need a dedicated cleanup PR before it can
-  # join the gate (#13453).
-  cargo clippy --profile ci-lint --workspace --exclude tsz-conformance \
+  # tsz-conformance joined this deny-level gate once measured clippy-clean
+  # under it (#13453 is closed; the exclusion outlived its justification).
+  # It stays excluded from the separate pedantic warn-level ratchet below
+  # (scripts/arch/check-clippy-warn-ratchet.py) — that group has a real,
+  # measured ~6.4k-warning backlog on this crate pending dedicated cleanup.
+  cargo clippy --profile ci-lint --workspace \
     --all-targets -- -D warnings || return $?
   scripts/arch/check-checker-boundaries.sh || return $?
   # Warn-level ratchet: counts must not rise above the committed baseline.


### PR DESCRIPTION
Removes `--exclude tsz-conformance` from the per-merge `cargo clippy -D warnings` gate (`.github/workflows/ci.yml:61`, `scripts/ci/full-ci.sh:432`). The exclusion cited #13453 ("has existing violations that need a dedicated cleanup PR before it can join the gate"), but #13453 closed on 2026-06-14 and the crate is measured clippy-clean under the deny-warnings flag set — the exclusion simply outlived its justification.

`tsz-conformance` keeps its separate exclusion from the pedantic warn-level ratchet (`scripts/arch/check-clippy-warn-ratchet.py`) — that group runs a much larger flag set (`clippy::pedantic` plus cherry-picks) and I measured a real ~6.4k-warning backlog there, unrelated to #13453. Only the deny-level gate changes in this PR.

Structural rule: when a per-merge lint gate's crate exclusion cites a closed tech-debt issue and the crate is independently measured clean under that gate's exact flag set, the exclusion is dead weight and should be dropped rather than carried forward.

## Goal
Goal: hold

## Verification
- `cargo clippy --profile ci-lint -p tsz-conformance --all-targets -- -D warnings` at head `79d9a4f`: exit 0, zero warnings/errors.
- `scripts/safe-run.sh --limit 88% -- cargo clippy --profile ci-lint --workspace --all-targets -- -D warnings` (the exact CI gate command with the exclusion removed) at head `79d9a4f`: exit 0, zero warnings/errors.
- `python3 scripts/arch/arch_guard.py`: passed (unaffected by this change).
- `bash -n scripts/ci/full-ci.sh` and YAML parse of `ci.yml`: both OK.
- Confirmed the pedantic warn-level ratchet exclusion in `scripts/arch/check-clippy-warn-ratchet.py` is untouched and independently justified: same crate under the ratchet's `clippy::pedantic` + cherry-pick flag set shows 6,386 warnings, so that gate correctly stays scoped out for now.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMteAQTCj9K4H3ZY3VJrH7)_