### PR TITLE
fix(checker): scope the generator `yield*` signature bail to evolving delegates

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -505,7 +505,10 @@ impl<'a> FlowAnalyzer<'a> {
         simplified
     }
 
-    pub(super) fn reference_is_evolving_array_symbol(&self, reference: NodeIndex) -> bool {
+    /// Whether `reference` reads a binding whose type is still evolving from
+    /// control flow — an implicit-any local, or an unannotated `var`/`let`
+    /// seeded with `[]`.
+    pub(crate) fn reference_is_evolving_array_symbol(&self, reference: NodeIndex) -> bool {
         let Some(sym_id) = self.reference_symbol(reference) else {
             return false;
         };

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -292,6 +292,9 @@ mod function_type_relation_routing_arch_tests;
 #[path = "tests/function_type_return_node_tests.rs"]
 mod function_type_return_node_tests;
 #[cfg(test)]
+#[path = "tests/generator_declaration_yield_star_inference_tests.rs"]
+mod generator_declaration_yield_star_inference_tests;
+#[cfg(test)]
 #[path = "../tests/generator_union_return_type_tests.rs"]
 mod generator_union_return_type_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/generator_declaration_yield_star_inference_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_declaration_yield_star_inference_tests.rs
@@ -1,0 +1,303 @@
+//! Regression tests for `yield*` delegation in *unannotated generator
+//! declarations* (#15632, declaration-signature half).
+//!
+//! `tsc` folds the delegated operand's iteration yield type into the inferred
+//! signature: `function* g() { yield* [1, 2, 3] }` is
+//! `Generator<number, void, unknown>`. tsz collected the same contribution in
+//! `dispatch/yield_.rs`, but `infer_generator_declaration_yield_type` — the
+//! suppressed pre-pass that computes a *declaration*'s yield type before its
+//! real body check runs — bailed on **any** `yield*` anywhere in the body, so
+//! the signature fell back to `any` and every delegating generator declaration
+//! silently accepted an incompatible `Generator<...>`.
+//!
+//! The bail exists for one real hazard, which these tests pin as negative
+//! controls: when the delegate reads an *evolving* (implicit-any) binding whose
+//! type depends circularly on the very aggregate being inferred
+//! (`var o = []; while (true) { o = yield* o }`, TypeScript's own
+//! `yieldExpressionInControlFlow.ts`), the speculative pass resolves that
+//! circularity as a side effect and the later real declaration check stops
+//! reporting the implicit-any diagnostics it owns. That shape is now detected
+//! structurally instead of by "contains a `yield*` at all".
+//!
+//! Scope: every row here delegates to an array, tuple, or type-parameter
+//! array, which is what `get_iterator_info`'s fast path answers. A delegate
+//! that has to go through `[Symbol.iterator]` resolution — `Generator<...>`,
+//! `Iterable<...>`, `Set<...>`, `string` — still contributes nothing to the
+//! aggregated yield type, on the generator *expression* path as well as this
+//! one, so it is a distinct root cause from the gate fixed here and is tracked
+//! separately. Do not read this suite as covering that family.
+//!
+//! Every expectation below was pinned against `tsc` 7.0.2
+//! (`--strict --target es2017`).
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+/// Shared probe preamble. `wants*` are the assignability oracle: a delegating
+/// generator's inferred yield type is only observable through whether its
+/// `Generator<...>` is accepted by a pinned parameter type.
+const PROBES: &str = r#"
+export {};
+declare function wantsNumber(g: Generator<number, void, unknown>): void;
+declare function wantsString(g: Generator<string, void, unknown>): void;
+declare function wantsBoolean(g: Generator<boolean, void, unknown>): void;
+declare function wantsNumberOrString(g: Generator<number | string, void, unknown>): void;
+"#;
+
+fn probed(body: &str) -> Vec<u32> {
+    strict_codes(&format!("{PROBES}{body}"))
+}
+
+#[test]
+fn array_literal_delegate_infers_element_type() {
+    assert!(
+        probed("function* fromArray() { yield* [1, 2, 3]; }\nwantsNumber(fromArray());").is_empty(),
+        "yield* over a number[] must infer Generator<number, ...>"
+    );
+}
+
+#[test]
+fn array_literal_delegate_rejects_wrong_yield_type() {
+    // The negative half of the pair above: without it, an inferred `any` would
+    // make the positive test pass for the wrong reason.
+    assert_eq!(
+        probed("function* fromArray() { yield* [1, 2, 3]; }\nwantsString(fromArray());"),
+        vec![2345],
+        "an inferred Generator<number, ...> must not satisfy Generator<string, ...>"
+    );
+}
+
+#[test]
+fn tuple_delegate_infers_the_element_union() {
+    assert!(
+        probed(
+            r#"
+declare const pair: [number, number];
+function* fromTuple() { yield* pair; }
+wantsNumber(fromTuple());
+"#
+        )
+        .is_empty(),
+        "yield* over a tuple must infer its element union"
+    );
+}
+
+#[test]
+fn tuple_delegate_rejects_wrong_yield_type() {
+    assert_eq!(
+        probed(
+            r#"
+declare const pair: [number, number];
+function* fromTuple() { yield* pair; }
+wantsString(fromTuple());
+"#
+        ),
+        vec![2345]
+    );
+}
+
+#[test]
+fn renamed_binders_do_not_change_the_outcome() {
+    // Anti-hardcoding control: identical shape, every binder renamed.
+    assert_eq!(
+        probed(
+            r#"
+function* qqq() {
+    const zzz = [1, 2, 3];
+    yield* zzz;
+}
+wantsString(qqq());
+"#
+        ),
+        vec![2345]
+    );
+}
+
+#[test]
+fn delegate_through_a_const_binding_infers_element_type() {
+    // Alias/wrapper row: the delegate is a reference, not a literal — and a
+    // `const` with an initializer is *not* an evolving binding, so the pass
+    // must still run.
+    assert_eq!(
+        probed(
+            r#"
+function* fromConst() {
+    const items = ["a", "b"];
+    yield* items;
+}
+wantsNumber(fromConst());
+"#
+        ),
+        vec![2345]
+    );
+}
+
+#[test]
+fn mixed_plain_and_delegated_yields_union_both() {
+    assert!(
+        probed(
+            r#"
+function* mixed() { yield 1; yield* ["a"]; }
+wantsNumberOrString(mixed());
+"#
+        )
+        .is_empty(),
+        "a body with both `yield 1` and `yield* string[]` must infer number | string"
+    );
+}
+
+#[test]
+fn mixed_plain_and_delegated_yields_reject_either_half_alone() {
+    assert_eq!(
+        probed(
+            r#"
+function* mixed() { yield 1; yield* ["a"]; }
+wantsNumber(mixed());
+"#
+        ),
+        vec![2345],
+        "the delegated half must not be dropped from the union"
+    );
+}
+
+#[test]
+fn generic_delegate_infers_the_type_parameter() {
+    assert!(
+        probed(
+            r#"
+function* eachOf<T>(xs: T[]) { yield* xs; }
+wantsBoolean(eachOf([true]));
+"#
+        )
+        .is_empty(),
+        "yield* over T[] must infer Generator<T, ...> and instantiate to boolean"
+    );
+}
+
+#[test]
+fn generic_delegate_rejects_wrong_instantiation() {
+    assert_eq!(
+        probed(
+            r#"
+function* eachOf<T>(xs: T[]) { yield* xs; }
+wantsNumber(eachOf([true]));
+"#
+        ),
+        vec![2345]
+    );
+}
+
+#[test]
+fn a_second_delegating_declaration_is_gated_independently() {
+    // The gate is evaluated per generator declaration: `inner`'s own `yield*`
+    // must not leak into `outer`'s decision or its inferred yield type.
+    assert_eq!(
+        probed(
+            r#"
+function* inner() { yield* [1, 2]; }
+function* outer() { yield* [3, 4]; inner(); }
+wantsString(outer());
+"#
+        ),
+        vec![2345]
+    );
+}
+
+#[test]
+fn yield_star_inside_a_nested_function_does_not_gate_the_outer_generator() {
+    // The walk must not see the inner generator's `yield*` as the outer's.
+    assert_eq!(
+        probed(
+            r#"
+function* outer() {
+    yield 1;
+    function* nested() { yield* ["a"]; }
+    nested();
+}
+wantsString(outer());
+"#
+        ),
+        vec![2345]
+    );
+}
+
+#[test]
+fn evolving_array_self_delegation_still_reports_implicit_any() {
+    // NEGATIVE CONTROL — the shape the bail exists for, reduced from
+    // TypeScript's own `yieldExpressionInControlFlow.ts`. `o` is an evolving
+    // binding whose type depends on the yield* aggregate that reads it; the
+    // pre-pass must keep bailing here so the real declaration check still owns
+    // the implicit-any family.
+    let codes = probed(
+        r#"
+function* circular() {
+    var o = [];
+    while (true) {
+        o = yield* o;
+    }
+}
+"#,
+    );
+    assert!(
+        !codes.is_empty(),
+        "the circular evolving-binding delegate must still report its implicit-any family, got {codes:?}"
+    );
+}
+
+#[test]
+fn evolving_array_self_delegation_is_unaffected_by_binder_names() {
+    // Same negative control with every binder renamed: the guard is structural,
+    // not name-shaped.
+    let codes = probed(
+        r#"
+function* zzz() {
+    var qqq = [];
+    while (true) {
+        qqq = yield* qqq;
+    }
+}
+"#,
+    );
+    assert!(
+        !codes.is_empty(),
+        "renaming the evolving binding must not change the guard, got {codes:?}"
+    );
+}
+
+#[test]
+fn a_non_evolving_delegate_beside_an_evolving_one_still_bails() {
+    // Fallback row: the guard is per-generator, not per-`yield*`. One evolving
+    // delegate anywhere in the body keeps the whole pre-pass off, which is the
+    // conservative direction.
+    let codes = probed(
+        r#"
+function* both() {
+    var o = [];
+    yield* [1, 2];
+    while (true) {
+        o = yield* o;
+    }
+}
+"#,
+    );
+    assert!(
+        !codes.is_empty(),
+        "an evolving delegate anywhere in the body keeps the bail, got {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
+++ b/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
@@ -3,6 +3,7 @@ use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 pub(super) struct GeneratorDeclarationYieldCtx {
@@ -39,20 +40,21 @@ impl CheckerState<'_> {
             function_is_async,
             early_yield_type,
         } = ctx;
-        // This speculative pass is not diagnostic-safe for `yield*`: when the
-        // delegate is itself an evolving (`var`/`let x = []`) binding whose type
-        // depends circularly on this same yield* aggregate, running the body
-        // check here resolves that circularity as a side effect, so the later
-        // "real" declaration-check pass no longer sees it as unresolved and
-        // skips the implicit-any diagnostics it owns (TS2322/TS7005/TS7034).
-        // This is not JS-specific — TypeScript's own `yieldExpressionInControlFlow.ts`
-        // conformance fixture hits the identical shape in a plain `.ts` file
-        // (`var o = []; while (true) { o = yield* o }`), confirmed by a
-        // corpus-wide compare-to-parent regression when this bail was narrowed
-        // to `is_js_file()` alone. Bail on any `yield*` until this pass can
-        // detect the circular-evolving-binding shape structurally instead of by
-        // file kind.
-        if self.generator_body_contains_yield_star(body, true) {
+        // This speculative pass is not diagnostic-safe for a `yield*` whose
+        // delegate reads an evolving (`var o;` / `let x = []`) binding: that
+        // binding's type depends circularly on the very yield* aggregate being
+        // inferred here, so running the body check resolves the circularity as
+        // a side effect and the later "real" declaration-check pass no longer
+        // sees it as unresolved — silently dropping the implicit-any
+        // diagnostics it owns (TS2322/TS7005/TS7034). This is not JS-specific:
+        // TypeScript's own `yieldExpressionInControlFlow.ts` conformance
+        // fixture hits the identical shape in a plain `.ts` file
+        // (`var o = []; while (true) { o = yield* o }`), which is why an
+        // earlier narrowing to `is_js_file()` alone regressed the corpus.
+        // The hazard is the *evolving delegate*, not `yield*` itself, so the
+        // gate is that shape structurally — an ordinary delegate (array,
+        // annotated generator, `const` binding, type parameter) infers through.
+        if self.generator_body_delegates_to_evolving_binding(body, true) {
             return None;
         }
 
@@ -115,19 +117,7 @@ impl CheckerState<'_> {
         let Some(node) = self.ctx.arena.get(node_idx) else {
             return false;
         };
-        if !is_root
-            && matches!(
-                node.kind,
-                k if k == syntax_kind_ext::FUNCTION_DECLARATION
-                    || k == syntax_kind_ext::FUNCTION_EXPRESSION
-                    || k == syntax_kind_ext::METHOD_DECLARATION
-                    || k == syntax_kind_ext::GET_ACCESSOR
-                    || k == syntax_kind_ext::SET_ACCESSOR
-                    || k == syntax_kind_ext::CONSTRUCTOR
-                    || k == syntax_kind_ext::CLASS_DECLARATION
-                    || k == syntax_kind_ext::CLASS_EXPRESSION
-            )
-        {
+        if !is_root && Self::node_kind_owns_its_own_yields(node.kind) {
             return false;
         }
         if node.kind == syntax_kind_ext::YIELD_EXPRESSION {
@@ -140,33 +130,28 @@ impl CheckerState<'_> {
             .any(|child| self.generator_body_contains_yield(child, false))
     }
 
-    /// Whether `node_idx` contains a `yield*` delegate for this generator, not
-    /// one nested inside another function or class.
-    fn generator_body_contains_yield_star(&self, node_idx: NodeIndex, is_root: bool) -> bool {
+    /// Whether `node_idx` contains a `yield*` whose delegate operand reads an
+    /// evolving (implicit-any) binding, for this generator rather than one
+    /// nested inside another function or class.
+    ///
+    /// This is the shape the speculative pass must not run on: the delegate's
+    /// own type is still being derived from control flow, and one of the
+    /// assignments feeding it is the `yield*` aggregate this pass is computing.
+    fn generator_body_delegates_to_evolving_binding(
+        &self,
+        node_idx: NodeIndex,
+        is_root: bool,
+    ) -> bool {
         let Some(node) = self.ctx.arena.get(node_idx) else {
             return false;
         };
-        if !is_root
-            && matches!(
-                node.kind,
-                k if k == syntax_kind_ext::FUNCTION_DECLARATION
-                    || k == syntax_kind_ext::FUNCTION_EXPRESSION
-                    || k == syntax_kind_ext::METHOD_DECLARATION
-                    || k == syntax_kind_ext::GET_ACCESSOR
-                    || k == syntax_kind_ext::SET_ACCESSOR
-                    || k == syntax_kind_ext::CONSTRUCTOR
-                    || k == syntax_kind_ext::CLASS_DECLARATION
-                    || k == syntax_kind_ext::CLASS_EXPRESSION
-            )
-        {
+        if !is_root && Self::node_kind_owns_its_own_yields(node.kind) {
             return false;
         }
         if node.kind == syntax_kind_ext::YIELD_EXPRESSION
-            && self
-                .ctx
-                .arena
-                .get_unary_expr_ex(node)
-                .is_some_and(|yield_expr| yield_expr.asterisk_token)
+            && let Some(yield_expr) = self.ctx.arena.get_unary_expr_ex(node)
+            && yield_expr.asterisk_token
+            && self.expression_reads_evolving_binding(yield_expr.expression)
         {
             return true;
         }
@@ -174,6 +159,48 @@ impl CheckerState<'_> {
             .arena
             .get_children(node_idx)
             .into_iter()
-            .any(|child| self.generator_body_contains_yield_star(child, false))
+            .any(|child| self.generator_body_delegates_to_evolving_binding(child, false))
+    }
+
+    /// Whether any reference anywhere in the delegate operand's subtree
+    /// resolves to an evolving binding.
+    ///
+    /// The whole subtree counts, nested closures included: a delegate built
+    /// from a closure that reads the evolving binding still routes that
+    /// binding's unresolved type into this aggregate, and bailing is the safe
+    /// direction.
+    fn expression_reads_evolving_binding(&self, node_idx: NodeIndex) -> bool {
+        if node_idx.is_none() {
+            return false;
+        }
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+        if node.kind == SyntaxKind::Identifier as u16
+            && self
+                .flow_analyzer()
+                .reference_is_evolving_array_symbol(node_idx)
+        {
+            return true;
+        }
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child| self.expression_reads_evolving_binding(child))
+    }
+
+    /// Node kinds that introduce a generator/function boundary, so their
+    /// `yield`s belong to that inner function rather than the one being
+    /// inferred.
+    const fn node_kind_owns_its_own_yields(kind: u16) -> bool {
+        kind == syntax_kind_ext::FUNCTION_DECLARATION
+            || kind == syntax_kind_ext::FUNCTION_EXPRESSION
+            || kind == syntax_kind_ext::METHOD_DECLARATION
+            || kind == syntax_kind_ext::GET_ACCESSOR
+            || kind == syntax_kind_ext::SET_ACCESSOR
+            || kind == syntax_kind_ext::CONSTRUCTOR
+            || kind == syntax_kind_ext::CLASS_DECLARATION
+            || kind == syntax_kind_ext::CLASS_EXPRESSION
     }
 }


### PR DESCRIPTION
Closes the declaration-signature half of #15632 — the gap Pumice's board NOTE (05:05Z) named as still open after #16011 fixed the emitter half, and after #16014 closed the `TReturn` direction as not-a-bug.

**Structural rule.** When an unannotated generator *declaration*'s body contains a `yield*`, tsc folds the delegated operand's iteration yield type into the inferred signature; tsz does this through the checker's `infer_generator_declaration_yield_type` pre-pass. That pre-pass previously returned `None` for **any** `yield*` anywhere in the body, so the signature fell back to `any` and every delegating generator declaration silently accepted an incompatible `Generator` instantiation. The bail now fires only on the shape it was actually protecting.

**What the bail was for, and why it was too wide.** Its own in-code comment already named the hazard and asked for exactly this narrowing: when the delegate reads an *evolving* (implicit-any) binding whose type depends circularly on the very aggregate being inferred, running the body check speculatively resolves that circularity as a side effect, so the later real declaration check no longer sees it as unresolved and drops the implicit-any diagnostics it owns (TS2322/TS7005/TS7034). TypeScript's own `yieldExpressionInControlFlow.ts` fixture is that shape in plain `.ts`, which is why an earlier attempt to narrow the bail by file kind (`is_js_file()`) regressed the corpus. The hazard is the *evolving delegate*, not `yield*` itself, so the gate is now that shape structurally: a `yield*` whose operand subtree reads a binding the flow analyzer already classifies as evolving (`reference_is_evolving_array_symbol`, widened from `pub(super)` to `pub(crate)` — no new predicate, no duplicated notion of "evolving").

**Owner layer.** Checker only. The downstream contribution machinery (`dispatch/yield_.rs`'s `push_generator_yield_contribution`) was already correct; only the gate above it was wrong. No solver, emitter, or diagnostic-display change.

Two DRY/altitude notes on the diff: the two copies of the "node kinds that own their own yields" list are consolidated into one helper (identical membership, no behavior change), and the operand walk deliberately does **not** skip nested closures — a delegate built from a closure that reads the evolving binding still routes that unresolved type into the aggregate, and bailing is the safe direction.

## Goal
Goal: hold

## Verification

**New acceptance suite** — `crates/tsz-checker/src/tests/generator_declaration_yield_star_inference_tests.rs`, 15 tests, every expectation pinned against a real `tsc` 7.0.2 oracle (`--noEmit --strict --pretty false --target es2017`) before writing the fix:

| | before | after |
| --- | --- | --- |
| `cargo test -p tsz-checker --lib generator_declaration_yield_star` | **8 passed / 7 failed** | **15 passed / 0 failed** |

Measured on the same commit with and without the two source hunks (`git stash push` of `generator_declaration_yield.rs` + `core.rs`), so the delta is the fix and not the harness. All 7 previously-failing rows are the *negative* half of each pair — the ones an inferred `any` makes pass for the wrong reason.

Adjacent-case matrix (positive **and** negative probe for each, since only the negative half can detect an inferred `any`):

- array-literal delegate; tuple delegate; delegate through a `const` binding (alias/wrapper row)
- generic `yield* xs` over `T[]`, checked at two different instantiations
- mixed body (`yield 1; yield* ["a"]`) — the union must keep both halves
- renamed binders throughout (anti-hardcoding control)
- `yield*` inside a nested generator must not gate the outer one; a second delegating declaration is gated independently
- **negative controls, must keep bailing:** the `yieldExpressionInControlFlow.ts` circular shape (`var o = []; while (true) { o = yield* o }`), the same with every binder renamed, and a body mixing one ordinary and one evolving delegate (the conservative direction — one evolving delegate keeps the whole pre-pass off)

**Adjacent suites:** `cargo test -p tsz-checker --lib -- generator yield_ iterat` → **167 passed / 0 failed**.

**Gates:** `cargo fmt` clean; pre-commit `cargo clippy --profile dist-fast -p tsz-checker --lib -- -D warnings` passed; architecture size guard passed.

**Conformance:** `scripts/conformance/compare-to-parent.sh` (two-sided vs this branch's own parent) is running in this container; result will be posted as a comment on this PR before it is queued. It is the gate that matters here — this diff *enables* a previously-suppressed inference pass, so the direction to check is newly-appearing diagnostics on delegating generators, which is exactly what the `is_js_file()` attempt tripped.

**Deliberately out of scope, measured and written down rather than banked.** A delegate that resolves through `[Symbol.iterator]` rather than `get_iterator_info`'s array/tuple fast path — `Generator`, `Iterable`, `Set`, `string` — still contributes nothing to the aggregated yield type. Probed all four plus a `string` literal delegate: all silently accept a mismatched instantiation, and they do so on the generator *expression* path too, so it is a distinct root cause from this gate rather than a remaining piece of it. Filed separately with the probe table; this PR's suite is scoped to what it actually owns, and its module doc says so explicitly.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Shale

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMJhEzFs4DkPVG92GA3Pzy)_