### PR TITLE
fix(solver): pair a naked intersection member positionally, not against every target member

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2564,3 +2564,6 @@ path = "tests/object_literal_synthetic_this_display_order_tests.rs"
 [[test]]
 name = "predicate_target_return_only_sibling_tests"
 path = "tests/predicate_target_return_only_sibling_tests.rs"
+[[test]]
+name = "getter_contextual_generic_call_typeparam_tests"
+path = "tests/getter_contextual_generic_call_typeparam_tests.rs"

--- a/crates/tsz-checker/tests/getter_contextual_generic_call_typeparam_tests.rs
+++ b/crates/tsz-checker/tests/getter_contextual_generic_call_typeparam_tests.rs
@@ -1,0 +1,201 @@
+//! Regression tests for #16025's standalone `jsonAgg`/`FunctionModule` repro:
+//! inferring a type argument from a contextual type when both the callee's
+//! return type and the contextual type are intersections of the same arity.
+//!
+//! Structural rule: `constrain_types_impl`
+//! (`crates/tsz-solver/src/operations/constraints/walker.rs`) matched a naked
+//! source type parameter appearing in an intersection (e.g. `TB` in
+//! `TB & string`) against *every* member of the target intersection instead
+//! of only its positional counterpart. tsc's `inferFromTypes` does not do
+//! this: for same-arity intersections it pairs members positionally, so a
+//! naked source member only picks up its counterpart's upper bound. tsz's
+//! nested single-side decompose (`(_, Intersection)` then, recursively,
+//! `(Intersection, _)`) instead matched `TB` against *both* target members —
+//! its real counterpart (correct) and the unrelated second member (spurious)
+//! — and the two upper bounds then combined into an artificial `X & string`
+//! candidate instead of `X`. Fixed by adding a same-arity
+//! `(Intersection, Intersection)` arm that positionally pairs a naked member
+//! with its counterpart and only falls back to broad member-to-member
+//! matching for non-naked (structured) members.
+//!
+//! The witness is kysely's `FunctionModule<DB, TB extends keyof DB>`
+//! (`src/kysely.ts:232`, via `get fn(): FunctionModule<DB, keyof DB>`), where
+//! a sibling generic method's own type parameter is constrained by
+//! `(TB & string) | Expr<unknown>`. Reduced from #16025's comment repro.
+
+use tsz_checker::context::{CheckerOptions, ScriptTarget};
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source;
+use tsz_common::ModuleKind;
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        target: ScriptTarget::ES2020,
+        module: ModuleKind::ESNext,
+        no_lib: true,
+        ..Default::default()
+    }
+}
+
+/// `no_lib` checking cannot resolve global types, so filter the unavoidable
+/// `TS2318` noise and assert on the real diagnostics.
+fn real_diagnostics(diags: &[Diagnostic]) -> Vec<(u32, &str)> {
+    diags
+        .iter()
+        .filter(|d| d.code != 2318)
+        .map(|d| (d.code, d.message_text.as_str()))
+        .collect()
+}
+
+/// Core repro: a getter's declared return type contextually types a
+/// zero-argument generic call whose type parameter appears, elsewhere in the
+/// same interface, inside an intersection with `string`. Renaming `DB`
+/// between `Holder` and `createFunctionModule` (both spell it `DB`) is
+/// incidental to kysely's real source, not the trigger — the assignability
+/// diagnostic disappears once the type parameter binds to the plain
+/// `keyof DB` upper bound instead of the artificial `keyof DB & string`.
+#[test]
+fn contextual_call_infers_positional_member_not_full_intersection() {
+    let diags = check_source(
+        r#"
+interface Expr<T> { __exprType: T }
+interface FunctionModule<DB, TB extends keyof DB> {
+  <O>(name: string): O;
+  jsonAgg<T extends (TB & string) | Expr<unknown>>(
+    table: T,
+  ): T extends TB ? DB[T][] : T extends Expr<infer O> ? O[] : never;
+}
+declare function createFunctionModule<DB, TB extends keyof DB>(): FunctionModule<DB, TB>;
+class Holder<DB> {
+  get fn(): FunctionModule<DB, keyof DB> { return createFunctionModule(); }
+}
+"#,
+        "test.ts",
+        opts(),
+    );
+    assert_eq!(
+        real_diagnostics(&diags),
+        Vec::<(u32, &str)>::new(),
+        "core repro should be clean"
+    );
+}
+
+/// Name-agnostic control: every binder renamed (`DB`→`Env`, `TB`→`Key`,
+/// `T`→`Elem`, `O`→`Out`, `Expr`→`Wrapped`). Proves the fix is about
+/// intersection member arity/position, not any particular spelling.
+#[test]
+fn contextual_call_infers_positional_member_is_name_agnostic() {
+    let diags = check_source(
+        r#"
+interface Wrapped<Elem> { __exprType: Elem }
+interface FunctionModule<Env, Key extends keyof Env> {
+  <Out>(name: string): Out;
+  jsonAgg<Elem extends (Key & string) | Wrapped<unknown>>(
+    table: Elem,
+  ): Elem extends Key ? Env[Elem][] : Elem extends Wrapped<infer Out> ? Out[] : never;
+}
+declare function createFunctionModule<Env, Key extends keyof Env>(): FunctionModule<Env, Key>;
+class Holder<Env> {
+  get fn(): FunctionModule<Env, keyof Env> { return createFunctionModule(); }
+}
+"#,
+        "test.ts",
+        opts(),
+    );
+    assert_eq!(
+        real_diagnostics(&diags),
+        Vec::<(u32, &str)>::new(),
+        "renamed-binder control should be clean"
+    );
+}
+
+/// Fallback control: neither intersection member is a naked type parameter
+/// (both `{tag: string}` and `{extra: boolean}` are structured object
+/// types), so the same-arity guard must not fire and both target members
+/// must still broadly match against the source's single structured member —
+/// exactly the pre-existing "structured members" behavior the fix leaves
+/// alone. If the guard incorrectly treated a structured member as naked, one
+/// of the two upper bounds would be dropped and this would spuriously fail
+/// with a missing-property diagnostic.
+#[test]
+fn structured_intersection_members_still_broadly_match() {
+    let diags = check_source(
+        r#"
+interface Tagged { tag: string }
+interface Extra { extra: boolean }
+declare function make(): Tagged & Extra;
+function use(): Tagged & Extra {
+    return make();
+}
+"#,
+        "test.ts",
+        opts(),
+    );
+    assert_eq!(
+        real_diagnostics(&diags),
+        Vec::<(u32, &str)>::new(),
+        "structured (non-naked) intersection members should still combine correctly"
+    );
+}
+
+/// Free-function control: the same shape without a class getter — a
+/// top-level generic function's declared return-type annotation supplies the
+/// contextual type instead of a getter's. Confirms the fix is keyed on the
+/// intersection arity/position, not on being read through a getter.
+#[test]
+fn contextual_call_infers_positional_member_through_plain_function_return() {
+    let diags = check_source(
+        r#"
+interface Expr<T> { __exprType: T }
+interface FunctionModule<DB, TB extends keyof DB> {
+  <O>(name: string): O;
+  jsonAgg<T extends (TB & string) | Expr<unknown>>(
+    table: T,
+  ): T extends TB ? DB[T][] : T extends Expr<infer O> ? O[] : never;
+}
+declare function createFunctionModule<DB, TB extends keyof DB>(): FunctionModule<DB, TB>;
+function fn<XX>(): FunctionModule<XX, keyof XX> {
+  return createFunctionModule();
+}
+"#,
+        "test.ts",
+        opts(),
+    );
+    assert_eq!(
+        real_diagnostics(&diags),
+        Vec::<(u32, &str)>::new(),
+        "free-function contextual-return control should be clean"
+    );
+}
+
+/// Genuine mismatch must still be reported: the fix must not silence a real
+/// error by mis-binding the naked member to the wrong positional
+/// counterpart. `boolean` cannot generally satisfy `TB extends keyof DB` for
+/// an unconstrained `DB`, so inferring `TB` from this contextual type must
+/// still surface a real diagnostic instead of going quiet.
+#[test]
+fn genuine_constraint_violation_still_reported() {
+    let diags = check_source(
+        r#"
+interface Expr<T> { __exprType: T }
+interface FunctionModule<DB, TB extends keyof DB> {
+  <O>(name: string): O;
+  jsonAgg<T extends (TB & string) | Expr<unknown>>(
+    table: T,
+  ): T extends TB ? DB[T][] : T extends Expr<infer O> ? O[] : never;
+}
+declare function createFunctionModule<DB, TB extends keyof DB>(): FunctionModule<DB, TB>;
+class Holder<DB> {
+  get fn(): FunctionModule<DB, boolean> { return createFunctionModule(); }
+}
+"#,
+        "test.ts",
+        opts(),
+    );
+    let real = real_diagnostics(&diags);
+    assert!(
+        !real.is_empty(),
+        "expected a real diagnostic for the FunctionModule<DB, boolean> constraint violation, got none"
+    );
+}

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -797,6 +797,38 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     }
                 }
             }
+            // Both source and target are intersections. Decomposing only one
+            // side and constraining the other's full (undecomposed) type
+            // against every member of the decomposed side turns a naked
+            // member on the un-decomposed side into candidates from every
+            // member of the other side: `T & string` (source) against
+            // `X & string` (target) would constrain naked `T` against both
+            // `X` (correct upper bound) and `string` (spurious upper bound),
+            // and the two upper bounds then combine into the artificial
+            // `X & string` instead of `X`. When both intersections have the
+            // same arity, pair a naked member only with its positional
+            // counterpart on the other side; structured (non-naked) members
+            // keep the broad, unpaired matching used by mismatched arities.
+            (Some(TypeData::Intersection(s_members)), Some(TypeData::Intersection(t_members))) => {
+                let s_members = self.interner.type_list(s_members);
+                let t_members = self.interner.type_list(t_members);
+                if s_members.len() == t_members.len() {
+                    for (index, &t_member) in t_members.iter().enumerate() {
+                        let s_member = s_members[index];
+                        if var_map.contains_key(&s_member) || var_map.contains_key(&t_member) {
+                            self.constrain_types(ctx, var_map, s_member, t_member, priority);
+                            continue;
+                        }
+                        for &other_s_member in s_members.iter() {
+                            self.constrain_types(ctx, var_map, other_s_member, t_member, priority);
+                        }
+                    }
+                } else {
+                    for &t_member in t_members.iter() {
+                        self.constrain_types(ctx, var_map, source, t_member, priority);
+                    }
+                }
+            }
             (_, Some(TypeData::Intersection(t_members))) => {
                 let t_members = self.interner.type_list(t_members);
                 for &member in t_members.iter() {


### PR DESCRIPTION
When `constrain_types_impl` (`crates/tsz-solver/src/operations/constraints/walker.rs`) sees a same-arity `(Intersection, Intersection)` pair, it had no dedicated arm — it fell through to the single-side decomposition arms, recursing `(_, Intersection)` and then, for each target member, `(Intersection, _)`. For a naked source type parameter inside an intersection (e.g. `TB` in `TB & string`), this matched `TB` against **every** member of the target intersection instead of only its positional counterpart: its real counterpart (correct upper bound) and an unrelated second member (spurious upper bound). The two upper bounds then combined into an artificial `X & string` candidate instead of `X`.

**Structural rule:** when inferring a type parameter from a same-arity `(Intersection, Intersection)` pair, `tsc`'s `inferFromTypes` pairs members positionally; tsz did this correctly for `infer_matching.rs::infer_intersections`'s inference-only path but not for `constrain_types_impl`'s separate constraint-collection path in the solver.

**The fix:** adds a dedicated same-arity `(Intersection, Intersection)` arm that pairs a naked member positionally with its counterpart, falling back to the pre-existing broad member-to-member matching for structured (non-naked) members or mismatched arities.

**Witness:** kysely's `FunctionModule[DB, TB extends keyof DB]` (`src/kysely.ts:232`), where a sibling generic method's own type parameter is constrained by `(TB & string) | Expr[unknown]`. A zero-arg call to `createFunctionModule[DB, TB]()`, contextually typed by a return-type annotation `FunctionModule[XX, keyof XX]`, corrupted the inferred `TB` to `keyof XX & string`, producing a spurious `TS2322` on the containing function/getter.

This continues investigation an earlier session under this account (branch `claude/hopeful-lovelace-9oajmr`, not yet opened as a PR) started and root-caused; I verified the fix independently against my own standalone repro (a plain generic function's return-type annotation, no class/getter needed — a shape a different session's dead-end DROP on the coordination board had reduced to and mis-attributed to a different, unresolved mechanism), extended the adjacent-case matrix with that shape, and ran full verification before landing.

**Owner layer.** Solver only (`constrain_types_impl`, a pure structural constraint-collection routine). No checker or emitter change.

Closes the standalone `jsonAgg`/`FunctionModule` repro noted in #16025's 10:54Z comment (a flagged "separate, quick win", not #16025's row-blocking family — that remains open per #10663).

## Goal
Goal: green

## Verification
- New suite `getter_contextual_generic_call_typeparam_tests.rs`, 5 tests (core getter repro, renamed-binder control, structured-non-naked fallback control, free-function contextual-return control I added, genuine-constraint-violation-still-reported control): `cargo test -p tsz-checker --test getter_contextual_generic_call_typeparam_tests` → 5/5 passed.
- Adjacent regression sweep: `cargo test -p tsz-checker --lib -- intersection constrain infer_ generic_call contextual_return` → 885 passed, 2 failed. Both failures reproduce identically on `origin/main` with this branch's changes stashed out (`return_context_type_param_shadowing_tests::async_return_of_generic_call_with_shadowed_param_async_callback_is_clean`, `state_type_environment_relation_routing_arch_tests::impossible_intersection_pruning_uses_subtype_outcome_boundary`) — pre-existing, unrelated to this change (part of the known #15983 batch).
- `cargo clippy --profile dist-fast -p tsz-solver -p tsz-checker --lib -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- `cargo fmt -p tsz-solver -p tsz-checker -- --check`: clean.
- `scripts/conformance/compare-to-parent.sh origin/main`: base `1d2b72b` vs branch, base failing=608, branch failing=608 — **0 newly failing, 0 newly passing** (expected null result: this exact shape has no corpus fixture, per the board's standing note for this bug family — the targeted oracle-pinned matrix above is the primary evidence, this sweep is the regression floor).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE