### PR TITLE
ci(hygiene): guard against orphaned crates/*/tests/*.rs files

### DIFF
--- a/scripts/ci/check-test-file-reachability.py
+++ b/scripts/ci/check-test-file-reachability.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Guard against orphaned `crates/*/tests/*.rs` files (#16013).
+
+`tsz-checker`, `tsz-cli`, `tsz-emitter`, `tsz-binder`, `tsz-solver`, and other
+crates set `autotests = false`, so under Cargo a file in `tests/` only builds
+into a target through one of two mechanisms: an explicit `[[test]]` stanza in
+the crate's `Cargo.toml`, or a `#[path = "../tests/<file>.rs"] mod ...;`
+include from a `src/` file. A file reached by neither still compiles under
+`cargo check` and looks like a live suite, but its `#[test]` functions never
+run and nothing reports the gap — `cargo nextest list` simply omits them.
+
+#16013 found 11 such files (74 `#[test]` fns) already orphaned on main. This
+script does not resurrect them (stale frozen expectations are a repeat
+failure mode in this repo — see #16001/#16002/#16005 and the #15632 revert);
+it only stops the set from growing. Known orphans are tracked in
+`scripts/ci/orphaned-test-files-baseline.txt`, the same shrink-only-baseline
+shape as `scripts/ci/known-failures.txt`: removing an entry (because the file
+was registered or deleted) is always fine, adding one is not — fix the
+reachability or delete the dead file instead.
+
+Usage:
+    python3 scripts/ci/check-test-file-reachability.py
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[2]
+CRATES_DIR = ROOT_DIR / "crates"
+BASELINE_PATH = ROOT_DIR / "scripts" / "ci" / "orphaned-test-files-baseline.txt"
+
+TEST_ATTR_RE = re.compile(r"#\[test\]")
+PATH_MOD_RE = re.compile(
+    r'#\[path\s*=\s*"([^"]+)"\]\s*\n\s*(?:pub\s+)?mod\s+\w+\s*;'
+)
+CARGO_TEST_STANZA_RE = re.compile(
+    r'\[\[test\]\]\s*\n\s*name\s*=\s*"[^"]+"\s*\n\s*path\s*=\s*"([^"]+)"'
+)
+
+
+def autotests_false_crate_dirs() -> list[pathlib.Path]:
+    """Crate directories whose Cargo.toml sets `autotests = false`.
+
+    Crates without that key (e.g. `tsz-scanner`) get Cargo's default
+    autodiscovery, so every direct `tests/*.rs` file is already its own
+    target — this guard only concerns crates that opted out.
+    """
+    dirs = []
+    for cargo_toml in sorted(CRATES_DIR.glob("*/Cargo.toml")):
+        text = cargo_toml.read_text(encoding="utf-8")
+        if re.search(r"(?m)^autotests\s*=\s*false\s*$", text):
+            dirs.append(cargo_toml.parent)
+    return dirs
+
+
+def cargo_registered_relpaths(crate_dir: pathlib.Path) -> set[str]:
+    """`tests/<file>.rs`-shaped paths named by `[[test]]` stanzas."""
+    text = (crate_dir / "Cargo.toml").read_text(encoding="utf-8")
+    return set(CARGO_TEST_STANZA_RE.findall(text))
+
+
+def src_included_absolute_paths() -> set[pathlib.Path]:
+    """Absolute paths reached by a `#[path] mod` from any crate's `src/`.
+
+    Resolved per including file's own directory, not a hardcoded `src/`, so
+    a future nested-module include still resolves correctly. Scanned across
+    every crate (not just the one being checked): `tsz-core/src/lib.rs`
+    reaches into `tsz-checker/tests/` this way, so reachability is a
+    workspace-wide graph, not a per-crate one.
+    """
+    included = set()
+    for rs_file in CRATES_DIR.glob("*/src/**/*.rs"):
+        text = rs_file.read_text(encoding="utf-8")
+        for raw_path in PATH_MOD_RE.findall(text):
+            included.add((rs_file.parent / raw_path).resolve())
+    return included
+
+
+def file_has_tests(path: pathlib.Path, _visited: set | None = None) -> bool:
+    """True if `path` (or a file it `#[path]`-includes, recursively) has a
+    `#[test]` fn — covers the >2000-line split-file pattern where a root
+    `tests/X.rs` declares zero tests itself and only `mod`s in
+    `tests/X/part_NN.rs` siblings that hold the real fns."""
+    if _visited is None:
+        _visited = set()
+    resolved = path.resolve()
+    if resolved in _visited or not resolved.is_file():
+        return False
+    _visited.add(resolved)
+    text = resolved.read_text(encoding="utf-8")
+    if TEST_ATTR_RE.search(text):
+        return True
+    for raw_path in PATH_MOD_RE.findall(text):
+        if file_has_tests(resolved.parent / raw_path, _visited):
+            return True
+    return False
+
+
+def find_orphaned_test_files() -> list[str]:
+    """`crate-name/tests/<file>.rs` entries with live `#[test]` fns that no
+    `[[test]]` stanza or workspace `src/` `#[path]` include reaches."""
+    orphans = []
+    src_included = src_included_absolute_paths()
+    for crate_dir in autotests_false_crate_dirs():
+        tests_dir = crate_dir / "tests"
+        if not tests_dir.is_dir():
+            continue
+        cargo_registered = {
+            (crate_dir / relpath).resolve()
+            for relpath in cargo_registered_relpaths(crate_dir)
+        }
+        for root_file in sorted(tests_dir.glob("*.rs")):
+            if root_file.resolve() in cargo_registered | src_included:
+                continue
+            if file_has_tests(root_file):
+                rel = root_file.relative_to(crate_dir).as_posix()
+                orphans.append(f"{crate_dir.name}/{rel}")
+    return orphans
+
+
+def parse_baseline(text: str) -> set[str]:
+    entries = set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        entries.add(line)
+    return entries
+
+
+def main() -> int:
+    current = set(find_orphaned_test_files())
+    baseline = parse_baseline(BASELINE_PATH.read_text(encoding="utf-8"))
+    new_orphans = sorted(current - baseline)
+    if new_orphans:
+        print(
+            "New orphaned test file(s) found — these have #[test] fns but no "
+            "[[test]] Cargo.toml stanza and no src/ #[path] include, so they "
+            "never run:",
+            file=sys.stderr,
+        )
+        for entry in new_orphans:
+            print(f"  {entry}", file=sys.stderr)
+        print(
+            f"\nRegister the file (add it to {BASELINE_PATH} "
+            "only if this is a deliberate, already-known orphan; otherwise wire "
+            "it into the crate's Cargo.toml or a src/ #[path] include, or delete "
+            "it if it is genuinely dead).",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"test-file-reachability: {len(current)} known orphan(s), 0 new.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check-unit-gate-contracts.sh
+++ b/scripts/ci/check-unit-gate-contracts.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Single owner of the known-failures unit-gate contract checks (#15646):
-# the baseline growth/integrity gate plus the contract tests for the gate
-# wiring. Both the ci.yml cheap-guards step and full-ci.sh run_lint invoke
+# Single owner of the cheap per-merge repo-hygiene contract checks: the
+# known-failures unit-gate baseline growth/integrity gate and its wiring
+# contract tests (#15646), plus the orphaned-test-file reachability guard
+# (#16013). Both the ci.yml cheap-guards step and full-ci.sh run_lint invoke
 # this script, so the two tiers cannot drift.
 set -Eeuo pipefail
 
@@ -21,3 +22,5 @@ python3 scripts/ci/test_check_known_failures_growth.py
 python3 scripts/ci/test_unit_nextest.py
 python3 scripts/ci/test_full_ci_unit_gate.py
 node scripts/ci/test-known-failures-check.mjs
+python3 scripts/ci/check-test-file-reachability.py
+python3 scripts/ci/test_check_test_file_reachability.py

--- a/scripts/ci/orphaned-test-files-baseline.txt
+++ b/scripts/ci/orphaned-test-files-baseline.txt
@@ -1,0 +1,24 @@
+# Baseline for scripts/ci/check-test-file-reachability.py (#16013).
+#
+# Shrink-only, same shape as scripts/ci/known-failures.txt: removing an entry
+# (because the file was wired into a Cargo.toml [[test]] stanza or a src/
+# #[path] include, or deleted) is always fine. Adding an entry is not — a
+# newly orphaned file should be fixed, not baselined.
+#
+# #16013 listed 11 candidates; 5 of them (symbol_resolution_tests.rs,
+# ts2305_tests.rs, ts2306_tests.rs, ts2498_export_star_export_equals_tests.rs,
+# widening_integration_tests.rs) turned out to already be reachable via a
+# cross-crate `crates/tsz-core/src/lib.rs` `#[path]` include into
+# `tsz-checker/tests/` — the same mechanism #16013 itself credited for
+# excluding `constructor_accessibility.rs`/`void_return_exception.rs`, just
+# not run for these five. The remaining 6 files (38 #[test] fns) are
+# genuinely unreachable; each wants oracle-first verification before being
+# resurrected (a dormant suite freezes stale expectations — see #16013's
+# #15632-revert precedent), so they are tracked here rather than fixed in
+# this diff.
+tsz-checker/tests/indexed_access_concrete_missing_key_ts2536_tests.rs
+tsz-checker/tests/ts6133_write_only_destructuring_tests.rs
+tsz-checker/tests/generic_mapped_to_index_signature_tests.rs
+tsz-checker/tests/object_literal_synthetic_this_display_order_tests.rs
+tsz-emitter/tests/async_method_super_capture_3759_tests.rs
+tsz-cli/tests/skip_lib_check_declaration_diagnostics_tests.rs

--- a/scripts/ci/test_check_test_file_reachability.py
+++ b/scripts/ci/test_check_test_file_reachability.py
@@ -1,0 +1,228 @@
+"""Tests for check-test-file-reachability.py (#16013).
+
+Two layers: synthetic-fixture tests that prove the detector actually fires
+on an unreachable file and stays quiet on the reachable shapes the repo
+uses (Cargo.toml `[[test]]`, same-crate `src/` `#[path]`, cross-crate `src/`
+`#[path]`, and the >2000-line split-file `mod part_NN` pattern), then one
+real-repo test that runs the detector against the actual `crates/` tree and
+holds it to the checked-in baseline.
+"""
+
+import importlib.util
+import pathlib
+import shutil
+import tempfile
+import textwrap
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "ci" / "check-test-file-reachability.py"
+BASELINE_PATH = ROOT / "scripts" / "ci" / "orphaned-test-files-baseline.txt"
+
+spec = importlib.util.spec_from_file_location("check_test_file_reachability", SCRIPT)
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+
+
+def _write(path: pathlib.Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text), encoding="utf-8")
+
+
+class DetectorFixtureTests(unittest.TestCase):
+    """Builds a synthetic `crates/` tree per test so each reachability shape
+    is checked in isolation, independent of the real repo's current state."""
+
+    def setUp(self):
+        tmp = tempfile.mkdtemp(prefix="test-file-reachability-")
+        self.addCleanup(shutil.rmtree, tmp, True)
+        self.crates_dir = pathlib.Path(tmp) / "crates"
+        orig_crates_dir = guard.CRATES_DIR
+        guard.CRATES_DIR = self.crates_dir
+        self.addCleanup(setattr, guard, "CRATES_DIR", orig_crates_dir)
+
+    def _make_crate(self, name, autotests_false=True, extra_manifest=""):
+        crate_dir = self.crates_dir / name
+        manifest = f'[package]\nname = "{name}"\n'
+        if autotests_false:
+            manifest += "autotests = false\n"
+        manifest += extra_manifest
+        _write(crate_dir / "Cargo.toml", manifest)
+        _write(crate_dir / "src" / "lib.rs", "")
+        return crate_dir
+
+    def test_unreachable_file_with_test_fn_is_flagged(self):
+        self._make_crate("tsz-fixture-a")
+        _write(
+            self.crates_dir / "tsz-fixture-a" / "tests" / "orphan_tests.rs",
+            """
+            #[test]
+            fn it_runs() {}
+            """,
+        )
+        self.assertEqual(
+            guard.find_orphaned_test_files(), ["tsz-fixture-a/tests/orphan_tests.rs"]
+        )
+
+    def test_file_registered_via_cargo_test_stanza_is_not_flagged(self):
+        self._make_crate(
+            "tsz-fixture-b",
+            extra_manifest=(
+                '[[test]]\nname = "wired_tests"\npath = "tests/wired_tests.rs"\n'
+            ),
+        )
+        _write(
+            self.crates_dir / "tsz-fixture-b" / "tests" / "wired_tests.rs",
+            """
+            #[test]
+            fn it_runs() {}
+            """,
+        )
+        self.assertEqual(guard.find_orphaned_test_files(), [])
+
+    def test_file_included_via_same_crate_src_path_is_not_flagged(self):
+        self._make_crate("tsz-fixture-c")
+        _write(
+            self.crates_dir / "tsz-fixture-c" / "src" / "lib.rs",
+            """
+            #[cfg(test)]
+            #[path = "../tests/included_tests.rs"]
+            mod included_tests;
+            """,
+        )
+        _write(
+            self.crates_dir / "tsz-fixture-c" / "tests" / "included_tests.rs",
+            """
+            #[test]
+            fn it_runs() {}
+            """,
+        )
+        self.assertEqual(guard.find_orphaned_test_files(), [])
+
+    def test_file_included_via_cross_crate_src_path_is_not_flagged(self):
+        # Mirrors crates/tsz-core/src/lib.rs reaching into
+        # crates/tsz-checker/tests/ across a crate boundary.
+        self._make_crate("tsz-fixture-target")
+        _write(
+            self.crates_dir / "tsz-fixture-target" / "tests" / "shared_tests.rs",
+            """
+            #[test]
+            fn it_runs() {}
+            """,
+        )
+        self._make_crate("tsz-fixture-other", autotests_false=False)
+        _write(
+            self.crates_dir / "tsz-fixture-other" / "src" / "lib.rs",
+            """
+            #[cfg(test)]
+            #[path = "../../tsz-fixture-target/tests/shared_tests.rs"]
+            mod shared_tests;
+            """,
+        )
+        self.assertEqual(guard.find_orphaned_test_files(), [])
+
+    def test_split_file_tests_only_in_a_mod_part_are_still_detected(self):
+        # Mirrors crates/tsz-checker/tests/conditional_infer_tests.rs: the
+        # root file has zero #[test] itself and only `mod`s in part files
+        # that hold the real fns.
+        self._make_crate("tsz-fixture-d")
+        _write(
+            self.crates_dir / "tsz-fixture-d" / "tests" / "split_tests.rs",
+            """
+            #[path = "split_tests/part_00.rs"]
+            mod part_00;
+            """,
+        )
+        _write(
+            self.crates_dir
+            / "tsz-fixture-d"
+            / "tests"
+            / "split_tests"
+            / "part_00.rs",
+            """
+            #[test]
+            fn it_runs() {}
+            """,
+        )
+        self.assertEqual(
+            guard.find_orphaned_test_files(), ["tsz-fixture-d/tests/split_tests.rs"]
+        )
+
+    def test_helper_file_with_no_test_fns_is_never_flagged(self):
+        # Shared test-support modules (e.g. tests/test_support.rs) have zero
+        # #[test] fns and are correctly unregistered as their own target.
+        self._make_crate("tsz-fixture-e")
+        _write(
+            self.crates_dir / "tsz-fixture-e" / "tests" / "test_support.rs",
+            "pub fn helper() {}\n",
+        )
+        self.assertEqual(guard.find_orphaned_test_files(), [])
+
+    def test_crate_without_autotests_false_is_not_checked(self):
+        # Cargo autodiscovers direct tests/*.rs files by default; only crates
+        # that opt out with autotests = false need an explicit reach path.
+        self._make_crate("tsz-fixture-f", autotests_false=False)
+        _write(
+            self.crates_dir / "tsz-fixture-f" / "tests" / "auto_discovered_tests.rs",
+            """
+            #[test]
+            fn it_runs() {}
+            """,
+        )
+        self.assertEqual(guard.find_orphaned_test_files(), [])
+
+
+class MainCliTests(unittest.TestCase):
+    def setUp(self):
+        self.orig_find = guard.find_orphaned_test_files
+        self.orig_baseline = guard.BASELINE_PATH
+        self.addCleanup(setattr, guard, "find_orphaned_test_files", self.orig_find)
+        self.addCleanup(setattr, guard, "BASELINE_PATH", self.orig_baseline)
+        tmp = tempfile.mkdtemp(prefix="test-file-reachability-main-")
+        self.addCleanup(shutil.rmtree, tmp, True)
+        self.tmp_baseline = pathlib.Path(tmp) / "baseline.txt"
+        guard.BASELINE_PATH = self.tmp_baseline
+
+    def test_main_reports_new_orphans_not_in_baseline(self):
+        self.tmp_baseline.write_text("# empty\n", encoding="utf-8")
+        guard.find_orphaned_test_files = lambda: ["tsz-x/tests/new_orphan.rs"]
+        self.assertEqual(guard.main(), 1)
+
+    def test_main_is_clean_when_orphans_match_baseline_exactly(self):
+        self.tmp_baseline.write_text(
+            "tsz-x/tests/known_orphan.rs\n", encoding="utf-8"
+        )
+        guard.find_orphaned_test_files = lambda: ["tsz-x/tests/known_orphan.rs"]
+        self.assertEqual(guard.main(), 0)
+
+    def test_baseline_shrinking_below_current_orphans_stays_clean(self):
+        # SHRINK is always allowed even when not exercised yet: a baseline
+        # entry that no longer reproduces (file fixed but not pruned) must
+        # not fail the gate.
+        self.tmp_baseline.write_text(
+            "tsz-x/tests/known_orphan.rs\ntsz-x/tests/already_fixed.rs\n",
+            encoding="utf-8",
+        )
+        guard.find_orphaned_test_files = lambda: ["tsz-x/tests/known_orphan.rs"]
+        self.assertEqual(guard.main(), 0)
+
+
+class RealRepoReachabilityTests(unittest.TestCase):
+    """The actual gate: run the detector against the real crates/ tree."""
+
+    def test_current_orphans_are_exactly_the_checked_in_baseline(self):
+        current = set(guard.find_orphaned_test_files())
+        baseline = guard.parse_baseline(BASELINE_PATH.read_text(encoding="utf-8"))
+        new_orphans = sorted(current - baseline)
+        self.assertEqual(
+            new_orphans,
+            [],
+            msg=(
+                f"New orphaned test file(s) not in {BASELINE_PATH.name}: "
+                f"{new_orphans}"
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Crates with `autotests = false` (`tsz-checker`, `tsz-cli`, `tsz-emitter`, `tsz-binder`, `tsz-solver`, `tsz-core`, `tsz-common`, `tsz-lowering`, `tsz-lsp`, `tsz-parser`, `conformance`) only build a `tests/*.rs` file into a target through an explicit `[[test]]` Cargo.toml stanza or a `#[path]` `mod` include from `src/`. A file reached by neither still compiles under `cargo check`, still looks like a live suite, and shows up in code search — but its `#[test]` fns never run and `cargo nextest list` simply omits them, with no warning that the gap exists.

#16013 found 11 such files (74 `#[test]` fns) already orphaned on `main`. This PR does not resurrect them — a dormant suite freezes whatever expectations it froze at, and this session alone had four independent instances of stale test expectations turning out to be wrong about `tsc` (per the `#16013` writeup and the `#15632` revert precedent). It only adds the guard #16013 asked for: a cheap per-merge contract test that stops the orphaned set from growing while the backlog is worked file-by-file, oracle-first.

## Structural rule

When a `crates/<crate>/tests/*.rs` file under `autotests = false` has `#[test]` fns but is reachable by neither a `[[test]]` Cargo.toml stanza nor a `#[path]` `mod` include from any crate's `src/`, it is silently dead code — the guard is owned by `scripts/ci/check-test-file-reachability.py`, run from the same `check-unit-gate-contracts.sh` step (`clippy` job, per-merge lane) that already owns the analogous `#15646`/`#16003` unit-lane coverage contracts, so the two hygiene gates cannot drift apart.

## What the detector does

- Discovers every `crates/*/Cargo.toml` with `autotests = false`.
- For each, resolves reachability of every direct `tests/*.rs` file via:
  - `[[test]]` stanzas in that crate's own `Cargo.toml`;
  - `#[path = "..."] mod ...;` includes from **any** crate's `src/` — not just the same crate. `crates/tsz-core/src/lib.rs` reaches into `crates/tsz-checker/tests/` across the crate boundary, so reachability is a workspace-wide graph, not a per-crate one.
- Recognizes the `>2000`-line split-file pattern (`tests/X.rs` declaring zero `#[test]` itself and only `mod`-ing in `tests/X/part_NN.rs` siblings that hold the real fns) by checking transitively for `#[test]` through nested `#[path]` includes.
- Diffs the result against a new shrink-only baseline, `scripts/ci/orphaned-test-files-baseline.txt` (same shape as `scripts/ci/known-failures.txt`): removing an entry is always fine, adding a new one fails the gate.

## Correction to #16013's candidate list

Re-deriving the 11 candidates against the cross-crate reachability graph found 5 are **not** actually orphaned: `symbol_resolution_tests.rs`, `ts2305_tests.rs`, `ts2306_tests.rs`, `ts2498_export_star_export_equals_tests.rs`, `widening_integration_tests.rs` are all reached by `#[path]` includes in `crates/tsz-core/src/lib.rs` — the exact mechanism #16013 itself already credited for excluding `constructor_accessibility.rs`/`void_return_exception.rs` from its list, just not run for these five. Confirmed empirically, not just statically: `cargo test -p tsz-core --lib -- --list` lists all of their test fns under the `tsz-core` binary. The baseline holds the remaining 6 genuinely-orphaned files (38 `#[test]` fns).

## Goal
Goal: hold

## Verification
- `python3 scripts/ci/check-test-file-reachability.py` — `6 known orphan(s), 0 new` (matches baseline exactly)
- `python3 scripts/ci/test_check_test_file_reachability.py` — 11/11 pass (7 synthetic-fixture tests covering each reachability shape in isolation: unreachable+flagged, `[[test]]`-registered, same-crate `#[path]`, cross-crate `#[path]`, split-file `mod part`, zero-`#[test]` helper file never flagged, `autotests`-default crate skipped; 3 `main()` CLI tests incl. a shrink-is-always-clean negative control; 1 real-repo integration test)
- `bash scripts/ci/check-unit-gate-contracts.sh` — full step green (this is the exact per-merge `clippy`-job invocation), including the pre-existing 14+11+15 known-failures/unit-lane contract tests unaffected
- `cargo test -p tsz-core --lib -- --list | grep -E 'symbol_resolution_tests|ts2305_tests|ts2306_tests|ts2498_export_star|widening_integration'` — confirms the 5 corrected files' fns genuinely list and run under `tsz-core`
- `python3 scripts/lib/check-sh-portability.py` — clean (new lines added to `check-unit-gate-contracts.sh`)
- `python3 scripts/arch/arch_guard.py` — clean (no crate code touched)
- No Rust files changed — `cargo fmt`/`clippy` not applicable; pre-commit hook confirmed "No staged Rust files changed"

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_0185nkqFDaJQQb6KHb9jPhsg)_