### PR TITLE
test(checker): pin class-static-block await as TS18037-only, add parse-health test harness

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -145,6 +145,9 @@ mod await_alias_union_distribution_tests;
 #[path = "tests/await_concise_arrow_body_grammar_tests.rs"]
 mod await_concise_arrow_body_grammar_tests;
 #[cfg(test)]
+#[path = "tests/await_static_block_grammar_tests.rs"]
+mod await_static_block_grammar_tests;
+#[cfg(test)]
 #[path = "tests/await_structural_thenable_tests.rs"]
 mod await_structural_thenable_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/test_utils.rs
+++ b/crates/tsz-checker/src/test_utils.rs
@@ -167,6 +167,75 @@ pub fn check_js_source_diagnostics(source: &str) -> Vec<Diagnostic> {
     )
 }
 
+/// Parse, bind, and type-check source with real parser-diagnostic wiring:
+/// `has_parse_errors`/`has_syntax_parse_errors`/the position vectors are set
+/// from the actual parser output, matching `tsz-cli`'s `check_file.rs`.
+///
+/// Every other helper in this module (`check_source`, `check_source_codes`,
+/// etc.) builds a `CheckerState` with those fields left at their `false`/empty
+/// defaults, so parser-only diagnostics (e.g. TS18037, emitted by
+/// `parse_await_expression`) never appear in the result, and grammar checks
+/// gated on `has_syntax_parse_errors` (e.g. `check_await_expression`'s TS1308,
+/// suppressed by tsc's `hasParseDiagnostics`) never see a parse error and so
+/// never suppress. A test built on the plain helpers can read as "tsz reports
+/// TS1308" when the compiled CLI reports only the parser's TS18037 and TS1308
+/// is correctly suppressed — reach for this helper instead whenever the
+/// source under test can trigger a parser-emitted diagnostic.
+///
+/// Returns `(parser diagnostic codes, checker diagnostic codes)` separately
+/// so a test can assert on each side, or combine them.
+///
+/// This mirrors an existing local pattern
+/// (`checkers/parameter_checker.rs`'s `checker_codes_with_parse_health`) using
+/// the coarse `!parse_diagnostics.is_empty()` signal rather than `tsz-cli`'s
+/// `is_non_suppressing_parse_error` allowlist (unreachable from this crate) —
+/// good enough for the common case of "did a parser diagnostic fire here",
+/// slightly more suppressive than production for the handful of codes on that
+/// allowlist (trailing commas, rest-parameter constraints, and similar).
+pub fn check_source_with_parse_health(source: &str) -> (Vec<u32>, Vec<u32>) {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let source_file = parser.parse_source_file();
+    let parse_diagnostics = parser.get_diagnostics().to_vec();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), source_file);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    checker.enable_source_file_test_pragmas();
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker.ctx.has_parse_errors = !parse_diagnostics.is_empty();
+    checker.ctx.has_syntax_parse_errors = !parse_diagnostics.is_empty();
+    checker.ctx.syntax_parse_error_positions =
+        parse_diagnostics.iter().map(|diag| diag.start).collect();
+    checker.ctx.all_parse_error_positions =
+        parse_diagnostics.iter().map(|diag| diag.start).collect();
+    checker.check_source_file(source_file);
+
+    let parse_codes = parse_diagnostics.iter().map(|diag| diag.code).collect();
+    let checker_codes = checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|diag| diag.code)
+        .collect();
+    (parse_codes, checker_codes)
+}
+
+/// [`check_source_with_parse_health`], with both diagnostic sources combined
+/// into one code list (parser codes first) for tests that just need
+/// membership/count across either side.
+pub fn check_source_codes_with_parse_health(source: &str) -> Vec<u32> {
+    let (parse_codes, checker_codes) = check_source_with_parse_health(source);
+    parse_codes.into_iter().chain(checker_codes).collect()
+}
+
 /// Types that expose a diagnostic code for code-only test assertions.
 pub trait HasDiagnosticCode {
     fn diagnostic_code(&self) -> u32;

--- a/crates/tsz-checker/src/tests/await_static_block_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/await_static_block_grammar_tests.rs
@@ -1,0 +1,139 @@
+//! Regression coverage for #16068 item 2: does a non-async `await` reached
+//! through a *nested* statement inside a class static block report TS18037
+//! (tsc's rule) or the ordinary TS1308 (`await` outside an async function)?
+//!
+//! `parse_await_expression` (`crates/tsz-parser/src/parser/state_expressions_unary.rs`)
+//! already emits TS18037 for any `await` parsed while `in_static_block_context()`
+//! is set, regardless of how deeply the `await` sits inside intervening
+//! statements (`while`, `for`, `switch`, ...) — the context flag survives
+//! statement nesting and is only cleared at a function/class boundary. That
+//! parser diagnostic sets `has_syntax_parse_errors`, which suppresses
+//! `check_await_expression`'s own TS1308 grammar walk
+//! (`core_statement_checks.rs`) for the same file. So on current `main` this
+//! family already matches tsc: exactly TS18037, never an accompanying TS1308.
+//!
+//! #16068 reported the opposite (TS1308 instead of TS18037) — that read came
+//! from `test_utils::check_source_codes`, which never wires real parser
+//! diagnostics or `has_syntax_parse_errors` into the `CheckerState` it builds
+//! (see `test_utils::check_source_with_parse_health`'s doc comment), so it
+//! can neither see the parser's TS18037 nor let it suppress the checker's
+//! TS1308. These tests use the parse-health-aware helper instead, so they
+//! reflect what the compiled CLI actually reports.
+
+use crate::test_utils::check_source_codes_with_parse_health;
+
+/// #16068's literal repro: `await` in a static block reached through a
+/// `while` condition, not the block's own top-level statement.
+#[test]
+fn static_block_while_condition_await_reports_only_ts18037() {
+    let codes = check_source_codes_with_parse_health(
+        r#"
+class Gate { static { while (await 1) {} } }
+"#,
+    );
+    assert!(
+        codes.contains(&18037),
+        "tsc reports TS18037 for `await` in a class static block; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&1308),
+        "TS18037 already covers this `await`; a second TS1308 would be extra output tsc never produces; got {codes:?}"
+    );
+}
+
+/// The block's own direct top-level `await` — the shape #16068's table
+/// measured with the (parse-health-blind) plain harness and read as TS1308.
+#[test]
+fn static_block_direct_expression_statement_await_reports_only_ts18037() {
+    let codes = check_source_codes_with_parse_health(
+        r#"
+class Gate { static { await 1; } }
+"#,
+    );
+    assert!(codes.contains(&18037), "got {codes:?}");
+    assert!(!codes.contains(&1308), "got {codes:?}");
+}
+
+/// Adjacent case: `for` condition instead of `while`.
+#[test]
+fn static_block_for_condition_await_reports_only_ts18037() {
+    let codes = check_source_codes_with_parse_health(
+        r#"
+class Gate { static { for (; await 1; ) {} } }
+"#,
+    );
+    assert!(codes.contains(&18037), "got {codes:?}");
+    assert!(!codes.contains(&1308), "got {codes:?}");
+}
+
+/// Adjacent case: `switch` discriminant.
+#[test]
+fn static_block_switch_discriminant_await_reports_only_ts18037() {
+    let codes = check_source_codes_with_parse_health(
+        r#"
+class Gate { static { switch (await 1) { default: break; } } }
+"#,
+    );
+    assert!(codes.contains(&18037), "got {codes:?}");
+    assert!(!codes.contains(&1308), "got {codes:?}");
+}
+
+/// Adjacent case: `if` condition.
+#[test]
+fn static_block_if_condition_await_reports_only_ts18037() {
+    let codes = check_source_codes_with_parse_health(
+        r#"
+class Gate { static { if (await 1) {} } }
+"#,
+    );
+    assert!(codes.contains(&18037), "got {codes:?}");
+    assert!(!codes.contains(&1308), "got {codes:?}");
+}
+
+/// Renamed-binder control: different class/member names, same shape.
+#[test]
+fn static_block_while_condition_await_renamed_binders() {
+    let codes = check_source_codes_with_parse_health(
+        r#"
+class ConnectionPool { static { while (await 2) {} } }
+"#,
+    );
+    assert!(codes.contains(&18037), "got {codes:?}");
+    assert!(!codes.contains(&1308), "got {codes:?}");
+}
+
+/// Positive/fallback control: an `async` static block's `await` is legal
+/// (tsc: `static { }` blocks cannot themselves be `async`, but a nested
+/// async function's own `await` is fine and must stay clean).
+#[test]
+fn static_block_nested_async_function_await_is_clean() {
+    let codes = check_source_codes_with_parse_health(
+        r#"
+class Gate {
+    static {
+        (async () => {
+            while (await Promise.resolve(true)) {}
+        })();
+    }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&18037) && !codes.contains(&1308),
+        "an async function nested inside a static block licenses its own `await`; got {codes:?}"
+    );
+}
+
+/// Negative control: no `await` anywhere, must stay clean.
+#[test]
+fn static_block_without_await_reports_nothing() {
+    let codes = check_source_codes_with_parse_health(
+        r#"
+class Gate { static { let x = 1; while (x) { x = 0; } } }
+"#,
+    );
+    assert!(
+        !codes.contains(&18037) && !codes.contains(&1308),
+        "no `await` present; got {codes:?}"
+    );
+}


### PR DESCRIPTION
#16068 item 2 claimed that a class static block's `await`, reached through a nested `while`/`for`/`switch`/`if` (not the block's own top-level statement), reports TS1308 instead of tsc's TS18037. That read came from `test_utils::check_source_codes`, which never wires real parser diagnostics or `has_syntax_parse_errors` into the `CheckerState` it builds — so it can neither see the parser's TS18037 (emitted by `parse_await_expression`, `crates/tsz-parser/src/parser/state_expressions_unary.rs`) nor let that diagnostic suppress the checker's own TS1308 grammar walk (`check_await_expression`, `crates/tsz-checker/src/types/type_checking/core_statement_checks.rs`), which is gated on that same `has_syntax_parse_errors` flag.

**Structural rule.** When `await` is parsed while `in_static_block_context()` is set (a context flag that survives statement nesting — `while`/`for`/`switch`/`if` — and is only cleared at a function/class boundary), tsc reports exactly TS18037 and nothing else; tsz's parser already does the same, and the resulting parse diagnostic already suppresses the checker's TS1308 through `has_syntax_parse_errors`. This is already correct on current `main`; no production code changes in this PR.

I verified both the current (correct) behavior and #16068's mis-read against a live tsc oracle (`typescript@6.0.2`, vendored at `/opt/node22`) — every static-block-await shape reports only TS18037, never a second TS1308:

```
class Gate { static { while (await 1) {} } }              -> TS18037 only
class Gate { static { await 1; } }                         -> TS18037 only
class Gate { static { for (; await 1; ) {} } }              -> TS18037 only
class Gate { static { switch (await 1) { default: break; } } } -> TS18037 only
class Gate { static { if (await 1) {} } }                   -> TS18037 only
```

### What this PR adds

1. `test_utils::check_source_with_parse_health` / `check_source_codes_with_parse_health` (`crates/tsz-checker/src/test_utils.rs`): a parse-health-aware harness that wires `has_parse_errors`/`has_syntax_parse_errors`/the position vectors from the real parser diagnostics, mirroring `tsz-cli`'s `check_file.rs` and an existing local one-off pattern in `checkers/parameter_checker.rs`'s `checker_codes_with_parse_health`. Every other `test_utils` helper leaves those fields at their defaults, so any test exercising a parser-emitted diagnostic or a grammar check gated on `has_syntax_parse_errors` gets a result that doesn't match the compiled CLI. This is purely additive — no existing helper or test changed.
2. `crates/tsz-checker/src/tests/await_static_block_grammar_tests.rs` (new, 8 tests): direct statement, `while`/`for`/`switch`/`if` condition, a renamed-binder control, a nested-async-function positive control (its own `await` stays legal and clean), and a no-`await` negative control. All pinned against the tsc oracle above.

### Adjacent-case matrix

Renamed binders (`ConnectionPool`/`2` vs `Gate`/`1`), four distinct owning-statement positions (`while`, `for`, `switch`, `if`) plus the block's own direct expression statement, a positive control (async function nested in the static block licenses its own await), and a negative control (no await anywhere stays clean).

### Out of scope

#16068 item 1 (`await` in a class method/constructor/accessor body answers `[TS1375, TS1378]` instead of TS1308 — `function_depth` isn't incremented entering those bodies) is untouched and still open. Rhyolite's own filing scoped it correctly as real but larger: ten `function_depth` read sites need auditing against tsc before raising it for member bodies is safe, out of reach for this session's budget.

## Goal
Goal: hold

## Verification
- New suite `await_static_block_grammar_tests` (8 cases): all pass, each cross-checked against a live `tsc@6.0.2 --noEmit --strict --pretty false --target es2022` run (not recalled).
- `cargo test -p tsz-checker --lib --profile ci-unit await_` → 77/77 passed (no regressions in adjacent await suites).
- `cargo test -p tsz-checker --lib --profile ci-unit static_block` → 15/15 passed.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` → clean.
- `python3 scripts/arch/arch_guard.py` → `Architecture guardrails passed.`
- `cargo fmt -p tsz-checker -- --check` → clean.
- Pre-commit hook (clippy + arch guard on `-p tsz-checker`) passed locally.

Conformance/emit/fourslash not run: this PR touches only `#[cfg(test)]`-gated test code and a new `pub fn` in `test_utils.rs` that no non-test code calls, so it cannot move the corpus, emit output, or LSP behavior.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BejstmihGx1rUSGd48b7gm)_