### PR TITLE
fix(solver): take the reverse inference edge only where contra routing is live

### DIFF
--- a/crates/tsz-checker/src/tests/return_context_type_param_shadowing_tests.rs
+++ b/crates/tsz-checker/src/tests/return_context_type_param_shadowing_tests.rs
@@ -150,3 +150,79 @@ async function bad<T>(callback: () => Promise<T>): Promise<T> {
         "expected TS2322 number-vs-T; got {diags:?}"
     );
 }
+
+#[test]
+fn async_arrow_argument_infers_awaited_return_without_enclosing_generics() {
+    // #16048 probe E: the trigger needs no type parameter on the enclosing
+    // function at all. The async arrow's contextual return type is the
+    // callee's own unresolved `T`, and the async return-context expansion
+    // (`T | PromiseLike<T> | Promise<T>`) must not survive as an inference
+    // candidate for `T`.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+declare function withConnection<T>(consumer: (connection: string) => Promise<T>): Promise<T>;
+
+async function run(): Promise<number> {
+    return withConnection(async (connection) => {
+        return connection.length;
+    });
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "async arrow argument must infer T = number, not T = number | PromiseLike<number>; got {diags:?}"
+    );
+}
+
+#[test]
+fn async_arrow_argument_infers_awaited_return_under_sync_enclosing_function() {
+    // #16048 probe F: the enclosing function need not be `async` either.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+declare function withConnection<T>(consumer: (connection: string) => Promise<T>): Promise<T>;
+
+function run(): Promise<number> {
+    return withConnection(async (connection) => {
+        return connection.length;
+    });
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "sync enclosing function with an async arrow argument must stay clean; got {diags:?}"
+    );
+}
+
+#[test]
+fn sync_arrow_argument_under_async_enclosing_function_drops_promiselike_leak() {
+    // #16048 probe D: a plain (non-async) arrow returning a `Promise` exhibits
+    // the same `PromiseLike` leak, so the arrow's own `async`ness is not the
+    // trigger. `tsc@7.0.2 --strict --target es2017` reports nothing here.
+    //
+    // This shape carries a *second*, independent false positive that predates
+    // and survives the leak fix (`Type 'number' is not assignable to type
+    // 'Promise<number>'`, tracked separately), so this case pins the leak
+    // signature rather than full cleanliness — asserting `is_empty()` here
+    // would make the test a proxy for an unrelated defect.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+declare function withConnection<T>(consumer: (connection: string) => Promise<T>): Promise<T>;
+
+async function run(): Promise<number> {
+    return withConnection((connection) => {
+        return Promise.resolve(connection.length);
+    });
+}
+"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.contains("PromiseLike")),
+        "the async return-context expansion must not survive as an inference \
+         candidate for the callee's type parameter; got {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -34,8 +34,17 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // Source placeholders become upper bounds outside contravariant
         // inference. Placeholder-free parameter dependency recovery can opt in
         // to candidate routing for its explicit reverse edge.
+        //
+        // The reverse edge exists only to model the contravariant role swap, so
+        // it is gated on the contravariant *routing* being live, not merely on
+        // the traversal direction. A target signature whose declaration origin
+        // grants parameter bivariance keeps `in_contra_mode` while deliberately
+        // suppressing contra-candidate routing (`collects_contra_candidates`);
+        // taking the reverse edge there would file the target as an ordinary
+        // covariant candidate, which `tsc` never does — it only ever infers into
+        // a variable in *target* position. Fall back to the upper bound instead.
         if let Some(&var) = var_map.get(&source) {
-            if ctx.in_contra_mode
+            if ctx.collects_contra_candidates()
                 || ctx.parameter_recovery_mode == ParameterRecoveryMode::StandaloneReverse
             {
                 ctx.add_candidate(var, target, priority);


### PR DESCRIPTION
Fixes #16048.

## Structural rule

**When a naked inference variable sits in *source* position, `tsc` records no candidate at all — `inferFromTypes` only ever files a candidate for a variable in *target* position. tsz models the contravariant role swap with an explicit reverse edge, so that edge must fire only where contravariant candidate *routing* is live; tsz does this through the solver's constraint walker (`constrain_types_impl`).**

`constrain_types_impl`'s source-placeholder branch gated the reverse edge on `ctx.in_contra_mode` alone:

```rust
if let Some(&var) = var_map.get(&source) {
    if ctx.in_contra_mode || ctx.parameter_recovery_mode == ParameterRecoveryMode::StandaloneReverse {
        ctx.add_candidate(var, target, priority);
    } else {
        ctx.add_upper_bound(var, target);
    }
    return;
}
```

But `in_contra_mode` is the *traversal direction*, not the routing decision. Routing is `collects_contra_candidates()` = `in_contra_mode && !in_bivariant_mode` — and the doc comment on it says so explicitly: "A target signature whose declaration origin grants parameter bivariance preserves the contravariant traversal direction while **deliberately suppressing this routing**."

So under method-parameter bivariance the two disagree, and the reverse edge fired anyway. `add_candidate` then saw `collects_contra_candidates() == false` and filed the target in the **covariant** candidate list — the one direction that has no `tsc` analogue. The fix gates the edge on `collects_contra_candidates()`, so when contra routing is suppressed the branch falls back to `add_upper_bound`, matching its own already-correct non-contravariant behaviour. The explicit `ParameterRecoveryMode::StandaloneReverse` reverse edge is untouched.

Behavioural delta is exactly one state: `in_contra_mode && in_bivariant_mode && !StandaloneReverse`.

## How #16048 reaches that state

An async arrow argument whose contextual return type is the callee's still-unresolved `T` gets compared against a structural `Promise`/`PromiseLike` shape (it misses the union walker's same-base fast path because one source member is a bare `TypeParam`, not an `Application`). That descends property-by-property into `.then`, whose `onfulfilled` parameter is a callback — and because `.then` is a **method**, `in_bivariant_mode` is set at `walker.rs:1190` while `in_contra_mode` stays true through the parameter walk. Comparing that callback's `TResult1 | PromiseLike[ TResult1 ]` return type — still carrying a raw `T` on the source side — against its already-substituted counterpart hits the reverse edge with source = naked `T`, and files `number | PromiseLike[ number ]` as a covariant candidate for `T`.

That is exactly the single corrupted `add_candidate(var=T, ty={number|PromiseLike[number]}, priority=ReturnType)` that ClaudeDE isolated with rdbg on #16048 (5 correct `number` candidates, 1 corrupted), and it explains why it landed next to the covariant ones instead of in `contra_candidates` where the reverse edge intends its output to go.

## Adjacent-case matrix

Probe letters are #16048's. All three new cases are oracle-pinned against `tsc@7.0.2 --strict --target es2017`, which reports **zero** diagnostics for each.

| Case | Shape | Before | After |
| --- | --- | --- | --- |
| baselined | `async_return_of_generic_call_with_shadowed_param_async_callback_is_clean` (class/method, shadowed `T`) | `TS2322: Type 'Promise' is not assignable to type 'T'` | clean |
| E (new) | no generics on the enclosing fn, async enclosing, async arrow | `TS2322: Type 'Promise[number \| PromiseLike[number]]' is not assignable to type 'number'` | clean |
| F (new) | no generics anywhere, **sync** enclosing, async arrow | same leak | clean |
| D (new) | async enclosing, **sync** arrow returning `Promise.resolve(...)` | leak + a second, unrelated FP | leak gone |
| shadowed (existing) | same-named callee/enclosing `T` | clean | clean |
| **renamed binders** (existing) | `TInner`/`TOuter`/`TResult1`, zero name overlap | clean | clean |
| sync (existing) | non-async enclosing, plain `Promise[T]` context | clean | clean |
| **negative** (existing) | `provide(Promise.resolve(123))` under `Promise[T]` | `TS2322` number-vs-`T`, once | unchanged — still reported exactly once |

The negative case is the one that matters most here: gating the reverse edge more tightly must not silence a real mismatch, and it does not.

### One residual, deliberately not papered over

Probe D carries a **second, independent** false positive that predates this change and survives it (`TS2322: Type 'number' is not assignable to type 'Promise[number]'`; `tsc` is clean). Its test therefore asserts the *leak signature* is gone rather than full cleanliness — asserting `is_empty()` there would make the test a proxy for an unrelated defect and would go red for the wrong reason. Filed separately rather than baselined; nothing was added to any accepted-regressions or known-failures file.

## Goal
Goal: hold

Removes the false positive behind `scripts/ci/known-failures.txt:130`. Per `known-failures-check.mjs`, a baselined test that starts passing is a shrink-ratchet warning, not a failure, so the entry is left for the next reconcile rather than hand-edited in this diff.

## Verification

- `cargo test -p tsz-checker --lib --profile ci-unit return_context_type_param_shadowing`
  - before: **4 passed / 4 failed** (the baselined test + probes D, E, F)
  - after: **8 passed / 0 failed**
- tsc oracle, `tsc@7.0.2 --noEmit --strict --pretty false --target es2017` on probes E, F and D: exit 0, no diagnostics — all three tsz diagnostics were false positives.
- `cargo fmt --all`: clean.
- Full `cargo test -p tsz-checker --lib --profile ci-unit` (all 8519 tests) and workspace clippy are still running in this container at the time of opening; results will be posted as a comment on this PR before it is queued. **Not run here:** `compare-to-parent.sh` / the conformance corpus — this container has no TypeScript submodule checkout and cannot close that loop, so the full-corpus two-sided diff has *not* been run for this change. That is the gate this PR most wants a second pair of eyes (or a warm seat) on.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Gneiss

---
_Generated by [Claude Code](https://claude.ai/code/session_014PRvLtQgYLjoQ5viXanG4k)_