### PR TITLE
fix(emitter): keep generator shape for unannotated generator function-expression initializers

### DIFF
--- a/crates/tsz-checker/src/tests/generator_yield_literal_widening_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_yield_literal_widening_tests.rs
@@ -12,9 +12,14 @@
 //!   callback signature) still widens — generatorTypeCheck63;
 //! - a fresh enum-member access widens to its parent enum.
 //!
-//! `yield*` delegation still collapses the inferred yield type to `any`
-//! (declarations bail in `infer_generator_declaration_yield_type`; expressions
-//! lose the generator shape entirely); that family is tracked separately.
+//! `yield*` delegation in unannotated generator *declarations* still bails
+//! in `infer_generator_declaration_yield_type`, collapsing the inferred
+//! yield type to `any`; that family is tracked separately. Unannotated
+//! generator *expressions* (`const g = function* () { ... }`) used to lose
+//! the entire `Generator<...>` shape in declaration emit, independent of
+//! `yield*` — fixed at the emitter layer (crates/tsz-cli's
+//! `generator_expression_initializer_dts_emit_tests`), since the checker's
+//! own inferred type was already correct.
 
 use crate::context::CheckerOptions;
 use crate::test_utils::{check_source_with_libs, load_default_lib_files};

--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -192,6 +192,10 @@ name = "generator_yield_literal_widening_dts_emit_tests"
 path = "tests/generator_yield_literal_widening_dts_emit_tests.rs"
 
 [[test]]
+name = "generator_expression_initializer_dts_emit_tests"
+path = "tests/generator_expression_initializer_dts_emit_tests.rs"
+
+[[test]]
 name = "declaration_type_walk_boundary_dts_emit_tests"
 path = "tests/declaration_type_walk_boundary_dts_emit_tests.rs"
 

--- a/crates/tsz-cli/tests/generator_expression_initializer_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/generator_expression_initializer_dts_emit_tests.rs
@@ -1,0 +1,204 @@
+//! Pin: an unannotated generator function *expression* assigned to a
+//! variable declaration keeps its `Generator<Y, R, N>` / `AsyncGenerator<...>`
+//! shape in declaration emit (issue #15632).
+//!
+//! `function_expression_type_text_from_ast_at` (the emitter's AST-only
+//! "preferred type text" fallback for unannotated function-expression
+//! initializers) treated a body with no explicit `return` statement as
+//! `void`, with no `func.asterisk_token` check. A generator's return type
+//! comes from `yield` operands the solver aggregates, never from `return`,
+//! so every unannotated generator function expression collapsed to a bare
+//! `() => void` in `.d.ts` output, discarding the generator shape entirely
+//! (not just the yield type) — regardless of whether the body used `yield`,
+//! `yield*`, or nothing at all. Function *declarations* were unaffected:
+//! they emit through a different, generator-aware signature path.
+//!
+//! The fix bails out of the AST-only reconstruction for unannotated
+//! generators and lets the caller fall back to the solver-resolved
+//! signature type, which already builds the correct `Generator<...>`
+//! application (`unannotated_generator_return_type` in the checker).
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_generator_expr_initializer_dts_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+/// Compile `source` with declaration emit and return the generated `.d.ts`
+/// text. Returns `None` when the tsz binary is unavailable (lets the test
+/// self-skip). `lib` selects the `--lib` flag so async-generator fixtures
+/// can request `es2018` while sync fixtures stay on the smaller `es6`.
+fn emit_dts_with_lib(name: &str, source: &str, lib: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let src_path = temp.path.join("repro.ts");
+    std::fs::write(&src_path, source).expect("write repro file");
+
+    let _ = Command::new(tsz_bin)
+        .args([
+            "repro.ts",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--target",
+            "es2015",
+            "--lib",
+            lib,
+            "--pretty",
+            "false",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz declaration emit");
+
+    Some(std::fs::read_to_string(temp.path.join("repro.d.ts")).unwrap_or_default())
+}
+
+fn emit_dts(name: &str, source: &str) -> Option<String> {
+    emit_dts_with_lib(name, source, "es6")
+}
+
+#[track_caller]
+fn assert_dts(name: &str, source: &str, expected: &str) {
+    let Some(dts) = emit_dts(name, source) else {
+        println!("skipping: tsz binary unavailable");
+        return;
+    };
+    assert_eq!(dts.trim_end(), expected.trim_end(), "fixture: {name}");
+}
+
+#[track_caller]
+fn assert_dts_with_lib(name: &str, source: &str, lib: &str, expected: &str) {
+    let Some(dts) = emit_dts_with_lib(name, source, lib) else {
+        println!("skipping: tsz binary unavailable");
+        return;
+    };
+    assert_eq!(dts.trim_end(), expected.trim_end(), "fixture: {name}");
+}
+
+/// Baseline: a plain (non-generator) unannotated function expression with no
+/// `return` statement still correctly infers `void`. The fix must not touch
+/// this case — it only bails out of the AST reconstruction when
+/// `asterisk_token` is set.
+#[test]
+fn plain_function_expression_still_infers_void() {
+    assert_dts(
+        "plain_void",
+        r#"export const plainFn = function () {};
+export const plainArrow = () => {};
+"#,
+        r#"export declare const plainFn: () => void;
+export declare const plainArrow: () => void;"#,
+    );
+}
+
+/// A generator function expression with plain `yield` operands and no
+/// `return` statement must keep the `Generator<...>` shape, not collapse to
+/// `void`.
+#[test]
+fn generator_function_expression_with_yield_keeps_generator_shape() {
+    assert_dts(
+        "yield_shape",
+        r#"export const counter = function* () { yield 1; yield 2; };
+"#,
+        r#"export declare const counter: () => Generator<1 | 2, void, unknown>;"#,
+    );
+}
+
+/// An empty generator body (no `yield`, no `return`) must still produce
+/// `Generator<never, void, unknown>`, not `void` — this is the shape most
+/// directly falsified by the old `body_returns_void` shortcut, since an
+/// empty body trivially "returns void" syntactically.
+#[test]
+fn empty_generator_function_expression_keeps_generator_shape() {
+    assert_dts(
+        "empty_body",
+        r#"export const empty = function* () {};
+"#,
+        r#"export declare const empty: () => Generator<never, void, unknown>;"#,
+    );
+}
+
+/// `yield*` delegating to an array must still infer the delegated element
+/// type through the generator wrapper.
+#[test]
+fn generator_function_expression_with_yield_star_keeps_generator_shape() {
+    assert_dts(
+        "yield_star",
+        r#"export const delegated = function* () { yield* [1, 2, 3]; };
+"#,
+        r#"export declare const delegated: () => Generator<number, void, unknown>;"#,
+    );
+}
+
+/// Async generator function expressions must keep the `AsyncGenerator<...>`
+/// shape, mirroring the sync case (`func.is_async && func.asterisk_token`).
+#[test]
+fn async_generator_function_expression_keeps_generator_shape() {
+    assert_dts_with_lib(
+        "async_generator",
+        r#"export const asyncGen = async function* () { yield 1; };
+"#,
+        "es2018",
+        r#"export declare const asyncGen: () => AsyncGenerator<number, void, unknown>;"#,
+    );
+}
+
+/// Adjacent case: renaming the binder must not change the shape (rules out
+/// any accidental name-keyed behavior per the anti-hardcoding gate).
+#[test]
+fn renamed_binder_generator_function_expression_keeps_generator_shape() {
+    assert_dts(
+        "renamed_binder",
+        r#"export const totallyDifferentName = function* () { yield "a"; yield "b"; };
+"#,
+        r#"export declare const totallyDifferentName: () => Generator<"a" | "b", void, unknown>;"#,
+    );
+}
+
+/// A function *declaration* (not an expression assigned to a variable) was
+/// already correct before this fix — it emits through a different,
+/// generator-aware signature path. Pinned here as a control so a future
+/// regression in the declaration path is caught by the same file.
+#[test]
+fn generator_function_declaration_keeps_generator_shape() {
+    assert_dts(
+        "declaration_control",
+        r#"export function* counterDecl() { yield 1; yield 2; }
+"#,
+        r#"export declare function counterDecl(): Generator<1 | 2, void, unknown>;"#,
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -583,6 +583,20 @@ impl<'a> DeclarationEmitter<'a> {
         {
             scratch.emit_type_parameters(type_params);
         }
+        // An unannotated generator's return type is `Generator<Y, R, N>` (or
+        // `AsyncGenerator<...>`), where `Y` comes from `yield` operands the
+        // solver already aggregated during checking, not from `return`
+        // statements. This AST-only reconstruction only ever looks at
+        // `return`, so `body_returns_void` below would collapse any
+        // no-explicit-return generator body (including ones that only
+        // `yield`) to a bare `void`, discarding the generator shape
+        // entirely. Bail out and let the caller fall back to the
+        // solver-resolved signature type, which already builds the correct
+        // `Generator<...>` application (`unannotated_generator_return_type`
+        // in the checker).
+        if func.type_annotation.is_none() && func.asterisk_token {
+            return None;
+        }
         scratch.write("(");
         scratch.emit_parameters_with_body(&func.parameters, func.body);
         scratch.write(") => ");


### PR DESCRIPTION
When an exported `const g = function* () { ... }` (or `async function* () { ... }`) has no return-type annotation, `.d.ts` emit collapsed it to a bare `() =&gt; void`, discarding the generator shape entirely — for *any* unannotated generator function expression whose body has no explicit `return` statement, which is every plain generator body (generators produce values through `yield`, not `return`).

Structural rule: when an unannotated generator function *expression* is the initializer of a declaration needing a synthesized `.d.ts` type, tsc emits `Generator&lt;Y, R, N&gt;`/`AsyncGenerator&lt;Y, R, N&gt;`; tsz's checker already computed that type correctly (`unannotated_generator_return_type`), but the declaration emitter's separate AST-only "preferred type text" reconstruction (`function_expression_type_text_from_ast_at` in `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs`) inferred `"void"` from `body_returns_void` with no `func.asterisk_token` check, and that text silently overrode the correct solver-resolved type in `declaration_emittable_type_text`. Function *declarations* were unaffected — they emit through a separate, generator-aware signature path (confirmed with a `function*` declaration control case in the new test file).

Root-caused with `resolve_declaration_type_text` tracing: the checker's cached type for the declaration was already `() =&gt; Generator&lt;number, void, unknown&gt;` (proved via `wants(g1())`-style internal assignability, which passed with zero diagnostics even while the emitted `.d.ts` said `() =&gt; void`), so this is a pure emitter-layer bug, not a checker/solver semantic gap.

This is a superset of what #15632 reported for `yield*`: the shape loss reproduces for any unannotated generator function expression — plain `yield`, `yield*`, or even an empty body. `yield*` was incidental to how the issue's repro was constructed; bisecting down showed `export const g3 = function* () {};` alone (no yield at all) already collapsed to `() =&gt; void`.

Not fixed by this PR (separate, deeper gap, left for #15632): the `yield*`-delegation yield-*type* aggregation itself. With this fix, `export const relayE = function* () { yield* src(); }` (delegating to `declare function src(): Generator;`) now correctly shows `() =&gt; Generator&lt;never, void, unknown&gt;` instead of `() =&gt; void` — the shape is right — but the yield type should reflect the delegated operand rather than collapsing to `never`. That's a checker/solver-level gap (iterator-info resolution during the generator body pre-check), out of scope here per one-invariant-per-PR.

## Goal
Goal: hold

## Adjacent cases covered (new test file `crates/tsz-cli/tests/generator_expression_initializer_dts_emit_tests.rs`)
- plain (non-generator) function expression/arrow still infers `void` (control — proves the fix is scoped to `asterisk_token`)
- generator function expression with plain `yield` operands
- empty generator body (no `yield`, no `return`) — the shape most directly falsified by the old `body_returns_void` shortcut
- `yield*` delegating to an array
- async generator function expression
- renamed binder (anti-hardcoding control)
- generator function *declaration* (control — already correct, unaffected by this change)

## Verification
- `cargo test -p tsz-cli --test generator_expression_initializer_dts_emit_tests`: 7/7 passed (new)
- `cargo test -p tsz-cli --test generator_yield_star_dts_emit_tests --test generator_yield_inference_dts_emit_tests --test generator_yield_literal_widening_dts_emit_tests --test declaration_type_walk_boundary_dts_emit_tests --test const_assertion_dts_emit_tests --test recursive_const_arrow_dts_emit_tests --test inferred_object_index_signature_dts_emit_tests --test inferred_function_value_apparent_member_return_dts_emit_tests`: 66/66 passed, 0 failed (no regressions in adjacent dts-emit families)
- `cargo clippy --profile ci-lint -p tsz-emitter -p tsz-cli --all-targets -- -D warnings`: clean
- `python3 scripts/arch/arch_guard.py`: passed
- `cargo fmt --check`: clean
- Manual CLI repro before/after (`--declaration --emitDeclarationOnly`):
  - before: `export declare const relayE: () =&gt; void;`
  - after: `export declare const relayE: () =&gt; Generator&lt;never, void, unknown&gt;;`
- Not run (time-boxed hourly session; cold container's `npm install` for the `scripts/` tsc-oracle harness hung with zero progress, a known environment gotcha — killed rather than waited on): full `conformance.sh` snapshot, `scripts/emit/run.sh`, fourslash. This change touches only the declaration-emitter's function-expression-initializer text-reconstruction path (not the checker/solver), scoped to unannotated generator function expressions specifically, with 66 passing adjacent dts-emit tests as a proxy; a full conformance/emit run before merge is still owed and recommended.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE