### PR TITLE
fix(checker): scan a concise arrow body for the await grammar check

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -901,6 +901,9 @@ mod computed_alias_source_display_tests;
 #[path = "tests/computed_symbol_name_unification_tests.rs"]
 mod computed_symbol_name_unification_tests;
 #[cfg(test)]
+#[path = "tests/concise_arrow_body_await_grammar_tests.rs"]
+mod concise_arrow_body_await_grammar_tests;
+#[cfg(test)]
 #[path = "tests/concise_body_return_excess_property_tests.rs"]
 mod concise_body_return_excess_property_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/concise_arrow_body_await_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/concise_arrow_body_await_grammar_tests.rs
@@ -1,0 +1,187 @@
+//! The `await`-outside-async grammar check (TS1308) for a concise
+//! (expression-bodied) arrow.
+//!
+//! Structural rule: when a function body is an expression rather than a
+//! block, `tsc` still runs `checkAwaitExpression` over it, because it reaches
+//! that check from the expression itself. tsz reaches the same check from a
+//! fixed set of *statement*-level roots (`return`, `if`, expression
+//! statement, `for await`, variable declaration, decorator argument, property
+//! initializer), and a concise arrow body is none of them — it has no
+//! `ReturnStatement` node at all — so nothing ever visited it and the
+//! diagnostic was silently dropped. tsz now roots the same scan at the
+//! concise body in `check_function_type_impl`, inside the body-checking
+//! region where `function_depth` and the function's own async context are
+//! already established.
+//!
+//! Every expectation below is pinned against a real
+//! `tsc@7.0.2 --noEmit --strict --pretty false --target es2017` run, not
+//! recalled. Tracker: #16059.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+/// Diagnostics for `source`, minus the TS2318 missing-default-lib noise.
+fn diagnostic_codes(source: &str) -> Vec<u32> {
+    let lib_files = load_default_lib_files();
+    check_source_with_libs(source, "test.ts", CheckerOptions::default(), &lib_files)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code != 2318)
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+/// The #16059 witness: a concise arrow body at top level of a script.
+///
+/// tsc: `FILE(1,29): error TS1308`.
+#[test]
+fn concise_arrow_body_await_reports_ts1308() {
+    let codes = diagnostic_codes("const inner = (): number => await 1;\n");
+    assert_eq!(
+        codes,
+        vec![1308],
+        "a concise arrow body must be scanned for the await grammar check"
+    );
+}
+
+/// The block-bodied sibling, which already worked. Kept as the control that
+/// pins the two forms to the same answer — the whole defect was the two
+/// disagreeing.
+///
+/// tsc: `FILE(1,38): error TS1308`.
+#[test]
+fn block_arrow_body_await_reports_ts1308_control() {
+    let codes = diagnostic_codes("const inner = (): number => { return await 1; };\n");
+    assert_eq!(
+        codes,
+        vec![1308],
+        "block-bodied control must keep reporting TS1308"
+    );
+}
+
+/// Renamed binder: the check keys off the body's syntactic position, never
+/// off the variable's name.
+///
+/// tsc: `FILE(1,37): error TS1308`.
+#[test]
+fn concise_arrow_body_await_reports_ts1308_with_renamed_binder() {
+    let codes = diagnostic_codes("const somethingElse = (): number => await 1;\n");
+    assert_eq!(codes, vec![1308], "binder name must not affect the check");
+}
+
+/// The `await` nested inside a larger body expression rather than being the
+/// whole body — the scan must walk into the expression, not just test its
+/// root kind.
+///
+/// tsc: `FILE(1,33): error TS1308`.
+#[test]
+fn concise_arrow_body_await_nested_in_larger_expression_reports_ts1308() {
+    let codes = diagnostic_codes("const inner = (): number => 1 + await 2;\n");
+    assert_eq!(
+        codes,
+        vec![1308],
+        "the scan must descend into the body expression"
+    );
+}
+
+/// A concise body reached through an object literal's property initializer
+/// rather than a variable declaration — an arrow whose owning position is a
+/// different one of the checker's scan roots.
+///
+/// tsc: `FILE(1,32): error TS1308`.
+#[test]
+fn concise_arrow_body_await_in_object_literal_property_reports_ts1308() {
+    let codes = diagnostic_codes("const obj = { m: (): number => await 1 };\n");
+    assert_eq!(
+        codes,
+        vec![1308],
+        "an arrow in a property initializer must be scanned too"
+    );
+}
+
+/// Top level of a *module*. Being in a module licenses top-level `await`, but
+/// this `await` is not at top level — it is inside a function — so TS1308
+/// still applies. This is the case that a naive "is the file a module" fix
+/// would get wrong.
+///
+/// tsc: `FILE(1,36): error TS1308`.
+#[test]
+fn concise_arrow_body_await_at_module_top_level_still_reports_ts1308() {
+    let codes = diagnostic_codes("export const inner = (): number => await 1;\n");
+    assert_eq!(
+        codes,
+        vec![1308],
+        "a module's top-level await allowance does not extend into a function body"
+    );
+}
+
+/// A contextually typed callback arrow. This is the shape whose body
+/// `check_function_type_impl` visits more than once — once while building the
+/// type environment and again with contextual parameter types — so it is the
+/// case that would double-report if the new scan root sat outside the
+/// body-checking region's visit guards. The exact-equality assertion is the
+/// point: one TS1308, not two.
+///
+/// tsc: `FILE(2,16): error TS1308`.
+#[test]
+fn concise_arrow_body_await_in_contextual_callback_reports_one_ts1308() {
+    let codes = diagnostic_codes(
+        "declare function run(cb: (x: number) => number): void;\nrun((x) => x + await 1);\n",
+    );
+    assert_eq!(
+        codes,
+        vec![1308],
+        "a re-visited contextual callback body must report TS1308 exactly once"
+    );
+}
+
+/// The generic sibling of the above, where inference re-enters the body with
+/// freshly instantiated parameter types.
+///
+/// tsc: `FILE(2,34): error TS1308`.
+#[test]
+fn concise_arrow_body_await_in_generic_contextual_callback_reports_one_ts1308() {
+    let codes = diagnostic_codes(
+        "declare function map<T, U>(xs: T[], cb: (x: T) => U): U[];\nconst r = map([1, 2], (x) => x + await 1);\n",
+    );
+    assert_eq!(
+        codes,
+        vec![1308],
+        "generic inference re-entry must not duplicate the grammar diagnostic"
+    );
+}
+
+/// The negative control that a "always report on a concise body" fix fails:
+/// an `async` arrow's concise body may contain `await`.
+///
+/// tsc: clean.
+#[test]
+fn concise_async_arrow_body_await_is_clean() {
+    let codes = diagnostic_codes("const inner = async (): Promise<number> => await 1;\n");
+    assert!(
+        codes.is_empty(),
+        "an async arrow's concise body legitimately awaits; got {codes:?}"
+    );
+}
+
+/// The generic fallback: a concise body with no `await` anywhere must stay
+/// silent, so the new scan root cannot report on its own.
+///
+/// tsc: clean.
+#[test]
+fn concise_arrow_body_without_await_is_clean() {
+    let codes = diagnostic_codes("const inner = (): number => 1 + 2;\n");
+    assert!(
+        codes.is_empty(),
+        "a concise body with no await must stay clean; got {codes:?}"
+    );
+}
+// A concise body nested inside an *async* function (`async function outer() {
+// const inner = (): number => await 1; }`) is TS1308 in tsc but stays silent
+// in tsz even with this scan root in place — measured on this branch, both
+// the `async function` and `async` arrow enclosing forms. That residue is a
+// second, independent defect: `CheckerContext::async_depth` is a
+// nesting-depth accumulator, so `in_async_context()` answers "is *any*
+// enclosing function async", and the scan correctly reaches the `await` only
+// to be told it is legal. PR #16058 scopes that flag to the immediately
+// enclosing function. Deliberately not asserted here — this file must not
+// encode the other PR's behavior, and #16059 records the pairing.

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1860,6 +1860,22 @@ impl<'a> CheckerState<'a> {
                     std::mem::take(&mut self.ctx.generator_yield_operand_types);
                 let saved_had_ts7057 = std::mem::replace(&mut self.ctx.generator_had_ts7057, false);
                 if !skip_body_check {
+                    // A concise (expression) body has no `ReturnStatement`, so
+                    // the statement-rooted `await` grammar scan never reaches
+                    // it: every root of that scan is a statement-level
+                    // expression position (return/if/expression-statement/
+                    // for-await/variable-declaration/decorator/property
+                    // initializer). Root it here so a concise body is scanned
+                    // exactly like the block body's `return` expression is.
+                    //
+                    // Placed inside the body-checking region so it inherits
+                    // that region's visit guards, and after `function_depth`
+                    // and this function's own async context are established —
+                    // the `await` is judged against the function that owns it,
+                    // not the file.
+                    if body_is_expression {
+                        self.check_await_expression(body);
+                    }
                     let body_request = self
                         .function_body_statement_request(body_is_expression, effective_body_ctx);
                     self.check_function_body_statement_with_own_literal_context(


### PR DESCRIPTION
Fixes #16059.

**Structural rule.** When a function body is an expression rather than a block, `tsc` still runs `checkAwaitExpression` over it — it reaches that check from the expression itself. tsz reaches the same check from a fixed set of **statement**-level roots, and a concise arrow body is none of them, so tsz does X through the checker's grammar-scan rooting in `check_function_type_impl`.

The wrong semantic operation is **diagnostic traversal**, not inference or narrowing: the scan simply never visited the node.

```ts
const inner = (): number => await 1;        // tsc: TS1308 — tsz: silent (the bug)
const inner = (): number => { return await 1; };  // tsc: TS1308 — tsz: TS1308 (already correct)
```

`check_await_expression` is rooted only at `return` expressions, `if` conditions, expression statements, `for await` expressions, variable declarations, decorator arguments, and property initializers. A concise arrow body has no `ReturnStatement` node at all, so nothing on any of those paths ever reached it.

**Where the fix goes.** #16059 asked for the arrow's expression body to become a scanned root rather than a special case at the diagnostic site, and that is what this does — one `if body_is_expression { self.check_await_expression(body); }` inside `check_function_type_impl`'s body-checking region. That placement is load-bearing for two reasons beyond tidiness:

- it runs after `function_depth` and this function's own async context are established, so the `await` is judged against the function that owns it rather than the file;
- it sits inside the same region as the block body's statement checking, so it inherits that region's existing visit guards. `check_function_type_impl` visits a contextually typed callback's body twice (environment building, then again with contextual parameter types), and a root placed outside those guards would double-report. The two contextual-callback tests assert exact equality with a one-element vector specifically to pin this.

No identifier, alias, property, or file-name string participates in the decision; the predicate is the body node's syntax kind.

## Goal
Goal: hold

## Verification

All expectations pinned against a real `tsc@7.0.2 --noEmit --strict --pretty false --target es2017` oracle (`npm i --no-save typescript@7.0.2`), not recalled.

New `crates/tsz-checker/src/tests/concise_arrow_body_await_grammar_tests.rs` — **10 cases, 10 passing (was 2 passing / 8 failing before the fix)**:

| case | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| concise body, top level of a script (#16059 witness) | TS1308 | *silent* | TS1308 |
| block body (control — the form that already worked) | TS1308 | TS1308 | TS1308 |
| renamed binder | TS1308 | *silent* | TS1308 |
| `await` nested in a larger body expression (`1 + await 2`) | TS1308 | *silent* | TS1308 |
| arrow in an object-literal property initializer | TS1308 | *silent* | TS1308 |
| top level of a **module** (allowance does not extend into a function) | TS1308 | *silent* | TS1308 |
| contextually typed callback (body visited twice) | TS1308 ×1 | *silent* | TS1308 **×1** |
| generic contextual callback (inference re-entry) | TS1308 ×1 | *silent* | TS1308 **×1** |
| `async` arrow's concise body (negative control) | clean | clean | clean |
| concise body with no `await` (fallback control) | clean | clean | clean |

Commands run in this container:

- `cargo test -p tsz-checker --lib --profile ci-unit concise_arrow_body_await` → **10 passed / 0 failed**
- `cargo test -p tsz-checker --lib --profile ci-unit await` → **78 passed / 0 failed** (every await-related test in the crate, incl. the pre-existing `test_for_await_top_level_non_module_emits_ts1431_ts1432`)
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` → clean (CI's exact invocation)
- `cargo fmt --all` → clean
- Full `cargo test -p tsz-checker --lib --profile ci-unit` → result posted as a PR comment when it finishes.

**Not run here, and why:** conformance, emit, and fourslash — this is a cold container with no `.target` corpus and no TypeScript submodule. The change is diagnostic-only (it adds no type, changes no inference, and touches nothing the emitter reads), but its blast radius is *every concise arrow body in the corpus*, so targeted verification provably cannot close it. A warm seat running `scripts/conformance/compare-to-parent.sh` against parent `f5c5f4c` is the gate this needs. Any conformance movement should be tsz **newly agreeing** with tsc on a TS1308 row — check the oracle on a row before reading a diff as a regression.

### One case deliberately left unasserted

A concise body nested inside an **async** function is TS1308 in tsc but stays silent in tsz even with this scan root in place. I measured it on this branch, in both the `async function` and `async` arrow enclosing forms — both `[]`. That residue is a second, independent defect and not this one: `CheckerContext::async_depth` is a nesting-depth accumulator, so `in_async_context()` answers "is *any* enclosing function async" and tells the (now correctly arriving) scan that the `await` is legal. #16058 scopes that flag to the immediately enclosing function. Once both land the case resolves with no further change; asserting it here would encode the other PR's behavior into this file, so the test file carries a comment instead.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Feldspar

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAMC7syudFjy79ZAcmCARn)_