### PR TITLE
fix(cli): make check order depend on the file set, not the tsconfig root list

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1316,7 +1316,8 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
         // files that import them, improving incremental invalidation accuracy.
         {
             let queue_vec: Vec<usize> = work_queue.iter().copied().collect();
-            let ordered = topological_file_order(&queue_vec, &resolved_module_paths);
+            let stable_key = stable_file_order_key(&queue_vec, program);
+            let ordered = topological_file_order(&queue_vec, &resolved_module_paths, &stable_key);
             work_queue.clear();
             for idx in ordered {
                 work_queue.push_back(idx);

--- a/crates/tsz-cli/src/driver/check_module_graph.rs
+++ b/crates/tsz-cli/src/driver/check_module_graph.rs
@@ -160,13 +160,37 @@ pub(super) fn propagate_module_export_maps(
 /// order (matching tsc behavior which gracefully handles circular imports).
 ///
 /// Only file indices present in `file_indices` are included in the output.
+///
+/// # Tie-breaking and root independence
+///
+/// A dependency graph rarely admits a single topological order, and an import
+/// cycle admits none at all, so every tie has to be broken by some secondary
+/// key. `stable_order_key` supplies that key: `stable_order_key[idx]` ranks
+/// file `idx` against its peers, and entries missing from the map rank last
+/// (falling back to the raw file index).
+///
+/// The key must not be derived from the program's file *index*. Indices are
+/// assigned in root-discovery order, so an index-keyed tie-break makes the
+/// resulting check order a function of the `tsconfig` root list rather than of
+/// the file set — the same eight files check in a different order depending on
+/// which of them the `include` glob happens to name (issue #16036). Callers
+/// pass a rank derived from the file *name*, which is a property of the file
+/// set alone.
 pub(super) fn topological_file_order(
     file_indices: &[usize],
     resolved_module_paths: &FxHashMap<(usize, String), usize>,
+    stable_order_key: &FxHashMap<usize, u32>,
 ) -> Vec<usize> {
     if file_indices.len() <= 1 {
         return file_indices.to_vec();
     }
+
+    // Rank a file for tie-breaking. Files absent from `stable_order_key` sort
+    // after every ranked file and among themselves by index, which keeps the
+    // empty-map case identical to the historical index-only ordering.
+    let rank = |idx: usize| -> (u32, usize) {
+        (stable_order_key.get(&idx).copied().unwrap_or(u32::MAX), idx)
+    };
 
     // Build adjacency list: src -> [targets it imports].
     // Edge A -> B means "A depends on B" (A imports B).
@@ -201,10 +225,11 @@ pub(super) fn topological_file_order(
         }
     }
 
-    // Seed queue with nodes that have no dependencies, in sorted order for determinism.
+    // Seed queue with nodes that have no dependencies, in stable-key order for
+    // determinism.
     let mut queue: VecDeque<usize> = VecDeque::new();
     let mut sorted_indices: Vec<usize> = file_indices.to_vec();
-    sorted_indices.sort_unstable();
+    sorted_indices.sort_unstable_by_key(|&idx| rank(idx));
     for &idx in &sorted_indices {
         if in_degree[&idx] == 0 {
             queue.push_back(idx);
@@ -216,7 +241,7 @@ pub(super) fn topological_file_order(
         result.push(node);
         if let Some(dependents) = reverse_deps.get(&node) {
             let mut sorted_dependents = dependents.clone();
-            sorted_dependents.sort_unstable();
+            sorted_dependents.sort_unstable_by_key(|&idx| rank(idx));
             for &dependent in &sorted_dependents {
                 let deg = in_degree.get_mut(&dependent).unwrap();
                 *deg -= 1;
@@ -227,14 +252,21 @@ pub(super) fn topological_file_order(
         }
     }
 
-    // If cycles exist, append remaining nodes in their original order.
+    // If cycles exist, append the remaining nodes. Kahn's algorithm drains
+    // every acyclic node, so what is left is exactly the cyclic component —
+    // the part of the graph that has no topological order at all and is
+    // therefore ordered *entirely* by the tie-break. Appending in
+    // `file_indices` order would make that order root-dependent (#16036), so
+    // append in stable-key order like every other tie above.
     if result.len() < file_indices.len() {
         let in_result: FxHashSet<usize> = result.iter().copied().collect();
-        for &idx in file_indices {
-            if !in_result.contains(&idx) {
-                result.push(idx);
-            }
-        }
+        let mut remaining: Vec<usize> = file_indices
+            .iter()
+            .copied()
+            .filter(|idx| !in_result.contains(idx))
+            .collect();
+        remaining.sort_unstable_by_key(|&idx| rank(idx));
+        result.extend(remaining);
     }
 
     result
@@ -251,11 +283,41 @@ fn is_node_modules_declaration_file(name: &str) -> bool {
             .any(|component| component.as_os_str() == "node_modules")
 }
 
+/// Rank file indices by file name so topological tie-breaks depend on the file
+/// *set* rather than on the root list that produced the file indices.
+///
+/// Program file indices are assigned in root-discovery order, so two runs over
+/// the identical eight-file program hand the same file a different index
+/// depending on which files the `tsconfig` `include` glob names as roots. Any
+/// ordering that tie-breaks on the index therefore inherits that dependence;
+/// ranking by name does not, because a file's name is the same in every root
+/// configuration that contains it (issue #16036).
+pub(super) fn stable_file_order_key(
+    file_indices: &[usize],
+    program: &MergedProgram,
+) -> FxHashMap<usize, u32> {
+    let mut by_name: Vec<usize> = file_indices.to_vec();
+    by_name.sort_unstable_by(|&a, &b| {
+        program.files[a]
+            .file_name
+            .cmp(&program.files[b].file_name)
+            // File names are unique within a program; the index tie-break only
+            // guards against a caller passing the same index twice.
+            .then_with(|| a.cmp(&b))
+    });
+    by_name
+        .into_iter()
+        .enumerate()
+        .map(|(rank, idx)| (idx, rank as u32))
+        .collect()
+}
+
 pub(super) fn order_fresh_check_work_items(
     work_items: &mut Vec<usize>,
     resolved_module_paths: &FxHashMap<(usize, String), usize>,
     program: &MergedProgram,
 ) {
-    *work_items = topological_file_order(work_items, resolved_module_paths);
+    let stable_key = stable_file_order_key(work_items, program);
+    *work_items = topological_file_order(work_items, resolved_module_paths, &stable_key);
     work_items.sort_by_key(|&idx| is_node_modules_declaration_file(&program.files[idx].file_name));
 }

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part3.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part3.rs
@@ -1067,20 +1067,20 @@ interface Node {
 
     #[test]
     fn topo_order_empty() {
-        let result = topological_file_order(&[], &FxHashMap::default());
+        let result = topological_file_order(&[], &FxHashMap::default(), &FxHashMap::default());
         assert!(result.is_empty());
     }
 
     #[test]
     fn topo_order_single_file() {
-        let result = topological_file_order(&[0], &FxHashMap::default());
+        let result = topological_file_order(&[0], &FxHashMap::default(), &FxHashMap::default());
         assert_eq!(result, vec![0]);
     }
 
     #[test]
     fn topo_order_no_deps() {
         // Three files with no dependencies — output should be sorted by index
-        let result = topological_file_order(&[2, 0, 1], &FxHashMap::default());
+        let result = topological_file_order(&[2, 0, 1], &FxHashMap::default(), &FxHashMap::default());
         assert_eq!(result, vec![0, 1, 2]);
     }
 
@@ -1092,7 +1092,7 @@ interface Node {
         deps.insert((0, "./b".to_string()), 1);
         deps.insert((1, "./c".to_string()), 2);
 
-        let result = topological_file_order(&[0, 1, 2], &deps);
+        let result = topological_file_order(&[0, 1, 2], &deps, &FxHashMap::default());
         assert_eq!(result, vec![2, 1, 0]);
     }
 
@@ -1106,7 +1106,7 @@ interface Node {
         deps.insert((1, "./c".to_string()), 3);
         deps.insert((2, "./c".to_string()), 3);
 
-        let result = topological_file_order(&[0, 1, 2, 3], &deps);
+        let result = topological_file_order(&[0, 1, 2, 3], &deps, &FxHashMap::default());
         assert_eq!(result, vec![3, 1, 2, 0]);
     }
 
@@ -1118,7 +1118,7 @@ interface Node {
         deps.insert((0, "./b".to_string()), 1);
         deps.insert((1, "./a".to_string()), 0);
 
-        let result = topological_file_order(&[0, 1], &deps);
+        let result = topological_file_order(&[0, 1], &deps, &FxHashMap::default());
         assert_eq!(result.len(), 2);
         assert!(result.contains(&0));
         assert!(result.contains(&1));
@@ -1132,7 +1132,7 @@ interface Node {
         deps.insert((0, "./b".to_string()), 1);
         deps.insert((1, "./a".to_string()), 0);
 
-        let result = topological_file_order(&[0, 1, 2], &deps);
+        let result = topological_file_order(&[0, 1, 2], &deps, &FxHashMap::default());
         assert_eq!(result[0], 2, "dependency-free file should come first");
         assert_eq!(result.len(), 3);
     }
@@ -1143,7 +1143,7 @@ interface Node {
         let mut deps = FxHashMap::default();
         deps.insert((0, "./ext".to_string()), 5);
 
-        let result = topological_file_order(&[0, 1], &deps);
+        let result = topological_file_order(&[0, 1], &deps, &FxHashMap::default());
         assert_eq!(result.len(), 2);
         // Both have no in-set dependencies, so sorted order
         assert_eq!(result, vec![0, 1]);
@@ -1155,8 +1155,91 @@ interface Node {
         let mut deps = FxHashMap::default();
         deps.insert((0, "./self".to_string()), 0);
 
-        let result = topological_file_order(&[0, 1], &deps);
+        let result = topological_file_order(&[0, 1], &deps, &FxHashMap::default());
         assert_eq!(result, vec![0, 1]);
+    }
+
+    /// Order the same four-file import cycle twice, under two different index
+    /// assignments, and return the resulting *name* sequences.
+    ///
+    /// Program file indices are assigned in root-discovery order, so changing
+    /// which file the `tsconfig` `include` glob names first hands the same file
+    /// a different index. Both runs below describe the identical module graph
+    /// (the edges are written in terms of names) and differ only in that
+    /// assignment — mirroring zod's `types.ts` / `helpers/partialUtil.ts` cycle
+    /// in issue #16036.
+    fn cycle_order_under_two_root_discovery_orders(
+        stable_key: bool,
+    ) -> (Vec<&'static str>, Vec<&'static str>) {
+        const CYCLE_EDGES: [(&str, &str); 4] = [
+            ("types.ts", "partialUtil.ts"),
+            ("partialUtil.ts", "index.ts"),
+            ("index.ts", "external.ts"),
+            ("external.ts", "types.ts"),
+        ];
+
+        let order_of = |names: [&'static str; 4]| -> Vec<&'static str> {
+            let position = |name: &str| names.iter().position(|n| *n == name).unwrap();
+            let mut deps = FxHashMap::default();
+            for (from, to) in CYCLE_EDGES {
+                deps.insert((position(from), to.to_string()), position(to));
+            }
+
+            let indices: Vec<usize> = (0..names.len()).collect();
+            // Mirrors `stable_file_order_key`: rank by file name, which is a
+            // property of the file set and not of the root list.
+            let key: FxHashMap<usize, u32> = if stable_key {
+                let mut by_name = indices.clone();
+                by_name.sort_unstable_by_key(|&idx| names[idx]);
+                by_name
+                    .into_iter()
+                    .enumerate()
+                    .map(|(rank, idx)| (idx, rank as u32))
+                    .collect()
+            } else {
+                FxHashMap::default()
+            };
+
+            topological_file_order(&indices, &deps, &key)
+                .into_iter()
+                .map(|idx| names[idx])
+                .collect()
+        };
+
+        (
+            order_of(["types.ts", "index.ts", "external.ts", "partialUtil.ts"]),
+            order_of(["partialUtil.ts", "index.ts", "external.ts", "types.ts"]),
+        )
+    }
+
+    #[test]
+    fn topo_order_of_a_cycle_is_independent_of_root_discovery_order() {
+        // Regression for #16036. A cycle admits no topological order at all, so
+        // Kahn's algorithm drains nothing and the entire component is ordered by
+        // the tie-break. With a name-derived key the two root configurations
+        // must check the identical file set in the identical order.
+        let (from_types_root, from_partial_util_root) =
+            cycle_order_under_two_root_discovery_orders(true);
+        assert_eq!(
+            from_types_root, from_partial_util_root,
+            "the same file set must check in the same order regardless of which \
+             of its files the tsconfig root list names"
+        );
+    }
+
+    #[test]
+    fn topo_order_of_a_cycle_without_a_stable_key_is_root_dependent() {
+        // Negative control: the same scenario with no stable key falls back to
+        // the raw file index, which is exactly the root-discovery-order
+        // dependence #16036 reports. Without this the positive test above could
+        // pass on a graph that never had a tie to break.
+        let (from_types_root, from_partial_util_root) =
+            cycle_order_under_two_root_discovery_orders(false);
+        assert_ne!(
+            from_types_root, from_partial_util_root,
+            "index tie-breaking is expected to be root-dependent; if this ever \
+             holds, the fixture stopped exercising the cycle-append path"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes the determinism half of #16036.

**Structural rule.** When a program's module graph contains an import cycle, that cycle admits no topological order, so the entire cyclic component is placed by the ordering's *tie-break* alone. `topological_file_order` broke ties by raw program file index — and program file indices are assigned in **root-discovery order**, so the same file gets a different index depending on which of the program's files the tsconfig `include` glob happens to name as roots. tsc's file order is likewise root-derived, but tsc's checking is order-independent, so its answer does not move; tsz's does. tsz now ranks files by **name**, a property of the file set rather than of the root list, through the driver's scheduling layer (`crates/tsz-cli/src/driver/check_module_graph.rs`) — no checker or solver semantics are touched.

### The witness

zod at `93b0b689`, five `include` globs over the **identical 8-file program** (verified with `--listFiles`: all five produce the same 8 files):

| `include` | before | after |
| --- | --- | --- |
| `["src/types.ts"]` | 2 | 2 |
| `["src/types.ts", "src/helpers/partialUtil.ts"]` | **11** | 2 |
| `["src/helpers/partialUtil.ts", "src/types.ts"]` | **11** | 2 |
| `["src/helpers/partialUtil.ts"]` | **6** | 2 |
| `["src/types.ts", "src/helpers/parseUtil.ts"]` | **0** | 2 |

One program, four different answers, three of them mutually disjoint diagnostic families (`TS2322` / `TS2339`+`TS2359`+`TS2416` / `TS2345`). After: one answer, byte-identical (`md5 16b4243974c5`) in all five.

### What this does *not* do — stated plainly

**The zod row's own number does not move.** Its real config is `include: ["src/**/*"]`, where every file is already a root; that run is **116 diagnostics before and byte-identical 116 after**. This PR is not a false-positive fix and does not make the row greener.

What it fixes is the trap #16036's "why this matters" section names: with root membership changing the answer, *narrowing `include` to isolate a witness measures a different program than the row compiles*. That is precisely the reduction workflow the coordination board runs on — two agents this week reduced against narrowed root sets. Those reductions are now sound.

### Corrections to #16036's framing, from measurement

- **The shared `QueryCache` is not involved.** `SharedQueryCache` is gated on `checker_item_count > 1`, which made it a prime suspect (count-dependent, order-independent — the bug's exact signature). `TSZ_EXPERIMENT_NO_SHARED_QC=1` leaves all five configurations unchanged.
- **File-session reuse is not the root cause either.** `TSZ_DISABLE_FILE_SESSION_REUSE=1` takes the 2-root config 11 → 6 but leaves the 1-root configs at 2 and 6 respectively — i.e. it removes one *symptom* of a wrong check order without removing the root-dependence. Both knobs are downstream of the ordering.
- The issue's `TSZ_XARENA_BASE_DECL` lead (11 → 9) is likewise a symptom of the same wrong order, not a pointer at a duplicate-publication defect.
- The **remaining 2 diagnostics are a real, order-independent false positive** (`TS2322` on `ZodEffects<this, this["_output"], this["_input"]>` at `types.ts:230,260`) — now stably reproducible under any root set, which it was not before. Left on #16036 for a follow-up.

### Change

- `topological_file_order` takes a `stable_order_key: &FxHashMap<usize, u32>` and uses it for **all three** tie-breaks: the Kahn seed order, the dependent-drain order, and — the load-bearing one — the cycle-append branch, which previously appended "in their original order".
- `stable_file_order_key` builds that rank by file name. Both driver call sites (fresh parallel path, cached sequential path) pass it.
- Files absent from the map rank last and fall back to the raw index, so the empty-map case is bit-for-bit the historical behaviour; the 9 pre-existing `topo_order_*` unit tests are unchanged in expectation.

## Goal
Goal: green

## Verification
- `cargo fmt`, `cargo clippy --workspace --all-targets` (warnings denied) — clean. Pre-commit `Clippy passed. / Architecture guard passed.`
- `cargo test -p tsz-cli --lib topo_order` — **11 passed / 0 failed** (9 pre-existing + 2 new).
  - `topo_order_of_a_cycle_is_independent_of_root_discovery_order` — same 4-file cycle under two index assignments must yield the same name sequence.
  - `topo_order_of_a_cycle_without_a_stable_key_is_root_dependent` — negative control asserting the fixture actually reaches the cycle-append path, so the positive test cannot pass vacuously on a graph with no tie to break.
- zod `93b0b689`, real row config `include: ["src/**/*"]`: 116 diagnostics before, 116 after, `diff` clean — no behaviour change on the row itself.
- zod, five narrowed root configurations: 2/11/11/6/0 before → 2/2/2/2/2 after, byte-identical.
- Emit suite (`./scripts/emit/run.sh`): running at time of opening; result posted as a comment.
- Conformance: **not run** — the TypeScript submodule is not checked out in this container and `compare-to-parent.sh` needs it. The corpus is overwhelmingly single-file, where `file_indices.len() <= 1` returns early and this code path is unreachable; multi-file fixtures with an import cycle are the exposed set. Flagging honestly rather than implying coverage I do not have.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Tephra

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZRudDkTXvUc6u2yxKkVtq)_