### PR TITLE
fix(checker): keep an enclosing signature's same-named type parameter out of contextual callback defaulting

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -928,6 +928,9 @@ mod constraint_position_nullable_access_tests;
 #[path = "tests/constraint_validation_relation_routing_arch_tests.rs"]
 mod constraint_validation_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/contextual_callback_shadowed_type_param_tests.rs"]
+mod contextual_callback_shadowed_type_param_tests;
+#[cfg(test)]
 #[path = "tests/contextual_return_wrapper_tests.rs"]
 mod contextual_return_wrapper_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/inference.rs
+++ b/crates/tsz-checker/src/query_boundaries/inference.rs
@@ -199,10 +199,30 @@ fn complete_contextual_type_param_plan(
         // own free parameter intact is what `tsc` reports, and it matches the
         // choice `instantiate_shadowed_contextual_type_param` already makes for
         // the narrower "candidate is the whole contextual type" case.
-        if plan
-            .substitution
-            .get(tp.name)
-            .is_some_and(|mapped| common::contains_type_parameter_named(db, mapped, tp.name))
+        //
+        // A *self-referential constraint* mentions its own parameter name for a
+        // completely different reason and must not be caught here:
+        //
+        // ```ts
+        // <O extends NoExcessProperties<RepeatOptions<A>, O>, A>(options: O): ...
+        // ```
+        //
+        // `O`'s candidate mentions `O` because `O`'s own constraint does, not
+        // because an enclosing signature declares a second `O`. Dropping that
+        // binding would strip the contextual type off `options`' nested callback
+        // parameters and report a spurious `TS7006` under `noImplicitAny`.
+        // Distinguish by where the self-mention comes from: the callee's own
+        // declaration, or an inferred argument. Binder identity cannot make this
+        // call -- two unconstrained same-named parameters intern to one
+        // `TypeId`, which is the very collision this guard exists for.
+        let constraint_is_self_referential = tp.constraint.is_some_and(|constraint| {
+            common::contains_type_parameter_named(db, constraint, tp.name)
+        });
+        if !constraint_is_self_referential
+            && plan
+                .substitution
+                .get(tp.name)
+                .is_some_and(|mapped| common::contains_type_parameter_named(db, mapped, tp.name))
         {
             plan.substitution.remove(tp.name);
             continue;

--- a/crates/tsz-checker/src/query_boundaries/inference.rs
+++ b/crates/tsz-checker/src/query_boundaries/inference.rs
@@ -180,6 +180,33 @@ fn complete_contextual_type_param_plan(
         }) {
             continue;
         }
+        // A round-1 candidate may legitimately mention a type parameter of an
+        // *enclosing* signature that happens to share this parameter's name:
+        //
+        // ```ts
+        // declare function each<T>(v: T, run: (v: T) => void): void;
+        // function outer<T>(v: Box<T>) { each(v, sub => { /* sub: Box<T> */ }); }
+        // ```
+        //
+        // Here the callee's `T` is fixed to `Box<T_outer>`, which is concrete
+        // enough for `tsc` -- the free `T_outer` belongs to `outer`, not to
+        // `each`. Substitutions are name-keyed, so at this point the two
+        // occurrences are indistinguishable and defaulting the callee's `T`
+        // would rewrite the enclosing `T` as well, yielding `Box<unknown>` and
+        // a spurious `TS2322`/`TS2345` on the callback body.
+        //
+        // Drop the binding instead of defaulting it: leaving the candidate's
+        // own free parameter intact is what `tsc` reports, and it matches the
+        // choice `instantiate_shadowed_contextual_type_param` already makes for
+        // the narrower "candidate is the whole contextual type" case.
+        if plan
+            .substitution
+            .get(tp.name)
+            .is_some_and(|mapped| common::contains_type_parameter_named(db, mapped, tp.name))
+        {
+            plan.substitution.remove(tp.name);
+            continue;
+        }
         let replacement = tp.default.or(tp.constraint).unwrap_or(TypeId::UNKNOWN);
         let replacement = common::instantiate_type(db, replacement, &plan.substitution);
         let replacement = if common::contains_type_parameters(db, replacement)

--- a/crates/tsz-checker/src/tests/contextual_callback_shadowed_type_param_tests.rs
+++ b/crates/tsz-checker/src/tests/contextual_callback_shadowed_type_param_tests.rs
@@ -185,6 +185,65 @@ function outer(v: Box<string>) {
     );
 }
 
+/// Self-referential-constraint control, reduced from
+/// `compiler/contextualParameterAndSelfReferentialConstraint1.ts`.
+///
+/// `O`'s candidate mentions `O` because `O`'s own constraint is
+/// self-referential, not because an enclosing signature declares a second `O`.
+/// The shadowing guard must not fire here: dropping the binding strips the
+/// contextual type off `options`' nested callback parameter and reports a
+/// spurious TS7006 under `noImplicitAny`. This is the shape that distinguishes
+/// "mentions a same-named parameter" from "mentions an *enclosing* one".
+#[test]
+fn self_referential_constraint_keeps_nested_callback_parameter_contextual() {
+    let diags = check_source_diagnostics(
+        r#"
+type Excl<T, U> = T extends U ? never : T;
+
+type NoExcessProperties<T, U> = T & {
+  readonly [K in Excl<keyof U, keyof T>]: never;
+};
+
+interface Effect<out A> {
+  readonly EffectTypeId: {
+    readonly _A: (_: never) => A;
+  };
+}
+
+declare function pipe<A, B>(a: A, ab: (a: A) => B): B;
+
+interface RepeatOptions<A> {
+  until?: (_: A) => boolean;
+}
+
+declare const repeat: {
+  <O extends NoExcessProperties<RepeatOptions<A>, O>, A>(
+    options: O,
+  ): (self: Effect<A>) => Effect<A>;
+};
+
+pipe(
+  {} as Effect<boolean>,
+  repeat({
+    until: (x) => {
+      return x;
+    },
+  }),
+);
+"#,
+    );
+
+    let implicit_any: Vec<_> = diags.iter().filter(|d| d.code == 7006).collect();
+    assert!(
+        implicit_any.is_empty(),
+        "expected no TS7006 — a self-referential constraint must keep its nested callback parameter contextually typed, got: {:?}",
+        implicit_any
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
 /// Negative/fallback control: a callee type parameter with *no* inference
 /// candidate must still be defaulted, so the callback parameter reads as
 /// `unknown` rather than staying generic. Guards the `new Promise((res) => ...)`

--- a/crates/tsz-checker/src/tests/contextual_callback_shadowed_type_param_tests.rs
+++ b/crates/tsz-checker/src/tests/contextual_callback_shadowed_type_param_tests.rs
@@ -1,0 +1,212 @@
+//! Regression tests for issue #15731 — a generic call's contextual callback
+//! parameter must not have an *enclosing* signature's same-named type
+//! parameter defaulted away.
+//!
+//! Structural rule: when round-1 inference fixes a callee type parameter to a
+//! candidate that still mentions a type parameter of an enclosing signature
+//! sharing the same name, `tsc` treats the candidate as fixed — the free
+//! parameter belongs to the outer signature. Substitutions in `tsz` are
+//! name-keyed, so defaulting the callee's parameter to `unknown` would rewrite
+//! the enclosing occurrence too, contextually typing the callback parameter as
+//! `Box<unknown>` instead of `Box<T>` and producing a tsz-only TS2322/TS2345.
+//!
+//! The witness is superjson's `plainer.ts` (`traverse` recursing through
+//! `forEach<T>`), but the trigger is purely the name collision: the same code
+//! with the callee's parameter renamed was always clean. Every case below is
+//! tsc-clean.
+use crate::test_utils::check_source_diagnostics;
+
+/// Assert no assignability diagnostics, reporting the offending ones.
+fn assert_no_assignability_diagnostics(source: &str, context: &str) {
+    let diags = check_source_diagnostics(source);
+    let unexpected: Vec<_> = diags
+        .iter()
+        .filter(|d| d.code == 2322 || d.code == 2345)
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "{context}: expected no TS2322/TS2345, got: {:?}",
+        unexpected
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Core repro: callee and caller both spell their type parameter `T`, and the
+/// callback parameter must contextually type as `Box<T>`, not `Box<unknown>`.
+#[test]
+fn colliding_type_param_name_keeps_outer_parameter_in_callback_context() {
+    assert_no_assignability_diagnostics(
+        r#"
+type Box<T> = { item: T };
+declare function apply<T>(v: T, run: (v: T) => void): void;
+
+function outer<T>(v: Box<T>) {
+    apply(v, (sub) => {
+        const probe: Box<T> = sub;
+    });
+}
+"#,
+        "colliding type parameter names",
+    );
+}
+
+/// Renamed binder control. The identical program with the enclosing parameter
+/// spelled `Q` was already clean; it must stay clean, proving the fix is about
+/// binder scope and not about the spelling `T`.
+#[test]
+fn renamed_outer_binder_keeps_callback_context() {
+    assert_no_assignability_diagnostics(
+        r#"
+type Box<T> = { item: T };
+declare function apply<T>(v: T, run: (v: T) => void): void;
+
+function outer<Q>(v: Box<Q>) {
+    apply(v, (sub) => {
+        const probe: Box<Q> = sub;
+    });
+}
+"#,
+        "renamed outer binder",
+    );
+}
+
+/// Renamed *callee* binder control — the other half of the matrix.
+#[test]
+fn renamed_callee_binder_keeps_callback_context() {
+    assert_no_assignability_diagnostics(
+        r#"
+type Box<T> = { item: T };
+declare function apply<U>(v: U, run: (v: U) => void): void;
+
+function outer<T>(v: Box<T>) {
+    apply(v, (sub) => {
+        const probe: Box<T> = sub;
+    });
+}
+"#,
+        "renamed callee binder",
+    );
+}
+
+/// The enclosing parameter carries a constraint while the callee's does not.
+/// The candidate is still fixed, so the constraint must not be substituted in
+/// place of the outer parameter either.
+#[test]
+fn constrained_outer_binder_keeps_callback_context() {
+    assert_no_assignability_diagnostics(
+        r#"
+type Box<T> = { item: T };
+declare function apply<T>(v: T, run: (v: T) => void): void;
+
+function outer<T extends object>(v: Box<T>) {
+    apply(v, (sub) => {
+        const probe: Box<T> = sub;
+    });
+}
+"#,
+        "constrained outer binder",
+    );
+}
+
+/// Wrapper/nesting form: the candidate reaches the callback through an index
+/// signature rather than directly.
+#[test]
+fn colliding_type_param_name_through_record_value_context() {
+    assert_no_assignability_diagnostics(
+        r#"
+type Box<T> = { item: T };
+type Dict<V> = { [key: string]: V };
+declare function forEach<T>(record: Dict<T>, run: (v: T, key: string) => void): void;
+
+function outer<T>(rec: Dict<Box<T>>) {
+    forEach(rec, (sub) => {
+        const probe: Box<T> = sub;
+    });
+}
+"#,
+        "record value context",
+    );
+}
+
+/// The superjson `plainer.ts` shape: a recursive generic alias reached through
+/// an index-signature value, recursing into the same generic function. This is the
+/// original canary witness reduced to its inference core.
+#[test]
+fn recursive_alias_through_record_recurses_without_losing_outer_param() {
+    assert_no_assignability_diagnostics(
+        r#"
+type Dict<V> = { [key: string]: V };
+type Tree<T> = InnerNode<T> | Leaf<T>;
+type Leaf<T> = [T];
+type InnerNode<T> = [T, Dict<Tree<T>>];
+type MinimisedTree<T> = Tree<T> | Dict<Tree<T>> | undefined;
+
+declare function forEach<T>(record: Dict<T>, run: (v: T, key: string) => void): void;
+declare function isArray(payload: any): payload is any[];
+
+function traverse<T>(tree: MinimisedTree<T>, walker: (v: T, path: string[]) => void): void {
+    if (!tree) {
+        return;
+    }
+    if (!isArray(tree)) {
+        forEach(tree, (subtree) => traverse(subtree, walker));
+        return;
+    }
+    const [, children] = tree;
+    if (children) {
+        forEach(children, (child) => {
+            traverse(child, walker);
+        });
+    }
+}
+"#,
+        "recursive alias through record",
+    );
+}
+
+/// Concrete (non-generic) caller: the candidate has no free type parameter at
+/// all, so the ordinary fixing path still applies.
+#[test]
+fn concrete_outer_argument_still_fixes_callback_context() {
+    assert_no_assignability_diagnostics(
+        r#"
+type Box<T> = { item: T };
+declare function apply<T>(v: T, run: (v: T) => void): void;
+
+function outer(v: Box<string>) {
+    apply(v, (sub) => {
+        const probe: Box<string> = sub;
+    });
+}
+"#,
+        "concrete outer argument",
+    );
+}
+
+/// Negative/fallback control: a callee type parameter with *no* inference
+/// candidate must still be defaulted, so the callback parameter reads as
+/// `unknown` rather than staying generic. Guards the `new Promise((res) => ...)`
+/// behavior that the defaulting path exists for.
+#[test]
+fn uninferrable_type_param_still_defaults_callback_parameter_to_unknown() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function run<T>(cb: (v: T) => void): void;
+
+run((v) => {
+    const probe: string = v;
+});
+"#,
+    );
+
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "expected TS2322 assigning the defaulted `unknown` callback parameter to `string`, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Fixes the `plainer.ts` TS2345 pair on the **superjson** canary row (#15731).

**Structural rule.** When round-1 inference fixes a callee type parameter to a candidate that mentions a same-named type parameter which the callee's *own constraint* does not introduce, that mention belongs to an **enclosing** signature and `tsc` treats the candidate as fixed. `tsz` does this through the contextual-instantiation query boundary (`query_boundaries/inference.rs`).

Before this change, `complete_contextual_type_param_plan` classified "candidate mentions *any* type parameter" as unfixed and defaulted the callee's parameter to `unknown`. Substitutions are name-keyed, so that default also rewrote the enclosing occurrence: the callback parameter contextually typed as `Box<unknown>` instead of `Box<T>`, producing a tsz-only `TS2322`/`TS2345` on the callback body. The fix drops the binding instead of defaulting it — the same choice `instantiate_shadowed_contextual_type_param` already makes for the narrower "candidate *is* the whole contextual type" case, generalized to candidates nested inside it.

**Owner layer:** checker query boundary (`crate::query_boundaries::inference`). No solver, relation, or printer change; no name/file-string predicate — the guard reads type structure (`contains_type_parameter_named`) over the candidate and the declared constraint, and the renamed-binder rows below are controls proving the decision is scope-shaped, not spelling-shaped.

### Reduced witness

```ts
type Box<T> = { item: T };
declare function apply<T>(v: T, run: (v: T) => void): void;

function outer<T>(v: Box<T>) {
    apply(v, (sub) => {
        const probe: Box<T> = sub;   // was: TS2322 Type 'Box<unknown>' is not assignable to type 'Box<T>'
    });
}
```

The identical program with either binder renamed (`outer<Q>` or `apply<U>`) was always clean — the trigger is purely that the two binders share the name `T`, which a name-keyed substitution cannot tell apart.

### The self-referential-constraint exemption

The first revision of this PR (`f697243`) keyed only on "candidate mentions a parameter named `T`" and regressed one conformance row, caught by @mohsen1 in review. A **self-referential constraint** mentions its own parameter for an unrelated reason:

```ts
<O extends NoExcessProperties<RepeatOptions<A>, O>, A>(options: O): (self: Effect<A>) => Effect<A>;
```

`O`'s candidate mentions `O` because `O`'s own constraint does, not because an enclosing signature declares a second `O`. Dropping that binding stripped the contextual type off `options`' nested callback parameter and reported a spurious `TS7006` under `noImplicitAny` on `compiler/contextualParameterAndSelfReferentialConstraint1.ts`.

Binder identity cannot make this call: two unconstrained `User`-origin `<T>` declarations have identical `TypeParamInfo` and intern to one `TypeId` — that collision *is* this bug, so an identity test would fix the constrained variants and silently re-break the core case. The available discriminator is where the self-mention originates — the callee's own declaration (`tp.constraint` mentions `tp.name`) versus an inferred argument.

### Adjacent-case matrix

`crates/tsz-checker/src/tests/contextual_callback_shadowed_type_param_tests.rs`, 9 tests:

| case | before | after |
| --- | --- | --- |
| colliding binder names, direct argument | ❌ TS2322 | ✅ |
| renamed *outer* binder (`outer<Q>`) — control | ✅ | ✅ |
| renamed *callee* binder (`apply<U>`) — control | ✅ | ✅ |
| constrained outer binder, unconstrained callee | ❌ TS2322 | ✅ |
| candidate reached through an index signature | ❌ TS2322 | ✅ |
| recursive generic alias through an index signature (superjson `plainer.ts` core) | ❌ TS2345 ×2 | ✅ |
| concrete (non-generic) caller — control | ✅ | ✅ |
| **self-referential constraint** (reduced `contextualParameterAndSelfReferentialConstraint1.ts`) | ❌ TS7006 at `f697243` | ✅ |
| negative/fallback: type param with *no* candidate still defaults to `unknown` | ✅ TS2322 | ✅ TS2322 |

The last two rows are load-bearing negative controls, not decoration — the self-referential row fails with `TS7006` on the previous head, and the final row guards the behavior the defaulting path exists for (`new Promise((res) => …)`), so this is not a blanket removal of defaulting.

## Goal
Goal: green

## Verification

At head `a7d3d28`:

- `cargo fmt --all` — clean.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` — **EXIT=0**, zero warnings.
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- `cargo test -p tsz-checker --lib contextual_callback_shadowed_type_param` — **9 passed, 0 failed**.
- Both directions held with the same binary and flags:

| | `f697243` | `a7d3d28` |
| --- | --- | --- |
| `contextualParameterAndSelfReferentialConstraint1.ts` | ❌ `TS7006` @ (30,13) | ✅ clean |
| superjson `plainer.ts(43,25)`/`(54,23)` `TS2345` | ✅ clean | ✅ clean |

- Real fixture, not just a reduced case: superjson `src/{is,util,accessDeep,plainer,transformer,…}.ts` fetched at upstream `main` and compiled with `.target/debug/tsz`. `plainer.ts(43,25)` and `plainer.ts(54,23)` `TS2345` — the two lines named in #15731 — **go from reported to clean**. The row's other FP families (`plainer.ts` 179/181/216/270/275 `TS2322`, `transformer.ts` `TS18046`/`TS2698`) are unchanged, as #15731 says they are separate root causes.

### Not run here, and why

Cold cloud container: 4 cores, no `.target`, no TypeScript submodule, no `cargo-nextest` (proxy 403s `get.nexte.st`). **Conformance, emit, fourslash and the unit lanes did not run in this container** — they need a `dist-fast`/release binary and the corpus tree. The full-corpus snapshot that caught the `f697243` regression was run by @mohsen1 on an m4; a re-run against `a7d3d28`, including the unit lanes, is owed before merge. Treat those as pending, not passing.

Two reds seen locally that are **pre-existing and reproduced at parent `7863cb3`**, neither caused by this change:

1. `assignability_failure_memo_tests::passing_program_does_zero_reason_collection` fails identically at `7863cb3` with this change reverted, and is **not** listed in `scripts/ci/known-failures.txt`.
2. A whole-crate `cargo test -p tsz-checker --lib` aborts with `fatal runtime error: stack overflow` even at `RUST_MIN_STACK=64M`. That is #16008's pair of unbounded recursions, not this branch.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Onyx