### PR TITLE
fix(checker): carry a predicate function's target type through return-context matching

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2547,6 +2547,9 @@ path = "tests/default_export_merge_diagnostics_tests.rs"
 name = "type_predicate_sibling_argument_evidence_tests"
 path = "tests/type_predicate_sibling_argument_evidence_tests.rs"
 [[test]]
+name = "predicate_target_round2_contextual_carrier_tests"
+path = "tests/predicate_target_round2_contextual_carrier_tests.rs"
+[[test]]
 name = "indexed_access_concrete_missing_key_ts2536_tests"
 path = "tests/indexed_access_concrete_missing_key_ts2536_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs
@@ -677,6 +677,27 @@ impl<'a> CheckerState<'a> {
                 substitution,
                 visited,
             );
+            // A type-predicate function's asserted type (`x is I`) is carried
+            // in `type_predicate.type_id`, not `return_type` (which is always
+            // `boolean`/`void`). Without this, a type parameter that only
+            // appears as a predicate target is invisible to return-context
+            // matching: two ordinary parameters or an ordinary return
+            // position bind the parameter fine, but a sibling predicate
+            // argument's inferred target type never reaches the substitution
+            // that types the rest of the call.
+            if let (Some(source_predicate), Some(target_predicate)) =
+                (source_fn.type_predicate, target_fn.type_predicate)
+                && let (Some(source_predicate_type), Some(target_predicate_type)) =
+                    (source_predicate.type_id, target_predicate.type_id)
+            {
+                self.collect_return_context_substitution(
+                    source_predicate_type,
+                    target_predicate_type,
+                    tracked_type_params,
+                    substitution,
+                    visited,
+                );
+            }
             if substitution.len() > substitution_len_before_callable
                 || (source_application.is_none() && target_application.is_none())
             {

--- a/crates/tsz-checker/tests/predicate_target_round2_contextual_carrier_tests.rs
+++ b/crates/tsz-checker/tests/predicate_target_round2_contextual_carrier_tests.rs
@@ -1,0 +1,198 @@
+//! Regression tests for issue #16022: a type parameter whose only Round-1
+//! evidence is a sibling predicate argument's target type (`x is I`) must
+//! survive into Round 2's contextual typing of *other* sensitive callbacks,
+//! including when the parameter is otherwise only return-only in one of
+//! them.
+//!
+//! Structural rule: `compute_round2_contextual_types`
+//! (`crates/tsz-checker/src/types/computation/call_inference/argument_context.rs`)
+//! re-instantiates a context-sensitive callback's contextual parameter type
+//! from the callee's declared shape plus a `TypeSubstitution` built by
+//! `merge_arg_return_context_into_round2` /
+//! `collect_return_context_substitution`
+//! (`crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs`).
+//! That walk matches two function types structurally — params
+//! contravariantly, then `return_type` — but a type-predicate function's
+//! asserted type (`x is I`) lives in `FunctionShape::type_predicate.type_id`,
+//! not in `return_type` (always `boolean`). A type parameter pinned only
+//! through a predicate target therefore had no carrier into the
+//! pre-seeded Round 2 substitution.
+//!
+//! With a single sensitive callback (`type_predicate_sibling_argument_evidence_tests`,
+//! #16024) this stayed hidden: the solver's full `resolve_call_with_checker_adapter`
+//! resolve independently recovers the type parameter from an ordinary
+//! covariant return position elsewhere in the signature. Once a *second*
+//! sensitive callback (here `annotation`) makes that recovery path itself
+//! depend on another not-yet-inferred type parameter, the recovery no longer
+//! fires and only the (missing) return-context carrier is left — producing
+//! the real superjson `classRule` false positives that #16024 alone did not
+//! close. Fixed by also recursing the predicate's target type when both
+//! sides of the structural function match carry a `type_predicate`.
+//!
+//! Every repro below is pinned against real `tsc` 7.0.2 (`--noEmit --strict`).
+
+use tsz_checker::test_utils::{
+    check_source_with_libs, diagnostic_codes, load_lib_files, strict_checker_options,
+};
+
+fn diagnostics(source: &str) -> Vec<u32> {
+    let libs = load_lib_files(&["es5.d.ts", "es2015.core.d.ts"]);
+    let mut codes = diagnostic_codes(&check_source_with_libs(
+        source,
+        "test.ts",
+        strict_checker_options(),
+        &libs,
+    ));
+    codes.sort_unstable();
+    codes
+}
+
+#[test]
+fn predicate_target_return_only_in_second_sensitive_callback_stays_clean() {
+    // The real superjson `transformer.ts` `classRule` shape (#15731/#16022):
+    // three type params, four arguments, two of them sensitive callbacks
+    // (`annotation`, `transform`). `I`'s only evidence is the predicate
+    // target on the non-sensitive `isApplicable` argument, and `I` is
+    // return-only in the sensitive `untransform` callback's declared type.
+    // tsc: clean.
+    let codes = diagnostics(
+        r#"
+declare function getAllowedProps(x: any): string[] | undefined;
+
+function isInstanceOfRegisteredClass(
+  potentialClass: any
+): potentialClass is any {
+  return !!potentialClass?.constructor;
+}
+
+function compositeTransformation<I, O, A>(
+  isApplicable: (v: any) => v is I,
+  annotation: (v: I) => A,
+  transform: (v: I) => O,
+  untransform: (v: O, a: A) => I
+) {
+  return { isApplicable, annotation, transform, untransform };
+}
+
+const classRule = compositeTransformation(
+  isInstanceOfRegisteredClass,
+  (clazz) => {
+    return 'x';
+  },
+  (clazz) => {
+    const allowedProps = getAllowedProps(clazz.constructor);
+    if (!allowedProps) {
+      return { ...clazz };
+    }
+    const result: any = {};
+    allowedProps.forEach(prop => {
+      result[prop] = clazz[prop];
+    });
+    return result;
+  },
+  (v, a) => v
+);
+"#,
+    );
+    assert_eq!(codes, Vec::<u32>::new(), "expected clean, got {codes:?}");
+}
+
+#[test]
+fn renamed_binder_predicate_target_return_only_carrier_is_structural() {
+    // Same shape with every type parameter, parameter, and argument name
+    // changed, proving the fix is structural (keyed on
+    // `FunctionShape::type_predicate`), not on identifiers.
+    let codes = diagnostics(
+        r#"
+function isTag(raw: any): raw is any {
+  return !!raw;
+}
+
+function makeCodec<Value, Encoded, Meta>(
+  guard: (raw: any) => raw is Value,
+  describe: (value: Value) => Meta,
+  encode: (value: Value) => Encoded,
+  decode: (encoded: Encoded, meta: Meta) => Value
+) {
+  return { guard, describe, encode, decode };
+}
+
+const codec = makeCodec(
+  isTag,
+  (value) => value,
+  (value) => {
+    const probe = value.field;
+    return probe;
+  },
+  (encoded, meta) => encoded
+);
+"#,
+    );
+    assert_eq!(codes, Vec::<u32>::new(), "expected clean, got {codes:?}");
+}
+
+#[test]
+fn two_type_param_variant_without_second_sensitive_callback_still_clean() {
+    // Positive/regression control: the simpler two-type-param shape (no `A`,
+    // `untransform: (v: O) => I`) already stayed clean before this fix
+    // because the solver's full resolve recovers `I` covariantly from
+    // `untransform`'s own return type. Confirms the fix does not disturb
+    // that independent recovery path.
+    let codes = diagnostics(
+        r#"
+function isInstanceOfRegisteredClass(
+  potentialClass: any
+): potentialClass is any {
+  return !!potentialClass?.constructor;
+}
+
+function compositeTransformation<I, O>(
+  isApplicable: (v: any) => v is I,
+  transform: (v: I) => O,
+  untransform: (v: O) => I
+) {
+  return { isApplicable, transform, untransform };
+}
+
+const rule = compositeTransformation(
+  isInstanceOfRegisteredClass,
+  (clazz) => {
+    return { ...clazz };
+  },
+  (v) => v
+);
+"#,
+    );
+    assert_eq!(codes, Vec::<u32>::new(), "expected clean, got {codes:?}");
+}
+
+#[test]
+fn non_predicate_sibling_without_evidence_still_reports_unknown() {
+    // Negative control (the two-type-param shape already covered by
+    // `type_predicate_sibling_argument_evidence_tests`): without a
+    // predicate (or any other evidence source) for `I`, `tsc` genuinely
+    // leaves the callback's parameter `unknown`. The predicate-target
+    // carrier must not manufacture evidence out of nothing.
+    let codes = diagnostics(
+        r#"
+function compositeTransformation<I, O>(
+  isApplicable: (v: any) => boolean,
+  transform: (v: I) => O
+) {
+  return { isApplicable, transform };
+}
+
+const rule = compositeTransformation(
+  (potentialClass) => !!potentialClass,
+  (clazz) => {
+    const ctor = clazz.constructor;
+    return { ...clazz };
+  }
+);
+"#,
+    );
+    assert!(
+        codes.contains(&18046),
+        "Expected TS18046 with no evidence for `I`. Got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Structural rule: when a generic call's Round 2 contextual substitution is pre-seeded by structurally matching two function types (`collect_return_context_substitution`, `crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs`), `tsc` treats a type-predicate function's asserted type (`x is I`) as a structural position on par with an ordinary parameter or return type; tsz's structural walk recursed into parameters and `return_type` but never into `FunctionShape::type_predicate.type_id` (the actual carrier of `I` for a predicate function — `return_type` is always `boolean`).

A type parameter pinned only through a sibling predicate argument's target therefore had no carrier into the substitution used to contextually type *another* sensitive callback in the same call. This stayed hidden for a single sensitive callback (#16024, merged `2a8c4d7`) because the solver's full call resolve (`resolve_call_with_checker_adapter`) independently recovers the type parameter from an ordinary covariant return position elsewhere in the signature. Once a second sensitive callback makes that recovery itself depend on another not-yet-inferred type parameter, the recovery no longer fires and the missing carrier is the only thing left — reproducing the real superjson `transformer.ts` `classRule` shape (#16022): spurious `TS18046` x2 + `TS2698` where real `tsc` 7.0.2 is clean.

Fix: when both sides of a structural function-type match carry a `type_predicate` with a target `type_id`, also recurse `collect_return_context_substitution` into the predicate targets, mirroring how `instantiate_function_shape` already treats `type_predicate.type_id` as a first-class structural position.

Fixes #16022.

## Goal
Goal: green

## Verification
- New adjacent-case matrix, `crates/tsz-checker/tests/predicate_target_round2_contextual_carrier_tests.rs` (4/4 pass): the real 3-type-param/4-argument #16022 repro (clean vs. previously TS18046 x2 + TS2698), a renamed-binder structural control, a 2-type-param regression control (already-clean path untouched), and a negative control (no predicate evidence still reports TS18046).
- Confirmed the fix is load-bearing by reverting the source change only (stash) and re-running the new suite against current `main` (`2a8c4d7`): the #16022 repro test fails with the exact pre-fix diagnostics (`[18046, 2698, 18046]`); restoring the fix returns it to clean.
- `cargo test -p tsz-checker --test predicate_target_round2_contextual_carrier_tests --test type_predicate_sibling_argument_evidence_tests --test predicate_callback_any_inference_tests` — 13/13 pass.
- `cargo test -p tsz-checker --lib -- contextual_callback_shadowed_type_param` — 9/9 pass (adjacent return-context-substitution suite, unaffected).
- `cargo test -p tsz-checker --test generic_call_assignment_flow_tests` — 25/27 pass; the 2 failures (`colliding_generic_terminals_keep_flow_diagnostics_clean_across_file_orders`, `imported_generic_result_narrows_inside_reduce_arrow`) are pre-existing, baselined in `scripts/ci/known-failures.txt` by #16023, unrelated to this change (identical failure on `main`).
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- `scripts/conformance/compare-to-parent.sh origin/main` (two-sided, base `2a8c4d7`): base failing=606, branch failing=606 — 0 newly failing / 0 newly passing (identical failure set). Expected null signature for this evidence family per prior sessions' notes: the corpus has no fixture for this exact "predicate target return-only in a second sensitive callback" shape; the targeted matrix above is the primary evidence and the corpus sweep is the regression floor.
- Emit floor (`scripts/emit/run.sh`) not verified at PR-open time: the harness's `npm install` step can hang indefinitely in this cloud container (documented prior-session behavior). This PR does not touch `crates/tsz-emitter` or any emit path — the change is confined to checker-side generic-call inference — so no emit-floor risk is expected, but will confirm on a follow-up run if CI or a later session flags it.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01446QpWM38ECTbeZ89MEVhX)_