### PR TITLE
test(checker): pin the concise-body await grammar check against duplicates

### DIFF
--- a/crates/tsz-checker/src/tests/await_concise_arrow_body_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/await_concise_arrow_body_grammar_tests.rs
@@ -101,3 +101,170 @@ const outer = (): (() => number) => (): number => await 1;
         "a concise arrow body nested inside another concise arrow body must still report its own TS1308; got {codes:?}"
     );
 }
+
+// --- Exactly-once and additional-position coverage (#16062) ---
+//
+// The cases above assert `codes.contains(&1308)`, which is satisfied by one
+// diagnostic or by five. The rooting that landed for #16061 sits in
+// `check_statement_with_request`'s catch-all arm, and `check_function_type_impl`
+// visits a contextually typed callback's body more than once — once while
+// building the type environment, then again with contextual parameter types.
+// It reports once today; nothing pinned that, so a future change to the
+// visit path could start double-reporting and every test above would still
+// pass. These count the diagnostics instead.
+//
+// Expectations pinned against a live `tsc@7.0.2 --noEmit --strict
+// --pretty false --target es2017` run, not recalled.
+
+/// How many TS1308s `source` produces.
+fn ts1308_count(source: &str) -> usize {
+    check_source_codes(source)
+        .into_iter()
+        .filter(|code| *code == 1308)
+        .count()
+}
+
+/// A contextually typed callback: the body is visited twice. tsc reports one
+/// TS1308, so tsz must report exactly one.
+#[test]
+fn concise_arrow_body_await_in_contextual_callback_reports_exactly_one_ts1308() {
+    let count = ts1308_count(
+        r#"
+declare function take(cb: () => number): void;
+take((): number => await 1);
+"#,
+    );
+    assert_eq!(
+        count, 1,
+        "a twice-visited contextual callback body must report TS1308 exactly once"
+    );
+}
+
+/// The generic sibling, where inference re-enters the body with freshly
+/// instantiated parameter types — a second, distinct re-visit path.
+#[test]
+fn concise_arrow_body_await_in_generic_contextual_callback_reports_exactly_one_ts1308() {
+    let count = ts1308_count(
+        r#"
+declare function map<T, U>(xs: T[], cb: (x: T) => U): U[];
+const r = map([1, 2], (x) => x + await 1);
+"#,
+    );
+    assert_eq!(
+        count, 1,
+        "generic inference re-entry must not duplicate the grammar diagnostic"
+    );
+}
+
+/// A concise body reached through an object-literal property initializer
+/// rather than a variable declaration — a different owning position for the
+/// arrow, and one no case above exercises.
+///
+/// tsc: `FILE(2,32): error TS1308`.
+#[test]
+fn concise_arrow_body_await_in_object_literal_property_reports_exactly_one_ts1308() {
+    let count = ts1308_count(
+        r#"
+const obj = { m: (): number => await 1 };
+"#,
+    );
+    assert_eq!(
+        count, 1,
+        "an arrow in a property initializer must be scanned exactly once"
+    );
+}
+
+/// Top level of a **module**.
+///
+/// #16061 recorded this case as out of scope on the premise that "TS1431 /
+/// TS1432 apply there instead, a different rule entirely". That premise does
+/// not hold for this shape: those rules govern a `for await` / top-level
+/// `await` *at* the module's top level, and this `await` is not at top level
+/// — it is inside a function body, so the ordinary TS1308 rule applies and a
+/// module's top-level-await allowance does not reach it.
+///
+/// Verified against the oracle rather than argued:
+/// `tsc@7.0.2` on `export const inner = (): number => await 1;` reports
+/// `FILE(1,36): error TS1308` — the same diagnostic as the script case, not
+/// TS1431 or TS1432.
+#[test]
+fn concise_arrow_body_await_at_module_top_level_reports_ts1308_not_ts1431() {
+    let codes = check_source_codes(
+        r#"
+export const inner = (): number => await 1;
+"#,
+    );
+    assert!(
+        codes.contains(&1308),
+        "being in a module does not license `await` inside a function body; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&1431) && !codes.contains(&1432),
+        "the top-level-await rules do not apply to an await inside a function; got {codes:?}"
+    );
+}
+
+/// The fallback control: a concise body with no `await` anywhere must stay
+/// clean, so the new rooting cannot report on its own.
+///
+/// tsc: clean.
+#[test]
+fn concise_arrow_body_without_await_reports_no_ts1308() {
+    let count = ts1308_count(
+        r#"
+const inner = (): number => 1 + 2;
+"#,
+    );
+    assert_eq!(count, 0, "a concise body with no await must stay clean");
+}
+
+// --- The #16058 x #16061 intersection ---
+//
+// A concise body nested inside an *async* function needs both fixes and
+// could not be asserted by either PR alone. #16061 supplied the traversal
+// root; without #16058 the scan arrived and was told the `await` was legal,
+// because `CheckerContext::async_depth` was a nesting-depth accumulator and
+// `in_async_context()` answered "is *any* enclosing function async" rather
+// than "is the function that owns this node async". #16059 named this
+// pairing and #16058's own case 6 used a block body to route around the
+// missing root. Both are on main now, so the case is finally pinnable — and
+// it is the one that regresses if either fix is later reverted or narrowed.
+
+/// A plain arrow with a concise body, nested inside an `async function`.
+///
+/// tsc: `FILE(3,33): error TS1308`.
+#[test]
+fn concise_arrow_body_await_nested_in_async_function_reports_ts1308() {
+    let count = ts1308_count(
+        r#"
+async function outer(): Promise<number> {
+    const inner = (): number => await 1;
+    return inner();
+}
+"#,
+    );
+    assert_eq!(
+        count, 1,
+        "the enclosing function's asyncness must not license `await` in a nested plain arrow"
+    );
+}
+
+/// The same, with an `async` *arrow* as the enclosing function — the second
+/// of the two body-entry paths that maintain the async flag.
+///
+/// tsc: `FILE(3,33): error TS1308`.
+#[test]
+fn concise_arrow_body_await_nested_in_async_arrow_reports_ts1308() {
+    let count = ts1308_count(
+        r#"
+const outer = async (): Promise<number> => {
+    const inner = (): number => await 1;
+    return inner();
+};
+"#,
+    );
+    assert_eq!(
+        count, 1,
+        "an enclosing async arrow must not license `await` in a nested plain arrow"
+    );
+}


### PR DESCRIPTION
Tests only; no production code changed. This is the salvage Quartz asked for on #16062 — that PR's production fix was superseded by #16061 (`b7d5f7a`), which I verified on merged main before dropping it, and #16062 is closed. Rebased onto `b7d5f7a` and reduced to the cases the merged rooting does not pin.

**Why these are not redundant.** #16061's six cases all assert `codes.contains(&1308)`, which is satisfied by one diagnostic or by five. `check_function_type_impl` visits a contextually typed callback's body more than once — once while building the type environment, then again with contextual parameter types — so "exactly one diagnostic for a twice-visited body" is a real property, currently correct, and currently unpinned: a future change to the visit path could start double-reporting and all six existing cases would still pass. These count diagnostics instead of testing membership.

## What is added (7 cases, +167 lines, one file)

Appended to the existing `await_concise_arrow_body_grammar_tests.rs` rather than a second file, so the family keeps one home.

| case | why it is not covered today |
| --- | --- |
| contextual callback → **exactly one** TS1308 | the twice-visited body path; `contains` cannot see a duplicate |
| generic contextual callback → **exactly one** TS1308 | second, distinct re-visit path (inference re-entry) |
| arrow in an object-literal property initializer | a body position no existing case exercises |
| top level of a **module** | recorded as out of scope by #16061 — see below |
| concise body with **no** `await` | fallback control: the rooting must not report on its own |
| concise body nested in an `async function` | needs #16058 **and** #16061 — see below |
| concise body nested in an `async` arrow | the second body-entry path that maintains the async flag |

### The module case, and a correction

#16061 recorded top-level-of-a-module as out of scope on the premise that "TS1431/TS1432 apply there instead, a different rule entirely". That premise does not hold for this shape. Those rules govern a top-level `await` *at* the module's top level; here the `await` is inside a function body, so the ordinary TS1308 rule applies and a module's top-level-await allowance does not reach it.

Checked against the oracle rather than argued — `tsc@7.0.2` on `export const inner = (): number => await 1;`:

```
FILE(1,36): error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
```

Same diagnostic as the script case, not TS1431 or TS1432. The test asserts TS1308 present **and** TS1431/TS1432 absent, so it pins the distinction rather than just the code. tsz already behaves correctly here; nothing was pinning it.

### The #16058 × #16061 intersection

A concise body nested inside an `async` function needs both fixes and could not be asserted by either PR alone. #16061 supplies the traversal root; without #16058's per-function async scoping, `async_depth` was a nesting-depth accumulator, so `in_async_context()` answered "is *any* enclosing function async" and the scan arrived only to be told the `await` was legal. I measured exactly this on my pre-rebase branch: root in place, both enclosing forms still `[]`. #16058's own case 6 used a block body to route around the missing root, and #16059 named the pairing. Both are on main now, so this is finally pinnable — and it is the case that regresses if either fix is later reverted or narrowed.

## Goal
Goal: hold

## Verification

All expectations pinned against a live `tsc@7.0.2 --noEmit --strict --pretty false --target es2017` run (`npm i --no-save typescript@7.0.2`), not recalled.

- `cargo test -p tsz-checker --lib --profile ci-unit await_concise_arrow_body_grammar_tests` → **13 passed / 0 failed** (6 pre-existing + 7 new), at `b7d5f7a`.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` → clean.
- `python3 scripts/arch/arch_guard.py` → `Architecture guardrails passed.` (file is 270 lines, well under the 2000 cap).
- `cargo fmt --all` → clean.

Conformance / emit / fourslash not run: cold container, no TypeScript submodule or corpus, and `scripts/emit/baselines-ts7` holds only its README. This diff adds no production code, so it cannot move those suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Feldspar

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAMC7syudFjy79ZAcmCARn)_