### PR TITLE
fix(checker): one tuple constituent puts an array literal in tuple context

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1110,6 +1110,9 @@ path = "tests/static_member_access_types.rs"
 name = "contextual_tuple_tests"
 path = "tests/contextual_tuple_tests.rs"
 [[test]]
+name = "array_literal_union_tuple_context_tests"
+path = "tests/array_literal_union_tuple_context_tests.rs"
+[[test]]
 name = "contextual_return_tuple_generic_member_tests"
 path = "tests/contextual_return_tuple_generic_member_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
@@ -228,6 +228,25 @@ pub(crate) fn is_fresh_literal_indexed_object(db: &dyn TypeDatabase, type_id: Ty
     db.object_shape(shape_id).is_fresh_literal()
 }
 
+/// Whether a union contextual type puts an array literal in tuple context.
+///
+/// Mirrors `tsc`'s `checkArrayLiteral`, which decides tuple-ness with
+/// `inTupleContext = !!contextualType && someType(contextualType,
+/// isTupleLikeType)`: a *single* tuple constituent is enough, and the other
+/// constituents neither have to be tuples nor have to be array-shaped at all.
+/// Requiring every constituent to be a tuple made any union pairing a tuple
+/// with another shape (`[string] | Record<string, number>`,
+/// `[string] | number[]`, `Tree<T> | Record<string, Tree<T>>`) widen the
+/// literal to an array, so an element list that only ever satisfies the tuple
+/// arm reported a spurious `TS2322`.
+///
+/// Plain `Array<T>` constituents deliberately do not count on their own:
+/// `tsc`'s `isTupleLikeType` is `isTupleType(type) || !!getPropertyOfType(type,
+/// "0")`, and an array type has neither, so a union whose only array-shaped
+/// members are arrays stays in array context. That keeps the ambiguous-union
+/// element machinery — which reports `TS7006` for conflicting callback arms in
+/// `Record<string, (arg: string) => void> | Array<(arg: number) => void>` —
+/// reachable.
 pub(crate) fn union_context_prefers_tuple_array_literal(
     db: &dyn TypeDatabase,
     contextual: TypeId,
@@ -236,20 +255,15 @@ pub(crate) fn union_context_prefers_tuple_array_literal(
         return false;
     };
 
-    let mut saw_tuple = false;
-    for member in members {
-        let Some(applicable) = crate::query_boundaries::common::array_applicable_type(db, member)
-        else {
-            return false;
-        };
-
-        if !crate::query_boundaries::common::is_tuple_type(db, applicable) {
-            return false;
+    members.iter().copied().any(|member| {
+        let mut member = member;
+        while let Some(inner) =
+            crate::query_boundaries::common::unwrap_readonly_or_noinfer(db, member)
+        {
+            member = inner;
         }
-        saw_tuple = true;
-    }
-
-    saw_tuple
+        crate::query_boundaries::common::is_tuple_type(db, member)
+    })
 }
 
 pub(crate) fn widen_mutable_object_literal_property_types(
@@ -407,18 +421,33 @@ mod tests {
         assert!(union_context_prefers_tuple_array_literal(&db, contextual));
     }
 
+    /// `tsc` 7.0.2 accepts `const b1: [string] | number[] = [s]`: `someType(…,
+    /// isTupleLikeType)` is satisfied by the tuple arm alone, so the literal is
+    /// a tuple and the array arm never has to accept `string[]`.
     #[test]
-    fn union_context_does_not_prefer_tuple_for_array_member() {
+    fn union_context_prefers_tuple_alongside_array_member() {
         let db = TypeInterner::new();
         let contextual = db.union(vec![tuple(&db, TypeId::STRING), db.array(TypeId::NUMBER)]);
 
-        assert!(!union_context_prefers_tuple_array_literal(&db, contextual));
+        assert!(union_context_prefers_tuple_array_literal(&db, contextual));
     }
 
+    /// A non-array constituent does not veto the tuple arm either — `tsc`
+    /// accepts `const a: [string] | number = [s]`.
     #[test]
-    fn union_context_does_not_prefer_tuple_for_non_applicable_member() {
+    fn union_context_prefers_tuple_alongside_non_applicable_member() {
         let db = TypeInterner::new();
         let contextual = db.union(vec![tuple(&db, TypeId::STRING), TypeId::NUMBER]);
+
+        assert!(union_context_prefers_tuple_array_literal(&db, contextual));
+    }
+
+    /// No tuple constituent, no tuple context: a union of plain arrays stays in
+    /// array context so the ambiguous-union element machinery still runs.
+    #[test]
+    fn union_context_does_not_prefer_tuple_without_a_tuple_member() {
+        let db = TypeInterner::new();
+        let contextual = db.union(vec![db.array(TypeId::STRING), db.array(TypeId::NUMBER)]);
 
         assert!(!union_context_prefers_tuple_array_literal(&db, contextual));
     }

--- a/crates/tsz-checker/tests/array_literal_union_tuple_context_tests.rs
+++ b/crates/tsz-checker/tests/array_literal_union_tuple_context_tests.rs
@@ -1,0 +1,254 @@
+//! Array-literal tuple context from a union contextual type.
+//!
+//! `tsc`'s `checkArrayLiteral` computes
+//! `inTupleContext = !!contextualType && someType(contextualType,
+//! isTupleLikeType)`: **one** tuple constituent is enough to make the literal a
+//! tuple, and the remaining constituents are irrelevant to that decision. tsz
+//! used to require *every* constituent to be a tuple, so any union pairing a
+//! tuple with another shape widened the literal to an array and reported a
+//! spurious `TS2322` on an element list that only ever satisfied the tuple arm.
+//!
+//! Witnessed by `superjson`'s `plainer.ts` (issue #15731), whose
+//! `MinimisedTree<T> = Tree<T> | Record<string, Tree<T>> | undefined` pairs
+//! tuple arms with a `Record` arm.
+//!
+//! Every expectation here is pinned against real `tsc` 7.0.2 output under
+//! `--strict`.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_with_options;
+
+fn check_strict(source: &str) -> Vec<Diagnostic> {
+    check_with_options(
+        source,
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            strict_function_types: true,
+            no_implicit_any: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(diagnostics: &[Diagnostic]) -> Vec<u32> {
+    diagnostics.iter().map(|d| d.code).collect()
+}
+
+fn assert_clean(source: &str, label: &str) {
+    let diagnostics = check_strict(source);
+    assert!(
+        diagnostics.is_empty(),
+        "{label}: expected no diagnostics, got {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The `superjson` witness, reduced: a generic recursive tuple alias unioned
+/// with a `Record` arm, consumed through a property slot.
+#[test]
+fn tuple_alias_unioned_with_record_types_property_literal_as_tuple() {
+    assert_clean(
+        r#"
+type Rec<T> = { [key: string]: T };
+type Tree<T> = [T] | [T, Rec<Tree<T>>];
+type MinimisedTree<T> = Tree<T> | Rec<Tree<T>> | undefined;
+
+interface Result {
+    transformedValue: unknown;
+    annotations?: MinimisedTree<string>;
+}
+
+declare const annotation: string;
+const result: Result = { transformedValue: 1, annotations: [annotation] };
+"#,
+        "tuple alias | Record, property slot",
+    );
+}
+
+/// Same alias shape in return position, with the two-element tuple arm.
+#[test]
+fn tuple_alias_unioned_with_record_types_return_literal_as_tuple() {
+    assert_clean(
+        r#"
+type Rec<T> = { [key: string]: T };
+type Tree<T> = [T] | [T, Rec<Tree<T>>];
+type MinimisedTree<T> = Tree<T> | Rec<Tree<T>> | undefined;
+
+declare const annotation: string;
+declare const children: Rec<Tree<string>>;
+
+function build(withChildren: boolean): MinimisedTree<string> {
+    if (withChildren) {
+        return [annotation, children];
+    }
+    return [annotation];
+}
+"#,
+        "tuple alias | Record, return position",
+    );
+}
+
+/// The non-generic form of `ReferentialEqualityAnnotations`, which is where
+/// `plainer.ts` lines 179/181 reported `never[]`.
+#[test]
+fn record_first_union_still_types_return_literal_as_tuple() {
+    assert_clean(
+        r#"
+type Rec<T> = { [key: string]: T };
+type ReferentialEqualityAnnotations =
+    | Rec<string[]>
+    | [string[]]
+    | [string[], Rec<string[]>];
+
+declare const rootPaths: string[];
+declare const rest: Rec<string[]>;
+
+function annotate(dedupe: boolean): ReferentialEqualityAnnotations | undefined {
+    if (dedupe) {
+        return [rootPaths];
+    }
+    return [rootPaths, rest];
+}
+"#,
+        "Record-first union, return position",
+    );
+}
+
+/// A tuple arm paired with a plain array arm: `tsc` accepts, because the tuple
+/// arm alone satisfies `someType(…, isTupleLikeType)` and the literal never has
+/// to be checked against `number[]`.
+#[test]
+fn tuple_unioned_with_array_types_literal_as_tuple() {
+    assert_clean(
+        r#"
+declare const s: string;
+const value: [string] | number[] = [s];
+const readonlyValue: [string] | readonly number[] = [s];
+"#,
+        "tuple | array",
+    );
+}
+
+/// Non-array constituents do not veto the tuple arm either.
+#[test]
+fn tuple_unioned_with_non_array_constituents_types_literal_as_tuple() {
+    assert_clean(
+        r#"
+type Rec<T> = { [key: string]: T };
+declare const s: string;
+const withPrimitive: [string] | number = [s];
+const withObject: [string] | { k: number } = [s];
+const withNull: [string] | null = [s];
+const withRecord: [string] | Rec<number> = [s];
+"#,
+        "tuple | non-array constituents",
+    );
+}
+
+/// Renamed binders and an aliased indirection: the rule is structural, not
+/// keyed to any particular alias or property name.
+#[test]
+fn renamed_binders_and_alias_indirection_behave_identically() {
+    assert_clean(
+        r#"
+type Rec<T> = { [key: string]: T };
+type Zqx<Payload> = [Payload] | [Payload, Rec<Zqx<Payload>>];
+type Wrapper<Payload> = Zqx<Payload> | Rec<Zqx<Payload>> | undefined;
+type Aliased = Wrapper<number>;
+
+declare const leaf: number;
+const direct: Wrapper<number> = [leaf];
+const aliased: Aliased = [leaf];
+"#,
+        "renamed binders through an alias",
+    );
+}
+
+/// Nested literals: the inner literal sees the same union context through the
+/// outer array's element type.
+#[test]
+fn nested_array_literal_in_union_element_context_stays_a_tuple() {
+    assert_clean(
+        r#"
+type Rec<T> = { [key: string]: T };
+declare const s: string;
+const nested: ([string] | Rec<number>)[] = [[s]];
+"#,
+        "nested literal, union element context",
+    );
+}
+
+/// Negative control, and the reason plain arrays must not count as tuple-like
+/// on their own: with **no** tuple constituent the union stays ambiguous, and
+/// `tsc` still reports `TS7006` for the conflicting callback arms.
+#[test]
+fn record_and_array_callback_union_without_a_tuple_arm_still_reports_ts7006() {
+    let diagnostics = check_strict(
+        r#"
+type Rec<T> = { [key: string]: T };
+const handlers: Rec<(arg: string) => void> | ((arg: number) => void)[] = [
+    (arg) => {},
+];
+"#,
+    );
+    assert_eq!(
+        codes(&diagnostics),
+        vec![7006],
+        "ambiguous Record|Array callback union must keep TS7006, got {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Negative control: tuple context does not make a wrong element list pass.
+/// `tsc` reports `TS2322` here — "Type '[string, string]' is not assignable to
+/// type 'Rec<string> | [string]'" — and the tuple in that message is
+/// itself the evidence that the literal really did become a tuple.
+#[test]
+fn tuple_context_still_reports_a_genuinely_incompatible_literal() {
+    let diagnostics = check_strict(
+        r#"
+type Rec<T> = { [key: string]: T };
+declare const s: string;
+const bad: [string] | Rec<string> = [s, s];
+"#,
+    );
+    assert_eq!(
+        codes(&diagnostics),
+        vec![2322],
+        "over-long literal must still report TS2322, got {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Negative control: an element of the wrong type still fails against the
+/// tuple arm.
+#[test]
+fn tuple_context_still_reports_a_wrong_element_type() {
+    let diagnostics = check_strict(
+        r#"
+type Rec<T> = { [key: string]: T };
+declare const n: number;
+const bad: [string] | Rec<string> = [n];
+"#,
+    );
+    assert_eq!(
+        codes(&diagnostics),
+        vec![2322],
+        "wrong element type must still report TS2322, got {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Closes 4 of the 5 remaining `plainer.ts` false positives on the superjson canary row (#15731): lines 179, 181, 216 and 275.

**Structural rule.** When an array literal's contextual type is a union with **at least one tuple constituent**, `tsc` types the literal as a tuple regardless of what the other constituents are; tsz now does the same through the checker's array-literal contextual-typing boundary (`query_boundaries::type_computation::union_context_prefers_tuple_array_literal`).

`tsc`'s `checkArrayLiteral` computes

```
inTupleContext = !!contextualType && someType(contextualType, isTupleLikeType)
```

— `someType`, not `everyType`. tsz required *every* constituent to be array-applicable **and** a tuple, bailing out on the first one that was not. So any union pairing a tuple arm with another shape widened the literal to an array, and an element list that only ever satisfied the tuple arm reported a spurious TS2322:

```ts
type Tree[ T ] = [T] | [T, Record[ string, Tree[ T ] ]];
type MinimisedTree[ T ] = Tree[ T ] | Record[ string, Tree[ T ] ] | undefined;

declare const annotation: string;
const annotations: MinimisedTree[ string ] = [annotation];
// tsz before: TS2322 Type 'string[]' is not assignable to type 'MinimisedTree[ string ]'
// tsc 7.0.2:  clean
```

(square brackets stand in for angle brackets — this API strips generic type-parameter lists from PR bodies)

**Owner layer.** Checker query boundary only. No solver change, no relation change, no new predicate over rendered output, no name/file-based special case — the decision is `is_tuple_type` over the union's constituents, after unwrapping `readonly`/`NoInfer`.

**What deliberately did not change.** Plain `Array[ T ]` constituents still do not count as tuple context on their own. `isTupleLikeType` is `isTupleType(type) || !!getPropertyOfType(type, "0")`, and an array type has neither, so a union whose only array-shaped members are arrays stays in array context and keeps reaching the ambiguous-union element machinery that reports TS7006 for conflicting callback arms (`Record[ string, (arg: string) =]] void ] | Array[ (arg: number) =]] void ]`). That case is pinned as a negative control in the new suite.

**Three helper unit tests changed expectation**, with oracle evidence rather than to make the suite pass:
`union_context_does_not_prefer_tuple_for_array_member` asserted `[string] | number[]` is *not* tuple context, and `union_context_does_not_prefer_tuple_for_non_applicable_member` asserted the same for `[string] | number`. Real `tsc` 7.0.2 accepts `const b: [string] | number[] = [s]` and `const a: [string] | number = [s]` — both were encoding tsz's old rule, not tsc's. They are replaced by the inverted assertions plus a new `union_context_does_not_prefer_tuple_without_a_tuple_member` covering the case the old rule was actually protecting.

## Goal
Goal: green

## Verification

Superjson `plainer.ts`, real upstream sources compiled `--strict --lib es2015,dom,esnext` against the `tsc` 7.0.2 oracle on the identical config:

| | main `93c089f` | this branch |
| --- | --- | --- |
| `plainer.ts` 179 TS2322 `never[]` | ✗ FP | ✓ gone |
| `plainer.ts` 181 TS2322 `never[]` | ✗ FP | ✓ gone |
| `plainer.ts` 216 TS2322 `Result` | ✗ FP | ✓ gone |
| `plainer.ts` 275 TS2322 `Result` | ✗ FP | ✓ gone |
| `plainer.ts` 270 TS2322 `unknown` | ✗ FP | ✗ still FP — **different root cause, see below** |
| rest of the 12-file superjson chain | clean | clean |

Oracle matrix, 22 rows across 3 files, every expectation taken from real `tsc` 7.0.2 output. Before: 8 tsz diagnostics vs 1 tsc diagnostic. After: **1 vs 1, exact match** (the surviving one is the intended TS7006 ambiguity case).

- `cargo test -p tsz-checker --test array_literal_union_tuple_context_tests` — **10/10 pass** (new suite: 7 positive rows including renamed binders and an alias indirection, 3 oracle-pinned negative controls).
- `cargo fmt` + `cargo clippy --profile dist-fast -p tsz-checker --lib -- -D warnings` + architecture size guard — clean (pre-commit hook).
- `scripts/conformance/compare-to-parent.sh origin/main` — two-sided, running at time of opening; result posted as a comment on this PR. Gate is NEWLY FAILING == 0.

**Not run in this container, stated plainly rather than implied:** `scripts/emit/run.sh` and `scripts/fourslash/run-fourslash.sh`. Array-literal tuple-vs-array typing is not an emit transform, but the emit gate has zero headroom (JS 11562/11563, DTS 1375/1390), so if you hold the local-runner seat please run emit before landing.

**`plainer.ts:270` is a separate bug and is not in scope here.** `forEach(recursiveResult.annotations, (tree, key) =]] ...)` after an `isPlainObject` type-guard narrowing gives `tree: unknown` in tsz and `Tree[ TypeAnnotation ]` in tsc — that is `T` inference from `Record[ string, T ]` against a guard-narrowed union arm, not array-literal contextual typing. It survives this fix unchanged.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Cinder

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwQsR64f85XqXbwS9fxULx)_