### PR TITLE
fix(checker): treat a class member body as a function boundary

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2567,3 +2567,6 @@ path = "tests/predicate_target_return_only_sibling_tests.rs"
 [[test]]
 name = "getter_contextual_generic_call_typeparam_tests"
 path = "tests/getter_contextual_generic_call_typeparam_tests.rs"
+[[test]]
+name = "class_member_body_function_boundary_tests"
+path = "tests/class_member_body_function_boundary_tests.rs"

--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -242,7 +242,7 @@ impl<'a> CheckerState<'a> {
         right_idx: NodeIndex,
     ) {
         let right_idx = self.ctx.arena.skip_parenthesized_and_assertions(right_idx);
-        if !self.is_this_expression(right_idx) || self.ctx.function_depth != 0 {
+        if !self.is_this_expression(right_idx) || !self.ctx.directly_in_class_member_body() {
             return;
         }
 

--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -249,6 +249,7 @@ generic_excess_skip = { lifetime = "FileLocalReset", capability = "FileTypeCache
 iteration_depth = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
 switch_depth = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
 function_depth = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
+class_member_body_depth = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "function_depth baseline of the enclosing class member body; drives grammar/boundary diagnostics; clear at file-session boundary" }
 is_unreachable = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
 has_reported_unreachable = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
 label_stack = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -493,6 +493,7 @@ impl<'a> CheckerContext<'a> {
             iteration_depth: 0,
             switch_depth: 0,
             function_depth: 0,
+            class_member_body_depth: 0,
             is_unreachable: false,
             has_reported_unreachable: false,
             label_stack: Vec::new(),

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1306,6 +1306,46 @@ impl<'a> CheckerContext<'a> {
         self.async_depth > 0
     }
 
+    /// Enter the body of a class member — method, constructor, accessor, or
+    /// static block.
+    ///
+    /// `tsc` treats a class member body as a function boundary for every
+    /// grammar and name-resolution decision that asks "am I at the top level
+    /// of a file?": TS1308 / TS1103 / TS2852 for the `await` forms, TS1107 for
+    /// `break`/`continue`, and the `await(...)`-as-identifier TS2311
+    /// special case. Free function bodies already raise
+    /// [`Self::function_depth`]; member bodies used not to, so their
+    /// statements answered all of those questions as if they were top level.
+    ///
+    /// Returns the previous member-body baseline, which the caller must hand
+    /// back to [`Self::exit_class_member_body`].
+    pub const fn enter_class_member_body(&mut self) -> u32 {
+        self.function_depth += 1;
+        let saved = self.class_member_body_depth;
+        self.class_member_body_depth = self.function_depth;
+        saved
+    }
+
+    /// Leave a class member body entered by [`Self::enter_class_member_body`].
+    pub const fn exit_class_member_body(&mut self, saved: u32) {
+        self.function_depth -= 1;
+        self.class_member_body_depth = saved;
+    }
+
+    /// True when checking is running directly in the enclosing class member's
+    /// body rather than inside a function nested within it.
+    ///
+    /// The abstract-property-access checks (TS2715) need this narrower
+    /// question than [`Self::function_depth`] alone can answer: `tsc` reports
+    /// `this.abstractProp` in a constructor body but not in a function
+    /// declared inside that constructor. Outside any member body both sides
+    /// are `0`, which keeps class *property initializers* — checked at the
+    /// class body's own depth, not in a member body — answering `true` as
+    /// they did before.
+    pub const fn directly_in_class_member_body(&self) -> bool {
+        self.function_depth == self.class_member_body_depth
+    }
+
     /// Consume one unit of type resolution fuel.
     /// Returns true if fuel is still available, false if exhausted.
     /// When exhausted, type resolution should return ERROR to prevent timeout.

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -429,6 +429,7 @@ impl<'a> CheckerContext<'a> {
         self.iteration_depth = 0;
         self.switch_depth = 0;
         self.function_depth = 0;
+        self.class_member_body_depth = 0;
         self.is_unreachable = false;
         self.has_reported_unreachable = false;
         self.label_stack.clear();

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -1876,6 +1876,18 @@ pub struct CheckerContext<'a> {
     /// Used to detect when labeled jumps cross function boundaries.
     pub function_depth: u32,
 
+    /// The [`Self::function_depth`] at which the innermost enclosing class
+    /// member body (method, constructor, accessor, or static block) was
+    /// entered; `0` when no class member body is being checked.
+    ///
+    /// A class member body is a function boundary — it raises
+    /// `function_depth` like any other function body — but the
+    /// abstract-property-access checks (TS2715) need the narrower question
+    /// "is this statement directly in the member body, or in a function
+    /// nested inside it?". Comparing against this baseline answers that
+    /// without a second notion of "function".
+    pub(crate) class_member_body_depth: u32,
+
     /// Track whether current code path is syntactically unreachable.
     pub is_unreachable: bool,
 

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_constructor_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_constructor_checks.rs
@@ -294,7 +294,9 @@ impl<'a> CheckerState<'a> {
             // SymbolId), the parameter type cached earlier gets erased. Re-caching
             // ensures the parameter type is available for initializer evaluation.
             self.cache_parameter_types(&ctor.parameters.nodes, None);
+            let saved_member_body_depth = self.ctx.enter_class_member_body();
             self.check_statement_with_request(ctor.body, &body_request);
+            self.ctx.exit_class_member_body(saved_member_body_depth);
             self.pop_return_type();
 
             // TS2377: Constructors for derived classes must contain a super() call.

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -1034,7 +1034,9 @@ impl<'a> CheckerState<'a> {
 
             let body_request = request.read().contextual_opt(None);
             self.clear_type_cache_recursive(method.body);
+            let saved_member_body_depth = self.ctx.enter_class_member_body();
             self.check_statement_with_request(method.body, &body_request);
+            self.ctx.exit_class_member_body(saved_member_body_depth);
 
             self.ctx.restore_async_context(saved_async_depth);
 
@@ -1505,7 +1507,9 @@ impl<'a> CheckerState<'a> {
 
             let body_request = request.read().contextual_opt(None);
             self.clear_type_cache_recursive(accessor.body);
+            let saved_member_body_depth = self.ctx.enter_class_member_body();
             self.check_statement_with_request(accessor.body, &body_request);
+            self.ctx.exit_class_member_body(saved_member_body_depth);
             if is_getter {
                 // Check if this is an async getter
                 let is_async = self.has_async_modifier(&accessor.modifiers);

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -1361,7 +1361,7 @@ impl<'a> CheckerState<'a> {
                     }
                     self.ctx.iteration_depth = 0;
                     self.ctx.switch_depth = 0;
-                    self.ctx.function_depth += 1;
+                    let saved_member_body_depth = self.ctx.enter_class_member_body();
                     // Check each statement in the block
                     for &stmt_idx in &block.statements.nodes {
                         let body_request = request.read().contextual_opt(None);
@@ -1372,7 +1372,7 @@ impl<'a> CheckerState<'a> {
                     }
                     self.ctx.iteration_depth = saved_cf_context.0;
                     self.ctx.switch_depth = saved_cf_context.1;
-                    self.ctx.function_depth -= 1;
+                    self.ctx.exit_class_member_body(saved_member_body_depth);
                     self.ctx.label_stack.truncate(saved_cf_context.2);
                     self.ctx.had_outer_loop = saved_cf_context.3;
                     self.ctx.is_unreachable = prev_unreachable;

--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -1394,7 +1394,7 @@ impl<'a> CheckerState<'a> {
 
         if let Some(ref prop_name_str) = property_name {
             if self.binding_pattern_direct_source_is_this(pattern_idx)
-                && self.ctx.function_depth == 0
+                && self.ctx.directly_in_class_member_body()
                 && let Some(class_info) = self.ctx.enclosing_class.as_ref()
                 && class_info.in_constructor
                 && let Some(declaring_class_name) =

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -183,7 +183,7 @@ impl<'a> CheckerState<'a> {
 
             if self.is_this_expression(access.expression)
                 && let Some(ref class_info) = self.ctx.enclosing_class.clone()
-                && self.ctx.function_depth == 0
+                && self.ctx.directly_in_class_member_body()
                 && (class_info.in_constructor || self.is_in_instance_property_initializer(idx))
                 && let Some(declaring_class_name) =
                     self.find_abstract_property_declaring_class(class_info.class_idx, property_name)

--- a/crates/tsz-checker/tests/class_member_body_function_boundary_tests.rs
+++ b/crates/tsz-checker/tests/class_member_body_function_boundary_tests.rs
@@ -1,0 +1,382 @@
+//! A class member body is a function boundary.
+//!
+//! `tsc` treats the body of a class **method**, **constructor**, **get
+//! accessor**, **set accessor** and **static block** as a function boundary for
+//! every grammar and name-resolution decision that asks "am I at the top level
+//! of a file?":
+//!
+//! | construct | inside a class member body | at file top level |
+//! | --- | --- | --- |
+//! | `await x` | TS1308 | TS1375 / TS1378 |
+//! | `await using x = …` | TS2852 | TS2853 / TS2854 |
+//! | `await(x)` in a script | TS2311 | TS1375 / TS1378 |
+//! | `break;` / `continue;` | TS1107 | TS1105 / TS1104 |
+//!
+//! tsz raised `ctx.function_depth` for free function bodies and static blocks
+//! but not for method/constructor/accessor bodies, so every one of those rows
+//! answered with the *top-level* diagnostic instead. The fix routes all four
+//! member-body entries through `enter_class_member_body`.
+//!
+//! The one check that needs the narrower "directly in this member body"
+//! question is the abstract-property-access family (TS2715): `tsc` reports
+//! `this.abstractProp` in a constructor body but **not** inside a function
+//! nested in that constructor. Those readers compare against the member-body
+//! baseline rather than absolute depth 0, and the last section pins both
+//! directions.
+//!
+//! Every expectation below was taken from `tsc@7.0.2`
+//! (`--noEmit --strict --pretty false --target es2022 --module esnext`).
+//! The rule keys only on syntactic nesting, so binder spellings are varied in
+//! the renamed-binder controls and never drive a decision.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+use tsz_common::common::{ModuleKind, ScriptTarget};
+
+/// Diagnostic codes for `source` under a module/target that supports
+/// top-level `await`, so the top-level branch is distinguishable by code
+/// rather than by count.
+fn codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            target: ScriptTarget::ES2022,
+            ..CheckerOptions::default()
+        },
+    )
+    .iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+fn has(source: &str, code: u32) -> bool {
+    codes(source).contains(&code)
+}
+
+/// Count occurrences so a cardinality claim is not satisfied by membership
+/// alone.
+fn count(source: &str, code: u32) -> usize {
+    codes(source).iter().filter(|c| **c == code).count()
+}
+
+const AWAIT_OUTSIDE_ASYNC: u32 = 1308;
+const TOP_LEVEL_AWAIT_NEEDS_MODULE: u32 = 1375;
+const TOP_LEVEL_AWAIT_NEEDS_OPTIONS: u32 = 1378;
+const AWAIT_USING_OUTSIDE_ASYNC: u32 = 2852;
+const TOP_LEVEL_AWAIT_USING_NEEDS_MODULE: u32 = 2853;
+const JUMP_CROSSES_FUNCTION_BOUNDARY: u32 = 1107;
+const BREAK_NEEDS_ENCLOSING_ITERATION: u32 = 1105;
+const CONTINUE_NEEDS_ENCLOSING_ITERATION: u32 = 1104;
+const ABSTRACT_PROPERTY_IN_CONSTRUCTOR: u32 = 2715;
+
+// ---------------------------------------------------------------------------
+// `await` in a class member body — TS1308, not the top-level pair.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn await_in_method_body_reports_ts1308() {
+    let source = "class K { m() { await 1; } }";
+    assert!(
+        has(source, AWAIT_OUTSIDE_ASYNC),
+        "codes: {:?}",
+        codes(source)
+    );
+    assert!(!has(source, TOP_LEVEL_AWAIT_NEEDS_MODULE));
+    assert!(!has(source, TOP_LEVEL_AWAIT_NEEDS_OPTIONS));
+}
+
+#[test]
+fn await_in_constructor_body_reports_ts1308() {
+    let source = "class K { constructor() { await 1; } }";
+    assert!(
+        has(source, AWAIT_OUTSIDE_ASYNC),
+        "codes: {:?}",
+        codes(source)
+    );
+    assert!(!has(source, TOP_LEVEL_AWAIT_NEEDS_MODULE));
+}
+
+#[test]
+fn await_in_get_accessor_body_reports_ts1308() {
+    let source = "class K { get g(): number { await 1; return 1; } }";
+    assert!(
+        has(source, AWAIT_OUTSIDE_ASYNC),
+        "codes: {:?}",
+        codes(source)
+    );
+    assert!(!has(source, TOP_LEVEL_AWAIT_NEEDS_MODULE));
+}
+
+#[test]
+fn await_in_set_accessor_body_reports_ts1308() {
+    let source = "class K { set s(v: number) { await 1; } }";
+    assert!(
+        has(source, AWAIT_OUTSIDE_ASYNC),
+        "codes: {:?}",
+        codes(source)
+    );
+    assert!(!has(source, TOP_LEVEL_AWAIT_NEEDS_MODULE));
+}
+
+/// The member-body rule is syntactic: renaming the class, the method and the
+/// awaited binding changes nothing.
+#[test]
+fn await_in_renamed_member_body_reports_ts1308() {
+    let source = "const zzz = 1; class QqqWidget { performOperation() { await zzz; } }";
+    assert!(
+        has(source, AWAIT_OUTSIDE_ASYNC),
+        "codes: {:?}",
+        codes(source)
+    );
+    assert!(!has(source, TOP_LEVEL_AWAIT_NEEDS_MODULE));
+}
+
+/// A class *expression*'s member body is the same boundary as a declaration's.
+#[test]
+fn await_in_class_expression_method_body_reports_ts1308() {
+    let source = "const C = class { m() { await 1; } };";
+    assert!(
+        has(source, AWAIT_OUTSIDE_ASYNC),
+        "codes: {:?}",
+        codes(source)
+    );
+    assert!(!has(source, TOP_LEVEL_AWAIT_NEEDS_MODULE));
+}
+
+// ---------------------------------------------------------------------------
+// Sibling `await` forms take the same branch.
+//
+// `for await` is deliberately absent: tsz never emits TS1103 from any
+// non-async function body — free functions included — so a member body cannot
+// be made to answer it by fixing the boundary alone. Filed separately.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn await_using_in_method_body_reports_ts2852() {
+    let source = "class K { m() { await using x = null as any; } }";
+    assert!(
+        has(source, AWAIT_USING_OUTSIDE_ASYNC),
+        "codes: {:?}",
+        codes(source)
+    );
+    assert!(!has(source, TOP_LEVEL_AWAIT_USING_NEEDS_MODULE));
+}
+
+// ---------------------------------------------------------------------------
+// `break` / `continue` cross a function boundary out of a member body.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unlabeled_break_in_method_body_reports_ts1107() {
+    let source = "class K { m() { break; } }";
+    assert!(
+        has(source, JUMP_CROSSES_FUNCTION_BOUNDARY),
+        "codes: {:?}",
+        codes(source)
+    );
+    assert!(!has(source, BREAK_NEEDS_ENCLOSING_ITERATION));
+}
+
+#[test]
+fn unlabeled_continue_in_method_body_reports_ts1107() {
+    let source = "class K { m() { continue; } }";
+    assert!(
+        has(source, JUMP_CROSSES_FUNCTION_BOUNDARY),
+        "codes: {:?}",
+        codes(source)
+    );
+    assert!(!has(source, CONTINUE_NEEDS_ENCLOSING_ITERATION));
+}
+
+#[test]
+fn unlabeled_break_in_constructor_body_reports_ts1107() {
+    let source = "class K { constructor() { break; } }";
+    assert!(
+        has(source, JUMP_CROSSES_FUNCTION_BOUNDARY),
+        "codes: {:?}",
+        codes(source)
+    );
+}
+
+/// A `break` that *does* have a target inside the same member body stays
+/// clean — the boundary must not turn well-formed jumps into errors.
+#[test]
+fn labeled_break_within_member_body_stays_clean() {
+    let source = "class K { m() { outer: for (;;) { break outer; } } }";
+    assert!(
+        !has(source, JUMP_CROSSES_FUNCTION_BOUNDARY),
+        "codes: {:?}",
+        codes(source)
+    );
+    assert!(!has(source, BREAK_NEEDS_ENCLOSING_ITERATION));
+}
+
+#[test]
+fn break_inside_member_body_loop_stays_clean() {
+    let source = "class K { m() { for (;;) { break; } } }";
+    assert!(
+        !has(source, JUMP_CROSSES_FUNCTION_BOUNDARY),
+        "codes: {:?}",
+        codes(source)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Controls that were already correct and must stay correct.
+// ---------------------------------------------------------------------------
+
+/// An object-literal method body was already a function body on the generic
+/// path — it never went through the class-member entry.
+#[test]
+fn await_in_object_literal_method_reports_ts1308() {
+    let source = "const o = { m() { await 1; } };";
+    assert!(
+        has(source, AWAIT_OUTSIDE_ASYNC),
+        "codes: {:?}",
+        codes(source)
+    );
+}
+
+/// A plain function nested in a method body: already TS1308 before the fix,
+/// and still exactly one diagnostic after it — the two nested boundaries must
+/// not report twice.
+#[test]
+fn await_in_function_nested_in_method_reports_one_ts1308() {
+    let source = "class K { m() { function inner() { await 1; } } }";
+    assert_eq!(
+        count(source, AWAIT_OUTSIDE_ASYNC),
+        1,
+        "codes: {:?}",
+        codes(source)
+    );
+}
+
+/// File top level is unchanged: still the top-level pair, not TS1308.
+#[test]
+fn await_at_file_top_level_still_reports_the_top_level_pair() {
+    let source = "await 1;";
+    assert!(
+        has(source, TOP_LEVEL_AWAIT_NEEDS_MODULE),
+        "codes: {:?}",
+        codes(source)
+    );
+    assert!(!has(source, AWAIT_OUTSIDE_ASYNC));
+}
+
+#[test]
+fn break_at_file_top_level_still_reports_ts1105() {
+    let source = "break;";
+    assert!(
+        has(source, BREAK_NEEDS_ENCLOSING_ITERATION),
+        "codes: {:?}",
+        codes(source)
+    );
+    assert!(!has(source, JUMP_CROSSES_FUNCTION_BOUNDARY));
+}
+
+/// An `async` member body has no grammar error at all — the boundary changes
+/// which diagnostic a *non-async* body gets, never whether a legal `await`
+/// becomes illegal.
+#[test]
+fn await_in_async_method_body_stays_clean() {
+    let source = "class K { async m() { await 1; } }";
+    assert!(
+        !has(source, AWAIT_OUTSIDE_ASYNC),
+        "codes: {:?}",
+        codes(source)
+    );
+    assert!(!has(source, TOP_LEVEL_AWAIT_NEEDS_MODULE));
+}
+
+#[test]
+fn await_in_async_constructor_adjacent_accessor_stays_clean() {
+    let source = "class K { async m() { await 1; } get g(): number { return 1; } }";
+    assert!(
+        !has(source, AWAIT_OUTSIDE_ASYNC),
+        "codes: {:?}",
+        codes(source)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TS2715 keeps the narrower "directly in this member body" question.
+// ---------------------------------------------------------------------------
+
+/// Positive: `this.p` directly in the constructor body still reports TS2715.
+/// This is the check that a blind `function_depth` bump would have silenced.
+#[test]
+fn abstract_property_read_in_constructor_still_reports_ts2715() {
+    let source = "abstract class A { abstract p: number; }\n\
+                  class B extends A { constructor() { super(); this.p; } }";
+    assert!(
+        has(source, ABSTRACT_PROPERTY_IN_CONSTRUCTOR),
+        "codes: {:?}",
+        codes(source)
+    );
+}
+
+/// Same, through a binding-pattern destructure of `this`.
+#[test]
+fn abstract_property_destructured_from_this_in_constructor_still_reports_ts2715() {
+    let source = "abstract class A { abstract p: number; }\n\
+                  class B extends A { constructor() { super(); const { p } = this; } }";
+    assert!(
+        has(source, ABSTRACT_PROPERTY_IN_CONSTRUCTOR),
+        "codes: {:?}",
+        codes(source)
+    );
+}
+
+/// Renamed-binder control for the positive case.
+#[test]
+fn abstract_property_read_in_constructor_renamed_binders_reports_ts2715() {
+    let source = "abstract class ShapeBase { abstract areaValue: number; }\n\
+                  class Square extends ShapeBase { constructor() { super(); this.areaValue; } }";
+    assert!(
+        has(source, ABSTRACT_PROPERTY_IN_CONSTRUCTOR),
+        "codes: {:?}",
+        codes(source)
+    );
+}
+
+/// Negative: a function *nested* inside the constructor is past the member
+/// body baseline, and `tsc` reports nothing there. This is the direction that
+/// `function_depth == 0` used to protect and that the baseline comparison now
+/// protects.
+#[test]
+fn abstract_property_read_in_function_nested_in_constructor_stays_clean() {
+    let source = "abstract class A { abstract p: number; }\n\
+                  class B extends A { constructor() { super(); function f(this: B) { this.p; } } }";
+    assert!(
+        !has(source, ABSTRACT_PROPERTY_IN_CONSTRUCTOR),
+        "codes: {:?}",
+        codes(source)
+    );
+}
+
+/// An instance property initializer is checked at the class body's own depth,
+/// not inside a member body, so it must keep reporting TS2715.
+#[test]
+fn abstract_property_read_in_instance_property_initializer_reports_ts2715() {
+    let source = "abstract class A { abstract p: number; }\n\
+                  class B extends A { q = this.p; }";
+    assert!(
+        has(source, ABSTRACT_PROPERTY_IN_CONSTRUCTOR),
+        "codes: {:?}",
+        codes(source)
+    );
+}
+
+/// A method body is not a constructor body, so an abstract read there is
+/// legal — the baseline must not turn every member body into a constructor.
+#[test]
+fn abstract_property_read_in_method_body_stays_clean() {
+    let source = "abstract class A { abstract p: number; m() { return this.p; } }";
+    assert!(
+        !has(source, ABSTRACT_PROPERTY_IN_CONSTRUCTOR),
+        "codes: {:?}",
+        codes(source)
+    );
+}

--- a/crates/tsz-checker/tests/class_member_body_function_boundary_tests.rs
+++ b/crates/tsz-checker/tests/class_member_body_function_boundary_tests.rs
@@ -9,8 +9,12 @@
 //! | --- | --- | --- |
 //! | `await x` | TS1308 | TS1375 / TS1378 |
 //! | `await using x = …` | TS2852 | TS2853 / TS2854 |
-//! | `await(x)` in a script | TS2311 | TS1375 / TS1378 |
 //! | `break;` / `continue;` | TS1107 | TS1105 / TS1104 |
+//!
+//! (`for await` and the `await(x)`-as-identifier TS2311 special case belong to
+//! the same family but are *silent* in tsz from every function body, member or
+//! free, so the boundary alone cannot make them answer. Both are tracked in
+//! #16071 rather than pinned red here.)
 //!
 //! tsz raised `ctx.function_depth` for free function bodies and static blocks
 //! but not for method/constructor/accessor bodies, so every one of those rows


### PR DESCRIPTION
Fixes **item 1 of #16068** — the half Rhyolite filed as "not a one-line fix, ten other `function_depth` readers need auditing first" and that ClaudeDE explicitly declined when taking item 2. The audit is done; the answer is unusually clean.

**Structural rule.** When a statement sits in the body of a class **method**, **constructor**, **get/set accessor** or **static block**, `tsc` treats it as being inside a function boundary for every grammar and name-resolution decision that asks *"am I at the top level of a file?"*; tsz now does the same through the checker's four member-body entry points, which route via `CheckerContext::enter_class_member_body`.

tsz raised `ctx.function_depth` for free function bodies (`function_type.rs`, `function_declaration_checks.rs`) and for static blocks (`member_declaration_checks.rs`), but the `METHOD_DECLARATION` / `CONSTRUCTOR` / `GET_ACCESSOR` / `SET_ACCESSOR` arms delegate to `ambient_signature_checks.rs` / `ambient_constructor_checks.rs`, which check the body without it. So a class member body answered every one of those questions as if it were file top level:

| source | tsz before | tsc 7.0.2 | tsz after |
| --- | --- | --- | --- |
| `class K { m() { await 1; } }` | TS1375 + TS1378 | **TS1308** | TS1308 |
| `class K { constructor() { await 1; } }` | TS1375 + TS1378 | **TS1308** | TS1308 |
| `class K { get g(): number { await 1; return 1; } }` | TS1375 + TS1378 | **TS1308** | TS1308 |
| `class K { set s(v: number) { await 1; } }` | TS1375 + TS1378 | **TS1308** | TS1308 |
| `class K { m() { await using x = null as any; } }` | TS2853 | **TS2852** | TS2852 |
| `class K { m() { break; } }` | TS1105 | **TS1107** | TS1107 |
| `class K { m() { continue; } }` | TS1104 | **TS1107** | TS1107 |
| `const o = { m() { await 1; } };` | TS1308 ✅ | TS1308 | TS1308 |
| `class K { m() { function inner() { await 1; } } }` | TS1308 ✅ | TS1308 | TS1308 (×1) |
| `await 1;` (top level) | TS1375 ✅ | TS1375 | TS1375 |
| `break;` (top level) | TS1105 ✅ | TS1105 | TS1105 |

### The reader audit

`function_depth` is read by ten decision sites outside the increment points. Every one of them wants a member body to count as a function boundary — **except** the abstract-property-access family (TS2715), which needs the narrower question "am I *directly* in this member body, or in a function nested inside it?". `tsc` reports `this.abstractProp` in a constructor body but not inside a function declared in that constructor, and those three readers (`property_access_type/resolve.rs`, `assignment_checker/destructuring.rs`, `variable_checking/destructuring.rs`) were using `function_depth == 0` to express it — correct only because member bodies never incremented.

Rather than add a second notion of "function", `enter_class_member_body` records the depth at which the member body was entered, and those three readers ask `directly_in_class_member_body()` (`function_depth == class_member_body_depth`). Outside any member body both sides are `0`, so class *property initializers* — checked at the class body's own depth, not in a member body — keep answering `true` exactly as before.

### Adjacent-case matrix

`crates/tsz-checker/tests/class_member_body_function_boundary_tests.rs`, 24 cases, every expectation taken from a live `tsc@7.0.2` (`--noEmit --strict --pretty false --target es2022 --module esnext`):

- all four member kinds × `await`; class **expression** member body; **renamed-binder** control (`QqqWidget.performOperation`, `zzz`) so no identifier spelling drives the rule
- `await using` sibling form
- `break` / `continue` unlabeled in method and constructor; **negative controls** — a labeled break with a target inside the same body, and a break inside a loop inside the body — both must stay clean
- already-correct controls that must not regress: object-literal method, plain function nested in a method (**counted**, not `contains`, so the two nested boundaries cannot start double-reporting unnoticed), file top level for both `await` and `break`, `async` member bodies stay clean
- TS2715 both directions: positive in constructor body (direct read, `this` destructure, renamed binders), positive in an instance property initializer, negative inside a function nested in the constructor, negative in an ordinary method body

### Deliberately out of scope

Four cases I wrote from the oracle and then removed, because they fail **identically with and without this diff** and belong to other work — recorded here so nobody re-derives them:

- `class K { m() { while (await 1) {} } }` and `class K { m(): never { throw await 1; } }` report **nothing** on `main`. The `while`-condition and `throw`-operand await-grammar roots are added by #16067, which is still open. Once it lands these become TS1308 for free via this change. (Note: #16068's table lists them as `[1375, 1378]` — that row was measured on #16067's branch, not on `main`.)
- `for await` outside async in a class member reports nothing — but so does `function f() { for await (const x of []) {} }`. **tsz never emits TS1103 from any non-async function body**: `check_for_await_statement` returns silently on the `function_depth > 0` path unless the enclosing scope is a static block. The message exists in the table (`part_000.rs:78`) and is emitted nowhere.
- `class K { m() { await(1); } }` reports nothing where tsc reports TS2311. The `await(x)`-as-identifier special case in `access_await.rs:63` is gated on `function_depth > 0`, so this diff satisfies its depth condition — and it still does not fire, which means the block is not reached or one of its other two conditions does not hold. Not chased further.

Both silent-path gaps are filed as **#16071** rather than widening this PR into new diagnostics firing corpus-wide unmeasured. They are invisible to conformance either way: missing diagnostics count as passes.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --profile ci-unit --test class_member_body_function_boundary_tests` — **two-sided against this PR's own parent `ea950e9`**, production diff stashed with the tests kept: **14 passed / 10 failed → 24 passed / 0 failed**. The 10 that flip are the member-body rows of the table above; the 14 that already passed are the controls.
- `cargo fmt` + `cargo clippy` (workspace, warnings denied) — clean, via the repo pre-commit hook on both commits.
- Architecture guard — clean; the new `CheckerContext` field is registered in `checker_context_lifetimes.toml` (T2.1.A inventory).
- **`cargo test -p tsz-checker --lib` — NOT COMPLETED in this container.** Correcting my own first version of this section, which claimed "no delta vs main": the run was still linking when I wrote that and it then died in this container's disk-pressure window without producing output. I have relaunched it, but I am not going to assert a number I did not see. Anyone landing this should treat the `--lib` suite as unmeasured from my seat. (Known-good context from another session tonight: `--lib` has 9 pre-existing failures on `main`, per ClaudeT's 15:04Z board note.)
- **Not run in this container:** conformance and emit. This is a cold hourly container with no TypeScript submodule, and `compare-to-parent.sh` needs the corpus. The change makes previously-silent-or-wrong grammar diagnostics fire on class member bodies across the corpus, so a two-sided `scripts/conformance/compare-to-parent.sh` against `ea950e9` from a warm seat is the right gate before this lands — same request Rhyolite and Feldspar made for #16058/#16061/#16067.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Obsidian