### PR TITLE
fix(checker): count an annotated sibling callback parameter as inference evidence

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1317,6 +1317,9 @@ path = "tests/issue_7653_parameterless_lambda_inference_tests.rs"
 name = "issue_16012_any_argument_type_param_evidence_tests"
 path = "tests/issue_16012_any_argument_type_param_evidence_tests.rs"
 [[test]]
+name = "issue_16018_annotated_sibling_callback_evidence_tests"
+path = "tests/issue_16018_annotated_sibling_callback_evidence_tests.rs"
+[[test]]
 name = "issue_9692_function_candidate_inference"
 path = "tests/issue_9692_function_candidate_inference.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs
@@ -224,18 +224,78 @@ impl<'a> CheckerState<'a> {
         if !self.is_callback_like_argument(other_arg_idx) {
             return true;
         }
-        // Only the return position of the sibling callback's contextual
-        // signature counts as inference evidence. Parameter positions are
-        // contravariant and supply context TO the lambda's parameters from
-        // `T`, not inference FROM the lambda back to `T`.
-        self.resolved_callback_contextual_signature(other_param_type)
-            .is_some_and(|other_callback| {
+        let Some(other_callback) = self.resolved_callback_contextual_signature(other_param_type)
+        else {
+            return false;
+        };
+        // The return position of the sibling callback's contextual signature
+        // always counts as inference evidence.
+        if crate::query_boundaries::generic_instantiation::type_contains_type_parameter_binder(
+            self.ctx.types,
+            other_callback.return_type,
+            type_param,
+        ) {
+            return true;
+        }
+        // A parameter position counts only when the sibling lambda annotates
+        // that parameter itself. An *unannotated* parameter is an inference
+        // sink: its type is produced by the contextual type, so it supplies
+        // context TO the lambda from `T` rather than inference FROM the lambda
+        // back to `T`. An *annotated* parameter is the opposite — `tsc` infers
+        // the enclosing signature's type parameters contravariantly from the
+        // annotation and fixes them before contextually typing any sibling
+        // callback body. The position matters: an annotation sitting at a slot
+        // whose contextual type does not mention `T` is not evidence for `T`.
+        let annotated_positions = self.annotated_callback_parameter_positions(other_arg_idx);
+        let param_type_at = |position: usize| -> Option<TypeId> {
+            other_callback
+                .params
+                .get(position)
+                .map(|param| param.type_id)
+                .or_else(|| {
+                    let last = other_callback.params.last()?;
+                    last.rest.then_some(last.type_id)
+                })
+        };
+        annotated_positions.iter().any(|&position| {
+            param_type_at(position).is_some_and(|param_type| {
                 crate::query_boundaries::generic_instantiation::type_contains_type_parameter_binder(
                     self.ctx.types,
-                    other_callback.return_type,
+                    param_type,
                     type_param,
                 )
             })
+        })
+    }
+
+    /// Positions of a callback argument's own parameters that carry an
+    /// explicit type annotation, and are therefore inference sources rather
+    /// than sinks for the enclosing generic signature's type parameters.
+    fn annotated_callback_parameter_positions(&self, arg_idx: NodeIndex) -> Vec<usize> {
+        let Some(callback_idx) = self.callback_function_index(arg_idx) else {
+            return Vec::new();
+        };
+        let Some(func) = self
+            .ctx
+            .arena
+            .get(callback_idx)
+            .and_then(|node| self.ctx.arena.get_function(node))
+        else {
+            return Vec::new();
+        };
+        func.parameters
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|&(_, &param_idx)| {
+                self.ctx
+                    .arena
+                    .get(param_idx)
+                    .and_then(|param_node| self.ctx.arena.get_parameter(param_node))
+                    .is_some_and(|param| param.type_annotation.is_some())
+            })
+            .map(|(position, _)| position)
+            .collect()
     }
 
     /// Resolve a callback parameter slot to its contextual `FunctionShape`,

--- a/crates/tsz-checker/tests/issue_16018_annotated_sibling_callback_evidence_tests.rs
+++ b/crates/tsz-checker/tests/issue_16018_annotated_sibling_callback_evidence_tests.rs
@@ -1,0 +1,200 @@
+//! Regression tests for [issue #16018]: an explicitly annotated parameter on a
+//! sibling callback argument must count as inference evidence for a shared
+//! type parameter.
+//!
+//! Structural rule: when a generic call passes two callback arguments whose
+//! contextual parameter types share a type parameter `T`, and the sibling
+//! callback annotates the parameter sitting at a position whose contextual
+//! type mentions `T`, `tsc` infers `T` contravariantly from that annotation
+//! and fixes it before contextually typing the other callback's body.
+//!
+//! tsz's post-generic `emit_uninferred_callback_unknown_body_diagnostics`
+//! recheck (`argument_provides_type_param_evidence`,
+//! `crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs`)
+//! counted a sibling *callback* argument as evidence only when `T` occurred in
+//! that callback's contextual **return** position, on the reasoning that
+//! parameter positions are contravariant and supply context *to* the lambda.
+//! That reasoning holds only for an *unannotated* parameter, whose type is
+//! genuinely produced by the contextual type. An explicitly annotated
+//! parameter is an inference *source*, so excluding it made the recheck
+//! conclude "no evidence", default `T` to `unknown`, and re-check the sibling
+//! callback body against it — a spurious `TS18046`.
+//!
+//! Every expectation below is pinned against real `tsc` 7.0.2
+//! (`--noEmit --strict`); the negative controls
+//! (`unannotated_sibling_callback_still_reports_unknown`,
+//! `annotation_at_a_non_type_param_position_is_not_evidence`) are the cases
+//! where `tsc` genuinely does report `TS18046`, and they are what force the
+//! rule to be *position-aware* rather than "the sibling has some annotation".
+//!
+//! [issue #16018]: https://github.com/tsz-org/tsz/issues/16018
+
+fn compile_and_get_diagnostics(source: &str) -> Vec<(u32, String)> {
+    tsz_checker::test_utils::check_source_code_messages(source)
+}
+
+fn assert_no_ts18046(diagnostics: &[(u32, String)], context: &str) {
+    assert!(
+        diagnostics.iter().all(|(code, _)| *code != 18046),
+        "Did not expect TS18046 in {context}. Got: {diagnostics:?}"
+    );
+}
+
+fn count_ts18046(diagnostics: &[(u32, String)]) -> usize {
+    diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 18046)
+        .count()
+}
+
+#[test]
+fn annotated_sibling_callback_param_seeds_type_param() {
+    // tsc 7.0.2: clean. `T` is inferred as `string` from `value: string`.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function run<T>(setup: (value: T) => void, use: (value: T) => void): void;
+run((value: string) => { value.length; }, (value) => { value.length; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "annotated sibling callback parameter");
+}
+
+#[test]
+fn annotated_sibling_callback_param_seeds_renamed_type_param() {
+    // Same shape with every binder renamed (`Elem`/`first`/`second`/`item`) —
+    // proves the rule is structural, not keyed on any identifier.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function apply<Elem>(first: (item: Elem) => void, second: (item: Elem) => void): void;
+apply((item: string) => { item.length; }, (item) => { item.length; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "renamed type parameter `Elem`");
+}
+
+#[test]
+fn partially_annotated_sibling_callback_is_still_evidence() {
+    // tsc 7.0.2: clean. The sibling is context-sensitive as a whole (its
+    // second parameter is unannotated), but the annotated first parameter
+    // still supplies the contravariant candidate for `T`.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function run<T>(setup: (value: T, extra: number) => void, use: (value: T) => void): void;
+run((value: string, extra) => { value.length; }, (value) => { value.length; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "partially annotated sibling callback");
+}
+
+#[test]
+fn annotated_function_expression_sibling_is_evidence() {
+    // The sibling need not be an arrow function.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function run<T>(setup: (value: T) => void, use: (value: T) => void): void;
+run(function (value: string): void { value.length; }, (value) => { value.length; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "annotated function-expression sibling");
+}
+
+#[test]
+fn type_param_nested_inside_annotated_param_is_evidence() {
+    // `T` occurs nested inside the contextual parameter type rather than
+    // being the whole parameter.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function run<T>(setup: (box: { item: T }) => void, use: (value: T) => void): void;
+run((box: { item: string }) => { box.item.length; }, (value) => { value.length; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "type parameter nested in an annotated param");
+}
+
+#[test]
+fn type_param_under_an_array_in_annotated_param_is_evidence() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function run<T>(setup: (values: T[]) => void, use: (value: T) => void): void;
+run((values: number[]) => { values.length; }, (value) => { value.toFixed(); });
+"#,
+    );
+    assert_no_ts18046(
+        &diagnostics,
+        "type parameter under an array in an annotated param",
+    );
+}
+
+#[test]
+fn annotated_param_through_a_generic_alias_callable_is_evidence() {
+    // The contextual parameter type is an aliased callable interface stored as
+    // an `Application`, not a bare function type — the same wrapper shape
+    // #7653 exercises for the return position.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+interface Take<U> { (n: U): void; }
+declare function run<U>(setup: Take<U>, use: Take<U>): void;
+run((value: string) => { value.length; }, (value) => { value.length; });
+"#,
+    );
+    assert_no_ts18046(
+        &diagnostics,
+        "annotated param through a generic alias callable",
+    );
+}
+
+#[test]
+fn unannotated_sibling_callback_still_reports_unknown() {
+    // NEGATIVE CONTROL. tsc 7.0.2 reports TS18046 twice here: neither lambda
+    // annotates anything, so `T` really is uninferred and falls to `unknown`.
+    // The fix must not silence this.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function run<T>(setup: (value: T) => void, use: (value: T) => void): void;
+run((value) => { value.length; }, (value) => { value.length; });
+"#,
+    );
+    assert_eq!(
+        count_ts18046(&diagnostics),
+        2,
+        "both unannotated callback bodies must keep TS18046. Got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn annotation_at_a_non_type_param_position_is_not_evidence() {
+    // NEGATIVE CONTROL, and the discriminating case. The sibling *does* carry
+    // an explicit annotation, but at the `tag: string` position — the `value`
+    // position that actually mentions `T` is unannotated. tsc 7.0.2 still
+    // reports TS18046 on the second callback's body, so "sibling has some
+    // annotation" is the wrong rule; the annotation must sit at a position
+    // whose contextual type mentions the type parameter.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function run<T>(setup: (value: T, tag: string) => void, use: (value: T) => void): void;
+run((value, tag: string) => { tag.length; }, (value) => { value.length; });
+"#,
+    );
+    assert_eq!(
+        count_ts18046(&diagnostics),
+        1,
+        "an annotation away from the type parameter's position is not evidence. Got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn return_position_evidence_still_works() {
+    // The pre-existing rule (#7653) must keep holding: `T` in the sibling
+    // callback's contextual return position is evidence on its own, with no
+    // annotated parameter anywhere.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+// @target: es2015
+function foo<T>(o: Take<T>, i: Make<T>) { }
+interface Make<T> { (): T; }
+interface Take<T> { (n: T): void; }
+foo(n => n.length, () => 'hi');
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "return-position evidence (#7653)");
+}


### PR DESCRIPTION
Closes the first concrete divergence predicted by #16018 (filed off `Quartz`'s review of #16016). Same false-positive family as #16012 / #15731, one layer over.

## Structural rule

**When a generic call passes a callback argument whose contextual parameter type mentions a type parameter `T`, and a *sibling* callback argument explicitly annotates the parameter sitting at a position whose contextual type also mentions `T`, `tsc` infers `T` contravariantly from that annotation and fixes it before contextually typing the first callback's body — tsz now does the same through the checker's `argument_provides_type_param_evidence` (`crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs`).**

### Wrong semantic operation

Inference evidence classification, in the post-generic uninferred-callback recheck — not the normal Round 1 / Round 2 contextual-typing path, which was already correct.

`emit_uninferred_callback_unknown_body_diagnostics` defaults a type parameter to `unknown` and re-checks a context-sensitive callback body against that default, but only when it believes the parameter was genuinely never inferred. It asked `argument_provides_type_param_evidence`, which for a sibling **callback** argument counted only the contextual **return** position. Its comment justified that with:

> Parameter positions are contravariant and supply context TO the lambda's parameters from `T`, not inference FROM the lambda back to `T`.

That is true for an *unannotated* parameter — an inference **sink**, whose type is produced by the contextual type. It is exactly backwards for an *annotated* parameter, which is an inference **source**. So the recheck concluded "no evidence", defaulted to `unknown`, and emitted a spurious `TS18046` on a body `tsc` types cleanly.

The fix keeps the return-position rule and adds the annotated-parameter rule beside it. It is **position-aware**: an annotation only counts when it sits at a slot whose contextual parameter type mentions the type parameter.

## Oracle

Every expectation is pinned against real `tsc` 7.0.2, `--noEmit --strict --pretty false`. Abbreviating the shared signature as `run` with one type parameter `T`, `setup` and `use` both callbacks over `T`:

| case | sibling `setup` argument | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| annotated param | `(value: string) => ...` | clean | **TS18046** | clean |
| renamed binders | same, all names changed | clean | **TS18046** | clean |
| partially annotated | `(value: string, extra) => ...` | clean | **TS18046** | clean |
| function expression | `function (value: string): void` | clean | **TS18046** | clean |
| `T` nested in object | `(box: { item: string }) => ...` | clean | **TS18046** | clean |
| `T` under an array | `(values: number[]) => ...` | clean | **TS18046** | clean |
| generic alias callable | `Take` interface wrapper | clean | **TS18046** | clean |
| **negative:** no annotations | `(value) => ...` | **2x TS18046** | 2x TS18046 | 2x TS18046 |
| **negative:** annotation off-position | `(value, tag: string) => ...` | **1x TS18046** | 1x TS18046 | 1x TS18046 |
| **negative:** return-position (#7653) | parameterless lambda | clean | clean | clean |

The two negative controls are what force the rule to be position-aware. In the off-position case the sibling *does* carry an explicit annotation, but at the `tag` slot; the slot that mentions `T` is unannotated, and `tsc` still reports `TS18046`. A "the sibling has some annotation" rule would have silenced a true positive.

## Anti-hardcoding

No identifier, alias, property or file-name string drives the decision; no predicate reads rendered type or printer output. Evidence is decided structurally from `type_contains_type_parameter_binder` over the contextual parameter type plus the presence of an AST `type_annotation` on the lambda's own parameter — the same annotation predicate `is_contextually_sensitive` already uses. Binders are renamed in a dedicated test row.

## Goal
Goal: green

## Verification

Local, this container. Before/after are the same suite on the same commit with and without the one-hunk change.

- `cargo test --test issue_16018_annotated_sibling_callback_evidence_tests` — new suite, 10 tests. **Before the fix: 3 passed / 7 failed** (all 7 failures the spurious `TS18046`; the 3 passes are exactly the negative controls). **After: 10 passed / 0 failed.**
- `cargo test --test issue_7653_parameterless_lambda_inference_tests` — **9/9 pass** (the return-position contract this function already encoded).
- `cargo test --test issue_16012_any_argument_type_param_evidence_tests` — **7/7 pass** (the `any`-sibling contract from #16016, including its own `unknown_and_error_siblings_still_do_not_count_as_evidence` negative).
- `cargo clippy --profile dist-fast -p tsz-checker --lib -- -D warnings` — clean (run by the repo pre-commit hook, which also ran the architecture size guard: passed).
- `cargo fmt --all` — clean.

### Not yet run, and why

`scripts/conformance/compare-to-parent.sh` has **not** run against this head. This container started cold (no cargo cache, no corpus, no release binary) and the release build needed for the conformance runner did not finish inside the session. I am flagging it rather than implying coverage I do not have — this is a diagnostic-gating change, so it wants the two-sided sweep before landing. Emit and fourslash are untouched surface (no emitter or LSP code in the diff), but the conformance sweep is the gate that matters here.

The change is confined to one predicate that can only ever *suppress* a `TS18046` the recheck was about to emit; it cannot introduce a new diagnostic. The risk it does carry is the opposite direction — silencing a true positive — which is what the two oracle-pinned negative controls exist to bound.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Obsidian


---
_Generated by [Claude Code](https://claude.ai/code/session_01QqDCt6ChDP5UzMAXLtruLZ)_