### PR TITLE
fix(checker): give a self-recursive variable-bound function a provisional signature during circular resolution

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1341,9 +1341,12 @@ impl CheckerState<'_> {
                     // (e.g., `typeof foo<T>` in foo's own return type). Without this sentinel, the re-entrant
                     // call finds ERROR, detects circularity, and calls provisional again → stack overflow.
                     self.ctx.symbol_types.insert(sym_id, TypeId::ANY);
-                    if let Some(provisional) =
-                        self.provisional_circular_function_symbol_type(sym_id)
-                    {
+                    let provisional = self
+                        .provisional_circular_function_symbol_type(sym_id)
+                        .or_else(|| {
+                            self.provisional_circular_variable_function_symbol_type(sym_id)
+                        });
+                    if let Some(provisional) = provisional {
                         self.ctx.symbol_types.insert(sym_id, provisional);
                         trace!(
                             sym_id = sym_id.0,
@@ -1413,6 +1416,14 @@ impl CheckerState<'_> {
                     self.ctx.symbol_types.insert(sym_id, provisional);
                     return provisional;
                 }
+
+                if flags & symbol_flags::VARIABLE != 0
+                    && let Some(provisional) =
+                        self.provisional_circular_variable_function_symbol_type(sym_id)
+                {
+                    self.ctx.symbol_types.insert(sym_id, provisional);
+                    return provisional;
+                }
             }
 
             // For non-named entities, cache ERROR to prevent repeated deep recursion
@@ -1472,6 +1483,20 @@ impl CheckerState<'_> {
                     // detection → calls provisional again → stack overflow.
                     self.ctx.symbol_types.insert(sym_id, TypeId::ANY);
                     self.provisional_circular_function_symbol_type(sym_id)
+                        .unwrap_or(TypeId::ERROR)
+                } else if flags & symbol_flags::VARIABLE != 0 {
+                    // A `const`/`let`/`var` bound to a fully-annotated arrow or
+                    // function expression that self-references inside its own
+                    // body (e.g. `const f = (x: number): T => { ... f(x) ... }`)
+                    // reaches this placeholder before its own initializer has
+                    // been checked. Without a provisional signature here, the
+                    // very first in-body reference to `f` freezes at `ERROR`
+                    // for the rest of the check (`param.map(f)` degrades to
+                    // `unknown[]`), even though the outer symbol later resolves
+                    // correctly once its initializer finishes. Same
+                    // re-entrancy guard as the FUNCTION branch above.
+                    self.ctx.symbol_types.insert(sym_id, TypeId::ANY);
+                    self.provisional_circular_variable_function_symbol_type(sym_id)
                         .unwrap_or(TypeId::ERROR)
                 } else {
                     TypeId::ERROR

--- a/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
@@ -431,7 +431,12 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Whether a function/arrow node has an explicit return-type annotation and
-    /// an explicit type annotation on every parameter.
+    /// every parameter's type is computable without analyzing the body: either
+    /// an explicit annotation, or a default value (its type comes from the
+    /// default expression itself, independent of the enclosing function body —
+    /// `call_signature_from_function` already resolves such a parameter without
+    /// needing the body, unlike a parameter whose type would need contextual
+    /// inference from a call site).
     fn function_has_explicit_param_and_return_annotations(
         &self,
         func: &tsz_parser::parser::node::FunctionData,
@@ -444,7 +449,9 @@ impl<'a> CheckerState<'a> {
                 .arena
                 .get(param_idx)
                 .and_then(|param_node| self.ctx.arena.get_parameter(param_node))
-                .is_some_and(|param| param.type_annotation != NodeIndex::NONE)
+                .is_some_and(|param| {
+                    param.type_annotation != NodeIndex::NONE || param.initializer != NodeIndex::NONE
+                })
         })
     }
 


### PR DESCRIPTION
When a self-recursive `const`-bound arrow/function-expression has an explicit
return-type annotation but a parameter whose type needs inference from a
default value (`const f = (x: number, flag = false): T => { ... f(x) ... }`),
the first in-body reference to the binding hit `get_type_of_symbol`'s
circular-placeholder path. That path already builds a provisional call
signature for `FUNCTION`-flagged symbols
(`provisional_circular_function_symbol_type`), but fell straight to
`TypeId::ERROR` for `VARIABLE`-flagged ones (an ordinary `const` bound to an
arrow function is never `FUNCTION`-flagged), freezing the self-call's result
at `ERROR` for the rest of the check. Downstream, a nested generic callback
inferring its type parameter from that `ERROR`-typed value finds no
structural evidence and defaults the parameter to `unknown`, producing a
spurious `TS2322`/`TS18046`.

**Structural rule:** when a self-recursive call's callee has an explicit
return-type annotation, `tsc` types the call from that declared signature
regardless of whether another parameter's type still needs to be inferred
from a default value; tsz did this correctly only when *every* parameter
carried an explicit annotation, through
`provisional_circular_variable_function_symbol_type`
(`crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs`).

`provisional_circular_variable_function_symbol_type` already existed for
exactly this shape but was (a) gated behind "every parameter is explicitly
annotated" — stricter than necessary, since a default-valued parameter's type
comes from the default expression itself, independent of the function body,
the same reasoning `call_signature_from_function` already relies on — and (b)
only wired into a later, unrelated cache-recovery path
(`state/type_analysis/computed/type_alias_variable_alias.rs`) that fixes the
*outer* symbol's final cached type too late to help a nested self-reference
that was already resolved to `ERROR` earlier in the same pass.

This PR:
- Relaxes the gate to accept a parameter with either an explicit annotation
  or a default value.
- Wires `provisional_circular_variable_function_symbol_type` into the same
  `get_type_of_symbol_inner` circular/placeholder branches
  (`crates/tsz-checker/src/state/type_analysis/core.rs`) that the
  `FUNCTION`-flagged case already uses, so the *first* in-body self-reference
  gets a real provisional signature instead of `ERROR`.

Root-caused with `rdbg`: broke `get_type_of_symbol_inner`'s placeholder
computation and confirmed it cached `TypeId::ERROR` for the self-reference
symbol only when an unannotated default parameter was present; the identical
fully-annotated shape resolved a real function `TypeId` at the same call
site. Adjacent-case matrix (all oracle-verified against `tsc` 7.0.2, all
clean before and after this change except the repro row):
- baseline, no extra param — clean
- extra default-valued param (`boolean`, `Map`) — **was TS2322, now clean**
- extra param with explicit annotation removing the need for inference — clean
- same shape calling a separate non-recursive `declare`d function — clean
- extra default param declared but unused in the recursive call — **was TS2322, now clean**

Closes the last `plainer.ts` false positive from #15731 / #16037 — the
`flightcontrolhq/superjson` `plainer.ts:270` row (and the whole file) is now
fully clean under `--strict --lib es2015,dom,esnext`.

## Goal
Goal: green

## Verification
- `cargo nextest run -p tsz-checker --lib circular_initializer_deferred_generic class_member_circular_return contextual_callback_shadowed_type_param circular_return provisional recursive_generic_arrow`: 102/102 pass (includes the exact analog `recursive_generic_arrow_tests::recursive_generic_const_arrow_curried_thenable_no_error`).
- `cargo clippy --profile dist-fast -p tsz-checker --lib -- -D warnings`: clean.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `scripts/conformance/compare-to-parent.sh`: base `e62d17b` vs branch, both 12043 runnable / 11436 passed (95.0%), base failing=606, branch failing=606 — **0 newly failing, 0 newly passing** (expected null result for this family per the board's standing note: this shape has no corpus fixture, so a zero-delta full-corpus sweep is the safety bound, not the detector — a targeted oracle-pinned matrix is the primary evidence here).
- Real-world fixture: `flightcontrolhq/superjson`'s full `src/` (11 files, `plainer.ts`/`transformer.ts`/etc., stubbing `copy-anything`) under `--strict --target es2017 --module esnext --moduleResolution bundler --lib es2015,dom,esnext`: 0 diagnostics (was 1, `plainer.ts:270` `TS2322`).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Marble


---
_Generated by [Claude Code](https://claude.ai/code/session_017L8bLEMm4FRWVWZHKLYYHG)_