### PR TITLE
fix(checker): carry a type-predicate target through return-context substitution

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2558,3 +2558,6 @@ path = "tests/generic_mapped_to_index_signature_tests.rs"
 [[test]]
 name = "object_literal_synthetic_this_display_order_tests"
 path = "tests/object_literal_synthetic_this_display_order_tests.rs"
+[[test]]
+name = "predicate_target_return_only_sibling_tests"
+path = "tests/predicate_target_return_only_sibling_tests.rs"

--- a/crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs
@@ -677,6 +677,25 @@ impl<'a> CheckerState<'a> {
                 substitution,
                 visited,
             );
+            // A type-predicate target (`x is I`) carries a tracked type
+            // parameter the same way an ordinary return type does; tsc infers
+            // `I` from it when a concrete sibling argument's predicate target
+            // is matched against it. `return_type` for a predicate-returning
+            // function is just `boolean`, so without this the predicate's own
+            // target type is never visited and `I` stays unresolved.
+            if let (Some(source_pred), Some(target_pred)) =
+                (source_fn.type_predicate, target_fn.type_predicate)
+                && let (Some(source_pred_ty), Some(target_pred_ty)) =
+                    (source_pred.type_id, target_pred.type_id)
+            {
+                self.collect_return_context_substitution(
+                    source_pred_ty,
+                    target_pred_ty,
+                    tracked_type_params,
+                    substitution,
+                    visited,
+                );
+            }
             if substitution.len() > substitution_len_before_callable
                 || (source_application.is_none() && target_application.is_none())
             {

--- a/crates/tsz-checker/tests/predicate_target_return_only_sibling_tests.rs
+++ b/crates/tsz-checker/tests/predicate_target_return_only_sibling_tests.rs
@@ -1,0 +1,135 @@
+//! Regression tests: a sibling argument's type-predicate target (`x is I`)
+//! must seed the shared type parameter `I` even when `I` is *also*
+//! return-only in another, unrelated sensitive callback's parameter type
+//! (`untransform: (v: O, a: A) => I` in the superjson `classRule` shape,
+//! issue #16022).
+//!
+//! Structural rule: `tsc` fixes a type parameter from non-deferred evidence
+//! (here, a concrete sibling argument's predicate target) before contextually
+//! typing any sensitive callback body, regardless of how many other sensitive
+//! callbacks also mention that parameter.
+//!
+//! Root cause: `collect_return_context_substitution`'s function-to-function
+//! matching arm
+//! (`crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs`)
+//! walked a callable pair's `params` and `return_type` to recover a tracked
+//! type parameter's binding, but never visited `type_predicate.type_id` — the
+//! only place a predicate-returning function's target type lives (its
+//! `return_type` is just `boolean`). A type parameter whose sole concrete
+//! evidence was a sibling's predicate target was therefore invisible to this
+//! pre-seed pass, which independently gates the deeper stripping/defaulting
+//! path (`should_strip_sensitive_placeholder_substitution`,
+//! `crates/tsz-checker/src/checkers/call_context.rs`) that issue #16022
+//! traced. #16024 (`argument_provides_type_param_evidence`) already fixed the
+//! simpler 2-type-param variant of this family; these tests cover the
+//! 3-type-param shape that survived it.
+//!
+//! Pinned against real `tsc` 7.0.2 (`--noEmit --strict`), reduced from
+//! `superjson/src/transformer.ts`'s `classRule`/`compositeTransformation`.
+
+fn compile_and_get_diagnostics(source: &str) -> Vec<(u32, String)> {
+    tsz_checker::test_utils::check_source_code_messages(source)
+}
+
+fn assert_no_ts18046(diagnostics: &[(u32, String)], context: &str) {
+    assert!(
+        diagnostics.iter().all(|(code, _)| *code != 18046),
+        "Did not expect TS18046 in {context}. Got: {diagnostics:?}"
+    );
+}
+
+fn assert_no_ts2698(diagnostics: &[(u32, String)], context: &str) {
+    assert!(
+        diagnostics.iter().all(|(code, _)| *code != 2698),
+        "Did not expect TS2698 in {context}. Got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn predicate_evidence_survives_when_type_param_is_also_return_only_elsewhere() {
+    // The real #16022 shape: `I` is evidenced only by `isApplicable`'s
+    // predicate target, and is *also* return-only in `untransform`'s
+    // parameter type alongside a third type parameter `A` that itself
+    // depends on the sensitive `annotation` callback.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+function isInstanceOfRegisteredClass(
+  potentialClass: any
+): potentialClass is any {
+  return !!potentialClass?.constructor;
+}
+
+function compositeTransformation<I, O, A>(
+  isApplicable: (v: any) => v is I,
+  annotation: (v: I) => A,
+  transform: (v: I) => O,
+  untransform: (v: O, a: A) => I
+) {
+  return { isApplicable, annotation, transform, untransform };
+}
+
+const classRule = compositeTransformation(
+  isInstanceOfRegisteredClass,
+  (clazz) => {
+    return 'x';
+  },
+  (clazz) => {
+    return { ...clazz };
+  },
+  (v, a) => v
+);
+export { classRule };
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "three-type-param classRule shape");
+    assert_no_ts2698(&diagnostics, "three-type-param classRule shape");
+}
+
+#[test]
+fn renamed_binders_three_type_param_predicate_evidence_is_structural() {
+    // Same shape with every type parameter and parameter name renamed,
+    // proving the rule is structural rather than keyed on a specific
+    // identifier.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+function isRegistered(candidate: any): candidate is any {
+  return !!candidate?.constructor;
+}
+
+function makeCodec<Target, Encoded, Meta>(
+  guard: (raw: any) => raw is Target,
+  describe: (value: Target) => Meta,
+  encode: (value: Target) => Encoded,
+  decode: (encoded: Encoded, meta: Meta) => Target
+) {
+  return { guard, describe, encode, decode };
+}
+
+const codec = makeCodec(
+  isRegistered,
+  (value) => {
+    return 'meta';
+  },
+  (value) => {
+    return { ...value };
+  },
+  (encoded, meta) => encoded
+);
+export { codec };
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "renamed three-type-param shape");
+    assert_no_ts2698(&diagnostics, "renamed three-type-param shape");
+}
+
+// A "no predicate evidence" negative control for this exact 3-type-param
+// shape is deliberately not included here: with `isApplicable` replaced by a
+// plain boolean-returning function, `I` has no evidence source at all, and a
+// separate, pre-existing gap in `should_strip_sensitive_placeholder_substitution`
+// (return-only type param in a third sensitive callback) already defaults it
+// to `any` instead of `unknown` on main, independent of this fix — verified
+// against real tsc 7.0.2, which reports TS2698 there and tsz does not, both
+// before and after this change. The simpler 2-type-param negative control
+// (`type_predicate_sibling_argument_evidence_tests.rs`,
+// `non_predicate_sibling_without_evidence_still_reports_unknown`) does not
+// hit that gap and stays green.


### PR DESCRIPTION
Closes #16022.

When `tsc` sees a generic call where one sibling argument's callable type has
a type predicate (`isApplicable: (v: any) => v is I`) and another sibling
callback's contextual parameter type mentions the same tracked type
parameter, it fixes `I` from the predicate target before contextually typing
the sibling callback body — even when `I` is *also* return-only in a third,
unrelated sensitive callback (`untransform: (v: O, a: A) => I`). tsz did not:
`collect_return_context_substitution`'s function-to-function matching arm
(`crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs`)
walked a callable pair's `params` and `return_type` to recover a tracked type
parameter's binding, but never visited `type_predicate.type_id` — the only
place a predicate-returning function's target type lives (its `return_type`
is just `boolean`). A type parameter whose sole concrete evidence was a
sibling's predicate target was therefore invisible to this pre-seed pass, so
the deeper stripping/defaulting path
(`should_strip_sensitive_placeholder_substitution`,
`crates/tsz-checker/src/checkers/call_context.rs`) that #16022 traced saw no
evidence for `I` and discarded it, leaving the real superjson
`classRule`/`compositeTransformation` shape (3 type params) reporting spurious
`TS18046`/`TS2698` inside callback bodies that tsc compiles clean.

#16024 already fixed the simpler 2-type-param variant of this family via
`argument_provides_type_param_evidence` (a different, Round-1 checker
heuristic). This PR fixes the deeper 3-type-param shape that survived it, via
the return-context substitution pre-seed pass instead — both of #16022's own
suggested directions (narrowing the strip helper, mirroring the predicate
branch into `resolve_generic_call_inner`) were investigated and found
empirically dead by an earlier session on this board; this is a third,
narrower fix at the pre-seed layer that both directions sit downstream of.

Structural rule: when a sibling argument's callable type has a type predicate
(`x is I`) and the contextual target callable also has one over the same
tracked type parameter, `tsc` treats the predicate target the same as an
ordinary return-position occurrence for return-context inference; tsz now
does the same in `collect_return_context_substitution`.

## Goal
Goal: green

## Verification
- New suite `predicate_target_return_only_sibling_tests.rs` (2 tests): the
  real #16022 3-type-param `classRule` repro (pinned against real tsc 7.0.2,
  clean) and a fully renamed-binder variant proving the rule is structural,
  not name-keyed. Both fail on current main (`TS18046` x2 + `TS2698`) and pass
  with this fix.
- Adjacent-family regression suites, all green:
  `type_predicate_sibling_argument_evidence_tests` (5/5),
  `predicate_callback_any_inference_tests` (4/4),
  `issue_16012_any_argument_type_param_evidence_tests` (7/7),
  `issue_16018_annotated_sibling_callback_evidence_tests` (10/10),
  `predicate_alias_generic_inference_tests` (3/3),
  `predicate_bare_target_nested_param_inference_tests` (5/5),
  `class_implements_predicate_inference_tests` (5/5),
  `any_user_predicate_keeps_any_for_object_function_tests` (5/5).
  `generic_call_assignment_flow_tests` shows the same 2 pre-existing failures
  as on main (`colliding_generic_terminals_keep_flow_diagnostics_clean_across_file_orders`,
  `imported_generic_result_narrows_inside_reduce_arrow`), baselined in #16023
  — verified unchanged by re-running on unmodified main.
- `cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: passes.
- `scripts/conformance/compare-to-parent.sh` (two-sided, against `2a8c4d7`):
  base failing=606, branch failing=606. **0 newly passing, 0 newly failing.**
  This null result is the expected signature for this evidence family (no
  corpus fixture exercises the "predicate-evidenced type param also
  return-only in a third sensitive callback" shape) — the targeted matrix
  above is the primary evidence, per this family's established precedent
  (#16016/#16020/#16024).
- Emit floor (`scripts/emit/run.sh`): **not verified this session** — the
  `npm install` step for the emit runner hung with zero progress for 8+
  minutes in this container, a previously-documented issue with this harness
  in cloud sessions. This PR only touches checker-side type-parameter
  substitution inference, not emit; flagging per the project's
  disclosure convention rather than claiming an unverified floor.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NphzngZrzWWFZPASMrR9iT)_