### PR TITLE
fix(checker): root the await-grammar walk on the remaining statement clauses

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -145,6 +145,9 @@ mod await_alias_union_distribution_tests;
 #[path = "tests/await_concise_arrow_body_grammar_tests.rs"]
 mod await_concise_arrow_body_grammar_tests;
 #[cfg(test)]
+#[path = "tests/await_grammar_statement_position_tests.rs"]
+mod await_grammar_statement_position_tests;
+#[cfg(test)]
 #[path = "tests/await_structural_thenable_tests.rs"]
 mod await_structural_thenable_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/statements.rs
+++ b/crates/tsz-checker/src/statements.rs
@@ -589,6 +589,7 @@ impl StatementChecker {
                         .map(|l| (l.condition, l.statement))
                 };
                 if let Some((condition, statement)) = loop_data {
+                    state.check_await_expression(condition);
                     state.get_type_of_node_with_request(condition, &non_contextual_request);
                     state.check_truthy_or_falsy(condition);
 
@@ -626,6 +627,21 @@ impl StatementChecker {
                         .map(|l| (l.initializer, l.condition, l.incrementor, l.statement))
                 };
                 if let Some((initializer, condition, incrementor, statement)) = loop_data {
+                    // The `for` clause expressions carry the TS1308/TS1375/TS1378
+                    // `await`-grammar walk themselves. Rooted here, before the
+                    // reachability analysis below, because tsc's grammar checks are
+                    // syntactic: `return; for (; await 1; await 2) {}` still reports,
+                    // while the branches below skip typing the condition and the
+                    // incrementor once the clause is known unreachable. An
+                    // initializer that is a variable declaration list is already
+                    // rooted by the declaration check.
+                    if condition.is_some() {
+                        state.check_await_expression(condition);
+                    }
+                    if incrementor.is_some() {
+                        state.check_await_expression(incrementor);
+                    }
+
                     // Track whether the initializer terminates control flow
                     // (e.g., calls an IIFE that always throws).
                     let mut init_terminates = false;
@@ -641,6 +657,7 @@ impl StatementChecker {
                             state
                                 .check_variable_declaration_list_with_request(initializer, request);
                         } else {
+                            state.check_await_expression(initializer);
                             state.get_type_of_node_with_request(
                                 initializer,
                                 &non_contextual_request,
@@ -853,6 +870,8 @@ impl StatementChecker {
                 };
 
                 if let Some((expression, case_block)) = switch_data {
+                    state.check_await_expression(expression);
+
                     // Use the declared/widened type (no flow narrowing) for the switch
                     // discriminant. tsc's checkExpression returns the non-narrowed type,
                     // preventing false TS2678 when flow narrows the discriminant
@@ -906,6 +925,7 @@ impl StatementChecker {
                             if clause_expr.is_none() {
                                 has_default = true;
                             } else {
+                                state.check_await_expression(*clause_expr);
                                 // Check case expression with switch type as contextual type.
                                 // This enables excess property checking (TS2353) for object
                                 // literal case expressions, matching tsc behavior.
@@ -1014,6 +1034,7 @@ impl StatementChecker {
                         .map(|r| r.expression)
                 };
                 if let Some(operand) = operand {
+                    state.check_await_expression(operand);
                     state.get_type_of_node_with_request(operand, &non_contextual_request);
                 }
             }

--- a/crates/tsz-checker/src/tests/await_grammar_statement_position_tests.rs
+++ b/crates/tsz-checker/src/tests/await_grammar_statement_position_tests.rs
@@ -1,0 +1,368 @@
+//! Regression tests for TS1308 (`await` outside an async function) in the
+//! statement positions the `await`-grammar walk never reached.
+//!
+//! `check_await_expression` is rooted per statement kind, on that statement's
+//! own expression children (`crates/tsz-checker/src/statements.rs`). Before
+//! this suite the rooted set was `ExpressionStatement`, an `if` condition, a
+//! `for..in`/`for..of` iterated expression, a `return` operand, variable
+//! declarations, property initializers, decorators, and (since #16061) the
+//! dispatcher's catch-all arm for a concise arrow body. Five statement kinds
+//! owned expression positions with no root at all, so tsz was silent where
+//! tsc reports:
+//!
+//! - `while` / `do..while` condition
+//! - `for` initializer (expression form), condition, incrementor
+//! - `switch` discriminant and `case` expressions
+//! - `throw` operand
+//!
+//! Every expectation here is pinned against a live
+//! `tsc@7.0.2 --noEmit --strict --pretty false --target es2017` run, not
+//! recalled. tsc's grammar checks are syntactic, so they fire in unreachable
+//! code too — `count_ts1308` cases below pin that as well.
+
+use crate::test_utils::{check_source_codes, check_source_diagnostics};
+
+/// TS1308 occurrences in `source`. Counting rather than testing membership:
+/// `error_at_node` deduplicates by `(start, code)`, so a body the checker
+/// visits more than once (a `while` body is visited twice, a contextually
+/// typed callback body twice) must still yield exactly one diagnostic. A
+/// `contains` assertion cannot see a regression that starts double-reporting
+/// at distinct positions.
+fn count_ts1308(source: &str) -> usize {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == 1308)
+        .count()
+}
+
+// --- while / do..while conditions ---
+
+/// `while (await 1) {}` in a non-async function. tsc:
+/// `(1,23): error TS1308`.
+#[test]
+fn while_condition_await_reports_ts1308() {
+    let source = r"
+function w() { while (await 1) {} }
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "a `while` condition's `await` outside an async function must report exactly one TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// `do {} while (await 1);` — the same arm, the other loop form. tsc:
+/// `(1,29): error TS1308`.
+#[test]
+fn do_while_condition_await_reports_ts1308() {
+    let source = r"
+function d() { do {} while (await 1); }
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "a `do..while` condition's `await` must report exactly one TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// A `while` body is checked twice (once, then again after the loop-body
+/// recheck caches are cleared). The body's own `await` must still report
+/// once — this is the case that regresses if the walk is ever rooted at the
+/// top of the dispatcher instead of per-arm.
+#[test]
+fn while_body_await_reports_exactly_one_ts1308_despite_double_visit() {
+    let source = r"
+function w() { while (true) { await 1; } }
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "a twice-visited `while` body must report exactly one TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// Renamed-binder control (anti-hardcoding): different function name,
+/// different awaited literal, same `while` shape.
+#[test]
+fn while_condition_await_reports_ts1308_renamed_binders() {
+    let source = r"
+function pollUntilSettled() { while (await 'ready') {} }
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "renamed binders must not change the `while` condition result; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+// --- for clause expressions ---
+
+/// `for (await 1; ; ) {}` — an expression-form initializer. tsc:
+/// `(1,21): error TS1308`.
+#[test]
+fn for_expression_initializer_await_reports_ts1308() {
+    let source = r"
+function a() { for (await 1; ; ) {} }
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "an expression-form `for` initializer must report exactly one TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// A variable-declaration-list initializer is rooted by the declaration
+/// check, not by the `for` arm. Pinned so the two roots cannot both be
+/// removed on the assumption the other covers it. tsc reports here too.
+#[test]
+fn for_declaration_initializer_await_reports_ts1308() {
+    let source = r"
+function a() { for (let i = await 0; ; ) {} }
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "a declaration-form `for` initializer must report exactly one TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// Condition and incrementor together. tsc reports both:
+/// `(1,29)` and `(1,38)`.
+#[test]
+fn for_condition_and_incrementor_await_report_two_ts1308() {
+    let source = r"
+function f() { for (; await 1; await 2) {} }
+";
+    assert_eq!(
+        count_ts1308(source),
+        2,
+        "a `for` condition and incrementor each report their own TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// tsc's grammar checks are syntactic and run in unreachable code:
+/// `function b() { return; for (; await 1; await 2) {} }` reports at both
+/// `(2,31)` and `(2,40)`. tsz skips *typing* an unreachable condition and
+/// incrementor, so the grammar roots must sit before that analysis.
+#[test]
+fn unreachable_for_clause_await_still_reports_ts1308() {
+    let source = r"
+function b() { return; for (; await 1; await 2) {} }
+";
+    assert_eq!(
+        count_ts1308(source),
+        2,
+        "grammar checks are syntactic: an unreachable `for` clause still reports TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// A `for` body's `await` was already reported through the
+/// `ExpressionStatement` root; pinning it here guards the interaction with
+/// the new clause roots. tsc: `(1,44)` for the body form below.
+#[test]
+fn for_body_await_reports_exactly_one_ts1308() {
+    let source = r"
+function d() { for (;;) { await 1; } }
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "a `for` body's `await` must report exactly one TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+// --- switch discriminant and case expressions ---
+
+/// `switch (await 1)` — the discriminant. tsc: `(1,24): error TS1308`.
+#[test]
+fn switch_discriminant_await_reports_ts1308() {
+    let source = r"
+function s() { switch (await 1) { default: break; } }
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "a `switch` discriminant's `await` must report exactly one TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// `case await 2:` — a case expression, which the arm visits through
+/// `get_type_of_case_expression_with_request` rather than the ordinary
+/// expression path. tsc reports TS1308 there as well.
+#[test]
+fn switch_case_expression_await_reports_ts1308() {
+    let source = r"
+function e() { switch (1) { default: break; case await 1: break; } }
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "a `case` expression's `await` must report exactly one TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// Discriminant and two case expressions: three distinct positions, three
+/// diagnostics. Pins that the walk roots per case clause and not once for
+/// the whole case block.
+#[test]
+fn switch_discriminant_and_two_cases_report_three_ts1308() {
+    let source = r"
+function e() { switch (await 0) { case await 1: break; case await 2: break; } }
+";
+    assert_eq!(
+        count_ts1308(source),
+        3,
+        "a discriminant and two `case` expressions report one TS1308 each; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+// --- throw operand ---
+
+/// `throw await 1;` — the `throw` arm carries its operand through
+/// `ReturnData`, so it never reached the `return` root. tsc:
+/// `(1,29): error TS1308`.
+#[test]
+fn throw_operand_await_reports_ts1308() {
+    let source = r"
+function t(): never { throw await 1; }
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "a `throw` operand's `await` must report exactly one TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// The same `throw` shape nested in an object-literal method — a different
+/// enclosing function form reaching the same arm. tsc reports it.
+#[test]
+fn throw_operand_await_in_object_literal_method_reports_ts1308() {
+    let source = r"
+function h() { const holder = { emit() { throw await 1; } }; }
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "a `throw` operand inside an object-literal method must report TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// And in a function expression, the third enclosing-function form. tsc:
+/// `(1,35): error TS1308`.
+///
+/// Two enclosing forms are deliberately *not* asserted here, both
+/// pre-existing wrong-diagnostic defects independent of these roots:
+/// - a class method, constructor, or accessor body, where tsz answers
+///   `[TS1375, TS1378]` (the top-level-await pair) because
+///   `ctx.function_depth` is still 0 inside them — it reproduces on the plain
+///   `class K { m() { await 1; } }` expression-statement witness, rooted long
+///   before this suite;
+/// - a class static block, where tsc reports TS18037 (`'await' expression
+///   cannot be used inside a class static block`) and tsz reports TS1308.
+///
+/// Both are tracked on their own issue rather than pinned red here.
+#[test]
+fn while_condition_await_in_function_expression_reports_ts1308() {
+    let source = r"
+const gate = function () { while (await 1) {} };
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "a `while` condition inside a function expression must report TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// A `label:` wrapper delegates to the labeled statement through the
+/// dispatcher, so the loop's own root still applies. tsc: `(1,30)`.
+#[test]
+fn labeled_while_condition_await_reports_ts1308() {
+    let source = r"
+function g() { outer: while (await 1) {} }
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "a labeled `while`'s condition must still report TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+// --- negative controls: the roots must not report on their own ---
+
+/// Every position above, legal inside an `async function`. No TS1308 —
+/// confirmed against tsc, which reports nothing for this source.
+#[test]
+fn async_function_await_in_every_statement_position_reports_no_ts1308() {
+    let source = r"
+async function all(p: Promise<number>) {
+    while (await p) { break; }
+    do { break; } while (await p);
+    for (await p; await p; await p) { break; }
+    switch (await p) { case await p: break; default: break; }
+    if (await p) { }
+    throw await p;
+}
+";
+    assert_eq!(
+        count_ts1308(source),
+        0,
+        "inside an async function every awaited position is legal; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// The same statement kinds with no `await` at all: the new roots must not
+/// synthesize a diagnostic of their own.
+#[test]
+fn statements_without_await_report_no_ts1308() {
+    let source = r"
+function none(): never {
+    while (false) { }
+    do { break; } while (false);
+    for (let i = 0; i < 1; i++) { }
+    switch (1) { case 2: break; default: break; }
+    throw new Error('x');
+}
+";
+    assert_eq!(
+        count_ts1308(source),
+        0,
+        "statements with no `await` must report no TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// A nested non-async function inside an `async` one still reports: the walk
+/// stops at function boundaries, so the inner function's own async state
+/// governs. tsc reports TS1308 for the inner `while`.
+#[test]
+fn non_async_function_nested_in_async_function_reports_ts1308() {
+    let source = r"
+async function outer(p: Promise<number>) {
+    function inner() { while (await 1) {} }
+    await p;
+}
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "a non-async function nested in an async one still reports TS1308 for its own `await`; got {:?}",
+        check_source_codes(source)
+    );
+}


### PR DESCRIPTION
`check_await_expression` (TS1308 / TS1375 / TS1378) is rooted **per statement kind**, on that statement's own expression children. #16061 closed the concise arrow-body witness from #16059 by adding a root to the dispatcher's catch-all arm. The reported repro was one witness: five statement kinds still owned expression positions with **no root at all**, so tsz was silent where tsc reports.

**Structural rule.** When a statement owns an expression clause, tsc's `checkAwaitExpression` grammar walk reaches that clause wherever it appears; tsz now does the same by rooting the walk in each arm on that arm's own expression children, through the same `StatementCheckCallbacks` entry point the already-rooted arms use.

### Rooted before this PR
`ExpressionStatement` (`statements.rs:488`), `if` condition (`:510`), `for..in`/`for..of` iterated expression (`:730`), `return` operand (`core_statement_checks.rs:88`), variable declarations (`variable_checking/core.rs:192`), property initializers, decorators, and #16061's catch-all arm (`:1137`).

### Added here

| position | tsc | tsz before |
| --- | --- | --- |
| `while (await 1) {}` | TS1308 | silent |
| `do {} while (await 1);` | TS1308 | silent |
| `for (await 1; ; )` — expression initializer | TS1308 | silent |
| `for (; await 1; )` — condition | TS1308 | silent |
| `for (; ; await 2)` — incrementor | TS1308 | silent |
| `switch (await 1)` — discriminant | TS1308 | silent |
| `case await 2:` — case expression | TS1308 | silent |
| `throw await 1;` | TS1308 | silent |

A `for` initializer that is a variable declaration list was already covered by the declaration root; both roots are now pinned so neither can be removed on the assumption the other covers it.

### Two deliberate design points

**Per-arm, not dispatcher-wide.** `check_await_expression` walks the whole subtree and stops only at function/class boundaries, so a single root at the top of `check_statement_with_request` would re-walk every nested statement subtree once per enclosing statement. `error_at_node` deduplicates by `(start, code)`, so that would not double-report — it would just be O(nesting depth) redundant walks. The new tests count diagnostics rather than testing membership, so a future regression that starts reporting at *distinct* positions is caught.

**Before the reachability analysis, in the `for` arm.** tsc's grammar checks are syntactic and fire in unreachable code — `function b() { return; for (; await 1; await 2) {} }` reports at both `(2,31)` and `(2,40)` — while tsz skips *typing* an unreachable condition and incrementor entirely. Pinned by `unreachable_for_clause_await_still_reports_ts1308`.

### Adjacent-case matrix

Renamed binders (`pollUntilSettled`, `'ready'` instead of `w`, `1`), three enclosing-function forms (function declaration, object-literal method, function expression), a labeled loop, positive controls inside an `async function` for all seven positions, a no-`await` control per statement kind so the new roots cannot synthesize a diagnostic of their own, a non-async function nested inside an `async` one, and exactly-one counts on the twice-visited `while` body.

### Out of scope — two pre-existing wrong-diagnostic defects found while pinning this

Both reproduce independently of this change and are filed separately rather than pinned red here:

1. **Class method / constructor / accessor bodies answer `[TS1375, TS1378]` instead of TS1308.** `ctx.function_depth` is still 0 inside them, so the walk takes the top-level-await branch. Reproduces on the plain `class K { m() { await 1; } }` expression-statement witness, which was rooted long before this PR. Object-literal methods and static blocks are unaffected.
2. **A class static block reports TS1308 where tsc reports TS18037** (`'await' expression cannot be used inside a class static block`).

## Goal
Goal: hold

## Verification

Every expectation pinned against a live `tsc@7.0.2 --noEmit --strict --pretty false --target es2017` run (`npm i --no-save typescript@7.0.2`), not recalled — including the two out-of-scope findings above and one negative: `for (const q of await [1])` is **not** part of this family (tsc reports `TS2304: Cannot find name 'await'` there — the for-of head parses `await` as an identifier).

- New suite `await_grammar_statement_position_tests` (19 cases), two-sided against this PR's own parent `b7d5f7a`:
  - **without** the `statements.rs` change (production diff stashed, tests kept): **5 passed / 14 failed**
  - **with** it: **19 passed / 0 failed**
- Adjacent unit suites at head, all green: `await` 97/97, `async` 82/82, `switch` 70/70, `for_` 501/501, `loop_` 32/32, `while_` 23/23, `throw` 14/14, `unreachable` 20/20.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` → clean.
- `python3 scripts/arch/arch_guard.py` → `Architecture guardrails passed.`
- `cargo fmt --all` → clean.

Conformance / emit / fourslash **not** run: cold container with no TypeScript submodule and no corpus, and a full `dist-fast` CLI build plus a two-sided sweep did not fit the session. This change adds diagnostics in positions that previously reported nothing, so it is exactly the shape that targeted verification cannot fully see — **a warm seat running `scripts/conformance/compare-to-parent.sh` against `b7d5f7a` on this branch before merge would be valuable**, and the same gap is already open on #16061 and #16058, which introduced the sibling roots and shipped unmeasured for the same reason.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Rhyolite

---
_Generated by [Claude Code](https://claude.ai/code/session_01QB1jvi1ZhpWexFhxW6JMbd)_