### PR TITLE
test(perf-counters): scope counter measurements to the measuring thread

### DIFF
--- a/crates/tsz-checker/src/tests/assignability_failure_memo_tests.rs
+++ b/crates/tsz-checker/src/tests/assignability_failure_memo_tests.rs
@@ -10,7 +10,7 @@
 
 use crate::context::{AssignabilityFailureMemo, CachedAssignabilityAnalysis, CheckerOptions};
 use crate::test_utils::check_source;
-use tsz_common::perf_counters::PerfCounters;
+use tsz_common::perf_counters::ScopedPerfCounters;
 use tsz_solver::TypeId;
 
 // ---------------------------------------------------------------------------
@@ -82,18 +82,33 @@ fn memo_drops_entries_when_any_stamp_component_moves() {
 }
 
 // ---------------------------------------------------------------------------
-// Counter-asserted single-pass behavior. nextest runs each test in its own
-// process, so the process-global counters are isolated per test.
+// Counter-asserted single-pass behavior.
+//
+// The perf counters are process-wide monotonic atomics with no reset, so
+// reading their *totals* measures everything the whole test binary has done so
+// far, not the program under test. That only happens to work under a
+// process-per-test runner: under any shared-process run the `== 0` assertion
+// below is a guaranteed false red, and — silently, which is worse — the `>= 1`
+// assertions are false greens served by a sibling test's increments.
+//
+// `ScopedPerfCounters` gives the measuring thread a private, zeroed set for the
+// duration of the check, so every assertion here is about this test's own work
+// under any runner.
 // ---------------------------------------------------------------------------
 
-fn enable_counters() {
-    tsz_common::perf_counters::force_enable_perf_counters_for_tests();
+/// Check `source` with counting scoped to this thread, returning the
+/// diagnostics alongside the `(reason_walks, memo_hits)` attributable to the
+/// check itself.
+fn check_source_counting_relation_failures(
+    source: &str,
+    name: &str,
+) -> (Vec<crate::diagnostics::Diagnostic>, u64, u64) {
+    let counted = ScopedPerfCounters::new();
     assert!(tsz_common::perf_counters::enabled_fast());
-}
-
-fn relation_failure_counts() -> (u64, u64) {
-    let snapshot = PerfCounters::snapshot();
+    let diagnostics = check_source(source, name, CheckerOptions::default());
+    let snapshot = counted.snapshot();
     (
+        diagnostics,
         snapshot.relation_failure.reason_walks,
         snapshot.relation_failure.memo_hits,
     )
@@ -105,17 +120,14 @@ fn relation_failure_counts() -> (u64, u64) {
 /// same prepared pair is a memo hit instead of a second walk.
 #[test]
 fn failing_assignment_serves_second_analysis_from_memo() {
-    enable_counters();
-    let diagnostics = check_source(
+    let (diagnostics, walks, hits) = check_source_counting_relation_failures(
         "let target: { outer: { inner: string } } = { outer: { inner: 42 } };",
         "memo_hit.ts",
-        CheckerOptions::default(),
     );
     assert!(
         diagnostics.iter().any(|d| d.code == 2322),
         "expected a TS2322 diagnostic, got {diagnostics:?}"
     );
-    let (walks, hits) = relation_failure_counts();
     assert!(walks >= 1, "a failing relation must walk a reason once");
     assert!(
         hits >= 1,
@@ -127,17 +139,14 @@ fn failing_assignment_serves_second_analysis_from_memo() {
 /// so an α-renamed failing assignment behaves identically.
 #[test]
 fn failing_assignment_renamed_binders_serves_second_analysis_from_memo() {
-    enable_counters();
-    let diagnostics = check_source(
+    let (diagnostics, walks, hits) = check_source_counting_relation_failures(
         "let zebra: { hull: { mast: string } } = { hull: { mast: 42 } };",
         "memo_hit_renamed.ts",
-        CheckerOptions::default(),
     );
     assert!(
         diagnostics.iter().any(|d| d.code == 2322),
         "expected a TS2322 diagnostic, got {diagnostics:?}"
     );
-    let (walks, hits) = relation_failure_counts();
     assert!(walks >= 1);
     assert!(hits >= 1, "walks={walks}, hits={hits}");
 }
@@ -147,17 +156,14 @@ fn failing_assignment_renamed_binders_serves_second_analysis_from_memo() {
 /// gateway already captured the pair.
 #[test]
 fn failing_call_argument_reports_ts2345_without_extra_walks() {
-    enable_counters();
-    let diagnostics = check_source(
+    let (diagnostics, walks, _hits) = check_source_counting_relation_failures(
         "function takeRecord(arg: { tag: string }): void {}\ndeclare let payload: { tag: number };\ntakeRecord(payload);",
         "memo_call_arg.ts",
-        CheckerOptions::default(),
     );
     assert!(
         diagnostics.iter().any(|d| d.code == 2345),
         "expected a TS2345 diagnostic, got {diagnostics:?}"
     );
-    let (walks, _hits) = relation_failure_counts();
     assert!(walks >= 1, "a failing call argument must walk a reason");
 }
 
@@ -166,23 +172,46 @@ fn failing_call_argument_reports_ts2345_without_extra_walks() {
 /// issue #13213) and zero memo traffic.
 #[test]
 fn passing_program_does_zero_reason_collection() {
-    enable_counters();
-    let diagnostics = check_source(
+    let (diagnostics, walks, hits) = check_source_counting_relation_failures(
         r#"
 let person: { name: string; age: number } = { name: "n", age: 3 };
 function consume(value: { name: string }): string { return value.name; }
 consume(person);
 "#,
         "memo_passing.ts",
-        CheckerOptions::default(),
     );
     assert!(
         diagnostics.is_empty(),
         "expected a clean program, got {diagnostics:?}"
     );
-    let (walks, hits) = relation_failure_counts();
     assert_eq!(walks, 0, "passing relations must not walk failure reasons");
     assert_eq!(hits, 0, "passing relations must not touch the memo");
+}
+
+/// The scope itself is the thing the four tests above depend on, so it gets a
+/// direct witness: a second measurement on the same thread must not inherit the
+/// first one's counts. Without the scope this asserts `12 == 0` — exactly the
+/// false red that made `passing_program_does_zero_reason_collection` look
+/// broken on clean `main` under any shared-process runner.
+#[test]
+fn scoped_counters_do_not_inherit_a_previous_measurement_on_the_same_thread() {
+    let (diagnostics, walks, _hits) = check_source_counting_relation_failures(
+        "let target: { outer: { inner: string } } = { outer: { inner: 42 } };",
+        "scope_witness_failing.ts",
+    );
+    assert!(diagnostics.iter().any(|d| d.code == 2322));
+    assert!(walks >= 1, "the failing check must have counted walks");
+
+    let (clean, clean_walks, clean_hits) = check_source_counting_relation_failures(
+        "let ok: { name: string } = { name: \"n\" };",
+        "scope_witness_passing.ts",
+    );
+    assert!(clean.is_empty(), "expected a clean program, got {clean:?}");
+    assert_eq!(
+        clean_walks, 0,
+        "a fresh scope must not see the previous measurement's walks"
+    );
+    assert_eq!(clean_hits, 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -630,9 +630,33 @@ impl PerfCounters {
     }
 }
 
-/// Get the process-wide counters. The first call also reads `TSZ_PERF_COUNTERS`
-/// to set the `enabled` flag.
+// Test-only per-thread counter overlay installed by `ScopedPerfCounters`.
+//
+// The counters are otherwise a single process-wide set of monotonic atomics
+// with no reset, so a test that asserts on counter *totals* is really asserting
+// on everything the whole test binary has done so far. That is only correct
+// under a process-per-test runner. When the overlay is active, `counters()`
+// hands the calling thread a private set instead, so a measurement is
+// attributable to exactly the work done inside the scope no matter which runner
+// (or thread count) is in play.
+#[cfg(any(test, debug_assertions))]
+thread_local! {
+    static SCOPED_COUNTERS: std::cell::Cell<Option<&'static PerfCounters>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// Get the counters to record into. Normally the process-wide set, whose first
+/// call also reads `TSZ_PERF_COUNTERS` to set the `enabled` flag.
+///
+/// In test and debug builds a [`ScopedPerfCounters`] guard can redirect the
+/// calling thread to a private set. Release builds compile that branch out
+/// entirely, and even in debug builds every recorder checks [`enabled_fast`]
+/// before it gets here, so the redirect costs nothing when counting is off.
 pub fn counters() -> &'static PerfCounters {
+    #[cfg(any(test, debug_assertions))]
+    if let Some(scoped) = SCOPED_COUNTERS.with(std::cell::Cell::get) {
+        return scoped;
+    }
     COUNTERS.get_or_init(|| {
         let c = PerfCounters::new_zero();
         if std::env::var_os("TSZ_PERF_COUNTERS").is_some() {
@@ -640,6 +664,67 @@ pub fn counters() -> &'static PerfCounters {
         }
         c
     })
+}
+
+/// RAII guard giving the current thread a private, zeroed counter set for the
+/// duration of a measurement, and turning the counter gate on so the recorders
+/// actually fire.
+///
+/// Test-only. Use it whenever a test asserts on counter values: without it a
+/// `== 0` assertion is a false red as soon as any sibling test has already
+/// counted in the same process, and — worse, because it is silent — a `>= 1`
+/// assertion is a false green served by a neighbor's increments rather than by
+/// the work under test.
+///
+/// ```ignore
+/// let counted = tsz_common::perf_counters::ScopedPerfCounters::new();
+/// run_the_work_under_test();
+/// let snapshot = counted.snapshot();
+/// ```
+///
+/// Increments made on *other* threads while the scope is live still land on the
+/// process-wide set, so measure work that runs on the thread holding the guard.
+#[cfg(any(test, debug_assertions))]
+pub struct ScopedPerfCounters {
+    previous: Option<&'static PerfCounters>,
+}
+
+#[cfg(any(test, debug_assertions))]
+impl ScopedPerfCounters {
+    /// Install a fresh counter set for this thread and force the gate on.
+    ///
+    /// The set is intentionally leaked: [`counters()`] hands out `&'static`
+    /// references that recorders may hold across the scope, and a test binary
+    /// creates a bounded number of scopes.
+    #[must_use]
+    pub fn new() -> Self {
+        force_enable_perf_counters_for_tests();
+        let fresh: &'static PerfCounters = Box::leak(Box::new(PerfCounters::new_zero()));
+        fresh.enabled.store(true, Ordering::Relaxed);
+        let previous = SCOPED_COUNTERS.with(|slot| slot.replace(Some(fresh)));
+        Self { previous }
+    }
+
+    /// Snapshot the scoped counters — the totals recorded on this thread since
+    /// the guard was created.
+    #[must_use]
+    pub fn snapshot(&self) -> PerfCounterSnapshot {
+        PerfCounters::snapshot()
+    }
+}
+
+#[cfg(any(test, debug_assertions))]
+impl Default for ScopedPerfCounters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(any(test, debug_assertions))]
+impl Drop for ScopedPerfCounters {
+    fn drop(&mut self) {
+        SCOPED_COUNTERS.with(|slot| slot.set(self.previous));
+    }
 }
 
 /// Increment a counter when counters are enabled. The branch is the


### PR DESCRIPTION
Fixes the #13243 assignability-failure-memo perf gate, which has been broken in **both** directions — one loud false red and three silent false greens — and has been reported as a main-branch regression by three separate agent sessions (#15999, and board comments at `00:26Z` and `03:08Z`).

## Structural rule

When a test asserts on `PerfCounters`, it must observe only the counter increments produced by the work under test; tsz does that through a test-scoped counter set owned by `tsz-common::perf_counters`, not through the process-wide totals.

`counters()` returns a single `OnceLock<PerfCounters>` of monotonic atomics with **no reset**. Reading `PerfCounters::snapshot()` therefore measures everything the entire test binary has done so far, not the program just checked. That only happens to be correct under a process-per-test runner. `assignability_failure_memo_tests` read those totals directly, and the file's own header comment named the hidden dependency out loud (`"nextest runs each test in its own process, so the process-global counters are isolated per test"`).

The sibling counter test in `cross_file_direct_source_option_bag_tests.rs` already takes before/after **deltas**, and `force_enable_perf_counters_for_tests`'s own doc comment says it exists so `"unit tests that assert on counter deltas"` can opt in. This file was the outlier.

## What was actually broken

Measured on unmodified `main` (`c4a837b`), running the module's own tests in one process:

```
test result: FAILED. 10 passed; 1 failed
---- passing_program_does_zero_reason_collection ----
assertion `left == right` failed: passing relations must not walk failure reasons
  left: 12
 right: 0
```

All 12 walks belong to the three sibling tests that deliberately walk reasons. The same test **passes** when run alone in its own process, which is why it looks like a phantom.

The quiet half is worse. Three assertions in the same file are `>= 1`:

| test | assertion | under a shared process |
| --- | --- | --- |
| `passing_program_does_zero_reason_collection` | `walks == 0`, `hits == 0` | **false red** — sees siblings' 12 |
| `failing_assignment_serves_second_analysis_from_memo` | `walks >= 1`, `hits >= 1` | **false green** — satisfied by a neighbour |
| `failing_assignment_renamed_binders_...` | `walks >= 1`, `hits >= 1` | **false green** |
| `failing_call_argument_reports_ts2345_without_extra_walks` | `walks >= 1` | **false green** |

So the memo could stop serving entries **entirely** and those three would still pass on borrowed counts. The gate that is supposed to protect "a passing relation never pays for reason collection" was measuring nothing.

## The fix

`ScopedPerfCounters` (in `crates/tsz-common/src/perf_counters/runtime.rs`) — a test/debug-only RAII guard that installs a private, zeroed counter set for the calling thread and restores the previous one on drop.

It hooks `counters()`, which is the single accessor every recorder in every family already funnels through, so one branch scopes all counters at once with **zero recorder changes**. Cost profile:

- `#[cfg(any(test, debug_assertions))]` — release builds compile the branch out entirely.
- Even in debug, every recorder checks `enabled_fast()` **before** reaching `counters()`, and that gate is false unless `TSZ_PERF_COUNTERS` is set or a test forces it. Counting-off paths are byte-identical.
- `ci-lint` inherits `dev`, so `debug_assertions` is on and the item exists for the lint lane — same cfg the already-used `force_enable_perf_counters_for_tests` relies on.

Stronger than a before/after delta: a delta is still polluted by *concurrent* increments from other threads, whereas the scope is per-thread, so all four assertions now hold under any runner and any thread count.

The four counter tests are rewritten onto one `check_source_counting_relation_failures` helper, and a new witness test pins the scope itself — a second measurement on the same thread must not inherit the first's counts, which is exactly the `12 == 0` shape that was failing.

## Goal
Goal: fast

This is the `fast` lane's regression floor, not test cleanup: the invariant being restored is that an error-free program performs **zero** failure-reason walks (`#13213` decision-only callers) — reason collection re-traverses the failing relation graph, and paying it on clean assignability checks is corpus-wide waste. That gate was inert.

## Verification

Run locally at `3ee314f`. This container is cold and has **no** TypeScript corpus (`TypeScript/` absent) and no `cargo-nextest` (proxy 403), so conformance, emit and fourslash did **not** run here — stating that plainly rather than implying otherwise. The change is test-scope-only outside of `counters()`, whose non-test behaviour is unchanged.

**Before → after, the memo module in one shared process** (the runner shape that was red):

| | before (`c4a837b`) | after (`3ee314f`) |
| --- | --- | --- |
| `assignability_failure_memo_tests` | 10 passed, **1 failed** | **12 passed, 0 failed** |

**Runner-shape matrix, after** — all green, which is the actual claim:

| shape | result |
| --- | --- |
| single test, own process | 12 filtered → ok |
| module, default parallelism | 12 passed, 0 failed |
| module, `--test-threads=1` | 12 passed, 0 failed |
| module, `--test-threads=16` | 12 passed, 0 failed |
| `cargo test -p tsz-checker --lib assignability` (236 tests sharing the process, heavy pollution) | **236 passed, 0 failed** |

Other lanes:

```
cargo test -p tsz-common --lib          573 passed, 0 failed
cargo test -p tsz-common (doctests)       2 passed, 0 failed, 5 ignored
cargo clippy --profile ci-lint -p tsz-common -p tsz-checker --all-targets -- -D warnings
                                        clean
cargo fmt                                clean
pre-commit hook (clippy + architecture guard + local verification)
                                        passed
```

Note for reviewers reproducing the matrix: running the compiled test binary directly (rather than through `cargo test`) makes 15 `architecture_contract_tests` fail with `No such file or directory` — they resolve source paths relative to the crate dir that `cargo test` sets as CWD. That is a harness artifact, not a regression; via `cargo test` the same filter is 236/236.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Jasper

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWKA2DroRTHkJkrtmk6SCb)_