### PR TITLE
fix(checker): scope async context to the immediately enclosing function

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1280,19 +1280,28 @@ impl<'a> CheckerContext<'a> {
         self.generator_next_type_stack.last().copied().flatten()
     }
 
-    /// Enter an async context (increment async depth).
-    pub const fn enter_async_context(&mut self) {
-        self.async_depth += 1;
+    /// Enter the body of a function whose own `async` modifier is `is_async`,
+    /// returning the previous state for [`Self::restore_async_context`].
+    ///
+    /// Async-ness is a property of the *immediately enclosing* function, never
+    /// of the nesting depth. `tsc` reads
+    /// `getFunctionFlags(func) & FunctionFlags.Async` on the function that owns
+    /// the node, so a plain function nested inside an `async` one is **not** in
+    /// an async context: its return expressions are not `Promise`-unwrapped and
+    /// an `await` in its body is a grammar error. Entering a body therefore
+    /// *replaces* the flag instead of inheriting it.
+    pub fn enter_function_async_context(&mut self, is_async: bool) -> u32 {
+        let saved = self.async_depth;
+        self.async_depth = u32::from(is_async);
+        saved
     }
 
-    /// Exit an async context (decrement async depth).
-    pub const fn exit_async_context(&mut self) {
-        if self.async_depth > 0 {
-            self.async_depth -= 1;
-        }
+    /// Restore the async context saved by [`Self::enter_function_async_context`].
+    pub const fn restore_async_context(&mut self, saved: u32) {
+        self.async_depth = saved;
     }
 
-    /// Check if we're currently inside an async function.
+    /// Check if the immediately enclosing function is async.
     pub const fn in_async_context(&self) -> bool {
         self.async_depth > 0
     }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1390,6 +1390,9 @@ mod narrowed_union_source_display_tests;
 #[path = "tests/narrowing_union_source_display_tests.rs"]
 mod narrowing_union_source_display_tests;
 #[cfg(test)]
+#[path = "tests/nested_function_async_context_scope_tests.rs"]
+mod nested_function_async_context_scope_tests;
+#[cfg(test)]
 #[path = "tests/nested_tuple_literal_source_display_tests.rs"]
 mod nested_tuple_literal_source_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -835,8 +835,7 @@ impl<'a> CheckerState<'a> {
 
         // Class bodies reset the async context — field initializers and static blocks
         // don't inherit async from the enclosing function. Methods define their own context.
-        let saved_async_depth = self.ctx.async_depth;
-        self.ctx.async_depth = 0;
+        let saved_async_depth = self.ctx.enter_function_async_context(false);
 
         // Check each class member
         for &member_idx in &class.members.nodes {
@@ -852,7 +851,7 @@ impl<'a> CheckerState<'a> {
         // self-reference (issue #14819).
         self.check_class_member_circular_annotations(stmt_idx, &class.members.nodes);
 
-        self.ctx.async_depth = saved_async_depth;
+        self.ctx.restore_async_context(saved_async_depth);
 
         // Check for duplicate member names (TS2300, TS2393)
         self.check_duplicate_class_members(&class.members.nodes);
@@ -1188,8 +1187,7 @@ impl<'a> CheckerState<'a> {
 
         // Class bodies reset the async context — field initializers don't
         // inherit async from the enclosing function.
-        let saved_async_depth = self.ctx.async_depth;
-        self.ctx.async_depth = 0;
+        let saved_async_depth = self.ctx.enter_function_async_context(false);
 
         for &member_idx in &class.members.nodes {
             self.check_class_member_with_request(member_idx, request);
@@ -1253,7 +1251,7 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        self.ctx.async_depth = saved_async_depth;
+        self.ctx.restore_async_context(saved_async_depth);
 
         // TS7023 / TS7024: un-annotated members whose inferred return type is
         // circular through a `this.`/`Class.` self-invocation (issue #14805).

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -1028,19 +1028,15 @@ impl<'a> CheckerState<'a> {
             };
             self.ctx.push_yield_type(contextual_yield_type);
 
-            // Enter async context for await expression checking
-            if is_async {
-                self.ctx.enter_async_context();
-            }
+            // Scope the async context to THIS method body. A non-async
+            // function nested inside an async one must not inherit the flag.
+            let saved_async_depth = self.ctx.enter_function_async_context(is_async);
 
             let body_request = request.read().contextual_opt(None);
             self.clear_type_cache_recursive(method.body);
             self.check_statement_with_request(method.body, &body_request);
 
-            // Exit async context
-            if is_async {
-                self.ctx.exit_async_context();
-            }
+            self.ctx.restore_async_context(saved_async_depth);
 
             let mut check_return_type =
                 self.return_type_for_implicit_return_check(return_type, is_async, is_generator);

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -631,10 +631,9 @@ impl<'a> CheckerState<'a> {
             func.type_annotation,
         );
 
-        // Enter async context for await expression checking
-        if func.is_async {
-            self.ctx.enter_async_context();
-        }
+        // Scope the async context to THIS function. A non-async function
+        // nested inside an async one must not inherit the outer flag.
+        let saved_async_depth = self.ctx.enter_function_async_context(func.is_async);
 
         // For generator functions with explicit return type (Generator<Y, R, N> or AsyncGenerator<Y, R, N>),
         // return statements should be checked against TReturn (R), not the full Generator type.
@@ -777,10 +776,7 @@ impl<'a> CheckerState<'a> {
         self.ctx.pop_yield_type();
         self.ctx.pop_generator_next_type();
 
-        // Exit async context
-        if func.is_async {
-            self.ctx.exit_async_context();
-        }
+        self.ctx.restore_async_context(saved_async_depth);
 
         if pushed_this_type {
             self.ctx.this_type_stack.pop();

--- a/crates/tsz-checker/src/tests/nested_function_async_context_scope_tests.rs
+++ b/crates/tsz-checker/src/tests/nested_function_async_context_scope_tests.rs
@@ -1,0 +1,225 @@
+//! Async context is a property of the immediately enclosing function.
+//!
+//! Structural rule: when a function body is entered, `tsc` decides whether the
+//! nodes inside it are "in an async context" from that function's own
+//! `getFunctionFlags(func) & FunctionFlags.Async` — never from how many `async`
+//! functions enclose it. A plain function nested inside an `async` one is
+//! therefore *not* in an async context: its return expressions keep their
+//! `Promise` wrapper (`checkReturnStatement` only unwraps for
+//! `FunctionFlags.Async`), and an `await` in its body is the TS1308 grammar
+//! error.
+//!
+//! tsz used to track this as a monotonically increasing `async_depth` counter
+//! that nested non-async bodies inherited, so both halves were wrong at once:
+//! a false positive on the return (`Promise<T>` unwrapped to `T`, then reported
+//! unassignable to the declared `Promise<T>` — issue #16053) and a false
+//! negative on the `await`. Entering a body now *replaces* the flag with that
+//! function's own asyncness (`CheckerContext::enter_function_async_context`).
+//!
+//! Every fixture below is pinned against
+//! `tsc@7.0.2 --noEmit --strict --pretty false --target es2017`.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn diagnostic_summaries(source: &str) -> Vec<String> {
+    // The `Promise` fixtures need the standard lib. TS2318 missing-default-lib
+    // noise is filtered so the assertions see only semantic diagnostics.
+    let lib_files = load_default_lib_files();
+    check_source_with_libs(source, "test.ts", CheckerOptions::default(), &lib_files)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code != 2318)
+        .map(|diagnostic| format!("TS{}: {}", diagnostic.code, diagnostic.message_text))
+        .collect()
+}
+
+#[test]
+fn sync_arrow_returning_promise_under_async_enclosing_function_is_clean() {
+    // #16053's witness: the arrow is contextually typed from the callee's
+    // `(connection: string) => Promise<T>` parameter, so its return statement
+    // is checked against `Promise<number>`. The enclosing `run` is async; the
+    // arrow is not. tsc: exit 0.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+declare function withConnection<T>(consumer: (connection: string) => Promise<T>): Promise<T>;
+
+async function run(): Promise<number> {
+    return withConnection((connection) => {
+        return Promise.resolve(connection.length);
+    });
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "a non-async arrow inside an async function must not have its returned \
+         Promise unwrapped; got {diags:?}"
+    );
+}
+
+#[test]
+fn sync_arrow_returning_promise_under_async_enclosing_function_renamed_binders_is_clean() {
+    // Renamed-binder control: nothing in the rule may key off `T`,
+    // `withConnection`, `connection`, or `run`.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+declare function borrow<Elem>(take: (handle: string) => Promise<Elem>): Promise<Elem>;
+
+async function drive(): Promise<boolean> {
+    return borrow((handle) => {
+        return Promise.resolve(handle.length > 0);
+    });
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "renamed binders must behave identically to the #16053 witness; got {diags:?}"
+    );
+}
+
+#[test]
+fn nested_function_declaration_with_declared_promise_return_is_clean() {
+    // The same defect without any contextual typing: a plain `function`
+    // declaration with its own `Promise<string>` annotation, nested in an async
+    // function. This travels the function-declaration body path rather than the
+    // contextually-typed-arrow path, so it pins the second owner site.
+    // tsc: exit 0.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+async function outer(): Promise<number> {
+    function inner(): Promise<string> {
+        return Promise.resolve("x");
+    }
+    inner();
+    return 1;
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "a nested non-async function declaration keeps its own Promise return; got {diags:?}"
+    );
+}
+
+#[test]
+fn nested_object_literal_method_with_declared_promise_return_is_clean() {
+    // Method-body path (the third site that scopes the flag). tsc: exit 0.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+async function outer(): Promise<number> {
+    const obj = {
+        m(): Promise<string> {
+            return Promise.resolve("x");
+        },
+    };
+    obj.m();
+    return 1;
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "a nested non-async method keeps its own Promise return; got {diags:?}"
+    );
+}
+
+#[test]
+fn await_inside_nested_plain_function_reports_ts1308() {
+    // The negative half of the same invariant: inheriting the outer async flag
+    // also *suppressed* a real grammar error. tsc reports TS1308 here.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+async function outer(): Promise<number> {
+    function inner(): number {
+        return await 1;
+    }
+    return inner();
+}
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.starts_with("TS1308:")),
+        "`await` in a non-async function nested in an async one is TS1308; got {diags:?}"
+    );
+}
+
+#[test]
+fn await_inside_nested_plain_arrow_reports_ts1308() {
+    // Same, through the arrow body path.
+    //
+    // The arrow deliberately uses a *block* body. A concise-bodied arrow
+    // (`(): number => await 1`) misses the TS1308 check entirely in tsz, even
+    // at top level with no `async` anywhere in the file, so it is a separate
+    // pre-existing false negative rather than a witness for this invariant —
+    // filed apart from this change rather than pinned here.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+async function outer(): Promise<number> {
+    const inner = (): number => {
+        return await 1;
+    };
+    return inner();
+}
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.starts_with("TS1308:")),
+        "`await` in a non-async arrow nested in an async one is TS1308; got {diags:?}"
+    );
+}
+
+#[test]
+fn async_arrow_under_async_enclosing_function_still_unwraps() {
+    // Fallback control: the unwrap must still happen when the inner function IS
+    // async. Scoping the flag must not turn the fix into a blanket disable.
+    // tsc: exit 0.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+declare function withConnection<T>(consumer: (connection: string) => Promise<T>): Promise<T>;
+
+async function run(): Promise<number> {
+    return withConnection(async (connection) => {
+        return connection.length;
+    });
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "an async arrow must still have its return auto-wrapped in Promise; got {diags:?}"
+    );
+}
+
+#[test]
+fn async_function_nested_inside_plain_function_inside_async_still_unwraps() {
+    // Three levels: async -> plain -> async. The innermost body must recover
+    // the async context that the middle body cleared, which a "clear once and
+    // never restore" fix would break. tsc: exit 0.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+async function outer(): Promise<number> {
+    function middle() {
+        async function inner(): Promise<string> {
+            return "x";
+        }
+        return inner();
+    }
+    middle();
+    return 1;
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "async context must be restored per body, not cleared globally; got {diags:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/return_context_type_param_shadowing_tests.rs
+++ b/crates/tsz-checker/src/tests/return_context_type_param_shadowing_tests.rs
@@ -203,11 +203,10 @@ fn sync_arrow_argument_under_async_enclosing_function_drops_promiselike_leak() {
     // the same `PromiseLike` leak, so the arrow's own `async`ness is not the
     // trigger. `tsc@7.0.2 --strict --target es2017` reports nothing here.
     //
-    // This shape carries a *second*, independent false positive that predates
-    // and survives the leak fix (`Type 'number' is not assignable to type
-    // 'Promise<number>'`, tracked separately), so this case pins the leak
-    // signature rather than full cleanliness — asserting `is_empty()` here
-    // would make the test a proxy for an unrelated defect.
+    // The second, independent false positive this shape used to carry
+    // (`Type 'number' is not assignable to type 'Promise<number>'`, #16053 —
+    // the non-async arrow inheriting its enclosing async function's
+    // `Promise`-unwrapping) is fixed, so this case now pins full cleanliness.
     let diags = diagnostic_summaries(
         r#"
 /// <reference lib="es2015.promise" />
@@ -221,7 +220,7 @@ async function run(): Promise<number> {
 "#,
     );
     assert!(
-        !diags.iter().any(|d| d.contains("PromiseLike")),
+        diags.is_empty(),
         "the async return-context expansion must not survive as an inference \
          candidate for the callee's type parameter; got {diags:?}"
     );

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1685,10 +1685,9 @@ impl<'a> CheckerState<'a> {
                 false
             };
 
-            // Enter async context if applicable
-            if is_async_for_context {
-                self.ctx.enter_async_context();
-            }
+            // Scope the async context to THIS function. A non-async function
+            // nested inside an async one must not inherit the outer flag.
+            let saved_async_depth = self.ctx.enter_function_async_context(is_async_for_context);
 
             // Push this_type to the stack before checking the body
             // This ensures this references inside the function have the proper type context
@@ -1916,9 +1915,7 @@ impl<'a> CheckerState<'a> {
             self.ctx.pop_yield_type();
             self.ctx.pop_generator_next_type();
 
-            if is_async_for_context {
-                self.ctx.exit_async_context();
-            }
+            self.ctx.restore_async_context(saved_async_depth);
 
             self.ctx.function_depth -= 1;
         }


### PR DESCRIPTION
Closes #16053.

**Structural rule:** when a node sits inside a function body, `tsc` decides whether it is "in an async context" from that function's own `getFunctionFlags(func) & FunctionFlags.Async` — never from how many `async` functions enclose it. tsz now does the same through the checker's `CheckerContext` async-context state.

`CheckerContext::async_depth` was a monotonically **increasing counter**: entering an `async` body incremented it, entering a plain body did nothing. So `in_async_context()` actually answered *"is any enclosing function async"*, and every one of its 11 readers was wrong inside a plain function nested in an `async` one. Two opposite defects fell out of the same bit:

- **False positive (#16053).** `check_return_statement` (`crates/tsz-checker/src/types/type_checking/core_statement_checks.rs:214`) unwrapped `Promise[ T ]` off the return expression's type, then compared the unwrapped `T` against the nested function's *own* declared/contextual `Promise[ T ]`. On the #16053 witness that is `TS2322: Type 'number' is not assignable to type 'Promise[ number ]'`, anchored on the inner arrow's `return Promise.resolve(connection.length);`.
- **False negative.** `await` inside the nested plain body saw `in_async_context() == true` and skipped the TS1308 grammar error that `tsc` reports.

**Fix (owner layer: checker context).** Entering a function body now *replaces* the flag with that function's own asyncness and restores the caller's on the way out, via `CheckerContext::enter_function_async_context` / `restore_async_context`. Applied at the three body-entry sites that previously did `if is_async { enter } … { exit }` — `types/function_type.rs`, `state/state_checking_members/function_declaration_checks.rs`, `state/state_checking_members/ambient_signature_checks.rs`. The two class-body sites in `state/state_checking/class.rs` already hand-rolled the same save/reset-to-0/restore against the raw field; they now route through the same pair, so `async_depth` has a single owner. No reader changed; no call site branches on a name, alias, property, or file name.

## Goal
Goal: green

## Adjacent-case matrix

New file `crates/tsz-checker/src/tests/nested_function_async_context_scope_tests.rs`, 8 cases, every one pinned against a real oracle — `tsc@7.0.2 --noEmit --strict --pretty false --target es2017`, run in this container.

| # | Case | tsc | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| 1 | #16053 witness: contextually-typed non-async arrow returning `Promise.resolve(...)` under an async function | clean | TS2322 | clean |
| 2 | Same, renamed binders (`borrow`/`Elem`/`handle`/`drive`, `boolean` not `number`) | clean | TS2322 | clean |
| 3 | Nested **`function` declaration** with its own `Promise[ string ]` annotation — no contextual typing, different owner site | clean | TS2322 | clean |
| 4 | Nested **object-literal method** with its own `Promise[ string ]` annotation — third owner site | clean | TS2322 | clean |
| 5 | Negative half: `await` in a nested plain `function` | TS1308 | *(nothing)* | TS1308 |
| 6 | Negative half: `await` in a nested plain **arrow** (block body) | TS1308 | *(nothing)* | TS1308 |
| 7 | Fallback control: **async** arrow under an async function still auto-wraps its return | clean | clean | clean |
| 8 | Restore control: `async` → plain → `async`, three deep — innermost must *recover* the context the middle body cleared | clean | clean | clean |

Case 8 is the one that fails for a "clear it and never restore" fix; case 7 is the one that fails for a blanket disable. Cases 3 and 4 exist because the arrow witness alone would have justified a fix in only one of the three body-entry sites.

`sync_arrow_argument_under_async_enclosing_function_drops_promiselike_leak` in `return_context_type_param_shadowing_tests.rs` — landed by #16052 asserting only that the `PromiseLike` leak was gone, because this defect was still standing — is tightened to `diags.is_empty()` and becomes the #16053 regression guard.

## Out of scope, filed not buried

A **concise-bodied** arrow (`(): number => await 1`) misses TS1308 in tsz *even at top level with no `async` anywhere in the file* — measured directly, so it is a pre-existing false negative independent of this change, not a partial fix. Case 6 therefore uses a block body; the concise-body gap is filed separately rather than pinned here. Nothing was added to any known-failures or accepted-regressions file.

## Verification

- `cargo fmt --all` — clean.
- Targeted, `cargo test -p tsz-checker --lib --profile ci-unit -- nested_function_async_context_scope_tests return_context_type_param_shadowing`: **16 passed / 0 failed**. Before the fix the same selection was **12 passed / 4 failed** (cases 1–6 above, minus the two that were only reachable once the new file existed).
- `tsc@7.0.2` oracle run on all 8 fixtures plus the two concise/block top-level `await` probes — the table above is that output, not a recollection.
- Full `cargo test -p tsz-checker --lib --profile ci-unit` (~8.5k tests) was still running at PR-open time; result posted as a comment on this PR.
- **Not run in this container, stated plainly:** `compare-to-parent.sh` / full conformance (no TypeScript submodule here), emit, fourslash. Per the board's standing gotcha that targeted verification is not sufficient for inference-adjacent changes (#16009), the two-sided full-corpus diff from a warm seat is the gate this PR most wants before it is queued. The blast radius to look at is the other `in_async_context()` readers — TS1308/TS1431/TS1432 `await` grammar checks, `for await`, and the `FeatureGate::AsyncFunction` gate — all of which now answer per-function rather than per-nesting-depth.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Diorite

---
_Generated by [Claude Code](https://claude.ai/code/session_014QNsYkVrrUHvPAVKgHsA2S)_