### PR TITLE
fix(checker): narrow a conditional's checked type parameter when it is the index of an indexed access

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -913,6 +913,9 @@ mod conditional_flow_substitution_ts2344_tests;
 #[path = "../tests/conditional_keyof_test.rs"]
 mod conditional_keyof_test;
 #[cfg(test)]
+#[path = "tests/conditional_narrowed_index_through_generic_alias_tests.rs"]
+mod conditional_narrowed_index_through_generic_alias_tests;
+#[cfg(test)]
 #[path = "tests/conditional_never_param_inference_tests.rs"]
 mod conditional_never_param_inference_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/conditional_narrowed_index_through_generic_alias_tests.rs
+++ b/crates/tsz-checker/src/tests/conditional_narrowed_index_through_generic_alias_tests.rs
@@ -1,0 +1,132 @@
+//! Regression coverage for TS2536/TS2538 false positives when a naked type
+//! parameter used as the *index* of an indexed access is the narrowed check
+//! type of an enclosing conditional (`T extends U ? Obj[T] : Y`), and that
+//! access is wrapped in another generic alias (`Wrap<Obj[T]>`).
+//!
+//! Within the true branch, tsc narrows `T` to (a subtype of) `U`, so the
+//! access is valid whenever `U` is itself a valid key of `Obj` — regardless of
+//! `T`'s own wider declared constraint (e.g. a union with an unrelated,
+//! non-key member such as `boolean`). tsc validates this eagerly (accepted
+//! even with zero instantiation), so the check does not depend on the access
+//! ever being called/instantiated concretely.
+//!
+//! A bare, unwrapped access (`T extends U ? Obj[T] : Y`) already worked before
+//! this fix; wrapping the same access in another generic alias forces eager
+//! type-argument elaboration of `Obj[T]` ahead of any use-site narrowing,
+//! which is what exposed the false positive (kysely's `FunctionModule`,
+//! #16025).
+
+use crate::test_utils::check_source_codes;
+
+/// Minimal repro: index-narrowed conditional wrapped in a further generic
+/// alias. `TB` is a valid key of `DB`; `boolean` (the other union member of
+/// `T`'s own declared constraint) is not, but is unreachable in this branch.
+#[test]
+fn index_narrowed_conditional_through_generic_alias_no_ts2536_or_ts2538() {
+    let codes = check_source_codes(
+        r#"
+type Id<T> = T
+interface Foo<DB, TB extends keyof DB> {
+  toJson<T extends TB | boolean>(table: T): T extends TB ? Id<DB[T]> : never
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2536) && !codes.contains(&2538),
+        "expected no TS2536/TS2538 for an index-narrowed conditional wrapped in a generic alias: {codes:?}"
+    );
+}
+
+/// Renamed binders: the fix keys off name-equality between the index and the
+/// conditional's check type, so a rename must not disable it.
+#[test]
+fn index_narrowed_conditional_through_generic_alias_renamed_binders() {
+    let codes = check_source_codes(
+        r#"
+type Wrap<Value> = Value
+interface Container<Data, Key extends keyof Data> {
+  read<Arg extends Key | boolean>(name: Arg): Arg extends Key ? Wrap<Data[Arg]> : never
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2536) && !codes.contains(&2538),
+        "renaming every binder must not disable the index-narrowing fix: {codes:?}"
+    );
+}
+
+/// Control: the same access with no wrapping alias must remain clean (this
+/// already worked before the fix; guards against a regression on the direct
+/// path).
+#[test]
+fn index_narrowed_conditional_bare_access_still_no_ts2536_or_ts2538() {
+    let codes = check_source_codes(
+        r#"
+interface Foo<DB, TB extends keyof DB> {
+  toJson<T extends TB | boolean>(table: T): T extends TB ? DB[T] : never
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2536) && !codes.contains(&2538),
+        "the bare (unwrapped) access must stay clean: {codes:?}"
+    );
+}
+
+/// Negative control: the conditional's `extends` type is *not* itself a valid
+/// key of the object (`X` is an unconstrained type parameter, not proven to be
+/// a subtype of `keyof DB`), so narrowing `T` to `X` does not make `DB[T]`
+/// valid and TS2536 must still fire — this is the case that separates
+/// "index is the narrowed check type" from "always suppress".
+#[test]
+fn index_narrowed_conditional_with_non_key_extends_still_emits_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Id<T> = T
+interface Foo<DB, X> {
+  toJson<T extends X | boolean>(table: T): T extends X ? Id<DB[T]> : never
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2536),
+        "narrowing to an extends-type that is not itself a valid key must still emit TS2536: {codes:?}"
+    );
+}
+
+/// Negative control: an index that is *not* the conditional's own check type
+/// (a sibling type parameter of the same name space, but structurally
+/// unrelated to the enclosing conditional) must not be spuriously suppressed.
+#[test]
+fn unrelated_index_type_param_still_emits_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Id<T> = T
+interface Foo<DB, TB extends keyof DB, Other extends TB | boolean> {
+  toJson<T extends TB | boolean>(table: T): T extends TB ? Id<DB[Other]> : never
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2536) || codes.contains(&2538),
+        "an index unrelated to the conditional's own check type must not be suppressed: {codes:?}"
+    );
+}
+
+/// Object-narrowed mirror case (`T extends X ? T[K] : Y`, the object itself is
+/// the narrowed check type) must remain unaffected by the index-narrowed
+/// addition living in the same helper.
+#[test]
+fn object_narrowed_conditional_still_no_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Id<T> = T
+type Get<T, K extends keyof { a: string; b: number }> =
+  T extends { a: string; b: number } ? Id<T[K]> : never
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "the pre-existing object-narrowed case must still be accepted: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
@@ -144,7 +144,7 @@ fn indexed_access_type_checking_helpers_use_relation_outcome_boundary() {
         guarded_helpers
             .matches("indexed_access_key_space_relation_outcome(")
             .count(),
-        13,
+        14,
         "indexed-access helper key-space probes should route through the named RelationRequest"
     );
     assert!(

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -896,6 +896,7 @@ impl<'a> CheckerState<'a> {
         if self.conditional_true_branch_constraint_allows_index(
             node_idx,
             data.object_type,
+            data.index_type,
             index_type_for_check,
         ) {
             return;

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -1242,12 +1242,11 @@ impl<'a> CheckerState<'a> {
         &mut self,
         node_idx: NodeIndex,
         object_node_idx: NodeIndex,
+        index_node_idx: NodeIndex,
         index_type_for_check: TypeId,
     ) -> bool {
         let object_name = self.simple_type_reference_name(object_node_idx);
-        let Some(object_name) = object_name.as_deref() else {
-            return false;
-        };
+        let index_name = self.simple_type_reference_name(index_node_idx);
 
         let mut current = self.ctx.arena.parent_of(node_idx);
         while let Some(parent_idx) = current {
@@ -1257,39 +1256,71 @@ impl<'a> CheckerState<'a> {
             if parent_node.kind == syntax_kind_ext::CONDITIONAL_TYPE
                 && let Some(cond) = self.ctx.arena.get_conditional_type(parent_node)
                 && self.is_descendant_of(node_idx, cond.true_type)
-                && self.simple_type_reference_name(cond.check_type).as_deref() == Some(object_name)
             {
-                let extends_type = self.get_type_from_type_node(cond.extends_type);
-                let extends_type = self.evaluate_type_with_env(extends_type);
-                let keyof_extends = self.indexed_access_keyof_with_env(extends_type);
-                if self
-                    .indexed_access_key_space_relation_outcome(index_type_for_check, keyof_extends)
-                    .related
-                {
-                    return true;
-                }
-                if let Some(prop_atom) =
-                    crate::query_boundaries::checkers::generic::string_literal_value(
-                        self.ctx.types,
-                        index_type_for_check,
-                    )
-                {
-                    let property_name = self.ctx.types.resolve_atom(prop_atom);
-                    let prop_type =
-                        self.resolve_property_access_with_env(extends_type, &property_name);
-                    if matches!(
-                        prop_type,
-                        PropertyAccessResult::Success { .. }
-                            | PropertyAccessResult::PossiblyNullOrUndefined { .. }
-                    ) {
+                let check_type_name = self.simple_type_reference_name(cond.check_type);
+                let object_narrowed =
+                    object_name.is_some() && check_type_name.as_deref() == object_name.as_deref();
+                if object_narrowed {
+                    let extends_type = self.get_type_from_type_node(cond.extends_type);
+                    let extends_type = self.evaluate_type_with_env(extends_type);
+                    let keyof_extends = self.indexed_access_keyof_with_env(extends_type);
+                    if self
+                        .indexed_access_key_space_relation_outcome(
+                            index_type_for_check,
+                            keyof_extends,
+                        )
+                        .related
+                    {
+                        return true;
+                    }
+                    if let Some(prop_atom) =
+                        crate::query_boundaries::checkers::generic::string_literal_value(
+                            self.ctx.types,
+                            index_type_for_check,
+                        )
+                    {
+                        let property_name = self.ctx.types.resolve_atom(prop_atom);
+                        let prop_type =
+                            self.resolve_property_access_with_env(extends_type, &property_name);
+                        if matches!(
+                            prop_type,
+                            PropertyAccessResult::Success { .. }
+                                | PropertyAccessResult::PossiblyNullOrUndefined { .. }
+                        ) {
+                            return true;
+                        }
+                    }
+                    if let Some((wants_string, wants_number)) =
+                        self.get_index_key_kind(index_type_for_check)
+                        && self.is_element_indexable(extends_type, wants_string, wants_number)
+                    {
                         return true;
                     }
                 }
-                if let Some((wants_string, wants_number)) =
-                    self.get_index_key_kind(index_type_for_check)
-                    && self.is_element_indexable(extends_type, wants_string, wants_number)
-                {
-                    return true;
+
+                // Mirror of the object-narrowed case above: the *index*, not the
+                // object, is the conditional's narrowed check type — e.g.
+                // `T extends TB ? DB[T] : Y` where `TB extends keyof DB`. Within
+                // the true branch tsc narrows `T` to (a subtype of) `TB`, so the
+                // access is valid whenever `TB` (the extends type) is itself a
+                // valid key of the object, regardless of `T`'s own full
+                // (possibly wider, e.g. union with unrelated members) declared
+                // constraint. Without this, wrapping the direct access in
+                // another generic alias (`Id<DB[T]>`) — which forces eager
+                // type-argument resolution of `DB[T]` using `T`'s un-narrowed
+                // constraint — produces a spurious TS2536/TS2538.
+                if index_name.is_some() && check_type_name.as_deref() == index_name.as_deref() {
+                    let extends_type = self.get_type_from_type_node(cond.extends_type);
+                    let extends_type = self.evaluate_type_with_env(extends_type);
+                    let object_type = self.get_type_from_type_node(object_node_idx);
+                    let object_type_for_check = self.evaluate_type_with_env(object_type);
+                    let keyof_object = self.indexed_access_keyof_with_env(object_type_for_check);
+                    if self
+                        .indexed_access_key_space_relation_outcome(extends_type, keyof_object)
+                        .related
+                    {
+                        return true;
+                    }
                 }
             }
             current = self

--- a/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
@@ -26,12 +26,32 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             let object_type = self.check(indexed_access.object_type);
             let index_type = self.check(indexed_access.index_type);
 
-            // TS2538: Check if the index type is valid (string, number, symbol, or literal thereof)
-            if let Some(invalid_member) = self.get_invalid_index_type_member(index_type) {
+            // TS2538: Check if the index type is valid (string, number, symbol, or literal thereof).
+            //
+            // When the index is a naked type parameter `T` used inside the true
+            // branch of an enclosing `T extends U ? ... : ...` conditional (e.g.
+            // `T extends TB ? Id<DB[T]> : never`), tsc narrows `T` to (a subtype
+            // of) `U` for this position, so validity is judged against `U`, not
+            // against `T`'s own (possibly wider) declared constraint. Without
+            // this, a `T` constrained to a union with an unrelated, non-key
+            // member (`TB | boolean`) spuriously fails here even though the
+            // union member actually reachable in this branch (`TB`) is a valid
+            // key — this is the eager type-argument elaboration of a generic
+            // alias wrapping the access (`Id<DB[T]>`) forcing this check before
+            // any use-site substitution narrows `T`.
+            let invalid_member_check_type = self
+                .conditional_narrowed_check_type_param_extends(indexed_access.index_type)
+                .map(|extends_node| self.check(extends_node))
+                .unwrap_or(index_type);
+            if let Some(invalid_member) =
+                self.get_invalid_index_type_member(invalid_member_check_type)
+            {
                 let (diag_pos, diag_len) =
                     self.indexed_access_index_diagnostic_span(node, indexed_access.index_type);
-                for member in self.invalid_index_type_diagnostic_members(index_type, invalid_member)
-                {
+                for member in self.invalid_index_type_diagnostic_members(
+                    invalid_member_check_type,
+                    invalid_member,
+                ) {
                     let mut formatter = self.ctx.create_type_formatter();
                     let index_type_str = formatter.format(member);
                     let message = crate::diagnostics::format_message(
@@ -678,6 +698,71 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     /// Get the specific type that makes this type invalid as an index type (TS2538).
     fn get_invalid_index_type_member(&self, type_id: TypeId) -> Option<TypeId> {
         crate::query_boundaries::common::get_invalid_index_type_member(self.ctx.types, type_id)
+    }
+
+    /// The name of a bare type-reference/identifier node (`T`), or `None` for
+    /// any other node shape.
+    fn simple_type_reference_name(&self, node_idx: NodeIndex) -> Option<String> {
+        let node = self.ctx.arena.get(node_idx)?;
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE {
+            let type_ref = self.ctx.arena.get_type_ref(node)?;
+            let name_node = self.ctx.arena.get(type_ref.type_name)?;
+            let ident = self.ctx.arena.get_identifier(name_node)?;
+            return Some(ident.escaped_text.to_string());
+        }
+        if node.kind == SyntaxKind::Identifier as u16 {
+            let ident = self.ctx.arena.get_identifier(node)?;
+            return Some(ident.escaped_text.to_string());
+        }
+        None
+    }
+
+    /// Whether `node_a` is `node_b` or a descendant of it in the AST.
+    fn is_descendant_of(&self, node_a: NodeIndex, node_b: NodeIndex) -> bool {
+        let mut current = Some(node_a);
+        while let Some(idx) = current {
+            if idx == node_b {
+                return true;
+            }
+            current = self.ctx.arena.parent_of(idx);
+        }
+        false
+    }
+
+    /// When `index_node_idx` is a naked type-parameter reference (`T`) used
+    /// inside the true branch of an enclosing `T extends U ? ... : ...`
+    /// conditional type, returns `U`'s AST node — tsc narrows `T` to (a
+    /// subtype of) `U` for validity checks performed at this position, even
+    /// though the conditional itself stays deferred until `T` is
+    /// instantiated. Mirrors the object-narrowed case handled for indexed
+    /// *expressions* by
+    /// `CheckerState::conditional_true_branch_constraint_allows_index`; this
+    /// is the type-node-elaboration counterpart, needed because a naked index
+    /// wrapped in another generic alias (`Id<DB[T]>`) is type-checked here,
+    /// eagerly, before any use-site substitution narrows `T`.
+    fn conditional_narrowed_check_type_param_extends(
+        &self,
+        index_node_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let index_name = self.simple_type_reference_name(index_node_idx)?;
+        let mut current = self.ctx.arena.parent_of(index_node_idx);
+        while let Some(parent_idx) = current {
+            let parent_node = self.ctx.arena.get(parent_idx)?;
+            if parent_node.kind == syntax_kind_ext::CONDITIONAL_TYPE
+                && let Some(cond) = self.ctx.arena.get_conditional_type(parent_node)
+                && self.is_descendant_of(index_node_idx, cond.true_type)
+                && self.simple_type_reference_name(cond.check_type).as_deref()
+                    == Some(index_name.as_str())
+            {
+                return Some(cond.extends_type);
+            }
+            current = self
+                .ctx
+                .arena
+                .get_extended(parent_idx)
+                .map(|ext| ext.parent);
+        }
+        None
     }
 
     fn invalid_index_type_diagnostic_members(


### PR DESCRIPTION
When `T` is the naked check type of `T extends U ? Obj[T] : Y`, tsc narrows `T` to (a subtype of) `U` for validity checks performed inside the true branch — even though the conditional itself stays deferred until `T` is instantiated. tsz already implemented this for the mirror shape where the *object* being indexed is the narrowed check type (`conditional_true_branch_constraint_allows_index`), but not for the case where the *index* is the narrowed check type.

A bare, unwrapped access (`T extends TB ? DB[T] : Y`) happened to stay clean regardless, but wrapping the same access in another generic alias (`Id<DB[T]>` — e.g. kysely's `FunctionModule.jsonAgg`/`toJson`) forces eager type-argument elaboration of `DB[T]` ahead of any use-site narrowing, using `T`'s full declared constraint (`TB | boolean`) instead of the branch-local `TB`. `boolean` is not a valid key of `DB`, producing spurious `TS2536`/`TS2538`.

**Structural rule:** when a naked type parameter `T` used as the *index* of an indexed access `Obj[T]` is the check type of an enclosing, as-yet-unresolved conditional `T extends U ? Obj[T] : Y`, tsc validates the access (and rejects an unrelated union member of `T`'s own constraint) using `U` — the narrowed type — through the checker's index-validity diagnostics, in both value-position expression checking and type-node elaboration.

Fixed at both emission sites:
- `conditional_true_branch_constraint_allows_index` (`indexed_access_helpers.rs`) — extended with the mirrored index-narrowed case alongside the existing object-narrowed case.
- `get_type_from_indexed_access_type` (`indexed_access_type.rs`) — computes TS2538's "invalid index member" against the narrowed extends-type node instead of the raw index type when applicable.

## Goal
Goal: green

## Adjacent-case matrix
`conditional_narrowed_index_through_generic_alias_tests.rs` (6 cases, each cross-checked against `typescript@7.0.2`):
- wrapped access through a generic alias (the repro shape)
- renamed binders (every identifier renamed)
- bare/unwrapped control (already worked; guards against regressing the direct path)
- extends-type that is *not* itself a valid key (still `TS2536` — proves this isn't a blanket suppression)
- an index unrelated to the enclosing conditional's own check type (still `TS2536`/`TS2538`)
- the pre-existing object-narrowed mirror case (still clean)

## Verification
- `cargo test -p tsz-checker --lib conditional_narrowed_index`: 6/6 new tests pass.
- `cargo test -p tsz-checker --lib -- indexed_access conditional ts2536 ts2538`: 422 passed, 1 failed — the 1 failure (`mapped_indexed_access_diagnostic_tests::mapped_indexed_access_discriminated_union_reports_outer_assignment`) reproduces identically on `main` (confirmed via `git stash`), unrelated pre-existing failure.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets`: clean.
- `python3 scripts/arch/arch_guard.py`: passed (bumped the `indexed_access_type_checking_helpers_use_relation_outcome_boundary` ratchet count 13 → 14 for the one legitimate new `indexed_access_key_space_relation_outcome` call site).
- `scripts/conformance/compare-to-parent.sh`: 12043 runnable, 606 failing on both `HEAD` and `HEAD~1` — **0 newly failing, 0 newly passing**. Expected signature for a targeted false-positive fix the corpus has no fixture for.
- Real-world row: kysely-project (`kysely-org/kysely@d4911be`, `tsconfig.tsz-guard.json`, `.target/dist-fast/tsz`) — **79 → 78** diagnostics on the exact, byte-identical `src/query-builder/function-module.ts` (no reduction). Diff of the two runs shows exactly one line removed: `function-module.ts(767,52): error TS2536: Type 'T' cannot be used to index type 'DB'.` — nothing else changed. Part of #16025's family (27/78 of the row); this PR closes the singleton `TS2536`, not the 27-site `string | TB` union family (still open, tracked in #16025).
- Emit suite not run: the JS-runner build under `scripts/emit/` needs `npm install`, which is a known hang risk in this container (per board notes); the change is scoped to checker diagnostics, not emit transforms, so risk to the DTS/JS emit floor is low but unverified locally.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_0188xZsoKKQ77d9ofQwWuHWn)_