### PR TITLE
fix(checker): self-recursive const-bound signatures tolerate default-valued params

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1623,6 +1623,9 @@ mod satisfies_callback_return_widening_tests;
 #[path = "tests/satisfies_relation_routing_arch_tests.rs"]
 mod satisfies_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/self_recursive_default_param_provisional_signature_tests.rs"]
+mod self_recursive_default_param_provisional_signature_tests;
+#[cfg(test)]
 #[path = "tests/self_referential_arrow_property_soundness_tests.rs"]
 mod self_referential_arrow_property_soundness_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
@@ -338,20 +338,26 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Provisional self-reference type for a circular `const`/`let`/`var` bound
-    /// to an arrow or function expression whose parameters and return type are
-    /// all explicitly annotated.
+    /// to an arrow or function expression whose return type is explicitly
+    /// annotated and whose every parameter has either an explicit type
+    /// annotation or a default-value initializer.
     ///
     /// `tsc` resolves an in-body self-reference of such a binding to the
-    /// initializer's declared signature, which is computable from the
-    /// annotations alone without analyzing the body. Without a provisional,
-    /// the variable symbol — which is not a `FUNCTION` symbol, so
+    /// initializer's declared signature, which is computable without
+    /// analyzing the body: a default-valued parameter's type comes from its
+    /// own initializer expression, not from the enclosing function's body or
+    /// return type, so it needs no circular resolution either. Without a
+    /// provisional, the variable symbol — which is not a `FUNCTION` symbol, so
     /// [`Self::provisional_circular_function_symbol_type`] does not apply —
     /// collapses to `ERROR`/`unknown` during the cycle, so `param.map(self)`
-    /// degrades to `unknown[]` and yields a false `TS18046`/`TS2571`.
+    /// degrades to `unknown[]` and yields a false `TS18046`/`TS2571`, or a
+    /// downstream sibling generic-callback inference silently defaults to
+    /// `unknown` and produces a false `TS2322`.
     ///
-    /// Only fires when every parameter and the return type are annotated: an
-    /// un-annotated arrow genuinely needs body inference to determine its
-    /// signature, so it is left to the existing cycle behavior.
+    /// Only fires when the return type is annotated and every parameter is
+    /// either annotated or has a default initializer: a parameter with
+    /// neither genuinely needs body inference to determine its type, so that
+    /// shape is left to the existing cycle behavior.
     pub(crate) fn provisional_circular_variable_function_symbol_type(
         &mut self,
         sym_id: SymbolId,
@@ -430,8 +436,10 @@ impl<'a> CheckerState<'a> {
         Some(decl.initializer)
     }
 
-    /// Whether a function/arrow node has an explicit return-type annotation and
-    /// an explicit type annotation on every parameter.
+    /// Whether a function/arrow node has an explicit return-type annotation
+    /// and every parameter is independently resolvable — either an explicit
+    /// type annotation or a default-value initializer, either of which gives
+    /// the parameter a type without analyzing the function's own body.
     fn function_has_explicit_param_and_return_annotations(
         &self,
         func: &tsz_parser::parser::node::FunctionData,
@@ -444,7 +452,9 @@ impl<'a> CheckerState<'a> {
                 .arena
                 .get(param_idx)
                 .and_then(|param_node| self.ctx.arena.get_parameter(param_node))
-                .is_some_and(|param| param.type_annotation != NodeIndex::NONE)
+                .is_some_and(|param| {
+                    param.type_annotation != NodeIndex::NONE || param.initializer != NodeIndex::NONE
+                })
         })
     }
 

--- a/crates/tsz-checker/src/tests/self_recursive_default_param_provisional_signature_tests.rs
+++ b/crates/tsz-checker/src/tests/self_recursive_default_param_provisional_signature_tests.rs
@@ -1,0 +1,222 @@
+//! Regression coverage for issue #16037: a `const`-bound self-recursive arrow
+//! (or function expression) with an explicit return-type annotation lost that
+//! annotation's benefit for in-body self-references as soon as ANY parameter
+//! in its own parameter list had a default-value initializer instead of an
+//! explicit type annotation — even when that parameter was unrelated to, and
+//! unused by, the recursive call.
+//!
+//! Structural rule: `tsc` resolves an in-body self-reference of an annotated
+//! function-like variable binding to the initializer's declared signature,
+//! which is computable without analyzing the body — a default-valued
+//! parameter's type comes from its own initializer expression, not from the
+//! enclosing function's body or return type, so it needs no circular
+//! resolution any more than an explicitly annotated parameter does. tsz's
+//! `provisional_circular_variable_function_symbol_type`
+//! (`state/type_analysis/symbol_type_helpers.rs`) already implements this
+//! short-circuit for fully-annotated signatures; its gate,
+//! `function_has_explicit_param_and_return_annotations`, required every
+//! parameter to carry an explicit type annotation, so a signature with a
+//! default-valued (but unannotated) parameter fell through to the general
+//! cycle-breaking path, which caches the self-reference as `TypeId::ERROR`.
+//! That `ERROR` result then defeats guard-based narrowing on the recursive
+//! call's result downstream, so a sibling generic-callback inference site
+//! finds no evidence for its type parameter and silently defaults it to
+//! `unknown`, producing a false `TS2322` (superjson's `plainer.ts` canary).
+//!
+//! Owner layer: checker (`state/type_analysis/symbol_type_helpers.rs`),
+//! `provisional_circular_variable_function_symbol_type`'s gate.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn assert_clean(src: &str) {
+    let diags = check_source_diagnostics(src);
+    assert!(
+        diags.is_empty(),
+        "expected no diagnostics, got {diags:?} for:\n{src}"
+    );
+}
+
+/// Shared fixture: a self-recursive arrow walker over a user-defined
+/// recursive `Tree`/dict shape, narrowed through two type guards before a
+/// nested generic callback consumes the narrowed member. `extra_param`
+/// varies per case; `head`/`tail` let a caller swap the arrow for an
+/// equivalent function-expression form.
+fn walker_source_with(extra_param: &str, head: &str, tail: &str) -> String {
+    format!(
+        r#"
+type Dict<T> = {{ [key: string]: T }};
+type Tree<T> = InnerNode<T> | Leaf<T>;
+type Leaf<T> = [T];
+type InnerNode<T> = [T, Dict<Tree<T>>];
+type MinimisedTree<T> = Tree<T> | Dict<Tree<T>> | undefined;
+
+declare const isArray: (payload: any) => payload is any[];
+declare const isPlainObject: (payload: any) => payload is {{ [key: string]: any }};
+declare function forEach<T>(record: Dict<T>, run: (v: T, key: string) => void): void;
+declare function transformValue(object: any): {{ value: any }} | undefined;
+
+interface Result {{
+  transformedValue: any;
+  annotations?: MinimisedTree<string>;
+}}
+
+export const walker = {head}(
+  object: any{extra_param}
+): Result {tail} {{
+  const transformationResult = transformValue(object);
+  const transformed = transformationResult?.value ?? object;
+  const innerAnnotations: Dict<Tree<string>> = {{}};
+
+  forEach(transformed, (value: any, index: string) => {{
+    const recursiveResult = walker(value);
+
+    if (isArray(recursiveResult.annotations)) {{
+      innerAnnotations[index] = recursiveResult.annotations;
+    }} else if (isPlainObject(recursiveResult.annotations)) {{
+      forEach(recursiveResult.annotations, (tree, key) => {{
+        innerAnnotations[index + '.' + key] = tree;
+      }});
+    }}
+  }});
+
+  return {{ transformedValue: transformed, annotations: innerAnnotations }};
+}};
+"#,
+        head = head,
+        tail = tail,
+        extra_param = extra_param,
+    )
+}
+
+fn walker_source(extra_param: &str) -> String {
+    walker_source_with(extra_param, "", "=>")
+}
+
+/// Baseline: no extra parameter at all. Must stay clean (pre-existing).
+#[test]
+fn self_recursive_arrow_no_extra_param_is_clean() {
+    assert_clean(&walker_source(""));
+}
+
+/// The exact #16037 repro: an extra default-valued, unannotated `boolean`
+/// parameter must not corrupt the recursive call's inferred type.
+#[test]
+fn self_recursive_arrow_with_unannotated_default_param_is_clean() {
+    assert_clean(&walker_source(", flag = false"));
+}
+
+/// The parameter's default-inferred type is irrelevant to the trigger: an
+/// object-typed default reproduces identically to a boolean one.
+#[test]
+fn self_recursive_arrow_with_unrelated_object_default_param_is_clean() {
+    assert_clean(&walker_source(", seen = { marker: 1 }"));
+}
+
+/// An explicit type annotation on the extra parameter was already the
+/// documented escape hatch; must remain clean (adjacent positive control).
+#[test]
+fn self_recursive_arrow_with_explicitly_annotated_extra_param_is_clean() {
+    assert_clean(&walker_source(", flag: boolean = false"));
+}
+
+/// Renamed-binder control: a differently-named recursive variable and
+/// differently-named default parameter must behave identically.
+#[test]
+fn self_recursive_arrow_renamed_binder_with_default_param_is_clean() {
+    let src = r#"
+type Dict<T> = { [key: string]: T };
+type Tree<T> = InnerNode<T> | Leaf<T>;
+type Leaf<T> = [T];
+type InnerNode<T> = [T, Dict<Tree<T>>];
+type MinimisedTree<T> = Tree<T> | Dict<Tree<T>> | undefined;
+
+declare const isArray: (payload: any) => payload is any[];
+declare const isPlainObject: (payload: any) => payload is { [key: string]: any };
+declare function forEach<T>(record: Dict<T>, run: (v: T, key: string) => void): void;
+declare function transformValue(object: any): { value: any } | undefined;
+
+interface Outcome {
+  transformedValue: any;
+  annotations?: MinimisedTree<string>;
+}
+
+export const traverse = (
+  payload: any,
+  seenObjects = 0
+): Outcome => {
+  const transformed = transformValue(payload)?.value ?? payload;
+  const collected: Dict<Tree<string>> = {};
+
+  forEach(transformed, (value: any, index: string) => {
+    const nested = traverse(value);
+
+    if (isArray(nested.annotations)) {
+      collected[index] = nested.annotations;
+    } else if (isPlainObject(nested.annotations)) {
+      forEach(nested.annotations, (leaf, key) => {
+        collected[index + '.' + key] = leaf;
+      });
+    }
+  });
+
+  return { transformedValue: transformed, annotations: collected };
+};
+"#;
+    assert_clean(src);
+}
+
+/// Function-expression form of the initializer (not just arrow) must also
+/// benefit from the provisional signature.
+#[test]
+fn self_recursive_function_expression_with_default_param_is_clean() {
+    assert_clean(&walker_source_with(", flag = false", "function ", ""));
+}
+
+/// Negative/fallback control: a parameter with NEITHER an annotation NOR a
+/// default initializer genuinely needs body inference, so it must still fall
+/// through to the pre-existing cycle-breaking behavior (no crash; `tsc`
+/// itself reports TS7006 here under `noImplicitAny`, so this only asserts
+/// tsz does not panic or hang, not that it is silent).
+#[test]
+fn self_recursive_arrow_with_bare_unannotated_param_does_not_panic() {
+    let src = r#"
+interface Result {
+  transformedValue: any;
+}
+
+export const walkerBareParam = (
+  object: any,
+  extra
+): Result => {
+  const r = walkerBareParam(object, extra);
+  return { transformedValue: r };
+};
+"#;
+    // Only guards against a panic/hang; diagnostics content for this
+    // genuinely-circular shape is out of scope for this suite.
+    let _ = check_source_diagnostics(src);
+}
+
+/// Negative control: no return-type annotation at all still requires real
+/// body inference and must not be affected by this provisional short-circuit.
+#[test]
+fn self_recursive_arrow_without_return_annotation_does_not_panic() {
+    let src = r#"
+type Dict<T> = { [key: string]: T };
+
+declare function forEach<T>(record: Dict<T>, run: (v: T, key: string) => void): void;
+
+export const walkerNoReturnAnnotation = (
+  object: any,
+  flag = false
+) => {
+  const innerAnnotations: Dict<any> = {};
+  forEach(innerAnnotations, (value: any, index: string) => {
+    const recursiveResult = walkerNoReturnAnnotation(value);
+    innerAnnotations[index] = recursiveResult;
+  });
+  return { annotations: innerAnnotations };
+};
+"#;
+    let _ = check_source_diagnostics(src);
+}


### PR DESCRIPTION
Closes #16037.

**Structural rule.** When a self-recursive `const`/`let`/`var`-bound arrow or function expression has an explicit return-type annotation, `tsc` resolves an in-body self-reference to that declared signature without needing full body inference — a default-valued parameter's type comes from its own initializer expression, not from the function's body or return type, so it needs no circular resolution any more than an explicitly annotated parameter does. tsz's `provisional_circular_variable_function_symbol_type` (`crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs`) already implements this short-circuit for fully-annotated signatures, but its gate (`function_has_explicit_param_and_return_annotations`) required *every* parameter to carry an explicit type annotation. A signature with a default-valued (but unannotated) parameter — regardless of the default's type, and regardless of whether the recursive call even uses that parameter — fell through to the general cycle-breaking path, which caches the self-reference as `TypeId::ERROR`. That `ERROR` result defeats guard-based narrowing on the recursive call's result downstream, so a sibling generic-callback inference site finds no evidence for its type parameter and silently defaults it to `unknown`, producing a false `TS2322` (superjson's `plainer.ts` canary, the last open FP of #15731's family).

**Fix.** Relax the gate to accept a parameter that is either explicitly annotated *or* carries a default-value initializer — both are resolvable without analyzing the function's own body. Plain `function` declarations were already unaffected (confirmed by direct repro): only the `const`/`let`-bound arrow/function-expression path, gated by this helper, had the bug.

**Owner layer.** Checker only (`state/type_analysis/symbol_type_helpers.rs`). No solver or emitter change.

## Goal
Goal: green

## Verification

New suite `self_recursive_default_param_provisional_signature_tests.rs`, 8 tests covering: the exact #16037 repro (unannotated `boolean` default), an unrelated object-typed default, a renamed-binder control (different variable/param names), the pre-existing explicitly-annotated-param case (adjacent positive control), the function-expression form (not just arrow), the no-extra-param baseline, and two negative/fallback controls (a bare unannotated-no-default param; no return-type annotation at all) that must still fall through to the existing cycle behavior without panicking:

```
cargo test -p tsz-checker --lib self_recursive_default_param_provisional_signature
8 passed; 0 failed
```

Before/after on the same commit (fix stashed vs applied): 4 of the 8 fail without the fix (the exact repro, the unrelated-default variant, the renamed-binder control, and the function-expression form); the other 4 (positive annotated-param control, baseline, and the two negative/fallback controls) pass regardless — confirming the suite exercises the fix rather than passing vacuously.

Adjacent regression suite (circularity/self-reference families): `cargo test -p tsz-checker --lib -- circular self_recursive self_referential provisional` → **146/146 passed**.

Gates: `cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings` clean; `python3 scripts/arch/arch_guard.py` passes; `cargo fmt --check -p tsz-checker` clean; pre-commit hook (fmt + clippy + arch guard) passed.

**Conformance** (`scripts/conformance/compare-to-parent.sh`, two-sided against this branch's own parent `1d2b72b`): base failing=605, branch failing=605. **0 newly passing, 0 newly failing.** Expected null result for this evidence family — the corpus has no fixture for "self-recursive const-bound function with a default-valued sibling parameter feeding a narrowed generic callback"; the oracle-pinned unit matrix above is the primary evidence, matching the documented pattern for adjacent FP families in this campaign (see #15994 standing gotchas).

**Full unit suite** (`cargo nextest run -p tsz-checker --lib`, 8521 tests): 8512 passed, 9 failed, 2 skipped. All 9 failures reproduce identically on parent `1d2b72b` with this branch's fix removed (verified by checking out the parent commit and re-running the same 9 filtered tests) — pre-existing, unrelated to this change, distinct from the already-tracked #15983 batch.

**Emit** (`scripts/emit/run.sh`): not run this session — the emit harness's `npm install` step hung with no progress in this container (a known issue in this environment). This PR only touches checker-side self-recursive signature resolution with no emit-path involvement, so flagging per the project's disclosure convention rather than claiming an unverified floor.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tnj2gpcGPHWEJARtUGwKb7)_