### PR TITLE
fix(checker): report TS2515/TS2654 for ambient classes with unimplemented inherited abstract members

### DIFF
--- a/crates/tsz-checker/src/classes/class_abstract_checker.rs
+++ b/crates/tsz-checker/src/classes/class_abstract_checker.rs
@@ -60,10 +60,11 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        let is_ambient = self.has_declare_modifier(&class_data.modifiers);
-        if is_ambient {
-            return;
-        }
+        // No ambient exemption here either — see the equivalent site in
+        // `class_implements_checker::core`. The `abstract`-modifier escape hatch is
+        // applied by `check_abstract_member_implementations` before it delegates to
+        // this type-level fallback, so reaching this point already means the derived
+        // class is non-abstract.
 
         let derived_class_name = if class_data.name.is_some() {
             if let Some(name_node) = self.ctx.arena.get(class_data.name)

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -752,9 +752,18 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // Report error if there are missing implementations
-        let is_ambient = self.has_declare_modifier(&class_data.modifiers);
-        if !is_ambient && !missing_members.is_empty() {
+        // Report error if there are missing implementations.
+        //
+        // Ambient-ness does NOT exempt the class. `tsc` decides this in
+        // `checkKindsOfPropertyMemberOverrides`, whose only escape hatch is the
+        // `abstract` modifier on the derived declaration — already handled by the
+        // early return in `check_abstract_member_implementations`. A `declare
+        // class` that leaves an inherited abstract member unimplemented is
+        // reported exactly like a non-ambient one, which also keeps this path
+        // consistent with the implicitly-ambient forms (a class inside `declare
+        // module` / `declare namespace`, or any class in a `.d.ts`) that carry no
+        // `declare` modifier of their own and were always checked.
+        if !missing_members.is_empty() {
             let derived_class_name = if class_data.name.is_some() {
                 if let Some(name_node) = self.ctx.arena.get(class_data.name) {
                     if let Some(ident) = self.ctx.arena.get_identifier(name_node) {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -685,6 +685,9 @@ mod ts2469_symbol_operator_tests;
 #[path = "../tests/ts2498_tests.rs"]
 mod ts2498_tests;
 #[cfg(test)]
+#[path = "tests/ts2515_ambient_class_abstract_member_tests.rs"]
+mod ts2515_ambient_class_abstract_member_tests;
+#[cfg(test)]
 #[path = "tests/ts2536_deferred_conditional_indexed_access_tests.rs"]
 mod ts2536_deferred_conditional_indexed_access_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/ts2515_ambient_class_abstract_member_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2515_ambient_class_abstract_member_tests.rs
@@ -1,0 +1,235 @@
+//! TS2515/TS2654 for ambient (`declare`) classes with unimplemented inherited
+//! abstract members.
+//!
+//! Structural rule: when a non-abstract class declaration inherits an
+//! unimplemented abstract member, `tsc` reports TS2515 (or TS2654 for two or
+//! more) regardless of whether the declaration is ambient. The only escape
+//! hatch is the `abstract` modifier on the derived declaration itself, which
+//! `check_abstract_member_implementations` applies before either reporting path
+//! runs.
+//!
+//! Before the fix, both reporting sites carried an extra
+//! `has_declare_modifier(class_data.modifiers)` gate, so `declare class B
+//! extends A {}` was silently clean. The boundary was the `declare` **modifier**,
+//! not ambient-ness: a class inside `declare module` / `declare namespace`, and
+//! any class in a `.d.ts`, carries no `declare` modifier of its own and was
+//! always reported correctly. That asymmetry is what the negative controls below
+//! pin down.
+//!
+//! Every expectation here was taken from the vendored `tsc` 7.0.2 oracle
+//! (`--noEmit --strict --pretty false --target es2020`), not from tsz's own
+//! output.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn assert_reports_2515(source: &str, label: &str) {
+    let got = codes(source);
+    assert!(
+        got.contains(&2515),
+        "{label}: expected TS2515, got codes {got:?}"
+    );
+}
+
+fn assert_no_missing_impl_diagnostic(source: &str, label: &str) {
+    let got = codes(source);
+    assert!(
+        !got.iter().any(|c| matches!(c, 2515 | 2653 | 2654 | 2656)),
+        "{label}: expected no missing-implementation diagnostic, got codes {got:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases: `declare` must not exempt the class.
+// ---------------------------------------------------------------------------
+
+/// The witness from the bug report: an ambient class leaving an inherited
+/// abstract *method* unimplemented.
+#[test]
+fn declare_class_missing_abstract_method_reports_ts2515() {
+    assert_reports_2515(
+        r#"
+abstract class A { abstract m(): string; }
+declare class B extends A {}
+"#,
+        "declare class, missing method",
+    );
+}
+
+/// Same rule for an abstract *property*. tsc does not distinguish member kinds
+/// here, so neither may tsz.
+#[test]
+fn declare_class_missing_abstract_property_reports_ts2515() {
+    assert_reports_2515(
+        r#"
+abstract class A { abstract p: string; }
+declare class B extends A {}
+"#,
+        "declare class, missing property",
+    );
+}
+
+/// Same rule for an abstract *accessor*.
+#[test]
+fn declare_class_missing_abstract_accessor_reports_ts2515() {
+    assert_reports_2515(
+        r#"
+abstract class A { abstract get g(): string; }
+declare class B extends A {}
+"#,
+        "declare class, missing accessor",
+    );
+}
+
+/// Binder-name control: the rule is structural, so renaming every binder must
+/// not change the outcome.
+#[test]
+fn declare_class_missing_abstract_member_renamed_binders_reports_ts2515() {
+    assert_reports_2515(
+        r#"
+abstract class Shape { abstract area(): number; }
+declare class Square extends Shape {}
+"#,
+        "declare class, renamed binders",
+    );
+}
+
+/// Two or more missing members promote TS2515 to TS2654, and the `declare`
+/// modifier must not suppress that variant either.
+#[test]
+fn declare_class_missing_two_abstract_members_reports_ts2654() {
+    let got = codes(
+        r#"
+abstract class A { abstract m(): string; abstract n(): number; }
+declare class B extends A {}
+"#,
+    );
+    assert!(
+        got.contains(&2654),
+        "declare class with two missing members: expected TS2654, got codes {got:?}"
+    );
+}
+
+/// A generic abstract base reached through an ambient derived class. Keeps the
+/// rule honest for the instantiated-heritage path, not just the bare one.
+#[test]
+fn declare_class_extending_generic_abstract_base_reports_ts2515() {
+    assert_reports_2515(
+        r#"
+abstract class Container<T> { abstract get(): T; }
+declare class NumberBox extends Container<number> {}
+"#,
+        "declare class, generic abstract base",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: what must stay clean.
+// ---------------------------------------------------------------------------
+
+/// `declare abstract class` stays exempt — because it is abstract, not because
+/// it is ambient. This is the control that fails if the fix is written as
+/// "always report" instead of "let the `abstract` gate decide".
+#[test]
+fn declare_abstract_class_stays_clean() {
+    assert_no_missing_impl_diagnostic(
+        r#"
+abstract class A { abstract m(): string; }
+declare abstract class B extends A {}
+"#,
+        "declare abstract class",
+    );
+}
+
+/// An ambient class that does declare the member is complete and must stay
+/// clean — the members of a `declare class` still count as implementations.
+#[test]
+fn declare_class_implementing_abstract_member_stays_clean() {
+    assert_no_missing_impl_diagnostic(
+        r#"
+abstract class A { abstract m(): string; }
+declare class B extends A { m(): string; }
+"#,
+        "declare class implementing the member",
+    );
+}
+
+/// Inheriting through an intermediate ambient class that implements the member
+/// must stay clean: the requirement is satisfied before it reaches `B`.
+#[test]
+fn declare_class_inheriting_through_implementing_intermediate_stays_clean() {
+    assert_no_missing_impl_diagnostic(
+        r#"
+abstract class A { abstract m(): string; }
+declare class Mid extends A { m(): string; }
+declare class B extends Mid {}
+"#,
+        "declare class via implementing intermediate",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Boundary controls: the forms that were already correct must not move.
+// ---------------------------------------------------------------------------
+
+/// The non-ambient form always worked; pinned so a future change to the gate
+/// cannot silently trade one direction for the other.
+#[test]
+fn plain_class_missing_abstract_method_still_reports_ts2515() {
+    assert_reports_2515(
+        r#"
+abstract class A { abstract m(): string; }
+class B extends A {}
+"#,
+        "plain class, missing method",
+    );
+}
+
+/// Implicitly-ambient via `declare module`: the class node carries no `declare`
+/// modifier, so this was reported correctly before the fix. It is the control
+/// proving the old boundary was the modifier rather than ambient-ness.
+#[test]
+fn implicitly_ambient_class_in_declare_module_reports_ts2515() {
+    assert_reports_2515(
+        r#"
+declare module "m" {
+  abstract class A { abstract m(): string; }
+  class B extends A {}
+}
+"#,
+        "class inside declare module",
+    );
+}
+
+/// Same for `declare namespace`.
+#[test]
+fn implicitly_ambient_class_in_declare_namespace_reports_ts2515() {
+    assert_reports_2515(
+        r#"
+declare namespace N {
+  abstract class A { abstract m(): string; }
+  class B extends A {}
+}
+"#,
+        "class inside declare namespace",
+    );
+}
+
+/// A `declare class` with no abstract members to inherit must stay clean —
+/// removing the gate must not make ambient classes noisy in general.
+#[test]
+fn declare_class_extending_concrete_base_stays_clean() {
+    assert_no_missing_impl_diagnostic(
+        r#"
+class A { m(): string { return ""; } }
+declare class B extends A {}
+"#,
+        "declare class over concrete base",
+    );
+}


### PR DESCRIPTION
Closes #16083.

## Structural rule

**When a non-abstract class declaration inherits an unimplemented abstract member, `tsc` reports TS2515 (TS2654 for two or more) regardless of whether the declaration is ambient; tsz now does the same through the checker's class-heritage checking layer (`class_implements_checker::core` and its `class_abstract_checker` type-level fallback).**

The wrong semantic operation was **diagnostic gating during class-heritage member checking** — not relation, inference, or evaluation. The abstract-member walk computed the correct missing-member set and then discarded it.

### What was wrong

Both reporting sites carried an extra gate on the derived class's `declare` modifier:

| site | path |
| --- | --- |
| `classes/class_implements_checker/core.rs:756` | AST-based, the primary path |
| `classes/class_abstract_checker.rs:63` | type-level fallback for expression-based heritage |

so `declare class B extends A {}` was silently clean.

**The boundary was the `declare` modifier, not ambient-ness.** That distinction is what makes this a real defect rather than a policy choice: a class inside `declare module` / `declare namespace`, and every class in a `.d.ts`, carries no `declare` modifier of its own and was *always* reported correctly. tsz was inconsistent with itself across two spellings of the same ambient concept.

### Why removing the gate is the whole fix

`tsc` decides this in `checkKindsOfPropertyMemberOverrides`, whose only escape hatch is the `abstract` modifier on the derived declaration. tsz already applies exactly that gate in `check_abstract_member_implementations` (`core.rs:587`), **upstream of both reporting paths** — including the delegation to the type-level fallback at `core.rs:653`. So deleting the two ambient gates leaves precisely tsc's rule, and `declare abstract class` stays exempt *because it is abstract*, not because it is ambient. No new predicate was introduced.

Why it matters beyond the witness: `declare class` is the dominant form in `.d.ts` files and ambient declarations for external libraries — exactly where an unimplemented abstract member is least likely to be caught by anything else, since there is no body to fail at runtime and no other diagnostic covering it.

## Goal
Goal: hold

## Verification

All expectations below were taken from the **vendored `tsc` 7.0.2 oracle** (`--noEmit --strict --pretty false --target es2020`), not from tsz's own output. Full adjacent-case matrix, 14 rows:

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `declare class` — missing **method** | TS2515 | clean | **TS2515** |
| `declare class` — missing **property** | TS2515 | clean | **TS2515** |
| `declare class` — missing **accessor** | TS2515 | clean | **TS2515** |
| `declare class` — renamed binders (`Shape`/`Square`/`area`) | TS2515 | clean | **TS2515** |
| `declare class` — **two** missing members | TS2654 | clean | **TS2654** |
| `declare class` — **generic** abstract base `Container[ T ]` | TS2515 | clean | **TS2515** |
| `declare abstract class` | clean | clean | clean |
| `declare class` that declares the member | clean | clean | clean |
| `declare class` via implementing intermediate | clean | clean | clean |
| `declare class` over a **concrete** base | clean | clean | clean |
| plain `class` (no `declare`) | TS2515 | TS2515 | TS2515 |
| class in `declare module` (implicitly ambient) | TS2515 | TS2515 | TS2515 |
| class in `declare namespace` (implicitly ambient) | TS2515 | TS2515 | TS2515 |

Six flips, seven controls unmoved — including the four negative controls that would fail if the fix were written as "always report" instead of "let the existing `abstract` gate decide", and the two implicitly-ambient rows that pin down the old boundary.

Commands actually run in this container (cold seat, `.target` empty at session start):

- `cargo test -p tsz-checker --lib ts2515_ambient_class_abstract_member` → **13 passed, 0 failed** (new regression file).
- `cargo test -p tsz-checker --lib` (full) → **8619 ok / 1 failed / 2 ignored** of 8625. The single failure is `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`, already baselined at `scripts/ci/known-failures.txt:128` — **zero delta**, and the same row Diorite and Quartz both reported on #16077 this cycle.
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` (CI's exact per-merge invocation) → **0 warnings, 0 errors**, `Finished in 11m 22s`.
- `cargo fmt --all` → clean.

**Not run in this container, disclosed rather than implied** (per the standing board gotcha that a suite you did not run locally did not run):

- **Conformance** — `TypeScript/tests/cases/conformance` had 0 entries at session start and the `--sparse` corpus checkout is ~25 min on a cold seat; it did not fit alongside the two builds this change needed. A two-sided `scripts/conformance/compare-to-parent.sh 06fb545` from a warm seat is the gate I could not reach.
- **Emit** — `scripts/emit/node_modules` absent. This change adds no type construction and touches no declaration/annotation typing (it deletes two boolean guards on a diagnostic-emission branch), so emit-visibility is implausible; the JS `11562/11563` and DTS `1375/1390` floors have zero headroom, so it is still worth a warm-seat confirmation.

Note this change can only ever **add** diagnostics to ambient classes that are genuinely missing an implementation, so the conformance risk is one-sided: newly-*failing* rows would be fixtures asserting the old false-negative, not newly-passing ones being lost.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Rhyolite

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7Br5qNreKfvCmGfTPtsMi)_