### PR TITLE
fix(checker): run the await-grammar walk on a concise arrow/function body

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -142,6 +142,9 @@ mod async_imported_promise_tests;
 #[path = "tests/await_alias_union_distribution_tests.rs"]
 mod await_alias_union_distribution_tests;
 #[cfg(test)]
+#[path = "tests/await_concise_arrow_body_grammar_tests.rs"]
+mod await_concise_arrow_body_grammar_tests;
+#[cfg(test)]
 #[path = "tests/await_structural_thenable_tests.rs"]
 mod await_structural_thenable_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/statements.rs
+++ b/crates/tsz-checker/src/statements.rs
@@ -1129,7 +1129,12 @@ impl StatementChecker {
                 state.get_type_of_node_with_request(stmt_idx, request);
             }
             _ => {
-                // Catch-all for other statement types
+                // Catch-all for other statement types, including a concise
+                // (expression-body) arrow/function body: unlike a block body,
+                // it has no wrapping `ExpressionStatement`/`ReturnStatement`
+                // node to carry the TS1308/TS1375/TS1378 `await`-grammar walk,
+                // so this is the only root that ever visits it.
+                state.check_await_expression(stmt_idx);
                 state.get_type_of_node_with_request(stmt_idx, &non_contextual_request);
             }
         }

--- a/crates/tsz-checker/src/tests/await_concise_arrow_body_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/await_concise_arrow_body_grammar_tests.rs
@@ -1,0 +1,103 @@
+//! Regression tests for TS1308 (`await` outside an async function) on a
+//! concise (expression) arrow body.
+//!
+//! A concise body has no wrapping `ExpressionStatement`/`ReturnStatement`
+//! node, so the `await`-grammar walk (`check_await_expression`) was never
+//! invoked on it: `check_statement_with_request`'s dispatcher
+//! (`crates/tsz-checker/src/statements.rs`) only ran the check from the
+//! `ExpressionStatement` and `ReturnStatement` arms, and fell through to the
+//! catch-all `_` arm for a bare expression body, which called
+//! `get_type_of_node_with_request` alone. tsc's `checkAwaitExpression` walk
+//! is reached from a concise arrow body exactly like any other expression, so
+//! `(): number => await 1` reported `TS1308` in tsc but nothing in tsz. The
+//! block-bodied form (`(): number => { return await 1; }`) already worked,
+//! since its `return` statement carries its own check.
+
+use crate::test_utils::check_source_codes;
+
+/// #16059's exact repro: a non-async, non-nested concise arrow body with a
+/// bare `await`. tsc reports TS1308.
+#[test]
+fn concise_arrow_body_top_level_await_reports_ts1308() {
+    let source = r#"
+const inner = (): number => await 1;
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&1308),
+        "a concise arrow body's `await` outside any async function must report TS1308; got {codes:?}"
+    );
+}
+
+/// The already-working block-bodied sibling stays working: same shape, body
+/// wrapped in braces with an explicit `return`.
+#[test]
+fn block_arrow_body_top_level_await_reports_ts1308() {
+    let source = r#"
+const inner = (): number => { return await 1; };
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&1308),
+        "the block-bodied sibling already reported TS1308 before this fix; got {codes:?}"
+    );
+}
+
+/// Renamed-binder control (anti-hardcoding): different identifier, different
+/// literal value and return type, same shape.
+#[test]
+fn concise_arrow_body_await_reports_ts1308_renamed_binders() {
+    let source = r#"
+const computeFlag = (): boolean => await true;
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&1308),
+        "renamed-binder concise arrow body must still report TS1308; got {codes:?}"
+    );
+}
+
+/// `await` nested inside a larger concise-body expression (not the direct
+/// body), e.g. `1 + await 2`. The traversal must descend past the top-level
+/// binary expression to find the await.
+#[test]
+fn concise_arrow_body_nested_await_reports_ts1308() {
+    let source = r#"
+const inner = (): number => 1 + await 2;
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&1308),
+        "a nested `await` inside a concise arrow body's expression must report TS1308; got {codes:?}"
+    );
+}
+
+/// Fallback/positive control: a concise-bodied *async* arrow's own `await` is
+/// legal, and must not report TS1308. Guards against a blanket fix that fires
+/// on any concise body regardless of the immediately enclosing function.
+#[test]
+fn concise_async_arrow_body_await_is_clean() {
+    let source = r#"
+const inner = async (): Promise<number> => await Promise.resolve(1);
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        !codes.contains(&1308),
+        "an async arrow's own concise-body await is legal; got {codes:?}"
+    );
+}
+
+/// A concise arrow body nested *inside* another concise arrow body: the
+/// traversal must not stop at the outer arrow's own boundary check and must
+/// still reach the inner arrow when it is itself visited as a body.
+#[test]
+fn concise_arrow_body_nested_inside_another_concise_arrow_reports_ts1308() {
+    let source = r#"
+const outer = (): (() => number) => (): number => await 1;
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&1308),
+        "a concise arrow body nested inside another concise arrow body must still report its own TS1308; got {codes:?}"
+    );
+}


### PR DESCRIPTION
Fixes #16059 (filed by Diorite while working #16053/#16058, deliberately not folded into that fix because it reproduces with no `async` function anywhere in the file).

`check_await_expression` (TS1308/TS1375/TS1378) was only ever reached from a statement's `ExpressionStatement`/`ReturnStatement` wrapper — the two arms in `check_statement_with_request`'s dispatcher (`crates/tsz-checker/src/statements.rs`) that explicitly call it. A concise (expression) arrow/function body has neither wrapper: `check_function_body_statement_with_own_literal_context` calls `check_statement_with_request(body, ...)` on the bare body expression, whose node kind (`AwaitExpression`, `BinaryExpression`, etc.) matches none of the enumerated arms, so it fell through to the catch-all `_` arm, which called `get_type_of_node_with_request` alone and never ran the grammar walk.

```ts
const inner = (): number => await 1;
```

`tsc@7.0.2 --noEmit --strict --pretty false --target es2017` reports `TS1308`; tsz reported nothing. The block-bodied sibling (`(): number => { return await 1; }`) already worked, since its `return` statement carries its own `check_await_expression` call in the `RETURN_STATEMENT` arm.

### Structural rule

When an expression is visited as a function/arrow body without a wrapping statement node, tsc's `checkAwaitExpression` walk still covers it — a concise body is just another expression to that walk. tsz now does the same by calling `check_await_expression` from the same catch-all arm that already types the body (`statements.rs`'s `_ =>` arm), instead of relying on a statement wrapper a concise body never has. No arrow/function-specific special case was added at the diagnostic site — the fix is in the shared dispatcher all body-kinds funnel through, so any future non-statement body-shape gets the same coverage automatically.

### Adjacent-case matrix (all oracle-verified against a live `tsc@7.0.2` run in this container)

| Case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| concise arrow body, top level, bare `await` (#16059's repro) | TS1308 | *(nothing)* | TS1308 |
| block-bodied sibling, same shape (already-working control) | TS1308 | TS1308 | TS1308 (unchanged) |
| renamed binders (anti-hardcoding control: `computeFlag`/`boolean`/`true`) | TS1308 | *(nothing)* | TS1308 |
| `await` nested inside a larger concise-body expression (`1 + await 2`) | TS1308 | *(nothing)* | TS1308 |
| concise-bodied **async** arrow awaiting its own operand (fallback/positive control) | clean | clean | clean (unchanged) |
| concise arrow body nested inside another concise arrow body | TS1308 | *(nothing)* | TS1308 |

Cases verified directly against the vendored oracle (`npm i --no-save typescript@7.0.2`, `tsc.js --noEmit --strict --pretty false --target es2017`) in addition to the in-repo assertions.

### Out of scope

#16059 also lists a top-level-of-a-module case (`TS1431`/`TS1432` apply there instead of `TS1308`, a different rule entirely) and notes the "nested inside an async function" case overlaps #16058's `async_depth`-scoping fix (still open, another agent's live claim) — neither is this fix's concern; this PR is purely the missing-traversal-root defect.

## Goal
Goal: hold

## Verification
- New file `crates/tsz-checker/src/tests/await_concise_arrow_body_grammar_tests.rs`, 6 cases (table above): `cargo test -p tsz-checker --lib --profile ci-unit await_concise_arrow_body_grammar_tests` — 6/6 pass.
- `cargo test -p tsz-checker --lib --profile ci-unit -- await async arrow`: 657/657 pass, 0 failed — broad regression check across every await/async/arrow-shaped unit test in the crate.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- Full `cargo test -p tsz-checker --lib --profile ci-unit` (~8.5k tests) was started but did not finish inside this session — matches the board's standing note that this run can stall past its container's time budget on an unrelated long-running test; the 657-test targeted superset above (every test whose name matches `await`, `async`, or `arrow`) already covers this change's blast radius directly.
- Conformance / emit / fourslash not run: no TypeScript submodule/corpus checked out in this container (per repo guidance, not checked out unless the task needs it) and no pre-warmed build cache for those suites. The change adds one diagnostic-emitting call (`check_await_expression`) inside the checker's statement dispatcher; it does not touch type computation, inference, or lowering, so it is not emit-visible. Flagging per the board's standing verification-gap note in case a local-runner seat wants to confirm.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

Claude-Session: https://claude.ai/code/session_01PkYqjr4AB9Ahjb6fQZwpiR

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkYqjr4AB9Ahjb6fQZwpiR)_