### PR TITLE
ci(conformance): auto-refresh the committed snapshot daily (#16081)

### DIFF
--- a/.github/workflows/conformance-snapshot-refresh.yml
+++ b/.github/workflows/conformance-snapshot-refresh.yml
@@ -71,7 +71,7 @@ jobs:
             git --no-pager diff --stat -- "${files[@]}"
           fi
 
-      - name: Open refresh PR
+      - name: Open or update refresh PR
         if: steps.diff.outputs.changed == 'true' && (inputs.dry_run != true)
         shell: bash
         env:
@@ -81,57 +81,110 @@ jobs:
           git config user.name "tsz-conformance-bot"
           git config user.email "tsz-conformance-bot@users.noreply.github.com"
 
-          stamp="$(date -u +%Y%m%d)"
-          branch="automation/conformance-snapshot-refresh-${stamp}"
-          if git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
-            echo "Branch ${branch} already exists on origin; today's refresh is already open."
-            exit 0
-          fi
+          # base_ref is the commit this checkout started from, i.e. the
+          # currently-committed snapshot, before the run above overwrote it
+          # in the working tree. check-snapshot-regression.py needs it as a
+          # git ref to diff against once the new state is committed below.
+          base_ref="$(git rev-parse HEAD)"
 
-          git checkout -b "${branch}"
+          # One standing branch, force-pushed, not one-per-day: a stale
+          # unmerged refresh PR would otherwise keep comparing against an
+          # ever-older base while new dated branches pile up beside it, each
+          # conflicting with the last (#16081 asked for "opens or updates a
+          # single standing PR", not a new one every day).
+          branch="automation/conformance-snapshot-refresh"
+          git checkout -B "${branch}"
           git add scripts/conformance/conformance-detail.json \
                   scripts/conformance/conformance-snapshot.json \
                   scripts/conformance/conformance-baseline.txt
           git commit -m "chore(conformance): refresh the committed snapshot to current main"
-          git push -u origin "${branch}"
 
-          body=$(cat <<'EOF'
-          Automated refresh of the committed conformance snapshot
-          (`conformance-detail.json`, `conformance-snapshot.json`,
-          `conformance-baseline.txt`) from a fresh full-corpus run against
-          `main`.
+          # Compare the new commit against the base it just displaced so the
+          # PR states the direction, not just the fact that something
+          # changed. This must never fail the job, even on a real regression
+          # (that's a report, not a gate) — --allow-new-failures alone does
+          # NOT guarantee that: has_blocking_regression() still returns exit
+          # 1 whenever pass_delta < 0 regardless of that flag, so capture the
+          # report with errexit suspended rather than trust the exit code.
+          set +e
+          report="$(python3 scripts/conformance/check-snapshot-regression.py \
+            --base-ref "${base_ref}" --head-ref HEAD --allow-new-failures)"
+          set -e
+          echo "${report}"
+          # Drop the script's "::error::" Actions annotations from the copy
+          # that goes into the PR body — meaningful in this step's log,
+          # meaningless (and confusing) as literal text in a PR description.
+          report_for_body="$(printf '%s\n' "${report}" | grep -v '^::error::' || true)"
+
+          passed_line="$(printf '%s\n' "${report}" | grep '^- passed:' || true)"
+          new_failures="$(printf '%s\n' "${report}" | grep -oE '^- new failures: [0-9]+' | grep -oE '[0-9]+' || echo 0)"
+          fixed_failures="$(printf '%s\n' "${report}" | grep -oE '^- fixed failures: [0-9]+' | grep -oE '[0-9]+' || echo 0)"
+
+          title="chore(conformance): refresh the committed snapshot to current main"
+          regression_banner=""
+          if [ "${new_failures:-0}" -gt 0 ]; then
+            # A refresh that silently accepts a regression as the new
+            # baseline is worse than the staleness it fixes: once merged, the
+            # newly-failing tests can never show up as "newly failing" again
+            # in any future diff against this file. Make that impossible to
+            # miss rather than gating on it — a legitimate baselined
+            # regression is sometimes the right call, but it must never look
+            # like a routine chore.
+            title="⚠️ conformance regression: refresh introduces ${new_failures} newly-failing test(s)"
+            regression_banner="**⚠️ This refresh does not just remove stale rows — it introduces ${new_failures} newly-failing test(s) that were not failing at \`${base_ref}\`. That means a real regression landed on \`main\` since the last refresh. Do NOT merge this on sight: find and fix (or consciously accept) the regression first, the same as any other conformance regression.**"$'\n\n'
+          fi
+
+          body="${regression_banner}Automated refresh of the committed conformance snapshot
+          (\`conformance-detail.json\`, \`conformance-snapshot.json\`,
+          \`conformance-baseline.txt\`) from a fresh full-corpus run against
+          \`main\` (\`${base_ref}\`).
+
+          ${passed_line} (fixed: ${fixed_failures}, new: ${new_failures})
 
           ## Goal
           Goal: hold
 
           ## Invariant
-          The committed conformance snapshot tracks the latest `main` instead
-          of drifting stale between manual `conformance.sh snapshot --force`
+          The committed conformance snapshot tracks the latest \`main\` instead
+          of drifting stale between manual \`conformance.sh snapshot --force\`
           runs (#16081). A stale snapshot lets a reviewer's branch-vs-snapshot
           diff read a real regression as an apparent improvement, because the
           drift and the branch's own delta add up.
 
           ## Scope
-          Generated artifacts only, via `scripts/conformance/conformance.sh
-          snapshot --workers 12 --force`. No source, script, or workflow
+          Generated artifacts only, via \`scripts/conformance/conformance.sh
+          snapshot --workers 12 --force\`. No source, script, or workflow
           changes.
 
           ## Verification
-          - This PR's diff *is* the output of `conformance.sh snapshot
-            --force` against `main` — the numbers in the diff are the
-            verification.
+          \`scripts/conformance/check-snapshot-regression.py --base-ref ${base_ref} --head-ref HEAD\`:
+
+          \`\`\`
+          ${report_for_body}
+          \`\`\`
 
           ## Provenance
           Machine: cloud
           Assistant: bot
           Model: github-actions
           Effort: low
-          EOF
-          )
+          "
 
-          gh pr create \
-            --base main \
-            --head "${branch}" \
-            --title "chore(conformance): refresh the committed snapshot to current main" \
-            --body "${body}" \
-            --label chore
+          # Plain --force, not --force-with-lease: this branch only this
+          # workflow ever writes, so there is no concurrent-push scenario
+          # for a lease to guard against, and a fresh checkout has no
+          # existing remote-tracking ref for --force-with-lease to compare
+          # against anyway.
+          git push --force -u origin "${branch}"
+
+          existing_pr="$(gh pr list --state open --head "${branch}" --json number --jq '.[0].number' 2>/dev/null || true)"
+          if [ -n "${existing_pr}" ]; then
+            gh pr edit "${existing_pr}" --title "${title}" --body "${body}"
+          else
+            gh pr create \
+              --base main \
+              --head "${branch}" \
+              --title "${title}" \
+              --body "${body}" \
+              --label chore
+          fi

--- a/.github/workflows/conformance-snapshot-refresh.yml
+++ b/.github/workflows/conformance-snapshot-refresh.yml
@@ -1,0 +1,137 @@
+name: Refresh conformance snapshot
+
+# scripts/conformance/conformance-detail.json, conformance-snapshot.json, and
+# conformance-baseline.txt are committed artifacts that only update when
+# someone runs `conformance.sh snapshot --force` by hand (#16081) — they
+# drift stale between manual refreshes, and nothing fails when they are
+# wrong. Staleness does not merely under-report: a reviewer diffing a
+# branch against a stale artifact receives the branch's real delta summed
+# with the accumulated drift, which can turn a real regression into an
+# apparent improvement (see #16081's #16076-v1 case: a -3 regression read
+# as +4 net against the stale committed detail file).
+#
+# This regenerates the three files from a fresh full-corpus run against
+# main and opens a PR when they drift (main is protected by the merge
+# queue, so a direct push is not possible). It intentionally runs the
+# single-machine `conformance.sh snapshot` path rather than reusing the
+# sharded ci.yml matrix job: that job emits per-shard ci-metrics JSON in a
+# different shape and never writes the three committed files, so
+# reassembling them from shards would be a second, riskier format
+# conversion. `conformance.sh snapshot` already materializes its own
+# TypeScript corpus and dist-fast build, so this job only needs a checkout.
+
+on:
+  schedule:
+    # Daily at 05:00 UTC, clear of ci.yml's nightly heavy lane (04:00 UTC).
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run and diff but do not open a PR"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: conformance-snapshot-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Refresh conformance snapshot
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Run full conformance snapshot
+        run: ./scripts/conformance/conformance.sh snapshot --workers 12 --force
+
+      - name: Detect changes
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+          files=(
+            scripts/conformance/conformance-detail.json
+            scripts/conformance/conformance-snapshot.json
+            scripts/conformance/conformance-baseline.txt
+          )
+          if git diff --quiet -- "${files[@]}"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Conformance snapshot already current; nothing to refresh."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git --no-pager diff --stat -- "${files[@]}"
+          fi
+
+      - name: Open refresh PR
+        if: steps.diff.outputs.changed == 'true' && (inputs.dry_run != true)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.TSZ_PR_AUTOMATION_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          git config user.name "tsz-conformance-bot"
+          git config user.email "tsz-conformance-bot@users.noreply.github.com"
+
+          stamp="$(date -u +%Y%m%d)"
+          branch="automation/conformance-snapshot-refresh-${stamp}"
+          if git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
+            echo "Branch ${branch} already exists on origin; today's refresh is already open."
+            exit 0
+          fi
+
+          git checkout -b "${branch}"
+          git add scripts/conformance/conformance-detail.json \
+                  scripts/conformance/conformance-snapshot.json \
+                  scripts/conformance/conformance-baseline.txt
+          git commit -m "chore(conformance): refresh the committed snapshot to current main"
+          git push -u origin "${branch}"
+
+          body=$(cat <<'EOF'
+          Automated refresh of the committed conformance snapshot
+          (`conformance-detail.json`, `conformance-snapshot.json`,
+          `conformance-baseline.txt`) from a fresh full-corpus run against
+          `main`.
+
+          ## Goal
+          Goal: hold
+
+          ## Invariant
+          The committed conformance snapshot tracks the latest `main` instead
+          of drifting stale between manual `conformance.sh snapshot --force`
+          runs (#16081). A stale snapshot lets a reviewer's branch-vs-snapshot
+          diff read a real regression as an apparent improvement, because the
+          drift and the branch's own delta add up.
+
+          ## Scope
+          Generated artifacts only, via `scripts/conformance/conformance.sh
+          snapshot --workers 12 --force`. No source, script, or workflow
+          changes.
+
+          ## Verification
+          - This PR's diff *is* the output of `conformance.sh snapshot
+            --force` against `main` — the numbers in the diff are the
+            verification.
+
+          ## Provenance
+          Machine: cloud
+          Assistant: bot
+          Model: github-actions
+          Effort: low
+          EOF
+          )
+
+          gh pr create \
+            --base main \
+            --head "${branch}" \
+            --title "chore(conformance): refresh the committed snapshot to current main" \
+            --body "${body}" \
+            --label chore


### PR DESCRIPTION
Closes the core gap named in #16081: `conformance-detail.json`, `conformance-snapshot.json`, and `conformance-baseline.txt` are committed artifacts that previously only updated when someone ran `conformance.sh snapshot --force` by hand (manually refreshed three times: `910c990faf`, #16028, #16080). Nothing failed when they drifted, and staleness doesn't merely under-report — it turns real regressions into apparent improvements, because a reviewer diffing a branch against a stale committed file gets the branch's real delta *summed with* the accumulated drift. #16081's concrete case: #16076 v1 introduced 3 real regressions but read as **+4 net / "7 newly passing"** against the stale artifact.

I confirmed there is currently no automation that refreshes these files: `ci.yml`'s nightly heavy lane shards conformance across 4 matrix jobs and writes per-shard `ci-metrics/conformance.json`, but never writes the three committed files back to the repo, and no other workflow does either.

## Structural rule

The committed conformance snapshot must track `main`, not drift stale between manual refreshes (#16081, Option 4: "nightly auto-refresh PR", which the issue's own reviewer called the best cost/benefit). Owner: a new scheduled `conformance-snapshot-refresh.yml` workflow, mirroring the existing `readme-benchmark-refresh.yml` pattern (schedule → run → diff → open PR, main is merge-queue-protected so no direct push).

## Why not extend the sharded `ci.yml` matrix job instead

`ci.yml`'s `conformance`/`conformance-aggregate` jobs partition the corpus across 4 shards and emit `ci-metrics/conformance.json` per shard — a different format from the three files this issue is about, and reassembling them from shards would be a second, riskier format-conversion change. `conformance.sh snapshot` is self-contained (it materializes its own pinned TypeScript corpus via `reset-ts-submodule.sh --sparse` and builds its own `dist-fast` binaries), so the new job only needs a plain checkout — no shared state with the existing matrix job, so it can't destabilize it.

## Scope

One new file: `.github/workflows/conformance-snapshot-refresh.yml`. No source, script, or existing-workflow changes.

## Goal
Goal: hold

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/conformance-snapshot-refresh.yml'))"`: valid YAML.
- Extracted and ran the "Detect changes" step's diff logic locally against a clean tree: reports `changed=false` as expected (no drift right now, since #16080 refreshed the snapshot this same session-day).
- Did not run the workflow's `conformance.sh snapshot --force` end-to-end in this container (full corpus + `dist-fast` build + full run is the ~8-25 min operation the workflow itself performs on schedule); the command line is the exact one `.claude/CLAUDE.md` already prescribes for local verification, unmodified.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01CKHiyGuceFzDQdbKmRE1d5)_