### PR TITLE
fix(solver,checker): stop infinite recursion narrowing a self-referential union

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -793,7 +793,16 @@ impl CheckerState<'_> {
         // the per-id resolve cache, which can otherwise return a stale identity
         // entry recorded on an earlier pass before the members were resolvable.
         if let Some(resolved) = self.resolve_union_application_members(type_id) {
-            return self.resolve_type_for_property_access(resolved);
+            // Depth guard: a non-converging application member (e.g. a
+            // `Record<K, V>`-indexed alias residue) can keep "changing" the
+            // union forever. Mirrors `resolve_type_for_property_access_inner`'s
+            // own recursion-depth guard, since nothing else bounds this path.
+            if !self.ctx.enter_recursion() {
+                return resolved;
+            }
+            let result = self.resolve_type_for_property_access(resolved);
+            self.ctx.leave_recursion();
+            return result;
         }
 
         // Lazy single-member fast path: a bare `Lazy(DefId)` reference to a

--- a/crates/tsz-solver/src/narrowing/cache.rs
+++ b/crates/tsz-solver/src/narrowing/cache.rs
@@ -204,6 +204,17 @@ pub struct NarrowingCache {
     /// means "use [`NARROW_EXCLUDING_WORK_BUDGET`]"; tests and tuning may lower
     /// it to exercise the bail path deterministically.
     pub(crate) narrow_excluding_budget: Cell<u32>,
+    /// In-progress `(source, property_name, present)` set for
+    /// `NarrowingContext::narrow_by_property_presence`.
+    ///
+    /// A union constituent can itself resolve back to an *ancestor* union
+    /// already being filtered in the same recursive descent — e.g. a
+    /// cross-file generic alias residue left by `Record<K, V>` indexed-access
+    /// evaluation, where a member's `resolve_type` re-derives the enclosing
+    /// alias union instead of a concrete structural member. Without this set,
+    /// the nested-union recursion re-enters the same `(source, property,
+    /// present)` triple forever and overflows the stack.
+    pub(crate) property_presence_visiting: RefCell<FxHashSet<PropertyPresenceKey>>,
 }
 
 /// Per-request cumulative work bound shared by the exclusion-narrowing families.
@@ -232,6 +243,15 @@ pub(crate) struct NarrowExcludingKey {
 pub(crate) struct NarrowExcludingStableKey {
     pub(crate) source: TypeId,
     pub(crate) excluded: TypeId,
+}
+
+/// Cache key for `NarrowingContext::narrow_by_property_presence`'s in-progress
+/// recursion set: `(source, property_name, present)`.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]
+pub(crate) struct PropertyPresenceKey {
+    pub(crate) source: TypeId,
+    pub(crate) property_name: Atom,
+    pub(crate) present: bool,
 }
 
 /// RAII guard for one exclusion-narrowing recursion frame.
@@ -274,6 +294,18 @@ impl Drop for NarrowExcludingVisitGuard<'_> {
     }
 }
 
+/// RAII guard for one in-progress `narrow_by_property_presence` key.
+pub(in crate::narrowing) struct PropertyPresenceVisitGuard<'b> {
+    visiting: &'b RefCell<FxHashSet<PropertyPresenceKey>>,
+    key: PropertyPresenceKey,
+}
+
+impl Drop for PropertyPresenceVisitGuard<'_> {
+    fn drop(&mut self) {
+        self.visiting.borrow_mut().remove(&self.key);
+    }
+}
+
 impl NarrowingCache {
     pub fn new() -> Self {
         Self {
@@ -305,6 +337,7 @@ impl NarrowingCache {
             narrow_excluding_depth: Cell::new(0),
             narrow_excluding_fuel: Cell::new(0),
             narrow_excluding_budget: Cell::new(0),
+            property_presence_visiting: RefCell::new(FxHashSet::default()),
         }
     }
 
@@ -525,6 +558,19 @@ impl NarrowingCache {
         }
         Some(NarrowExcludingVisitGuard {
             visiting: &self.narrow_excluding_visiting,
+            key,
+        })
+    }
+
+    pub(in crate::narrowing) fn property_presence_visit_guard(
+        &self,
+        key: PropertyPresenceKey,
+    ) -> Option<PropertyPresenceVisitGuard<'_>> {
+        if !self.property_presence_visiting.borrow_mut().insert(key) {
+            return None;
+        }
+        Some(PropertyPresenceVisitGuard {
+            visiting: &self.property_presence_visiting,
             key,
         })
     }

--- a/crates/tsz-solver/src/narrowing/property.rs
+++ b/crates/tsz-solver/src/narrowing/property.rs
@@ -5,6 +5,7 @@
 //! - Property type lookup for narrowing
 //! - Object-like type detection for instanceof support
 
+use super::cache::PropertyPresenceKey;
 use super::{CachedPropertyType, NarrowingContext};
 use crate::operations::property::PropertyAccessResult;
 use crate::types::{
@@ -78,6 +79,25 @@ impl<'a> NarrowingContext<'a> {
             present
         )
         .entered();
+
+        // Guard against re-entering the same (source, property, present) triple
+        // within this recursive descent. A union constituent can resolve back
+        // to an *ancestor* union already being filtered a few frames up — e.g.
+        // `Record<K, V>` indexed-access can leave a member whose `resolve_type`
+        // re-derives the enclosing alias union instead of a concrete
+        // structural member (#15999). Without this, the nested-union recursion
+        // below re-enters the identical triple forever and overflows the
+        // stack. Re-entry returns the source unchanged, the same conservative
+        // answer `narrow_excluding_type`'s cycle guard uses: the in-flight
+        // outer frame owns the result.
+        let presence_key = PropertyPresenceKey {
+            source: source_type,
+            property_name,
+            present,
+        };
+        let Some(_presence_guard) = self.cache.property_presence_visit_guard(presence_key) else {
+            return source_type;
+        };
 
         // Handle special cases
         if source_type == TypeId::ANY {


### PR DESCRIPTION
Fixes 2 of the 4 unbaselined `tsz-checker` failures from #15999 §1 — the two that abort the whole test process with `SIGABRT: stack overflow`, not merely a wrong diagnostic.

## Structural rule

When a union constituent's resolution re-derives an **ancestor union already being processed in the same recursive descent**, the recursion must stop and hand the unresolved result back to the in-flight outer frame. tsz had no such guard on two independent paths, so `'right' in a` narrowing over a cross-file generic alias indexed through `Record<K, V>` recurses forever and overflows the stack. Repro: `Either<X, A> = Left<X> | Right<A>`, `m: Record<string, Either<X, A>>`, `const a = m[k]; if ('right' in a) { return a.right }`.

Two independent unguarded recursions hit the same underlying residue:

1. **Solver** — `tsz_solver::narrowing::property::narrow_by_property_presence`'s nested-union branch (a member resolves to a nested union, e.g. a generic alias residue) recurses into the resolved member with **no cycle guard**, unlike its sibling `narrow_excluding_type`, which already has exactly this protection (`narrow_excluding_visiting` / `NarrowExcludingVisitGuard` in `narrowing/cache.rs`). Added the same RAII visited-set pattern for this function: a new `PropertyPresenceKey { source, property_name, present }` and `property_presence_visit_guard`. Re-entry on an in-flight key returns the source unchanged — the same conservative answer `narrow_excluding_type`'s cycle guard already uses ("the in-flight outer frame owns the result").

2. **Checker** — `tsz_checker::state::type_environment::lazy::resolve_type_for_property_access` recurses into itself whenever `resolve_union_application_members` reports the union "changed", with **no depth bound on that specific path** — unlike its own `_inner` helper a few lines below, which already tracks `PropertyAccessVisited` and calls `enter_recursion`/`leave_recursion`. Wrapped the self-recursive call with that same shared recursion-depth budget, so a non-converging application-member evaluation bails to the partially-resolved union instead of recursing forever.

Owner layers: (1) is solver narrowing (`crates/tsz-solver/src/narrowing`), a solver-owned relation/narrowing operation; (2) is the checker's `TypeEnvironment` property-access resolution (`crates/tsz-checker/src/state/type_environment`), consistent with `.claude/CLAUDE.md`'s boundary (type semantics in solver or a solver-backed query boundary; the checker's own `TypeEnvironment` owns `DefId -> TypeId` resolution).

Both fixes reuse an **existing, established pattern already in the same file** (RAII visited-set / shared recursion-depth budget) rather than inventing new machinery — no identifier/name/file-string checks, no rendered-type-string predicates.

## Adjacent-case matrix

All 10 cases in `cross_file_in_operator_indexed_element_narrowing_tests.rs` pass, including the 2 that previously crashed:

| receiver shape | binder names | result |
| --- | --- | --- |
| `Array<Either<X,A>>` (2-way union) | default | ok (pre-existing pass) |
| `ReadonlyArray<Either<X,A>>` | default | ok (pre-existing pass) |
| `[Either<X,A>, Either<X,A>]` tuple | default | ok (pre-existing pass) |
| `Record<string, Either<X,A>>` | default | **was SIGABRT, now ok** |
| `Array<These<X,A>>` (3-way union, `Left\|Right\|Both`) | default | **was SIGABRT, now ok** |
| `Array<Either<string, number>>` (concrete, no use-site generics) | default | ok (pre-existing pass) |
| `Array<Result<V,E>>` | renamed (`Ok`/`Fail`/`variant`/`payload`) | ok (pre-existing pass) |
| same-file DU, wrong-branch access | n/a | still reports TS2339 (fix doesn't silence genuine mismatches) |
| same-file DU, genuinely-absent property | n/a | still reports TS2339 |

## Known remaining gap (not in scope here)

Two further pre-existing failures in `generic_call_assignment_flow_tests.rs` (`colliding_generic_terminals_keep_flow_diagnostics_clean_across_file_orders`, `imported_generic_result_narrows_inside_reduce_arrow`) are a **distinct** wrong-diagnostic bug (false `TS18048`) in cross-file generic-call flow / symbol identity — confirmed via `git stash` that they already fail identically on unmodified `main`, unrelated to this fix. Left for separate follow-up; likely adjacent to the `#15983` `SymbolId`/`DefId` identity family already tracked on the board.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- cross_file_in_operator_indexed_element_narrowing_tests --test-threads 1`: **10 passed; 0 failed** (was 8 passed, 2 aborted the whole binary with SIGABRT before this fix).
- `cargo test -p tsz-checker --test generic_call_assignment_flow_tests`: 25 passed, 2 failed — the 2 pre-existing failures above, confirmed via `git stash` to already fail identically on `main` before this diff.
- `cargo test -p tsz-solver --lib`: **7617 passed; 0 failed** (full crate, no regressions from the new cache field/guard).
- `cargo test -p tsz-checker --lib` (full crate): ran through alphabetically to `ts2589_tests` (a pre-existing, unrelated, very slow deep-recursion stress test) without any new failures beyond the one already-confirmed-pre-existing `generic_promise_then_flattens_promise_return_from_callback` (also verified via `git stash` to fail identically on `main`); did not complete the full run end-to-end in-session due to time.
- `cargo clippy --profile ci-lint -p tsz-solver -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-solver -p tsz-checker`: no changes beyond what's in this diff.
- `./scripts/arch/arch_guard.py` (via the repo's pre-commit hook): passed (`lazy.rs` trimmed to 1999 lines, under the 2000-line cap).
- `./scripts/emit/run.sh`: **JS 11562/11563, DTS 1375/1390** — exactly the current floor, no regression.
- Fourslash: **not run** — `./scripts/fourslash/run-fourslash.sh` needs `npx hereby tests --no-bundle` (TypeScript harness build) which this session didn't have time to set up cold; flagging honestly rather than skipping the line. This change touches solver narrowing + checker property-access resolution, not LSP-specific code, so risk is believed low, but this is unverified.
- No conformance run: this is a crash fix on a code path (`Record<K,V>`-indexed `in`-narrowing residue) not currently exercised by the conformance corpus as far as I found; the fixed behavior is additive (previously-aborting cases now resolve) rather than changing any passing diagnostic.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT(4)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UrU35itNnhJEdpjM35FRhz)_