### PR TITLE
fix(checker): add a distinct top-level-await container query for #16072

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -589,6 +589,9 @@ mod this_prop_nullish_operand_code_tests;
 #[path = "../tests/this_type_tests.rs"]
 mod this_type_tests;
 #[cfg(test)]
+#[path = "tests/top_level_await_boundary_tests.rs"]
+mod top_level_await_boundary_tests;
+#[cfg(test)]
 #[path = "../tests/ts1214_let_strict_mode_tests.rs"]
 mod ts1214_let_strict_mode_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/symbols/scope_finder_contexts.rs
+++ b/crates/tsz-checker/src/symbols/scope_finder_contexts.rs
@@ -1034,6 +1034,52 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// True when `idx`'s nearest enclosing container is the source file
+    /// itself — the predicate `tsc`'s grammar checks use to choose between
+    /// the top-level `await`/`await using` diagnostics (TS1375/TS1378,
+    /// TS2853/TS2854) and the non-top-level ones (TS1308, TS2852).
+    ///
+    /// This is a narrower and distinct question from
+    /// [`crate::context::CheckerContext::function_depth`], which tracks the
+    /// jump-statement (`break`/`continue`) boundary: a namespace body, a
+    /// class property initializer, and a parameter default value each
+    /// disqualify a node from being top-level without being function-like,
+    /// so `function_depth` alone (which only rises at function-like body
+    /// entry) cannot answer this. Do not widen `function_depth` to cover
+    /// these — that would re-break the TS2715 family, which relies on
+    /// property initializers and parameter defaults being checked at the
+    /// class body's own depth.
+    pub(crate) fn is_directly_at_source_file_top_level(&self, idx: NodeIndex) -> bool {
+        let mut current = idx;
+        let mut iterations = 0;
+        loop {
+            iterations += 1;
+            if iterations > MAX_TREE_WALK_ITERATIONS {
+                return false;
+            }
+            let Some(ext) = self.ctx.arena.get_extended(current) else {
+                return false;
+            };
+            let parent = ext.parent;
+            let Some(parent_node) = self.ctx.arena.get(parent) else {
+                return false;
+            };
+            if parent_node.kind == syntax_kind_ext::SOURCE_FILE {
+                return true;
+            }
+            if parent_node.is_function_like()
+                || parent_node.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION
+                || parent_node.kind == syntax_kind_ext::MODULE_BLOCK
+                || parent_node.kind == syntax_kind_ext::MODULE_DECLARATION
+                || parent_node.kind == syntax_kind_ext::PROPERTY_DECLARATION
+                || parent_node.kind == syntax_kind_ext::PARAMETER
+            {
+                return false;
+            }
+            current = parent;
+        }
+    }
+
     // =========================================================================
     // Class Field / Static Block Arguments Check (TS2815)
     // =========================================================================

--- a/crates/tsz-checker/src/tests/top_level_await_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/top_level_await_boundary_tests.rs
@@ -1,0 +1,140 @@
+//! Regression coverage for #16072's "wrong branch" half: two constructs
+//! disqualify a node from being "directly at the top level of the source
+//! file" for the `await` / `await using` grammar question, without being
+//! function-like and without affecting `function_depth`'s own
+//! `break`/`continue` jump-boundary question (#16070) — a class property
+//! initializer and a namespace body.
+//!
+//! Before this fix `check_await_expression`
+//! (`crates/tsz-checker/src/types/type_checking/core_statement_checks.rs`)
+//! and the `await using` check
+//! (`crates/tsz-checker/src/types/type_checking/core.rs`) both used
+//! `function_depth == 0` as "am I at the top level of the file", which is
+//! only true incidentally: these two containers never bump
+//! `function_depth`, so a non-async `await` inside them wrongly took the
+//! top-level branch (TS1375/TS1378, or TS2853/TS2854 for `await using`)
+//! instead of tsc's TS1308 (TS2852 for `await using`).
+//!
+//! #16072's other two rows — `await` in a method/constructor parameter
+//! default — are a *different*, deeper bug (not covered here): tsz's
+//! `parse_await_expression` (`crates/tsz-parser/src/parser/state_expressions_unary.rs:190-192`)
+//! deliberately excludes `in_parameter_default_context()` from
+//! `AwaitExpression` construction outside an async context, so no AST node
+//! exists for this checker-level walk to visit — `await` parses as a bare
+//! `Identifier` there instead, and the observed TS2524 comes from a wholly
+//! separate special-case in identifier resolution
+//! (`crates/tsz-checker/src/types/computation/identifier/resolution.rs:404-413`),
+//! not from a grammar walk. That is parser-owned, filed separately as
+//! #16078.
+//!
+//! Every expectation here is pinned against a live `tsc@7.0.2 --noEmit
+//! --strict --pretty false --target es2022 --module esnext` run, not
+//! recalled.
+
+use crate::test_utils::check_source_codes;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_codes(source)
+}
+
+// --- class property initializers ---
+
+#[test]
+fn instance_property_initializer_await_reports_ts1308_not_ts1375() {
+    let out = codes("class K { p = await 1; }");
+    assert!(out.contains(&1308), "got {out:?}");
+    assert!(!out.contains(&1375), "got {out:?}");
+    assert!(!out.contains(&1378), "got {out:?}");
+}
+
+#[test]
+fn static_property_initializer_await_reports_ts1308_not_ts1375() {
+    let out = codes("class K { static p = await 1; }");
+    assert!(out.contains(&1308), "got {out:?}");
+    assert!(!out.contains(&1375), "got {out:?}");
+    assert!(!out.contains(&1378), "got {out:?}");
+}
+
+/// Renamed-binder control: different class/property names, different
+/// awaited literal.
+#[test]
+fn instance_property_initializer_await_reports_ts1308_renamed_binders() {
+    let out = codes("class Gate { ready = await 2; }");
+    assert!(out.contains(&1308), "got {out:?}");
+    assert!(!out.contains(&1375), "got {out:?}");
+}
+
+// --- namespace bodies ---
+
+#[test]
+fn namespace_body_await_reports_ts1308_not_ts1375() {
+    let out = codes("namespace N { await 1; }");
+    assert!(out.contains(&1308), "got {out:?}");
+    assert!(!out.contains(&1375), "got {out:?}");
+    assert!(!out.contains(&1378), "got {out:?}");
+}
+
+/// Renamed-binder control for the namespace case.
+#[test]
+fn namespace_body_await_reports_ts1308_renamed_binders() {
+    let out = codes("namespace Config { await 1; }");
+    assert!(out.contains(&1308), "got {out:?}");
+    assert!(!out.contains(&1375), "got {out:?}");
+}
+
+/// `await using` inside a namespace body: tsc reports TS2852 (the
+/// non-top-level form), not TS2853/TS2854 (the top-level-only forms).
+#[test]
+fn namespace_body_await_using_reports_ts2852_not_ts2853() {
+    let out = codes(
+        r"
+namespace N { await using x = getResource(); }
+function getResource(): any { return {}; }
+",
+    );
+    assert!(out.contains(&2852), "got {out:?}");
+    assert!(!out.contains(&2853), "got {out:?}");
+    assert!(!out.contains(&2854), "got {out:?}");
+}
+
+// --- negative controls: unaffected constructs stay unaffected ---
+
+/// A genuine top-level `await` outside a module still reports TS1375 — the
+/// new walk-based query must still say "yes, this is at the top level of
+/// the file" for the file's own direct statements.
+#[test]
+fn genuine_top_level_await_still_reports_ts1375() {
+    let out = codes("await 1;");
+    assert!(out.contains(&1375), "got {out:?}");
+    assert!(!out.contains(&1308), "got {out:?}");
+}
+
+/// `namespace N { break; }` is still TS1105 (a namespace body IS a
+/// `break`/`continue` top-level boundary) — the jump-boundary question owned
+/// by `function_depth` must stay untouched by this fix.
+#[test]
+fn namespace_body_break_still_reports_ts1105() {
+    let out = codes("namespace N { break; }");
+    assert!(out.contains(&1105), "got {out:?}");
+}
+
+/// A non-async method body's own direct `await` (not inside a nested
+/// initializer/default) is unaffected: still the ordinary TS1308 through the
+/// pre-existing `function_depth > 0` path.
+#[test]
+fn method_body_await_still_reports_ts1308() {
+    let out = codes("class K { m() { await 1; } }");
+    assert!(out.contains(&1308), "got {out:?}");
+    assert!(!out.contains(&1375), "got {out:?}");
+}
+
+/// A class static block's own direct `await` never takes the top-level
+/// branch (TS1375/TS1378) — `function_depth > 0` from
+/// `enter_class_member_body` routes it away from the new walk entirely,
+/// same as an ordinary method body.
+#[test]
+fn static_block_await_does_not_report_ts1375() {
+    let out = codes("class K { static { await 1; } }");
+    assert!(!out.contains(&1375), "got {out:?}");
+    assert!(!out.contains(&1378), "got {out:?}");
+}

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1572,7 +1572,7 @@ impl<'a> CheckerState<'a> {
         if is_await_using {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
 
-            if self.ctx.function_depth == 0 {
+            if self.is_directly_at_source_file_top_level(list_idx) {
                 // TS2853: Top-level 'await using' is only valid in modules.
                 if !self.ctx.is_external_module_file() {
                     self.error_at_node(

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -595,8 +595,13 @@ impl<'a> CheckerState<'a> {
                     if !self.ctx.in_async_context() && !self.ctx.has_syntax_parse_errors {
                         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
 
-                        // Check if we're at top level of a module
-                        let at_top_level = self.ctx.function_depth == 0;
+                        // Check if we're directly at the top level of the
+                        // source file. This is a distinct question from
+                        // `function_depth == 0`: a namespace body, a class
+                        // property initializer, and a parameter default
+                        // value all disqualify a node from being top-level
+                        // without being function-like.
+                        let at_top_level = self.is_directly_at_source_file_top_level(current_idx);
 
                         if at_top_level {
                             // tsc's `checkAwaitExpression` emits these two


### PR DESCRIPTION
`check_await_expression` (`crates/tsz-checker/src/types/type_checking/core_statement_checks.rs`) and the `await using` check (`crates/tsz-checker/src/types/type_checking/core.rs`) both used `function_depth == 0` to decide "am I at the top level of the file". That is only true incidentally: a class property initializer and a namespace body never bump `function_depth` (only function-like bodies do, per #16070), so a non-async `await` inside them wrongly took the top-level branch (TS1375/TS1378, or TS2853/TS2854 for `await using`) instead of tsc's TS1308 (TS2852 for `await using`).

**Structural rule.** When an `await` (or `await using`) grammar check's node has a namespace body or a class property initializer as its nearest enclosing container, `tsc` reports the non-top-level diagnostic (TS1308 / TS2852) because that node is not directly at the top level of the source file; tsz now answers the same "am I at the top level of the file" question through a dedicated walk-based query, `CheckerState::is_directly_at_source_file_top_level` (`crates/tsz-checker/src/symbols/scope_finder_contexts.rs`), instead of conflating it with `function_depth`'s jump-boundary (`break`/`continue`) question.

#16072 enumerated 5 rows against `tsc@7.0.2`. Of those, 3 are this "wrong branch" bug and are fixed here: class property initializer (instance + static) and namespace body. The other 2 (method/constructor parameter default `await`) turned out to be a different, deeper bug — tsz's parser never constructs an `AwaitExpression` node for a parameter default's `await` outside an async context, so there is no node for a checker-level grammar walk to visit at all. That's parser-owned and out of scope for this diff; split off as #16078.

### Adjacent-case matrix
Instance property initializer, static property initializer, namespace body, `await using` inside a namespace body (TS2852 not TS2853/2854), renamed binders for the property and namespace cases, and negative controls: a genuine top-level `await` outside a module still reports TS1375, `namespace N { break; }` still reports TS1105 (the jump-boundary question stays untouched), an ordinary non-async method body's own `await` is unaffected, and a class static block's `await` still doesn't take the top-level branch.

## Goal
Goal: hold

## Verification
- New suite `top_level_await_boundary_tests` (10 cases), oracle-verified against `typescript@7.0.2` (`--noEmit --strict --pretty false --target es2022 --module esnext`).
- `cargo nextest run -p tsz-checker --lib -E 'test(for_) + test(loop_) + test(while_) + test(throw) + test(unreachable) + test(await) + test(async) + test(switch) + test(class_member_body) + test(namespace)'` → 909/909.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` → clean.
- `cargo fmt --all -- --check` → clean.
- `python3 scripts/arch/arch_guard.py` → `Architecture guardrails passed.`
- `scripts/conformance/compare-to-parent.sh fe28b39` — running at PR-creation time in this session's container; this PR body will be updated with the newly-passing/newly-failing numbers once it completes. Family precedent (#16067, #16070, #16071 in this same await-grammar campaign) is 0 newly-failing / a small positive newly-passing delta for silent-gap and wrong-branch fixes of this shape.
- Emit/fourslash not run this session (narrow diagnostic-branch-selection change, not an emit or LSP path).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_0138sDsgVk32uWwC34W1CigP)_