### PR TITLE
fix(ci): raise bench-latest-freshness threshold to match daily publish cadence

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -319,10 +319,22 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Threshold is 9h, not the 6h script default: it avoids false alarms
-          # during normal long benchmark queueing while still catching a real
-          # freeze within a few hours. --file-issue opens /
-          # updates / closes one deduplicated tracking issue; no --strict so a
-          # transient fetch blip never reds this advisory job.
-          node scripts/bench/check-latest-freshness.mjs --file-issue --max-age-hours 9 \
+          # bench.yml publishes only from its once-daily `0 3 * * *` scheduled
+          # run (bench.yml:26), whose full-suite job has a 360-minute timeout
+          # (bench.yml:48). So the *minimum* possible gap between two
+          # publishes is already 24h, and the worst case is ~24h + one run's
+          # full duration (observed up to ~8h in practice, e.g. #16066's
+          # 11:14Z publish following a 03:00Z start) before the next day's run
+          # even starts queueing. A 9h threshold is stale by construction: it
+          # fires every day for the ~15-21h between "one cadence past the last
+          # publish" and "the next run finishes" regardless of whether bench
+          # is healthy (see #16066 and its 15 predecessor sentinel issues,
+          # all false alarms — confirmed via 8 consecutive successful daily
+          # runs). 36h covers 24h cadence + double the observed worst-case
+          # run duration, while still catching a genuine multi-day freeze
+          # (the original "46-commit" incident this monitor was built for).
+          # --file-issue opens / updates / closes one deduplicated tracking
+          # issue; no --strict so a transient fetch blip never reds this
+          # advisory job.
+          node scripts/bench/check-latest-freshness.mjs --file-issue --max-age-hours 36 \
             | tee -a "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
`bench-latest-freshness` (ci-health.yml) checks the published `latest.json` against a fixed wall-clock age threshold; the threshold must match the actual publish cadence, not a value copied from the script's generic 6h default plus a small buffer.

`bench.yml` publishes `latest.json` only from its once-daily `0 3 * * *` scheduled run, whose full-suite job carries a 360-minute (6h) timeout. That means the *minimum* possible gap between two publishes is already 24h, and the observed worst case is ~24h plus one run's actual duration (up to ~8h seen in practice, e.g. the run behind #16066 published at 11:14Z after a 03:00Z start). The `bench-latest-freshness` job's `--max-age-hours 9` threshold was miscalibrated from the moment it was introduced in the same commit as the daily schedule — it is stale by construction, firing a false "stale" sentinel for roughly 15-21h of every 24 regardless of whether bench is healthy.

Quartz's board investigation (issue #15994 comment thread) confirmed this directly: 8 consecutive daily bench runs all succeeded while the sentinel fired 15 separate false-alarm issues, explicitly recommending "the fix is a threshold, left to the bench-lane owner." This PR is that fix.

Raised `--max-age-hours` from `9` to `36` (24h cadence + 2x the observed worst-case run duration), which still catches a genuine multi-day publish freeze — the kind of incident (`46-commit` freeze) this monitor was originally built to catch — while no longer alarming on ordinary day-to-day cadence variance.

## Goal
Goal: hold

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-health.yml'))"` — YAML parses clean.
- `python3 scripts/lib/check-sh-portability.py` — exit 0 (embedded bash comments/script stay portable).
- `node scripts/bench/test-check-latest-freshness.mjs` — passes unchanged (script behavior itself is untouched; only the workflow's CLI argument changed).
- No Rust/checker/solver/emitter code touched; conformance/emit/fourslash are not applicable to this change.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
