### PR TITLE
hold(tsz-checker): assert the diagnostic tsc actually emits for a class prototype late attachment

### DIFF
--- a/crates/tsz-checker/src/tests/ts2565_jsdoc_prototype_type_decl_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2565_jsdoc_prototype_type_decl_tests.rs
@@ -6,9 +6,15 @@
 //! property's type via JSDoc. tsc treats this as a declaration, not an
 //! "used before assigned" read.
 //!
-//! For ES `class C {}` declarations the same prototype attachment is still a
-//! genuine "used before assigned" because the prototype shape is the class
-//! instance type — tsc emits TS2565 there.
+//! For ES `class C {}` declarations the same prototype attachment does NOT
+//! declare anything: `C.prototype` is the class instance type, which is closed,
+//! so the member simply does not exist. tsc reports **TS2339**, not TS2565.
+//!
+//! That second rule was previously asserted here as TS2565, which describes a
+//! diagnostic `tsc` never emits for this shape. See #16049 for the oracle
+//! matrix (`tsc` 7.0.2, `--strict --allowJs --checkJs`) and for the underlying
+//! tsz defect: the TS path already reports TS2339 for `K.prototype.late`, and
+//! only the checked-JS path stays silent.
 
 use crate::context::CheckerOptions;
 use crate::test_utils::check_source;
@@ -50,6 +56,13 @@ new C().x;
     );
 }
 
+/// A JSDoc `@type` statement does not open an ES `class`'s prototype: the
+/// instance type is closed, so the member does not exist and the read is a
+/// plain TS2339. Oracle (`tsc` 7.0.2 `--strict --allowJs --checkJs`):
+/// `error TS2339: Property 'late' does not exist on type 'K'.`
+///
+/// The suppression that makes this silent is checked-JS-only — the identical
+/// program in a `.ts` file already reports TS2339 today. See #16049.
 #[test]
 fn ts2565_still_fires_for_jsdoc_typed_prototype_on_class() {
     let codes = diag_codes_js(
@@ -62,8 +75,31 @@ K.prototype.late;
 "#,
     );
     assert!(
-        codes.contains(&2565),
-        "TS2565 must STILL fire for JSDoc-typed prototype on ES `class` (the prototype shape is the class instance type, late attachment is genuinely 'used before assigned'). Got: {codes:?}"
+        codes.contains(&2339),
+        "an ES `class` prototype is closed, so a JSDoc-typed late attachment must report TS2339 (tsc 7.0.2 does), not be silently accepted. Got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2565),
+        "tsc reports TS2339 here, never TS2565 — the prototype member is absent, not read before assignment. Got: {codes:?}"
+    );
+}
+
+/// Positive control, oracle-confirmed clean: reading a member the class really
+/// declares through `.prototype` must stay silent. This is the case the TS2339
+/// rule above must not over-fire on.
+#[test]
+fn class_prototype_read_of_declared_member_is_clean() {
+    let codes = diag_codes_js(
+        r#"
+class K {
+    method() {}
+}
+K.prototype.method;
+"#,
+    );
+    assert!(
+        !codes.contains(&2339),
+        "a member the class declares is present on its prototype. Got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
A baselined test was asserting a diagnostic `tsc` never emits, and its file's doc header spent 11 lines explaining the wrong rule. This corrects the assertion to the oracle-verified truth and records the real defect in #16049. **No compiler source is changed.**

The test stays red under the same, unchanged `scripts/ci/known-failures.txt` entry — nothing was added to any baseline.

### Structural rule

When the receiver of a property access is `C.prototype` and `C` resolves to an ES `class` declaration, the prototype is the closed class instance type, so an absent member read is an ordinary missing-member error: **tsc reports TS2339, never TS2565.** tsz owns this in the checker's checked-JS property-access gate (`is_expando_capable_read_root` → `is_js_prototype_read_root`), which currently accepts a `FUNCTION | CLASS` receiver and draws no function-vs-class line at all.

`scripts/ci/known-failures.txt:130`-adjacent entry
`ts2565_jsdoc_prototype_type_decl_tests::ts2565_still_fires_for_jsdoc_typed_prototype_on_class`
asserted TS2565. Oracle says otherwise:

```
class K { method() {} }
/** @type {(x: number) => void} */
K.prototype.late;
```

`tsc` 7.0.2 `--strict --allowJs --checkJs` → `error TS2339: Property 'late' does not exist on type 'K'.`

### The finding underneath it

The identical program reports TS2339 in a `.ts` file on `1eeeb6d` today and reports **nothing** in a `.js` file. The receiver type is not the problem — `K.prototype` resolves to `K` in both harnesses (forcing a mismatch yields `Type 'K' is not assignable to type 'number'.` either way). Only the missing-member gate is skipped, and only under checked JS. Full 7-row probe matrix, the suspected gate, and an explicit "this is a suspect, not a confirmed cause" caveat are in #16049.

This is the same failure mode #16048 documented an hour earlier: a test whose *name and doc header describe a different bug than the one it measures*. Correcting the assertion is what stops the next session paying for it again.

### What changed

- `ts2565_still_fires_for_jsdoc_typed_prototype_on_class` now asserts TS2339 **and** asserts TS2565 is absent, with the oracle output quoted in the doc comment.
- The module header's TS2565 explanation is replaced with the closed-prototype rule and a pointer to #16049.
- Adds `class_prototype_read_of_declared_member_is_clean` — the oracle-confirmed positive control (`K.prototype.method`, a member the class really declares) that the eventual fix must not over-fire on. It passes today.
- The red adjacent probes (no-JSDoc, renamed binders, write position) are deliberately **not** committed as tests. Adding baseline entries to make a suite pass is forbidden, so they live in #16049 in full rather than growing `known-failures.txt`.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib --profile ci-unit ts2565_jsdoc_prototype` — before: 5 passed / 1 failed. After: 5 passed / 1 failed. Same single failure (the pre-existing baselined entry), now asserting the diagnostic `tsc` emits; the added positive control is one of the 5 green.
- `cargo fmt -p tsz-checker` — clean.
- `tsc` oracle: `npm i typescript@7.0.2`, then `node node_modules/typescript/lib/tsc.js --noEmit --strict --allowJs --checkJs --pretty false f.js` for each row in #16049. TS 7.0.2 is the native port, so every oracle cell is an executed run, not a source reading.
- Conformance / emit / fourslash **not run** — this container has no `.target` and no TypeScript submodule, so `compare-to-parent.sh` and the corpus are unavailable. Stating this explicitly per the board's standing gotcha. The diff touches one `#[cfg(test)]` file and no compiler source, so there is nothing for those suites to regress.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Chert

---
_Generated by [Claude Code](https://claude.ai/code/session_012x7Ny2JnpsgM2QHWMWUnLy)_