### PR TITLE
fix(checker): break two unbounded recursions in in-operator narrowing

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -779,7 +779,7 @@ impl CheckerState<'_> {
         self.resolve_type_for_property_access_inner(type_id, &mut visited)
     }
 
-    pub(crate) fn resolve_type_for_property_access(&mut self, type_id: TypeId) -> TypeId {
+    pub(crate) fn resolve_type_for_property_access(&mut self, mut type_id: TypeId) -> TypeId {
         // A union whose members are `Application(Lazy(DefId), …)` instantiations
         // of generic lib references (e.g. `Int32Array | Uint8Array`) keeps those
         // members opaque under the solver's environment-free evaluator, hiding
@@ -788,12 +788,22 @@ impl CheckerState<'_> {
         // members are interned in their raw application form rather than the
         // resolved object form a directly-declared union would carry. Resolve
         // the application members through the type environment first so property
-        // and element access see the interface shape; the recursion then runs
+        // and element access see the interface shape; the loop below then runs
         // the normal per-member resolution on the resolved union. This precedes
         // the per-id resolve cache, which can otherwise return a stale identity
         // entry recorded on an earlier pass before the members were resolvable.
-        if let Some(resolved) = self.resolve_union_application_members(type_id) {
-            return self.resolve_type_for_property_access(resolved);
+        // Bounded by a fuel counter (matching `resolve_type_uncached`'s cycle
+        // guard): a cross-file generic union member can re-evaluate to a
+        // freshly interned but structurally-equal application each pass, so
+        // unbounded recursion here previously stack-overflowed instead of
+        // reaching a fixed point.
+        let mut fuel = 100;
+        while fuel > 0 {
+            fuel -= 1;
+            match self.resolve_union_application_members(type_id) {
+                Some(resolved) if resolved != type_id => type_id = resolved,
+                _ => break,
+            }
         }
 
         // Lazy single-member fast path: a bare `Lazy(DefId)` reference to a

--- a/crates/tsz-solver/src/narrowing/cache.rs
+++ b/crates/tsz-solver/src/narrowing/cache.rs
@@ -185,6 +185,13 @@ pub struct NarrowingCache {
     /// In-progress `(source, excluded, resolver_generation)` set for
     /// `narrow_excluding_type`.
     pub(crate) narrow_excluding_visiting: RefCell<FxHashSet<NarrowExcludingKey>>,
+    /// In-progress `(source, property, present)` set for
+    /// `narrow_by_property_presence`'s nested-union recursion (the resolved
+    /// alias of one union member can itself resolve back to the enclosing
+    /// union, e.g. a `Record<string, Either<X, A>>` indexed-access element or
+    /// a 3-way discriminated union reached through a generic instantiation
+    /// path). Returning the type unchanged on a cycle prevents stack overflow.
+    pub(crate) narrow_property_presence_visiting: RefCell<FxHashSet<NarrowPropertyPresenceKey>>,
     /// Memo for the narrowing-boundary assignability check keyed by
     /// `(source, target, resolver_generation)`.
     pub(crate) narrow_assignable_cache: RefCell<GenerationMemo<NarrowExcludingStableKey, bool>>,
@@ -234,6 +241,15 @@ pub(crate) struct NarrowExcludingStableKey {
     pub(crate) excluded: TypeId,
 }
 
+/// Cache key for `NarrowingContext::narrow_by_property_presence`'s
+/// nested-union recursion guard: a `(source, property, present)` triple.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]
+pub(crate) struct NarrowPropertyPresenceKey {
+    pub(crate) source: TypeId,
+    pub(crate) property: Atom,
+    pub(crate) present: bool,
+}
+
 /// RAII guard for one exclusion-narrowing recursion frame.
 pub(in crate::narrowing) struct ExclusionFrame<'b> {
     depth: &'b Cell<u32>,
@@ -274,6 +290,18 @@ impl Drop for NarrowExcludingVisitGuard<'_> {
     }
 }
 
+/// RAII guard for one in-progress `narrow_by_property_presence` key.
+pub(in crate::narrowing) struct NarrowPropertyPresenceVisitGuard<'b> {
+    visiting: &'b RefCell<FxHashSet<NarrowPropertyPresenceKey>>,
+    key: NarrowPropertyPresenceKey,
+}
+
+impl Drop for NarrowPropertyPresenceVisitGuard<'_> {
+    fn drop(&mut self) {
+        self.visiting.borrow_mut().remove(&self.key);
+    }
+}
+
 impl NarrowingCache {
     pub fn new() -> Self {
         Self {
@@ -299,6 +327,7 @@ impl NarrowingCache {
             narrow_type_cache: RefCell::new(GenerationMemo::default()),
             narrow_excluding_cache: RefCell::new(GenerationMemo::default()),
             narrow_excluding_visiting: RefCell::new(FxHashSet::default()),
+            narrow_property_presence_visiting: RefCell::new(FxHashSet::default()),
             narrow_assignable_cache: RefCell::new(GenerationMemo::default()),
             narrow_subtype_cache: RefCell::new(GenerationMemo::default()),
             narrow_relation_budget_events: Cell::new(0),
@@ -525,6 +554,23 @@ impl NarrowingCache {
         }
         Some(NarrowExcludingVisitGuard {
             visiting: &self.narrow_excluding_visiting,
+            key,
+        })
+    }
+
+    pub(in crate::narrowing) fn narrow_property_presence_visit_guard(
+        &self,
+        key: NarrowPropertyPresenceKey,
+    ) -> Option<NarrowPropertyPresenceVisitGuard<'_>> {
+        if !self
+            .narrow_property_presence_visiting
+            .borrow_mut()
+            .insert(key)
+        {
+            return None;
+        }
+        Some(NarrowPropertyPresenceVisitGuard {
+            visiting: &self.narrow_property_presence_visiting,
             key,
         })
     }

--- a/crates/tsz-solver/src/narrowing/property.rs
+++ b/crates/tsz-solver/src/narrowing/property.rs
@@ -5,6 +5,7 @@
 //! - Property type lookup for narrowing
 //! - Object-like type detection for instanceof support
 
+use super::cache::NarrowPropertyPresenceKey;
 use super::{CachedPropertyType, NarrowingContext};
 use crate::operations::property::PropertyAccessResult;
 use crate::types::{
@@ -78,6 +79,24 @@ impl<'a> NarrowingContext<'a> {
             present
         )
         .entered();
+
+        // A union member's alias can resolve back to the enclosing union
+        // itself (e.g. a `Record<string, Either<X, A>>` indexed-access
+        // element, or a 3-way discriminated union reached through a generic
+        // instantiation path): the nested-union recursion below would then
+        // re-enter this function with the identical `(source_type,
+        // property_name, present)` triple forever. Guard the whole call so a
+        // re-entrant cycle returns the type unchanged instead of overflowing
+        // the stack.
+        let guard_key = NarrowPropertyPresenceKey {
+            source: source_type,
+            property: property_name,
+            present,
+        };
+        let Some(_visit_guard) = self.cache.narrow_property_presence_visit_guard(guard_key) else {
+            trace!("Cyclic narrow_by_property_presence re-entry, returning source unchanged");
+            return source_type;
+        };
 
         // Handle special cases
         if source_type == TypeId::ANY {


### PR DESCRIPTION
When a `Record<string, Either<X, A>>` indexed-access element or a 3-way
discriminated union's members reach `in`-operator narrowing through a
cross-file generic instantiation, tsz crashes with a stack overflow
(`SIGABRT`) instead of narrowing; tsc narrows cleanly. tsz now does the
same narrowing through the solver's `NarrowingContext` and the checker's
`CheckerState` type environment, both of which lacked a cycle/fixed-point
guard on two specific recursive re-entries.

Two independent unbounded recursions, found by attaching `gdb` to the
crashing test binary and reading `bt`/frame locals at the fault:

1. **Solver — `NarrowingContext::narrow_by_property_presence`**
   (`crates/tsz-solver/src/narrowing/property.rs`). When a union member's
   resolved alias loops back to the *enclosing* union itself, the
   nested-union recursion (added for generic alias distribution) re-enters
   the function with the identical `(source_type, property_name, present)`
   triple forever. Confirmed via `gdb`: `source_type` was the identical
   `TypeId(378)` at every one of thousands of recursion frames for
   `Record<string, Either<X, A>>` value-indexed narrowing. Fixed with a
   `NarrowPropertyPresenceKey`-keyed visiting-set RAII guard in
   `NarrowingCache`, mirroring the existing `resolve_visiting` /
   `narrow_excluding_visiting` guards in the same file — a cyclic re-entry
   now returns the type unchanged (no narrowing) instead of overflowing the
   stack.

2. **Checker — `CheckerState::resolve_type_for_property_access`**
   (`crates/tsz-checker/src/state/type_environment/lazy.rs`). Fixing (1)
   exposed a second, independent cycle one layer down: this function's
   `resolve_union_application_members` loop re-enters itself as long as
   evaluating a union's `Application` members reports `changed`, which
   never settled for a 3-way discriminated union's interface-application
   members reached through this path (each cross-file interface
   instantiation apparently re-evaluates to a freshly interned but
   structurally-equal application rather than a stable fixed point).
   Bounded the loop with a fuel counter — the same idiom
   `resolve_type_uncached` already uses one file over in
   `crates/tsz-solver/src/narrowing/core.rs` for this exact class of
   problem.

Structural rule: when a recursive type-resolution helper's termination
depends on reaching a *fixed point* (an unchanged/already-seen `TypeId`)
rather than a *fuel-bounded* structural descent, the recursive call site
needs an explicit cycle guard — assuming resolution "must" terminate
because the alias-nesting is finite is unsound once a resolved member can
structurally equal an ancestor in the call chain.

Both crashing tests were **SIGABRT / stack-overflow failures on `main`**,
not simple diagnostic mismatches — found via issue #15999's unit-lane
signoff sweep (`in_operator_narrows_record_value_indexed`,
`in_operator_narrows_three_way_indexed`), unbaselined and previously
untested because the unit lane only runs nightly.

Not in scope: #15999 also lists two `generic_call_assignment_flow_tests`
failures. Those are unrelated false-positive `TS18048` diagnostics (not
crashes) — one of them constructs two cross-file symbols that deliberately
collide on the same binder-relative terminal id, which looks like the same
contested-`SymbolId` family as #15983 (four sessions deep already).
Flagged on the coordination board rather than duplicated here.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib cross_file_in_operator_indexed_element_narrowing_tests::` — 10/10 pass (was: 2 SIGABRT stack-overflow crashes, 8 pass)
- `cargo test -p tsz-checker --lib -- narrow in_operator` — 418/418 pass, unaffected
- `cargo test -p tsz-checker --lib -- cross_file property_access application` — 624/624 pass (1 pre-existing ignore), unaffected
- `cargo fmt --check` — clean
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` — clean
- `scripts/conformance/compare-to-parent.sh origin/main` — branch vs parent `20f2e87`, both 11436/12043 passed, 606 failing on both sides, **0 newly passing / 0 newly failing** (crash was outside the corpus's exercised shapes; no regression)
- `python3 scripts/arch/arch_guard.py` — passes (`lazy.rs` trimmed to exactly 2000 lines)
- `./scripts/emit/run.sh` — **not run**: its `npm install` genuinely hung in this container for 30+ min with zero progress (not a slow network — `node_modules` stopped growing entirely), a known environment limitation (see #16001's fourslash note for the same class of issue). The change is confined to checker/solver-internal narrowing (`in`-operator property presence) and property-access type resolution — no emitter code touched, and the fuel/guard only engages on the specific cyclic shape that previously crashed, so it is not expected to be emit-visible. Flagging on the coordination board for a follow-up run in a container where the emit harness builds cleanly.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gd92A2GtJQ4w9mmtAd9BwN)_