### PR TITLE
fix(solver): infer intersection members like tsc's inferFromTypes, not by position

### DIFF
--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -797,36 +797,96 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     }
                 }
             }
-            // Both source and target are intersections. Decomposing only one
-            // side and constraining the other's full (undecomposed) type
-            // against every member of the decomposed side turns a naked
-            // member on the un-decomposed side into candidates from every
-            // member of the other side: `T & string` (source) against
-            // `X & string` (target) would constrain naked `T` against both
-            // `X` (correct upper bound) and `string` (spurious upper bound),
-            // and the two upper bounds then combine into the artificial
-            // `X & string` instead of `X`. When both intersections have the
-            // same arity, pair a naked member only with its positional
-            // counterpart on the other side; structured (non-naked) members
-            // keep the broad, unpaired matching used by mismatched arities.
+            // Both source and target are intersections. tsc's inferFromTypes
+            // (checker.ts) does not pair members positionally by index: it
+            // first cancels constituent pairs that are literally identical
+            // between the two sides (`inferFromMatchingTypes` with
+            // `isTypeIdenticalTo`), then infers each *remaining* target
+            // member from the *whole* remaining (re-combined) source
+            // (`inferToMultipleTypes`). A naked type-variable member is not
+            // matched against its positional counterpart — it is matched
+            // against the whole reduced source, same as every other member,
+            // and only gets its own dedicated (lower-priority) inference when
+            // it is the *only* naked member left standing.
+            //
+            // Decomposing only one side and constraining the other's full
+            // (undecomposed) type against every member of the decomposed
+            // side is correct in the common case, but without the identical-
+            // pair cancellation step it over-constrains: `T & string`
+            // (source) against `X & string` (target) would broadly constrain
+            // naked `T` against both `X` (its real counterpart) and `string`
+            // (an unrelated member), combining into an artificial
+            // `X & string` upper bound instead of `X`. Once the identical
+            // `string` members are cancelled from both sides first, the
+            // reduced pair is just `T` against `X`, which the existing naked-
+            // target-variable path below already infers correctly.
+            //
+            // A naked member that is NOT cancelled away, and is not the
+            // intersection's only naked member, must still see the whole
+            // (reduced) source rather than one positional slice of it —
+            // dropping the other source members loses real structure tsc
+            // keeps (`silentNeverPropagation.ts`: `TActions` alone in
+            // `ModuleWithState<TState> & TActions` must be inferred as the
+            // full `ModuleWithState<{a:number}> & {foo():true}` candidate,
+            // not just `{foo():true}`).
             (Some(TypeData::Intersection(s_members)), Some(TypeData::Intersection(t_members))) => {
                 let s_members = self.interner.type_list(s_members);
                 let t_members = self.interner.type_list(t_members);
-                if s_members.len() == t_members.len() {
-                    for (index, &t_member) in t_members.iter().enumerate() {
-                        let s_member = s_members[index];
-                        if var_map.contains_key(&s_member) || var_map.contains_key(&t_member) {
-                            self.constrain_types(ctx, var_map, s_member, t_member, priority);
-                            continue;
+                let mut source_cancelled = vec![false; s_members.len()];
+                let mut any_cancelled = false;
+                let remaining_targets: Vec<TypeId> = t_members
+                    .iter()
+                    .copied()
+                    .filter(|&t_member| {
+                        let mut matched = false;
+                        for (si, &s_member) in s_members.iter().enumerate() {
+                            if !source_cancelled[si] && s_member == t_member {
+                                source_cancelled[si] = true;
+                                matched = true;
+                                any_cancelled = true;
+                                break;
+                            }
                         }
-                        for &other_s_member in s_members.iter() {
-                            self.constrain_types(ctx, var_map, other_s_member, t_member, priority);
-                        }
-                    }
+                        !matched
+                    })
+                    .collect();
+                let remaining_sources: Vec<TypeId> = s_members
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| !source_cancelled[*index])
+                    .map(|(_, &s_member)| s_member)
+                    .collect();
+                if remaining_sources.is_empty() || remaining_targets.is_empty() {
+                    // tsc makes no further inference once one side is fully
+                    // cancelled by identical-member matches.
+                    return;
+                }
+                let reduced_source = if !any_cancelled {
+                    source
+                } else if remaining_sources.len() == 1 {
+                    remaining_sources[0]
                 } else {
-                    for &t_member in t_members.iter() {
-                        self.constrain_types(ctx, var_map, source, t_member, priority);
+                    self.interner.intersection(remaining_sources)
+                };
+                let naked_target_vars: Vec<TypeId> = remaining_targets
+                    .iter()
+                    .copied()
+                    .filter(|t| var_map.contains_key(t))
+                    .collect();
+                for &t_member in &remaining_targets {
+                    if var_map.contains_key(&t_member) {
+                        continue;
                     }
+                    self.constrain_types(ctx, var_map, reduced_source, t_member, priority);
+                }
+                if naked_target_vars.len() == 1 {
+                    self.constrain_types(
+                        ctx,
+                        var_map,
+                        reduced_source,
+                        naked_target_vars[0],
+                        priority,
+                    );
                 }
             }
             (_, Some(TypeData::Intersection(t_members))) => {


### PR DESCRIPTION
Continuing #16042 (merged 10506b3), which added same-arity `(Intersection, Intersection)` positional-by-index pairing to `constrain_types_impl`. A post-merge review (Quartz, posted on the PR before it landed) found it regresses declaration emit for TypeScript's own `silentNeverPropagation.ts` fixture: DTS 1374/1390, below the ROADMAP floor of 1375/1390, which has zero headroom. The PR merged before the comment could block it (the per-merge CI lane is only clippy + arch-size).

**Structural rule:** positional-by-index pairing isn't tsc's actual algorithm for same-arity `(Intersection, Intersection)` inference. Per `checker.ts`'s `inferFromTypes`/`inferToMultipleTypes` (read from the pinned TypeScript corpus SHA for ground truth), tsc:
1. cancels constituent pairs that are literally identical between source and target first (`inferFromMatchingTypes` + `isTypeIdenticalTo`),
2. infers each *remaining* target member from the *whole* remaining (re-combined) source — never from one positional source member,
3. and gives a naked target type-variable member its own dedicated inference only when it is the *only* naked member left after step 1's cancellation.

This is why #16042's kysely repro (`TB & string` vs `X & string`) "looked" positional: cancelling the identical `string` members from both sides first reduces the pair to bare `TB` vs bare `X`, which the pre-existing single-naked-var path already infers correctly — no index-based pairing involved. Pairing by index instead of cancelling identical members first breaks any case where a naked target member isn't the intersection's only naked member and cancellation doesn't collapse it to a 1:1 correspondence: `ModuleWithState<TState> & TActions` inferred from `ModuleWithState<{a:number}> & {foo():true}` must give `TActions` the *whole* candidate (matches tsc), not just its positional slice `{foo():true}` (#16042's regression).

**The fix:** replaces the positional-by-index arm with the real algorithm — cancel identical constituent pairs from both sides, broadly match each remaining non-var target member against the whole reduced source, and give the whole reduced source to a remaining naked target member only when it is the sole one left.

**Owner layer.** Solver only (`constrain_types_impl`, a pure structural constraint-collection routine). No checker or emitter change.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test getter_contextual_generic_call_typeparam_tests` (the 5 tests #16042 added for the kysely family): 5/5 passed, unmodified.
- `cargo test -p tsz-checker --lib -- intersection constrain infer_ generic_call contextual_return`: 885 passed, 2 failed — the same 2 pre-existing failures #16042's own verification named (`return_context_type_param_shadowing_tests::async_return_of_generic_call_with_shadowed_param_async_callback_is_clean`, `state_type_environment_relation_routing_arch_tests::impossible_intersection_pruning_uses_subtype_outcome_boundary`), part of the known #15983 batch, unrelated to this change.
- Direct DTS repro: built `tsz-cli` (dist-fast) from this branch and from unpatched main (10506b3), ran both on TypeScript's `silentNeverPropagation.ts` fixture with `--declaration --emitDeclarationOnly --strict --target es2015`. Unpatched main drops `& ModuleWithState<{a: number}>` from `breaks`'s inferred type (matching Quartz's report); this branch's output is byte-identical to tsc's own baseline for the fixture (fetched from raw.githubusercontent.com/microsoft/TypeScript at the pinned SHA `4d4f005c8541e0255a9d8791205fdce326e462bc`).
- `cargo clippy --profile dist-fast -p tsz-solver -p tsz-checker --lib -- -D warnings`: clean.
- `cargo fmt -p tsz-solver -p tsz-checker -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_011RsTo2LKiTeVfC1KyxdkEe)_