### PR TITLE
test(perf-counters): finish the ScopedPerfCounters migration sweep

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_source_option_bag_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_source_option_bag_tests.rs
@@ -98,13 +98,23 @@ fn setup_cross_file_index_state<'a>(
     (state, sym)
 }
 
-fn enable_perf_counters_for_direct_lowering_test() {
-    #[cfg(any(test, debug_assertions))]
-    tsz_common::perf_counters::force_enable_perf_counters_for_tests();
+/// Give the calling test a private, thread-scoped counter set instead of the
+/// process-wide atomics: `direct_interface_lowering_count` /
+/// `with_parent_cache_constructed_count` below take before/after snapshots
+/// and diff them, and a plain before/after delta on process-wide counters is
+/// immune to increments made before the window but not to increments a
+/// sibling thread makes *inside* it under a shared-process runner (`cargo
+/// test`, not `nextest`). Keep the returned guard alive for the rest of the
+/// test.
+#[must_use]
+fn scoped_perf_counters_for_direct_lowering_test() -> tsz_common::perf_counters::ScopedPerfCounters
+{
+    let scope = tsz_common::perf_counters::ScopedPerfCounters::new();
     assert!(
         tsz_common::perf_counters::enabled_fast(),
         "direct-lowering branch tests need perf counters enabled"
     );
+    scope
 }
 
 fn direct_interface_lowering_count(outcome: DirectCrossFileInterfaceLoweringOutcome) -> u64 {
@@ -145,7 +155,7 @@ fn delegate_cross_arena_source_option_bag_lowers_directly_via_cross_file_index()
         &target_binder,
     );
 
-    enable_perf_counters_for_direct_lowering_test();
+    let _scope = scoped_perf_counters_for_direct_lowering_test();
     let success_before =
         direct_interface_lowering_count(DirectCrossFileInterfaceLoweringOutcome::Success);
     let child_checkers_before = with_parent_cache_constructed_count();
@@ -213,7 +223,7 @@ fn delegate_cross_arena_source_option_bag_with_sibling_alias_lowers_directly_via
         &target_binder,
     );
 
-    enable_perf_counters_for_direct_lowering_test();
+    let _scope = scoped_perf_counters_for_direct_lowering_test();
     let success_before =
         direct_interface_lowering_count(DirectCrossFileInterfaceLoweringOutcome::Success);
     let child_checkers_before = with_parent_cache_constructed_count();
@@ -323,7 +333,7 @@ fn delegate_cross_arena_source_option_bag_resolves_in_program_with_module_augmen
         "fixture should make the source-file symbol-arena cache ineligible"
     );
 
-    enable_perf_counters_for_direct_lowering_test();
+    let _scope = scoped_perf_counters_for_direct_lowering_test();
     let success_before =
         direct_interface_lowering_count(DirectCrossFileInterfaceLoweringOutcome::Success);
     let child_checkers_before = with_parent_cache_constructed_count();
@@ -569,7 +579,7 @@ fn delegate_cross_arena_source_interface_with_heritage_still_falls_back() {
         &target_binder,
     );
 
-    enable_perf_counters_for_direct_lowering_test();
+    let _scope = scoped_perf_counters_for_direct_lowering_test();
     let success_before =
         direct_interface_lowering_count(DirectCrossFileInterfaceLoweringOutcome::Success);
     let complex_before = direct_interface_lowering_count(

--- a/crates/tsz-common/src/perf_counters/dump_tests.rs
+++ b/crates/tsz-common/src/perf_counters/dump_tests.rs
@@ -7,7 +7,13 @@ mod dump_tests {
         // added to storage/snapshot state without being surfaced in the text
         // dump. Bump one distinctive bucket per family and lock the formatter
         // surface so future bucket-family additions have to update this test.
-        force_enable_perf_counters_for_tests();
+        //
+        // Scoped: the dump only prints a bucket's label when its count is
+        // nonzero (see `dump.rs`), so an unscoped process-wide counter could
+        // in principle pass because a concurrently-running sibling test
+        // happened to bump the same enum variant, not because this test's own
+        // formatter wiring is correct.
+        let _scope = ScopedPerfCounters::new();
 
         let c = counters();
         c.with_parent_cache_by_reason[CheckerCreationReason::ImportType.as_index()]
@@ -121,7 +127,7 @@ mod dump_tests {
         // Keep scalar snapshot sections from repeating the original #13130
         // drift pattern: a counter can be wired into storage and JSON while
         // remaining invisible to humans reading the text dump.
-        force_enable_perf_counters_for_tests();
+        let _scope = ScopedPerfCounters::new();
 
         let c = counters();
         c.relation_limit_cache_hits
@@ -197,9 +203,14 @@ mod dump_tests {
     #[test]
     fn eval_termination_guard_recorder_targets_named_bucket() {
         // #14346: `record_eval_termination_guard` increments exactly the
-        // bucket for the guard that fired, with counters on. Delta-based so it
-        // tolerates other tests sharing the process-wide atomics.
-        force_enable_perf_counters_for_tests();
+        // bucket for the guard that fired. Scoped rather than delta-based:
+        // a before/after delta on the process-wide atomics is immune to
+        // increments made before the window but not to increments a sibling
+        // thread makes concurrently inside it (see #16017's `assignability_
+        // failure_memo_tests` false red/green pair for the general failure
+        // mode), so a private per-thread counter set is the version of this
+        // test that cannot be perturbed by anything but its own call.
+        let _scope = ScopedPerfCounters::new();
         let c = counters();
         let load = |g: EvaluationTerminationGuard| {
             c.eval_termination_guard_fires[g.as_index()].load(Ordering::Relaxed)

--- a/crates/tsz-common/src/perf_counters/residency.rs
+++ b/crates/tsz-common/src/perf_counters/residency.rs
@@ -42,29 +42,54 @@ pub struct ResidencyGauges {
     type_cache_bytes_est: AtomicU64,
 }
 
+impl ResidencyGauges {
+    const fn new_zero() -> Self {
+        Self {
+            recorded_any: AtomicBool::new(false),
+            ast_unique_arena_count: AtomicU64::new(0),
+            ast_unique_arena_bytes_est: AtomicU64::new(0),
+            bound_file_count: AtomicU64::new(0),
+            bound_file_state_bytes_est: AtomicU64::new(0),
+            lib_binder_count: AtomicU64::new(0),
+            lib_binder_symbol_bytes_est: AtomicU64::new(0),
+            program_symbol_state_bytes_est: AtomicU64::new(0),
+            definition_store_bytes_est: AtomicU64::new(0),
+            type_interner_bytes_est: AtomicU64::new(0),
+            skeleton_index_bytes_est: AtomicU64::new(0),
+            pre_merge_bind_total_bytes_est: AtomicU64::new(0),
+            retained_file_state_bytes_est: AtomicU64::new(0),
+            retained_file_state_pressure: AtomicU64::new(0),
+            shared_query_cache_entries: AtomicU64::new(0),
+            shared_query_cache_bytes_est: AtomicU64::new(0),
+            type_cache_count: AtomicU64::new(0),
+            type_cache_bytes_est: AtomicU64::new(0),
+        }
+    }
+}
+
 static RESIDENCY_GAUGES: OnceLock<ResidencyGauges> = OnceLock::new();
 
+// Test-only per-thread residency-gauge overlay, installed by
+// `ScopedPerfCounters` alongside its `SCOPED_COUNTERS` overlay (see
+// `runtime.rs`). Residency is a gauge, not an accumulating counter: two
+// threads recording different programs' residency concurrently on the
+// process-wide `RESIDENCY_GAUGES` statics would each overwrite the other's
+// values with `Ordering::Relaxed` stores, so a shared-process test reading
+// its own recorded values back has no guarantee it sees them rather than a
+// sibling's. Scoping this the same way `counters()` is scoped removes that
+// race for any test built on `ScopedPerfCounters`.
+#[cfg(any(test, debug_assertions))]
+thread_local! {
+    static SCOPED_RESIDENCY_GAUGES: std::cell::Cell<Option<&'static ResidencyGauges>> =
+        const { std::cell::Cell::new(None) };
+}
+
 fn residency_gauges() -> &'static ResidencyGauges {
-    RESIDENCY_GAUGES.get_or_init(|| ResidencyGauges {
-        recorded_any: AtomicBool::new(false),
-        ast_unique_arena_count: AtomicU64::new(0),
-        ast_unique_arena_bytes_est: AtomicU64::new(0),
-        bound_file_count: AtomicU64::new(0),
-        bound_file_state_bytes_est: AtomicU64::new(0),
-        lib_binder_count: AtomicU64::new(0),
-        lib_binder_symbol_bytes_est: AtomicU64::new(0),
-        program_symbol_state_bytes_est: AtomicU64::new(0),
-        definition_store_bytes_est: AtomicU64::new(0),
-        type_interner_bytes_est: AtomicU64::new(0),
-        skeleton_index_bytes_est: AtomicU64::new(0),
-        pre_merge_bind_total_bytes_est: AtomicU64::new(0),
-        retained_file_state_bytes_est: AtomicU64::new(0),
-        retained_file_state_pressure: AtomicU64::new(0),
-        shared_query_cache_entries: AtomicU64::new(0),
-        shared_query_cache_bytes_est: AtomicU64::new(0),
-        type_cache_count: AtomicU64::new(0),
-        type_cache_bytes_est: AtomicU64::new(0),
-    })
+    #[cfg(any(test, debug_assertions))]
+    if let Some(scoped) = SCOPED_RESIDENCY_GAUGES.with(std::cell::Cell::get) {
+        return scoped;
+    }
+    RESIDENCY_GAUGES.get_or_init(ResidencyGauges::new_zero)
 }
 
 /// Merged-program residency categories, recorded by
@@ -240,7 +265,7 @@ pub struct ResidencySnapshot {
 /// category has been recorded (counters disabled, or a driver that does
 /// not wire residency recording).
 pub(crate) fn snapshot_residency() -> Option<ResidencySnapshot> {
-    let g = RESIDENCY_GAUGES.get()?;
+    let g = residency_gauges();
     if !g.recorded_any.load(Ordering::Relaxed) {
         return None;
     }

--- a/crates/tsz-common/src/perf_counters/residency_tests.rs
+++ b/crates/tsz-common/src/perf_counters/residency_tests.rs
@@ -6,11 +6,15 @@ mod residency_tests {
     /// `Some(residency)` snapshot with the recorded values and a coherent
     /// tracked total.
     ///
-    /// Note: the gauges are process-wide and nextest runs each test in its
-    /// own process, so this test owns the gauge state for its lifetime.
+    /// Uses `ScopedPerfCounters` rather than relying on process ownership:
+    /// the residency gauges are last-write-wins `store`s (a program's byte
+    /// estimate, not an accumulating count), so under a shared-process
+    /// runner a sibling test recording a different program's residency
+    /// concurrently would silently overwrite the values asserted below. The
+    /// scope gives this thread a private gauge set for its duration.
     #[test]
     fn residency_record_propagates_into_snapshot() {
-        force_enable_perf_counters_for_tests();
+        let _scope = ScopedPerfCounters::new();
 
         record_merged_program_residency(&MergedProgramResidencyRecord {
             ast_unique_arena_count: 12,

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -684,9 +684,20 @@ pub fn counters() -> &'static PerfCounters {
 ///
 /// Increments made on *other* threads while the scope is live still land on the
 /// process-wide set, so measure work that runs on the thread holding the guard.
+///
+/// This also scopes the residency gauges (`record_merged_program_residency`
+/// and friends, in `residency.rs`): those live in a separate process-wide
+/// `OnceLock<ResidencyGauges>` disjoint from the `PerfCounters` atomics this
+/// guard was originally written for, but they are gauges (last-write-wins
+/// `store`s), not accumulating counters, so a second thread recording a
+/// different program's residency while this scope is live would otherwise
+/// silently overwrite the values a test just recorded. Installing both
+/// overlays from one guard keeps a single `ScopedPerfCounters::new()` call
+/// sufficient for tests that touch either family.
 #[cfg(any(test, debug_assertions))]
 pub struct ScopedPerfCounters {
     previous: Option<&'static PerfCounters>,
+    previous_residency: Option<&'static ResidencyGauges>,
 }
 
 #[cfg(any(test, debug_assertions))]
@@ -702,7 +713,16 @@ impl ScopedPerfCounters {
         let fresh: &'static PerfCounters = Box::leak(Box::new(PerfCounters::new_zero()));
         fresh.enabled.store(true, Ordering::Relaxed);
         let previous = SCOPED_COUNTERS.with(|slot| slot.replace(Some(fresh)));
-        Self { previous }
+
+        let fresh_residency: &'static ResidencyGauges =
+            Box::leak(Box::new(ResidencyGauges::new_zero()));
+        let previous_residency =
+            SCOPED_RESIDENCY_GAUGES.with(|slot| slot.replace(Some(fresh_residency)));
+
+        Self {
+            previous,
+            previous_residency,
+        }
     }
 
     /// Snapshot the scoped counters — the totals recorded on this thread since
@@ -724,6 +744,7 @@ impl Default for ScopedPerfCounters {
 impl Drop for ScopedPerfCounters {
     fn drop(&mut self) {
         SCOPED_COUNTERS.with(|slot| slot.set(self.previous));
+        SCOPED_RESIDENCY_GAUGES.with(|slot| slot.set(self.previous_residency));
     }
 }
 

--- a/crates/tsz-solver/src/caches/instantiation_cache_test.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache_test.rs
@@ -712,7 +712,14 @@ fn unchanged_conditional_instantiation_skips_conditional_reintern() {
     // non-empty substitution. If all four arms remain unchanged, though, the
     // walk should return the original `TypeId` without probing the conditional
     // interner again.
-    tsz_common::perf_counters::force_enable_perf_counters_for_tests();
+    //
+    // Scoped: `conditional_intern_calls` is a process-wide atomic, and this
+    // test reads a before/after delta on it. Without `ScopedPerfCounters`, a
+    // sibling thread interning an unrelated conditional between the two reads
+    // would inflate `after` and mask a real regression here just as easily as
+    // it would produce a false failure (see #16017's writeup of this counter
+    // class under a shared-process runner).
+    let _scope = tsz_common::perf_counters::ScopedPerfCounters::new();
 
     let interner = TypeInterner::new();
     let (u_atom, _u_id) = type_param(&interner, "U");
@@ -747,7 +754,10 @@ fn unchanged_conditional_instantiation_skips_conditional_reintern() {
 
 #[test]
 fn changed_conditional_instantiation_still_rebuilds_conditional() {
-    tsz_common::perf_counters::force_enable_perf_counters_for_tests();
+    // Scoped for the same reason as `unchanged_conditional_instantiation_
+    // skips_conditional_reintern` above: `conditional_intern_calls` is a
+    // process-wide atomic and this test reads a before/after delta on it.
+    let _scope = tsz_common::perf_counters::ScopedPerfCounters::new();
 
     let interner = TypeInterner::new();
     let (t_atom, t_id) = type_param(&interner, "T");


### PR DESCRIPTION
Migrates the four counter-asserting test files #16017 flagged as an unclaimed, reviewer-endorsed follow-on onto `ScopedPerfCounters`, closing the same process-global-state false-red/false-green class #16017 fixed for the #13243 memo gate:

- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_source_option_bag_tests.rs` and two tests in `crates/tsz-solver/src/caches/instantiation_cache_test.rs` (`unchanged_conditional_instantiation_skips_conditional_reintern`, `changed_conditional_instantiation_still_rebuilds_conditional`): before/after deltas on process-wide atomics, exposed to concurrent writes from sibling threads *inside* the measurement window under a shared-process runner (`cargo test`, not `nextest`) — a delta is immune to counts made before the window but not to counts made during it.
- `crates/tsz-common/src/perf_counters/dump_tests.rs`: one test has the same delta exposure; the other two check `dump_string().contains(label)`, and `dump.rs` only prints a bucket's label when its count is nonzero, so an unscoped process-wide counter could in principle pass because a concurrently-running sibling test happened to bump the same enum variant, not because this test's own formatter wiring is correct.

## Structural rule

When a unit test asserts on `tsz_common::perf_counters` state (`counters()`/`PerfCounters::snapshot()` or the residency gauges), tsz's counters/gauges are process-wide statics with no per-test reset, so the assertion is only sound if the test owns a private view of that state for its duration — via `tsz_common::perf_counters::ScopedPerfCounters` (`crates/tsz-common/src/perf_counters/runtime.rs`), not via `force_enable_perf_counters_for_tests()` plus a raw before/after delta.

## A structural gap this surfaced

`residency_tests.rs`'s `residency_record_propagates_into_snapshot` couldn't be fixed by simply swapping in the existing guard: `ScopedPerfCounters` only ever redirected `counters()` (the `PerfCounters` atomics). The residency gauges (`record_merged_program_residency` and friends, `crates/tsz-common/src/perf_counters/residency.rs`) live in a **disjoint** process-wide `OnceLock<ResidencyGauges>` that bypassed the guard entirely — and they are last-write-wins gauges (a program's byte estimate), not accumulating counters, so a sibling thread recording a different program's residency mid-scope would silently overwrite this thread's values rather than merely inflating a count.

Fixed at the owning layer (`tsz-common::perf_counters`, same module the original `ScopedPerfCounters` lives in): extended `residency.rs` with a `SCOPED_RESIDENCY_GAUGES` thread-local overlay mirroring the existing `SCOPED_COUNTERS` pattern, and `snapshot_residency()` now reads through the same `residency_gauges()` accessor instead of the raw `OnceLock`. `ScopedPerfCounters::new()`/`Drop` install and restore both overlays together, so one guard scopes both families — matching its existing doc comment's claim that it "scopes all families at once."

`residency_absent_when_disabled` is intentionally left unscoped: it tests the *disabled* path, and `ScopedPerfCounters::new()` always forces counters on, which would defeat its premise. Its existing defensive `if enabled_fast() { return; }` (pre-existing, unchanged) already documents why that test is inherently order-sensitive under a shared process — out of scope here since it's testing a different code path (`enabled_fast()`/`FORCE_ENABLED_FOR_TESTS`, not `counters()`) than the one this PR scopes.

## Adjacent-case coverage

All four flagged files, both comparison directions Jasper's note called out (`==` deltas and label-presence checks driven by `count > 0`), plus the one file (`residency.rs`) where the existing scoping mechanism didn't reach at all.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-common --lib -- perf_counters` — 55/55 pass (includes both `residency_tests` and all three `dump_tests`)
- `cargo test -p tsz-checker --lib -- delegate_cross_arena_source` — 6/6 pass
- `cargo test -p tsz-solver --lib -- instantiation_cache_wiring_tests` — 32/32 pass (full file, not just the two touched tests)
- `cargo fmt --check -p tsz-common -p tsz-checker -p tsz-solver` — clean
- `cargo clippy --profile ci-lint -p tsz-common -p tsz-checker -p tsz-solver --all-targets -- -D warnings` — clean
- `python3 scripts/arch/arch_guard.py` — clean
- `bash scripts/ci/check-unit-gate-contracts.sh` — full step green (the exact per-merge `clippy`-job invocation)
- Test-only change (`#[cfg(any(test, debug_assertions))]` on all new scoping code): no conformance/emit/fourslash surface to regress; not run.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUKMx5giptJD2eYgc3sJeA)_