### PR TITLE
fix(checker): treat an any-typed sibling argument as type-param evidence

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1314,6 +1314,9 @@ path = "tests/issue_3768_generic_callback_outer_inference_tests.rs"
 name = "issue_7653_parameterless_lambda_inference_tests"
 path = "tests/issue_7653_parameterless_lambda_inference_tests.rs"
 [[test]]
+name = "issue_16012_any_argument_type_param_evidence_tests"
+path = "tests/issue_16012_any_argument_type_param_evidence_tests.rs"
+[[test]]
 name = "issue_9692_function_candidate_inference"
 path = "tests/issue_9692_function_candidate_inference.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs
@@ -209,8 +209,13 @@ impl<'a> CheckerState<'a> {
             .get(other_index)
             .copied()
             .unwrap_or(TypeId::UNKNOWN);
-        if other_arg_type == TypeId::ANY
-            || other_arg_type == TypeId::UNKNOWN
+        // `any` is a fully resolved, deliberate type: `tsc` infers the shared
+        // type parameter as `any` from an `any`-typed sibling argument (the
+        // same candidate Round 1 inference already computes), so it counts as
+        // evidence like any other concrete type. Only `unknown`/`error`/still
+        // resolving (`infer`-containing) sibling types are genuinely
+        // uninformative and must not gate off this diagnostic.
+        if other_arg_type == TypeId::UNKNOWN
             || other_arg_type == TypeId::ERROR
             || common::contains_infer_types(self.ctx.types, other_arg_type)
         {

--- a/crates/tsz-checker/tests/issue_16012_any_argument_type_param_evidence_tests.rs
+++ b/crates/tsz-checker/tests/issue_16012_any_argument_type_param_evidence_tests.rs
@@ -1,0 +1,124 @@
+//! Regression tests for [issue #16012]: an `any`-typed sibling argument must
+//! count as inference evidence for a shared, unconstrained type parameter.
+//!
+//! Structural rule: when a generic call's only inference candidate for an
+//! unconstrained type parameter is `any` (from an `any`-typed sibling
+//! argument), `tsc` fixes the parameter to `any` before contextually typing a
+//! context-sensitive callback argument that mentions it. tsz's post-generic
+//! `emit_uninferred_callback_unknown_body_diagnostics` recheck
+//! (`argument_provides_type_param_evidence`,
+//! `crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs`)
+//! excluded `TypeId::ANY` from counting as evidence, alongside the genuinely
+//! uninformative `unknown`/`error`/still-resolving cases. That made the
+//! recheck conclude the type parameter had no evidence, default it to
+//! `unknown` (no constraint), and re-check the callback body against that
+//! defaulted type — surfacing a spurious `TS18046` even though Round 1
+//! inference had already correctly fixed the parameter to `any`.
+//!
+//! [issue #16012]: https://github.com/tsz-org/tsz/issues/16012
+
+fn compile_and_get_diagnostics(source: &str) -> Vec<(u32, String)> {
+    tsz_checker::test_utils::check_source_code_messages(source)
+}
+
+fn assert_no_ts18046(diagnostics: &[(u32, String)], context: &str) {
+    assert!(
+        diagnostics.iter().all(|(code, _)| *code != 18046),
+        "Did not expect TS18046 in {context}. Got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn any_seed_argument_seeds_type_param_for_sibling_callback() {
+    // Minimal repro from #16012.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function ap<I>(seed: I, use: (v: I) => void): void;
+declare var anyVal: any;
+ap(anyVal, item => { item.field; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "any-seed callback param evidence");
+}
+
+#[test]
+fn any_seed_seeds_type_param_with_renamed_binder() {
+    // Same shape with `J`/`use`/`v` renamed — proves the rule is structural,
+    // not keyed on a specific identifier.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function apply<J>(x: J, run: (w: J) => void): void;
+declare var dyn: any;
+apply(dyn, w => { w.member; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "renamed type parameter `J`");
+}
+
+#[test]
+fn any_seed_via_property_access_seeds_type_param() {
+    // The `any`-typed sibling need not be a bare identifier.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function ap<I>(seed: I, use: (v: I) => void): void;
+declare var holder: { inner: any };
+ap(holder.inner, item => { item.field; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "any via property access");
+}
+
+#[test]
+fn any_seed_with_type_param_in_return_position_seeds_type_param() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function ap2<I>(seed: I, use: (v: I) => void): I;
+declare var anyVal: any;
+ap2(anyVal, item => { item.field; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "type param also in return position");
+}
+
+#[test]
+fn any_seed_with_callback_listed_first_seeds_type_param() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function ap3<I>(use: (v: I) => void, seed: I): void;
+declare var anyVal: any;
+ap3(item => { item.field; }, anyVal);
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "callback argument listed before seed");
+}
+
+#[test]
+fn any_seed_with_second_type_param_seeds_type_param() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function ap6<I, O>(seed: I, use: (v: I) => O): O;
+declare var anyVal: any;
+ap6(anyVal, item => { item.field; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "second, return-only type param");
+}
+
+#[test]
+fn unknown_and_error_siblings_still_do_not_count_as_evidence() {
+    // Negative control: an `unknown`-typed sibling must NOT seed the type
+    // parameter, so the genuinely-uninferred recheck still fires. This locks
+    // in that only `TypeId::ANY` moved, not the `unknown`/`error` cases.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function ap<I>(seed: I, use: (v: I) => void): void;
+declare var unknownVal: unknown;
+ap(unknownVal, item => { item.field; });
+"#,
+    );
+    assert!(
+        diagnostics.iter().any(|(code, _)| *code == 18046),
+        "Expected TS18046 for an unknown-typed seed (no real evidence for `I`). \
+         Got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
Fixes #16012.

When a generic call's only inference candidate for an unconstrained type parameter is `any` (from an `any`-typed sibling argument), `tsc` fixes the parameter to `any` before contextually typing a context-sensitive callback argument that mentions it; tsz does this through Round 1 inference (`round1_instantiated_params`) — which already computes the correct substitution — but the post-generic `emit_uninferred_callback_unknown_body_diagnostics` recheck (`crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs`) independently re-derives whether the type parameter has "evidence" via `argument_provides_type_param_evidence`, and that helper excluded `TypeId::ANY` from counting as evidence alongside the genuinely uninformative `unknown`/`error`/still-resolving cases. That made it conclude the type parameter had no evidence, default it to `unknown` (no constraint), clear the callback's cached types, and re-check the callback body against that defaulted substitution — surfacing a spurious `TS18046` (`'x' is of type 'unknown'`) even though Round 1 inference had already fixed the parameter to `any` and a later, correct recheck pass confirms it. The bad pass's diagnostic is not part of any speculative/rollback snapshot, so it survives into the final diagnostic set.

Traced live with a debug backtrace probe (`std::backtrace::Backtrace::force_capture()` gated on the bad `contextual_type == UNKNOWN`) through:
`get_type_of_call_expression_inner` → `run_post_generic_call_diagnostics` → `emit_post_generic_callback_diagnostics` → `maybe_emit_unknown_callback_body_diagnostics` → `emit_uninferred_callback_unknown_body_diagnostics` → `compute_callback_argument_type_rollback_unknown_body_diagnostics` → `compute_single_call_argument_type` → `get_type_of_function_impl`, confirming this post-generic recheck — not the normal Round 1/Round 2 path (which was independently confirmed correct via instrumentation, only ever producing the right `(v: any) => void` contextual type) — is what pushes the raw, unsubstituted callback shape and produces the false positive.

Minimal repro (#16012):
```ts
declare function ap<I>(seed: I, use: (v: I) => void): void;
declare var anyVal: any;
ap(anyVal, item => { item.field; });  // was: TS18046 'item' is of type 'unknown'. Now: clean.
```

This is the root cause of superjson's `transformer.ts` TS18046×2 / TS2698×1 family from #15731 (`compositeTransformation`'s `I` is inferred solely from a type predicate `potentialClass is any`).

## Goal
Goal: green

## Verification
- `cargo test -p tsz-checker --test issue_16012_any_argument_type_param_evidence_tests` — 7/7 new tests pass (6 positive cases across the adjacent-case matrix: renamed binder, property-access `any` source, type-param-in-return-position, callback-listed-first, second-type-param; 1 negative control confirming `unknown`/`error` siblings still correctly trigger the recheck).
- `cargo test -p tsz-checker --test issue_7653_parameterless_lambda_inference_tests` — 9/9 pass unchanged (same mechanism's existing regression suite, including the true-uninferred-`T` negative case).
- Manually verified all 11 rows of #16012's adjacent-case matrix (`ap<I>` with concrete seed, `any` seed, annotated param, no callback, two `any`-seed params, return-position type param, callback-first argument order, expression-body callback, second type param, property-access `any` source, constrained type param) — all match `tsc`.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- `scripts/conformance/compare-to-parent.sh origin/main` — base failing=613, branch failing=613, 0 newly passing / 0 newly failing (the TypeScript conformance corpus does not happen to exercise this project-corpus-sourced shape; the regression floor is unaffected).
- Emit/fourslash not run locally (TypeScript submodule/baselines not checked out in this container); this is a checker-only diagnostic-emission change with no emit-path involvement, so no impact is expected — flagging per CLAUDE.md so a session with the submodule available can confirm before landing if desired.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBtf9yvga7gUPHdJi4fQvx)_