### PR TITLE
refactor(checker): trust Round 1's own substitution for bare-typaram evidence (#16018)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1323,6 +1323,9 @@ path = "tests/issue_16012_any_argument_type_param_evidence_tests.rs"
 name = "issue_16018_annotated_sibling_callback_evidence_tests"
 path = "tests/issue_16018_annotated_sibling_callback_evidence_tests.rs"
 [[test]]
+name = "issue_16018_round1_bare_position_trust_tests"
+path = "tests/issue_16018_round1_bare_position_trust_tests.rs"
+[[test]]
 name = "issue_9692_function_candidate_inference"
 path = "tests/issue_9692_function_candidate_inference.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs
@@ -34,6 +34,7 @@ impl<'a> CheckerState<'a> {
             shape,
             args,
             arg_types,
+            finalized_contextual_param_types,
             check_excess_properties,
             callable_ctx,
         );
@@ -45,6 +46,7 @@ impl<'a> CheckerState<'a> {
         shape: Option<&FunctionShape>,
         args: &[NodeIndex],
         arg_types: &[TypeId],
+        finalized_contextual_param_types: Option<&[Option<TypeId>]>,
         check_excess_properties: bool,
         callable_ctx: CallableContext,
     ) {
@@ -55,6 +57,7 @@ impl<'a> CheckerState<'a> {
             shape,
             args,
             arg_types,
+            finalized_contextual_param_types,
             check_excess_properties,
             callable_ctx,
         );
@@ -65,6 +68,7 @@ impl<'a> CheckerState<'a> {
         shape: &FunctionShape,
         args: &[NodeIndex],
         arg_types: &[TypeId],
+        finalized_contextual_param_types: Option<&[Option<TypeId>]>,
         check_excess_properties: bool,
         callable_ctx: CallableContext,
     ) {
@@ -105,8 +109,16 @@ impl<'a> CheckerState<'a> {
                     continue;
                 }
 
-                let has_other_evidence =
-                    args.iter()
+                let has_other_evidence = self
+                    .bare_type_param_position_resolved_by_round1(
+                        shape,
+                        finalized_contextual_param_types,
+                        index,
+                        *tp,
+                    )
+                    .is_some()
+                    || args
+                        .iter()
                         .enumerate()
                         .any(|(other_index, &other_arg_idx)| {
                             self.argument_provides_type_param_evidence(
@@ -274,6 +286,58 @@ impl<'a> CheckerState<'a> {
                 )
             })
         })
+    }
+
+    /// Whether the call's own already-computed generic solve (threaded down
+    /// as `finalized_contextual_param_types`, the callee's parameter types
+    /// after substituting the real inferred type arguments) resolved
+    /// `type_param` to a concrete type through some OTHER bare-typed
+    /// parameter position.
+    ///
+    /// This complements `argument_provides_type_param_evidence`'s
+    /// argument-shape heuristic rather than replacing it (#16018): for a
+    /// parameter slot declared as a bare type-parameter reference (`x: T`,
+    /// no nesting), substituting the solver's real answer into that slot
+    /// yields `type_param`'s own resolved value directly, with no need to
+    /// re-derive "was there evidence" from the sibling argument's shape.
+    /// That answer can be more informed than the raw per-argument
+    /// `arg_types` the heuristic reads — e.g. a sibling argument that itself
+    /// failed to check cleanly still leaves the OTHER, correctly computed
+    /// parameter substitution behind. Only bare positions are handled: a
+    /// type parameter nested inside a compound parameter type (`Array<T>`)
+    /// cannot be recovered from the substituted slot without structural
+    /// unification, so those sibling positions still fall through to the
+    /// heuristic below.
+    fn bare_type_param_position_resolved_by_round1(
+        &self,
+        shape: &FunctionShape,
+        finalized_contextual_param_types: Option<&[Option<TypeId>]>,
+        current_index: usize,
+        type_param: tsz_solver::TypeParamInfo,
+    ) -> Option<TypeId> {
+        let finalized = finalized_contextual_param_types?;
+        shape
+            .params
+            .iter()
+            .enumerate()
+            .find_map(|(position, param)| {
+                if position == current_index {
+                    return None;
+                }
+                let bare_type_param = common::type_param_info(self.ctx.types, param.type_id)?;
+                if !bare_type_param.is_same_binder(type_param) {
+                    return None;
+                }
+                let resolved = finalized.get(position).copied().flatten()?;
+                if resolved == TypeId::UNKNOWN
+                    || resolved == TypeId::ERROR
+                    || common::contains_infer_types(self.ctx.types, resolved)
+                    || common::contains_type_parameters(self.ctx.types, resolved)
+                {
+                    return None;
+                }
+                Some(resolved)
+            })
     }
 
     /// Positions of a callback argument's own parameters that carry an

--- a/crates/tsz-checker/tests/issue_16018_round1_bare_position_trust_tests.rs
+++ b/crates/tsz-checker/tests/issue_16018_round1_bare_position_trust_tests.rs
@@ -1,0 +1,95 @@
+//! Regression tests for [issue #16018]: the post-generic uninferred-callback
+//! recheck must trust the call's own already-computed generic solve for a
+//! bare type-parameter position, instead of exclusively re-deriving "was
+//! there evidence" from a narrower argument-shape heuristic.
+//!
+//! Structural rule: `emit_uninferred_callback_unknown_body_diagnostics`
+//! (`crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs`)
+//! decides whether a shared type parameter `T`, consumed by a
+//! context-sensitive callback argument, was genuinely left uninferred by
+//! Round 1. For a sibling parameter position declared as a bare `T`
+//! reference, the call's own `finalized_contextual_param_types` (the
+//! callee's parameter types after substituting the real solver-inferred type
+//! arguments — the same answer `tsc` already computed) is authoritative and
+//! must be consulted directly (`bare_type_param_position_resolved_by_round1`)
+//! rather than re-derived solely from the sibling argument's own checked
+//! type, which can lag the checker's own later refinements
+//! (`refine_instantiated_params_with_checker_substitution`,
+//! `refine_bare_instantiated_params_with_direct_literal_conflicts`) that
+//! land in the substituted parameter type but not in the raw argument type
+//! array.
+//!
+//! This complements `issue_16018_annotated_sibling_callback_evidence_tests`
+//! (the annotated-sibling-parameter evidence channel), which is a different
+//! sub-fix under the same tracking issue.
+//!
+//! [issue #16018]: https://github.com/tsz-org/tsz/issues/16018
+
+fn compile_and_get_diagnostics(source: &str) -> Vec<(u32, String)> {
+    tsz_checker::test_utils::check_source_code_messages(source)
+}
+
+fn assert_no_ts18046(diagnostics: &[(u32, String)], context: &str) {
+    assert!(
+        diagnostics.iter().all(|(code, _)| *code != 18046),
+        "Did not expect TS18046 in {context}. Got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn bare_sibling_seeds_type_param_for_callback() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function ap<I>(seed: I, use: (v: I) => void): void;
+declare const seed: { field: number };
+ap(seed, item => { item.field; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "bare sibling seeds I");
+}
+
+#[test]
+fn bare_sibling_seeds_type_param_with_renamed_binder() {
+    // Same shape with `J`/`use`/`v` renamed — proves the rule is structural,
+    // not keyed on a specific identifier (per CLAUDE.md's anti-hardcoding
+    // gate).
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function apply<J>(x: J, run: (w: J) => void): void;
+declare const x: { member: string };
+apply(x, w => { w.member; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "renamed type parameter J");
+}
+
+#[test]
+fn bare_sibling_seeds_type_param_when_third_argument_present() {
+    // Three arguments, current callback last, bare-T seed first — exercises
+    // the "other" position scan beyond the minimal two-argument shape.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function ap3<I>(seed: I, label: string, use: (v: I) => void): void;
+declare const seed: { field: number };
+ap3(seed, "l", item => { item.field; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "bare sibling seeds I with extra argument");
+}
+
+#[test]
+fn callback_with_unannotated_param_still_emits_when_t_truly_uninferred() {
+    // Negative control (mirrors issue_7653's own fallback case): neither
+    // argument is a bare-T position, so the trusted-Round1 path must not
+    // fire, and the narrower heuristic still correctly reports TS18046.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+function foo<T>(o: (n: T) => void, i: (t: T) => void) { }
+foo(n => n.length, t => { });
+"#,
+    );
+    assert!(
+        diagnostics.iter().any(|(code, _)| *code == 18046),
+        "Expected TS18046 for genuinely uninferred T. Got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
When a generic call's post-generic recheck (`emit_uninferred_callback_unknown_body_diagnostics`, `crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs`) decides whether a shared type parameter `T` was genuinely left uninferred by Round 1, it re-derives "was there evidence" from each sibling argument's raw checked type (`argument_provides_type_param_evidence`) instead of consulting the answer Round 1's own solver call already computed.

Structural rule: when a sibling parameter position is declared as a bare type-parameter reference (`x: T`, no nesting) and the call's own `finalized_contextual_param_types` (the callee's parameter types after substituting the real solver-inferred type arguments) already resolved that position to a concrete type, tsc's behavior follows that resolved value; tsz's recheck should trust it directly, through the new `bare_type_param_position_resolved_by_round1` (owner layer: checker's post-generic call-inference query boundary), rather than re-deriving evidence from the raw per-argument-expression type array.

That raw array can lag the checker's own later refinements — `refine_instantiated_params_with_checker_substitution` and `refine_bare_instantiated_params_with_direct_literal_conflicts` (`crates/tsz-checker/src/types/computation/call_inference.rs`) — both of which write their corrected answer into the callee's substituted parameter type (`generic_instantiated_params`) but never back into the argument-type array the heuristic reads. This is the same "two subsystems compute the same fact, the less-informed one wins on ordering" duplication pattern #16016 fixed a different instance of, named as the general tech-debt item in #16018.

**Relabeled after review (Quartz, m4 seat):** this session could not construct a repro where the two signals concretely diverge, and Quartz's full corpus sweep confirms it: conformance 11442/12043 with **0 newly failing, 0 newly passing**. The change makes `has_other_evidence` true in strictly more cases (fewer diagnostics emitted, never more), which is safe by construction but is not a `green` flip — filing it as `green` would book a no-op as row progress, the same phantom-improvement pattern #16081 describes. This is a `hold`-goal structural refactor: it removes one instance of the two-subsystems-compute-the-same-fact duplication #16018 tracks, with no observed behavior change on any input found so far. The remaining piece of #16018 (making this a genuine `green` fix) is constructing the divergence case — checker-substitution refinement firing at a bare-typaram sibling position whose raw argument type independently reads unknown/error — which Quartz's comment traces precisely and leaves open for whoever picks it up next.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test issue_7653_parameterless_lambda_inference_tests --test issue_16012_any_argument_type_param_evidence_tests --test issue_16018_annotated_sibling_callback_evidence_tests --test issue_16018_round1_bare_position_trust_tests`: 25/25 pass (4 new tests added).
- `cargo test -p tsz-checker --test context_sensitive_callback_inference_tests --test generic_call_assignment_flow_tests --test new_generic_callback_contextual_infer_tests --test generic_callback_local_literal_widening_tests --test generic_call_inference_tests --test issue_3768_generic_callback_outer_inference_tests --test issue_9780_typeof_generic_call_callback_param --test getter_contextual_generic_call_typeparam_tests --test failed_generic_call_default_type_args_tests`: all pass except 2 pre-existing failures in `generic_call_assignment_flow_tests` (`colliding_generic_terminals_keep_flow_diagnostics_clean_across_file_orders`, `imported_generic_result_narrows_inside_reduce_arrow`) — confirmed unrelated (reproduce identically on `main` with this change stashed out) and confirmed by Quartz to already be in `known-failures.txt`.
- `cargo clippy -p tsz-checker --profile ci-lint --all-targets -- -D warnings`: clean (pre-commit hook also ran this + arch-size guard, both passed).
- `cargo fmt -p tsz-checker -- --check`: clean.
- **Quartz (m4, full corpus)**: conformance 11442/12043, 0 newly failing / 0 newly passing; emit JS 11562/11563 (floor holds); emit DTS 1375/1390 (floor holds); `tsz-checker --lib` 8610 run, 1 failed (baselined `ts2303`, zero delta); new suite 4/4 pass; the two `generic_call_assignment_flow_tests` failures confirmed pre-existing and already baselined.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE
